### PR TITLE
feat(trace_api): runner-side causal trace persistence (Section 5b)

### DIFF
--- a/src-tauri/queries/ui_bridge.sql
+++ b/src-tauri/queries/ui_bridge.sql
@@ -192,3 +192,82 @@ WHERE element_id IS NOT NULL
 GROUP BY element_id
 HAVING COUNT(*) >= :min_interactions
 ORDER BY interaction_count DESC;
+
+-- ============================================================================
+-- SECTION 5B: causal-chain queries (require migration
+--             section_5b_01_ui_bridge_causal_columns)
+-- ----------------------------------------------------------------------------
+-- These queries depend on two new columns on `project.ui_bridge_events`:
+--   recording_session_id text
+--   caused_by_event_id   bigint REFERENCES project.ui_bridge_events(id)
+-- Plus a partial index:
+--   ui_bridge_events_recording_session_idx
+--     ON project.ui_bridge_events(recording_session_id)
+--     WHERE recording_session_id IS NOT NULL
+--
+-- Until that Alembic migration is applied on the spaceship Postgres host
+-- (and `schema.pg.sql.generated` is regenerated from there), Clorinde will
+-- reject these queries against the locally-cached schema. The runner-side
+-- trace_api module uses raw `tokio_postgres` execution and DOES NOT depend
+-- on the bindings these queries would generate. After the migration applies
+-- and the generated schema catches up, these definitions can be enabled and
+-- the trace_api storage layer can be converted over.
+--
+-- NOTE: the build's Clorinde codegen step may silently drop these query
+-- blocks when validation runs against the pre-migration schema; the
+-- definitions are kept in source so they're trivially rehydrated post-
+-- migration without rewriting the SQL by hand.
+-- ============================================================================
+
+--! insert_causal_event (task_run_id?, element_id?, state_id?, transition_id?, action?, params?, result?, duration_ms?, error_message?, metadata?, recording_session_id?, caused_by_event_id?)
+INSERT INTO ui_bridge_events
+    (task_run_id, timestamp, sequence, event_type, element_id,
+     state_id, transition_id, action, params, result,
+     duration_ms, success, error_message, metadata,
+     recording_session_id, caused_by_event_id)
+VALUES (:task_run_id, :timestamp, :sequence, :event_type, :element_id,
+        :state_id, :transition_id, :action, :params, :result,
+        :duration_ms, :success, :error_message, :metadata,
+        :recording_session_id, :caused_by_event_id)
+RETURNING id;
+
+--! list_recording_sessions
+SELECT recording_session_id,
+       COUNT(*)::bigint AS event_count,
+       MIN(timestamp)::bigint AS started_at,
+       MAX(timestamp)::bigint AS ended_at
+FROM ui_bridge_events
+WHERE recording_session_id IS NOT NULL
+GROUP BY recording_session_id
+ORDER BY MIN(timestamp) DESC
+LIMIT :limit;
+
+--! get_recording_session : UiBridgeEventRow
+SELECT id, task_run_id, timestamp, sequence, event_type,
+       element_id, state_id, transition_id, action, params,
+       result, duration_ms, success, error_message, metadata
+FROM ui_bridge_events
+WHERE recording_session_id = :recording_session_id
+ORDER BY sequence ASC;
+
+--! get_causal_chain : UiBridgeEventRow
+WITH RECURSIVE chain AS (
+    SELECT id, task_run_id, timestamp, sequence, event_type,
+           element_id, state_id, transition_id, action, params,
+           result, duration_ms, success, error_message, metadata,
+           caused_by_event_id, 0 AS depth
+    FROM ui_bridge_events
+    WHERE id = :event_id
+    UNION ALL
+    SELECT p.id, p.task_run_id, p.timestamp, p.sequence, p.event_type,
+           p.element_id, p.state_id, p.transition_id, p.action, p.params,
+           p.result, p.duration_ms, p.success, p.error_message, p.metadata,
+           p.caused_by_event_id, c.depth + 1
+    FROM ui_bridge_events p
+    JOIN chain c ON p.id = c.caused_by_event_id
+)
+SELECT id, task_run_id, timestamp, sequence, event_type,
+       element_id, state_id, transition_id, action, params,
+       result, duration_ms, success, error_message, metadata
+FROM chain
+ORDER BY depth DESC;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -115,6 +115,7 @@ mod skills;
 mod slash_commands;
 mod spawn_placement;
 mod spec_api;
