### PR TITLE
ci: disable test profile debug info (Windows linker OOM)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -252,3 +252,13 @@ tempfile = "3"
 [profile.dev]
 debug = 0  # No debug info — prevents LLVM OOM during linking
 split-debuginfo = "packed"
+
+# Tests inherit from dev by default but cargo test forces `debuginfo=2`
+# unless explicitly overridden. On Windows CI the test binary's link
+# step crashes with STATUS_ILLEGAL_INSTRUCTION (0xc000001d) at the
+# final link of qontinui_runner — almost certainly link.exe OOM
+# under the combined size of debug info across ~100 dependency rlibs.
+# Mirror the dev profile's debug=0.
+[profile.test]
+debug = 0
+split-debuginfo = "packed"


### PR DESCRIPTION
## Summary

`[profile.dev]` already sets `debug = 0` to prevent `link.exe` OOM (existing workaround). But `cargo test` forces `debuginfo = 2` unless `[profile.test]` explicitly overrides — defeating the workaround for the test binary.

Result on Windows: `STATUS_ILLEGAL_INSTRUCTION (0xc000001d)` at the final link of the `qontinui_runner` test binary. Observed in CI run 25276744422 after a 55-minute hang during `Run Rust tests`. The combined debug info across ~100 dependency rlibs exceeds `link.exe`'s memory pressure threshold.

Fix: mirror `[profile.dev]`'s settings for `[profile.test]`.

## Scope

This PR was originally bundled with 5 clippy-lint allows from the same investigation. Those are dropped — clippy lint cleanup is being handled in parallel work that needs more allows than I'd identified. Keeping this PR narrowly focused on the linker OOM, which is unrelated to clippy and unblocks `Run Rust tests` on Windows independently.

## Mergeability

Cannot merge until the parallel clippy work lands first (CI is currently red on Linux/macOS clippy on main). Once main is green, rebase + merge.

## Test plan

- [ ] After clippy work merges and main is green, rebase this PR
- [ ] Confirm Windows `Run Rust tests` step completes in reasonable time (was 55+ min hang before)