### PR TITLE
fix(accessibility/ax): handle Option<ItemRef> from CFArray::get and CFDictionary::find

### DIFF
--- a/src-tauri/src/accessibility/adapters/ax.rs
+++ b/src-tauri/src/accessibility/adapters/ax.rs
@@ -307,7 +307,10 @@ fn ax_children(element: AXUIElementRef) -> Vec<AXUIElementRef> {
     let count = array.len();
     let mut children = Vec::with_capacity(count as usize);
     for i in 0..count {
-        let child = unsafe { *array.get(i) };
+        // core-foundation 0.10: CFArray::get returns Option<ItemRef<'_, T>>; deref ItemRef to recover T.
+        let Some(child) = array.get(i).map(|r| *r) else {
+            continue;
+        };
         if !child.is_null() {
             // Retain so that the child outlives the parent array
             unsafe { CFRetain(child as CFTypeRef) };
@@ -538,7 +541,10 @@ fn find_window_by_title(title: &str) -> anyhow::Result<AXUIElementRef> {
     let title_lower = title.to_lowercase();
 
     for i in 0..array.len() {
-        let dict_ref = unsafe { *array.get(i) };
+        // core-foundation 0.10: CFArray::get returns Option<ItemRef<'_, T>>; deref ItemRef to recover T.
+        let Some(dict_ref) = array.get(i).map(|r| *r) else {
+            continue;
+        };
         if dict_ref.is_null() {
             continue;
         }
@@ -551,11 +557,11 @@ fn find_window_by_title(title: &str) -> anyhow::Result<AXUIElementRef> {
             core_foundation::dictionary::CFDictionary::wrap_under_get_rule(dict_ref as *const _)
         };
 
-        // Use find() on the dictionary
-        let maybe_pid = pid_val.find(pid_key.as_CFTypeRef());
-        let maybe_name = pid_val.find(name_key.as_CFTypeRef());
+        // core-foundation 0.10: CFDictionary::find returns Option<ItemRef<'_, V>>; collapse to inner pointer.
+        let maybe_pid = pid_val.find(pid_key.as_CFTypeRef()).map(|r| *r);
+        let maybe_name = pid_val.find(name_key.as_CFTypeRef()).map(|r| *r);
 
-        if let (Some(&pid_ref), Some(&name_ref)) = (maybe_pid, maybe_name) {
+        if let (Some(pid_ref), Some(name_ref)) = (maybe_pid, maybe_name) {
             // Extract window name
             if name_ref.is_null() {
                 continue;
@@ -592,7 +598,10 @@ fn find_window_by_title(title: &str) -> anyhow::Result<AXUIElementRef> {
                         unsafe { CFArray::wrap_under_create_rule(windows_val as *const _) };
 
                     for j in 0..windows.len() {
-                        let win = unsafe { *windows.get(j) };
+                        // core-foundation 0.10: CFArray::get returns Option<ItemRef<'_, T>>; deref ItemRef to recover T.
+                        let Some(win) = windows.get(j).map(|r| *r) else {
+                            continue;
+                        };
                         if win.is_null() {
                             continue;
                         }

--- a/src-tauri/src/accessibility/adapters/ax.rs
+++ b/src-tauri/src/accessibility/adapters/ax.rs
@@ -38,6 +38,8 @@ use super::super::traits::{
 /// Opaque handle to an AXUIElement. This is a CFTypeRef under the hood.
 type AXUIElementRef = *const c_void;
 type AXError = i32;
+// Mirrors libc's `pid_t` to match the AX FFI signature; intentional snake_case.
+#[allow(non_camel_case_types)]
 type pid_t = i32;
 
 const AX_ERROR_SUCCESS: AXError = 0;
@@ -188,7 +190,7 @@ fn ax_string_attr(element: AXUIElementRef, attr_name: &str) -> Option<String> {
     // value is a CFStringRef — attempt to downcast
     let cf_type: CFType = unsafe { TCFType::wrap_under_create_rule(value) };
     // Try to interpret as CFString
-    if cf_type.type_of() == unsafe { core_foundation::string::CFString::type_id() } {
+    if cf_type.type_of() == core_foundation::string::CFString::type_id() {
         let s: CFString = unsafe { TCFType::wrap_under_get_rule(value as CFStringRef) };
         Some(s.to_string())
     } else {
@@ -553,7 +555,9 @@ fn find_window_by_title(title: &str) -> anyhow::Result<AXUIElementRef> {
         let pid_key = CFString::new("kCGWindowOwnerPID");
         let name_key = CFString::new("kCGWindowName");
 
-        let pid_val = unsafe {
+        // Explicit K/V annotation: without it, the find() + map(|r| *r) chain below leaves V
+        // ambiguous in core-foundation 0.10 (E0282).
+        let pid_val: core_foundation::dictionary::CFDictionary<*const c_void, *const c_void> = unsafe {
             core_foundation::dictionary::CFDictionary::wrap_under_get_rule(dict_ref as *const _)
         };
 


### PR DESCRIPTION
## Summary

Restores macOS CI compilation. The AX adapter (`src-tauri/src/accessibility/adapters/ax.rs`) had been emitting clippy errors on macOS since it landed on 2026-03-31 (`e2326981`); the failure was masked by an earlier lint step until that step was fixed by #19. With #19 merged + `fail-fast: false` in place, the macOS leg of CI is now the only red one — this PR is what unblocks it.

`core-foundation` 0.10 changed `CFArray::get` to return `Option<ItemRef<'_, T>>` and `CFDictionary::find` to return `Option<ItemRef<'_, V>>`. The adapter still dereferenced both directly, producing five compile errors:

| Site | Error | Function |
| --- | --- | --- |
| `ax.rs:310` | E0614 | `ax_children` (`*array.get(i)`) |
| `ax.rs:541` | E0614 | `find_window_by_title` (CGWindowList loop) |
| `ax.rs:595` | E0614 | `find_window_by_title` (AXWindows loop) |
| `ax.rs:555` | E0308 | `pid_val.find(pid_key…)` |
| `ax.rs:556` | E0308 | `pid_val.find(name_key…)` |

Fix at every site collapses the `ItemRef` back to the inner pointer with `.map(|r| *r)`; the array sites use `let Some(..) else { continue }` so the original null-pointer guard remains as a second filter. No behavioral change.

Linux + Windows are unaffected — the adapter is gated behind `#[cfg(target_os = "macos")]`.

## Test plan

- [ ] `test (macos-latest)` job — Clippy step passes (`cargo clippy -- -D warnings`)
- [ ] `test (macos-latest)` job — Rust tests pass (no AX integration tests run in CI; pure unit tests only)
- [ ] `test (ubuntu-22.04)` and `test (windows-latest)` jobs remain green (no regression)
- [ ] No new clippy warnings in `find_window_by_title` (the most refactored function)

This fix unblocks the macOS build legs of `release.yml` too — the same code is compiled on tag push or `workflow_dispatch`.