### PR TITLE
ci: build frontend before cargo steps so generate_context! resolves frontendDist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,13 @@ jobs:
       - name: Lint frontend code
         run: pnpm run lint
 
+      # Build the frontend before any cargo step. tauri::generate_context!()
+      # in src-tauri/src/lib.rs reads tauri.conf.json at compile time and
+      # panics if frontendDist (../dist) is missing — which broke `Clippy
+      # check`, `Run Rust tests`, and `Build Tauri app` on every platform.
+      - name: Build frontend
+        run: pnpm run build
+
       - name: Format Rust code check
         run: |
           cd src-tauri
@@ -110,9 +117,6 @@ jobs:
         run: |
           cd src-tauri
           cargo test --verbose
-
-      - name: Build frontend
-        run: pnpm run build
 
       - name: Build Tauri app (development)
         run: pnpm run tauri build -- --debug


### PR DESCRIPTION
## Summary

Every cargo step (`Clippy check`, `Run Rust tests`, `Build Tauri app`) currently proc-macro-panics on a clean cache because `tauri::generate_context!()` in `src-tauri/src/lib.rs:84` reads `tauri.conf.json` at compile time and verifies `frontendDist = "../dist"` exists. The workflow only built the frontend AFTER those cargo steps:

```
- Lint frontend code
- Format Rust check
- Clippy check          ← needs frontendDist (../dist)
- Run Rust tests        ← same
- Build frontend        ← creates dist/
- Build Tauri app       ← redundant by the time it runs
```

This was masked while clippy was already failing on earlier code errors. Once those cleared (PR #23), the proc-macro panic was the SOLE remaining failure on all three platform legs:

```
error: proc macro panicked
  --> src-tauri/src/lib.rs:84:14
   = help: message: The `frontendDist` configuration is set to "../dist" but this path doesn't exist
```

This PR moves `Build frontend` to immediately after `Lint frontend code`, so the dist directory exists for every subsequent cargo invocation.

## Test plan

- [ ] All three `test (...)` jobs reach `Clippy check` without `proc macro panicked` failure
- [ ] Linux/Windows test jobs go green (no other latent issues lurking — the macOS leg has its own separate clippy work in PR #23)
- [ ] No regression in `forbid-runner-schema` or `security` jobs

Companion to #23 (which fixes the macOS-only `core-foundation` 0.10 API drift).