### PR TITLE
fix(ci): add pgvector dep + main fallback to schema-pg-sql-fresh

### DIFF
--- a/.github/workflows/schema-pg-sql-fresh.yml
+++ b/.github/workflows/schema-pg-sql-fresh.yml
@@ -55,7 +55,12 @@ jobs:
           path: qontinui-web
           # Use the same branch name if it exists in qontinui-web,
           # otherwise main. Avoids drift when both repos move together.
-          ref: ${{ github.head_ref || github.ref_name }}
+          # The `|| 'main'` fallback is required: if the PR's branch
+          # name doesn't exist on qontinui-web, actions/checkout's
+          # bare `head_ref` resolves to a 404 before alembic ever runs
+          # (the workflow's own comment promised the main fallback but
+          # didn't implement it).
+          ref: ${{ github.head_ref || github.ref_name || 'main' }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -66,7 +71,14 @@ jobs:
         working-directory: qontinui-web/backend
         run: |
           python -m pip install --upgrade pip
-          pip install alembic sqlalchemy psycopg2-binary python-dotenv
+          # `pgvector` is required because three migrations
+          # (05a366f58455_initial_schema_squashed.py,
+          # a84bf9dcb2dc_add_text_embedding_to_project_embeddings.py,
+          # b5c6d7e8f9a0_add_semantic_search_embeddings.py) do
+          # `from pgvector.sqlalchemy import Vector` at module
+          # import time. Without it, `alembic upgrade head` blows
+          # up with `ImportError` before the schema-diff step.
+          pip install alembic sqlalchemy psycopg2-binary pgvector python-dotenv
 
       - name: Apply alembic chain
         working-directory: qontinui-web/backend


### PR DESCRIPTION
## Summary

Promotes \`schema-pg-sql-fresh.yml\` from \"conditional gate (currently being repaired)\" to a working gate. Per the merge-readiness section in \`CONTRIBUTING.md\` and the inventory at \`_dev-notes-main/schema-pg-sql-fresh-pr-failures/SESSION_PROMPT.md\`, the workflow has been failing on every recent PR run with the schema-diff step never actually executing. Two distinct infra bugs upstream of the diff:

### 1. Missing \`pgvector\` pip dep

The \`Install alembic dependencies\` step installed \`alembic sqlalchemy psycopg2-binary python-dotenv\` only. Three migrations under \`qontinui-web/backend/alembic/versions/\` (\`05a366f58455\`, \`a84bf9dcb2dc\`, \`b5c6d7e8f9a0\`) do \`from pgvector.sqlalchemy import Vector\` at import time, so \`alembic upgrade head\` crashed with \`ModuleNotFoundError: No module named 'pgvector'\` before reaching the diff. Added \`pgvector\` to the install list.

### 2. Missing \`main\` fallback in sibling checkout

\`Checkout qontinui-web (sibling)\` set \`ref: \${{ github.head_ref || github.ref_name }}\` with no fallback. If the PR branch name didn't exist on qontinui-web, actions/checkout 404'd before alembic ever ran. The workflow's own header comment promised \"otherwise main\" but didn't implement it. Added \`|| 'main'\`.

## Diff scope

Single file, 14 insertions / 2 deletions: \`.github/workflows/schema-pg-sql-fresh.yml\`. Comments inline explain *why* each change is load-bearing so future maintainers don't accidentally undo them.

## Test plan

- [ ] Workflow triggers on this PR (paths-filter is \`src-tauri/queries/**\` and \`src-tauri/schema.pg.sql.generated\` — neither touched here, so the workflow won't run on this PR's checks). Validate by manually triggering via \`workflow_dispatch\` after merge, **or** force a follow-up PR that touches one of the trigger paths.
- [ ] On the next triggered run, the \`Install alembic dependencies\` step now installs \`pgvector\` cleanly.
- [ ] \`alembic upgrade head\` reaches \`head\` instead of \`ModuleNotFoundError\`-ing during migration import.
- [ ] The schema-diff step actually executes — green if checked-in artifact matches a fresh dump, red with a real signal if drift.

## Follow-up

Once this is verified working on a real triggering PR, promote \`schema-pg-sql-fresh.yml\` from \"conditional gate\" to \"required\" in branch protection. The merge-readiness section in \`CONTRIBUTING.md\` already calls this out as the next step.