### PR TITLE
fix(pg): v33 — add missing ENUM columns to runner.* (Phase 1 batch 2)

### DIFF
--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -1219,6 +1219,93 @@ const MIGRATIONS: &[Migration] = &[
                   AND user_decision IS NULL;
         "#,
     },
+    Migration {
+        version: 33,
+        description: "Schema-drift Phase 1 batch 2: add ENUM columns to runner.* tables that the qontinui-web SQLAlchemy models expect (execution_issues.status etc.)",
+        // Companion to v32 (batch 1). Same idea, different table set.
+        // Adds 13 ENUM columns across 8 of the 10 batch-2 tables that the
+        // qontinui-web SQLAlchemy models declare but were missing from
+        // the runner-side schema. Two of the 10 tables — domain_knowledge
+        // and project_embeddings — have no enum drift so they're not in
+        // the spec list (they're still part of the structural drift
+        // survey but resolve via Phase 2/3 work, not enum addition).
+        //
+        // Cross-schema enum reference (`public.<enumtype>`) matches v32:
+        // the ENUM types already exist in `public` (created by alembic);
+        // schema-level enum consolidation is deferred to Phase 4 of the
+        // drift-cleanup plan.
+        //
+        // Defensive DO block: skips any (table, column, enum) triple if
+        // either the runner.X table or the public.<enumtype> doesn't
+        // exist (fresh-DB ordering scenarios), with a NOTICE. Columns
+        // are nullable; SQLAlchemy enforces NOT NULL at the application
+        // layer for new inserts, and existing 0-row tables don't need
+        // backfill.
+        //
+        // After this migration applies (in tandem with v32), the matching
+        // public.* duplicates for these tables become structurally
+        // identical to runner.* and can be dropped by the qontinui-web
+        // alembic migration that re-runs e8a3c5b9d142 on a post-batch-1+2
+        // DB. Drift count: after v32 33→23, after v33 23→13.
+        sql: r#"
+            DO $$
+            DECLARE
+                spec RECORD;
+                added INT := 0;
+                skipped_table INT := 0;
+                skipped_enum INT := 0;
+            BEGIN
+                FOR spec IN
+                    SELECT * FROM (VALUES
+                        ('automation_input_events',      'event_type',      'input_event_type_enum'),
+                        ('execution_issues',             'issue_type',      'execution_issue_type'),
+                        ('execution_issues',             'severity',        'execution_issue_severity'),
+                        ('execution_issues',             'status',          'execution_issue_status'),
+                        ('execution_issues',             'source',          'execution_issue_source'),
+                        ('notifications',                'type',            'notificationtype'),
+                        ('processing_logs',              'phase',           'processingphase'),
+                        ('project_locks',                'resource_type',   'resourcetype'),
+                        ('training_dataset_annotations', 'source',          'annotation_source_enum'),
+                        ('training_dataset_annotations', 'element_type',    'element_type_enum'),
+                        ('training_dataset_annotations', 'review_status',   'review_status_enum'),
+                        ('training_datasets',            'source',          'dataset_source_enum'),
+                        ('workflow_test_associations',   'trigger_point',   'trigger_point')
+                    ) AS s(tbl, col, enum_name)
+                LOOP
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.tables
+                        WHERE table_schema = 'runner' AND table_name = spec.tbl
+                    ) THEN
+                        skipped_table := skipped_table + 1;
+                        RAISE NOTICE 'v33 skip: runner.% does not exist', spec.tbl;
+                        CONTINUE;
+                    END IF;
+
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_type t
+                        JOIN pg_namespace n ON n.oid = t.typnamespace
+                        WHERE t.typname = spec.enum_name AND n.nspname = 'public'
+                    ) THEN
+                        skipped_enum := skipped_enum + 1;
+                        RAISE NOTICE 'v33 skip: enum public.% (for runner.%.%) does not exist',
+                            spec.enum_name, spec.tbl, spec.col;
+                        CONTINUE;
+                    END IF;
+
+                    EXECUTE format(
+                        'ALTER TABLE runner.%I ADD COLUMN IF NOT EXISTS %I public.%I',
+                        spec.tbl, spec.col, spec.enum_name
+                    );
+                    added := added + 1;
+                    RAISE NOTICE 'v33 add: runner.%.% (public.%)',
+                        spec.tbl, spec.col, spec.enum_name;
+                END LOOP;
+
+                RAISE NOTICE 'v33 summary: added=%, skipped_table=%, skipped_enum=%',
+                    added, skipped_table, skipped_enum;
+            END $$;
+        "#,
+    },
 ];
 
 /// Global PgDb instance, set once during app initialization.