+mod trace_api;
 mod spec_experimentation;
 mod spec_utils;
 mod startup_panic;

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1532,6 +1532,15 @@ pub fn create_router(
         // outside `/ui-bridge/...` because the surface is consumed
         // differently (IR + projection storage, not page-control RPC).
         .merge(crate::spec_api::routes())
+        // Section 5b of UI Bridge redesign — `/trace/...` Trace API. Gated
+        // on `settings.trace_api.enabled` (default false) because it
+        // depends on the Alembic migration `section_5b_01_ui_bridge_causal_columns`
+        // being applied to the shared Postgres host.
+        .merge(if crate::settings::load_settings().trace_api.enabled {
+            crate::trace_api::routes()
+        } else {
+            axum::Router::new()
+        })
         .layer(axum::middleware::from_fn(
             crate::middleware::trace_propagation_middleware,
         ))

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1159,6 +1159,26 @@ pub struct Settings {
     /// Back-compat: missing key in an existing settings.json loads as empty.
     #[serde(default)]
     pub saved_projects: Vec<SavedProject>,
+    /// Trace API gate (Section 5b of the UI Bridge redesign). When enabled,
+    /// `/trace/...` routes are mounted on the runner's HTTP API and the
+    /// runner persists causal traces to `project.ui_bridge_events` (requires
+    /// Alembic migration `section_5b_01_ui_bridge_causal_columns`).
+    /// Default: false (shipped but inert until the migration is applied).
+    #[serde(default)]
+    pub trace_api: TraceApiSettings,
+}
+
+// ============================================================================
+// Trace API Settings (Section 5b)
+// ============================================================================
+
+/// Trace API gate. When `enabled` is false, the `/trace/...` routes are not
+/// mounted and no causal-trace DB writes are issued. The default is `false` —
+/// matches the "shipped but inert" rollout pattern used elsewhere in the
+/// redesign.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TraceApiSettings {
+    pub enabled: bool,
 }
 
 // ============================================================================

