### PR TITLE
chore(specs): drop dead pairingPolicy block from active IR

### DIFF
--- a/specs/pages/active/state-machine.derived.json
+++ b/specs/pages/active/state-machine.derived.json
@@ -7,14 +7,6 @@
     "purpose": "ActiveDashboardPage",
     "tags": ["active-dashboard", "monitoring", "real-time", "tier-1"]
   },
-  "pairingPolicy": {
-    "acceptDrift": {
-      "axes": ["groupCount", "groupIds", "assertionCount"],
-      "reason": "Section 2 of the UI Bridge redesign hand-authored this IR against a 4-state canonical model (idle / running / paused / completion-overlay) rather than the legacy spec's 9-group convention. Harmonizing them would lose the section-2 worked sample. Honored by check-spec-pairing >= 0.1.1.",
-      "since": "2026-04-15",
-      "expiresAt": "2026-10-15"
-    }
-  },
   "states": [
     {
       "id": "idle",


### PR DESCRIPTION
## Summary
Sections 12 + 13.5 deleted the legacy \`*.spec.uibridge.json\` files and removed the \`check-spec-pairing\` bin from \`@qontinui/ui-bridge-auto\` (only \`ui-bridge-build-ir\` remains as of 0.1.5). The IR is now the sole authoring surface — there's nothing left to pair against.

That makes \`pairingPolicy.acceptDrift\` on this IR purely vestigial. The reason field even references a bin (\`check-spec-pairing >= 0.1.1\`) that no longer exists. Drop the block.

\`IRPairingPolicy\` is still exported from \`@qontinui/shared-types\` and harmless to leave there for later consumers, but no IR in this repo needs it anymore.

## Test plan
- [x] Single-file edit to \`specs/pages/active/state-machine.derived.json\`
- [x] No remaining \`pairingPolicy\` references in this repo (verified by grep)