--- a/src-tauri/src/mcp/ui_bridge/sdk_spec_sync.rs
+++ b/src-tauri/src/mcp/ui_bridge/sdk_spec_sync.rs
@@ -75,8 +75,10 @@ pub async fn handle_spec_sync_status(
 /// shutdown).
 pub async fn handle_spec_sync_stream(
     State(state): State<Arc<ApiState>>,
-) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, std::convert::Infallible>>>, (StatusCode, String)>
-{
+) -> Result<
+    Sse<impl futures_util::Stream<Item = Result<Event, std::convert::Infallible>>>,
+    (StatusCode, String),
+> {
     let bus = bus_from_state(&state).ok_or((
         StatusCode::INTERNAL_SERVER_ERROR,
         "SpecSyncStateBus not registered".to_string(),


### PR DESCRIPTION
## Summary
- Adds runner-side migration **v33** that adds 13 ENUM columns across 8 of the 10 \`runner.*\` tables in batch 2 of the schema-drift cleanup.
- Sibling to PR #2 (v32, batch 1). Same idempotent \`DO \$\$ … \$\$\` pattern, different table set.
- Drift count between \`public.*\` and \`runner.*\` will drop 33 → 23 (after v32) → 13 (after v33).

## Background
Phase 1 batch 2 (laptop machine, runner-side half) of the drift-cleanup plan. Ten tables identified by the coordination plan; eight have missing ENUM columns the qontinui-web SQLAlchemy models declare. The other two (\`domain_knowledge\`, \`project_embeddings\`) have no enum drift and resolve via Phase 2/3 work, not enum addition.

## Migration design
- Single \`DO \$\$ … \$\$\` block iterating a static \`(table, column, public.enum_name)\` spec list.
- Each triple: skip with NOTICE if \`runner.<table>\` or \`public.<enumtype>\` doesn't exist; otherwise \`ALTER TABLE … ADD COLUMN IF NOT EXISTS … public.<enumtype>\`.
- Columns added as nullable. SQLAlchemy enforces NOT NULL at the application layer; existing 0-row tables don't need backfill.
- Cross-schema enum reference (\`public.<enumtype>\`) avoids duplicating ENUM types into \`runner\` — schema-level enum consolidation is deferred to Phase 4.

## Tables touched
| Table | Columns added |
|---|---|
| automation_input_events | event_type |
| execution_issues | issue_type, severity, status, source |
| notifications | type |
| processing_logs | phase |
| project_locks | resource_type |
| training_dataset_annotations | source, element_type, review_status |
| training_datasets | source |
| workflow_test_associations | trigger_point |

## Test plan
- [x] \`cargo check\` (via cargo-guard) passes.
- [x] Migration SQL applies cleanly to live dev DB; summary reports \`added=13, skipped_table=0, skipped_enum=0\`.
- [x] Migration is idempotent — re-run on the already-populated laptop DB produces 13 \"column already exists, skipping\" notices via PG's \`ADD COLUMN IF NOT EXISTS\`, matching v32's idempotency contract.
- [ ] On next runner restart, v33 is recorded in \`runner.schema_migrations\`.
- [ ] On a DB that has v32 applied but lacks the batch-2 columns, all 13 ALTER TABLEs land.
- [ ] Web-side companion PR (after v32 + v33) drops the matching \`public.*\` duplicates via re-running \`e8a3c5b9d142\`.

## Coordination
Per the schema-drift coordination plan: this is independent of PR #2 (v32, batch 1, PC). Both PRs touch \`pg/mod.rs\` but each appends its own \`Migration\` entry — git can merge automatically and migrations apply in numeric order regardless of slice position. v32 and v33 do not share table sets.

The first commit on this branch (\`5476a8f8\`) is a small \`cargo fmt\` fix for a pre-existing line-wrap drift in \`sdk_spec_sync.rs\` that the local pre-commit hook caught when committing v33. Unrelated to drift Phase 1 but bundled here so the PR's CI can pass.