### PR TITLE
chore(deps): bump @qontinui/ui-bridge-auto ^0.1.4 → ^0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/shared-types": "^0.2.1",
     "@qontinui/ui-bridge": "^0.3.2",
-    "@qontinui/ui-bridge-auto": "^0.1.4",
+    "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,16 +22,16 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.1
         version: 0.2.1
       '@qontinui/ui-bridge':
         specifier: ^0.3.2
-        version: 0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        version: 0.3.2(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
-        specifier: ^0.1.4
-        version: 0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.1.5
+        version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/workflow-ui':
         specifier: ^0.1.0
         version: 0.1.0(@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(mermaid@11.14.0)(react-window@2.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -1128,8 +1128,8 @@ packages:
   '@qontinui/shared-types@0.2.1':
     resolution: {integrity: sha512-j3fQg0gCMqQ7Rzfuhlxm0p5GhwsIb4i+ge0S9tBaUZiXAxCjm2lG4WZK6VMqjxo9Rg2yknMmyZ1RE1KigDSzmA==}
 
-  '@qontinui/ui-bridge-auto@0.1.4':
-    resolution: {integrity: sha512-8NMbndNelaGfLUc6LxOabDL0Uzfwlm6fcEi7aqSVMs74vBr7d9gBa/TfleIT0mm3EFb1JsalL7hul0w40ARvhw==}
+  '@qontinui/ui-bridge-auto@0.1.5':
+    resolution: {integrity: sha512-C4i4SNHsfMNHzBTUIp9MQc8XXjQGFUkPD71IudfYRXxsJ24nDklsbPjBVpjEBS+SGQczQc0TAXZ2YnAM/XD2BQ==}
     hasBin: true
     peerDependencies:
       tesseract.js: '>=5.0.0'
@@ -6103,17 +6103,17 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.1': {}
 
-  '@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       '@qontinui/shared-types': 0.2.1
-      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.2(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - express
@@ -6131,11 +6131,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.3.2(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:
-      '@qontinui/ui-bridge-auto': 0.1.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge-auto': 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@tauri-apps/api': 2.11.0
       react-dom: 19.2.5(react@19.2.5)
       ws: 8.20.0


### PR DESCRIPTION
## Summary

Bumps `@qontinui/ui-bridge-auto` from `^0.1.4` to `^0.1.5`.

## What's in 0.1.5

- **`fix ir-builder dts emission (clean-race)`** — the third tsup config (`./ir-builder` library subpath) was emitting `.d.ts` / `.d.mts` correctly, but config #1's `clean: true` was racing with parallel DTS workers and wiping the files between config #3's write (~3s) and config #1's DTS finish (~10s). Fix: hoist dist cleanup into the npm script and `clean: false` on every tsup config. New `scripts/check-dts-completeness.js` walks `package.json#exports` and stats every subpath's `types` entry.
- `feat: add verify-published spot-check script` — runs `npm install <version>` in a fresh tempdir and `tsc --noEmit`s a stub importing one symbol per subpath. This is what found the 0.1.4 missing-`./ir-builder`-dts bug.
- `ci: add tag-triggered npm publish workflow` + OIDC trusted-publishing migration + `repository.url` for provenance. Eliminates manual publish handoffs for future releases.

## Why this consumer

This repo does **not** currently import `@qontinui/ui-bridge-auto/ir-builder` (verified by grep — zero references), so 0.1.5 is hygiene rather than a fix. Bumping anyway to keep the lockfile aligned with the latest published version, so future imports of `./ir-builder` don't break on missing types.

## Diff scope

`package.json` (1 line) + `pnpm-lock.yaml` (24 lines, 12+/12-, all references to `ui-bridge-auto` 0.1.4 → 0.1.5). No collateral package churn.

## Test plan

- [ ] `Build frontend` step on CI passes (frontend builds against the new 0.1.5 tarball with all 9 subpaths).
- [ ] Per the new `CONTRIBUTING.md` "hidden-red discipline" — any leg failures should be compared against `main`'s most recent run for the same workflow + platform; doc-only-style PRs should match main exactly.