### PR TITLE
chore: migrate qontinui-types to registry dep (phase 9b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.1.2-rc.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "schemars 1.2.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -97,7 +97,7 @@ regex = "1.10"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
-qontinui-types = { path = "../../qontinui-schemas/rust" }
+qontinui-types = { path = "../../qontinui-schemas/rust", version = "^0.1.2" }
 socket2 = "0.6"
 cron = "0.15"
 chrono-tz = "0.10"


### PR DESCRIPTION
## Summary

Phase 9b of qontinui-dev-notes/rust-release-engineering. Adds a version field alongside the existing path-dep for `qontinui-types`, making the runner's manifest publishable-shape correct without changing local dev behavior.

```diff
-qontinui-types = { path = "../../qontinui-schemas/rust" }
+qontinui-types = { path = "../../qontinui-schemas/rust", version = "^0.1.2" }
```

`qontinui-types 0.1.2` is the GA on crates.io: https://crates.io/crates/qontinui-types/0.1.2

Caret range matches the supervisor-side migration shipped at https://github.com/qontinui/qontinui-supervisor/pull/14 (2026-05-07).

## Out of scope

Runner doesn't depend on `qontinui-runner-client` (supervisor-only per the modularity plan's per-item table) — no `runner-client` field added.

No code changes; no `qontinui_types::wire::*` API migration.

## Pre-flight verified locally

- [x] `cargo check` passes on `src-tauri/`
- [x] `Cargo.lock` updated transparently from `0.1.2-rc.1` (stale from before phase 10a's GA promotion) → `0.1.2` (path-dep resolves to current schemas tree)

## Heads-up

Per the rust-release-engineering plan, runner has the main-merge-gates ruleset requiring `schema-fresh` (path-filtered to `src-tauri/queries/**` or `schema.pg.sql.generated`). PR #51 yesterday hit this and needed `--admin` bypass. This PR's diff is just `Cargo.toml` + `Cargo.lock` — won't trigger the path filter — so expect the same blocker. The structural fix (no-op-fallback in the workflow) is queued separately.