### PR TITLE
feat(profiles): canonical-DB topology profile loader + qontinui_profile CLI

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -1,0 +1,329 @@
+//! `qontinui_profile` — manage `~/.qontinui/profiles.json` from the CLI.
+//!
+//! Per topology plan §3 (`tmp_canonical_db_topology_plan.md`), every runner
+//! reads its DB / Redis / blob / coord-service connection from a profile in
+//! `~/.qontinui/profiles.json`. This binary lets a developer inspect, switch,
+//! and bootstrap that file without hand-editing JSON.
+//!
+//! ## Usage
+//!
+//! ```text
+//! qontinui_profile show                       # print the resolved active profile
+//! qontinui_profile list                       # list available profiles
+//! qontinui_profile use <name>                 # set the file's "active" field
+//! qontinui_profile init                       # write starter profiles.json (host=localhost)
+//! qontinui_profile init --host 192.168.1.x    # ... pointing at a remote canonical-stack host
+//! qontinui_profile path                       # print the profiles.json path
+//! ```
+//!
+//! `init --host` is the LAN-client setup path: an MSI laptop / third
+//! machine runs `qontinui_profile init --host <PC-LAN-IP>` once and is
+//! immediately wired into the PC's canonical Postgres + Redis + MinIO
+//! + coord service.
+//!
+//! Environment overrides (`QONTINUI_ENV`) still take precedence at runtime;
+//! `qontinui_profile use foo` only updates the file's stored default.
+//!
+//! Exit codes follow the convention used by `runner_coordination/runner_lock.py`:
+//! `0` success, `1` recoverable failure (e.g. profile not found), `2` error.
+
+use qontinui_runner_lib::profiles::{
+    load_strict, profiles_path, AuthConfig, BlobConfig, Profile, ProfilesFile,
+};
+use serde_json::json;
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+    let cmd = args.get(1).map(|s| s.as_str()).unwrap_or("show");
+
+    match cmd {
+        "show" => cmd_show(),
+        "list" => cmd_list(),
+        "use" => match args.get(2) {
+            Some(name) => cmd_use(name),
+            None => {
+                eprintln!("usage: qontinui_profile use <name>");
+                ExitCode::from(2)
+            }
+        },
+        "init" => {
+            // Parse `--host <ip>` if present; otherwise default to localhost.
+            // Position-independent so `init --host 1.2.3.4` and the
+            // accidentally-permuted `init` (no flag) both work.
+            let host = parse_host_arg(&args).unwrap_or_else(|| "localhost".to_string());
+            cmd_init(&host)
+        }
+        "path" => cmd_path(),
+        "help" | "-h" | "--help" => {
+            print_help();
+            ExitCode::SUCCESS
+        }
+        other => {
+            eprintln!("unknown command: {}", other);
+            print_help();
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn print_help() {
+    println!(
+        "qontinui_profile — manage ~/.qontinui/profiles.json\n\n\
+         Commands:\n\
+         \x20 show                       Print the resolved active profile\n\
+         \x20 list                       List profile names\n\
+         \x20 use <name>                 Set the file's 'active' field\n\
+         \x20 init [--host <ip>]         Write a starter profiles.json. Default host is\n\
+         \x20                            localhost (PC-local dev). Pass --host <PC-LAN-IP>\n\
+         \x20                            from a laptop / third machine to point at the PC.\n\
+         \x20 path                       Print the profiles.json path\n\
+         \x20 help                       Show this message\n"
+    );
+}
+
+/// Parse `--host <value>` out of an arg list. Position-independent.
+/// Returns None if the flag is absent; returns Some("") if `--host` is the
+/// last token (caller should treat that the same as default).
+fn parse_host_arg(args: &[String]) -> Option<String> {
+    let mut iter = args.iter();
+    while let Some(a) = iter.next() {
+        if a == "--host" {
+            return iter.next().cloned();
+        }
+    }
+    None
+}
+
+fn cmd_path() -> ExitCode {
+    match profiles_path() {
+        Some(p) => {
+            println!("{}", p.display());
+            ExitCode::SUCCESS
+        }
+        None => {
+            eprintln!("could not resolve home directory");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn cmd_show() -> ExitCode {
+    match load_strict() {
+        Ok(p) => {
+            // Redact secrets in display — same idea as `printenv` not
+            // dumping passwords. The DSN is shown as-is because that's the
+            // primary debugging signal; access keys and tokens get masked.
+            let mut blob_view = serde_json::Value::Null;
+            if let Some(b) = &p.blob {
+                blob_view = json!({
+                    "kind":     b.kind,
+                    "endpoint": b.endpoint,
+                    "region":   b.region,
+                    "bucket":   b.bucket,
+                    "access_key": b.access_key.as_ref().map(|_| "<set>"),
+                    "secret_key": b.secret_key.as_ref().map(|_| "<set>"),
+                });
+            }
+            let mut auth_view = serde_json::Value::Null;
+            if let Some(a) = &p.auth {
+                auth_view = json!({
+                    "kind":      a.kind,
+                    "issuer":    a.issuer,
+                    "client_id": a.client_id,
+                    "token":     a.token.as_ref().map(|_| "<set>"),
+                });
+            }
+            let out = json!({
+                "active":       p.source,
+                "database_url": p.database_url,
+                "redis_url":    p.redis_url,
+                "blob":         blob_view,
+                "coord_url":    p.coord_url,
+                "auth":         auth_view,
+            });
+            println!("{}", serde_json::to_string_pretty(&out).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {}", e);
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn cmd_list() -> ExitCode {
+    let path = match profiles_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("could not resolve home directory");
+            return ExitCode::from(2);
+        }
+    };
+    if !path.exists() {
+        eprintln!(
+            "profiles.json not found at {}\n\
+             Run 'qontinui_profile init' (PC-local) or 'qontinui_profile init --host <PC-LAN-IP>' (laptop / 3rd machine).",
+            path.display()
+        );
+        return ExitCode::from(1);
+    }
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("read failed: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let file: ProfilesFile = match serde_json::from_slice(&bytes) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("parse failed: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let active = file.active.as_deref().unwrap_or("(unset)");
+    let mut names: Vec<&str> = file.profiles.keys().map(|s| s.as_str()).collect();
+    names.sort();
+    for n in names {
+        let marker = if n == active { "*" } else { " " };
+        println!("{} {}", marker, n);
+    }
+    ExitCode::SUCCESS
+}
+
+fn cmd_use(name: &str) -> ExitCode {
+    let path = match profiles_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("could not resolve home directory");
+            return ExitCode::from(2);
+        }
+    };
+    if !path.exists() {
+        eprintln!(
+            "profiles.json not found at {}\n\
+             Run 'qontinui_profile init' (PC-local) or 'qontinui_profile init --host <PC-LAN-IP>' (laptop / 3rd machine).",
+            path.display()
+        );
+        return ExitCode::from(1);
+    }
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("read failed: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    let mut file: ProfilesFile = match serde_json::from_slice(&bytes) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("parse failed: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+    if !file.profiles.contains_key(name) {
+        let mut available: Vec<&str> = file.profiles.keys().map(|s| s.as_str()).collect();
+        available.sort();
+        eprintln!(
+            "profile '{}' not found. Available: {}",
+            name,
+            available.join(", ")
+        );
+        return ExitCode::from(1);
+    }
+    file.active = Some(name.to_string());
+    if let Err(e) = atomic_write(&path, &file) {
+        eprintln!("write failed: {}", e);
+        return ExitCode::from(2);
+    }
+    println!("active profile set to '{}'", name);
+    ExitCode::SUCCESS
+}
+
+fn cmd_init(host: &str) -> ExitCode {
+    let path = match profiles_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("could not resolve home directory");
+            return ExitCode::from(2);
+        }
+    };
+    if path.exists() {
+        eprintln!(
+            "profiles.json already exists at {} — refusing to overwrite. \
+             Edit by hand, or `rm {}` and re-run.",
+            path.display(),
+            path.display()
+        );
+        return ExitCode::from(1);
+    }
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("mkdir {} failed: {}", parent.display(), e);
+            return ExitCode::from(2);
+        }
+    }
+    let dev = Profile {
+        // Defaults match qontinui-stack/.env.example. `host` defaults to
+        // `localhost` for PC-local dev; LAN clients pass `--host <PC-IP>`.
+        database_url: Some(format!(
+            "host={host} port=5433 user=qontinui_user password=qontinui_dev_password dbname=qontinui_db"
+        )),
+        redis_url: Some(format!("redis://:qontinui_dev_redis@{host}:6380/0")),
+        blob: Some(BlobConfig {
+            kind: "s3-compatible".to_string(),
+            endpoint: Some(format!("http://{host}:9100")),
+            region: Some("us-east-1".to_string()),
+            access_key: Some("minioadmin".to_string()),
+            secret_key: Some("minioadmin".to_string()),
+            bucket: Some("qontinui-dev".to_string()),
+        }),
+        // Coord service runs at qontinui-stack's :9870 — see qontinui-coord.
+        // ws:// (not wss://) for dev because there's no TLS termination on
+        // the LAN. AWS staging flips to wss:// via the ALB.
+        coord_url: Some(format!("ws://{host}:9870/ws")),
+        auth: Some(AuthConfig {
+            kind: "static-dev-token".to_string(),
+            token: Some("dev-token-replace-me".to_string()),
+            issuer: None,
+            client_id: None,
+        }),
+    };
+    let mut profiles = HashMap::new();
+    profiles.insert("dev".to_string(), dev);
+    let file = ProfilesFile {
+        active: Some("dev".to_string()),
+        profiles,
+    };
+    if let Err(e) = atomic_write(&path, &file) {
+        eprintln!("write failed: {}", e);
+        return ExitCode::from(2);
+    }
+    println!(
+        "wrote starter profiles.json to {}\n\
+         active profile: dev (host={host}, ports 5433/6380/9100/9870)",
+        path.display()
+    );
+    if host == "localhost" {
+        println!(
+            "\nTo wire a laptop / third machine into the PC's canonical stack:\n\
+             \x20 qontinui_profile init --host <PC-LAN-IP>"
+        );
+    }
+    ExitCode::SUCCESS
+}
+
+/// Write `file` atomically: serialize to a sibling `.tmp`, then rename.
+/// Avoids a partial-write window where a reader could observe an
+/// invalid-JSON profiles.json.
+fn atomic_write(path: &Path, file: &ProfilesFile) -> std::io::Result<()> {
+    let pretty = serde_json::to_vec_pretty(file)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &pretty)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use std::sync::OnceLock;
 use tauri::Manager;
 
 pub mod accessibility;
+pub mod profiles;
 pub mod schema_export;
 
 // ============================================================================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -269,16 +269,27 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize VideoRecordingService
     let video_recorder = Arc::new(Mutex::new(VideoRecordingService::new()));
 
-    // Initialize PostgreSQL connection (required — local docker-compose PG).
-    // Uses RUNNER_DATABASE_URL env var, or defaults to the local docker-compose PostgreSQL.
-    // Uses a dedicated tokio runtime for the one-shot async connection — cannot use
-    // tauri::async_runtime::block_on here because the Tauri runtime hasn't started yet.
-    // Initialize PG and run one-time data migration in the same tokio runtime.
-    // Critical: PG pool connections are tied to their creating runtime.
+    // Initialize PostgreSQL connection.
+    //
+    // Connection settings come from `~/.qontinui/profiles.json` per the
+    // canonical-DB topology (see `tmp_canonical_db_topology_plan.md` §3 and
+    // `crate::profiles`). Selection order: `QONTINUI_ENV` env var → file's
+    // `active` field → `dev`. Falls back to legacy `RUNNER_DATABASE_URL`
+    // env var (and ultimately a localhost default) when profiles.json is
+    // missing, so unmigrated machines remain bootable.
+    //
+    // Uses a dedicated tokio runtime for the one-shot async connection —
+    // cannot use tauri::async_runtime::block_on here because the Tauri
+    // runtime hasn't started yet. PG pool connections are tied to their
+    // creating runtime, so this same runtime stays alive for the rest of
+    // the bootstrap path.
     let pg_db: Arc<crate::database::pg::PgDb> = {
-        let pg_url = std::env::var("RUNNER_DATABASE_URL").unwrap_or_else(|_| {
-            "host=localhost port=5432 user=qontinui_user password=qontinui_dev_password dbname=qontinui_db".to_string()
-        });
+        let profile = qontinui_runner_lib::profiles::load();
+        info!(
+            "Connecting to canonical PG via profile '{}'",
+            profile.source
+        );
+        let pg_url = profile.database_url;
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -1,0 +1,281 @@
+//! Connection profile loader for the canonical-DB topology.
+//!
+//! Per topology plan §3 (`tmp_canonical_db_topology_plan.md`), the runner
+//! reads its DB / Redis / blob / coord-service connection settings from
+//! `~/.qontinui/profiles.json`. The active profile is selected by:
+//!
+//!   1. `QONTINUI_ENV` env var (highest priority).
+//!   2. The file's top-level `"active"` field.
+//!   3. `"dev"` if neither is set.
+//!
+//! Profiles file layout:
+//!
+//! ```json
+//! {
+//!   "active": "dev",
+//!   "profiles": {
+//!     "dev":     { "database_url": "...", "redis_url": "...", "blob": {...}, "coord_url": "...", "auth": {...} },
+//!     "staging": { ... },
+//!     "prod":    { ... }
+//!   }
+//! }
+//! ```
+//!
+//! ## Fallback chain
+//!
+//! When profiles.json is missing or the chosen profile lacks a setting, the
+//! loader falls back to legacy env vars so the runner remains bootable on
+//! machines that haven't been migrated yet:
+//!
+//! | Setting       | Legacy env var          |
+//! |---------------|-------------------------|
+//! | database_url  | `RUNNER_DATABASE_URL`   |
+//! | redis_url     | `REDIS_URL`             |
+//! | blob.endpoint | `S3_ENDPOINT`           |
+//! | coord_url     | `COORD_URL`             |
+//!
+//! When even the env-var fallback is unavailable for `database_url`, a
+//! hardcoded localhost default is returned (matches `main.rs:279`'s prior
+//! behavior). Callers needing strict-mode validation can use
+//! [`load_strict`].
+
+use anyhow::{anyhow, Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use tracing::{debug, info, warn};
+
+/// Top-level shape of `~/.qontinui/profiles.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfilesFile {
+    /// Default profile name when `QONTINUI_ENV` is unset.
+    #[serde(default)]
+    pub active: Option<String>,
+    /// Named profiles keyed by environment label (`dev`, `staging`, `prod`,
+    /// `cloud`, custom).
+    #[serde(default)]
+    pub profiles: HashMap<String, Profile>,
+}
+
+/// One environment's connection settings.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct Profile {
+    /// Postgres DSN.
+    #[serde(default)]
+    pub database_url: Option<String>,
+    /// Redis URL (`redis://host:port/db`).
+    #[serde(default)]
+    pub redis_url: Option<String>,
+    /// S3-compatible blob configuration (MinIO in dev, real S3 in prod).
+    #[serde(default)]
+    pub blob: Option<BlobConfig>,
+    /// Coordinator service URL (WebSocket — `ws://` or `wss://`).
+    #[serde(default)]
+    pub coord_url: Option<String>,
+    /// Auth provider configuration.
+    #[serde(default)]
+    pub auth: Option<AuthConfig>,
+}
+
+/// S3-compatible blob storage settings. `kind` distinguishes MinIO from
+/// real S3 — both speak the same wire protocol but signing/region defaults
+/// differ.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobConfig {
+    pub kind: String,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub region: Option<String>,
+    #[serde(default)]
+    pub access_key: Option<String>,
+    #[serde(default)]
+    pub secret_key: Option<String>,
+    #[serde(default)]
+    pub bucket: Option<String>,
+}
+
+/// Auth posture. Dev profiles use a static token; staging+ uses OIDC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthConfig {
+    pub kind: String,
+    #[serde(default)]
+    pub token: Option<String>,
+    #[serde(default)]
+    pub issuer: Option<String>,
+    #[serde(default)]
+    pub client_id: Option<String>,
+}
+
+/// Resolved profile after fallback chain — every consumer reads this.
+#[derive(Debug, Clone)]
+pub struct ResolvedProfile {
+    /// Which profile name produced this resolution (`dev`, etc., or
+    /// `legacy-env` when no profiles.json existed).
+    pub source: String,
+    pub database_url: String,
+    pub redis_url: Option<String>,
+    pub blob: Option<BlobConfig>,
+    pub coord_url: Option<String>,
+    pub auth: Option<AuthConfig>,
+}
+
+/// Path of `~/.qontinui/profiles.json` for the current user.
+pub fn profiles_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".qontinui").join("profiles.json"))
+}
+
+/// Resolve the active profile, applying the fallback chain. Always
+/// returns a `ResolvedProfile` — never errors. Callers that need an
+/// error-on-missing variant should use [`load_strict`].
+pub fn load() -> ResolvedProfile {
+    match load_inner() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(
+                "Profile load failed: {}. Falling back to legacy env vars.",
+                e
+            );
+            legacy_env_fallback()
+        }
+    }
+}
+
+/// Strict variant: errors if profiles.json is missing or the active
+/// profile lacks a `database_url`. Used by tooling that must not silently
+/// connect to localhost.
+pub fn load_strict() -> Result<ResolvedProfile> {
+    load_inner()
+}
+
+fn load_inner() -> Result<ResolvedProfile> {
+    let path = profiles_path().ok_or_else(|| anyhow!("Could not resolve home directory"))?;
+    if !path.exists() {
+        return Err(anyhow!("profiles.json not found at {}", path.display()));
+    }
+
+    let bytes = std::fs::read(&path)
+        .with_context(|| format!("Reading profiles file at {}", path.display()))?;
+    let file: ProfilesFile = serde_json::from_slice(&bytes)
+        .with_context(|| format!("Parsing profiles file at {}", path.display()))?;
+
+    let active = std::env::var("QONTINUI_ENV")
+        .ok()
+        .or_else(|| file.active.clone())
+        .unwrap_or_else(|| "dev".to_string());
+
+    let profile = file.profiles.get(&active).cloned().ok_or_else(|| {
+        anyhow!(
+            "Active profile '{}' not present in {}",
+            active,
+            path.display()
+        )
+    })?;
+
+    let database_url = profile
+        .database_url
+        .clone()
+        .or_else(|| std::env::var("RUNNER_DATABASE_URL").ok())
+        .ok_or_else(|| anyhow!("Profile '{}' has no database_url and RUNNER_DATABASE_URL is unset", active))?;
+
+    debug!("Loaded profile '{}' from {}", active, path.display());
+
+    Ok(ResolvedProfile {
+        source: active,
+        database_url,
+        redis_url: profile
+            .redis_url
+            .or_else(|| std::env::var("REDIS_URL").ok()),
+        blob: profile.blob,
+        coord_url: profile
+            .coord_url
+            .or_else(|| std::env::var("COORD_URL").ok()),
+        auth: profile.auth,
+    })
+}
+
+/// Pure-env-var fallback when profiles.json is missing or unparseable.
+/// Mirrors the legacy main.rs:279 default so machines that haven't been
+/// migrated to the canonical-DB topology continue to work.
+fn legacy_env_fallback() -> ResolvedProfile {
+    let database_url = std::env::var("RUNNER_DATABASE_URL").unwrap_or_else(|_| {
+        "host=localhost port=5432 user=qontinui_user password=qontinui_dev_password dbname=qontinui_db".to_string()
+    });
+
+    info!("Using legacy env-var configuration (profiles.json not found)");
+
+    ResolvedProfile {
+        source: "legacy-env".to_string(),
+        database_url,
+        redis_url: std::env::var("REDIS_URL").ok(),
+        blob: None,
+        coord_url: std::env::var("COORD_URL").ok(),
+        auth: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_profiles_file() {
+        let json = r#"{
+            "active": "dev",
+            "profiles": {
+                "dev": {
+                    "database_url": "postgres://u:p@h:5433/db"
+                }
+            }
+        }"#;
+        let parsed: ProfilesFile = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.active.as_deref(), Some("dev"));
+        let dev = parsed.profiles.get("dev").unwrap();
+        assert_eq!(
+            dev.database_url.as_deref(),
+            Some("postgres://u:p@h:5433/db")
+        );
+    }
+
+    #[test]
+    fn parses_full_profiles_file() {
+        let json = r#"{
+            "active": "dev",
+            "profiles": {
+                "dev": {
+                    "database_url": "postgres://u:p@h:5433/db",
+                    "redis_url": "redis://h:6380/0",
+                    "blob": {
+                        "kind": "s3-compatible",
+                        "endpoint": "http://h:9100",
+                        "access_key": "k",
+                        "secret_key": "s",
+                        "bucket": "qontinui-dev"
+                    },
+                    "coord_url": "ws://h:9870",
+                    "auth": { "kind": "static-dev-token", "token": "t" }
+                }
+            }
+        }"#;
+        let parsed: ProfilesFile = serde_json::from_str(json).unwrap();
+        let dev = parsed.profiles.get("dev").unwrap();
+        assert!(dev.blob.is_some());
+        assert_eq!(dev.blob.as_ref().unwrap().kind, "s3-compatible");
+        assert_eq!(dev.coord_url.as_deref(), Some("ws://h:9870"));
+        assert_eq!(dev.auth.as_ref().unwrap().kind, "static-dev-token");
+    }
+
+    #[test]
+    fn legacy_fallback_uses_env_or_localhost_default() {
+        // SAFETY of env mutation in tests: we read-and-restore. Single-thread
+        // test runs avoid cross-test interference.
+        let prior = std::env::var("RUNNER_DATABASE_URL").ok();
+        std::env::remove_var("RUNNER_DATABASE_URL");
+        let p = legacy_env_fallback();
+        assert_eq!(p.source, "legacy-env");
+        assert!(p.database_url.contains("qontinui_user"));
+        if let Some(prev) = prior {
+            std::env::set_var("RUNNER_DATABASE_URL", prev);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Topology plan Phase 1 deliverable. Runner reads `~/.qontinui/profiles.json` for connection settings, falls back to the legacy `RUNNER_DATABASE_URL` env var when the file is missing. Ships the `qontinui_profile` CLI for managing that file.

No behavior change for users without a `profiles.json`.

## What changed

- `src-tauri/src/profiles.rs` — `ResolvedProfile` loader with fallback chain (active profile → legacy env var → in-memory defaults). `load()` is forgiving for general callers; `load_strict()` returns an error when the file is malformed for callers that need to surface the problem.
- `src-tauri/src/bin/qontinui_profile.rs` — new CLI binary: `show`, `list`, `use`, `init [--host <ip>]`, `path`, `help`. Atomic write via `.tmp` + rename. Secrets redacted in `show` output.
- `src-tauri/src/main.rs` — wire profile loader into bootstrap.
- `src-tauri/src/lib.rs` — expose `profiles` module.

## Why now

§3 of `tmp_canonical_db_topology_plan.md` Phase 1 is "runner reads profiles." The qontinui-stack canonical PG/Redis/MinIO is live (5433/6380/9100), the coordinator is live (9870), and LAN-client work is gated on this loader. Self-host users still without a profiles.json keep their existing env-var flow.

## Test plan

- [ ] `cargo check` clean (cargo-guard'd CI job)
- [ ] Manual: `qontinui_profile init --host 127.0.0.1` writes a sane profile, `qontinui_profile show` redacts the password
- [ ] Manual: runner without `~/.qontinui/profiles.json` still boots via `RUNNER_DATABASE_URL`
- [ ] Manual: runner with `profiles.json` connects to canonical PG/Redis on the configured ports