### PR TITLE
fix(paths): symmetric UNC normalization in check_path_containment

### DIFF
--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -354,12 +354,19 @@ fn check_path_containment(
 ) -> Result<PathBuf, String> {
     // Canonicalize both paths for reliable comparison.
     // If canonicalization fails (path doesn't exist yet), use the raw paths.
-    let canonical_resolved = std::fs::canonicalize(resolved)
-        .map(normalize_path_separators)
-        .unwrap_or_else(|_| resolved.to_path_buf());
-    let canonical_boundary = std::fs::canonicalize(boundary)
-        .map(normalize_path_separators)
-        .unwrap_or_else(|_| boundary.to_path_buf());
+    // Normalize symmetrically across both branches: on Windows, `canonicalize`
+    // adds a `\\?\` UNC prefix that `normalize_path_separators` strips. If we
+    // only normalize on the success branch, a non-existent `resolved` whose
+    // raw form already carries `\\?\` (typically because it was joined onto a
+    // canonicalized boundary) keeps the prefix while `boundary` loses it,
+    // and the `starts_with` check at the bottom of this function spuriously
+    // fails.
+    let canonical_resolved = normalize_path_separators(
+        std::fs::canonicalize(resolved).unwrap_or_else(|_| resolved.to_path_buf()),
+    );
+    let canonical_boundary = normalize_path_separators(
+        std::fs::canonicalize(boundary).unwrap_or_else(|_| boundary.to_path_buf()),
+    );
 
     let resolved_str = canonical_resolved.to_string_lossy().to_lowercase();
     let boundary_str = canonical_boundary.to_string_lossy().to_lowercase();


### PR DESCRIPTION
## Summary

- Fix Windows-only failure of `paths::tests::test_check_path_containment_passes_for_subdirectory` (panicked at `paths.rs:470`).
- Root cause: `normalize_path_separators` was applied only to the canonicalize-success branch in `check_path_containment`. On Windows, a non-existent `resolved` path inheriting the `\?\` UNC prefix from a canonicalized `boundary` kept the prefix via the fallback, while `boundary` lost it via canonicalize+normalize — breaking the `starts_with` comparison at `paths.rs:374`.
- Fix: wrap both branches in `normalize_path_separators` so the result is shape-consistent regardless of which branch ran. `normalize_path_separators` is a no-op on non-Windows, so Linux/macOS behavior is unchanged.

## Test plan

- [x] `cargo test paths::tests` passes locally on Windows (8/8, including the boundary-escape rejection).
- [ ] CI \`test (windows-latest)\` \`Run Rust tests\` step turns green.
- [ ] CI \`test (ubuntu-22.04)\` and \`test (macos-latest)\` \`Run Rust tests\` continue to pass.

After this lands, the windows-latest leg progresses to \`Build Tauri app (development)\`, which trips a separate pre-existing Tauri version mismatch tracked elsewhere — not addressed by this PR.