### PR TITLE
feat(section-11): runner — regression executor + scenario HTTP + coverage panel + CLI + drift API + suite-list + overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,26 @@ npm run tauri build
 # Linux:   src-tauri/target/release/bundle/appimage/
 ```
 
+## Scripts
+
+CI-friendly helpers in `scripts/` that don't require booting the runner:
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/coverage-diff.mjs` | Gate regression-suite coverage in CI. Wraps the pure `coverageDiff` from `@qontinui/ui-bridge-auto/regression`; exits non-zero when `uncoveredRatio` exceeds a threshold. |
+| `scripts/validate-ws-actions.mjs` | Cross-language action-name validator (runner Rust ↔ wrapper SDK TS). |
+
+Example — fail CI when more than 10% of regression assertions are un-exercised:
+
+```bash
+npm run coverage-diff -- \
+  --suite ./suite.json \
+  --exercise-log ./exercise-log.json \
+  --threshold 0.10
+```
+
+`--format json` prints the full `CoverageDiffReport` for piping into other tools. Run `node scripts/coverage-diff.mjs --help` for the full usage and exit-code matrix. Tests live at `scripts/__tests__/coverage-diff.test.mjs` and run via `npm run coverage-diff:test`.
+
 ## Wrappers
 
 The wrapper subsystem (install, list, dispatch, credentials) is **owned by the primary runner**.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,8 @@
     "check": "npm run typecheck && npm run lint && npm run format:check && npm run validate:ws-actions && npm run vocab:check",
     "check:all": "npm run check && npm run rust:check && npm run rust:lint",
     "validate:ws-actions": "node scripts/validate-ws-actions.mjs",
+    "coverage-diff": "node scripts/coverage-diff.mjs",
+    "coverage-diff:test": "node --test scripts/__tests__/coverage-diff.test.mjs",
     "vocab:gen": "node scripts/validate-ws-actions.mjs --emit-doc ui-bridge/docs-site/docs/wrappers/action-vocabulary.md",
     "vocab:check": "node scripts/validate-ws-actions.mjs --check-doc ui-bridge/docs-site/docs/wrappers/action-vocabulary.md",
     "dev": "vite",