--- a/src-tauri/src/trace_api/events.rs
+++ b/src-tauri/src/trace_api/events.rs
@@ -1,0 +1,53 @@
+//! Trace API change-event broadcaster.
+//!
+//! Stub for v1 — `trace.changed` SSE is not exposed yet, but the broadcast
+//! channel is wired so downstream code (and a follow-up SSE endpoint) can
+//! subscribe today without further plumbing. Mirrors `spec_api::events` so
+//! the migration to a public SSE handler is mechanical.
+
+use std::sync::OnceLock;
+use tokio::sync::broadcast;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceChanged {
+    /// The recording session whose event set was just mutated.
+    pub recording_session_id: String,
+    /// "session-saved" today; future kinds may include "session-replayed"
+    /// once `/trace/replay` lands in v2.
+    pub kind: String,
+    /// How many events were touched by the change (0 when not applicable).
+    pub event_count: i64,
+    /// Epoch milliseconds the event was emitted at.
+    pub at_ms: u64,
+}
+
+/// Broadcast capacity. Slow subscribers will Lag if they fall this far
+/// behind; consumers are expected to drop laggy subscriptions and resubscribe.
+const CAPACITY: usize = 256;
+
+static SENDER: OnceLock<broadcast::Sender<TraceChanged>> = OnceLock::new();
+
+fn sender() -> &'static broadcast::Sender<TraceChanged> {
+    SENDER.get_or_init(|| broadcast::channel::<TraceChanged>(CAPACITY).0)
+}
+
+#[allow(dead_code)]
+pub fn subscribe() -> broadcast::Receiver<TraceChanged> {
+    sender().subscribe()
+}
+
+pub fn emit(event: TraceChanged) {
+    // Ignore SendError: it just means there are no subscribers — drop the
+    // event silently in that case.
+    let _ = sender().send(event);
+}
+
+pub fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/trace_api/handlers.rs
+++ b/src-tauri/src/trace_api/handlers.rs
@@ -1,0 +1,332 @@
+//! Axum handlers for the Trace API. Endpoints under `/trace/...`.
+//!
+//! Surface (Section 5b plan):
+//! - `GET  /trace/health`                       — health check
+//! - `GET  /trace/list?limit=N`                 — list recording sessions
+//! - `GET  /trace/session/{id}`                 — full event timeline for a session
+//! - `GET  /trace/event/{id}/causal-chain`      — backward walk to roots
+//! - `POST /trace/save`                         — persist a recorder session
+//! - `POST /trace/replay`                       — 501 (deferred to v2)
+//!
+//! Every empty/error response carries a `reason` field per the
+//! "no silent empty responses" constraint shared with the Spec API.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path as AxPath, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tracing::warn;
+
+use crate::database::pg::PgDb;
+use crate::mcp::types::ApiState;
+
+use super::events::{self, TraceChanged};
+use super::responses::{EmptyOk, TraceError};
+use super::storage;
+use super::types::{CausalChain, InboundRecordingSession};
+
+/// Resolve the global `PgDb` or return a `503` error envelope. The trace API
+/// is only useful when PG is wired; we make that explicit rather than
+/// silently degrading.
+fn require_pg() -> Result<Arc<PgDb>, Response> {
+    PgDb::try_global().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(TraceError::new("pg-unavailable")),
+        )
+            .into_response()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// GET /trace/health
+// ---------------------------------------------------------------------------
+
+pub async fn get_health(State(_state): State<Arc<ApiState>>) -> Response {
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "status": "ok",
+            "enabled": true,
+            "reason": "trace-api-mounted",
+        })),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// GET /trace/list?limit=N
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    pub limit: Option<i64>,
+}
+
+pub async fn get_list(
+    State(_state): State<Arc<ApiState>>,
+    Query(q): Query<ListQuery>,
+) -> Response {
+    let pg = match require_pg() {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+    let limit = q.limit.unwrap_or(50).clamp(1, 500);
+    match storage::list_recording_sessions(&pg, limit).await {
+        Ok(sessions) => {
+            let reason = if sessions.is_empty() {
+                "no-recording-sessions"
+            } else {
+                "recording-sessions-listed"
+            };
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "ok": true,
+                    "sessions": sessions,
+                    "limit": limit,
+                    "reason": reason,
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(TraceError::with_detail(
+                "list-failed",
+                json!({ "error": e }),
+            )),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /trace/session/{id}
+// ---------------------------------------------------------------------------
+
+pub async fn get_session(
+    State(_state): State<Arc<ApiState>>,
+    AxPath(id): AxPath<String>,
+) -> Response {
+    if id.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(TraceError::new("missing-recording-session-id")),
+        )
+            .into_response();
+    }
+    let pg = match require_pg() {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+    match storage::get_recording_session(&pg, &id).await {
+        Ok(events) => {
+            if events.is_empty() {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(TraceError::with_detail(
+                        "recording-session-not-found",
+                        json!({ "recordingSessionId": id }),
+                    )),
+                )
+                    .into_response();
+            }
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "ok": true,
+                    "recordingSessionId": id,
+                    "events": events,
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(TraceError::with_detail(
+                "session-read-failed",
+                json!({ "recordingSessionId": id, "error": e }),
+            )),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /trace/event/{id}/causal-chain
+// ---------------------------------------------------------------------------
+
+pub async fn get_causal_chain(
+    State(_state): State<Arc<ApiState>>,
+    AxPath(id): AxPath<i64>,
+) -> Response {
+    let pg = match require_pg() {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+    match storage::get_causal_chain(&pg, id).await {
+        Ok(chain) => {
+            if chain.is_empty() {
+                return (
+                    StatusCode::NOT_FOUND,
+                    Json(TraceError::with_detail(
+                        "event-not-found",
+                        json!({ "eventId": id }),
+                    )),
+                )
+                    .into_response();
+            }
+            let payload = CausalChain {
+                event_id: id,
+                chain,
+            };
+            (StatusCode::OK, Json(json!({ "ok": true, "payload": payload }))).into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(TraceError::with_detail(
+                "causal-chain-read-failed",
+                json!({ "eventId": id, "error": e }),
+            )),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// POST /trace/save
+// ---------------------------------------------------------------------------
+
+pub async fn post_save(
+    State(_state): State<Arc<ApiState>>,
+    Json(body): Json<InboundRecordingSession>,
+) -> Response {
+    let session_id = body.recording_session_id.trim().to_string();
+    if session_id.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(TraceError::new("missing-recording-session-id")),
+        )
+            .into_response();
+    }
+    if body.events.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(TraceError::with_detail(
+                "empty-events-array",
+                json!({ "recordingSessionId": session_id }),
+            )),
+        )
+            .into_response();
+    }
+
+    let pg = match require_pg() {
+        Ok(p) => p,
+        Err(r) => return r,
+    };
+
+    // First pass: assign sequence/timestamp defaults and remember client-id ->
+    // db-id wiring so the second pass can resolve `caused_by` references.
+    let mut client_to_db: HashMap<String, i64> = HashMap::new();
+    let mut inserted: Vec<i64> = Vec::with_capacity(body.events.len());
+    let now_ms = events::now_ms() as i64;
+
+    for (idx, event) in body.events.iter().enumerate() {
+        let sequence = event.sequence.unwrap_or(idx as i64);
+        let timestamp = event.timestamp.unwrap_or(now_ms);
+        let caused_by = event
+            .caused_by
+            .as_ref()
+            .and_then(|cid| client_to_db.get(cid).copied());
+
+        match storage::insert_causal_event(
+            &pg,
+            event,
+            &session_id,
+            sequence,
+            timestamp,
+            caused_by,
+        )
+        .await
+        {
+            Ok(db_id) => {
+                if let Some(client_id) = event.client_id.as_ref() {
+                    client_to_db.insert(client_id.clone(), db_id);
+                }
+                inserted.push(db_id);
+            }
+            Err(e) => {
+                warn!(
+                    "trace_api: insert_causal_event failed at index {} of session {}: {}",
+                    idx, session_id, e
+                );
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(TraceError::with_detail(
+                        "insert-failed",
+                        json!({
+                            "recordingSessionId": session_id,
+                            "indexFailed": idx,
+                            "insertedSoFar": inserted.len(),
+                            "error": e,
+                        }),
+                    )),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let event_count = inserted.len() as i64;
+    events::emit(TraceChanged {
+        recording_session_id: session_id.clone(),
+        kind: "session-saved".to_string(),
+        event_count,
+        at_ms: events::now_ms(),
+    });
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "recordingSessionId": session_id,
+            "insertedCount": event_count,
+            "insertedIds": inserted,
+        })),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// POST /trace/replay
+// ---------------------------------------------------------------------------
+
+/// Deferred to v2 per ADR-005 — the v1 trace API only persists and reads.
+pub async fn post_replay(
+    State(_state): State<Arc<ApiState>>,
+    Json(_body): Json<Value>,
+) -> Response {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(TraceError::new("replay deferred to v2; see ADR-005")),
+    )
+        .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Available for unit tests / quick smoke handlers — same envelope as
+/// `EmptyOk::new` but returned as a fully-typed JSON response.
+#[allow(dead_code)]
+pub fn empty_ok(reason: impl Into<String>) -> Response {
+    (StatusCode::OK, Json(EmptyOk::new(reason))).into_response()
+}

--- a/src-tauri/src/trace_api/mod.rs
+++ b/src-tauri/src/trace_api/mod.rs
@@ -1,0 +1,75 @@
+//! Trace API — Section 5b deliverable of the UI Bridge redesign.
+//!
+//! Runner-side persistence + read API for the in-memory causal trace shipped
+//! by Section 5 Plan A in `ui-bridge-auto`. Mounted at `/trace/...` on the
+//! runner's Axum router (port 9876), mirroring the existing `/spec/...`
+//! Spec API surface.
+//!
+//! ## Required migration
+//!
+//! This module assumes two new columns on `project.ui_bridge_events`:
+//!
+//! ```sql
+//! ALTER TABLE project.ui_bridge_events
+//!   ADD COLUMN recording_session_id text,
+//!   ADD COLUMN caused_by_event_id bigint REFERENCES project.ui_bridge_events(id);
+//! CREATE INDEX ui_bridge_events_recording_session_idx
+//!   ON project.ui_bridge_events(recording_session_id)
+//!   WHERE recording_session_id IS NOT NULL;
+//! ```
+//!
+//! These are added by the Alembic migration
+//! `section_5b_01_ui_bridge_causal_columns`, which is applied later by the
+//! user on the shared Postgres host ("spaceship"). Until that migration runs,
+//! enabling the trace API will produce SQL errors at runtime.
+//!
+//! ## Runtime gate
+//!
+//! The routes are mounted only when `settings.trace_api.enabled` is true.
+//! The default is `false`, matching the "shipped but inert" rollout pattern
+//! used by the rest of the redesign.
+//!
+//! ## Storage approach
+//!
+//! All DB access uses raw `tokio_postgres` via `PgDb::pool()`. The Clorinde
+//! queries declared in `queries/ui_bridge.sql` (under the `SECTION 5B` block)
+//! reference the new columns and would fail to validate against the cached
+//! `schema.pg.sql.generated` until spaceship regenerates it. Raw SQL keeps
+//! this module compilable today; the Clorinde swap-over is mechanical once
+//! the schema catches up.
+//!
+//! ## Submodules
+//! - [`types`]      Wire types — inbound recorder session + outbound rows
+//! - [`storage`]    Raw `tokio_postgres` queries
+//! - [`responses`]  Empty/error envelope shapes — every empty response carries `reason`
+//! - [`events`]     Broadcast channel for `trace.changed` (SSE wiring deferred)
+//! - [`handlers`]   Axum handlers; one per endpoint
+//!
+//! Entry point: [`routes`]. Merge into the main router from `mcp_api.rs`.
+
+pub mod events;
+pub mod handlers;
+pub mod responses;
+pub mod storage;
+pub mod types;
+
+use axum::routing::{get, post};
+use axum::Router;
+use std::sync::Arc;
+
+use crate::mcp::types::ApiState;
+
+/// Routes for the Trace API. Mount only when `settings.trace_api.enabled`
+/// is true — wiring lives in `mcp_api.rs` next to the `/spec/...` merge.
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route("/trace/health", get(handlers::get_health))
+        .route("/trace/list", get(handlers::get_list))
+        .route("/trace/session/{recording_session_id}", get(handlers::get_session))
+        .route(
+            "/trace/event/{id}/causal-chain",
+            get(handlers::get_causal_chain),
+        )
+        .route("/trace/save", post(handlers::post_save))
+        .route("/trace/replay", post(handlers::post_replay))
+}

--- a/src-tauri/src/trace_api/responses.rs
+++ b/src-tauri/src/trace_api/responses.rs
@@ -1,0 +1,56 @@
+//! Response shapes for the Trace API (Section 5b).
+//!
+//! Mirrors the `spec_api::responses` idiom: every empty/error response carries
+//! a `reason: String` field — the constructors below are the only way to build
+//! these values, so we never produce a silent "ok: false" without a reason.
+
+use serde::Serialize;
+use serde_json::Value;
+
+/// Generic error envelope. Used wherever the success shape would otherwise
+/// be a different type — handlers wrap this in `axum::response::Json`.
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceError {
+    pub ok: bool,
+    pub reason: String,
+    /// Optional structured detail attached to the reason (e.g. the missing
+    /// session id). Always serialized when present so callers can do
+    /// `if (err.id) ...` without a second probe.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<Value>,
+}
+
+impl TraceError {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            reason: reason.into(),
+            detail: None,
+        }
+    }
+
+    pub fn with_detail(reason: impl Into<String>, detail: Value) -> Self {
+        Self {
+            ok: false,
+            reason: reason.into(),
+            detail: Some(detail),
+        }
+    }
+}
+
+/// Wrapper for "successful but empty" results. Carries a reason so callers
+/// can tell apart "no recording sessions yet" from "trace api unwired".
+#[derive(Debug, Clone, Serialize)]
+pub struct EmptyOk {
+    pub ok: bool,
+    pub reason: String,
+}
+
+impl EmptyOk {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            ok: true,
+            reason: reason.into(),
+        }
+    }
+}

--- a/src-tauri/src/trace_api/storage.rs
+++ b/src-tauri/src/trace_api/storage.rs
@@ -1,0 +1,239 @@
+//! Storage layer for the Trace API (Section 5b).
+//!
+//! All access goes through raw `tokio_postgres` queries via `PgDb::pool`
+//! (see `database/pg/recordings.rs` for the established pattern). We avoid
+//! the Clorinde-generated bindings here on purpose: the queries we depend on
+//! reference the `recording_session_id` and `caused_by_event_id` columns
+//! added by the `section_5b_01_ui_bridge_causal_columns` migration, and that
+//! migration is applied on a different machine ("spaceship"). Until that
+//! schema regen lands locally, Clorinde would refuse to compile against the
+//! cached `schema.pg.sql.generated`. Raw SQL sidesteps the validation gate.
+//!
+//! After the migration applies and the cached schema catches up, the
+//! Clorinde queries declared in `queries/ui_bridge.sql` (under the
+//! `SECTION 5B` block) can replace the bodies here.
+
+use std::sync::Arc;
+
+use tokio_postgres::types::ToSql;
+
+use crate::database::pg::PgDb;
+
+use super::types::{InboundRecorderEvent, RecordingSessionMeta, TraceEvent};
+
+/// Insert a single causal event row into `ui_bridge_events`. Returns the new
+/// row id assigned by Postgres. Errors carry a short human-readable string so
+/// handlers can wrap them in the standard `TraceError` envelope.
+pub async fn insert_causal_event(
+    pg: &Arc<PgDb>,
+    event: &InboundRecorderEvent,
+    recording_session_id: &str,
+    sequence: i64,
+    timestamp_ms: i64,
+    caused_by_event_id: Option<i64>,
+) -> Result<i64, String> {
+    let conn = pg
+        .pool()
+        .get()
+        .await
+        .map_err(|e| format!("PG pool error: {}", e))?;
+
+    let event_type: String = event
+        .event_type
+        .clone()
+        .unwrap_or_else(|| "unknown".to_string());
+    let success: bool = event.success.unwrap_or(true);
+
+    let params_json: Option<String> = event
+        .params
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_else(|_| "null".to_string()));
+    let result_json: Option<String> = event
+        .result
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_else(|_| "null".to_string()));
+    let metadata_json: Option<String> = event
+        .metadata
+        .as_ref()
+        .map(|v| serde_json::to_string(v).unwrap_or_else(|_| "null".to_string()));
+
+    let row = conn
+        .query_one(
+            r#"
+            INSERT INTO ui_bridge_events
+                (task_run_id, timestamp, sequence, event_type, element_id,
+                 state_id, transition_id, action, params, result,
+                 duration_ms, success, error_message, metadata,
+                 recording_session_id, caused_by_event_id)
+            VALUES ($1, $2, $3, $4, $5,
+                    $6, $7, $8, $9, $10,
+                    $11, $12, $13, $14,
+                    $15, $16)
+            RETURNING id
+            "#,
+            &[
+                &event.task_run_id as &(dyn ToSql + Sync),
+                &timestamp_ms as &(dyn ToSql + Sync),
+                &sequence as &(dyn ToSql + Sync),
+                &event_type as &(dyn ToSql + Sync),
+                &event.element_id as &(dyn ToSql + Sync),
+                &event.state_id as &(dyn ToSql + Sync),
+                &event.transition_id as &(dyn ToSql + Sync),
+                &event.action as &(dyn ToSql + Sync),
+                &params_json as &(dyn ToSql + Sync),
+                &result_json as &(dyn ToSql + Sync),
+                &event.duration_ms as &(dyn ToSql + Sync),
+                &success as &(dyn ToSql + Sync),
+                &event.error_message as &(dyn ToSql + Sync),
+                &metadata_json as &(dyn ToSql + Sync),
+                &recording_session_id as &(dyn ToSql + Sync),
+                &caused_by_event_id as &(dyn ToSql + Sync),
+            ],
+        )
+        .await
+        .map_err(|e| format!("PG insert_causal_event: {}", e))?;
+
+    let id: i64 = row.get(0);
+    Ok(id)
+}
+
+/// List recording sessions, newest first, capped at `limit`. Sessions with
+/// no events are not returned (the GROUP BY excludes them).
+pub async fn list_recording_sessions(
+    pg: &Arc<PgDb>,
+    limit: i64,
+) -> Result<Vec<RecordingSessionMeta>, String> {
+    let conn = pg
+        .pool()
+        .get()
+        .await
+        .map_err(|e| format!("PG pool error: {}", e))?;
+
+    let rows = conn
+        .query(
+            r#"
+            SELECT recording_session_id,
+                   COUNT(*)::bigint AS event_count,
+                   MIN(timestamp)::bigint AS started_at,
+                   MAX(timestamp)::bigint AS ended_at
+            FROM ui_bridge_events
+            WHERE recording_session_id IS NOT NULL
+            GROUP BY recording_session_id
+            ORDER BY MIN(timestamp) DESC
+            LIMIT $1
+            "#,
+            &[&limit],
+        )
+        .await
+        .map_err(|e| format!("PG list_recording_sessions: {}", e))?;
+
+    Ok(rows
+        .iter()
+        .map(|r| RecordingSessionMeta {
+            recording_session_id: r.get(0),
+            event_count: r.get(1),
+            started_at: r.get(2),
+            ended_at: r.get(3),
+        })
+        .collect())
+}
+
+/// Read every event belonging to a recording session, ordered by sequence.
+pub async fn get_recording_session(
+    pg: &Arc<PgDb>,
+    recording_session_id: &str,
+) -> Result<Vec<TraceEvent>, String> {
+    let conn = pg
+        .pool()
+        .get()
+        .await
+        .map_err(|e| format!("PG pool error: {}", e))?;
+
+    let rows = conn
+        .query(
+            r#"
+            SELECT id, task_run_id, timestamp, sequence, event_type,
+                   element_id, state_id, transition_id, action, params,
+                   result, duration_ms, success, error_message, metadata,
+                   recording_session_id, caused_by_event_id
+            FROM ui_bridge_events
+            WHERE recording_session_id = $1
+            ORDER BY sequence ASC
+            "#,
+            &[&recording_session_id],
+        )
+        .await
+        .map_err(|e| format!("PG get_recording_session: {}", e))?;
+
+    Ok(rows.iter().map(row_to_trace_event).collect())
+}
+
+/// Walk the `caused_by_event_id` chain backwards starting from `event_id`.
+/// Returns rows in root-first order — i.e. the requested event is the last
+/// entry. Returns an empty vector if `event_id` is not present.
+pub async fn get_causal_chain(
+    pg: &Arc<PgDb>,
+    event_id: i64,
+) -> Result<Vec<TraceEvent>, String> {
+    let conn = pg
+        .pool()
+        .get()
+        .await
+        .map_err(|e| format!("PG pool error: {}", e))?;
+
+    let rows = conn
+        .query(
+            r#"
+            WITH RECURSIVE chain AS (
+                SELECT id, task_run_id, timestamp, sequence, event_type,
+                       element_id, state_id, transition_id, action, params,
+                       result, duration_ms, success, error_message, metadata,
+                       recording_session_id, caused_by_event_id, 0 AS depth
+                FROM ui_bridge_events
+                WHERE id = $1
+                UNION ALL
+                SELECT p.id, p.task_run_id, p.timestamp, p.sequence, p.event_type,
+                       p.element_id, p.state_id, p.transition_id, p.action, p.params,
+                       p.result, p.duration_ms, p.success, p.error_message, p.metadata,
+                       p.recording_session_id, p.caused_by_event_id, c.depth + 1
+                FROM ui_bridge_events p
+                JOIN chain c ON p.id = c.caused_by_event_id
+            )
+            SELECT id, task_run_id, timestamp, sequence, event_type,
+                   element_id, state_id, transition_id, action, params,
+                   result, duration_ms, success, error_message, metadata,
+                   recording_session_id, caused_by_event_id
+            FROM chain
+            ORDER BY depth DESC
+            "#,
+            &[&event_id],
+        )
+        .await
+        .map_err(|e| format!("PG get_causal_chain: {}", e))?;
+
+    Ok(rows.iter().map(row_to_trace_event).collect())
+}
+
+/// Map a `tokio_postgres::Row` (selected with the column order the helpers
+/// above use) into a `TraceEvent`.
+fn row_to_trace_event(row: &tokio_postgres::Row) -> TraceEvent {
+    TraceEvent {
+        id: row.get(0),
+        task_run_id: row.get(1),
+        timestamp: row.get(2),
+        sequence: row.get(3),
+        event_type: row.get(4),
+        element_id: row.get(5),
+        state_id: row.get(6),
+        transition_id: row.get(7),
+        action: row.get(8),
+        params: row.get(9),
+        result: row.get(10),
+        duration_ms: row.get(11),
+        success: row.get(12),
+        error_message: row.get(13),
+        metadata: row.get(14),
+        recording_session_id: row.get(15),
+        caused_by_event_id: row.get(16),
+    }
+}

