### PR TITLE
ci(spec-pairing): apply acceptDrift policy to active + flip to block mode

### DIFF
--- a/.github/workflows/spec-pairing.yml
+++ b/.github/workflows/spec-pairing.yml
@@ -17,9 +17,11 @@ name: Spec Pairing Gate
 # Local snapshot after policy lands: paired: 94, accepted-drift: 1,
 # missing: 0, mismatched: 0.
 #
-# Requires `@qontinui/ui-bridge-auto >= 0.1.1` for `pairingPolicy`
-# support — older versions ignore the field and would still flag
-# `active` as a mismatch.
+# Requires `@qontinui/ui-bridge-auto >= 0.1.2` for `pairingPolicy`
+# support. The on-registry 0.1.1 was published from a checkout that
+# missed the policy-reader commit, so 0.1.2 is the first version that
+# actually honors `acceptDrift`. Older versions ignore the field and
+# would still flag `active` as a mismatch.
 
 on:
   pull_request:
@@ -50,4 +52,4 @@ jobs:
           node-version: "20"
 
       - name: Run pairing check (block mode)
-        run: npx --yes -p @qontinui/ui-bridge-auto@^0.1.1 check-spec-pairing --root . --mode=block
+        run: npx --yes -p @qontinui/ui-bridge-auto@^0.1.2 check-spec-pairing --root . --mode=block

--- a/.github/workflows/spec-pairing.yml
+++ b/.github/workflows/spec-pairing.yml
@@ -4,15 +4,22 @@ name: Spec Pairing Gate
 # under `specs/pages/<id>/`, and that the pairing round-trips cleanly
 # (group count + ids + assertion total match the IR's forward projection).
 #
-# Currently warn-only: runner has one intentional drift (`active.spec`)
-# from section 2 of the UI Bridge redesign — the IR is hand-authored
-# against a 4-state canonical model, while the legacy spec follows the
-# 9-group convention. Block mode would fail every PR until either:
-#   (a) `active.spec` is harmonized with its IR, or
-#   (b) check-spec-pairing grows a per-page exclusion mechanism.
-# At that point flip `--mode=warn` to `--mode=block`.
+# Block mode: the job fails the PR on any missing or mismatched
+# pairing that isn't covered by an IR's `pairingPolicy.acceptDrift`.
 #
-# Local snapshot at workflow creation: paired: 94, missing: 0, mismatched: 1.
+# `active.spec` carries an `acceptDrift` policy (see
+# `specs/pages/active/state-machine.derived.json`) — section 2 of the
+# UI Bridge redesign hand-authored its IR against a 4-state canonical
+# model rather than the legacy 9-group convention. The policy expires
+# 2026-10-15, after which this gate will start failing the PR until
+# the policy is renewed or `active`'s IR is harmonized.
+#
+# Local snapshot after policy lands: paired: 94, accepted-drift: 1,
+# missing: 0, mismatched: 0.
+#
+# Requires `@qontinui/ui-bridge-auto >= 0.1.1` for `pairingPolicy`
+# support — older versions ignore the field and would still flag
+# `active` as a mismatch.
 
 on:
   pull_request:
@@ -42,5 +49,5 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Run pairing check (warn-only)
-        run: npx --yes -p @qontinui/ui-bridge-auto check-spec-pairing --root . --mode=warn
+      - name: Run pairing check (block mode)
+        run: npx --yes -p @qontinui/ui-bridge-auto@^0.1.1 check-spec-pairing --root . --mode=block

--- a/specs/pages/active/state-machine.derived.json
+++ b/specs/pages/active/state-machine.derived.json
@@ -7,6 +7,14 @@
     "purpose": "ActiveDashboardPage",
     "tags": ["active-dashboard", "monitoring", "real-time", "tier-1"]
   },
+  "pairingPolicy": {
+    "acceptDrift": {
+      "axes": ["groupCount", "groupIds", "assertionCount"],
+      "reason": "Section 2 of the UI Bridge redesign hand-authored this IR against a 4-state canonical model (idle / running / paused / completion-overlay) rather than the legacy spec's 9-group convention. Harmonizing them would lose the section-2 worked sample. Honored by check-spec-pairing >= 0.1.1.",
+      "since": "2026-04-15",
+      "expiresAt": "2026-10-15"
+    }
+  },
   "states": [
     {
       "id": "idle",


### PR DESCRIPTION
## Summary
Apply \`IRPairingPolicy.acceptDrift\` to \`active.spec\`'s IR (the only intentional drift in the runner) and flip the pairing gate from \`--mode=warn\` to \`--mode=block\`.

### \`active\`'s policy block
\`specs/pages/active/state-machine.derived.json\` gains:

\`\`\`json
"pairingPolicy": {
  "acceptDrift": {
    "axes": ["groupCount", "groupIds", "assertionCount"],
    "reason": "Section 2 of the UI Bridge redesign hand-authored this IR against a 4-state canonical model (idle / running / paused / completion-overlay) rather than the legacy spec's 9-group convention. Harmonizing them would lose the section-2 worked sample. Honored by check-spec-pairing >= 0.1.1.",
    "since": "2026-04-15",
    "expiresAt": "2026-10-15"
  }
}
\`\`\`

The expiresAt forces re-justification in ~5 months — when the policy expires, the gate downgrades it back to an ordinary mismatch with a \`[policy EXPIRED]\` annotation.

### Workflow flip
\`.github/workflows/spec-pairing.yml\` flips \`--mode=warn\` to \`--mode=block\`. Also pins the npx invocation to \`@^0.1.1\` so the gate doesn't silently regress to a version that ignores the policy field.

### Verification
With the new gate version honoring the policy, local check-pairing reports:
\`\`\`
paired: 94, accepted-drift: 1, missing: 0, mismatched: 0
[check-pairing] DRIFT src\specs\active.spec.uibridge.json (page-id active): axes=[groupCount, groupIds, assertionCount] reason="..."
\`\`\`

## Sequencing — DRAFT until prerequisites land

This PR is **draft** because it requires:

1. **qontinui-schemas#5** merged + \`@qontinui/shared-types@0.2.2\` published (carries the \`IRPairingPolicy\` type)
2. **qontinui/ui-bridge-auto#5** merged + \`@qontinui/ui-bridge-auto@0.1.1\` published (carries the policy reader)

Once 0.1.1 is on the npm registry, mark this PR Ready for Review and merge. Until then, merging would flip the gate to block mode while CI fetches \`@qontinui/ui-bridge-auto@latest\` (still 0.1.0), which doesn't honor the policy and would fail every PR.

The policy block on active's IR is **harmless** with 0.1.0 (extra JSON field is ignored). Only the workflow's mode flip is timing-sensitive — but they're bundled here so the failure mode is "draft is held until the dep is ready" rather than "two separate PRs forget about each other."

## Test plan
- [x] Local \`check-spec-pairing\` (built from feat/metro-plugin) reports \`paired: 94, accepted-drift: 1, missing: 0, mismatched: 0\`, exits 0 in block mode
- [x] DRIFT log line shows the policy reason
- [ ] After undraft + merge: CI run on a follow-up PR exits 0