### PR TITLE
fix(ci): clone qontinui-schemas sibling in release.yml build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # qontinui-schemas is a workspace path-dep
+      # (`qontinui-types = { path = "../../qontinui-schemas/rust" }`
+      # in src-tauri/Cargo.toml). Without the sibling clone,
+      # `cargo build` (invoked by `tauri build` below) fails to
+      # resolve the path. Public org-owned repo, default github.token.
+      - name: Checkout sibling repos
+        run: |
+          cd "$GITHUB_WORKSPACE/.."
+          git clone --depth 1 https://github.com/qontinui/qontinui-schemas.git
+        shell: bash
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary

\`release.yml\`'s build matrix was missing the \`qontinui-schemas\` sibling checkout. \`src-tauri/Cargo.toml\` has \`qontinui-types = { path = \"../../qontinui-schemas/rust\" }\` — a workspace path-dep that requires the sibling repo present at \`\$GITHUB_WORKSPACE/..\` for \`cargo build\` (invoked by \`pnpm run tauri build\`) to resolve. Without this step, any \`v*\` tag push would fail at the build step on every platform.

\`ci.yml\` already does this clone in both its test/build matrix and its security job; \`release.yml\` just inherits the same pattern.

## What's added

A single new step right after the \`actions/checkout@v4\` of qontinui-runner, before pnpm/Node/Rust setup:

\`\`\`yaml
- name: Checkout sibling repos
  run: |
    cd \"\$GITHUB_WORKSPACE/..\"
    git clone --depth 1 https://github.com/qontinui/qontinui-schemas.git
  shell: bash
\`\`\`

\`qontinui-schemas\` is a public org-owned repo, so the default \`github.token\` authenticates the clone — no PAT needed.

## Diff scope

Single file, 11 insertions, 0 deletions: \`.github/workflows/release.yml\`.

## Why now

\`release.yml\` is tag-only (\`push: tags: ['v*']\` + \`workflow_dispatch\`), so it doesn't run on this PR or on \`main\` pushes — the bug wouldn't bite until the next tag cut. Per the merge-readiness section in \`CONTRIBUTING.md\` and the cross-repo CI map memo (\`project_qontinui_ci_setup.md\`), this was an open follow-up since 2026-05-02. Landing it now keeps the next release green by default rather than red-by-omission.

## Test plan

- [ ] Trigger \`release.yml\` via \`workflow_dispatch\` after merge to verify the sibling clone resolves and \`pnpm run tauri build\` proceeds. (No \`v*\` tag needed for the dispatch path.)
- [ ] Confirm all four matrix legs (linux-x64, macos-x64, macos-arm64, windows-x64) reach the \`Build Tauri app\` step.