--- a/src-tauri/src/trace_api/types.rs
+++ b/src-tauri/src/trace_api/types.rs
@@ -1,0 +1,117 @@
+//! Wire types for the Trace API.
+//!
+//! These mirror the TS `RecordingSession` / `RecorderEvent` shapes emitted by
+//! `ui-bridge-auto`'s in-memory causal trace (Section 5 Plan A). They're kept
+//! deliberately liberal — unknown fields on incoming JSON are accepted and
+//! preserved as raw `serde_json::Value`s where useful, so the TS shape can
+//! evolve without forcing a Rust-side breaking change.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Inbound: recorder session payload (POST /trace/save)
+// ---------------------------------------------------------------------------
+
+/// A single event emitted by the in-memory causal trace on the runner-frontend
+/// side. Field set is intentionally loose; unknown fields land in `extra`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct InboundRecorderEvent {
+    /// Optional client-side id. The DB row gets a fresh PG-assigned id; this
+    /// field is purely informational and used to wire `caused_by` links.
+    pub client_id: Option<String>,
+    /// Client id of the parent event in the same session, if any.
+    pub caused_by: Option<String>,
+    /// Epoch milliseconds the event was observed at.
+    pub timestamp: Option<i64>,
+    /// Sequence number within the session. When omitted we fall back to the
+    /// position in the `events` array.
+    pub sequence: Option<i64>,
+    /// Event type tag (e.g. `"action_executed"`, `"discover_returned"`).
+    pub event_type: Option<String>,
+    pub element_id: Option<String>,
+    pub state_id: Option<String>,
+    pub transition_id: Option<String>,
+    pub action: Option<String>,
+    /// Free-form structured params (serialized to JSON string in the DB row).
+    pub params: Option<Value>,
+    /// Free-form structured result (serialized to JSON string in the DB row).
+    pub result: Option<Value>,
+    pub duration_ms: Option<f64>,
+    pub success: Option<bool>,
+    pub error_message: Option<String>,
+    /// Free-form metadata (serialized to JSON string in the DB row).
+    pub metadata: Option<Value>,
+    /// Optional task-run linkage; when set the row is also discoverable via
+    /// the existing `get_element_interactions(task_run_id)` path.
+    pub task_run_id: Option<i64>,
+    /// Catch-all for unknown fields, preserved so future TS-side evolutions
+    /// don't break this endpoint.
+    #[serde(flatten)]
+    pub extra: std::collections::BTreeMap<String, Value>,
+}
+
+/// JSON body for `POST /trace/save`. The recorder posts a single session
+/// containing an ordered list of events. `recordingSessionId` is required —
+/// it's the join key for `/trace/session/{id}` lookups.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase", default)]
+pub struct InboundRecordingSession {
+    pub recording_session_id: String,
+    pub events: Vec<InboundRecorderEvent>,
+    /// Pass-through metadata about the session as a whole. Currently unused
+    /// server-side but accepted so the TS recorder can post a single object.
+    pub session_metadata: Option<Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Outbound: shared row + session/chain envelopes
+// ---------------------------------------------------------------------------
+
+/// Stored row shape returned by the read endpoints. Mirrors the columns
+/// selected by the new `get_recording_session` / `get_causal_chain` queries.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceEvent {
+    pub id: i64,
+    pub task_run_id: Option<i64>,
+    pub timestamp: i64,
+    pub sequence: i64,
+    pub event_type: String,
+    pub element_id: Option<String>,
+    pub state_id: Option<String>,
+    pub transition_id: Option<String>,
+    pub action: Option<String>,
+    /// Stored as JSON-encoded text in the DB; surfaced verbatim here so
+    /// callers can re-parse if they need structured data.
+    pub params: Option<String>,
+    pub result: Option<String>,
+    pub duration_ms: Option<f64>,
+    pub success: bool,
+    pub error_message: Option<String>,
+    pub metadata: Option<String>,
+    pub recording_session_id: Option<String>,
+    pub caused_by_event_id: Option<i64>,
+}
+
+/// Aggregate row produced by `list_recording_sessions`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingSessionMeta {
+    pub recording_session_id: String,
+    pub event_count: i64,
+    pub started_at: i64,
+    pub ended_at: i64,
+}
+
+/// Output of `GET /trace/event/{id}/causal-chain`. The query walks parent
+/// links backward; we surface both the ordered chain and the originating
+/// `event_id` for caller convenience.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CausalChain {
+    pub event_id: i64,
+    /// Ordered root-first; the requested event is the last entry.
+    pub chain: Vec<TraceEvent>,
+}


