### PR TITLE
fix(pg): v33 — align runner.deferred_questions column types (Phase 2 slice)

### DIFF
--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -1315,6 +1315,84 @@ const MIGRATIONS: &[Migration] = &[
             END $$;
         "#,
     },
+    Migration {
+        version: 33,
+        description: "Schema-drift Phase 2 (deferred_questions slice): align runner.deferred_questions column types to match the SQLAlchemy model (text → uuid/varchar)",
+        // Background: runner.deferred_questions has 6 columns typed as TEXT
+        // (the runner-historical default, originally for sqlite parity) where
+        // the qontinui-web SQLAlchemy model expects UUID and VARCHAR(N). Both
+        // schemas have 0 rows currently, so the type changes are risk-free.
+        //
+        // Once these align, the empty public.deferred_questions duplicate
+        // becomes droppable by the next re-run of the introspection-based
+        // drop logic from `e8a3c5b9d142` (paired qontinui-web migration in
+        // a sibling PR).
+        //
+        // Defensive: each ALTER COLUMN TYPE is wrapped so it skips if the
+        // column is already the target type (idempotent re-run). All run
+        // inside the migration's enclosing transaction.
+        sql: r#"
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM information_schema.tables
+                    WHERE table_schema = 'runner' AND table_name = 'deferred_questions'
+                ) THEN
+                    RAISE NOTICE 'v33 skip: runner.deferred_questions does not exist';
+                    RETURN;
+                END IF;
+
+                -- id: text -> uuid + add gen_random_uuid() default
+                IF (SELECT data_type FROM information_schema.columns
+                    WHERE table_schema='runner' AND table_name='deferred_questions' AND column_name='id') = 'text' THEN
+                    ALTER TABLE runner.deferred_questions
+                        ALTER COLUMN id TYPE uuid USING id::uuid,
+                        ALTER COLUMN id SET DEFAULT gen_random_uuid();
+                    RAISE NOTICE 'v33 fix: runner.deferred_questions.id text -> uuid (with gen_random_uuid default)';
+                END IF;
+
+                -- task_run_id: text -> uuid
+                IF (SELECT data_type FROM information_schema.columns
+                    WHERE table_schema='runner' AND table_name='deferred_questions' AND column_name='task_run_id') = 'text' THEN
+                    ALTER TABLE runner.deferred_questions
+                        ALTER COLUMN task_run_id TYPE uuid USING task_run_id::uuid;
+                    RAISE NOTICE 'v33 fix: runner.deferred_questions.task_run_id text -> uuid';
+                END IF;
+
+                -- status: text -> varchar(50), keep 'pending' default
+                IF (SELECT data_type FROM information_schema.columns
+                    WHERE table_schema='runner' AND table_name='deferred_questions' AND column_name='status') = 'text' THEN
+                    ALTER TABLE runner.deferred_questions
+                        ALTER COLUMN status TYPE varchar(50);
+                    RAISE NOTICE 'v33 fix: runner.deferred_questions.status text -> varchar(50)';
+                END IF;
+
+                -- risk_level: text -> varchar(50)
+                IF (SELECT data_type FROM information_schema.columns
+                    WHERE table_schema='runner' AND table_name='deferred_questions' AND column_name='risk_level') = 'text' THEN
+                    ALTER TABLE runner.deferred_questions
+                        ALTER COLUMN risk_level TYPE varchar(50);
+                    RAISE NOTICE 'v33 fix: runner.deferred_questions.risk_level text -> varchar(50)';
+                END IF;
+
+                -- auto_decision_type: text -> varchar(100)
+                IF (SELECT data_type FROM information_schema.columns
+                    WHERE table_schema='runner' AND table_name='deferred_questions' AND column_name='auto_decision_type') = 'text' THEN
+                    ALTER TABLE runner.deferred_questions
+                        ALTER COLUMN auto_decision_type TYPE varchar(100);
+                    RAISE NOTICE 'v33 fix: runner.deferred_questions.auto_decision_type text -> varchar(100)';
+                END IF;
+
+                -- git_checkpoint: text -> varchar(255)
+                IF (SELECT data_type FROM information_schema.columns
+                    WHERE table_schema='runner' AND table_name='deferred_questions' AND column_name='git_checkpoint') = 'text' THEN
+                    ALTER TABLE runner.deferred_questions
+                        ALTER COLUMN git_checkpoint TYPE varchar(255);
+                    RAISE NOTICE 'v33 fix: runner.deferred_questions.git_checkpoint text -> varchar(255)';
+                END IF;
+            END $$;
+        "#,
+    },
 ];
 
 /// Global PgDb instance, set once during app initialization.


### PR DESCRIPTION
## Summary
- Aligns 6 columns in \`runner.deferred_questions\` from \`TEXT\` to the proper PG types the qontinui-web SQLAlchemy model expects (\`UUID\`, \`VARCHAR(N)\`).
- Both schemas have 0 rows, so the ALTER COLUMN TYPE is risk-free.
- Idempotent (gated on \`data_type = 'text'\`).
- Phase 2 demonstration slice. After it lands, the matching \`public.deferred_questions\` duplicate becomes droppable by a paired qontinui-web PR.

## Columns aligned

| Column | text → |
|---|---|
| id | uuid (default gen_random_uuid()) |
| task_run_id | uuid |
| status | varchar(50) |
| risk_level | varchar(50) |
| auto_decision_type | varchar(100) |
| git_checkpoint | varchar(255) |

## Coordination note

I claimed **v33** here (next available after v32 from PR #2 merged earlier today).

The original logistics plan had the laptop's batch-2 work earmarked for v33, but the laptop hasn't started it. Per a protocol issue we surfaced today (\`mod.rs:3087\` filters \`version > current_version\` — out-of-order versions get silently skipped on DBs that have already applied a higher version), **pre-claiming version numbers is unsafe**. Whoever pushes first takes the next available number. Laptop's batch 2 should claim **v34** when it starts. Plan file (\`tmp_drift_implementation_logistics.md\` in the working tree) updated.

## Test plan

- [x] \`cargo check\` passes
- [x] DO block applies cleanly to PC's dev DB: all 6 columns flipped to expected types
- [x] Idempotent: re-running produces 0 NOTICEs
- [x] After apply, \`public.deferred_questions\` and \`runner.deferred_questions\` have matching column sets (verified)
- [ ] On next runner restart, v33 records in \`runner.schema_migrations\`
- [ ] Paired qontinui-web PR drops \`public.deferred_questions\` via re-run of the e8a3c5b9d142 introspection drop logic

## Why only one table this session

The original plan estimated Phase 2 as "1 session, modest scope". When I dug into the actual drift, every other Phase-2 table (task_runs, unified_workflows, task_run_findings, phase_results, verification_tests, ui_bridge_transitions) has either (a) populated runner-side rows requiring CAST validation per row, or (b) significantly more than 6 type drifts. \`deferred_questions\` is the only pure type-drift, 0-rows-everywhere case — the cleanest demonstration of the pattern. The other tables get separate PRs with proper data-validation pre-flight.