### PR TITLE
chore(clippy): fix 3 pre-existing test-code lints

### DIFF
--- a/src-tauri/src/mcp/ws_relay.rs
+++ b/src-tauri/src/mcp/ws_relay.rs
@@ -703,7 +703,7 @@ mod tests {
         uninstall_ws_sdk_connection(&mgr, &synthetic, prior).await;
         let guard = mgr.lock().await;
         assert!(guard.active_url.is_none());
-        assert!(guard.connections.get("ws-app://wapp").is_none());
+        assert!(!guard.connections.contains_key("ws-app://wapp"));
     }
 
     #[tokio::test]
@@ -720,6 +720,6 @@ mod tests {
         let guard = mgr.lock().await;
         assert_eq!(guard.active_url.as_deref(), Some("http://other"));
         // Our synthetic entry should still be removed even if active_url moved on.
-        assert!(guard.connections.get("ws-app://wapp").is_none());
+        assert!(!guard.connections.contains_key("ws-app://wapp"));
     }
 }

--- a/src-tauri/src/wake_handler.rs
+++ b/src-tauri/src/wake_handler.rs
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn detects_deep_link_args_from_argv() {
-        let argv = vec![
+        let argv = [
             "C:\\path\\to\\runner.exe".to_string(),
             "qontinui://wake?intent=abc".to_string(),
             "--unrelated-flag".to_string(),


### PR DESCRIPTION
## Why

Three pre-existing clippy errors in test code have been failing the runner pre-push hook and CI's `Rust Check` on every PR against `main`. Removing them clears the hidden-red and unblocks cleaner CI on dependent work (#40 navigation rename, upcoming Step 3a coordinator-launch-controls).

Single-purpose, no functional change. Suggestions are clippy's own machine-applicable rewrites.

## What changed

| File:line | Lint | Change |
|---|---|---|
| `src-tauri/src/mcp/ws_relay.rs:706` | `clippy::unnecessary_get_then_check` | `guard.connections.get("ws-app://wapp").is_none()` -> `!guard.connections.contains_key("ws-app://wapp")` |
| `src-tauri/src/mcp/ws_relay.rs:723` | `clippy::unnecessary_get_then_check` | Same as above (second test). |
| `src-tauri/src/wake_handler.rs:201` | `clippy::useless_vec` | `let argv = vec![...]` (three `String` literals) -> `let argv = [...]` array literal. |

Net diff: 3 lines changed across 2 files.

## Verification

```
$ cargo clippy --bin qontinui-runner --tests -- -D warnings
    Finished `dev` profile [unoptimized] target(s)
# exit 0  (was 101 with the 3 known errors before this change)

$ cargo check --bin qontinui-runner
    Finished `dev` profile [unoptimized] target(s)
# exit 0
```

Pre-push hook (`cargo fmt + clippy`) passed without `QONTINUI_PREPUSH_SKIP=1`.

## Connects to

- #40 (navigation rename) — currently open; will benefit from clean clippy on `main` once this lands.
- Upcoming Step 3a coordinator-launch-controls PR — same.

## What this is NOT

- Not bundling other clippy fixes — only the 3 specifically failing on `main`.
- No `cargo fmt` reflow, dependency bumps, or unrelated cleanups.