### PR DESCRIPTION
## Summary

Section 5b of the UI Bridge redesign — runner half. New `src/trace_api/` Axum module that persists the in-memory causal traces produced by Section 5 Plan A (in ui-bridge-auto) to `project.ui_bridge_events`, exposed via a `/trace/...` HTTP API mirroring the existing `/spec/...` Spec API surface.

### Routes (mounted only when `settings.trace_api.enabled`)

- `GET /trace/health`
- `GET /trace/list?limit=N` — list recording sessions
- `GET /trace/session/{recording_session_id}` — full event timeline
- `GET /trace/event/{id}/causal-chain` — backward walk to roots
- `POST /trace/save` — persist a recorder session
- `POST /trace/replay` — returns 501 with `reason: "replay deferred to v2; see ADR-005"` for v1

All empty/error responses carry a `reason` field, matching the `spec_api/responses.rs` envelope idiom.

### Module shape (mirrors `spec_api/`)

`mod / types / storage / responses / events / handlers`.

### Storage approach

Raw `tokio_postgres` via `PgDb::pool()` (mirrors `database/pg/recordings.rs`), **not** Clorinde-generated bindings. The new schema columns (`recording_session_id`, `caused_by_event_id` — see qontinui-web PR) don't exist in the cached `schema.pg.sql.generated` until that migration applies + the regen script runs. Raw SQL keeps this module compilable today; the Clorinde queries are authored under a `SECTION 5B` block in `queries/ui_bridge.sql` and will validate post-migration. Storage layer can be swapped to Clorinde mechanically once the schema catches up.

