### PR TITLE
ci: fix security job path — drop stale qontinui-runner/ prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Run security audit on Rust dependencies
         run: |
           cargo install cargo-audit
-          cd qontinui-runner/src-tauri
+          cd src-tauri
           cargo audit
 
       - name: Setup pnpm
@@ -126,5 +126,4 @@ jobs:
 
       - name: Run pnpm audit
         run: |
-          cd qontinui-runner
           pnpm audit --audit-level=moderate || true


### PR DESCRIPTION
## Summary
- Security job's cargo audit step did `cd qontinui-runner/src-tauri` and pnpm audit step did `cd qontinui-runner` — both fail with `No such file or directory` because the repo is checked out at workspace root.
- Fix: `cd src-tauri` for cargo audit; pnpm audit runs from repo root (which has `package.json`).

Note: the same bad-path pattern exists in `release.yml` and `schema-pg-sql-fresh.yml` and should be addressed in a follow-up. (Other jobs in `ci.yml` are swept by the parallel ci/runner-test-matrix-setup-node PR.)

## Test plan
- [ ] Security job clears both `cd` lines
- [ ] cargo audit and pnpm audit run to completion