### PR TITLE
ci: add spec-pairing gate (warn-only)

### DIFF
--- a/.github/workflows/spec-pairing.yml
+++ b/.github/workflows/spec-pairing.yml
@@ -1,0 +1,46 @@
+name: Spec Pairing Gate
+
+# Verify every legacy `*.spec.uibridge.json` is paired with an IR file
+# under `specs/pages/<id>/`, and that the pairing round-trips cleanly
+# (group count + ids + assertion total match the IR's forward projection).
+#
+# Currently warn-only: runner has one intentional drift (`active.spec`)
+# from section 2 of the UI Bridge redesign — the IR is hand-authored
+# against a 4-state canonical model, while the legacy spec follows the
+# 9-group convention. Block mode would fail every PR until either:
+#   (a) `active.spec` is harmonized with its IR, or
+#   (b) check-spec-pairing grows a per-page exclusion mechanism.
+# At that point flip `--mode=warn` to `--mode=block`.
+#
+# Local snapshot at workflow creation: paired: 94, missing: 0, mismatched: 1.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.spec.uibridge.json"
+      - "**/specs/pages/**"
+      - ".github/workflows/spec-pairing.yml"
+  push:
+    branches: [main]
+    paths:
+      - "**/*.spec.uibridge.json"
+      - "**/specs/pages/**"
+      - ".github/workflows/spec-pairing.yml"
+  workflow_dispatch:
+
+jobs:
+  check-pairing:
+    name: Check spec <-> IR pairing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout qontinui-runner
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run pairing check (warn-only)
+        run: npx --yes -p @qontinui/ui-bridge-auto check-spec-pairing --root . --mode=warn


### PR DESCRIPTION
## Summary
- Adds the spec <-> IR pairing CI gate now that \`@qontinui/ui-bridge-auto@0.1.0\` is on npm.
- **Warn-only** because the runner has one intentional drift (\`active.spec\`): its IR is hand-authored against a 4-state canonical model from section 2 of the UI Bridge redesign, not the 9-group legacy convention. Block mode would fail every PR.
- Path to block mode: either harmonize \`active.spec\` with its IR, or land a per-page exclusion mechanism in \`check-spec-pairing\`. Then flip \`--mode=warn\` to \`--mode=block\`.

## Snapshot at PR open
\`paired: 94, missing: 0, mismatched: 1\` — only \`active.spec\` mismatches.

## Test plan
- [x] Local check matches snapshot
- [ ] CI run on this PR exits 0 (warn mode always exits 0; verify the report appears in logs)