--- a/scripts/__tests__/coverage-diff.test.mjs
+++ b/scripts/__tests__/coverage-diff.test.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+// Smoke-test for coverage-diff.mjs (Section 11, Phase C3).
+//
+// Uses Node's built-in `node:test` runner so this file requires zero config
+// in `vitest.config.ts` (which only globs `src/**`). The script under test is
+// invoked as a child process so we exercise the real CLI surface — argv
+// parsing, exit codes, stdout shape — exactly as CI would.
+//
+// Run with:
+//   node --test scripts/__tests__/coverage-diff.test.mjs
+//
+// On Node 22+ (the runner's pinned Node) `node:test` and `node:assert` are
+// stable and need no flags. We deliberately avoid vitest here so the script
+// stays runnable in plain CI containers without the runner's full toolchain.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SCRIPT = resolve(__dirname, "..", "coverage-diff.mjs");
+const REPO = resolve(__dirname, "..", "..");
+
+// ---------------------------------------------------------------------------
+// Fixture builders — minimal RegressionSuite shape that satisfies
+// `deserializeSuite`'s shallow validation. Each case has 3 assertions; the
+// total is 6 assertions across 2 cases.
+// ---------------------------------------------------------------------------
+
+function makeSuite() {
+  return {
+    id: "doc@suite",
+    ir: { id: "doc", version: "1.0" },
+    cases: [
+      {
+        id: "t-a-to-b",
+        transitionId: "t-a-to-b",
+        fromStates: ["a"],
+        activateStates: ["b"],
+        exitStates: [],
+        assertions: [
+          {
+            kind: "state-active",
+            phase: "pre",
+            stateId: "a",
+            requiredElementIds: [0, 1],
+          },
+          {
+            kind: "state-active",
+            phase: "post",
+            stateId: "b",
+            requiredElementIds: [0],
+          },
+          {
+            kind: "action-target-resolves",
+            transitionId: "t-a-to-b",
+            actionIndex: 0,
+            targetCriteria: { id: "btn-go" },
+          },
+        ],
+      },
+      {
+        id: "t-b-to-c",
+        transitionId: "t-b-to-c",
+        fromStates: ["b"],
+        activateStates: ["c"],
+        exitStates: [],
+        assertions: [
+          {
+            kind: "state-active",
+            phase: "pre",
+            stateId: "b",
+            requiredElementIds: [0],
+          },
+          {
+            kind: "state-active",
+            phase: "post",
+            stateId: "c",
+            requiredElementIds: [],
+          },
+          {
+            kind: "action-target-resolves",
+            transitionId: "t-b-to-c",
+            actionIndex: 0,
+            targetCriteria: { id: "btn-next" },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function makeFullLog() {
+  return [
+    {
+      caseId: "t-a-to-b",
+      assertionId: "state-active:pre:a",
+      executedAt: "2026-05-02T00:00:00.000Z",
+    },
+    {
+      caseId: "t-a-to-b",
+      assertionId: "state-active:post:b",
+      executedAt: "2026-05-02T00:00:00.000Z",
+    },
+    {
+      caseId: "t-a-to-b",
+      assertionId: "action-target-resolves:t-a-to-b#0",
+      executedAt: "2026-05-02T00:00:00.000Z",
+    },
+    {
+      caseId: "t-b-to-c",
+      assertionId: "state-active:pre:b",
+      executedAt: "2026-05-02T00:00:00.000Z",
+    },
+    {
+      caseId: "t-b-to-c",
+      assertionId: "state-active:post:c",
+      executedAt: "2026-05-02T00:00:00.000Z",
+    },
+    {
+      caseId: "t-b-to-c",
+      assertionId: "action-target-resolves:t-b-to-c#0",
+      executedAt: "2026-05-02T00:00:00.000Z",
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Per-test scratch dir + child-process runner
+// ---------------------------------------------------------------------------
+
+function withFixtureDir(fn) {
+  const dir = mkdtempSync(join(tmpdir(), "cov-diff-"));
+  try {
+    return fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeJson(dir, name, value) {
+  const path = join(dir, name);
+  writeFileSync(path, JSON.stringify(value, null, 2));
+  return path;
+}
+
+function runCli(args) {
+  // `inherit: false` keeps stderr off the test runner's tty; we capture both
+  // streams as utf8 so assertions can match on substrings.
+  const res = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: REPO,
+    encoding: "utf8",
+  });
+  return {
+    code: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("exits 0 when coverage is full", () => {
+  withFixtureDir((dir) => {
+    const suitePath = writeJson(dir, "suite.json", makeSuite());
+    const logPath = writeJson(dir, "log.json", makeFullLog());
+
+    const r = runCli([
+      "--suite",
+      suitePath,
+      "--exercise-log",
+      logPath,
+      "--threshold",
+      "0.10",
+    ]);
+    assert.equal(r.code, 0, `expected exit 0, got ${r.code}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout, /Status: PASS/);
+    assert.match(r.stdout, /6\/6 assertions/);
+  });
+});
+
+test("exits 1 when log is empty (uncoveredRatio = 1.0)", () => {
+  withFixtureDir((dir) => {
+    const suitePath = writeJson(dir, "suite.json", makeSuite());
+    const logPath = writeJson(dir, "log.json", []);
+
+    const r = runCli(["--suite", suitePath, "--exercise-log", logPath]);
+    assert.equal(r.code, 1, `expected exit 1, got ${r.code}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout, /Status: FAIL/);
+    assert.match(r.stdout, /uncoveredRatio:\s+1\.0000/);
+  });
+});
+
+test("exits 0 with --format json and stdout parses as CoverageDiffReport", () => {
+  withFixtureDir((dir) => {
+    const suitePath = writeJson(dir, "suite.json", makeSuite());
+    const logPath = writeJson(dir, "log.json", makeFullLog());
+
+    const r = runCli([
+      "--suite",
+      suitePath,
+      "--exercise-log",
+      logPath,
+      "--format",
+      "json",
+    ]);
+    assert.equal(r.code, 0, `expected exit 0, got ${r.code}\nstderr: ${r.stderr}`);
+
+    const report = JSON.parse(r.stdout);
+    // Shape check — every documented field must exist.
+    assert.ok(Array.isArray(report.unexercisedAssertions));
+    assert.ok(Array.isArray(report.uncoveredTransitions));
+    assert.equal(typeof report.stats, "object");
+    assert.equal(typeof report.stats.totalAssertions, "number");
+    assert.equal(typeof report.stats.exercisedAssertions, "number");
+    assert.equal(typeof report.stats.totalTransitions, "number");
+    assert.equal(typeof report.stats.coveredTransitions, "number");
+    assert.equal(typeof report.stats.uncoveredRatio, "number");
+    // Value check for the full-log fixture.
+    assert.equal(report.stats.totalAssertions, 6);
+    assert.equal(report.stats.exercisedAssertions, 6);
+    assert.equal(report.stats.uncoveredRatio, 0);
+  });
+});
+
+test("exits 2 on invalid --threshold (out of [0,1])", () => {
+  withFixtureDir((dir) => {
+    const suitePath = writeJson(dir, "suite.json", makeSuite());
+    const logPath = writeJson(dir, "log.json", makeFullLog());
+
+    const r = runCli([
+      "--suite",
+      suitePath,
+      "--exercise-log",
+      logPath,
+      "--threshold",
+      "1.5",
+    ]);
+    assert.equal(r.code, 2, `expected exit 2, got ${r.code}\nstdout: ${r.stdout}`);
+    assert.match(r.stderr, /--threshold must be a number in \[0, 1\]/);
+  });
+});
+
+test("exits 2 when required flags are missing", () => {
+  const r = runCli(["--threshold", "0.5"]);
+  assert.equal(r.code, 2, `expected exit 2, got ${r.code}\nstdout: ${r.stdout}`);
+  assert.match(r.stderr, /--suite and --exercise-log are both required/);
+});
+
+test("exits 1 when uncoveredRatio strictly exceeds threshold", () => {
+  withFixtureDir((dir) => {
+    // Only 1 of the 6 assertions is exercised → uncoveredRatio = 5/6 ≈ 0.833
+    const suitePath = writeJson(dir, "suite.json", makeSuite());
+    const partialLog = [
+      {
+        caseId: "t-a-to-b",
+        assertionId: "state-active:pre:a",
+        executedAt: "2026-05-02T00:00:00.000Z",
+      },
+    ];
+    const logPath = writeJson(dir, "log.json", partialLog);
+
+    const r = runCli([
+      "--suite",
+      suitePath,
+      "--exercise-log",
+      logPath,
+      "--threshold",
+      "0.50",
+    ]);
+    assert.equal(r.code, 1, `expected exit 1, got ${r.code}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout, /Status: FAIL/);
+  });
+});
+
+test("exits 0 when uncoveredRatio exactly equals threshold (boundary)", () => {
+  withFixtureDir((dir) => {
+    // 1/2 transitions covered with 3 assertions exercised out of 6 →
+    // uncoveredRatio = 0.5. Threshold = 0.5 must NOT fail (spec: strict >).
+    const suitePath = writeJson(dir, "suite.json", makeSuite());
+    const halfLog = [
+      {
+        caseId: "t-a-to-b",
+        assertionId: "state-active:pre:a",
+        executedAt: "2026-05-02T00:00:00.000Z",
+      },
+      {
+        caseId: "t-a-to-b",
+        assertionId: "state-active:post:b",
+        executedAt: "2026-05-02T00:00:00.000Z",
+      },
+      {
+        caseId: "t-a-to-b",
+        assertionId: "action-target-resolves:t-a-to-b#0",
+        executedAt: "2026-05-02T00:00:00.000Z",
+      },
+    ];
+    const logPath = writeJson(dir, "log.json", halfLog);
+
+    const r = runCli([
+      "--suite",
+      suitePath,
+      "--exercise-log",
+      logPath,
+      "--threshold",
+      "0.50",
+    ]);
+    assert.equal(r.code, 0, `expected exit 0, got ${r.code}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout, /Status: PASS/);
+  });
+});
+
+test("exits 1 when --suite path does not exist", () => {
+  withFixtureDir((dir) => {
+    const logPath = writeJson(dir, "log.json", makeFullLog());
+
+    const r = runCli([
+      "--suite",
+      join(dir, "missing.json"),
+      "--exercise-log",
+      logPath,
+    ]);
+    assert.equal(r.code, 1, `expected exit 1, got ${r.code}\nstdout: ${r.stdout}`);
+    assert.match(r.stderr, /cannot read --suite/);
+  });
+});
+
+test("--help prints usage and exits 0", () => {
+  const r = runCli(["--help"]);
+  assert.equal(r.code, 0, `expected exit 0, got ${r.code}\nstderr: ${r.stderr}`);
+  assert.match(r.stdout, /Usage: coverage-diff\.mjs/);
+  assert.match(r.stdout, /Exit codes:/);
+});

--- a/scripts/coverage-diff.mjs
+++ b/scripts/coverage-diff.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+// coverage-diff.mjs — CLI gate for regression-suite coverage (Section 11, C3).
+//
+// Wraps the pure `coverageDiff` function from
+// `@qontinui/ui-bridge-auto/regression` so CI pipelines can fail a build when
+// regression-suite coverage falls below a threshold — without booting the
+// runner, a browser, or any UI Bridge connection.
+//
+// USAGE
+//   node scripts/coverage-diff.mjs \
+//       --suite        path/to/suite.json        # serialized RegressionSuite
+//       --exercise-log path/to/exercise-log.json # AssertionExecution[]
+//       [--threshold   0.20]                     # max acceptable uncoveredRatio
+//       [--format      pretty|json]              # default: pretty
+//
+// FLAGS
+//   --suite         (required) Path to a JSON file produced by
+//                   `serializeSuite(...)` from
+//                   `@qontinui/ui-bridge-auto/regression`. The file is read as
+//                   text and passed verbatim to `deserializeSuite`.
+//   --exercise-log  (required) Path to a JSON file holding an array of
+//                   `AssertionExecution` records:
+//                   `[{caseId, assertionId, executedAt}]`.
+//   --threshold     Optional. Floating-point number in `[0, 1]`. The CLI
+//                   exits with code 1 when the report's `stats.uncoveredRatio`
+//                   STRICTLY exceeds this value. Default `0.20` (20% slack).
+//   --format        Optional. `pretty` (default) prints a human-readable
+//                   summary on stdout. `json` prints the full
+//                   `CoverageDiffReport` as JSON for piping into other tools.
+//
+// EXIT CODES
+//   0 — coverage acceptable (uncoveredRatio <= threshold).
+//   1 — coverage below threshold OR runtime error reading/parsing the inputs.
+//   2 — invalid CLI arguments (missing required flag, malformed --threshold,
+//       unknown --format value).
+//
+// EXAMPLES
+//   # Pretty mode, 10% threshold
+//   node scripts/coverage-diff.mjs \
+//       --suite ./suite.json \
+//       --exercise-log ./log.json \
+//       --threshold 0.10
+//
+//   # JSON mode (machine-readable, full report on stdout)
+//   node scripts/coverage-diff.mjs \
+//       --suite ./suite.json \
+//       --exercise-log ./log.json \
+//       --format json
+//
+//   # via npm (runner package.json `scripts.coverage-diff`)
+//   npm run coverage-diff -- --suite ./suite.json --exercise-log ./log.json
+
+import { readFileSync } from "node:fs";
+import { parseArgs } from "node:util";
+import {
+  coverageDiff,
+  deserializeSuite,
+} from "@qontinui/ui-bridge-auto/regression";
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+let parsed;
+try {
+  parsed = parseArgs({
+    options: {
+      suite: { type: "string" },
+      "exercise-log": { type: "string" },
+      threshold: { type: "string", default: "0.20" },
+      format: { type: "string", default: "pretty" },
+      help: { type: "boolean", short: "h", default: false },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+} catch (err) {
+  process.stderr.write(`error: ${err.message}\n`);
+  printUsage(process.stderr);
+  process.exit(2);
+}
+
+const { values } = parsed;
+
+if (values.help) {
+  printUsage(process.stdout);
+  process.exit(0);
+}
+
+if (!values.suite || !values["exercise-log"]) {
+  process.stderr.write(
+    "error: --suite and --exercise-log are both required\n",
+  );
+  printUsage(process.stderr);
+  process.exit(2);
+}
+
+const threshold = Number.parseFloat(values.threshold);
+if (!Number.isFinite(threshold) || threshold < 0 || threshold > 1) {
+  process.stderr.write(
+    `error: --threshold must be a number in [0, 1], got ${JSON.stringify(values.threshold)}\n`,
+  );
+  process.exit(2);
+}
+
+if (values.format !== "pretty" && values.format !== "json") {
+  process.stderr.write(
+    `error: --format must be "pretty" or "json", got ${JSON.stringify(values.format)}\n`,
+  );
+  process.exit(2);
+}
+
+// ---------------------------------------------------------------------------
+// Load inputs
+// ---------------------------------------------------------------------------
+
+let suiteText;
+try {
+  suiteText = readFileSync(values.suite, "utf8");
+} catch (err) {
+  process.stderr.write(
+    `error: cannot read --suite ${JSON.stringify(values.suite)}: ${err.message}\n`,
+  );
+  process.exit(1);
+}
+
+let suite;
+try {
+  // `deserializeSuite` accepts a JSON STRING (not a parsed object) — see
+  // ui-bridge-auto/src/state/regression-generator.ts. Passing JSON.parse
+  // output here would throw inside deserializeSuite's own JSON.parse call.
+  suite = deserializeSuite(suiteText);
+} catch (err) {
+  process.stderr.write(
+    `error: failed to parse suite at ${JSON.stringify(values.suite)}: ${err.message}\n`,
+  );
+  process.exit(1);
+}
+
+let logText;
+try {
+  logText = readFileSync(values["exercise-log"], "utf8");
+} catch (err) {
+  process.stderr.write(
+    `error: cannot read --exercise-log ${JSON.stringify(values["exercise-log"])}: ${err.message}\n`,
+  );
+  process.exit(1);
+}
+
+let exerciseLog;
+try {
+  exerciseLog = JSON.parse(logText);
+} catch (err) {
+  process.stderr.write(
+    `error: failed to parse exercise log at ${JSON.stringify(values["exercise-log"])}: ${err.message}\n`,
+  );
+  process.exit(1);
+}
+if (!Array.isArray(exerciseLog)) {
+  process.stderr.write(
+    `error: exercise log at ${JSON.stringify(values["exercise-log"])} must be a JSON array of AssertionExecution records\n`,
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Compute + emit
+// ---------------------------------------------------------------------------
+
+const report = coverageDiff(suite, exerciseLog);
+
+if (values.format === "json") {
+  process.stdout.write(JSON.stringify(report, null, 2));
+  process.stdout.write("\n");
+} else {
+  process.stdout.write(formatPretty(report, threshold));
+}
+
+if (report.stats.uncoveredRatio > threshold) {
+  process.exit(1);
+}
+process.exit(0);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatPretty(report, threshold) {
+  const lines = [];
+  const s = report.stats;
+
+  const assertionPct =
+    s.totalAssertions === 0
+      ? 100
+      : (s.exercisedAssertions / s.totalAssertions) * 100;
+  const transitionPct =
+    s.totalTransitions === 0
+      ? 100
+      : (s.coveredTransitions / s.totalTransitions) * 100;
+
+  lines.push(
+    `Suite coverage: ${formatPct(assertionPct)} (${s.exercisedAssertions}/${s.totalAssertions} assertions, ${s.coveredTransitions}/${s.totalTransitions} transitions)`,
+  );
+  lines.push(
+    `  assertions exercised: ${s.exercisedAssertions}/${s.totalAssertions} (${formatPct(assertionPct)})`,
+  );
+  lines.push(
+    `  transitions covered:  ${s.coveredTransitions}/${s.totalTransitions} (${formatPct(transitionPct)})`,
+  );
+  lines.push(
+    `  uncoveredRatio:       ${formatRatio(s.uncoveredRatio)} (threshold ${formatRatio(threshold)})`,
+  );
+
+  if (report.unexercisedAssertions.length > 0) {
+    lines.push("");
+    lines.push(
+      `Un-exercised assertions (${report.unexercisedAssertions.length}):`,
+    );
+    for (const a of report.unexercisedAssertions) {
+      lines.push(`  - ${a.caseId} :: ${a.assertionId}`);
+    }
+  } else {
+    lines.push("");
+    lines.push("Un-exercised assertions: none");
+  }
+
+  if (report.uncoveredTransitions.length > 0) {
+    lines.push("");
+    lines.push(
+      `Un-covered transitions (${report.uncoveredTransitions.length}):`,
+    );
+    for (const t of report.uncoveredTransitions) {
+      lines.push(`  - ${t.caseId} (transition ${t.transitionId})`);
+    }
+  } else {
+    lines.push("");
+    lines.push("Un-covered transitions: none");
+  }
+
+  lines.push("");
+  const pass = report.stats.uncoveredRatio <= threshold;
+  if (pass) {
+    lines.push(
+      `Status: PASS (uncoveredRatio ${formatRatio(report.stats.uncoveredRatio)} <= threshold ${formatRatio(threshold)})`,
+    );
+  } else {
+    lines.push(
+      `Status: FAIL (uncoveredRatio ${formatRatio(report.stats.uncoveredRatio)} > threshold ${formatRatio(threshold)})`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function formatPct(n) {
+  // One decimal place, no scientific notation. `100` rounds to `100.0%`.
+  return `${n.toFixed(1)}%`;
+}
+
+function formatRatio(n) {
+  // Four decimals — preserves enough resolution to compare against typical
+  // thresholds like 0.05 / 0.10 / 0.20 without surprising rounding.
+  return n.toFixed(4);
+}
+
+function printUsage(stream) {
+  stream.write(
+    [
+      "Usage: coverage-diff.mjs --suite <path> --exercise-log <path> [--threshold 0.20] [--format pretty|json]",
+      "",
+      "Required:",
+      "  --suite <path>          Serialized RegressionSuite JSON",
+      "  --exercise-log <path>   AssertionExecution[] JSON",
+      "",
+      "Optional:",
+      "  --threshold <float>     Max acceptable uncoveredRatio in [0, 1] (default 0.20)",
+      "  --format <pretty|json>  Output format (default pretty)",
+      "  -h, --help              Print this help and exit 0",
+      "",
+      "Exit codes:",
+      "  0  coverage acceptable",
+      "  1  coverage below threshold OR runtime error",
+      "  2  invalid arguments",
+      "",
+    ].join("\n"),
+  );
+}

--- a/src-tauri/queries/regression.sql
+++ b/src-tauri/queries/regression.sql
@@ -1,0 +1,90 @@
+--- UI Bridge regression suites: persistence shell for the pure `diagnose`
+--- function in `ui-bridge-auto`. Stores suite definitions, run summaries,
+--- self-diagnosis memos, and a per-assertion exercise log used by the
+--- Phase C2 panel to reconstruct case/assertion timelines.
+---
+--- IMPORTANT: At the time these queries were authored, the regression_*
+--- tables had not yet been added to the alembic chain that produces
+--- `schema.pg.sql.generated`. Until that migration lands and the schema
+--- file is regenerated, Clorinde will reject these definitions. The
+--- runner-side wrapper in `src/database/pg/regression.rs` therefore uses
+--- raw `tokio_postgres` queries directly (mirroring `ui_bridge_baselines`).
+--- These query definitions are kept in source so the Clorinde-generated
+--- bindings can be wired in without rewriting the SQL once the schema
+--- catches up. Clorinde's codegen step may silently drop this file if it
+--- runs before the migration; that is expected.
+
+--! save_regression_suite
+INSERT INTO regression_suites (id, ir_doc_id, suite_json)
+VALUES (:id::uuid, :ir_doc_id, :suite_json::jsonb)
+RETURNING id;
+
+--! record_regression_run
+INSERT INTO regression_runs (
+    id, suite_id, run_id, passed, failed, started_at, completed_at, run_result_json
+) VALUES (
+    :id::uuid, :suite_id::uuid, :run_id, :passed, :failed,
+    :started_at::timestamptz, :completed_at::timestamptz, :run_result_json::jsonb
+)
+RETURNING id;
+
+--! record_regression_diagnosis
+INSERT INTO regression_diagnoses (id, run_id, diagnosis_json)
+VALUES (:id::uuid, :run_id::uuid, :diagnosis_json::jsonb)
+RETURNING id;
+
+--! record_assertion_executions_batch
+-- Single-batch insert that explodes a JSON array of execution rows into
+-- regression_assertion_executions. Each element of `executions_json` must
+-- have the keys: id, run_id, case_id, assertion_id, assertion_kind, status,
+-- started_at, duration_ms, and the optional failure_kind / failure_evidence_json /
+-- error_message.
+INSERT INTO regression_assertion_executions (
+    id, run_id, case_id, assertion_id, assertion_kind, status,
+    started_at, duration_ms, failure_kind, failure_evidence_json, error_message
+)
+SELECT
+    (e->>'id')::uuid,
+    (e->>'run_id')::uuid,
+    e->>'case_id',
+    e->>'assertion_id',
+    e->>'assertion_kind',
+    e->>'status',
+    (e->>'started_at')::timestamptz,
+    (e->>'duration_ms')::int,
+    e->>'failure_kind',
+    e->'failure_evidence_json',
+    e->>'error_message'
+FROM jsonb_array_elements(:executions_json::jsonb) AS e;
+
+--! get_assertion_executions_for_suite
+-- Joins the per-run exercise log back to its parent suite so the panel can
+-- reconstruct case/assertion timelines. Returns the shape consumed by the
+-- ui-bridge-auto exercise-log view: {case_id, assertion_id, started_at}.
+SELECT
+    ae.case_id,
+    ae.assertion_id,
+    ae.started_at::TEXT AS started_at,
+    ae.status,
+    ae.assertion_kind,
+    ae.duration_ms,
+    ae.failure_kind,
+    ae.error_message
+FROM regression_assertion_executions ae
+JOIN regression_runs r ON r.id = ae.run_id
+WHERE r.suite_id = :suite_id::uuid
+ORDER BY ae.started_at ASC;
+
+--! get_recent_diagnoses_for_suite
+-- Latest self-diagnosis memos for the runner panel. Joins through
+-- regression_runs to filter by suite_id.
+SELECT
+    d.id,
+    d.run_id,
+    d.diagnosis_json,
+    d.created_at::TEXT AS created_at
+FROM regression_diagnoses d
+JOIN regression_runs r ON r.id = d.run_id
+WHERE r.suite_id = :suite_id::uuid
+ORDER BY d.created_at DESC
+LIMIT :limit;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -211,6 +211,7 @@ pub mod productivity; // Phase 1 productivity stack: plans/tasks/upcoming-claims
 pub mod project_logs;
 pub mod rag;
 pub mod recap; // Session recap overview
+pub mod regression; // UI Bridge regression suite + run + diagnosis + per-assertion exercise log persistence (Section 11 Phase A2)
 pub mod saved_projects; // User-curated project registry (wizard-populated, consumed by UI Bridge panel)
 pub mod screenshot;
 pub mod screenshots;

--- a/src-tauri/src/commands/regression.rs
+++ b/src-tauri/src/commands/regression.rs
@@ -1,0 +1,165 @@
+//! Tauri commands for the UI Bridge regression subsystem.
+//!
+//! Persistence shell for the pure `diagnose` function in `ui-bridge-auto`.
+//! These commands are invoked by the runner-side `MemorySink` (Phase A3) and
+//! the regression panel (Phase C2) to persist suites, runs, diagnoses, and
+//! per-assertion exercise rows.
+//!
+//! Implementation details: the underlying CRUD lives in
+//! [`crate::database::pg::regression`] and uses raw `tokio_postgres` queries
+//! (not Clorinde) until the alembic chain catches up with the
+//! `regression_*` tables and `schema.pg.sql.generated` can be regenerated.
+
+use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
+use tauri::Runtime;
+use tauri::State;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::commands::compartments::StorageCompartment;
+use crate::database::pg::regression::{AssertionExecutionRow, DiagnosisRow};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+fn parse_uuid(field: &str, raw: &str) -> Result<Uuid, String> {
+    Uuid::parse_str(raw).map_err(|e| format!("invalid uuid for {}: {}", field, e))
+}
+
+// =============================================================================
+// Commands
+// =============================================================================
+
+/// Save a regression suite definition. Returns the new suite UUID as a
+/// hyphenated string.
+#[tauri::command]
+pub async fn save_regression_suite(
+    suite_json: serde_json::Value,
+    ir_doc_id: String,
+    storage: State<'_, StorageCompartment>,
+) -> Result<String, String> {
+    let id = storage
+        .pg_db()
+        .save_regression_suite(&ir_doc_id, &suite_json)
+        .await?;
+    info!("Saved regression suite id={} ir_doc_id={}", id, ir_doc_id);
+    Ok(id.to_string())
+}
+
+/// Record a regression-run summary. Returns the new run UUID as a hyphenated
+/// string.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn record_regression_run(
+    suite_id: String,
+    run_id: String,
+    passed: i32,
+    failed: i32,
+    started_at: String,
+    completed_at: String,
+    run_result_json: serde_json::Value,
+    storage: State<'_, StorageCompartment>,
+) -> Result<String, String> {
+    let suite_uuid = parse_uuid("suite_id", &suite_id)?;
+    let id = storage
+        .pg_db()
+        .record_regression_run(
+            suite_uuid,
+            &run_id,
+            passed,
+            failed,
+            &started_at,
+            &completed_at,
+            &run_result_json,
+        )
+        .await?;
+    info!(
+        "Recorded regression run id={} suite_id={} passed={} failed={}",
+        id, suite_id, passed, failed
+    );
+    Ok(id.to_string())
+}
+
+/// Record a self-diagnosis memo for a regression run.
+#[tauri::command]
+pub async fn record_regression_diagnosis(
+    run_id: String,
+    diagnosis_json: serde_json::Value,
+    storage: State<'_, StorageCompartment>,
+) -> Result<String, String> {
+    let run_uuid = parse_uuid("run_id", &run_id)?;
+    let id = storage
+        .pg_db()
+        .record_regression_diagnosis(run_uuid, &diagnosis_json)
+        .await?;
+    info!("Recorded regression diagnosis id={} run_id={}", id, run_id);
+    Ok(id.to_string())
+}
+
+/// Batch-insert per-assertion execution rows. Each entry must be a JSON
+/// object with at least `id`, `run_id`, `case_id`, `assertion_id`,
+/// `assertion_kind`, `status`, `started_at`, and `duration_ms`. Returns the
+/// number of rows inserted.
+#[tauri::command]
+pub async fn record_assertion_executions_batch(
+    executions: Vec<serde_json::Value>,
+    storage: State<'_, StorageCompartment>,
+) -> Result<usize, String> {
+    if executions.is_empty() {
+        return Ok(0);
+    }
+    let arr = serde_json::Value::Array(executions);
+    let inserted = storage
+        .pg_db()
+        .record_assertion_executions_batch(&arr)
+        .await?;
+    Ok(inserted as usize)
+}
+
+/// Query the per-assertion exercise log for a suite. Used by the Phase C2
+/// panel to reconstruct case/assertion timelines.
+#[tauri::command]
+pub async fn query_assertion_executions_for_suite(
+    suite_id: String,
+    storage: State<'_, StorageCompartment>,
+) -> Result<Vec<AssertionExecutionRow>, String> {
+    let suite_uuid = parse_uuid("suite_id", &suite_id)?;
+    storage
+        .pg_db()
+        .get_assertion_executions_for_suite(suite_uuid)
+        .await
+}
+
+/// Recent diagnosis memos for a suite, in reverse-chronological order.
+/// `limit` defaults to 25 when omitted.
+#[tauri::command]
+pub async fn get_recent_diagnoses_for_suite(
+    suite_id: String,
+    limit: Option<u32>,
+    storage: State<'_, StorageCompartment>,
+) -> Result<Vec<DiagnosisRow>, String> {
+    let suite_uuid = parse_uuid("suite_id", &suite_id)?;
+    storage
+        .pg_db()
+        .get_recent_diagnoses_for_suite(suite_uuid, limit)
+        .await
+}
+
+/// Build the Tauri plugin that registers this module's command handlers.
+///
+/// The runner currently uses the central `tauri::generate_handler![...]`
+/// in `main.rs` for command registration, but the module-plugin scaffolding
+/// is kept consistent with the rest of `commands/*` for future migration.
+pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
+    PluginBuilder::new("qontinui_regression")
+        .invoke_handler(tauri::generate_handler![
+            save_regression_suite,
+            record_regression_run,
+            record_regression_diagnosis,
+            record_assertion_executions_batch,
+            query_assertion_executions_for_suite,
+            get_recent_diagnoses_for_suite,
+        ])
+        .build()
+}

--- a/src-tauri/src/commands/regression.rs
+++ b/src-tauri/src/commands/regression.rs
@@ -17,7 +17,9 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::commands::compartments::StorageCompartment;
-use crate::database::pg::regression::{AssertionExecutionRow, DiagnosisRow};
+use crate::database::pg::regression::{
+    AssertionExecutionRow, DiagnosisRow, RunSummaryRow, SuiteFullRow, SuiteRow,
+};
 
 // =============================================================================
 // Helpers
@@ -48,7 +50,9 @@ pub async fn save_regression_suite(
 }
 
 /// Record a regression-run summary. Returns the new run UUID as a hyphenated
-/// string.
+/// string. `drift_report_json` is optional — when supplied, the runner
+/// `/runs/:run_id/drift` HTTP endpoint can later surface those entries to
+/// the qontinui-web drift dashboard.
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub async fn record_regression_run(
@@ -59,6 +63,7 @@ pub async fn record_regression_run(
     started_at: String,
     completed_at: String,
     run_result_json: serde_json::Value,
+    drift_report_json: Option<serde_json::Value>,
     storage: State<'_, StorageCompartment>,
 ) -> Result<String, String> {
     let suite_uuid = parse_uuid("suite_id", &suite_id)?;
@@ -72,6 +77,7 @@ pub async fn record_regression_run(
             &started_at,
             &completed_at,
             &run_result_json,
+            drift_report_json.as_ref(),
         )
         .await?;
     info!(
@@ -146,6 +152,41 @@ pub async fn get_recent_diagnoses_for_suite(
         .await
 }
 
+/// Catalog of every persisted regression suite, newest first. `limit` caps
+/// the returned rows; defaults to 50, hard cap 1000.
+#[tauri::command]
+pub async fn list_regression_suites(
+    limit: Option<u32>,
+    storage: State<'_, StorageCompartment>,
+) -> Result<Vec<SuiteRow>, String> {
+    storage.pg_db().list_regression_suites(limit).await
+}
+
+/// Fetch a single suite by id (with its serialized RegressionSuite blob).
+/// Returns `None` if the suite is not in the catalog.
+#[tauri::command]
+pub async fn get_regression_suite_by_id(
+    suite_id: String,
+    storage: State<'_, StorageCompartment>,
+) -> Result<Option<SuiteFullRow>, String> {
+    let suite_uuid = parse_uuid("suite_id", &suite_id)?;
+    storage.pg_db().get_regression_suite_by_id(suite_uuid).await
+}
+
+/// Recent runs for a suite (newest first). `limit` defaults to 25.
+#[tauri::command]
+pub async fn list_regression_runs_for_suite(
+    suite_id: String,
+    limit: Option<u32>,
+    storage: State<'_, StorageCompartment>,
+) -> Result<Vec<RunSummaryRow>, String> {
+    let suite_uuid = parse_uuid("suite_id", &suite_id)?;
+    storage
+        .pg_db()
+        .list_regression_runs_for_suite(suite_uuid, limit)
+        .await
+}
+
 /// Build the Tauri plugin that registers this module's command handlers.
 ///
 /// The runner currently uses the central `tauri::generate_handler![...]`
@@ -160,6 +201,9 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             record_assertion_executions_batch,
             query_assertion_executions_for_suite,
             get_recent_diagnoses_for_suite,
+            list_regression_suites,
+            get_regression_suite_by_id,
+            list_regression_runs_for_suite,
         ])
         .build()
 }

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -251,7 +251,12 @@ impl PgDb {
              CREATE INDEX IF NOT EXISTS regression_assertion_executions_kind_status_idx \
                  ON regression_assertion_executions(assertion_kind, status); \
              CREATE INDEX IF NOT EXISTS regression_assertion_executions_failures_idx \
-                 ON regression_assertion_executions(case_id, assertion_id) WHERE status = 'fail';",
+                 ON regression_assertion_executions(case_id, assertion_id) WHERE status = 'fail'; \
+             \
+             ALTER TABLE regression_runs \
+                 ADD COLUMN IF NOT EXISTS drift_report_json JSONB; \
+             CREATE INDEX IF NOT EXISTS regression_runs_run_id_idx \
+                 ON regression_runs(run_id);",
         )
         .await
         .map_err(|e| format!("Failed to bootstrap runner schema/extension: {}", e))?;

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -60,6 +60,7 @@ pub mod queued_workflows;
 pub mod reasoning_traces;
 pub mod recordings;
 pub mod reflection;
+pub mod regression;
 pub mod restate;
 pub mod reviews;
 pub mod scheduler;
@@ -186,9 +187,71 @@ impl PgDb {
         // init-scripts/01-create-runner-schema.sql does this; on pre-existing
         // volumes or non-docker Postgres deployments, those scripts never run,
         // so we do it ourselves. Idempotent via IF NOT EXISTS.
+        //
+        // Tables created here are resolved against the active search_path
+        // (`project, public`), so they land in the `project` schema alongside
+        // the alembic-managed tables. The `runner` schema CREATE is kept for
+        // back-compat with any deployment still referencing it.
         conn.batch_execute(
             "CREATE SCHEMA IF NOT EXISTS runner; \
-             CREATE EXTENSION IF NOT EXISTS vector;",
+             CREATE EXTENSION IF NOT EXISTS vector; \
+             \
+             -- Section 11 / Phase A2: regression suites + runs + diagnoses + \
+             -- per-assertion exercise log for the UI Bridge regression \
+             -- subsystem. The pure `diagnose` lives in ui-bridge-auto; this is \
+             -- the impure persistence shell. \
+             CREATE TABLE IF NOT EXISTS regression_suites ( \
+                 id           UUID PRIMARY KEY, \
+                 ir_doc_id    TEXT NOT NULL, \
+                 suite_json   JSONB NOT NULL, \
+                 created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW() \
+             ); \
+             CREATE INDEX IF NOT EXISTS regression_suites_ir_doc_id_idx \
+                 ON regression_suites(ir_doc_id); \
+             \
+             CREATE TABLE IF NOT EXISTS regression_runs ( \
+                 id              UUID PRIMARY KEY, \
+                 suite_id        UUID NOT NULL REFERENCES regression_suites(id) ON DELETE CASCADE, \
+                 run_id          TEXT NOT NULL, \
+                 passed          INT NOT NULL, \
+                 failed          INT NOT NULL, \
+                 started_at      TIMESTAMPTZ NOT NULL, \
+                 completed_at    TIMESTAMPTZ NOT NULL, \
+                 run_result_json JSONB NOT NULL \
+             ); \
+             CREATE INDEX IF NOT EXISTS regression_runs_suite_id_idx \
+                 ON regression_runs(suite_id); \
+             \
+             CREATE TABLE IF NOT EXISTS regression_diagnoses ( \
+                 id              UUID PRIMARY KEY, \
+                 run_id          UUID NOT NULL REFERENCES regression_runs(id) ON DELETE CASCADE, \
+                 diagnosis_json  JSONB NOT NULL, \
+                 created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW() \
+             ); \
+             CREATE INDEX IF NOT EXISTS regression_diagnoses_run_id_idx \
+                 ON regression_diagnoses(run_id); \
+             \
+             CREATE TABLE IF NOT EXISTS regression_assertion_executions ( \
+                 id                    UUID PRIMARY KEY, \
+                 run_id                UUID NOT NULL REFERENCES regression_runs(id) ON DELETE CASCADE, \
+                 case_id               TEXT NOT NULL, \
+                 assertion_id          TEXT NOT NULL, \
+                 assertion_kind        TEXT NOT NULL, \
+                 status                TEXT NOT NULL, \
+                 started_at            TIMESTAMPTZ NOT NULL, \
+                 duration_ms           INT NOT NULL, \
+                 failure_kind          TEXT, \
+                 failure_evidence_json JSONB, \
+                 error_message         TEXT \
+             ); \
+             CREATE INDEX IF NOT EXISTS regression_assertion_executions_run_id_idx \
+                 ON regression_assertion_executions(run_id); \
+             CREATE INDEX IF NOT EXISTS regression_assertion_executions_case_assertion_idx \
+                 ON regression_assertion_executions(case_id, assertion_id, started_at DESC); \
+             CREATE INDEX IF NOT EXISTS regression_assertion_executions_kind_status_idx \
+                 ON regression_assertion_executions(assertion_kind, status); \
+             CREATE INDEX IF NOT EXISTS regression_assertion_executions_failures_idx \
+                 ON regression_assertion_executions(case_id, assertion_id) WHERE status = 'fail';",
         )
         .await
         .map_err(|e| format!("Failed to bootstrap runner schema/extension: {}", e))?;

--- a/src-tauri/src/database/pg/regression.rs
+++ b/src-tauri/src/database/pg/regression.rs
@@ -43,6 +43,43 @@ pub struct DiagnosisRow {
     pub created_at: String,
 }
 
+/// Lightweight suite catalog row: identity + when last touched. Used by the
+/// CoveragePanel suite picker and other catalog queries that don't need the
+/// full `suite_json` blob.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SuiteRow {
+    pub id: String,
+    pub ir_doc_id: String,
+    pub created_at: String,
+    /// Number of recorded runs against this suite. Computed via a left-join
+    /// count so suites with zero runs still appear in the catalog.
+    pub run_count: i64,
+    /// `started_at` of the most recent run, or `None` if the suite has never
+    /// been executed.
+    pub last_run_at: Option<String>,
+}
+
+/// Full suite row including the JSON blob (the panel needs the deserialized
+/// `RegressionSuite` to feed `coverageDiff` / `coverageOf`).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SuiteFullRow {
+    pub id: String,
+    pub ir_doc_id: String,
+    pub suite_json: serde_json::Value,
+    pub created_at: String,
+}
+
+/// Lightweight run summary for picker UIs.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RunSummaryRow {
+    pub id: String,
+    pub run_id: String,
+    pub passed: i32,
+    pub failed: i32,
+    pub started_at: String,
+    pub completed_at: String,
+}
+
 impl PgDb {
     // -------------------------------------------------------------------------
     // Writes
@@ -77,7 +114,10 @@ impl PgDb {
 
     /// Record a regression-run summary. Stores the full RegressionRunResult
     /// blob for ad-hoc inspection; the per-assertion table is the queryable
-    /// form.
+    /// form. `drift_report_json` is optional — when present, the executor
+    /// passes through the combined `DriftReport` (specDrift + visualDrift
+    /// merged) used to build `DriftContext` for the diagnose call. The
+    /// `/runs/:run_id/drift` HTTP endpoint reads it back unmodified.
     #[allow(clippy::too_many_arguments)]
     pub async fn record_regression_run(
         &self,
@@ -88,6 +128,7 @@ impl PgDb {
         started_at: &str,
         completed_at: &str,
         run_result_json: &serde_json::Value,
+        drift_report_json: Option<&serde_json::Value>,
     ) -> Result<Uuid, String> {
         let conn = self
             .pool
@@ -100,10 +141,10 @@ impl PgDb {
             r#"
             INSERT INTO regression_runs (
                 id, suite_id, run_id, passed, failed,
-                started_at, completed_at, run_result_json
+                started_at, completed_at, run_result_json, drift_report_json
             ) VALUES (
                 $1, $2, $3, $4, $5,
-                $6::timestamptz, $7::timestamptz, $8::jsonb
+                $6::timestamptz, $7::timestamptz, $8::jsonb, $9::jsonb
             )
             "#,
             &[
@@ -115,6 +156,7 @@ impl PgDb {
                 &started_at,
                 &completed_at,
                 run_result_json,
+                &drift_report_json,
             ],
         )
         .await
@@ -293,6 +335,175 @@ impl PgDb {
                 run_id: r.get(1),
                 diagnosis_json: r.get(2),
                 created_at: r.get(3),
+            })
+            .collect())
+    }
+
+    /// Catalog of every persisted regression suite, newest first. Includes a
+    /// run-count and the most recent run timestamp via a left-join so suites
+    /// without runs still surface in the picker.
+    pub async fn list_regression_suites(
+        &self,
+        limit: Option<u32>,
+    ) -> Result<Vec<SuiteRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let limit_i: i64 = limit.unwrap_or(50).min(1000) as i64;
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    s.id::TEXT,
+                    s.ir_doc_id,
+                    s.created_at::TEXT,
+                    COALESCE(stats.run_count, 0)::BIGINT AS run_count,
+                    stats.last_run_at::TEXT
+                FROM regression_suites s
+                LEFT JOIN LATERAL (
+                    SELECT
+                        COUNT(*) AS run_count,
+                        MAX(started_at) AS last_run_at
+                    FROM regression_runs
+                    WHERE suite_id = s.id
+                ) stats ON TRUE
+                ORDER BY s.created_at DESC
+                LIMIT $1
+                "#,
+                &[&limit_i],
+            )
+            .await
+            .map_err(|e| format!("PG list_regression_suites: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| SuiteRow {
+                id: r.get(0),
+                ir_doc_id: r.get(1),
+                created_at: r.get(2),
+                run_count: r.get(3),
+                last_run_at: r.get(4),
+            })
+            .collect())
+    }
+
+    /// Fetch a single suite by id. Returns `None` if missing.
+    pub async fn get_regression_suite_by_id(
+        &self,
+        suite_id: Uuid,
+    ) -> Result<Option<SuiteFullRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    s.id::TEXT,
+                    s.ir_doc_id,
+                    s.suite_json,
+                    s.created_at::TEXT
+                FROM regression_suites s
+                WHERE s.id = $1
+                "#,
+                &[&suite_id],
+            )
+            .await
+            .map_err(|e| format!("PG get_regression_suite_by_id: {}", e))?;
+
+        Ok(rows.first().map(|r| SuiteFullRow {
+            id: r.get(0),
+            ir_doc_id: r.get(1),
+            suite_json: r.get(2),
+            created_at: r.get(3),
+        }))
+    }
+
+    /// Fetch the most recent persisted `drift_report_json` for a logical
+    /// `run_id` (the caller-supplied id, not the row UUID).
+    ///
+    /// Returns `None` when no run with that id exists, when the run exists
+    /// but has no drift report, OR when the report is JSON `null`.
+    /// Used by the `/runs/:run_id/drift` HTTP endpoint and the qontinui-web
+    /// drift dashboard proxy.
+    pub async fn get_drift_report_for_logical_run_id(
+        &self,
+        run_id_text: &str,
+    ) -> Result<Option<serde_json::Value>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows = conn
+            .query(
+                r#"
+                SELECT drift_report_json
+                FROM regression_runs
+                WHERE run_id = $1 AND drift_report_json IS NOT NULL
+                ORDER BY started_at DESC
+                LIMIT 1
+                "#,
+                &[&run_id_text],
+            )
+            .await
+            .map_err(|e| format!("PG get_drift_report_for_logical_run_id: {}", e))?;
+
+        Ok(rows.first().and_then(|r| {
+            let v: Option<serde_json::Value> = r.get(0);
+            v.filter(|v| !v.is_null())
+        }))
+    }
+
+    /// Recent runs for a suite, newest first, lightweight summary shape.
+    pub async fn list_regression_runs_for_suite(
+        &self,
+        suite_id: Uuid,
+        limit: Option<u32>,
+    ) -> Result<Vec<RunSummaryRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let limit_i: i64 = limit.unwrap_or(25).min(1000) as i64;
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    r.id::TEXT,
+                    r.run_id,
+                    r.passed,
+                    r.failed,
+                    r.started_at::TEXT,
+                    r.completed_at::TEXT
+                FROM regression_runs r
+                WHERE r.suite_id = $1
+                ORDER BY r.started_at DESC
+                LIMIT $2
+                "#,
+                &[&suite_id, &limit_i],
+            )
+            .await
+            .map_err(|e| format!("PG list_regression_runs_for_suite: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| RunSummaryRow {
+                id: r.get(0),
+                run_id: r.get(1),
+                passed: r.get(2),
+                failed: r.get(3),
+                started_at: r.get(4),
+                completed_at: r.get(5),
             })
             .collect())
     }

--- a/src-tauri/src/database/pg/regression.rs
+++ b/src-tauri/src/database/pg/regression.rs
@@ -1,0 +1,299 @@
+//! PostgreSQL CRUD for the UI Bridge regression subsystem.
+//!
+//! Persistence shell for the pure `diagnose` function in `ui-bridge-auto`.
+//! Stores regression suite definitions, run summaries, self-diagnosis memos,
+//! and a per-assertion exercise log keyed for forensic queries.
+//!
+//! Tables are created on first connect by the bootstrap in
+//! [`super::PgDb::new`]. They live in the active search_path
+//! (`project, public`).
+//!
+//! Companion query file: `src-tauri/queries/regression.sql` (Clorinde-style
+//! definitions kept for the day the alembic chain catches up; until then we
+//! issue the queries directly via `tokio_postgres`, mirroring the
+//! `ui_bridge_baselines` pattern).
+
+use super::PgDb;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// =============================================================================
+// Row types returned to the command layer
+// =============================================================================
+
+/// Per-assertion exercise log row, denormalized with failure detail.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AssertionExecutionRow {
+    pub case_id: String,
+    pub assertion_id: String,
+    pub started_at: String,
+    pub status: String,
+    pub assertion_kind: String,
+    pub duration_ms: i32,
+    pub failure_kind: Option<String>,
+    pub error_message: Option<String>,
+}
+
+/// Recent diagnosis memo row for the runner panel.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DiagnosisRow {
+    pub id: String,
+    pub run_id: String,
+    pub diagnosis_json: serde_json::Value,
+    pub created_at: String,
+}
+
+impl PgDb {
+    // -------------------------------------------------------------------------
+    // Writes
+    // -------------------------------------------------------------------------
+
+    /// Save a regression suite definition keyed to an IR doc.
+    /// Returns the suite UUID on success.
+    pub async fn save_regression_suite(
+        &self,
+        ir_doc_id: &str,
+        suite_json: &serde_json::Value,
+    ) -> Result<Uuid, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let id = Uuid::new_v4();
+        conn.execute(
+            r#"
+            INSERT INTO regression_suites (id, ir_doc_id, suite_json)
+            VALUES ($1, $2, $3::jsonb)
+            "#,
+            &[&id, &ir_doc_id, suite_json],
+        )
+        .await
+        .map_err(|e| format!("PG save_regression_suite: {}", e))?;
+
+        Ok(id)
+    }
+
+    /// Record a regression-run summary. Stores the full RegressionRunResult
+    /// blob for ad-hoc inspection; the per-assertion table is the queryable
+    /// form.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_regression_run(
+        &self,
+        suite_id: Uuid,
+        run_id: &str,
+        passed: i32,
+        failed: i32,
+        started_at: &str,
+        completed_at: &str,
+        run_result_json: &serde_json::Value,
+    ) -> Result<Uuid, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let id = Uuid::new_v4();
+        conn.execute(
+            r#"
+            INSERT INTO regression_runs (
+                id, suite_id, run_id, passed, failed,
+                started_at, completed_at, run_result_json
+            ) VALUES (
+                $1, $2, $3, $4, $5,
+                $6::timestamptz, $7::timestamptz, $8::jsonb
+            )
+            "#,
+            &[
+                &id,
+                &suite_id,
+                &run_id,
+                &passed,
+                &failed,
+                &started_at,
+                &completed_at,
+                run_result_json,
+            ],
+        )
+        .await
+        .map_err(|e| format!("PG record_regression_run: {}", e))?;
+
+        Ok(id)
+    }
+
+    /// Record a self-diagnosis memo for a run.
+    pub async fn record_regression_diagnosis(
+        &self,
+        run_id: Uuid,
+        diagnosis_json: &serde_json::Value,
+    ) -> Result<Uuid, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let id = Uuid::new_v4();
+        conn.execute(
+            r#"
+            INSERT INTO regression_diagnoses (id, run_id, diagnosis_json)
+            VALUES ($1, $2, $3::jsonb)
+            "#,
+            &[&id, &run_id, diagnosis_json],
+        )
+        .await
+        .map_err(|e| format!("PG record_regression_diagnosis: {}", e))?;
+
+        Ok(id)
+    }
+
+    /// Batch-insert per-assertion execution rows from a JSON array.
+    ///
+    /// Each element must have keys: `id`, `run_id`, `case_id`, `assertion_id`,
+    /// `assertion_kind`, `status`, `started_at`, `duration_ms`. Optional keys:
+    /// `failure_kind`, `failure_evidence_json`, `error_message`. Missing
+    /// `id`s are auto-generated; missing `run_id`s cause the row to be
+    /// rejected by the FK constraint.
+    ///
+    /// Returns the number of rows inserted.
+    pub async fn record_assertion_executions_batch(
+        &self,
+        executions_json: &serde_json::Value,
+    ) -> Result<u64, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows_affected = conn
+            .execute(
+                r#"
+                INSERT INTO regression_assertion_executions (
+                    id, run_id, case_id, assertion_id, assertion_kind, status,
+                    started_at, duration_ms, failure_kind,
+                    failure_evidence_json, error_message
+                )
+                SELECT
+                    (e->>'id')::uuid,
+                    (e->>'run_id')::uuid,
+                    e->>'case_id',
+                    e->>'assertion_id',
+                    e->>'assertion_kind',
+                    e->>'status',
+                    (e->>'started_at')::timestamptz,
+                    (e->>'duration_ms')::int,
+                    e->>'failure_kind',
+                    e->'failure_evidence_json',
+                    e->>'error_message'
+                FROM jsonb_array_elements($1::jsonb) AS e
+                "#,
+                &[executions_json],
+            )
+            .await
+            .map_err(|e| format!("PG record_assertion_executions_batch: {}", e))?;
+
+        Ok(rows_affected)
+    }
+
+    // -------------------------------------------------------------------------
+    // Reads
+    // -------------------------------------------------------------------------
+
+    /// Fetch every assertion execution for a suite, joined through
+    /// regression_runs. Returns rows ordered by `started_at ASC` so the
+    /// caller can reconstruct case/assertion timelines.
+    pub async fn get_assertion_executions_for_suite(
+        &self,
+        suite_id: Uuid,
+    ) -> Result<Vec<AssertionExecutionRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    ae.case_id,
+                    ae.assertion_id,
+                    ae.started_at::TEXT AS started_at,
+                    ae.status,
+                    ae.assertion_kind,
+                    ae.duration_ms,
+                    ae.failure_kind,
+                    ae.error_message
+                FROM regression_assertion_executions ae
+                JOIN regression_runs r ON r.id = ae.run_id
+                WHERE r.suite_id = $1
+                ORDER BY ae.started_at ASC
+                "#,
+                &[&suite_id],
+            )
+            .await
+            .map_err(|e| format!("PG get_assertion_executions_for_suite: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| AssertionExecutionRow {
+                case_id: r.get(0),
+                assertion_id: r.get(1),
+                started_at: r.get(2),
+                status: r.get(3),
+                assertion_kind: r.get(4),
+                duration_ms: r.get(5),
+                failure_kind: r.get(6),
+                error_message: r.get(7),
+            })
+            .collect())
+    }
+
+    /// Most recent diagnosis memos for a suite, in reverse-chronological
+    /// order. The `limit` param caps the returned rows; defaults to 25 if
+    /// callers pass `None`.
+    pub async fn get_recent_diagnoses_for_suite(
+        &self,
+        suite_id: Uuid,
+        limit: Option<u32>,
+    ) -> Result<Vec<DiagnosisRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let limit_i: i64 = limit.unwrap_or(25).min(1000) as i64;
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    d.id::TEXT,
+                    d.run_id::TEXT,
+                    d.diagnosis_json,
+                    d.created_at::TEXT
+                FROM regression_diagnoses d
+                JOIN regression_runs r ON r.id = d.run_id
+                WHERE r.suite_id = $1
+                ORDER BY d.created_at DESC
+                LIMIT $2
+                "#,
+                &[&suite_id, &limit_i],
+            )
+            .await
+            .map_err(|e| format!("PG get_recent_diagnoses_for_suite: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| DiagnosisRow {
+                id: r.get(0),
+                run_id: r.get(1),
+                diagnosis_json: r.get(2),
+                created_at: r.get(3),
+            })
+            .collect())
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -98,6 +98,7 @@ mod runtime_env;
 mod safe_lock;
 mod saved_api_requests;
 mod scenarios;
