### PR TITLE
feat(profile): qontinui_profile machine subcommand for identity bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5790,6 +5790,7 @@ dependencies = [
  "postgres-protocol",
  "serde_core",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -94,7 +94,7 @@ hex = "0.4"
 scopeguard = "1.2"
 regex = "1.10"
 # PostgreSQL (Clorinde-generated queries)
-tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
 qontinui-types = { path = "../../qontinui-schemas/rust" }

--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -14,6 +14,9 @@
 //! qontinui_profile init                       # write starter profiles.json (host=localhost)
 //! qontinui_profile init --host 192.168.1.x    # ... pointing at a remote canonical-stack host
 //! qontinui_profile path                       # print the profiles.json path
+//! qontinui_profile machine init               # mint ~/.qontinui/machine.json + register in coord.machines
+//! qontinui_profile machine show               # print machine_id + coord registration status
+//! qontinui_profile machine path               # print the machine.json path
 //! ```
 //!
 //! `init --host` is the LAN-client setup path: an MSI laptop / third
@@ -30,9 +33,10 @@
 use qontinui_runner_lib::profiles::{
     load_strict, profiles_path, AuthConfig, BlobConfig, Profile, ProfilesFile,
 };
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
@@ -57,6 +61,7 @@ fn main() -> ExitCode {
             cmd_init(&host)
         }
         "path" => cmd_path(),
+        "machine" => cmd_machine(&args),
         "help" | "-h" | "--help" => {
             print_help();
             ExitCode::SUCCESS
@@ -80,7 +85,22 @@ fn print_help() {
          \x20                            localhost (PC-local dev). Pass --host <PC-LAN-IP>\n\
          \x20                            from a laptop / third machine to point at the PC.\n\
          \x20 path                       Print the profiles.json path\n\
+         \x20 machine <init|show|path>   Manage ~/.qontinui/machine.json (machine identity\n\
+         \x20                            for coord.machines registration; required for\n\
+         \x20                            /coord/status POSTs and non-NULL claims_audit rows)\n\
          \x20 help                       Show this message\n"
+    );
+}
+
+fn print_machine_help() {
+    println!(
+        "qontinui_profile machine — manage ~/.qontinui/machine.json\n\n\
+         Commands:\n\
+         \x20 init    Mint UUID v4 + hostname to machine.json (atomic), then UPSERT\n\
+         \x20         into the active profile's coord.machines. Idempotent: re-runs\n\
+         \x20         re-use the existing UUID and bump last_seen_at.\n\
+         \x20 show    Print machine_id + coord.machines registration timestamps.\n\
+         \x20 path    Print the absolute machine.json path.\n"
     );
 }
 
@@ -326,4 +346,304 @@ fn atomic_write(path: &Path, file: &ProfilesFile) -> std::io::Result<()> {
     std::fs::write(&tmp, &pretty)?;
     std::fs::rename(&tmp, path)?;
     Ok(())
+}
+
+// ============================================================================
+// machine subcommand
+// ============================================================================
+//
+// Per topology plan §3, every runner has a stable machine identity stored at
+// ~/.qontinui/machine.json. The active profile's coord service uses this UUID
+// as the foreign key in coord.claims_audit / coord.machine_status / etc.
+// `qontinui_profile init` writes profiles.json but NOT machine.json — this
+// gap left new machines with NULL machine_id audit rows and rejected
+// /coord/status POSTs (qontinui-coord/src/status.rs:116-122).
+
+/// Shape of `~/.qontinui/machine.json`. UUID v4 + hostname only — additional
+/// per-machine state (current_branches, last_alembic_head) lives in
+/// coord.machines, not this file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MachineFile {
+    machine_id: String,
+    hostname: String,
+}
+
+fn machine_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".qontinui").join("machine.json"))
+}
+
+fn read_machine_file(path: &Path) -> std::io::Result<MachineFile> {
+    let bytes = std::fs::read(path)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+fn atomic_write_machine(path: &Path, file: &MachineFile) -> std::io::Result<()> {
+    let pretty = serde_json::to_vec_pretty(file)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &pretty)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+fn detect_hostname() -> String {
+    hostname::get()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn cmd_machine(args: &[String]) -> ExitCode {
+    let sub = args.get(2).map(|s| s.as_str()).unwrap_or("show");
+    match sub {
+        "init" => cmd_machine_init(),
+        "show" => cmd_machine_show(),
+        "path" => cmd_machine_path(),
+        "help" | "-h" | "--help" => {
+            print_machine_help();
+            ExitCode::SUCCESS
+        }
+        other => {
+            eprintln!("unknown machine subcommand: {}", other);
+            print_machine_help();
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn cmd_machine_path() -> ExitCode {
+    match machine_path() {
+        Some(p) => {
+            println!("{}", p.display());
+            ExitCode::SUCCESS
+        }
+        None => {
+            eprintln!("could not resolve home directory");
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn cmd_machine_init() -> ExitCode {
+    let path = match machine_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("could not resolve home directory");
+            return ExitCode::from(2);
+        }
+    };
+
+    // Read existing machine.json if present (re-use UUID for idempotence);
+    // otherwise mint a fresh UUID v4. Hostname is always re-detected — a
+    // laptop can rename between boots and the file should reflect current.
+    let hostname_now = detect_hostname();
+    let (file, was_new) = if path.exists() {
+        match read_machine_file(&path) {
+            Ok(mut existing) => {
+                existing.hostname = hostname_now.clone();
+                (existing, false)
+            }
+            Err(e) => {
+                eprintln!(
+                    "machine.json at {} is unreadable ({}). \
+                     Refusing to overwrite — inspect or `rm` and re-run.",
+                    path.display(),
+                    e
+                );
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        let id = uuid::Uuid::new_v4().to_string();
+        (
+            MachineFile {
+                machine_id: id,
+                hostname: hostname_now.clone(),
+            },
+            true,
+        )
+    };
+
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("mkdir {} failed: {}", parent.display(), e);
+            return ExitCode::from(2);
+        }
+    }
+    if let Err(e) = atomic_write_machine(&path, &file) {
+        eprintln!("write {} failed: {}", path.display(), e);
+        return ExitCode::from(2);
+    }
+    if was_new {
+        println!("wrote machine.json: {} (host={})", file.machine_id, file.hostname);
+    } else {
+        println!("re-using existing machine.json: {} (host={})", file.machine_id, file.hostname);
+    }
+
+    // Register with coord by UPSERTing coord.machines on the active profile's
+    // PG. File creation succeeds even if coord registration fails — the local
+    // identity is the canonical record; coord.machines is a derived view
+    // (qontinui-coord re-syncs from machine.json on next /coord/status POST).
+    match register_with_coord(&file.machine_id, &file.hostname) {
+        Ok(()) => {
+            println!("registered with coord (UPSERT into coord.machines)");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!(
+                "warning: coord registration failed: {}\n\
+                 (machine.json was still written; re-run `qontinui_profile machine init` once coord is reachable)",
+                e
+            );
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+fn cmd_machine_show() -> ExitCode {
+    let path = match machine_path() {
+        Some(p) => p,
+        None => {
+            eprintln!("could not resolve home directory");
+            return ExitCode::from(2);
+        }
+    };
+    if !path.exists() {
+        eprintln!(
+            "machine.json not found at {}\n\
+             Run 'qontinui_profile machine init' to mint identity and register with coord.",
+            path.display()
+        );
+        return ExitCode::from(1);
+    }
+    let file = match read_machine_file(&path) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("read failed: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let coord_status = match query_coord_registration(&file.machine_id) {
+        Ok(Some((created_at, last_seen_at))) => {
+            json!({ "registered": true, "created_at": created_at, "last_seen_at": last_seen_at })
+        }
+        Ok(None) => json!({ "registered": false }),
+        Err(e) => json!({ "registered": null, "error": e }),
+    };
+
+    let out = json!({
+        "machine_id": file.machine_id,
+        "hostname":   file.hostname,
+        "path":       path.display().to_string(),
+        "coord":      coord_status,
+    });
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    ExitCode::SUCCESS
+}
+
+/// UPSERT into the active profile's `coord.machines`. Constructs a one-shot
+/// tokio runtime since the rest of this CLI is sync — keeps the binary
+/// otherwise unchanged. Uses NoTls (LAN/loopback dev posture; staging+ via
+/// stunnel or pgbouncer-tls if it ships later).
+fn register_with_coord(machine_id: &str, hostname: &str) -> Result<(), String> {
+    let id = uuid::Uuid::parse_str(machine_id)
+        .map_err(|e| format!("machine_id is not a valid UUID: {}", e))?;
+    let dsn = active_profile_dsn()?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("tokio runtime build failed: {}", e))?;
+    rt.block_on(async move {
+        let (client, conn) = tokio_postgres::connect(&dsn, tokio_postgres::NoTls)
+            .await
+            .map_err(|e| format!("connect to coord PG failed: {}", e))?;
+        let join = tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                tracing::debug!("pg connection ended: {}", e);
+            }
+        });
+        let res = client
+            .execute(
+                "INSERT INTO coord.machines (machine_id, hostname) \
+                 VALUES ($1, $2) \
+                 ON CONFLICT (machine_id) DO UPDATE \
+                 SET hostname = EXCLUDED.hostname, last_seen_at = now()",
+                &[&id, &hostname],
+            )
+            .await
+            .map_err(|e| format!("UPSERT coord.machines failed: {}", e))?;
+        drop(client);
+        let _ = join.await;
+        if res == 0 {
+            return Err("UPSERT coord.machines affected 0 rows".to_string());
+        }
+        Ok(())
+    })
+}
+
+fn query_coord_registration(machine_id: &str) -> Result<Option<(String, String)>, String> {
+    let id = uuid::Uuid::parse_str(machine_id)
+        .map_err(|e| format!("machine_id is not a valid UUID: {}", e))?;
+    let dsn = active_profile_dsn()?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("tokio runtime build failed: {}", e))?;
+    rt.block_on(async move {
+        let (client, conn) = tokio_postgres::connect(&dsn, tokio_postgres::NoTls)
+            .await
+            .map_err(|e| format!("connect to coord PG failed: {}", e))?;
+        let join = tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                tracing::debug!("pg connection ended: {}", e);
+            }
+        });
+        let row = client
+            .query_opt(
+                "SELECT created_at::text, last_seen_at::text \
+                 FROM coord.machines WHERE machine_id = $1",
+                &[&id],
+            )
+            .await
+            .map_err(|e| format!("SELECT coord.machines failed: {}", e))?;
+        drop(client);
+        let _ = join.await;
+        Ok(row.map(|r| (r.get::<_, String>(0), r.get::<_, String>(1))))
+    })
+}
+
+fn active_profile_dsn() -> Result<String, String> {
+    load_strict()
+        .map(|p| p.database_url)
+        .map_err(|e| format!("active profile has no database_url: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_write_machine_via_tmp_then_rename() {
+        let dir = tempfile::tempdir().expect("tmpdir");
+        let path = dir.path().join("machine.json");
+        let file = MachineFile {
+            machine_id: "00000000-0000-4000-8000-000000000000".to_string(),
+            hostname: "test-host".to_string(),
+        };
+        atomic_write_machine(&path, &file).expect("write");
+        let loaded = read_machine_file(&path).expect("read");
+        assert_eq!(loaded.machine_id, file.machine_id);
+        assert_eq!(loaded.hostname, file.hostname);
+        // The .tmp sibling must not linger after a successful rename.
+        let tmp = path.with_extension("json.tmp");
+        assert!(!tmp.exists(), "tmp file should be renamed away");
+    }
+
+    #[test]
+    fn detect_hostname_returns_non_empty() {
+        let h = detect_hostname();
+        assert!(!h.is_empty(), "hostname should be detectable on this host");
+    }
 }


### PR DESCRIPTION
## Summary

Backlog item #5. Closes the gap left by PR #8: `qontinui_profile init`
writes `~/.qontinui/profiles.json` but does NOT mint
`~/.qontinui/machine.json` or insert into `coord.machines`, so new
machines joining the canonical stack get NULL `machine_id` audit rows
and qontinui-coord rejects `/coord/status` POSTs
(qontinui-coord/src/status.rs:116-122).

## What changed

Three new sub-actions matching the existing CLI shape:

```text
qontinui_profile machine init   # mint UUID v4 + hostname (atomic write),
                                # then UPSERT coord.machines on the active
                                # profile's PG. Idempotent: re-runs re-use
                                # the existing UUID and bump last_seen_at.
qontinui_profile machine show   # print machine_id + coord registration
                                # timestamps (created_at, last_seen_at).
qontinui_profile machine path   # print absolute machine.json path.
```

**Idempotence:** if `machine.json` exists, the existing UUID is re-used;
only hostname is refreshed (laptops can rename between boots). The
UPSERT is `ON CONFLICT (machine_id) DO UPDATE` so re-registration bumps
`last_seen_at` without disturbing `created_at`.

**Resilience:** file creation does not block on coord availability. If
the PG UPSERT fails the file is still written and the user is told to
re-run once coord is reachable. The local file is the canonical record;
`coord.machines` is a derived view.

**Schema reference:** `machine_id` (uuid pk), `hostname` (text),
`last_seen_at` (default now()), `current_branches` (jsonb default '{}'),
`last_alembic_head` (text nullable), `created_at` (default now()).
Verified via `\d coord.machines` before authoring the INSERT — no
schema changes proposed. The earlier workaround one-liner during
Phase 7 had a column-name mismatch (assumed `first_seen_at`); this
PR uses `created_at` correctly.

**Wire format:** `tokio-postgres` `with-uuid-1` feature added so
`uuid::Uuid` serializes as the canonical UUID binary type. Without it
parameter serialization fails with "error serializing parameter 0"
because the prepared statement's parameter slot expects `uuid`, not
`text`.

## Test plan

- [x] `cargo test --bin qontinui_profile` — 2 unit tests passing
  (atomic-write contract, hostname detection)
- [x] Manual smoke: `machine init` (idempotent re-init re-uses UUID and
  bumps `last_seen_at`; fresh-mint creates new UUID + new
  `coord.machines` row)
- [x] `machine show` returns registered status with `created_at` /
  `last_seen_at`; `machine path` prints absolute path
- [ ] CI green