### PR TITLE
chore(deps): bump @qontinui/ui-bridge-auto ^0.1.3 → ^0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/shared-types": "^0.2.1",
     "@qontinui/ui-bridge": "^0.3.2",
-    "@qontinui/ui-bridge-auto": "^0.1.3",
+    "@qontinui/ui-bridge-auto": "^0.1.4",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,10 @@ importers:
         version: 0.2.1
       '@qontinui/ui-bridge':
         specifier: ^0.3.2
-        version: 0.3.2(@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        version: 0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
-        specifier: ^0.1.3
-        version: 0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.1.4
+        version: 0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/workflow-ui':
         specifier: ^0.1.0
         version: 0.1.0(@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(mermaid@11.14.0)(react-window@2.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -148,7 +148,7 @@ importers:
         version: 2.4.1(react@19.2.5)
       qontinui-navigation:
         specifier: ^0.1.0
-        version: 0.1.0(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.0(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.5)
@@ -1117,8 +1117,8 @@ packages:
   '@qontinui/shared-types@0.2.1':
     resolution: {integrity: sha512-j3fQg0gCMqQ7Rzfuhlxm0p5GhwsIb4i+ge0S9tBaUZiXAxCjm2lG4WZK6VMqjxo9Rg2yknMmyZ1RE1KigDSzmA==}
 
-  '@qontinui/ui-bridge-auto@0.1.3':
-    resolution: {integrity: sha512-pWeRIyRMGg+hTjUmhau/sPpN89JcKeocX4QZUI+glxxxCtIeDjVOMaEJ3R3+ZNfjQHKqq/SbtSMGjLSKzlMFjw==}
+  '@qontinui/ui-bridge-auto@0.1.4':
+    resolution: {integrity: sha512-8NMbndNelaGfLUc6LxOabDL0Uzfwlm6fcEi7aqSVMs74vBr7d9gBa/TfleIT0mm3EFb1JsalL7hul0w40ARvhw==}
     hasBin: true
     peerDependencies:
       tesseract.js: '>=5.0.0'
@@ -6105,10 +6105,10 @@ snapshots:
 
   '@qontinui/shared-types@0.2.1': {}
 
-  '@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       '@qontinui/shared-types': 0.2.1
-      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - express
@@ -6126,11 +6126,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:
-      '@qontinui/ui-bridge-auto': 0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge-auto': 0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@tauri-apps/api': 2.11.0
       react-dom: 19.2.5(react@19.2.5)
       ws: 8.20.0
@@ -9691,9 +9691,9 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qontinui-navigation@0.1.0(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5):
+  qontinui-navigation@0.1.0(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5):
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   qrcode.react@4.2.0(react@19.2.5):


### PR DESCRIPTION
## Summary

- Bumps `@qontinui/ui-bridge-auto` from `^0.1.3` to `^0.1.4`.
- Picks up upstream changes from [`qontinui/ui-bridge-auto@97abb65`](https://github.com/qontinui/ui-bridge-auto/commit/97abb65): eslint 10 alignment + Windows-portable build post-check.
- Cosmetic refresh — semver `^0.1.3` already auto-resolves to `0.1.4`, so this just makes the explicit pin and lockfile entry current.

No runner source code changes; no behavioral change.

## Test plan

- [ ] `pnpm install` resolves `@qontinui/ui-bridge-auto@0.1.4` cleanly.
- [ ] `pnpm run typecheck` passes.
- [ ] CI green.

Note: under the dev-link symlink overlay (set up by `qontinui-claude-config/scripts/dev-link.ps1`), the on-disk `node_modules/@qontinui/ui-bridge-auto` resolves to the local sibling rather than the registry tarball — so the typecheck doesn't actually exercise `0.1.4`'s published artifact. That's the [consumer-spot-check tautology](https://github.com/qontinui/qontinui-dev-notes/blob/main/consumer-spot-check-against-published-npm/SESSION_PROMPT.md) that's been documented separately. The published artifact was verified independently via `npm run verify-published` from `ui-bridge-auto`.