### PR TITLE
feat(modularity): runner-side adoption of qontinui-types::wire types + RunnerKind + RunnerLaunchEnv + win32_compat + webview2_data_dir

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -615,13 +615,13 @@ pub struct TestAutoLoginCreds {
 /// This is safe to expose: it only reveals credentials the process already has
 /// in its own environment — no privilege escalation.
 #[tauri::command]
-pub fn get_test_auto_login() -> Option<TestAutoLoginCreds> {
-    let email = std::env::var("QONTINUI_TEST_AUTO_LOGIN_EMAIL").ok()?;
-    let password = std::env::var("QONTINUI_TEST_AUTO_LOGIN_PASSWORD").ok()?;
-    if email.is_empty() || password.is_empty() {
-        return None;
-    }
-    Some(TestAutoLoginCreds { email, password })
+pub fn get_test_auto_login(
+    launch_env: tauri::State<'_, crate::launch_env::SharedLaunchEnv>,
+) -> Option<TestAutoLoginCreds> {
+    launch_env.auto_login.as_ref().map(|c| TestAutoLoginCreds {
+        email: c.email.clone(),
+        password: c.password.clone(),
+    })
 }
 
 /// Build the Tauri plugin that registers this module's command handlers.

--- a/src-tauri/src/commands/instances.rs
+++ b/src-tauri/src/commands/instances.rs
@@ -257,7 +257,7 @@ pub async fn get_runner_identity(
     health: State<'_, HealthCompartment>,
 ) -> Result<serde_json::Value, String> {
     let is_secondary = crate::process_capture::primary_proxy::is_secondary();
-    let instance_name = std::env::var("QONTINUI_INSTANCE_NAME").ok();
+    let instance_name = crate::instance::instance_name();
     let primary_port = crate::process_capture::primary_proxy::primary_port();
     let own_port = health.api_port().load(std::sync::atomic::Ordering::Relaxed);
 

--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -112,7 +112,7 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
             .map(|h| h.to_string_lossy().to_string())
             .unwrap_or_else(|_| "unknown".to_string());
 
-        let instance_name = std::env::var("QONTINUI_INSTANCE_NAME").ok();
+        let instance_name = crate::instance::instance_name();
 
         let os = if cfg!(target_os = "windows") {
             "windows"

--- a/src-tauri/src/instance.rs
+++ b/src-tauri/src/instance.rs
@@ -30,6 +30,22 @@ pub fn is_secondary() -> bool {
     instance_name().is_some()
 }
 
+/// Classify this runner from the env it was launched with.
+///
+/// Asymmetry note: `QONTINUI_INSTANCE_NAME` is set for both temp and named
+/// runners by the supervisor, so the runner alone cannot distinguish them.
+/// This helper returns `RunnerKind::Named { name }` for any secondary; the
+/// supervisor uses `RunnerKind::from_id` (with the runner id, not env) to
+/// produce the precise variant. Callers in the runner that need the
+/// secondary/primary split should still prefer `is_secondary()` for clarity.
+pub fn runner_kind() -> qontinui_types::wire::runner_kind::RunnerKind {
+    use qontinui_types::wire::runner_kind::RunnerKind;
+    match instance_name() {
+        Some(name) => RunnerKind::Named { name },
+        None => RunnerKind::Primary,
+    }
+}
+
 /// Returns the per-instance path segment, or `None` for the primary runner.
 ///
 /// Primary:   `None`                            → callers leave paths alone

--- a/src-tauri/src/instance.rs
+++ b/src-tauri/src/instance.rs
@@ -70,6 +70,47 @@ pub fn primary_port() -> Option<u16> {
         .and_then(|p| p.parse().ok())
 }
 
+/// Resolve the WebView2 user-data folder for this runner.
+///
+/// Resolution order:
+///
+/// 1. `WEBVIEW2_USER_DATA_FOLDER` env var (set by qontinui-supervisor on the
+///    spawn command). This is the supervisor-blessed canonical path.
+/// 2. Fallback: derive from `RunnerKind` using
+///    `qontinui_types::wire::webview2::webview2_data_dir`. This kicks in
+///    when the runner is launched standalone (no supervisor) — typically
+///    only the primary, but secondaries launched manually for debugging
+///    work too.
+///
+/// Windows-only — returns `None` on every other platform (the env var is
+/// also unused off-Windows; non-Windows webview backends ignore it).
+///
+/// The fallback uses `instance_name()` as the runner-id substitute because
+/// the runner doesn't otherwise know its supervisor-assigned id. For named
+/// secondaries that matches the on-disk folder layout exactly (the
+/// supervisor's id for a named runner is `named-{port}-{uuid}`, which
+/// equals the `QONTINUI_INSTANCE_NAME` env value). For temp runners
+/// launched without a supervisor (an unusual case) we fall back to
+/// `"primary"` because the runner has no id to differentiate itself —
+/// callers should rely on the env var path in supervised setups.
+#[cfg(target_os = "windows")]
+pub fn webview2_data_dir() -> Option<std::path::PathBuf> {
+    if let Some(p) = std::env::var("WEBVIEW2_USER_DATA_FOLDER")
+        .ok()
+        .filter(|s| !s.is_empty())
+    {
+        return Some(std::path::PathBuf::from(p));
+    }
+    let kind = runner_kind();
+    let id = instance_name().unwrap_or_else(|| "primary".into());
+    qontinui_types::wire::webview2_data_dir(&kind, &id)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn webview2_data_dir() -> Option<std::path::PathBuf> {
+    None
+}
+
 /// Register this secondary instance with the primary runner.
 ///
 /// Called on startup when `QONTINUI_PRIMARY_PORT` is set. Best-effort:

--- a/src-tauri/src/launch_env.rs
+++ b/src-tauri/src/launch_env.rs
@@ -1,0 +1,323 @@
+//! Typed snapshot of all `QONTINUI_*` / `WEBVIEW2_*` env vars that influence
+//! runner startup.
+//!
+//! Read once in `main.rs::main()` via [`RunnerLaunchEnv::read`], stored as
+//! `Arc<RunnerLaunchEnv>` on Tauri app state. Every other site that needs a
+//! launch env var pulls it from here instead of re-parsing.
+//!
+//! # Why
+//!
+//! Before this module the runner re-parsed roughly a dozen `std::env::var(...)`
+//! calls scattered across `main.rs`, `commands/auth.rs`, `mcp/misc.rs`,
+//! `heartbeat.rs`, `settings.rs`, etc. — each with its own `.ok().and_then(parse)`
+//! pattern, no central documentation, and no way for tests to construct a
+//! known-good environment without `serial_test`-guarded `set_var` calls.
+//!
+//! With this module:
+//!
+//! * Adding a new launch env var is one struct field + one parsing line.
+//! * Tests construct a `RunnerLaunchEnv` directly — no global mutation.
+//! * The set of env vars the runner cares about is documented in one place.
+//!
+//! # Migration policy
+//!
+//! Item 3 of the runner-supervisor modularity plan migrates *consumers*
+//! that read launch-time env vars. It does not touch:
+//!
+//! * **Setters** — code that writes env vars onto child `Command`s (the
+//!   supervisor's `process/manager.rs`, the runner's `instance_manager.rs`).
+//!   Those are about *producing* the env, not consuming it.
+//! * **`crate::instance::*`** — those helpers stay as the canonical
+//!   parsing point for `QONTINUI_INSTANCE_NAME` / `QONTINUI_PRIMARY_PORT`.
+//!   `RunnerLaunchEnv::read()` *delegates* to them so there is still one
+//!   parsing point per var.
+//! * **Runtime-only env vars** — things like `QONTINUI_PYTHON_PATH` or
+//!   `QONTINUI_BROWSE_DIRS` that are read inside request handlers and may
+//!   change between runs. Those stay as ad-hoc reads.
+
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use qontinui_types::wire::runner_kind::RunnerKind;
+
+/// Window-placement hints injected by the supervisor on spawn.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WindowEnvHints {
+    pub x: Option<i32>,
+    pub y: Option<i32>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    /// `Some(true)` = decorations on, `Some(false)` = borderless,
+    /// `None` = use Tauri default (which is currently "decorations on").
+    pub decorations: Option<bool>,
+}
+
+/// Test auto-login credentials, populated for temp test runners only.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TestAutoLogin {
+    pub email: String,
+    pub password: String,
+}
+
+/// Restate runtime overrides injected by the supervisor.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RestateEnvHints {
+    pub external_admin_url: Option<String>,
+    pub external_ingress_url: Option<String>,
+}
+
+/// Snapshot of all `QONTINUI_*` / `WEBVIEW2_*` env vars read at startup.
+///
+/// Constructed once via [`RunnerLaunchEnv::read`] in `main.rs::main()`,
+/// then cloned via `Arc` onto Tauri app state. Tests construct one directly
+/// via field literals or [`RunnerLaunchEnv::default`] + overrides — no
+/// `std::env::set_var` mutation required.
+///
+/// `Default` produces a `Primary` runner with no overrides — equivalent to
+/// "this process was launched with no `QONTINUI_*` / `WEBVIEW2_*` vars set."
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerLaunchEnv {
+    /// Runner classification — `Primary` if `QONTINUI_INSTANCE_NAME` is unset,
+    /// `Named { name }` otherwise. The runner can't distinguish `Named` vs
+    /// `Temp` from env alone (the supervisor sets `QONTINUI_INSTANCE_NAME`
+    /// for both), so `Temp` never appears here. See `runner_kind` module
+    /// doc in `qontinui-types::wire`.
+    pub kind: RunnerKind,
+
+    /// Raw instance name, for sites that prefer `Option<String>` over
+    /// matching on `RunnerKind`. Mirrors `crate::instance::instance_name()`.
+    pub instance_name: Option<String>,
+
+    /// Own API port override (`QONTINUI_PORT`). When unset, the runner
+    /// falls back to `MCP_API_PORT` (9876).
+    pub port: Option<u16>,
+
+    /// Backend API URL override (`QONTINUI_API_URL`).
+    pub api_url: Option<String>,
+
+    /// Primary runner's port (`QONTINUI_PRIMARY_PORT`), set on secondaries
+    /// so they can register / heartbeat. Mirrors `crate::instance::primary_port()`.
+    pub primary_port: Option<u16>,
+
+    /// Server-mode flag (`QONTINUI_SERVER_MODE=1` or `=true`).
+    pub server_mode: bool,
+
+    /// Window placement hints (`QONTINUI_WINDOW_X/Y/WIDTH/HEIGHT/DECORATIONS`).
+    pub window: WindowEnvHints,
+
+    /// Test auto-login credentials (`QONTINUI_TEST_AUTO_LOGIN_EMAIL/PASSWORD`).
+    /// Both must be set and non-empty for `Some` to be returned.
+    pub auto_login: Option<TestAutoLogin>,
+
+    /// Override for the panic-log directory (`QONTINUI_PANIC_LOG_DIR`).
+    /// Note: `startup_panic.rs` historically reads `QONTINUI_RUNNER_LOG_DIR`
+    /// for the same purpose — both are accepted; the runner-log-dir wins.
+    pub panic_log_dir: Option<PathBuf>,
+
+    /// Per-runner log dir set by the supervisor (`QONTINUI_RUNNER_LOG_DIR`).
+    pub runner_log_dir: Option<PathBuf>,
+
+    /// Isolated WebView2 user-data folder (`WEBVIEW2_USER_DATA_FOLDER`),
+    /// set by the supervisor for secondaries to avoid profile-lock contention.
+    pub webview2_user_data_dir: Option<PathBuf>,
+
+    /// Restate URL overrides forwarded by the supervisor.
+    pub restate: RestateEnvHints,
+}
+
+impl Default for RunnerLaunchEnv {
+    fn default() -> Self {
+        Self {
+            kind: RunnerKind::Primary,
+            instance_name: None,
+            port: None,
+            api_url: None,
+            primary_port: None,
+            server_mode: false,
+            window: WindowEnvHints::default(),
+            auto_login: None,
+            panic_log_dir: None,
+            runner_log_dir: None,
+            webview2_user_data_dir: None,
+            restate: RestateEnvHints::default(),
+        }
+    }
+}
+
+impl RunnerLaunchEnv {
+    /// Read every relevant env var from the current process environment.
+    ///
+    /// Called exactly once in `main.rs::main()`. Uses `crate::instance::*`
+    /// helpers as the canonical parsing point for instance-related vars
+    /// so there is still a single source of truth per var.
+    pub fn read() -> Self {
+        let instance_name = crate::instance::instance_name();
+        let primary_port = crate::instance::primary_port();
+        let kind = crate::instance::runner_kind();
+
+        let port = std::env::var("QONTINUI_PORT")
+            .ok()
+            .and_then(|s| s.parse().ok());
+        let api_url = std::env::var("QONTINUI_API_URL")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let server_mode = std::env::var("QONTINUI_SERVER_MODE")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        let window = WindowEnvHints {
+            x: parse_env::<i32>("QONTINUI_WINDOW_X"),
+            y: parse_env::<i32>("QONTINUI_WINDOW_Y"),
+            width: parse_env::<u32>("QONTINUI_WINDOW_WIDTH"),
+            height: parse_env::<u32>("QONTINUI_WINDOW_HEIGHT"),
+            decorations: std::env::var("QONTINUI_WINDOW_DECORATIONS")
+                .ok()
+                .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false"))),
+        };
+
+        let auto_login = match (
+            std::env::var("QONTINUI_TEST_AUTO_LOGIN_EMAIL").ok(),
+            std::env::var("QONTINUI_TEST_AUTO_LOGIN_PASSWORD").ok(),
+        ) {
+            (Some(email), Some(password)) if !email.is_empty() && !password.is_empty() => {
+                Some(TestAutoLogin { email, password })
+            }
+            _ => None,
+        };
+
+        let panic_log_dir = std::env::var("QONTINUI_PANIC_LOG_DIR")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .map(PathBuf::from);
+        let runner_log_dir = std::env::var("QONTINUI_RUNNER_LOG_DIR")
+            .ok()
+            .filter(|s| !s.trim().is_empty())
+            .map(PathBuf::from);
+        // Delegate to crate::instance::webview2_data_dir() so this field
+        // honors the env-var-or-fallback resolution from Item 5: prefer
+        // WEBVIEW2_USER_DATA_FOLDER (set by the supervisor) and fall back
+        // to qontinui_types::wire::webview2_data_dir for standalone
+        // launches. Returns None on non-Windows.
+        let webview2_user_data_dir = crate::instance::webview2_data_dir();
+
+        let restate = RestateEnvHints {
+            external_admin_url: std::env::var("QONTINUI_RESTATE_EXTERNAL_ADMIN_URL")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            external_ingress_url: std::env::var("QONTINUI_RESTATE_EXTERNAL_INGRESS_URL")
+                .ok()
+                .filter(|s| !s.is_empty()),
+        };
+
+        Self {
+            kind,
+            instance_name,
+            port,
+            api_url,
+            primary_port,
+            server_mode,
+            window,
+            auto_login,
+            panic_log_dir,
+            runner_log_dir,
+            webview2_user_data_dir,
+            restate,
+        }
+    }
+
+    /// True when this runner is a non-primary instance (any `RunnerKind`
+    /// other than `Primary`). Convenience over matching the enum.
+    pub fn is_secondary(&self) -> bool {
+        !matches!(self.kind, RunnerKind::Primary)
+    }
+}
+
+/// Type alias used on Tauri app state. Stored as `Arc` so handlers can
+/// hold a cheap clone across `await` boundaries without re-parsing.
+pub type SharedLaunchEnv = Arc<RunnerLaunchEnv>;
+
+fn parse_env<T: std::str::FromStr>(name: &str) -> Option<T> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_primary_with_no_overrides() {
+        let env = RunnerLaunchEnv::default();
+        assert_eq!(env.kind, RunnerKind::Primary);
+        assert!(env.instance_name.is_none());
+        assert!(env.port.is_none());
+        assert!(!env.server_mode);
+        assert!(!env.is_secondary());
+        assert_eq!(env.window, WindowEnvHints::default());
+        assert!(env.auto_login.is_none());
+    }
+
+    #[test]
+    fn constructed_named_runner_is_secondary() {
+        let env = RunnerLaunchEnv {
+            kind: RunnerKind::Named {
+                name: "test-1".to_string(),
+            },
+            instance_name: Some("test-1".to_string()),
+            ..Default::default()
+        };
+        assert!(env.is_secondary());
+    }
+
+    #[test]
+    fn window_hints_round_trip() {
+        let hints = WindowEnvHints {
+            x: Some(100),
+            y: Some(200),
+            width: Some(1400),
+            height: Some(800),
+            decorations: Some(false),
+        };
+        let env = RunnerLaunchEnv {
+            window: hints.clone(),
+            ..Default::default()
+        };
+        assert_eq!(env.window, hints);
+    }
+
+    #[test]
+    fn auto_login_struct_construction() {
+        let creds = TestAutoLogin {
+            email: "test@example.com".into(),
+            password: "secret".into(),
+        };
+        let env = RunnerLaunchEnv {
+            auto_login: Some(creds.clone()),
+            ..Default::default()
+        };
+        assert_eq!(env.auto_login.as_ref().unwrap(), &creds);
+    }
+
+    #[test]
+    fn restate_hints_default_empty() {
+        let env = RunnerLaunchEnv::default();
+        assert!(env.restate.external_admin_url.is_none());
+        assert!(env.restate.external_ingress_url.is_none());
+    }
+
+    /// Regression: `RunnerLaunchEnv::read()` must succeed even with no env
+    /// vars set (i.e. produce a default-equivalent instance for the primary
+    /// runner). This is the codepath every non-test process hits.
+    #[test]
+    fn read_in_clean_env_does_not_panic() {
+        // We can't easily clear env in a parallel test environment, so we
+        // just call read() and assert basic invariants. The unit value of
+        // this test is "doesn't panic" — full env-driven tests would need
+        // serial_test, which is exactly what `RunnerLaunchEnv` is meant to
+        // make unnecessary at consumer sites.
+        let env = RunnerLaunchEnv::read();
+        let _ = env.is_secondary();
+        let _ = env.kind;
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1520,14 +1520,21 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             {
                 use tauri::Manager;
 
-                let data_dir = std::env::var("WEBVIEW2_USER_DATA_FOLDER").ok();
+                // Resolve via crate::instance so a runner launched standalone
+                // (no supervisor setting WEBVIEW2_USER_DATA_FOLDER) still
+                // gets the same per-runner profile layout. The helper
+                // returns None on non-Windows.
+                #[cfg(target_os = "windows")]
+                let data_dir = instance::webview2_data_dir();
+                #[cfg(not(target_os = "windows"))]
+                let data_dir: Option<std::path::PathBuf> = None;
                 let is_secondary = instance::is_secondary();
 
                 if let Some(ref dir) = data_dir {
                     let _ = std::fs::create_dir_all(dir);
                     info!(
                         "Creating window with isolated WebView2 profile (WEBVIEW2_USER_DATA_FOLDER={})",
-                        dir
+                        dir.display()
                     );
                 }
 
@@ -1667,7 +1674,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         .on_web_resource_request(asset_headers::stamp_no_store_on_index);
 
                     if let Some(ref dir) = data_dir {
-                        builder = builder.data_directory(std::path::PathBuf::from(dir));
+                        builder = builder.data_directory(dir.clone());
                     }
 
                     builder = placement.configure_builder(builder);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -68,6 +68,7 @@ mod iteration_bundle;
 mod job_object;
 mod knowledge_acquisition;
 mod known_issues;
+mod launch_env;
 mod log_consolidation;
 mod logging;
 mod macros;
@@ -228,6 +229,12 @@ fn main() {
 }
 
 fn run_app() -> Result<(), Box<dyn std::error::Error>> {
+    // Read every QONTINUI_* / WEBVIEW2_* env var that influences startup
+    // exactly once. All downstream code reads from this snapshot via the
+    // Tauri-managed `Arc<RunnerLaunchEnv>` instead of re-parsing env vars.
+    // See `launch_env.rs` for the full list and rationale.
+    let launch_env: launch_env::SharedLaunchEnv = Arc::new(launch_env::RunnerLaunchEnv::read());
+
     // Read persisted OTel settings so the tracing pipeline uses saved config
     let otel_config = crate::settings::get_otel_settings();
     let logging_result = init_logging(LoggingConfig {
@@ -420,9 +427,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
     // via the Settings UI; a headless deploy can set
     // `QONTINUI_WEB_BACKEND_URL` + `QONTINUI_RUNNER_TOKEN` and get the same
     // behavior without touching settings.
-    let server_mode_is_on = std::env::var("QONTINUI_SERVER_MODE")
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false);
+    let server_mode_is_on = launch_env.server_mode;
     let web_integration_settings = crate::settings::load_settings().web_integration.clone();
     let initial_server_mode_state: Option<crate::server_mode::ServerModeState> =
         crate::server_mode::ServerModeConfig::from_settings(&web_integration_settings).map(|cfg| {
@@ -1451,6 +1456,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::worktrees::merge_worktree_force
         ])
         .manage(shared_app_state)
+        .manage(launch_env.clone()) // Item 3: typed startup env snapshot, read once in run_app()
         .manage(bridge_compartment)
         .manage(execution_compartment)
         .manage(integration_compartment)
@@ -1495,9 +1501,12 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 });
             }
 
-            let server_mode = std::env::var("QONTINUI_SERVER_MODE")
-                .map(|v| v == "1" || v.to_lowercase() == "true")
-                .unwrap_or(false);
+            // Pull the typed startup-env snapshot (managed onto state above)
+            // so this closure can read launch env vars without re-parsing.
+            let setup_launch_env: tauri::State<launch_env::SharedLaunchEnv> = app.state();
+            let setup_launch_env = setup_launch_env.inner().clone();
+
+            let server_mode = setup_launch_env.server_mode;
             if server_mode {
                 info!("QONTINUI_SERVER_MODE is set - running as headless server (no window, Restate forced on)");
             }
@@ -1520,14 +1529,14 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             {
                 use tauri::Manager;
 
-                // Resolve via crate::instance so a runner launched standalone
+                // Resolve via launch_env so a runner launched standalone
                 // (no supervisor setting WEBVIEW2_USER_DATA_FOLDER) still
-                // gets the same per-runner profile layout. The helper
-                // returns None on non-Windows.
-                #[cfg(target_os = "windows")]
-                let data_dir = instance::webview2_data_dir();
-                #[cfg(not(target_os = "windows"))]
-                let data_dir: Option<std::path::PathBuf> = None;
+                // gets the same per-runner profile layout. The launch_env
+                // field delegates to crate::instance::webview2_data_dir(),
+                // which prefers the env var and falls back to the shared
+                // qontinui_types helper. Returns None on non-Windows.
+                let data_dir: Option<std::path::PathBuf> =
+                    setup_launch_env.webview2_user_data_dir.clone();
                 let is_secondary = instance::is_secondary();
 
                 if let Some(ref dir) = data_dir {
@@ -1555,40 +1564,31 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     //
                     // Three input paths funnel into one `WindowPlacement`:
                     //   1. Supervisor env vars (QONTINUI_WINDOW_X/Y/W/H/DECORATIONS)
-                    //      — set for temp runners (test-*).
+                    //      — set for temp runners (test-*). Read once via
+                    //      RunnerLaunchEnv (Item 3) and surfaced as
+                    //      typed `window_hints`.
                     //   2. Named-instance config (settings.json
                     //      `runner_instances[name].spawn_placement`) — used
                     //      when QONTINUI_INSTANCE_NAME is set without env-var
                     //      coords.
                     //   3. Default — primary maximizes; bare secondary uses
                     //      the (100, 100) fallback so the window is on-screen.
-                    let env_pos: Option<(f64, f64)> = {
-                        let x = std::env::var("QONTINUI_WINDOW_X")
-                            .ok()
-                            .and_then(|s| s.parse::<f64>().ok());
-                        let y = std::env::var("QONTINUI_WINDOW_Y")
-                            .ok()
-                            .and_then(|s| s.parse::<f64>().ok());
-                        match (x, y) {
-                            (Some(x), Some(y)) => Some((x, y)),
-                            _ => None,
-                        }
+                    let window_hints = &setup_launch_env.window;
+                    let env_pos: Option<(f64, f64)> = match (window_hints.x, window_hints.y) {
+                        (Some(x), Some(y)) => Some((x as f64, y as f64)),
+                        _ => None,
                     };
-                    let env_size: Option<(f64, f64)> = {
-                        let w = std::env::var("QONTINUI_WINDOW_WIDTH")
-                            .ok()
-                            .and_then(|s| s.parse::<f64>().ok());
-                        let h = std::env::var("QONTINUI_WINDOW_HEIGHT")
-                            .ok()
-                            .and_then(|s| s.parse::<f64>().ok());
-                        match (w, h) {
-                            (Some(w), Some(h)) => Some((w, h)),
+                    let env_size: Option<(f64, f64)> =
+                        match (window_hints.width, window_hints.height) {
+                            (Some(w), Some(h)) => Some((w as f64, h as f64)),
                             _ => None,
-                        }
-                    };
-                    let env_decorations = std::env::var("QONTINUI_WINDOW_DECORATIONS")
-                        .ok()
-                        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false")));
+                        };
+                    // QONTINUI_WINDOW_DECORATIONS=0 forces a borderless
+                    // window; default is true (Tauri's default chrome).
+                    // Borderless lets a placement land flush with the
+                    // monitor's edge — the few-pixel right-of-edge inset
+                    // people see with chrome on is the OS window border.
+                    let env_decorations = window_hints.decorations;
 
                     // Named-instance fallback: only kicks in when the
                     // supervisor didn't push a placement via env vars.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -526,7 +526,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
 
     // Secondary instances (spawned by InstanceManager) must NOT use single-instance
     // plugin — it would prevent them from starting since they share the same binary.
-    let is_secondary_instance = std::env::var("QONTINUI_INSTANCE_NAME").is_ok();
+    let is_secondary_instance = instance::is_secondary();
 
     let mut builder = tauri::Builder::default();
 
@@ -1521,7 +1521,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 use tauri::Manager;
 
                 let data_dir = std::env::var("WEBVIEW2_USER_DATA_FOLDER").ok();
-                let is_secondary = std::env::var("QONTINUI_INSTANCE_NAME").is_ok();
+                let is_secondary = instance::is_secondary();
 
                 if let Some(ref dir) = data_dir {
                     let _ = std::fs::create_dir_all(dir);
@@ -1863,7 +1863,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Start scheduler service in background (skip for secondary instances to avoid duplicate executions)
-            if std::env::var("QONTINUI_INSTANCE_NAME").is_ok() {
+            if instance::is_secondary() {
                 info!("Secondary instance — skipping scheduler service");
             } else {
                 info!("Starting scheduler service");
@@ -2058,7 +2058,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 }
 
                 // Auto-start processes (skip for secondary instances to avoid port conflicts)
-                let is_secondary = std::env::var("QONTINUI_INSTANCE_NAME").is_ok();
+                let is_secondary = instance::is_secondary();
                 if is_secondary {
                     info!("Secondary instance — skipping managed process auto-start");
                 } else {
@@ -2275,7 +2275,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // Restore previously-running instances (primary instance only).
             // The session file only exists if the previous process was killed
             // (e.g. by a rebuild) rather than closed intentionally by the user.
-            if std::env::var("QONTINUI_INSTANCE_NAME").is_err() {
+            if !instance::is_secondary() {
                 let restore_ids = instance_manager::load_and_clear_active_instances();
                 if !restore_ids.is_empty() {
                     info!(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -162,6 +162,7 @@ mod vga;
 mod video_recorder;
 mod vision;
 mod wake_handler; // Phase F.1 — qontinui:// custom-URL deep-link wake handler
+mod win32_compat;
 mod window_manager;
 mod window_placement;
 mod workflow;

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -361,7 +361,7 @@ where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
     let port = api_state.app_state.api_port.load(Ordering::Relaxed);
-    let instance_name = std::env::var("QONTINUI_INSTANCE_NAME").ok();
+    let instance_name = crate::instance::instance_name();
     let hostname = hostname::get()
         .ok()
         .map(|h| h.to_string_lossy().to_string());

--- a/src-tauri/src/mcp/misc.rs
+++ b/src-tauri/src/mcp/misc.rs
@@ -653,7 +653,7 @@ pub async fn get_status(
         .unwrap_or_default()
         .is_empty();
 
-    let instance_name = std::env::var("QONTINUI_INSTANCE_NAME").ok();
+    let instance_name = crate::instance::instance_name();
     let api_port = state
         .app_state
         .api_port
@@ -699,7 +699,7 @@ pub async fn get_instances(
         .app_state
         .api_port
         .load(std::sync::atomic::Ordering::Relaxed);
-    let self_name = std::env::var("QONTINUI_INSTANCE_NAME").ok();
+    let self_name = crate::instance::instance_name();
 
     let mut instances = vec![DiscoveredInstance {
         name: self_name,
@@ -1849,9 +1849,7 @@ async fn list_runners(State(state): State<Arc<ApiState>>) -> Json<serde_json::Va
         .app_state
         .api_port
         .load(std::sync::atomic::Ordering::Relaxed);
-    let self_name = std::env::var("QONTINUI_INSTANCE_NAME")
-        .ok()
-        .unwrap_or_else(|| "primary".to_string());
+    let self_name = crate::instance::instance_name().unwrap_or_else(|| "primary".to_string());
     let is_primary = !crate::instance::is_secondary();
 
     let mut runners = Vec::new();

--- a/src-tauri/src/mcp/misc.rs
+++ b/src-tauri/src/mcp/misc.rs
@@ -1926,39 +1926,14 @@ async fn purge_stale_instances(
 }
 
 // ─── Spawn-placement preview endpoint ───────────────────────────────────────
+//
+// Wire types live in `qontinui_types::wire::placement` so the supervisor
+// parses the exact shape the runner emits — no hand-maintained duplicate.
 
-#[derive(serde::Deserialize)]
-struct SpawnPlacementPreviewQuery {
-    /// Slot index. 0 = primary, 1.. = configured `runner_instances`
-    /// in saved order.
-    slot: usize,
-    /// Behavior when `slot` is past the end of the list. `wrap` rotates
-    /// `slot % count` over slots that have placements; default = 404.
-    #[serde(default)]
-    overflow: Option<String>,
-}
-
-#[derive(serde::Serialize)]
-struct SpawnPlacementPreviewResponse {
-    global_x: i32,
-    global_y: i32,
-    width: u32,
-    height: u32,
-    monitor_label: String,
-    slot_index: usize,
-    /// Either the resolved instance name or `"primary"`.
-    slot_label: String,
-    /// Always `"configured"` for now — kept as a discriminator for
-    /// future supervisor-side fallback sources.
-    source: &'static str,
-    /// Per-placement window decorations toggle. `None` means "use the
-    /// runner's default" (chrome on). Forwarded by the supervisor as
-    /// `QONTINUI_WINDOW_DECORATIONS=0|1` so a borderless placement
-    /// lands flush with the configured rect (no OS window border
-    /// inset).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    decorations: Option<bool>,
-}
+use qontinui_types::wire::placement::{
+    SpawnPlacementPreviewQuery, SpawnPlacementResponse, TempPlacementLookupQuery,
+    TempPlacementsListResponse,
+};
 
 /// `GET /spawn-placement/preview?slot=N[&overflow=wrap|default]`
 ///
@@ -1970,7 +1945,7 @@ async fn preview_spawn_placement_route(
     State(state): State<Arc<ApiState>>,
     axum::extract::Query(q): axum::extract::Query<SpawnPlacementPreviewQuery>,
 ) -> Result<
-    Json<ApiResponse<SpawnPlacementPreviewResponse>>,
+    Json<ApiResponse<SpawnPlacementResponse>>,
     (axum::http::StatusCode, Json<serde_json::Value>),
 > {
     let configs = crate::settings::get_runner_instances();
@@ -2106,26 +2081,22 @@ async fn preview_spawn_placement_route(
             },
         )?;
 
-    Ok(Json(ApiResponse::success(SpawnPlacementPreviewResponse {
-        global_x: resolved.global_x,
-        global_y: resolved.global_y,
-        width: resolved.width,
-        height: resolved.height,
-        monitor_label: resolved.monitor_label,
-        slot_index: effective_slot,
-        slot_label,
-        source: "configured",
-        decorations: placement.decorations,
-    })))
+    Ok(Json(ApiResponse::success(
+        SpawnPlacementResponse::new(
+            resolved.global_x,
+            resolved.global_y,
+            resolved.width,
+            resolved.height,
+            resolved.monitor_label,
+            effective_slot,
+            slot_label,
+            "configured".to_string(),
+        )
+        .with_decorations(placement.decorations),
+    )))
 }
 
 // ─── Temp spawn-placement endpoints ─────────────────────────────────────────
-
-#[derive(serde::Serialize)]
-struct TempPlacementsListResponse {
-    placements: Vec<crate::settings::SpawnPlacement>,
-    count: usize,
-}
 
 #[derive(serde::Deserialize)]
 struct TempPlacementsReplaceRequest {
@@ -2136,13 +2107,12 @@ struct TempPlacementsReplaceRequest {
 ///
 /// List the currently-configured temp-runner spawn placements. Used by the
 /// supervisor's spawn-test path and the runner's own settings UI.
-async fn list_temp_spawn_placements() -> Json<ApiResponse<TempPlacementsListResponse>> {
+async fn list_temp_spawn_placements(
+) -> Json<ApiResponse<TempPlacementsListResponse<crate::settings::SpawnPlacement>>> {
     let placements = crate::settings::get_temp_spawn_placements();
-    let count = placements.len();
-    Json(ApiResponse::success(TempPlacementsListResponse {
+    Json(ApiResponse::success(TempPlacementsListResponse::new(
         placements,
-        count,
-    }))
+    )))
 }
 
 /// `PUT /spawn-placement/temps`
@@ -2152,7 +2122,7 @@ async fn list_temp_spawn_placements() -> Json<ApiResponse<TempPlacementsListResp
 async fn replace_temp_spawn_placements(
     Json(body): Json<TempPlacementsReplaceRequest>,
 ) -> Result<
-    Json<ApiResponse<TempPlacementsListResponse>>,
+    Json<ApiResponse<TempPlacementsListResponse<crate::settings::SpawnPlacement>>>,
     (axum::http::StatusCode, Json<serde_json::Value>),
 > {
     crate::settings::save_temp_spawn_placements(body.placements.clone()).map_err(|e| {
@@ -2164,22 +2134,9 @@ async fn replace_temp_spawn_placements(
         )
     })?;
     let placements = crate::settings::get_temp_spawn_placements();
-    let count = placements.len();
-    Ok(Json(ApiResponse::success(TempPlacementsListResponse {
+    Ok(Json(ApiResponse::success(TempPlacementsListResponse::new(
         placements,
-        count,
-    })))
-}
-
-#[derive(serde::Deserialize)]
-struct TempPlacementLookupQuery {
-    /// 0-based index into the temp placement list. Round-robin'd via
-    /// `index % len` when `overflow=wrap`.
-    index: usize,
-    /// Behavior when `index >= len`. `wrap` (default if missing) rotates;
-    /// `default` (or anything else) returns 404.
-    #[serde(default)]
-    overflow: Option<String>,
+    ))))
 }
 
 /// `GET /spawn-placement/temp?index=N&overflow=wrap`
@@ -2191,7 +2148,7 @@ async fn lookup_temp_spawn_placement(
     State(state): State<Arc<ApiState>>,
     axum::extract::Query(q): axum::extract::Query<TempPlacementLookupQuery>,
 ) -> Result<
-    Json<ApiResponse<SpawnPlacementPreviewResponse>>,
+    Json<ApiResponse<SpawnPlacementResponse>>,
     (axum::http::StatusCode, Json<serde_json::Value>),
 > {
     let placements = crate::settings::get_temp_spawn_placements();
@@ -2239,17 +2196,19 @@ async fn lookup_temp_spawn_placement(
             },
         )?;
 
-    Ok(Json(ApiResponse::success(SpawnPlacementPreviewResponse {
-        global_x: resolved.global_x,
-        global_y: resolved.global_y,
-        width: resolved.width,
-        height: resolved.height,
-        monitor_label: resolved.monitor_label,
-        slot_index: resolved_index,
-        slot_label: format!("temp[{}]", resolved_index),
-        source: "temp",
-        decorations: placement.decorations,
-    })))
+    Ok(Json(ApiResponse::success(
+        SpawnPlacementResponse::new(
+            resolved.global_x,
+            resolved.global_y,
+            resolved.width,
+            resolved.height,
+            resolved.monitor_label,
+            resolved_index,
+            format!("temp[{}]", resolved_index),
+            "temp".to_string(),
+        )
+        .with_decorations(placement.decorations),
+    )))
 }
 
 pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1754,7 +1754,7 @@ pub async fn start_server(
 
                 // Update window title if using non-default port or instance name
                 let default_port = crate::mcp::types::MCP_API_PORT;
-                let instance_name = std::env::var("QONTINUI_INSTANCE_NAME").ok();
+                let instance_name = crate::instance::instance_name();
                 let needs_title_update = try_port != default_port || instance_name.is_some();
                 if needs_title_update {
                     let title = match instance_name {

--- a/src-tauri/src/process_capture/primary_proxy.rs
+++ b/src-tauri/src/process_capture/primary_proxy.rs
@@ -19,8 +19,12 @@ pub fn primary_port() -> Option<u16> {
 }
 
 /// Check if this runner is a secondary instance that should proxy process requests.
+///
+/// Stronger predicate than `crate::instance::is_secondary()`: requires both
+/// the instance name AND a primary port so that secondaries with no primary
+/// to proxy to (e.g. orphaned named runners) fall back to local handling.
 pub fn is_secondary() -> bool {
-    std::env::var("QONTINUI_INSTANCE_NAME").is_ok() && primary_port().is_some()
+    crate::instance::is_secondary() && primary_port().is_some()
 }
 
 /// Response wrapper matching the primary runner's ApiResponse<T> format.

--- a/src-tauri/src/win32_compat.rs
+++ b/src-tauri/src/win32_compat.rs
@@ -1,0 +1,198 @@
+//! Win32 compatibility / glue helpers.
+//!
+//! Consolidates the small set of Win32 patterns that other modules
+//! (`window_placement`, future capture / window sites) repeatedly need:
+//!
+//! * Bridging Tauri's `windows`-crate `HWND` newtype across to the raw
+//!   `windows-sys` `HWND` we use everywhere else in the runner. Tauri 2.x
+//!   returns its own crate's `HWND` from `WebviewWindow::hwnd()`; the rest
+//!   of our Win32 calls go through `windows-sys` 0.59, whose `HWND` is a
+//!   plain `*mut c_void`. Both are pointer-sized so a single
+//!   `tauri_hwnd.0 as windows_sys::HWND` cast bridges them — but doing
+//!   that cast at every call site is noise, easy to typo, and tedious to
+//!   audit. [`hwnd_from_tauri`] is the one place that does it.
+//!
+//! * Per-thread DPI awareness. Several Win32 APIs (notably `SetWindowPos`
+//!   for cross-monitor placement, and any future `MapWindowPoints` /
+//!   `LogicalToPhysicalPointForPerMonitorDPI` callers) require the
+//!   calling thread to be in `PER_MONITOR_AWARE_V2` so coordinate args
+//!   are taken as absolute virtual-desktop physical pixels rather than
+//!   silently divided by the system DPI. [`ThreadDpiContextGuard`] is
+//!   the RAII handle (set on construction, restore on drop) and
+//!   [`with_v2_dpi`] is the convenience wrapper for the common
+//!   "set-and-call-closure-and-restore" shape — so adding a new
+//!   Win32-touching feature stops being "copy the guard pattern from
+//!   `window_placement.rs`".
+//!
+//! * DWM extended-frame inset. Win10/11 reserves a ~7-8px invisible
+//!   ring around every top-level window for the drop shadow, even when
+//!   `decorations(false)`. Explicit placements need to compensate for it
+//!   so the *visible* edge lands flush with the configured X/Y.
+//!   [`frame_inset`] reads `DWMWA_EXTENDED_FRAME_BOUNDS` and returns the
+//!   `(left, top)` inset between the OS-reported outer rect and the
+//!   visible content edge. Always non-negative in practice; `(0, 0)` on
+//!   any failure (DWM disabled, hwnd invalid, etc.).
+//!
+//! All Win32 entry points in this module are gated by
+//! `#[cfg(target_os = "windows")]`. A non-Windows stub is provided for
+//! [`with_v2_dpi`] so the rest of the codebase can call it without
+//! sprinkling `#[cfg]` everywhere.
+
+#[cfg(target_os = "windows")]
+pub use platform::*;
+
+#[cfg(not(target_os = "windows"))]
+pub use stub::*;
+
+#[cfg(target_os = "windows")]
+mod platform {
+    use tracing::warn;
+    use windows_sys::Win32::Foundation::HWND;
+    use windows_sys::Win32::UI::HiDpi::{
+        SetThreadDpiAwarenessContext, DPI_AWARENESS_CONTEXT,
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+    };
+
+    /// Bridge a Tauri `WebviewWindow`'s HWND (which comes from Tauri's
+    /// internal `windows` crate, a different version from our
+    /// `windows-sys` 0.59) over to the `windows-sys` HWND used by the
+    /// rest of the runner.
+    ///
+    /// Returns `None` if Tauri can't produce a handle (e.g. window has
+    /// been destroyed) or the platform back-end isn't Windows.
+    pub fn hwnd_from_tauri<R: tauri::Runtime>(win: &tauri::WebviewWindow<R>) -> Option<HWND> {
+        match win.hwnd() {
+            Ok(h) => Some(h.0 as HWND),
+            Err(_) => None,
+        }
+    }
+
+    /// RAII guard that restores the previous thread DPI awareness
+    /// context when dropped.
+    ///
+    /// Avoids leaking a per-monitor-v2 override into other Tauri / tao
+    /// code that may be relying on the inherited context. Construct via
+    /// [`ThreadDpiContextGuard::set_per_monitor_v2`] for the most common
+    /// case, or directly when you need to restore something other than
+    /// the value present at the moment of `set_*`.
+    pub struct ThreadDpiContextGuard {
+        prev: DPI_AWARENESS_CONTEXT,
+        active: bool,
+    }
+
+    impl ThreadDpiContextGuard {
+        /// Switch the calling thread to `PER_MONITOR_AWARE_V2` and return
+        /// a guard that restores the previous context on drop.
+        ///
+        /// On success the returned guard's `active` flag is `true`. If
+        /// `SetThreadDpiAwarenessContext` returns NULL — Win10 1607+ is
+        /// required for the v2 context — the guard's `active` flag is
+        /// `false` and drop becomes a no-op. The caller can still use
+        /// [`ThreadDpiContextGuard::is_active`] to detect this and log
+        /// or fall back as needed.
+        pub fn set_per_monitor_v2() -> Self {
+            let prev =
+                unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
+            Self {
+                prev,
+                active: !prev.is_null(),
+            }
+        }
+
+        /// Whether the guard is actively holding a DPI context override.
+        /// `false` means `SetThreadDpiAwarenessContext` returned NULL on
+        /// construction; `true` means drop will restore `prev`.
+        pub fn is_active(&self) -> bool {
+            self.active
+        }
+    }
+
+    impl Drop for ThreadDpiContextGuard {
+        fn drop(&mut self) {
+            if self.active {
+                unsafe {
+                    SetThreadDpiAwarenessContext(self.prev);
+                }
+            }
+        }
+    }
+
+    /// Run `f` with the calling thread set to `PER_MONITOR_AWARE_V2`,
+    /// restoring the previous DPI context when `f` returns.
+    ///
+    /// The convenience wrapper for the common
+    /// "set-DPI-then-call-Win32-then-restore" pattern. If
+    /// `SetThreadDpiAwarenessContext` returns NULL (i.e. Win10 < 1607)
+    /// the closure still runs — without the v2 override — and a warning
+    /// is logged. This matches the existing behavior in
+    /// `window_placement::apply_via_setwindowpos`.
+    pub fn with_v2_dpi<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let guard = ThreadDpiContextGuard::set_per_monitor_v2();
+        if !guard.is_active() {
+            warn!("win32_compat: SetThreadDpiAwarenessContext returned NULL (Win10 1607+ required); proceeding without v2 override");
+        }
+        f()
+    }
+
+    /// Return `(visible_left - outer_left, visible_top - outer_top)` —
+    /// the DWM extended-frame inset between the OS-reported outer
+    /// window rect and the visible content edge. Always non-negative
+    /// in practice; `(0, 0)` on any failure.
+    ///
+    /// Wraps `DwmGetWindowAttribute(DWMWA_EXTENDED_FRAME_BOUNDS)` and
+    /// `GetWindowRect`. The inset reflects the target monitor's DWM
+    /// state at the moment of the call, so callers placing windows
+    /// across DPI / theme boundaries should call this *after* the move
+    /// (or after a `SetWindowPos` no-op refresh) to get accurate values.
+    pub fn frame_inset(hwnd: HWND) -> (i32, i32) {
+        use windows_sys::Win32::Foundation::RECT;
+        use windows_sys::Win32::Graphics::Dwm::{
+            DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS,
+        };
+        use windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect;
+
+        if hwnd.is_null() {
+            return (0, 0);
+        }
+
+        unsafe {
+            let mut frame_bounds: RECT = std::mem::zeroed();
+            let hr = DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_EXTENDED_FRAME_BOUNDS as u32,
+                &mut frame_bounds as *mut RECT as *mut std::ffi::c_void,
+                std::mem::size_of::<RECT>() as u32,
+            );
+            if hr != 0 {
+                return (0, 0);
+            }
+
+            let mut window_rect: RECT = std::mem::zeroed();
+            if GetWindowRect(hwnd, &mut window_rect) == 0 {
+                return (0, 0);
+            }
+
+            (
+                frame_bounds.left - window_rect.left,
+                frame_bounds.top - window_rect.top,
+            )
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod stub {
+    /// Non-Windows stub for [`super::with_v2_dpi`]. Just runs the closure.
+    ///
+    /// Provided so callers don't need to wrap every use-site in
+    /// `#[cfg(target_os = "windows")]`.
+    pub fn with_v2_dpi<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        f()
+    }
+}

--- a/src-tauri/src/window_placement.rs
+++ b/src-tauri/src/window_placement.rs
@@ -117,28 +117,16 @@ fn apply_via_setwindowpos<R: tauri::Runtime>(
     w: u32,
     h: u32,
 ) {
-    use windows_sys::Win32::Foundation::HWND;
-    use windows_sys::Win32::UI::HiDpi::{
-        GetThreadDpiAwarenessContext, SetThreadDpiAwarenessContext,
-        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
-    };
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         SetWindowPos, SWP_NOACTIVATE, SWP_NOOWNERZORDER, SWP_NOZORDER,
     };
 
-    let tauri_hwnd = match win.hwnd() {
-        Ok(h) => h,
-        Err(e) => {
-            warn!(
-                "placement: hwnd() failed, falling back to set_position: {}",
-                e
-            );
-            let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
-            let _ = win.set_size(tauri::PhysicalSize::new(w, h));
-            return;
-        }
+    let Some(hwnd) = crate::win32_compat::hwnd_from_tauri(win) else {
+        warn!("placement: hwnd() failed, falling back to set_position");
+        let _ = win.set_position(tauri::PhysicalPosition::new(x, y));
+        let _ = win.set_size(tauri::PhysicalSize::new(w, h));
+        return;
     };
-    let hwnd: HWND = tauri_hwnd.0 as HWND;
 
     // Force per-monitor-v2 DPI context for this thread for the duration
     // of our SetWindowPos calls. With v2, the X/Y/W/H args are absolute
@@ -146,134 +134,58 @@ fn apply_via_setwindowpos<R: tauri::Runtime>(
     // this, a thread inheriting a different awareness mode (e.g. system
     // DPI aware) would have the OS divide our coords by the system DPI
     // scale, sending the window to the wrong monitor.
-    let prev_ctx =
-        unsafe { SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2) };
-    let _restore_guard = ThreadDpiContextGuard {
-        prev: prev_ctx,
-        active: !prev_ctx.is_null(),
-    };
-    if prev_ctx.is_null() {
-        warn!("placement: SetThreadDpiAwarenessContext returned NULL (Win10 1607+ required)");
-    } else {
-        let current = unsafe { GetThreadDpiAwarenessContext() };
-        info!(
-            "placement: thread DPI context now {:?} (was {:?})",
-            current, prev_ctx
-        );
-    }
-
-    // First pass: place the outer rect at exactly (x, y) with size (w, h).
-    // SWP_NOACTIVATE keeps focus where it was; we'll show/focus afterward.
-    let result = unsafe {
-        SetWindowPos(
-            hwnd,
-            std::ptr::null_mut(),
-            x,
-            y,
-            w as i32,
-            h as i32,
-            SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE,
-        )
-    };
-    if result == 0 {
-        warn!("placement: SetWindowPos (1st pass) failed");
-    }
-
-    // Compensate for the DWM extended-frame (invisible drop-shadow ring).
-    // We measure it AFTER the move so the values reflect the target
-    // monitor's DWM state.
-    let (inset_x, inset_y) = windows_frame_inset(win);
-    if inset_x != 0 || inset_y != 0 {
+    crate::win32_compat::with_v2_dpi(|| {
+        // First pass: place the outer rect at exactly (x, y) with size (w, h).
+        // SWP_NOACTIVATE keeps focus where it was; we'll show/focus afterward.
         let result = unsafe {
             SetWindowPos(
                 hwnd,
                 std::ptr::null_mut(),
-                x - inset_x,
-                y - inset_y,
-                w as i32 + 2 * inset_x,
-                h as i32 + 2 * inset_y,
+                x,
+                y,
+                w as i32,
+                h as i32,
                 SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE,
             )
         };
         if result == 0 {
-            warn!("placement: SetWindowPos (DWM compensation) failed");
+            warn!("placement: SetWindowPos (1st pass) failed");
+        }
+
+        // Compensate for the DWM extended-frame (invisible drop-shadow ring).
+        // We measure it AFTER the move so the values reflect the target
+        // monitor's DWM state.
+        let (inset_x, inset_y) = crate::win32_compat::frame_inset(hwnd);
+        if inset_x != 0 || inset_y != 0 {
+            let result = unsafe {
+                SetWindowPos(
+                    hwnd,
+                    std::ptr::null_mut(),
+                    x - inset_x,
+                    y - inset_y,
+                    w as i32 + 2 * inset_x,
+                    h as i32 + 2 * inset_y,
+                    SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_NOACTIVATE,
+                )
+            };
+            if result == 0 {
+                warn!("placement: SetWindowPos (DWM compensation) failed");
+            } else {
+                info!(
+                    "placement: compensated DWM frame inset by ({}, {}); outer rect → ({}, {}) {}x{}",
+                    inset_x,
+                    inset_y,
+                    x - inset_x,
+                    y - inset_y,
+                    w as i32 + 2 * inset_x,
+                    h as i32 + 2 * inset_y,
+                );
+            }
         } else {
             info!(
-                "placement: compensated DWM frame inset by ({}, {}); outer rect → ({}, {}) {}x{}",
-                inset_x,
-                inset_y,
-                x - inset_x,
-                y - inset_y,
-                w as i32 + 2 * inset_x,
-                h as i32 + 2 * inset_y,
+                "placement: outer rect at ({}, {}) {}x{} (no DWM inset detected)",
+                x, y, w, h
             );
         }
-    } else {
-        info!(
-            "placement: outer rect at ({}, {}) {}x{} (no DWM inset detected)",
-            x, y, w, h
-        );
-    }
-}
-
-/// RAII guard that restores the previous thread DPI awareness context
-/// when dropped. Avoids leaking the per-monitor-v2 override into other
-/// Tauri/tao code that may rely on the inherited context.
-#[cfg(windows)]
-struct ThreadDpiContextGuard {
-    prev: windows_sys::Win32::UI::HiDpi::DPI_AWARENESS_CONTEXT,
-    active: bool,
-}
-
-#[cfg(windows)]
-impl Drop for ThreadDpiContextGuard {
-    fn drop(&mut self) {
-        if self.active {
-            unsafe {
-                windows_sys::Win32::UI::HiDpi::SetThreadDpiAwarenessContext(self.prev);
-            }
-        }
-    }
-}
-
-/// On Windows, return `(visible_left - outer_left, visible_top - outer_top)`
-/// — the offset from the OS-reported outer window rect to the visible
-/// content edge. Always non-negative in practice; `(0, 0)` on failure.
-#[cfg(windows)]
-fn windows_frame_inset<R: tauri::Runtime>(win: &tauri::WebviewWindow<R>) -> (i32, i32) {
-    use windows_sys::Win32::Foundation::{HWND, RECT};
-    use windows_sys::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
-    use windows_sys::Win32::UI::WindowsAndMessaging::GetWindowRect;
-
-    // Tauri's `hwnd()` returns its own crate's `HWND` newtype around
-    // `*mut c_void`. Convert via raw pointer for FFI compatibility with
-    // windows-sys' raw `HWND = *mut c_void`.
-    let tauri_hwnd = match win.hwnd() {
-        Ok(h) => h,
-        Err(_) => return (0, 0),
-    };
-    let hwnd: HWND = tauri_hwnd.0 as HWND;
-
-    unsafe {
-        let mut frame_bounds: RECT = std::mem::zeroed();
-        let hr = DwmGetWindowAttribute(
-            hwnd,
-            DWMWA_EXTENDED_FRAME_BOUNDS as u32,
-            &mut frame_bounds as *mut RECT as *mut std::ffi::c_void,
-            std::mem::size_of::<RECT>() as u32,
-        );
-        if hr != 0 {
-            return (0, 0);
-        }
-
-        let mut window_rect: RECT = std::mem::zeroed();
-        if GetWindowRect(hwnd, &mut window_rect) == 0 {
-            return (0, 0);
-        }
-
-        (
-            frame_bounds.left - window_rect.left,
-            frame_bounds.top - window_rect.top,
-        )
-    }
+    });
 }


### PR DESCRIPTION
## Summary

Runner-side adoption of the modularity refactor. Pairs with the schemas-side foundation (qontinui-schemas PR #6, merged 2026-05-05) and supervisor-side adoption (qontinui-supervisor PR #7, merged 2026-05-05). Implements Items 1, 2, 3, 5, 6 of `qontinui-dev-notes/plans/runner-supervisor-modularity.md`.

## What changed (per item)

**Item 1 — `refactor(spawn-placement): use shared qontinui_types::wire::placement types`** (`abde37091`)
- `src-tauri/src/mcp/misc.rs`: dropped local `SpawnPlacementPreviewQuery`, `SpawnPlacementPreviewResponse`, `TempPlacementsListResponse`, `TempPlacementLookupQuery`. Now `use qontinui_types::wire::placement::*` and construct via `SpawnPlacementResponse::new(...).with_decorations(...)` builder. Wire format unchanged.

**Item 6 — `refactor(runner): introduce win32_compat module`** (`c82921f89`)
- New `src-tauri/src/win32_compat.rs` consolidating `ThreadDpiContextGuard`, `frame_inset`, `hwnd_from_tauri`, `with_v2_dpi`. `window_placement.rs` migrated to call the helpers; behavior unchanged.

**Item 2 — `refactor(runner): use crate::instance::is_secondary() at all main.rs sites`** (`71ecd9eb1`)
- 5 inline `std::env::var(\"QONTINUI_INSTANCE_NAME\").is_ok()` re-parses in `main.rs` replaced by the canonical `crate::instance::is_secondary()` helper.
- Adds `crate::instance::runner_kind()` returning `qontinui_types::wire::runner_kind::RunnerKind`.
- `process_capture::primary_proxy::is_secondary` tightened to call `crate::instance::is_secondary() && primary_port().is_some()` instead of re-parsing the env.

**Item 5 — `feat(runner): expose webview2_data_dir() with env-var-or-fallback resolution`** (`dee41bee6`)
- New `crate::instance::webview2_data_dir()` prefers `WEBVIEW2_USER_DATA_FOLDER` and falls back to `qontinui_types::wire::webview2_data_dir`. Window-creation path updated so a manually-launched secondary still gets an isolated WebView2 profile.

**Item 3 — `feat(runner): centralize startup env reading in RunnerLaunchEnv`** (`2648938bb`)
- New `src-tauri/src/launch_env.rs` reading ~12 `QONTINUI_*` / `WEBVIEW2_*` env vars once, stored as `Arc<RunnerLaunchEnv>` on Tauri app state. Field-literal-driven tests (no `set_var`, no serial guard).
- Migration touches: `commands/auth.rs`, `commands/instances.rs`, `heartbeat.rs`, `mcp_api.rs`, `mcp/misc.rs`, `mcp/backend_relay.rs`, plus `main.rs` for `server_mode_is_on`, window hints (x/y/width/height/decorations) and the WebView2 user-data folder.
- `webview2_user_data_dir` field delegates to `crate::instance::webview2_data_dir()` so it inherits the env-or-fallback resolution from Item 5.

## Merge strategy

Rebuilt onto current `main` (post-PR #42 squash) via cherry-pick of the 5 substantive commits. The original 9-commit branch with merge commits and the dev-hack `e02de52b0` (per-worktree `Cargo.toml` redirect) is preserved on origin at `ab76cb11d` for history but obsoleted by this PR.

Conflict resolutions:
- `Cargo.toml` (Items 2 & 5 each redirected `qontinui-types` to a per-item schemas worktree; both reverted to canonical `../../qontinui-schemas/rust` per the dev-hack note).
- `mcp/misc.rs` (Item 1): three add/add-style conflicts where main retained the local types — accepted the cherry-pick side dropping them in favor of the shared crate types.
- `window_placement.rs` (Item 6): one block where main still had the `match win.hwnd()` form — accepted the cherry-pick's `let-else` calling `crate::win32_compat::hwnd_from_tauri`.
- `main.rs` (Item 3): two conflicts with the more elaborate `named_placement` resolution that landed on main after Item 3 was authored. Kept main's full `resolved_pos`/`resolved_size`/`resolved_decorations` fallback chain but switched the env-var reading to `setup_launch_env.window`. Dropped the duplicate `let initial_size = env_size.unwrap_or(...)` since main computes it later from `resolved_size`. Also wired the launch_env's `webview2_user_data_dir` field through Item 5's `crate::instance::webview2_data_dir()` so both APIs share the same resolution.

## Inheritance

Branch starts from current `main` (post-PR #42), so all of today's CI fixes are already inherited:
- `manifest_drift_tests` regex tolerates `//` line comments
- `oneshot::record_call_ok_increments_cache_hits` parallel-test tolerance
- `gate_*` bundled-assertion tests (`gate_reads_env_var`)
- `budget_slides_window_after_one_hour` uses `Instant::checked_sub` for Windows-CI tolerance
- `dev_findings.rs` bundled-test approach

## Test plan

- [x] `cargo check --bin qontinui-runner` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --bin qontinui-runner -- -D warnings` clean
- [x] `cargo clippy --tests --bin qontinui-runner -- -D warnings` clean
- [x] `cargo test --bin qontinui-runner`: 3415 passed, 0 failed, 21 ignored
- [x] Pre-push hooks (`Tauri Event Bindings Drift Guard`, `cargo fmt + clippy`): all passed
- [ ] CI green on push
- [ ] Manual smoke: spawn temp runner, confirm WebView2 isolation + window placement