### PR TITLE
ci(release): drop stale qontinui-runner/ prefix from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
-          cache-dependency-path: qontinui-runner/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -143,9 +143,7 @@ jobs:
             librsvg2-dev
 
       - name: Install frontend dependencies
-        run: |
-          cd qontinui-runner
-          pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       # Download bundled Python executor if it was built
       - name: Download Python executor
@@ -204,9 +202,7 @@ jobs:
         # env:
         #   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: |
-          cd qontinui-runner
-          pnpm run tauri build -- --target ${{ matrix.target }}
+        run: pnpm run tauri build -- --target ${{ matrix.target }}
 
       # - name: Sign Windows executable
       #   if: runner.os == 'Windows'


### PR DESCRIPTION
## Summary
Follow-up to PR #12 (which swept \`ci.yml\`). Drops 3 stale \`qontinui-runner/\` references from \`release.yml\`:

- \`cache-dependency-path: qontinui-runner/pnpm-lock.yaml\` → \`pnpm-lock.yaml\`
- \`cd qontinui-runner; pnpm install --frozen-lockfile\` → bare \`pnpm install --frozen-lockfile\`
- \`cd qontinui-runner; pnpm run tauri build\` → bare \`pnpm run tauri build\`

The repo is checked out at workspace root (no nested \`qontinui-runner/\` subdir), so these prefixes resolved to non-existent paths.

\`schema-pg-sql-fresh.yml\` was investigated and found to be CORRECT as-is — it deliberately checks out the runner repo into a \`qontinui-runner/\` subdir (\`actions/checkout@v4\` with \`path: qontinui-runner\`) so it can sit alongside a \`qontinui-web/\` checkout. Its \`working-directory: qontinui-runner/...\` keys match that intentional layout. PR #13's mention of those lines was preemptive without accounting for the dual-repo checkout pattern.

## Test plan
- [ ] release.yml's pnpm install + tauri build steps run from the right directory
- [ ] cache-dependency-path resolves the lockfile