### Runtime gate

`settings.trace_api.enabled` (default `false`). Shipped-but-inert — routes only mount when flipped on. The flip should not happen until the qontinui-web migration has been applied to the shared Postgres host (otherwise `/trace/save` errors with column-does-not-exist).

## Cross-repo PRs (Section 5)

- **ui-bridge-auto** TS recorder + replay + determinism gate: https://github.com/qontinui/ui-bridge-auto/pull/2
- **qontinui-web** alembic migration adding `recording_session_id` + `caused_by_event_id` (required before flipping the gate): https://github.com/jspinak/qontinui-web/pull/30

## Deployment ordering

1. Apply qontinui-web migration on shared Postgres host.
2. Re-run `scripts/regenerate_schema_pg_sql.sh` so `schema.pg.sql.generated` includes the new columns.
3. Merge this PR.
4. Flip `settings.trace_api.enabled = true` on the runner you want traces from. Restart only that runner (do NOT touch active runners — use a temp runner via the supervisor for testing).

## Test plan

- [ ] CI: `cargo check --bin qontinui-runner` clean
- [ ] CI: `cargo test` — no regressions
- [ ] Local: spawn a temp runner via supervisor with `trace_api.enabled = true`, `curl :PORT/trace/health` returns `{ "status": "ok", "enabled": true }`
- [ ] Local: `POST /trace/save` with a fixture session inserts rows into `ui_bridge_events` with `recording_session_id` + `caused_by_event_id` populated correctly
- [ ] Local: `GET /trace/event/{id}/causal-chain` walks the chain backward in correct order

## Reference

- Plan: `qontinui-dev-notes/ui-bridge-redesign/SESSION_PROMPTS.md` Section 5
- Decisions: `qontinui-dev-notes/ui-bridge-redesign/section-5-causal/ADR-005-causal-tracing-replay.md` (decisions #2, #3, #6)
