### PR TITLE
fix(ci): clone + install qontinui-schemas in schema-pg-sql-fresh

### DIFF
--- a/.github/workflows/schema-pg-sql-fresh.yml
+++ b/.github/workflows/schema-pg-sql-fresh.yml
@@ -62,6 +62,19 @@ jobs:
           # didn't implement it).
           ref: ${{ github.head_ref || github.ref_name || 'main' }}
 
+      - name: Checkout qontinui-schemas (sibling)
+        uses: actions/checkout@v4
+        with:
+          # qontinui-web/backend models import `qontinui_schemas` at
+          # module-load time (see app/models/execution_run.py:13:
+          # `from qontinui_schemas.common import utc_now`). Without
+          # this clone the alembic env.py crashes on import before
+          # the schema-diff step. We follow the same head-ref-or-main
+          # convention as the qontinui-web checkout above.
+          repository: qontinui/qontinui-schemas
+          path: qontinui-schemas
+          ref: ${{ github.head_ref || github.ref_name || 'main' }}
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -79,6 +92,12 @@ jobs:
           # import time. Without it, `alembic upgrade head` blows
           # up with `ImportError` before the schema-diff step.
           pip install alembic sqlalchemy psycopg2-binary pgvector python-dotenv
+          # `qontinui-schemas` is the path-dep declared in
+          # qontinui-web/backend/pyproject.toml as
+          # `qontinui-schemas = {path = "../../qontinui-schemas"}`.
+          # Backend models import it at module-load time, so the
+          # alembic env.py needs it on sys.path.
+          pip install ../../qontinui-schemas
 
       - name: Apply alembic chain
         working-directory: qontinui-web/backend


### PR DESCRIPTION
## Summary

Third infra fix in the `schema-pg-sql-fresh.yml` chain after PR #44 (pgvector + sibling-checkout main fallback). With #44 in `main`, the first real `workflow_dispatch` run reached the next failure anticipated in the [gate-promotion plan](https://github.com/qontinui/qontinui-dev-notes) (failure mode #2 — new backend dep imported by alembic models):

```
File ".../qontinui-web/backend/app/models/execution_run.py", line 13
  from qontinui_schemas.common import utc_now
ModuleNotFoundError: No module named 'qontinui_schemas'
```

`qontinui-web/backend/pyproject.toml` declares the dep as a local path:

```toml
qontinui-schemas = {path = "../../qontinui-schemas", develop = true}
```

We mirror what `qontinui-web`'s `backend-ci.yml` does: clone `qontinui/qontinui-schemas` next to `qontinui-web` and `pip install ../../qontinui-schemas` after the existing alembic deps. Same `head_ref || ref_name || 'main'` fallback as the sibling-checkout from #44.

## Why this targeted fix (not `pip install -e .` from backend)

The plan explicitly puts the broader `pip install -e .` refactor out of scope (separate, larger change with its own risks). Adding the missing dep is the minimal, in-scope fix. Verified the targeted approach is sufficient by grepping `qontinui-web/backend/app/` — zero hits for `from qontinui ` (core lib) or `import qontinui`. Only `qontinui_schemas` is needed for the alembic env.py to load.

## Verifying run

Failure run that motivated this fix: https://github.com/qontinui/qontinui-runner/actions/runs/25416300511 (workflow_dispatch on main, post-#44).

After merge, `workflow_dispatch` on main should reach the schema-diff step. Tracked in `_dev-notes-main/qontinui-runner-schema-pg-sql-fresh-promote-to-gate/SESSION_PROMPT.md`.

## Test plan

- [x] Edit verified locally (no syntax errors in YAML)
- [ ] Merge → fire `gh workflow run schema-pg-sql-fresh.yml --ref main` → confirm schema-diff step actually runs (green or schema-drift red, but no `ModuleNotFoundError`)
- [ ] If schema-drift red, regenerate locally and follow up
- [ ] Once verified, gate-promotion PR lands