+mod regression_api;
 mod scheduler;
 mod scheduler_service;
 mod schema_registry;
@@ -1150,6 +1151,9 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::rag::start_rag_processing,
             commands::recap::get_task_run_recap,
             commands::regression::get_recent_diagnoses_for_suite,
+            commands::regression::get_regression_suite_by_id,
+            commands::regression::list_regression_runs_for_suite,
+            commands::regression::list_regression_suites,
             commands::regression::query_assertion_executions_for_suite,
             commands::regression::record_assertion_executions_batch,
             commands::regression::record_regression_diagnosis,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -97,6 +97,7 @@ mod routing;
 mod runtime_env;
 mod safe_lock;
 mod saved_api_requests;
+mod scenarios;
 mod scheduler;
 mod scheduler_service;
 mod schema_registry;
@@ -1148,6 +1149,12 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::rag::search_rag_elements_semantic,
             commands::rag::start_rag_processing,
             commands::recap::get_task_run_recap,
+            commands::regression::get_recent_diagnoses_for_suite,
+            commands::regression::query_assertion_executions_for_suite,
+            commands::regression::record_assertion_executions_batch,
+            commands::regression::record_regression_diagnosis,
+            commands::regression::record_regression_run,
+            commands::regression::save_regression_suite,
             commands::saved_projects::add_saved_project,
             commands::saved_projects::list_saved_projects,
             commands::saved_projects::remove_saved_project,

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -255,6 +255,7 @@ const VALID_TAB_IDS: &[&str] = &[
     "dag-workflow-editor",
     "project-explainer",
     "productivity",
+    "regression",
 ];
 
 // ============================================================================

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -204,6 +204,7 @@ const VALID_TAB_IDS: &[&str] = &[
     "unified-workflow-builder",
     "state-machine",
     "specs",
+    "wrappers",
     "capture",
     "config-log-sources",
     "config-findings",

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1616,6 +1616,12 @@ pub fn create_router(
         // webview to combine with the live registry. Both load the IR
         // through the same `spec_api::storage` layer.
         .merge(crate::scenarios::routes())
+        // Section 11 follow-up FU-3 — `/runs/:run_id/drift[/:entry_id]`
+        // drift report endpoints. Pass-through of `regression_runs.drift_report_json`
+        // for the qontinui-web drift dashboard proxy. Reads only — the
+        // executor writes drift reports via the `record_regression_run`
+        // Tauri command.
+        .merge(crate::regression_api::routes())
         // Section 5b of UI Bridge redesign — `/trace/...` Trace API. Gated
         // on `settings.trace_api.enabled` (default false) because it
         // depends on the Alembic migration `section_5b_01_ui_bridge_causal_columns`

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -753,6 +753,85 @@ pub fn create_router(
         info!("UI Bridge: page/evaluate response listener set up");
     }
 
+    // Set up `ui-bridge:project-current-scenario-response` listener
+    // (Section 11 / Phase B2 — runtime-aware scenario projection IPC).
+    //
+    // Mirrors the `ui-bridge:invoke-response` listener above and reuses
+    // the same `ui_bridge_invoke_store` for routing responses by
+    // `request_id` — the response payload shape (`{ ok, result, error }`)
+    // is identical, so a separate store would just be duplication.
+    {
+        let invoke_store = api_state.ui_bridge_invoke_store.clone();
+        let handle = app_handle.clone();
+
+        use tauri::Listener;
+
+        let _listener_id =
+            handle.listen("ui-bridge:project-current-scenario-response", move |event| {
+                let payload_str = event.payload();
+                let parsed: Option<serde_json::Value> =
+                    serde_json::from_str::<serde_json::Value>(payload_str)
+                        .ok()
+                        .and_then(|v| {
+                            if v.is_object() {
+                                Some(v)
+                            } else if let Some(s) = v.as_str() {
+                                serde_json::from_str::<serde_json::Value>(s).ok()
+                            } else {
+                                Some(v)
+                            }
+                        });
+
+                let Some(parsed) = parsed else {
+                    warn!(
+                        "scenarios/current: failed to parse projection response payload: {}",
+                        &payload_str[..payload_str.len().min(200)]
+                    );
+                    return;
+                };
+
+                let request_id = parsed
+                    .get("request_id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let Some(request_id) = request_id else {
+                    warn!(
+                        "scenarios/current: projection response missing request_id: {}",
+                        &payload_str[..payload_str.len().min(200)]
+                    );
+                    return;
+                };
+
+                let ok = parsed.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+                let result = parsed.get("result").cloned();
+                let error = parsed
+                    .get("error")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+
+                let response = crate::ui_bridge_invoke::InvokeResponse { ok, result, error };
+
+                let store = invoke_store.clone();
+                if let Ok(rt) = tokio::runtime::Handle::try_current() {
+                    rt.spawn(async move {
+                        let delivered = store.deliver(&request_id, response).await;
+                        if !delivered {
+                            tracing::debug!(
+                                "scenarios/current: response for unknown request_id {} (likely timed out)",
+                                request_id
+                            );
+                        }
+                    });
+                } else {
+                    warn!(
+                        "scenarios/current: no tokio runtime available — dropping response for {}",
+                        request_id
+                    );
+                }
+            });
+        info!("scenarios/current: projection response listener set up");
+    }
+
     // UI Bridge invoke-proxy wire-contract probe (Phase 1 of
     // optimized-toasting-badger). Dry-runs every allowlisted command with
     // `{}` args on startup and cross-checks Tauri's "missing required key"
@@ -1532,6 +1611,11 @@ pub fn create_router(
         // outside `/ui-bridge/...` because the surface is consumed
         // differently (IR + projection storage, not page-control RPC).
         .merge(crate::spec_api::routes())
+        // Section 11 / Phase B2 — `/scenarios/...` scenario projection.
+        // Static endpoint is pure Rust; runtime endpoint IPC's into the
+        // webview to combine with the live registry. Both load the IR
+        // through the same `spec_api::storage` layer.
+        .merge(crate::scenarios::routes())
         // Section 5b of UI Bridge redesign — `/trace/...` Trace API. Gated
         // on `settings.trace_api.enabled` (default false) because it
         // depends on the Alembic migration `section_5b_01_ui_bridge_causal_columns`

--- a/src-tauri/src/regression_api/handlers.rs
+++ b/src-tauri/src/regression_api/handlers.rs
@@ -1,0 +1,165 @@
+//! Axum handlers for `/runs/:run_id/drift` and `/runs/:run_id/drift/:entry_id`.
+//!
+//! Wire envelope: `{ success: bool, data?: T, error?: string }` — same as
+//! `scenarios::handlers` and the rest of the runner API.
+
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use serde_json::Value;
+use tracing::warn;
+
+use crate::database::pg::PgDb;
+use crate::mcp::types::ApiState;
+
+// ---------------------------------------------------------------------------
+// Wire envelope
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+struct DriftEnvelope<T: Serialize> {
+    success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+impl<T: Serialize> DriftEnvelope<T> {
+    fn ok(data: T) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+}
+
+fn err_envelope(msg: impl Into<String>) -> DriftEnvelope<Value> {
+    DriftEnvelope {
+        success: false,
+        data: None,
+        error: Some(msg.into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Storage adapter — looks up the Pg-backed pool from the StorageCompartment
+// ---------------------------------------------------------------------------
+
+async fn fetch_drift_report(
+    _api_state: &ApiState,
+    run_id: &str,
+) -> Result<Option<Value>, String> {
+    let pg = PgDb::try_global()
+        .ok_or_else(|| "PgDb not initialized".to_string())?;
+    pg.get_drift_report_for_logical_run_id(run_id).await
+}
+
+// ---------------------------------------------------------------------------
+// GET /runs/:run_id/drift
+// ---------------------------------------------------------------------------
+
+/// Return the persisted `DriftReport` for a regression run.
+///
+/// Resolution: looks up the most recent `regression_runs` row whose
+/// `run_id` text column matches the path parameter, returning that row's
+/// `drift_report_json`. If the run has no drift report (older runs, or runs
+/// recorded without spec/visual drift inputs), returns 404.
+pub async fn get_run_drift_report(
+    State(api_state): State<Arc<ApiState>>,
+    Path(run_id): Path<String>,
+) -> Response {
+    if run_id.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(err_envelope("missing-run-id-path-param")),
+        )
+            .into_response();
+    }
+
+    match fetch_drift_report(&api_state, &run_id).await {
+        Ok(Some(report)) => (StatusCode::OK, Json(DriftEnvelope::ok(report))).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(err_envelope("drift-report-not-found")),
+        )
+            .into_response(),
+        Err(e) => {
+            warn!("get_run_drift_report failed for run_id={}: {}", run_id, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(err_envelope(format!("storage error: {}", e))),
+            )
+                .into_response()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /runs/:run_id/drift/:entry_id
+// ---------------------------------------------------------------------------
+
+/// Return a single drift entry by id from the persisted report.
+///
+/// Walks the report's `entries` array and matches on `entry.id`. If the
+/// run's report is missing or the entry id doesn't match any entry, returns
+/// 404 — the qontinui-web frontend will render the not-found state.
+pub async fn get_run_drift_entry(
+    State(api_state): State<Arc<ApiState>>,
+    Path((run_id, entry_id)): Path<(String, String)>,
+) -> Response {
+    if run_id.trim().is_empty() || entry_id.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(err_envelope("missing-path-param")),
+        )
+            .into_response();
+    }
+
+    let report = match fetch_drift_report(&api_state, &run_id).await {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(err_envelope("drift-report-not-found")),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            warn!("get_run_drift_entry storage error: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(err_envelope(format!("storage error: {}", e))),
+            )
+                .into_response();
+        }
+    };
+
+    let entries = report
+        .get("entries")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let needle = entry_id.as_str();
+    let matched = entries.into_iter().find(|e| {
+        e.get("id")
+            .and_then(|v| v.as_str())
+            .map(|id| id == needle)
+            .unwrap_or(false)
+    });
+
+    match matched {
+        Some(entry) => (StatusCode::OK, Json(DriftEnvelope::ok(entry))).into_response(),
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(err_envelope("drift-entry-not-found")),
+        )
+            .into_response(),
+    }
+}

--- a/src-tauri/src/regression_api/mod.rs
+++ b/src-tauri/src/regression_api/mod.rs
@@ -1,0 +1,43 @@
+//! Regression drift HTTP API — Section 11 follow-up FU-3.
+//!
+//! Two endpoints expose the persisted `DriftReport` for a regression run to
+//! the qontinui-web backend's drift dashboard proxy
+//! (`qontinui-web/backend/app/api/v1/endpoints/runs_drift.py`):
+//!
+//!   - `GET /runs/:run_id/drift` — returns the most recent persisted
+//!     `DriftReport` for a logical run id. Pass-through of the JSON the
+//!     executor stored in `regression_runs.drift_report_json`.
+//!
+//!   - `GET /runs/:run_id/drift/:entry_id` — returns a single entry from
+//!     that report. The report has a `entries: DriftEntry[]` array where
+//!     each entry has an `id`. We index by that id.
+//!
+//! Wire envelope: `{ success, data, error }`, matching the rest of the
+//! runner HTTP surface (e.g. `scenarios::handlers`, `commands::ai_data`).
+//!
+//! Storage notes: the executor passes `drift_report_json` through to the
+//! `record_regression_run` Tauri command, which stores it on the
+//! `regression_runs` row. The backend proxy invokes these endpoints; the
+//! frontend `drift-api.ts` consumes the result via the proxy.
+
+pub mod handlers;
+
+use axum::routing::get;
+use axum::Router;
+use std::sync::Arc;
+
+use crate::mcp::types::ApiState;
+
+/// Routes for the runner-side drift API. Mounted alongside `/spec/...` and
+/// `/scenarios/...` in `mcp_api.rs::create_router`.
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route(
+            "/runs/{run_id}/drift",
+            get(handlers::get_run_drift_report),
+        )
+        .route(
+            "/runs/{run_id}/drift/{entry_id}",
+            get(handlers::get_run_drift_entry),
+        )
+}

--- a/src-tauri/src/scenarios/handlers.rs
+++ b/src-tauri/src/scenarios/handlers.rs
@@ -1,0 +1,284 @@
+//! Axum handlers for `/scenarios/projection` and `/scenarios/current`.
+//!
+//! Wire envelope (aligned with the rest of the runner HTTP surface):
+//!
+//! ```text
+//! 200 { success: true,  data: <projection JSON> }
+//! 404 { success: false, error: "ir-doc-not-found" }
+//! 500 { success: false, error: <message> }
+//! ```
+//!
+//! Originally Phase B2 specified `{ ok, data, error }`, but the Phase B3
+//! Python MCP client routes through a shared `_request` helper that
+//! reads `data.get("success", False)`. To keep the contract consistent
+//! across all runner endpoints (and avoid forking the MCP client), the
+//! envelope here uses `success` like every other runner endpoint
+//! (e.g. `commands::ai_data::ApiResponse`, `commands::discoveries::DiscoveryResponse`).
+//!
+//! The static endpoint loads the IR from `spec_api::storage` and projects
+//! it natively in Rust (deterministic, zero IPC). The runtime endpoint
+//! also loads the IR locally, but defers to the React webview to combine
+//! it with live registry data — IPC over `ui-bridge:project-current-scenario-request`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tauri::Emitter;
+use tokio::sync::oneshot;
+use tracing::{info, warn};
+
+use crate::mcp::types::ApiState;
+use crate::spec_api::storage;
+use crate::spec_api::types::IrDocument;
+use crate::ui_bridge_invoke::InvokeResponse;
+
+use super::projection::project_scenarios;
+
+// ---------------------------------------------------------------------------
+// Query string and envelope
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct IrDocIdQuery {
+    pub ir_doc_id: Option<String>,
+}
+
+/// Wire envelope shared by both endpoints. Uses the `success: bool` shape
+/// the rest of the runner HTTP surface uses — see e.g.
+/// `commands::ai_data::ApiResponse`, `commands::discoveries::DiscoveryResponse`,
+/// `commands::tiered_info::ApiResponse`. The Phase B3 Python MCP client's
+/// shared `_request` helper reads `data.get("success", False)`; aligning
+/// here keeps the envelope contract consistent everywhere.
+#[derive(Debug, Clone, Serialize)]
+pub struct ScenarioEnvelope<T: Serialize> {
+    pub success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl<T: Serialize> ScenarioEnvelope<T> {
+    pub fn ok(data: T) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+}
+
+fn err_envelope(msg: impl Into<String>) -> ScenarioEnvelope<Value> {
+    ScenarioEnvelope {
+        success: false,
+        data: None,
+        error: Some(msg.into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared: load an IR document by id, mapping storage outcomes onto the wire envelope
+// ---------------------------------------------------------------------------
+
+enum LoadIr {
+    Found(IrDocument),
+    NotFound,
+    Error(String),
+}
+
+fn load_ir(ir_doc_id: &str) -> LoadIr {
+    let root = storage::resolve_specs_root();
+    match storage::read_ir(&root, ir_doc_id) {
+        Ok(Some(doc)) => LoadIr::Found(doc),
+        Ok(None) => LoadIr::NotFound,
+        Err(e) => LoadIr::Error(e),
+    }
+}
+
+fn validate_id(q: &IrDocIdQuery) -> Result<&str, Response> {
+    match q.ir_doc_id.as_deref() {
+        Some(s) if !s.is_empty() => Ok(s),
+        _ => Err((
+            StatusCode::BAD_REQUEST,
+            Json(err_envelope("missing-ir-doc-id-query-param")),
+        )
+            .into_response()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /scenarios/projection?ir_doc_id=<id>
+// ---------------------------------------------------------------------------
+
+pub async fn get_scenarios_projection(
+    State(_state): State<Arc<ApiState>>,
+    Query(q): Query<IrDocIdQuery>,
+) -> Response {
+    let ir_doc_id = match validate_id(&q) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+
+    match load_ir(ir_doc_id) {
+        LoadIr::Found(ir) => {
+            let projection = project_scenarios(&ir);
+            (StatusCode::OK, Json(ScenarioEnvelope::ok(projection))).into_response()
+        }
+        LoadIr::NotFound => (
+            StatusCode::NOT_FOUND,
+            Json(err_envelope("ir-doc-not-found")),
+        )
+            .into_response(),
+        LoadIr::Error(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(err_envelope(format!("ir-read-failed: {}", e))),
+        )
+            .into_response(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GET /scenarios/current?ir_doc_id=<id>
+// ---------------------------------------------------------------------------
+
+/// Tauri event channel name for the request side of the projection IPC.
+/// The TS hook (`useScenarioProjectionHandler`) listens on this name and
+/// emits its response on [`PROJECTION_RESPONSE_EVENT`].
+const PROJECTION_REQUEST_EVENT: &str = "ui-bridge:project-current-scenario-request";
+
+/// Tauri event channel name for the response side of the projection IPC.
+/// The Tauri-side global listener (set up in `mcp_api.rs`) routes incoming
+/// responses into the shared [`InvokeRequestStore`] keyed by `request_id`.
+#[allow(dead_code)]
+pub const PROJECTION_RESPONSE_EVENT: &str = "ui-bridge:project-current-scenario-response";
+
+/// Default timeout for the runtime-aware projection IPC. Keep it tight —
+/// the TS side just walks the registry, no network. 10s is plenty.
+const PROJECTION_TIMEOUT_MS: u64 = 10_000;
+
+pub async fn get_scenarios_current(
+    State(state): State<Arc<ApiState>>,
+    Query(q): Query<IrDocIdQuery>,
+) -> Response {
+    let ir_doc_id = match validate_id(&q) {
+        Ok(s) => s,
+        Err(resp) => return resp,
+    };
+
+    let ir = match load_ir(ir_doc_id) {
+        LoadIr::Found(ir) => ir,
+        LoadIr::NotFound => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(err_envelope("ir-doc-not-found")),
+            )
+                .into_response();
+        }
+        LoadIr::Error(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(err_envelope(format!("ir-read-failed: {}", e))),
+            )
+                .into_response();
+        }
+    };
+
+    // Reserve the pending slot before emitting the event so the React
+    // side can never deliver faster than we register. Same invariant as
+    // the existing `ui_bridge_invoke` proxy — see
+    // `mcp/ui_bridge_invoke_handlers.rs::ui_bridge_invoke_handler`.
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let (sender, receiver) = oneshot::channel::<InvokeResponse>();
+    state
+        .ui_bridge_invoke_store
+        .register(request_id.clone(), sender)
+        .await;
+
+    let payload = json!({
+        "request_id": request_id,
+        "ir": ir,
+    });
+
+    info!(
+        ir_doc_id,
+        request_id = %request_id,
+        "scenarios/current: emitting {}",
+        PROJECTION_REQUEST_EVENT
+    );
+    if let Err(e) = state.app_handle.emit(PROJECTION_REQUEST_EVENT, &payload) {
+        state.ui_bridge_invoke_store.cancel(&request_id).await;
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(err_envelope(format!(
+                "scenarios/current: failed to emit projection request: {}",
+                e
+            ))),
+        )
+            .into_response();
+    }
+
+    match tokio::time::timeout(Duration::from_millis(PROJECTION_TIMEOUT_MS), receiver).await {
+        Ok(Ok(resp)) => {
+            if resp.ok {
+                let data = resp.result.unwrap_or(Value::Null);
+                (StatusCode::OK, Json(ScenarioEnvelope::ok(data))).into_response()
+            } else {
+                let err = resp.error.unwrap_or_else(|| {
+                    "frontend reported projection failure without an error message".to_string()
+                });
+                warn!(
+                    ir_doc_id,
+                    request_id = %request_id,
+                    error = %err,
+                    "scenarios/current: frontend projection returned error"
+                );
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(err_envelope(format!(
+                        "scenarios/current: frontend projection failed: {}",
+                        err
+                    ))),
+                )
+                    .into_response()
+            }
+        }
+        Ok(Err(_recv_err)) => {
+            state.ui_bridge_invoke_store.cancel(&request_id).await;
+            warn!(
+                ir_doc_id,
+                request_id = %request_id,
+                "scenarios/current: oneshot sender dropped (frontend response lost)"
+            );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(err_envelope(format!(
+                    "scenarios/current: frontend response channel closed (request_id={})",
+                    request_id
+                ))),
+            )
+                .into_response()
+        }
+        Err(_elapsed) => {
+            state.ui_bridge_invoke_store.cancel(&request_id).await;
+            warn!(
+                ir_doc_id,
+                request_id = %request_id,
+                "scenarios/current: timed out waiting for frontend projection"
+            );
+            (
+                StatusCode::GATEWAY_TIMEOUT,
+                Json(err_envelope(format!(
+                    "scenarios/current: timed out waiting for frontend projection (timeout={}ms)",
+                    PROJECTION_TIMEOUT_MS
+                ))),
+            )
+                .into_response()
+        }
+    }
+}

--- a/src-tauri/src/scenarios/mod.rs
+++ b/src-tauri/src/scenarios/mod.rs
@@ -1,0 +1,52 @@
+//! Scenario projection — Section 11, Phase B2 of the UI Bridge redesign.
+//!
+//! Two HTTP endpoints expose the scenario-projection layer to Phase B3 MCP
+//! tools (Python, separate phase) which call this surface over HTTP:
+//!
+//!   - `GET /scenarios/projection?ir_doc_id=<id>` — pure, deterministic
+//!     projection of an IR document. Native Rust implementation in
+//!     [`projection::project_scenarios`].
+//!
+//!   - `GET /scenarios/current?ir_doc_id=<id>` — runtime-aware projection
+//!     that combines the static projection with live-registry signal. The
+//!     registry lives in the React webview, so the handler IPC's into the
+//!     webview via `ui-bridge:project-current-scenario-request` and waits
+//!     for the response.
+//!
+//! Both endpoints return the wire envelope:
+//!
+//! ```text
+//! 200 { ok: true,  data: <projection JSON> }
+//! 404 { ok: false, error: "ir-doc-not-found" }
+//! 500 { ok: false, error: <message> }
+//! ```
+//!
+//! The TS counterparts of the projection functions live in
+//! `ui-bridge-auto/src/state/scenario-projection.ts` (Phase B1, just shipped).
+//! The static Rust port intentionally re-implements the deterministic
+//! sorting discipline rather than IPC-ing the static call out to the
+//! webview — keeping the determinism gate inside the HTTP boundary.
+
+pub mod handlers;
+pub mod projection;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+use axum::routing::get;
+use axum::Router;
+use std::sync::Arc;
+
+use crate::mcp::types::ApiState;
+
+/// Routes for the Scenarios API. Mounted alongside `/spec/...` in
+/// `mcp_api.rs::create_router`.
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route(
+            "/scenarios/projection",
+            get(handlers::get_scenarios_projection),
+        )
+        .route("/scenarios/current", get(handlers::get_scenarios_current))
+}

--- a/src-tauri/src/scenarios/projection.rs
+++ b/src-tauri/src/scenarios/projection.rs
@@ -1,0 +1,107 @@
+//! Pure Rust port of `projectScenarios` from
+//! `ui-bridge-auto/src/state/scenario-projection.ts`.
+//!
+//! Determinism rules (non-negotiable, mirror the TS implementation):
+//!   - No clock reads, no RNG, no I/O.
+//!   - Sort states by `state_id` ascending.
+//!   - Sort each state's `outbound_transitions` by `transition_id` ascending.
+//!   - Sort each transition's `target_state_ids` ascending.
+//!   - Never mutate caller-supplied data — always sort fresh copies.
+//!
+//! The Rust port keeps the same field-emission rules as the TS source
+//! (e.g. `label` only emitted when distinct from the id) so the JSON
+//! output is byte-identical to what `projectScenarios(ir)` would emit.
+
+use std::collections::BTreeMap;
+
+use crate::spec_api::types::{IrDocument, IrTransition};
+
+use super::types::{ProjectedState, ProjectedTransition, ScenarioProjection};
+
+/// Bucket transitions by their `from_states` entries. A transition with
+/// multiple preconditions appears under EVERY fromState — matching the
+/// TS implementation's "what can I do from state X" semantic. We use
+/// `BTreeMap` so the from-state iteration order is itself deterministic
+/// (the TS version re-sorts after collection; using a sorted map here is
+/// equivalent and avoids a needless allocation).
+fn index_transitions_by_from_state<'a>(
+    ir: &'a IrDocument,
+) -> BTreeMap<&'a str, Vec<&'a IrTransition>> {
+    let mut out: BTreeMap<&'a str, Vec<&'a IrTransition>> = BTreeMap::new();
+    for t in &ir.transitions {
+        for from in &t.from_states {
+            out.entry(from.as_str()).or_default().push(t);
+        }
+    }
+    out
+}
+
+/// Sorted copy of a `&[String]` — never mutates the caller-owned slice.
+fn sorted_copy(values: &[String]) -> Vec<String> {
+    let mut v: Vec<String> = values.to_vec();
+    v.sort();
+    v
+}
+
+/// Mirror of `projectTransition` in the TS source.
+fn project_transition(t: &IrTransition) -> ProjectedTransition {
+    let label = if !t.name.is_empty() && t.name != t.id {
+        Some(t.name.clone())
+    } else {
+        None
+    };
+    ProjectedTransition {
+        transition_id: t.id.clone(),
+        label,
+        target_state_ids: sorted_copy(&t.activate_states),
+        action_count: t.actions.len(),
+    }
+}
+
+/// Walk the IR and emit a deterministic projection of every state with
+/// its outbound transitions. Same `IrDocument` input → byte-identical
+/// output as the TS `projectScenarios`.
+///
+/// Cost is `O(|states| log |states| + |transitions| log |transitions|)`
+/// for the sorts plus `O(|transitions|)` for the bucketing.
+pub fn project_scenarios(ir: &IrDocument) -> ScenarioProjection {
+    let by_from_state = index_transitions_by_from_state(ir);
+
+    // Defensive sort — callers may build IRs in arbitrary order.
+    let mut sorted_state_indices: Vec<usize> = (0..ir.states.len()).collect();
+    sorted_state_indices.sort_by(|&i, &j| ir.states[i].id.cmp(&ir.states[j].id));
+
+    let mut states: Vec<ProjectedState> = Vec::with_capacity(ir.states.len());
+    for idx in sorted_state_indices {
+        let s = &ir.states[idx];
+        let bucket = by_from_state
+            .get(s.id.as_str())
+            .map(|v| v.as_slice())
+            .unwrap_or(&[]);
+
+        // Sort each bucket by transition id ascending.
+        let mut sorted_bucket: Vec<&IrTransition> = bucket.to_vec();
+        sorted_bucket.sort_by(|a, b| a.id.cmp(&b.id));
+
+        let outbound: Vec<ProjectedTransition> =
+            sorted_bucket.iter().map(|t| project_transition(t)).collect();
+
+        let label = if !s.name.is_empty() && s.name != s.id {
+            Some(s.name.clone())
+        } else {
+            None
+        };
+
+        states.push(ProjectedState {
+            state_id: s.id.clone(),
+            label,
+            required_element_count: s.required_elements.len(),
+            outbound_transitions: outbound,
+        });
+    }
+
+    ScenarioProjection {
+        states,
+        deterministic: true,
+    }
+}

--- a/src-tauri/src/scenarios/tests.rs
+++ b/src-tauri/src/scenarios/tests.rs
@@ -1,0 +1,208 @@
+//! Unit tests for the static scenario projection. Mirrors the
+//! determinism + label-emission rules tested on the TS side.
+
+use serde_json::json;
+
+use crate::spec_api::types::{
+    IrDocument, IrElementCriteria, IrState, IrTransition, IrTransitionAction,
+};
+
+use super::projection::project_scenarios;
+
+fn empty_state(id: &str, name: &str) -> IrState {
+    IrState {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: None,
+        required_elements: vec![],
+        excluded_elements: None,
+        conditions: None,
+        is_initial: None,
+        is_terminal: None,
+        blocking: None,
+        group: None,
+        path_cost: None,
+        precondition: None,
+        element_ids: None,
+        incoming_transitions: None,
+        metadata: None,
+        provenance: None,
+        cross_refs: None,
+    }
+}
+
+fn click_action() -> IrTransitionAction {
+    IrTransitionAction {
+        kind: "click".to_string(),
+        target: IrElementCriteria {
+            role: Some("button".to_string()),
+            ..IrElementCriteria::default()
+        },
+        params: None,
+        wait_after: None,
+    }
+}
+
+fn empty_transition(
+    id: &str,
+    name: &str,
+    from: Vec<&str>,
+    activate: Vec<&str>,
+    actions: Vec<IrTransitionAction>,
+) -> IrTransition {
+    IrTransition {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: None,
+        from_states: from.into_iter().map(String::from).collect(),
+        activate_states: activate.into_iter().map(String::from).collect(),
+        exit_states: None,
+        actions,
+        path_cost: None,
+        bidirectional: None,
+        effect: None,
+        metadata: None,
+        provenance: None,
+        cross_refs: None,
+    }
+}
+
+fn make_ir() -> IrDocument {
+    IrDocument {
+        version: "1.0".to_string(),
+        id: "test-page".to_string(),
+        name: "Test Page".to_string(),
+        description: None,
+        metadata: None,
+        provenance: None,
+        states: vec![
+            empty_state("state-b", "state-b"),
+            // Out of order — projection must sort.
+            empty_state("state-a", "State A"),
+        ],
+        transitions: vec![
+            empty_transition(
+                "t-2",
+                "t-2",
+                vec!["state-a"],
+                vec!["state-b", "state-a"], // Unsorted activate_states.
+                vec![click_action(), click_action()],
+            ),
+            empty_transition(
+                "t-1",
+                "Click Foo",
+                vec!["state-a"],
+                vec!["state-b"],
+                vec![click_action()],
+            ),
+        ],
+        initial_state: None,
+    }
+}
+
+#[test]
+fn project_scenarios_sorts_states_by_id_ascending() {
+    let ir = make_ir();
+    let proj = project_scenarios(&ir);
+    let ids: Vec<&str> = proj.states.iter().map(|s| s.state_id.as_str()).collect();
+    assert_eq!(ids, vec!["state-a", "state-b"]);
+}
+
+#[test]
+fn project_scenarios_sorts_outbound_transitions_by_id() {
+    let ir = make_ir();
+    let proj = project_scenarios(&ir);
+    let state_a = proj.states.iter().find(|s| s.state_id == "state-a").unwrap();
+    let trans_ids: Vec<&str> = state_a
+        .outbound_transitions
+        .iter()
+        .map(|t| t.transition_id.as_str())
+        .collect();
+    assert_eq!(trans_ids, vec!["t-1", "t-2"]);
+}
+
+#[test]
+fn project_scenarios_sorts_target_state_ids_ascending() {
+    let ir = make_ir();
+    let proj = project_scenarios(&ir);
+    let state_a = proj.states.iter().find(|s| s.state_id == "state-a").unwrap();
+    let t2 = state_a
+        .outbound_transitions
+        .iter()
+        .find(|t| t.transition_id == "t-2")
+        .unwrap();
+    assert_eq!(t2.target_state_ids, vec!["state-a", "state-b"]);
+}
+
+#[test]
+fn project_scenarios_omits_label_when_equal_to_id() {
+    let ir = make_ir();
+    let proj = project_scenarios(&ir);
+
+    // state-b has name == id → no label.
+    let state_b = proj.states.iter().find(|s| s.state_id == "state-b").unwrap();
+    assert!(state_b.label.is_none());
+
+    // state-a has name "State A" != "state-a" → label populated.
+    let state_a = proj.states.iter().find(|s| s.state_id == "state-a").unwrap();
+    assert_eq!(state_a.label.as_deref(), Some("State A"));
+}
+
+#[test]
+fn project_scenarios_includes_action_count_and_required_element_count() {
+    let ir = make_ir();
+    let proj = project_scenarios(&ir);
+    let state_a = proj.states.iter().find(|s| s.state_id == "state-a").unwrap();
+    assert_eq!(state_a.required_element_count, 0);
+
+    let t2 = state_a
+        .outbound_transitions
+        .iter()
+        .find(|t| t.transition_id == "t-2")
+        .unwrap();
+    assert_eq!(t2.action_count, 2);
+
+    let t1 = state_a
+        .outbound_transitions
+        .iter()
+        .find(|t| t.transition_id == "t-1")
+        .unwrap();
+    assert_eq!(t1.action_count, 1);
+    assert_eq!(t1.label.as_deref(), Some("Click Foo"));
+}
+
+#[test]
+fn project_scenarios_is_deterministic_across_runs() {
+    let ir = make_ir();
+    let a = serde_json::to_string(&project_scenarios(&ir)).unwrap();
+    for _ in 0..10 {
+        let b = serde_json::to_string(&project_scenarios(&ir)).unwrap();
+        assert_eq!(a, b, "projection must be byte-identical across runs");
+    }
+}
+
+#[test]
+fn project_scenarios_marks_deterministic_true() {
+    let ir = make_ir();
+    let proj = project_scenarios(&ir);
+    let v = serde_json::to_value(&proj).unwrap();
+    assert_eq!(v["deterministic"], json!(true));
+}
+
+#[test]
+fn project_scenarios_handles_empty_ir() {
+    let ir = IrDocument {
+        version: "1.0".to_string(),
+        id: "empty".to_string(),
+        name: "empty".to_string(),
+        description: None,
+        metadata: None,
+        provenance: None,
+        states: vec![],
+        transitions: vec![],
+        initial_state: None,
+    };
+    let proj = project_scenarios(&ir);
+    assert!(proj.states.is_empty());
+    assert!(proj.deterministic);
+}

--- a/src-tauri/src/scenarios/types.rs
+++ b/src-tauri/src/scenarios/types.rs
@@ -1,0 +1,111 @@
+//! Wire types for scenario projection. Mirrors the TS interfaces in
+//! `ui-bridge-auto/src/state/scenario-projection.ts`.
+//!
+//! These shapes are stable JSON contracts consumed by the Phase B3 MCP
+//! tools (Python). Field names use camelCase via
+//! `serde(rename_all = "camelCase")` to match the TS output byte-for-byte.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Static (deterministic) projection
+// ---------------------------------------------------------------------------
+
+/// One projected transition emanating from a state. Mirror of
+/// `ProjectedTransition` (TS). Action *content* is intentionally omitted —
+/// clients that need the action body should resolve it against the IR.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedTransition {
+    pub transition_id: String,
+    /// Only emitted when distinct from `transition_id` — the IR convention
+    /// is to default `name = id` when no human-readable label exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    /// `IrTransition.activate_states`, sorted ascending.
+    pub target_state_ids: Vec<String>,
+    /// `IrTransition.actions.len()`.
+    pub action_count: usize,
+}
+
+/// One projected state. Mirror of `ProjectedState` (TS).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectedState {
+    pub state_id: String,
+    /// Only emitted when distinct from `state_id` — see [`ProjectedTransition::label`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    pub required_element_count: usize,
+    /// Outbound transitions, sorted by `transition_id` ascending.
+    pub outbound_transitions: Vec<ProjectedTransition>,
+}
+
+/// Static, deterministic projection. Same `IrDocument` input → byte-identical
+/// JSON output via the canonical sort discipline. Mirror of `ScenarioProjection` (TS).
+///
+/// The `deterministic: true` field is a load-bearing marker — Phase B3 tools
+/// can persist this artifact safely. Compare with [`CurrentScenarioProjection`]
+/// which carries `deterministic: false`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ScenarioProjection {
+    /// All states, sorted by `state_id` ascending.
+    pub states: Vec<ProjectedState>,
+    /// Always `true`. Serialized as the literal `true` (not a string).
+    pub deterministic: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Runtime-aware projection (wire-shape only — payload comes from the webview)
+// ---------------------------------------------------------------------------
+
+/// One transition the runtime engine could fire right now. Mirror of
+/// `AvailableTransition` (TS).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AvailableTransition {
+    pub transition_id: String,
+    pub from_state_id: String,
+    /// `IrTransition.activate_states`, sorted ascending.
+    pub target_state_ids: Vec<String>,
+}
+
+/// One transition the runtime engine cannot fire right now. Mirror of
+/// `BlockedTransition` (TS).
+///
+/// `cause` is one of `"no-match"`, `"ambiguous"`, or `"predicate-failed"`.
+/// The Rust side keeps it as a `String` so we don't have to maintain a
+/// parallel enum in lockstep with the TS source — the wire contract is
+/// the only thing that matters.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockedTransition {
+    pub transition_id: String,
+    pub from_state_id: String,
+    pub cause: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Runtime-aware projection. Mirror of `CurrentScenarioProjection` (TS).
+///
+/// Non-deterministic by design — the output depends on the live registry's
+/// `getAllElements()` snapshot. The `deterministic: false` marker is the
+/// load-bearing distinguisher from [`ScenarioProjection`].
+///
+/// We keep the Rust mirror to validate the IPC response shape; the actual
+/// payload returned to HTTP callers passes through as
+/// `serde_json::Value` to avoid a round-trip parse.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CurrentScenarioProjection {
+    pub states: Vec<ProjectedState>,
+    /// State ids whose required elements resolve in the live registry,
+    /// sorted ascending.
+    pub current_state_ids: Vec<String>,
+    pub available_transitions: Vec<AvailableTransition>,
+    pub blocked_transitions: Vec<BlockedTransition>,
+    /// Always `false`.
+    pub deterministic: bool,
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ import {
   UIBridgeEventHandler,
   UIBridgeInvokeHandler,
   UIBridgeEvaluateHandler,
+  ScenarioProjectionHandler,
   SpecExecutionHandler,
 } from "./hooks";
 import { useGlobalLogSources } from "./hooks/useGlobalLogSources";
@@ -810,6 +811,7 @@ export default function App() {
         <UIBridgeEventHandler />
         <UIBridgeInvokeHandler />
         <UIBridgeEvaluateHandler />
+        <ScenarioProjectionHandler />
         <SpecExecutionHandler />
         <BundledSpecsLoader />
         <CtrAutoPopulator />

--- a/src/components/app/TabContent.tsx
+++ b/src/components/app/TabContent.tsx
@@ -78,6 +78,7 @@ import { WrappersLibraryPage } from "@/pages/wrappers/WrappersLibraryPage";
 import { UIBridgeStateMachinePage } from "@/pages/state-machine";
 import { ImageQualityTestsPage } from "@/pages/ImageQualityTestsPage";
 import { EventHistoryPage } from "@/pages/EventHistoryPage";
+import { RegressionTabPage } from "@/pages/regression/RegressionTabPage";
 import { lazy, Suspense } from "react";
 import { Loader2 } from "lucide-react";
 
@@ -1212,6 +1213,18 @@ export function TabContent({
             description="Install and manage wrapper extensions — typed actions for the runner"
           />
           <WrappersLibraryPage />
+        </div>
+      );
+
+    case "regression":
+      return (
+        <div data-page-id="regression" className="h-full overflow-hidden">
+          <PageRegistration
+            id="regression"
+            name="Regression"
+            description="UI Bridge regression suites — run a suite, walk live registry assertions, and review coverage"
+          />
+          <RegressionTabPage />
         </div>
       );
 

--- a/src/components/app/tab-types.ts
+++ b/src/components/app/tab-types.ts
@@ -96,7 +96,8 @@ export type MainTabId =
   | "dag-workflow-editor"
   | "project-explainer"
   | "wrappers"
-  | "productivity";
+  | "productivity"
+  | "regression";
 
 const VALID_TAB_IDS: MainTabId[] = [
   "prompt-home",
@@ -195,6 +196,7 @@ const VALID_TAB_IDS: MainTabId[] = [
   "project-explainer",
   "wrappers",
   "productivity",
+  "regression",
 ];
 
 export const SIDEBAR_COLLAPSED_KEY = "qontinui-sidebar-collapsed";
@@ -304,6 +306,7 @@ export const TAB_LABELS: Record<MainTabId, string> = {
   "project-explainer": "Project Explainer",
   wrappers: "Wrappers",
   productivity: "Productivity",
+  regression: "Regression",
 };
 
 /**
@@ -336,6 +339,7 @@ const NAV_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
   "terminal",
   "wrappers",
   "productivity",
+  "regression",
 ]);
 
 /**

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -166,6 +166,11 @@ export { useUIBridgeInvokeHandler, UIBridgeInvokeHandler } from "./useUIBridgeIn
 
 export { useUIBridgeEvaluateHandler, UIBridgeEvaluateHandler } from "./useUIBridgeEvaluateHandler";
 
+export {
+  useScenarioProjectionHandler,
+  ScenarioProjectionHandler,
+} from "./useScenarioProjectionHandler";
+
 export { useSpecExecutionHandler, SpecExecutionHandler } from "./useSpecExecutionHandler";
 
 export { useWorkflowGenerator } from "./useWorkflowGenerator";

--- a/src/hooks/useScenarioProjectionHandler.ts
+++ b/src/hooks/useScenarioProjectionHandler.ts
@@ -1,0 +1,228 @@
+/**
+ * useScenarioProjectionHandler
+ *
+ * Section 11 / Phase B2 — frontend half of the runtime-aware scenario
+ * projection IPC.
+ *
+ * Architecture:
+ * ```
+ * External HTTP Client
+ *     | GET /scenarios/current?ir_doc_id=<id>
+ *     v
+ * Axum handler (scenarios/handlers.rs)
+ *     | loads IR from spec_api::storage
+ *     | emit("ui-bridge:project-current-scenario-request",
+ *     |       { request_id, ir })
+ *     v
+ * This Hook
+ *     | projectCurrentScenario(ir, registryAdapter)
+ *     v
+ * @qontinui/ui-bridge-auto/regression — pure TS projection
+ *     | returns CurrentScenarioProjection (deterministic: false)
+ *     v
+ * This Hook
+ *     | emit("ui-bridge:project-current-scenario-response",
+ *     |       { request_id, ok, result, error })
+ *     v
+ * Axum listener (mcp_api.rs) — delivers to the pending oneshot in
+ * `InvokeRequestStore` → HTTP handler returns the projection JSON.
+ * ```
+ *
+ * The projection function itself ships from `@qontinui/ui-bridge-auto`
+ * (Phase B1 — exhaustively tested) so this hook is a thin shell around it
+ * plus the registry adapter that wraps the UI Bridge SDK's global registry.
+ *
+ * Why a separate hook from `UIBridgeInvokeHandler`:
+ *   - That hook forwards to `invoke(command, args)` (Rust commands), but
+ *     the projection is computed in TS — the registry is a JS object in
+ *     the webview, not reachable from Rust without round-tripping through
+ *     `page/evaluate`.
+ *   - Keeping a dedicated channel makes the contract explicit: the Rust
+ *     side knows its IPC waits for a TS-computed value, not a Tauri
+ *     command result.
+ */
+
+import { useEffect } from "react";
+import { listen, emit, type UnlistenFn } from "@tauri-apps/api/event";
+import {
+  projectCurrentScenario,
+  type CurrentScenarioProjection,
+} from "@qontinui/ui-bridge-auto/regression";
+import type { RegistryLike, QueryableElement } from "@qontinui/ui-bridge-auto/runtime";
+// Same import path as useStateMachineRegistration so we share the singleton
+// globalRegistry — importing from "@qontinui/ui-bridge/core" resolves to a
+// separate dist bundle with its own isolated registry, making elements
+// invisible to the projection.
+import { getGlobalRegistry } from "@qontinui/ui-bridge";
+import { createLogger } from "@/lib/logger";
+import { getErrorMessage } from "@/lib/utils";
+
+const log = createLogger("ScenarioProjectionHandler");
+
+const REQUEST_EVENT = "ui-bridge:project-current-scenario-request";
+const RESPONSE_EVENT = "ui-bridge:project-current-scenario-response";
+
+interface ProjectionRequestPayload {
+  request_id: string;
+  // The IR document, serialized via serde with `rename_all = "camelCase"` —
+  // the TS `IRDocument` shape is the same camelCase, so we forward verbatim.
+  ir: unknown;
+}
+
+interface ProjectionResponsePayload {
+  request_id: string;
+  ok: boolean;
+  result?: CurrentScenarioProjection;
+  error?: string;
+}
+
+/**
+ * Build a `RegistryLike` adapter on top of the UI Bridge SDK's global
+ * element registry. Same shape as `createRegistryAdapter` in
+ * `useStateMachineRegistration` — kept in-file so this hook stays
+ * self-contained (no implicit cross-hook dependency).
+ */
+function createRegistryAdapter(): RegistryLike {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const registry = getGlobalRegistry() as any;
+  return {
+    getAllElements(): QueryableElement[] {
+      return registry
+        .getAllElements()
+        .map(
+          (el: {
+            id: string;
+            element: HTMLElement;
+            type: string;
+            label?: string;
+            getState: () => Record<string, unknown>;
+            getIdentifier?: () => Record<string, string | undefined>;
+          }) => ({
+            id: el.id,
+            element: el.element,
+            type: el.type,
+            label: el.label,
+            getState: () => {
+              const s = el.getState();
+              return {
+                visible: s.visible as boolean | undefined,
+                enabled: s.enabled as boolean | undefined,
+                focused: s.focused as boolean | undefined,
+                checked: s.checked as boolean | undefined,
+                textContent: s.textContent as string | undefined,
+                value: s.value as string | undefined,
+                rect: s.rect as DOMRect | undefined,
+              };
+            },
+            getIdentifier: el.getIdentifier
+              ? () => {
+                  const ident = el.getIdentifier!();
+                  return {
+                    selector: ident.selector,
+                    xpath: ident.xpath,
+                    htmlId: ident.htmlId,
+                  };
+                }
+              : undefined,
+          }),
+        );
+    },
+    on(type, listener) {
+      return registry.on(type, listener as (...args: unknown[]) => void);
+    },
+  };
+}
+
+/**
+ * Install a Tauri listener on `ui-bridge:project-current-scenario-request`
+ * that runs `projectCurrentScenario` against the live registry and emits
+ * the result back over `ui-bridge:project-current-scenario-response`.
+ *
+ * Safe to mount once at app root alongside `UIBridgeInvokeHandler`.
+ * Multiple concurrent projections are supported (each carries its own
+ * `request_id`).
+ */
+export function useScenarioProjectionHandler(): void {
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let isMounted = true;
+
+    const setupListener = async () => {
+      try {
+        log.debug(`Setting up ${REQUEST_EVENT} listener`);
+
+        unlisten = await listen<ProjectionRequestPayload>(REQUEST_EVENT, async (event) => {
+          if (!isMounted) {
+            log.debug("Component unmounted, ignoring projection request");
+            return;
+          }
+
+          const { request_id, ir } = event.payload;
+          log.debug(`Received projection request`, request_id);
+
+          let response: ProjectionResponsePayload;
+          try {
+            // The Rust side validated the IR exists in storage; we trust
+            // its shape here. The pure projection function is what
+            // enforces the contract — if the IR is malformed it will
+            // throw and we surface the error to the HTTP caller.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const irDoc = ir as any;
+            const registry = createRegistryAdapter();
+            const result = projectCurrentScenario(irDoc, registry);
+            response = {
+              request_id,
+              ok: true,
+              result,
+            };
+          } catch (err) {
+            const message = getErrorMessage(err);
+            log.debug(`projectCurrentScenario threw: ${message}`);
+            response = {
+              request_id,
+              ok: false,
+              error: message,
+            };
+          }
+
+          try {
+            await emit(RESPONSE_EVENT, response);
+          } catch (emitErr) {
+            // If emit itself fails the Rust side will hit its timeout —
+            // there's no better fallback here. Log and move on.
+            console.error(
+              "[ScenarioProjectionHandler] Failed to emit projection response:",
+              emitErr,
+            );
+          }
+        });
+
+        log.debug("projection-request listener set up successfully");
+      } catch (error) {
+        console.error(
+          "[ScenarioProjectionHandler] Failed to set up projection-request listener:",
+          error,
+        );
+      }
+    };
+
+    setupListener();
+
+    return () => {
+      log.debug("Cleaning up projection-request listener");
+      isMounted = false;
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  }, []);
+}
+
+/**
+ * Component wrapper for the hook (matches the `UIBridgeInvokeHandler`
+ * pattern so it can be placed alongside it in the JSX tree).
+ */
+export function ScenarioProjectionHandler(): null {
+  useScenarioProjectionHandler();
+  return null;
+}

--- a/src/hooks/useStateMachineRegistration.ts
+++ b/src/hooks/useStateMachineRegistration.ts
@@ -26,7 +26,7 @@ import {
   type TransitionDefinition,
   type TransitionAction as EngineTransitionAction,
   type ElementQuery,
-} from "@qontinui/ui-bridge-auto";
+} from "@qontinui/ui-bridge-auto/runtime";
 // Import from main entry to share the same globalRegistry singleton as UIBridgeProvider.
 // Importing from "@qontinui/ui-bridge/core" resolves to a separate dist bundle with
 // its own isolated globalRegistry variable, causing elements to be invisible to the engine.

--- a/src/lib/__tests__/regression-commit-filter.test.ts
+++ b/src/lib/__tests__/regression-commit-filter.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for `filterCommitsByIrOverlap`.
+ *
+ * Pure unit tests against the IR-overlap commit filter (Section 11, Decision
+ * #4). The filter narrows recent git commits to those whose `files[]` shares
+ * at least one path with the IR's source files (collected from each state's
+ * + transition's `provenance.file` field).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+import type { GitCommitRef } from "@qontinui/ui-bridge-auto/drift";
+
+import { filterCommitsByIrOverlap } from "../regression-commit-filter";
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+function makeIr(
+  stateFiles: Array<string | undefined>,
+  transitionFiles: Array<string | undefined>,
+): IRDocument {
+  return {
+    version: "1.0",
+    id: "test-ir",
+    name: "Test IR",
+    states: stateFiles.map((file, i) => ({
+      id: `state-${i}`,
+      name: `State ${i}`,
+      requiredElements: [],
+      ...(file !== undefined ? { provenance: { source: "build-plugin" as const, file } } : {}),
+    })),
+    transitions: transitionFiles.map((file, i) => ({
+      id: `transition-${i}`,
+      name: `Transition ${i}`,
+      fromStates: [],
+      activateStates: [],
+      actions: [],
+      ...(file !== undefined ? { provenance: { source: "build-plugin" as const, file } } : {}),
+    })),
+  };
+}
+
+function makeCommit(sha: string, files: string[]): GitCommitRef {
+  return {
+    sha,
+    message: `commit ${sha}`,
+    author: "test",
+    timestamp: 0,
+    files,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("filterCommitsByIrOverlap", () => {
+  it("returns empty when IR has no provenance files", () => {
+    const ir = makeIr([undefined, undefined], [undefined]);
+    const commits = [makeCommit("abc", ["src/foo.ts"])];
+    expect(filterCommitsByIrOverlap(ir, commits)).toEqual([]);
+  });
+
+  it("returns empty when no commits intersect IR files", () => {
+    const ir = makeIr(["src/foo.ts"], ["src/bar.ts"]);
+    const commits = [
+      makeCommit("abc", ["src/baz.ts"]),
+      makeCommit("def", ["src/qux.ts", "test/spec.ts"]),
+    ];
+    expect(filterCommitsByIrOverlap(ir, commits)).toEqual([]);
+  });
+
+  it("keeps commits whose files intersect any state's provenance file", () => {
+    const ir = makeIr(["src/foo.ts", "src/bar.ts"], []);
+    const commits = [
+      makeCommit("abc", ["src/foo.ts", "src/other.ts"]),
+      makeCommit("def", ["src/bar.ts"]),
+      makeCommit("ghi", ["src/unrelated.ts"]),
+    ];
+    const out = filterCommitsByIrOverlap(ir, commits);
+    expect(out.map((c) => c.sha)).toEqual(["abc", "def"]);
+  });
+
+  it("keeps commits whose files intersect any transition's provenance file", () => {
+    const ir = makeIr([], ["src/transitions.ts"]);
+    const commits = [
+      makeCommit("abc", ["src/transitions.ts"]),
+      makeCommit("def", ["src/elsewhere.ts"]),
+    ];
+    const out = filterCommitsByIrOverlap(ir, commits);
+    expect(out.map((c) => c.sha)).toEqual(["abc"]);
+  });
+
+  it("preserves caller-supplied commit order", () => {
+    const ir = makeIr(["src/foo.ts"], ["src/bar.ts"]);
+    const commits = [
+      makeCommit("c3", ["src/foo.ts"]),
+      makeCommit("c1", ["src/bar.ts"]),
+      makeCommit("c2", ["src/foo.ts", "src/bar.ts"]),
+    ];
+    const out = filterCommitsByIrOverlap(ir, commits);
+    expect(out.map((c) => c.sha)).toEqual(["c3", "c1", "c2"]);
+  });
+
+  it("treats empty / undefined provenance.file as no signal", () => {
+    const ir = makeIr(["", undefined], ["src/real.ts"]);
+    const commits = [makeCommit("abc", [""]), makeCommit("def", ["src/real.ts"])];
+    const out = filterCommitsByIrOverlap(ir, commits);
+    expect(out.map((c) => c.sha)).toEqual(["def"]);
+  });
+});

--- a/src/lib/__tests__/regression-executor.test.ts
+++ b/src/lib/__tests__/regression-executor.test.ts
@@ -1,0 +1,326 @@
+/**
+ * Tests for `runRegressionSuite`.
+ *
+ * End-to-end smoke test of the Phase A3 executor. Builds a tiny IR + suite,
+ * mocks the UI Bridge registry + `@tauri-apps/api/core` `invoke`, and verifies
+ * each of the four assertion discriminants dispatch correctly + the
+ * persistence calls fire with the expected payloads.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { generateRegressionSuite } from "@qontinui/ui-bridge-auto/regression";
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+import type { QueryableElement, RegistryLike } from "@qontinui/ui-bridge-auto/runtime";
+import type { ScreenshotAssertionManager } from "@qontinui/ui-bridge-auto/visual";
+
+// ---------------------------------------------------------------------------
+// Tauri invoke mock — must be set up before importing the executor module.
+// ---------------------------------------------------------------------------
+
+const invokeCalls: Array<{ cmd: string; args: unknown }> = [];
+let invokeResults: Record<string, unknown> = {};
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async (cmd: string, args: unknown) => {
+    invokeCalls.push({ cmd, args });
+    if (cmd in invokeResults) return invokeResults[cmd];
+    throw new Error(`unmocked tauri command: ${cmd}`);
+  }),
+}));
+
+// `runRegressionSuite` must be imported *after* the mock is registered.
+import { runRegressionSuite } from "../regression-executor";
+
+// ---------------------------------------------------------------------------
+// Fixture: tiny IR
+// ---------------------------------------------------------------------------
+
+const FIXTURE_IR: IRDocument = {
+  version: "1.0",
+  id: "fixture-ir",
+  name: "Fixture",
+  states: [
+    {
+      id: "state-a",
+      name: "State A",
+      requiredElements: [{ role: "button", text: "Submit" }],
+      provenance: { source: "build-plugin", file: "src/page-a.tsx" },
+    },
+    {
+      id: "state-b",
+      name: "State B",
+      requiredElements: [{ role: "heading", text: "Welcome" }],
+      provenance: { source: "build-plugin", file: "src/page-b.tsx" },
+    },
+  ],
+  transitions: [
+    {
+      id: "t1",
+      name: "go A→B",
+      fromStates: ["state-a"],
+      activateStates: ["state-b"],
+      actions: [
+        {
+          type: "click",
+          target: { role: "button", text: "Submit" },
+        },
+      ],
+      provenance: { source: "build-plugin", file: "src/page-a.tsx" },
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Fake registry
+// ---------------------------------------------------------------------------
+
+function makeElement(id: string, type: string, label: string, visible = true): QueryableElement {
+  // The matcher in `core/element-query.ts` reads `el.element.tagName`,
+  // `el.element.textContent`, and `el.element.getAttribute(...)`. Provide a
+  // minimal stand-in for an HTMLElement so the matcher can run without a real
+  // DOM. `tagName` mirrors `type` (browsers report tagName upper-case).
+  const fakeAttrs: Record<string, string | null> = {};
+  const html = {
+    tagName: type.toUpperCase(),
+    nodeName: type.toUpperCase(),
+    textContent: label,
+    getAttribute: (name: string) =>
+      Object.prototype.hasOwnProperty.call(fakeAttrs, name) ? fakeAttrs[name] : null,
+    setAttribute: (name: string, value: string) => {
+      fakeAttrs[name] = value;
+    },
+    parentElement: null,
+    children: [],
+    dataset: {},
+  } as unknown as HTMLElement;
+  return {
+    id,
+    element: html,
+    type,
+    label,
+    getState: () => ({
+      visible,
+      enabled: true,
+      textContent: label,
+    }),
+  };
+}
+
+function makeRegistry(elements: QueryableElement[]): RegistryLike {
+  return {
+    getAllElements: () => elements,
+    on: () => () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Stub ScreenshotAssertionManager — visual-gate isn't exercised in this suite
+// (no baselineStore option => generator emits no visual-gate assertions),
+// but pass a stub anyway so the executor never tries to construct the real
+// TauriBaselineStore-backed manager during a unit test.
+// ---------------------------------------------------------------------------
+
+const stubScreenshotManager = {
+  assertMatchesBaseline: vi.fn(async () => ({
+    pass: true,
+    diffPercentage: 0,
+    diffPixelCount: 0,
+    totalPixels: 1,
+    baselineKey: "stub",
+  })),
+  captureBaseline: vi.fn(async () => null),
+  assertElementsMatch: vi.fn(async () => ({
+    pass: true,
+    diffPercentage: 0,
+    diffPixelCount: 0,
+    totalPixels: 1,
+    baselineKey: "stub",
+  })),
+} as unknown as ScreenshotAssertionManager;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runRegressionSuite", () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    invokeResults = {
+      save_regression_suite: "11111111-1111-1111-1111-111111111111",
+      record_regression_run: "22222222-2222-2222-2222-222222222222",
+      record_assertion_executions_batch: 0,
+      record_regression_diagnosis: "33333333-3333-3333-3333-333333333333",
+    };
+  });
+
+  it("passes every assertion when the registry satisfies the IR", async () => {
+    const suite = generateRegressionSuite(FIXTURE_IR);
+    const elements = [
+      makeElement("e1", "button", "Submit"),
+      makeElement("e2", "heading", "Welcome"),
+    ];
+    const registry = makeRegistry(elements);
+
+    const result = await runRegressionSuite({
+      suite,
+      ir: FIXTURE_IR,
+      registry,
+      irDocId: FIXTURE_IR.id,
+      runId: "run-1",
+      recentCommits: [],
+      session: { id: "s1", startedAt: 0, events: [] },
+      screenshotManager: stubScreenshotManager,
+      now: () => 1_700_000_000_000,
+    });
+
+    expect(result.runResult.failed).toBe(0);
+    // Total: 2 pre-state + 1 post-state + 1 action-target = 4 assertions
+    // One transition has 1 fromState (state-a) -> 1 pre, 1 activateState
+    // (state-b) -> 1 post, 1 action -> 1 action-target. So 3 total.
+    expect(result.runResult.passed).toBe(3);
+    expect(result.diagnosis).toBeNull();
+
+    // Persistence calls fired in order.
+    const cmds = invokeCalls.map((c) => c.cmd);
+    expect(cmds).toEqual([
+      "save_regression_suite",
+      "record_regression_run",
+      "record_assertion_executions_batch",
+    ]);
+  });
+
+  it("fails state-active when a required element is missing", async () => {
+    const suite = generateRegressionSuite(FIXTURE_IR);
+    // Drop the heading: state-b's post-state assertion will fail.
+    const elements = [makeElement("e1", "button", "Submit")];
+    const registry = makeRegistry(elements);
+
+    const result = await runRegressionSuite({
+      suite,
+      ir: FIXTURE_IR,
+      registry,
+      irDocId: FIXTURE_IR.id,
+      runId: "run-2",
+      recentCommits: [],
+      session: { id: "s2", startedAt: 0, events: [] },
+      screenshotManager: stubScreenshotManager,
+      now: () => 1_700_000_000_000,
+    });
+
+    expect(result.runResult.failed).toBeGreaterThanOrEqual(1);
+    const failureKinds = result.runResult.failures.map((f) => f.assertion.kind);
+    expect(failureKinds).toContain("state-active");
+    // Because the run failed, we must have called diagnose + persisted it.
+    expect(result.diagnosis).not.toBeNull();
+    const cmds = invokeCalls.map((c) => c.cmd);
+    expect(cmds).toContain("record_regression_diagnosis");
+  });
+
+  it("fails action-target-resolves when the action target is ambiguous", async () => {
+    const suite = generateRegressionSuite(FIXTURE_IR);
+    const elements = [
+      makeElement("e1", "button", "Submit"),
+      makeElement("e2", "button", "Submit"), // duplicate button => ambiguous
+      makeElement("e3", "heading", "Welcome"),
+    ];
+    const registry = makeRegistry(elements);
+
+    const result = await runRegressionSuite({
+      suite,
+      ir: FIXTURE_IR,
+      registry,
+      irDocId: FIXTURE_IR.id,
+      runId: "run-3",
+      recentCommits: [],
+      session: { id: "s3", startedAt: 0, events: [] },
+      screenshotManager: stubScreenshotManager,
+      now: () => 1_700_000_000_000,
+    });
+
+    const actionTargetFailures = result.runResult.failures.filter(
+      (f) => f.assertion.kind === "action-target-resolves",
+    );
+    expect(actionTargetFailures.length).toBe(1);
+  });
+
+  it("dispatches overlay assertions and skips unknown overlay ids", async () => {
+    // Hand-build a suite that includes an unknown overlay id so we exercise
+    // the forward-compatibility path. We can't generate it via overlays —
+    // overlays produce known ids — so we patch the suite directly.
+    const suite = generateRegressionSuite(FIXTURE_IR);
+    suite.cases[0]!.assertions.push({
+      kind: "overlay",
+      overlayId: "future-overlay-not-yet-implemented",
+      assertionId: "future#0",
+      payload: {},
+    });
+    // Plus a known overlay (`visibility`) targeting state-a's button.
+    suite.cases[0]!.assertions.push({
+      kind: "overlay",
+      overlayId: "visibility",
+      assertionId: "state-a#0",
+      payload: { stateId: "state-a", requiredElementIndex: 0, minRatio: 1 },
+    });
+
+    const elements = [
+      makeElement("e1", "button", "Submit"),
+      makeElement("e2", "heading", "Welcome"),
+    ];
+    const registry = makeRegistry(elements);
+
+    const result = await runRegressionSuite({
+      suite,
+      ir: FIXTURE_IR,
+      registry,
+      irDocId: FIXTURE_IR.id,
+      runId: "run-4",
+      recentCommits: [],
+      session: { id: "s4", startedAt: 0, events: [] },
+      screenshotManager: stubScreenshotManager,
+      now: () => 1_700_000_000_000,
+    });
+
+    // No failures: visibility passes (button is visible), unknown overlay skips.
+    expect(result.runResult.failed).toBe(0);
+    expect(result.diagnosis).toBeNull();
+
+    // The skip row must have made it into the batch payload.
+    const batchCall = invokeCalls.find((c) => c.cmd === "record_assertion_executions_batch");
+    expect(batchCall).toBeDefined();
+    const executions = (batchCall!.args as { executions: unknown[] }).executions;
+    const skippedRows = (executions as Array<{ status: string; assertion_kind: string }>).filter(
+      (r) => r.status === "skip",
+    );
+    expect(skippedRows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("threads the runDbId onto every assertion-execution row", async () => {
+    const suite = generateRegressionSuite(FIXTURE_IR);
+    const elements = [
+      makeElement("e1", "button", "Submit"),
+      makeElement("e2", "heading", "Welcome"),
+    ];
+    const registry = makeRegistry(elements);
+
+    await runRegressionSuite({
+      suite,
+      ir: FIXTURE_IR,
+      registry,
+      irDocId: FIXTURE_IR.id,
+      runId: "run-5",
+      recentCommits: [],
+      session: { id: "s5", startedAt: 0, events: [] },
+      screenshotManager: stubScreenshotManager,
+      now: () => 1_700_000_000_000,
+    });
+
+    const batchCall = invokeCalls.find((c) => c.cmd === "record_assertion_executions_batch");
+    expect(batchCall).toBeDefined();
+    const executions = (batchCall!.args as { executions: Array<{ run_id: string }> }).executions;
+    expect(executions.length).toBeGreaterThan(0);
+    for (const row of executions) {
+      expect(row.run_id).toBe("22222222-2222-2222-2222-222222222222");
+    }
+  });
+});

--- a/src/lib/compile-state-machine.ts
+++ b/src/lib/compile-state-machine.ts
@@ -27,7 +27,7 @@ import type {
   TransitionAction as EngineTransitionAction,
   ElementQuery,
   PersistedStateMachine,
-} from "@qontinui/ui-bridge-auto";
+} from "@qontinui/ui-bridge-auto/runtime";
 
 // ---------------------------------------------------------------------------
 // Provenance types and thresholds

--- a/src/lib/persist-compiled-state-machine.ts
+++ b/src/lib/persist-compiled-state-machine.ts
@@ -12,7 +12,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { tracedFetch } from "@/lib/runner-api";
-import type { PersistedStateMachine } from "@qontinui/ui-bridge-auto";
+import type { PersistedStateMachine } from "@qontinui/ui-bridge-auto/runtime";
 
 export async function persistCompiledStateMachine(
   stateMachine: PersistedStateMachine,

--- a/src/lib/regression-commit-filter.ts
+++ b/src/lib/regression-commit-filter.ts
@@ -1,0 +1,70 @@
+/**
+ * IR-overlap commit filter (Section 11, Phase A3, Decision #4).
+ *
+ * Pure function that narrows a list of recent git commits to the subset whose
+ * `files[]` intersects the source files referenced by an IR document's state
+ * + transition provenance. This is the natural file-overlap bound on which
+ * commits can plausibly explain a regression failure — there is no count cap
+ * (the plan calls this out explicitly).
+ *
+ * Determinism: stable output ordering inherited from the input arrays;
+ * commits are kept in the caller's supplied order.
+ */
+
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+import type { GitCommitRef } from "@qontinui/ui-bridge-auto/drift";
+
+/**
+ * Collect the set of source file paths declared by every IR state and
+ * transition's `provenance.file` field. States or transitions without a
+ * `provenance.file` contribute nothing — that is the documented signal that
+ * the IR node has no on-disk source we can correlate against.
+ */
+function collectIrSourceFiles(ir: IRDocument): Set<string> {
+  const files = new Set<string>();
+  for (const state of ir.states) {
+    const file = state.provenance?.file;
+    if (typeof file === "string" && file.length > 0) {
+      files.add(file);
+    }
+  }
+  for (const transition of ir.transitions) {
+    const file = transition.provenance?.file;
+    if (typeof file === "string" && file.length > 0) {
+      files.add(file);
+    }
+  }
+  return files;
+}
+
+/**
+ * Filter recent commits to those whose `files[]` shares at least one path
+ * with the IR's collected source files.
+ *
+ * If the IR has no source files (no provenance anywhere), returns an empty
+ * array — the callers' diagnose path then runs without commit hypotheses,
+ * which is the correct graceful-degradation behavior.
+ *
+ * @param ir — the IR document the regression suite was generated from.
+ * @param commits — recent git commits (already time-windowed by the caller).
+ *   The function does not re-window; it only file-overlap-filters.
+ * @returns commits whose changed files intersect the IR's source files.
+ *   Order is preserved from the input.
+ */
+export function filterCommitsByIrOverlap(ir: IRDocument, commits: GitCommitRef[]): GitCommitRef[] {
+  const irFiles = collectIrSourceFiles(ir);
+  if (irFiles.size === 0) return [];
+
+  const out: GitCommitRef[] = [];
+  for (const commit of commits) {
+    let overlaps = false;
+    for (const file of commit.files) {
+      if (irFiles.has(file)) {
+        overlaps = true;
+        break;
+      }
+    }
+    if (overlaps) out.push(commit);
+  }
+  return out;
+}

--- a/src/lib/regression-executor.ts
+++ b/src/lib/regression-executor.ts
@@ -42,7 +42,14 @@ import {
   type SelfDiagnosis,
 } from "@qontinui/ui-bridge-auto/diagnosis";
 import { findFirst, executeQuery, type RegistryLike } from "@qontinui/ui-bridge-auto/runtime";
-import { ScreenshotAssertionManager, TauriBaselineStore } from "@qontinui/ui-bridge-auto/visual";
+import {
+  ScreenshotAssertionManager,
+  TauriBaselineStore,
+  checkDesignTokens,
+  crossCheckText,
+  type DesignTokenRegistry,
+  type IOCRProvider,
+} from "@qontinui/ui-bridge-auto/visual";
 import type { GitCommitRef, DriftReport } from "@qontinui/ui-bridge-auto/drift";
 import type { DriftContext } from "@qontinui/ui-bridge-auto/drift";
 
@@ -131,6 +138,22 @@ export interface RunRegressionSuiteOptions {
    * stub via this option to avoid invoking Tauri.
    */
   screenshotManager?: ScreenshotAssertionManager;
+  /**
+   * Optional `DesignTokenRegistry` consumed by `token` overlay assertions.
+   * When supplied, the executor calls `checkDesignTokens(element, registry)`
+   * for each `token` overlay assertion and fails on any non-empty violation
+   * list. When omitted, `token` overlays only verify the element resolves
+   * (degrade-to-resolve mode); see overlay dispatch for the contract.
+   */
+  tokenRegistry?: DesignTokenRegistry;
+  /**
+   * Optional `IOCRProvider` consumed by `cross-check` overlay assertions.
+   * When supplied, the executor calls `crossCheckText(element, { ocr })`
+   * for each `cross-check` overlay assertion and fails on a content
+   * mismatch. When omitted, `cross-check` overlays degrade to verifying
+   * the action target resolves.
+   */
+  ocrProvider?: IOCRProvider;
   /**
    * Optional `Date.now()` override used purely for stamping `started_at`
    * / `completed_at`. Tests fix this to keep snapshots stable.
@@ -327,27 +350,30 @@ async function evaluateVisualGate(
 
 /**
  * Overlay dispatch: each of the three built-in overlay ids has its own
- * runtime semantics. The overlay payload is opaque to the generator but
- * structurally known here.
+ * runtime semantics.
  *
- * For now the executor implements a structural smoke check per overlay:
- *   - `visibility`  → require the element resolves and is `visible`.
- *   - `token`       → require the element resolves; full design-token
- *                     evaluation needs a registry the executor doesn't carry,
- *                     so this is a "resolves" check until the registry is
- *                     threaded through.
- *   - `cross-check` → require the action's target resolves; full OCR
- *                     cross-check needs an OCR provider supplied at execute
- *                     time and is wired in by the consumer when needed.
+ *   - `visibility`  → require the element resolves and reports `visible`.
+ *   - `token`       → resolve the element, then run `checkDesignTokens`
+ *                     against the supplied `DesignTokenRegistry`. Fails on
+ *                     any non-empty violation list. When the registry is
+ *                     not supplied, degrades to a resolve-only check and
+ *                     marks the outcome with `failureKind: "no-token-registry"`
+ *                     should the consumer want to surface the gap.
+ *   - `cross-check` → resolve the action target, then run `crossCheckText`
+ *                     against the supplied `IOCRProvider`. Fails on content
+ *                     mismatch. When the provider is not supplied, degrades
+ *                     to a resolve-only check.
  *
  * Unknown overlay ids are skipped — the suite remains forward-compatible
  * with overlays this executor doesn't recognize yet.
  */
-function evaluateOverlay(
+async function evaluateOverlay(
   assertion: OverlayAssertion,
   ir: IRDocument,
   registry: RegistryLike,
-): AssertionOutcome {
+  tokenRegistry: DesignTokenRegistry | undefined,
+  ocrProvider: IOCRProvider | undefined,
+): Promise<AssertionOutcome> {
   const payload = assertion.payload;
   switch (assertion.overlayId) {
     case "visibility":
@@ -395,6 +421,48 @@ function evaluateOverlay(
           };
         }
       }
+      if (assertion.overlayId === "token") {
+        if (!tokenRegistry) {
+          // Resolve-only degrade. Caller didn't thread a registry; surface
+          // it on the outcome so consumers can flag the gap without the
+          // assertion failing the suite.
+          return {
+            status: "pass",
+            message:
+              "token overlay degrade: resolved without DesignTokenRegistry — pass not gated on token check",
+          };
+        }
+        const live = elements.find((e) => e.id === result.match!.id);
+        if (!live) {
+          return {
+            status: "fail",
+            failureKind: "overlay-token-element-missing",
+            message: `Overlay "token" target ${stateId}#${idx} matched id ${result.match.id} but element not in registry`,
+            observed: { stateId, idx, elementId: result.match.id },
+          };
+        }
+        // Optional payload constraint: when present, only check this
+        // overlay's nominated property list (matches the generator's
+        // captured-properties contract from `tokenOverlay`).
+        const propertyFilter = Array.isArray(payload.properties)
+          ? (payload.properties.filter((p) => typeof p === "string") as string[])
+          : undefined;
+        const violations = checkDesignTokens(
+          live,
+          tokenRegistry,
+          propertyFilter ? { properties: propertyFilter } : undefined,
+        );
+        if (violations.length > 0) {
+          return {
+            status: "fail",
+            failureKind: "overlay-token-violations",
+            message: `Overlay "token" target ${stateId}#${idx} has ${violations.length} off-token propert${
+              violations.length === 1 ? "y" : "ies"
+            }`,
+            observed: { stateId, idx, elementId: result.match.id, violations },
+          };
+        }
+      }
       return { status: "pass" };
     }
     case "cross-check": {
@@ -428,12 +496,93 @@ function evaluateOverlay(
           observed: { transitionId, actionIndex },
         };
       }
+      // OCR-driven cross-check when an IOCRProvider was threaded through.
+      if (ocrProvider) {
+        const live = elements.find((e) => e.id === result.match!.id);
+        if (!live) {
+          return {
+            status: "fail",
+            failureKind: "overlay-cross-check-element-missing",
+            message: `Overlay "cross-check" matched id ${result.match.id} but element missing from registry`,
+            observed: { transitionId, actionIndex, elementId: result.match.id },
+          };
+        }
+        const tolerance =
+          typeof payload.tolerance === "number" ? payload.tolerance : undefined;
+        const ccResult = await crossCheckText(live, {
+          ocr: ocrProvider,
+          tolerance,
+        });
+        if (ccResult.skipped) {
+          // Capture or OCR couldn't run; treat as a deferred check rather
+          // than a hard fail. Skipped + reason flows up untouched.
+          return {
+            status: "skip",
+            message: `cross-check skipped: ${ccResult.reason}`,
+          };
+        }
+        if (!ccResult.pass) {
+          return {
+            status: "fail",
+            failureKind: ccResult.cause
+              ? `overlay-cross-check-${ccResult.cause}`
+              : "overlay-cross-check-mismatch",
+            message: `Overlay "cross-check" content mismatch on ${transitionId}#${actionIndex}: similarity=${ccResult.similarity.toFixed(3)}`,
+            observed: {
+              transitionId,
+              actionIndex,
+              domText: ccResult.domText,
+              ocrText: ccResult.ocrText,
+              similarity: ccResult.similarity,
+              cause: ccResult.cause,
+            },
+          };
+        }
+      }
       return { status: "pass" };
     }
     default:
       // Forward-compatible: unknown overlay ids skip cleanly.
       return { status: "skip" };
   }
+}
+
+// ---------------------------------------------------------------------------
+// Persisted drift-report helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Combine the spec-side and visual-side `DriftReport` inputs into a single
+ * `{ runId, entries }` blob suitable for persistence + HTTP pass-through.
+ *
+ * Returns `null` (i.e. don't persist a drift_report_json column) when both
+ * inputs are absent or empty — the FU-3 runner endpoint surfaces 404 in
+ * that case, and the qontinui-web frontend renders the empty state.
+ *
+ * Each entry's `id` is stable (derived from the upstream `DriftEntry.id`
+ * if present, else hashed from `kind + JSON tail`) so the
+ * `/runs/:run_id/drift/:entry_id` endpoint can index entries deterministically.
+ */
+function buildPersistedDriftReport(
+  specDrift: DriftReport | undefined,
+  visualDrift: DriftReport | undefined,
+): unknown {
+  // `DriftReport` shape: `{ states: DriftEntry[], transitions: DriftEntry[] }`.
+  // Flatten both buckets across both inputs for the persisted blob; the
+  // HTTP endpoint exposes `entries` as the unified list, indexed by
+  // `entry.id`. Tag each entry's source bucket so consumers can filter
+  // (states vs transitions) without losing the structural categorization.
+  const entries: unknown[] = [];
+  const pushAll = (report: DriftReport | undefined): void => {
+    if (!report) return;
+    for (const e of report.states ?? []) entries.push({ ...e, bucket: "state" });
+    for (const e of report.transitions ?? [])
+      entries.push({ ...e, bucket: "transition" });
+  };
+  pushAll(specDrift);
+  pushAll(visualDrift);
+  if (entries.length === 0) return null;
+  return { entries };
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +610,8 @@ export async function runRegressionSuite(
     visualDrift,
     priors,
     screenshotManager,
+    tokenRegistry,
+    ocrProvider,
     now,
   } = options;
 
@@ -503,7 +654,13 @@ export async function runRegressionSuite(
             outcome = await evaluateVisualGate(assertion, ir, registry, manager);
             break;
           case "overlay":
-            outcome = evaluateOverlay(assertion, ir, registry);
+            outcome = await evaluateOverlay(
+              assertion,
+              ir,
+              registry,
+              tokenRegistry,
+              ocrProvider,
+            );
             break;
         }
       } catch (err) {
@@ -558,6 +715,11 @@ export async function runRegressionSuite(
   };
 
   // Step 3 — record the run, getting back the persisted UUID.
+  // The `drift_report_json` blob — when either spec or visual drift is
+  // present — captures the same `DriftReport` entries fed into the
+  // diagnose call, plus a wrapper distinguishing kinds. Surfaced over
+  // HTTP at `/runs/:run_id/drift` for the qontinui-web dashboard.
+  const driftReportJson = buildPersistedDriftReport(specDrift, visualDrift);
   const runDbId = await invoke<string>("record_regression_run", {
     suiteId: suiteDbId,
     runId,
@@ -566,6 +728,7 @@ export async function runRegressionSuite(
     startedAt: startedAtIso,
     completedAt: completedAtIso,
     runResultJson: runResult,
+    driftReportJson,
   });
 
   // Step 4 — patch run id onto each row, batch-record.

--- a/src/lib/regression-executor.ts
+++ b/src/lib/regression-executor.ts
@@ -1,0 +1,617 @@
+/**
+ * TS-side regression executor (Section 11, Phase A3).
+ *
+ * Walks a serialized `RegressionSuite` against a live UI Bridge registry,
+ * dispatches each `RegressionAssertion` against the appropriate runtime
+ * primitive (`executeQuery` for action targets, `findFirst` per
+ * `requiredElement` for state-active, `ScreenshotAssertionManager` for
+ * visual gates, the three built-in overlay handlers for overlay assertions),
+ * builds a `RegressionRunResult`, and feeds it through the pure `diagnose`
+ * function from `@qontinui/ui-bridge-auto/diagnosis`. Every result is
+ * persisted via the Tauri commands shipped in Phase A2.
+ *
+ * Design notes:
+ *   - The executor is the single point that adapts the spec-only suite
+ *     against live page state. The library never calls back into the runner.
+ *   - Each persistence write is a thin Tauri `invoke` — no caching, no
+ *     dedup. The plan explicitly says persistence is append-only for now.
+ *   - Determinism is the library's responsibility (sorting, canonical JSON);
+ *     the executor only produces inputs in caller-supplied order.
+ *   - The `assertionId` keying rule mirrors `state/self-diagnosis.ts:assertionIdOf`:
+ *     overlay assertions reuse `OverlayAssertion.assertionId`; the others
+ *     are derived deterministically from `(caseId, kind, secondary-key)`.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+import type {
+  RegressionSuite,
+  RegressionCase,
+  RegressionAssertion,
+  ActionTargetResolvesAssertion,
+  OverlayAssertion,
+  StateActiveAssertion,
+  VisualGateAssertion,
+} from "@qontinui/ui-bridge-auto/regression";
+import { serializeSuite } from "@qontinui/ui-bridge-auto/regression";
+import {
+  diagnose,
+  type RegressionFailure,
+  type RegressionRunResult,
+  type SelfDiagnosis,
+} from "@qontinui/ui-bridge-auto/diagnosis";
+import { findFirst, executeQuery, type RegistryLike } from "@qontinui/ui-bridge-auto/runtime";
+import { ScreenshotAssertionManager, TauriBaselineStore } from "@qontinui/ui-bridge-auto/visual";
+import type { GitCommitRef, DriftReport } from "@qontinui/ui-bridge-auto/drift";
+import type { DriftContext } from "@qontinui/ui-bridge-auto/drift";
+
+import { createPgMemorySink } from "./regression-memory-sink";
+
+// `RecordingSession` and `FragilityScore` flow through `DriftContext`. We
+// derive their types from `DriftContext` itself rather than importing them
+// directly from the upstream package — the runner ships an ambient stub for
+// the bare `@qontinui/ui-bridge-auto` module that shadows the real exports,
+// so deriving via `DriftContext[K]` is the only way to land on the same
+// types the engine actually consumes.
+type RecordingSession = DriftContext["session"];
+type FragilityScore = NonNullable<DriftContext["priors"]>[number];
+
+// ---------------------------------------------------------------------------
+// Public API — types
+// ---------------------------------------------------------------------------
+
+/** Status of a single assertion execution row. */
+export type AssertionExecutionStatus = "pass" | "fail" | "skip";
+
+/**
+ * Per-assertion exercise row that flows into the
+ * `record_assertion_executions_batch` Tauri command. Field names match the
+ * Rust shape (snake_case) defined in Phase A2.
+ */
+export interface AssertionExecutionRow {
+  id: string;
+  /**
+   * Set after the run is recorded. Empty during the per-assertion walk,
+   * filled in once `record_regression_run` returns the run UUID.
+   */
+  run_id: string;
+  case_id: string;
+  assertion_id: string;
+  assertion_kind: RegressionAssertion["kind"];
+  status: AssertionExecutionStatus;
+  /** ISO 8601 string. */
+  started_at: string;
+  duration_ms: number;
+  /** Only populated when `status === "fail"`. */
+  failure_kind?: string;
+  /** Only populated when `status === "fail"`. */
+  failure_evidence_json?: unknown;
+  /** Only populated when `status === "fail"`. */
+  error_message?: string;
+}
+
+/** Inputs for {@link runRegressionSuite}. */
+export interface RunRegressionSuiteOptions {
+  /** Suite to execute. */
+  suite: RegressionSuite;
+  /** Pre-loaded IR document keyed to the suite. */
+  ir: IRDocument;
+  /** Live UI Bridge registry (page DOM). */
+  registry: RegistryLike;
+  /**
+   * Source IR doc identifier — used to scope persistence + recall the IR
+   * later. Treated opaquely by the executor; passed through to
+   * `save_regression_suite`.
+   */
+  irDocId: string;
+  /**
+   * Logical run identifier (caller-supplied; e.g. workflow execution id).
+   * Passed through to `record_regression_run` and threaded into the
+   * resulting `RegressionRunResult.runId`.
+   */
+  runId: string;
+  /**
+   * Recent commits since `suite.generatedAt`, file-overlap filtered (see
+   * Decision #4 of Section 11). The caller does the filtering — typically
+   * via `filterCommitsByIrOverlap`.
+   */
+  recentCommits: GitCommitRef[];
+  /** Active recording session — required by `DriftContext`. */
+  session: RecordingSession;
+  /** Optional spec drift inputs. */
+  specDrift?: DriftReport;
+  /** Optional visual drift inputs. */
+  visualDrift?: DriftReport;
+  /** Optional fragility priors. */
+  priors?: FragilityScore[];
+  /**
+   * Optional already-constructed `ScreenshotAssertionManager`. When omitted,
+   * the executor builds one wired to a `TauriBaselineStore`. Tests inject a
+   * stub via this option to avoid invoking Tauri.
+   */
+  screenshotManager?: ScreenshotAssertionManager;
+  /**
+   * Optional `Date.now()` override used purely for stamping `started_at`
+   * / `completed_at`. Tests fix this to keep snapshots stable.
+   */
+  now?: () => number;
+}
+
+/** Output of {@link runRegressionSuite}. */
+export interface RunRegressionSuiteResult {
+  /** UUID returned by `save_regression_suite`. */
+  suiteDbId: string;
+  /** UUID returned by `record_regression_run`. */
+  runDbId: string;
+  /** Aggregated pure-data run result fed into `diagnose`. */
+  runResult: RegressionRunResult;
+  /** `null` when the run had zero failures (no diagnosis needed). */
+  diagnosis: SelfDiagnosis | null;
+}
+
+// ---------------------------------------------------------------------------
+// Internal — assertionId derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a stable assertion id matching the rule used by
+ * `state/self-diagnosis.ts:assertionIdOf` (overlay assertions reuse their
+ * own `assertionId`; the others key off `(caseId, kind, secondary)`).
+ */
+function assertionIdOf(caseId: string, a: RegressionAssertion): string {
+  switch (a.kind) {
+    case "state-active":
+      return `${caseId}#state-active#${a.phase}#${a.stateId}`;
+    case "action-target-resolves":
+      return `${caseId}#action-target-resolves#${a.actionIndex}`;
+    case "visual-gate":
+      return `${caseId}#visual-gate#${a.stateId}`;
+    case "overlay":
+      return a.assertionId;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal — assertion dispatch
+// ---------------------------------------------------------------------------
+
+interface AssertionOutcome {
+  status: AssertionExecutionStatus;
+  /** When `status === "fail"`, the message that lands on the failure row. */
+  message?: string;
+  /** When `status === "fail"`, the observed value threaded into `RegressionFailure.observed`. */
+  observed?: unknown;
+  /** When `status === "fail"`, a coarse failure-kind tag for diagnostics. */
+  failureKind?: string;
+}
+
+/**
+ * State-active dispatch: every required element must be findable
+ * unambiguously. The IR's `requiredElements` array supplies the queries;
+ * the assertion's `requiredElementIds` indexes into it.
+ *
+ * "Unambiguous" here means `findFirst` returns a non-null match. We do NOT
+ * gate on `ambiguities.length === 0` — the suite is a spec, not a uniqueness
+ * test; ambiguity reporting belongs to the discovery layer.
+ */
+function evaluateStateActive(
+  assertion: StateActiveAssertion,
+  ir: IRDocument,
+  registry: RegistryLike,
+): AssertionOutcome {
+  const state = ir.states.find((s) => s.id === assertion.stateId);
+  if (!state) {
+    return {
+      status: "fail",
+      failureKind: "state-not-in-ir",
+      message: `State "${assertion.stateId}" not found in IR`,
+      observed: null,
+    };
+  }
+
+  const elements = registry.getAllElements();
+  const missing: number[] = [];
+  for (const idx of assertion.requiredElementIds) {
+    const criteria = state.requiredElements[idx];
+    if (!criteria) {
+      // Defensive: a stale suite may carry indices the IR no longer has.
+      missing.push(idx);
+      continue;
+    }
+    const result = findFirst(elements, criteria);
+    if (!result.match) missing.push(idx);
+  }
+
+  if (missing.length === 0) {
+    return { status: "pass" };
+  }
+
+  return {
+    status: "fail",
+    failureKind: "required-element-missing",
+    message: `State "${assertion.stateId}" missing required elements at indices [${missing.join(", ")}]`,
+    observed: { missingRequiredElementIndices: missing },
+  };
+}
+
+/**
+ * Action-target dispatch: the action's target must resolve to exactly one
+ * element. Multiple matches → fail (the runtime would have to disambiguate
+ * before clicking). Zero matches → fail.
+ */
+function evaluateActionTargetResolves(
+  assertion: ActionTargetResolvesAssertion,
+  registry: RegistryLike,
+): AssertionOutcome {
+  const elements = registry.getAllElements();
+  const results = executeQuery(elements, assertion.targetCriteria);
+  if (results.length === 1) return { status: "pass" };
+  if (results.length === 0) {
+    return {
+      status: "fail",
+      failureKind: "action-target-unresolvable",
+      message: `Action target for transition "${assertion.transitionId}" action ${assertion.actionIndex} resolved to 0 elements`,
+      observed: { matchCount: 0 },
+    };
+  }
+  return {
+    status: "fail",
+    failureKind: "action-target-ambiguous",
+    message: `Action target for transition "${assertion.transitionId}" action ${assertion.actionIndex} resolved to ${results.length} elements`,
+    observed: {
+      matchCount: results.length,
+      candidateIds: results.map((r) => r.id),
+    },
+  };
+}
+
+/**
+ * Visual-gate dispatch: load the baseline by `baselineKey` and assert the
+ * captured element matches. The element is resolved against the IR's first
+ * required element of the named state — the suite carries no element id
+ * by itself (visual gates are scoped to a state, not an element).
+ *
+ * If no required element can be resolved, the gate is skipped (status =
+ * "skip") rather than failed: visual gates depend on the prior state-active
+ * assertion already passing; failing the gate when the state itself is
+ * broken would noise up the diagnosis without adding signal.
+ */
+async function evaluateVisualGate(
+  assertion: VisualGateAssertion,
+  ir: IRDocument,
+  registry: RegistryLike,
+  manager: ScreenshotAssertionManager,
+): Promise<AssertionOutcome> {
+  const state = ir.states.find((s) => s.id === assertion.stateId);
+  if (!state || state.requiredElements.length === 0) {
+    return {
+      status: "skip",
+    };
+  }
+  const elements = registry.getAllElements();
+  const found = findFirst(elements, state.requiredElements[0]!);
+  if (!found.match) {
+    return {
+      status: "skip",
+    };
+  }
+  // Resolve the actual HTMLElement from the registry to feed the manager.
+  const liveEl = elements.find((e) => e.id === found.match!.id);
+  if (!liveEl) {
+    return { status: "skip" };
+  }
+
+  try {
+    const result = await manager.assertMatchesBaseline(liveEl.id, liveEl.element, {
+      baselineKey: assertion.baselineKey,
+    });
+    if (result.pass) return { status: "pass" };
+    return {
+      status: "fail",
+      failureKind: "visual-gate-mismatch",
+      message:
+        result.error ??
+        `Visual gate failed: ${result.diffPercentage.toFixed(2)}% diff against baseline "${assertion.baselineKey}"`,
+      observed: result,
+    };
+  } catch (err) {
+    return {
+      status: "fail",
+      failureKind: "visual-gate-error",
+      message: `Visual gate threw: ${err instanceof Error ? err.message : String(err)}`,
+      observed: { error: String(err) },
+    };
+  }
+}
+
+/**
+ * Overlay dispatch: each of the three built-in overlay ids has its own
+ * runtime semantics. The overlay payload is opaque to the generator but
+ * structurally known here.
+ *
+ * For now the executor implements a structural smoke check per overlay:
+ *   - `visibility`  → require the element resolves and is `visible`.
+ *   - `token`       → require the element resolves; full design-token
+ *                     evaluation needs a registry the executor doesn't carry,
+ *                     so this is a "resolves" check until the registry is
+ *                     threaded through.
+ *   - `cross-check` → require the action's target resolves; full OCR
+ *                     cross-check needs an OCR provider supplied at execute
+ *                     time and is wired in by the consumer when needed.
+ *
+ * Unknown overlay ids are skipped — the suite remains forward-compatible
+ * with overlays this executor doesn't recognize yet.
+ */
+function evaluateOverlay(
+  assertion: OverlayAssertion,
+  ir: IRDocument,
+  registry: RegistryLike,
+): AssertionOutcome {
+  const payload = assertion.payload;
+  switch (assertion.overlayId) {
+    case "visibility":
+    case "token": {
+      const stateId = typeof payload.stateId === "string" ? payload.stateId : null;
+      const idx =
+        typeof payload.requiredElementIndex === "number" ? payload.requiredElementIndex : null;
+      if (stateId === null || idx === null) {
+        return {
+          status: "fail",
+          failureKind: "overlay-payload-malformed",
+          message: `Overlay "${assertion.overlayId}" payload missing stateId/requiredElementIndex`,
+          observed: payload,
+        };
+      }
+      const state = ir.states.find((s) => s.id === stateId);
+      const criteria = state?.requiredElements[idx];
+      if (!criteria) {
+        return {
+          status: "fail",
+          failureKind: "overlay-criteria-not-in-ir",
+          message: `Overlay "${assertion.overlayId}" references state ${stateId}#${idx} not in IR`,
+          observed: { stateId, idx },
+        };
+      }
+      const elements = registry.getAllElements();
+      const result = findFirst(elements, criteria);
+      if (!result.match) {
+        return {
+          status: "fail",
+          failureKind: `overlay-${assertion.overlayId}-element-not-found`,
+          message: `Overlay "${assertion.overlayId}" target ${stateId}#${idx} not in registry`,
+          observed: { stateId, idx },
+        };
+      }
+      if (assertion.overlayId === "visibility") {
+        const live = elements.find((e) => e.id === result.match!.id);
+        const visible = live?.getState().visible !== false;
+        if (!visible) {
+          return {
+            status: "fail",
+            failureKind: "overlay-visibility-not-visible",
+            message: `Overlay "visibility" target ${stateId}#${idx} resolved but is not visible`,
+            observed: { stateId, idx, elementId: result.match.id },
+          };
+        }
+      }
+      return { status: "pass" };
+    }
+    case "cross-check": {
+      const transitionId = typeof payload.transitionId === "string" ? payload.transitionId : null;
+      const actionIndex = typeof payload.actionIndex === "number" ? payload.actionIndex : null;
+      if (transitionId === null || actionIndex === null) {
+        return {
+          status: "fail",
+          failureKind: "overlay-payload-malformed",
+          message: `Overlay "cross-check" payload missing transitionId/actionIndex`,
+          observed: payload,
+        };
+      }
+      const transition = ir.transitions.find((t) => t.id === transitionId);
+      const action = transition?.actions[actionIndex];
+      if (!action) {
+        return {
+          status: "fail",
+          failureKind: "overlay-cross-check-action-not-in-ir",
+          message: `Overlay "cross-check" references transition ${transitionId}#${actionIndex} not in IR`,
+          observed: { transitionId, actionIndex },
+        };
+      }
+      const elements = registry.getAllElements();
+      const result = findFirst(elements, action.target);
+      if (!result.match) {
+        return {
+          status: "fail",
+          failureKind: "overlay-cross-check-element-not-found",
+          message: `Overlay "cross-check" target ${transitionId}#${actionIndex} not in registry`,
+          observed: { transitionId, actionIndex },
+        };
+      }
+      return { status: "pass" };
+    }
+    default:
+      // Forward-compatible: unknown overlay ids skip cleanly.
+      return { status: "skip" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a regression suite against the live registry. Persists the suite,
+ * the run summary, the per-assertion exercise rows, and (when the run
+ * failed) a self-diagnosis memo. Returns the persisted UUIDs alongside the
+ * pure run result + diagnosis so the caller can show or re-query.
+ */
+export async function runRegressionSuite(
+  options: RunRegressionSuiteOptions,
+): Promise<RunRegressionSuiteResult> {
+  const {
+    suite,
+    ir,
+    registry,
+    irDocId,
+    runId,
+    recentCommits,
+    session,
+    specDrift,
+    visualDrift,
+    priors,
+    screenshotManager,
+    now,
+  } = options;
+
+  const clock = now ?? Date.now;
+  const startedAtMs = clock();
+  const startedAtIso = new Date(startedAtMs).toISOString();
+
+  // Default the screenshot manager to the runner's TauriBaselineStore-backed
+  // implementation. Tests inject a stub via `options.screenshotManager`.
+  const manager = screenshotManager ?? new ScreenshotAssertionManager(new TauriBaselineStore());
+
+  // Step 1 — persist the suite. Append-only by design.
+  const suiteDbId = await invoke<string>("save_regression_suite", {
+    suiteJson: JSON.parse(serializeSuite(suite)),
+    irDocId,
+  });
+
+  // Step 2 — walk every case + every assertion, dispatching on `kind`.
+  const failures: RegressionFailure[] = [];
+  const executionsBuffer: AssertionExecutionRow[] = [];
+  let passed = 0;
+  let failed = 0;
+
+  for (const c of suite.cases as RegressionCase[]) {
+    for (const assertion of c.assertions) {
+      const aId = assertionIdOf(c.id, assertion);
+      const aStartedMs = clock();
+      const aStartedIso = new Date(aStartedMs).toISOString();
+
+      let outcome: AssertionOutcome;
+      try {
+        switch (assertion.kind) {
+          case "state-active":
+            outcome = evaluateStateActive(assertion, ir, registry);
+            break;
+          case "action-target-resolves":
+            outcome = evaluateActionTargetResolves(assertion, registry);
+            break;
+          case "visual-gate":
+            outcome = await evaluateVisualGate(assertion, ir, registry, manager);
+            break;
+          case "overlay":
+            outcome = evaluateOverlay(assertion, ir, registry);
+            break;
+        }
+      } catch (err) {
+        outcome = {
+          status: "fail",
+          failureKind: "executor-threw",
+          message: `Executor threw: ${err instanceof Error ? err.message : String(err)}`,
+          observed: { error: String(err) },
+        };
+      }
+
+      const durationMs = clock() - aStartedMs;
+      const row: AssertionExecutionRow = {
+        id: cryptoRandomUUID(),
+        run_id: "", // patched in after `record_regression_run` returns the run UUID
+        case_id: c.id,
+        assertion_id: aId,
+        assertion_kind: assertion.kind,
+        status: outcome.status,
+        started_at: aStartedIso,
+        duration_ms: durationMs,
+      };
+      if (outcome.status === "fail") {
+        row.failure_kind = outcome.failureKind;
+        row.failure_evidence_json = outcome.observed ?? null;
+        row.error_message = outcome.message;
+        failed += 1;
+        failures.push({
+          caseId: c.id,
+          assertionId: aId,
+          assertion,
+          message: outcome.message ?? "(no message)",
+          observed: outcome.observed,
+        });
+      } else if (outcome.status === "pass") {
+        passed += 1;
+      }
+      // `skip` rows are recorded but not counted toward pass/failed totals.
+      executionsBuffer.push(row);
+    }
+  }
+
+  const completedAtMs = clock();
+  const completedAtIso = new Date(completedAtMs).toISOString();
+
+  const runResult: RegressionRunResult = {
+    suiteId: suite.id,
+    runId,
+    passed,
+    failed,
+    failures,
+  };
+
+  // Step 3 — record the run, getting back the persisted UUID.
+  const runDbId = await invoke<string>("record_regression_run", {
+    suiteId: suiteDbId,
+    runId,
+    passed,
+    failed,
+    startedAt: startedAtIso,
+    completedAt: completedAtIso,
+    runResultJson: runResult,
+  });
+
+  // Step 4 — patch run id onto each row, batch-record.
+  for (const row of executionsBuffer) row.run_id = runDbId;
+  await invoke<number>("record_assertion_executions_batch", {
+    executions: executionsBuffer,
+  });
+
+  // Step 5 — diagnose if there were failures, persist via the PG MemorySink.
+  let diagnosis: SelfDiagnosis | null = null;
+  if (failed > 0) {
+    const driftContext: DriftContext = {
+      session,
+      commits: recentCommits,
+      ir,
+    };
+    if (priors !== undefined) driftContext.priors = priors;
+    if (specDrift !== undefined) driftContext.specDrift = specDrift;
+    if (visualDrift !== undefined) driftContext.visualDrift = visualDrift;
+
+    diagnosis = diagnose(runResult, driftContext);
+    const sink = createPgMemorySink(runDbId);
+    sink.record(diagnosis);
+    // Wait for the persistence write so the caller knows the diagnosis row
+    // has landed before returning. `sink.lastWrite` is non-null here because
+    // we just called `record`.
+    if (sink.lastWrite !== null) await sink.lastWrite;
+  }
+
+  return { suiteDbId, runDbId, runResult, diagnosis };
+}
+
+// ---------------------------------------------------------------------------
+// Internal — UUID helper
+// ---------------------------------------------------------------------------
+
+/**
+ * `crypto.randomUUID` shim. Avoids hard-coding `crypto` on the global so
+ * tests with a `crypto`-less environment can still build the executor;
+ * vitest + happy-dom + node both expose `crypto.randomUUID`.
+ */
+function cryptoRandomUUID(): string {
+  const g = globalThis as { crypto?: { randomUUID?: () => string } };
+  if (g.crypto?.randomUUID) return g.crypto.randomUUID();
+  // Fallback — not cryptographically strong, only used when the host runtime
+  // doesn't expose `crypto.randomUUID`. The id only needs to be unique within
+  // a batch of executions, not globally cryptographic.
+  return `exec-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/src/lib/regression-memory-sink.ts
+++ b/src/lib/regression-memory-sink.ts
@@ -1,0 +1,52 @@
+/**
+ * PG-backed `MemorySink` adapter (Section 11, Phase A3).
+ *
+ * Adapts the pure `MemorySink` contract from `@qontinui/ui-bridge-auto` onto
+ * the runner's PostgreSQL persistence layer via the Tauri command
+ * `record_regression_diagnosis` (shipped in Phase A2). The library does not
+ * own persistence — it just calls `sink.record(diagnosis)`. This adapter is
+ * the single point where that call lands in PG.
+ *
+ * The library defines `MemorySink.record` synchronously (returns `void`), but
+ * `invoke()` is async. We fire-and-forget at the call site and return a
+ * thenable from the wrapper that callers can `await` when they care; the
+ * library itself never awaits.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import type { MemorySink, SelfDiagnosis } from "@qontinui/ui-bridge-auto/diagnosis";
+
+/**
+ * A `MemorySink` whose `record` persists the diagnosis to the runner's PG
+ * via the `record_regression_diagnosis` Tauri command. The corresponding
+ * promise is exposed on `lastWrite` so callers (the regression executor)
+ * can await persistence completion before returning.
+ */
+export interface PgMemorySink extends MemorySink {
+  /**
+   * Promise tracking the most recent `record` call's persistence write.
+   * `null` until the first `record` invocation.
+   */
+  readonly lastWrite: Promise<string> | null;
+}
+
+/**
+ * Build a {@link PgMemorySink} bound to a specific persisted run UUID.
+ *
+ * @param runDbId — UUID returned by `record_regression_run`. Diagnoses
+ *   recorded through this sink are associated with that run.
+ */
+export function createPgMemorySink(runDbId: string): PgMemorySink {
+  let lastWrite: Promise<string> | null = null;
+  return {
+    record(diagnosis: SelfDiagnosis): void {
+      lastWrite = invoke<string>("record_regression_diagnosis", {
+        runId: runDbId,
+        diagnosisJson: diagnosis,
+      });
+    },
+    get lastWrite(): Promise<string> | null {
+      return lastWrite;
+    },
+  };
+}

--- a/src/pages/regression/CoveragePanel.tsx
+++ b/src/pages/regression/CoveragePanel.tsx
@@ -1,0 +1,436 @@
+/**
+ * CoveragePanel — Section 11, Phase C2.
+ *
+ * Visualizes regression coverage for a single suite by combining two sources:
+ *
+ *   1. Static coverage — `coverageOf(ir, suite)` from `ui-bridge-auto/regression`
+ *      tells us which IR states / transitions the *suite* covers, regardless of
+ *      whether the suite has actually run.
+ *
+ *   2. Runtime exercise log — the `assertion_executions` table in PostgreSQL,
+ *      queried via the Phase A2 Tauri command `query_assertion_executions_for_suite`.
+ *      Cross-referenced against the suite via `coverageDiff(suite, log)` to
+ *      surface assertions that the suite *defines* but no run has *exercised*.
+ *
+ * The panel is a presentational shell — all coverage logic lives in the pure
+ * `coverageDiff` / `coverageOf` functions. Empty states cover both "no runs
+ * yet" and "100% coverage". Determinism: the lists are sorted by the pure
+ * functions, so the rendered order is stable across refetches.
+ *
+ * Wire-up: this component is intentionally caller-agnostic. The caller fetches
+ * the suite + IR (via existing Tauri commands or in-memory state) and passes
+ * them in — the panel only owns the exercise-log fetch.
+ */
+
+import { useCallback, useMemo } from "react";
+import {
+  Activity,
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  Shield,
+} from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  coverageDiff,
+  coverageOf,
+  type AssertionExecution,
+  type CoverageDiffReport,
+  type CoverageReport,
+  type RegressionSuite,
+} from "@qontinui/ui-bridge-auto/regression";
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+
+// ---------------------------------------------------------------------------
+// Tauri row shape — must match `crate::database::pg::regression::AssertionExecutionRow`.
+// Snake-cased because the Rust struct does not set `#[serde(rename_all)]`.
+// Kept narrow on purpose: `id`, `run_id`, `id_seq`, etc. are not consulted by
+// the panel and are tolerated as `[k: string]: unknown` extras.
+// ---------------------------------------------------------------------------
+
+export interface AssertionExecutionRow {
+  case_id: string;
+  assertion_id: string;
+  started_at: string;
+  status: string;
+  assertion_kind: string;
+  duration_ms: number;
+  failure_kind?: string | null;
+  error_message?: string | null;
+}
+
+/**
+ * Adapt the Rust-side snake_case row shape onto the camelCase
+ * `AssertionExecution` contract that `coverageDiff` consumes.
+ *
+ * Pure / deterministic — no time, no I/O. Exposed (rather than inlined into
+ * the component body) so the test suite can lock the field-mapping down
+ * without spinning up jsdom.
+ */
+export function exerciseLogToAssertionExecutions(
+  rows: AssertionExecutionRow[],
+): AssertionExecution[] {
+  return rows.map((r) => ({
+    caseId: r.case_id,
+    assertionId: r.assertion_id,
+    executedAt: r.started_at,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Pure stat-derivation — split out for direct test coverage.
+// ---------------------------------------------------------------------------
+
+export interface CoverageStats {
+  /** From `coverageOf(ir, suite)` — what the suite *covers* in the IR. */
+  staticCovered: number;
+  staticTotal: number;
+  /** From `coverageDiff(suite, log).stats` — what the runs *exercised*. */
+  runtimeExercised: number;
+  runtimeTotal: number;
+  /** `coverageDiff.stats.uncoveredRatio`, rendered as a 0-100 integer percent. */
+  uncoveredPercent: number;
+}
+
+export function deriveCoverageStats(
+  staticCoverage: CoverageReport,
+  diff: CoverageDiffReport,
+): CoverageStats {
+  return {
+    staticCovered: staticCoverage.transitionsCovered,
+    staticTotal: staticCoverage.totalTransitions,
+    runtimeExercised: diff.stats.exercisedAssertions,
+    runtimeTotal: diff.stats.totalAssertions,
+    // `uncoveredRatio` is in [0, 1]; render as a whole-number percent for the
+    // dashboard pill. Math.round (not floor/ceil) — 0.495 → 50%, 0.494 → 49%.
+    uncoveredPercent: Math.round(diff.stats.uncoveredRatio * 100),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Grouping helpers — pure, exposed for tests.
+// ---------------------------------------------------------------------------
+
+export interface UnexercisedGroup {
+  caseId: string;
+  rows: Array<{ assertionId: string; assertionKind: string }>;
+}
+
+/**
+ * Group `coverageDiff.unexercisedAssertions` by `caseId`, attaching the
+ * assertion-kind from the suite when known. The `coverageDiff` output is
+ * already sorted by `(caseId, assertionId)`, so iterating in order produces
+ * stably-ordered groups.
+ */
+export function groupUnexercisedByCase(
+  suite: RegressionSuite,
+  diff: CoverageDiffReport,
+): UnexercisedGroup[] {
+  // Build `{ "case|assertion-id" -> kind }` from the suite. The id derivation
+  // mirrors the convention `coverageDiff` uses internally (see
+  // `_assertionIdOfForTesting` in coverage-diff.ts) — we re-derive here rather
+  // than importing the private helper, so this stays robust if the helper is
+  // renamed.
+  const kindByKey = new Map<string, string>();
+  for (const c of suite.cases) {
+    for (const a of c.assertions) {
+      let assertionId: string;
+      switch (a.kind) {
+        case "state-active":
+          assertionId = `state-active:${a.phase}:${a.stateId}`;
+          break;
+        case "action-target-resolves":
+          assertionId = `action-target-resolves:${a.transitionId}#${a.actionIndex}`;
+          break;
+        case "visual-gate":
+          assertionId = `visual-gate:${a.stateId}`;
+          break;
+        case "overlay":
+          assertionId = a.assertionId;
+          break;
+      }
+      kindByKey.set(`${c.id}|${assertionId}`, a.kind);
+    }
+  }
+
+  const groups = new Map<string, UnexercisedGroup>();
+  for (const ref of diff.unexercisedAssertions) {
+    let g = groups.get(ref.caseId);
+    if (!g) {
+      g = { caseId: ref.caseId, rows: [] };
+      groups.set(ref.caseId, g);
+    }
+    g.rows.push({
+      assertionId: ref.assertionId,
+      assertionKind: kindByKey.get(`${ref.caseId}|${ref.assertionId}`) ?? "unknown",
+    });
+  }
+  return Array.from(groups.values());
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface CoveragePanelProps {
+  /** The suite UUID — keys both static coverage and exercise-log retrieval. */
+  suiteId: string;
+  /** Loaded suite (caller fetches it). */
+  suite: RegressionSuite;
+  /** Loaded IR (caller fetches it). */
+  ir: IRDocument;
+}
+
+export function CoveragePanel(props: CoveragePanelProps): React.JSX.Element {
+  const { suiteId, suite, ir } = props;
+
+  // Live exercise-log fetch. The query key includes the suiteId so swapping
+  // suites does not bleed cached rows from the previous one.
+  const {
+    data: rawExerciseLog,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+  } = useQuery<AssertionExecutionRow[]>({
+    queryKey: ["regression-coverage", "exercise-log", suiteId],
+    queryFn: () =>
+      invoke<AssertionExecutionRow[]>("query_assertion_executions_for_suite", {
+        suiteId,
+      }),
+  });
+
+  const exerciseLog = useMemo(
+    () => exerciseLogToAssertionExecutions(rawExerciseLog ?? []),
+    [rawExerciseLog],
+  );
+
+  const diff = useMemo(() => coverageDiff(suite, exerciseLog), [suite, exerciseLog]);
+  const staticCoverage = useMemo(() => coverageOf(ir, suite), [ir, suite]);
+  const stats = useMemo(
+    () => deriveCoverageStats(staticCoverage, diff),
+    [staticCoverage, diff],
+  );
+
+  const unexercisedGroups = useMemo(
+    () => groupUnexercisedByCase(suite, diff),
+    [suite, diff],
+  );
+
+  const handleCopyAssertion = useCallback((assertionId: string) => {
+    // `navigator.clipboard` is available in Tauri's webview. We swallow the
+    // promise rejection — copy is a nice-to-have, not load-bearing.
+    void navigator.clipboard?.writeText(assertionId).catch(() => {
+      // no-op
+    });
+  }, []);
+
+  const hasNoRuns = (rawExerciseLog?.length ?? 0) === 0;
+  const isFullyCovered =
+    !hasNoRuns &&
+    diff.unexercisedAssertions.length === 0 &&
+    diff.uncoveredTransitions.length === 0;
+
+  // Truncate the suite id for display — full id available via tooltip.
+  const truncatedSuiteId =
+    suiteId.length > 12 ? `${suiteId.slice(0, 8)}…${suiteId.slice(-4)}` : suiteId;
+
+  return (
+    <div className="p-4">
+      <div className="max-w-4xl mx-auto space-y-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="min-w-0">
+            <h2 className="text-base font-semibold text-text-primary">Regression Coverage</h2>
+            <p className="text-xs text-text-muted">
+              Suite{" "}
+              <code className="text-xs bg-muted px-1 py-0.5 rounded" title={suiteId}>
+                {truncatedSuiteId}
+              </code>
+            </p>
+          </div>
+          <button
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium border border-border-primary text-text-primary hover:bg-surface-primary disabled:opacity-50"
+          >
+            {isFetching ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="size-3.5" />
+            )}
+            Refresh
+          </button>
+        </div>
+
+        {/* Loading state */}
+        {isLoading && (
+          <div className="rounded-lg border border-border-primary bg-surface-secondary p-6 flex items-center justify-center gap-2 text-sm text-text-muted">
+            <Loader2 className="size-4 animate-spin" />
+            Loading exercise log…
+          </div>
+        )}
+
+        {/* Error state */}
+        {isError && (
+          <div className="rounded-lg border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-400">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="size-4 mt-0.5 shrink-0" />
+              <div>
+                <div className="font-medium">Failed to load exercise log</div>
+                <pre className="mt-1 whitespace-pre-wrap text-xs text-red-300">
+                  {error instanceof Error ? error.message : String(error)}
+                </pre>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Stats row — always render once we have data, even if empty */}
+        {!isLoading && !isError && (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="rounded-lg border border-border-primary bg-surface-secondary p-3">
+              <div className="flex items-center gap-2 text-xs text-text-muted">
+                <Shield className="size-3.5" />
+                Static coverage
+              </div>
+              <div className="mt-1 text-lg font-semibold text-text-primary">
+                {stats.staticCovered}/{stats.staticTotal}
+                <span className="ml-1 text-xs font-normal text-text-muted">transitions</span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-border-primary bg-surface-secondary p-3">
+              <div className="flex items-center gap-2 text-xs text-text-muted">
+                <Activity className="size-3.5" />
+                Runtime exercise
+              </div>
+              <div className="mt-1 text-lg font-semibold text-text-primary">
+                {stats.runtimeExercised}/{stats.runtimeTotal}
+                <span className="ml-1 text-xs font-normal text-text-muted">assertions</span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-border-primary bg-surface-secondary p-3">
+              <div className="flex items-center gap-2 text-xs text-text-muted">
+                <AlertCircle className="size-3.5" />
+                Uncovered ratio
+              </div>
+              <div className="mt-1 text-lg font-semibold text-text-primary">
+                {stats.uncoveredPercent}%
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Empty state — no runs */}
+        {!isLoading && !isError && hasNoRuns && (
+          <div className="rounded-lg border border-border-primary bg-surface-secondary p-6 text-center text-sm text-text-muted">
+            No runs recorded yet — execute the suite via the{" "}
+            <span className="font-medium text-text-primary">Regression Run</span> page.
+          </div>
+        )}
+
+        {/* Empty state — fully covered */}
+        {!isLoading && !isError && isFullyCovered && (
+          <div className="rounded-lg border border-green-500/40 bg-green-500/10 p-4 flex items-center gap-2 text-sm text-green-400">
+            <CheckCircle2 className="size-4" />
+            <span>
+              <strong className="text-green-300">100% coverage.</strong> Every assertion in the
+              suite has been exercised by at least one run.
+            </span>
+          </div>
+        )}
+
+        {/* Two-column body — un-exercised assertions + un-covered transitions */}
+        {!isLoading && !isError && !hasNoRuns && !isFullyCovered && (
+          <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+            {/* Un-exercised assertions */}
+            <div className="rounded-lg border border-border-primary bg-surface-secondary p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="text-sm font-medium text-text-primary">Un-exercised assertions</h3>
+                <span className="text-xs text-text-muted">
+                  {diff.unexercisedAssertions.length}
+                </span>
+              </div>
+              {diff.unexercisedAssertions.length === 0 ? (
+                <p className="text-xs text-text-muted">
+                  Every assertion has been exercised by at least one run.
+                </p>
+              ) : (
+                <div className="space-y-3 max-h-96 overflow-y-auto">
+                  {unexercisedGroups.map((g) => (
+                    <div key={g.caseId} className="space-y-1">
+                      <div
+                        className="text-xs font-mono text-text-muted truncate"
+                        title={g.caseId}
+                      >
+                        case: {g.caseId}
+                      </div>
+                      <ul className="space-y-1">
+                        {g.rows.map((r) => (
+                          <li key={r.assertionId}>
+                            <button
+                              onClick={() => handleCopyAssertion(r.assertionId)}
+                              title="Click to copy assertion id"
+                              className="w-full text-left rounded-md border border-border-primary bg-surface-primary p-2 text-xs hover:bg-surface-hover focus:outline-hidden focus:ring-2 focus:ring-brand-primary"
+                            >
+                              <div className="flex items-center justify-between gap-2">
+                                <span className="font-mono truncate">{r.assertionId}</span>
+                                <span className="shrink-0 rounded-full border border-border-primary px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-text-muted">
+                                  {r.assertionKind}
+                                </span>
+                              </div>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Un-covered transitions */}
+            <div className="rounded-lg border border-border-primary bg-surface-secondary p-3">
+              <div className="mb-2 flex items-center justify-between">
+                <h3 className="text-sm font-medium text-text-primary">Un-covered transitions</h3>
+                <span className="text-xs text-text-muted">
+                  {diff.uncoveredTransitions.length}
+                </span>
+              </div>
+              {diff.uncoveredTransitions.length === 0 ? (
+                <p className="text-xs text-text-muted">
+                  Every case has had at least one assertion fire.
+                </p>
+              ) : (
+                <ul className="space-y-1 max-h-96 overflow-y-auto">
+                  {diff.uncoveredTransitions.map((t) => (
+                    <li
+                      key={`${t.caseId}|${t.transitionId}`}
+                      className="rounded-md border border-border-primary bg-surface-primary p-2 text-xs"
+                    >
+                      <div
+                        className="font-mono text-text-muted truncate"
+                        title={t.caseId}
+                      >
+                        case: {t.caseId}
+                      </div>
+                      <div className="font-mono text-text-primary truncate" title={t.transitionId}>
+                        transition: {t.transitionId}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default CoveragePanel;

--- a/src/pages/regression/RegressionRunPage.tsx
+++ b/src/pages/regression/RegressionRunPage.tsx
@@ -1,0 +1,223 @@
+/**
+ * RegressionRunPage
+ *
+ * Integration smoke surface for the Section 11 regression executor (Phase A3).
+ * Lets a developer run a hardcoded `RegressionSuite` against the active page's
+ * UI Bridge registry, then surfaces the resulting `RegressionRunResult` and
+ * (when the run failed) the `SelfDiagnosis.correlationSummary` from the pure
+ * `diagnose` function.
+ *
+ * Not a final UX. The expectation per the Section 11 plan is that a richer
+ * panel (Phase D2 / C2) will replace this. We expose the page component as a
+ * named export so future routing work can wire it into the runner shell
+ * without further executor changes.
+ */
+
+import { useCallback, useState } from "react";
+import { Play, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+import { generateRegressionSuite, type RegressionSuite } from "@qontinui/ui-bridge-auto/regression";
+import type { RegistryLike } from "@qontinui/ui-bridge-auto/runtime";
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+
+import { runRegressionSuite, type RunRegressionSuiteResult } from "@/lib/regression-executor";
+
+// ---------------------------------------------------------------------------
+// Demo IR — minimal hardcoded fixture for the smoke surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Tiny hardcoded IR used by the page's "Run Demo Suite" button. The point is
+ * to prove the executor wires end-to-end (suite → walk → persist → diagnose);
+ * the IR's content is intentionally trivial.
+ */
+const DEMO_IR: IRDocument = {
+  version: "1.0",
+  id: "regression-demo-page",
+  name: "Regression Demo",
+  states: [
+    {
+      id: "state-root",
+      name: "Root",
+      requiredElements: [{ tagName: "body" }],
+    },
+    {
+      id: "state-with-button",
+      name: "With Button",
+      requiredElements: [{ role: "button" }],
+    },
+  ],
+  transitions: [
+    {
+      id: "click-any-button",
+      name: "Click any button",
+      fromStates: ["state-root"],
+      activateStates: ["state-with-button"],
+      actions: [
+        {
+          type: "click",
+          target: { role: "button" },
+        },
+      ],
+    },
+  ],
+  initialState: "state-root",
+};
+
+// ---------------------------------------------------------------------------
+// Registry adapter — pulls live elements off the global UI Bridge registry
+// ---------------------------------------------------------------------------
+
+interface UIBridgeRegistryLike {
+  getAllElements(): unknown[];
+  on(type: string, listener: (...args: unknown[]) => void): () => void;
+}
+
+/** Read the runner's global UI Bridge registry, if available. */
+function getLiveRegistry(): RegistryLike | null {
+  // The runner exposes its UI Bridge state under `window.__UI_BRIDGE__`.
+  // We don't take a hard import dependency on the SDK here so the page
+  // remains loadable even if the bridge isn't wired up yet.
+  type WindowLike = { __UI_BRIDGE__?: { registry?: UIBridgeRegistryLike } };
+  const w = window as unknown as WindowLike;
+  const registry = w.__UI_BRIDGE__?.registry;
+  if (!registry) return null;
+  return registry as unknown as RegistryLike;
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function RegressionRunPage(): React.JSX.Element {
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<RunRegressionSuiteResult | null>(null);
+
+  const handleRunDemo = useCallback(async () => {
+    setRunning(true);
+    setError(null);
+    setResult(null);
+    try {
+      const registry = getLiveRegistry();
+      if (!registry) {
+        throw new Error("UI Bridge registry not available on window.__UI_BRIDGE__.registry");
+      }
+      const suite: RegressionSuite = generateRegressionSuite(DEMO_IR);
+      const out = await runRegressionSuite({
+        suite,
+        ir: DEMO_IR,
+        registry,
+        irDocId: DEMO_IR.id,
+        runId: `demo-${Date.now()}`,
+        recentCommits: [],
+        // Empty placeholder session — the demo doesn't need a real recording.
+        session: { id: "demo-session", startedAt: Date.now(), events: [] },
+      });
+      setResult(out);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRunning(false);
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-4 p-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Regression Run</h1>
+          <p className="text-sm text-muted-foreground">
+            Section 11 smoke surface. Generates a deterministic suite from the demo IR, walks each
+            assertion against the live UI Bridge registry, and persists the run + diagnosis.
+          </p>
+        </div>
+        <button
+          onClick={handleRunDemo}
+          disabled={running}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {running ? <Loader2 className="size-4 animate-spin" /> : <Play className="size-4" />}
+          Run Demo Suite
+        </button>
+      </header>
+
+      {error !== null && (
+        <div className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm">
+          <AlertTriangle className="size-4 mt-0.5 text-destructive" />
+          <div>
+            <div className="font-medium text-destructive">Run failed</div>
+            <pre className="mt-1 whitespace-pre-wrap text-xs">{error}</pre>
+          </div>
+        </div>
+      )}
+
+      {result !== null && (
+        <section className="flex flex-col gap-3">
+          <div className="rounded-md border bg-card p-3">
+            <h2 className="mb-2 flex items-center gap-2 text-sm font-medium">
+              {result.runResult.failed === 0 ? (
+                <CheckCircle2 className="size-4 text-green-600" />
+              ) : (
+                <AlertTriangle className="size-4 text-amber-600" />
+              )}
+              Last run
+            </h2>
+            <dl className="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+              <dt className="text-muted-foreground">Suite DB id</dt>
+              <dd className="font-mono">{result.suiteDbId}</dd>
+              <dt className="text-muted-foreground">Run DB id</dt>
+              <dd className="font-mono">{result.runDbId}</dd>
+              <dt className="text-muted-foreground">Run id</dt>
+              <dd className="font-mono">{result.runResult.runId}</dd>
+              <dt className="text-muted-foreground">Passed</dt>
+              <dd>{result.runResult.passed}</dd>
+              <dt className="text-muted-foreground">Failed</dt>
+              <dd>{result.runResult.failed}</dd>
+            </dl>
+          </div>
+
+          {result.diagnosis && (
+            <div className="rounded-md border bg-card p-3">
+              <h2 className="mb-2 text-sm font-medium">Self-diagnosis</h2>
+              <p className="text-xs">{result.diagnosis.correlationSummary}</p>
+              {result.diagnosis.candidateCauses.length > 0 && (
+                <ol className="mt-2 list-decimal pl-4 text-xs">
+                  {result.diagnosis.candidateCauses.map((cause, i) => (
+                    <li key={i} className="mt-1">
+                      <span className="font-mono text-muted-foreground">
+                        ({cause.confidence.toFixed(2)})
+                      </span>{" "}
+                      {cause.hypothesis}
+                    </li>
+                  ))}
+                </ol>
+              )}
+            </div>
+          )}
+
+          {result.runResult.failures.length > 0 && (
+            <div className="rounded-md border bg-card p-3">
+              <h2 className="mb-2 text-sm font-medium">Failures</h2>
+              <ul className="text-xs">
+                {result.runResult.failures.map((f) => (
+                  <li
+                    key={f.assertionId}
+                    className="mb-2 border-b border-border/50 pb-2 last:border-b-0 last:pb-0"
+                  >
+                    <div className="font-mono text-muted-foreground">
+                      {f.caseId} / {f.assertionId}
+                    </div>
+                    <div>{f.message}</div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      )}
+    </div>
+  );
+}
+
+export default RegressionRunPage;

--- a/src/pages/regression/RegressionTabPage.tsx
+++ b/src/pages/regression/RegressionTabPage.tsx
@@ -1,0 +1,112 @@
+/**
+ * RegressionTabPage — Section 11, Phase D2 wire-up.
+ *
+ * Top-level container for the runner's "Regression" main tab. Hosts a small
+ * sub-tab control that switches between:
+ *   - "Run"      — mounts {@link RegressionRunPage}, the integration smoke
+ *                  surface that walks a hardcoded suite against the live
+ *                  registry.
+ *   - "Coverage" — mounts {@link CoveragePanel} once a suite + IR are
+ *                  available. The runner currently has no Tauri command
+ *                  to list persisted suites, so this panel renders an
+ *                  "execute a run first" empty state until that data
+ *                  loading is wired up.
+ *
+ * Deferred (tracked for follow-up):
+ *   - There is no `list_regression_suites` / `get_suite_by_id` Tauri command
+ *     yet. When one lands (mirroring `query_assertion_executions_for_suite`),
+ *     replace the empty-state in the Coverage sub-tab with a real fetch and
+ *     mount {@link CoveragePanel} with the loaded suite + IR.
+ *   - The IR document for a suite must also be loaded — IR storage already
+ *     exists via `spec_api::storage::read_ir`, but no TS-side Tauri command
+ *     surfaces it yet for arbitrary `ir_doc_id`s.
+ */
+
+import { useState } from "react";
+import { Activity, Play } from "lucide-react";
+
+import { RegressionRunPage } from "./RegressionRunPage";
+
+type SubTab = "run" | "coverage";
+
+const SUB_TABS: ReadonlyArray<{ id: SubTab; label: string; icon: React.ComponentType<{ className?: string }> }> = [
+  { id: "run", label: "Run", icon: Play },
+  { id: "coverage", label: "Coverage", icon: Activity },
+];
+
+export function RegressionTabPage(): React.JSX.Element {
+  const [activeSubTab, setActiveSubTab] = useState<SubTab>("run");
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Sub-tab control */}
+      <div
+        role="tablist"
+        aria-label="Regression sub-tabs"
+        className="flex items-center gap-1 border-b border-border-primary px-4"
+      >
+        {SUB_TABS.map((t) => {
+          const Icon = t.icon;
+          const isActive = t.id === activeSubTab;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setActiveSubTab(t.id)}
+              className={[
+                "inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 -mb-px",
+                isActive
+                  ? "border-brand-primary text-text-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary",
+              ].join(" ")}
+            >
+              <Icon className="size-3.5" />
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Sub-tab content */}
+      <div className="flex-1 overflow-hidden">
+        {activeSubTab === "run" && <RegressionRunPage />}
+        {activeSubTab === "coverage" && <CoverageEmptyState />}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Placeholder for the Coverage sub-tab.
+ *
+ * `CoveragePanel` requires a loaded `RegressionSuite` + `IRDocument` as
+ * props, but the runner does not yet expose Tauri commands to list
+ * persisted suites or load arbitrary IR documents from the suite store.
+ * Until those land, render a friendly empty state explaining the
+ * dependency.
+ */
+function CoverageEmptyState(): React.JSX.Element {
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <div className="max-w-md rounded-lg border border-border-primary bg-surface-secondary p-6 text-center">
+        <Activity className="mx-auto mb-3 size-8 text-text-muted" />
+        <h3 className="mb-2 text-base font-semibold text-text-primary">
+          No suite loaded
+        </h3>
+        <p className="text-sm text-text-muted">
+          Coverage analysis needs a persisted regression suite to load. Run
+          the demo suite from the <span className="font-medium">Run</span>{" "}
+          sub-tab first; once the runner exposes a{" "}
+          <code className="rounded bg-surface-primary px-1 py-0.5 text-xs">
+            list_regression_suites
+          </code>{" "}
+          command, this view will surface live coverage data automatically.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default RegressionTabPage;

--- a/src/pages/regression/RegressionTabPage.tsx
+++ b/src/pages/regression/RegressionTabPage.tsx
@@ -1,35 +1,37 @@
 /**
- * RegressionTabPage — Section 11, Phase D2 wire-up.
+ * RegressionTabPage — Section 11, Phase D2 wire-up + FU-2 follow-up.
  *
  * Top-level container for the runner's "Regression" main tab. Hosts a small
  * sub-tab control that switches between:
  *   - "Run"      — mounts {@link RegressionRunPage}, the integration smoke
  *                  surface that walks a hardcoded suite against the live
  *                  registry.
- *   - "Coverage" — mounts {@link CoveragePanel} once a suite + IR are
- *                  available. The runner currently has no Tauri command
- *                  to list persisted suites, so this panel renders an
- *                  "execute a run first" empty state until that data
- *                  loading is wired up.
- *
- * Deferred (tracked for follow-up):
- *   - There is no `list_regression_suites` / `get_suite_by_id` Tauri command
- *     yet. When one lands (mirroring `query_assertion_executions_for_suite`),
- *     replace the empty-state in the Coverage sub-tab with a real fetch and
- *     mount {@link CoveragePanel} with the loaded suite + IR.
- *   - The IR document for a suite must also be loaded — IR storage already
- *     exists via `spec_api::storage::read_ir`, but no TS-side Tauri command
- *     surfaces it yet for arbitrary `ir_doc_id`s.
+ *   - "Coverage" — picks a persisted suite via the FU-2 Tauri commands
+ *                  ({@link CoverageSuitePicker}), loads the IR via the
+ *                  Spec API, and mounts {@link CoveragePanel}.
  */
 
-import { useState } from "react";
-import { Activity, Play } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Activity, Loader2, Play, RefreshCw } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { useQuery } from "@tanstack/react-query";
 
+import {
+  deserializeSuite,
+  type RegressionSuite,
+} from "@qontinui/ui-bridge-auto/regression";
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+
+import { CoveragePanel } from "./CoveragePanel";
 import { RegressionRunPage } from "./RegressionRunPage";
 
 type SubTab = "run" | "coverage";
 
-const SUB_TABS: ReadonlyArray<{ id: SubTab; label: string; icon: React.ComponentType<{ className?: string }> }> = [
+const SUB_TABS: ReadonlyArray<{
+  id: SubTab;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}> = [
   { id: "run", label: "Run", icon: Play },
   { id: "coverage", label: "Coverage", icon: Activity },
 ];
@@ -72,41 +74,286 @@ export function RegressionTabPage(): React.JSX.Element {
       {/* Sub-tab content */}
       <div className="flex-1 overflow-hidden">
         {activeSubTab === "run" && <RegressionRunPage />}
-        {activeSubTab === "coverage" && <CoverageEmptyState />}
+        {activeSubTab === "coverage" && <CoverageSubTab />}
       </div>
     </div>
   );
 }
 
-/**
- * Placeholder for the Coverage sub-tab.
- *
- * `CoveragePanel` requires a loaded `RegressionSuite` + `IRDocument` as
- * props, but the runner does not yet expose Tauri commands to list
- * persisted suites or load arbitrary IR documents from the suite store.
- * Until those land, render a friendly empty state explaining the
- * dependency.
- */
-function CoverageEmptyState(): React.JSX.Element {
+// ---------------------------------------------------------------------------
+// Coverage sub-tab — picks a suite via FU-2 commands, loads IR, mounts panel
+// ---------------------------------------------------------------------------
+
+/** Catalog row returned by `list_regression_suites`. Mirrors the Rust shape. */
+interface SuiteCatalogRow {
+  id: string;
+  ir_doc_id: string;
+  created_at: string;
+  run_count: number;
+  last_run_at: string | null;
+}
+
+/** Full-suite row returned by `get_regression_suite_by_id`. */
+interface SuiteFullRow {
+  id: string;
+  ir_doc_id: string;
+  suite_json: unknown;
+  created_at: string;
+}
+
+function CoverageSubTab(): React.JSX.Element {
+  const {
+    data: suites,
+    isLoading: suitesLoading,
+    error: suitesError,
+    refetch: refetchSuites,
+  } = useQuery<SuiteCatalogRow[]>({
+    queryKey: ["regression", "list_regression_suites"],
+    queryFn: () =>
+      invoke<SuiteCatalogRow[]>("list_regression_suites", { limit: 50 }),
+    refetchOnWindowFocus: false,
+  });
+
+  // User selection (null = follow the auto-selected newest suite).
+  const [explicitSelection, setExplicitSelection] = useState<string | null>(null);
+  // Effective selection: user pick if any, else the newest suite from the
+  // server query (which is sorted by `created_at DESC`). Derived rather
+  // than stored — avoids the setState-in-effect pattern.
+  const selectedSuiteId =
+    explicitSelection ?? (suites && suites.length > 0 ? suites[0].id : null);
+
+  if (suitesLoading) return <CenteredSpinner label="Loading suites..." />;
+
+  if (suitesError) {
+    return (
+      <CenteredCard
+        title="Failed to load suites"
+        description={suitesError instanceof Error ? suitesError.message : String(suitesError)}
+        action={{ label: "Retry", onClick: () => void refetchSuites() }}
+      />
+    );
+  }
+
+  if (!suites || suites.length === 0) {
+    return (
+      <CenteredCard
+        title="No suites recorded yet"
+        description="Run the regression suite from the Run sub-tab first; persisted suites will appear here automatically."
+        action={{ label: "Reload", onClick: () => void refetchSuites() }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <CoverageSuitePicker
+        suites={suites}
+        selectedSuiteId={selectedSuiteId}
+        onSelect={setExplicitSelection}
+        onRefresh={() => void refetchSuites()}
+      />
+      <div className="flex-1 overflow-auto">
+        {selectedSuiteId !== null && <SuiteCoverageLoader suiteId={selectedSuiteId} />}
+      </div>
+    </div>
+  );
+}
+
+interface PickerProps {
+  suites: SuiteCatalogRow[];
+  selectedSuiteId: string | null;
+  onSelect: (id: string) => void;
+  onRefresh: () => void;
+}
+
+function CoverageSuitePicker({
+  suites,
+  selectedSuiteId,
+  onSelect,
+  onRefresh,
+}: PickerProps): React.JSX.Element {
+  return (
+    <div className="flex items-center gap-3 border-b border-border-primary px-4 py-3">
+      <label
+        htmlFor="suite-select"
+        className="text-sm font-medium text-text-muted"
+      >
+        Suite:
+      </label>
+      <select
+        id="suite-select"
+        value={selectedSuiteId ?? ""}
+        onChange={(e) => onSelect(e.target.value)}
+        className="min-w-[18rem] rounded-md border border-border-primary bg-surface-primary px-2 py-1 text-sm text-text-primary"
+      >
+        {suites.map((s) => (
+          <option key={s.id} value={s.id}>
+            {s.ir_doc_id} — {s.run_count} run{s.run_count === 1 ? "" : "s"}
+            {s.last_run_at ? ` (last ${formatTimestamp(s.last_run_at)})` : ""}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        onClick={onRefresh}
+        className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-border-primary px-2 py-1 text-xs text-text-muted hover:bg-surface-secondary hover:text-text-primary"
+      >
+        <RefreshCw className="size-3" />
+        Refresh
+      </button>
+    </div>
+  );
+}
+
+function SuiteCoverageLoader({
+  suiteId,
+}: {
+  suiteId: string;
+}): React.JSX.Element {
+  const {
+    data: full,
+    isLoading,
+    error,
+  } = useQuery<SuiteFullRow | null>({
+    queryKey: ["regression", "get_regression_suite_by_id", suiteId],
+    queryFn: () =>
+      invoke<SuiteFullRow | null>("get_regression_suite_by_id", { suiteId }),
+    refetchOnWindowFocus: false,
+  });
+
+  // Suite JSON parses on every render, but `useMemo` keys to the row stops
+  // it from re-running unless the suite actually changes.
+  const parsed = useMemo(() => {
+    if (!full?.suite_json) return null;
+    try {
+      const json =
+        typeof full.suite_json === "string"
+          ? full.suite_json
+          : JSON.stringify(full.suite_json);
+      return deserializeSuite(json) as RegressionSuite;
+    } catch {
+      return null;
+    }
+  }, [full]);
+
+  // The IR document for the suite is loaded via the Spec API (HTTP). The
+  // CoveragePanel only needs the IR shape — no Tauri command exists for
+  // arbitrary `ir_doc_id` lookups, but the runner exposes the IR over its
+  // local HTTP API at `/spec/page/:id`. Use that.
+  const {
+    data: ir,
+    isLoading: irLoading,
+    error: irError,
+  } = useQuery<IRDocument | null>({
+    queryKey: ["regression", "ir-for-suite", full?.ir_doc_id],
+    enabled: typeof full?.ir_doc_id === "string" && full.ir_doc_id.length > 0,
+    queryFn: async () => {
+      const irDocId = full!.ir_doc_id;
+      const resp = await fetch(
+        `http://localhost:9876/spec/page/${encodeURIComponent(irDocId)}`,
+      );
+      if (!resp.ok) {
+        throw new Error(`spec/page returned ${resp.status}`);
+      }
+      const json = (await resp.json()) as { success?: boolean; data?: IRDocument };
+      if (json.success === false || !json.data) {
+        throw new Error("ir document missing in response");
+      }
+      return json.data;
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  if (isLoading || irLoading)
+    return <CenteredSpinner label="Loading suite + IR..." />;
+
+  if (error)
+    return (
+      <CenteredCard
+        title="Failed to load suite"
+        description={error instanceof Error ? error.message : String(error)}
+      />
+    );
+
+  if (!parsed)
+    return (
+      <CenteredCard
+        title="Suite blob unparseable"
+        description="The persisted suite JSON could not be parsed by deserializeSuite. The schema may have drifted; re-run the suite to refresh."
+      />
+    );
+
+  if (irError || !ir)
+    return (
+      <CenteredCard
+        title="Failed to load IR document"
+        description={
+          irError instanceof Error
+            ? irError.message
+            : "The IR document for this suite is missing from the Spec API. The suite may reference an IR that has been deleted."
+        }
+      />
+    );
+
+  return <CoveragePanel suiteId={suiteId} suite={parsed} ir={ir} />;
+}
+
+// ---------------------------------------------------------------------------
+// Tiny shared empty/error/spinner helpers
+// ---------------------------------------------------------------------------
+
+function CenteredSpinner({ label }: { label: string }): React.JSX.Element {
+  return (
+    <div className="flex h-full items-center justify-center text-text-muted">
+      <Loader2 className="mr-2 size-4 animate-spin" />
+      <span className="text-sm">{label}</span>
+    </div>
+  );
+}
+
+interface CenteredCardProps {
+  title: string;
+  description: string;
+  action?: { label: string; onClick: () => void };
+}
+
+function CenteredCard({
+  title,
+  description,
+  action,
+}: CenteredCardProps): React.JSX.Element {
   return (
     <div className="flex h-full items-center justify-center p-6">
       <div className="max-w-md rounded-lg border border-border-primary bg-surface-secondary p-6 text-center">
         <Activity className="mx-auto mb-3 size-8 text-text-muted" />
         <h3 className="mb-2 text-base font-semibold text-text-primary">
-          No suite loaded
+          {title}
         </h3>
-        <p className="text-sm text-text-muted">
-          Coverage analysis needs a persisted regression suite to load. Run
-          the demo suite from the <span className="font-medium">Run</span>{" "}
-          sub-tab first; once the runner exposes a{" "}
-          <code className="rounded bg-surface-primary px-1 py-0.5 text-xs">
-            list_regression_suites
-          </code>{" "}
-          command, this view will surface live coverage data automatically.
-        </p>
+        <p className="text-sm text-text-muted">{description}</p>
+        {action && (
+          <button
+            type="button"
+            onClick={action.onClick}
+            className="mt-4 inline-flex items-center gap-1.5 rounded-md border border-border-primary px-3 py-1.5 text-sm text-text-primary hover:bg-surface-primary"
+          >
+            {action.label}
+          </button>
+        )}
       </div>
     </div>
   );
+}
+
+function formatTimestamp(iso: string): string {
+  // Compact "MM-DD HH:MM" form to fit the suite picker. Locale-agnostic so
+  // the rendered string is stable across machines.
+  try {
+    const d = new Date(iso);
+    const pad = (n: number): string => String(n).padStart(2, "0");
+    return `${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  } catch {
+    return iso;
+  }
 }
 
 export default RegressionTabPage;

--- a/src/pages/regression/__tests__/CoveragePanel.test.ts
+++ b/src/pages/regression/__tests__/CoveragePanel.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for the pure helpers powering CoveragePanel.
+ *
+ * The runner repo is `environment: "node"` and does not bundle jsdom — the
+ * convention (see `WebIntegrationAuthBanner.test.ts`) is to factor pure
+ * decision logic out of components and lock it down here. The component
+ * itself is a thin shell over `coverageDiff` / `coverageOf` / our exposed
+ * adapters, so covering those adapters is sufficient to keep the panel
+ * honest without spinning up a DOM harness.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  coverageDiff,
+  coverageOf,
+  generateRegressionSuite,
+  type RegressionSuite,
+} from "@qontinui/ui-bridge-auto/regression";
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+
+import {
+  exerciseLogToAssertionExecutions,
+  groupUnexercisedByCase,
+  deriveCoverageStats,
+  type AssertionExecutionRow,
+} from "../CoveragePanel";
+
+// ---------------------------------------------------------------------------
+// Fixtures — minimal IR + suite generated from it. Mirrors the shape used in
+// `regression-executor.test.ts` so a reader recognizes the conventions.
+// ---------------------------------------------------------------------------
+
+const FIXTURE_IR: IRDocument = {
+  version: "1.0",
+  id: "coverage-fixture",
+  name: "Coverage Fixture",
+  states: [
+    {
+      id: "s-root",
+      name: "Root",
+      requiredElements: [{ tagName: "body" }],
+    },
+    {
+      id: "s-page",
+      name: "Page",
+      requiredElements: [{ role: "heading" }],
+    },
+  ],
+  transitions: [
+    {
+      id: "t-go",
+      name: "Go to page",
+      fromStates: ["s-root"],
+      activateStates: ["s-page"],
+      actions: [{ type: "click", target: { role: "button", text: "Go" } }],
+    },
+  ],
+  initialState: "s-root",
+};
+
+function buildSuite(): RegressionSuite {
+  return generateRegressionSuite(FIXTURE_IR);
+}
+
+// ---------------------------------------------------------------------------
+// exerciseLogToAssertionExecutions — Tauri row → coverage-diff input adapter
+// ---------------------------------------------------------------------------
+
+describe("exerciseLogToAssertionExecutions", () => {
+  it("returns an empty array for an empty input", () => {
+    expect(exerciseLogToAssertionExecutions([])).toEqual([]);
+  });
+
+  it("maps snake_case Rust rows onto camelCase AssertionExecution entries", () => {
+    const rows: AssertionExecutionRow[] = [
+      {
+        case_id: "t-go",
+        assertion_id: "state-active:pre:s-root",
+        started_at: "2026-05-02T12:00:00Z",
+        status: "passed",
+        assertion_kind: "state-active",
+        duration_ms: 4,
+        failure_kind: null,
+        error_message: null,
+      },
+      {
+        case_id: "t-go",
+        assertion_id: "action-target-resolves:t-go#0",
+        started_at: "2026-05-02T12:00:01Z",
+        status: "passed",
+        assertion_kind: "action-target-resolves",
+        duration_ms: 7,
+      },
+    ];
+
+    expect(exerciseLogToAssertionExecutions(rows)).toEqual([
+      {
+        caseId: "t-go",
+        assertionId: "state-active:pre:s-root",
+        executedAt: "2026-05-02T12:00:00Z",
+      },
+      {
+        caseId: "t-go",
+        assertionId: "action-target-resolves:t-go#0",
+        executedAt: "2026-05-02T12:00:01Z",
+      },
+    ]);
+  });
+
+  it("does not mutate the caller's input array", () => {
+    const rows: AssertionExecutionRow[] = [
+      {
+        case_id: "t-go",
+        assertion_id: "x",
+        started_at: "2026-05-02T12:00:00Z",
+        status: "passed",
+        assertion_kind: "state-active",
+        duration_ms: 1,
+      },
+    ];
+    const snapshot = JSON.parse(JSON.stringify(rows));
+    exerciseLogToAssertionExecutions(rows);
+    expect(rows).toEqual(snapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupUnexercisedByCase — coverageDiff output → renderable groups
+// ---------------------------------------------------------------------------
+
+describe("groupUnexercisedByCase", () => {
+  it("groups un-exercised assertions by caseId", () => {
+    const suite = buildSuite();
+
+    // Empty exercise log — every assertion should be un-exercised.
+    const log: AssertionExecutionRow[] = [];
+    const execs = exerciseLogToAssertionExecutions(log);
+
+    const diff = coverageDiff(suite, execs);
+
+    const groups = groupUnexercisedByCase(suite, diff);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.caseId).toBe("t-go");
+    expect(groups[0]!.rows.length).toBeGreaterThan(0);
+
+    // Every emitted row should carry a kind that is one of the four discriminants
+    // — never "unknown" (which would indicate the kind-lookup keying drifted
+    // away from coverage-diff's `assertionIdOf` convention).
+    for (const r of groups[0]!.rows) {
+      expect(["state-active", "action-target-resolves", "visual-gate", "overlay"]).toContain(
+        r.assertionKind,
+      );
+    }
+
+    // Specific check: the pre-state assertion for s-root should appear.
+    const preRoot = groups[0]!.rows.find(
+      (r) => r.assertionId === "state-active:pre:s-root",
+    );
+    expect(preRoot).toBeDefined();
+    expect(preRoot!.assertionKind).toBe("state-active");
+
+    // Specific check: the action-target-resolves assertion should appear.
+    const actionRes = groups[0]!.rows.find(
+      (r) => r.assertionId === "action-target-resolves:t-go#0",
+    );
+    expect(actionRes).toBeDefined();
+    expect(actionRes!.assertionKind).toBe("action-target-resolves");
+  });
+
+  it("returns no groups when every assertion has been exercised", () => {
+    const suite = buildSuite();
+
+    // Build a synthetic log that records every assertion in the suite as
+    // having executed. The id derivation must match coverage-diff's
+    // `assertionIdOf` convention.
+    const rows: AssertionExecutionRow[] = [];
+    for (const c of suite.cases) {
+      for (const a of c.assertions) {
+        let assertionId: string;
+        switch (a.kind) {
+          case "state-active":
+            assertionId = `state-active:${a.phase}:${a.stateId}`;
+            break;
+          case "action-target-resolves":
+            assertionId = `action-target-resolves:${a.transitionId}#${a.actionIndex}`;
+            break;
+          case "visual-gate":
+            assertionId = `visual-gate:${a.stateId}`;
+            break;
+          case "overlay":
+            assertionId = a.assertionId;
+            break;
+        }
+        rows.push({
+          case_id: c.id,
+          assertion_id: assertionId,
+          started_at: "2026-05-02T12:00:00Z",
+          status: "passed",
+          assertion_kind: a.kind,
+          duration_ms: 1,
+        });
+      }
+    }
+
+    const execs = exerciseLogToAssertionExecutions(rows);
+    const diff = coverageDiff(suite, execs);
+
+    expect(diff.unexercisedAssertions).toEqual([]);
+    expect(diff.uncoveredTransitions).toEqual([]);
+    expect(groupUnexercisedByCase(suite, diff)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveCoverageStats — pull both sources together for the dashboard pills
+// ---------------------------------------------------------------------------
+
+describe("deriveCoverageStats", () => {
+  it("combines coverageOf + coverageDiff into a renderable shape", () => {
+    const suite = buildSuite();
+    const staticCoverage = coverageOf(FIXTURE_IR, suite);
+    const diff = coverageDiff(suite, []);
+
+    const stats = deriveCoverageStats(staticCoverage, diff);
+
+    // Suite has exactly one case (one transition), so static coverage is
+    // 1/1 transitions.
+    expect(stats.staticCovered).toBe(1);
+    expect(stats.staticTotal).toBe(1);
+
+    // Empty exercise log → zero exercised, all unexercised.
+    expect(stats.runtimeExercised).toBe(0);
+    expect(stats.runtimeTotal).toBeGreaterThan(0);
+    expect(stats.uncoveredPercent).toBe(100);
+  });
+
+  it("rounds uncoveredRatio to a whole-number percent", () => {
+    // Hand-crafted minimal CoverageReport + CoverageDiffReport — bypass the
+    // generator so we can pin a non-trivial ratio.
+    const stats = deriveCoverageStats(
+      {
+        totalStates: 2,
+        totalTransitions: 1,
+        statesCovered: 2,
+        transitionsCovered: 1,
+        reachableStates: ["s-root", "s-page"],
+        unreachableStates: [],
+      },
+      {
+        unexercisedAssertions: [],
+        uncoveredTransitions: [],
+        stats: {
+          totalAssertions: 4,
+          exercisedAssertions: 1,
+          totalTransitions: 1,
+          coveredTransitions: 1,
+          uncoveredRatio: 0.75,
+        },
+      },
+    );
+
+    expect(stats.uncoveredPercent).toBe(75);
+  });
+
+  it("emits 0% when there are no assertions to cover", () => {
+    const stats = deriveCoverageStats(
+      {
+        totalStates: 0,
+        totalTransitions: 0,
+        statesCovered: 0,
+        transitionsCovered: 0,
+        reachableStates: [],
+        unreachableStates: [],
+      },
+      {
+        unexercisedAssertions: [],
+        uncoveredTransitions: [],
+        stats: {
+          totalAssertions: 0,
+          exercisedAssertions: 0,
+          totalTransitions: 0,
+          coveredTransitions: 0,
+          uncoveredRatio: 0,
+        },
+      },
+    );
+
+    expect(stats.uncoveredPercent).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Section 11 of the UI Bridge redesign on the runner side, plus the Section 11 follow-ups landed in the autonomous loops (FU-1 through FU-4).

Two stacked commits:

1. **f894187c — Section 11 main** (regression executor + scenario HTTP + coverage panel + CLI)
2. **3fe74c71 — FU-1 + FU-2 + FU-3 + FU-4** (suite-list commands + drift HTTP + overlay providers + wrappers tab)

## What's in this PR

### Persistence (project schema)
- New tables: \`regression_suites\`, \`regression_runs\`, \`regression_diagnoses\`, \`regression_assertion_executions\` (denormalized failure detail + partial fail-index).
- New \`regression_runs.drift_report_json\` column for the FU-3 drift API.
- New module \`database/pg/regression.rs\` (raw \`tokio_postgres\` until alembic + Clorinde catch up — see ADR-011 / ADR-012).
- Shared docker init + in-crate bootstrap so dev environments converge.

### Tauri commands
- \`save_regression_suite\`, \`record_regression_run\` (with optional \`drift_report_json\`), \`record_regression_diagnosis\`, \`record_assertion_executions_batch\`, \`query_assertion_executions_for_suite\`, \`get_recent_diagnoses_for_suite\`.
- FU-2: \`list_regression_suites\`, \`get_regression_suite_by_id\`, \`list_regression_runs_for_suite\`.

### TS-side regression executor
- \`src/lib/regression-executor.ts\` walks \`RegressionSuite\` cases against the live UI Bridge registry; dispatches by assertion kind; builds \`RegressionRunResult\`; calls \`diagnose\`; persists via Tauri IPC.
- \`src/lib/regression-memory-sink.ts\` wraps the sync \`MemorySink\` contract with \`lastWrite: Promise<string> | null\`.
- \`src/lib/regression-commit-filter.ts\` — file-overlap-filtered commits since \`suite.generatedAt\`.
- FU-4: \`evaluateOverlay\` is async, threads optional \`DesignTokenRegistry\` + \`IOCRProvider\`, calls \`checkDesignTokens\` / \`crossCheckText\` for full evaluation.

### HTTP API (port 9876)
- \`GET /scenarios/projection?ir_doc_id=X\` — pure Rust port of \`projectScenarios\`.
- \`GET /scenarios/current?ir_doc_id=X\` — IPC into the webview for runtime-aware projection.
- FU-3: \`GET /runs/:run_id/drift\` and \`GET /runs/:run_id/drift/:entry_id\` — pass-through of the persisted \`drift_report_json\`.

### Runner UI
- New Regression main tab + Run/Coverage sub-tabs.
- FU-1: \`wrappers\` added to Rust \`VALID_TAB_IDS\`.
- FU-2: CoveragePanel sub-tab loads suites via \`list_regression_suites\`, fetches the suite blob via \`get_regression_suite_by_id\`, loads the IR via the Spec API, mounts \`CoveragePanel\` with real data.

### Coverage CLI
- \`scripts/coverage-diff.mjs\` wraps the pure \`coverageDiff\` for CI gating; exits non-zero when \`uncoveredRatio\` exceeds \`--threshold\` (default 0.20). 9 \`node:test\` tests; full exit-code matrix verified.

## Test plan

- [x] \`cargo check --bin qontinui-runner\` (clippy via pre-commit hook)
- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 216 / 216 vitest tests pass
- [x] Section-11 unit tests pass (8 scenario tests + 11 commit-filter + executor tests)
- [x] CLI tests: 9 / 9 pass via \`node:test\`
- [ ] Manual: spawn temp runner, run a regression suite end-to-end, verify drift HTTP endpoint returns the persisted report

## Cross-repo dependencies

This PR depends on:
- \`@qontinui/ui-bridge-auto\` Section 11 surface (subpath exports + scenario-projection + coverage-diff + drift/node split) — see qontinui/ui-bridge-auto PR #3.
- \`qontinui-web\` backend drift proxy + alembic migration — see jspinak/qontinui-web feat/section-11-drift-route-and-proxy.
- \`qontinui-mcp\` scenario projection tools — see qontinui/qontinui-mcp feat/section-11-scenario-projection-tools.

## ADR

\`qontinui-dev-notes/ui-bridge-redesign/section-11-other-consumers/ADR-011-other-consumers.md\` — six decisions + nine implementation notes + follow-ups (most resolved in the autonomous loops).