### PR TITLE
Migration consolidation: rename runner.* -> project.* / coord.* / agent.* / auth.* + Clorinde regen + CI gates

### DIFF
--- a/.github/workflows/forbid-runner-schema.yml
+++ b/.github/workflows/forbid-runner-schema.yml
@@ -34,22 +34,46 @@ jobs:
       - name: Scan for forbidden runner.* references
         run: |
           set -e
-          # Patterns that must not appear in source post-consolidation:
+          # Two pattern passes (combined fail semantics):
+          #
+          # Pass 1 — case-sensitive, matches conventional SQL/Rust/Python:
           # - SCHEMA runner   (DDL)
-          # - FROM runner.<table>  /  JOIN runner.<table>  /  INTO runner.<table>
-          # - UPDATE runner.<table>  /  DELETE FROM runner.<table>
+          # - FROM/JOIN/INTO/UPDATE/DELETE FROM runner.<table>
           # - ForeignKey("runner.<table>...
           # - schema="runner"  /  schema='runner'
-          PATTERN='SCHEMA runner|FROM runner\.|JOIN runner\.|INTO runner\.|UPDATE runner\.|DELETE FROM runner\.|ForeignKey\([^)]*runner\.|schema\s*=\s*["'\'']runner["'\'']'
+          PATTERN_CS='SCHEMA runner|FROM runner\.|JOIN runner\.|INTO runner\.|UPDATE runner\.|DELETE FROM runner\.|ForeignKey\([^)]*runner\.|schema\s*=\s*["'\'']runner["'\'']'
 
-          # git grep returns 1 when nothing matches; flip the exit code so
-          # the workflow fails when patterns ARE found.
-          if git grep -nE "$PATTERN" \
-              -- ':!*.md' \
-                 ':!**/alembic/versions/' \
-                 ':!**/alembic/_staged_consolidation/' \
-                 ':!**/scripts/regenerate_schema_pg_sql.sh' \
-              ; then
+          # Pass 2 — case-insensitive, narrowly targets `SET search_path TO
+          # runner`. Caught at consumer-audit edit time in qontinui/vga;
+          # gating it here prevents regressions. Case-insensitive because
+          # SQL keywords vary in case across the codebase.
+          PATTERN_CI='SET\s+search_path\s+TO\s+runner'
+
+          # Shared exclude list (legitimate runner.* references):
+          EXCLUDES=(
+            ':!*.md'
+            ':!**/alembic/versions/'
+            ':!**/alembic/_staged_consolidation/'
+            ':!**/scripts/regenerate_schema_pg_sql.sh'
+            # Self-reference: this workflow file contains the pattern
+            # strings as part of its definition.
+            ':!.github/workflows/forbid-runner-schema.yml'
+            # Transitional: the runner-native MIGRATIONS array references
+            # the runner schema legitimately (it's the schema being
+            # migrated). Phase 4 of the consolidation plan deletes this
+            # file entirely. After that lands, drop this exclude.
+            ':!src-tauri/src/database/pg/mod.rs'
+          )
+
+          found_any=0
+          if git grep -nE "$PATTERN_CS" -- "${EXCLUDES[@]}"; then
+            found_any=1
+          fi
+          if git grep -niE "$PATTERN_CI" -- "${EXCLUDES[@]}"; then
+            found_any=1
+          fi
+
+          if [ "$found_any" = "1" ]; then
             echo "::error::runner.* schema reference detected in source. The runner schema is retired post-consolidation; tables now live in project / coord / agent / auth."
             echo "::error::If this is a legitimate historical reference (docs, alembic chain history), add the file pattern to the exclude list in .github/workflows/forbid-runner-schema.yml."
             exit 1

--- a/.github/workflows/forbid-runner-schema.yml
+++ b/.github/workflows/forbid-runner-schema.yml
@@ -1,0 +1,57 @@
+name: forbid runner.* schema regressions
+
+# Phase 6 deliverable of the migration consolidation
+# (D:/qontinui-root/tmp_migration_consolidation_plan.md §"Phase 6").
+#
+# Fails if any source file (re-)introduces a `runner.<table>` schema
+# reference. Post-consolidation the `runner` schema is retired; tables
+# live in project / coord / agent / auth.
+#
+# Exclusions (legitimate runner.* references that must not trigger):
+# - All Markdown documentation (historical context, plan archaeology).
+# - alembic/versions/ — pre-consolidation chain history.
+# - alembic/_staged_consolidation/ — Phase 1 batches that legitimately
+#   reference runner.* in cleanup ALTER statements; Phase 2 v_32/v_33
+#   preserve runner.* literals in RAISE NOTICE strings by design; the
+#   cleanup revision (zz_final_runner_cleanup) drops the schema and
+#   relocates the survivors.
+# - Clorinde regen script — has documentation comments describing the
+#   runner-schema concept.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+jobs:
+  forbid-runner-schema:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for forbidden runner.* references
+        run: |
+          set -e
+          # Patterns that must not appear in source post-consolidation:
+          # - SCHEMA runner   (DDL)
+          # - FROM runner.<table>  /  JOIN runner.<table>  /  INTO runner.<table>
+          # - UPDATE runner.<table>  /  DELETE FROM runner.<table>
+          # - ForeignKey("runner.<table>...
+          # - schema="runner"  /  schema='runner'
+          PATTERN='SCHEMA runner|FROM runner\.|JOIN runner\.|INTO runner\.|UPDATE runner\.|DELETE FROM runner\.|ForeignKey\([^)]*runner\.|schema\s*=\s*["'\'']runner["'\'']'
+
+          # git grep returns 1 when nothing matches; flip the exit code so
+          # the workflow fails when patterns ARE found.
+          if git grep -nE "$PATTERN" \
+              -- ':!*.md' \
+                 ':!**/alembic/versions/' \
+                 ':!**/alembic/_staged_consolidation/' \
+                 ':!**/scripts/regenerate_schema_pg_sql.sh' \
+              ; then
+            echo "::error::runner.* schema reference detected in source. The runner schema is retired post-consolidation; tables now live in project / coord / agent / auth."
+            echo "::error::If this is a legitimate historical reference (docs, alembic chain history), add the file pattern to the exclude list in .github/workflows/forbid-runner-schema.yml."
+            exit 1
+          fi
+          echo "No forbidden runner.* references found."

--- a/.github/workflows/schema-pg-sql-fresh.yml
+++ b/.github/workflows/schema-pg-sql-fresh.yml
@@ -1,0 +1,114 @@
+name: schema.pg.sql.generated freshness
+
+# Runs the Clorinde schema regenerator and fails if the checked-in
+# schema.pg.sql.generated differs from a fresh dump. This is the
+# Phase 6 deliverable of the migration consolidation
+# (D:/qontinui-root/tmp_migration_consolidation_plan.md §"Phase 5"
+# verification gate).
+#
+# Trigger posture
+# ---------------
+# Currently set to `workflow_dispatch` only (manual). Reason: the
+# regenerator depends on the alembic chain in the sibling qontinui-web
+# repository, which isn't checked out in this workflow yet.
+#
+# After the consolidation transplants `_staged_consolidation/*` into
+# `qontinui-web/backend/alembic/versions/`, change `on:` to include
+# `pull_request: branches: [main, develop]` so every PR is gated.
+
+on:
+  workflow_dispatch:
+  # Pre-transplant: keep this disabled.
+  # pull_request:
+  #   branches: [main, develop]
+  #   paths:
+  #     - "qontinui-runner/src-tauri/queries/**"
+  #     - "qontinui-runner/src-tauri/schema.pg.sql.generated"
+
+jobs:
+  schema-fresh:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: qontinui_user
+          POSTGRES_PASSWORD: qontinui_dev_password
+          POSTGRES_DB: qontinui_db
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U qontinui_user -d qontinui_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - name: Checkout qontinui-runner
+        uses: actions/checkout@v4
+        with:
+          path: qontinui-runner
+
+      - name: Checkout qontinui-web (sibling)
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/qontinui-web
+          path: qontinui-web
+          # Use the same branch name if it exists in qontinui-web,
+          # otherwise main. Avoids drift when both repos move together.
+          ref: ${{ github.head_ref || github.ref_name }}
+          # Token in the workflow secrets to allow cross-repo checkout.
+          token: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install alembic dependencies
+        working-directory: qontinui-web/backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install alembic sqlalchemy psycopg2-binary python-dotenv
+
+      - name: Apply alembic chain
+        working-directory: qontinui-web/backend
+        env:
+          DATABASE_URL: postgresql://qontinui_user:qontinui_dev_password@localhost:5433/qontinui_db
+        run: alembic upgrade head
+
+      - name: Install Postgres client (for pg_dump)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client-16
+
+      - name: Stash checked-in artifact
+        working-directory: qontinui-runner/src-tauri
+        run: cp schema.pg.sql.generated /tmp/schema.checked-in.sql
+
+      - name: Regenerate (native pg_dump, no docker)
+        working-directory: qontinui-runner
+        env:
+          # Empty CLORINDE_PG_CONTAINER triggers the script's native
+          # pg_dump path (no docker-exec). Postgres client was installed
+          # in the previous step.
+          CLORINDE_PG_CONTAINER: ""
+          CLORINDE_PG_HOST: localhost
+          CLORINDE_PG_PORT: "5433"
+          PGPASSWORD: qontinui_dev_password
+        run: bash src-tauri/scripts/regenerate_schema_pg_sql.sh
+
+      - name: Diff against checked-in
+        working-directory: qontinui-runner/src-tauri
+        run: |
+          if ! diff -q /tmp/schema.checked-in.sql schema.pg.sql.generated; then
+            echo "::error::schema.pg.sql.generated is stale relative to a fresh alembic upgrade head + pg_dump."
+            echo "::error::Regenerate locally via:"
+            echo "::error::  bash src-tauri/scripts/regenerate_schema_pg_sql.sh"
+            echo ""
+            echo "Diff:"
+            diff -u /tmp/schema.checked-in.sql schema.pg.sql.generated | head -80
+            exit 1
+          fi
+          echo "schema.pg.sql.generated is up to date."

--- a/src-tauri/schema.pg.sql.generated
+++ b/src-tauri/schema.pg.sql.generated
@@ -3,7 +3,7 @@
 --
 -- Source: alembic-managed schema, dumped via pg_dump with
 --   --schema=project --schema=coord --schema=agent --schema=auth
---   --schema=public --no-owner --no-privileges.
+--   --schema=cloud --schema=public --no-owner --no-privileges.
 --
 -- Consumers: Clorinde (validates queries/*.sql against this file).
 --
@@ -45,6 +45,13 @@ CREATE SCHEMA auth;
 
 
 --
+-- Name: cloud; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA cloud;
+
+
+--
 -- Name: coord; Type: SCHEMA; Schema: -; Owner: -
 --
 
@@ -63,6 +70,13 @@ CREATE SCHEMA project;
 --
 
 CREATE SCHEMA public;
+
+
+--
+-- Name: SCHEMA public; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON SCHEMA public IS 'standard public schema';
 
 
 --
@@ -638,12 +652,5121 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: api_surface_snapshots; Type: TABLE; Schema: agent; Owner: -
+--
+
+CREATE TABLE agent.api_surface_snapshots (
+    id bigint NOT NULL,
+    scan_json text NOT NULL,
+    summary text NOT NULL,
+    total_endpoints integer NOT NULL,
+    orphan_count integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: api_surface_snapshots_id_seq; Type: SEQUENCE; Schema: agent; Owner: -
+--
+
+CREATE SEQUENCE agent.api_surface_snapshots_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: api_surface_snapshots_id_seq; Type: SEQUENCE OWNED BY; Schema: agent; Owner: -
+--
+
+ALTER SEQUENCE agent.api_surface_snapshots_id_seq OWNED BY agent.api_surface_snapshots.id;
+
+
+--
+-- Name: cached_app_specs; Type: TABLE; Schema: agent; Owner: -
+--
+
+CREATE TABLE agent.cached_app_specs (
+    id text NOT NULL,
+    app_url text NOT NULL,
+    app_name text NOT NULL,
+    spec_id text NOT NULL,
+    spec_json text NOT NULL,
+    discovered_at timestamp with time zone DEFAULT now() NOT NULL,
+    page_url text
+);
+
+
+--
+-- Name: memory_query_cache; Type: TABLE; Schema: agent; Owner: -
+--
+
+CREATE TABLE agent.memory_query_cache (
+    id bigint NOT NULL,
+    query_hash text NOT NULL,
+    reasoning_level text NOT NULL,
+    result_json text NOT NULL,
+    hit_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    expires_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: memory_query_cache_id_seq; Type: SEQUENCE; Schema: agent; Owner: -
+--
+
+CREATE SEQUENCE agent.memory_query_cache_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: memory_query_cache_id_seq; Type: SEQUENCE OWNED BY; Schema: agent; Owner: -
+--
+
+ALTER SEQUENCE agent.memory_query_cache_id_seq OWNED BY agent.memory_query_cache.id;
+
+
+--
+-- Name: users; Type: TABLE; Schema: auth; Owner: -
+--
+
+CREATE TABLE auth.users (
+    username character varying NOT NULL,
+    full_name character varying,
+    is_beta boolean NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    company character varying,
+    phone character varying,
+    avatar_url character varying,
+    email_verification_token character varying,
+    subscription_tier character varying NOT NULL,
+    login_count integer NOT NULL,
+    remember_me_usage_count integer NOT NULL,
+    last_login_at timestamp without time zone,
+    last_device_fingerprint text,
+    automation_streaming_enabled boolean NOT NULL,
+    automation_sessions_limit integer,
+    automation_sessions_used integer NOT NULL,
+    automation_sessions_reset_at timestamp with time zone,
+    id uuid NOT NULL,
+    email character varying(320) NOT NULL,
+    hashed_password character varying(1024) NOT NULL,
+    is_active boolean NOT NULL,
+    is_superuser boolean NOT NULL,
+    is_verified boolean NOT NULL,
+    preferences jsonb
+);
+
+
+--
+-- Name: COLUMN users.preferences; Type: COMMENT; Schema: auth; Owner: -
+--
+
+COMMENT ON COLUMN auth.users.preferences IS 'User preferences (product_mode, theme, etc.)';
+
+
+--
+-- Name: coordinator_decisions; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.coordinator_decisions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id text NOT NULL,
+    iteration bigint NOT NULL,
+    rule text NOT NULL,
+    action text NOT NULL,
+    target_id text,
+    reasoning text NOT NULL,
+    auto_acted boolean NOT NULL,
+    resolved boolean DEFAULT false NOT NULL,
+    resolution text,
+    resolved_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: coordinator_leader; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.coordinator_leader (
+    id boolean DEFAULT true NOT NULL,
+    instance_id text NOT NULL,
+    leased_until timestamp with time zone NOT NULL,
+    acquired_at timestamp with time zone DEFAULT now() NOT NULL,
+    renewed_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT coordinator_leader_singleton CHECK ((id = true))
+);
+
+
+--
+-- Name: gui_lock; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.gui_lock (
+    id integer NOT NULL,
+    holder_session_id text,
+    acquired_at timestamp with time zone,
+    CONSTRAINT gui_lock_singleton CHECK ((id = 1))
+);
+
+
+--
+-- Name: gui_lock_id_seq; Type: SEQUENCE; Schema: coord; Owner: -
+--
+
+CREATE SEQUENCE coord.gui_lock_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: gui_lock_id_seq; Type: SEQUENCE OWNED BY; Schema: coord; Owner: -
+--
+
+ALTER SEQUENCE coord.gui_lock_id_seq OWNED BY coord.gui_lock.id;
+
+
+--
+-- Name: plans; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.plans (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    markdown_path text NOT NULL,
+    version_hash text NOT NULL,
+    status text DEFAULT 'draft'::text NOT NULL,
+    title text,
+    summary text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: process_session_output; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.process_session_output (
+    id bigint NOT NULL,
+    session_id text NOT NULL,
+    "timestamp" text NOT NULL,
+    stream text NOT NULL,
+    line text NOT NULL
+);
+
+
+--
+-- Name: process_session_output_id_seq; Type: SEQUENCE; Schema: coord; Owner: -
+--
+
+CREATE SEQUENCE coord.process_session_output_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: process_session_output_id_seq; Type: SEQUENCE OWNED BY; Schema: coord; Owner: -
+--
+
+ALTER SEQUENCE coord.process_session_output_id_seq OWNED BY coord.process_session_output.id;
+
+
+--
+-- Name: process_sessions; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.process_sessions (
+    id text NOT NULL,
+    process_config_id text NOT NULL,
+    process_name text NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    stopped_at timestamp with time zone,
+    exit_code integer,
+    state text DEFAULT 'running'::text NOT NULL,
+    error_count integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: reviews; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.reviews (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_id uuid NOT NULL,
+    reviewer_session_id text NOT NULL,
+    reviewed_session_id text NOT NULL,
+    verdict text NOT NULL,
+    confidence double precision NOT NULL,
+    reasoning text NOT NULL,
+    diff_summary jsonb,
+    test_results jsonb,
+    user_decision text,
+    user_decided_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: runner_instances; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.runner_instances (
+    id text NOT NULL,
+    name text NOT NULL,
+    port integer NOT NULL,
+    hostname text DEFAULT 'localhost'::text NOT NULL,
+    is_primary boolean DEFAULT false NOT NULL,
+    pid integer,
+    status text DEFAULT 'starting'::text NOT NULL,
+    last_heartbeat timestamp with time zone DEFAULT now() NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    running_tasks integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: session_file_snapshots; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.session_file_snapshots (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id text NOT NULL,
+    file_path text NOT NULL,
+    snapshot_blob_path text NOT NULL,
+    blob_sha256 text NOT NULL,
+    captured_before boolean NOT NULL,
+    taken_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: session_touched_files; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.session_touched_files (
+    task_run_id text NOT NULL,
+    file_path text NOT NULL,
+    worktree_id text,
+    recorded_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: tasks; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.tasks (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    plan_id uuid NOT NULL,
+    plan_version_hash text NOT NULL,
+    phase_name text NOT NULL,
+    sequence_in_phase integer NOT NULL,
+    description text NOT NULL,
+    expected_file_claims text[] DEFAULT '{}'::text[] NOT NULL,
+    expected_dirs text[] DEFAULT '{}'::text[] NOT NULL,
+    depends_on uuid[] DEFAULT '{}'::uuid[] NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    assigned_session_id text,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    notes text
+);
+
+
+--
+-- Name: worktrees; Type: TABLE; Schema: coord; Owner: -
+--
+
+CREATE TABLE coord.worktrees (
+    id text NOT NULL,
+    worktree_path text NOT NULL,
+    branch_name text NOT NULL,
+    source_branch text NOT NULL,
+    source_commit text NOT NULL,
+    repo_path text NOT NULL,
+    task_run_id text,
+    workflow_name text,
+    status text DEFAULT 'active'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: active_workflows; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.active_workflows (
+    id bigint NOT NULL,
+    workflow_name text NOT NULL,
+    checkpoint_data text NOT NULL,
+    run_id text NOT NULL,
+    phase_field text DEFAULT 'current_phase'::text NOT NULL,
+    completion_value integer DEFAULT 1 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: active_workflows_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.active_workflows_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: active_workflows_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.active_workflows_id_seq OWNED BY project.active_workflows.id;
+
+
+--
+-- Name: activity_timeline; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.activity_timeline (
+    id bigint NOT NULL,
+    text_content text NOT NULL,
+    content_hash text NOT NULL,
+    source_type text NOT NULL,
+    capture_mode text NOT NULL,
+    app_name text,
+    window_title text,
+    url text,
+    task_run_id text,
+    screenshot_path text,
+    element_count integer,
+    confidence double precision,
+    metadata_json text,
+    duplicate_count integer DEFAULT 0 NOT NULL,
+    is_deleted boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: activity_timeline_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.activity_timeline_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: activity_timeline_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.activity_timeline_id_seq OWNED BY project.activity_timeline.id;
+
+
+--
+-- Name: agentic_metric_baselines; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.agentic_metric_baselines (
+    id text NOT NULL,
+    workflow_id text,
+    metric_type text NOT NULL,
+    baseline_value text NOT NULL,
+    sample_count integer DEFAULT 0 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: agentic_metric_scores; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.agentic_metric_scores (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    metric_type text NOT NULL,
+    score double precision NOT NULL,
+    confidence double precision DEFAULT 1.0 NOT NULL,
+    rationale text,
+    is_llm_judged boolean DEFAULT false NOT NULL,
+    model_used text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ai_workflows; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ai_workflows (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    config text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: approval_gates; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.approval_gates (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    prompt text NOT NULL,
+    context_json text DEFAULT '{}'::text,
+    action text,
+    comment text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: architecture_components; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.architecture_components (
+    id text NOT NULL,
+    workflow_name text NOT NULL,
+    component_path text NOT NULL,
+    component_type text DEFAULT 'file'::text NOT NULL,
+    fix_count integer DEFAULT 0 NOT NULL,
+    error_count integer DEFAULT 0 NOT NULL,
+    causal_involvement_count integer DEFAULT 0 NOT NULL,
+    effective_fix_count integer DEFAULT 0 NOT NULL,
+    ineffective_fix_count integer DEFAULT 0 NOT NULL,
+    health_score double precision DEFAULT 1.0 NOT NULL,
+    change_velocity double precision DEFAULT 0.0 NOT NULL,
+    last_activity_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: artifacts; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.artifacts (
+    artifact_id text NOT NULL,
+    source_json text NOT NULL,
+    result_json text NOT NULL,
+    environment_json text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    passed integer
+);
+
+
+--
+-- Name: beam_candidates; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.beam_candidates (
+    id text NOT NULL,
+    beam_run_id text NOT NULL,
+    parent_id text,
+    prompt_content text NOT NULL,
+    critique text,
+    changes_summary text,
+    generation integer DEFAULT 0 NOT NULL,
+    thinking_style text,
+    variant_id text,
+    status text DEFAULT 'active'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: beam_search_runs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.beam_search_runs (
+    id text NOT NULL,
+    agent_type text NOT NULL,
+    pool_id text,
+    config_json text NOT NULL,
+    generation integer DEFAULT 0 NOT NULL,
+    status text DEFAULT 'running'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: breakpoint_snapshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.breakpoint_snapshots (
+    id text NOT NULL,
+    execution_id text NOT NULL,
+    step_index integer NOT NULL,
+    step_name text,
+    phase text,
+    iteration integer,
+    variables_json text NOT NULL,
+    last_screenshot_ref text,
+    pending_steps_json text NOT NULL,
+    freshness_ts timestamp with time zone DEFAULT now() NOT NULL,
+    status text DEFAULT 'waiting'::text NOT NULL,
+    resumed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: canary_rollouts; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.canary_rollouts (
+    id text NOT NULL,
+    recommendation_id text NOT NULL,
+    percentage bigint DEFAULT 10 NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    start_date timestamp with time zone NOT NULL,
+    end_date timestamp with time zone,
+    baseline_run_count bigint DEFAULT 0,
+    canary_run_count bigint DEFAULT 0,
+    baseline_metrics_json text DEFAULT '{}'::text,
+    canary_metrics_json text DEFAULT '{}'::text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: canary_run_records; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.canary_run_records (
+    id text NOT NULL,
+    canary_id text NOT NULL,
+    is_canary boolean NOT NULL,
+    task_run_id text,
+    success boolean NOT NULL,
+    cost_usd double precision DEFAULT 0.0,
+    duration_ms double precision DEFAULT 0.0,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: canvas_panels; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.canvas_panels (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    component text NOT NULL,
+    title text NOT NULL,
+    data_json text NOT NULL,
+    priority integer DEFAULT 50,
+    size text DEFAULT 'normal'::text,
+    group_name text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: causal_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.causal_events (
+    id text NOT NULL,
+    cause_event_type text NOT NULL,
+    cause_event_id text NOT NULL,
+    effect_event_type text NOT NULL,
+    effect_event_id text NOT NULL,
+    relationship text NOT NULL,
+    confidence text DEFAULT 'high'::text NOT NULL,
+    source text DEFAULT 'automated'::text NOT NULL,
+    task_run_id text,
+    workflow_name text,
+    description text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: check_group_members; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.check_group_members (
+    id text NOT NULL,
+    group_id text NOT NULL,
+    check_id text NOT NULL,
+    sort_order integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: check_groups; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.check_groups (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    color text,
+    enabled boolean DEFAULT true NOT NULL,
+    run_in_parallel boolean DEFAULT false NOT NULL,
+    stop_on_failure boolean DEFAULT true NOT NULL,
+    tags text DEFAULT '[]'::text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: check_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.check_results (
+    id text NOT NULL,
+    check_id text NOT NULL,
+    task_run_id text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    duration_ms integer,
+    output text,
+    error_message text,
+    issues_found bigint DEFAULT 0,
+    issues_fixed bigint DEFAULT 0,
+    files_checked bigint DEFAULT 0,
+    structured_output text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: checks; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.checks (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    check_type text NOT NULL,
+    tool text NOT NULL,
+    command text,
+    working_directory text,
+    config_path text,
+    auto_fix boolean DEFAULT false NOT NULL,
+    fail_on_warning boolean DEFAULT false NOT NULL,
+    timeout_seconds integer,
+    is_critical boolean DEFAULT false NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    ai_generated boolean DEFAULT false NOT NULL,
+    ai_generation_prompt text,
+    tags text DEFAULT '[]'::text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: chunk_labels; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.chunk_labels (
+    config_id text NOT NULL,
+    chunk_id text NOT NULL,
+    label text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: co_occurrence_observations; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.co_occurrence_observations (
+    id uuid NOT NULL,
+    captured_at timestamp with time zone DEFAULT now() NOT NULL,
+    spec_id text,
+    runner_instance text,
+    fingerprints jsonb NOT NULL,
+    snapshot_metadata jsonb,
+    invalidated_at timestamp with time zone,
+    invalidated_reason text,
+    invalidated_by text,
+    invalidation_token text
+);
+
+
+--
+-- Name: comparison_runs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.comparison_runs (
+    id text NOT NULL,
+    workflow_id text NOT NULL,
+    variation_type text NOT NULL,
+    status text DEFAULT 'running'::text NOT NULL,
+    entries_json text DEFAULT '[]'::text NOT NULL,
+    report text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: compensation_actions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.compensation_actions (
+    id bigint NOT NULL,
+    execution_id text NOT NULL,
+    action_index integer NOT NULL,
+    action_json jsonb NOT NULL,
+    executed boolean DEFAULT false NOT NULL,
+    result_json jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    executed_at timestamp with time zone
+);
+
+
+--
+-- Name: compensation_actions_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.compensation_actions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: compensation_actions_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.compensation_actions_id_seq OWNED BY project.compensation_actions.id;
+
+
+--
+-- Name: component_health_snapshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.component_health_snapshots (
+    id text NOT NULL,
+    workflow_name text NOT NULL,
+    component_path text NOT NULL,
+    health_score double precision NOT NULL,
+    fix_count integer DEFAULT 0 NOT NULL,
+    effective_fix_count integer DEFAULT 0 NOT NULL,
+    change_velocity double precision DEFAULT 0.0 NOT NULL,
+    snapshot_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: component_relationships; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.component_relationships (
+    id text NOT NULL,
+    workflow_name text NOT NULL,
+    source_component text NOT NULL,
+    target_component text NOT NULL,
+    relationship_type text NOT NULL,
+    strength integer DEFAULT 1 NOT NULL,
+    last_seen_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: concept_summaries; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.concept_summaries (
+    id text NOT NULL,
+    name text NOT NULL,
+    tagline text NOT NULL,
+    description text NOT NULL,
+    inspiration_json text,
+    benefits_json text DEFAULT '[]'::text NOT NULL,
+    components_json text DEFAULT '[]'::text NOT NULL,
+    related_decisions_json text DEFAULT '[]'::text NOT NULL,
+    metrics_json text,
+    is_deleted boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: config_statistics; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.config_statistics (
+    id text NOT NULL,
+    config_id text NOT NULL,
+    config_hash text,
+    total_runs integer DEFAULT 0,
+    successful_runs integer DEFAULT 0,
+    failed_runs integer DEFAULT 0,
+    timeout_runs integer DEFAULT 0,
+    avg_duration_ms integer,
+    recent_success_rate double precision,
+    recent_avg_duration_ms integer,
+    transition_stats text,
+    template_stats text,
+    state_stats text,
+    error_patterns text,
+    flaky_transitions text,
+    flaky_templates text,
+    first_run_at timestamp with time zone,
+    last_run_at timestamp with time zone,
+    last_updated_at timestamp with time zone
+);
+
+
+--
+-- Name: configs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.configs (
+    id text NOT NULL,
+    name text NOT NULL,
+    config_json text NOT NULL,
+    source_type text NOT NULL,
+    source_path text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: contradiction_resolutions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.contradiction_resolutions (
+    id bigint NOT NULL,
+    observation_a_id bigint NOT NULL,
+    observation_b_id bigint NOT NULL,
+    resolution_type text NOT NULL,
+    winner_id bigint,
+    loser_id bigint,
+    confidence double precision DEFAULT 0.5 NOT NULL,
+    rationale text NOT NULL,
+    evidence_json text,
+    resolved_at timestamp with time zone DEFAULT now() NOT NULL,
+    resolved_by text DEFAULT 'system'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: contradiction_resolutions_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.contradiction_resolutions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: contradiction_resolutions_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.contradiction_resolutions_id_seq OWNED BY project.contradiction_resolutions.id;
+
+
+--
+-- Name: convergence_snapshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.convergence_snapshots (
+    id text NOT NULL,
+    workflow_name text NOT NULL,
+    project_path text,
+    scope text DEFAULT 'workflow'::text NOT NULL,
+    convergence_score double precision NOT NULL,
+    consecutive_clean_runs integer NOT NULL,
+    novelty_score double precision NOT NULL,
+    effective_fix_rate double precision NOT NULL,
+    change_velocity double precision NOT NULL,
+    total_fixes integer NOT NULL,
+    effective_fixes integer NOT NULL,
+    snapshot_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: cross_run_patterns; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.cross_run_patterns (
+    id text NOT NULL,
+    pattern_type text NOT NULL,
+    signature_hash text NOT NULL,
+    workflow_name text,
+    occurrence_count integer DEFAULT 1 NOT NULL,
+    first_seen_task_run_id text,
+    last_seen_task_run_id text,
+    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    affected_components text,
+    pattern_data text,
+    status text DEFAULT 'active'::text NOT NULL,
+    resolved_by_fix_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: curated_examples; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.curated_examples (
+    id text NOT NULL,
+    domain text NOT NULL,
+    criterion_description text NOT NULL,
+    steps_json text NOT NULL,
+    quality_score double precision DEFAULT 0.0 NOT NULL,
+    execution_verified integer DEFAULT 0 NOT NULL,
+    times_used integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: decisions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.decisions (
+    id text NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    scale text NOT NULL,
+    category text NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    title text NOT NULL,
+    summary text NOT NULL,
+    rationale text NOT NULL,
+    alternatives_json text DEFAULT '[]'::text NOT NULL,
+    tradeoffs_json text DEFAULT '[]'::text NOT NULL,
+    triggered_by text,
+    inspiration_json text,
+    related_decisions_json text DEFAULT '[]'::text NOT NULL,
+    affected_files_json text DEFAULT '[]'::text NOT NULL,
+    affected_endpoints_json text DEFAULT '[]'::text NOT NULL,
+    affected_tables_json text DEFAULT '[]'::text NOT NULL,
+    created_by text,
+    superseded_by text,
+    tags_json text DEFAULT '[]'::text NOT NULL,
+    is_deleted boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: deferred_questions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.deferred_questions (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    question text NOT NULL,
+    context_json text DEFAULT '{}'::text,
+    auto_decision_type text NOT NULL,
+    auto_decision_detail text,
+    confidence double precision NOT NULL,
+    risk_level text NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    git_checkpoint text,
+    contingent_iterations text DEFAULT '[]'::text,
+    reviewer_comment text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    reviewed_at timestamp with time zone
+);
+
+
+--
+-- Name: development_intelligence; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.development_intelligence (
+    id bigint NOT NULL,
+    project_path text NOT NULL,
+    analysis_type text NOT NULL,
+    page_route text NOT NULL,
+    score double precision,
+    details_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: development_intelligence_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.development_intelligence_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: development_intelligence_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.development_intelligence_id_seq OWNED BY project.development_intelligence.id;
+
+
+--
+-- Name: drift_detector_state; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.drift_detector_state (
+    detector_id text NOT NULL,
+    detector_type text NOT NULL,
+    state_json text NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: duel_candidates; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.duel_candidates (
+    id text NOT NULL,
+    pool_id text NOT NULL,
+    prompt_content text NOT NULL,
+    variant_id text,
+    generation integer DEFAULT 0 NOT NULL,
+    parent_id text,
+    copeland_score double precision DEFAULT 0.0 NOT NULL,
+    alpha double precision DEFAULT 1.0 NOT NULL,
+    beta double precision DEFAULT 1.0 NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: duel_pools; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.duel_pools (
+    id text NOT NULL,
+    agent_type text NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    generation integer DEFAULT 0 NOT NULL,
+    config_json text DEFAULT '{}'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: duel_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.duel_results (
+    id text NOT NULL,
+    pool_id text NOT NULL,
+    candidate_a_id text NOT NULL,
+    candidate_b_id text NOT NULL,
+    winner_id text NOT NULL,
+    judge_rationale text,
+    position_swapped boolean DEFAULT false NOT NULL,
+    confidence double precision DEFAULT 0.5 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: entailment_cache; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.entailment_cache (
+    criterion_hash bigint NOT NULL,
+    step_hash bigint NOT NULL,
+    score double precision NOT NULL,
+    explanation text,
+    tier text,
+    cached_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: entity_profiles; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.entity_profiles (
+    id bigint NOT NULL,
+    entity_kind text NOT NULL,
+    entity_id text NOT NULL,
+    entity_label text NOT NULL,
+    profile_summary text NOT NULL,
+    profile_detail text,
+    topic_key text NOT NULL,
+    content_hash text NOT NULL,
+    importance double precision DEFAULT 0.5 NOT NULL,
+    decay_rate double precision DEFAULT 0.02 NOT NULL,
+    access_count integer DEFAULT 0 NOT NULL,
+    last_accessed_at timestamp with time zone,
+    revision_count integer DEFAULT 1 NOT NULL,
+    source_observation_ids bigint[],
+    source_finding_ids text[],
+    source_fix_ids text[],
+    source_cross_run_pattern_ids text[],
+    valid_from timestamp with time zone DEFAULT now() NOT NULL,
+    valid_until timestamp with time zone,
+    superseded_by bigint,
+    is_deleted boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: entity_profiles_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.entity_profiles_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: entity_profiles_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.entity_profiles_id_seq OWNED BY project.entity_profiles.id;
+
+
+--
+-- Name: error_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.error_events (
+    id bigint NOT NULL,
+    log_source_id bigint,
+    log_source_name text NOT NULL,
+    task_run_id text,
+    workflow_step_id text,
+    log_timestamp timestamp with time zone,
+    captured_at timestamp with time zone DEFAULT now() NOT NULL,
+    severity text DEFAULT 'error'::text NOT NULL,
+    error_type text,
+    error_code text,
+    message text NOT NULL,
+    stack_trace text,
+    context_lines text,
+    raw_entry text,
+    file_path text,
+    line_number integer,
+    column_number integer,
+    function_name text,
+    signature_hash text NOT NULL,
+    occurrence_count integer DEFAULT 1,
+    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    status text DEFAULT 'new'::text,
+    finding_id text,
+    resolved_by_task_run_id text,
+    resolved_by_fix_id text,
+    resolution_notes text,
+    message_embedding bytea,
+    trace_id text,
+    acknowledged_at timestamp with time zone,
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: error_events_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.error_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: error_events_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.error_events_id_seq OWNED BY project.error_events.id;
+
+
+--
+-- Name: eval_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.eval_results (
+    id text NOT NULL,
+    spec_id text NOT NULL,
+    recommendation_id text,
+    status text DEFAULT 'running'::text NOT NULL,
+    result_json text DEFAULT '{}'::text NOT NULL,
+    p_value double precision,
+    trials_run integer DEFAULT 0,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: eval_specs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.eval_specs (
+    id text NOT NULL,
+    name text NOT NULL,
+    target_agent text,
+    spec_json text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: execution_spans; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.execution_spans (
+    id bigint NOT NULL,
+    execution_id text,
+    trace_id text NOT NULL,
+    span_id text NOT NULL,
+    parent_span_id text,
+    name text NOT NULL,
+    start_ts text NOT NULL,
+    end_ts text,
+    duration_ms bigint,
+    attributes text,
+    success boolean DEFAULT true,
+    error text,
+    queue_wait_ms bigint,
+    retry_attempt integer,
+    phase text,
+    iteration integer,
+    workflow_id text,
+    input_tokens integer,
+    output_tokens integer,
+    cost_cents integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: execution_spans_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.execution_spans_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: execution_spans_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.execution_spans_id_seq OWNED BY project.execution_spans.id;
+
+
+--
+-- Name: execution_state_snapshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.execution_state_snapshots (
+    id bigint NOT NULL,
+    execution_id text NOT NULL,
+    span_id text DEFAULT ''::text NOT NULL,
+    snapshot_ts timestamp with time zone DEFAULT now() NOT NULL,
+    state_type text NOT NULL,
+    summary text,
+    context_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: execution_state_snapshots_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.execution_state_snapshots_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: execution_state_snapshots_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.execution_state_snapshots_id_seq OWNED BY project.execution_state_snapshots.id;
+
+
+--
+-- Name: executions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.executions (
+    id text NOT NULL,
+    workflow_name text,
+    config_path text,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    status text NOT NULL,
+    success boolean,
+    result_data text,
+    error_message text
+);
+
+
+--
+-- Name: experience_summaries; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.experience_summaries (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    domain text NOT NULL,
+    complexity_tier text NOT NULL,
+    outcome text NOT NULL,
+    key_decisions_json text DEFAULT '[]'::text NOT NULL,
+    failure_points_json text DEFAULT '[]'::text NOT NULL,
+    effective_patterns_json text DEFAULT '[]'::text NOT NULL,
+    embedding bytea,
+    similarity_cluster text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: exploration_stats; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.exploration_stats (
+    id text NOT NULL,
+    workflow_id text,
+    task_run_id text,
+    total_candidates integer DEFAULT 0 NOT NULL,
+    search_depth integer DEFAULT 0 NOT NULL,
+    search_duration_ms bigint DEFAULT 0 NOT NULL,
+    best_score double precision,
+    strategy_used text,
+    score_progression text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: fix_applications; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.fix_applications (
+    id text NOT NULL,
+    fix_id text NOT NULL,
+    task_run_id text NOT NULL,
+    error_signature_hash text,
+    outcome text DEFAULT 'pending'::text,
+    applied_at timestamp with time zone DEFAULT now() NOT NULL,
+    evaluated_at timestamp with time zone
+);
+
+
+--
+-- Name: flow_executions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.flow_executions (
+    instance_id text NOT NULL,
+    flow_id text NOT NULL,
+    current_step text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    context text,
+    history text,
+    error text,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: flow_versions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.flow_versions (
+    id text NOT NULL,
+    flow_id text NOT NULL,
+    version integer NOT NULL,
+    definition text NOT NULL,
+    message text,
+    created_by text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: generation_pipeline_artifacts; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.generation_pipeline_artifacts (
+    id text NOT NULL,
+    workflow_id text,
+    task_run_id text,
+    description text NOT NULL,
+    category text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    investigation_duration_ms integer,
+    investigation_enriched_description text,
+    discovery_duration_ms integer,
+    builder_duration_ms integer,
+    autofix_duration_ms integer,
+    verification_duration_ms integer,
+    hardener_duration_ms integer,
+    total_duration_ms bigint,
+    discovery_calls text,
+    builder_raw_output text,
+    builder_parsed_json text,
+    autofix_diff text,
+    verification_iterations text,
+    fixer_snapshots text,
+    hardening_summary text,
+    hardened_json text,
+    final_json text,
+    validation_errors text,
+    specification_duration_ms integer,
+    specification_criteria text,
+    specification_prompt text,
+    builder_prompt text,
+    verification_prompts text,
+    hardener_prompt text,
+    revision_duration_ms integer,
+    quality_report text,
+    revision_cycles integer,
+    confidence_score double precision,
+    success boolean DEFAULT true NOT NULL,
+    error_message text,
+    model_used text
+);
+
+
+--
+-- Name: generation_pipeline_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.generation_pipeline_events (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    workflow_id text,
+    event_type text NOT NULL,
+    phase text,
+    iteration integer,
+    payload text,
+    duration_ms bigint,
+    token_count bigint,
+    validation_errors_before integer,
+    validation_errors_after integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: generation_rules; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.generation_rules (
+    id text NOT NULL,
+    agent text NOT NULL,
+    section text NOT NULL,
+    rule_number integer NOT NULL,
+    title text NOT NULL,
+    content text NOT NULL,
+    condition text,
+    status text DEFAULT 'active'::text NOT NULL,
+    provenance text DEFAULT 'seed'::text NOT NULL,
+    source_fix_id text,
+    confidence double precision DEFAULT 1.0,
+    auto_generated_at timestamp with time zone,
+    evidence_count integer DEFAULT 0,
+    severity text DEFAULT 'normal'::text NOT NULL,
+    failure_count integer DEFAULT 0 NOT NULL,
+    examples_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: gepa_optimization_runs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.gepa_optimization_runs (
+    id text NOT NULL,
+    domain text NOT NULL,
+    old_instructions text NOT NULL,
+    new_instructions text,
+    old_score double precision,
+    new_score double precision,
+    improvement double precision,
+    status text DEFAULT 'pending'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: golden_datasets; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.golden_datasets (
+    id text NOT NULL,
+    agent_type text NOT NULL,
+    name text NOT NULL,
+    entries_json text DEFAULT '[]'::text NOT NULL,
+    entry_count integer DEFAULT 0,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: issue_pattern_templates; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.issue_pattern_templates (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text NOT NULL,
+    category text NOT NULL,
+    detection_type text NOT NULL,
+    step_template text,
+    ai_prompt_template text,
+    parameters text DEFAULT '[]'::text NOT NULL,
+    built_in boolean DEFAULT false NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: iteration_logs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.iteration_logs (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer DEFAULT 0 NOT NULL,
+    provider_used text,
+    model_used text,
+    duration_ms integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: known_issues; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.known_issues (
+    id text NOT NULL,
+    title text NOT NULL,
+    description text NOT NULL,
+    category text DEFAULT 'other'::text NOT NULL,
+    scope_type text DEFAULT 'global'::text NOT NULL,
+    scope_value text,
+    scope_tags text DEFAULT '[]'::text,
+    detection_method text DEFAULT 'ai_judgment'::text NOT NULL,
+    detection_config text DEFAULT '{}'::text,
+    pattern_template_id text,
+    reproduction_context text,
+    trigger_conditions text DEFAULT '[]'::text,
+    severity text DEFAULT 'medium'::text NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    confidence double precision DEFAULT 1.0 NOT NULL,
+    provenance text DEFAULT 'manual'::text NOT NULL,
+    source_finding_ids text DEFAULT '[]'::text,
+    source_task_run_id text,
+    verification_hint text,
+    verification_step_template text,
+    times_detected integer DEFAULT 1,
+    times_checked integer DEFAULT 0,
+    last_detected_at timestamp with time zone,
+    last_checked_at timestamp with time zone,
+    resolved_at timestamp with time zone,
+    description_embedding bytea,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: learned_patterns; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.learned_patterns (
+    id text NOT NULL,
+    problem_hash text NOT NULL,
+    trigger_keywords jsonb NOT NULL,
+    problem_description text NOT NULL,
+    solution_description text NOT NULL,
+    confidence double precision DEFAULT 0.0 NOT NULL,
+    sample_count integer DEFAULT 0 NOT NULL,
+    project_path text,
+    workflow_name text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: learning_outcomes; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.learning_outcomes (
+    id text NOT NULL,
+    task_id text NOT NULL,
+    status text NOT NULL,
+    duration_secs double precision,
+    iterations integer,
+    strategy text,
+    tools_used text,
+    files_modified text,
+    error_type text,
+    error_message text,
+    feedback text,
+    workflow_architecture text,
+    context_embedding bytea,
+    step_count bigint,
+    verification_step_count bigint,
+    agentic_step_count bigint,
+    has_ui_bridge boolean DEFAULT false,
+    total_tokens bigint,
+    total_cost_usd double precision,
+    composite_agentic_score double precision,
+    technology_tags text,
+    domain_tags text,
+    complexity_tier text,
+    dag_node_metrics text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    model_used text
+);
+
+
+--
+-- Name: learning_patterns; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.learning_patterns (
+    id text NOT NULL,
+    pattern_type text NOT NULL,
+    description text NOT NULL,
+    confidence double precision NOT NULL,
+    occurrences integer DEFAULT 1 NOT NULL,
+    context text,
+    description_embedding bytea,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: log_sources; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.log_sources (
+    id bigint NOT NULL,
+    name text NOT NULL,
+    description text,
+    path text NOT NULL,
+    path_type text DEFAULT 'file'::text,
+    format text DEFAULT 'plaintext'::text,
+    parser text DEFAULT 'generic'::text,
+    timestamp_pattern text,
+    timezone text DEFAULT 'local'::text,
+    error_patterns text,
+    warning_patterns text,
+    ignore_patterns text,
+    enabled boolean DEFAULT true,
+    poll_interval_ms integer DEFAULT 5000,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: log_sources_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.log_sources_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: log_sources_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.log_sources_id_seq OWNED BY project.log_sources.id;
+
+
+--
+-- Name: mcp_servers; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.mcp_servers (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    transport text NOT NULL,
+    stdio_config text,
+    http_config text,
+    enabled boolean DEFAULT true NOT NULL,
+    auto_start boolean DEFAULT false NOT NULL,
+    timeout_seconds integer DEFAULT 30 NOT NULL,
+    cached_tools text,
+    tools_cached_at timestamp with time zone,
+    connection_state text DEFAULT 'disconnected'::text NOT NULL,
+    last_connected_at timestamp with time zone,
+    last_error text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: memory_consolidation_log; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.memory_consolidation_log (
+    id bigint NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    observations_scanned integer DEFAULT 0 NOT NULL,
+    groups_found integer DEFAULT 0 NOT NULL,
+    models_created integer DEFAULT 0 NOT NULL,
+    observations_merged integer DEFAULT 0 NOT NULL,
+    observations_decayed integer DEFAULT 0 NOT NULL,
+    observations_archived integer DEFAULT 0 NOT NULL,
+    error text,
+    is_dreamer boolean DEFAULT false NOT NULL,
+    inductive_traces integer DEFAULT 0 NOT NULL,
+    deductive_traces integer DEFAULT 0 NOT NULL,
+    abductive_traces integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: memory_consolidation_log_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.memory_consolidation_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: memory_consolidation_log_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.memory_consolidation_log_id_seq OWNED BY project.memory_consolidation_log.id;
+
+
+--
+-- Name: meta_optimizer_recommendations; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.meta_optimizer_recommendations (
+    id text NOT NULL,
+    optimizer_type text NOT NULL,
+    recommendation_type text NOT NULL,
+    target_agent text,
+    title text NOT NULL,
+    description text NOT NULL,
+    current_value text DEFAULT '{}'::text,
+    recommended_value text DEFAULT '{}'::text,
+    evidence text DEFAULT '{}'::text,
+    confidence double precision DEFAULT 0.0 NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    applied_at timestamp with time zone,
+    outcome_after_apply text,
+    optimizer_run_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    content_hash text,
+    eval_result_id text,
+    eval_status text
+);
+
+
+--
+-- Name: meta_optimizer_runs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.meta_optimizer_runs (
+    id text NOT NULL,
+    optimizer_type text NOT NULL,
+    trigger_type text DEFAULT 'threshold'::text NOT NULL,
+    runs_analyzed integer DEFAULT 0 NOT NULL,
+    recommendations_produced integer DEFAULT 0 NOT NULL,
+    task_run_id text,
+    status text DEFAULT 'running'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: meta_optimizer_snapshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.meta_optimizer_snapshots (
+    id text NOT NULL,
+    snapshot_type text NOT NULL,
+    period_start text NOT NULL,
+    period_end text NOT NULL,
+    metrics_json text NOT NULL,
+    breakdown_json text DEFAULT '{}'::text,
+    recommendation_id text,
+    runs_included bigint DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: model_profiles; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.model_profiles (
+    id text NOT NULL,
+    model_id text NOT NULL,
+    profile_json text NOT NULL,
+    trial_count integer DEFAULT 0,
+    last_updated text NOT NULL
+);
+
+
+--
+-- Name: model_routing_decisions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.model_routing_decisions (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    context_key text NOT NULL,
+    model_selected text NOT NULL,
+    source text NOT NULL,
+    exploration boolean DEFAULT false NOT NULL,
+    reward double precision,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: model_routing_overrides; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.model_routing_overrides (
+    context_key text NOT NULL,
+    forced_model text NOT NULL,
+    reason text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: model_routing_table; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.model_routing_table (
+    context_key text NOT NULL,
+    model_id text NOT NULL,
+    q_value double precision DEFAULT 0.0 NOT NULL,
+    visit_count integer DEFAULT 0 NOT NULL,
+    sum_of_squares double precision DEFAULT 0.0 NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: observation_history; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.observation_history (
+    id bigint NOT NULL,
+    observation_id bigint NOT NULL,
+    title text NOT NULL,
+    content text NOT NULL,
+    content_hash text NOT NULL,
+    valid_from timestamp with time zone NOT NULL,
+    valid_until timestamp with time zone DEFAULT now() NOT NULL,
+    revision_number integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: observation_history_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.observation_history_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: observation_history_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.observation_history_id_seq OWNED BY project.observation_history.id;
+
+
+--
+-- Name: observations; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.observations (
+    id bigint NOT NULL,
+    title text NOT NULL,
+    content text NOT NULL,
+    observation_type text NOT NULL,
+    scope text DEFAULT 'project'::text NOT NULL,
+    topic_key text,
+    content_hash text NOT NULL,
+    revision_count integer DEFAULT 1 NOT NULL,
+    duplicate_count integer DEFAULT 0 NOT NULL,
+    project_id text,
+    workflow_id text,
+    task_run_id text,
+    session_id text,
+    is_deleted boolean DEFAULT false NOT NULL,
+    valid_from timestamp with time zone DEFAULT now() NOT NULL,
+    valid_until timestamp with time zone,
+    superseded_by bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    importance double precision DEFAULT 0.5 NOT NULL,
+    last_accessed_at timestamp with time zone,
+    access_count integer DEFAULT 0 NOT NULL,
+    decay_rate double precision DEFAULT 0.1 NOT NULL,
+    consolidated_from bigint[],
+    is_mental_model boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: observations_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.observations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: observations_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.observations_id_seq OWNED BY project.observations.id;
+
+
+--
+-- Name: orchestration_loop_configs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.orchestration_loop_configs (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    is_favorite boolean DEFAULT false,
+    config_json text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: orchestrator_checkpoints; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.orchestrator_checkpoints (
+    id text NOT NULL,
+    task_id text NOT NULL,
+    iteration bigint DEFAULT 0 NOT NULL,
+    trigger text NOT NULL,
+    state text DEFAULT '{}'::text NOT NULL,
+    name text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: orchestrator_flows; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.orchestrator_flows (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    steps text DEFAULT '[]'::text NOT NULL,
+    start_step text,
+    timeout_secs integer,
+    inputs text,
+    outputs text,
+    tags text DEFAULT '[]'::text,
+    version text DEFAULT '1.0.0'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: orchestrator_verification_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.orchestrator_verification_results (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    plan_id text NOT NULL,
+    iteration integer NOT NULL,
+    criterion_id text NOT NULL,
+    criterion_type text NOT NULL,
+    passed boolean NOT NULL,
+    is_critical boolean DEFAULT true NOT NULL,
+    confidence text,
+    observations text DEFAULT '[]'::text,
+    issues text DEFAULT '[]'::text,
+    suggestions text DEFAULT '[]'::text,
+    raw_output text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: pending_discoveries; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.pending_discoveries (
+    id text NOT NULL,
+    payload text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_attempt text,
+    attempt_count integer DEFAULT 0,
+    error text
+);
+
+
+--
+-- Name: performance_drift_signals; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.performance_drift_signals (
+    id text NOT NULL,
+    detector_type text NOT NULL,
+    metric_name text NOT NULL,
+    context_key text DEFAULT ''::text NOT NULL,
+    drift_level text NOT NULL,
+    pre_drift_mean double precision,
+    post_drift_mean double precision,
+    window_size bigint,
+    acknowledged boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: phase_model_routing; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.phase_model_routing (
+    state_key text NOT NULL,
+    phase text NOT NULL,
+    model_tier text NOT NULL,
+    q_value double precision DEFAULT 0.0 NOT NULL,
+    visit_count integer DEFAULT 0 NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: phase_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.phase_results (
+    id bigint NOT NULL,
+    execution_id text NOT NULL,
+    phase text NOT NULL,
+    iteration integer,
+    stage_index integer,
+    success boolean NOT NULL,
+    all_passed boolean NOT NULL,
+    duration_ms bigint NOT NULL,
+    failure_context text,
+    commit_hash text,
+    step_results jsonb DEFAULT '[]'::jsonb NOT NULL,
+    variables_set jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: phase_results_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.phase_results_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phase_results_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.phase_results_id_seq OWNED BY project.phase_results.id;
+
+
+--
+-- Name: phase_token_usage; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.phase_token_usage (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    phase text NOT NULL,
+    stage_index integer,
+    iteration integer,
+    model_used text,
+    provider_used text,
+    input_tokens bigint DEFAULT 0 NOT NULL,
+    output_tokens bigint DEFAULT 0 NOT NULL,
+    cost_cents bigint DEFAULT 0 NOT NULL,
+    duration_ms bigint,
+    cache_creation_tokens bigint DEFAULT 0 NOT NULL,
+    cache_read_tokens bigint DEFAULT 0 NOT NULL,
+    target_app text,
+    target_page_url text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: phase_token_usage_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.phase_token_usage_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: phase_token_usage_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.phase_token_usage_id_seq OWNED BY project.phase_token_usage.id;
+
+
+--
+-- Name: pipeline_agent_traces; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.pipeline_agent_traces (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    agent_type text NOT NULL,
+    agent_id text NOT NULL,
+    run_id text NOT NULL,
+    input_snapshot text DEFAULT '{}'::text NOT NULL,
+    output_snapshot text DEFAULT '{}'::text NOT NULL,
+    config_json text DEFAULT '{}'::text NOT NULL,
+    duration_ms bigint DEFAULT 0 NOT NULL,
+    tokens_in bigint DEFAULT 0 NOT NULL,
+    tokens_out bigint DEFAULT 0 NOT NULL,
+    cost_usd double precision DEFAULT 0.0 NOT NULL,
+    downstream_success boolean,
+    output_quality_score double precision,
+    parent_span_id text,
+    span_type text DEFAULT 'agent'::text,
+    guardrail_results_json text,
+    handoff_context_json text,
+    schema_valid_first_attempt boolean,
+    validation_retries integer,
+    validation_error_summary text,
+    coercions_applied text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: playbook_entries; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.playbook_entries (
+    id text NOT NULL,
+    lesson text NOT NULL,
+    category text NOT NULL,
+    domain text,
+    severity text DEFAULT 'minor'::text NOT NULL,
+    source_run_id text NOT NULL,
+    source_step_id text,
+    positive integer DEFAULT 1 NOT NULL,
+    times_applied integer DEFAULT 0 NOT NULL,
+    times_helped integer DEFAULT 0 NOT NULL,
+    embedding bytea,
+    status text DEFAULT 'staged'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: pr_watch_state; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.pr_watch_state (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    pr_number bigint NOT NULL,
+    repo_full_name text NOT NULL,
+    head_sha text DEFAULT ''::text NOT NULL,
+    workflow_id text DEFAULT ''::text NOT NULL,
+    last_checks_status text DEFAULT 'pending'::text NOT NULL,
+    last_review_status text DEFAULT 'pending'::text NOT NULL,
+    auto_resume_count integer DEFAULT 0 NOT NULL,
+    max_auto_resumes integer DEFAULT 10 NOT NULL,
+    github_token text DEFAULT ''::text NOT NULL,
+    auto_resume_enabled boolean DEFAULT true NOT NULL,
+    completed_at timestamp with time zone,
+    completion_reason text,
+    last_polled_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: prm_training_exports; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.prm_training_exports (
+    id text NOT NULL,
+    export_format text DEFAULT 'jsonl'::text NOT NULL,
+    total_examples integer DEFAULT 0 NOT NULL,
+    passed_count integer DEFAULT 0 NOT NULL,
+    failed_count integer DEFAULT 0 NOT NULL,
+    fixed_count integer DEFAULT 0 NOT NULL,
+    runs_processed integer DEFAULT 0 NOT NULL,
+    file_path text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: productivity_knowledge; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.productivity_knowledge (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_id uuid,
+    session_id text,
+    area text NOT NULL,
+    summary text NOT NULL,
+    body text NOT NULL,
+    embedding bytea,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: prompt_evolution; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.prompt_evolution (
+    id text NOT NULL,
+    agent_type text NOT NULL,
+    parent_variant_id text,
+    variant_id text NOT NULL,
+    recommendation_id text,
+    critique text,
+    changes_summary text,
+    canary_verdict text,
+    score_before double precision,
+    score_after double precision,
+    baseline_prompt_hash text,
+    consecutive_rejections integer DEFAULT 0,
+    beam_run_id text,
+    generation integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: prompt_registry; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.prompt_registry (
+    id text NOT NULL,
+    agent_type text NOT NULL,
+    variant_name text NOT NULL,
+    prompt_content text NOT NULL,
+    version integer DEFAULT 1 NOT NULL,
+    is_active boolean DEFAULT false NOT NULL,
+    source_recommendation_id text,
+    performance_metrics text DEFAULT '{}'::text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: prompt_template_canaries; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.prompt_template_canaries (
+    id text NOT NULL,
+    template_id text NOT NULL,
+    baseline_version integer NOT NULL,
+    candidate_version integer NOT NULL,
+    traffic_percentage double precision DEFAULT 0.1 NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    baseline_metrics_json text DEFAULT '{}'::text NOT NULL,
+    candidate_metrics_json text DEFAULT '{}'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone
+);
+
+
+--
+-- Name: prompts; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.prompts (
+    id text NOT NULL,
+    name text NOT NULL,
+    category text DEFAULT 'general'::text NOT NULL,
+    content text NOT NULL,
+    variables text DEFAULT '[]'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: q_routing_overrides; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.q_routing_overrides (
+    state_key text NOT NULL,
+    forced_action text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: q_routing_table; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.q_routing_table (
+    state_key text NOT NULL,
+    action text NOT NULL,
+    q_value double precision DEFAULT 0.0 NOT NULL,
+    visit_count integer DEFAULT 0 NOT NULL,
+    last_updated timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: queued_workflows; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.queued_workflows (
+    id text NOT NULL,
+    workflow_id text NOT NULL,
+    workflow_name text NOT NULL,
+    queued_at timestamp with time zone NOT NULL,
+    priority integer DEFAULT 0 NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    error_message text,
+    task_run_id text,
+    retry_count integer DEFAULT 0 NOT NULL,
+    max_retries integer DEFAULT 3 NOT NULL
+);
+
+
+--
+-- Name: reasoning_traces; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.reasoning_traces (
+    id bigint NOT NULL,
+    reasoning_type text NOT NULL,
+    premise_ids bigint[] NOT NULL,
+    conclusion text NOT NULL,
+    confidence double precision DEFAULT 0.5 NOT NULL,
+    evidence_json text,
+    created_observation_id bigint,
+    dreamer_run_id bigint,
+    is_valid boolean DEFAULT true NOT NULL,
+    invalidated_by bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: reasoning_traces_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.reasoning_traces_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: reasoning_traces_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.reasoning_traces_id_seq OWNED BY project.reasoning_traces.id;
+
+
+--
+-- Name: recording_actions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.recording_actions (
+    id text NOT NULL,
+    recording_id text NOT NULL,
+    sequence_number integer NOT NULL,
+    action_type text NOT NULL,
+    url text NOT NULL,
+    page_title text,
+    target_json text NOT NULL,
+    action_data_json text,
+    screenshot_path text,
+    "timestamp" text NOT NULL,
+    duration_ms integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: recording_exports; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.recording_exports (
+    id text NOT NULL,
+    recording_id text NOT NULL,
+    export_format text NOT NULL,
+    script_content text NOT NULL,
+    file_name text NOT NULL,
+    options_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: recordings; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.recordings (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    base_url text NOT NULL,
+    action_count integer DEFAULT 0,
+    status text DEFAULT 'recording'::text,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    duration_ms integer,
+    browser_info text,
+    tab_id integer,
+    tags text DEFAULT '[]'::text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: reflection_fixes; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.reflection_fixes (
+    id text NOT NULL,
+    source_task_run_id text NOT NULL,
+    reflection_task_run_id text NOT NULL,
+    source_finding_id text,
+    source_knowledge_id text,
+    fix_type text NOT NULL,
+    fix_description text NOT NULL,
+    file_changed text,
+    old_value text,
+    new_value text,
+    confidence text DEFAULT 'medium'::text NOT NULL,
+    content_hash text,
+    status text DEFAULT 'applied'::text NOT NULL,
+    effectiveness text,
+    effectiveness_evidence text,
+    applied_at timestamp with time zone DEFAULT now() NOT NULL,
+    evaluated_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    source_agent text,
+    reasoning text,
+    alternatives_considered text,
+    reflection_scope text DEFAULT 'workflow'::text,
+    project_path text,
+    target_component text,
+    reuse_count integer DEFAULT 0,
+    applicability_context text,
+    fix_description_embedding bytea
+);
+
+
+--
+-- Name: resource_versions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.resource_versions (
+    id text NOT NULL,
+    resource_type text NOT NULL,
+    resource_key text NOT NULL,
+    version bigint NOT NULL,
+    content_hash text NOT NULL,
+    content text NOT NULL,
+    metadata_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: restate_awakeables; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.restate_awakeables (
+    awakeable_id text NOT NULL,
+    execution_id text NOT NULL,
+    awakeable_type text NOT NULL,
+    type_data text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: restate_workflow_executions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.restate_workflow_executions (
+    execution_id text NOT NULL,
+    restate_workflow_id text NOT NULL,
+    restate_invocation_id text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    launched_via_restate boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: robustness_reports; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.robustness_reports (
+    id text NOT NULL,
+    prompt_variant_id text,
+    recommendation_id text,
+    total_tests integer NOT NULL,
+    passed integer NOT NULL,
+    failed integer NOT NULL,
+    report_json text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: rule_influence_log; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.rule_influence_log (
+    id text NOT NULL,
+    rule_id text NOT NULL,
+    task_run_id text NOT NULL,
+    workflow_id text,
+    influence_type text DEFAULT 'loaded'::text NOT NULL,
+    evidence text,
+    phase text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: saved_api_requests; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.saved_api_requests (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    category text DEFAULT 'general'::text,
+    tags text DEFAULT '[]'::text,
+    method text DEFAULT 'GET'::text NOT NULL,
+    url text NOT NULL,
+    headers text DEFAULT '{}'::text,
+    body text,
+    body_content_type text DEFAULT 'application/json'::text,
+    timeout_ms integer DEFAULT 30000,
+    follow_redirects boolean DEFAULT true,
+    variable_extractions text DEFAULT '[]'::text,
+    assertions text DEFAULT '[]'::text,
+    credential_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: scheduled_tasks; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.scheduled_tasks (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    enabled boolean DEFAULT true NOT NULL,
+    schedule_type text DEFAULT 'cron'::text NOT NULL,
+    schedule_value text DEFAULT ''::text NOT NULL,
+    task_config text DEFAULT '{}'::text NOT NULL,
+    skip_if_completed boolean DEFAULT false NOT NULL,
+    auto_fix_on_failure boolean DEFAULT false NOT NULL,
+    success_criteria text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    modified_at timestamp with time zone DEFAULT now() NOT NULL,
+    next_run timestamp with time zone,
+    last_run_id text,
+    condition_status text,
+    catch_up_policy text DEFAULT 'run_once'::text NOT NULL,
+    catch_up_grace_seconds integer DEFAULT 300 NOT NULL,
+    consecutive_launch_failures integer DEFAULT 0 NOT NULL,
+    launch_failure_backoff_seconds integer DEFAULT 60 NOT NULL
+);
+
+
+--
+-- Name: scheduler_history; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.scheduler_history (
+    execution_id text NOT NULL,
+    task_id text NOT NULL,
+    session_id text,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    status text DEFAULT 'pending'::text NOT NULL,
+    success boolean DEFAULT false NOT NULL,
+    error_message text,
+    triggered_auto_fix boolean DEFAULT false NOT NULL,
+    auto_fix_session_id text,
+    scheduled_for timestamp with time zone,
+    catch_up_run boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: scheduler_settings; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.scheduler_settings (
+    id integer NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    max_concurrent integer DEFAULT 1 NOT NULL,
+    default_auto_fix_on_failure boolean DEFAULT false NOT NULL,
+    timezone text,
+    CONSTRAINT scheduler_settings_singleton CHECK ((id = 1))
+);
+
+
+--
+-- Name: scheduler_settings_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.scheduler_settings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: scheduler_settings_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.scheduler_settings_id_seq OWNED BY project.scheduler_settings.id;
+
+
+--
+-- Name: security_audit_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.security_audit_events (
+    id text NOT NULL,
+    "timestamp" text NOT NULL,
+    task_run_id text,
+    step_name text,
+    workflow_id text,
+    event_type text NOT NULL,
+    action text NOT NULL,
+    decision text NOT NULL,
+    reason text,
+    metadata text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: session_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.session_events (
+    id bigint NOT NULL,
+    session_id text NOT NULL,
+    event_type text NOT NULL,
+    message text NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: session_events_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.session_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: session_events_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.session_events_id_seq OWNED BY project.session_events.id;
+
+
+--
+-- Name: sessions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.sessions (
+    id text NOT NULL,
+    session_type text NOT NULL,
+    name text NOT NULL,
+    status text DEFAULT 'starting'::text NOT NULL,
+    current_phase integer DEFAULT 0 NOT NULL,
+    total_phases integer DEFAULT 0 NOT NULL,
+    completed boolean DEFAULT false NOT NULL,
+    restart_permitted boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    error_message text,
+    custom_data text DEFAULT '{}'::text,
+    activity_log text DEFAULT '[]'::text,
+    run_id text,
+    workflow_name text
+);
+
+
+--
+-- Name: settings; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.settings (
+    key text NOT NULL,
+    value text NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: shell_command_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.shell_command_results (
+    id text NOT NULL,
+    shell_command_id text NOT NULL,
+    task_run_id text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    exit_code integer,
+    stdout text,
+    stderr text,
+    duration_ms integer,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: shell_commands; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.shell_commands (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    command text NOT NULL,
+    working_directory text,
+    timeout_seconds integer,
+    fail_on_error boolean DEFAULT true NOT NULL,
+    category text DEFAULT 'general'::text,
+    tags text DEFAULT '[]'::text,
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: sm_capture_screenshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.sm_capture_screenshots (
+    id text NOT NULL,
+    config_id text NOT NULL,
+    capture_index integer NOT NULL,
+    screenshot_webp bytea NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    element_bounds_json text DEFAULT '{}'::text NOT NULL,
+    fingerprint_hashes_json text DEFAULT '[]'::text NOT NULL,
+    captured_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: sm_element_thumbnails; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.sm_element_thumbnails (
+    config_id text NOT NULL,
+    fingerprint_hash text NOT NULL,
+    thumbnail_base64 text NOT NULL
+);
+
+
+--
+-- Name: span_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.span_events (
+    id text NOT NULL,
+    execution_id text NOT NULL,
+    trace_id text NOT NULL,
+    agent_type text NOT NULL,
+    event_type text NOT NULL,
+    step_index integer DEFAULT 0 NOT NULL,
+    metric_name text,
+    reward_value double precision,
+    data_key text,
+    data_json text,
+    role text,
+    content text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: spec_accuracy_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.spec_accuracy_results (
+    id text NOT NULL,
+    spec_id text NOT NULL,
+    analysis_type text NOT NULL,
+    score double precision NOT NULL,
+    detail_json text DEFAULT '{}'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: spec_compliance_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.spec_compliance_results (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    spec_id text,
+    iteration integer NOT NULL,
+    overall_score double precision NOT NULL,
+    raw_pass_rate double precision NOT NULL,
+    critical_passed integer DEFAULT 0 NOT NULL,
+    critical_total integer DEFAULT 0 NOT NULL,
+    warning_passed integer DEFAULT 0 NOT NULL,
+    warning_total integer DEFAULT 0 NOT NULL,
+    info_passed integer DEFAULT 0 NOT NULL,
+    info_total integer DEFAULT 0 NOT NULL,
+    assertions_passed integer NOT NULL,
+    assertions_total integer NOT NULL,
+    group_scores_json text DEFAULT '[]'::text NOT NULL,
+    assertion_details_json text DEFAULT '[]'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: spec_versions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.spec_versions (
+    id text NOT NULL,
+    spec_id text NOT NULL,
+    version_number integer NOT NULL,
+    content_hash text NOT NULL,
+    spec_json text NOT NULL,
+    change_summary text,
+    change_type text DEFAULT 'manual'::text NOT NULL,
+    parent_version_id text,
+    assertion_count integer NOT NULL,
+    group_count integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: stall_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.stall_events (
+    id text DEFAULT (gen_random_uuid())::text NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    pattern_type text NOT NULL,
+    pattern_details text,
+    action_count integer,
+    intervention_action text,
+    intervention_result text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: state_discovery_artifacts; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.state_discovery_artifacts (
+    id uuid NOT NULL,
+    spec_id text,
+    derived_at timestamp with time zone DEFAULT now() NOT NULL,
+    window_days integer NOT NULL,
+    artifact jsonb NOT NULL,
+    observation_count integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: state_discovery_drift_scores; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.state_discovery_drift_scores (
+    id bigint NOT NULL,
+    spec_id text,
+    computed_at timestamp with time zone DEFAULT now() NOT NULL,
+    window_size integer NOT NULL,
+    fit_score double precision NOT NULL,
+    observations_considered integer NOT NULL,
+    states_matched integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: state_discovery_drift_scores_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.state_discovery_drift_scores_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: state_discovery_drift_scores_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.state_discovery_drift_scores_id_seq OWNED BY project.state_discovery_drift_scores.id;
+
+
+--
+-- Name: state_machine_configs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.state_machine_configs (
+    id text NOT NULL,
+    name text DEFAULT 'default'::text NOT NULL,
+    description text,
+    render_count integer DEFAULT 0 NOT NULL,
+    element_count integer DEFAULT 0 NOT NULL,
+    include_html_ids boolean DEFAULT false NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: state_machine_states; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.state_machine_states (
+    id text NOT NULL,
+    config_id text NOT NULL,
+    state_id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    element_ids text DEFAULT '[]'::text NOT NULL,
+    render_ids text DEFAULT '[]'::text NOT NULL,
+    confidence double precision DEFAULT 0.9 NOT NULL,
+    acceptance_criteria text DEFAULT '[]'::text NOT NULL,
+    extra_metadata text DEFAULT '{}'::text NOT NULL,
+    domain_knowledge text DEFAULT '[]'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: state_machine_transitions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.state_machine_transitions (
+    id text NOT NULL,
+    config_id text NOT NULL,
+    transition_id text NOT NULL,
+    name text NOT NULL,
+    from_states text DEFAULT '[]'::text NOT NULL,
+    activate_states text DEFAULT '[]'::text NOT NULL,
+    exit_states text DEFAULT '[]'::text NOT NULL,
+    actions text DEFAULT '[]'::text NOT NULL,
+    path_cost double precision DEFAULT 1.0 NOT NULL,
+    stays_visible boolean DEFAULT false NOT NULL,
+    extra_metadata text DEFAULT '{}'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: step_credit_assignments; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.step_credit_assignments (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    step_index integer NOT NULL,
+    step_type text NOT NULL,
+    agent_type text,
+    raw_credit double precision NOT NULL,
+    normalized_credit double precision NOT NULL,
+    temporal_proximity double precision,
+    output_utilization double precision,
+    confidence_delta_signal double precision,
+    downstream_success_signal double precision,
+    cost_efficiency_signal double precision,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: step_finding_links; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.step_finding_links (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    step_name text NOT NULL,
+    step_index integer NOT NULL,
+    finding_id text NOT NULL,
+    link_type text DEFAULT 'detected_during'::text NOT NULL,
+    confidence double precision DEFAULT 1.0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: step_progress_markers; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.step_progress_markers (
+    id bigint NOT NULL,
+    checkpoint_id text NOT NULL,
+    marker_type text NOT NULL,
+    current_value bigint NOT NULL,
+    total_value bigint,
+    description text,
+    data_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: step_progress_markers_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.step_progress_markers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: step_progress_markers_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.step_progress_markers_id_seq OWNED BY project.step_progress_markers.id;
+
+
+--
+-- Name: step_provenance; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.step_provenance (
+    id text NOT NULL,
+    workflow_id text NOT NULL,
+    workflow_version_id text,
+    step_name text NOT NULL,
+    step_index integer NOT NULL,
+    phase text NOT NULL,
+    generating_agent text NOT NULL,
+    generation_iteration integer,
+    original_step_json text,
+    final_step_json text,
+    ui_bridge_event_ids text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: step_templates; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.step_templates (
+    id text NOT NULL,
+    domain text NOT NULL,
+    pattern_description text NOT NULL,
+    template_steps_json text NOT NULL,
+    parameters_json text DEFAULT '[]'::text NOT NULL,
+    success_count integer DEFAULT 0 NOT NULL,
+    failure_count integer DEFAULT 0 NOT NULL,
+    confidence double precision DEFAULT 0.5 NOT NULL,
+    source text DEFAULT 'seeded'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: step_type_knowledge; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.step_type_knowledge (
+    id text NOT NULL,
+    step_type text NOT NULL,
+    layer text DEFAULT 'universal'::text NOT NULL,
+    title text NOT NULL,
+    content text NOT NULL,
+    priority integer DEFAULT 0 NOT NULL,
+    status text DEFAULT 'active'::text NOT NULL,
+    provenance text DEFAULT 'seed'::text NOT NULL,
+    source_fix_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: strategy_bank; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.strategy_bank (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text NOT NULL,
+    applicability_json text NOT NULL,
+    components_json text NOT NULL,
+    stats_json text DEFAULT '{}'::text NOT NULL,
+    provenance_json text NOT NULL,
+    status text DEFAULT 'candidate'::text NOT NULL,
+    parent_strategy_id text,
+    embedding bytea,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_hooks; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_hooks (
+    id text NOT NULL,
+    name text NOT NULL,
+    hook_type text NOT NULL,
+    trigger_event text NOT NULL,
+    command text NOT NULL,
+    working_directory text,
+    timeout_seconds integer DEFAULT 30,
+    enabled boolean DEFAULT true NOT NULL,
+    workflow_filter text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_knowledge; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_knowledge (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    category text NOT NULL,
+    agent_type text DEFAULT 'system'::text NOT NULL,
+    iteration integer DEFAULT 0 NOT NULL,
+    content text NOT NULL,
+    evidence text,
+    confidence text DEFAULT 'medium'::text NOT NULL,
+    related_files text DEFAULT '[]'::text NOT NULL,
+    related_criterion_id text,
+    is_resolved boolean DEFAULT false NOT NULL,
+    resolution_notes text,
+    resolved_at timestamp with time zone,
+    archived_at timestamp with time zone,
+    summary_entry_id text,
+    content_embedding bytea,
+    project_path text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_knowledge_summaries; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_knowledge_summaries (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    category text NOT NULL,
+    summary text NOT NULL,
+    covered_iterations text NOT NULL,
+    item_count integer NOT NULL,
+    original_tokens integer,
+    compressed_tokens integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_api_requests; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_api_requests (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    step_id text NOT NULL,
+    step_name text,
+    method text NOT NULL,
+    url text NOT NULL,
+    resolved_url text NOT NULL,
+    request_headers text,
+    request_body text,
+    status_code integer NOT NULL,
+    status_text text,
+    response_headers text,
+    response_time_ms bigint NOT NULL,
+    response_body_type text NOT NULL,
+    response_body text,
+    response_size_bytes bigint,
+    extractions text,
+    assertions text,
+    success boolean NOT NULL,
+    error_message text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_automation; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_automation (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    workflow_name text,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    duration_ms integer,
+    automation_status text DEFAULT 'running'::text NOT NULL,
+    success boolean,
+    error_type text,
+    error_message text,
+    actions_summary text,
+    states_visited text,
+    transitions_executed text,
+    template_matches text,
+    anomalies text,
+    iteration_number bigint DEFAULT 1 NOT NULL
+);
+
+
+--
+-- Name: task_run_awas_steps; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_awas_steps (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    step_id text,
+    step_name text,
+    step_type text NOT NULL,
+    url text,
+    action_id text,
+    parameters text,
+    response_data text,
+    success boolean DEFAULT true NOT NULL,
+    error_message text,
+    duration_ms bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_events (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    event_type text NOT NULL,
+    event_subtype text,
+    message text NOT NULL,
+    data text,
+    workflow_name text,
+    state_name text,
+    action_id text,
+    "timestamp" text NOT NULL,
+    duration_ms bigint
+);
+
+
+--
+-- Name: task_run_events_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.task_run_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: task_run_events_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.task_run_events_id_seq OWNED BY project.task_run_events.id;
+
+
+--
+-- Name: task_run_findings; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_findings (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    category text NOT NULL,
+    severity text NOT NULL,
+    signature_hash text,
+    title text NOT NULL,
+    description text NOT NULL,
+    file_path text,
+    line_number integer,
+    column_number integer,
+    code_snippet text,
+    status text DEFAULT 'detected'::text NOT NULL,
+    action_type text DEFAULT 'auto_fix'::text NOT NULL,
+    resolution text,
+    detected_in_session integer NOT NULL,
+    resolved_in_session integer,
+    needs_input boolean DEFAULT false,
+    question text,
+    input_options text,
+    user_response text,
+    title_embedding bytea,
+    description_embedding bytea,
+    reflection_fix_id text,
+    detected_at timestamp with time zone DEFAULT now() NOT NULL,
+    resolved_at timestamp with time zone,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_mcp_calls; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_mcp_calls (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    step_id text NOT NULL,
+    step_name text,
+    server_id text NOT NULL,
+    server_name text,
+    tool_name text NOT NULL,
+    arguments text,
+    resolved_arguments text,
+    response text,
+    response_type text NOT NULL,
+    duration_ms integer NOT NULL,
+    extractions text,
+    assertions text,
+    success boolean NOT NULL,
+    error_message text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_mobile_logs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_mobile_logs (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    mobile_state_id bigint,
+    log_source text NOT NULL,
+    log_level text,
+    log_tag text,
+    message text NOT NULL,
+    raw_line text,
+    data text,
+    error_type text,
+    error_code text,
+    stack_trace text,
+    file_path text,
+    line_number integer,
+    column_number integer,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    device_timestamp text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_mobile_logs_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.task_run_mobile_logs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: task_run_mobile_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.task_run_mobile_logs_id_seq OWNED BY project.task_run_mobile_logs.id;
+
+
+--
+-- Name: task_run_mobile_state; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_mobile_state (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    device_id text,
+    device_type text,
+    device_model text,
+    app_package text,
+    app_activity text,
+    app_state text,
+    metro_connected boolean DEFAULT false,
+    bundle_status text,
+    last_reload_type text,
+    last_reload_time text,
+    screenshot_path text,
+    logcat_path text,
+    has_errors boolean DEFAULT false,
+    error_summary text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_mobile_state_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.task_run_mobile_state_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: task_run_mobile_state_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.task_run_mobile_state_id_seq OWNED BY project.task_run_mobile_state.id;
+
+
+--
+-- Name: task_run_output_chunks; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_output_chunks (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    chunk_sequence integer NOT NULL,
+    content text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_output_chunks_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.task_run_output_chunks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: task_run_output_chunks_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.task_run_output_chunks_id_seq OWNED BY project.task_run_output_chunks.id;
+
+
+--
+-- Name: task_run_playwright_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_playwright_results (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    test_name text NOT NULL,
+    spec_file text,
+    status text NOT NULL,
+    duration_ms bigint,
+    stdout text,
+    stderr text,
+    console_output text,
+    page_snapshot text,
+    error_message text,
+    failure_screenshot_path text,
+    assertions_passed integer DEFAULT 0,
+    assertions_failed integer DEFAULT 0,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_run_screenshots; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_run_screenshots (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    event_id bigint,
+    file_path text NOT NULL,
+    screenshot_type text NOT NULL,
+    template_name text,
+    confidence double precision,
+    match_location text,
+    width integer,
+    height integer,
+    file_size_bytes bigint,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: task_runs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.task_runs (
+    id text NOT NULL,
+    task_name text NOT NULL,
+    prompt text,
+    task_type text DEFAULT 'task'::text NOT NULL,
+    status text DEFAULT 'running'::text NOT NULL,
+    sessions_count integer DEFAULT 0 NOT NULL,
+    max_sessions integer,
+    auto_continue boolean DEFAULT true NOT NULL,
+    output_log text DEFAULT ''::text,
+    error_message text,
+    execution_steps_json text,
+    log_sources_json text,
+    config_id text,
+    workflow_name text,
+    workflow_id text,
+    summary text,
+    ai_summary text,
+    goal_achieved boolean,
+    remaining_work text,
+    summary_generated_at timestamp with time zone,
+    runtime_context_json text,
+    transition_history_json text,
+    parent_task_run_id text,
+    root_task_run_id text,
+    depth integer DEFAULT 0,
+    bridge_id text,
+    workflow_type text,
+    result_data text,
+    workspace_id text,
+    triggered_by text,
+    prompt_embedding bytea,
+    summary_embedding bytea,
+    is_reflection boolean DEFAULT false,
+    reflection_source_task_run_id text,
+    is_follow_up boolean DEFAULT false,
+    follow_up_source_task_run_id text,
+    runner_port integer,
+    is_fixer boolean DEFAULT false,
+    fixer_source_task_run_id text,
+    fix_attempts integer DEFAULT 0,
+    is_review boolean DEFAULT false,
+    blocks_parent boolean DEFAULT false,
+    ci_auto_resumes integer DEFAULT 0,
+    is_meta_optimizer boolean DEFAULT false,
+    iteration_history text,
+    pipeline_checkpoint text,
+    iteration_diffs text,
+    iteration_commits text,
+    verification_passed boolean,
+    total_input_tokens bigint DEFAULT 0,
+    total_output_tokens bigint DEFAULT 0,
+    total_cost_cents bigint DEFAULT 0,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: template_lifecycle_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.template_lifecycle_events (
+    id text NOT NULL,
+    template_id text NOT NULL,
+    action text NOT NULL,
+    old_source text NOT NULL,
+    new_source text NOT NULL,
+    confidence_at_transition double precision DEFAULT 0.0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: template_performance; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.template_performance (
+    template_id text NOT NULL,
+    template_name text NOT NULL,
+    source text DEFAULT 'manual'::text NOT NULL,
+    success_count integer DEFAULT 0 NOT NULL,
+    failure_count integer DEFAULT 0 NOT NULL,
+    total_quality_score double precision DEFAULT 0.0 NOT NULL,
+    last_used_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: test_associations; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.test_associations (
+    id text NOT NULL,
+    test_id text NOT NULL,
+    config_id text,
+    workflow_name text,
+    trigger_point text NOT NULL,
+    action_id text,
+    execution_order integer DEFAULT 0,
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: test_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.test_results (
+    id text NOT NULL,
+    test_id text NOT NULL,
+    task_run_id text,
+    status text DEFAULT 'pending'::text NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    duration_ms integer,
+    output text,
+    error_message text,
+    structured_output text,
+    assertions_passed integer DEFAULT 0,
+    assertions_failed integer DEFAULT 0,
+    screenshots text DEFAULT '[]'::text,
+    visual_evidence text,
+    ai_analysis text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ticket_provider_configs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ticket_provider_configs (
+    id text NOT NULL,
+    workflow_id text NOT NULL,
+    source text NOT NULL,
+    config_json text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ticket_task_mapping; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ticket_task_mapping (
+    id text NOT NULL,
+    ticket_source text NOT NULL,
+    ticket_external_id text NOT NULL,
+    ticket_url text NOT NULL,
+    task_run_id text NOT NULL,
+    workflow_id text NOT NULL,
+    sync_status text DEFAULT 'synced'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: trigger_history; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.trigger_history (
+    id text NOT NULL,
+    trigger_id text NOT NULL,
+    event_type text NOT NULL,
+    event_data text DEFAULT '{}'::text,
+    action text NOT NULL,
+    task_run_id text,
+    error_message text,
+    triggered_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_baselines; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_baselines (
+    id text NOT NULL,
+    target_scope text NOT NULL,
+    fingerprint text,
+    png_bytes bytea NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    metadata_json text,
+    ttl_days integer
+);
+
+
+--
+-- Name: ui_bridge_elements; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_elements (
+    id bigint NOT NULL,
+    task_run_id bigint,
+    "timestamp" bigint NOT NULL,
+    element_id text NOT NULL,
+    tag_name text,
+    element_type text,
+    bounds text,
+    visible boolean DEFAULT true,
+    enabled boolean DEFAULT true,
+    focused boolean DEFAULT false,
+    value text,
+    text_content text,
+    label text,
+    role text,
+    parent_element_id text,
+    page_url text,
+    selector text,
+    state_ids text,
+    metadata text
+);
+
+
+--
+-- Name: ui_bridge_elements_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.ui_bridge_elements_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ui_bridge_elements_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.ui_bridge_elements_id_seq OWNED BY project.ui_bridge_elements.id;
+
+
+--
+-- Name: ui_bridge_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_events (
+    id bigint NOT NULL,
+    task_run_id bigint,
+    "timestamp" bigint NOT NULL,
+    sequence bigint NOT NULL,
+    event_type text NOT NULL,
+    element_id text,
+    state_id text,
+    transition_id text,
+    action text,
+    params text,
+    result text,
+    duration_ms double precision,
+    success boolean DEFAULT true,
+    error_message text,
+    metadata text
+);
+
+
+--
+-- Name: ui_bridge_events_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.ui_bridge_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ui_bridge_events_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.ui_bridge_events_id_seq OWNED BY project.ui_bridge_events.id;
+
+
+--
+-- Name: ui_bridge_integrations; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_integrations (
+    id text NOT NULL,
+    project_path text NOT NULL,
+    label text,
+    framework text,
+    integration_type text NOT NULL,
+    sdk_version text,
+    status text DEFAULT 'active'::text NOT NULL,
+    target_url text,
+    last_health_check integer,
+    element_count integer,
+    created_at integer NOT NULL,
+    updated_at integer NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_navigation_history; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_navigation_history (
+    id bigint NOT NULL,
+    task_run_id bigint,
+    "timestamp" bigint NOT NULL,
+    target_states text NOT NULL,
+    path_found boolean NOT NULL,
+    transitions_planned text,
+    transitions_executed text,
+    total_cost double precision,
+    duration_ms double precision,
+    success boolean DEFAULT false,
+    final_active_states text,
+    error_message text
+);
+
+
+--
+-- Name: ui_bridge_navigation_history_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.ui_bridge_navigation_history_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ui_bridge_navigation_history_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.ui_bridge_navigation_history_id_seq OWNED BY project.ui_bridge_navigation_history.id;
+
+
+--
+-- Name: ui_bridge_states; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_states (
+    id bigint NOT NULL,
+    state_id text NOT NULL,
+    name text NOT NULL,
+    elements text,
+    blocking integer DEFAULT 0,
+    blocks text,
+    group_id text,
+    path_cost double precision DEFAULT 1.0,
+    is_active integer DEFAULT 0,
+    active_when text,
+    metadata text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_states_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.ui_bridge_states_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ui_bridge_states_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.ui_bridge_states_id_seq OWNED BY project.ui_bridge_states.id;
+
+
+--
+-- Name: ui_bridge_transitions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.ui_bridge_transitions (
+    id bigint NOT NULL,
+    transition_id text NOT NULL,
+    name text NOT NULL,
+    from_states text NOT NULL,
+    activate_states text NOT NULL,
+    exit_states text,
+    activate_groups text,
+    exit_groups text,
+    actions text,
+    path_cost double precision DEFAULT 1.0,
+    stays_visible boolean DEFAULT false,
+    metadata text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_transitions_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.ui_bridge_transitions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: ui_bridge_transitions_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.ui_bridge_transitions_id_seq OWNED BY project.ui_bridge_transitions.id;
+
+
+--
+-- Name: unified_workflows; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.unified_workflows (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text DEFAULT ''::text,
+    category text DEFAULT 'general'::text,
+    tags text DEFAULT '[]'::text,
+    setup_steps text DEFAULT '[]'::text,
+    verification_steps text DEFAULT '[]'::text,
+    agentic_steps text DEFAULT '[]'::text,
+    completion_steps text DEFAULT '[]'::text,
+    max_iterations bigint,
+    provider text,
+    model text,
+    skip_ai_summary boolean DEFAULT false NOT NULL,
+    timeout_seconds bigint,
+    prompt_template text,
+    context_ids text DEFAULT '[]'::text,
+    disabled_context_ids text DEFAULT '[]'::text,
+    auto_include_contexts boolean DEFAULT true,
+    log_watch_enabled boolean DEFAULT true,
+    log_source_selection text DEFAULT '"default"'::text,
+    health_check_enabled boolean DEFAULT true,
+    health_check_urls text DEFAULT '[]'::text,
+    preflight_check_enabled boolean DEFAULT true,
+    enable_sweep boolean DEFAULT false,
+    max_sweep_iterations bigint DEFAULT 5,
+    stages text DEFAULT '[]'::text,
+    stop_on_failure boolean DEFAULT false,
+    constraint_overrides text DEFAULT '{}'::text,
+    approval_gate boolean DEFAULT false,
+    reflection_mode boolean DEFAULT true,
+    completion_prompts_first boolean DEFAULT false NOT NULL,
+    model_overrides text DEFAULT '{}'::text,
+    generated_by_task_run_id text,
+    description_embedding bytea,
+    example_status text DEFAULT 'pending'::text,
+    sync_pending boolean DEFAULT false,
+    is_favorite boolean DEFAULT false,
+    dependency_graph text,
+    cost_annotations text,
+    quality_report text,
+    acceptance_criteria text,
+    ai_reviewed boolean DEFAULT true,
+    workflow_architecture text,
+    source_file_path text,
+    source_content_hash text,
+    rollback_policy text DEFAULT 'none'::text,
+    strict_cwd boolean DEFAULT false,
+    tool_tags text DEFAULT '[]'::text,
+    enforce_token_budget boolean DEFAULT false,
+    flow_control_json text,
+    phase_timeouts_json text,
+    htn_enabled boolean DEFAULT false NOT NULL,
+    htn_ui_bridge_url text,
+    htn_state_machine_path text,
+    source_yaml text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: user_skills; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.user_skills (
+    id text NOT NULL,
+    name text NOT NULL,
+    slug text NOT NULL,
+    description text DEFAULT ''::text,
+    category text DEFAULT 'custom'::text,
+    tags text DEFAULT '[]'::text,
+    icon text DEFAULT 'puzzle'::text,
+    color text DEFAULT 'gray'::text,
+    allowed_phases text DEFAULT '["setup"]'::text NOT NULL,
+    parameters text DEFAULT '[]'::text,
+    template text NOT NULL,
+    source text DEFAULT 'user'::text NOT NULL,
+    version text DEFAULT '1.0.0'::text,
+    author text,
+    checksum text,
+    depends_on text DEFAULT '[]'::text,
+    usage_count bigint DEFAULT 0,
+    approval_status text,
+    forked_from text,
+    source_fix_id text,
+    source_pattern_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: verification_plans; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.verification_plans (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    version integer DEFAULT 1 NOT NULL,
+    plan_json text NOT NULL,
+    goal_summary text NOT NULL,
+    criteria_count integer DEFAULT 0 NOT NULL,
+    has_ai_criteria boolean DEFAULT false NOT NULL,
+    replan_reason text,
+    previous_version_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: verification_tests; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.verification_tests (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    workflow_id text,
+    test_type text DEFAULT 'python_script'::text NOT NULL,
+    command text,
+    expected_exit_code integer DEFAULT 0,
+    expected_output text,
+    timeout_seconds integer DEFAULT 60,
+    enabled boolean DEFAULT true NOT NULL,
+    tags text DEFAULT '[]'::text,
+    category text,
+    playwright_code text,
+    vision_config text,
+    python_code text,
+    repo_test_config text,
+    success_criteria text,
+    config text DEFAULT '{}'::text NOT NULL,
+    is_critical boolean DEFAULT false NOT NULL,
+    ai_generated boolean DEFAULT false NOT NULL,
+    ai_generation_prompt text,
+    creation_analysis text,
+    source_file text,
+    last_exported_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: vga_runs; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.vga_runs (
+    id uuid NOT NULL,
+    state_machine_id uuid NOT NULL,
+    task_run_id text,
+    grounding_model text NOT NULL,
+    status text NOT NULL,
+    step_log jsonb DEFAULT '[]'::jsonb NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone
+);
+
+
+--
+-- Name: vga_shadow_samples; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.vga_shadow_samples (
+    id bigint NOT NULL,
+    state_machine_id uuid,
+    image_sha text NOT NULL,
+    image_path text NOT NULL,
+    prompt text NOT NULL,
+    target_process text NOT NULL,
+    predicted_bbox jsonb NOT NULL,
+    model_used text NOT NULL,
+    confidence double precision,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: vga_shadow_samples_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.vga_shadow_samples_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: vga_shadow_samples_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.vga_shadow_samples_id_seq OWNED BY project.vga_shadow_samples.id;
+
+
+--
+-- Name: vga_state_machines; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.vga_state_machines (
+    id uuid NOT NULL,
+    name text NOT NULL,
+    target_process text NOT NULL,
+    target_os text NOT NULL,
+    grounding_model text DEFAULT 'qontinui-grounding-v5'::text NOT NULL,
+    private boolean DEFAULT true NOT NULL,
+    state_graph jsonb NOT NULL,
+    v5_proposed integer DEFAULT 0 NOT NULL,
+    v5_confirmed integer DEFAULT 0 NOT NULL,
+    v5_corrected integer DEFAULT 0 NOT NULL,
+    content_hash text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: watchers; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.watchers (
+    id text NOT NULL,
+    name text NOT NULL,
+    schedule_json text NOT NULL,
+    timeline_query text NOT NULL,
+    app_name_filter text,
+    source_type_filter text,
+    lookback_window text DEFAULT '15 minutes'::text NOT NULL,
+    reasoning_prompt text NOT NULL,
+    action_json text NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    last_run_at timestamp with time zone,
+    last_result_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_ai_sessions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_ai_sessions (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    phase text NOT NULL,
+    stage_index integer,
+    claude_cli_session_id text,
+    session_started_at timestamp with time zone NOT NULL,
+    session_completed_at timestamp with time zone,
+    output_length integer DEFAULT 0 NOT NULL,
+    status text DEFAULT 'running'::text NOT NULL
+);
+
+
+--
+-- Name: workflow_ai_sessions_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.workflow_ai_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: workflow_ai_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.workflow_ai_sessions_id_seq OWNED BY project.workflow_ai_sessions.id;
+
+
+--
+-- Name: workflow_constraint_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_constraint_results (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    constraint_id text NOT NULL,
+    constraint_name text NOT NULL,
+    passed boolean NOT NULL,
+    severity text NOT NULL,
+    violations_json text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_constraint_results_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.workflow_constraint_results_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: workflow_constraint_results_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.workflow_constraint_results_id_seq OWNED BY project.workflow_constraint_results.id;
+
+
+--
+-- Name: workflow_event_log; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_event_log (
+    id bigint NOT NULL,
+    execution_id text NOT NULL,
+    node_id text NOT NULL,
+    event_type text NOT NULL,
+    event_data text,
+    cursor bigint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_event_log_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.workflow_event_log_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: workflow_event_log_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.workflow_event_log_id_seq OWNED BY project.workflow_event_log.id;
+
+
+--
+-- Name: workflow_execution_state; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_execution_state (
+    execution_id text NOT NULL,
+    workflow_type text NOT NULL,
+    state_name text NOT NULL,
+    state_data text,
+    phase text,
+    iteration integer,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_generation_feedback; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_generation_feedback (
+    id text NOT NULL,
+    workflow_id text NOT NULL,
+    task_run_id text,
+    feedback_type text NOT NULL,
+    edited_field text,
+    old_value text,
+    new_value text,
+    delete_reason text,
+    rating integer,
+    rating_comment text,
+    workflow_category text,
+    workflow_description text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_step_checkpoints; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_step_checkpoints (
+    id text NOT NULL,
+    execution_id text NOT NULL,
+    workflow_type text NOT NULL,
+    phase text NOT NULL,
+    iteration integer,
+    step_index integer NOT NULL,
+    step_type text NOT NULL,
+    step_name text,
+    status text NOT NULL,
+    result_json text,
+    step_config_json text,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    duration_ms integer,
+    error text,
+    stage_index integer DEFAULT 0
+);
+
+
+--
+-- Name: workflow_triggers; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_triggers (
+    id text NOT NULL,
+    name text NOT NULL,
+    description text,
+    trigger_type text NOT NULL,
+    trigger_config text NOT NULL,
+    workflow_id text NOT NULL,
+    workflow_overrides text,
+    conditions text DEFAULT '[]'::text,
+    debounce_ms bigint DEFAULT 1000,
+    cooldown_seconds bigint DEFAULT 60,
+    max_concurrent integer DEFAULT 1,
+    retry_count integer DEFAULT 0,
+    retry_delay_seconds bigint DEFAULT 30,
+    enabled boolean DEFAULT true,
+    last_triggered_at timestamp with time zone,
+    last_execution_id text,
+    trigger_count bigint DEFAULT 0,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_variables; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_variables (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    variable_name text NOT NULL,
+    variable_value text NOT NULL,
+    source text NOT NULL,
+    source_step_id text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_verification_phase_results; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_verification_phase_results (
+    id text NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    all_passed boolean NOT NULL,
+    total_steps integer NOT NULL,
+    passed_steps integer NOT NULL,
+    failed_steps integer NOT NULL,
+    skipped_steps integer NOT NULL,
+    total_duration_ms bigint NOT NULL,
+    critical_failure boolean DEFAULT false NOT NULL,
+    result_json text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_versions; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.workflow_versions (
+    id text NOT NULL,
+    workflow_id text NOT NULL,
+    version_number integer NOT NULL,
+    parent_version_id text,
+    generation_task_run_id text,
+    workflow_json text NOT NULL,
+    diff_summary text,
+    diff_json text,
+    trigger text DEFAULT 'manual'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: working_representations; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.working_representations (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    observations_json text DEFAULT '[]'::text NOT NULL,
+    cross_run_patterns_json text DEFAULT '[]'::text NOT NULL,
+    entity_profiles_json text DEFAULT '[]'::text NOT NULL,
+    recent_findings_json text DEFAULT '[]'::text NOT NULL,
+    recent_fixes_json text DEFAULT '[]'::text NOT NULL,
+    applicable_skills_json text DEFAULT '[]'::text NOT NULL,
+    workflow_id text,
+    workflow_name text,
+    total_items integer DEFAULT 0 NOT NULL,
+    build_duration_ms bigint,
+    built_at timestamp with time zone DEFAULT now() NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    is_stale boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: working_representations_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.working_representations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: working_representations_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.working_representations_id_seq OWNED BY project.working_representations.id;
+
+
+--
+-- Name: wsv_shadow_disagreements; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.wsv_shadow_disagreements (
+    id bigint NOT NULL,
+    task_run_id text NOT NULL,
+    iteration integer NOT NULL,
+    text_status text NOT NULL,
+    wsm_status text NOT NULL,
+    text_confidence double precision NOT NULL,
+    wsm_confidence double precision NOT NULL,
+    intent text NOT NULL,
+    wsm_observations text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: wsv_shadow_disagreements_id_seq; Type: SEQUENCE; Schema: project; Owner: -
+--
+
+CREATE SEQUENCE project.wsv_shadow_disagreements_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: wsv_shadow_disagreements_id_seq; Type: SEQUENCE OWNED BY; Schema: project; Owner: -
+--
+
+ALTER SEQUENCE project.wsv_shadow_disagreements_id_seq OWNED BY project.wsv_shadow_disagreements.id;
+
+
+--
+-- Name: action_executions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.action_executions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid NOT NULL,
+    sequence_number integer NOT NULL,
+    action_type public.action_execution_type NOT NULL,
+    action_name character varying(255) NOT NULL,
+    status public.action_execution_status NOT NULL,
+    started_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone,
+    duration_ms integer,
+    from_state character varying(255),
+    to_state character varying(255),
+    actual_state character varying(255),
+    input_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    output_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    error_message text,
+    error_type character varying(100),
+    screenshot_id uuid,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    parent_id uuid,
+    span_type character varying(50),
+    trace_id character varying(255)
+);
+
+
+--
+-- Name: COLUMN action_executions.sequence_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.sequence_number IS 'Order of execution within the run';
+
+
+--
+-- Name: COLUMN action_executions.duration_ms; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.duration_ms IS 'Action duration in milliseconds';
+
+
+--
+-- Name: COLUMN action_executions.from_state; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.from_state IS 'Source state before action';
+
+
+--
+-- Name: COLUMN action_executions.to_state; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.to_state IS 'Expected target state after action';
+
+
+--
+-- Name: COLUMN action_executions.actual_state; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.actual_state IS 'Actual state reached after action';
+
+
+--
+-- Name: COLUMN action_executions.input_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.input_data IS 'Action input parameters';
+
+
+--
+-- Name: COLUMN action_executions.output_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.output_data IS 'Action output/results';
+
+
+--
+-- Name: COLUMN action_executions.error_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.error_type IS 'Error classification: timeout, element_not_found, etc.';
+
+
+--
+-- Name: COLUMN action_executions.screenshot_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.screenshot_id IS 'Primary screenshot for this action';
+
+
+--
+-- Name: COLUMN action_executions.metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.metadata IS 'Additional action metadata';
+
+
+--
+-- Name: COLUMN action_executions.parent_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.parent_id IS 'Parent action execution for span nesting';
+
+
+--
+-- Name: COLUMN action_executions.span_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.span_type IS 'Span type: action, llm_call, tool_use, retrieval (None defaults to action)';
+
+
+--
+-- Name: COLUMN action_executions.trace_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.action_executions.trace_id IS 'Distributed trace correlation ID';
+
+
+--
+-- Name: action_frames; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.action_frames (
+    id integer NOT NULL,
+    video_capture_session_id integer NOT NULL,
+    snapshot_action_id integer NOT NULL,
+    frame_number integer NOT NULL,
+    timestamp_ms bigint NOT NULL,
+    frame_type character varying(20) NOT NULL,
+    cached_frame_path text,
+    cache_storage_backend character varying(20)
+);
+
+
+--
+-- Name: action_frames_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.action_frames_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: action_frames_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.action_frames_id_seq OWNED BY public.action_frames.id;
+
+
+--
+-- Name: activity_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.activity_logs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    action_type public.actiontype NOT NULL,
+    resource_type public.resourcetype NOT NULL,
+    resource_id character varying NOT NULL,
+    resource_name character varying,
+    changes json,
+    metadata json,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: admin_notification_settings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.admin_notification_settings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    notification_email character varying NOT NULL,
+    notify_on_user_signup boolean NOT NULL,
+    notify_on_project_created boolean NOT NULL,
+    notifications_enabled boolean NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN admin_notification_settings.notification_email; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.admin_notification_settings.notification_email IS 'Email address to send admin notifications to';
+
+
+--
+-- Name: COLUMN admin_notification_settings.notify_on_user_signup; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.admin_notification_settings.notify_on_user_signup IS 'Send notification when a new user signs up';
+
+
+--
+-- Name: COLUMN admin_notification_settings.notify_on_project_created; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.admin_notification_settings.notify_on_project_created IS 'Send notification when a new project is created';
+
+
+--
+-- Name: COLUMN admin_notification_settings.notifications_enabled; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.admin_notification_settings.notifications_enabled IS 'Master toggle for all admin notifications';
+
+
+--
+-- Name: ai_prompt_templates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ai_prompt_templates (
+    id character varying NOT NULL,
+    project_id uuid NOT NULL,
+    created_by uuid NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    category character varying,
+    tags json NOT NULL,
+    prompt text NOT NULL,
+    parameters json NOT NULL,
+    default_timeout integer,
+    default_working_directory character varying,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    current_version integer
+);
+
+
+--
 -- Name: alembic_version; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.alembic_version (
-    version_num character varying(32) NOT NULL
+    version_num character varying(128) NOT NULL
 );
+
+
+--
+-- Name: analytics_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.analytics_events (
+    id uuid NOT NULL,
+    event_name character varying(255) NOT NULL,
+    user_id uuid,
+    properties jsonb NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: annotation_sets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.annotation_sets (
+    id uuid NOT NULL,
+    screenshot_name character varying NOT NULL,
+    screenshot_url character varying NOT NULL,
+    image_width integer NOT NULL,
+    image_height integer NOT NULL,
+    screenshots json,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    created_by_id uuid NOT NULL,
+    notes text,
+    boundary_width integer NOT NULL
+);
+
+
+--
+-- Name: annotations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.annotations (
+    id uuid NOT NULL,
+    annotation_set_id uuid NOT NULL,
+    screenshot_index integer NOT NULL,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    label character varying,
+    description text,
+    reason text,
+    extra_data json,
+    "order" integer
+);
+
+
+--
+-- Name: application_profiles; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.application_profiles (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    inference_config json DEFAULT '{}'::json NOT NULL,
+    preferred_strategies json,
+    avg_element_size json,
+    common_color_ranges json,
+    edge_threshold_overrides json,
+    tuning_metrics json,
+    success_rate double precision DEFAULT '0'::double precision NOT NULL,
+    sample_count integer DEFAULT 0 NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: audit_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.audit_logs (
+    id integer NOT NULL,
+    user_id uuid,
+    action character varying NOT NULL,
+    resource_type character varying,
+    resource_id character varying,
+    log_metadata json,
+    ip_address character varying,
+    created_at timestamp with time zone,
+    event_category character varying,
+    correlation_id character varying,
+    target_user_id uuid,
+    changes json
+);
+
+
+--
+-- Name: COLUMN audit_logs.event_category; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.audit_logs.event_category IS 'Category: permission_change, membership_change, pii_access, account_modification, etc.';
+
+
+--
+-- Name: COLUMN audit_logs.correlation_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.audit_logs.correlation_id IS 'Request correlation ID for tracing related events';
+
+
+--
+-- Name: COLUMN audit_logs.target_user_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.audit_logs.target_user_id IS 'User being affected by the action (for permission/membership changes)';
+
+
+--
+-- Name: COLUMN audit_logs.changes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.audit_logs.changes IS 'Before/after state for modifications as {before: {...}, after: {...}}';
+
+
+--
+-- Name: audit_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.audit_logs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: audit_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.audit_logs_id_seq OWNED BY public.audit_logs.id;
 
 
 --
@@ -694,6 +5817,557 @@ ALTER SEQUENCE public.automation_input_events_id_seq OWNED BY public.automation_
 
 
 --
+-- Name: automation_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.automation_logs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id uuid NOT NULL,
+    sequence_number integer NOT NULL,
+    level character varying(50) NOT NULL,
+    message text NOT NULL,
+    log_data jsonb NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: automation_screenshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.automation_screenshots (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    storage_path character varying(500) NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    content_type character varying(100) NOT NULL,
+    automation_metadata json NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    presigned_url character varying(2048),
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: automation_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.automation_sessions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid,
+    user_id uuid NOT NULL,
+    runner_version character varying(100) NOT NULL,
+    runner_os character varying(100) NOT NULL,
+    runner_hostname character varying(255) NOT NULL,
+    status character varying(50) NOT NULL,
+    configuration_snapshot json NOT NULL,
+    max_duration_seconds integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    ended_at timestamp with time zone
+);
+
+
+--
+-- Name: automation_videos; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.automation_videos (
+    id integer NOT NULL,
+    session_id character varying NOT NULL,
+    user_id uuid NOT NULL,
+    project_id uuid,
+    s3_key character varying NOT NULL,
+    duration_seconds integer,
+    fps integer,
+    quality character varying,
+    file_size_bytes integer NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: automation_videos_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.automation_videos_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automation_videos_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.automation_videos_id_seq OWNED BY public.automation_videos.id;
+
+
+--
+-- Name: capture_actions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.capture_actions (
+    id uuid NOT NULL,
+    screenshot_id uuid NOT NULL,
+    sequence_number integer NOT NULL,
+    action_type character varying(50) NOT NULL,
+    x integer,
+    y integer,
+    text text,
+    key character varying(50),
+    button character varying(20),
+    scroll_delta integer,
+    "timestamp" timestamp with time zone NOT NULL,
+    extra_metadata json
+);
+
+
+--
+-- Name: capture_detected_elements; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.capture_detected_elements (
+    id uuid NOT NULL,
+    screenshot_id uuid NOT NULL,
+    element_type character varying(50) NOT NULL,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    text_content text,
+    confidence double precision NOT NULL,
+    properties json,
+    visual_hash character varying(64)
+);
+
+
+--
+-- Name: capture_screenshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.capture_screenshots (
+    id uuid NOT NULL,
+    session_id uuid NOT NULL,
+    sequence_number integer NOT NULL,
+    image_url character varying(500) NOT NULL,
+    thumbnail_url character varying(500),
+    width integer NOT NULL,
+    height integer NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    extra_metadata json,
+    analysis_status character varying(50) NOT NULL
+);
+
+
+--
+-- Name: capture_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.capture_sessions (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    status character varying(50) NOT NULL,
+    extra_metadata json,
+    created_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: clipboard_entries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.clipboard_entries (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    source_device_id character varying(255) NOT NULL,
+    source_device_name character varying(255) NOT NULL,
+    content_type character varying(50) NOT NULL,
+    text_content text,
+    image_url character varying(2048),
+    file_ref jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    expires_at timestamp with time zone DEFAULT (now() + '24:00:00'::interval) NOT NULL
+);
+
+
+--
+-- Name: code_packages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.code_packages (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    slug character varying NOT NULL,
+    description text NOT NULL,
+    long_description text,
+    author_id uuid NOT NULL,
+    category_id integer,
+    license character varying,
+    tags json NOT NULL,
+    is_verified boolean NOT NULL,
+    total_downloads integer NOT NULL,
+    avg_rating numeric(3,2),
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: code_packages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.code_packages_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: code_packages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.code_packages_id_seq OWNED BY public.code_packages.id;
+
+
+--
+-- Name: conflict_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.conflict_logs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    resource_type character varying NOT NULL,
+    resource_id character varying NOT NULL,
+    local_version integer NOT NULL,
+    remote_version integer NOT NULL,
+    local_user_id uuid NOT NULL,
+    remote_user_id uuid NOT NULL,
+    base_data json,
+    local_data json,
+    remote_data json,
+    changes json,
+    detected_at timestamp with time zone NOT NULL,
+    resolved boolean NOT NULL,
+    resolved_at timestamp with time zone,
+    resolution_type character varying,
+    resolved_data json,
+    metadata json
+);
+
+
+--
+-- Name: coverage_snapshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.coverage_snapshots (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_run_id uuid,
+    project_id uuid NOT NULL,
+    workflow_id character varying(255),
+    snapshot_time timestamp with time zone NOT NULL,
+    transitions_covered integer NOT NULL,
+    transitions_total integer NOT NULL,
+    coverage_percentage numeric(5,2) NOT NULL,
+    states_covered integer NOT NULL,
+    states_total integer NOT NULL,
+    state_coverage_percentage numeric(5,2) NOT NULL,
+    paths_discovered integer NOT NULL,
+    unique_paths integer NOT NULL,
+    coverage_map jsonb NOT NULL,
+    state_coverage_map jsonb NOT NULL,
+    uncovered_transitions jsonb NOT NULL,
+    uncovered_states jsonb NOT NULL,
+    snapshot_metadata jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN coverage_snapshots.coverage_map; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.coverage_snapshots.coverage_map IS '{transition_id: execution_count, ...}';
+
+
+--
+-- Name: COLUMN coverage_snapshots.state_coverage_map; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.coverage_snapshots.state_coverage_map IS '{state_id: visit_count, ...}';
+
+
+--
+-- Name: COLUMN coverage_snapshots.uncovered_transitions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.coverage_snapshots.uncovered_transitions IS 'Array of transition IDs';
+
+
+--
+-- Name: COLUMN coverage_snapshots.uncovered_states; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.coverage_snapshots.uncovered_states IS 'Array of state IDs';
+
+
+--
+-- Name: custom_functions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.custom_functions (
+    id integer NOT NULL,
+    project_id uuid NOT NULL,
+    file_path character varying NOT NULL,
+    function_name character varying NOT NULL,
+    display_name character varying,
+    description text,
+    category character varying,
+    tags json NOT NULL,
+    parameters json NOT NULL,
+    return_type character varying,
+    inputs json NOT NULL,
+    outputs json NOT NULL,
+    observable_outputs json NOT NULL,
+    source_code text,
+    docstring text,
+    line_start integer,
+    line_end integer,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: custom_functions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.custom_functions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: custom_functions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.custom_functions_id_seq OWNED BY public.custom_functions.id;
+
+
+--
+-- Name: dataset_items; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.dataset_items (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    dataset_id uuid NOT NULL,
+    input jsonb NOT NULL,
+    expected_output jsonb,
+    metadata jsonb,
+    content_hash character varying(64) NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: deferred_questions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.deferred_questions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_run_id uuid NOT NULL,
+    iteration integer NOT NULL,
+    question text NOT NULL,
+    context_json text DEFAULT '{}'::text NOT NULL,
+    auto_decision_type character varying(100) NOT NULL,
+    auto_decision_detail text,
+    confidence double precision NOT NULL,
+    risk_level character varying(50) NOT NULL,
+    status character varying(50) DEFAULT 'pending'::character varying NOT NULL,
+    git_checkpoint character varying(255),
+    contingent_iterations text DEFAULT '[]'::text NOT NULL,
+    reviewer_comment text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    reviewed_at timestamp with time zone
+);
+
+
+--
+-- Name: detected_issues; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.detected_issues (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id character varying(255) NOT NULL,
+    project_id uuid,
+    user_id uuid NOT NULL,
+    type character varying(50) NOT NULL,
+    severity character varying(20) NOT NULL,
+    title character varying(500) NOT NULL,
+    description text,
+    file character varying(1000),
+    line integer,
+    source jsonb NOT NULL,
+    status character varying(20) NOT NULL,
+    resolution text,
+    detected_at timestamp with time zone NOT NULL,
+    resolved_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: device_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.device_sessions (
+    id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    device_fingerprint character varying(255) NOT NULL,
+    ip_address character varying(45) NOT NULL,
+    user_agent text NOT NULL,
+    accept_language character varying(255),
+    is_trusted boolean NOT NULL,
+    first_seen timestamp with time zone NOT NULL,
+    last_seen timestamp with time zone NOT NULL,
+    last_ip character varying(45) NOT NULL,
+    device_name character varying(255),
+    email_verified boolean NOT NULL,
+    verification_token text,
+    verification_sent_at timestamp with time zone,
+    country character varying(100),
+    city character varying(100),
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: discovered_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.discovered_states (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    source_type character varying(50) NOT NULL,
+    automation_session_id uuid,
+    recording_id uuid,
+    session_id uuid,
+    state_id character varying(100),
+    name character varying(255),
+    description text,
+    cluster_id integer,
+    confidence double precision NOT NULL,
+    uniqueness_score double precision,
+    stability_score double precision,
+    distinctiveness_score double precision,
+    metadata json DEFAULT '{}'::json NOT NULL,
+    screenshot_ids uuid[] DEFAULT '{}'::uuid[],
+    frame_ids json DEFAULT '[]'::json,
+    frame_count integer,
+    state_images json DEFAULT '[]'::json NOT NULL,
+    regions json DEFAULT '[]'::json,
+    locations json DEFAULT '[]'::json,
+    strings json DEFAULT '[]'::json,
+    position_x double precision,
+    position_y double precision,
+    is_initial boolean,
+    is_error_state boolean,
+    is_transient boolean,
+    window_context json,
+    url_context character varying,
+    user_edited boolean,
+    user_approved boolean,
+    user_notes text,
+    converted_to_state_id uuid,
+    converted_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT check_single_source CHECK ((((automation_session_id IS NOT NULL) AND (recording_id IS NULL) AND ((source_type)::text = 'automation_session'::text)) OR ((automation_session_id IS NULL) AND (recording_id IS NOT NULL) AND ((source_type)::text = 'recording'::text))))
+);
+
+
+--
+-- Name: discovered_transitions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.discovered_transitions (
+    id uuid NOT NULL,
+    recording_id uuid NOT NULL,
+    from_state_id uuid NOT NULL,
+    to_state_id uuid,
+    activate_state_ids json,
+    deactivate_state_ids json,
+    stays_visible boolean,
+    trigger_interaction_id uuid,
+    trigger_type character varying,
+    trigger_description text,
+    latency_ms integer,
+    recommended_timeout_ms integer,
+    recommended_retry_count integer,
+    workflow json,
+    workflow_name character varying,
+    confidence double precision,
+    clarity_score double precision,
+    consistency_score double precision,
+    completeness_score double precision,
+    position_x double precision,
+    position_y double precision,
+    user_edited boolean,
+    user_approved boolean,
+    user_notes text,
+    converted_to_transition_id uuid,
+    converted_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: discoveries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.discoveries (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    runner_id character varying(100) NOT NULL,
+    runner_name character varying(255),
+    config_id character varying(100) NOT NULL,
+    config_name character varying(255),
+    discovery_type character varying(50) NOT NULL,
+    title character varying(500) NOT NULL,
+    description text,
+    discovery_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    evidence jsonb DEFAULT '{}'::jsonb NOT NULL,
+    confidence double precision NOT NULL,
+    runs_observed integer NOT NULL,
+    status character varying(20) NOT NULL,
+    reviewed_at timestamp with time zone,
+    reviewed_by_id uuid,
+    user_notes text,
+    applied_to_config boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
 -- Name: domain_knowledge; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -714,6 +6388,149 @@ CREATE TABLE public.domain_knowledge (
 --
 
 COMMENT ON COLUMN public.domain_knowledge.content_embedding IS '384-dim MiniLM embedding of the knowledge content';
+
+
+--
+-- Name: edit_commands; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.edit_commands (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid,
+    command_type character varying NOT NULL,
+    entity_type character varying NOT NULL,
+    entity_id character varying NOT NULL,
+    payload json NOT NULL,
+    sequence_number integer NOT NULL,
+    applied_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: element_annotation_sets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.element_annotation_sets (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    screenshot_width integer NOT NULL,
+    screenshot_height integer NOT NULL,
+    screenshot_url character varying,
+    version_number integer DEFAULT 1 NOT NULL,
+    is_current boolean DEFAULT true NOT NULL,
+    version_comment text,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_by_id uuid NOT NULL
+);
+
+
+--
+-- Name: element_annotations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.element_annotations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    annotation_set_id uuid NOT NULL,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    label character varying,
+    element_type character varying,
+    description text,
+    notes text,
+    extra_data json,
+    "order" integer DEFAULT 0 NOT NULL,
+    client_id character varying
+);
+
+
+--
+-- Name: embedding_generation_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.embedding_generation_jobs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    status character varying(50) NOT NULL,
+    total_patterns integer NOT NULL,
+    processed_patterns integer NOT NULL,
+    error_message text,
+    retry_count integer NOT NULL,
+    max_retries integer NOT NULL,
+    job_metadata jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: error_monitor_entries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.error_monitor_entries (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    task_run_id uuid,
+    error_type character varying(255) NOT NULL,
+    message text NOT NULL,
+    stack_trace text,
+    severity character varying(20) DEFAULT 'medium'::character varying NOT NULL,
+    status character varying(20) DEFAULT 'open'::character varying NOT NULL,
+    category character varying(100),
+    source character varying(255),
+    file_path character varying(500),
+    line_number integer,
+    occurrence_count integer DEFAULT 1 NOT NULL,
+    first_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    last_seen_at timestamp with time zone DEFAULT now() NOT NULL,
+    acknowledged boolean DEFAULT false NOT NULL,
+    acknowledged_at timestamp with time zone,
+    resolved_at timestamp with time zone,
+    resolution_notes text,
+    resolved_by_task_run_id uuid,
+    extra_metadata jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: evaluation_datasets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evaluation_datasets (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    version integer DEFAULT 1 NOT NULL,
+    content_hash character varying(64),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone
+);
+
+
+--
+-- Name: evaluation_experiments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.evaluation_experiments (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying(255) NOT NULL,
+    dataset_id uuid NOT NULL,
+    dataset_version integer DEFAULT 1 NOT NULL,
+    prompt_variant_id character varying(255),
+    description text,
+    status character varying(50) DEFAULT 'pending'::character varying NOT NULL,
+    metrics jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
 
 
 --
@@ -802,6 +6619,554 @@ COMMENT ON COLUMN public.execution_issues.resolution_embedding IS '384-dim MiniL
 
 
 --
+-- Name: execution_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.execution_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    run_type public.execution_run_type NOT NULL,
+    run_name character varying(255) NOT NULL,
+    description text,
+    status public.execution_run_status NOT NULL,
+    started_at timestamp with time zone NOT NULL,
+    ended_at timestamp with time zone,
+    duration_seconds integer,
+    runner_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    workflow_metadata jsonb,
+    configuration jsonb DEFAULT '{}'::jsonb NOT NULL,
+    stats jsonb DEFAULT '{}'::jsonb NOT NULL,
+    coverage_data jsonb,
+    max_duration_seconds integer,
+    error_message text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_by_user_id uuid
+);
+
+
+--
+-- Name: COLUMN execution_runs.duration_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.duration_seconds IS 'Total run duration in seconds';
+
+
+--
+-- Name: COLUMN execution_runs.runner_metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.runner_metadata IS 'Runner info: version, os, hostname, capabilities';
+
+
+--
+-- Name: COLUMN execution_runs.workflow_metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.workflow_metadata IS 'Workflow info: workflow_id, workflow_name, version';
+
+
+--
+-- Name: COLUMN execution_runs.configuration; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.configuration IS 'Run configuration: timeouts, retries, environment';
+
+
+--
+-- Name: COLUMN execution_runs.stats; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.stats IS 'Run statistics: total_actions, successful_actions, failed_actions';
+
+
+--
+-- Name: COLUMN execution_runs.coverage_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.coverage_data IS 'Coverage data: states_visited, transitions_executed, etc.';
+
+
+--
+-- Name: COLUMN execution_runs.max_duration_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_runs.max_duration_seconds IS 'Maximum allowed duration before timeout';
+
+
+--
+-- Name: execution_screenshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.execution_screenshots (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid NOT NULL,
+    action_execution_id uuid,
+    sequence_number integer NOT NULL,
+    screenshot_type public.execution_screenshot_type NOT NULL,
+    storage_path character varying(500) NOT NULL,
+    image_url character varying(500) NOT NULL,
+    thumbnail_url character varying(500),
+    width integer NOT NULL,
+    height integer NOT NULL,
+    file_size_bytes integer NOT NULL,
+    state_name character varying(255),
+    perceptual_hash character varying(64),
+    captured_at timestamp with time zone NOT NULL,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN execution_screenshots.sequence_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.sequence_number IS 'Order of screenshot within the run';
+
+
+--
+-- Name: COLUMN execution_screenshots.storage_path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.storage_path IS 'Path in storage system (S3, MinIO, local)';
+
+
+--
+-- Name: COLUMN execution_screenshots.image_url; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.image_url IS 'Public URL to access the image';
+
+
+--
+-- Name: COLUMN execution_screenshots.thumbnail_url; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.thumbnail_url IS 'URL to thumbnail version';
+
+
+--
+-- Name: COLUMN execution_screenshots.state_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.state_name IS 'State name when screenshot was taken';
+
+
+--
+-- Name: COLUMN execution_screenshots.perceptual_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.perceptual_hash IS 'Perceptual hash for image similarity comparison';
+
+
+--
+-- Name: COLUMN execution_screenshots.metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_screenshots.metadata IS 'Additional screenshot metadata: annotations, regions, etc.';
+
+
+--
+-- Name: execution_tree_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.execution_tree_events (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid NOT NULL,
+    event_type character varying(50) NOT NULL,
+    node_id character varying(100) NOT NULL,
+    node_type character varying(20) NOT NULL,
+    node_name character varying(255) NOT NULL,
+    parent_node_id character varying(100),
+    path jsonb,
+    sequence integer NOT NULL,
+    event_timestamp double precision NOT NULL,
+    node_start_timestamp double precision,
+    node_end_timestamp double precision,
+    duration_ms double precision,
+    status character varying(20) NOT NULL,
+    error_message text,
+    active_states_before jsonb,
+    active_states_after jsonb,
+    states_changed boolean NOT NULL,
+    node_metadata jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN execution_tree_events.event_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.event_type IS 'Type of tree event (workflow_started, action_completed, etc.)';
+
+
+--
+-- Name: COLUMN execution_tree_events.node_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.node_id IS 'Unique identifier of the node within this execution';
+
+
+--
+-- Name: COLUMN execution_tree_events.node_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.node_type IS 'Type of node (workflow, action, transition)';
+
+
+--
+-- Name: COLUMN execution_tree_events.node_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.node_name IS 'Display name of the node';
+
+
+--
+-- Name: COLUMN execution_tree_events.parent_node_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.parent_node_id IS 'Parent node ID, null for root nodes';
+
+
+--
+-- Name: COLUMN execution_tree_events.path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.path IS 'Path from root to this node (list of PathElement objects)';
+
+
+--
+-- Name: COLUMN execution_tree_events.sequence; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.sequence IS 'Sequence number for event ordering within a run';
+
+
+--
+-- Name: COLUMN execution_tree_events.event_timestamp; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.event_timestamp IS 'When this event was emitted (Unix epoch in seconds)';
+
+
+--
+-- Name: COLUMN execution_tree_events.node_start_timestamp; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.node_start_timestamp IS 'When the node started (Unix epoch)';
+
+
+--
+-- Name: COLUMN execution_tree_events.node_end_timestamp; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.node_end_timestamp IS 'When the node completed (Unix epoch)';
+
+
+--
+-- Name: COLUMN execution_tree_events.duration_ms; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.duration_ms IS 'Node duration in milliseconds';
+
+
+--
+-- Name: COLUMN execution_tree_events.status; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.status IS 'Node status (pending, running, success, failed)';
+
+
+--
+-- Name: COLUMN execution_tree_events.error_message; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.error_message IS 'Error message if the node failed';
+
+
+--
+-- Name: COLUMN execution_tree_events.active_states_before; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.active_states_before IS 'Active states before this event';
+
+
+--
+-- Name: COLUMN execution_tree_events.active_states_after; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.active_states_after IS 'Active states after this event';
+
+
+--
+-- Name: COLUMN execution_tree_events.states_changed; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.states_changed IS 'Whether the active states changed';
+
+
+--
+-- Name: COLUMN execution_tree_events.node_metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_tree_events.node_metadata IS 'Full node metadata including runtime data, timing, outcome, etc.';
+
+
+--
+-- Name: experiment_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.experiment_results (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    experiment_id uuid NOT NULL,
+    dataset_item_id uuid NOT NULL,
+    output jsonb NOT NULL,
+    scores jsonb,
+    duration_ms double precision,
+    cost_usd double precision,
+    tokens_total integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: extraction_annotations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.extraction_annotations (
+    id uuid NOT NULL,
+    session_id uuid NOT NULL,
+    screenshot_id character varying(100) NOT NULL,
+    source_url text NOT NULL,
+    viewport_width integer NOT NULL,
+    viewport_height integer NOT NULL,
+    elements json NOT NULL,
+    states json NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    vision_results json
+);
+
+
+--
+-- Name: extraction_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.extraction_sessions (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    source_urls character varying[] NOT NULL,
+    config json NOT NULL,
+    status character varying(50) NOT NULL,
+    error_message text,
+    stats json NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    created_by uuid,
+    state_machine json
+);
+
+
+--
+-- Name: feedback_scores; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.feedback_scores (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid,
+    action_execution_id uuid,
+    name character varying(255) NOT NULL,
+    value double precision NOT NULL,
+    category_value character varying(255),
+    source character varying(50) DEFAULT 'manual'::character varying NOT NULL,
+    reason text,
+    metadata jsonb,
+    created_by character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: finding_category_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.finding_category_configs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    slug character varying(100) NOT NULL,
+    name character varying(255) NOT NULL,
+    description text NOT NULL,
+    icon character varying(50) NOT NULL,
+    color character varying(30) NOT NULL,
+    is_built_in boolean NOT NULL,
+    default_action_type character varying(30) NOT NULL,
+    sort_order integer NOT NULL,
+    enabled boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: frame_index; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.frame_index (
+    id bigint NOT NULL,
+    video_capture_session_id integer NOT NULL,
+    frame_number integer NOT NULL,
+    timestamp_ms bigint NOT NULL,
+    byte_offset bigint,
+    is_keyframe boolean NOT NULL,
+    frame_hash character varying(64)
+);
+
+
+--
+-- Name: frame_index_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.frame_index_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: frame_index_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.frame_index_id_seq OWNED BY public.frame_index.id;
+
+
+--
+-- Name: gui_action_type_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.gui_action_type_configs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    action_type character varying(50) NOT NULL,
+    label character varying(255) NOT NULL,
+    description text NOT NULL,
+    icon character varying(50) NOT NULL,
+    is_built_in boolean NOT NULL,
+    sort_order integer NOT NULL,
+    enabled boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: historical_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.historical_results (
+    id bigint NOT NULL,
+    snapshot_run_id integer,
+    snapshot_action_id integer,
+    video_capture_session_id integer,
+    pattern_id character varying(255),
+    pattern_name character varying(255),
+    action_type character varying(50) NOT NULL,
+    active_states text[],
+    success boolean NOT NULL,
+    match_count integer,
+    best_match_score numeric(5,4),
+    duration_ms numeric(10,3),
+    match_x integer,
+    match_y integer,
+    match_width integer,
+    match_height integer,
+    frame_timestamp_ms bigint,
+    frame_number integer,
+    result_data_json jsonb NOT NULL,
+    workflow_id integer,
+    project_id uuid,
+    recorded_at timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    test_run_id uuid,
+    sequence_number integer
+);
+
+
+--
+-- Name: COLUMN historical_results.sequence_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.historical_results.sequence_number IS 'Order of recognition within the test run';
+
+
+--
+-- Name: historical_results_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.historical_results_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: historical_results_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.historical_results_id_seq OWNED BY public.historical_results.id;
+
+
+--
+-- Name: input_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.input_events (
+    id bigint NOT NULL,
+    video_capture_session_id integer NOT NULL,
+    timestamp_ms bigint NOT NULL,
+    event_type character varying(50) NOT NULL,
+    mouse_x integer,
+    mouse_y integer,
+    mouse_button smallint,
+    scroll_dx integer,
+    scroll_dy integer,
+    key_code character varying(50),
+    key_name character varying(50),
+    key_char character varying(10),
+    shift_pressed boolean,
+    ctrl_pressed boolean,
+    alt_pressed boolean,
+    meta_pressed boolean,
+    event_data_json jsonb
+);
+
+
+--
+-- Name: input_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.input_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: input_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.input_events_id_seq OWNED BY public.input_events.id;
+
+
+--
 -- Name: known_issues; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -839,6 +7204,198 @@ CREATE TABLE public.known_issues (
 
 
 --
+-- Name: learned_workflows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.learned_workflows (
+    id uuid NOT NULL,
+    session_id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    workflow_json json NOT NULL,
+    confidence double precision NOT NULL,
+    status character varying(50) NOT NULL,
+    warnings json,
+    created_at timestamp with time zone NOT NULL,
+    reviewed_at timestamp with time zone,
+    reviewer_id uuid,
+    published_info json
+);
+
+
+--
+-- Name: library_check_groups; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_check_groups (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    check_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    stop_on_failure boolean DEFAULT false NOT NULL,
+    run_in_parallel boolean DEFAULT false NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: library_checks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_checks (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    check_type character varying(50) DEFAULT 'custom'::character varying NOT NULL,
+    tool character varying(100),
+    command text,
+    working_directory character varying(500),
+    config_path character varying(500),
+    auto_fix boolean DEFAULT false NOT NULL,
+    fail_on_warning boolean DEFAULT false NOT NULL,
+    is_critical boolean DEFAULT false NOT NULL,
+    timeout_seconds integer DEFAULT 300 NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: library_contexts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_contexts (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    content text NOT NULL,
+    category character varying(100),
+    scope character varying(50),
+    enabled boolean DEFAULT true NOT NULL,
+    auto_include jsonb,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: library_macros; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_macros (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    category character varying(100),
+    steps jsonb DEFAULT '[]'::jsonb NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: library_prompt_snippets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_prompt_snippets (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    language character varying(50) DEFAULT 'python'::character varying NOT NULL,
+    code text NOT NULL,
+    category character varying(100),
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: library_saved_api_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_saved_api_requests (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    method character varying(10) DEFAULT 'GET'::character varying NOT NULL,
+    url text NOT NULL,
+    headers jsonb DEFAULT '{}'::jsonb NOT NULL,
+    body text,
+    auth_config jsonb,
+    variables jsonb DEFAULT '{}'::jsonb NOT NULL,
+    timeout_ms integer DEFAULT 30000 NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: library_shell_commands; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.library_shell_commands (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    command text NOT NULL,
+    working_directory character varying(500),
+    platform character varying(50),
+    timeout_seconds integer DEFAULT 60 NOT NULL,
+    fail_on_error boolean DEFAULT true NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: notification_preferences; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notification_preferences (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    email_mentions boolean NOT NULL,
+    email_comments boolean NOT NULL,
+    email_shares boolean NOT NULL,
+    email_replies boolean NOT NULL,
+    email_team_invites boolean NOT NULL,
+    in_app_mentions boolean NOT NULL,
+    in_app_comments boolean NOT NULL,
+    in_app_shares boolean NOT NULL,
+    in_app_replies boolean NOT NULL,
+    in_app_team_invites boolean NOT NULL,
+    in_app_project_updates boolean NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
 -- Name: notifications; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -857,6 +7414,274 @@ CREATE TABLE public.notifications (
     metadata json,
     created_at timestamp with time zone NOT NULL
 );
+
+
+--
+-- Name: organization_invitations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_invitations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    email character varying NOT NULL,
+    role character varying NOT NULL,
+    invited_by uuid,
+    token character varying NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    accepted_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: organizations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organizations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying NOT NULL,
+    slug character varying NOT NULL,
+    description text,
+    owner_id uuid NOT NULL,
+    avatar_url character varying,
+    settings json NOT NULL,
+    is_active boolean NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: package_categories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.package_categories (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    slug character varying NOT NULL,
+    description text,
+    icon character varying,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: package_categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.package_categories_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: package_categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.package_categories_id_seq OWNED BY public.package_categories.id;
+
+
+--
+-- Name: package_installations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.package_installations (
+    id integer NOT NULL,
+    package_id integer NOT NULL,
+    version_id integer NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    status character varying NOT NULL,
+    installed_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT chk_installation_status CHECK (((status)::text = ANY ((ARRAY['active'::character varying, 'disabled'::character varying])::text[])))
+);
+
+
+--
+-- Name: package_installations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.package_installations_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: package_installations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.package_installations_id_seq OWNED BY public.package_installations.id;
+
+
+--
+-- Name: package_ratings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.package_ratings (
+    id integer NOT NULL,
+    package_id integer NOT NULL,
+    user_id uuid NOT NULL,
+    rating integer NOT NULL,
+    review_text text,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    CONSTRAINT chk_rating_range CHECK (((rating >= 1) AND (rating <= 5)))
+);
+
+
+--
+-- Name: package_ratings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.package_ratings_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: package_ratings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.package_ratings_id_seq OWNED BY public.package_ratings.id;
+
+
+--
+-- Name: package_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.package_versions (
+    id integer NOT NULL,
+    package_id integer NOT NULL,
+    version character varying NOT NULL,
+    code_content text NOT NULL,
+    function_name character varying NOT NULL,
+    changelog text,
+    dependencies json NOT NULL,
+    min_python_version character varying,
+    security_scan_status character varying NOT NULL,
+    security_scan_result json,
+    download_count integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    CONSTRAINT chk_security_scan_status CHECK (((security_scan_status)::text = ANY ((ARRAY['pending'::character varying, 'scanning'::character varying, 'passed'::character varying, 'failed'::character varying, 'skipped'::character varying])::text[])))
+);
+
+
+--
+-- Name: package_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.package_versions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: package_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.package_versions_id_seq OWNED BY public.package_versions.id;
+
+
+--
+-- Name: path_discoveries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.path_discoveries (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_run_id uuid NOT NULL,
+    path_hash character varying(64) NOT NULL,
+    path_sequence jsonb NOT NULL,
+    path_length integer NOT NULL,
+    unique_states_visited integer NOT NULL,
+    unique_transitions_used integer NOT NULL,
+    discovered_at timestamp with time zone NOT NULL,
+    execution_time_ms integer,
+    success boolean NOT NULL,
+    end_state character varying(255),
+    is_cyclic boolean NOT NULL,
+    cycle_detected_at integer,
+    occurrence_count integer NOT NULL,
+    last_traversed_at timestamp with time zone NOT NULL,
+    path_metadata jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN path_discoveries.path_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.path_discoveries.path_hash IS 'SHA256 of path_sequence for quick lookup';
+
+
+--
+-- Name: COLUMN path_discoveries.path_sequence; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.path_discoveries.path_sequence IS 'Array of {state: "", transition: ""}';
+
+
+--
+-- Name: COLUMN path_discoveries.cycle_detected_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.path_discoveries.cycle_detected_at IS 'Step number where cycle detected';
+
+
+--
+-- Name: patterns; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.patterns (
+    id integer NOT NULL,
+    snapshot_run_id integer NOT NULL,
+    pattern_id character varying(255) NOT NULL,
+    name character varying(255) NOT NULL,
+    type character varying(50) NOT NULL,
+    screenshot_path character varying(500) NOT NULL,
+    region json NOT NULL,
+    active_states json NOT NULL,
+    confidence double precision NOT NULL,
+    metadata json NOT NULL
+);
+
+
+--
+-- Name: patterns_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.patterns_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: patterns_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.patterns_id_seq OWNED BY public.patterns.id;
 
 
 --
@@ -961,6 +7786,105 @@ CREATE TABLE public.processing_logs (
 
 
 --
+-- Name: project_access_control; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_access_control (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid,
+    organization_id uuid,
+    permission_level character varying NOT NULL,
+    created_by uuid,
+    expires_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL,
+    CONSTRAINT chk_user_or_org CHECK ((((user_id IS NOT NULL) AND (organization_id IS NULL)) OR ((user_id IS NULL) AND (organization_id IS NOT NULL))))
+);
+
+
+--
+-- Name: project_annotation_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_annotation_states (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    version_id character varying(36) NOT NULL,
+    version_number integer DEFAULT 1 NOT NULL,
+    element_count integer DEFAULT 0 NOT NULL,
+    elements_hash character varying(32) DEFAULT ''::character varying NOT NULL,
+    annotation_data json,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_by_id uuid
+);
+
+
+--
+-- Name: COLUMN project_annotation_states.version_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.project_annotation_states.version_id IS 'UUID string for version identification';
+
+
+--
+-- Name: COLUMN project_annotation_states.version_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.project_annotation_states.version_number IS 'Incrementing version number';
+
+
+--
+-- Name: COLUMN project_annotation_states.element_count; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.project_annotation_states.element_count IS 'Number of annotation elements';
+
+
+--
+-- Name: COLUMN project_annotation_states.elements_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.project_annotation_states.elements_hash IS 'MD5 hash of JSON-stringified elements for comparison';
+
+
+--
+-- Name: COLUMN project_annotation_states.annotation_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.project_annotation_states.annotation_data IS 'Full annotation data for storage and merging';
+
+
+--
+-- Name: COLUMN project_annotation_states.updated_by_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.project_annotation_states.updated_by_id IS 'User who last updated the annotations';
+
+
+--
+-- Name: project_comments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_comments (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    workflow_id character varying,
+    action_id character varying,
+    author_id uuid NOT NULL,
+    content text NOT NULL,
+    "position" json,
+    mentions json,
+    resolved boolean NOT NULL,
+    resolved_by uuid,
+    resolved_at timestamp with time zone,
+    parent_comment_id uuid,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    metadata json
+);
+
+
+--
 -- Name: project_embeddings; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -987,6 +7911,30 @@ CREATE TABLE public.project_embeddings (
 
 
 --
+-- Name: project_images; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_images (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    s3_key character varying(500) NOT NULL,
+    mask_s3_key character varying(500),
+    thumbnail_s3_key character varying(500),
+    width integer NOT NULL,
+    height integer NOT NULL,
+    size_bytes integer NOT NULL,
+    source character varying(50) NOT NULL,
+    source_screenshot_id uuid,
+    source_region json,
+    metadata json,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
 -- Name: project_locks; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1000,6 +7948,259 @@ CREATE TABLE public.project_locks (
     expires_at timestamp with time zone NOT NULL,
     auto_release boolean NOT NULL,
     metadata json
+);
+
+
+--
+-- Name: project_screenshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_screenshots (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    s3_key character varying(500) NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    size_bytes integer NOT NULL,
+    source character varying(50) NOT NULL,
+    capture_session_id uuid,
+    monitor_index integer,
+    metadata json,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: project_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_versions (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    version_number integer NOT NULL,
+    snapshot json NOT NULL,
+    created_by uuid,
+    created_at timestamp with time zone NOT NULL,
+    comment text
+);
+
+
+--
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.projects (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    configuration json NOT NULL,
+    version integer NOT NULL,
+    is_public boolean NOT NULL,
+    owner_id uuid NOT NULL,
+    organization_id uuid,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+
+--
+-- Name: prompt_sequences; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.prompt_sequences (
+    id character varying NOT NULL,
+    project_id uuid NOT NULL,
+    created_by uuid NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    category character varying,
+    tags json NOT NULL,
+    steps json NOT NULL,
+    on_failure character varying NOT NULL,
+    max_retries integer NOT NULL,
+    results_directory character varying,
+    default_timeout integer,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: prompt_template_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.prompt_template_versions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    template_id character varying NOT NULL,
+    version_number integer NOT NULL,
+    prompt_content text NOT NULL,
+    parameters_json jsonb,
+    content_hash character varying NOT NULL,
+    change_description text,
+    created_by character varying,
+    performance_metrics jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: push_devices; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.push_devices (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    push_token character varying(255) NOT NULL,
+    platform character varying(50) DEFAULT 'expo'::character varying NOT NULL,
+    device_name character varying(255),
+    is_active boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: recording_contexts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recording_contexts (
+    id uuid NOT NULL,
+    recording_id uuid NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    relative_time_ms integer NOT NULL,
+    frame_number integer,
+    event_type character varying NOT NULL,
+    window_title character varying,
+    process_name character varying,
+    process_id integer,
+    window_bounds json,
+    window_state character varying,
+    window_z_index integer,
+    is_modal boolean,
+    previous_window json,
+    url character varying,
+    previous_url character varying,
+    page_title character varying,
+    domain character varying,
+    pathname character varying,
+    navigation_type character varying,
+    load_time_ms integer,
+    load_complete boolean,
+    focused_element json,
+    previous_focus json,
+    app_state json,
+    cpu_usage double precision,
+    memory_usage integer,
+    network_activity boolean,
+    is_loading boolean,
+    metadata json,
+    description text
+);
+
+
+--
+-- Name: recording_frames; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recording_frames (
+    id uuid NOT NULL,
+    recording_id uuid NOT NULL,
+    frame_number integer NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    relative_time_ms integer NOT NULL,
+    s3_key character varying NOT NULL,
+    image_url character varying,
+    url_expires_at timestamp with time zone,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    size_bytes integer,
+    format character varying,
+    perceptual_hash character varying,
+    phash_computed boolean,
+    cluster_id integer,
+    state_id uuid,
+    sharpness double precision,
+    brightness double precision,
+    contrast double precision,
+    window_title character varying,
+    window_bounds json,
+    window_state character varying,
+    url character varying,
+    page_title character varying,
+    user_notes text,
+    user_annotations json
+);
+
+
+--
+-- Name: recording_interactions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recording_interactions (
+    id uuid NOT NULL,
+    recording_id uuid NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    relative_time_ms integer NOT NULL,
+    frame_number integer,
+    interaction_type character varying NOT NULL,
+    action character varying,
+    x integer,
+    y integer,
+    button character varying,
+    click_count integer,
+    start_x integer,
+    start_y integer,
+    end_x integer,
+    end_y integer,
+    drag_path json,
+    key character varying,
+    key_code integer,
+    "char" character varying,
+    text character varying,
+    is_sensitive boolean,
+    modifiers json,
+    is_combo boolean,
+    scroll_delta_x integer,
+    scroll_delta_y integer,
+    scroll_direction character varying,
+    hover_duration_ms integer,
+    hover_triggered boolean,
+    target_element json,
+    duration_ms integer,
+    metadata json,
+    causes_state_change boolean,
+    target_state_id uuid,
+    transition_id uuid
+);
+
+
+--
+-- Name: recording_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recording_sessions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    session_id character varying(100) NOT NULL,
+    app_name character varying(255),
+    app_url character varying(2048),
+    app_domain character varying(255),
+    duration_ms integer DEFAULT 0 NOT NULL,
+    interaction_count integer DEFAULT 0 NOT NULL,
+    capture_count integer DEFAULT 0 NOT NULL,
+    state_count integer DEFAULT 0 NOT NULL,
+    transition_count integer DEFAULT 0 NOT NULL,
+    variable_count integer DEFAULT 0 NOT NULL,
+    avg_confidence double precision DEFAULT '0'::double precision NOT NULL,
+    export_data jsonb DEFAULT '{}'::jsonb NOT NULL,
+    variables jsonb DEFAULT '[]'::jsonb NOT NULL,
+    playbook_content text,
+    state_config_id uuid,
+    recorded_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -1055,6 +8256,207 @@ CREATE TABLE public.recordings (
     accepted_at timestamp with time zone,
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: render_images; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.render_images (
+    id integer NOT NULL,
+    render_log_id integer NOT NULL,
+    image_type character varying(32) NOT NULL,
+    element_selector text,
+    file_path character varying(512) NOT NULL,
+    width integer,
+    height integer,
+    file_size_bytes integer,
+    mime_type character varying(64),
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: render_images_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.render_images_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: render_images_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.render_images_id_seq OWNED BY public.render_images.id;
+
+
+--
+-- Name: render_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.render_logs (
+    id integer NOT NULL,
+    session_id character varying(64) NOT NULL,
+    "timestamp" timestamp with time zone DEFAULT now() NOT NULL,
+    page_url character varying(512) NOT NULL,
+    page_title character varying(256),
+    trigger character varying(64) NOT NULL,
+    mutation_type character varying(32),
+    target_selector text,
+    snapshot jsonb NOT NULL,
+    viewport_width integer,
+    viewport_height integer,
+    scroll_x integer,
+    scroll_y integer,
+    capture_duration_ms integer,
+    element_count integer,
+    user_id uuid
+);
+
+
+--
+-- Name: render_logs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.render_logs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: render_logs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.render_logs_id_seq OWNED BY public.render_logs.id;
+
+
+--
+-- Name: runner_connections; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.runner_connections (
+    id integer NOT NULL,
+    user_id uuid NOT NULL,
+    connected_at timestamp with time zone NOT NULL,
+    disconnected_at timestamp with time zone,
+    duration_seconds integer,
+    ip_address character varying(45),
+    user_agent character varying(500),
+    runner_name character varying(255),
+    project_id uuid,
+    session_id character varying(255),
+    runner_port integer
+);
+
+
+--
+-- Name: COLUMN runner_connections.connected_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.connected_at IS 'When the WebSocket connection was established';
+
+
+--
+-- Name: COLUMN runner_connections.disconnected_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.disconnected_at IS 'When the WebSocket connection was closed';
+
+
+--
+-- Name: COLUMN runner_connections.duration_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.duration_seconds IS 'Connection duration in seconds (calculated on disconnect)';
+
+
+--
+-- Name: COLUMN runner_connections.ip_address; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.ip_address IS 'IP address of the connection';
+
+
+--
+-- Name: COLUMN runner_connections.user_agent; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.user_agent IS 'User agent string from the client';
+
+
+--
+-- Name: COLUMN runner_connections.runner_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.runner_name IS 'Custom user-defined name for this runner (e.g., ''My Laptop'')';
+
+
+--
+-- Name: COLUMN runner_connections.project_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.project_id IS 'Project ID if connection was associated with a specific project';
+
+
+--
+-- Name: COLUMN runner_connections.session_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.session_id IS 'WebSocket session ID for correlation with logs';
+
+
+--
+-- Name: COLUMN runner_connections.runner_port; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_connections.runner_port IS 'HTTP API port the runner is listening on';
+
+
+--
+-- Name: runner_connections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.runner_connections_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: runner_connections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.runner_connections_id_seq OWNED BY public.runner_connections.id;
+
+
+--
+-- Name: runner_devices; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.runner_devices (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    device_id character varying(255) NOT NULL,
+    device_name character varying(255) NOT NULL,
+    platform character varying(50) NOT NULL,
+    last_seen_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    is_active boolean NOT NULL
 );
 
 
@@ -1245,6 +8647,380 @@ COMMENT ON COLUMN public.scheduled_workflow_runs.redbeat_entry_id IS 'Redbeat sc
 
 
 --
+-- Name: screenshot_input_associations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.screenshot_input_associations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    screenshot_id uuid NOT NULL,
+    log_id uuid NOT NULL,
+    input_type character varying(100) NOT NULL,
+    input_data json NOT NULL,
+    timestamp_diff_ms integer NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: screenshot_state_matches; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.screenshot_state_matches (
+    id uuid NOT NULL,
+    screenshot_id uuid NOT NULL,
+    state_identifier character varying(255) NOT NULL,
+    state_metadata json,
+    confidence double precision NOT NULL,
+    matched_elements json NOT NULL,
+    is_confirmed boolean,
+    review_notes text,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: screenshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.screenshots (
+    id integer NOT NULL,
+    snapshot_run_id integer NOT NULL,
+    screenshot_path character varying(500) NOT NULL,
+    active_states json NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    state_hash character varying(64) NOT NULL,
+    metadata json NOT NULL
+);
+
+
+--
+-- Name: screenshots_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.screenshots_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: screenshots_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.screenshots_id_seq OWNED BY public.screenshots.id;
+
+
+--
+-- Name: session_activities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.session_activities (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    jti character varying NOT NULL,
+    first_login_at timestamp with time zone NOT NULL,
+    last_activity_at timestamp with time zone NOT NULL,
+    absolute_expiry_at timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: shared_files; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.shared_files (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    source_device_id character varying(255) NOT NULL,
+    filename character varying(512) NOT NULL,
+    content_type character varying(255) NOT NULL,
+    size_bytes bigint NOT NULL,
+    storage_path character varying(1024) NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    expires_at timestamp with time zone DEFAULT (now() + '7 days'::interval) NOT NULL
+);
+
+
+--
+-- Name: skills; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.skills (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid,
+    name character varying(255) NOT NULL,
+    slug character varying(255) NOT NULL,
+    description text DEFAULT ''::text NOT NULL,
+    category character varying(100) DEFAULT 'custom'::character varying NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    icon character varying(100) DEFAULT 'puzzle'::character varying NOT NULL,
+    color character varying(50) DEFAULT 'gray'::character varying NOT NULL,
+    allowed_phases jsonb DEFAULT '["setup"]'::jsonb NOT NULL,
+    parameters jsonb DEFAULT '[]'::jsonb NOT NULL,
+    template jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    organization_id uuid,
+    is_shared boolean DEFAULT false NOT NULL,
+    version character varying(50) DEFAULT '1.0.0'::character varying NOT NULL,
+    author jsonb,
+    checksum character varying(128),
+    depends_on jsonb DEFAULT '[]'::jsonb NOT NULL,
+    usage_count integer DEFAULT 0 NOT NULL,
+    approval_status character varying(50),
+    forked_from character varying(255)
+);
+
+
+--
+-- Name: snapshot_actions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.snapshot_actions (
+    id integer NOT NULL,
+    snapshot_run_id integer NOT NULL,
+    sequence_number integer NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    action_type character varying(50) NOT NULL,
+    pattern_id character varying(255),
+    pattern_name character varying(255),
+    success boolean NOT NULL,
+    match_count integer,
+    duration_ms numeric(10,3),
+    active_states text[],
+    screenshot_path text,
+    is_start_screenshot boolean NOT NULL,
+    action_data_json json NOT NULL
+);
+
+
+--
+-- Name: snapshot_actions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.snapshot_actions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: snapshot_actions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.snapshot_actions_id_seq OWNED BY public.snapshot_actions.id;
+
+
+--
+-- Name: snapshot_matches; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.snapshot_matches (
+    id integer NOT NULL,
+    pattern_id integer NOT NULL,
+    action_id integer NOT NULL,
+    match_index integer NOT NULL,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    score numeric(5,4),
+    match_data_json json NOT NULL
+);
+
+
+--
+-- Name: snapshot_matches_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.snapshot_matches_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: snapshot_matches_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.snapshot_matches_id_seq OWNED BY public.snapshot_matches.id;
+
+
+--
+-- Name: snapshot_patterns; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.snapshot_patterns (
+    id integer NOT NULL,
+    snapshot_run_id integer NOT NULL,
+    pattern_id character varying(255) NOT NULL,
+    pattern_name character varying(255) NOT NULL,
+    total_finds integer NOT NULL,
+    successful_finds integer NOT NULL,
+    failed_finds integer NOT NULL,
+    total_matches integer NOT NULL,
+    avg_duration_ms numeric(10,3),
+    pattern_data_json json NOT NULL
+);
+
+
+--
+-- Name: snapshot_patterns_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.snapshot_patterns_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: snapshot_patterns_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.snapshot_patterns_id_seq OWNED BY public.snapshot_patterns.id;
+
+
+--
+-- Name: snapshot_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.snapshot_runs (
+    id integer NOT NULL,
+    run_id character varying(255) NOT NULL,
+    run_name character varying(255) NOT NULL,
+    project_id uuid,
+    workflow_id integer,
+    "timestamp" timestamp with time zone NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    states json NOT NULL,
+    metadata json NOT NULL,
+    tags json NOT NULL,
+    num_screenshots integer NOT NULL,
+    num_patterns integer NOT NULL,
+    description text
+);
+
+
+--
+-- Name: snapshot_runs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.snapshot_runs_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: snapshot_runs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.snapshot_runs_id_seq OWNED BY public.snapshot_runs.id;
+
+
+--
+-- Name: software_test_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.software_test_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    runner_connection_id integer,
+    workflow_id character varying(255),
+    status public.testrunstatus NOT NULL,
+    started_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone,
+    total_transitions integer NOT NULL,
+    successful_transitions integer NOT NULL,
+    failed_transitions integer NOT NULL,
+    skipped_transitions integer NOT NULL,
+    coverage_percentage numeric(5,2) NOT NULL,
+    unique_paths_found integer NOT NULL,
+    unique_states_visited integer NOT NULL,
+    configuration_snapshot jsonb NOT NULL,
+    test_mode character varying(50),
+    max_duration_seconds integer NOT NULL,
+    seed_value character varying(255),
+    error_summary text,
+    deficiencies_found integer NOT NULL,
+    runner_metadata jsonb NOT NULL,
+    tags jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN software_test_runs.workflow_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.software_test_runs.workflow_id IS 'Workflow identifier from project configuration';
+
+
+--
+-- Name: COLUMN software_test_runs.test_mode; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.software_test_runs.test_mode IS 'exploration, regression, coverage, stress';
+
+
+--
+-- Name: COLUMN software_test_runs.seed_value; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.software_test_runs.seed_value IS 'For reproducible random exploration';
+
+
+--
+-- Name: state_discovery_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.state_discovery_results (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    source_type character varying(50) NOT NULL,
+    source_session_id uuid,
+    discovery_strategy character varying(100),
+    images json DEFAULT '[]'::json NOT NULL,
+    states json DEFAULT '[]'::json NOT NULL,
+    transitions json DEFAULT '[]'::json NOT NULL,
+    element_to_renders json DEFAULT '{}'::json NOT NULL,
+    image_count integer DEFAULT 0 NOT NULL,
+    state_count integer DEFAULT 0 NOT NULL,
+    transition_count integer DEFAULT 0 NOT NULL,
+    render_count integer DEFAULT 0 NOT NULL,
+    unique_element_count integer DEFAULT 0 NOT NULL,
+    confidence double precision DEFAULT '0'::double precision NOT NULL,
+    discovery_metadata json DEFAULT '{}'::json NOT NULL,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
 -- Name: state_machine_configs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1260,6 +9036,245 @@ CREATE TABLE public.state_machine_configs (
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL
 );
+
+
+--
+-- Name: state_transitions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.state_transitions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    from_state_id uuid NOT NULL,
+    to_state_id uuid NOT NULL,
+    trigger_event_id integer,
+    event_type character varying(100),
+    confidence double precision NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: step_type_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.step_type_configs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    step_type character varying(50) NOT NULL,
+    phase character varying(20) NOT NULL,
+    label character varying(255) NOT NULL,
+    description text NOT NULL,
+    icon character varying(50) NOT NULL,
+    color character varying(30) NOT NULL,
+    is_built_in boolean NOT NULL,
+    sort_order integer NOT NULL,
+    enabled boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: storage_usage; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.storage_usage (
+    id integer NOT NULL,
+    user_id uuid NOT NULL,
+    file_type character varying NOT NULL,
+    file_size bigint NOT NULL,
+    file_path character varying NOT NULL,
+    project_id uuid,
+    file_metadata jsonb,
+    created_at timestamp with time zone
+);
+
+
+--
+-- Name: storage_usage_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.storage_usage_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: storage_usage_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.storage_usage_id_seq OWNED BY public.storage_usage.id;
+
+
+--
+-- Name: subscriptions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.subscriptions (
+    id integer NOT NULL,
+    user_id uuid NOT NULL,
+    stripe_customer_id character varying,
+    stripe_subscription_id character varying,
+    stripe_price_id character varying,
+    tier character varying NOT NULL,
+    status character varying NOT NULL,
+    current_period_start timestamp with time zone,
+    current_period_end timestamp with time zone,
+    cancel_at_period_end boolean,
+    canceled_at timestamp with time zone,
+    created_at timestamp with time zone,
+    updated_at timestamp with time zone
+);
+
+
+--
+-- Name: subscriptions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.subscriptions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: subscriptions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.subscriptions_id_seq OWNED BY public.subscriptions.id;
+
+
+--
+-- Name: sync_locks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sync_locks (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    operation character varying(100) NOT NULL,
+    acquired_at timestamp with time zone DEFAULT now() NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    released_at timestamp with time zone,
+    error_message text
+);
+
+
+--
+-- Name: COLUMN sync_locks.operation; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sync_locks.operation IS 'Description of the operation holding the lock';
+
+
+--
+-- Name: COLUMN sync_locks.expires_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sync_locks.expires_at IS 'When the lock automatically expires';
+
+
+--
+-- Name: COLUMN sync_locks.released_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sync_locks.released_at IS 'When the lock was explicitly released (null if still held or expired)';
+
+
+--
+-- Name: COLUMN sync_locks.error_message; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.sync_locks.error_message IS 'Error message if the operation failed';
+
+
+--
+-- Name: task_run_automations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.task_run_automations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_run_id uuid NOT NULL,
+    workflow_name character varying(255),
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    duration_ms integer,
+    automation_status character varying(50) DEFAULT 'running'::character varying NOT NULL,
+    success boolean,
+    error_type character varying(100),
+    error_message text,
+    actions_summary text,
+    states_visited text,
+    transitions_executed text,
+    template_matches text,
+    anomalies text,
+    screenshots text,
+    iteration_number integer DEFAULT 1 NOT NULL
+);
+
+
+--
+-- Name: COLUMN task_run_automations.automation_status; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.automation_status IS 'Automation status: running, completed, failed, timeout';
+
+
+--
+-- Name: COLUMN task_run_automations.actions_summary; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.actions_summary IS 'JSON summary of actions executed';
+
+
+--
+-- Name: COLUMN task_run_automations.states_visited; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.states_visited IS 'JSON list of states visited';
+
+
+--
+-- Name: COLUMN task_run_automations.transitions_executed; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.transitions_executed IS 'JSON list of transitions executed';
+
+
+--
+-- Name: COLUMN task_run_automations.template_matches; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.template_matches IS 'JSON list of template match results';
+
+
+--
+-- Name: COLUMN task_run_automations.anomalies; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.anomalies IS 'JSON list of detected anomalies';
+
+
+--
+-- Name: COLUMN task_run_automations.screenshots; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.screenshots IS 'JSON list of screenshot records';
+
+
+--
+-- Name: COLUMN task_run_automations.iteration_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_automations.iteration_number IS 'Iteration number within the task run';
 
 
 --
@@ -1361,6 +9376,62 @@ COMMENT ON COLUMN public.task_run_findings.input_options IS 'Array of options fo
 --
 
 COMMENT ON COLUMN public.task_run_findings.user_response IS 'User''s response to the question';
+
+
+--
+-- Name: task_run_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.task_run_sessions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_run_id uuid NOT NULL,
+    session_number integer NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    duration_seconds integer,
+    output_summary text
+);
+
+
+--
+-- Name: COLUMN task_run_sessions.session_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_sessions.session_number IS 'Session number within the task (1-indexed)';
+
+
+--
+-- Name: COLUMN task_run_sessions.duration_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_sessions.duration_seconds IS 'Session duration in seconds';
+
+
+--
+-- Name: COLUMN task_run_sessions.output_summary; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_sessions.output_summary IS 'Summary of session output';
+
+
+--
+-- Name: task_run_verification_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.task_run_verification_results (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_run_id uuid NOT NULL,
+    iteration integer NOT NULL,
+    all_passed boolean NOT NULL,
+    total_steps integer NOT NULL,
+    passed_steps integer NOT NULL,
+    failed_steps integer NOT NULL,
+    skipped_steps integer DEFAULT 0 NOT NULL,
+    total_duration_ms bigint NOT NULL,
+    critical_failure boolean DEFAULT false NOT NULL,
+    result_json jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
@@ -1525,6 +9596,256 @@ COMMENT ON COLUMN public.task_runs.log_sources_json IS 'JSON array of log source
 
 
 --
+-- Name: team_members; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.team_members (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    role character varying NOT NULL,
+    permissions json NOT NULL,
+    invited_by uuid,
+    joined_at timestamp with time zone NOT NULL,
+    last_active_at timestamp with time zone
+);
+
+
+--
+-- Name: template_candidates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.template_candidates (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id character varying(100) NOT NULL,
+    project_id uuid,
+    click_x integer NOT NULL,
+    click_y integer NOT NULL,
+    click_button character varying(20) DEFAULT 'left'::character varying NOT NULL,
+    "timestamp" double precision NOT NULL,
+    frame_number integer NOT NULL,
+    primary_boundary json NOT NULL,
+    alternative_boundaries json,
+    detection_strategies json,
+    pixel_data_path character varying(500),
+    pixel_data_url character varying(500),
+    thumbnail_url character varying(500),
+    mask_path character varying(500),
+    mask_url character varying(500),
+    status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
+    adjusted_boundary json,
+    reviewed_by_id uuid,
+    reviewed_at timestamp with time zone,
+    confidence_score double precision DEFAULT '0'::double precision NOT NULL,
+    element_type character varying(50) DEFAULT 'unknown'::character varying NOT NULL,
+    application_name character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    user_metadata json
+);
+
+
+--
+-- Name: test_deficiencies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.test_deficiencies (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_run_id uuid NOT NULL,
+    transition_execution_id uuid,
+    assigned_to_user_id uuid,
+    severity public.deficiencyseverity NOT NULL,
+    deficiency_type public.deficiencytype NOT NULL,
+    category character varying(100),
+    title character varying(500) NOT NULL,
+    description text NOT NULL,
+    screenshot_urls jsonb NOT NULL,
+    video_url character varying(500),
+    reproduction_steps jsonb NOT NULL,
+    reproduction_rate numeric(5,2),
+    reproducible boolean NOT NULL,
+    environment_info jsonb NOT NULL,
+    preconditions jsonb NOT NULL,
+    status public.deficiencystatus NOT NULL,
+    resolution character varying(100),
+    assigned_at timestamp with time zone,
+    first_seen_at timestamp with time zone NOT NULL,
+    last_seen_at timestamp with time zone NOT NULL,
+    occurrence_count integer NOT NULL,
+    external_ticket_id character varying(255),
+    external_ticket_url character varying(500),
+    tags jsonb NOT NULL,
+    custom_fields jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    resolved_at timestamp with time zone
+);
+
+
+--
+-- Name: COLUMN test_deficiencies.category; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.category IS 'Custom categorization';
+
+
+--
+-- Name: COLUMN test_deficiencies.screenshot_urls; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.screenshot_urls IS 'Array of S3 URLs';
+
+
+--
+-- Name: COLUMN test_deficiencies.reproduction_steps; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.reproduction_steps IS 'Array of step descriptions';
+
+
+--
+-- Name: COLUMN test_deficiencies.reproduction_rate; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.reproduction_rate IS 'Percentage (0-100)';
+
+
+--
+-- Name: COLUMN test_deficiencies.environment_info; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.environment_info IS 'OS, browser, screen res, etc.';
+
+
+--
+-- Name: COLUMN test_deficiencies.preconditions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.preconditions IS 'Required setup';
+
+
+--
+-- Name: COLUMN test_deficiencies.resolution; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.resolution IS 'fixed, duplicate, wont_fix, cannot_reproduce';
+
+
+--
+-- Name: COLUMN test_deficiencies.external_ticket_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_deficiencies.external_ticket_id IS 'JIRA, GitHub, etc.';
+
+
+--
+-- Name: test_notification_preferences; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.test_notification_preferences (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    notify_test_run_completed boolean NOT NULL,
+    notify_test_run_failed boolean NOT NULL,
+    notify_critical_deficiency boolean NOT NULL,
+    notify_high_deficiency boolean NOT NULL,
+    notify_medium_deficiency boolean NOT NULL,
+    notify_low_deficiency boolean NOT NULL,
+    notify_coverage_drop boolean NOT NULL,
+    coverage_drop_threshold numeric(5,2) NOT NULL,
+    websocket_config jsonb NOT NULL,
+    email_config jsonb NOT NULL,
+    slack_config jsonb NOT NULL,
+    webhook_config jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_test_run_completed; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_test_run_completed IS 'Send notification when test run completes successfully';
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_test_run_failed; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_test_run_failed IS 'Send notification when test run fails or times out';
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_critical_deficiency; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_critical_deficiency IS 'Send immediate notification for critical deficiencies';
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_high_deficiency; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_high_deficiency IS 'Send immediate notification for high severity deficiencies';
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_medium_deficiency; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_medium_deficiency IS 'Send notification for medium severity deficiencies';
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_low_deficiency; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_low_deficiency IS 'Send notification for low severity deficiencies';
+
+
+--
+-- Name: COLUMN test_notification_preferences.notify_coverage_drop; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.notify_coverage_drop IS 'Alert when coverage drops below threshold';
+
+
+--
+-- Name: COLUMN test_notification_preferences.coverage_drop_threshold; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.coverage_drop_threshold IS 'Coverage percentage threshold (0-100)';
+
+
+--
+-- Name: COLUMN test_notification_preferences.websocket_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.websocket_config IS 'WebSocket notification configuration';
+
+
+--
+-- Name: COLUMN test_notification_preferences.email_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.email_config IS 'Email notification configuration';
+
+
+--
+-- Name: COLUMN test_notification_preferences.slack_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.slack_config IS 'Slack webhook configuration';
+
+
+--
+-- Name: COLUMN test_notification_preferences.webhook_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_notification_preferences.webhook_config IS 'Generic webhook configuration';
+
+
+--
 -- Name: test_results; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1643,6 +9964,92 @@ COMMENT ON COLUMN public.test_results.exit_code IS 'Process exit code';
 
 
 --
+-- Name: test_screenshots; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.test_screenshots (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_run_id uuid NOT NULL,
+    transition_execution_id uuid,
+    deficiency_id uuid,
+    screenshot_type public.testscreenshottype NOT NULL,
+    storage_path character varying(1000) NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    captured_at timestamp with time zone NOT NULL,
+    screenshot_metadata jsonb NOT NULL,
+    description text,
+    state_name character varying(500),
+    perceptual_hash character varying(256),
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN test_screenshots.screenshot_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.screenshot_type IS 'Type of screenshot (state_verification, action_result, etc.)';
+
+
+--
+-- Name: COLUMN test_screenshots.storage_path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.storage_path IS 'S3/MinIO storage key';
+
+
+--
+-- Name: COLUMN test_screenshots.width; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.width IS 'Image width in pixels';
+
+
+--
+-- Name: COLUMN test_screenshots.height; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.height IS 'Image height in pixels';
+
+
+--
+-- Name: COLUMN test_screenshots.captured_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.captured_at IS 'When the screenshot was captured';
+
+
+--
+-- Name: COLUMN test_screenshots.screenshot_metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.screenshot_metadata IS 'Additional metadata (confidence scores, match locations, etc.)';
+
+
+--
+-- Name: COLUMN test_screenshots.description; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.description IS 'Optional description of what the screenshot shows';
+
+
+--
+-- Name: COLUMN test_screenshots.state_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.state_name IS 'State name for matching against visual baselines';
+
+
+--
+-- Name: COLUMN test_screenshots.perceptual_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_screenshots.perceptual_hash IS 'Perceptual hash for quick visual comparison filtering';
+
+
+--
 -- Name: training_dataset_annotations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1671,6 +10078,55 @@ CREATE TABLE public.training_dataset_annotations (
 
 
 --
+-- Name: training_dataset_export_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.training_dataset_export_jobs (
+    id uuid NOT NULL,
+    dataset_id uuid NOT NULL,
+    format public.export_format_enum NOT NULL,
+    include_images boolean NOT NULL,
+    train_percent double precision,
+    val_percent double precision,
+    test_percent double precision,
+    random_seed integer,
+    filters json,
+    status public.export_job_status_enum NOT NULL,
+    progress integer NOT NULL,
+    error text,
+    download_url character varying(1024),
+    file_size integer,
+    created_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone,
+    created_by_id uuid NOT NULL
+);
+
+
+--
+-- Name: training_dataset_images; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.training_dataset_images (
+    id uuid NOT NULL,
+    dataset_id uuid NOT NULL,
+    image_hash character varying(64) NOT NULL,
+    filename character varying(255) NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    storage_path character varying(512) NOT NULL,
+    action_id character varying(255),
+    action_type character varying(100),
+    active_states json,
+    "timestamp" timestamp with time zone,
+    reviewed boolean NOT NULL,
+    reviewed_by_id uuid,
+    reviewed_at timestamp with time zone,
+    reviewer_notes text,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
 -- Name: training_datasets; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1687,6 +10143,265 @@ CREATE TABLE public.training_datasets (
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
     created_by_id uuid NOT NULL
+);
+
+
+--
+-- Name: training_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.training_jobs (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid,
+    annotation_set_id uuid,
+    name character varying(255),
+    description text,
+    model_type character varying(50) DEFAULT 'detection'::character varying NOT NULL,
+    config json NOT NULL,
+    status character varying(50) DEFAULT 'pending'::character varying NOT NULL,
+    progress integer DEFAULT 0 NOT NULL,
+    current_epoch integer,
+    total_epochs integer,
+    logs text,
+    error text,
+    metrics json,
+    output_path character varying(500),
+    model_url character varying(500),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: transition_executions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.transition_executions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_run_id uuid NOT NULL,
+    transition_id character varying(255) NOT NULL,
+    transition_name character varying(500),
+    sequence_number integer NOT NULL,
+    status public.transitionexecutionstatus NOT NULL,
+    started_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone,
+    execution_time_ms integer,
+    error_type character varying(100),
+    error_message text,
+    error_stacktrace text,
+    screenshot_urls jsonb NOT NULL,
+    video_url character varying(500),
+    source_state character varying(255),
+    target_state character varying(255),
+    actual_state character varying(255),
+    state_match boolean,
+    input_data jsonb NOT NULL,
+    output_data jsonb NOT NULL,
+    path_sequence jsonb NOT NULL,
+    path_depth integer,
+    action_count integer NOT NULL,
+    retry_count integer NOT NULL,
+    execution_metadata jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN transition_executions.transition_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.transition_id IS 'From workflow configuration';
+
+
+--
+-- Name: COLUMN transition_executions.sequence_number; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.sequence_number IS 'Order within test run';
+
+
+--
+-- Name: COLUMN transition_executions.execution_time_ms; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.execution_time_ms IS 'Calculated duration in milliseconds';
+
+
+--
+-- Name: COLUMN transition_executions.screenshot_urls; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.screenshot_urls IS 'Array of S3 URLs';
+
+
+--
+-- Name: COLUMN transition_executions.actual_state; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.actual_state IS 'Where we actually ended up';
+
+
+--
+-- Name: COLUMN transition_executions.state_match; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.state_match IS 'Did we reach expected state?';
+
+
+--
+-- Name: COLUMN transition_executions.input_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.input_data IS 'Variables/context at start';
+
+
+--
+-- Name: COLUMN transition_executions.output_data; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.output_data IS 'Variables/context at end';
+
+
+--
+-- Name: COLUMN transition_executions.path_sequence; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.path_sequence IS 'Array of state IDs visited';
+
+
+--
+-- Name: COLUMN transition_executions.path_depth; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_executions.path_depth IS 'How deep in exploration';
+
+
+--
+-- Name: transition_reliability; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.transition_reliability (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    workflow_id character varying(255),
+    transition_id character varying(255) NOT NULL,
+    total_executions integer NOT NULL,
+    successful_executions integer NOT NULL,
+    failed_executions integer NOT NULL,
+    timeout_executions integer NOT NULL,
+    success_rate numeric(5,2) NOT NULL,
+    avg_execution_time_ms integer,
+    min_execution_time_ms integer,
+    max_execution_time_ms integer,
+    stddev_execution_time_ms numeric(10,2),
+    first_executed_at timestamp with time zone,
+    last_executed_at timestamp with time zone,
+    last_success_at timestamp with time zone,
+    last_failure_at timestamp with time zone,
+    failure_patterns jsonb NOT NULL,
+    common_errors jsonb NOT NULL,
+    consecutive_successes integer NOT NULL,
+    consecutive_failures integer NOT NULL,
+    is_flaky boolean NOT NULL,
+    flakiness_score numeric(5,2),
+    reliability_metadata jsonb NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    last_calculated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN transition_reliability.success_rate; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_reliability.success_rate IS 'Percentage';
+
+
+--
+-- Name: COLUMN transition_reliability.failure_patterns; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_reliability.failure_patterns IS '{error_type: count, ...}';
+
+
+--
+-- Name: COLUMN transition_reliability.common_errors; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_reliability.common_errors IS 'Array of {error: "", count: N}';
+
+
+--
+-- Name: COLUMN transition_reliability.is_flaky; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_reliability.is_flaky IS 'Auto-calculated';
+
+
+--
+-- Name: COLUMN transition_reliability.flakiness_score; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.transition_reliability.flakiness_score IS '0-100, higher = more flaky';
+
+
+--
+-- Name: ui_bridge_exploration_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ui_bridge_exploration_sessions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    status character varying(50) DEFAULT 'running'::character varying NOT NULL,
+    target_type character varying(50) DEFAULT 'extension'::character varying NOT NULL,
+    target_url character varying(2048),
+    exploration_config json DEFAULT '{}'::json NOT NULL,
+    render_logs json DEFAULT '[]'::json NOT NULL,
+    elements_discovered integer DEFAULT 0 NOT NULL,
+    elements_explored integer DEFAULT 0 NOT NULL,
+    render_count integer DEFAULT 0 NOT NULL,
+    error_message text,
+    discovery_completed boolean DEFAULT false NOT NULL,
+    saved_config_id uuid,
+    started_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    completed_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_state_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ui_bridge_state_configs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    name character varying(255) DEFAULT 'default'::character varying NOT NULL,
+    description text,
+    render_count integer DEFAULT 0 NOT NULL,
+    element_count integer DEFAULT 0 NOT NULL,
+    include_html_ids boolean DEFAULT false NOT NULL,
+    discovery_result jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_state_domain_knowledge; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ui_bridge_state_domain_knowledge (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    state_id uuid NOT NULL,
+    knowledge_id uuid NOT NULL,
+    "order" integer DEFAULT 0 NOT NULL
 );
 
 
@@ -1825,6 +10540,75 @@ COMMENT ON COLUMN public.unified_workflows.constraint_overrides IS 'Per-constrai
 
 
 --
+-- Name: usage_metrics; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.usage_metrics (
+    id integer NOT NULL,
+    user_id uuid NOT NULL,
+    metric_type character varying NOT NULL,
+    value numeric NOT NULL,
+    "timestamp" timestamp with time zone,
+    metric_metadata json
+);
+
+
+--
+-- Name: usage_metrics_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.usage_metrics_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: usage_metrics_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.usage_metrics_id_seq OWNED BY public.usage_metrics.id;
+
+
+--
+-- Name: variable_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.variable_history (
+    id integer NOT NULL,
+    variable_id character varying NOT NULL,
+    workflow_run_id character varying,
+    old_value json,
+    new_value json,
+    changed_at timestamp with time zone NOT NULL,
+    changed_by_action character varying
+);
+
+
+--
+-- Name: variable_history_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.variable_history_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: variable_history_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.variable_history_id_seq OWNED BY public.variable_history.id;
+
+
+--
 -- Name: verification_tests; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1913,6 +10697,380 @@ COMMENT ON COLUMN public.verification_tests.is_critical IS 'Whether test failure
 --
 
 COMMENT ON COLUMN public.verification_tests.ai_generated IS 'Whether test was generated by AI';
+
+
+--
+-- Name: video_capture_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.video_capture_sessions (
+    id integer NOT NULL,
+    session_id character varying(36) NOT NULL,
+    started_at timestamp with time zone NOT NULL,
+    ended_at timestamp with time zone,
+    duration_ms bigint,
+    video_width integer NOT NULL,
+    video_height integer NOT NULL,
+    video_fps double precision NOT NULL,
+    video_codec character varying(50) NOT NULL,
+    video_format character varying(10) NOT NULL,
+    total_frames integer,
+    storage_backend character varying(20) NOT NULL,
+    video_path text NOT NULL,
+    video_size_bytes bigint,
+    compressed_video_path text,
+    compressed_video_size_bytes bigint,
+    monitor_id integer,
+    monitor_name character varying(255),
+    monitor_scale_factor double precision,
+    snapshot_run_id integer,
+    workflow_id integer,
+    project_id uuid,
+    created_by uuid,
+    is_complete boolean NOT NULL,
+    is_processed boolean NOT NULL,
+    metadata_json jsonb,
+    tags text[],
+    notes text,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: video_capture_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.video_capture_sessions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: video_capture_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.video_capture_sessions_id_seq OWNED BY public.video_capture_sessions.id;
+
+
+--
+-- Name: visual_baselines; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.visual_baselines (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    state_name character varying(500) NOT NULL,
+    workflow_id character varying(500),
+    storage_path character varying(1000) NOT NULL,
+    thumbnail_path character varying(1000),
+    width integer NOT NULL,
+    height integer NOT NULL,
+    file_size_bytes integer,
+    perceptual_hash character varying(256),
+    version integer NOT NULL,
+    is_active boolean NOT NULL,
+    approved_by_user_id uuid,
+    approved_at timestamp with time zone,
+    approval_notes text,
+    comparison_settings jsonb NOT NULL,
+    source_test_run_id uuid,
+    source_screenshot_id uuid,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN visual_baselines.state_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.state_name IS 'State name used to match screenshots to this baseline';
+
+
+--
+-- Name: COLUMN visual_baselines.workflow_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.workflow_id IS 'Optional workflow ID to scope baseline to specific workflow';
+
+
+--
+-- Name: COLUMN visual_baselines.storage_path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.storage_path IS 'S3/MinIO storage path for baseline image';
+
+
+--
+-- Name: COLUMN visual_baselines.thumbnail_path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.thumbnail_path IS 'S3/MinIO storage path for thumbnail preview';
+
+
+--
+-- Name: COLUMN visual_baselines.width; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.width IS 'Image width in pixels';
+
+
+--
+-- Name: COLUMN visual_baselines.height; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.height IS 'Image height in pixels';
+
+
+--
+-- Name: COLUMN visual_baselines.file_size_bytes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.file_size_bytes IS 'File size in bytes';
+
+
+--
+-- Name: COLUMN visual_baselines.perceptual_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.perceptual_hash IS 'Perceptual hash for quick comparison filtering';
+
+
+--
+-- Name: COLUMN visual_baselines.version; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.version IS 'Version number of this baseline (incremented on updates)';
+
+
+--
+-- Name: COLUMN visual_baselines.is_active; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.is_active IS 'Whether this is the active baseline for this state';
+
+
+--
+-- Name: COLUMN visual_baselines.approved_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.approved_at IS 'When the baseline was approved';
+
+
+--
+-- Name: COLUMN visual_baselines.approval_notes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.approval_notes IS 'Optional notes explaining the approval';
+
+
+--
+-- Name: COLUMN visual_baselines.comparison_settings; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.comparison_settings IS 'Comparison configuration:
+        {
+            "algorithm": "ssim" | "pixel_diff" | "perceptual_hash",
+            "threshold": float (0.0-1.0),
+            "ignore_regions": [{"x": int, "y": int, "width": int, "height": int, "name": str}]
+        }';
+
+
+--
+-- Name: COLUMN visual_baselines.source_test_run_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.source_test_run_id IS 'Test run this baseline was created from (if auto-created)';
+
+
+--
+-- Name: COLUMN visual_baselines.source_screenshot_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_baselines.source_screenshot_id IS 'Screenshot this baseline was created from';
+
+
+--
+-- Name: visual_comparison_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.visual_comparison_results (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_run_id uuid NOT NULL,
+    baseline_id uuid,
+    screenshot_id uuid NOT NULL,
+    transition_execution_id uuid,
+    state_name character varying(500) NOT NULL,
+    comparison_algorithm character varying(50) NOT NULL,
+    similarity_score double precision NOT NULL,
+    threshold_used double precision NOT NULL,
+    status public.visualcomparisonstatus NOT NULL,
+    diff_image_path character varying(1000),
+    diff_regions jsonb NOT NULL,
+    execution_time_ms integer,
+    reviewed_by_user_id uuid,
+    reviewed_at timestamp with time zone,
+    review_decision public.reviewdecision,
+    review_notes text,
+    deficiency_id uuid,
+    error_message text,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: COLUMN visual_comparison_results.state_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.state_name IS 'State name this comparison was for';
+
+
+--
+-- Name: COLUMN visual_comparison_results.comparison_algorithm; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.comparison_algorithm IS 'Algorithm used: ssim, pixel_diff, or perceptual_hash';
+
+
+--
+-- Name: COLUMN visual_comparison_results.similarity_score; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.similarity_score IS 'Similarity score from 0.0 to 1.0 (1.0 = identical)';
+
+
+--
+-- Name: COLUMN visual_comparison_results.threshold_used; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.threshold_used IS 'Threshold that was used for pass/fail determination';
+
+
+--
+-- Name: COLUMN visual_comparison_results.status; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.status IS 'Result status: passed, failed, pending_review, approved_as_new, no_baseline';
+
+
+--
+-- Name: COLUMN visual_comparison_results.diff_image_path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.diff_image_path IS 'S3/MinIO path for diff visualization image';
+
+
+--
+-- Name: COLUMN visual_comparison_results.diff_regions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.diff_regions IS 'List of diff regions detected:
+        [{"x": int, "y": int, "width": int, "height": int, "change_percentage": float}]';
+
+
+--
+-- Name: COLUMN visual_comparison_results.execution_time_ms; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.execution_time_ms IS 'Time taken to perform comparison in milliseconds';
+
+
+--
+-- Name: COLUMN visual_comparison_results.reviewed_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.reviewed_at IS 'When the comparison was reviewed';
+
+
+--
+-- Name: COLUMN visual_comparison_results.review_decision; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.review_decision IS 'Decision made during review: approved, rejected, new_baseline';
+
+
+--
+-- Name: COLUMN visual_comparison_results.review_notes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.review_notes IS 'Notes explaining the review decision';
+
+
+--
+-- Name: COLUMN visual_comparison_results.deficiency_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.deficiency_id IS 'Deficiency created from this failed comparison';
+
+
+--
+-- Name: COLUMN visual_comparison_results.error_message; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.visual_comparison_results.error_message IS 'Error message if comparison failed to execute';
+
+
+--
+-- Name: workflow_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.workflow_events (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    event_type character varying(50) NOT NULL,
+    device_id character varying(255) NOT NULL,
+    runner_name character varying(255) NOT NULL,
+    run_id character varying(255),
+    summary text NOT NULL,
+    payload jsonb,
+    seen boolean DEFAULT false NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: workflow_execution_history; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.workflow_execution_history (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    session_id uuid NOT NULL,
+    workflow_id character varying(255) NOT NULL,
+    workflow_name character varying(255) NOT NULL,
+    monitor_index integer NOT NULL,
+    execution_status character varying(50) NOT NULL,
+    results jsonb NOT NULL,
+    total_states_visited integer,
+    total_transitions integer,
+    error_count integer NOT NULL,
+    started_at timestamp with time zone NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+--
+-- Name: workflow_phase_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.workflow_phase_configs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    phase character varying(20) NOT NULL,
+    label character varying(255) NOT NULL,
+    description text NOT NULL,
+    color character varying(30) NOT NULL,
+    is_built_in boolean NOT NULL,
+    sort_order integer NOT NULL,
+    enabled boolean NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
 
 
 --
@@ -2121,10 +11279,2289 @@ ALTER TABLE public.wrapper_ratings ALTER COLUMN id ADD GENERATED BY DEFAULT AS I
 
 
 --
+-- Name: api_surface_snapshots id; Type: DEFAULT; Schema: agent; Owner: -
+--
+
+ALTER TABLE ONLY agent.api_surface_snapshots ALTER COLUMN id SET DEFAULT nextval('agent.api_surface_snapshots_id_seq'::regclass);
+
+
+--
+-- Name: memory_query_cache id; Type: DEFAULT; Schema: agent; Owner: -
+--
+
+ALTER TABLE ONLY agent.memory_query_cache ALTER COLUMN id SET DEFAULT nextval('agent.memory_query_cache_id_seq'::regclass);
+
+
+--
+-- Name: gui_lock id; Type: DEFAULT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.gui_lock ALTER COLUMN id SET DEFAULT nextval('coord.gui_lock_id_seq'::regclass);
+
+
+--
+-- Name: process_session_output id; Type: DEFAULT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.process_session_output ALTER COLUMN id SET DEFAULT nextval('coord.process_session_output_id_seq'::regclass);
+
+
+--
+-- Name: active_workflows id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.active_workflows ALTER COLUMN id SET DEFAULT nextval('project.active_workflows_id_seq'::regclass);
+
+
+--
+-- Name: activity_timeline id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.activity_timeline ALTER COLUMN id SET DEFAULT nextval('project.activity_timeline_id_seq'::regclass);
+
+
+--
+-- Name: compensation_actions id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.compensation_actions ALTER COLUMN id SET DEFAULT nextval('project.compensation_actions_id_seq'::regclass);
+
+
+--
+-- Name: contradiction_resolutions id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.contradiction_resolutions ALTER COLUMN id SET DEFAULT nextval('project.contradiction_resolutions_id_seq'::regclass);
+
+
+--
+-- Name: development_intelligence id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.development_intelligence ALTER COLUMN id SET DEFAULT nextval('project.development_intelligence_id_seq'::regclass);
+
+
+--
+-- Name: entity_profiles id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.entity_profiles ALTER COLUMN id SET DEFAULT nextval('project.entity_profiles_id_seq'::regclass);
+
+
+--
+-- Name: error_events id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.error_events ALTER COLUMN id SET DEFAULT nextval('project.error_events_id_seq'::regclass);
+
+
+--
+-- Name: execution_spans id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.execution_spans ALTER COLUMN id SET DEFAULT nextval('project.execution_spans_id_seq'::regclass);
+
+
+--
+-- Name: execution_state_snapshots id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.execution_state_snapshots ALTER COLUMN id SET DEFAULT nextval('project.execution_state_snapshots_id_seq'::regclass);
+
+
+--
+-- Name: log_sources id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.log_sources ALTER COLUMN id SET DEFAULT nextval('project.log_sources_id_seq'::regclass);
+
+
+--
+-- Name: memory_consolidation_log id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.memory_consolidation_log ALTER COLUMN id SET DEFAULT nextval('project.memory_consolidation_log_id_seq'::regclass);
+
+
+--
+-- Name: observation_history id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observation_history ALTER COLUMN id SET DEFAULT nextval('project.observation_history_id_seq'::regclass);
+
+
+--
+-- Name: observations id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observations ALTER COLUMN id SET DEFAULT nextval('project.observations_id_seq'::regclass);
+
+
+--
+-- Name: phase_results id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.phase_results ALTER COLUMN id SET DEFAULT nextval('project.phase_results_id_seq'::regclass);
+
+
+--
+-- Name: phase_token_usage id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.phase_token_usage ALTER COLUMN id SET DEFAULT nextval('project.phase_token_usage_id_seq'::regclass);
+
+
+--
+-- Name: reasoning_traces id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reasoning_traces ALTER COLUMN id SET DEFAULT nextval('project.reasoning_traces_id_seq'::regclass);
+
+
+--
+-- Name: scheduler_settings id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.scheduler_settings ALTER COLUMN id SET DEFAULT nextval('project.scheduler_settings_id_seq'::regclass);
+
+
+--
+-- Name: session_events id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.session_events ALTER COLUMN id SET DEFAULT nextval('project.session_events_id_seq'::regclass);
+
+
+--
+-- Name: state_discovery_drift_scores id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_discovery_drift_scores ALTER COLUMN id SET DEFAULT nextval('project.state_discovery_drift_scores_id_seq'::regclass);
+
+
+--
+-- Name: step_progress_markers id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_progress_markers ALTER COLUMN id SET DEFAULT nextval('project.step_progress_markers_id_seq'::regclass);
+
+
+--
+-- Name: task_run_events id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_events ALTER COLUMN id SET DEFAULT nextval('project.task_run_events_id_seq'::regclass);
+
+
+--
+-- Name: task_run_mobile_logs id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mobile_logs ALTER COLUMN id SET DEFAULT nextval('project.task_run_mobile_logs_id_seq'::regclass);
+
+
+--
+-- Name: task_run_mobile_state id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mobile_state ALTER COLUMN id SET DEFAULT nextval('project.task_run_mobile_state_id_seq'::regclass);
+
+
+--
+-- Name: task_run_output_chunks id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_output_chunks ALTER COLUMN id SET DEFAULT nextval('project.task_run_output_chunks_id_seq'::regclass);
+
+
+--
+-- Name: ui_bridge_elements id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_elements ALTER COLUMN id SET DEFAULT nextval('project.ui_bridge_elements_id_seq'::regclass);
+
+
+--
+-- Name: ui_bridge_events id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_events ALTER COLUMN id SET DEFAULT nextval('project.ui_bridge_events_id_seq'::regclass);
+
+
+--
+-- Name: ui_bridge_navigation_history id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_navigation_history ALTER COLUMN id SET DEFAULT nextval('project.ui_bridge_navigation_history_id_seq'::regclass);
+
+
+--
+-- Name: ui_bridge_states id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_states ALTER COLUMN id SET DEFAULT nextval('project.ui_bridge_states_id_seq'::regclass);
+
+
+--
+-- Name: ui_bridge_transitions id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_transitions ALTER COLUMN id SET DEFAULT nextval('project.ui_bridge_transitions_id_seq'::regclass);
+
+
+--
+-- Name: vga_shadow_samples id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.vga_shadow_samples ALTER COLUMN id SET DEFAULT nextval('project.vga_shadow_samples_id_seq'::regclass);
+
+
+--
+-- Name: workflow_ai_sessions id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_ai_sessions ALTER COLUMN id SET DEFAULT nextval('project.workflow_ai_sessions_id_seq'::regclass);
+
+
+--
+-- Name: workflow_constraint_results id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_constraint_results ALTER COLUMN id SET DEFAULT nextval('project.workflow_constraint_results_id_seq'::regclass);
+
+
+--
+-- Name: workflow_event_log id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_event_log ALTER COLUMN id SET DEFAULT nextval('project.workflow_event_log_id_seq'::regclass);
+
+
+--
+-- Name: working_representations id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.working_representations ALTER COLUMN id SET DEFAULT nextval('project.working_representations_id_seq'::regclass);
+
+
+--
+-- Name: wsv_shadow_disagreements id; Type: DEFAULT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.wsv_shadow_disagreements ALTER COLUMN id SET DEFAULT nextval('project.wsv_shadow_disagreements_id_seq'::regclass);
+
+
+--
+-- Name: action_frames id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_frames ALTER COLUMN id SET DEFAULT nextval('public.action_frames_id_seq'::regclass);
+
+
+--
+-- Name: audit_logs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audit_logs ALTER COLUMN id SET DEFAULT nextval('public.audit_logs_id_seq'::regclass);
+
+
+--
 -- Name: automation_input_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.automation_input_events ALTER COLUMN id SET DEFAULT nextval('public.automation_input_events_id_seq'::regclass);
+
+
+--
+-- Name: automation_videos id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_videos ALTER COLUMN id SET DEFAULT nextval('public.automation_videos_id_seq'::regclass);
+
+
+--
+-- Name: code_packages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.code_packages ALTER COLUMN id SET DEFAULT nextval('public.code_packages_id_seq'::regclass);
+
+
+--
+-- Name: custom_functions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.custom_functions ALTER COLUMN id SET DEFAULT nextval('public.custom_functions_id_seq'::regclass);
+
+
+--
+-- Name: frame_index id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.frame_index ALTER COLUMN id SET DEFAULT nextval('public.frame_index_id_seq'::regclass);
+
+
+--
+-- Name: historical_results id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results ALTER COLUMN id SET DEFAULT nextval('public.historical_results_id_seq'::regclass);
+
+
+--
+-- Name: input_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.input_events ALTER COLUMN id SET DEFAULT nextval('public.input_events_id_seq'::regclass);
+
+
+--
+-- Name: package_categories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_categories ALTER COLUMN id SET DEFAULT nextval('public.package_categories_id_seq'::regclass);
+
+
+--
+-- Name: package_installations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations ALTER COLUMN id SET DEFAULT nextval('public.package_installations_id_seq'::regclass);
+
+
+--
+-- Name: package_ratings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_ratings ALTER COLUMN id SET DEFAULT nextval('public.package_ratings_id_seq'::regclass);
+
+
+--
+-- Name: package_versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_versions ALTER COLUMN id SET DEFAULT nextval('public.package_versions_id_seq'::regclass);
+
+
+--
+-- Name: patterns id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.patterns ALTER COLUMN id SET DEFAULT nextval('public.patterns_id_seq'::regclass);
+
+
+--
+-- Name: render_images id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.render_images ALTER COLUMN id SET DEFAULT nextval('public.render_images_id_seq'::regclass);
+
+
+--
+-- Name: render_logs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.render_logs ALTER COLUMN id SET DEFAULT nextval('public.render_logs_id_seq'::regclass);
+
+
+--
+-- Name: runner_connections id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_connections ALTER COLUMN id SET DEFAULT nextval('public.runner_connections_id_seq'::regclass);
+
+
+--
+-- Name: screenshots id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshots ALTER COLUMN id SET DEFAULT nextval('public.screenshots_id_seq'::regclass);
+
+
+--
+-- Name: snapshot_actions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_actions ALTER COLUMN id SET DEFAULT nextval('public.snapshot_actions_id_seq'::regclass);
+
+
+--
+-- Name: snapshot_matches id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_matches ALTER COLUMN id SET DEFAULT nextval('public.snapshot_matches_id_seq'::regclass);
+
+
+--
+-- Name: snapshot_patterns id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_patterns ALTER COLUMN id SET DEFAULT nextval('public.snapshot_patterns_id_seq'::regclass);
+
+
+--
+-- Name: snapshot_runs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_runs ALTER COLUMN id SET DEFAULT nextval('public.snapshot_runs_id_seq'::regclass);
+
+
+--
+-- Name: storage_usage id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storage_usage ALTER COLUMN id SET DEFAULT nextval('public.storage_usage_id_seq'::regclass);
+
+
+--
+-- Name: subscriptions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions ALTER COLUMN id SET DEFAULT nextval('public.subscriptions_id_seq'::regclass);
+
+
+--
+-- Name: usage_metrics id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_metrics ALTER COLUMN id SET DEFAULT nextval('public.usage_metrics_id_seq'::regclass);
+
+
+--
+-- Name: variable_history id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.variable_history ALTER COLUMN id SET DEFAULT nextval('public.variable_history_id_seq'::regclass);
+
+
+--
+-- Name: video_capture_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.video_capture_sessions ALTER COLUMN id SET DEFAULT nextval('public.video_capture_sessions_id_seq'::regclass);
+
+
+--
+-- Name: api_surface_snapshots api_surface_snapshots_pkey; Type: CONSTRAINT; Schema: agent; Owner: -
+--
+
+ALTER TABLE ONLY agent.api_surface_snapshots
+    ADD CONSTRAINT api_surface_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cached_app_specs cached_app_specs_pkey; Type: CONSTRAINT; Schema: agent; Owner: -
+--
+
+ALTER TABLE ONLY agent.cached_app_specs
+    ADD CONSTRAINT cached_app_specs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: memory_query_cache memory_query_cache_pkey; Type: CONSTRAINT; Schema: agent; Owner: -
+--
+
+ALTER TABLE ONLY agent.memory_query_cache
+    ADD CONSTRAINT memory_query_cache_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: auth; Owner: -
+--
+
+ALTER TABLE ONLY auth.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: coordinator_decisions coordinator_decisions_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.coordinator_decisions
+    ADD CONSTRAINT coordinator_decisions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: coordinator_leader coordinator_leader_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.coordinator_leader
+    ADD CONSTRAINT coordinator_leader_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gui_lock gui_lock_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.gui_lock
+    ADD CONSTRAINT gui_lock_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: plans plans_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.plans
+    ADD CONSTRAINT plans_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: process_session_output process_session_output_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.process_session_output
+    ADD CONSTRAINT process_session_output_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: process_sessions process_sessions_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.process_sessions
+    ADD CONSTRAINT process_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reviews reviews_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.reviews
+    ADD CONSTRAINT reviews_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runner_instances runner_instances_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.runner_instances
+    ADD CONSTRAINT runner_instances_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runner_instances runner_instances_port_key; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.runner_instances
+    ADD CONSTRAINT runner_instances_port_key UNIQUE (port);
+
+
+--
+-- Name: session_file_snapshots session_file_snapshots_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.session_file_snapshots
+    ADD CONSTRAINT session_file_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: session_touched_files session_touched_files_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.session_touched_files
+    ADD CONSTRAINT session_touched_files_pkey PRIMARY KEY (task_run_id, file_path);
+
+
+--
+-- Name: tasks tasks_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.tasks
+    ADD CONSTRAINT tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: worktrees worktrees_pkey; Type: CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.worktrees
+    ADD CONSTRAINT worktrees_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: active_workflows active_workflows_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.active_workflows
+    ADD CONSTRAINT active_workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: active_workflows active_workflows_workflow_name_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.active_workflows
+    ADD CONSTRAINT active_workflows_workflow_name_key UNIQUE (workflow_name);
+
+
+--
+-- Name: activity_timeline activity_timeline_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.activity_timeline
+    ADD CONSTRAINT activity_timeline_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agentic_metric_baselines agentic_metric_baselines_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.agentic_metric_baselines
+    ADD CONSTRAINT agentic_metric_baselines_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: agentic_metric_scores agentic_metric_scores_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.agentic_metric_scores
+    ADD CONSTRAINT agentic_metric_scores_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ai_workflows ai_workflows_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ai_workflows
+    ADD CONSTRAINT ai_workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: approval_gates approval_gates_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.approval_gates
+    ADD CONSTRAINT approval_gates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: architecture_components architecture_components_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.architecture_components
+    ADD CONSTRAINT architecture_components_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: architecture_components architecture_components_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.architecture_components
+    ADD CONSTRAINT architecture_components_uniq UNIQUE (workflow_name, component_path);
+
+
+--
+-- Name: artifacts artifacts_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.artifacts
+    ADD CONSTRAINT artifacts_pkey PRIMARY KEY (artifact_id);
+
+
+--
+-- Name: beam_candidates beam_candidates_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.beam_candidates
+    ADD CONSTRAINT beam_candidates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: beam_search_runs beam_search_runs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.beam_search_runs
+    ADD CONSTRAINT beam_search_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: breakpoint_snapshots breakpoint_snapshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.breakpoint_snapshots
+    ADD CONSTRAINT breakpoint_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: canary_rollouts canary_rollouts_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.canary_rollouts
+    ADD CONSTRAINT canary_rollouts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: canary_run_records canary_run_records_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.canary_run_records
+    ADD CONSTRAINT canary_run_records_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: canvas_panels canvas_panels_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.canvas_panels
+    ADD CONSTRAINT canvas_panels_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: causal_events causal_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.causal_events
+    ADD CONSTRAINT causal_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: check_group_members check_group_members_group_check_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_group_members
+    ADD CONSTRAINT check_group_members_group_check_uniq UNIQUE (group_id, check_id);
+
+
+--
+-- Name: check_group_members check_group_members_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_group_members
+    ADD CONSTRAINT check_group_members_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: check_groups check_groups_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_groups
+    ADD CONSTRAINT check_groups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: check_results check_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_results
+    ADD CONSTRAINT check_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: checks checks_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.checks
+    ADD CONSTRAINT checks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: chunk_labels chunk_labels_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.chunk_labels
+    ADD CONSTRAINT chunk_labels_pkey PRIMARY KEY (config_id, chunk_id);
+
+
+--
+-- Name: co_occurrence_observations co_occurrence_observations_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.co_occurrence_observations
+    ADD CONSTRAINT co_occurrence_observations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: comparison_runs comparison_runs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.comparison_runs
+    ADD CONSTRAINT comparison_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: compensation_actions compensation_actions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.compensation_actions
+    ADD CONSTRAINT compensation_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: component_health_snapshots component_health_snapshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.component_health_snapshots
+    ADD CONSTRAINT component_health_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: component_relationships component_relationships_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.component_relationships
+    ADD CONSTRAINT component_relationships_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: component_relationships component_relationships_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.component_relationships
+    ADD CONSTRAINT component_relationships_uniq UNIQUE (workflow_name, source_component, target_component, relationship_type);
+
+
+--
+-- Name: concept_summaries concept_summaries_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.concept_summaries
+    ADD CONSTRAINT concept_summaries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: config_statistics config_statistics_config_id_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.config_statistics
+    ADD CONSTRAINT config_statistics_config_id_key UNIQUE (config_id);
+
+
+--
+-- Name: config_statistics config_statistics_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.config_statistics
+    ADD CONSTRAINT config_statistics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: configs configs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.configs
+    ADD CONSTRAINT configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: contradiction_resolutions contradiction_resolutions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.contradiction_resolutions
+    ADD CONSTRAINT contradiction_resolutions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: convergence_snapshots convergence_snapshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.convergence_snapshots
+    ADD CONSTRAINT convergence_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cross_run_patterns cross_run_patterns_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.cross_run_patterns
+    ADD CONSTRAINT cross_run_patterns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: cross_run_patterns cross_run_patterns_unique; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.cross_run_patterns
+    ADD CONSTRAINT cross_run_patterns_unique UNIQUE (pattern_type, signature_hash);
+
+
+--
+-- Name: curated_examples curated_examples_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.curated_examples
+    ADD CONSTRAINT curated_examples_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: decisions decisions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.decisions
+    ADD CONSTRAINT decisions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deferred_questions deferred_questions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.deferred_questions
+    ADD CONSTRAINT deferred_questions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: development_intelligence development_intelligence_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.development_intelligence
+    ADD CONSTRAINT development_intelligence_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: drift_detector_state drift_detector_state_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.drift_detector_state
+    ADD CONSTRAINT drift_detector_state_pkey PRIMARY KEY (detector_id);
+
+
+--
+-- Name: duel_candidates duel_candidates_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.duel_candidates
+    ADD CONSTRAINT duel_candidates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: duel_pools duel_pools_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.duel_pools
+    ADD CONSTRAINT duel_pools_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: duel_results duel_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.duel_results
+    ADD CONSTRAINT duel_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: entailment_cache entailment_cache_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.entailment_cache
+    ADD CONSTRAINT entailment_cache_pkey PRIMARY KEY (criterion_hash, step_hash);
+
+
+--
+-- Name: entity_profiles entity_profiles_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.entity_profiles
+    ADD CONSTRAINT entity_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: error_events error_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.error_events
+    ADD CONSTRAINT error_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: eval_results eval_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.eval_results
+    ADD CONSTRAINT eval_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: eval_specs eval_specs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.eval_specs
+    ADD CONSTRAINT eval_specs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: execution_spans execution_spans_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.execution_spans
+    ADD CONSTRAINT execution_spans_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: execution_state_snapshots execution_state_snapshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.execution_state_snapshots
+    ADD CONSTRAINT execution_state_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: executions executions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.executions
+    ADD CONSTRAINT executions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: experience_summaries experience_summaries_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.experience_summaries
+    ADD CONSTRAINT experience_summaries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: exploration_stats exploration_stats_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.exploration_stats
+    ADD CONSTRAINT exploration_stats_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: fix_applications fix_applications_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.fix_applications
+    ADD CONSTRAINT fix_applications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: flow_executions flow_executions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.flow_executions
+    ADD CONSTRAINT flow_executions_pkey PRIMARY KEY (instance_id);
+
+
+--
+-- Name: flow_versions flow_versions_flow_version_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.flow_versions
+    ADD CONSTRAINT flow_versions_flow_version_uniq UNIQUE (flow_id, version);
+
+
+--
+-- Name: flow_versions flow_versions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.flow_versions
+    ADD CONSTRAINT flow_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: generation_pipeline_artifacts generation_pipeline_artifacts_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.generation_pipeline_artifacts
+    ADD CONSTRAINT generation_pipeline_artifacts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: generation_pipeline_events generation_pipeline_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.generation_pipeline_events
+    ADD CONSTRAINT generation_pipeline_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: generation_rules generation_rules_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.generation_rules
+    ADD CONSTRAINT generation_rules_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gepa_optimization_runs gepa_optimization_runs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.gepa_optimization_runs
+    ADD CONSTRAINT gepa_optimization_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: golden_datasets golden_datasets_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.golden_datasets
+    ADD CONSTRAINT golden_datasets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: issue_pattern_templates issue_pattern_templates_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.issue_pattern_templates
+    ADD CONSTRAINT issue_pattern_templates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: iteration_logs iteration_logs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.iteration_logs
+    ADD CONSTRAINT iteration_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: known_issues known_issues_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.known_issues
+    ADD CONSTRAINT known_issues_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: learned_patterns learned_patterns_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.learned_patterns
+    ADD CONSTRAINT learned_patterns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: learned_patterns learned_patterns_problem_hash_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.learned_patterns
+    ADD CONSTRAINT learned_patterns_problem_hash_key UNIQUE (problem_hash);
+
+
+--
+-- Name: learning_outcomes learning_outcomes_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.learning_outcomes
+    ADD CONSTRAINT learning_outcomes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: learning_patterns learning_patterns_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.learning_patterns
+    ADD CONSTRAINT learning_patterns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: log_sources log_sources_name_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.log_sources
+    ADD CONSTRAINT log_sources_name_key UNIQUE (name);
+
+
+--
+-- Name: log_sources log_sources_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.log_sources
+    ADD CONSTRAINT log_sources_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: mcp_servers mcp_servers_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.mcp_servers
+    ADD CONSTRAINT mcp_servers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: memory_consolidation_log memory_consolidation_log_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.memory_consolidation_log
+    ADD CONSTRAINT memory_consolidation_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: meta_optimizer_recommendations meta_optimizer_recommendations_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.meta_optimizer_recommendations
+    ADD CONSTRAINT meta_optimizer_recommendations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: meta_optimizer_runs meta_optimizer_runs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.meta_optimizer_runs
+    ADD CONSTRAINT meta_optimizer_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: meta_optimizer_snapshots meta_optimizer_snapshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.meta_optimizer_snapshots
+    ADD CONSTRAINT meta_optimizer_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: model_profiles model_profiles_model_id_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.model_profiles
+    ADD CONSTRAINT model_profiles_model_id_key UNIQUE (model_id);
+
+
+--
+-- Name: model_profiles model_profiles_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.model_profiles
+    ADD CONSTRAINT model_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: model_routing_decisions model_routing_decisions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.model_routing_decisions
+    ADD CONSTRAINT model_routing_decisions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: model_routing_overrides model_routing_overrides_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.model_routing_overrides
+    ADD CONSTRAINT model_routing_overrides_pkey PRIMARY KEY (context_key);
+
+
+--
+-- Name: model_routing_table model_routing_table_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.model_routing_table
+    ADD CONSTRAINT model_routing_table_pkey PRIMARY KEY (context_key, model_id);
+
+
+--
+-- Name: observation_history observation_history_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observation_history
+    ADD CONSTRAINT observation_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: observations observations_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observations
+    ADD CONSTRAINT observations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: orchestration_loop_configs orchestration_loop_configs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.orchestration_loop_configs
+    ADD CONSTRAINT orchestration_loop_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: orchestrator_checkpoints orchestrator_checkpoints_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.orchestrator_checkpoints
+    ADD CONSTRAINT orchestrator_checkpoints_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: orchestrator_flows orchestrator_flows_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.orchestrator_flows
+    ADD CONSTRAINT orchestrator_flows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: orchestrator_verification_results orchestrator_verification_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.orchestrator_verification_results
+    ADD CONSTRAINT orchestrator_verification_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pending_discoveries pending_discoveries_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.pending_discoveries
+    ADD CONSTRAINT pending_discoveries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: performance_drift_signals performance_drift_signals_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.performance_drift_signals
+    ADD CONSTRAINT performance_drift_signals_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: phase_model_routing phase_model_routing_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.phase_model_routing
+    ADD CONSTRAINT phase_model_routing_pkey PRIMARY KEY (state_key, phase, model_tier);
+
+
+--
+-- Name: phase_results phase_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.phase_results
+    ADD CONSTRAINT phase_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: phase_token_usage phase_token_usage_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.phase_token_usage
+    ADD CONSTRAINT phase_token_usage_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pipeline_agent_traces pipeline_agent_traces_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.pipeline_agent_traces
+    ADD CONSTRAINT pipeline_agent_traces_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: playbook_entries playbook_entries_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.playbook_entries
+    ADD CONSTRAINT playbook_entries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pr_watch_state pr_watch_state_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.pr_watch_state
+    ADD CONSTRAINT pr_watch_state_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pr_watch_state pr_watch_state_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.pr_watch_state
+    ADD CONSTRAINT pr_watch_state_uniq UNIQUE (task_run_id, pr_number);
+
+
+--
+-- Name: prm_training_exports prm_training_exports_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.prm_training_exports
+    ADD CONSTRAINT prm_training_exports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: productivity_knowledge productivity_knowledge_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.productivity_knowledge
+    ADD CONSTRAINT productivity_knowledge_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prompt_evolution prompt_evolution_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.prompt_evolution
+    ADD CONSTRAINT prompt_evolution_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prompt_registry prompt_registry_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.prompt_registry
+    ADD CONSTRAINT prompt_registry_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prompt_registry prompt_registry_variant_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.prompt_registry
+    ADD CONSTRAINT prompt_registry_variant_uniq UNIQUE (agent_type, variant_name, version);
+
+
+--
+-- Name: prompt_template_canaries prompt_template_canaries_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.prompt_template_canaries
+    ADD CONSTRAINT prompt_template_canaries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prompts prompts_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.prompts
+    ADD CONSTRAINT prompts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: q_routing_overrides q_routing_overrides_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.q_routing_overrides
+    ADD CONSTRAINT q_routing_overrides_pkey PRIMARY KEY (state_key);
+
+
+--
+-- Name: q_routing_table q_routing_table_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.q_routing_table
+    ADD CONSTRAINT q_routing_table_pkey PRIMARY KEY (state_key, action);
+
+
+--
+-- Name: queued_workflows queued_workflows_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.queued_workflows
+    ADD CONSTRAINT queued_workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reasoning_traces reasoning_traces_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reasoning_traces
+    ADD CONSTRAINT reasoning_traces_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recording_actions recording_actions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.recording_actions
+    ADD CONSTRAINT recording_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recording_exports recording_exports_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.recording_exports
+    ADD CONSTRAINT recording_exports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recordings recordings_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.recordings
+    ADD CONSTRAINT recordings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: reflection_fixes reflection_fixes_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reflection_fixes
+    ADD CONSTRAINT reflection_fixes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: resource_versions resource_versions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.resource_versions
+    ADD CONSTRAINT resource_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: resource_versions resource_versions_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.resource_versions
+    ADD CONSTRAINT resource_versions_uniq UNIQUE (resource_type, resource_key, version);
+
+
+--
+-- Name: restate_awakeables restate_awakeables_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.restate_awakeables
+    ADD CONSTRAINT restate_awakeables_pkey PRIMARY KEY (awakeable_id);
+
+
+--
+-- Name: restate_workflow_executions restate_workflow_executions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.restate_workflow_executions
+    ADD CONSTRAINT restate_workflow_executions_pkey PRIMARY KEY (execution_id);
+
+
+--
+-- Name: robustness_reports robustness_reports_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.robustness_reports
+    ADD CONSTRAINT robustness_reports_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: rule_influence_log rule_influence_log_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.rule_influence_log
+    ADD CONSTRAINT rule_influence_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: saved_api_requests saved_api_requests_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.saved_api_requests
+    ADD CONSTRAINT saved_api_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: scheduled_tasks scheduled_tasks_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.scheduled_tasks
+    ADD CONSTRAINT scheduled_tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: scheduler_history scheduler_history_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.scheduler_history
+    ADD CONSTRAINT scheduler_history_pkey PRIMARY KEY (execution_id);
+
+
+--
+-- Name: scheduler_settings scheduler_settings_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.scheduler_settings
+    ADD CONSTRAINT scheduler_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: security_audit_events security_audit_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.security_audit_events
+    ADD CONSTRAINT security_audit_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: session_events session_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.session_events
+    ADD CONSTRAINT session_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sessions sessions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.sessions
+    ADD CONSTRAINT sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: settings settings_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.settings
+    ADD CONSTRAINT settings_pkey PRIMARY KEY (key);
+
+
+--
+-- Name: shell_command_results shell_command_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.shell_command_results
+    ADD CONSTRAINT shell_command_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: shell_commands shell_commands_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.shell_commands
+    ADD CONSTRAINT shell_commands_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sm_capture_screenshots sm_capture_screenshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.sm_capture_screenshots
+    ADD CONSTRAINT sm_capture_screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sm_element_thumbnails sm_element_thumbnails_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.sm_element_thumbnails
+    ADD CONSTRAINT sm_element_thumbnails_pkey PRIMARY KEY (config_id, fingerprint_hash);
+
+
+--
+-- Name: span_events span_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.span_events
+    ADD CONSTRAINT span_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: spec_accuracy_results spec_accuracy_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.spec_accuracy_results
+    ADD CONSTRAINT spec_accuracy_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: spec_compliance_results spec_compliance_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.spec_compliance_results
+    ADD CONSTRAINT spec_compliance_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: spec_versions spec_versions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.spec_versions
+    ADD CONSTRAINT spec_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: stall_events stall_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.stall_events
+    ADD CONSTRAINT stall_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_discovery_artifacts state_discovery_artifacts_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_discovery_artifacts
+    ADD CONSTRAINT state_discovery_artifacts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_discovery_drift_scores state_discovery_drift_scores_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_discovery_drift_scores
+    ADD CONSTRAINT state_discovery_drift_scores_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_machine_configs state_machine_configs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_machine_configs
+    ADD CONSTRAINT state_machine_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_machine_states state_machine_states_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_machine_states
+    ADD CONSTRAINT state_machine_states_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_machine_transitions state_machine_transitions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_machine_transitions
+    ADD CONSTRAINT state_machine_transitions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_credit_assignments step_credit_assignments_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_credit_assignments
+    ADD CONSTRAINT step_credit_assignments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_finding_links step_finding_links_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_finding_links
+    ADD CONSTRAINT step_finding_links_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_progress_markers step_progress_markers_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_progress_markers
+    ADD CONSTRAINT step_progress_markers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_provenance step_provenance_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_provenance
+    ADD CONSTRAINT step_provenance_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_templates step_templates_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_templates
+    ADD CONSTRAINT step_templates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_type_knowledge step_type_knowledge_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_type_knowledge
+    ADD CONSTRAINT step_type_knowledge_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: strategy_bank strategy_bank_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.strategy_bank
+    ADD CONSTRAINT strategy_bank_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_hooks task_hooks_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_hooks
+    ADD CONSTRAINT task_hooks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_knowledge task_knowledge_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_knowledge
+    ADD CONSTRAINT task_knowledge_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_knowledge_summaries task_knowledge_summaries_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_knowledge_summaries
+    ADD CONSTRAINT task_knowledge_summaries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_api_requests task_run_api_requests_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_api_requests
+    ADD CONSTRAINT task_run_api_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_automation task_run_automation_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_automation
+    ADD CONSTRAINT task_run_automation_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_awas_steps task_run_awas_steps_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_awas_steps
+    ADD CONSTRAINT task_run_awas_steps_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_events task_run_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_events
+    ADD CONSTRAINT task_run_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_findings task_run_findings_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_findings
+    ADD CONSTRAINT task_run_findings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_mcp_calls task_run_mcp_calls_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mcp_calls
+    ADD CONSTRAINT task_run_mcp_calls_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_mobile_logs task_run_mobile_logs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mobile_logs
+    ADD CONSTRAINT task_run_mobile_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_mobile_state task_run_mobile_state_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mobile_state
+    ADD CONSTRAINT task_run_mobile_state_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_output_chunks task_run_output_chunks_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_output_chunks
+    ADD CONSTRAINT task_run_output_chunks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_playwright_results task_run_playwright_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_playwright_results
+    ADD CONSTRAINT task_run_playwright_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_screenshots task_run_screenshots_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_screenshots
+    ADD CONSTRAINT task_run_screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_runs task_runs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_runs
+    ADD CONSTRAINT task_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: template_lifecycle_events template_lifecycle_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.template_lifecycle_events
+    ADD CONSTRAINT template_lifecycle_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: template_performance template_performance_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.template_performance
+    ADD CONSTRAINT template_performance_pkey PRIMARY KEY (template_id);
+
+
+--
+-- Name: test_associations test_associations_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.test_associations
+    ADD CONSTRAINT test_associations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test_results test_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.test_results
+    ADD CONSTRAINT test_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ticket_provider_configs ticket_provider_configs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ticket_provider_configs
+    ADD CONSTRAINT ticket_provider_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ticket_provider_configs ticket_provider_configs_workflow_id_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ticket_provider_configs
+    ADD CONSTRAINT ticket_provider_configs_workflow_id_key UNIQUE (workflow_id);
+
+
+--
+-- Name: ticket_task_mapping ticket_task_mapping_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ticket_task_mapping
+    ADD CONSTRAINT ticket_task_mapping_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ticket_task_mapping ticket_task_mapping_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ticket_task_mapping
+    ADD CONSTRAINT ticket_task_mapping_uniq UNIQUE (ticket_source, ticket_external_id);
+
+
+--
+-- Name: trigger_history trigger_history_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.trigger_history
+    ADD CONSTRAINT trigger_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_baselines ui_bridge_baselines_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_baselines
+    ADD CONSTRAINT ui_bridge_baselines_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_elements ui_bridge_elements_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_elements
+    ADD CONSTRAINT ui_bridge_elements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_events ui_bridge_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_events
+    ADD CONSTRAINT ui_bridge_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_integrations ui_bridge_integrations_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_integrations
+    ADD CONSTRAINT ui_bridge_integrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_navigation_history ui_bridge_navigation_history_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_navigation_history
+    ADD CONSTRAINT ui_bridge_navigation_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_states ui_bridge_states_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_states
+    ADD CONSTRAINT ui_bridge_states_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_states ui_bridge_states_state_id_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_states
+    ADD CONSTRAINT ui_bridge_states_state_id_key UNIQUE (state_id);
+
+
+--
+-- Name: ui_bridge_transitions ui_bridge_transitions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_transitions
+    ADD CONSTRAINT ui_bridge_transitions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_transitions ui_bridge_transitions_transition_id_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.ui_bridge_transitions
+    ADD CONSTRAINT ui_bridge_transitions_transition_id_key UNIQUE (transition_id);
+
+
+--
+-- Name: unified_workflows unified_workflows_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.unified_workflows
+    ADD CONSTRAINT unified_workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_skills user_skills_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.user_skills
+    ADD CONSTRAINT user_skills_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_skills user_skills_slug_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.user_skills
+    ADD CONSTRAINT user_skills_slug_key UNIQUE (slug);
+
+
+--
+-- Name: verification_plans verification_plans_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.verification_plans
+    ADD CONSTRAINT verification_plans_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: verification_tests verification_tests_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.verification_tests
+    ADD CONSTRAINT verification_tests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vga_runs vga_runs_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.vga_runs
+    ADD CONSTRAINT vga_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vga_shadow_samples vga_shadow_samples_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.vga_shadow_samples
+    ADD CONSTRAINT vga_shadow_samples_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: vga_state_machines vga_state_machines_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.vga_state_machines
+    ADD CONSTRAINT vga_state_machines_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: watchers watchers_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.watchers
+    ADD CONSTRAINT watchers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_ai_sessions workflow_ai_sessions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_ai_sessions
+    ADD CONSTRAINT workflow_ai_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_constraint_results workflow_constraint_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_constraint_results
+    ADD CONSTRAINT workflow_constraint_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_event_log workflow_event_log_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_event_log
+    ADD CONSTRAINT workflow_event_log_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_execution_state workflow_execution_state_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_execution_state
+    ADD CONSTRAINT workflow_execution_state_pkey PRIMARY KEY (execution_id);
+
+
+--
+-- Name: workflow_generation_feedback workflow_generation_feedback_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_generation_feedback
+    ADD CONSTRAINT workflow_generation_feedback_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_step_checkpoints workflow_step_checkpoints_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_step_checkpoints
+    ADD CONSTRAINT workflow_step_checkpoints_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_step_checkpoints workflow_step_checkpoints_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_step_checkpoints
+    ADD CONSTRAINT workflow_step_checkpoints_uniq UNIQUE (execution_id, phase, iteration, step_index, stage_index);
+
+
+--
+-- Name: workflow_triggers workflow_triggers_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_triggers
+    ADD CONSTRAINT workflow_triggers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_variables workflow_variables_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_variables
+    ADD CONSTRAINT workflow_variables_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_variables workflow_variables_uniq; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_variables
+    ADD CONSTRAINT workflow_variables_uniq UNIQUE (task_run_id, variable_name);
+
+
+--
+-- Name: workflow_verification_phase_results workflow_verification_phase_results_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_verification_phase_results
+    ADD CONSTRAINT workflow_verification_phase_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_versions workflow_versions_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_versions
+    ADD CONSTRAINT workflow_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_versions workflow_versions_unique; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_versions
+    ADD CONSTRAINT workflow_versions_unique UNIQUE (workflow_id, version_number);
+
+
+--
+-- Name: working_representations working_representations_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.working_representations
+    ADD CONSTRAINT working_representations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: working_representations working_representations_task_run_id_key; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.working_representations
+    ADD CONSTRAINT working_representations_task_run_id_key UNIQUE (task_run_id);
+
+
+--
+-- Name: wsv_shadow_disagreements wsv_shadow_disagreements_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.wsv_shadow_disagreements
+    ADD CONSTRAINT wsv_shadow_disagreements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: action_executions action_executions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_executions
+    ADD CONSTRAINT action_executions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: action_frames action_frames_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_frames
+    ADD CONSTRAINT action_frames_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: activity_logs activity_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.activity_logs
+    ADD CONSTRAINT activity_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: admin_notification_settings admin_notification_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_notification_settings
+    ADD CONSTRAINT admin_notification_settings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ai_prompt_templates ai_prompt_templates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_prompt_templates
+    ADD CONSTRAINT ai_prompt_templates_pkey PRIMARY KEY (id);
 
 
 --
@@ -2133,6 +13570,14 @@ ALTER TABLE ONLY public.automation_input_events ALTER COLUMN id SET DEFAULT next
 
 ALTER TABLE ONLY public.task_run_findings
     ADD CONSTRAINT ai_task_findings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_sessions ai_task_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_sessions
+    ADD CONSTRAINT ai_task_sessions_pkey PRIMARY KEY (id);
 
 
 --
@@ -2152,11 +13597,227 @@ ALTER TABLE ONLY public.alembic_version
 
 
 --
+-- Name: analytics_events analytics_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analytics_events
+    ADD CONSTRAINT analytics_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: annotation_sets annotation_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.annotation_sets
+    ADD CONSTRAINT annotation_sets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: annotations annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.annotations
+    ADD CONSTRAINT annotations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: application_profiles application_profiles_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.application_profiles
+    ADD CONSTRAINT application_profiles_name_key UNIQUE (name);
+
+
+--
+-- Name: application_profiles application_profiles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.application_profiles
+    ADD CONSTRAINT application_profiles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: audit_logs audit_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: automation_input_events automation_input_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.automation_input_events
     ADD CONSTRAINT automation_input_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automation_logs automation_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_logs
+    ADD CONSTRAINT automation_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automation_screenshots automation_screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_screenshots
+    ADD CONSTRAINT automation_screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automation_sessions automation_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_sessions
+    ADD CONSTRAINT automation_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automation_videos automation_videos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_videos
+    ADD CONSTRAINT automation_videos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: automation_videos automation_videos_s3_key_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_videos
+    ADD CONSTRAINT automation_videos_s3_key_key UNIQUE (s3_key);
+
+
+--
+-- Name: capture_actions capture_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_actions
+    ADD CONSTRAINT capture_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: capture_detected_elements capture_detected_elements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_detected_elements
+    ADD CONSTRAINT capture_detected_elements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: capture_screenshots capture_screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_screenshots
+    ADD CONSTRAINT capture_screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: capture_sessions capture_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_sessions
+    ADD CONSTRAINT capture_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: clipboard_entries clipboard_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.clipboard_entries
+    ADD CONSTRAINT clipboard_entries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: code_packages code_packages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.code_packages
+    ADD CONSTRAINT code_packages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: conflict_logs conflict_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.conflict_logs
+    ADD CONSTRAINT conflict_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: coverage_snapshots coverage_snapshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.coverage_snapshots
+    ADD CONSTRAINT coverage_snapshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: custom_functions custom_functions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.custom_functions
+    ADD CONSTRAINT custom_functions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: dataset_items dataset_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dataset_items
+    ADD CONSTRAINT dataset_items_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: deferred_questions deferred_questions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deferred_questions
+    ADD CONSTRAINT deferred_questions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: detected_issues detected_issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.detected_issues
+    ADD CONSTRAINT detected_issues_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: device_sessions device_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_sessions
+    ADD CONSTRAINT device_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: discovered_states discovered_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_states
+    ADD CONSTRAINT discovered_states_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: discovered_transitions discovered_transitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_transitions
+    ADD CONSTRAINT discovered_transitions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: discoveries discoveries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discoveries
+    ADD CONSTRAINT discoveries_pkey PRIMARY KEY (id);
 
 
 --
@@ -2168,11 +13829,163 @@ ALTER TABLE ONLY public.domain_knowledge
 
 
 --
+-- Name: edit_commands edit_commands_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_commands
+    ADD CONSTRAINT edit_commands_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: element_annotation_sets element_annotation_sets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.element_annotation_sets
+    ADD CONSTRAINT element_annotation_sets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: element_annotations element_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.element_annotations
+    ADD CONSTRAINT element_annotations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: embedding_generation_jobs embedding_generation_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.embedding_generation_jobs
+    ADD CONSTRAINT embedding_generation_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: error_monitor_entries error_monitor_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.error_monitor_entries
+    ADD CONSTRAINT error_monitor_entries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evaluation_datasets evaluation_datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluation_datasets
+    ADD CONSTRAINT evaluation_datasets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: evaluation_experiments evaluation_experiments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluation_experiments
+    ADD CONSTRAINT evaluation_experiments_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: execution_issues execution_issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.execution_issues
     ADD CONSTRAINT execution_issues_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: execution_runs execution_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_runs
+    ADD CONSTRAINT execution_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: execution_screenshots execution_screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_screenshots
+    ADD CONSTRAINT execution_screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: execution_tree_events execution_tree_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_tree_events
+    ADD CONSTRAINT execution_tree_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: experiment_results experiment_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.experiment_results
+    ADD CONSTRAINT experiment_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: extraction_annotations extraction_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extraction_annotations
+    ADD CONSTRAINT extraction_annotations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: extraction_sessions extraction_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extraction_sessions
+    ADD CONSTRAINT extraction_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: feedback_scores feedback_scores_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.feedback_scores
+    ADD CONSTRAINT feedback_scores_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: finding_category_configs finding_category_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.finding_category_configs
+    ADD CONSTRAINT finding_category_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: frame_index frame_index_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.frame_index
+    ADD CONSTRAINT frame_index_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: gui_action_type_configs gui_action_type_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gui_action_type_configs
+    ADD CONSTRAINT gui_action_type_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: historical_results historical_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results
+    ADD CONSTRAINT historical_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: input_events input_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.input_events
+    ADD CONSTRAINT input_events_pkey PRIMARY KEY (id);
 
 
 --
@@ -2184,11 +13997,163 @@ ALTER TABLE ONLY public.known_issues
 
 
 --
+-- Name: learned_workflows learned_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learned_workflows
+    ADD CONSTRAINT learned_workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_check_groups library_check_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_check_groups
+    ADD CONSTRAINT library_check_groups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_checks library_checks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_checks
+    ADD CONSTRAINT library_checks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_contexts library_contexts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_contexts
+    ADD CONSTRAINT library_contexts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_macros library_macros_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_macros
+    ADD CONSTRAINT library_macros_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_prompt_snippets library_prompt_snippets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_prompt_snippets
+    ADD CONSTRAINT library_prompt_snippets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_saved_api_requests library_saved_api_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_saved_api_requests
+    ADD CONSTRAINT library_saved_api_requests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: library_shell_commands library_shell_commands_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_shell_commands
+    ADD CONSTRAINT library_shell_commands_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notification_preferences notification_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_preferences
+    ADD CONSTRAINT notification_preferences_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notification_preferences notification_preferences_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_preferences
+    ADD CONSTRAINT notification_preferences_user_id_key UNIQUE (user_id);
+
+
+--
 -- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.notifications
     ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organization_invitations organization_invitations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invitations
+    ADD CONSTRAINT organization_invitations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: organizations organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organizations
+    ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: package_categories package_categories_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_categories
+    ADD CONSTRAINT package_categories_name_key UNIQUE (name);
+
+
+--
+-- Name: package_categories package_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_categories
+    ADD CONSTRAINT package_categories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: package_installations package_installations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations
+    ADD CONSTRAINT package_installations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: package_ratings package_ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_ratings
+    ADD CONSTRAINT package_ratings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: package_versions package_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_versions
+    ADD CONSTRAINT package_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: path_discoveries path_discoveries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.path_discoveries
+    ADD CONSTRAINT path_discoveries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: patterns patterns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.patterns
+    ADD CONSTRAINT patterns_pkey PRIMARY KEY (id);
 
 
 --
@@ -2200,11 +14165,51 @@ ALTER TABLE ONLY public.phase_results
 
 
 --
+-- Name: training_jobs pk_training_jobs; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_jobs
+    ADD CONSTRAINT pk_training_jobs PRIMARY KEY (id);
+
+
+--
 -- Name: processing_logs processing_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.processing_logs
     ADD CONSTRAINT processing_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_access_control project_access_control_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_access_control
+    ADD CONSTRAINT project_access_control_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_annotation_states project_annotation_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_annotation_states
+    ADD CONSTRAINT project_annotation_states_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_annotation_states project_annotation_states_project_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_annotation_states
+    ADD CONSTRAINT project_annotation_states_project_id_key UNIQUE (project_id);
+
+
+--
+-- Name: project_comments project_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_comments
+    ADD CONSTRAINT project_comments_pkey PRIMARY KEY (id);
 
 
 --
@@ -2216,6 +14221,14 @@ ALTER TABLE ONLY public.project_embeddings
 
 
 --
+-- Name: project_images project_images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_images
+    ADD CONSTRAINT project_images_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: project_locks project_locks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2224,11 +14237,123 @@ ALTER TABLE ONLY public.project_locks
 
 
 --
+-- Name: project_screenshots project_screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_screenshots
+    ADD CONSTRAINT project_screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_versions project_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_versions
+    ADD CONSTRAINT project_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT projects_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prompt_sequences prompt_sequences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prompt_sequences
+    ADD CONSTRAINT prompt_sequences_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: prompt_template_versions prompt_template_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prompt_template_versions
+    ADD CONSTRAINT prompt_template_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: push_devices push_devices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.push_devices
+    ADD CONSTRAINT push_devices_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recording_contexts recording_contexts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_contexts
+    ADD CONSTRAINT recording_contexts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recording_frames recording_frames_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_frames
+    ADD CONSTRAINT recording_frames_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recording_interactions recording_interactions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_interactions
+    ADD CONSTRAINT recording_interactions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recording_sessions recording_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_sessions
+    ADD CONSTRAINT recording_sessions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: recordings recordings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.recordings
     ADD CONSTRAINT recordings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: render_images render_images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.render_images
+    ADD CONSTRAINT render_images_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: render_logs render_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.render_logs
+    ADD CONSTRAINT render_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runner_connections runner_connections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_connections
+    ADD CONSTRAINT runner_connections_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runner_devices runner_devices_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_devices
+    ADD CONSTRAINT runner_devices_pkey PRIMARY KEY (id);
 
 
 --
@@ -2264,11 +14389,211 @@ ALTER TABLE ONLY public.scheduled_workflow_runs
 
 
 --
+-- Name: screenshot_input_associations screenshot_input_associations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshot_input_associations
+    ADD CONSTRAINT screenshot_input_associations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: screenshot_state_matches screenshot_state_matches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshot_state_matches
+    ADD CONSTRAINT screenshot_state_matches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: screenshots screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshots
+    ADD CONSTRAINT screenshots_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: session_activities session_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_activities
+    ADD CONSTRAINT session_activities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: shared_files shared_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.shared_files
+    ADD CONSTRAINT shared_files_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: skills skills_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.skills
+    ADD CONSTRAINT skills_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: skills skills_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.skills
+    ADD CONSTRAINT skills_slug_key UNIQUE (slug);
+
+
+--
+-- Name: snapshot_actions snapshot_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_actions
+    ADD CONSTRAINT snapshot_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: snapshot_matches snapshot_matches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_matches
+    ADD CONSTRAINT snapshot_matches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: snapshot_patterns snapshot_patterns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_patterns
+    ADD CONSTRAINT snapshot_patterns_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: snapshot_runs snapshot_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_runs
+    ADD CONSTRAINT snapshot_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: software_test_runs software_test_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.software_test_runs
+    ADD CONSTRAINT software_test_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_discovery_results state_discovery_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_discovery_results
+    ADD CONSTRAINT state_discovery_results_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: state_machine_configs state_machine_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.state_machine_configs
     ADD CONSTRAINT state_machine_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: state_transitions state_transitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_transitions
+    ADD CONSTRAINT state_transitions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: step_type_configs step_type_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.step_type_configs
+    ADD CONSTRAINT step_type_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: storage_usage storage_usage_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storage_usage
+    ADD CONSTRAINT storage_usage_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: subscriptions subscriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: subscriptions subscriptions_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_user_id_key UNIQUE (user_id);
+
+
+--
+-- Name: sync_locks sync_locks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sync_locks
+    ADD CONSTRAINT sync_locks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_automations task_run_automations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_automations
+    ADD CONSTRAINT task_run_automations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_run_verification_results task_run_verification_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_verification_results
+    ADD CONSTRAINT task_run_verification_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: team_members team_members_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.team_members
+    ADD CONSTRAINT team_members_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: template_candidates template_candidates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.template_candidates
+    ADD CONSTRAINT template_candidates_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test_deficiencies test_deficiencies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_deficiencies
+    ADD CONSTRAINT test_deficiencies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test_notification_preferences test_notification_preferences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_notification_preferences
+    ADD CONSTRAINT test_notification_preferences_pkey PRIMARY KEY (id);
 
 
 --
@@ -2280,6 +14605,14 @@ ALTER TABLE ONLY public.test_results
 
 
 --
+-- Name: test_screenshots test_screenshots_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_screenshots
+    ADD CONSTRAINT test_screenshots_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: training_dataset_annotations training_dataset_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2288,11 +14621,67 @@ ALTER TABLE ONLY public.training_dataset_annotations
 
 
 --
+-- Name: training_dataset_export_jobs training_dataset_export_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_export_jobs
+    ADD CONSTRAINT training_dataset_export_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: training_dataset_images training_dataset_images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_images
+    ADD CONSTRAINT training_dataset_images_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: training_datasets training_datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.training_datasets
     ADD CONSTRAINT training_datasets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transition_executions transition_executions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.transition_executions
+    ADD CONSTRAINT transition_executions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: transition_reliability transition_reliability_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.transition_reliability
+    ADD CONSTRAINT transition_reliability_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_exploration_sessions ui_bridge_exploration_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_exploration_sessions
+    ADD CONSTRAINT ui_bridge_exploration_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_state_configs ui_bridge_state_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_state_configs
+    ADD CONSTRAINT ui_bridge_state_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_state_domain_knowledge ui_bridge_state_domain_knowledge_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_state_domain_knowledge
+    ADD CONSTRAINT ui_bridge_state_domain_knowledge_pkey PRIMARY KEY (id);
 
 
 --
@@ -2320,6 +14709,94 @@ ALTER TABLE ONLY public.unified_workflows
 
 
 --
+-- Name: action_frames uq_action_frames_session_action_type; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_frames
+    ADD CONSTRAINT uq_action_frames_session_action_type UNIQUE (video_capture_session_id, snapshot_action_id, frame_type);
+
+
+--
+-- Name: finding_category_configs uq_finding_category_user_slug; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.finding_category_configs
+    ADD CONSTRAINT uq_finding_category_user_slug UNIQUE (user_id, slug);
+
+
+--
+-- Name: frame_index uq_frame_index_session_frame; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.frame_index
+    ADD CONSTRAINT uq_frame_index_session_frame UNIQUE (video_capture_session_id, frame_number);
+
+
+--
+-- Name: gui_action_type_configs uq_gui_action_type_user_type; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gui_action_type_configs
+    ADD CONSTRAINT uq_gui_action_type_user_type UNIQUE (user_id, action_type);
+
+
+--
+-- Name: team_members uq_org_user; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.team_members
+    ADD CONSTRAINT uq_org_user UNIQUE (organization_id, user_id);
+
+
+--
+-- Name: package_ratings uq_package_user_rating; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_ratings
+    ADD CONSTRAINT uq_package_user_rating UNIQUE (package_id, user_id);
+
+
+--
+-- Name: package_versions uq_package_version; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_versions
+    ADD CONSTRAINT uq_package_version UNIQUE (package_id, version);
+
+
+--
+-- Name: edit_commands uq_project_command_seq; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_commands
+    ADD CONSTRAINT uq_project_command_seq UNIQUE (project_id, sequence_number);
+
+
+--
+-- Name: custom_functions uq_project_file_function; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.custom_functions
+    ADD CONSTRAINT uq_project_file_function UNIQUE (project_id, file_path, function_name);
+
+
+--
+-- Name: package_installations uq_project_package; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations
+    ADD CONSTRAINT uq_project_package UNIQUE (project_id, package_id);
+
+
+--
+-- Name: project_versions uq_project_version; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_versions
+    ADD CONSTRAINT uq_project_version UNIQUE (project_id, version_number);
+
+
+--
 -- Name: workflow_variables uq_project_workflow_var; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2328,11 +14805,107 @@ ALTER TABLE ONLY public.workflow_variables
 
 
 --
+-- Name: step_type_configs uq_step_type_user_type_phase; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.step_type_configs
+    ADD CONSTRAINT uq_step_type_user_type_phase UNIQUE (user_id, step_type, phase);
+
+
+--
+-- Name: task_run_verification_results uq_task_run_verification_iteration; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_verification_results
+    ADD CONSTRAINT uq_task_run_verification_iteration UNIQUE (task_run_id, iteration);
+
+
+--
+-- Name: prompt_template_versions uq_template_version; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prompt_template_versions
+    ADD CONSTRAINT uq_template_version UNIQUE (template_id, version_number);
+
+
+--
+-- Name: workflow_phase_configs uq_workflow_phase_user_phase; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_phase_configs
+    ADD CONSTRAINT uq_workflow_phase_user_phase UNIQUE (user_id, phase);
+
+
+--
+-- Name: usage_metrics usage_metrics_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_metrics
+    ADD CONSTRAINT usage_metrics_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: variable_history variable_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.variable_history
+    ADD CONSTRAINT variable_history_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: verification_tests verification_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.verification_tests
     ADD CONSTRAINT verification_tests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: video_capture_sessions video_capture_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.video_capture_sessions
+    ADD CONSTRAINT video_capture_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: visual_baselines visual_baselines_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_baselines
+    ADD CONSTRAINT visual_baselines_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_events workflow_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_events
+    ADD CONSTRAINT workflow_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_execution_history workflow_execution_history_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_execution_history
+    ADD CONSTRAINT workflow_execution_history_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_phase_configs workflow_phase_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_phase_configs
+    ADD CONSTRAINT workflow_phase_configs_pkey PRIMARY KEY (id);
 
 
 --
@@ -2392,6 +14965,3884 @@ ALTER TABLE ONLY public.wrapper_ratings
 
 
 --
+-- Name: idx_api_surface_snapshots_created; Type: INDEX; Schema: agent; Owner: -
+--
+
+CREATE INDEX idx_api_surface_snapshots_created ON agent.api_surface_snapshots USING btree (created_at DESC);
+
+
+--
+-- Name: idx_cached_specs_app; Type: INDEX; Schema: agent; Owner: -
+--
+
+CREATE INDEX idx_cached_specs_app ON agent.cached_app_specs USING btree (app_url);
+
+
+--
+-- Name: idx_mqc_expires; Type: INDEX; Schema: agent; Owner: -
+--
+
+CREATE INDEX idx_mqc_expires ON agent.memory_query_cache USING btree (expires_at);
+
+
+--
+-- Name: idx_mqc_hash_level; Type: INDEX; Schema: agent; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_mqc_hash_level ON agent.memory_query_cache USING btree (query_hash, reasoning_level);
+
+
+--
+-- Name: ix_users_automation_streaming_enabled; Type: INDEX; Schema: auth; Owner: -
+--
+
+CREATE INDEX ix_users_automation_streaming_enabled ON auth.users USING btree (automation_streaming_enabled);
+
+
+--
+-- Name: ix_users_email; Type: INDEX; Schema: auth; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_users_email ON auth.users USING btree (email);
+
+
+--
+-- Name: ix_users_last_login_at; Type: INDEX; Schema: auth; Owner: -
+--
+
+CREATE INDEX ix_users_last_login_at ON auth.users USING btree (last_login_at);
+
+
+--
+-- Name: ix_users_username; Type: INDEX; Schema: auth; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_users_username ON auth.users USING btree (username);
+
+
+--
+-- Name: idx_cd_created; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_cd_created ON coord.coordinator_decisions USING btree (created_at DESC);
+
+
+--
+-- Name: idx_cd_open_escalations; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_cd_open_escalations ON coord.coordinator_decisions USING btree (created_at DESC) WHERE ((resolved = false) AND (auto_acted = false) AND (action = ANY (ARRAY['escalate'::text, 'kill-session'::text, 'force-promote-to-worktree'::text])));
+
+
+--
+-- Name: idx_cd_rule_action; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_cd_rule_action ON coord.coordinator_decisions USING btree (rule, action);
+
+
+--
+-- Name: idx_cd_session; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_cd_session ON coord.coordinator_decisions USING btree (session_id);
+
+
+--
+-- Name: idx_plans_path; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_plans_path ON coord.plans USING btree (markdown_path);
+
+
+--
+-- Name: idx_plans_status; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_plans_status ON coord.plans USING btree (status);
+
+
+--
+-- Name: idx_process_session_output_session; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_process_session_output_session ON coord.process_session_output USING btree (session_id);
+
+
+--
+-- Name: idx_process_sessions_config_id; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_process_sessions_config_id ON coord.process_sessions USING btree (process_config_id);
+
+
+--
+-- Name: idx_process_sessions_started_at; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_process_sessions_started_at ON coord.process_sessions USING btree (started_at);
+
+
+--
+-- Name: idx_reviews_pending_recommendations; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_reviews_pending_recommendations ON coord.reviews USING btree (created_at DESC) WHERE ((verdict = 'approved'::text) AND (confidence >= (0.7)::double precision) AND (confidence < (0.85)::double precision) AND (user_decision IS NULL));
+
+
+--
+-- Name: idx_reviews_reviewed_session; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_reviews_reviewed_session ON coord.reviews USING btree (reviewed_session_id);
+
+
+--
+-- Name: idx_reviews_task; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_reviews_task ON coord.reviews USING btree (task_id);
+
+
+--
+-- Name: idx_reviews_verdict; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_reviews_verdict ON coord.reviews USING btree (verdict);
+
+
+--
+-- Name: idx_ri_heartbeat; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_ri_heartbeat ON coord.runner_instances USING btree (last_heartbeat);
+
+
+--
+-- Name: idx_ri_port; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_ri_port ON coord.runner_instances USING btree (port);
+
+
+--
+-- Name: idx_ri_status; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_ri_status ON coord.runner_instances USING btree (status);
+
+
+--
+-- Name: idx_session_touched_files_recorded_at; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_session_touched_files_recorded_at ON coord.session_touched_files USING btree (recorded_at);
+
+
+--
+-- Name: idx_session_touched_files_task_run; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_session_touched_files_task_run ON coord.session_touched_files USING btree (task_run_id);
+
+
+--
+-- Name: idx_sfs_session; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_sfs_session ON coord.session_file_snapshots USING btree (session_id);
+
+
+--
+-- Name: idx_sfs_session_file; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_sfs_session_file ON coord.session_file_snapshots USING btree (session_id, file_path);
+
+
+--
+-- Name: idx_tasks_assigned_session; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_tasks_assigned_session ON coord.tasks USING btree (assigned_session_id) WHERE (assigned_session_id IS NOT NULL);
+
+
+--
+-- Name: idx_tasks_phase; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_tasks_phase ON coord.tasks USING btree (plan_id, phase_name, sequence_in_phase);
+
+
+--
+-- Name: idx_tasks_plan; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_tasks_plan ON coord.tasks USING btree (plan_id);
+
+
+--
+-- Name: idx_tasks_status; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_tasks_status ON coord.tasks USING btree (status);
+
+
+--
+-- Name: idx_worktrees_status; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_worktrees_status ON coord.worktrees USING btree (status);
+
+
+--
+-- Name: idx_worktrees_task_run; Type: INDEX; Schema: coord; Owner: -
+--
+
+CREATE INDEX idx_worktrees_task_run ON coord.worktrees USING btree (task_run_id);
+
+
+--
+-- Name: idx_ag_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ag_status ON project.approval_gates USING btree (status);
+
+
+--
+-- Name: idx_ag_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ag_task_run_id ON project.approval_gates USING btree (task_run_id);
+
+
+--
+-- Name: idx_ams_metric; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ams_metric ON project.agentic_metric_scores USING btree (metric_type);
+
+
+--
+-- Name: idx_ams_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ams_task_run ON project.agentic_metric_scores USING btree (task_run_id);
+
+
+--
+-- Name: idx_ams_unique; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_ams_unique ON project.agentic_metric_scores USING btree (task_run_id, metric_type);
+
+
+--
+-- Name: idx_arch_comp_health; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_arch_comp_health ON project.architecture_components USING btree (health_score);
+
+
+--
+-- Name: idx_arch_comp_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_arch_comp_workflow ON project.architecture_components USING btree (workflow_name);
+
+
+--
+-- Name: idx_artifacts_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_artifacts_created_at ON project.artifacts USING btree (created_at);
+
+
+--
+-- Name: idx_artifacts_passed; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_artifacts_passed ON project.artifacts USING btree (passed);
+
+
+--
+-- Name: idx_at_app_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_at_app_name ON project.activity_timeline USING btree (app_name) WHERE (app_name IS NOT NULL);
+
+
+--
+-- Name: idx_at_content_hash; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_at_content_hash ON project.activity_timeline USING btree (content_hash);
+
+
+--
+-- Name: idx_at_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_at_created_at ON project.activity_timeline USING btree (created_at);
+
+
+--
+-- Name: idx_at_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_at_fts ON project.activity_timeline USING gin (to_tsvector('english'::regconfig, text_content)) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_at_source_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_at_source_type ON project.activity_timeline USING btree (source_type) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_at_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_at_task_run ON project.activity_timeline USING btree (task_run_id) WHERE (task_run_id IS NOT NULL);
+
+
+--
+-- Name: idx_baselines_unique; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_baselines_unique ON project.agentic_metric_baselines USING btree (workflow_id, metric_type);
+
+
+--
+-- Name: idx_bc_gen; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_bc_gen ON project.beam_candidates USING btree (beam_run_id, generation);
+
+
+--
+-- Name: idx_bc_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_bc_run ON project.beam_candidates USING btree (beam_run_id);
+
+
+--
+-- Name: idx_bps_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_bps_execution ON project.breakpoint_snapshots USING btree (execution_id);
+
+
+--
+-- Name: idx_bps_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_bps_status ON project.breakpoint_snapshots USING btree (status);
+
+
+--
+-- Name: idx_bsr_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_bsr_agent ON project.beam_search_runs USING btree (agent_type);
+
+
+--
+-- Name: idx_bsr_pool; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_bsr_pool ON project.beam_search_runs USING btree (pool_id);
+
+
+--
+-- Name: idx_ca_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ca_execution ON project.compensation_actions USING btree (execution_id);
+
+
+--
+-- Name: idx_ca_pending; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ca_pending ON project.compensation_actions USING btree (execution_id) WHERE (NOT executed);
+
+
+--
+-- Name: idx_canvas_panels_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_canvas_panels_task_run_id ON project.canvas_panels USING btree (task_run_id);
+
+
+--
+-- Name: idx_causal_cause; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_causal_cause ON project.causal_events USING btree (cause_event_type, cause_event_id);
+
+
+--
+-- Name: idx_causal_dedup; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_causal_dedup ON project.causal_events USING btree (cause_event_type, cause_event_id, effect_event_type, effect_event_id);
+
+
+--
+-- Name: idx_causal_effect; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_causal_effect ON project.causal_events USING btree (effect_event_type, effect_event_id);
+
+
+--
+-- Name: idx_causal_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_causal_task_run ON project.causal_events USING btree (task_run_id);
+
+
+--
+-- Name: idx_causal_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_causal_workflow ON project.causal_events USING btree (workflow_name);
+
+
+--
+-- Name: idx_cg_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cg_enabled ON project.check_groups USING btree (enabled);
+
+
+--
+-- Name: idx_cgm_check; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cgm_check ON project.check_group_members USING btree (check_id);
+
+
+--
+-- Name: idx_cgm_group; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cgm_group ON project.check_group_members USING btree (group_id);
+
+
+--
+-- Name: idx_check_results_check_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_check_results_check_id ON project.check_results USING btree (check_id);
+
+
+--
+-- Name: idx_check_results_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_check_results_created_at ON project.check_results USING btree (created_at);
+
+
+--
+-- Name: idx_check_results_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_check_results_status ON project.check_results USING btree (status);
+
+
+--
+-- Name: idx_check_results_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_check_results_task_run_id ON project.check_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_checks_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_checks_enabled ON project.checks USING btree (enabled);
+
+
+--
+-- Name: idx_checks_tool; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_checks_tool ON project.checks USING btree (tool);
+
+
+--
+-- Name: idx_checks_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_checks_type ON project.checks USING btree (check_type);
+
+
+--
+-- Name: idx_chunk_labels_config; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_chunk_labels_config ON project.chunk_labels USING btree (config_id);
+
+
+--
+-- Name: idx_chunks_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_chunks_task_run ON project.task_run_output_chunks USING btree (task_run_id, chunk_sequence);
+
+
+--
+-- Name: idx_comp_health_snap_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comp_health_snap_at ON project.component_health_snapshots USING btree (snapshot_at);
+
+
+--
+-- Name: idx_comp_health_snap_comp; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comp_health_snap_comp ON project.component_health_snapshots USING btree (workflow_name, component_path);
+
+
+--
+-- Name: idx_comp_health_snap_wf; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comp_health_snap_wf ON project.component_health_snapshots USING btree (workflow_name);
+
+
+--
+-- Name: idx_comp_rel_source; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comp_rel_source ON project.component_relationships USING btree (source_component);
+
+
+--
+-- Name: idx_comp_rel_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comp_rel_workflow ON project.component_relationships USING btree (workflow_name);
+
+
+--
+-- Name: idx_comparison_runs_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comparison_runs_status ON project.comparison_runs USING btree (status);
+
+
+--
+-- Name: idx_comparison_runs_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_comparison_runs_workflow ON project.comparison_runs USING btree (workflow_id);
+
+
+--
+-- Name: idx_config_statistics_config_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_config_statistics_config_id ON project.config_statistics USING btree (config_id);
+
+
+--
+-- Name: idx_configs_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_configs_name ON project.configs USING btree (name);
+
+
+--
+-- Name: idx_convergence_project; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_convergence_project ON project.convergence_snapshots USING btree (project_path);
+
+
+--
+-- Name: idx_convergence_scope; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_convergence_scope ON project.convergence_snapshots USING btree (scope);
+
+
+--
+-- Name: idx_convergence_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_convergence_workflow ON project.convergence_snapshots USING btree (workflow_name);
+
+
+--
+-- Name: idx_cr_obs_a; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cr_obs_a ON project.contradiction_resolutions USING btree (observation_a_id);
+
+
+--
+-- Name: idx_cr_obs_b; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cr_obs_b ON project.contradiction_resolutions USING btree (observation_b_id);
+
+
+--
+-- Name: idx_cr_rec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cr_rec ON project.canary_rollouts USING btree (recommendation_id);
+
+
+--
+-- Name: idx_cr_resolved; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cr_resolved ON project.contradiction_resolutions USING btree (resolved_at);
+
+
+--
+-- Name: idx_cr_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cr_status ON project.canary_rollouts USING btree (status);
+
+
+--
+-- Name: idx_crp_signature; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_crp_signature ON project.cross_run_patterns USING btree (signature_hash);
+
+
+--
+-- Name: idx_crp_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_crp_status ON project.cross_run_patterns USING btree (status);
+
+
+--
+-- Name: idx_crp_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_crp_type ON project.cross_run_patterns USING btree (pattern_type);
+
+
+--
+-- Name: idx_crp_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_crp_workflow ON project.cross_run_patterns USING btree (workflow_name);
+
+
+--
+-- Name: idx_crr_canary; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_crr_canary ON project.canary_run_records USING btree (canary_id, is_canary);
+
+
+--
+-- Name: idx_cs_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_cs_fts ON project.concept_summaries USING gin (to_tsvector('english'::regconfig, ((((name || ' '::text) || tagline) || ' '::text) || description))) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_curated_examples_domain; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_curated_examples_domain ON project.curated_examples USING btree (domain);
+
+
+--
+-- Name: idx_curated_examples_quality; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_curated_examples_quality ON project.curated_examples USING btree (quality_score);
+
+
+--
+-- Name: idx_dc_pool; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dc_pool ON project.duel_candidates USING btree (pool_id);
+
+
+--
+-- Name: idx_dc_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dc_status ON project.duel_candidates USING btree (pool_id, status);
+
+
+--
+-- Name: idx_dec_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dec_category ON project.decisions USING btree (category);
+
+
+--
+-- Name: idx_dec_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dec_fts ON project.decisions USING gin (to_tsvector('english'::regconfig, ((((title || ' '::text) || summary) || ' '::text) || rationale))) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_dec_scale; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dec_scale ON project.decisions USING btree (scale);
+
+
+--
+-- Name: idx_dec_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dec_status ON project.decisions USING btree (status) WHERE (status = 'active'::text);
+
+
+--
+-- Name: idx_dec_timestamp; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dec_timestamp ON project.decisions USING btree ("timestamp");
+
+
+--
+-- Name: idx_di_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_di_created ON project.development_intelligence USING btree (created_at);
+
+
+--
+-- Name: idx_di_project; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_di_project ON project.development_intelligence USING btree (project_path, analysis_type);
+
+
+--
+-- Name: idx_discovery_spec_derived; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_discovery_spec_derived ON project.state_discovery_artifacts USING btree (spec_id, derived_at DESC);
+
+
+--
+-- Name: idx_dp_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dp_agent ON project.duel_pools USING btree (agent_type);
+
+
+--
+-- Name: idx_dp_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dp_status ON project.duel_pools USING btree (status);
+
+
+--
+-- Name: idx_dq_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dq_fts ON project.deferred_questions USING gin (to_tsvector('english'::regconfig, ((question || ' '::text) || COALESCE(context_json, ''::text))));
+
+
+--
+-- Name: idx_dq_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dq_status ON project.deferred_questions USING btree (status);
+
+
+--
+-- Name: idx_dq_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dq_task_run_id ON project.deferred_questions USING btree (task_run_id);
+
+
+--
+-- Name: idx_dr_pool; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_dr_pool ON project.duel_results USING btree (pool_id);
+
+
+--
+-- Name: idx_drift_context; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_drift_context ON project.performance_drift_signals USING btree (context_key, metric_name);
+
+
+--
+-- Name: idx_drift_scores_spec_computed; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_drift_scores_spec_computed ON project.state_discovery_drift_scores USING btree (spec_id, computed_at DESC);
+
+
+--
+-- Name: idx_drift_unack; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_drift_unack ON project.performance_drift_signals USING btree (acknowledged) WHERE (acknowledged = false);
+
+
+--
+-- Name: idx_ee_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ee_fts ON project.error_events USING gin (to_tsvector('english'::regconfig, ((((message || ' '::text) || COALESCE(stack_trace, ''::text)) || ' '::text) || COALESCE(context_lines, ''::text))));
+
+
+--
+-- Name: idx_entailment_cache_cached_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_entailment_cache_cached_at ON project.entailment_cache USING btree (cached_at);
+
+
+--
+-- Name: idx_ep_entity; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_ep_entity ON project.entity_profiles USING btree (entity_kind, entity_id) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_ep_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ep_fts ON project.entity_profiles USING gin (to_tsvector('english'::regconfig, ((entity_label || ' '::text) || profile_summary))) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_ep_importance; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ep_importance ON project.entity_profiles USING btree (importance) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_ep_topic_key; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ep_topic_key ON project.entity_profiles USING btree (topic_key) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_error_events_captured; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_captured ON project.error_events USING btree (captured_at DESC);
+
+
+--
+-- Name: idx_error_events_last_seen; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_last_seen ON project.error_events USING btree (last_seen_at DESC);
+
+
+--
+-- Name: idx_error_events_log_source; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_log_source ON project.error_events USING btree (log_source_id);
+
+
+--
+-- Name: idx_error_events_severity; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_severity ON project.error_events USING btree (severity);
+
+
+--
+-- Name: idx_error_events_signature; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_signature ON project.error_events USING btree (signature_hash);
+
+
+--
+-- Name: idx_error_events_source_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_source_name ON project.error_events USING btree (log_source_name);
+
+
+--
+-- Name: idx_error_events_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_status ON project.error_events USING btree (status);
+
+
+--
+-- Name: idx_error_events_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_task_run ON project.error_events USING btree (task_run_id);
+
+
+--
+-- Name: idx_error_events_trace_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_error_events_trace_id ON project.error_events USING btree (trace_id);
+
+
+--
+-- Name: idx_ess_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ess_execution ON project.execution_state_snapshots USING btree (execution_id);
+
+
+--
+-- Name: idx_ess_ts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ess_ts ON project.execution_state_snapshots USING btree (snapshot_ts);
+
+
+--
+-- Name: idx_eval_results_rec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_eval_results_rec ON project.eval_results USING btree (recommendation_id);
+
+
+--
+-- Name: idx_eval_results_spec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_eval_results_spec ON project.eval_results USING btree (spec_id);
+
+
+--
+-- Name: idx_event_log_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_event_log_execution ON project.workflow_event_log USING btree (execution_id, cursor);
+
+
+--
+-- Name: idx_event_log_node; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_event_log_node ON project.workflow_event_log USING btree (execution_id, node_id);
+
+
+--
+-- Name: idx_executions_started_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_executions_started_at ON project.executions USING btree (started_at);
+
+
+--
+-- Name: idx_executions_workflow_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_executions_workflow_name ON project.executions USING btree (workflow_name);
+
+
+--
+-- Name: idx_exp_domain; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_exp_domain ON project.experience_summaries USING btree (domain);
+
+
+--
+-- Name: idx_exp_outcome; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_exp_outcome ON project.experience_summaries USING btree (outcome);
+
+
+--
+-- Name: idx_exploration_stats_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_exploration_stats_workflow ON project.exploration_stats USING btree (workflow_id);
+
+
+--
+-- Name: idx_findings_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_findings_category ON project.task_run_findings USING btree (category);
+
+
+--
+-- Name: idx_findings_signature; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_findings_signature ON project.task_run_findings USING btree (signature_hash);
+
+
+--
+-- Name: idx_findings_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_findings_status ON project.task_run_findings USING btree (status);
+
+
+--
+-- Name: idx_findings_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_findings_task_run ON project.task_run_findings USING btree (task_run_id);
+
+
+--
+-- Name: idx_fix_applications_fix; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_fix_applications_fix ON project.fix_applications USING btree (fix_id);
+
+
+--
+-- Name: idx_fix_applications_sig; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_fix_applications_sig ON project.fix_applications USING btree (error_signature_hash);
+
+
+--
+-- Name: idx_fix_applications_task; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_fix_applications_task ON project.fix_applications USING btree (task_run_id);
+
+
+--
+-- Name: idx_flow_exec_flow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_flow_exec_flow ON project.flow_executions USING btree (flow_id);
+
+
+--
+-- Name: idx_flow_exec_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_flow_exec_status ON project.flow_executions USING btree (status);
+
+
+--
+-- Name: idx_flow_versions_flow_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_flow_versions_flow_id ON project.flow_versions USING btree (flow_id);
+
+
+--
+-- Name: idx_flow_versions_flow_version; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_flow_versions_flow_version ON project.flow_versions USING btree (flow_id, version);
+
+
+--
+-- Name: idx_generation_rules_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_generation_rules_agent ON project.generation_rules USING btree (agent);
+
+
+--
+-- Name: idx_generation_rules_agent_section; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_generation_rules_agent_section ON project.generation_rules USING btree (agent, section, rule_number);
+
+
+--
+-- Name: idx_generation_rules_severity; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_generation_rules_severity ON project.generation_rules USING btree (severity);
+
+
+--
+-- Name: idx_generation_rules_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_generation_rules_status ON project.generation_rules USING btree (status);
+
+
+--
+-- Name: idx_gepa_runs_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_gepa_runs_created ON project.gepa_optimization_runs USING btree (created_at);
+
+
+--
+-- Name: idx_gepa_runs_domain; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_gepa_runs_domain ON project.gepa_optimization_runs USING btree (domain);
+
+
+--
+-- Name: idx_golden_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_golden_agent ON project.golden_datasets USING btree (agent_type);
+
+
+--
+-- Name: idx_gpe_phase; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_gpe_phase ON project.generation_pipeline_events USING btree (phase);
+
+
+--
+-- Name: idx_gpe_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_gpe_task_run ON project.generation_pipeline_events USING btree (task_run_id);
+
+
+--
+-- Name: idx_gpe_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_gpe_type ON project.generation_pipeline_events USING btree (event_type);
+
+
+--
+-- Name: idx_ipt_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ipt_category ON project.issue_pattern_templates USING btree (category);
+
+
+--
+-- Name: idx_ipt_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ipt_status ON project.issue_pattern_templates USING btree (status);
+
+
+--
+-- Name: idx_iteration_logs_provider; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_iteration_logs_provider ON project.iteration_logs USING btree (provider_used) WHERE (provider_used IS NOT NULL);
+
+
+--
+-- Name: idx_iteration_logs_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_iteration_logs_task_run ON project.iteration_logs USING btree (task_run_id);
+
+
+--
+-- Name: idx_known_issues_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_known_issues_category ON project.known_issues USING btree (category);
+
+
+--
+-- Name: idx_known_issues_scope_compound; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_known_issues_scope_compound ON project.known_issues USING btree (scope_type, scope_value, status);
+
+
+--
+-- Name: idx_known_issues_scope_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_known_issues_scope_type ON project.known_issues USING btree (scope_type);
+
+
+--
+-- Name: idx_known_issues_scope_value; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_known_issues_scope_value ON project.known_issues USING btree (scope_value);
+
+
+--
+-- Name: idx_known_issues_severity; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_known_issues_severity ON project.known_issues USING btree (severity);
+
+
+--
+-- Name: idx_known_issues_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_known_issues_status ON project.known_issues USING btree (status);
+
+
+--
+-- Name: idx_learned_patterns_confidence; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_learned_patterns_confidence ON project.learned_patterns USING btree (confidence DESC);
+
+
+--
+-- Name: idx_learned_patterns_keywords_gin; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_learned_patterns_keywords_gin ON project.learned_patterns USING gin (trigger_keywords);
+
+
+--
+-- Name: idx_learned_patterns_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_learned_patterns_workflow ON project.learned_patterns USING btree (workflow_name);
+
+
+--
+-- Name: idx_lifecycle_events_template; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lifecycle_events_template ON project.template_lifecycle_events USING btree (template_id);
+
+
+--
+-- Name: idx_lo_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lo_created_at ON project.learning_outcomes USING btree (created_at);
+
+
+--
+-- Name: idx_lo_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lo_status ON project.learning_outcomes USING btree (status);
+
+
+--
+-- Name: idx_lo_strategy; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lo_strategy ON project.learning_outcomes USING btree (strategy);
+
+
+--
+-- Name: idx_lo_task_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lo_task_id ON project.learning_outcomes USING btree (task_id);
+
+
+--
+-- Name: idx_log_sources_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_log_sources_enabled ON project.log_sources USING btree (enabled);
+
+
+--
+-- Name: idx_log_sources_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_log_sources_name ON project.log_sources USING btree (name);
+
+
+--
+-- Name: idx_lp_confidence; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lp_confidence ON project.learning_patterns USING btree (confidence);
+
+
+--
+-- Name: idx_lp_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_lp_type ON project.learning_patterns USING btree (pattern_type);
+
+
+--
+-- Name: idx_mcp_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mcp_enabled ON project.mcp_servers USING btree (enabled);
+
+
+--
+-- Name: idx_meta_optimizer_runs_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_meta_optimizer_runs_type ON project.meta_optimizer_runs USING btree (optimizer_type);
+
+
+--
+-- Name: idx_meta_optimizer_snapshots_rec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_meta_optimizer_snapshots_rec ON project.meta_optimizer_snapshots USING btree (recommendation_id);
+
+
+--
+-- Name: idx_meta_optimizer_snapshots_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_meta_optimizer_snapshots_type ON project.meta_optimizer_snapshots USING btree (snapshot_type);
+
+
+--
+-- Name: idx_mobile_logs_source; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mobile_logs_source ON project.task_run_mobile_logs USING btree (log_source);
+
+
+--
+-- Name: idx_mobile_logs_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mobile_logs_task_run ON project.task_run_mobile_logs USING btree (task_run_id);
+
+
+--
+-- Name: idx_mobile_state_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mobile_state_task_run ON project.task_run_mobile_state USING btree (task_run_id);
+
+
+--
+-- Name: idx_mobile_state_timestamp; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mobile_state_timestamp ON project.task_run_mobile_state USING btree ("timestamp");
+
+
+--
+-- Name: idx_model_profiles_model; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_model_profiles_model ON project.model_profiles USING btree (model_id);
+
+
+--
+-- Name: idx_mor_content_hash; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mor_content_hash ON project.meta_optimizer_recommendations USING btree (content_hash);
+
+
+--
+-- Name: idx_mor_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mor_run ON project.meta_optimizer_recommendations USING btree (optimizer_run_id);
+
+
+--
+-- Name: idx_mor_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mor_status ON project.meta_optimizer_recommendations USING btree (status);
+
+
+--
+-- Name: idx_mor_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mor_type ON project.meta_optimizer_recommendations USING btree (optimizer_type);
+
+
+--
+-- Name: idx_mrd_model; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mrd_model ON project.model_routing_decisions USING btree (model_selected);
+
+
+--
+-- Name: idx_mrd_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_mrd_task_run ON project.model_routing_decisions USING btree (task_run_id);
+
+
+--
+-- Name: idx_obs_content_hash; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_content_hash ON project.observations USING btree (content_hash);
+
+
+--
+-- Name: idx_obs_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_created_at ON project.observations USING btree (created_at);
+
+
+--
+-- Name: idx_obs_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_fts ON project.observations USING gin (to_tsvector('english'::regconfig, ((title || ' '::text) || content))) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_obs_history_obs_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_history_obs_id ON project.observation_history USING btree (observation_id);
+
+
+--
+-- Name: idx_obs_history_valid; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_history_valid ON project.observation_history USING btree (valid_from, valid_until);
+
+
+--
+-- Name: idx_obs_importance; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_importance ON project.observations USING btree (importance) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_obs_last_accessed; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_last_accessed ON project.observations USING btree (last_accessed_at) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_obs_mental_model; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_mental_model ON project.observations USING btree (is_mental_model) WHERE ((NOT is_deleted) AND is_mental_model);
+
+
+--
+-- Name: idx_obs_project_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_project_type ON project.observations USING btree (project_id, observation_type) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_obs_scope; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_scope ON project.observations USING btree (scope) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_obs_superseded; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_superseded ON project.observations USING btree (superseded_by) WHERE (superseded_by IS NOT NULL);
+
+
+--
+-- Name: idx_obs_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_task_run ON project.observations USING btree (task_run_id) WHERE (task_run_id IS NOT NULL);
+
+
+--
+-- Name: idx_obs_topic_key; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_obs_topic_key ON project.observations USING btree (topic_key) WHERE ((topic_key IS NOT NULL) AND (NOT is_deleted));
+
+
+--
+-- Name: idx_obs_valid_from; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_valid_from ON project.observations USING btree (valid_from) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_obs_valid_until; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_obs_valid_until ON project.observations USING btree (valid_until) WHERE (NOT is_deleted);
+
+
+--
+-- Name: idx_observations_captured_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_observations_captured_at ON project.co_occurrence_observations USING btree (captured_at) WHERE (invalidated_at IS NULL);
+
+
+--
+-- Name: idx_observations_fingerprints; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_observations_fingerprints ON project.co_occurrence_observations USING gin (fingerprints);
+
+
+--
+-- Name: idx_observations_invalidation_token; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_observations_invalidation_token ON project.co_occurrence_observations USING btree (invalidation_token) WHERE (invalidation_token IS NOT NULL);
+
+
+--
+-- Name: idx_observations_spec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_observations_spec ON project.co_occurrence_observations USING btree (spec_id, captured_at) WHERE (invalidated_at IS NULL);
+
+
+--
+-- Name: idx_ol_configs_favorite; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ol_configs_favorite ON project.orchestration_loop_configs USING btree (is_favorite);
+
+
+--
+-- Name: idx_ol_configs_updated; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ol_configs_updated ON project.orchestration_loop_configs USING btree (updated_at);
+
+
+--
+-- Name: idx_orch_checkpoints_task; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_checkpoints_task ON project.orchestrator_checkpoints USING btree (task_id);
+
+
+--
+-- Name: idx_orch_checkpoints_task_iter; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_checkpoints_task_iter ON project.orchestrator_checkpoints USING btree (task_id, iteration);
+
+
+--
+-- Name: idx_orch_flows_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_flows_name ON project.orchestrator_flows USING btree (name);
+
+
+--
+-- Name: idx_orch_ver_results_criterion_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_ver_results_criterion_id ON project.orchestrator_verification_results USING btree (criterion_id);
+
+
+--
+-- Name: idx_orch_ver_results_iteration; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_ver_results_iteration ON project.orchestrator_verification_results USING btree (iteration);
+
+
+--
+-- Name: idx_orch_ver_results_passed; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_ver_results_passed ON project.orchestrator_verification_results USING btree (passed);
+
+
+--
+-- Name: idx_orch_ver_results_plan_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_ver_results_plan_id ON project.orchestrator_verification_results USING btree (plan_id);
+
+
+--
+-- Name: idx_orch_ver_results_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_orch_ver_results_task_run_id ON project.orchestrator_verification_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_pe_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pe_agent ON project.prompt_evolution USING btree (agent_type);
+
+
+--
+-- Name: idx_pe_variant; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pe_variant ON project.prompt_evolution USING btree (variant_id);
+
+
+--
+-- Name: idx_pe_verdict; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pe_verdict ON project.prompt_evolution USING btree (agent_type, canary_verdict);
+
+
+--
+-- Name: idx_pending_discoveries_attempt_count; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pending_discoveries_attempt_count ON project.pending_discoveries USING btree (attempt_count);
+
+
+--
+-- Name: idx_pending_discoveries_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pending_discoveries_created_at ON project.pending_discoveries USING btree (created_at);
+
+
+--
+-- Name: idx_phase_model_routing_state; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_phase_model_routing_state ON project.phase_model_routing USING btree (state_key);
+
+
+--
+-- Name: idx_pipeline_agent_traces_agent_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_agent_traces_agent_type ON project.pipeline_agent_traces USING btree (agent_type);
+
+
+--
+-- Name: idx_pipeline_agent_traces_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_agent_traces_run_id ON project.pipeline_agent_traces USING btree (run_id);
+
+
+--
+-- Name: idx_pipeline_agent_traces_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_agent_traces_task_run ON project.pipeline_agent_traces USING btree (task_run_id);
+
+
+--
+-- Name: idx_pipeline_artifacts_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_artifacts_created ON project.generation_pipeline_artifacts USING btree (created_at);
+
+
+--
+-- Name: idx_pipeline_artifacts_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_artifacts_workflow ON project.generation_pipeline_artifacts USING btree (workflow_id);
+
+
+--
+-- Name: idx_pipeline_traces_parent_span; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_traces_parent_span ON project.pipeline_agent_traces USING btree (parent_span_id);
+
+
+--
+-- Name: idx_pipeline_traces_span_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pipeline_traces_span_type ON project.pipeline_agent_traces USING btree (span_type);
+
+
+--
+-- Name: idx_pk_area; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pk_area ON project.productivity_knowledge USING btree (area);
+
+
+--
+-- Name: idx_pk_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pk_created ON project.productivity_knowledge USING btree (created_at DESC);
+
+
+--
+-- Name: idx_pk_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pk_fts ON project.productivity_knowledge USING gin (to_tsvector('english'::regconfig, ((((area || ' '::text) || summary) || ' '::text) || body)));
+
+
+--
+-- Name: idx_pk_session; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pk_session ON project.productivity_knowledge USING btree (session_id) WHERE (session_id IS NOT NULL);
+
+
+--
+-- Name: idx_pk_task; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pk_task ON project.productivity_knowledge USING btree (task_id) WHERE (task_id IS NOT NULL);
+
+
+--
+-- Name: idx_playbook_entries_domain; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_playbook_entries_domain ON project.playbook_entries USING btree (domain);
+
+
+--
+-- Name: idx_playbook_entries_severity; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_playbook_entries_severity ON project.playbook_entries USING btree (severity);
+
+
+--
+-- Name: idx_playbook_entries_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_playbook_entries_status ON project.playbook_entries USING btree (status);
+
+
+--
+-- Name: idx_pr_active; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pr_active ON project.prompt_registry USING btree (agent_type, is_active);
+
+
+--
+-- Name: idx_pr_agent_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pr_agent_type ON project.prompt_registry USING btree (agent_type);
+
+
+--
+-- Name: idx_pr_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pr_execution ON project.phase_results USING btree (execution_id);
+
+
+--
+-- Name: idx_pr_execution_phase; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_pr_execution_phase ON project.phase_results USING btree (execution_id, phase, iteration);
+
+
+--
+-- Name: idx_prm_exports_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_prm_exports_created ON project.prm_training_exports USING btree (created_at);
+
+
+--
+-- Name: idx_prompts_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_prompts_name ON project.prompts USING btree (name);
+
+
+--
+-- Name: idx_prw_active; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_prw_active ON project.pr_watch_state USING btree (completed_at) WHERE (completed_at IS NULL);
+
+
+--
+-- Name: idx_prw_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_prw_task_run ON project.pr_watch_state USING btree (task_run_id);
+
+
+--
+-- Name: idx_ptc_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ptc_status ON project.prompt_template_canaries USING btree (status);
+
+
+--
+-- Name: idx_ptc_template; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ptc_template ON project.prompt_template_canaries USING btree (template_id);
+
+
+--
+-- Name: idx_ptu_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ptu_created_at ON project.phase_token_usage USING btree (created_at);
+
+
+--
+-- Name: idx_ptu_target_app; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ptu_target_app ON project.phase_token_usage USING btree (target_app) WHERE (target_app IS NOT NULL);
+
+
+--
+-- Name: idx_ptu_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ptu_task_run ON project.phase_token_usage USING btree (task_run_id);
+
+
+--
+-- Name: idx_queued_workflows_priority; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_queued_workflows_priority ON project.queued_workflows USING btree (priority DESC, queued_at);
+
+
+--
+-- Name: idx_queued_workflows_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_queued_workflows_status ON project.queued_workflows USING btree (status);
+
+
+--
+-- Name: idx_ra_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ra_execution ON project.restate_awakeables USING btree (execution_id);
+
+
+--
+-- Name: idx_ra_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ra_status ON project.restate_awakeables USING btree (status);
+
+
+--
+-- Name: idx_recording_actions_action_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recording_actions_action_type ON project.recording_actions USING btree (action_type);
+
+
+--
+-- Name: idx_recording_actions_recording_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recording_actions_recording_id ON project.recording_actions USING btree (recording_id);
+
+
+--
+-- Name: idx_recording_actions_sequence; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recording_actions_sequence ON project.recording_actions USING btree (recording_id, sequence_number);
+
+
+--
+-- Name: idx_recording_exports_format; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recording_exports_format ON project.recording_exports USING btree (export_format);
+
+
+--
+-- Name: idx_recording_exports_recording_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recording_exports_recording_id ON project.recording_exports USING btree (recording_id);
+
+
+--
+-- Name: idx_recordings_base_url; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recordings_base_url ON project.recordings USING btree (base_url);
+
+
+--
+-- Name: idx_recordings_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recordings_created_at ON project.recordings USING btree (created_at);
+
+
+--
+-- Name: idx_recordings_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_recordings_status ON project.recordings USING btree (status);
+
+
+--
+-- Name: idx_reflection_fixes_applied_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_applied_at ON project.reflection_fixes USING btree (applied_at);
+
+
+--
+-- Name: idx_reflection_fixes_content_hash; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_content_hash ON project.reflection_fixes USING btree (content_hash);
+
+
+--
+-- Name: idx_reflection_fixes_effectiveness; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_effectiveness ON project.reflection_fixes USING btree (effectiveness);
+
+
+--
+-- Name: idx_reflection_fixes_project; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_project ON project.reflection_fixes USING btree (project_path);
+
+
+--
+-- Name: idx_reflection_fixes_reflection; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_reflection ON project.reflection_fixes USING btree (reflection_task_run_id);
+
+
+--
+-- Name: idx_reflection_fixes_scope; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_scope ON project.reflection_fixes USING btree (reflection_scope);
+
+
+--
+-- Name: idx_reflection_fixes_source; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_source ON project.reflection_fixes USING btree (source_task_run_id);
+
+
+--
+-- Name: idx_reflection_fixes_source_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_source_agent ON project.reflection_fixes USING btree (source_agent);
+
+
+--
+-- Name: idx_reflection_fixes_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_reflection_fixes_status ON project.reflection_fixes USING btree (status);
+
+
+--
+-- Name: idx_ril_influence; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ril_influence ON project.rule_influence_log USING btree (influence_type);
+
+
+--
+-- Name: idx_ril_rule; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ril_rule ON project.rule_influence_log USING btree (rule_id);
+
+
+--
+-- Name: idx_ril_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ril_task_run ON project.rule_influence_log USING btree (task_run_id);
+
+
+--
+-- Name: idx_robustness_variant; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_robustness_variant ON project.robustness_reports USING btree (prompt_variant_id);
+
+
+--
+-- Name: idx_rt_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rt_created ON project.reasoning_traces USING btree (created_at);
+
+
+--
+-- Name: idx_rt_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rt_run ON project.reasoning_traces USING btree (dreamer_run_id);
+
+
+--
+-- Name: idx_rt_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rt_type ON project.reasoning_traces USING btree (reasoning_type);
+
+
+--
+-- Name: idx_rt_valid; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rt_valid ON project.reasoning_traces USING btree (is_valid) WHERE is_valid;
+
+
+--
+-- Name: idx_rv_hash; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rv_hash ON project.resource_versions USING btree (content_hash);
+
+
+--
+-- Name: idx_rv_latest; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rv_latest ON project.resource_versions USING btree (resource_type, resource_key, version DESC);
+
+
+--
+-- Name: idx_rv_resource; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rv_resource ON project.resource_versions USING btree (resource_type, resource_key);
+
+
+--
+-- Name: idx_rwe_restate_wf; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rwe_restate_wf ON project.restate_workflow_executions USING btree (restate_workflow_id);
+
+
+--
+-- Name: idx_rwe_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_rwe_status ON project.restate_workflow_executions USING btree (status);
+
+
+--
+-- Name: idx_sar_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sar_category ON project.saved_api_requests USING btree (category);
+
+
+--
+-- Name: idx_sc_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sc_category ON project.shell_commands USING btree (category);
+
+
+--
+-- Name: idx_sc_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sc_enabled ON project.shell_commands USING btree (enabled);
+
+
+--
+-- Name: idx_sca_step_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sca_step_type ON project.step_credit_assignments USING btree (step_type);
+
+
+--
+-- Name: idx_sca_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sca_task_run ON project.step_credit_assignments USING btree (task_run_id);
+
+
+--
+-- Name: idx_scheduled_tasks_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_scheduled_tasks_enabled ON project.scheduled_tasks USING btree (enabled);
+
+
+--
+-- Name: idx_scheduler_history_started_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_scheduler_history_started_at ON project.scheduler_history USING btree (started_at);
+
+
+--
+-- Name: idx_scheduler_history_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_scheduler_history_status ON project.scheduler_history USING btree (status);
+
+
+--
+-- Name: idx_scheduler_history_task_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_scheduler_history_task_id ON project.scheduler_history USING btree (task_id);
+
+
+--
+-- Name: idx_scheduler_history_task_scheduled_for; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_scheduler_history_task_scheduled_for ON project.scheduler_history USING btree (task_id, scheduled_for);
+
+
+--
+-- Name: idx_sec_audit_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sec_audit_created ON project.security_audit_events USING btree (created_at);
+
+
+--
+-- Name: idx_sec_audit_decision; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sec_audit_decision ON project.security_audit_events USING btree (decision);
+
+
+--
+-- Name: idx_sec_audit_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sec_audit_task_run ON project.security_audit_events USING btree (task_run_id) WHERE (task_run_id IS NOT NULL);
+
+
+--
+-- Name: idx_sec_audit_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sec_audit_type ON project.security_audit_events USING btree (event_type);
+
+
+--
+-- Name: idx_session_events_session_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_session_events_session_id ON project.session_events USING btree (session_id);
+
+
+--
+-- Name: idx_sessions_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sessions_created_at ON project.sessions USING btree (created_at);
+
+
+--
+-- Name: idx_sessions_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sessions_run_id ON project.sessions USING btree (run_id);
+
+
+--
+-- Name: idx_sessions_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sessions_status ON project.sessions USING btree (status);
+
+
+--
+-- Name: idx_sessions_workflow_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sessions_workflow_name ON project.sessions USING btree (workflow_name);
+
+
+--
+-- Name: idx_sfl_finding; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sfl_finding ON project.step_finding_links USING btree (finding_id);
+
+
+--
+-- Name: idx_sfl_step; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sfl_step ON project.step_finding_links USING btree (step_name);
+
+
+--
+-- Name: idx_sfl_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sfl_task_run ON project.step_finding_links USING btree (task_run_id);
+
+
+--
+-- Name: idx_shell_command_results_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_shell_command_results_created_at ON project.shell_command_results USING btree (created_at);
+
+
+--
+-- Name: idx_shell_command_results_shell_command_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_shell_command_results_shell_command_id ON project.shell_command_results USING btree (shell_command_id);
+
+
+--
+-- Name: idx_shell_command_results_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_shell_command_results_status ON project.shell_command_results USING btree (status);
+
+
+--
+-- Name: idx_shell_command_results_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_shell_command_results_task_run_id ON project.shell_command_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_sm_screenshots_config; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sm_screenshots_config ON project.sm_capture_screenshots USING btree (config_id);
+
+
+--
+-- Name: idx_sm_states_config_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sm_states_config_id ON project.state_machine_states USING btree (config_id);
+
+
+--
+-- Name: idx_sm_thumbnails_config; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sm_thumbnails_config ON project.sm_element_thumbnails USING btree (config_id);
+
+
+--
+-- Name: idx_sm_transitions_config_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sm_transitions_config_id ON project.state_machine_transitions USING btree (config_id);
+
+
+--
+-- Name: idx_sp_agent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sp_agent ON project.step_provenance USING btree (generating_agent);
+
+
+--
+-- Name: idx_sp_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_sp_workflow ON project.step_provenance USING btree (workflow_id);
+
+
+--
+-- Name: idx_span_events_exec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_span_events_exec ON project.span_events USING btree (execution_id);
+
+
+--
+-- Name: idx_span_events_trace; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_span_events_trace ON project.span_events USING btree (trace_id);
+
+
+--
+-- Name: idx_span_events_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_span_events_type ON project.span_events USING btree (event_type);
+
+
+--
+-- Name: idx_spans_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spans_execution ON project.execution_spans USING btree (execution_id);
+
+
+--
+-- Name: idx_spans_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spans_name ON project.execution_spans USING btree (name);
+
+
+--
+-- Name: idx_spans_trace; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spans_trace ON project.execution_spans USING btree (trace_id);
+
+
+--
+-- Name: idx_spec_accuracy_spec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_accuracy_spec ON project.spec_accuracy_results USING btree (spec_id);
+
+
+--
+-- Name: idx_spec_accuracy_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_accuracy_type ON project.spec_accuracy_results USING btree (analysis_type);
+
+
+--
+-- Name: idx_spec_compliance_score; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_compliance_score ON project.spec_compliance_results USING btree (overall_score);
+
+
+--
+-- Name: idx_spec_compliance_spec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_compliance_spec ON project.spec_compliance_results USING btree (spec_id);
+
+
+--
+-- Name: idx_spec_compliance_task; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_compliance_task ON project.spec_compliance_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_spec_versions_hash; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_versions_hash ON project.spec_versions USING btree (content_hash);
+
+
+--
+-- Name: idx_spec_versions_num; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_spec_versions_num ON project.spec_versions USING btree (spec_id, version_number);
+
+
+--
+-- Name: idx_spec_versions_spec; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spec_versions_spec ON project.spec_versions USING btree (spec_id);
+
+
+--
+-- Name: idx_spm_checkpoint; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_spm_checkpoint ON project.step_progress_markers USING btree (checkpoint_id);
+
+
+--
+-- Name: idx_stall_pattern; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_stall_pattern ON project.stall_events USING btree (pattern_type);
+
+
+--
+-- Name: idx_stall_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_stall_task_run ON project.stall_events USING btree (task_run_id);
+
+
+--
+-- Name: idx_step_templates_domain; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_step_templates_domain ON project.step_templates USING btree (domain);
+
+
+--
+-- Name: idx_stk_composite; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_stk_composite ON project.step_type_knowledge USING btree (step_type, layer, status);
+
+
+--
+-- Name: idx_stk_layer; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_stk_layer ON project.step_type_knowledge USING btree (layer);
+
+
+--
+-- Name: idx_stk_step_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_stk_step_type ON project.step_type_knowledge USING btree (step_type);
+
+
+--
+-- Name: idx_strategy_parent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_strategy_parent ON project.strategy_bank USING btree (parent_strategy_id);
+
+
+--
+-- Name: idx_strategy_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_strategy_status ON project.strategy_bank USING btree (status);
+
+
+--
+-- Name: idx_task_hooks_trigger; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_hooks_trigger ON project.task_hooks USING btree (trigger_event);
+
+
+--
+-- Name: idx_task_knowledge_summaries_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_knowledge_summaries_category ON project.task_knowledge_summaries USING btree (category);
+
+
+--
+-- Name: idx_task_knowledge_summaries_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_knowledge_summaries_task_run_id ON project.task_knowledge_summaries USING btree (task_run_id);
+
+
+--
+-- Name: idx_task_run_automation_started_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_automation_started_at ON project.task_run_automation USING btree (started_at);
+
+
+--
+-- Name: idx_task_run_automation_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_automation_status ON project.task_run_automation USING btree (automation_status);
+
+
+--
+-- Name: idx_task_run_automation_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_automation_task_run_id ON project.task_run_automation USING btree (task_run_id);
+
+
+--
+-- Name: idx_task_run_mcp_calls_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_mcp_calls_created_at ON project.task_run_mcp_calls USING btree (created_at);
+
+
+--
+-- Name: idx_task_run_mcp_calls_server_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_mcp_calls_server_id ON project.task_run_mcp_calls USING btree (server_id);
+
+
+--
+-- Name: idx_task_run_mcp_calls_step_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_mcp_calls_step_id ON project.task_run_mcp_calls USING btree (step_id);
+
+
+--
+-- Name: idx_task_run_mcp_calls_success; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_mcp_calls_success ON project.task_run_mcp_calls USING btree (success);
+
+
+--
+-- Name: idx_task_run_mcp_calls_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_run_mcp_calls_task_run_id ON project.task_run_mcp_calls USING btree (task_run_id);
+
+
+--
+-- Name: idx_task_runs_blocking_children; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_task_runs_blocking_children ON project.task_runs USING btree (parent_task_run_id, blocks_parent) WHERE ((blocks_parent = true) AND (status <> ALL (ARRAY['complete'::text, 'failed'::text, 'stopped'::text])));
+
+
+--
+-- Name: idx_test_associations_config_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_test_associations_config_id ON project.test_associations USING btree (config_id);
+
+
+--
+-- Name: idx_test_associations_test_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_test_associations_test_id ON project.test_associations USING btree (test_id);
+
+
+--
+-- Name: idx_test_results_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_test_results_created_at ON project.test_results USING btree (created_at);
+
+
+--
+-- Name: idx_test_results_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_test_results_status ON project.test_results USING btree (status);
+
+
+--
+-- Name: idx_test_results_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_test_results_task_run_id ON project.test_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_test_results_test_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_test_results_test_id ON project.test_results USING btree (test_id);
+
+
+--
+-- Name: idx_ticket_provider_configs_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ticket_provider_configs_workflow ON project.ticket_provider_configs USING btree (workflow_id);
+
+
+--
+-- Name: idx_ticket_task_mapping_task; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ticket_task_mapping_task ON project.ticket_task_mapping USING btree (task_run_id);
+
+
+--
+-- Name: idx_tk_active; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tk_active ON project.task_knowledge USING btree (task_run_id, category) WHERE (archived_at IS NULL);
+
+
+--
+-- Name: idx_tk_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tk_category ON project.task_knowledge USING btree (category);
+
+
+--
+-- Name: idx_tk_created; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tk_created ON project.task_knowledge USING btree (created_at DESC);
+
+
+--
+-- Name: idx_tk_project_path; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tk_project_path ON project.task_knowledge USING btree (project_path) WHERE (project_path IS NOT NULL);
+
+
+--
+-- Name: idx_tk_resolved; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tk_resolved ON project.task_knowledge USING btree (is_resolved) WHERE (NOT is_resolved);
+
+
+--
+-- Name: idx_tk_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tk_task_run ON project.task_knowledge USING btree (task_run_id);
+
+
+--
+-- Name: idx_tr_bridge_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_bridge_id ON project.task_runs USING btree (bridge_id);
+
+
+--
+-- Name: idx_tr_config_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_config_id ON project.task_runs USING btree (config_id);
+
+
+--
+-- Name: idx_tr_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_created_at ON project.task_runs USING btree (created_at);
+
+
+--
+-- Name: idx_tr_parent; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_parent ON project.task_runs USING btree (parent_task_run_id);
+
+
+--
+-- Name: idx_tr_root; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_root ON project.task_runs USING btree (root_task_run_id);
+
+
+--
+-- Name: idx_tr_runner_port; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_runner_port ON project.task_runs USING btree (runner_port);
+
+
+--
+-- Name: idx_tr_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_status ON project.task_runs USING btree (status);
+
+
+--
+-- Name: idx_tr_task_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_task_type ON project.task_runs USING btree (task_type);
+
+
+--
+-- Name: idx_tr_workflow_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tr_workflow_id ON project.task_runs USING btree (workflow_id);
+
+
+--
+-- Name: idx_trar_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trar_created_at ON project.task_run_api_requests USING btree (created_at);
+
+
+--
+-- Name: idx_trar_step_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trar_step_id ON project.task_run_api_requests USING btree (step_id);
+
+
+--
+-- Name: idx_trar_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trar_task_run_id ON project.task_run_api_requests USING btree (task_run_id);
+
+
+--
+-- Name: idx_traw_step_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_traw_step_type ON project.task_run_awas_steps USING btree (step_type);
+
+
+--
+-- Name: idx_traw_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_traw_task_run_id ON project.task_run_awas_steps USING btree (task_run_id);
+
+
+--
+-- Name: idx_tre_event_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tre_event_type ON project.task_run_events USING btree (event_type);
+
+
+--
+-- Name: idx_tre_subtype; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tre_subtype ON project.task_run_events USING btree (event_subtype);
+
+
+--
+-- Name: idx_tre_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tre_task_run_id ON project.task_run_events USING btree (task_run_id);
+
+
+--
+-- Name: idx_tre_timestamp; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tre_timestamp ON project.task_run_events USING btree ("timestamp");
+
+
+--
+-- Name: idx_tre_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_tre_workflow ON project.task_run_events USING btree (workflow_name);
+
+
+--
+-- Name: idx_trigger_history_trigger_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trigger_history_trigger_id ON project.trigger_history USING btree (trigger_id);
+
+
+--
+-- Name: idx_trigger_history_triggered_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trigger_history_triggered_at ON project.trigger_history USING btree (triggered_at);
+
+
+--
+-- Name: idx_trp_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trp_status ON project.task_run_playwright_results USING btree (status);
+
+
+--
+-- Name: idx_trp_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trp_task_run_id ON project.task_run_playwright_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_trs_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trs_task_run_id ON project.task_run_screenshots USING btree (task_run_id);
+
+
+--
+-- Name: idx_trs_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_trs_type ON project.task_run_screenshots USING btree (screenshot_type);
+
+
+--
+-- Name: idx_ube_element_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ube_element_id ON project.ui_bridge_elements USING btree (element_id);
+
+
+--
+-- Name: idx_ube_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ube_task_run ON project.ui_bridge_elements USING btree (task_run_id);
+
+
+--
+-- Name: idx_ube_timestamp; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ube_timestamp ON project.ui_bridge_elements USING btree ("timestamp");
+
+
+--
+-- Name: idx_ubev_element; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubev_element ON project.ui_bridge_events USING btree (element_id);
+
+
+--
+-- Name: idx_ubev_state; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubev_state ON project.ui_bridge_events USING btree (state_id);
+
+
+--
+-- Name: idx_ubev_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubev_task_run ON project.ui_bridge_events USING btree (task_run_id);
+
+
+--
+-- Name: idx_ubev_timestamp; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubev_timestamp ON project.ui_bridge_events USING btree ("timestamp");
+
+
+--
+-- Name: idx_ubev_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubev_type ON project.ui_bridge_events USING btree (event_type);
+
+
+--
+-- Name: idx_ubnav_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubnav_task_run ON project.ui_bridge_navigation_history USING btree (task_run_id);
+
+
+--
+-- Name: idx_ubt_transition_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ubt_transition_id ON project.ui_bridge_transitions USING btree (transition_id);
+
+
+--
+-- Name: idx_ui_bridge_baselines_target; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ui_bridge_baselines_target ON project.ui_bridge_baselines USING btree (target_scope);
+
+
+--
+-- Name: idx_ui_bridge_integrations_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ui_bridge_integrations_status ON project.ui_bridge_integrations USING btree (status);
+
+
+--
+-- Name: idx_ui_bridge_integrations_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ui_bridge_integrations_type ON project.ui_bridge_integrations USING btree (integration_type);
+
+
+--
+-- Name: idx_ui_bridge_states_active; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ui_bridge_states_active ON project.ui_bridge_states USING btree (is_active);
+
+
+--
+-- Name: idx_ui_bridge_states_group; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ui_bridge_states_group ON project.ui_bridge_states USING btree (group_id);
+
+
+--
+-- Name: idx_ui_bridge_states_state_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_ui_bridge_states_state_id ON project.ui_bridge_states USING btree (state_id);
+
+
+--
+-- Name: idx_us_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_us_category ON project.user_skills USING btree (category);
+
+
+--
+-- Name: idx_us_slug; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_us_slug ON project.user_skills USING btree (slug);
+
+
+--
+-- Name: idx_us_source; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_us_source ON project.user_skills USING btree (source);
+
+
+--
+-- Name: idx_us_updated_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_us_updated_at ON project.user_skills USING btree (updated_at);
+
+
+--
+-- Name: idx_uw_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_category ON project.unified_workflows USING btree (category);
+
+
+--
+-- Name: idx_uw_example_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_example_status ON project.unified_workflows USING btree (example_status);
+
+
+--
+-- Name: idx_uw_fts; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_fts ON project.unified_workflows USING gin (to_tsvector('english'::regconfig, ((name || ' '::text) || COALESCE(description, ''::text))));
+
+
+--
+-- Name: idx_uw_is_favorite; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_is_favorite ON project.unified_workflows USING btree (is_favorite);
+
+
+--
+-- Name: idx_uw_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_name ON project.unified_workflows USING btree (name);
+
+
+--
+-- Name: idx_uw_source_file; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_source_file ON project.unified_workflows USING btree (source_file_path);
+
+
+--
+-- Name: idx_uw_sync_pending; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_sync_pending ON project.unified_workflows USING btree (sync_pending);
+
+
+--
+-- Name: idx_uw_updated_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_uw_updated_at ON project.unified_workflows USING btree (updated_at);
+
+
+--
+-- Name: idx_verification_plans_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_verification_plans_created_at ON project.verification_plans USING btree (created_at);
+
+
+--
+-- Name: idx_verification_plans_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_verification_plans_task_run_id ON project.verification_plans USING btree (task_run_id);
+
+
+--
+-- Name: idx_verification_plans_version; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_verification_plans_version ON project.verification_plans USING btree (version);
+
+
+--
+-- Name: idx_verification_tests_category; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_verification_tests_category ON project.verification_tests USING btree (category) WHERE (category IS NOT NULL);
+
+
+--
+-- Name: idx_verification_tests_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_verification_tests_enabled ON project.verification_tests USING btree (enabled) WHERE enabled;
+
+
+--
+-- Name: idx_verification_tests_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_verification_tests_workflow ON project.verification_tests USING btree (workflow_id);
+
+
+--
+-- Name: idx_vga_runs_sm; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_runs_sm ON project.vga_runs USING btree (state_machine_id);
+
+
+--
+-- Name: idx_vga_runs_task; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_runs_task ON project.vga_runs USING btree (task_run_id) WHERE (task_run_id IS NOT NULL);
+
+
+--
+-- Name: idx_vga_shadow_model; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_shadow_model ON project.vga_shadow_samples USING btree (model_used);
+
+
+--
+-- Name: idx_vga_shadow_sm; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_shadow_sm ON project.vga_shadow_samples USING btree (state_machine_id);
+
+
+--
+-- Name: idx_vga_shadow_target; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_shadow_target ON project.vga_shadow_samples USING btree (target_process);
+
+
+--
+-- Name: idx_vga_sm_grounding_model; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_sm_grounding_model ON project.vga_state_machines USING btree (grounding_model);
+
+
+--
+-- Name: idx_vga_sm_target_process; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_vga_sm_target_process ON project.vga_state_machines USING btree (target_process);
+
+
+--
+-- Name: idx_watchers_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_watchers_enabled ON project.watchers USING btree (enabled) WHERE enabled;
+
+
+--
+-- Name: idx_wes_state; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wes_state ON project.workflow_execution_state USING btree (state_name);
+
+
+--
+-- Name: idx_wes_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wes_type ON project.workflow_execution_state USING btree (workflow_type);
+
+
+--
+-- Name: idx_wf_ai_sessions_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ai_sessions_task_run ON project.workflow_ai_sessions USING btree (task_run_id);
+
+
+--
+-- Name: idx_wf_ai_sessions_unique; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_wf_ai_sessions_unique ON project.workflow_ai_sessions USING btree (task_run_id, iteration, phase, COALESCE(stage_index, '-1'::integer));
+
+
+--
+-- Name: idx_wf_constraint_iteration; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_constraint_iteration ON project.workflow_constraint_results USING btree (iteration);
+
+
+--
+-- Name: idx_wf_constraint_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_constraint_task_run ON project.workflow_constraint_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_wf_ver_phase_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_task_run ON project.workflow_verification_phase_results USING btree (task_run_id);
+
+
+--
+-- Name: idx_wf_ver_phase_unique; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_wf_ver_phase_unique ON project.workflow_verification_phase_results USING btree (task_run_id, iteration);
+
+
+--
+-- Name: idx_wgf_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wgf_created_at ON project.workflow_generation_feedback USING btree (created_at);
+
+
+--
+-- Name: idx_wgf_feedback_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wgf_feedback_type ON project.workflow_generation_feedback USING btree (feedback_type);
+
+
+--
+-- Name: idx_wgf_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wgf_task_run_id ON project.workflow_generation_feedback USING btree (task_run_id);
+
+
+--
+-- Name: idx_wgf_workflow_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wgf_workflow_id ON project.workflow_generation_feedback USING btree (workflow_id);
+
+
+--
+-- Name: idx_workflow_triggers_enabled; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_workflow_triggers_enabled ON project.workflow_triggers USING btree (enabled);
+
+
+--
+-- Name: idx_workflow_triggers_type; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_workflow_triggers_type ON project.workflow_triggers USING btree (trigger_type);
+
+
+--
+-- Name: idx_workflow_variables_name; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_workflow_variables_name ON project.workflow_variables USING btree (variable_name);
+
+
+--
+-- Name: idx_workflow_variables_task_run_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_workflow_variables_task_run_id ON project.workflow_variables USING btree (task_run_id);
+
+
+--
+-- Name: idx_wr_expires; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wr_expires ON project.working_representations USING btree (expires_at);
+
+
+--
+-- Name: idx_wr_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wr_task_run ON project.working_representations USING btree (task_run_id);
+
+
+--
+-- Name: idx_wsc_cursor; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wsc_cursor ON project.workflow_step_checkpoints USING btree (execution_id, step_index);
+
+
+--
+-- Name: idx_wsc_execution; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wsc_execution ON project.workflow_step_checkpoints USING btree (execution_id);
+
+
+--
+-- Name: idx_wsc_lookup; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wsc_lookup ON project.workflow_step_checkpoints USING btree (execution_id, phase, iteration);
+
+
+--
+-- Name: idx_wsc_status; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wsc_status ON project.workflow_step_checkpoints USING btree (status);
+
+
+--
+-- Name: idx_wsv_disagreements_created_at; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wsv_disagreements_created_at ON project.wsv_shadow_disagreements USING btree (created_at DESC);
+
+
+--
+-- Name: idx_wsv_disagreements_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wsv_disagreements_task_run ON project.wsv_shadow_disagreements USING btree (task_run_id);
+
+
+--
+-- Name: idx_wv_task_run; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wv_task_run ON project.workflow_versions USING btree (generation_task_run_id);
+
+
+--
+-- Name: idx_wv_workflow; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wv_workflow ON project.workflow_versions USING btree (workflow_id);
+
+
+--
+-- Name: idx_action_frames_action; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_action_frames_action ON public.action_frames USING btree (snapshot_action_id);
+
+
+--
+-- Name: idx_action_frames_session; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_action_frames_session ON public.action_frames USING btree (video_capture_session_id);
+
+
+--
+-- Name: idx_action_frames_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_action_frames_type ON public.action_frames USING btree (frame_type);
+
+
+--
+-- Name: idx_category_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_category_slug ON public.package_categories USING btree (slug);
+
+
+--
+-- Name: idx_frame_index_keyframes; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_frame_index_keyframes ON public.frame_index USING btree (video_capture_session_id, is_keyframe);
+
+
+--
+-- Name: idx_frame_index_session_frame; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_frame_index_session_frame ON public.frame_index USING btree (video_capture_session_id, frame_number);
+
+
+--
+-- Name: idx_frame_index_session_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_frame_index_session_timestamp ON public.frame_index USING btree (video_capture_session_id, timestamp_ms);
+
+
+--
+-- Name: idx_historical_action_type_success; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_action_type_success ON public.historical_results USING btree (action_type, success);
+
+
+--
+-- Name: idx_historical_pattern_states; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_pattern_states ON public.historical_results USING btree (pattern_id, active_states);
+
+
+--
+-- Name: idx_historical_project_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_project_pattern ON public.historical_results USING btree (project_id, pattern_id);
+
+
+--
+-- Name: idx_historical_selection; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_selection ON public.historical_results USING btree (pattern_id, action_type, success, recorded_at);
+
+
+--
+-- Name: idx_historical_test_run_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_test_run_pattern ON public.historical_results USING btree (test_run_id, pattern_id);
+
+
+--
+-- Name: idx_historical_test_run_seq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_test_run_seq ON public.historical_results USING btree (test_run_id, sequence_number);
+
+
+--
+-- Name: idx_historical_workflow_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_historical_workflow_pattern ON public.historical_results USING btree (workflow_id, pattern_id);
+
+
+--
+-- Name: idx_input_events_session_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_input_events_session_timestamp ON public.input_events USING btree (video_capture_session_id, timestamp_ms);
+
+
+--
+-- Name: idx_input_events_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_input_events_type ON public.input_events USING btree (event_type);
+
+
+--
+-- Name: idx_installation_package; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_installation_package ON public.package_installations USING btree (package_id);
+
+
+--
+-- Name: idx_installation_project; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_installation_project ON public.package_installations USING btree (project_id);
+
+
+--
+-- Name: idx_installation_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_installation_status ON public.package_installations USING btree (status);
+
+
+--
+-- Name: idx_installation_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_installation_user ON public.package_installations USING btree (user_id);
+
+
+--
+-- Name: idx_installation_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_installation_version ON public.package_installations USING btree (version_id);
+
+
+--
+-- Name: idx_invitation_email; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_invitation_email ON public.organization_invitations USING btree (email);
+
+
+--
+-- Name: idx_invitation_org; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_invitation_org ON public.organization_invitations USING btree (organization_id);
+
+
+--
+-- Name: idx_invitation_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_invitation_token ON public.organization_invitations USING btree (token);
+
+
+--
+-- Name: idx_org_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_org_slug ON public.organizations USING btree (slug);
+
+
+--
+-- Name: idx_org_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_org_user ON public.team_members USING btree (organization_id, user_id);
+
+
+--
+-- Name: idx_package_author; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_package_author ON public.code_packages USING btree (author_id);
+
+
+--
+-- Name: idx_package_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_package_category ON public.code_packages USING btree (category_id);
+
+
+--
+-- Name: idx_package_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_package_created ON public.code_packages USING btree (created_at);
+
+
+--
+-- Name: idx_package_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_package_name ON public.code_packages USING btree (name);
+
+
+--
+-- Name: idx_package_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_package_slug ON public.code_packages USING btree (slug);
+
+
+--
+-- Name: idx_package_verified; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_package_verified ON public.code_packages USING btree (is_verified);
+
+
+--
+-- Name: idx_project_access_expires_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_project_access_expires_at ON public.project_access_control USING btree (expires_at);
+
+
+--
+-- Name: idx_project_access_org; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_project_access_org ON public.project_access_control USING btree (organization_id);
+
+
+--
+-- Name: idx_project_access_project; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_project_access_project ON public.project_access_control USING btree (project_id);
+
+
+--
+-- Name: idx_project_access_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_project_access_user ON public.project_access_control USING btree (user_id);
+
+
+--
+-- Name: idx_rating_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rating_created ON public.package_ratings USING btree (created_at);
+
+
+--
+-- Name: idx_rating_package; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rating_package ON public.package_ratings USING btree (package_id);
+
+
+--
+-- Name: idx_rating_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_rating_user ON public.package_ratings USING btree (user_id);
+
+
+--
+-- Name: idx_snapshot_actions_action_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_actions_action_type ON public.snapshot_actions USING btree (action_type);
+
+
+--
+-- Name: idx_snapshot_actions_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_actions_pattern_id ON public.snapshot_actions USING btree (pattern_id);
+
+
+--
+-- Name: idx_snapshot_actions_run_sequence; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_actions_run_sequence ON public.snapshot_actions USING btree (snapshot_run_id, sequence_number);
+
+
+--
+-- Name: idx_snapshot_actions_success; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_actions_success ON public.snapshot_actions USING btree (success);
+
+
+--
+-- Name: idx_snapshot_actions_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_actions_timestamp ON public.snapshot_actions USING btree ("timestamp");
+
+
+--
+-- Name: idx_snapshot_matches_action; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_matches_action ON public.snapshot_matches USING btree (action_id);
+
+
+--
+-- Name: idx_snapshot_matches_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_matches_pattern ON public.snapshot_matches USING btree (pattern_id);
+
+
+--
+-- Name: idx_snapshot_patterns_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_patterns_pattern_id ON public.snapshot_patterns USING btree (pattern_id);
+
+
+--
+-- Name: idx_snapshot_patterns_run_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_snapshot_patterns_run_pattern ON public.snapshot_patterns USING btree (snapshot_run_id, pattern_id);
+
+
+--
+-- Name: idx_team_member_org; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_team_member_org ON public.team_members USING btree (organization_id);
+
+
+--
+-- Name: idx_team_member_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_team_member_user ON public.team_members USING btree (user_id);
+
+
+--
+-- Name: idx_version_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_version_created ON public.package_versions USING btree (created_at);
+
+
+--
+-- Name: idx_version_package; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_version_package ON public.package_versions USING btree (package_id);
+
+
+--
+-- Name: idx_version_security; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_version_security ON public.package_versions USING btree (security_scan_status);
+
+
+--
+-- Name: idx_video_capture_sessions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_video_capture_sessions_project_id ON public.video_capture_sessions USING btree (project_id);
+
+
+--
+-- Name: idx_video_capture_sessions_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_video_capture_sessions_snapshot_run_id ON public.video_capture_sessions USING btree (snapshot_run_id);
+
+
+--
+-- Name: idx_video_capture_sessions_started_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_video_capture_sessions_started_at ON public.video_capture_sessions USING btree (started_at);
+
+
+--
+-- Name: idx_video_capture_sessions_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_video_capture_sessions_workflow_id ON public.video_capture_sessions USING btree (workflow_id);
+
+
+--
+-- Name: ix_action_executions_action_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_action_type ON public.action_executions USING btree (action_type);
+
+
+--
+-- Name: ix_action_executions_from_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_from_state ON public.action_executions USING btree (from_state);
+
+
+--
+-- Name: ix_action_executions_parent_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_parent_id ON public.action_executions USING btree (parent_id);
+
+
+--
+-- Name: ix_action_executions_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_run_id ON public.action_executions USING btree (run_id);
+
+
+--
+-- Name: ix_action_executions_run_sequence; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_action_executions_run_sequence ON public.action_executions USING btree (run_id, sequence_number);
+
+
+--
+-- Name: ix_action_executions_run_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_run_status ON public.action_executions USING btree (run_id, status);
+
+
+--
+-- Name: ix_action_executions_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_status ON public.action_executions USING btree (status);
+
+
+--
+-- Name: ix_action_executions_to_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_to_state ON public.action_executions USING btree (to_state);
+
+
+--
+-- Name: ix_action_executions_trace_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_executions_trace_id ON public.action_executions USING btree (trace_id);
+
+
+--
+-- Name: ix_action_frames_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_frames_id ON public.action_frames USING btree (id);
+
+
+--
+-- Name: ix_action_frames_snapshot_action_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_frames_snapshot_action_id ON public.action_frames USING btree (snapshot_action_id);
+
+
+--
+-- Name: ix_action_frames_video_capture_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_action_frames_video_capture_session_id ON public.action_frames USING btree (video_capture_session_id);
+
+
+--
+-- Name: ix_activity_logs_action_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_activity_logs_action_type ON public.activity_logs USING btree (action_type);
+
+
+--
+-- Name: ix_activity_logs_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_activity_logs_created_at ON public.activity_logs USING btree (created_at);
+
+
+--
+-- Name: ix_activity_logs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_activity_logs_project_id ON public.activity_logs USING btree (project_id);
+
+
+--
+-- Name: ix_activity_logs_resource_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_activity_logs_resource_id ON public.activity_logs USING btree (resource_id);
+
+
+--
+-- Name: ix_activity_logs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_activity_logs_user_id ON public.activity_logs USING btree (user_id);
+
+
+--
+-- Name: ix_ai_prompt_templates_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_prompt_templates_category ON public.ai_prompt_templates USING btree (category);
+
+
+--
+-- Name: ix_ai_prompt_templates_created_by; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_prompt_templates_created_by ON public.ai_prompt_templates USING btree (created_by);
+
+
+--
+-- Name: ix_ai_prompt_templates_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_prompt_templates_id ON public.ai_prompt_templates USING btree (id);
+
+
+--
+-- Name: ix_ai_prompt_templates_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_prompt_templates_name ON public.ai_prompt_templates USING btree (name);
+
+
+--
+-- Name: ix_ai_prompt_templates_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_prompt_templates_project_id ON public.ai_prompt_templates USING btree (project_id);
+
+
+--
 -- Name: ix_ai_task_findings_category; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2427,6 +18878,13 @@ CREATE INDEX ix_ai_task_findings_task_id ON public.task_run_findings USING btree
 
 
 --
+-- Name: ix_ai_task_sessions_task_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_task_sessions_task_id ON public.task_run_sessions USING btree (task_run_id);
+
+
+--
 -- Name: ix_ai_tasks_created_by_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2452,6 +18910,160 @@ CREATE INDEX ix_ai_tasks_runner_id ON public.task_runs USING btree (runner_id);
 --
 
 CREATE INDEX ix_ai_tasks_status ON public.task_runs USING btree (status);
+
+
+--
+-- Name: ix_analytics_events_event_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_event_name ON public.analytics_events USING btree (event_name);
+
+
+--
+-- Name: ix_analytics_events_name_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_name_timestamp ON public.analytics_events USING btree (event_name, "timestamp");
+
+
+--
+-- Name: ix_analytics_events_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_timestamp ON public.analytics_events USING btree ("timestamp");
+
+
+--
+-- Name: ix_analytics_events_timestamp_desc; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_timestamp_desc ON public.analytics_events USING btree ("timestamp" DESC);
+
+
+--
+-- Name: ix_analytics_events_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_user_id ON public.analytics_events USING btree (user_id);
+
+
+--
+-- Name: ix_analytics_events_user_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_analytics_events_user_name ON public.analytics_events USING btree (user_id, event_name);
+
+
+--
+-- Name: ix_annotation_sets_screenshot_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_annotation_sets_screenshot_name ON public.annotation_sets USING btree (screenshot_name);
+
+
+--
+-- Name: ix_annotations_screenshot_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_annotations_screenshot_index ON public.annotations USING btree (screenshot_index);
+
+
+--
+-- Name: ix_annotations_set_screenshot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_annotations_set_screenshot ON public.annotations USING btree (annotation_set_id, screenshot_index);
+
+
+--
+-- Name: ix_application_profiles_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_application_profiles_name ON public.application_profiles USING btree (name);
+
+
+--
+-- Name: ix_audit_logs_action; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_action ON public.audit_logs USING btree (action);
+
+
+--
+-- Name: ix_audit_logs_category_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_category_created ON public.audit_logs USING btree (event_category, created_at);
+
+
+--
+-- Name: ix_audit_logs_correlation_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_correlation_id ON public.audit_logs USING btree (correlation_id);
+
+
+--
+-- Name: ix_audit_logs_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_created_at ON public.audit_logs USING btree (created_at);
+
+
+--
+-- Name: ix_audit_logs_event_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_event_category ON public.audit_logs USING btree (event_category);
+
+
+--
+-- Name: ix_audit_logs_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_id ON public.audit_logs USING btree (id);
+
+
+--
+-- Name: ix_audit_logs_resource; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_resource ON public.audit_logs USING btree (resource_type, resource_id, created_at);
+
+
+--
+-- Name: ix_audit_logs_resource_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_resource_id ON public.audit_logs USING btree (resource_id);
+
+
+--
+-- Name: ix_audit_logs_resource_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_resource_type ON public.audit_logs USING btree (resource_type);
+
+
+--
+-- Name: ix_audit_logs_target_user; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_target_user ON public.audit_logs USING btree (target_user_id, created_at);
+
+
+--
+-- Name: ix_audit_logs_user_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_user_created ON public.audit_logs USING btree (user_id, created_at);
+
+
+--
+-- Name: ix_audit_logs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_audit_logs_user_id ON public.audit_logs USING btree (user_id);
 
 
 --
@@ -2483,6 +19095,482 @@ CREATE INDEX ix_automation_input_events_session_timestamp ON public.automation_i
 
 
 --
+-- Name: ix_automation_logs_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_logs_event_type ON public.automation_logs USING gin (log_data jsonb_path_ops);
+
+
+--
+-- Name: ix_automation_logs_level; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_logs_level ON public.automation_logs USING btree (level);
+
+
+--
+-- Name: ix_automation_logs_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_logs_session_id ON public.automation_logs USING btree (session_id);
+
+
+--
+-- Name: ix_automation_logs_session_sequence; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_logs_session_sequence ON public.automation_logs USING btree (session_id, sequence_number);
+
+
+--
+-- Name: ix_automation_logs_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_logs_timestamp ON public.automation_logs USING btree ("timestamp");
+
+
+--
+-- Name: ix_automation_screenshots_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_screenshots_name ON public.automation_screenshots USING btree (name);
+
+
+--
+-- Name: ix_automation_screenshots_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_screenshots_project_id ON public.automation_screenshots USING btree (project_id);
+
+
+--
+-- Name: ix_automation_screenshots_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_screenshots_session_id ON public.automation_screenshots USING btree (session_id);
+
+
+--
+-- Name: ix_automation_screenshots_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_screenshots_timestamp ON public.automation_screenshots USING btree ("timestamp");
+
+
+--
+-- Name: ix_automation_sessions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_sessions_project_id ON public.automation_sessions USING btree (project_id);
+
+
+--
+-- Name: ix_automation_sessions_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_sessions_status ON public.automation_sessions USING btree (status);
+
+
+--
+-- Name: ix_automation_sessions_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_sessions_user_id ON public.automation_sessions USING btree (user_id);
+
+
+--
+-- Name: ix_automation_videos_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_videos_id ON public.automation_videos USING btree (id);
+
+
+--
+-- Name: ix_automation_videos_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_videos_project_id ON public.automation_videos USING btree (project_id);
+
+
+--
+-- Name: ix_automation_videos_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_automation_videos_session_id ON public.automation_videos USING btree (session_id);
+
+
+--
+-- Name: ix_automation_videos_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_videos_user_id ON public.automation_videos USING btree (user_id);
+
+
+--
+-- Name: ix_clipboard_entries_expires_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_clipboard_entries_expires_at ON public.clipboard_entries USING btree (expires_at);
+
+
+--
+-- Name: ix_clipboard_entries_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_clipboard_entries_user_id ON public.clipboard_entries USING btree (user_id);
+
+
+--
+-- Name: ix_code_packages_category_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_code_packages_category_id ON public.code_packages USING btree (category_id);
+
+
+--
+-- Name: ix_code_packages_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_code_packages_created_at ON public.code_packages USING btree (created_at);
+
+
+--
+-- Name: ix_code_packages_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_code_packages_id ON public.code_packages USING btree (id);
+
+
+--
+-- Name: ix_code_packages_is_verified; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_code_packages_is_verified ON public.code_packages USING btree (is_verified);
+
+
+--
+-- Name: ix_code_packages_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_code_packages_name ON public.code_packages USING btree (name);
+
+
+--
+-- Name: ix_code_packages_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_code_packages_slug ON public.code_packages USING btree (slug);
+
+
+--
+-- Name: ix_conflict_logs_local_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_conflict_logs_local_user_id ON public.conflict_logs USING btree (local_user_id);
+
+
+--
+-- Name: ix_conflict_logs_remote_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_conflict_logs_remote_user_id ON public.conflict_logs USING btree (remote_user_id);
+
+
+--
+-- Name: ix_conflict_logs_resource_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_conflict_logs_resource_id ON public.conflict_logs USING btree (resource_id);
+
+
+--
+-- Name: ix_coverage_snapshots_coverage_percentage; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_coverage_snapshots_coverage_percentage ON public.coverage_snapshots USING btree (coverage_percentage);
+
+
+--
+-- Name: ix_coverage_snapshots_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_coverage_snapshots_project_id ON public.coverage_snapshots USING btree (project_id);
+
+
+--
+-- Name: ix_coverage_snapshots_snapshot_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_coverage_snapshots_snapshot_time ON public.coverage_snapshots USING btree (snapshot_time);
+
+
+--
+-- Name: ix_coverage_snapshots_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_coverage_snapshots_test_run_id ON public.coverage_snapshots USING btree (test_run_id);
+
+
+--
+-- Name: ix_coverage_snapshots_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_coverage_snapshots_workflow_id ON public.coverage_snapshots USING btree (workflow_id);
+
+
+--
+-- Name: ix_custom_functions_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_custom_functions_category ON public.custom_functions USING btree (category);
+
+
+--
+-- Name: ix_custom_functions_file_path; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_custom_functions_file_path ON public.custom_functions USING btree (file_path);
+
+
+--
+-- Name: ix_custom_functions_function_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_custom_functions_function_name ON public.custom_functions USING btree (function_name);
+
+
+--
+-- Name: ix_custom_functions_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_custom_functions_id ON public.custom_functions USING btree (id);
+
+
+--
+-- Name: ix_custom_functions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_custom_functions_project_id ON public.custom_functions USING btree (project_id);
+
+
+--
+-- Name: ix_dataset_items_dataset_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_dataset_items_dataset_id ON public.dataset_items USING btree (dataset_id);
+
+
+--
+-- Name: ix_deferred_questions_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_deferred_questions_status ON public.deferred_questions USING btree (status);
+
+
+--
+-- Name: ix_deferred_questions_task_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_deferred_questions_task_run_id ON public.deferred_questions USING btree (task_run_id);
+
+
+--
+-- Name: ix_detected_issues_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_project_id ON public.detected_issues USING btree (project_id);
+
+
+--
+-- Name: ix_detected_issues_project_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_project_status ON public.detected_issues USING btree (project_id, status);
+
+
+--
+-- Name: ix_detected_issues_session; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_session ON public.detected_issues USING btree (session_id);
+
+
+--
+-- Name: ix_detected_issues_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_session_id ON public.detected_issues USING btree (session_id);
+
+
+--
+-- Name: ix_detected_issues_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_severity ON public.detected_issues USING btree (severity);
+
+
+--
+-- Name: ix_detected_issues_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_source ON public.detected_issues USING gin (source jsonb_path_ops);
+
+
+--
+-- Name: ix_detected_issues_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_status ON public.detected_issues USING btree (status);
+
+
+--
+-- Name: ix_detected_issues_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_user_id ON public.detected_issues USING btree (user_id);
+
+
+--
+-- Name: ix_detected_issues_user_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_detected_issues_user_severity ON public.detected_issues USING btree (user_id, severity);
+
+
+--
+-- Name: ix_device_sessions_device_fingerprint; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_device_sessions_device_fingerprint ON public.device_sessions USING btree (device_fingerprint);
+
+
+--
+-- Name: ix_device_sessions_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_device_sessions_user_id ON public.device_sessions USING btree (user_id);
+
+
+--
+-- Name: ix_device_sessions_verification_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_device_sessions_verification_token ON public.device_sessions USING btree (verification_token);
+
+
+--
+-- Name: ix_discovered_states_automation_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_states_automation_session_id ON public.discovered_states USING btree (automation_session_id);
+
+
+--
+-- Name: ix_discovered_states_recording_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_states_recording_id ON public.discovered_states USING btree (recording_id);
+
+
+--
+-- Name: ix_discovered_states_source_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_states_source_type ON public.discovered_states USING btree (source_type);
+
+
+--
+-- Name: ix_discovered_transitions_from_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_transitions_from_state ON public.discovered_transitions USING btree (from_state_id);
+
+
+--
+-- Name: ix_discovered_transitions_recording; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_transitions_recording ON public.discovered_transitions USING btree (recording_id);
+
+
+--
+-- Name: ix_discovered_transitions_recording_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_transitions_recording_id ON public.discovered_transitions USING btree (recording_id);
+
+
+--
+-- Name: ix_discovered_transitions_to_state; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discovered_transitions_to_state ON public.discovered_transitions USING btree (to_state_id);
+
+
+--
+-- Name: ix_discoveries_config_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_config_id ON public.discoveries USING btree (config_id);
+
+
+--
+-- Name: ix_discoveries_config_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_config_type ON public.discoveries USING btree (config_id, discovery_type);
+
+
+--
+-- Name: ix_discoveries_discovery_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_discovery_type ON public.discoveries USING btree (discovery_type);
+
+
+--
+-- Name: ix_discoveries_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_project_id ON public.discoveries USING btree (project_id);
+
+
+--
+-- Name: ix_discoveries_project_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_project_status ON public.discoveries USING btree (project_id, status);
+
+
+--
+-- Name: ix_discoveries_runner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_runner_id ON public.discoveries USING btree (runner_id);
+
+
+--
+-- Name: ix_discoveries_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_status ON public.discoveries USING btree (status);
+
+
+--
+-- Name: ix_discoveries_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_user_id ON public.discoveries USING btree (user_id);
+
+
+--
+-- Name: ix_discoveries_user_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_discoveries_user_status ON public.discoveries USING btree (user_id, status);
+
+
+--
 -- Name: ix_domain_knowledge_content_embedding; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2494,6 +19582,146 @@ CREATE INDEX ix_domain_knowledge_content_embedding ON public.domain_knowledge US
 --
 
 CREATE INDEX ix_domain_knowledge_project_id ON public.domain_knowledge USING btree (project_id);
+
+
+--
+-- Name: ix_edit_commands_applied_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_edit_commands_applied_at ON public.edit_commands USING btree (applied_at);
+
+
+--
+-- Name: ix_edit_commands_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_edit_commands_project_id ON public.edit_commands USING btree (project_id);
+
+
+--
+-- Name: ix_element_annotation_sets_project_current; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotation_sets_project_current ON public.element_annotation_sets USING btree (project_id, is_current);
+
+
+--
+-- Name: ix_element_annotation_sets_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotation_sets_project_id ON public.element_annotation_sets USING btree (project_id);
+
+
+--
+-- Name: ix_element_annotation_sets_project_version; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotation_sets_project_version ON public.element_annotation_sets USING btree (project_id, version_number);
+
+
+--
+-- Name: ix_element_annotations_element_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotations_element_type ON public.element_annotations USING btree (element_type);
+
+
+--
+-- Name: ix_element_annotations_label; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotations_label ON public.element_annotations USING btree (label);
+
+
+--
+-- Name: ix_element_annotations_set_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotations_set_id ON public.element_annotations USING btree (annotation_set_id);
+
+
+--
+-- Name: ix_element_annotations_set_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_element_annotations_set_order ON public.element_annotations USING btree (annotation_set_id, "order");
+
+
+--
+-- Name: ix_embedding_generation_jobs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_embedding_generation_jobs_project_id ON public.embedding_generation_jobs USING btree (project_id);
+
+
+--
+-- Name: ix_embedding_generation_jobs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_embedding_generation_jobs_status ON public.embedding_generation_jobs USING btree (status);
+
+
+--
+-- Name: ix_embedding_generation_jobs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_embedding_generation_jobs_user_id ON public.embedding_generation_jobs USING btree (user_id);
+
+
+--
+-- Name: ix_error_monitor_entries_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_category ON public.error_monitor_entries USING btree (category);
+
+
+--
+-- Name: ix_error_monitor_entries_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_created_by_user_id ON public.error_monitor_entries USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_error_monitor_entries_error_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_error_type ON public.error_monitor_entries USING btree (error_type);
+
+
+--
+-- Name: ix_error_monitor_entries_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_project_id ON public.error_monitor_entries USING btree (project_id);
+
+
+--
+-- Name: ix_error_monitor_entries_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_severity ON public.error_monitor_entries USING btree (severity);
+
+
+--
+-- Name: ix_error_monitor_entries_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_status ON public.error_monitor_entries USING btree (status);
+
+
+--
+-- Name: ix_error_monitor_entries_task_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_error_monitor_entries_task_run_id ON public.error_monitor_entries USING btree (task_run_id);
+
+
+--
+-- Name: ix_evaluation_experiments_dataset_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_evaluation_experiments_dataset_id ON public.evaluation_experiments USING btree (dataset_id);
 
 
 --
@@ -2588,6 +19816,321 @@ CREATE INDEX ix_execution_issues_title_embedding ON public.execution_issues USIN
 
 
 --
+-- Name: ix_execution_runs_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_created_by_user_id ON public.execution_runs USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_execution_runs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_project_id ON public.execution_runs USING btree (project_id);
+
+
+--
+-- Name: ix_execution_runs_project_started; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_project_started ON public.execution_runs USING btree (project_id, started_at DESC);
+
+
+--
+-- Name: ix_execution_runs_project_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_project_status ON public.execution_runs USING btree (project_id, status);
+
+
+--
+-- Name: ix_execution_runs_project_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_project_type ON public.execution_runs USING btree (project_id, run_type);
+
+
+--
+-- Name: ix_execution_runs_run_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_run_type ON public.execution_runs USING btree (run_type);
+
+
+--
+-- Name: ix_execution_runs_started_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_started_at ON public.execution_runs USING btree (started_at);
+
+
+--
+-- Name: ix_execution_runs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_runs_status ON public.execution_runs USING btree (status);
+
+
+--
+-- Name: ix_execution_screenshots_action_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_screenshots_action_execution_id ON public.execution_screenshots USING btree (action_execution_id);
+
+
+--
+-- Name: ix_execution_screenshots_perceptual_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_screenshots_perceptual_hash ON public.execution_screenshots USING btree (perceptual_hash);
+
+
+--
+-- Name: ix_execution_screenshots_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_screenshots_run_id ON public.execution_screenshots USING btree (run_id);
+
+
+--
+-- Name: ix_execution_screenshots_run_sequence; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_screenshots_run_sequence ON public.execution_screenshots USING btree (run_id, sequence_number);
+
+
+--
+-- Name: ix_execution_screenshots_screenshot_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_screenshots_screenshot_type ON public.execution_screenshots USING btree (screenshot_type);
+
+
+--
+-- Name: ix_execution_screenshots_state_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_screenshots_state_name ON public.execution_screenshots USING btree (state_name);
+
+
+--
+-- Name: ix_execution_tree_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_tree_events_event_type ON public.execution_tree_events USING btree (event_type);
+
+
+--
+-- Name: ix_execution_tree_events_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_tree_events_run_id ON public.execution_tree_events USING btree (run_id);
+
+
+--
+-- Name: ix_experiment_results_dataset_item_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_experiment_results_dataset_item_id ON public.experiment_results USING btree (dataset_item_id);
+
+
+--
+-- Name: ix_experiment_results_experiment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_experiment_results_experiment_id ON public.experiment_results USING btree (experiment_id);
+
+
+--
+-- Name: ix_exploration_sessions_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_exploration_sessions_created_at ON public.ui_bridge_exploration_sessions USING btree (created_at);
+
+
+--
+-- Name: ix_exploration_sessions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_exploration_sessions_project_id ON public.ui_bridge_exploration_sessions USING btree (project_id);
+
+
+--
+-- Name: ix_exploration_sessions_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_exploration_sessions_status ON public.ui_bridge_exploration_sessions USING btree (status);
+
+
+--
+-- Name: ix_feedback_scores_action_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_feedback_scores_action_execution_id ON public.feedback_scores USING btree (action_execution_id);
+
+
+--
+-- Name: ix_feedback_scores_name_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_feedback_scores_name_source ON public.feedback_scores USING btree (name, source);
+
+
+--
+-- Name: ix_feedback_scores_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_feedback_scores_run_id ON public.feedback_scores USING btree (run_id);
+
+
+--
+-- Name: ix_finding_category_configs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_finding_category_configs_user_id ON public.finding_category_configs USING btree (user_id);
+
+
+--
+-- Name: ix_frame_index_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_frame_index_id ON public.frame_index USING btree (id);
+
+
+--
+-- Name: ix_frame_index_is_keyframe; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_frame_index_is_keyframe ON public.frame_index USING btree (is_keyframe);
+
+
+--
+-- Name: ix_frame_index_timestamp_ms; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_frame_index_timestamp_ms ON public.frame_index USING btree (timestamp_ms);
+
+
+--
+-- Name: ix_frame_index_video_capture_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_frame_index_video_capture_session_id ON public.frame_index USING btree (video_capture_session_id);
+
+
+--
+-- Name: ix_gui_action_type_configs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_gui_action_type_configs_user_id ON public.gui_action_type_configs USING btree (user_id);
+
+
+--
+-- Name: ix_historical_results_action_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_action_type ON public.historical_results USING btree (action_type);
+
+
+--
+-- Name: ix_historical_results_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_id ON public.historical_results USING btree (id);
+
+
+--
+-- Name: ix_historical_results_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_pattern_id ON public.historical_results USING btree (pattern_id);
+
+
+--
+-- Name: ix_historical_results_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_project_id ON public.historical_results USING btree (project_id);
+
+
+--
+-- Name: ix_historical_results_recorded_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_recorded_at ON public.historical_results USING btree (recorded_at);
+
+
+--
+-- Name: ix_historical_results_snapshot_action_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_snapshot_action_id ON public.historical_results USING btree (snapshot_action_id);
+
+
+--
+-- Name: ix_historical_results_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_snapshot_run_id ON public.historical_results USING btree (snapshot_run_id);
+
+
+--
+-- Name: ix_historical_results_success; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_success ON public.historical_results USING btree (success);
+
+
+--
+-- Name: ix_historical_results_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_test_run_id ON public.historical_results USING btree (test_run_id);
+
+
+--
+-- Name: ix_historical_results_video_capture_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_video_capture_session_id ON public.historical_results USING btree (video_capture_session_id);
+
+
+--
+-- Name: ix_historical_results_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_historical_results_workflow_id ON public.historical_results USING btree (workflow_id);
+
+
+--
+-- Name: ix_input_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_input_events_event_type ON public.input_events USING btree (event_type);
+
+
+--
+-- Name: ix_input_events_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_input_events_id ON public.input_events USING btree (id);
+
+
+--
+-- Name: ix_input_events_timestamp_ms; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_input_events_timestamp_ms ON public.input_events USING btree (timestamp_ms);
+
+
+--
+-- Name: ix_input_events_video_capture_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_input_events_video_capture_session_id ON public.input_events USING btree (video_capture_session_id);
+
+
+--
 -- Name: ix_known_issues_category; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2623,6 +20166,125 @@ CREATE INDEX ix_known_issues_status ON public.known_issues USING btree (status);
 
 
 --
+-- Name: ix_library_check_groups_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_check_groups_created_by_user_id ON public.library_check_groups USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_check_groups_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_check_groups_project_id ON public.library_check_groups USING btree (project_id);
+
+
+--
+-- Name: ix_library_checks_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_checks_created_by_user_id ON public.library_checks USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_checks_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_checks_project_id ON public.library_checks USING btree (project_id);
+
+
+--
+-- Name: ix_library_contexts_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_contexts_category ON public.library_contexts USING btree (category);
+
+
+--
+-- Name: ix_library_contexts_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_contexts_created_by_user_id ON public.library_contexts USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_contexts_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_contexts_project_id ON public.library_contexts USING btree (project_id);
+
+
+--
+-- Name: ix_library_macros_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_macros_category ON public.library_macros USING btree (category);
+
+
+--
+-- Name: ix_library_macros_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_macros_created_by_user_id ON public.library_macros USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_macros_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_macros_project_id ON public.library_macros USING btree (project_id);
+
+
+--
+-- Name: ix_library_prompt_snippets_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_prompt_snippets_category ON public.library_prompt_snippets USING btree (category);
+
+
+--
+-- Name: ix_library_prompt_snippets_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_prompt_snippets_created_by_user_id ON public.library_prompt_snippets USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_prompt_snippets_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_prompt_snippets_project_id ON public.library_prompt_snippets USING btree (project_id);
+
+
+--
+-- Name: ix_library_saved_api_requests_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_saved_api_requests_created_by_user_id ON public.library_saved_api_requests USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_saved_api_requests_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_saved_api_requests_project_id ON public.library_saved_api_requests USING btree (project_id);
+
+
+--
+-- Name: ix_library_shell_commands_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_shell_commands_created_by_user_id ON public.library_shell_commands USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_library_shell_commands_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_library_shell_commands_project_id ON public.library_shell_commands USING btree (project_id);
+
+
+--
 -- Name: ix_notifications_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2655,6 +20317,174 @@ CREATE INDEX ix_notifications_type ON public.notifications USING btree (type);
 --
 
 CREATE INDEX ix_notifications_user_id ON public.notifications USING btree (user_id);
+
+
+--
+-- Name: ix_organization_invitations_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_organization_invitations_token ON public.organization_invitations USING btree (token);
+
+
+--
+-- Name: ix_organizations_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_organizations_name ON public.organizations USING btree (name);
+
+
+--
+-- Name: ix_organizations_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_organizations_slug ON public.organizations USING btree (slug);
+
+
+--
+-- Name: ix_package_categories_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_categories_id ON public.package_categories USING btree (id);
+
+
+--
+-- Name: ix_package_categories_slug; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_package_categories_slug ON public.package_categories USING btree (slug);
+
+
+--
+-- Name: ix_package_installations_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_installations_id ON public.package_installations USING btree (id);
+
+
+--
+-- Name: ix_package_installations_package_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_installations_package_id ON public.package_installations USING btree (package_id);
+
+
+--
+-- Name: ix_package_installations_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_installations_status ON public.package_installations USING btree (status);
+
+
+--
+-- Name: ix_package_installations_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_installations_version_id ON public.package_installations USING btree (version_id);
+
+
+--
+-- Name: ix_package_ratings_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_ratings_created_at ON public.package_ratings USING btree (created_at);
+
+
+--
+-- Name: ix_package_ratings_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_ratings_id ON public.package_ratings USING btree (id);
+
+
+--
+-- Name: ix_package_ratings_package_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_ratings_package_id ON public.package_ratings USING btree (package_id);
+
+
+--
+-- Name: ix_package_versions_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_versions_created_at ON public.package_versions USING btree (created_at);
+
+
+--
+-- Name: ix_package_versions_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_versions_id ON public.package_versions USING btree (id);
+
+
+--
+-- Name: ix_package_versions_package_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_versions_package_id ON public.package_versions USING btree (package_id);
+
+
+--
+-- Name: ix_package_versions_security_scan_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_package_versions_security_scan_status ON public.package_versions USING btree (security_scan_status);
+
+
+--
+-- Name: ix_path_discoveries_discovered_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_path_discoveries_discovered_at ON public.path_discoveries USING btree (discovered_at);
+
+
+--
+-- Name: ix_path_discoveries_path_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_path_discoveries_path_hash ON public.path_discoveries USING btree (path_hash);
+
+
+--
+-- Name: ix_path_discoveries_success; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_path_discoveries_success ON public.path_discoveries USING btree (success);
+
+
+--
+-- Name: ix_path_discoveries_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_path_discoveries_test_run_id ON public.path_discoveries USING btree (test_run_id);
+
+
+--
+-- Name: ix_patterns_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_patterns_id ON public.patterns USING btree (id);
+
+
+--
+-- Name: ix_patterns_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_patterns_pattern_id ON public.patterns USING btree (pattern_id);
+
+
+--
+-- Name: ix_patterns_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_patterns_snapshot_run_id ON public.patterns USING btree (snapshot_run_id);
+
+
+--
+-- Name: ix_patterns_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_patterns_type ON public.patterns USING btree (type);
 
 
 --
@@ -2697,6 +20527,55 @@ CREATE INDEX ix_processing_logs_recording_id ON public.processing_logs USING btr
 --
 
 CREATE INDEX ix_processing_logs_recording_time ON public.processing_logs USING btree (recording_id, "timestamp");
+
+
+--
+-- Name: ix_project_annotation_state_updated; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_annotation_state_updated ON public.project_annotation_states USING btree (updated_at);
+
+
+--
+-- Name: ix_project_annotation_states_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_annotation_states_project_id ON public.project_annotation_states USING btree (project_id);
+
+
+--
+-- Name: ix_project_comments_action_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_comments_action_id ON public.project_comments USING btree (action_id);
+
+
+--
+-- Name: ix_project_comments_author_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_comments_author_id ON public.project_comments USING btree (author_id);
+
+
+--
+-- Name: ix_project_comments_parent_comment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_comments_parent_comment_id ON public.project_comments USING btree (parent_comment_id);
+
+
+--
+-- Name: ix_project_comments_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_comments_project_id ON public.project_comments USING btree (project_id);
+
+
+--
+-- Name: ix_project_comments_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_comments_workflow_id ON public.project_comments USING btree (workflow_id);
 
 
 --
@@ -2756,6 +20635,202 @@ CREATE INDEX ix_project_locks_user_id ON public.project_locks USING btree (user_
 
 
 --
+-- Name: ix_project_versions_project_created; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_versions_project_created ON public.project_versions USING btree (project_id, created_at);
+
+
+--
+-- Name: ix_project_versions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_versions_project_id ON public.project_versions USING btree (project_id);
+
+
+--
+-- Name: ix_projects_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_projects_id ON public.projects USING btree (id);
+
+
+--
+-- Name: ix_projects_is_public; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_projects_is_public ON public.projects USING btree (is_public);
+
+
+--
+-- Name: ix_projects_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_projects_organization_id ON public.projects USING btree (organization_id);
+
+
+--
+-- Name: ix_prompt_sequences_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_prompt_sequences_category ON public.prompt_sequences USING btree (category);
+
+
+--
+-- Name: ix_prompt_sequences_created_by; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_prompt_sequences_created_by ON public.prompt_sequences USING btree (created_by);
+
+
+--
+-- Name: ix_prompt_sequences_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_prompt_sequences_id ON public.prompt_sequences USING btree (id);
+
+
+--
+-- Name: ix_prompt_sequences_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_prompt_sequences_name ON public.prompt_sequences USING btree (name);
+
+
+--
+-- Name: ix_prompt_sequences_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_prompt_sequences_project_id ON public.prompt_sequences USING btree (project_id);
+
+
+--
+-- Name: ix_prompt_template_versions_template_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_prompt_template_versions_template_id ON public.prompt_template_versions USING btree (template_id);
+
+
+--
+-- Name: ix_push_devices_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_push_devices_id ON public.push_devices USING btree (id);
+
+
+--
+-- Name: ix_push_devices_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_push_devices_is_active ON public.push_devices USING btree (is_active);
+
+
+--
+-- Name: ix_push_devices_push_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_push_devices_push_token ON public.push_devices USING btree (push_token);
+
+
+--
+-- Name: ix_push_devices_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_push_devices_user_id ON public.push_devices USING btree (user_id);
+
+
+--
+-- Name: ix_recording_contexts_recording_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_contexts_recording_id ON public.recording_contexts USING btree (recording_id);
+
+
+--
+-- Name: ix_recording_contexts_recording_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_contexts_recording_time ON public.recording_contexts USING btree (recording_id, relative_time_ms);
+
+
+--
+-- Name: ix_recording_contexts_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_contexts_type ON public.recording_contexts USING btree (recording_id, event_type);
+
+
+--
+-- Name: ix_recording_frames_cluster; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_frames_cluster ON public.recording_frames USING btree (recording_id, cluster_id);
+
+
+--
+-- Name: ix_recording_frames_recording_frame; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_frames_recording_frame ON public.recording_frames USING btree (recording_id, frame_number);
+
+
+--
+-- Name: ix_recording_frames_recording_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_frames_recording_id ON public.recording_frames USING btree (recording_id);
+
+
+--
+-- Name: ix_recording_frames_recording_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_frames_recording_time ON public.recording_frames USING btree (recording_id, relative_time_ms);
+
+
+--
+-- Name: ix_recording_interactions_recording_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_interactions_recording_id ON public.recording_interactions USING btree (recording_id);
+
+
+--
+-- Name: ix_recording_interactions_recording_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_interactions_recording_time ON public.recording_interactions USING btree (recording_id, relative_time_ms);
+
+
+--
+-- Name: ix_recording_interactions_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_interactions_type ON public.recording_interactions USING btree (recording_id, interaction_type);
+
+
+--
+-- Name: ix_recording_sessions_app_domain; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_sessions_app_domain ON public.recording_sessions USING btree (app_domain);
+
+
+--
+-- Name: ix_recording_sessions_app_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_sessions_app_name ON public.recording_sessions USING btree (app_name);
+
+
+--
+-- Name: ix_recording_sessions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recording_sessions_project_id ON public.recording_sessions USING btree (project_id);
+
+
+--
 -- Name: ix_recordings_created_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2781,6 +20856,76 @@ CREATE INDEX ix_recordings_project_status ON public.recordings USING btree (proj
 --
 
 CREATE INDEX ix_recordings_status ON public.recordings USING btree (status);
+
+
+--
+-- Name: ix_render_images_render_log_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_render_images_render_log_id ON public.render_images USING btree (render_log_id);
+
+
+--
+-- Name: ix_render_logs_page_url; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_render_logs_page_url ON public.render_logs USING btree (page_url);
+
+
+--
+-- Name: ix_render_logs_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_render_logs_session_id ON public.render_logs USING btree (session_id);
+
+
+--
+-- Name: ix_render_logs_session_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_render_logs_session_timestamp ON public.render_logs USING btree (session_id, "timestamp");
+
+
+--
+-- Name: ix_runner_connections_connected_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_connections_connected_at ON public.runner_connections USING btree (connected_at);
+
+
+--
+-- Name: ix_runner_connections_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_connections_user_id ON public.runner_connections USING btree (user_id);
+
+
+--
+-- Name: ix_runner_devices_device_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_runner_devices_device_id ON public.runner_devices USING btree (device_id);
+
+
+--
+-- Name: ix_runner_devices_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_devices_id ON public.runner_devices USING btree (id);
+
+
+--
+-- Name: ix_runner_devices_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_devices_is_active ON public.runner_devices USING btree (is_active);
+
+
+--
+-- Name: ix_runner_devices_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_devices_user_id ON public.runner_devices USING btree (user_id);
 
 
 --
@@ -2854,6 +20999,293 @@ CREATE INDEX ix_scheduled_workflow_runs_workflow_id ON public.scheduled_workflow
 
 
 --
+-- Name: ix_screenshot_input_assoc_log; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshot_input_assoc_log ON public.screenshot_input_associations USING btree (log_id);
+
+
+--
+-- Name: ix_screenshot_input_assoc_screenshot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshot_input_assoc_screenshot ON public.screenshot_input_associations USING btree (screenshot_id);
+
+
+--
+-- Name: ix_screenshot_input_associations_input_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshot_input_associations_input_type ON public.screenshot_input_associations USING btree (input_type);
+
+
+--
+-- Name: ix_screenshot_input_associations_log_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshot_input_associations_log_id ON public.screenshot_input_associations USING btree (log_id);
+
+
+--
+-- Name: ix_screenshot_input_associations_screenshot_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshot_input_associations_screenshot_id ON public.screenshot_input_associations USING btree (screenshot_id);
+
+
+--
+-- Name: ix_screenshots_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshots_id ON public.screenshots USING btree (id);
+
+
+--
+-- Name: ix_screenshots_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshots_snapshot_run_id ON public.screenshots USING btree (snapshot_run_id);
+
+
+--
+-- Name: ix_screenshots_state_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_screenshots_state_hash ON public.screenshots USING btree (state_hash);
+
+
+--
+-- Name: ix_session_activities_jti; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_session_activities_jti ON public.session_activities USING btree (jti);
+
+
+--
+-- Name: ix_session_activities_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_session_activities_user_id ON public.session_activities USING btree (user_id);
+
+
+--
+-- Name: ix_shared_files_expires_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_shared_files_expires_at ON public.shared_files USING btree (expires_at);
+
+
+--
+-- Name: ix_shared_files_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_shared_files_user_id ON public.shared_files USING btree (user_id);
+
+
+--
+-- Name: ix_skills_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_skills_category ON public.skills USING btree (category);
+
+
+--
+-- Name: ix_skills_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_skills_created_by_user_id ON public.skills USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_skills_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_skills_organization_id ON public.skills USING btree (organization_id);
+
+
+--
+-- Name: ix_snapshot_actions_action_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_action_type ON public.snapshot_actions USING btree (action_type);
+
+
+--
+-- Name: ix_snapshot_actions_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_id ON public.snapshot_actions USING btree (id);
+
+
+--
+-- Name: ix_snapshot_actions_is_start_screenshot; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_is_start_screenshot ON public.snapshot_actions USING btree (is_start_screenshot);
+
+
+--
+-- Name: ix_snapshot_actions_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_pattern_id ON public.snapshot_actions USING btree (pattern_id);
+
+
+--
+-- Name: ix_snapshot_actions_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_snapshot_run_id ON public.snapshot_actions USING btree (snapshot_run_id);
+
+
+--
+-- Name: ix_snapshot_actions_success; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_success ON public.snapshot_actions USING btree (success);
+
+
+--
+-- Name: ix_snapshot_actions_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_actions_timestamp ON public.snapshot_actions USING btree ("timestamp");
+
+
+--
+-- Name: ix_snapshot_matches_action_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_matches_action_id ON public.snapshot_matches USING btree (action_id);
+
+
+--
+-- Name: ix_snapshot_matches_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_matches_id ON public.snapshot_matches USING btree (id);
+
+
+--
+-- Name: ix_snapshot_matches_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_matches_pattern_id ON public.snapshot_matches USING btree (pattern_id);
+
+
+--
+-- Name: ix_snapshot_patterns_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_patterns_id ON public.snapshot_patterns USING btree (id);
+
+
+--
+-- Name: ix_snapshot_patterns_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_patterns_pattern_id ON public.snapshot_patterns USING btree (pattern_id);
+
+
+--
+-- Name: ix_snapshot_patterns_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_patterns_snapshot_run_id ON public.snapshot_patterns USING btree (snapshot_run_id);
+
+
+--
+-- Name: ix_snapshot_runs_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_runs_id ON public.snapshot_runs USING btree (id);
+
+
+--
+-- Name: ix_snapshot_runs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_runs_project_id ON public.snapshot_runs USING btree (project_id);
+
+
+--
+-- Name: ix_snapshot_runs_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_snapshot_runs_run_id ON public.snapshot_runs USING btree (run_id);
+
+
+--
+-- Name: ix_snapshot_runs_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_snapshot_runs_workflow_id ON public.snapshot_runs USING btree (workflow_id);
+
+
+--
+-- Name: ix_software_test_runs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_software_test_runs_project_id ON public.software_test_runs USING btree (project_id);
+
+
+--
+-- Name: ix_software_test_runs_runner_connection_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_software_test_runs_runner_connection_id ON public.software_test_runs USING btree (runner_connection_id);
+
+
+--
+-- Name: ix_software_test_runs_started_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_software_test_runs_started_at ON public.software_test_runs USING btree (started_at);
+
+
+--
+-- Name: ix_software_test_runs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_software_test_runs_status ON public.software_test_runs USING btree (status);
+
+
+--
+-- Name: ix_software_test_runs_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_software_test_runs_workflow_id ON public.software_test_runs USING btree (workflow_id);
+
+
+--
+-- Name: ix_state_discovery_results_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_discovery_results_created_at ON public.state_discovery_results USING btree (created_at);
+
+
+--
+-- Name: ix_state_discovery_results_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_discovery_results_project_id ON public.state_discovery_results USING btree (project_id);
+
+
+--
+-- Name: ix_state_discovery_results_source_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_discovery_results_source_session_id ON public.state_discovery_results USING btree (source_session_id);
+
+
+--
+-- Name: ix_state_discovery_results_source_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_discovery_results_source_type ON public.state_discovery_results USING btree (source_type);
+
+
+--
 -- Name: ix_state_machine_configs_created_by; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2882,6 +21314,90 @@ CREATE INDEX ix_state_machine_configs_project_id ON public.state_machine_configs
 
 
 --
+-- Name: ix_state_transitions_from_state_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_transitions_from_state_id ON public.state_transitions USING btree (from_state_id);
+
+
+--
+-- Name: ix_state_transitions_to_state_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_transitions_to_state_id ON public.state_transitions USING btree (to_state_id);
+
+
+--
+-- Name: ix_step_type_configs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_step_type_configs_user_id ON public.step_type_configs USING btree (user_id);
+
+
+--
+-- Name: ix_storage_usage_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_storage_usage_id ON public.storage_usage USING btree (id);
+
+
+--
+-- Name: ix_storage_usage_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_storage_usage_user_id ON public.storage_usage USING btree (user_id);
+
+
+--
+-- Name: ix_subscriptions_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_subscriptions_id ON public.subscriptions USING btree (id);
+
+
+--
+-- Name: ix_subscriptions_stripe_customer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_subscriptions_stripe_customer_id ON public.subscriptions USING btree (stripe_customer_id);
+
+
+--
+-- Name: ix_subscriptions_stripe_subscription_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_subscriptions_stripe_subscription_id ON public.subscriptions USING btree (stripe_subscription_id);
+
+
+--
+-- Name: ix_sync_locks_project_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_sync_locks_project_active ON public.sync_locks USING btree (project_id) WHERE (released_at IS NULL);
+
+
+--
+-- Name: ix_sync_locks_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_sync_locks_project_id ON public.sync_locks USING btree (project_id);
+
+
+--
+-- Name: ix_task_run_automations_task_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_task_run_automations_task_run_id ON public.task_run_automations USING btree (task_run_id);
+
+
+--
+-- Name: ix_task_run_verification_results_task_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_task_run_verification_results_task_run_id ON public.task_run_verification_results USING btree (task_run_id);
+
+
+--
 -- Name: ix_task_runs_config_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2893,6 +21409,83 @@ CREATE INDEX ix_task_runs_config_id ON public.task_runs USING btree (config_id);
 --
 
 CREATE INDEX ix_task_runs_task_type ON public.task_runs USING btree (task_type);
+
+
+--
+-- Name: ix_template_candidates_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_template_candidates_project_id ON public.template_candidates USING btree (project_id);
+
+
+--
+-- Name: ix_template_candidates_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_template_candidates_session_id ON public.template_candidates USING btree (session_id);
+
+
+--
+-- Name: ix_template_candidates_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_template_candidates_status ON public.template_candidates USING btree (status);
+
+
+--
+-- Name: ix_test_deficiencies_assigned_to_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_assigned_to_user_id ON public.test_deficiencies USING btree (assigned_to_user_id);
+
+
+--
+-- Name: ix_test_deficiencies_deficiency_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_deficiency_type ON public.test_deficiencies USING btree (deficiency_type);
+
+
+--
+-- Name: ix_test_deficiencies_first_seen_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_first_seen_at ON public.test_deficiencies USING btree (first_seen_at);
+
+
+--
+-- Name: ix_test_deficiencies_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_severity ON public.test_deficiencies USING btree (severity);
+
+
+--
+-- Name: ix_test_deficiencies_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_status ON public.test_deficiencies USING btree (status);
+
+
+--
+-- Name: ix_test_deficiencies_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_test_run_id ON public.test_deficiencies USING btree (test_run_id);
+
+
+--
+-- Name: ix_test_deficiencies_transition_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_deficiencies_transition_execution_id ON public.test_deficiencies USING btree (transition_execution_id);
+
+
+--
+-- Name: ix_test_notification_preferences_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_test_notification_preferences_project_id ON public.test_notification_preferences USING btree (project_id);
 
 
 --
@@ -2921,6 +21514,55 @@ CREATE INDEX ix_test_results_task_run_id ON public.test_results USING btree (tas
 --
 
 CREATE INDEX ix_test_results_test_id ON public.test_results USING btree (test_id);
+
+
+--
+-- Name: ix_test_screenshots_captured_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_captured_at ON public.test_screenshots USING btree (captured_at);
+
+
+--
+-- Name: ix_test_screenshots_deficiency_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_deficiency_id ON public.test_screenshots USING btree (deficiency_id);
+
+
+--
+-- Name: ix_test_screenshots_perceptual_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_perceptual_hash ON public.test_screenshots USING btree (perceptual_hash);
+
+
+--
+-- Name: ix_test_screenshots_screenshot_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_screenshot_type ON public.test_screenshots USING btree (screenshot_type);
+
+
+--
+-- Name: ix_test_screenshots_state_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_state_name ON public.test_screenshots USING btree (state_name);
+
+
+--
+-- Name: ix_test_screenshots_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_test_run_id ON public.test_screenshots USING btree (test_run_id);
+
+
+--
+-- Name: ix_test_screenshots_transition_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_screenshots_transition_execution_id ON public.test_screenshots USING btree (transition_execution_id);
 
 
 --
@@ -2959,6 +21601,41 @@ CREATE INDEX ix_training_dataset_annotations_source ON public.training_dataset_a
 
 
 --
+-- Name: ix_training_dataset_export_jobs_dataset; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_export_jobs_dataset ON public.training_dataset_export_jobs USING btree (dataset_id);
+
+
+--
+-- Name: ix_training_dataset_export_jobs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_export_jobs_status ON public.training_dataset_export_jobs USING btree (status);
+
+
+--
+-- Name: ix_training_dataset_images_dataset_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_images_dataset_hash ON public.training_dataset_images USING btree (dataset_id, image_hash);
+
+
+--
+-- Name: ix_training_dataset_images_image_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_images_image_hash ON public.training_dataset_images USING btree (image_hash);
+
+
+--
+-- Name: ix_training_dataset_images_reviewed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_images_reviewed ON public.training_dataset_images USING btree (dataset_id, reviewed);
+
+
+--
 -- Name: ix_training_datasets_created_by; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2970,6 +21647,139 @@ CREATE INDEX ix_training_datasets_created_by ON public.training_datasets USING b
 --
 
 CREATE INDEX ix_training_datasets_name ON public.training_datasets USING btree (name);
+
+
+--
+-- Name: ix_training_jobs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_jobs_project_id ON public.training_jobs USING btree (project_id);
+
+
+--
+-- Name: ix_training_jobs_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_jobs_status ON public.training_jobs USING btree (status);
+
+
+--
+-- Name: ix_training_jobs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_jobs_user_id ON public.training_jobs USING btree (user_id);
+
+
+--
+-- Name: ix_transition_executions_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_executions_status ON public.transition_executions USING btree (status);
+
+
+--
+-- Name: ix_transition_executions_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_executions_test_run_id ON public.transition_executions USING btree (test_run_id);
+
+
+--
+-- Name: ix_transition_executions_transition_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_executions_transition_id ON public.transition_executions USING btree (transition_id);
+
+
+--
+-- Name: ix_transition_reliability_is_flaky; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_reliability_is_flaky ON public.transition_reliability USING btree (is_flaky);
+
+
+--
+-- Name: ix_transition_reliability_last_executed_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_reliability_last_executed_at ON public.transition_reliability USING btree (last_executed_at);
+
+
+--
+-- Name: ix_transition_reliability_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_reliability_project_id ON public.transition_reliability USING btree (project_id);
+
+
+--
+-- Name: ix_transition_reliability_success_rate; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_reliability_success_rate ON public.transition_reliability USING btree (success_rate);
+
+
+--
+-- Name: ix_transition_reliability_transition_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_reliability_transition_id ON public.transition_reliability USING btree (transition_id);
+
+
+--
+-- Name: ix_transition_reliability_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_transition_reliability_workflow_id ON public.transition_reliability USING btree (workflow_id);
+
+
+--
+-- Name: ix_tree_events_run_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_tree_events_run_event_type ON public.execution_tree_events USING btree (run_id, event_type);
+
+
+--
+-- Name: ix_tree_events_run_node_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_tree_events_run_node_id ON public.execution_tree_events USING btree (run_id, node_id);
+
+
+--
+-- Name: ix_tree_events_run_node_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_tree_events_run_node_type ON public.execution_tree_events USING btree (run_id, node_type);
+
+
+--
+-- Name: ix_tree_events_run_sequence; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_tree_events_run_sequence ON public.execution_tree_events USING btree (run_id, sequence);
+
+
+--
+-- Name: ix_ui_bridge_state_configs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ui_bridge_state_configs_project_id ON public.ui_bridge_state_configs USING btree (project_id);
+
+
+--
+-- Name: ix_ui_bridge_state_domain_knowledge_knowledge_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ui_bridge_state_domain_knowledge_knowledge_id ON public.ui_bridge_state_domain_knowledge USING btree (knowledge_id);
+
+
+--
+-- Name: ix_ui_bridge_state_domain_knowledge_state_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ui_bridge_state_domain_knowledge_state_id ON public.ui_bridge_state_domain_knowledge USING btree (state_id);
 
 
 --
@@ -3008,6 +21818,41 @@ CREATE INDEX ix_unified_workflows_project_id ON public.unified_workflows USING b
 
 
 --
+-- Name: ix_usage_metrics_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_usage_metrics_id ON public.usage_metrics USING btree (id);
+
+
+--
+-- Name: ix_usage_metrics_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_usage_metrics_timestamp ON public.usage_metrics USING btree ("timestamp");
+
+
+--
+-- Name: ix_variable_history_changed_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_variable_history_changed_at ON public.variable_history USING btree (changed_at);
+
+
+--
+-- Name: ix_variable_history_variable_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_variable_history_variable_id ON public.variable_history USING btree (variable_id);
+
+
+--
+-- Name: ix_variable_history_workflow_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_variable_history_workflow_run_id ON public.variable_history USING btree (workflow_run_id);
+
+
+--
 -- Name: ix_verification_tests_category; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3040,6 +21885,216 @@ CREATE INDEX ix_verification_tests_project_id ON public.verification_tests USING
 --
 
 CREATE INDEX ix_verification_tests_test_type ON public.verification_tests USING btree (test_type);
+
+
+--
+-- Name: ix_video_capture_sessions_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_video_capture_sessions_id ON public.video_capture_sessions USING btree (id);
+
+
+--
+-- Name: ix_video_capture_sessions_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_video_capture_sessions_project_id ON public.video_capture_sessions USING btree (project_id);
+
+
+--
+-- Name: ix_video_capture_sessions_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_video_capture_sessions_session_id ON public.video_capture_sessions USING btree (session_id);
+
+
+--
+-- Name: ix_video_capture_sessions_snapshot_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_video_capture_sessions_snapshot_run_id ON public.video_capture_sessions USING btree (snapshot_run_id);
+
+
+--
+-- Name: ix_video_capture_sessions_started_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_video_capture_sessions_started_at ON public.video_capture_sessions USING btree (started_at);
+
+
+--
+-- Name: ix_video_capture_sessions_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_video_capture_sessions_workflow_id ON public.video_capture_sessions USING btree (workflow_id);
+
+
+--
+-- Name: ix_visual_baselines_approved_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_baselines_approved_by_user_id ON public.visual_baselines USING btree (approved_by_user_id);
+
+
+--
+-- Name: ix_visual_baselines_is_active; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_baselines_is_active ON public.visual_baselines USING btree (is_active);
+
+
+--
+-- Name: ix_visual_baselines_perceptual_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_baselines_perceptual_hash ON public.visual_baselines USING btree (perceptual_hash);
+
+
+--
+-- Name: ix_visual_baselines_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_baselines_project_id ON public.visual_baselines USING btree (project_id);
+
+
+--
+-- Name: ix_visual_baselines_state_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_baselines_state_name ON public.visual_baselines USING btree (state_name);
+
+
+--
+-- Name: ix_visual_baselines_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_baselines_workflow_id ON public.visual_baselines USING btree (workflow_id);
+
+
+--
+-- Name: ix_visual_comparison_results_baseline_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_baseline_id ON public.visual_comparison_results USING btree (baseline_id);
+
+
+--
+-- Name: ix_visual_comparison_results_deficiency_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_deficiency_id ON public.visual_comparison_results USING btree (deficiency_id);
+
+
+--
+-- Name: ix_visual_comparison_results_reviewed_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_reviewed_by_user_id ON public.visual_comparison_results USING btree (reviewed_by_user_id);
+
+
+--
+-- Name: ix_visual_comparison_results_screenshot_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_screenshot_id ON public.visual_comparison_results USING btree (screenshot_id);
+
+
+--
+-- Name: ix_visual_comparison_results_state_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_state_name ON public.visual_comparison_results USING btree (state_name);
+
+
+--
+-- Name: ix_visual_comparison_results_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_status ON public.visual_comparison_results USING btree (status);
+
+
+--
+-- Name: ix_visual_comparison_results_test_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_test_run_id ON public.visual_comparison_results USING btree (test_run_id);
+
+
+--
+-- Name: ix_visual_comparison_results_transition_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_visual_comparison_results_transition_execution_id ON public.visual_comparison_results USING btree (transition_execution_id);
+
+
+--
+-- Name: ix_workflow_events_device_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_events_device_id ON public.workflow_events USING btree (device_id);
+
+
+--
+-- Name: ix_workflow_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_events_event_type ON public.workflow_events USING btree (event_type);
+
+
+--
+-- Name: ix_workflow_events_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_events_id ON public.workflow_events USING btree (id);
+
+
+--
+-- Name: ix_workflow_events_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_events_run_id ON public.workflow_events USING btree (run_id);
+
+
+--
+-- Name: ix_workflow_events_seen; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_events_seen ON public.workflow_events USING btree (seen);
+
+
+--
+-- Name: ix_workflow_events_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_events_user_id ON public.workflow_events USING btree (user_id);
+
+
+--
+-- Name: ix_workflow_execution_history_execution_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_execution_history_execution_status ON public.workflow_execution_history USING btree (execution_status);
+
+
+--
+-- Name: ix_workflow_execution_history_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_workflow_execution_history_session_id ON public.workflow_execution_history USING btree (session_id);
+
+
+--
+-- Name: ix_workflow_execution_history_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_execution_history_workflow_id ON public.workflow_execution_history USING btree (workflow_id);
+
+
+--
+-- Name: ix_workflow_phase_configs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_phase_configs_user_id ON public.workflow_phase_configs USING btree (user_id);
 
 
 --
@@ -3134,6 +22189,854 @@ CREATE INDEX wrapper_ratings_wrapper_idx ON public.wrapper_ratings USING btree (
 
 
 --
+-- Name: gui_lock gui_lock_holder_session_id_fkey; Type: FK CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.gui_lock
+    ADD CONSTRAINT gui_lock_holder_session_id_fkey FOREIGN KEY (holder_session_id) REFERENCES project.sessions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: process_session_output process_session_output_session_id_fkey; Type: FK CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.process_session_output
+    ADD CONSTRAINT process_session_output_session_id_fkey FOREIGN KEY (session_id) REFERENCES coord.process_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reviews reviews_task_id_fkey; Type: FK CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.reviews
+    ADD CONSTRAINT reviews_task_id_fkey FOREIGN KEY (task_id) REFERENCES coord.tasks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: tasks tasks_plan_id_fkey; Type: FK CONSTRAINT; Schema: coord; Owner: -
+--
+
+ALTER TABLE ONLY coord.tasks
+    ADD CONSTRAINT tasks_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES coord.plans(id) ON DELETE CASCADE;
+
+
+--
+-- Name: activity_timeline activity_timeline_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.activity_timeline
+    ADD CONSTRAINT activity_timeline_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: approval_gates approval_gates_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.approval_gates
+    ADD CONSTRAINT approval_gates_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: breakpoint_snapshots breakpoint_snapshots_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.breakpoint_snapshots
+    ADD CONSTRAINT breakpoint_snapshots_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: canvas_panels canvas_panels_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.canvas_panels
+    ADD CONSTRAINT canvas_panels_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: check_group_members check_group_members_check_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_group_members
+    ADD CONSTRAINT check_group_members_check_id_fkey FOREIGN KEY (check_id) REFERENCES project.checks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: check_group_members check_group_members_group_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_group_members
+    ADD CONSTRAINT check_group_members_group_id_fkey FOREIGN KEY (group_id) REFERENCES project.check_groups(id) ON DELETE CASCADE;
+
+
+--
+-- Name: check_results check_results_check_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_results
+    ADD CONSTRAINT check_results_check_id_fkey FOREIGN KEY (check_id) REFERENCES project.checks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: check_results check_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.check_results
+    ADD CONSTRAINT check_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: config_statistics config_statistics_config_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.config_statistics
+    ADD CONSTRAINT config_statistics_config_id_fkey FOREIGN KEY (config_id) REFERENCES project.configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: contradiction_resolutions contradiction_resolutions_loser_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.contradiction_resolutions
+    ADD CONSTRAINT contradiction_resolutions_loser_id_fkey FOREIGN KEY (loser_id) REFERENCES project.observations(id);
+
+
+--
+-- Name: contradiction_resolutions contradiction_resolutions_observation_a_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.contradiction_resolutions
+    ADD CONSTRAINT contradiction_resolutions_observation_a_id_fkey FOREIGN KEY (observation_a_id) REFERENCES project.observations(id);
+
+
+--
+-- Name: contradiction_resolutions contradiction_resolutions_observation_b_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.contradiction_resolutions
+    ADD CONSTRAINT contradiction_resolutions_observation_b_id_fkey FOREIGN KEY (observation_b_id) REFERENCES project.observations(id);
+
+
+--
+-- Name: contradiction_resolutions contradiction_resolutions_winner_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.contradiction_resolutions
+    ADD CONSTRAINT contradiction_resolutions_winner_id_fkey FOREIGN KEY (winner_id) REFERENCES project.observations(id);
+
+
+--
+-- Name: deferred_questions deferred_questions_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.deferred_questions
+    ADD CONSTRAINT deferred_questions_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: entity_profiles entity_profiles_superseded_by_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.entity_profiles
+    ADD CONSTRAINT entity_profiles_superseded_by_fkey FOREIGN KEY (superseded_by) REFERENCES project.entity_profiles(id);
+
+
+--
+-- Name: error_events error_events_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.error_events
+    ADD CONSTRAINT error_events_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: execution_spans execution_spans_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.execution_spans
+    ADD CONSTRAINT execution_spans_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: fix_applications fix_applications_fix_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.fix_applications
+    ADD CONSTRAINT fix_applications_fix_id_fkey FOREIGN KEY (fix_id) REFERENCES project.reflection_fixes(id) ON DELETE CASCADE;
+
+
+--
+-- Name: fix_applications fix_applications_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.fix_applications
+    ADD CONSTRAINT fix_applications_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: flow_executions flow_executions_flow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.flow_executions
+    ADD CONSTRAINT flow_executions_flow_id_fkey FOREIGN KEY (flow_id) REFERENCES project.orchestrator_flows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: flow_versions flow_versions_flow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.flow_versions
+    ADD CONSTRAINT flow_versions_flow_id_fkey FOREIGN KEY (flow_id) REFERENCES project.orchestrator_flows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: generation_pipeline_events generation_pipeline_events_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.generation_pipeline_events
+    ADD CONSTRAINT generation_pipeline_events_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: generation_pipeline_events generation_pipeline_events_workflow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.generation_pipeline_events
+    ADD CONSTRAINT generation_pipeline_events_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES project.unified_workflows(id) ON DELETE SET NULL;
+
+
+--
+-- Name: known_issues known_issues_source_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.known_issues
+    ADD CONSTRAINT known_issues_source_task_run_id_fkey FOREIGN KEY (source_task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: observation_history observation_history_observation_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observation_history
+    ADD CONSTRAINT observation_history_observation_id_fkey FOREIGN KEY (observation_id) REFERENCES project.observations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: observations observations_superseded_by_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observations
+    ADD CONSTRAINT observations_superseded_by_fkey FOREIGN KEY (superseded_by) REFERENCES project.observations(id);
+
+
+--
+-- Name: observations observations_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.observations
+    ADD CONSTRAINT observations_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: orchestrator_verification_results orchestrator_verification_results_plan_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.orchestrator_verification_results
+    ADD CONSTRAINT orchestrator_verification_results_plan_id_fkey FOREIGN KEY (plan_id) REFERENCES project.verification_plans(id) ON DELETE CASCADE;
+
+
+--
+-- Name: orchestrator_verification_results orchestrator_verification_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.orchestrator_verification_results
+    ADD CONSTRAINT orchestrator_verification_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: phase_token_usage phase_token_usage_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.phase_token_usage
+    ADD CONSTRAINT phase_token_usage_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: productivity_knowledge productivity_knowledge_task_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.productivity_knowledge
+    ADD CONSTRAINT productivity_knowledge_task_id_fkey FOREIGN KEY (task_id) REFERENCES coord.tasks(id) ON DELETE SET NULL;
+
+
+--
+-- Name: reasoning_traces reasoning_traces_created_observation_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reasoning_traces
+    ADD CONSTRAINT reasoning_traces_created_observation_id_fkey FOREIGN KEY (created_observation_id) REFERENCES project.observations(id);
+
+
+--
+-- Name: reasoning_traces reasoning_traces_invalidated_by_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reasoning_traces
+    ADD CONSTRAINT reasoning_traces_invalidated_by_fkey FOREIGN KEY (invalidated_by) REFERENCES project.reasoning_traces(id);
+
+
+--
+-- Name: recording_actions recording_actions_recording_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.recording_actions
+    ADD CONSTRAINT recording_actions_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES project.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_exports recording_exports_recording_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.recording_exports
+    ADD CONSTRAINT recording_exports_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES project.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reflection_fixes reflection_fixes_reflection_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reflection_fixes
+    ADD CONSTRAINT reflection_fixes_reflection_task_run_id_fkey FOREIGN KEY (reflection_task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reflection_fixes reflection_fixes_source_finding_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reflection_fixes
+    ADD CONSTRAINT reflection_fixes_source_finding_id_fkey FOREIGN KEY (source_finding_id) REFERENCES project.task_run_findings(id) ON DELETE SET NULL;
+
+
+--
+-- Name: reflection_fixes reflection_fixes_source_knowledge_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reflection_fixes
+    ADD CONSTRAINT reflection_fixes_source_knowledge_id_fkey FOREIGN KEY (source_knowledge_id) REFERENCES project.task_knowledge(id) ON DELETE SET NULL;
+
+
+--
+-- Name: reflection_fixes reflection_fixes_source_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.reflection_fixes
+    ADD CONSTRAINT reflection_fixes_source_task_run_id_fkey FOREIGN KEY (source_task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: restate_awakeables restate_awakeables_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.restate_awakeables
+    ADD CONSTRAINT restate_awakeables_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: restate_workflow_executions restate_workflow_executions_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.restate_workflow_executions
+    ADD CONSTRAINT restate_workflow_executions_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: rule_influence_log rule_influence_log_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.rule_influence_log
+    ADD CONSTRAINT rule_influence_log_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: rule_influence_log rule_influence_log_workflow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.rule_influence_log
+    ADD CONSTRAINT rule_influence_log_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES project.unified_workflows(id) ON DELETE SET NULL;
+
+
+--
+-- Name: scheduler_history scheduler_history_task_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.scheduler_history
+    ADD CONSTRAINT scheduler_history_task_id_fkey FOREIGN KEY (task_id) REFERENCES project.scheduled_tasks(id) ON DELETE CASCADE;
+
+
+--
+-- Name: shell_command_results shell_command_results_shell_command_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.shell_command_results
+    ADD CONSTRAINT shell_command_results_shell_command_id_fkey FOREIGN KEY (shell_command_id) REFERENCES project.shell_commands(id) ON DELETE CASCADE;
+
+
+--
+-- Name: shell_command_results shell_command_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.shell_command_results
+    ADD CONSTRAINT shell_command_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: sm_capture_screenshots sm_capture_screenshots_config_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.sm_capture_screenshots
+    ADD CONSTRAINT sm_capture_screenshots_config_id_fkey FOREIGN KEY (config_id) REFERENCES project.state_machine_configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: sm_element_thumbnails sm_element_thumbnails_config_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.sm_element_thumbnails
+    ADD CONSTRAINT sm_element_thumbnails_config_id_fkey FOREIGN KEY (config_id) REFERENCES project.state_machine_configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: state_machine_states state_machine_states_config_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_machine_states
+    ADD CONSTRAINT state_machine_states_config_id_fkey FOREIGN KEY (config_id) REFERENCES project.state_machine_configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: state_machine_transitions state_machine_transitions_config_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.state_machine_transitions
+    ADD CONSTRAINT state_machine_transitions_config_id_fkey FOREIGN KEY (config_id) REFERENCES project.state_machine_configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: step_finding_links step_finding_links_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_finding_links
+    ADD CONSTRAINT step_finding_links_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: step_progress_markers step_progress_markers_checkpoint_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_progress_markers
+    ADD CONSTRAINT step_progress_markers_checkpoint_id_fkey FOREIGN KEY (checkpoint_id) REFERENCES project.workflow_step_checkpoints(id) ON DELETE CASCADE;
+
+
+--
+-- Name: step_provenance step_provenance_workflow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_provenance
+    ADD CONSTRAINT step_provenance_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES project.unified_workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: step_provenance step_provenance_workflow_version_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_provenance
+    ADD CONSTRAINT step_provenance_workflow_version_id_fkey FOREIGN KEY (workflow_version_id) REFERENCES project.workflow_versions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: step_type_knowledge step_type_knowledge_source_fix_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.step_type_knowledge
+    ADD CONSTRAINT step_type_knowledge_source_fix_id_fkey FOREIGN KEY (source_fix_id) REFERENCES project.reflection_fixes(id) ON DELETE SET NULL;
+
+
+--
+-- Name: strategy_bank strategy_bank_parent_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.strategy_bank
+    ADD CONSTRAINT strategy_bank_parent_fkey FOREIGN KEY (parent_strategy_id) REFERENCES project.strategy_bank(id) ON DELETE SET NULL;
+
+
+--
+-- Name: task_knowledge_summaries task_knowledge_summaries_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_knowledge_summaries
+    ADD CONSTRAINT task_knowledge_summaries_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_api_requests task_run_api_requests_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_api_requests
+    ADD CONSTRAINT task_run_api_requests_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_automation task_run_automation_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_automation
+    ADD CONSTRAINT task_run_automation_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_awas_steps task_run_awas_steps_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_awas_steps
+    ADD CONSTRAINT task_run_awas_steps_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_events task_run_events_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_events
+    ADD CONSTRAINT task_run_events_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_findings task_run_findings_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_findings
+    ADD CONSTRAINT task_run_findings_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_mcp_calls task_run_mcp_calls_server_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mcp_calls
+    ADD CONSTRAINT task_run_mcp_calls_server_id_fkey FOREIGN KEY (server_id) REFERENCES project.mcp_servers(id) ON DELETE SET NULL;
+
+
+--
+-- Name: task_run_mcp_calls task_run_mcp_calls_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mcp_calls
+    ADD CONSTRAINT task_run_mcp_calls_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_mobile_logs task_run_mobile_logs_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mobile_logs
+    ADD CONSTRAINT task_run_mobile_logs_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_mobile_state task_run_mobile_state_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_mobile_state
+    ADD CONSTRAINT task_run_mobile_state_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_output_chunks task_run_output_chunks_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_output_chunks
+    ADD CONSTRAINT task_run_output_chunks_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_playwright_results task_run_playwright_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_playwright_results
+    ADD CONSTRAINT task_run_playwright_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_screenshots task_run_screenshots_event_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_screenshots
+    ADD CONSTRAINT task_run_screenshots_event_id_fkey FOREIGN KEY (event_id) REFERENCES project.task_run_events(id) ON DELETE SET NULL;
+
+
+--
+-- Name: task_run_screenshots task_run_screenshots_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_run_screenshots
+    ADD CONSTRAINT task_run_screenshots_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_runs task_runs_parent_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.task_runs
+    ADD CONSTRAINT task_runs_parent_task_run_id_fkey FOREIGN KEY (parent_task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: test_associations test_associations_config_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.test_associations
+    ADD CONSTRAINT test_associations_config_id_fkey FOREIGN KEY (config_id) REFERENCES project.configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_associations test_associations_test_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.test_associations
+    ADD CONSTRAINT test_associations_test_id_fkey FOREIGN KEY (test_id) REFERENCES project.verification_tests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_results test_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.test_results
+    ADD CONSTRAINT test_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_results test_results_test_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.test_results
+    ADD CONSTRAINT test_results_test_id_fkey FOREIGN KEY (test_id) REFERENCES project.verification_tests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: unified_workflows unified_workflows_generated_by_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.unified_workflows
+    ADD CONSTRAINT unified_workflows_generated_by_task_run_id_fkey FOREIGN KEY (generated_by_task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: verification_plans verification_plans_previous_version_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.verification_plans
+    ADD CONSTRAINT verification_plans_previous_version_fkey FOREIGN KEY (previous_version_id) REFERENCES project.verification_plans(id) ON DELETE SET NULL;
+
+
+--
+-- Name: verification_plans verification_plans_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.verification_plans
+    ADD CONSTRAINT verification_plans_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vga_runs vga_runs_state_machine_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.vga_runs
+    ADD CONSTRAINT vga_runs_state_machine_id_fkey FOREIGN KEY (state_machine_id) REFERENCES project.vga_state_machines(id) ON DELETE CASCADE;
+
+
+--
+-- Name: vga_shadow_samples vga_shadow_samples_state_machine_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.vga_shadow_samples
+    ADD CONSTRAINT vga_shadow_samples_state_machine_id_fkey FOREIGN KEY (state_machine_id) REFERENCES project.vga_state_machines(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_ai_sessions workflow_ai_sessions_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_ai_sessions
+    ADD CONSTRAINT workflow_ai_sessions_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_constraint_results workflow_constraint_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_constraint_results
+    ADD CONSTRAINT workflow_constraint_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_event_log workflow_event_log_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_event_log
+    ADD CONSTRAINT workflow_event_log_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_execution_state workflow_execution_state_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_execution_state
+    ADD CONSTRAINT workflow_execution_state_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_generation_feedback workflow_generation_feedback_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_generation_feedback
+    ADD CONSTRAINT workflow_generation_feedback_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: workflow_generation_feedback workflow_generation_feedback_workflow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_generation_feedback
+    ADD CONSTRAINT workflow_generation_feedback_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES project.unified_workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_step_checkpoints workflow_step_checkpoints_execution_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_step_checkpoints
+    ADD CONSTRAINT workflow_step_checkpoints_execution_id_fkey FOREIGN KEY (execution_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_triggers workflow_triggers_workflow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_triggers
+    ADD CONSTRAINT workflow_triggers_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES project.unified_workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_variables workflow_variables_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_variables
+    ADD CONSTRAINT workflow_variables_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_verification_phase_results workflow_verification_phase_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_verification_phase_results
+    ADD CONSTRAINT workflow_verification_phase_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_versions workflow_versions_generation_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_versions
+    ADD CONSTRAINT workflow_versions_generation_task_run_id_fkey FOREIGN KEY (generation_task_run_id) REFERENCES project.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: workflow_versions workflow_versions_parent_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_versions
+    ADD CONSTRAINT workflow_versions_parent_fkey FOREIGN KEY (parent_version_id) REFERENCES project.workflow_versions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: workflow_versions workflow_versions_workflow_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.workflow_versions
+    ADD CONSTRAINT workflow_versions_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES project.unified_workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: working_representations working_representations_task_run_id_fkey; Type: FK CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.working_representations
+    ADD CONSTRAINT working_representations_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES project.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: action_executions action_executions_parent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_executions
+    ADD CONSTRAINT action_executions_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.action_executions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: action_executions action_executions_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_executions
+    ADD CONSTRAINT action_executions_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.execution_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: action_frames action_frames_snapshot_action_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_frames
+    ADD CONSTRAINT action_frames_snapshot_action_id_fkey FOREIGN KEY (snapshot_action_id) REFERENCES public.snapshot_actions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: action_frames action_frames_video_capture_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_frames
+    ADD CONSTRAINT action_frames_video_capture_session_id_fkey FOREIGN KEY (video_capture_session_id) REFERENCES public.video_capture_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: activity_logs activity_logs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.activity_logs
+    ADD CONSTRAINT activity_logs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: activity_logs activity_logs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.activity_logs
+    ADD CONSTRAINT activity_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ai_prompt_templates ai_prompt_templates_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_prompt_templates
+    ADD CONSTRAINT ai_prompt_templates_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id);
+
+
+--
+-- Name: ai_prompt_templates ai_prompt_templates_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ai_prompt_templates
+    ADD CONSTRAINT ai_prompt_templates_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
 -- Name: task_run_findings ai_task_findings_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3142,11 +23045,443 @@ ALTER TABLE ONLY public.task_run_findings
 
 
 --
+-- Name: task_run_sessions ai_task_sessions_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_sessions
+    ADD CONSTRAINT ai_task_sessions_task_id_fkey FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE CASCADE;
+
+
+--
 -- Name: task_runs ai_tasks_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.task_runs
-    ADD CONSTRAINT ai_tasks_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+    ADD CONSTRAINT ai_tasks_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: task_runs ai_tasks_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_runs
+    ADD CONSTRAINT ai_tasks_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: analytics_events analytics_events_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.analytics_events
+    ADD CONSTRAINT analytics_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: annotation_sets annotation_sets_created_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.annotation_sets
+    ADD CONSTRAINT annotation_sets_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: annotations annotations_annotation_set_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.annotations
+    ADD CONSTRAINT annotations_annotation_set_id_fkey FOREIGN KEY (annotation_set_id) REFERENCES public.annotation_sets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: audit_logs audit_logs_target_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_target_user_id_fkey FOREIGN KEY (target_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: audit_logs audit_logs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: automation_input_events automation_input_events_screenshot_after_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_input_events
+    ADD CONSTRAINT automation_input_events_screenshot_after_id_fkey FOREIGN KEY (screenshot_after_id) REFERENCES public.automation_screenshots(id) ON DELETE SET NULL;
+
+
+--
+-- Name: automation_input_events automation_input_events_screenshot_before_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_input_events
+    ADD CONSTRAINT automation_input_events_screenshot_before_id_fkey FOREIGN KEY (screenshot_before_id) REFERENCES public.automation_screenshots(id) ON DELETE SET NULL;
+
+
+--
+-- Name: automation_input_events automation_input_events_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_input_events
+    ADD CONSTRAINT automation_input_events_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.automation_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: automation_logs automation_logs_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_logs
+    ADD CONSTRAINT automation_logs_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.automation_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: automation_screenshots automation_screenshots_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_screenshots
+    ADD CONSTRAINT automation_screenshots_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: automation_screenshots automation_screenshots_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_screenshots
+    ADD CONSTRAINT automation_screenshots_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.automation_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: automation_sessions automation_sessions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_sessions
+    ADD CONSTRAINT automation_sessions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: automation_sessions automation_sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_sessions
+    ADD CONSTRAINT automation_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: automation_videos automation_videos_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_videos
+    ADD CONSTRAINT automation_videos_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
+-- Name: automation_videos automation_videos_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_videos
+    ADD CONSTRAINT automation_videos_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: capture_actions capture_actions_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_actions
+    ADD CONSTRAINT capture_actions_screenshot_id_fkey FOREIGN KEY (screenshot_id) REFERENCES public.capture_screenshots(id) ON DELETE CASCADE;
+
+
+--
+-- Name: capture_detected_elements capture_detected_elements_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_detected_elements
+    ADD CONSTRAINT capture_detected_elements_screenshot_id_fkey FOREIGN KEY (screenshot_id) REFERENCES public.capture_screenshots(id) ON DELETE CASCADE;
+
+
+--
+-- Name: capture_screenshots capture_screenshots_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_screenshots
+    ADD CONSTRAINT capture_screenshots_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.capture_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: capture_sessions capture_sessions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_sessions
+    ADD CONSTRAINT capture_sessions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: capture_sessions capture_sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.capture_sessions
+    ADD CONSTRAINT capture_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: clipboard_entries clipboard_entries_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.clipboard_entries
+    ADD CONSTRAINT clipboard_entries_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: code_packages code_packages_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.code_packages
+    ADD CONSTRAINT code_packages_author_id_fkey FOREIGN KEY (author_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: code_packages code_packages_category_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.code_packages
+    ADD CONSTRAINT code_packages_category_id_fkey FOREIGN KEY (category_id) REFERENCES public.package_categories(id) ON DELETE SET NULL;
+
+
+--
+-- Name: conflict_logs conflict_logs_local_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.conflict_logs
+    ADD CONSTRAINT conflict_logs_local_user_id_fkey FOREIGN KEY (local_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: conflict_logs conflict_logs_remote_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.conflict_logs
+    ADD CONSTRAINT conflict_logs_remote_user_id_fkey FOREIGN KEY (remote_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: coverage_snapshots coverage_snapshots_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.coverage_snapshots
+    ADD CONSTRAINT coverage_snapshots_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: coverage_snapshots coverage_snapshots_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.coverage_snapshots
+    ADD CONSTRAINT coverage_snapshots_test_run_id_fkey FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: custom_functions custom_functions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.custom_functions
+    ADD CONSTRAINT custom_functions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
+-- Name: dataset_items dataset_items_dataset_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dataset_items
+    ADD CONSTRAINT dataset_items_dataset_id_fkey FOREIGN KEY (dataset_id) REFERENCES public.evaluation_datasets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: deferred_questions deferred_questions_task_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.deferred_questions
+    ADD CONSTRAINT deferred_questions_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: detected_issues detected_issues_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.detected_issues
+    ADD CONSTRAINT detected_issues_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: detected_issues detected_issues_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.detected_issues
+    ADD CONSTRAINT detected_issues_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: device_sessions device_sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_sessions
+    ADD CONSTRAINT device_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: discovered_states discovered_states_automation_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_states
+    ADD CONSTRAINT discovered_states_automation_session_id_fkey FOREIGN KEY (automation_session_id) REFERENCES public.automation_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: discovered_states discovered_states_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_states
+    ADD CONSTRAINT discovered_states_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: discovered_transitions discovered_transitions_from_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_transitions
+    ADD CONSTRAINT discovered_transitions_from_state_id_fkey FOREIGN KEY (from_state_id) REFERENCES public.discovered_states(id);
+
+
+--
+-- Name: discovered_transitions discovered_transitions_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_transitions
+    ADD CONSTRAINT discovered_transitions_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: discovered_transitions discovered_transitions_to_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_transitions
+    ADD CONSTRAINT discovered_transitions_to_state_id_fkey FOREIGN KEY (to_state_id) REFERENCES public.discovered_states(id);
+
+
+--
+-- Name: discovered_transitions discovered_transitions_trigger_interaction_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discovered_transitions
+    ADD CONSTRAINT discovered_transitions_trigger_interaction_id_fkey FOREIGN KEY (trigger_interaction_id) REFERENCES public.recording_interactions(id);
+
+
+--
+-- Name: discoveries discoveries_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discoveries
+    ADD CONSTRAINT discoveries_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: discoveries discoveries_reviewed_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discoveries
+    ADD CONSTRAINT discoveries_reviewed_by_id_fkey FOREIGN KEY (reviewed_by_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: discoveries discoveries_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.discoveries
+    ADD CONSTRAINT discoveries_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: domain_knowledge domain_knowledge_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.domain_knowledge
+    ADD CONSTRAINT domain_knowledge_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: edit_commands edit_commands_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_commands
+    ADD CONSTRAINT edit_commands_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: edit_commands edit_commands_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.edit_commands
+    ADD CONSTRAINT edit_commands_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: embedding_generation_jobs embedding_generation_jobs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.embedding_generation_jobs
+    ADD CONSTRAINT embedding_generation_jobs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: embedding_generation_jobs embedding_generation_jobs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.embedding_generation_jobs
+    ADD CONSTRAINT embedding_generation_jobs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: error_monitor_entries error_monitor_entries_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.error_monitor_entries
+    ADD CONSTRAINT error_monitor_entries_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: error_monitor_entries error_monitor_entries_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.error_monitor_entries
+    ADD CONSTRAINT error_monitor_entries_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: error_monitor_entries error_monitor_entries_task_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.error_monitor_entries
+    ADD CONSTRAINT error_monitor_entries_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: evaluation_experiments evaluation_experiments_dataset_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.evaluation_experiments
+    ADD CONSTRAINT evaluation_experiments_dataset_id_fkey FOREIGN KEY (dataset_id) REFERENCES public.evaluation_datasets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: execution_issues execution_issues_action_execution_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_issues
+    ADD CONSTRAINT execution_issues_action_execution_id_fkey FOREIGN KEY (action_execution_id) REFERENCES public.action_executions(id) ON DELETE SET NULL;
 
 
 --
@@ -3154,7 +23489,287 @@ ALTER TABLE ONLY public.task_runs
 --
 
 ALTER TABLE ONLY public.execution_issues
-    ADD CONSTRAINT execution_issues_assigned_to_user_id_fkey FOREIGN KEY (assigned_to_user_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+    ADD CONSTRAINT execution_issues_assigned_to_user_id_fkey FOREIGN KEY (assigned_to_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: execution_issues execution_issues_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_issues
+    ADD CONSTRAINT execution_issues_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.execution_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: execution_runs execution_runs_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_runs
+    ADD CONSTRAINT execution_runs_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: execution_runs execution_runs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_runs
+    ADD CONSTRAINT execution_runs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: execution_screenshots execution_screenshots_action_execution_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_screenshots
+    ADD CONSTRAINT execution_screenshots_action_execution_id_fkey FOREIGN KEY (action_execution_id) REFERENCES public.action_executions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: execution_screenshots execution_screenshots_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_screenshots
+    ADD CONSTRAINT execution_screenshots_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.execution_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: execution_tree_events execution_tree_events_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_tree_events
+    ADD CONSTRAINT execution_tree_events_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.execution_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: experiment_results experiment_results_dataset_item_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.experiment_results
+    ADD CONSTRAINT experiment_results_dataset_item_id_fkey FOREIGN KEY (dataset_item_id) REFERENCES public.dataset_items(id) ON DELETE CASCADE;
+
+
+--
+-- Name: experiment_results experiment_results_experiment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.experiment_results
+    ADD CONSTRAINT experiment_results_experiment_id_fkey FOREIGN KEY (experiment_id) REFERENCES public.evaluation_experiments(id) ON DELETE CASCADE;
+
+
+--
+-- Name: extraction_annotations extraction_annotations_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extraction_annotations
+    ADD CONSTRAINT extraction_annotations_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.extraction_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: extraction_sessions extraction_sessions_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extraction_sessions
+    ADD CONSTRAINT extraction_sessions_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: extraction_sessions extraction_sessions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.extraction_sessions
+    ADD CONSTRAINT extraction_sessions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: feedback_scores feedback_scores_action_execution_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.feedback_scores
+    ADD CONSTRAINT feedback_scores_action_execution_id_fkey FOREIGN KEY (action_execution_id) REFERENCES public.action_executions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: feedback_scores feedback_scores_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.feedback_scores
+    ADD CONSTRAINT feedback_scores_run_id_fkey FOREIGN KEY (run_id) REFERENCES public.execution_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: finding_category_configs finding_category_configs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.finding_category_configs
+    ADD CONSTRAINT finding_category_configs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: action_executions fk_action_executions_screenshot_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_executions
+    ADD CONSTRAINT fk_action_executions_screenshot_id FOREIGN KEY (screenshot_id) REFERENCES public.execution_screenshots(id) ON DELETE SET NULL;
+
+
+--
+-- Name: element_annotation_sets fk_element_annotation_sets_created_by_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.element_annotation_sets
+    ADD CONSTRAINT fk_element_annotation_sets_created_by_id FOREIGN KEY (created_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: element_annotation_sets fk_element_annotation_sets_project_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.element_annotation_sets
+    ADD CONSTRAINT fk_element_annotation_sets_project_id FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: element_annotations fk_element_annotations_annotation_set_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.element_annotations
+    ADD CONSTRAINT fk_element_annotations_annotation_set_id FOREIGN KEY (annotation_set_id) REFERENCES public.element_annotation_sets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_exploration_sessions fk_exploration_sessions_project_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_exploration_sessions
+    ADD CONSTRAINT fk_exploration_sessions_project_id FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_exploration_sessions fk_exploration_sessions_saved_config_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_exploration_sessions
+    ADD CONSTRAINT fk_exploration_sessions_saved_config_id FOREIGN KEY (saved_config_id) REFERENCES public.ui_bridge_state_configs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: historical_results fk_historical_results_test_run_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results
+    ADD CONSTRAINT fk_historical_results_test_run_id FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_interactions fk_recording_interactions_transition_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_interactions
+    ADD CONSTRAINT fk_recording_interactions_transition_id FOREIGN KEY (transition_id) REFERENCES public.discovered_transitions(id);
+
+
+--
+-- Name: skills fk_skills_organization_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.skills
+    ADD CONSTRAINT fk_skills_organization_id FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: state_discovery_results fk_state_discovery_results_project_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_discovery_results
+    ADD CONSTRAINT fk_state_discovery_results_project_id FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: training_jobs fk_training_jobs_annotation_set_id_annotation_sets; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_jobs
+    ADD CONSTRAINT fk_training_jobs_annotation_set_id_annotation_sets FOREIGN KEY (annotation_set_id) REFERENCES public.annotation_sets(id) ON DELETE SET NULL;
+
+
+--
+-- Name: training_jobs fk_training_jobs_project_id_projects; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_jobs
+    ADD CONSTRAINT fk_training_jobs_project_id_projects FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: training_jobs fk_training_jobs_user_id_users; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_jobs
+    ADD CONSTRAINT fk_training_jobs_user_id_users FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: task_run_verification_results fk_verification_results_task_run_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_verification_results
+    ADD CONSTRAINT fk_verification_results_task_run_id FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: frame_index frame_index_video_capture_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.frame_index
+    ADD CONSTRAINT frame_index_video_capture_session_id_fkey FOREIGN KEY (video_capture_session_id) REFERENCES public.video_capture_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: gui_action_type_configs gui_action_type_configs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.gui_action_type_configs
+    ADD CONSTRAINT gui_action_type_configs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: historical_results historical_results_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results
+    ADD CONSTRAINT historical_results_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: historical_results historical_results_snapshot_action_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results
+    ADD CONSTRAINT historical_results_snapshot_action_id_fkey FOREIGN KEY (snapshot_action_id) REFERENCES public.snapshot_actions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: historical_results historical_results_snapshot_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results
+    ADD CONSTRAINT historical_results_snapshot_run_id_fkey FOREIGN KEY (snapshot_run_id) REFERENCES public.snapshot_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: historical_results historical_results_video_capture_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.historical_results
+    ADD CONSTRAINT historical_results_video_capture_session_id_fkey FOREIGN KEY (video_capture_session_id) REFERENCES public.video_capture_sessions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: input_events input_events_video_capture_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.input_events
+    ADD CONSTRAINT input_events_video_capture_session_id_fkey FOREIGN KEY (video_capture_session_id) REFERENCES public.video_capture_sessions(id) ON DELETE CASCADE;
 
 
 --
@@ -3162,7 +23777,159 @@ ALTER TABLE ONLY public.execution_issues
 --
 
 ALTER TABLE ONLY public.known_issues
-    ADD CONSTRAINT known_issues_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT known_issues_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: known_issues known_issues_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.known_issues
+    ADD CONSTRAINT known_issues_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: learned_workflows learned_workflows_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learned_workflows
+    ADD CONSTRAINT learned_workflows_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: learned_workflows learned_workflows_reviewer_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learned_workflows
+    ADD CONSTRAINT learned_workflows_reviewer_id_fkey FOREIGN KEY (reviewer_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: learned_workflows learned_workflows_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.learned_workflows
+    ADD CONSTRAINT learned_workflows_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.capture_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_check_groups library_check_groups_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_check_groups
+    ADD CONSTRAINT library_check_groups_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_check_groups library_check_groups_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_check_groups
+    ADD CONSTRAINT library_check_groups_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: library_checks library_checks_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_checks
+    ADD CONSTRAINT library_checks_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_checks library_checks_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_checks
+    ADD CONSTRAINT library_checks_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: library_contexts library_contexts_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_contexts
+    ADD CONSTRAINT library_contexts_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_contexts library_contexts_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_contexts
+    ADD CONSTRAINT library_contexts_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: library_macros library_macros_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_macros
+    ADD CONSTRAINT library_macros_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_macros library_macros_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_macros
+    ADD CONSTRAINT library_macros_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: library_saved_api_requests library_saved_api_requests_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_saved_api_requests
+    ADD CONSTRAINT library_saved_api_requests_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_saved_api_requests library_saved_api_requests_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_saved_api_requests
+    ADD CONSTRAINT library_saved_api_requests_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: library_prompt_snippets library_scriptlets_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_prompt_snippets
+    ADD CONSTRAINT library_scriptlets_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_prompt_snippets library_scriptlets_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_prompt_snippets
+    ADD CONSTRAINT library_scriptlets_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: library_shell_commands library_shell_commands_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_shell_commands
+    ADD CONSTRAINT library_shell_commands_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: library_shell_commands library_shell_commands_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.library_shell_commands
+    ADD CONSTRAINT library_shell_commands_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: notification_preferences notification_preferences_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notification_preferences
+    ADD CONSTRAINT notification_preferences_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -3170,7 +23937,15 @@ ALTER TABLE ONLY public.known_issues
 --
 
 ALTER TABLE ONLY public.notifications
-    ADD CONSTRAINT notifications_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+    ADD CONSTRAINT notifications_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: notifications notifications_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT notifications_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
 
 
 --
@@ -3178,7 +23953,103 @@ ALTER TABLE ONLY public.notifications
 --
 
 ALTER TABLE ONLY public.notifications
-    ADD CONSTRAINT notifications_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT notifications_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: organization_invitations organization_invitations_invited_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invitations
+    ADD CONSTRAINT organization_invitations_invited_by_fkey FOREIGN KEY (invited_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: organization_invitations organization_invitations_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_invitations
+    ADD CONSTRAINT organization_invitations_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: organizations organizations_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organizations
+    ADD CONSTRAINT organizations_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: package_installations package_installations_package_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations
+    ADD CONSTRAINT package_installations_package_id_fkey FOREIGN KEY (package_id) REFERENCES public.code_packages(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_installations package_installations_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations
+    ADD CONSTRAINT package_installations_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_installations package_installations_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations
+    ADD CONSTRAINT package_installations_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_installations package_installations_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_installations
+    ADD CONSTRAINT package_installations_version_id_fkey FOREIGN KEY (version_id) REFERENCES public.package_versions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_ratings package_ratings_package_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_ratings
+    ADD CONSTRAINT package_ratings_package_id_fkey FOREIGN KEY (package_id) REFERENCES public.code_packages(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_ratings package_ratings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_ratings
+    ADD CONSTRAINT package_ratings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_versions package_versions_package_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_versions
+    ADD CONSTRAINT package_versions_package_id_fkey FOREIGN KEY (package_id) REFERENCES public.code_packages(id) ON DELETE CASCADE;
+
+
+--
+-- Name: path_discoveries path_discoveries_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.path_discoveries
+    ADD CONSTRAINT path_discoveries_test_run_id_fkey FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: patterns patterns_snapshot_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.patterns
+    ADD CONSTRAINT patterns_snapshot_run_id_fkey FOREIGN KEY (snapshot_run_id) REFERENCES public.snapshot_runs(id) ON DELETE CASCADE;
 
 
 --
@@ -3198,11 +24069,275 @@ ALTER TABLE ONLY public.processing_logs
 
 
 --
+-- Name: project_access_control project_access_control_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_access_control
+    ADD CONSTRAINT project_access_control_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: project_access_control project_access_control_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_access_control
+    ADD CONSTRAINT project_access_control_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_access_control project_access_control_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_access_control
+    ADD CONSTRAINT project_access_control_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_access_control project_access_control_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_access_control
+    ADD CONSTRAINT project_access_control_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_annotation_states project_annotation_states_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_annotation_states
+    ADD CONSTRAINT project_annotation_states_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_annotation_states project_annotation_states_updated_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_annotation_states
+    ADD CONSTRAINT project_annotation_states_updated_by_id_fkey FOREIGN KEY (updated_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: project_comments project_comments_author_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_comments
+    ADD CONSTRAINT project_comments_author_id_fkey FOREIGN KEY (author_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_comments project_comments_parent_comment_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_comments
+    ADD CONSTRAINT project_comments_parent_comment_id_fkey FOREIGN KEY (parent_comment_id) REFERENCES public.project_comments(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_comments project_comments_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_comments
+    ADD CONSTRAINT project_comments_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_comments project_comments_resolved_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_comments
+    ADD CONSTRAINT project_comments_resolved_by_fkey FOREIGN KEY (resolved_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: project_embeddings project_embeddings_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_embeddings
+    ADD CONSTRAINT project_embeddings_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_images project_images_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_images
+    ADD CONSTRAINT project_images_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_images project_images_source_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_images
+    ADD CONSTRAINT project_images_source_screenshot_id_fkey FOREIGN KEY (source_screenshot_id) REFERENCES public.project_screenshots(id) ON DELETE SET NULL;
+
+
+--
+-- Name: project_images project_images_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_images
+    ADD CONSTRAINT project_images_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_locks project_locks_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_locks
+    ADD CONSTRAINT project_locks_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
 -- Name: project_locks project_locks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_locks
-    ADD CONSTRAINT project_locks_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT project_locks_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_screenshots project_screenshots_capture_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_screenshots
+    ADD CONSTRAINT project_screenshots_capture_session_id_fkey FOREIGN KEY (capture_session_id) REFERENCES public.capture_sessions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: project_screenshots project_screenshots_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_screenshots
+    ADD CONSTRAINT project_screenshots_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_screenshots project_screenshots_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_screenshots
+    ADD CONSTRAINT project_screenshots_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_versions project_versions_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_versions
+    ADD CONSTRAINT project_versions_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: project_versions project_versions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_versions
+    ADD CONSTRAINT project_versions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: projects projects_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT projects_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE SET NULL;
+
+
+--
+-- Name: projects projects_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.projects
+    ADD CONSTRAINT projects_owner_id_fkey FOREIGN KEY (owner_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: prompt_sequences prompt_sequences_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prompt_sequences
+    ADD CONSTRAINT prompt_sequences_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id);
+
+
+--
+-- Name: prompt_sequences prompt_sequences_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prompt_sequences
+    ADD CONSTRAINT prompt_sequences_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
+-- Name: prompt_template_versions prompt_template_versions_template_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.prompt_template_versions
+    ADD CONSTRAINT prompt_template_versions_template_id_fkey FOREIGN KEY (template_id) REFERENCES public.ai_prompt_templates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: push_devices push_devices_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.push_devices
+    ADD CONSTRAINT push_devices_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_contexts recording_contexts_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_contexts
+    ADD CONSTRAINT recording_contexts_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_frames recording_frames_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_frames
+    ADD CONSTRAINT recording_frames_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_frames recording_frames_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_frames
+    ADD CONSTRAINT recording_frames_state_id_fkey FOREIGN KEY (state_id) REFERENCES public.discovered_states(id);
+
+
+--
+-- Name: recording_interactions recording_interactions_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_interactions
+    ADD CONSTRAINT recording_interactions_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_interactions recording_interactions_target_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_interactions
+    ADD CONSTRAINT recording_interactions_target_state_id_fkey FOREIGN KEY (target_state_id) REFERENCES public.discovered_states(id);
+
+
+--
+-- Name: recording_sessions recording_sessions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_sessions
+    ADD CONSTRAINT recording_sessions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recording_sessions recording_sessions_state_config_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recording_sessions
+    ADD CONSTRAINT recording_sessions_state_config_id_fkey FOREIGN KEY (state_config_id) REFERENCES public.ui_bridge_state_configs(id) ON DELETE SET NULL;
 
 
 --
@@ -3210,7 +24345,47 @@ ALTER TABLE ONLY public.project_locks
 --
 
 ALTER TABLE ONLY public.recordings
-    ADD CONSTRAINT recordings_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES runner.users(id);
+    ADD CONSTRAINT recordings_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: recordings recordings_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recordings
+    ADD CONSTRAINT recordings_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: render_images render_images_render_log_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.render_images
+    ADD CONSTRAINT render_images_render_log_id_fkey FOREIGN KEY (render_log_id) REFERENCES public.render_logs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: render_logs render_logs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.render_logs
+    ADD CONSTRAINT render_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: runner_connections runner_connections_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_connections
+    ADD CONSTRAINT runner_connections_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: runner_devices runner_devices_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_devices
+    ADD CONSTRAINT runner_devices_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -3218,7 +24393,7 @@ ALTER TABLE ONLY public.recordings
 --
 
 ALTER TABLE ONLY public.runner_tokens
-    ADD CONSTRAINT runner_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT runner_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -3234,7 +24409,7 @@ ALTER TABLE ONLY public.runners
 --
 
 ALTER TABLE ONLY public.runners
-    ADD CONSTRAINT runners_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT runners_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -3242,7 +24417,7 @@ ALTER TABLE ONLY public.runners
 --
 
 ALTER TABLE ONLY public.scheduled_workflow_runs
-    ADD CONSTRAINT scheduled_workflow_runs_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT scheduled_workflow_runs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -3254,11 +24429,275 @@ ALTER TABLE ONLY public.scheduled_workflow_runs
 
 
 --
+-- Name: screenshot_input_associations screenshot_input_associations_log_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshot_input_associations
+    ADD CONSTRAINT screenshot_input_associations_log_id_fkey FOREIGN KEY (log_id) REFERENCES public.automation_logs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: screenshot_input_associations screenshot_input_associations_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshot_input_associations
+    ADD CONSTRAINT screenshot_input_associations_screenshot_id_fkey FOREIGN KEY (screenshot_id) REFERENCES public.automation_screenshots(id) ON DELETE CASCADE;
+
+
+--
+-- Name: screenshot_state_matches screenshot_state_matches_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshot_state_matches
+    ADD CONSTRAINT screenshot_state_matches_screenshot_id_fkey FOREIGN KEY (screenshot_id) REFERENCES public.capture_screenshots(id) ON DELETE CASCADE;
+
+
+--
+-- Name: screenshots screenshots_snapshot_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.screenshots
+    ADD CONSTRAINT screenshots_snapshot_run_id_fkey FOREIGN KEY (snapshot_run_id) REFERENCES public.snapshot_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: session_activities session_activities_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.session_activities
+    ADD CONSTRAINT session_activities_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: shared_files shared_files_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.shared_files
+    ADD CONSTRAINT shared_files_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: snapshot_actions snapshot_actions_snapshot_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_actions
+    ADD CONSTRAINT snapshot_actions_snapshot_run_id_fkey FOREIGN KEY (snapshot_run_id) REFERENCES public.snapshot_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: snapshot_matches snapshot_matches_action_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_matches
+    ADD CONSTRAINT snapshot_matches_action_id_fkey FOREIGN KEY (action_id) REFERENCES public.snapshot_actions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: snapshot_matches snapshot_matches_pattern_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_matches
+    ADD CONSTRAINT snapshot_matches_pattern_id_fkey FOREIGN KEY (pattern_id) REFERENCES public.snapshot_patterns(id) ON DELETE CASCADE;
+
+
+--
+-- Name: snapshot_patterns snapshot_patterns_snapshot_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_patterns
+    ADD CONSTRAINT snapshot_patterns_snapshot_run_id_fkey FOREIGN KEY (snapshot_run_id) REFERENCES public.snapshot_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: snapshot_runs snapshot_runs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.snapshot_runs
+    ADD CONSTRAINT snapshot_runs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: software_test_runs software_test_runs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.software_test_runs
+    ADD CONSTRAINT software_test_runs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: software_test_runs software_test_runs_runner_connection_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.software_test_runs
+    ADD CONSTRAINT software_test_runs_runner_connection_id_fkey FOREIGN KEY (runner_connection_id) REFERENCES public.runner_connections(id) ON DELETE SET NULL;
+
+
+--
 -- Name: state_machine_configs state_machine_configs_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.state_machine_configs
-    ADD CONSTRAINT state_machine_configs_created_by_fkey FOREIGN KEY (created_by) REFERENCES runner.users(id);
+    ADD CONSTRAINT state_machine_configs_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id);
+
+
+--
+-- Name: state_machine_configs state_machine_configs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_machine_configs
+    ADD CONSTRAINT state_machine_configs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id);
+
+
+--
+-- Name: state_transitions state_transitions_from_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_transitions
+    ADD CONSTRAINT state_transitions_from_state_id_fkey FOREIGN KEY (from_state_id) REFERENCES public.discovered_states(id) ON DELETE CASCADE;
+
+
+--
+-- Name: state_transitions state_transitions_to_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_transitions
+    ADD CONSTRAINT state_transitions_to_state_id_fkey FOREIGN KEY (to_state_id) REFERENCES public.discovered_states(id) ON DELETE CASCADE;
+
+
+--
+-- Name: step_type_configs step_type_configs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.step_type_configs
+    ADD CONSTRAINT step_type_configs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: storage_usage storage_usage_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storage_usage
+    ADD CONSTRAINT storage_usage_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: storage_usage storage_usage_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.storage_usage
+    ADD CONSTRAINT storage_usage_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: subscriptions subscriptions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.subscriptions
+    ADD CONSTRAINT subscriptions_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: sync_locks sync_locks_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sync_locks
+    ADD CONSTRAINT sync_locks_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: sync_locks sync_locks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sync_locks
+    ADD CONSTRAINT sync_locks_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_run_automations task_run_automations_task_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_automations
+    ADD CONSTRAINT task_run_automations_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: team_members team_members_invited_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.team_members
+    ADD CONSTRAINT team_members_invited_by_fkey FOREIGN KEY (invited_by) REFERENCES auth.users(id);
+
+
+--
+-- Name: team_members team_members_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.team_members
+    ADD CONSTRAINT team_members_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: team_members team_members_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.team_members
+    ADD CONSTRAINT team_members_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: template_candidates template_candidates_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.template_candidates
+    ADD CONSTRAINT template_candidates_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: template_candidates template_candidates_reviewed_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.template_candidates
+    ADD CONSTRAINT template_candidates_reviewed_by_id_fkey FOREIGN KEY (reviewed_by_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: test_deficiencies test_deficiencies_assigned_to_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_deficiencies
+    ADD CONSTRAINT test_deficiencies_assigned_to_user_id_fkey FOREIGN KEY (assigned_to_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: test_deficiencies test_deficiencies_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_deficiencies
+    ADD CONSTRAINT test_deficiencies_test_run_id_fkey FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_deficiencies test_deficiencies_transition_execution_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_deficiencies
+    ADD CONSTRAINT test_deficiencies_transition_execution_id_fkey FOREIGN KEY (transition_execution_id) REFERENCES public.transition_executions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: test_notification_preferences test_notification_preferences_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_notification_preferences
+    ADD CONSTRAINT test_notification_preferences_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_results test_results_execution_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_results
+    ADD CONSTRAINT test_results_execution_run_id_fkey FOREIGN KEY (execution_run_id) REFERENCES public.execution_runs(id) ON DELETE CASCADE;
 
 
 --
@@ -3278,6 +24717,30 @@ ALTER TABLE ONLY public.test_results
 
 
 --
+-- Name: test_screenshots test_screenshots_deficiency_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_screenshots
+    ADD CONSTRAINT test_screenshots_deficiency_id_fkey FOREIGN KEY (deficiency_id) REFERENCES public.test_deficiencies(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_screenshots test_screenshots_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_screenshots
+    ADD CONSTRAINT test_screenshots_test_run_id_fkey FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_screenshots test_screenshots_transition_execution_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_screenshots
+    ADD CONSTRAINT test_screenshots_transition_execution_id_fkey FOREIGN KEY (transition_execution_id) REFERENCES public.transition_executions(id) ON DELETE CASCADE;
+
+
+--
 -- Name: training_dataset_annotations training_dataset_annotations_dataset_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3286,11 +24749,51 @@ ALTER TABLE ONLY public.training_dataset_annotations
 
 
 --
+-- Name: training_dataset_annotations training_dataset_annotations_image_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_annotations
+    ADD CONSTRAINT training_dataset_annotations_image_id_fkey FOREIGN KEY (image_id) REFERENCES public.training_dataset_images(id) ON DELETE CASCADE;
+
+
+--
 -- Name: training_dataset_annotations training_dataset_annotations_reviewed_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.training_dataset_annotations
-    ADD CONSTRAINT training_dataset_annotations_reviewed_by_id_fkey FOREIGN KEY (reviewed_by_id) REFERENCES runner.users(id);
+    ADD CONSTRAINT training_dataset_annotations_reviewed_by_id_fkey FOREIGN KEY (reviewed_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: training_dataset_export_jobs training_dataset_export_jobs_created_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_export_jobs
+    ADD CONSTRAINT training_dataset_export_jobs_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: training_dataset_export_jobs training_dataset_export_jobs_dataset_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_export_jobs
+    ADD CONSTRAINT training_dataset_export_jobs_dataset_id_fkey FOREIGN KEY (dataset_id) REFERENCES public.training_datasets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: training_dataset_images training_dataset_images_dataset_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_images
+    ADD CONSTRAINT training_dataset_images_dataset_id_fkey FOREIGN KEY (dataset_id) REFERENCES public.training_datasets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: training_dataset_images training_dataset_images_reviewed_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_images
+    ADD CONSTRAINT training_dataset_images_reviewed_by_id_fkey FOREIGN KEY (reviewed_by_id) REFERENCES auth.users(id);
 
 
 --
@@ -3298,7 +24801,79 @@ ALTER TABLE ONLY public.training_dataset_annotations
 --
 
 ALTER TABLE ONLY public.training_datasets
-    ADD CONSTRAINT training_datasets_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES runner.users(id);
+    ADD CONSTRAINT training_datasets_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES auth.users(id);
+
+
+--
+-- Name: transition_executions transition_executions_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.transition_executions
+    ADD CONSTRAINT transition_executions_test_run_id_fkey FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: transition_reliability transition_reliability_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.transition_reliability
+    ADD CONSTRAINT transition_reliability_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_state_configs ui_bridge_state_configs_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_state_configs
+    ADD CONSTRAINT ui_bridge_state_configs_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_state_domain_knowledge ui_bridge_state_domain_knowledge_knowledge_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_state_domain_knowledge
+    ADD CONSTRAINT ui_bridge_state_domain_knowledge_knowledge_id_fkey FOREIGN KEY (knowledge_id) REFERENCES public.domain_knowledge(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_state_domain_knowledge ui_bridge_state_domain_knowledge_state_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_state_domain_knowledge
+    ADD CONSTRAINT ui_bridge_state_domain_knowledge_state_id_fkey FOREIGN KEY (state_id) REFERENCES public.ui_bridge_states(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_states ui_bridge_states_config_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_states
+    ADD CONSTRAINT ui_bridge_states_config_id_fkey FOREIGN KEY (config_id) REFERENCES public.ui_bridge_state_configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ui_bridge_transitions ui_bridge_transitions_config_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_transitions
+    ADD CONSTRAINT ui_bridge_transitions_config_id_fkey FOREIGN KEY (config_id) REFERENCES public.ui_bridge_state_configs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: usage_metrics usage_metrics_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.usage_metrics
+    ADD CONSTRAINT usage_metrics_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: variable_history variable_history_variable_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.variable_history
+    ADD CONSTRAINT variable_history_variable_id_fkey FOREIGN KEY (variable_id) REFERENCES public.workflow_variables(id);
 
 
 --
@@ -3306,7 +24881,151 @@ ALTER TABLE ONLY public.training_datasets
 --
 
 ALTER TABLE ONLY public.verification_tests
-    ADD CONSTRAINT verification_tests_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+    ADD CONSTRAINT verification_tests_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: verification_tests verification_tests_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verification_tests
+    ADD CONSTRAINT verification_tests_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: video_capture_sessions video_capture_sessions_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.video_capture_sessions
+    ADD CONSTRAINT video_capture_sessions_created_by_fkey FOREIGN KEY (created_by) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: video_capture_sessions video_capture_sessions_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.video_capture_sessions
+    ADD CONSTRAINT video_capture_sessions_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE SET NULL;
+
+
+--
+-- Name: video_capture_sessions video_capture_sessions_snapshot_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.video_capture_sessions
+    ADD CONSTRAINT video_capture_sessions_snapshot_run_id_fkey FOREIGN KEY (snapshot_run_id) REFERENCES public.snapshot_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_baselines visual_baselines_approved_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_baselines
+    ADD CONSTRAINT visual_baselines_approved_by_user_id_fkey FOREIGN KEY (approved_by_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_baselines visual_baselines_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_baselines
+    ADD CONSTRAINT visual_baselines_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
+
+
+--
+-- Name: visual_baselines visual_baselines_source_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_baselines
+    ADD CONSTRAINT visual_baselines_source_screenshot_id_fkey FOREIGN KEY (source_screenshot_id) REFERENCES public.test_screenshots(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_baselines visual_baselines_source_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_baselines
+    ADD CONSTRAINT visual_baselines_source_test_run_id_fkey FOREIGN KEY (source_test_run_id) REFERENCES public.software_test_runs(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_baseline_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_baseline_id_fkey FOREIGN KEY (baseline_id) REFERENCES public.visual_baselines(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_deficiency_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_deficiency_id_fkey FOREIGN KEY (deficiency_id) REFERENCES public.test_deficiencies(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_reviewed_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_reviewed_by_user_id_fkey FOREIGN KEY (reviewed_by_user_id) REFERENCES auth.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_screenshot_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_screenshot_id_fkey FOREIGN KEY (screenshot_id) REFERENCES public.test_screenshots(id) ON DELETE CASCADE;
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_test_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_test_run_id_fkey FOREIGN KEY (test_run_id) REFERENCES public.software_test_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: visual_comparison_results visual_comparison_results_transition_execution_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.visual_comparison_results
+    ADD CONSTRAINT visual_comparison_results_transition_execution_id_fkey FOREIGN KEY (transition_execution_id) REFERENCES public.transition_executions(id) ON DELETE SET NULL;
+
+
+--
+-- Name: workflow_events workflow_events_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_events
+    ADD CONSTRAINT workflow_events_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_execution_history workflow_execution_history_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_execution_history
+    ADD CONSTRAINT workflow_execution_history_session_id_fkey FOREIGN KEY (session_id) REFERENCES public.automation_sessions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_phase_configs workflow_phase_configs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_phase_configs
+    ADD CONSTRAINT workflow_phase_configs_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_test_associations workflow_test_associations_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_test_associations
+    ADD CONSTRAINT workflow_test_associations_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id) ON DELETE CASCADE;
 
 
 --
@@ -3315,6 +25034,14 @@ ALTER TABLE ONLY public.verification_tests
 
 ALTER TABLE ONLY public.workflow_test_associations
     ADD CONSTRAINT workflow_test_associations_test_id_fkey FOREIGN KEY (test_id) REFERENCES public.verification_tests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: workflow_variables workflow_variables_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_variables
+    ADD CONSTRAINT workflow_variables_project_id_fkey FOREIGN KEY (project_id) REFERENCES public.projects(id);
 
 
 --
@@ -3330,7 +25057,7 @@ ALTER TABLE ONLY public.wrapper_comments
 --
 
 ALTER TABLE ONLY public.wrapper_comments
-    ADD CONSTRAINT wrapper_comments_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT wrapper_comments_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --
@@ -3354,7 +25081,7 @@ ALTER TABLE ONLY public.wrapper_install_events
 --
 
 ALTER TABLE ONLY public.wrapper_ratings
-    ADD CONSTRAINT wrapper_ratings_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+    ADD CONSTRAINT wrapper_ratings_user_id_fkey FOREIGN KEY (user_id) REFERENCES auth.users(id) ON DELETE CASCADE;
 
 
 --

--- a/src-tauri/schema.pg.sql.generated
+++ b/src-tauri/schema.pg.sql.generated
@@ -1,0 +1,3370 @@
+-- GENERATED FILE — do not hand-edit.
+-- Regenerate via: src-tauri/scripts/regenerate_schema_pg_sql.sh
+--
+-- Source: alembic-managed schema, dumped via pg_dump with
+--   --schema=project --schema=coord --schema=agent --schema=auth
+--   --schema=public --no-owner --no-privileges.
+--
+-- Consumers: Clorinde (validates queries/*.sql against this file).
+--
+-- Determinism: timestamp/runtime-context lines are stripped so two
+-- consecutive runs produce byte-equal output. CI gate fails if
+-- `git diff schema.pg.sql.generated` is non-empty after a fresh run.
+
+--
+-- PostgreSQL database dump
+--
+
+
+-- Dumped from database version 16.13 (Debian 16.13-1.pgdg12+1)
+-- Dumped by pg_dump version 16.13 (Debian 16.13-1.pgdg12+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: agent; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA agent;
+
+
+--
+-- Name: auth; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA auth;
+
+
+--
+-- Name: coord; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA coord;
+
+
+--
+-- Name: project; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA project;
+
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+CREATE SCHEMA public;
+
+
+--
+-- Name: action_execution_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.action_execution_status AS ENUM (
+    'success',
+    'failed',
+    'timeout',
+    'skipped',
+    'error',
+    'pending'
+);
+
+
+--
+-- Name: action_execution_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.action_execution_type AS ENUM (
+    'find',
+    'click',
+    'double_click',
+    'right_click',
+    'type',
+    'key_press',
+    'scroll',
+    'drag',
+    'hover',
+    'wait',
+    'screenshot',
+    'go_to_state',
+    'assert_state',
+    'assert_element',
+    'custom'
+);
+
+
+--
+-- Name: actiontype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.actiontype AS ENUM (
+    'created',
+    'modified',
+    'deleted',
+    'shared',
+    'commented',
+    'locked',
+    'unlocked',
+    'viewed',
+    'exported',
+    'imported'
+);
+
+
+--
+-- Name: annotation_source_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.annotation_source_enum AS ENUM (
+    'USER_CLICK',
+    'TEMPLATE_MATCHING',
+    'SMART_CLICK_ANALYSIS',
+    'MANUAL'
+);
+
+
+--
+-- Name: dataset_source_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.dataset_source_enum AS ENUM (
+    'RUNNER_EXPORT',
+    'MANUAL_UPLOAD',
+    'MERGED'
+);
+
+
+--
+-- Name: deficiencyseverity; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.deficiencyseverity AS ENUM (
+    'CRITICAL',
+    'HIGH',
+    'MEDIUM',
+    'LOW',
+    'INFO'
+);
+
+
+--
+-- Name: deficiencystatus; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.deficiencystatus AS ENUM (
+    'NEW',
+    'TRIAGED',
+    'ASSIGNED',
+    'IN_PROGRESS',
+    'RESOLVED',
+    'CLOSED',
+    'WONT_FIX'
+);
+
+
+--
+-- Name: deficiencytype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.deficiencytype AS ENUM (
+    'CRASH',
+    'TIMEOUT',
+    'VISUAL',
+    'FUNCTIONAL',
+    'PERFORMANCE',
+    'DATA',
+    'ACCESSIBILITY',
+    'SECURITY'
+);
+
+
+--
+-- Name: element_type_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.element_type_enum AS ENUM (
+    'BUTTON',
+    'ICON',
+    'TEXT',
+    'IMAGE',
+    'CHECKBOX',
+    'RADIO',
+    'INPUT_FIELD',
+    'LINK',
+    'MENU_ITEM',
+    'TAB',
+    'UNKNOWN'
+);
+
+
+--
+-- Name: execution_issue_severity; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_issue_severity AS ENUM (
+    'critical',
+    'high',
+    'medium',
+    'low',
+    'info'
+);
+
+
+--
+-- Name: execution_issue_source; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_issue_source AS ENUM (
+    'automation',
+    'ai_analysis',
+    'visual_regression',
+    'user_reported'
+);
+
+
+--
+-- Name: execution_issue_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_issue_status AS ENUM (
+    'open',
+    'in_progress',
+    'resolved',
+    'wont_fix',
+    'duplicate',
+    'cannot_reproduce'
+);
+
+
+--
+-- Name: execution_issue_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_issue_type AS ENUM (
+    'visual_regression',
+    'element_not_found',
+    'state_mismatch',
+    'timeout',
+    'assertion_failed',
+    'navigation_error',
+    'script_error',
+    'performance',
+    'accessibility',
+    'other'
+);
+
+
+--
+-- Name: execution_run_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_run_status AS ENUM (
+    'pending',
+    'running',
+    'completed',
+    'failed',
+    'timeout',
+    'cancelled',
+    'paused'
+);
+
+
+--
+-- Name: execution_run_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_run_type AS ENUM (
+    'qa_test',
+    'integration_test',
+    'live_automation',
+    'recording',
+    'debug'
+);
+
+
+--
+-- Name: execution_screenshot_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.execution_screenshot_type AS ENUM (
+    'before_action',
+    'after_action',
+    'on_error',
+    'on_success',
+    'state_capture',
+    'diff_baseline',
+    'diff_comparison',
+    'manual'
+);
+
+
+--
+-- Name: export_format_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.export_format_enum AS ENUM (
+    'COCO',
+    'YOLO',
+    'PASCAL_VOC',
+    'CSV',
+    'JSONL'
+);
+
+
+--
+-- Name: export_job_status_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.export_job_status_enum AS ENUM (
+    'PENDING',
+    'PROCESSING',
+    'COMPLETED',
+    'FAILED'
+);
+
+
+--
+-- Name: finding_action_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.finding_action_type AS ENUM (
+    'auto_fix',
+    'needs_user_input',
+    'informational',
+    'manual'
+);
+
+
+--
+-- Name: finding_category; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.finding_category AS ENUM (
+    'code_bug',
+    'security',
+    'performance',
+    'todo',
+    'enhancement',
+    'config_issue',
+    'test_issue',
+    'documentation',
+    'runtime_issue',
+    'already_fixed',
+    'expected_behavior',
+    'data_migration',
+    'warning'
+);
+
+
+--
+-- Name: finding_severity; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.finding_severity AS ENUM (
+    'critical',
+    'high',
+    'medium',
+    'low',
+    'info'
+);
+
+
+--
+-- Name: finding_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.finding_status AS ENUM (
+    'detected',
+    'in_progress',
+    'needs_input',
+    'resolved',
+    'wont_fix',
+    'deferred'
+);
+
+
+--
+-- Name: input_event_type_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.input_event_type_enum AS ENUM (
+    'MOUSE_CLICKED',
+    'MOUSE_MOVED',
+    'MOUSE_DRAGGED',
+    'KEYBOARD_TEXT_TYPED'
+);
+
+
+--
+-- Name: notificationtype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.notificationtype AS ENUM (
+    'MENTION',
+    'SHARE',
+    'COMMENT',
+    'REPLY',
+    'LOCK_RELEASED',
+    'PROJECT_UPDATE',
+    'TEAM_INVITE',
+    'ACCESS_GRANTED',
+    'ACCESS_REVOKED'
+);
+
+
+--
+-- Name: processingphase; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.processingphase AS ENUM (
+    'FRAME_ANALYSIS',
+    'STATE_IDENTIFICATION',
+    'INTERACTION_PROCESSING',
+    'TRANSITION_DISCOVERY',
+    'STATE_MACHINE_ASSEMBLY',
+    'OPTIMIZATION',
+    'COMPLETED'
+);
+
+
+--
+-- Name: recordingstatus; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.recordingstatus AS ENUM (
+    'UPLOADED',
+    'VALIDATING',
+    'PROCESSING',
+    'COMPLETED',
+    'FAILED',
+    'CANCELLED'
+);
+
+
+--
+-- Name: resourcetype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.resourcetype AS ENUM (
+    'workflow',
+    'state',
+    'image',
+    'transition',
+    'action',
+    'project'
+);
+
+
+--
+-- Name: review_status_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.review_status_enum AS ENUM (
+    'PENDING',
+    'APPROVED',
+    'REJECTED',
+    'FLAGGED'
+);
+
+
+--
+-- Name: reviewdecision; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.reviewdecision AS ENUM (
+    'APPROVED',
+    'REJECTED',
+    'NEW_BASELINE'
+);
+
+
+--
+-- Name: task_run_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.task_run_status AS ENUM (
+    'running',
+    'complete',
+    'failed',
+    'stopped'
+);
+
+
+--
+-- Name: task_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.task_type AS ENUM (
+    'task',
+    'automation',
+    'scheduled'
+);
+
+
+--
+-- Name: test_result_status; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.test_result_status AS ENUM (
+    'pending',
+    'running',
+    'passed',
+    'failed',
+    'skipped',
+    'error',
+    'timeout'
+);
+
+
+--
+-- Name: testrunstatus; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.testrunstatus AS ENUM (
+    'RUNNING',
+    'COMPLETED',
+    'FAILED',
+    'CANCELLED',
+    'TIMEOUT'
+);
+
+
+--
+-- Name: testscreenshottype; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.testscreenshottype AS ENUM (
+    'STATE_VERIFICATION',
+    'ACTION_RESULT',
+    'FAILURE',
+    'BEFORE_ACTION',
+    'AFTER_ACTION'
+);
+
+
+--
+-- Name: transitionexecutionstatus; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.transitionexecutionstatus AS ENUM (
+    'SUCCESS',
+    'FAILED',
+    'TIMEOUT',
+    'SKIPPED',
+    'ERROR'
+);
+
+
+--
+-- Name: trigger_point; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.trigger_point AS ENUM (
+    'before_workflow',
+    'after_workflow',
+    'on_checkpoint',
+    'on_action',
+    'on_state_entry',
+    'on_state_exit',
+    'on_error'
+);
+
+
+--
+-- Name: variablescope; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.variablescope AS ENUM (
+    'GLOBAL',
+    'WORKFLOW'
+);
+
+
+--
+-- Name: verification_test_category; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.verification_test_category AS ENUM (
+    'smoke',
+    'regression',
+    'integration',
+    'e2e',
+    'unit',
+    'performance',
+    'security',
+    'accessibility',
+    'visual',
+    'custom'
+);
+
+
+--
+-- Name: verification_test_type; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.verification_test_type AS ENUM (
+    'playwright',
+    'vision',
+    'python',
+    'repo_test',
+    'custom'
+);
+
+
+--
+-- Name: visualcomparisonstatus; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.visualcomparisonstatus AS ENUM (
+    'PASSED',
+    'FAILED',
+    'PENDING_REVIEW',
+    'APPROVED_AS_NEW',
+    'NO_BASELINE'
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: alembic_version; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.alembic_version (
+    version_num character varying(32) NOT NULL
+);
+
+
+--
+-- Name: automation_input_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.automation_input_events (
+    id bigint NOT NULL,
+    session_id uuid NOT NULL,
+    event_type public.input_event_type_enum NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    mouse_x integer,
+    mouse_y integer,
+    mouse_button character varying(20),
+    drag_from_x integer,
+    drag_from_y integer,
+    drag_to_x integer,
+    drag_to_y integer,
+    drag_duration double precision,
+    drag_path_points jsonb,
+    drag_avg_speed double precision,
+    drag_max_speed double precision,
+    text_typed text,
+    character_count integer,
+    screenshot_before_id uuid,
+    screenshot_after_id uuid,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: automation_input_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.automation_input_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: automation_input_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.automation_input_events_id_seq OWNED BY public.automation_input_events.id;
+
+
+--
+-- Name: domain_knowledge; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.domain_knowledge (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid,
+    title character varying(255) NOT NULL,
+    content text NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    content_embedding public.vector(384)
+);
+
+
+--
+-- Name: COLUMN domain_knowledge.content_embedding; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.domain_knowledge.content_embedding IS '384-dim MiniLM embedding of the knowledge content';
+
+
+--
+-- Name: execution_issues; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.execution_issues (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    run_id uuid NOT NULL,
+    action_execution_id uuid,
+    issue_type public.execution_issue_type NOT NULL,
+    severity public.execution_issue_severity NOT NULL,
+    status public.execution_issue_status NOT NULL,
+    source public.execution_issue_source NOT NULL,
+    title character varying(500) NOT NULL,
+    description text NOT NULL,
+    state_name character varying(255),
+    screenshot_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    reproduction_steps jsonb DEFAULT '[]'::jsonb NOT NULL,
+    error_details jsonb DEFAULT '{}'::jsonb NOT NULL,
+    metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    assigned_to_user_id uuid,
+    resolution_notes text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    title_embedding public.vector(384),
+    description_embedding public.vector(384),
+    resolution_embedding public.vector(384)
+);
+
+
+--
+-- Name: COLUMN execution_issues.state_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.state_name IS 'State where issue was detected';
+
+
+--
+-- Name: COLUMN execution_issues.screenshot_ids; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.screenshot_ids IS 'Array of screenshot UUIDs related to this issue';
+
+
+--
+-- Name: COLUMN execution_issues.reproduction_steps; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.reproduction_steps IS 'Array of steps to reproduce the issue';
+
+
+--
+-- Name: COLUMN execution_issues.error_details; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.error_details IS 'Detailed error information: stack trace, logs, etc.';
+
+
+--
+-- Name: COLUMN execution_issues.metadata; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.metadata IS 'Additional issue metadata';
+
+
+--
+-- Name: COLUMN execution_issues.title_embedding; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.title_embedding IS '384-dim MiniLM embedding of the issue title';
+
+
+--
+-- Name: COLUMN execution_issues.description_embedding; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.description_embedding IS '384-dim MiniLM embedding of the issue description';
+
+
+--
+-- Name: COLUMN execution_issues.resolution_embedding; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.execution_issues.resolution_embedding IS '384-dim MiniLM embedding of the resolution notes';
+
+
+--
+-- Name: known_issues; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.known_issues (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    organization_id uuid NOT NULL,
+    created_by_user_id uuid NOT NULL,
+    title character varying(500) NOT NULL,
+    description text NOT NULL,
+    category character varying(50) DEFAULT 'other'::character varying NOT NULL,
+    severity character varying(20) DEFAULT 'medium'::character varying NOT NULL,
+    status character varying(20) DEFAULT 'active'::character varying NOT NULL,
+    scope_type character varying(50) DEFAULT 'global'::character varying NOT NULL,
+    scope_value character varying(500),
+    scope_tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    detection_method character varying(50) DEFAULT 'ai_judgment'::character varying NOT NULL,
+    detection_config jsonb DEFAULT '{}'::jsonb NOT NULL,
+    pattern_template_id character varying(255),
+    reproduction_context text,
+    trigger_conditions jsonb DEFAULT '[]'::jsonb NOT NULL,
+    confidence double precision DEFAULT 0.5 NOT NULL,
+    provenance character varying(50) DEFAULT 'manual'::character varying NOT NULL,
+    source_finding_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    source_task_run_id character varying(255),
+    verification_hint text,
+    verification_step_template jsonb,
+    times_detected integer DEFAULT 1 NOT NULL,
+    times_checked integer DEFAULT 0 NOT NULL,
+    last_detected_at timestamp with time zone,
+    last_checked_at timestamp with time zone,
+    resolved_at timestamp with time zone,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: notifications; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.notifications (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    type public.notificationtype NOT NULL,
+    title character varying NOT NULL,
+    message text NOT NULL,
+    project_id uuid,
+    resource_type character varying,
+    resource_id character varying,
+    actor_id uuid,
+    read boolean NOT NULL,
+    read_at timestamp with time zone,
+    metadata json,
+    created_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: phase_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.phase_results (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    runner_id uuid,
+    execution_id character varying(255) NOT NULL,
+    phase character varying(32) NOT NULL,
+    iteration integer,
+    stage_index integer,
+    success boolean NOT NULL,
+    all_passed boolean NOT NULL,
+    duration_ms bigint NOT NULL,
+    failure_context text,
+    commit_hash character varying(64),
+    step_results jsonb DEFAULT '[]'::jsonb NOT NULL,
+    variables_set jsonb,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN phase_results.runner_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.runner_id IS 'Runner fleet id that produced this phase result (nullable so history is preserved after a runner is deregistered).';
+
+
+--
+-- Name: COLUMN phase_results.execution_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.execution_id IS 'Runner-generated execution identifier the phase belongs to.';
+
+
+--
+-- Name: COLUMN phase_results.phase; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.phase IS '''setup'' | ''verification'' | ''agentic'' | ''completion''';
+
+
+--
+-- Name: COLUMN phase_results.iteration; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.iteration IS 'Iteration number (NULL for setup/completion).';
+
+
+--
+-- Name: COLUMN phase_results.stage_index; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.stage_index IS 'Stage index for multi-stage workflows (NULL = single-stage).';
+
+
+--
+-- Name: COLUMN phase_results.duration_ms; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.duration_ms IS 'Phase duration in milliseconds.';
+
+
+--
+-- Name: COLUMN phase_results.commit_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.commit_hash IS 'Git commit hash at end of phase (compensation correlation).';
+
+
+--
+-- Name: COLUMN phase_results.step_results; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.step_results IS 'Per-step results (list of StepResultRecord JSON objects).';
+
+
+--
+-- Name: COLUMN phase_results.variables_set; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.phase_results.variables_set IS 'Variables set during this phase (NULL = not captured).';
+
+
+--
+-- Name: processing_logs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.processing_logs (
+    id uuid NOT NULL,
+    recording_id uuid NOT NULL,
+    "timestamp" timestamp with time zone NOT NULL,
+    phase public.processingphase NOT NULL,
+    level character varying NOT NULL,
+    message text NOT NULL,
+    data json,
+    progress double precision
+);
+
+
+--
+-- Name: project_embeddings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_embeddings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    pattern_id character varying(255) NOT NULL,
+    pattern_name character varying(255),
+    state_id character varying(255) NOT NULL,
+    state_name character varying(255) NOT NULL,
+    image_id character varying(255) NOT NULL,
+    image_storage_path character varying(500) NOT NULL,
+    embedding public.vector(512) NOT NULL,
+    embedding_model character varying(100) NOT NULL,
+    embedding_version character varying(50) NOT NULL,
+    pattern_metadata jsonb NOT NULL,
+    image_width integer NOT NULL,
+    image_height integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    text_description character varying(1000),
+    text_embedding public.vector(384)
+);
+
+
+--
+-- Name: project_locks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.project_locks (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    user_id uuid NOT NULL,
+    resource_type public.resourcetype NOT NULL,
+    resource_id character varying NOT NULL,
+    acquired_at timestamp with time zone NOT NULL,
+    expires_at timestamp with time zone NOT NULL,
+    auto_release boolean NOT NULL,
+    metadata json
+);
+
+
+--
+-- Name: recordings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.recordings (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    created_by_id uuid NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    tags json,
+    recording_start_time timestamp with time zone NOT NULL,
+    recording_end_time timestamp with time zone NOT NULL,
+    duration_ms integer NOT NULL,
+    recorder_name character varying,
+    recorder_version character varying,
+    recorder_platform character varying,
+    screen_width integer NOT NULL,
+    screen_height integer NOT NULL,
+    screen_dpi integer,
+    os_name character varying,
+    os_version character varying,
+    locale character varying,
+    app_name character varying NOT NULL,
+    app_version character varying,
+    app_type character varying,
+    app_url character varying,
+    frame_rate double precision NOT NULL,
+    total_frames integer NOT NULL,
+    total_interactions integer,
+    total_context_events integer,
+    s3_bucket character varying,
+    s3_prefix character varying,
+    upload_size_bytes integer,
+    status public.recordingstatus NOT NULL,
+    processing_phase public.processingphase,
+    processing_progress double precision,
+    processing_started_at timestamp with time zone,
+    processing_completed_at timestamp with time zone,
+    processing_error text,
+    validation_errors json,
+    validation_warnings json,
+    discovered_states_count integer,
+    discovered_transitions_count integer,
+    discovered_workflows_count integer,
+    discovery_confidence double precision,
+    reviewed boolean,
+    reviewed_at timestamp with time zone,
+    accepted boolean,
+    accepted_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: runner_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.runner_tokens (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    token_hash character varying(255) NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    expires_at timestamp with time zone,
+    last_used_at timestamp with time zone,
+    is_revoked boolean DEFAULT false NOT NULL,
+    revoked_at timestamp with time zone,
+    last_ip_address character varying(45),
+    last_user_agent character varying(500)
+);
+
+
+--
+-- Name: COLUMN runner_tokens.name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.name IS 'User-friendly name like ''My Laptop'', ''Work Desktop''';
+
+
+--
+-- Name: COLUMN runner_tokens.token_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.token_hash IS 'Argon2 hash of the plain token (plain never persisted)';
+
+
+--
+-- Name: COLUMN runner_tokens.expires_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.expires_at IS 'Token expiration time. None = never expires';
+
+
+--
+-- Name: COLUMN runner_tokens.last_used_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.last_used_at IS 'Last time this token was used for authentication';
+
+
+--
+-- Name: COLUMN runner_tokens.is_revoked; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.is_revoked IS 'Soft-delete flag for audit trail';
+
+
+--
+-- Name: COLUMN runner_tokens.revoked_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.revoked_at IS 'When the token was revoked';
+
+
+--
+-- Name: COLUMN runner_tokens.last_ip_address; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.last_ip_address IS 'Last IP address that used this token';
+
+
+--
+-- Name: COLUMN runner_tokens.last_user_agent; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runner_tokens.last_user_agent IS 'Last user agent that used this token';
+
+
+--
+-- Name: runners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.runners (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    hostname character varying(255) NOT NULL,
+    port integer NOT NULL,
+    capabilities jsonb DEFAULT '[]'::jsonb NOT NULL,
+    server_mode boolean DEFAULT true NOT NULL,
+    restate_enabled boolean DEFAULT false NOT NULL,
+    restate_healthy boolean DEFAULT false NOT NULL,
+    last_heartbeat timestamp with time zone,
+    status character varying(32) DEFAULT 'offline'::character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    runner_token_id uuid,
+    dispatch_secret character varying(128) DEFAULT encode(public.gen_random_bytes(32), 'hex'::text) NOT NULL,
+    ui_error jsonb,
+    derived_status character varying(32),
+    recent_crash jsonb
+);
+
+
+--
+-- Name: COLUMN runners.dispatch_secret; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runners.dispatch_secret IS 'Per-runner m2m secret used by web to authenticate workflow dispatch POSTs to the runner. Stored plaintext; rotated on re-registration.';
+
+
+--
+-- Name: COLUMN runners.ui_error; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runners.ui_error IS 'Most recent UI error reported by the runner (message/stack/component_stack/digest/first_seen/reported_at/count) or NULL if none is outstanding.';
+
+
+--
+-- Name: COLUMN runners.derived_status; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runners.derived_status IS 'Runner-derived overall status (healthy|degraded|errored|offline|starting). NULL for pre-Phase-3J runners that have not yet heartbeat with the extended payload.';
+
+
+--
+-- Name: COLUMN runners.recent_crash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.runners.recent_crash IS 'Most recent Rust crash dump surfaced by the runner''s startup scanner (file_path/reported_at/panic_location/panic_message/thread) or NULL if no fresh dump is present.';
+
+
+--
+-- Name: scheduled_workflow_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.scheduled_workflow_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    workflow_id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    cron_expression character varying(255) NOT NULL,
+    target character varying(255) NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    last_fired_at timestamp with time zone,
+    last_execution_id character varying(255),
+    last_status character varying(32),
+    last_error text,
+    redbeat_entry_id character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN scheduled_workflow_runs.cron_expression; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.scheduled_workflow_runs.cron_expression IS '5-field cron expression, validated via croniter on write.';
+
+
+--
+-- Name: COLUMN scheduled_workflow_runs.target; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.scheduled_workflow_runs.target IS 'Either the literal string ''auto'' or a stringified runner UUID — mirrors the WorkflowDispatchRequest.target shape.';
+
+
+--
+-- Name: COLUMN scheduled_workflow_runs.last_execution_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.scheduled_workflow_runs.last_execution_id IS 'Runner-returned execution_id from the most recent successful dispatch.';
+
+
+--
+-- Name: COLUMN scheduled_workflow_runs.last_status; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.scheduled_workflow_runs.last_status IS '''dispatched'' | ''failed'' — outcome of the most recent fire.';
+
+
+--
+-- Name: COLUMN scheduled_workflow_runs.redbeat_entry_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.scheduled_workflow_runs.redbeat_entry_id IS 'Redbeat scheduler key for this row, conventionally ''qontinui:schedule:{id}''. Present when a redbeat entry exists in Redis; cleared when the entry is removed (disable/delete).';
+
+
+--
+-- Name: state_machine_configs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.state_machine_configs (
+    id uuid NOT NULL,
+    project_id uuid NOT NULL,
+    created_by uuid NOT NULL,
+    name character varying NOT NULL,
+    description text,
+    version character varying DEFAULT '1.0.0'::character varying NOT NULL,
+    configuration json NOT NULL,
+    tags json DEFAULT '[]'::json NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: task_run_findings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.task_run_findings (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    task_run_id uuid NOT NULL,
+    category public.finding_category NOT NULL,
+    severity public.finding_severity NOT NULL,
+    status public.finding_status DEFAULT 'detected'::public.finding_status NOT NULL,
+    action_type public.finding_action_type DEFAULT 'auto_fix'::public.finding_action_type NOT NULL,
+    signature_hash character varying(64),
+    title character varying(500) NOT NULL,
+    description text NOT NULL,
+    resolution text,
+    file_path character varying(1000),
+    line_number integer,
+    column_number integer,
+    code_snippet text,
+    detected_in_session integer NOT NULL,
+    resolved_in_session integer,
+    needs_input boolean DEFAULT false NOT NULL,
+    question text,
+    input_options jsonb,
+    user_response text,
+    detected_at timestamp with time zone DEFAULT now() NOT NULL,
+    resolved_at timestamp with time zone,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN task_run_findings.signature_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.signature_hash IS 'Hash for finding deduplication';
+
+
+--
+-- Name: COLUMN task_run_findings.resolution; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.resolution IS 'How the finding was resolved';
+
+
+--
+-- Name: COLUMN task_run_findings.file_path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.file_path IS 'File path where finding was detected';
+
+
+--
+-- Name: COLUMN task_run_findings.code_snippet; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.code_snippet IS 'Code snippet showing the issue';
+
+
+--
+-- Name: COLUMN task_run_findings.detected_in_session; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.detected_in_session IS 'Session number where finding was detected';
+
+
+--
+-- Name: COLUMN task_run_findings.resolved_in_session; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.resolved_in_session IS 'Session number where finding was resolved';
+
+
+--
+-- Name: COLUMN task_run_findings.needs_input; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.needs_input IS 'Whether user input is required';
+
+
+--
+-- Name: COLUMN task_run_findings.question; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.question IS 'Question to ask user if input needed';
+
+
+--
+-- Name: COLUMN task_run_findings.input_options; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.input_options IS 'Array of options for user selection';
+
+
+--
+-- Name: COLUMN task_run_findings.user_response; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_run_findings.user_response IS 'User''s response to the question';
+
+
+--
+-- Name: task_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.task_runs (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid,
+    created_by_user_id uuid,
+    runner_id character varying(255),
+    task_name character varying(255) NOT NULL,
+    prompt text,
+    status public.task_run_status DEFAULT 'running'::public.task_run_status NOT NULL,
+    sessions_count integer DEFAULT 0 NOT NULL,
+    max_sessions integer,
+    auto_continue boolean DEFAULT true NOT NULL,
+    output_summary text,
+    full_output_stored boolean DEFAULT false NOT NULL,
+    full_output text,
+    error_message text,
+    duration_seconds integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone,
+    task_type public.task_type DEFAULT 'task'::public.task_type NOT NULL,
+    config_id character varying(255),
+    workflow_name character varying(255),
+    summary text,
+    goal_achieved boolean,
+    remaining_work text,
+    summary_generated_at timestamp with time zone,
+    execution_steps_json text,
+    log_sources_json text
+);
+
+
+--
+-- Name: COLUMN task_runs.runner_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.runner_id IS 'Runner instance identifier';
+
+
+--
+-- Name: COLUMN task_runs.prompt; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.prompt IS 'The task description/instructions (NULL for pure automation)';
+
+
+--
+-- Name: COLUMN task_runs.sessions_count; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.sessions_count IS 'Number of Claude sessions spawned';
+
+
+--
+-- Name: COLUMN task_runs.max_sessions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.max_sessions IS 'Maximum sessions before giving up (null = unlimited)';
+
+
+--
+-- Name: COLUMN task_runs.auto_continue; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.auto_continue IS 'Whether to automatically spawn new sessions';
+
+
+--
+-- Name: COLUMN task_runs.output_summary; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.output_summary IS 'Summary of task output for display';
+
+
+--
+-- Name: COLUMN task_runs.full_output_stored; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.full_output_stored IS 'Whether full output is stored';
+
+
+--
+-- Name: COLUMN task_runs.full_output; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.full_output IS 'Complete Claude conversation history (premium)';
+
+
+--
+-- Name: COLUMN task_runs.duration_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.duration_seconds IS 'Total task duration in seconds';
+
+
+--
+-- Name: COLUMN task_runs.task_type; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.task_type IS 'Type of task: task, automation, scheduled';
+
+
+--
+-- Name: COLUMN task_runs.config_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.config_id IS 'Config ID for automation tasks';
+
+
+--
+-- Name: COLUMN task_runs.workflow_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.workflow_name IS 'Workflow name for automation tasks';
+
+
+--
+-- Name: COLUMN task_runs.summary; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.summary IS 'Post-completion summary';
+
+
+--
+-- Name: COLUMN task_runs.goal_achieved; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.goal_achieved IS 'Whether the task goal was achieved';
+
+
+--
+-- Name: COLUMN task_runs.remaining_work; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.remaining_work IS 'Description of remaining work';
+
+
+--
+-- Name: COLUMN task_runs.summary_generated_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.summary_generated_at IS 'When the summary was generated';
+
+
+--
+-- Name: COLUMN task_runs.execution_steps_json; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.execution_steps_json IS 'JSON array of execution steps configuration';
+
+
+--
+-- Name: COLUMN task_runs.log_sources_json; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.task_runs.log_sources_json IS 'JSON array of log sources to capture';
+
+
+--
+-- Name: test_results; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.test_results (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    test_id uuid,
+    task_run_id uuid,
+    execution_run_id uuid,
+    status public.test_result_status DEFAULT 'pending'::public.test_result_status NOT NULL,
+    started_at timestamp with time zone,
+    completed_at timestamp with time zone,
+    duration_ms integer,
+    output text,
+    error_message text,
+    structured_output jsonb,
+    screenshots jsonb DEFAULT '[]'::jsonb NOT NULL,
+    assertions_passed integer,
+    assertions_failed integer,
+    individual_tests jsonb,
+    coverage jsonb,
+    exit_code integer,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN test_results.test_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.test_id IS 'Reference to the verification test definition';
+
+
+--
+-- Name: COLUMN test_results.task_run_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.task_run_id IS 'Optional reference to AI task run context';
+
+
+--
+-- Name: COLUMN test_results.execution_run_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.execution_run_id IS 'Optional reference to execution run context';
+
+
+--
+-- Name: COLUMN test_results.duration_ms; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.duration_ms IS 'Test execution duration in milliseconds';
+
+
+--
+-- Name: COLUMN test_results.output; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.output IS 'Raw test output (stdout/stderr)';
+
+
+--
+-- Name: COLUMN test_results.error_message; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.error_message IS 'Error message if test failed';
+
+
+--
+-- Name: COLUMN test_results.structured_output; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.structured_output IS 'Structured output data (JSON)';
+
+
+--
+-- Name: COLUMN test_results.screenshots; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.screenshots IS 'Array of screenshot references';
+
+
+--
+-- Name: COLUMN test_results.assertions_passed; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.assertions_passed IS 'Number of assertions that passed';
+
+
+--
+-- Name: COLUMN test_results.assertions_failed; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.assertions_failed IS 'Number of assertions that failed';
+
+
+--
+-- Name: COLUMN test_results.individual_tests; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.individual_tests IS 'Individual test results within a suite';
+
+
+--
+-- Name: COLUMN test_results.coverage; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.coverage IS 'Code/state coverage data';
+
+
+--
+-- Name: COLUMN test_results.exit_code; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.test_results.exit_code IS 'Process exit code';
+
+
+--
+-- Name: training_dataset_annotations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.training_dataset_annotations (
+    id uuid NOT NULL,
+    dataset_id uuid NOT NULL,
+    image_id uuid NOT NULL,
+    x integer NOT NULL,
+    y integer NOT NULL,
+    width integer NOT NULL,
+    height integer NOT NULL,
+    category_id integer NOT NULL,
+    category_name character varying(100) NOT NULL,
+    confidence double precision NOT NULL,
+    source public.annotation_source_enum NOT NULL,
+    element_type public.element_type_enum,
+    verified boolean NOT NULL,
+    inference_metadata json,
+    review_status public.review_status_enum NOT NULL,
+    reviewer_notes text,
+    reviewed_by_id uuid,
+    reviewed_at timestamp with time zone,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: training_datasets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.training_datasets (
+    id uuid NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    source public.dataset_source_enum NOT NULL,
+    total_images integer NOT NULL,
+    total_annotations integer NOT NULL,
+    reviewed_count integer NOT NULL,
+    dataset_version character varying(50),
+    export_metadata json,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL,
+    created_by_id uuid NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_states; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ui_bridge_states (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    config_id uuid NOT NULL,
+    state_id character varying(100) NOT NULL,
+    name character varying(255) NOT NULL,
+    description text,
+    element_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    render_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    confidence double precision DEFAULT '0.9'::double precision NOT NULL,
+    acceptance_criteria jsonb DEFAULT '[]'::jsonb NOT NULL,
+    extra_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: ui_bridge_transitions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.ui_bridge_transitions (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    config_id uuid NOT NULL,
+    transition_id character varying(100) NOT NULL,
+    name character varying(255) NOT NULL,
+    from_states json DEFAULT '[]'::json NOT NULL,
+    activate_states json DEFAULT '[]'::json NOT NULL,
+    exit_states json DEFAULT '[]'::json NOT NULL,
+    actions json DEFAULT '[]'::json NOT NULL,
+    path_cost double precision DEFAULT '1'::double precision NOT NULL,
+    stays_visible boolean DEFAULT false NOT NULL,
+    extra_metadata json DEFAULT '{}'::json NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: unified_workflows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.unified_workflows (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    created_by_user_id uuid,
+    project_id uuid,
+    name character varying(255) NOT NULL,
+    description text DEFAULT ''::text NOT NULL,
+    category character varying(100) DEFAULT 'general'::character varying NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    setup_steps jsonb DEFAULT '[]'::jsonb NOT NULL,
+    verification_steps jsonb DEFAULT '[]'::jsonb NOT NULL,
+    agentic_steps jsonb DEFAULT '[]'::jsonb NOT NULL,
+    completion_steps jsonb DEFAULT '[]'::jsonb NOT NULL,
+    max_iterations integer DEFAULT 10 NOT NULL,
+    timeout_seconds integer,
+    provider character varying(100),
+    model character varying(100),
+    skip_ai_summary boolean DEFAULT false NOT NULL,
+    log_watch_enabled boolean DEFAULT true NOT NULL,
+    health_check_enabled boolean DEFAULT true NOT NULL,
+    health_check_urls jsonb DEFAULT '[]'::jsonb NOT NULL,
+    preflight_check_enabled boolean DEFAULT true NOT NULL,
+    log_source_selection jsonb DEFAULT '"default"'::jsonb NOT NULL,
+    context_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    disabled_context_ids jsonb DEFAULT '[]'::jsonb NOT NULL,
+    auto_include_contexts boolean DEFAULT true NOT NULL,
+    prompt_template text,
+    generated_by_task_run_id character varying(255),
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    enable_sweep boolean DEFAULT false NOT NULL,
+    max_sweep_iterations integer DEFAULT 5 NOT NULL,
+    stages jsonb,
+    stop_on_failure boolean DEFAULT false NOT NULL,
+    reflection_mode boolean DEFAULT true NOT NULL,
+    model_overrides jsonb DEFAULT '{}'::jsonb,
+    approval_gate boolean DEFAULT false NOT NULL,
+    constraint_overrides jsonb
+);
+
+
+--
+-- Name: COLUMN unified_workflows.generated_by_task_run_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.generated_by_task_run_id IS 'Task run ID that generated this workflow (e.g. error-fix generator)';
+
+
+--
+-- Name: COLUMN unified_workflows.stages; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.stages IS 'JSON array of WorkflowStage objects for multi-stage execution';
+
+
+--
+-- Name: COLUMN unified_workflows.stop_on_failure; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.stop_on_failure IS 'Whether to stop execution if a stage fails verification';
+
+
+--
+-- Name: COLUMN unified_workflows.reflection_mode; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.reflection_mode IS 'Whether to enable reflection mode during AI iterations';
+
+
+--
+-- Name: COLUMN unified_workflows.model_overrides; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.model_overrides IS 'Per-phase AI model overrides: {phase: {provider, model}}';
+
+
+--
+-- Name: COLUMN unified_workflows.approval_gate; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.approval_gate IS 'Whether to pause for human approval before agentic phase';
+
+
+--
+-- Name: COLUMN unified_workflows.constraint_overrides; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.unified_workflows.constraint_overrides IS 'Per-constraint enable/disable overrides keyed by constraint ID';
+
+
+--
+-- Name: verification_tests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.verification_tests (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    created_by_user_id uuid,
+    name character varying(255) NOT NULL,
+    description text,
+    test_type public.verification_test_type NOT NULL,
+    category public.verification_test_category,
+    playwright_code text,
+    vision_config jsonb,
+    python_code text,
+    repo_test_config jsonb,
+    success_criteria text,
+    config jsonb DEFAULT '{}'::jsonb NOT NULL,
+    timeout_seconds integer DEFAULT 300 NOT NULL,
+    is_critical boolean DEFAULT false NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    ai_generated boolean DEFAULT false NOT NULL,
+    tags jsonb DEFAULT '[]'::jsonb NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN verification_tests.playwright_code; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.playwright_code IS 'Playwright test code (TypeScript)';
+
+
+--
+-- Name: COLUMN verification_tests.vision_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.vision_config IS 'Vision test configuration (patterns, assertions)';
+
+
+--
+-- Name: COLUMN verification_tests.python_code; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.python_code IS 'Python test code';
+
+
+--
+-- Name: COLUMN verification_tests.repo_test_config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.repo_test_config IS 'External test runner config (command, working_dir, etc.)';
+
+
+--
+-- Name: COLUMN verification_tests.success_criteria; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.success_criteria IS 'Human-readable success criteria';
+
+
+--
+-- Name: COLUMN verification_tests.config; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.config IS 'Additional test configuration';
+
+
+--
+-- Name: COLUMN verification_tests.timeout_seconds; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.timeout_seconds IS 'Test timeout in seconds';
+
+
+--
+-- Name: COLUMN verification_tests.is_critical; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.is_critical IS 'Whether test failure should block deployment';
+
+
+--
+-- Name: COLUMN verification_tests.ai_generated; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.verification_tests.ai_generated IS 'Whether test was generated by AI';
+
+
+--
+-- Name: workflow_test_associations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.workflow_test_associations (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    project_id uuid NOT NULL,
+    test_id uuid NOT NULL,
+    workflow_id character varying(255) NOT NULL,
+    trigger_point public.trigger_point NOT NULL,
+    checkpoint_name character varying(255),
+    action_id character varying(255),
+    execution_order integer DEFAULT 0 NOT NULL,
+    enabled boolean DEFAULT true NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN workflow_test_associations.workflow_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.workflow_test_associations.workflow_id IS 'Workflow ID from project configuration';
+
+
+--
+-- Name: COLUMN workflow_test_associations.checkpoint_name; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.workflow_test_associations.checkpoint_name IS 'Checkpoint name for on_checkpoint trigger';
+
+
+--
+-- Name: COLUMN workflow_test_associations.action_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.workflow_test_associations.action_id IS 'Action ID for on_action trigger';
+
+
+--
+-- Name: COLUMN workflow_test_associations.execution_order; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.workflow_test_associations.execution_order IS 'Order of execution when multiple tests triggered';
+
+
+--
+-- Name: workflow_variables; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.workflow_variables (
+    id character varying NOT NULL,
+    project_id uuid NOT NULL,
+    workflow_id character varying,
+    name character varying NOT NULL,
+    value json,
+    scope public.variablescope NOT NULL,
+    description character varying,
+    created_at timestamp with time zone NOT NULL,
+    updated_at timestamp with time zone NOT NULL
+);
+
+
+--
+-- Name: wrapper_comments; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.wrapper_comments (
+    id bigint NOT NULL,
+    wrapper_id text NOT NULL,
+    user_id uuid NOT NULL,
+    parent_id bigint,
+    body text NOT NULL,
+    moderation_state text DEFAULT 'visible'::text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN wrapper_comments.moderation_state; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.wrapper_comments.moderation_state IS 'visible | flagged | hidden';
+
+
+--
+-- Name: wrapper_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.wrapper_comments ALTER COLUMN id ADD GENERATED BY DEFAULT AS IDENTITY (
+    SEQUENCE NAME public.wrapper_comments_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: wrapper_entries; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.wrapper_entries (
+    id text NOT NULL,
+    package text NOT NULL,
+    latest_version text NOT NULL,
+    display_name text NOT NULL,
+    description text,
+    categories jsonb DEFAULT '[]'::jsonb NOT NULL,
+    transport text NOT NULL,
+    author_json jsonb NOT NULL,
+    repo text,
+    license text,
+    verified boolean DEFAULT false NOT NULL,
+    registry_synced_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN wrapper_entries.id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.wrapper_entries.id IS 'Mirrors the wrapper.id field in registry.json.';
+
+
+--
+-- Name: COLUMN wrapper_entries.transport; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.wrapper_entries.transport IS 'api | headless | headed | live';
+
+
+--
+-- Name: COLUMN wrapper_entries.author_json; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.wrapper_entries.author_json IS '{name, url?, email?}';
+
+
+--
+-- Name: wrapper_install_events; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.wrapper_install_events (
+    id bigint NOT NULL,
+    wrapper_id text NOT NULL,
+    runner_id_hash text NOT NULL,
+    version text,
+    installed_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: COLUMN wrapper_install_events.runner_id_hash; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.wrapper_install_events.runner_id_hash IS 'sha256 of runner id; never the raw value (privacy).';
+
+
+--
+-- Name: wrapper_install_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.wrapper_install_events ALTER COLUMN id ADD GENERATED BY DEFAULT AS IDENTITY (
+    SEQUENCE NAME public.wrapper_install_events_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: wrapper_ratings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.wrapper_ratings (
+    id bigint NOT NULL,
+    wrapper_id text NOT NULL,
+    user_id uuid NOT NULL,
+    stars smallint NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT wrapper_ratings_stars_check CHECK (((stars >= 1) AND (stars <= 5)))
+);
+
+
+--
+-- Name: wrapper_ratings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+ALTER TABLE public.wrapper_ratings ALTER COLUMN id ADD GENERATED BY DEFAULT AS IDENTITY (
+    SEQUENCE NAME public.wrapper_ratings_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1
+);
+
+
+--
+-- Name: automation_input_events id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_input_events ALTER COLUMN id SET DEFAULT nextval('public.automation_input_events_id_seq'::regclass);
+
+
+--
+-- Name: task_run_findings ai_task_findings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_findings
+    ADD CONSTRAINT ai_task_findings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: task_runs ai_tasks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_runs
+    ADD CONSTRAINT ai_tasks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: alembic_version alembic_version_pkc; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.alembic_version
+    ADD CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num);
+
+
+--
+-- Name: automation_input_events automation_input_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.automation_input_events
+    ADD CONSTRAINT automation_input_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: domain_knowledge domain_knowledge_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.domain_knowledge
+    ADD CONSTRAINT domain_knowledge_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: execution_issues execution_issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_issues
+    ADD CONSTRAINT execution_issues_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: known_issues known_issues_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.known_issues
+    ADD CONSTRAINT known_issues_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: notifications notifications_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT notifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: phase_results phase_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phase_results
+    ADD CONSTRAINT phase_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: processing_logs processing_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.processing_logs
+    ADD CONSTRAINT processing_logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_embeddings project_embeddings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_embeddings
+    ADD CONSTRAINT project_embeddings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: project_locks project_locks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_locks
+    ADD CONSTRAINT project_locks_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: recordings recordings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recordings
+    ADD CONSTRAINT recordings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runner_tokens runner_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_tokens
+    ADD CONSTRAINT runner_tokens_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: runners runners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runners
+    ADD CONSTRAINT runners_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: scheduled_workflow_runs scheduled_workflow_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_workflow_runs
+    ADD CONSTRAINT scheduled_workflow_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: scheduled_workflow_runs scheduled_workflow_runs_redbeat_entry_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_workflow_runs
+    ADD CONSTRAINT scheduled_workflow_runs_redbeat_entry_id_key UNIQUE (redbeat_entry_id);
+
+
+--
+-- Name: state_machine_configs state_machine_configs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_machine_configs
+    ADD CONSTRAINT state_machine_configs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: test_results test_results_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_results
+    ADD CONSTRAINT test_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: training_dataset_annotations training_dataset_annotations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_annotations
+    ADD CONSTRAINT training_dataset_annotations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: training_datasets training_datasets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_datasets
+    ADD CONSTRAINT training_datasets_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_states ui_bridge_states_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_states
+    ADD CONSTRAINT ui_bridge_states_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ui_bridge_transitions ui_bridge_transitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.ui_bridge_transitions
+    ADD CONSTRAINT ui_bridge_transitions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: unified_workflows unified_workflows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.unified_workflows
+    ADD CONSTRAINT unified_workflows_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_variables uq_project_workflow_var; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_variables
+    ADD CONSTRAINT uq_project_workflow_var UNIQUE (project_id, workflow_id, name);
+
+
+--
+-- Name: verification_tests verification_tests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verification_tests
+    ADD CONSTRAINT verification_tests_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_test_associations workflow_test_associations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_test_associations
+    ADD CONSTRAINT workflow_test_associations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: workflow_variables workflow_variables_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_variables
+    ADD CONSTRAINT workflow_variables_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: wrapper_comments wrapper_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_comments
+    ADD CONSTRAINT wrapper_comments_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: wrapper_entries wrapper_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_entries
+    ADD CONSTRAINT wrapper_entries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: wrapper_install_events wrapper_install_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_install_events
+    ADD CONSTRAINT wrapper_install_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: wrapper_ratings wrapper_ratings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_ratings
+    ADD CONSTRAINT wrapper_ratings_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: wrapper_ratings wrapper_ratings_wrapper_id_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_ratings
+    ADD CONSTRAINT wrapper_ratings_wrapper_id_user_id_key UNIQUE (wrapper_id, user_id);
+
+
+--
+-- Name: ix_ai_task_findings_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_task_findings_category ON public.task_run_findings USING btree (category);
+
+
+--
+-- Name: ix_ai_task_findings_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_task_findings_severity ON public.task_run_findings USING btree (severity);
+
+
+--
+-- Name: ix_ai_task_findings_signature_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_task_findings_signature_hash ON public.task_run_findings USING btree (signature_hash);
+
+
+--
+-- Name: ix_ai_task_findings_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_task_findings_status ON public.task_run_findings USING btree (status);
+
+
+--
+-- Name: ix_ai_task_findings_task_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_task_findings_task_id ON public.task_run_findings USING btree (task_run_id);
+
+
+--
+-- Name: ix_ai_tasks_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_tasks_created_by_user_id ON public.task_runs USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_ai_tasks_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_tasks_project_id ON public.task_runs USING btree (project_id);
+
+
+--
+-- Name: ix_ai_tasks_runner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_tasks_runner_id ON public.task_runs USING btree (runner_id);
+
+
+--
+-- Name: ix_ai_tasks_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ai_tasks_status ON public.task_runs USING btree (status);
+
+
+--
+-- Name: ix_automation_input_events_event_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_input_events_event_type ON public.automation_input_events USING btree (event_type);
+
+
+--
+-- Name: ix_automation_input_events_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_input_events_id ON public.automation_input_events USING btree (id);
+
+
+--
+-- Name: ix_automation_input_events_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_input_events_session_id ON public.automation_input_events USING btree (session_id);
+
+
+--
+-- Name: ix_automation_input_events_session_timestamp; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_automation_input_events_session_timestamp ON public.automation_input_events USING btree (session_id, "timestamp");
+
+
+--
+-- Name: ix_domain_knowledge_content_embedding; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_domain_knowledge_content_embedding ON public.domain_knowledge USING ivfflat (content_embedding public.vector_cosine_ops) WITH (lists='10');
+
+
+--
+-- Name: ix_domain_knowledge_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_domain_knowledge_project_id ON public.domain_knowledge USING btree (project_id);
+
+
+--
+-- Name: ix_execution_issues_action_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_action_execution_id ON public.execution_issues USING btree (action_execution_id);
+
+
+--
+-- Name: ix_execution_issues_assigned_to_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_assigned_to_user_id ON public.execution_issues USING btree (assigned_to_user_id);
+
+
+--
+-- Name: ix_execution_issues_description_embedding; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_description_embedding ON public.execution_issues USING ivfflat (description_embedding public.vector_cosine_ops) WITH (lists='10');
+
+
+--
+-- Name: ix_execution_issues_issue_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_issue_type ON public.execution_issues USING btree (issue_type);
+
+
+--
+-- Name: ix_execution_issues_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_run_id ON public.execution_issues USING btree (run_id);
+
+
+--
+-- Name: ix_execution_issues_run_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_run_severity ON public.execution_issues USING btree (run_id, severity);
+
+
+--
+-- Name: ix_execution_issues_run_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_run_status ON public.execution_issues USING btree (run_id, status);
+
+
+--
+-- Name: ix_execution_issues_screenshot_ids; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_screenshot_ids ON public.execution_issues USING gin (screenshot_ids jsonb_path_ops);
+
+
+--
+-- Name: ix_execution_issues_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_severity ON public.execution_issues USING btree (severity);
+
+
+--
+-- Name: ix_execution_issues_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_source ON public.execution_issues USING btree (source);
+
+
+--
+-- Name: ix_execution_issues_state_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_state_name ON public.execution_issues USING btree (state_name);
+
+
+--
+-- Name: ix_execution_issues_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_status ON public.execution_issues USING btree (status);
+
+
+--
+-- Name: ix_execution_issues_title_embedding; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_execution_issues_title_embedding ON public.execution_issues USING ivfflat (title_embedding public.vector_cosine_ops) WITH (lists='10');
+
+
+--
+-- Name: ix_known_issues_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_known_issues_category ON public.known_issues USING btree (category);
+
+
+--
+-- Name: ix_known_issues_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_known_issues_created_by_user_id ON public.known_issues USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_known_issues_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_known_issues_organization_id ON public.known_issues USING btree (organization_id);
+
+
+--
+-- Name: ix_known_issues_severity; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_known_issues_severity ON public.known_issues USING btree (severity);
+
+
+--
+-- Name: ix_known_issues_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_known_issues_status ON public.known_issues USING btree (status);
+
+
+--
+-- Name: ix_notifications_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_notifications_created_at ON public.notifications USING btree (created_at);
+
+
+--
+-- Name: ix_notifications_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_notifications_project_id ON public.notifications USING btree (project_id);
+
+
+--
+-- Name: ix_notifications_read; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_notifications_read ON public.notifications USING btree (read);
+
+
+--
+-- Name: ix_notifications_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_notifications_type ON public.notifications USING btree (type);
+
+
+--
+-- Name: ix_notifications_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_notifications_user_id ON public.notifications USING btree (user_id);
+
+
+--
+-- Name: ix_phase_results_execution_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_phase_results_execution_id ON public.phase_results USING btree (execution_id);
+
+
+--
+-- Name: ix_phase_results_execution_id_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_phase_results_execution_id_created_at ON public.phase_results USING btree (execution_id, created_at);
+
+
+--
+-- Name: ix_phase_results_runner_id_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_phase_results_runner_id_created_at ON public.phase_results USING btree (runner_id, created_at);
+
+
+--
+-- Name: ix_processing_logs_phase; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_processing_logs_phase ON public.processing_logs USING btree (recording_id, phase);
+
+
+--
+-- Name: ix_processing_logs_recording_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_processing_logs_recording_id ON public.processing_logs USING btree (recording_id);
+
+
+--
+-- Name: ix_processing_logs_recording_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_processing_logs_recording_time ON public.processing_logs USING btree (recording_id, "timestamp");
+
+
+--
+-- Name: ix_project_embeddings_image_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_embeddings_image_id ON public.project_embeddings USING btree (image_id);
+
+
+--
+-- Name: ix_project_embeddings_pattern_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_embeddings_pattern_id ON public.project_embeddings USING btree (pattern_id);
+
+
+--
+-- Name: ix_project_embeddings_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_embeddings_project_id ON public.project_embeddings USING btree (project_id);
+
+
+--
+-- Name: ix_project_embeddings_project_pattern; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_embeddings_project_pattern ON public.project_embeddings USING btree (project_id, pattern_id);
+
+
+--
+-- Name: ix_project_embeddings_state_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_embeddings_state_id ON public.project_embeddings USING btree (state_id);
+
+
+--
+-- Name: ix_project_locks_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_locks_project_id ON public.project_locks USING btree (project_id);
+
+
+--
+-- Name: ix_project_locks_resource_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_locks_resource_id ON public.project_locks USING btree (resource_id);
+
+
+--
+-- Name: ix_project_locks_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_project_locks_user_id ON public.project_locks USING btree (user_id);
+
+
+--
+-- Name: ix_recordings_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recordings_created_at ON public.recordings USING btree (created_at);
+
+
+--
+-- Name: ix_recordings_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recordings_project_id ON public.recordings USING btree (project_id);
+
+
+--
+-- Name: ix_recordings_project_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recordings_project_status ON public.recordings USING btree (project_id, status);
+
+
+--
+-- Name: ix_recordings_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_recordings_status ON public.recordings USING btree (status);
+
+
+--
+-- Name: ix_runner_tokens_is_revoked; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_tokens_is_revoked ON public.runner_tokens USING btree (is_revoked);
+
+
+--
+-- Name: ix_runner_tokens_last_used_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_tokens_last_used_at ON public.runner_tokens USING btree (last_used_at);
+
+
+--
+-- Name: ix_runner_tokens_token_hash; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX ix_runner_tokens_token_hash ON public.runner_tokens USING btree (token_hash);
+
+
+--
+-- Name: ix_runner_tokens_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runner_tokens_user_id ON public.runner_tokens USING btree (user_id);
+
+
+--
+-- Name: ix_runners_runner_token_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runners_runner_token_id ON public.runners USING btree (runner_token_id);
+
+
+--
+-- Name: ix_runners_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runners_status ON public.runners USING btree (status);
+
+
+--
+-- Name: ix_runners_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_runners_user_id ON public.runners USING btree (user_id);
+
+
+--
+-- Name: ix_scheduled_workflow_runs_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_workflow_runs_user_id ON public.scheduled_workflow_runs USING btree (user_id);
+
+
+--
+-- Name: ix_scheduled_workflow_runs_user_workflow; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_workflow_runs_user_workflow ON public.scheduled_workflow_runs USING btree (user_id, workflow_id);
+
+
+--
+-- Name: ix_scheduled_workflow_runs_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_scheduled_workflow_runs_workflow_id ON public.scheduled_workflow_runs USING btree (workflow_id);
+
+
+--
+-- Name: ix_state_machine_configs_created_by; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_machine_configs_created_by ON public.state_machine_configs USING btree (created_by);
+
+
+--
+-- Name: ix_state_machine_configs_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_machine_configs_id ON public.state_machine_configs USING btree (id);
+
+
+--
+-- Name: ix_state_machine_configs_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_machine_configs_name ON public.state_machine_configs USING btree (name);
+
+
+--
+-- Name: ix_state_machine_configs_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_state_machine_configs_project_id ON public.state_machine_configs USING btree (project_id);
+
+
+--
+-- Name: ix_task_runs_config_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_task_runs_config_id ON public.task_runs USING btree (config_id);
+
+
+--
+-- Name: ix_task_runs_task_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_task_runs_task_type ON public.task_runs USING btree (task_type);
+
+
+--
+-- Name: ix_test_results_execution_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_results_execution_run_id ON public.test_results USING btree (execution_run_id);
+
+
+--
+-- Name: ix_test_results_status; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_results_status ON public.test_results USING btree (status);
+
+
+--
+-- Name: ix_test_results_task_run_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_results_task_run_id ON public.test_results USING btree (task_run_id);
+
+
+--
+-- Name: ix_test_results_test_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_test_results_test_id ON public.test_results USING btree (test_id);
+
+
+--
+-- Name: ix_training_dataset_annotations_confidence; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_annotations_confidence ON public.training_dataset_annotations USING btree (dataset_id, confidence);
+
+
+--
+-- Name: ix_training_dataset_annotations_dataset; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_annotations_dataset ON public.training_dataset_annotations USING btree (dataset_id);
+
+
+--
+-- Name: ix_training_dataset_annotations_image; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_annotations_image ON public.training_dataset_annotations USING btree (image_id);
+
+
+--
+-- Name: ix_training_dataset_annotations_review; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_annotations_review ON public.training_dataset_annotations USING btree (dataset_id, review_status);
+
+
+--
+-- Name: ix_training_dataset_annotations_source; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_dataset_annotations_source ON public.training_dataset_annotations USING btree (dataset_id, source);
+
+
+--
+-- Name: ix_training_datasets_created_by; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_datasets_created_by ON public.training_datasets USING btree (created_by_id);
+
+
+--
+-- Name: ix_training_datasets_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_training_datasets_name ON public.training_datasets USING btree (name);
+
+
+--
+-- Name: ix_ui_bridge_states_config_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ui_bridge_states_config_id ON public.ui_bridge_states USING btree (config_id);
+
+
+--
+-- Name: ix_ui_bridge_transitions_config_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_ui_bridge_transitions_config_id ON public.ui_bridge_transitions USING btree (config_id);
+
+
+--
+-- Name: ix_unified_workflows_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_unified_workflows_category ON public.unified_workflows USING btree (category);
+
+
+--
+-- Name: ix_unified_workflows_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_unified_workflows_created_by_user_id ON public.unified_workflows USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_unified_workflows_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_unified_workflows_project_id ON public.unified_workflows USING btree (project_id);
+
+
+--
+-- Name: ix_verification_tests_category; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_verification_tests_category ON public.verification_tests USING btree (category);
+
+
+--
+-- Name: ix_verification_tests_created_by_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_verification_tests_created_by_user_id ON public.verification_tests USING btree (created_by_user_id);
+
+
+--
+-- Name: ix_verification_tests_enabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_verification_tests_enabled ON public.verification_tests USING btree (enabled);
+
+
+--
+-- Name: ix_verification_tests_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_verification_tests_project_id ON public.verification_tests USING btree (project_id);
+
+
+--
+-- Name: ix_verification_tests_test_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_verification_tests_test_type ON public.verification_tests USING btree (test_type);
+
+
+--
+-- Name: ix_workflow_test_associations_enabled; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_test_associations_enabled ON public.workflow_test_associations USING btree (enabled);
+
+
+--
+-- Name: ix_workflow_test_associations_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_test_associations_project_id ON public.workflow_test_associations USING btree (project_id);
+
+
+--
+-- Name: ix_workflow_test_associations_test_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_test_associations_test_id ON public.workflow_test_associations USING btree (test_id);
+
+
+--
+-- Name: ix_workflow_test_associations_trigger_point; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_test_associations_trigger_point ON public.workflow_test_associations USING btree (trigger_point);
+
+
+--
+-- Name: ix_workflow_test_associations_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_test_associations_workflow_id ON public.workflow_test_associations USING btree (workflow_id);
+
+
+--
+-- Name: ix_workflow_variables_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_variables_name ON public.workflow_variables USING btree (name);
+
+
+--
+-- Name: ix_workflow_variables_project_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_variables_project_id ON public.workflow_variables USING btree (project_id);
+
+
+--
+-- Name: ix_workflow_variables_scope; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_variables_scope ON public.workflow_variables USING btree (scope);
+
+
+--
+-- Name: ix_workflow_variables_workflow_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX ix_workflow_variables_workflow_id ON public.workflow_variables USING btree (workflow_id);
+
+
+--
+-- Name: wrapper_comments_wrapper_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX wrapper_comments_wrapper_idx ON public.wrapper_comments USING btree (wrapper_id, created_at);
+
+
+--
+-- Name: wrapper_entries_categories_gin; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX wrapper_entries_categories_gin ON public.wrapper_entries USING gin (categories);
+
+
+--
+-- Name: wrapper_install_events_wrapper_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX wrapper_install_events_wrapper_idx ON public.wrapper_install_events USING btree (wrapper_id);
+
+
+--
+-- Name: wrapper_ratings_wrapper_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX wrapper_ratings_wrapper_idx ON public.wrapper_ratings USING btree (wrapper_id);
+
+
+--
+-- Name: task_run_findings ai_task_findings_task_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_run_findings
+    ADD CONSTRAINT ai_task_findings_task_id_fkey FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: task_runs ai_tasks_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.task_runs
+    ADD CONSTRAINT ai_tasks_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: execution_issues execution_issues_assigned_to_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.execution_issues
+    ADD CONSTRAINT execution_issues_assigned_to_user_id_fkey FOREIGN KEY (assigned_to_user_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: known_issues known_issues_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.known_issues
+    ADD CONSTRAINT known_issues_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: notifications notifications_actor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT notifications_actor_id_fkey FOREIGN KEY (actor_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: notifications notifications_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.notifications
+    ADD CONSTRAINT notifications_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: phase_results phase_results_runner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.phase_results
+    ADD CONSTRAINT phase_results_runner_id_fkey FOREIGN KEY (runner_id) REFERENCES public.runners(id) ON DELETE SET NULL;
+
+
+--
+-- Name: processing_logs processing_logs_recording_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.processing_logs
+    ADD CONSTRAINT processing_logs_recording_id_fkey FOREIGN KEY (recording_id) REFERENCES public.recordings(id) ON DELETE CASCADE;
+
+
+--
+-- Name: project_locks project_locks_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.project_locks
+    ADD CONSTRAINT project_locks_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: recordings recordings_created_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.recordings
+    ADD CONSTRAINT recordings_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES runner.users(id);
+
+
+--
+-- Name: runner_tokens runner_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runner_tokens
+    ADD CONSTRAINT runner_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: runners runners_runner_token_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runners
+    ADD CONSTRAINT runners_runner_token_id_fkey FOREIGN KEY (runner_token_id) REFERENCES public.runner_tokens(id) ON DELETE SET NULL;
+
+
+--
+-- Name: runners runners_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.runners
+    ADD CONSTRAINT runners_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: scheduled_workflow_runs scheduled_workflow_runs_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_workflow_runs
+    ADD CONSTRAINT scheduled_workflow_runs_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: scheduled_workflow_runs scheduled_workflow_runs_workflow_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.scheduled_workflow_runs
+    ADD CONSTRAINT scheduled_workflow_runs_workflow_id_fkey FOREIGN KEY (workflow_id) REFERENCES public.unified_workflows(id) ON DELETE CASCADE;
+
+
+--
+-- Name: state_machine_configs state_machine_configs_created_by_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.state_machine_configs
+    ADD CONSTRAINT state_machine_configs_created_by_fkey FOREIGN KEY (created_by) REFERENCES runner.users(id);
+
+
+--
+-- Name: test_results test_results_task_run_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_results
+    ADD CONSTRAINT test_results_task_run_id_fkey FOREIGN KEY (task_run_id) REFERENCES public.task_runs(id) ON DELETE CASCADE;
+
+
+--
+-- Name: test_results test_results_test_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.test_results
+    ADD CONSTRAINT test_results_test_id_fkey FOREIGN KEY (test_id) REFERENCES public.verification_tests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: training_dataset_annotations training_dataset_annotations_dataset_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_annotations
+    ADD CONSTRAINT training_dataset_annotations_dataset_id_fkey FOREIGN KEY (dataset_id) REFERENCES public.training_datasets(id) ON DELETE CASCADE;
+
+
+--
+-- Name: training_dataset_annotations training_dataset_annotations_reviewed_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_dataset_annotations
+    ADD CONSTRAINT training_dataset_annotations_reviewed_by_id_fkey FOREIGN KEY (reviewed_by_id) REFERENCES runner.users(id);
+
+
+--
+-- Name: training_datasets training_datasets_created_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.training_datasets
+    ADD CONSTRAINT training_datasets_created_by_id_fkey FOREIGN KEY (created_by_id) REFERENCES runner.users(id);
+
+
+--
+-- Name: verification_tests verification_tests_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.verification_tests
+    ADD CONSTRAINT verification_tests_created_by_user_id_fkey FOREIGN KEY (created_by_user_id) REFERENCES runner.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: workflow_test_associations workflow_test_associations_test_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.workflow_test_associations
+    ADD CONSTRAINT workflow_test_associations_test_id_fkey FOREIGN KEY (test_id) REFERENCES public.verification_tests(id) ON DELETE CASCADE;
+
+
+--
+-- Name: wrapper_comments wrapper_comments_parent_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_comments
+    ADD CONSTRAINT wrapper_comments_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES public.wrapper_comments(id) ON DELETE CASCADE;
+
+
+--
+-- Name: wrapper_comments wrapper_comments_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_comments
+    ADD CONSTRAINT wrapper_comments_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: wrapper_comments wrapper_comments_wrapper_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_comments
+    ADD CONSTRAINT wrapper_comments_wrapper_id_fkey FOREIGN KEY (wrapper_id) REFERENCES public.wrapper_entries(id) ON DELETE CASCADE;
+
+
+--
+-- Name: wrapper_install_events wrapper_install_events_wrapper_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_install_events
+    ADD CONSTRAINT wrapper_install_events_wrapper_id_fkey FOREIGN KEY (wrapper_id) REFERENCES public.wrapper_entries(id) ON DELETE CASCADE;
+
+
+--
+-- Name: wrapper_ratings wrapper_ratings_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_ratings
+    ADD CONSTRAINT wrapper_ratings_user_id_fkey FOREIGN KEY (user_id) REFERENCES runner.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: wrapper_ratings wrapper_ratings_wrapper_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.wrapper_ratings
+    ADD CONSTRAINT wrapper_ratings_wrapper_id_fkey FOREIGN KEY (wrapper_id) REFERENCES public.wrapper_entries(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--

--- a/src-tauri/scripts/regenerate_schema_pg_sql.sh
+++ b/src-tauri/scripts/regenerate_schema_pg_sql.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Regenerate schema.pg.sql.generated from the canonical alembic-managed schema.
+#
+# Phase 5 deliverable of the migration consolidation
+# (D:/qontinui-root/tmp_migration_consolidation_plan.md §"Phase 5").
+#
+# Purpose: produce the source-of-truth file that Clorinde reads to
+# validate queries/*.sql against, sourced from a real Postgres dump
+# rather than the hand-authored schema.pg.sql. Once Phase 4 of the
+# consolidation plan deletes the hand-authored schema.pg.sql, this
+# generated file takes over.
+#
+# Modes
+# -----
+# Default (no flag): dump from a running canonical Postgres container.
+#   Expects the qontinui-canonical-postgres container to be up with
+#   schemas project/coord/agent/auth/public created and populated by
+#   the alembic chain (which, post-transplant, includes the
+#   _staged_consolidation/ revisions).
+#
+# --fresh-temp-db: create a throwaway database inside the same container,
+#   apply alembic upgrade head into it from qontinui-web/backend, dump
+#   the temp DB, drop it. This is the post-transplant CI mode — it
+#   guarantees the dump reflects the ALEMBIC-AUTHORITATIVE state,
+#   independent of any drift in the long-lived dev DB.
+#
+# Output: src-tauri/schema.pg.sql.generated.
+#
+# Determinism: pg_dump headers that contain timestamps or runtime info
+# (Started on / Completed on) are stripped post-dump so two consecutive
+# runs produce byte-equal output. The pg_dump version line is kept (it
+# changes only when the container is rebuilt with a newer Postgres,
+# which is a reviewable event).
+#
+# Environment overrides:
+#   CLORINDE_PG_CONTAINER (default: qontinui-canonical-postgres)
+#                         If set to empty string, native pg_dump is used.
+#   CLORINDE_PG_HOST      (default: localhost)
+#   CLORINDE_PG_PORT      (default: 5433)
+#   CLORINDE_PG_DB        (default: qontinui_db)
+#   CLORINDE_PG_USER      (default: qontinui_user)
+#   PGPASSWORD            (read by native pg_dump; ignored in docker-exec mode)
+#   QONTINUI_WEB_DIR      (default: ../../../qontinui-web/backend)
+#                         Used by --fresh-temp-db to find alembic.
+#
+# Container vs native pg_dump:
+# By default the script uses `docker exec <container> pg_dump` so a host
+# without pg_dump installed can still run it. If CLORINDE_PG_CONTAINER
+# is set to the empty string, the script falls back to host `pg_dump`
+# (the CI workflow uses this path with a postgres-client install).
+
+set -euo pipefail
+
+CONTAINER="${CLORINDE_PG_CONTAINER-qontinui-canonical-postgres}"
+HOST="${CLORINDE_PG_HOST:-localhost}"
+PORT="${CLORINDE_PG_PORT:-5433}"
+DB="${CLORINDE_PG_DB:-qontinui_db}"
+PG_USER="${CLORINDE_PG_USER:-qontinui_user}"
+SCHEMAS=(project coord agent auth public)
+
+# Default to relative path; can be overridden by env.
+QONTINUI_WEB_DIR="${QONTINUI_WEB_DIR:-../../../qontinui-web/backend}"
+
+cd "$(dirname "$0")/.."  # src-tauri/
+
+OUTPUT="schema.pg.sql.generated"
+TMP="${OUTPUT}.tmp"
+
+mode="default"
+if [[ "${1:-}" == "--fresh-temp-db" ]]; then
+    mode="fresh-temp-db"
+fi
+
+# ---------------------------------------------------------------------
+# Build the pg_dump arg list (shared between modes).
+# ---------------------------------------------------------------------
+PG_DUMP_ARGS=(--schema-only --no-owner --no-privileges)
+for s in "${SCHEMAS[@]}"; do
+    PG_DUMP_ARGS+=(--schema="$s")
+done
+
+# ---------------------------------------------------------------------
+# Source DB selection (default vs --fresh-temp-db).
+# ---------------------------------------------------------------------
+if [[ "$mode" == "fresh-temp-db" ]]; then
+    echo "[regen] Mode: fresh-temp-db. Creating temp DB inside $CONTAINER." >&2
+    TEMP_DB="clorinde_regen_$(date +%s)_$$"
+    cleanup_temp_db() {
+        echo "[regen] Dropping temp DB $TEMP_DB" >&2
+        docker exec "$CONTAINER" psql -U "$PG_USER" -d "$DB" \
+            -c "DROP DATABASE IF EXISTS $TEMP_DB" >/dev/null 2>&1 || true
+    }
+    trap cleanup_temp_db EXIT
+
+    docker exec "$CONTAINER" psql -U "$PG_USER" -d "$DB" \
+        -c "CREATE DATABASE $TEMP_DB" >/dev/null
+
+    # Apply alembic upgrade head against the temp DB. This requires the
+    # alembic chain in qontinui-web (post-transplant, that includes the
+    # consolidation revisions).
+    if [[ ! -d "$QONTINUI_WEB_DIR" ]]; then
+        echo "[regen] ERROR: QONTINUI_WEB_DIR not found at $QONTINUI_WEB_DIR" >&2
+        echo "        Set QONTINUI_WEB_DIR env var to qontinui-web/backend path." >&2
+        exit 2
+    fi
+    (
+        cd "$QONTINUI_WEB_DIR"
+        # Container is on host network port 5433; assume that.
+        DATABASE_URL="postgresql://${PG_USER}:qontinui_dev_password@localhost:5433/${TEMP_DB}" \
+            python -m alembic upgrade head
+    )
+    DUMP_DB="$TEMP_DB"
+else
+    echo "[regen] Mode: default. Dumping $DB from $CONTAINER." >&2
+    DUMP_DB="$DB"
+fi
+
+# ---------------------------------------------------------------------
+# Header. Single quotes prevent shell expansion of the body.
+# ---------------------------------------------------------------------
+cat > "$TMP" <<'EOF'
+-- GENERATED FILE — do not hand-edit.
+-- Regenerate via: src-tauri/scripts/regenerate_schema_pg_sql.sh
+--
+-- Source: alembic-managed schema, dumped via pg_dump with
+--   --schema=project --schema=coord --schema=agent --schema=auth
+--   --schema=public --no-owner --no-privileges.
+--
+-- Consumers: Clorinde (validates queries/*.sql against this file).
+--
+-- Determinism: timestamp/runtime-context lines are stripped so two
+-- consecutive runs produce byte-equal output. CI gate fails if
+-- `git diff schema.pg.sql.generated` is non-empty after a fresh run.
+
+EOF
+
+# ---------------------------------------------------------------------
+# pg_dump → strip non-deterministic lines → append.
+# ---------------------------------------------------------------------
+# Pick docker-exec vs native pg_dump based on whether CLORINDE_PG_CONTAINER
+# is set to a non-empty value.
+#
+# Filter notes:
+# - `\restrict` / `\unrestrict` are pg_dump session tokens (PG 17+) used to
+#   scope restoration privileges. The token is regenerated on every run,
+#   so stripping them is required for byte-stable output. They're psql-meta
+#   commands, not DDL, so Clorinde doesn't need them.
+# - `-- Started on` / `-- Completed on` are pg_dump runtime timestamps;
+#   not present in every PG version but defensively stripped.
+if [[ -n "$CONTAINER" ]]; then
+    docker exec "$CONTAINER" pg_dump -U "$PG_USER" -d "$DUMP_DB" "${PG_DUMP_ARGS[@]}" \
+        | sed -e '/^-- Started on /d' \
+              -e '/^-- Completed on /d' \
+              -e '/^\\restrict /d' \
+              -e '/^\\unrestrict /d' \
+        >> "$TMP"
+else
+    pg_dump -h "$HOST" -p "$PORT" -U "$PG_USER" -d "$DUMP_DB" "${PG_DUMP_ARGS[@]}" \
+        | sed -e '/^-- Started on /d' \
+              -e '/^-- Completed on /d' \
+              -e '/^\\restrict /d' \
+              -e '/^\\unrestrict /d' \
+        >> "$TMP"
+fi
+
+# pg_dump finishes with two trailing blank lines after "PostgreSQL
+# database dump complete". The repo's end-of-file-fixer pre-commit hook
+# strips trailing blank lines, leaving exactly one final newline. To
+# stay byte-stable across `regenerate` + `git commit` cycles, normalize
+# here: strip trailing blank lines, ensure exactly one final newline.
+python3 -c '
+import sys
+data = open(sys.argv[1], "rb").read()
+data = data.rstrip(b"\n") + b"\n"
+open(sys.argv[1], "wb").write(data)
+' "$TMP"
+
+mv "$TMP" "$OUTPUT"
+echo "[regen] Wrote: $(pwd)/$OUTPUT ($(wc -l < "$OUTPUT") lines)" >&2

--- a/src-tauri/scripts/regenerate_schema_pg_sql.sh
+++ b/src-tauri/scripts/regenerate_schema_pg_sql.sh
@@ -14,9 +14,9 @@
 # -----
 # Default (no flag): dump from a running canonical Postgres container.
 #   Expects the qontinui-canonical-postgres container to be up with
-#   schemas project/coord/agent/auth/public created and populated by
-#   the alembic chain (which, post-transplant, includes the
-#   _staged_consolidation/ revisions).
+#   schemas project/coord/agent/auth/cloud/public created and
+#   populated by the alembic chain (which post-transplant includes
+#   the consolidation revisions formerly in _staged_consolidation/).
 #
 # --fresh-temp-db: create a throwaway database inside the same container,
 #   apply alembic upgrade head into it from qontinui-web/backend, dump
@@ -56,7 +56,7 @@ HOST="${CLORINDE_PG_HOST:-localhost}"
 PORT="${CLORINDE_PG_PORT:-5433}"
 DB="${CLORINDE_PG_DB:-qontinui_db}"
 PG_USER="${CLORINDE_PG_USER:-qontinui_user}"
-SCHEMAS=(project coord agent auth public)
+SCHEMAS=(project coord agent auth cloud public)
 
 # Default to relative path; can be overridden by env.
 QONTINUI_WEB_DIR="${QONTINUI_WEB_DIR:-../../../qontinui-web/backend}"
@@ -124,7 +124,7 @@ cat > "$TMP" <<'EOF'
 --
 -- Source: alembic-managed schema, dumped via pg_dump with
 --   --schema=project --schema=coord --schema=agent --schema=auth
---   --schema=public --no-owner --no-privileges.
+--   --schema=cloud --schema=public --no-owner --no-privileges.
 --
 -- Consumers: Clorinde (validates queries/*.sql against this file).
 --

--- a/src-tauri/src/database/pg/cached_specs.rs
+++ b/src-tauri/src/database/pg/cached_specs.rs
@@ -34,7 +34,7 @@ impl PgDb {
         let now = chrono::Utc::now();
 
         conn.execute(
-            r#"INSERT INTO cached_app_specs (id, app_url, app_name, spec_id, spec_json, discovered_at, page_url)
+            r#"INSERT INTO agent.cached_app_specs (id, app_url, app_name, spec_id, spec_json, discovered_at, page_url)
                VALUES ($1, $2, $3, $4, $5, $6, $7)
                ON CONFLICT (id) DO UPDATE SET
                    app_name = EXCLUDED.app_name,
@@ -63,7 +63,7 @@ impl PgDb {
         let rows = conn
             .query(
                 r#"SELECT id, app_url, app_name, spec_id, spec_json, discovered_at, page_url
-                   FROM cached_app_specs
+                   FROM agent.cached_app_specs
                    WHERE app_url = $1
                    ORDER BY spec_id"#,
                 &[&app_url],
@@ -96,7 +96,7 @@ impl PgDb {
         let rows = conn
             .query(
                 r#"SELECT id, app_url, app_name, spec_id, spec_json, discovered_at, page_url
-                   FROM cached_app_specs
+                   FROM agent.cached_app_specs
                    ORDER BY app_url, spec_id"#,
                 &[],
             )
@@ -127,7 +127,7 @@ impl PgDb {
 
         let deleted = conn
             .execute(
-                "DELETE FROM cached_app_specs WHERE app_url = $1",
+                "DELETE FROM agent.cached_app_specs WHERE app_url = $1",
                 &[&app_url],
             )
             .await

--- a/src-tauri/src/database/pg/coordinator_decisions.rs
+++ b/src-tauri/src/database/pg/coordinator_decisions.rs
@@ -92,7 +92,7 @@ impl PgDb {
             .query_one(
                 &format!(
                     r#"
-                    INSERT INTO coordinator_decisions
+                    INSERT INTO coord.coordinator_decisions
                         (session_id, iteration, rule, action, target_id,
                          reasoning, auto_acted)
                     VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -130,7 +130,7 @@ impl PgDb {
         let row = conn
             .query_opt(
                 &format!(
-                    "SELECT {} FROM coordinator_decisions WHERE id = $1::uuid",
+                    "SELECT {} FROM coord.coordinator_decisions WHERE id = $1::uuid",
                     SELECT_COLS
                 ),
                 &[&decision_id],
@@ -163,7 +163,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM coordinator_decisions
+                    FROM coord.coordinator_decisions
                     WHERE ($2::text IS NULL OR rule = $2)
                       AND ($3::text IS NULL OR action = $3)
                     ORDER BY created_at DESC
@@ -196,7 +196,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM coordinator_decisions
+                    FROM coord.coordinator_decisions
                     WHERE session_id = $1
                     ORDER BY created_at DESC
                     LIMIT $2
@@ -226,7 +226,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM coordinator_decisions
+                    FROM coord.coordinator_decisions
                     WHERE resolved = FALSE
                       AND auto_acted = FALSE
                       AND action IN ('escalate', 'kill-session', 'force-promote-to-worktree')
@@ -259,7 +259,7 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                UPDATE coordinator_decisions
+                UPDATE coord.coordinator_decisions
                 SET resolved = TRUE,
                     resolution = $2,
                     resolved_at = NOW()

--- a/src-tauri/src/database/pg/coordinator_leader.rs
+++ b/src-tauri/src/database/pg/coordinator_leader.rs
@@ -1,4 +1,4 @@
-//! PostgreSQL CRUD for the `coordinator_leader` singleton (migration v29).
+//! PostgreSQL CRUD for the `coord.coordinator_leader` singleton (migration v29).
 //!
 //! Per productivity-stack §6 ("Multi-instance awareness"), only one
 //! `/coordinate` session may run at a time across the runner's PG-shared
@@ -58,19 +58,19 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                INSERT INTO coordinator_leader (id, instance_id, leased_until, acquired_at, renewed_at)
+                INSERT INTO coord.coordinator_leader (id, instance_id, leased_until, acquired_at, renewed_at)
                 VALUES (TRUE, $1, NOW() + ($2::bigint || ' seconds')::interval, NOW(), NOW())
                 ON CONFLICT (id) DO UPDATE
                     SET instance_id   = EXCLUDED.instance_id,
                         leased_until  = EXCLUDED.leased_until,
                         acquired_at   = CASE
-                            WHEN coordinator_leader.instance_id = EXCLUDED.instance_id
-                                THEN coordinator_leader.acquired_at
+                            WHEN coord.coordinator_leader.instance_id = EXCLUDED.instance_id
+                                THEN coord.coordinator_leader.acquired_at
                             ELSE NOW()
                         END,
                         renewed_at    = NOW()
-                    WHERE coordinator_leader.leased_until <= NOW()
-                       OR coordinator_leader.instance_id = EXCLUDED.instance_id
+                    WHERE coord.coordinator_leader.leased_until <= NOW()
+                       OR coord.coordinator_leader.instance_id = EXCLUDED.instance_id
                 "#,
                 &[&instance_id, &ttl_seconds],
             )
@@ -97,7 +97,7 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                UPDATE coordinator_leader
+                UPDATE coord.coordinator_leader
                 SET leased_until = NOW() + ($2::bigint || ' seconds')::interval,
                     renewed_at   = NOW()
                 WHERE id = TRUE
@@ -128,7 +128,7 @@ impl PgDb {
                        leased_until::text,
                        acquired_at::text,
                        renewed_at::text
-                FROM coordinator_leader
+                FROM coord.coordinator_leader
                 WHERE id = TRUE
                 "#,
                 &[],

--- a/src-tauri/src/database/pg/instances.rs
+++ b/src-tauri/src/database/pg/instances.rs
@@ -1,4 +1,4 @@
-//! PostgreSQL runner_instances operations for multi-instance coordination.
+//! PostgreSQL coord.runner_instances operations for multi-instance coordination.
 
 use super::PgDb;
 use serde::Serialize;
@@ -41,7 +41,7 @@ impl PgDb {
         // Remove any stale entry on the same port (from a previous runner with a different id)
         // before upserting. This avoids a unique-constraint violation on the port column.
         conn.execute(
-            "DELETE FROM runner_instances WHERE port = $1 AND id != $2",
+            "DELETE FROM coord.runner_instances WHERE port = $1 AND id != $2",
             &[
                 &port_i32 as &(dyn tokio_postgres::types::ToSql + Sync),
                 &id as &(dyn tokio_postgres::types::ToSql + Sync),
@@ -52,7 +52,7 @@ impl PgDb {
 
         conn.execute(
             r#"
-            INSERT INTO runner_instances (id, name, port, hostname, is_primary, pid, status, last_heartbeat, started_at, running_tasks)
+            INSERT INTO coord.runner_instances (id, name, port, hostname, is_primary, pid, status, last_heartbeat, started_at, running_tasks)
             VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW(), 0)
             ON CONFLICT (id) DO UPDATE SET
                 name = EXCLUDED.name,
@@ -92,7 +92,7 @@ impl PgDb {
                 r#"
                 SELECT id, name, port, hostname, is_primary, pid, status,
                        last_heartbeat::TEXT, started_at::TEXT, running_tasks
-                FROM runner_instances
+                FROM coord.runner_instances
                 ORDER BY is_primary DESC, port ASC
                 "#,
                 &[],
@@ -126,7 +126,7 @@ impl PgDb {
             .map_err(|e| format!("PG pool error: {}", e))?;
 
         let count = conn
-            .execute("DELETE FROM runner_instances WHERE id = $1", &[&id])
+            .execute("DELETE FROM coord.runner_instances WHERE id = $1", &[&id])
             .await
             .map_err(|e| format!("PG remove_runner_instance: {}", e))?;
 
@@ -150,7 +150,7 @@ impl PgDb {
         let count = conn
             .execute(
                 r#"
-                UPDATE runner_instances
+                UPDATE coord.runner_instances
                 SET last_heartbeat = NOW(),
                     status = $2,
                     running_tasks = COALESCE($3, running_tasks)
@@ -183,7 +183,7 @@ impl PgDb {
         let count = conn
             .execute(
                 r#"
-                UPDATE runner_instances
+                UPDATE coord.runner_instances
                 SET status = 'unhealthy'
                 WHERE status = 'healthy'
                   AND is_primary = FALSE
@@ -212,7 +212,7 @@ impl PgDb {
         let count = conn
             .execute(
                 r#"
-                DELETE FROM runner_instances
+                DELETE FROM coord.runner_instances
                 WHERE status IN ('stopped', 'unhealthy')
                   AND last_heartbeat < NOW() - ($1 * INTERVAL '1 second')
                 "#,

--- a/src-tauri/src/database/pg/memory_query_cache.rs
+++ b/src-tauri/src/database/pg/memory_query_cache.rs
@@ -20,7 +20,7 @@ impl PgDb {
 
         let row = conn
             .query_opt(
-                "UPDATE memory_query_cache
+                "UPDATE agent.memory_query_cache
                  SET hit_count = hit_count + 1
                  WHERE query_hash = $1 AND reasoning_level = $2 AND expires_at > NOW()
                  RETURNING result_json",
@@ -47,7 +47,7 @@ impl PgDb {
             .map_err(|e| format!("PG pool error: {}", e))?;
 
         conn.execute(
-            "INSERT INTO memory_query_cache (query_hash, reasoning_level, result_json, expires_at)
+            "INSERT INTO agent.memory_query_cache (query_hash, reasoning_level, result_json, expires_at)
              VALUES ($1, $2, $3, NOW() + ($4 || ' minutes')::INTERVAL)
              ON CONFLICT (query_hash, reasoning_level)
              DO UPDATE SET result_json = EXCLUDED.result_json,
@@ -77,7 +77,7 @@ impl PgDb {
 
         let deleted = conn
             .execute(
-                "DELETE FROM memory_query_cache WHERE expires_at <= NOW()",
+                "DELETE FROM agent.memory_query_cache WHERE expires_at <= NOW()",
                 &[],
             )
             .await

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -1470,7 +1470,7 @@ impl PgDb {
             .max_size(8)
             .post_create(deadpool_postgres::Hook::async_fn(|conn, _| {
                 Box::pin(async move {
-                    conn.simple_query("SET search_path TO runner, public")
+                    conn.simple_query("SET search_path TO project, public")
                         .await
                         .map_err(|e| {
                             deadpool_postgres::HookError::Message(

--- a/src-tauri/src/database/pg/plans.rs
+++ b/src-tauri/src/database/pg/plans.rs
@@ -55,7 +55,7 @@ impl PgDb {
         let row = conn
             .query_one(
                 r#"
-                INSERT INTO plans (markdown_path, version_hash, status, title, summary)
+                INSERT INTO coord.plans (markdown_path, version_hash, status, title, summary)
                 VALUES ($1, $2, $3, $4, $5)
                 RETURNING id::text, markdown_path, version_hash, status, title, summary,
                           created_at::text, updated_at::text
@@ -97,7 +97,7 @@ impl PgDb {
                 r#"
                 SELECT id::text, markdown_path, version_hash, status, title, summary,
                        created_at::text, updated_at::text
-                FROM plans
+                FROM coord.plans
                 WHERE markdown_path = $1
                 "#,
                 &[&markdown_path],
@@ -130,7 +130,7 @@ impl PgDb {
                 r#"
                 SELECT id::text, markdown_path, version_hash, status, title, summary,
                        created_at::text, updated_at::text
-                FROM plans
+                FROM coord.plans
                 WHERE id = $1::uuid
                 "#,
                 &[&plan_id],
@@ -175,14 +175,14 @@ impl PgDb {
             r#"
             SELECT id::text, markdown_path, version_hash, status, title, summary,
                    created_at::text, updated_at::text
-            FROM plans
+            FROM coord.plans
             ORDER BY created_at DESC
             "#
         } else {
             r#"
             SELECT id::text, markdown_path, version_hash, status, title, summary,
                    created_at::text, updated_at::text
-            FROM plans
+            FROM coord.plans
             WHERE status NOT IN ('done', 'abandoned')
             ORDER BY created_at DESC
             "#
@@ -227,7 +227,7 @@ impl PgDb {
 
         let task_count: i64 = conn
             .query_one(
-                "SELECT COUNT(*)::bigint FROM tasks WHERE plan_id = $1::uuid",
+                "SELECT COUNT(*)::bigint FROM coord.tasks WHERE plan_id = $1::uuid",
                 &[&plan_id],
             )
             .await
@@ -253,7 +253,7 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                UPDATE plans
+                UPDATE coord.plans
                 SET status = $2, updated_at = NOW()
                 WHERE id = $1::uuid
                 "#,
@@ -277,7 +277,7 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                DELETE FROM plans WHERE id = $1::uuid
+                DELETE FROM coord.plans WHERE id = $1::uuid
                 "#,
                 &[&plan_id],
             )

--- a/src-tauri/src/database/pg/process_sessions.rs
+++ b/src-tauri/src/database/pg/process_sessions.rs
@@ -25,7 +25,7 @@ impl PgDb {
 
         conn.execute(
             r#"
-            INSERT INTO process_sessions (id, process_config_id, process_name, started_at, state)
+            INSERT INTO coord.process_sessions (id, process_config_id, process_name, started_at, state)
             VALUES ($1, $2, $3, $4, 'running')
             "#,
             &[&id, &config_id, &name, &now],
@@ -54,7 +54,7 @@ impl PgDb {
 
         conn.execute(
             r#"
-            UPDATE process_sessions
+            UPDATE coord.process_sessions
             SET stopped_at = $1, state = $2, exit_code = $3, error_count = $4
             WHERE id = $5
             "#,
@@ -89,7 +89,7 @@ impl PgDb {
             conn.query(
                 r#"
                 SELECT id, process_config_id, process_name, started_at, stopped_at, exit_code, state, error_count
-                FROM process_sessions
+                FROM coord.process_sessions
                 WHERE process_config_id = $1
                 ORDER BY started_at DESC
                 LIMIT $2
@@ -101,7 +101,7 @@ impl PgDb {
             conn.query(
                 r#"
                 SELECT id, process_config_id, process_name, started_at, stopped_at, exit_code, state, error_count
-                FROM process_sessions
+                FROM coord.process_sessions
                 ORDER BY started_at DESC
                 LIMIT $1
                 "#,
@@ -152,7 +152,7 @@ impl PgDb {
         // Build a single INSERT with N value tuples: ($1,$2,$3,$4),($5,$6,$7,$8),...
         // Each row has 4 params: session_id, timestamp, stream, line.
         let mut sql = String::from(
-            "INSERT INTO process_session_output (session_id, timestamp, stream, line) VALUES ",
+            "INSERT INTO coord.process_session_output (session_id, timestamp, stream, line) VALUES ",
         );
         let mut params: Vec<&(dyn tokio_postgres::types::ToSql + Sync)> = Vec::new();
         for (i, (timestamp, stream, line)) in lines.iter().enumerate() {
@@ -199,7 +199,7 @@ impl PgDb {
             .query(
                 r#"
                 SELECT id, session_id, timestamp, stream, line
-                FROM process_session_output
+                FROM coord.process_session_output
                 WHERE session_id = $1
                 ORDER BY id ASC
                 LIMIT $2 OFFSET $3
@@ -244,7 +244,7 @@ impl PgDb {
         let session_row = conn
             .query_opt(
                 r#"
-                SELECT id FROM process_sessions
+                SELECT id FROM coord.process_sessions
                 WHERE process_name = $1
                   AND started_at <= $2::timestamptz
                   AND (stopped_at IS NULL OR stopped_at >= $2::timestamptz)
@@ -271,7 +271,7 @@ impl PgDb {
                 r#"
                 (
                     SELECT id, session_id, timestamp, stream, line
-                    FROM process_session_output
+                    FROM coord.process_session_output
                     WHERE session_id = $1
                       AND timestamp <= $2
                     ORDER BY id DESC
@@ -280,7 +280,7 @@ impl PgDb {
                 UNION ALL
                 (
                     SELECT id, session_id, timestamp, stream, line
-                    FROM process_session_output
+                    FROM coord.process_session_output
                     WHERE session_id = $1
                       AND timestamp > $2
                     ORDER BY id ASC
@@ -329,8 +329,8 @@ impl PgDb {
                 r#"
                 SELECT pso.id, pso.session_id, pso.timestamp, pso.stream, pso.line,
                        ps.process_config_id, ps.process_name
-                FROM process_session_output pso
-                JOIN process_sessions ps ON pso.session_id = ps.id
+                FROM coord.process_session_output pso
+                JOIN coord.process_sessions ps ON pso.session_id = ps.id
                 WHERE pso.line ILIKE $1
                   AND ps.process_config_id = $2
                 ORDER BY pso.id DESC
@@ -344,8 +344,8 @@ impl PgDb {
                 r#"
                 SELECT pso.id, pso.session_id, pso.timestamp, pso.stream, pso.line,
                        ps.process_config_id, ps.process_name
-                FROM process_session_output pso
-                JOIN process_sessions ps ON pso.session_id = ps.id
+                FROM coord.process_session_output pso
+                JOIN coord.process_sessions ps ON pso.session_id = ps.id
                 WHERE pso.line ILIKE $1
                 ORDER BY pso.id DESC
                 LIMIT $2
@@ -398,7 +398,7 @@ impl PgDb {
         let now = Utc::now().to_rfc3339();
         let affected = conn
             .execute(
-                "UPDATE process_sessions \
+                "UPDATE coord.process_sessions \
                  SET state = 'failed', \
                      stopped_at = COALESCE(stopped_at, $1::timestamptz) \
                  WHERE state NOT IN ('stopped', 'failed') \
@@ -423,7 +423,7 @@ impl PgDb {
         let days = retention_days as f64;
         let affected = conn
             .execute(
-                "DELETE FROM process_sessions \
+                "DELETE FROM coord.process_sessions \
                  WHERE started_at < NOW() - ($1 || ' days')::interval",
                 &[&days.to_string()],
             )
@@ -449,10 +449,10 @@ impl PgDb {
         let affected = conn
             .execute(
                 r#"
-                DELETE FROM process_session_output
+                DELETE FROM coord.process_session_output
                 WHERE session_id = $1
                 AND id NOT IN (
-                    SELECT id FROM process_session_output
+                    SELECT id FROM coord.process_session_output
                     WHERE session_id = $1
                     ORDER BY id DESC
                     LIMIT $2

--- a/src-tauri/src/database/pg/reviews.rs
+++ b/src-tauri/src/database/pg/reviews.rs
@@ -149,7 +149,7 @@ impl PgDb {
             .query_one(
                 &format!(
                     r#"
-                    INSERT INTO reviews (
+                    INSERT INTO coord.reviews (
                         task_id, reviewer_session_id, reviewed_session_id,
                         verdict, confidence, reasoning,
                         diff_summary, test_results
@@ -188,7 +188,7 @@ impl PgDb {
 
         let row = conn
             .query_opt(
-                &format!("SELECT {} FROM reviews WHERE id = $1::uuid", SELECT_COLS),
+                &format!("SELECT {} FROM coord.reviews WHERE id = $1::uuid", SELECT_COLS),
                 &[&review_id],
             )
             .await
@@ -215,7 +215,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM reviews
+                    FROM coord.reviews
                     WHERE reviewed_session_id = $1
                     ORDER BY created_at DESC
                     LIMIT 1
@@ -244,7 +244,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM reviews
+                    FROM coord.reviews
                     WHERE task_id = $1::uuid
                     ORDER BY created_at DESC
                     "#,
@@ -277,7 +277,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM reviews
+                    FROM coord.reviews
                     WHERE created_at >= NOW() - make_interval(secs => $1::double precision)
                     ORDER BY created_at DESC
                     LIMIT $2
@@ -305,7 +305,7 @@ impl PgDb {
             .query_one(
                 r#"
                 SELECT COUNT(*)::bigint
-                FROM reviews
+                FROM coord.reviews
                 WHERE task_id = $1::uuid AND verdict = 'needs_fix'
                 "#,
                 &[&task_id],
@@ -331,7 +331,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM reviews
+                    FROM coord.reviews
                     WHERE verdict = 'approved'
                       AND confidence >= 0.7
                       AND confidence < 0.85
@@ -371,7 +371,7 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                UPDATE reviews
+                UPDATE coord.reviews
                 SET user_decision = $2,
                     user_decided_at = NOW()
                 WHERE id = $1::uuid

--- a/src-tauri/src/database/pg/session_file_snapshots.rs
+++ b/src-tauri/src/database/pg/session_file_snapshots.rs
@@ -76,7 +76,7 @@ impl PgDb {
             .query_one(
                 &format!(
                     r#"
-                    INSERT INTO session_file_snapshots
+                    INSERT INTO coord.session_file_snapshots
                         (session_id, file_path, snapshot_blob_path, blob_sha256,
                          captured_before)
                     VALUES ($1, $2, $3, $4, $5)
@@ -115,7 +115,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM session_file_snapshots
+                    FROM coord.session_file_snapshots
                     WHERE session_id = $1
                     ORDER BY taken_at ASC
                     "#,
@@ -149,7 +149,7 @@ impl PgDb {
             .query_one(
                 r#"
                 SELECT EXISTS(
-                    SELECT 1 FROM session_file_snapshots
+                    SELECT 1 FROM coord.session_file_snapshots
                     WHERE session_id = $1
                       AND file_path = $2
                       AND captured_before = TRUE
@@ -187,7 +187,7 @@ impl PgDb {
             .query(
                 r#"
                 SELECT id::text, snapshot_blob_path
-                FROM session_file_snapshots
+                FROM coord.session_file_snapshots
                 WHERE taken_at < NOW() - ($1 || ' days')::interval
                 "#,
                 &[&days.to_string()],
@@ -217,7 +217,7 @@ impl PgDb {
         let deleted =
             conn.execute(
                 r#"
-                DELETE FROM session_file_snapshots
+                DELETE FROM coord.session_file_snapshots
                 WHERE taken_at < NOW() - ($1 || ' days')::interval
                 "#,
                 &[&days.to_string()],

--- a/src-tauri/src/database/pg/session_touched_files.rs
+++ b/src-tauri/src/database/pg/session_touched_files.rs
@@ -44,7 +44,7 @@ impl PgDb {
         // into a worktree mid-flight (Phase 2 promote method); the latest
         // observed scope wins.
         conn.execute(
-            r#"INSERT INTO session_touched_files
+            r#"INSERT INTO coord.session_touched_files
                    (task_run_id, file_path, worktree_id, recorded_at)
                VALUES ($1, $2, $3, NOW())
                ON CONFLICT (task_run_id, file_path) DO UPDATE
@@ -72,7 +72,7 @@ impl PgDb {
         let rows = conn
             .query(
                 r#"SELECT file_path
-                   FROM session_touched_files
+                   FROM coord.session_touched_files
                    WHERE task_run_id = $1
                    ORDER BY recorded_at ASC, file_path ASC"#,
                 &[&task_run_id],
@@ -109,7 +109,7 @@ impl PgDb {
         let rows = conn
             .query(
                 r#"SELECT file_path, task_run_id
-                   FROM session_touched_files
+                   FROM coord.session_touched_files
                    WHERE file_path = ANY($1)
                    ORDER BY recorded_at DESC, file_path ASC"#,
                 &[&file_paths],
@@ -135,7 +135,7 @@ impl PgDb {
 
         let n = conn
             .execute(
-                "DELETE FROM session_touched_files WHERE task_run_id = $1",
+                "DELETE FROM coord.session_touched_files WHERE task_run_id = $1",
                 &[&task_run_id],
             )
             .await
@@ -338,7 +338,7 @@ mod tests {
         let conn = db.pool().get().await.expect("pool");
         let rows = conn
             .query(
-                "SELECT file_path, worktree_id FROM session_touched_files \
+                "SELECT file_path, worktree_id FROM coord.session_touched_files \
                  WHERE task_run_id = $1 ORDER BY file_path ASC",
                 &[&task_run_id],
             )
@@ -381,7 +381,7 @@ mod tests {
         let conn = db.pool().get().await.unwrap();
         let row = conn
             .query_one(
-                "SELECT worktree_id FROM session_touched_files \
+                "SELECT worktree_id FROM coord.session_touched_files \
                  WHERE task_run_id = $1 AND file_path = $2",
                 &[&task_run_id, &"/repo/promoted.rs"],
             )

--- a/src-tauri/src/database/pg/tasks.rs
+++ b/src-tauri/src/database/pg/tasks.rs
@@ -117,7 +117,7 @@ impl PgDb {
             .query_one(
                 &format!(
                     r#"
-                    INSERT INTO tasks (
+                    INSERT INTO coord.tasks (
                         plan_id, plan_version_hash, phase_name, sequence_in_phase,
                         description, expected_file_claims, expected_dirs,
                         depends_on, status, notes
@@ -161,7 +161,7 @@ impl PgDb {
         let row = conn
             .query_opt(
                 &format!(
-                    "SELECT {} FROM tasks WHERE id = $1::uuid",
+                    "SELECT {} FROM coord.tasks WHERE id = $1::uuid",
                     SELECT_TASK_COLUMNS
                 ),
                 &[&task_id],
@@ -185,7 +185,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM tasks
+                    FROM coord.tasks
                     WHERE plan_id = $1::uuid
                     ORDER BY phase_name, sequence_in_phase
                     "#,
@@ -213,7 +213,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM tasks
+                    FROM coord.tasks
                     WHERE plan_id = $1::uuid
                       AND status = ANY($2::text[])
                     ORDER BY phase_name, sequence_in_phase
@@ -242,7 +242,7 @@ impl PgDb {
                 &format!(
                     r#"
                     SELECT {}
-                    FROM tasks
+                    FROM coord.tasks
                     WHERE status = ANY($1::text[])
                     ORDER BY created_at ASC
                     "#,
@@ -271,14 +271,14 @@ impl PgDb {
         let rows = conn
             .query(
                 r#"
-                UPDATE tasks t
+                UPDATE coord.tasks t
                 SET status = 'ready', updated_at = NOW()
                 WHERE t.plan_id = $1::uuid
                   AND t.status = 'pending'
                   AND NOT EXISTS (
                       SELECT 1 FROM unnest(t.depends_on) AS dep_id
                       WHERE NOT EXISTS (
-                          SELECT 1 FROM tasks d
+                          SELECT 1 FROM coord.tasks d
                           WHERE d.id = dep_id AND d.status = 'done'
                       )
                   )
@@ -312,7 +312,7 @@ impl PgDb {
         let n = conn
             .execute(
                 r#"
-                UPDATE tasks
+                UPDATE coord.tasks
                 SET assigned_session_id = $2,
                     status = CASE WHEN status IN ('ready', 'needs_fix')
                                   THEN 'assigned' ELSE status END,
@@ -356,7 +356,7 @@ impl PgDb {
         let sql = match to {
             "running" => {
                 r#"
-                UPDATE tasks
+                UPDATE coord.tasks
                 SET status = $3,
                     started_at = COALESCE(started_at, NOW()),
                     updated_at = NOW()
@@ -365,7 +365,7 @@ impl PgDb {
             }
             "done" | "cancelled" => {
                 r#"
-                UPDATE tasks
+                UPDATE coord.tasks
                 SET status = $3,
                     completed_at = NOW(),
                     updated_at = NOW()
@@ -374,7 +374,7 @@ impl PgDb {
             }
             _ => {
                 r#"
-                UPDATE tasks
+                UPDATE coord.tasks
                 SET status = $3, updated_at = NOW()
                 WHERE id = $1::uuid AND status = $2
                 "#

--- a/src-tauri/src/database/pg/worktrees.rs
+++ b/src-tauri/src/database/pg/worktrees.rs
@@ -18,7 +18,7 @@ impl PgDb {
             conn.query(
                 r#"SELECT id, worktree_path, branch_name, source_branch, source_commit,
                           repo_path, task_run_id, workflow_name, status, created_at, updated_at
-                   FROM worktrees WHERE status = $1 ORDER BY created_at DESC"#,
+                   FROM coord.worktrees WHERE status = $1 ORDER BY created_at DESC"#,
                 &[&s],
             )
             .await
@@ -27,7 +27,7 @@ impl PgDb {
             conn.query(
                 r#"SELECT id, worktree_path, branch_name, source_branch, source_commit,
                           repo_path, task_run_id, workflow_name, status, created_at, updated_at
-                   FROM worktrees ORDER BY created_at DESC"#,
+                   FROM coord.worktrees ORDER BY created_at DESC"#,
                 &[],
             )
             .await
@@ -70,7 +70,7 @@ impl PgDb {
         let status_str = record.status.to_string();
 
         conn.execute(
-            r#"INSERT INTO worktrees
+            r#"INSERT INTO coord.worktrees
                (id, worktree_path, branch_name, source_branch, source_commit, repo_path,
                 task_run_id, workflow_name, status, created_at, updated_at)
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10::timestamptz, $11::timestamptz)"#,

--- a/src-tauri/src/mcp/api_surface_diff.rs
+++ b/src-tauri/src/mcp/api_surface_diff.rs
@@ -143,7 +143,7 @@ async fn handle_save_snapshot(
 
     let row = conn
         .query_one(
-            "INSERT INTO api_surface_snapshots (scan_json, summary, total_endpoints, orphan_count) \
+            "INSERT INTO agent.api_surface_snapshots (scan_json, summary, total_endpoints, orphan_count) \
              VALUES ($1, $2, $3, $4) RETURNING id, created_at::text",
             &[&scan_json, &summary, &total_endpoints, &orphan_count],
         )
@@ -207,7 +207,7 @@ async fn handle_list_snapshots(
     let rows = conn
         .query(
             "SELECT id, total_endpoints, orphan_count, summary, created_at::text \
-             FROM api_surface_snapshots ORDER BY created_at DESC LIMIT 50",
+             FROM agent.api_surface_snapshots ORDER BY created_at DESC LIMIT 50",
             &[],
         )
         .await
@@ -250,7 +250,7 @@ async fn load_latest_snapshot(pg: &crate::database::pg::PgDb) -> Option<ApiSurfa
     let conn = pg.pool().get().await.ok()?;
     let row = conn
         .query_opt(
-            "SELECT scan_json FROM api_surface_snapshots ORDER BY created_at DESC LIMIT 1",
+            "SELECT scan_json FROM agent.api_surface_snapshots ORDER BY created_at DESC LIMIT 1",
             &[],
         )
         .await

--- a/src-tauri/src/mcp/plans.rs
+++ b/src-tauri/src/mcp/plans.rs
@@ -138,13 +138,13 @@ async fn decompose_plan(
     let plan_row = txn
         .query_one(
             r#"
-            INSERT INTO plans (markdown_path, version_hash, status, title, summary)
+            INSERT INTO coord.plans (markdown_path, version_hash, status, title, summary)
             VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (markdown_path) DO UPDATE
                 SET version_hash = EXCLUDED.version_hash,
                     status       = EXCLUDED.status,
-                    title        = COALESCE(EXCLUDED.title, plans.title),
-                    summary      = COALESCE(EXCLUDED.summary, plans.summary),
+                    title        = COALESCE(EXCLUDED.title, coord.plans.title),
+                    summary      = COALESCE(EXCLUDED.summary, coord.plans.summary),
                     updated_at   = NOW()
             RETURNING id::text, version_hash
             "#,
@@ -168,7 +168,7 @@ async fn decompose_plan(
 
     // 2. Replace tasks for this plan. The cascade-on-delete also removes
     //    any review/snapshot rows once those tables exist (later phases).
-    txn.execute("DELETE FROM tasks WHERE plan_id = $1::uuid", &[&plan_id])
+    txn.execute("DELETE FROM coord.tasks WHERE plan_id = $1::uuid", &[&plan_id])
         .await
         .map_err(|e| {
             (
@@ -185,7 +185,7 @@ async fn decompose_plan(
         let row = txn
             .query_one(
                 r#"
-                INSERT INTO tasks (
+                INSERT INTO coord.tasks (
                     plan_id, plan_version_hash, phase_name, sequence_in_phase,
                     description, expected_file_claims, expected_dirs,
                     depends_on, status, notes
@@ -226,7 +226,7 @@ async fn decompose_plan(
             .collect();
         txn.execute(
             r#"
-            UPDATE tasks
+            UPDATE coord.tasks
             SET depends_on = (
                 SELECT COALESCE(array_agg(d::uuid), '{}'::uuid[])
                 FROM unnest($2::text[]) d
@@ -249,7 +249,7 @@ async fn decompose_plan(
     //    used elsewhere by mark_ready_for_unblocked, scoped to this plan.
     txn.execute(
         r#"
-        UPDATE tasks
+        UPDATE coord.tasks
         SET status = 'ready', updated_at = NOW()
         WHERE plan_id = $1::uuid
           AND status = 'pending'

--- a/src-tauri/src/mcp/reflection.rs
+++ b/src-tauri/src/mcp/reflection.rs
@@ -101,7 +101,7 @@ pub async fn compute_reflection(
                 COUNT(*)::bigint                                                AS total,
                 COUNT(*) FILTER (WHERE status = 'done')::bigint                 AS completed,
                 COUNT(*) FILTER (WHERE status = 'escalated')::bigint            AS escalated
-            FROM tasks
+            FROM coord.tasks
             WHERE plan_id = $1::uuid
             "#,
             &[&plan_id],
@@ -119,8 +119,8 @@ pub async fn compute_reflection(
         .query_one(
             r#"
             SELECT AVG(r.confidence)::float8 AS avg_conf
-            FROM reviews r
-            JOIN tasks  t ON t.id = r.task_id
+            FROM coord.reviews r
+            JOIN coord.tasks  t ON t.id = r.task_id
             WHERE t.plan_id = $1::uuid
             "#,
             &[&plan_id],
@@ -137,7 +137,7 @@ pub async fn compute_reflection(
             r#"
             SELECT COUNT(*)::bigint
             FROM productivity_knowledge k
-            JOIN tasks t ON t.id = k.task_id
+            JOIN coord.tasks t ON t.id = k.task_id
             WHERE t.plan_id = $1::uuid
             "#,
             &[&plan_id],
@@ -153,7 +153,7 @@ pub async fn compute_reflection(
             r#"
             SELECT k.id::text, k.area, k.summary
             FROM productivity_knowledge k
-            JOIN tasks t ON t.id = k.task_id
+            JOIN coord.tasks t ON t.id = k.task_id
             WHERE t.plan_id = $1::uuid
             ORDER BY k.created_at DESC
             LIMIT 5
@@ -177,8 +177,8 @@ pub async fn compute_reflection(
         .query(
             r#"
             SELECT r.id::text, r.task_id::text, r.verdict, r.confidence, r.created_at::text
-            FROM reviews r
-            JOIN tasks t ON t.id = r.task_id
+            FROM coord.reviews r
+            JOIN coord.tasks t ON t.id = r.task_id
             WHERE t.plan_id = $1::uuid
             ORDER BY r.created_at DESC
             "#,
@@ -276,7 +276,7 @@ pub async fn compute_plan_recommendations(
         .query(
             r#"
             SELECT DISTINCT assigned_session_id
-            FROM tasks
+            FROM coord.tasks
             WHERE assigned_session_id IS NOT NULL
               AND status IN ('assigned', 'running', 'review', 'needs_fix')
             "#,
@@ -302,7 +302,7 @@ pub async fn compute_plan_recommendations(
             .query_one(
                 r#"
                 SELECT COUNT(*)::bigint
-                FROM tasks
+                FROM coord.tasks
                 WHERE plan_id = $1::uuid
                   AND status IN ('ready', 'pending')
                   AND assigned_session_id IS NULL


### PR DESCRIPTION
## Summary

Runner-side companion to the qontinui-web transplant PR. Three logical pieces:

1. **Schema-rename audit applied (15 source files + search_path swap)**. Schema-qualifies SQL for tables that move out of the runner schema in the migration consolidation. Pairs with the search_path swap in `mod.rs:1473` (`runner` -> `project`) so consumer queries continue to resolve correctly post-transplant.

   - **coord.*** (12 files): runner_instances, coordinator_leader, coordinator_decisions, process_sessions / process_session_output, worktrees, session_touched_files, session_file_snapshots, plans, tasks, reviews; `mcp/plans.rs` and `mcp/reflection.rs`.
   - **agent.*** (3 files): cached_specs (cached_app_specs), memory_query_cache, mcp/api_surface_diff (api_surface_snapshots).
   - **search_path** (1 file): `database/pg/mod.rs:1473` deadpool post_create hook.

2. **Clorinde regen script + freshness CI workflow**:
   - `src-tauri/scripts/regenerate_schema_pg_sql.sh` — bash script with two backends (docker exec / native pg_dump) and two modes (default / `--fresh-temp-db`). Determinism: PG 17+ session tokens + timestamps stripped; output byte-stable across runs.
   - `.github/workflows/schema-pg-sql-fresh.yml` — CI gate that fails if `schema.pg.sql.generated` is stale relative to a fresh dump. Currently `workflow_dispatch` only; flip to `pull_request` post-transplant.

3. **Post-transplant `forbid-runner-schema` CI gate** — `.github/workflows/forbid-runner-schema.yml`. Two-pass grep (case-sensitive for `SCHEMA runner` / `FROM runner.` / `ForeignKey("runner.*")` / `schema="runner"`; case-insensitive for `SET search_path TO runner`). Excludes: `*.md`, `**/alembic/versions/`, `**/alembic/_staged_consolidation/`, `**/scripts/regenerate_schema_pg_sql.sh`, the workflow file itself, and `src-tauri/src/database/pg/mod.rs` (transitional — Phase 4 of the consolidation deletes the MIGRATIONS array; drop this exclude after Phase 4 lands).

### Regenerated artifact

`src-tauri/schema.pg.sql.generated` regenerated against the post-transplant canonical DB:
- Size: **705 KB** (was 89 KB pre-transplant — ~7x larger).
- Lines: **25,097** (was 3,370).
- Schemas covered: project + coord + agent + auth + cloud + public.
- Determinism: byte-equal across two consecutive runs.

### Dependency on qontinui-web transplant PR

The renamed queries reference tables in `coord.*`, `agent.*`, and the search_path expects `project` to exist. **Merge qontinui-web's transplant PR first** so the canonical schemas are in place. CI on this PR must run against a canonical-DB-aware setup; if CI doesn't include the consolidation chain, queries against `coord.tasks` etc. will fail at integration-test time.

## Test plan

- [x] `cargo check --bin qontinui-runner` exit 0 against rebased branch (4m40s).
- [x] Regen script byte-equal across two runs (`diff -q` exit 0).
- [x] First 30 lines of `schema.pg.sql.generated` confirm header + schema list + standard pg_dump prologue.
- [ ] CI must pass before merge.
- [ ] Integration: post-merge, runner queries against `coord.tasks` / `auth.users` / etc. should resolve correctly.

## Plan reference

`tmp_migration_consolidation_plan.md` (Phase 4 search_path swap, Phase 6 CI gates).