### PR TITLE
Revert "fix(productivity): close §1-§4 of productivity-stack-followups"

### DIFF
--- a/src/components/productivity/CoordinatorDashboard.tsx
+++ b/src/components/productivity/CoordinatorDashboard.tsx
@@ -880,15 +880,6 @@ export function CoordinatorDashboard() {
           </p>
         </header>
 
-        {/*
-         * Panel order is part of the productivity-stack spec
-         * (productivity-stack.md §6, productivity.spec.uibridge.json
-         * group `productivity-coordinator-panels:order-invariant`):
-         * PlanRecommendations → Recommendations → Advisories →
-         * Escalations → Decision Log. Spec assertions read this
-         * order top-to-bottom. Don't reorder without updating the
-         * spec assertion in the same PR.
-         */}
         <PlanRecommendations />
 
         <RecommendationsPanel

--- a/src/components/productivity/KnowledgeBrowser.tsx
+++ b/src/components/productivity/KnowledgeBrowser.tsx
@@ -121,7 +121,7 @@ export function KnowledgeBrowser({ mode = "modal", open = true, onClose }: Knowl
   const body = (
     <div
       className="flex flex-col h-full bg-background"
-      data-page-id={mode === "modal" ? "productivity-knowledge-modal" : "productivity-knowledge"}
+      data-page-id="productivity-knowledge"
       data-ui-bridge-id="productivity.knowledge-browser"
     >
       {/* Header / search bar */}

--- a/src/components/productivity/PlanTaskBoard.tsx
+++ b/src/components/productivity/PlanTaskBoard.tsx
@@ -741,37 +741,6 @@ export function PlanTaskBoard() {
     return () => window.removeEventListener("productivity-select-plan", onSelectPlan);
   }, []);
 
-  // Listen for cross-component task-selection events (e.g. from the
-  // Recommendations queue's "Open task" button on the Coordinator
-  // dashboard). The task may belong to a plan that isn't yet selected,
-  // so we fetch the task detail to discover its parent plan, switch to
-  // that plan, then highlight the task.
-  useEffect(() => {
-    function onSelectTask(e: Event) {
-      const detail = (e as CustomEvent<{ taskId?: string }>).detail;
-      const taskId = detail?.taskId;
-      if (!taskId) return;
-      let cancelled = false;
-      void (async () => {
-        try {
-          const td = await getTaskDetail(taskId);
-          if (cancelled) return;
-          setSelectedPlanId(td.task.planId);
-          setSelectedTaskId(taskId);
-        } catch {
-          // Best-effort: silently ignore. The Coordinator dashboard
-          // already navigated to the Plans sub-view; user can pick
-          // the task by hand.
-        }
-      })();
-      return () => {
-        cancelled = true;
-      };
-    }
-    window.addEventListener("productivity-select-task", onSelectTask);
-    return () => window.removeEventListener("productivity-select-task", onSelectTask);
-  }, []);
-
   const selectedPlan = useMemo(
     () => plans.find((p) => p.id === selectedPlanId) ?? null,
     [plans, selectedPlanId],
@@ -800,8 +769,6 @@ export function PlanTaskBoard() {
             <button
               type="button"
               onClick={handleReflectionToggle}
-              data-ui-bridge-id="productivity.reflection-toggle"
-              data-plan-id={selectedPlan.id}
               className="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
               aria-expanded={reflectionOpen}
             >


### PR DESCRIPTION
## Summary
Reverts commit \`1db0e50b\` (\`fix(productivity): close §1-§4 of productivity-stack-followups\`).

## Reason for revert
Authored intentionally by the user; pushing for visibility. PR body to be expanded by author with the specific regression / problem the original commit caused before merge.

## Coordination
This is a clean revert (no manual conflict resolution). Re-applying the original later would be a new PR.