### PR TITLE
feat(ui-bridge): Bucket C runner handlers + alias cleanup + auto-login retry fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.1.2-rc.1"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "schemars 1.2.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -97,7 +97,7 @@ regex = "1.10"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
-qontinui-types = { path = "../../qontinui-schemas/rust" }
+qontinui-types = { path = "../../qontinui-schemas/rust", version = "^0.1.2" }
 socket2 = "0.6"
 cron = "0.15"
 chrono-tz = "0.10"

--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -3594,7 +3594,9 @@ async fn handle_render_log(State(state): State<Arc<ApiState>>) -> Json<serde_jso
 }
 
 /// DELETE /ui-bridge/sdk/render-log — Clear render log
-async fn handle_clear_render_log(State(state): State<Arc<ApiState>>) -> Json<serde_json::Value> {
+pub(crate) async fn handle_clear_render_log(
+    State(state): State<Arc<ApiState>>,
+) -> Json<serde_json::Value> {
     match dispatch_app_request(
         &state,
         "clearRenderLog",
@@ -3611,7 +3613,9 @@ async fn handle_clear_render_log(State(state): State<Arc<ApiState>>) -> Json<ser
 }
 
 /// POST /ui-bridge/sdk/render-log/snapshot — Capture render log snapshot
-async fn handle_render_log_snapshot(State(state): State<Arc<ApiState>>) -> Json<serde_json::Value> {
+pub(crate) async fn handle_render_log_snapshot(
+    State(state): State<Arc<ApiState>>,
+) -> Json<serde_json::Value> {
     match dispatch_app_request(
         &state,
         "captureSnapshot",
@@ -3628,7 +3632,9 @@ async fn handle_render_log_snapshot(State(state): State<Arc<ApiState>>) -> Json<
 }
 
 /// GET /ui-bridge/sdk/render-log/path — Get render log path
-async fn handle_render_log_path(State(state): State<Arc<ApiState>>) -> Json<serde_json::Value> {
+pub(crate) async fn handle_render_log_path(
+    State(state): State<Arc<ApiState>>,
+) -> Json<serde_json::Value> {
     match sdk_request(&state, Method::GET, "/render-log/path", None).await {
         Ok(data) => Json(data),
         Err(e) => Json(serde_json::json!({ "success": false, "error": e })),

--- a/src-tauri/src/mcp/ui_bridge/ai.rs
+++ b/src-tauri/src/mcp/ui_bridge/ai.rs
@@ -738,6 +738,12 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/ai/assert-batch",
             post(ui_bridge_ai_assert_batch_handler),
         )
+        // SDK declares the slash-form /ai/assert/batch — same handler as the
+        // hyphen-form above, mounted as an alias for symmetry with the contract.
+        .route(
+            "/ui-bridge/ai/assert/batch",
+            post(ui_bridge_ai_assert_batch_handler),
+        )
         .route("/ui-bridge/ai/snapshot", get(ui_bridge_ai_snapshot_handler))
         .route("/ui-bridge/ai/summary", get(ui_bridge_ai_summary_handler))
         // Action plan execution & caching
@@ -764,6 +770,7 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/ai/execute"),
         ("POST", "/ui-bridge/ai/assert"),
         ("POST", "/ui-bridge/ai/assert-batch"),
+        ("POST", "/ui-bridge/ai/assert/batch"),
         ("GET", "/ui-bridge/ai/snapshot"),
         ("GET", "/ui-bridge/ai/summary"),
         ("POST", "/ui-bridge/control/action-plan"),

--- a/src-tauri/src/mcp/ui_bridge/capabilities.rs
+++ b/src-tauri/src/mcp/ui_bridge/capabilities.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, info};
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
 use super::helpers::compute_snapshot_diff;
+use super::ipc_handler_post;
 use super::request::{handle_ui_bridge_response, ui_bridge_request_sync};
 use super::types::{classify_transport_error, UiBridgeError};
 
@@ -886,6 +887,13 @@ pub async fn ui_bridge_pong_handler(
     )))
 }
 
+// SDK relay liveness ping. Distinct from `/ui-bridge/pong` (which is the
+// runner's response to its own ping). The relay-side SDK contract returns
+// `{ received: true }`; the React-side `receive_heartbeat` IPC handler is not
+// yet implemented — until then, callers will get the standard
+// "no IPC handler" error from `ui_bridge_request_sync`.
+ipc_handler_post!(ui_bridge_heartbeat_handler, "receive_heartbeat");
+
 /// Accept an IPC response via HTTP (fallback when Tauri event system is unavailable).
 pub async fn ui_bridge_ipc_response_handler(
     State(state): State<Arc<ApiState>>,
@@ -1245,7 +1253,10 @@ pub async fn ui_bridge_routes_manifest_handler(
 // ============================================================================
 
 pub fn routes() -> axum::Router<Arc<ApiState>> {
-    use axum::routing::{get, post};
+    use crate::mcp::sdk_client::{
+        handle_clear_render_log, handle_render_log_path, handle_render_log_snapshot,
+    };
+    use axum::routing::{delete, get, post};
     axum::Router::new()
         // Endpoint discovery. `_help` is a cross-platform alias that works on
         // both runner and mobile UI Bridge.
@@ -1326,8 +1337,17 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
         )
         .route(
             "/ui-bridge/render-log",
-            get(ui_bridge_get_render_log_handler).post(ui_bridge_append_render_log_handler),
+            get(ui_bridge_get_render_log_handler)
+                .post(ui_bridge_append_render_log_handler)
+                .delete(handle_clear_render_log),
         )
+        .route(
+            "/ui-bridge/render-log/snapshot",
+            post(handle_render_log_snapshot),
+        )
+        .route("/ui-bridge/render-log/path", get(handle_render_log_path))
+        // SDK relay liveness ping (distinct from `/ui-bridge/pong`)
+        .route("/ui-bridge/heartbeat", post(ui_bridge_heartbeat_handler))
         // Pong + IPC response
         .route("/ui-bridge/pong", post(ui_bridge_pong_handler))
         .route(
@@ -1367,6 +1387,10 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/render-log"),
         ("GET", "/ui-bridge/render-log"),
         ("POST", "/ui-bridge/render-log"),
+        ("DELETE", "/ui-bridge/render-log"),
+        ("POST", "/ui-bridge/render-log/snapshot"),
+        ("GET", "/ui-bridge/render-log/path"),
+        ("POST", "/ui-bridge/heartbeat"),
         ("POST", "/ui-bridge/pong"),
         ("POST", "/ui-bridge/ipc-response"),
         ("POST", "/ui-bridge/batch"),

--- a/src-tauri/src/mcp/ui_bridge/capabilities.rs
+++ b/src-tauri/src/mcp/ui_bridge/capabilities.rs
@@ -1282,6 +1282,26 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/control/metrics",
             get(ui_bridge_get_interaction_metrics_handler),
         )
+        // SDK aliases — `/control/history` and `/control/interaction-metrics`
+        // resolve to the same getActionHistory / getMetrics handlers as the
+        // canonical paths above. `/debug/*` mirrors round out the cross-app
+        // debug namespace declared by UI_BRIDGE_ROUTES.
+        .route(
+            "/ui-bridge/control/history",
+            get(ui_bridge_get_action_history_handler),
+        )
+        .route(
+            "/ui-bridge/control/interaction-metrics",
+            get(ui_bridge_get_interaction_metrics_handler),
+        )
+        .route(
+            "/ui-bridge/debug/action-history",
+            get(ui_bridge_get_action_history_handler),
+        )
+        .route(
+            "/ui-bridge/debug/metrics",
+            get(ui_bridge_get_interaction_metrics_handler),
+        )
         // Workflows
         .route(
             "/ui-bridge/control/workflows",
@@ -1334,6 +1354,11 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("GET", "/ui-bridge/capabilities"),
         ("GET", "/ui-bridge/control/action-history"),
         ("GET", "/ui-bridge/control/metrics"),
+        // SDK aliases for the same handlers.
+        ("GET", "/ui-bridge/control/history"),
+        ("GET", "/ui-bridge/control/interaction-metrics"),
+        ("GET", "/ui-bridge/debug/action-history"),
+        ("GET", "/ui-bridge/debug/metrics"),
         ("GET", "/ui-bridge/control/workflows"),
         ("POST", "/ui-bridge/control/workflow/{id}/run"),
         ("GET", "/ui-bridge/control/workflow/{run_id}/status"),

--- a/src-tauri/src/mcp/ui_bridge/design.rs
+++ b/src-tauri/src/mcp/ui_bridge/design.rs
@@ -176,6 +176,38 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/ai/design-audit",
             post(ui_bridge_design_audit_handler),
         )
+        // SDK top-level /design/* aliases — same handlers as the
+        // /control/design/* family above. Mounted here for symmetry with
+        // the SDK contract (see UI_BRIDGE_ROUTES `path: '/design/...'`).
+        .route(
+            "/ui-bridge/design/element/{id}/styles",
+            get(ui_bridge_design_element_styles_handler),
+        )
+        .route(
+            "/ui-bridge/design/element/{id}/state-styles",
+            post(ui_bridge_design_state_styles_handler),
+        )
+        .route(
+            "/ui-bridge/design/snapshot",
+            post(ui_bridge_design_snapshot_handler),
+        )
+        .route(
+            "/ui-bridge/design/responsive",
+            post(ui_bridge_design_responsive_handler),
+        )
+        .route(
+            "/ui-bridge/design/audit",
+            post(ui_bridge_design_audit_handler),
+        )
+        .route(
+            "/ui-bridge/design/style-guide/load",
+            post(ui_bridge_design_load_style_guide_handler),
+        )
+        .route(
+            "/ui-bridge/design/style-guide",
+            get(ui_bridge_design_get_style_guide_handler)
+                .delete(ui_bridge_design_clear_style_guide_handler),
+        )
 }
 
 /// Static (method, path) tuples corresponding to every route registered
@@ -195,6 +227,15 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("GET", "/ui-bridge/control/design/style-guide"),
         ("POST", "/ui-bridge/control/design/style-guide/clear"),
         ("POST", "/ui-bridge/ai/design-audit"),
+        // SDK top-level /design/* aliases
+        ("GET", "/ui-bridge/design/element/{id}/styles"),
+        ("POST", "/ui-bridge/design/element/{id}/state-styles"),
+        ("POST", "/ui-bridge/design/snapshot"),
+        ("POST", "/ui-bridge/design/responsive"),
+        ("POST", "/ui-bridge/design/audit"),
+        ("POST", "/ui-bridge/design/style-guide/load"),
+        ("GET", "/ui-bridge/design/style-guide"),
+        ("DELETE", "/ui-bridge/design/style-guide"),
     ]
 }
 

--- a/src-tauri/src/mcp/ui_bridge/design_eval.rs
+++ b/src-tauri/src/mcp/ui_bridge/design_eval.rs
@@ -47,6 +47,24 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/control/design/evaluate/diff",
             post(ui_bridge_design_evaluate_diff_handler),
         )
+        // SDK top-level /design/evaluate/* aliases — same handlers as the
+        // /control/design/evaluate/* family above.
+        .route(
+            "/ui-bridge/design/evaluate",
+            post(ui_bridge_design_evaluate_handler),
+        )
+        .route(
+            "/ui-bridge/design/evaluate/baseline",
+            post(ui_bridge_design_evaluate_baseline_handler),
+        )
+        .route(
+            "/ui-bridge/design/evaluate/contexts",
+            get(ui_bridge_design_evaluate_contexts_handler),
+        )
+        .route(
+            "/ui-bridge/design/evaluate/diff",
+            post(ui_bridge_design_evaluate_diff_handler),
+        )
 }
 
 pub fn route_entries() -> &'static [(&'static str, &'static str)] {
@@ -55,5 +73,10 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/design/evaluate/baseline"),
         ("GET", "/ui-bridge/control/design/evaluate/contexts"),
         ("POST", "/ui-bridge/control/design/evaluate/diff"),
+        // SDK top-level /design/evaluate/* aliases
+        ("POST", "/ui-bridge/design/evaluate"),
+        ("POST", "/ui-bridge/design/evaluate/baseline"),
+        ("GET", "/ui-bridge/design/evaluate/contexts"),
+        ("POST", "/ui-bridge/design/evaluate/diff"),
     ]
 }

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -45,6 +45,7 @@ use super::types::{
     classify_transport_error, UIBridgeActionRequest, UIBridgeComponentActionRequest,
     UIBridgeDiscoveryRequest, UiBridgeError,
 };
+use super::{ipc_handler_path_get, ipc_handler_post};
 
 /// Phase 3.2b (plan 2026-05-03) — bidirectional simple-glob match between
 /// a query value and a single `reveals` entry. Mirrors the canonical SDK
@@ -2944,6 +2945,43 @@ pub async fn ui_bridge_expect_element_handler(
     }
 }
 
+// =========================================================================
+// Macro-generated IPC proxies — react-state, history, rank
+// =========================================================================
+ipc_handler_path_get!(
+    ui_bridge_get_element_react_state_handler,
+    "get_element_react_state",
+    "id"
+);
+ipc_handler_path_get!(
+    ui_bridge_get_element_history_handler,
+    "get_element_history",
+    "id"
+);
+ipc_handler_post!(ui_bridge_rank_elements_handler, "rank_elements");
+
+/// `GET /ui-bridge/control/changes/since?since=<i64>&limit=<usize>` — proxy
+/// for the SDK's mutation-buffer query. Custom (not macro-generated) because
+/// the macros don't accept query params.
+///
+/// Forwards to the frontend's `get_changes_since` IPC handler with payload
+/// `{ params: { since, limit } }`. Defaults: `since=0`, `limit=100`. Matches
+/// the SDK shape from `relay-handlers.ts:1609-1614`.
+pub async fn ui_bridge_get_changes_since_handler(
+    State(state): State<Arc<ApiState>>,
+    axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    let since: i64 = query.get("since").and_then(|s| s.parse().ok()).unwrap_or(0);
+    let limit: usize = query
+        .get("limit")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(100);
+    let payload = serde_json::json!({ "params": { "since": since, "limit": limit } });
+    super::request::wrap_ipc_result(
+        ui_bridge_request_sync(&state, "get_changes_since", payload).await,
+    )
+}
+
 /// Primary element operations, components, discovery/snapshot, wait-for-element,
 /// and the DOM-convenience family (find / find-by-text / click-by-text /
 /// click-by-selector / read-value / type-into).
@@ -2983,7 +3021,33 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             post(ui_bridge_execute_action_handler),
         )
         .route(
+            "/ui-bridge/control/element/{id}/react-state",
+            get(ui_bridge_get_element_react_state_handler),
+        )
+        .route(
+            "/ui-bridge/control/element/{id}/history",
+            get(ui_bridge_get_element_history_handler),
+        )
+        // Alias for /control/element/{id}/history — same handler, debug path
+        .route(
+            "/ui-bridge/debug/element-history/{id}",
+            get(ui_bridge_get_element_history_handler),
+        )
+        .route(
+            "/ui-bridge/control/elements/rank",
+            post(ui_bridge_rank_elements_handler),
+        )
+        .route(
+            "/ui-bridge/control/changes/since",
+            get(ui_bridge_get_changes_since_handler),
+        )
+        .route(
             "/ui-bridge/control/batch-actions",
+            post(ui_bridge_batch_actions_handler),
+        )
+        // Alias for /control/batch-actions — same handler, plural path
+        .route(
+            "/ui-bridge/control/actions/batch",
             post(ui_bridge_batch_actions_handler),
         )
         .route(
@@ -3055,7 +3119,13 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/element/{id}/assert"),
         ("POST", "/ui-bridge/control/element/{id}/expect"),
         ("POST", "/ui-bridge/control/element/{id}/action"),
+        ("GET", "/ui-bridge/control/element/{id}/react-state"),
+        ("GET", "/ui-bridge/control/element/{id}/history"),
+        ("GET", "/ui-bridge/debug/element-history/{id}"),
+        ("POST", "/ui-bridge/control/elements/rank"),
+        ("GET", "/ui-bridge/control/changes/since"),
         ("POST", "/ui-bridge/control/batch-actions"),
+        ("POST", "/ui-bridge/control/actions/batch"),
         ("GET", "/ui-bridge/control/components"),
         ("GET", "/ui-bridge/control/component/{id}"),
         (

--- a/src-tauri/src/mcp/ui_bridge/forms.rs
+++ b/src-tauri/src/mcp/ui_bridge/forms.rs
@@ -147,6 +147,17 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/control/clipboard",
             get(ui_bridge_clipboard_read_handler).post(ui_bridge_clipboard_write_handler),
         )
+        // SDK declares the read/write split form — same handlers as the
+        // /control/clipboard combined route above, mounted as aliases for
+        // symmetry with the contract.
+        .route(
+            "/ui-bridge/control/clipboard/read",
+            get(ui_bridge_clipboard_read_handler),
+        )
+        .route(
+            "/ui-bridge/control/clipboard/write",
+            post(ui_bridge_clipboard_write_handler),
+        )
 }
 
 /// Static (method, path) tuples corresponding to every route registered
@@ -161,5 +172,7 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/ai/fill-form"),
         ("GET", "/ui-bridge/control/clipboard"),
         ("POST", "/ui-bridge/control/clipboard"),
+        ("GET", "/ui-bridge/control/clipboard/read"),
+        ("POST", "/ui-bridge/control/clipboard/write"),
     ]
 }

--- a/src-tauri/src/mcp/ui_bridge/intents_registry.rs
+++ b/src-tauri/src/mcp/ui_bridge/intents_registry.rs
@@ -42,6 +42,30 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/control/intents/execute-from-query",
             post(ui_bridge_execute_intent_from_query_handler),
         )
+        // SDK /ai/intents/* aliases — same handlers as the /control/intents/*
+        // family above. /ai/intents GET = listIntents, /ai/intents/register POST
+        // = registerIntent (the SDK splits register out into its own path; the
+        // runner's /control/intents POST does the same job).
+        .route(
+            "/ui-bridge/ai/intents",
+            get(ui_bridge_get_intents_handler),
+        )
+        .route(
+            "/ui-bridge/ai/intents/register",
+            post(ui_bridge_register_intent_handler),
+        )
+        .route(
+            "/ui-bridge/ai/intents/find",
+            post(ui_bridge_find_intent_handler),
+        )
+        .route(
+            "/ui-bridge/ai/intents/execute",
+            post(ui_bridge_execute_intent_handler),
+        )
+        .route(
+            "/ui-bridge/ai/intents/execute-from-query",
+            post(ui_bridge_execute_intent_from_query_handler),
+        )
 }
 
 pub fn route_entries() -> &'static [(&'static str, &'static str)] {
@@ -51,5 +75,11 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/intents/find"),
         ("POST", "/ui-bridge/control/intents/execute"),
         ("POST", "/ui-bridge/control/intents/execute-from-query"),
+        // SDK /ai/intents/* aliases
+        ("GET", "/ui-bridge/ai/intents"),
+        ("POST", "/ui-bridge/ai/intents/register"),
+        ("POST", "/ui-bridge/ai/intents/find"),
+        ("POST", "/ui-bridge/ai/intents/execute"),
+        ("POST", "/ui-bridge/ai/intents/execute-from-query"),
     ]
 }

--- a/src-tauri/src/mcp/ui_bridge/intents_registry.rs
+++ b/src-tauri/src/mcp/ui_bridge/intents_registry.rs
@@ -23,8 +23,23 @@ ipc_handler_post!(
     "execute_intent_from_query"
 );
 
+/// `DELETE /ui-bridge/control/intent/{name}` — delete a registered intent by
+/// name. SDK contract: `relayCommand('deleteIntent', { name })` returning
+/// `APIResponse<{ deleted: boolean }>`.
+///
+/// One-off shape (DELETE with path param, no body), so written inline rather
+/// than adding an `ipc_handler_path_delete!` macro for a single caller. Mirrors
+/// `ipc_handler_path_get!` body but uses `name` as the IPC param key.
+pub async fn ui_bridge_delete_intent_handler(
+    State(state): State<Arc<ApiState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    let payload = serde_json::json!({ "params": { "name": name } });
+    super::request::wrap_ipc_result(ui_bridge_request_sync(&state, "delete_intent", payload).await)
+}
+
 pub fn routes() -> axum::Router<Arc<ApiState>> {
-    use axum::routing::{get, post};
+    use axum::routing::{delete, get, post};
     axum::Router::new()
         .route(
             "/ui-bridge/control/intents",
@@ -41,6 +56,10 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
         .route(
             "/ui-bridge/control/intents/execute-from-query",
             post(ui_bridge_execute_intent_from_query_handler),
+        )
+        .route(
+            "/ui-bridge/control/intent/{name}",
+            delete(ui_bridge_delete_intent_handler),
         )
         // SDK /ai/intents/* aliases — same handlers as the /control/intents/*
         // family above. /ai/intents GET = listIntents, /ai/intents/register POST
@@ -72,6 +91,7 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/intents/find"),
         ("POST", "/ui-bridge/control/intents/execute"),
         ("POST", "/ui-bridge/control/intents/execute-from-query"),
+        ("DELETE", "/ui-bridge/control/intent/{name}"),
         // SDK /ai/intents/* aliases
         ("GET", "/ui-bridge/ai/intents"),
         ("POST", "/ui-bridge/ai/intents/register"),

--- a/src-tauri/src/mcp/ui_bridge/intents_registry.rs
+++ b/src-tauri/src/mcp/ui_bridge/intents_registry.rs
@@ -46,10 +46,7 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
         // family above. /ai/intents GET = listIntents, /ai/intents/register POST
         // = registerIntent (the SDK splits register out into its own path; the
         // runner's /control/intents POST does the same job).
-        .route(
-            "/ui-bridge/ai/intents",
-            get(ui_bridge_get_intents_handler),
-        )
+        .route("/ui-bridge/ai/intents", get(ui_bridge_get_intents_handler))
         .route(
             "/ui-bridge/ai/intents/register",
             post(ui_bridge_register_intent_handler),

--- a/src-tauri/src/mcp/ui_bridge/misc.rs
+++ b/src-tauri/src/mcp/ui_bridge/misc.rs
@@ -194,6 +194,11 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/control/annotations/import",
             post(ui_bridge_annotations_import_handler),
         )
+        // SDK top-level alias — `/annotations/import` (SDK's importAnnotations).
+        .route(
+            "/ui-bridge/annotations/import",
+            post(ui_bridge_annotations_import_handler),
+        )
         // Debug
         .route(
             "/ui-bridge/debug/element-tree",
@@ -227,6 +232,7 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("GET", "/ui-bridge/control/performance-entries"),
         ("POST", "/ui-bridge/control/performance-entries/clear"),
         ("POST", "/ui-bridge/control/annotations/import"),
+        ("POST", "/ui-bridge/annotations/import"),
         ("GET", "/ui-bridge/debug/element-tree"),
         ("POST", "/ui-bridge/debug/highlight/{id}"),
         ("POST", "/ui-bridge/control/navigate-tab"),

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -666,8 +666,11 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/circuit-breaker/reset"),
             // /control/ai/* aliases mirroring SDK /ai/* (runner-side dual mount)
             ("DELETE", "/ui-bridge/control/ai/bookmark/{}"),
+            ("DELETE", "/ui-bridge/control/ai/bookmarks/{}"),
             ("GET", "/ui-bridge/control/ai/bookmark/{}"),
             ("GET", "/ui-bridge/control/ai/bookmark/{}/diff"),
+            ("GET", "/ui-bridge/control/ai/bookmarks/{}"),
+            ("GET", "/ui-bridge/control/ai/bookmarks/{}/diff"),
             ("GET", "/ui-bridge/control/ai/bookmarks"),
             ("GET", "/ui-bridge/control/ai/categorize-last-diff"),
             ("GET", "/ui-bridge/control/ai/change-buffer/size"),
@@ -803,73 +806,53 @@ mod manifest_drift_tests {
         // delete the line below. The test will then assert end-to-end
         // wiring forever after.
         let sdk_only_baseline: HashSet<(&str, &str)> = [
-            // Render log file ops
+            // Render log file ops — no runner handler (clearRenderLog,
+            // getRenderLogPath, captureSnapshot are SDK-only today).
             ("DELETE", "/ui-bridge/render-log"),
             ("GET", "/ui-bridge/render-log/path"),
             ("POST", "/ui-bridge/render-log/snapshot"),
-            // Annotations top-level surface (runner exposes /control/annotations only)
-            ("DELETE", "/ui-bridge/annotations/{}"),
-            ("GET", "/ui-bridge/annotations"),
-            ("GET", "/ui-bridge/annotations/coverage"),
-            ("GET", "/ui-bridge/annotations/export"),
-            ("GET", "/ui-bridge/annotations/{}"),
-            ("POST", "/ui-bridge/annotations/import"),
-            ("PUT", "/ui-bridge/annotations/{}"),
-            ("POST", "/ui-bridge/control/annotation/{}"),
-            // Design top-level surface (runner exposes /control/design/* aliases only)
-            ("DELETE", "/ui-bridge/design/style-guide"),
-            ("GET", "/ui-bridge/design/element/{}/styles"),
-            ("GET", "/ui-bridge/design/evaluate/contexts"),
-            ("GET", "/ui-bridge/design/style-guide"),
-            ("POST", "/ui-bridge/design/audit"),
-            ("POST", "/ui-bridge/design/element/{}/state-styles"),
-            ("POST", "/ui-bridge/design/evaluate"),
-            ("POST", "/ui-bridge/design/evaluate/baseline"),
-            ("POST", "/ui-bridge/design/evaluate/diff"),
-            ("POST", "/ui-bridge/design/responsive"),
-            ("POST", "/ui-bridge/design/snapshot"),
-            ("POST", "/ui-bridge/design/style-guide/load"),
-            // Bookmark singular form (runner only exposes /ai/bookmark/{}, not /ai/bookmarks/{})
-            ("DELETE", "/ui-bridge/ai/bookmarks/{}"),
-            ("GET", "/ui-bridge/ai/bookmarks/{}"),
-            ("GET", "/ui-bridge/ai/bookmarks/{}/diff"),
-            // /ai/intents — runner exposes /ai/intents/* and /control/intents/*; SDK declares both shapes
-            ("GET", "/ui-bridge/ai/intents"),
-            ("POST", "/ui-bridge/ai/intents/execute"),
-            ("POST", "/ui-bridge/ai/intents/execute-from-query"),
-            ("POST", "/ui-bridge/ai/intents/find"),
-            ("POST", "/ui-bridge/ai/intents/register"),
+            // Intent name-in-URL forms — runner's /control/intents/execute
+            // takes the name in the JSON body (different shape from SDK's
+            // /control/intent/:name/execute). DELETE has no runner handler.
             ("DELETE", "/ui-bridge/control/intent/{}"),
             ("POST", "/ui-bridge/control/intent/{}/execute"),
-            // Cross-app analyze GET form (runner exposes POST form only)
+            // Cross-app analyze GET form — runner's analyze handlers are
+            // POST-only (they accept a request body); SDK declares a GET
+            // shape with query-string args. Different shape, not a simple alias.
             ("GET", "/ui-bridge/ai/analyze/data"),
             ("GET", "/ui-bridge/ai/analyze/regions"),
             ("GET", "/ui-bridge/ai/analyze/structured-data"),
-            // Media audit named subpaths (runner exposes /ai/media/audit/{} param form)
+            // Media audit named subpaths — runner exposes the parameterised
+            // /ai/media/audit/{audit_type} form which routes via Path<String>.
+            // SDK declares concrete subpaths; aliasing them would require
+            // wrapper handlers that hardcode the audit-type string.
             ("POST", "/ui-bridge/ai/media/audit/accessibility"),
             ("POST", "/ui-bridge/ai/media/audit/performance"),
-            // Misc /control/* the runner hasn't plumbed
+            // Misc /control/* the runner hasn't plumbed — each needs a real
+            // handler (no existing handler matches the SDK contract):
+            //   - getChangesSince (push-based change observation)
+            //   - getElementHistory / getElementReactState (per-element)
+            //   - getRoutes (page-route enumeration)
+            //   - executeBatchAction (different from /control/batch-actions
+            //     which is already runner-only)
+            //   - rankElements (element ranking)
+            //   - navigateByAdapter (adapter-based navigation)
+            //   - spawnHeadless (Phase 4.1 of plan; not yet wired)
+            //   - setViewportConstraints (viewport adjustment)
             ("GET", "/ui-bridge/control/changes/since"),
-            ("GET", "/ui-bridge/control/clipboard/read"),
             ("GET", "/ui-bridge/control/element/{}/history"),
             ("GET", "/ui-bridge/control/element/{}/react-state"),
-            ("GET", "/ui-bridge/control/history"),
-            ("GET", "/ui-bridge/control/interaction-metrics"),
             ("GET", "/ui-bridge/control/page/routes"),
             ("POST", "/ui-bridge/control/actions/batch"),
-            ("POST", "/ui-bridge/control/clipboard/write"),
             ("POST", "/ui-bridge/control/elements/rank"),
             ("POST", "/ui-bridge/control/page/navigate-to"),
             ("POST", "/ui-bridge/control/sdk/spawn-headless"),
             ("POST", "/ui-bridge/control/viewport-constraints"),
-            // Debug top-level surface (runner exposes /control/* equivalents)
-            ("GET", "/ui-bridge/debug/action-history"),
+            // Per-element debug history — needs a getElementHistory handler.
             ("GET", "/ui-bridge/debug/element-history/{}"),
-            ("GET", "/ui-bridge/debug/metrics"),
-            // Heartbeat — runner uses /pong/IPC plumbing instead
+            // Heartbeat — runner uses /pong + IPC plumbing for liveness; the
+            // SDK's receiveHeartbeat handler has no runner counterpart.
             ("POST", "/ui-bridge/heartbeat"),
-            // /ai/assert/batch slash form (runner exposes /ai/assert-batch hyphen form)
-            ("POST", "/ui-bridge/ai/assert/batch"),
         ]
         .into_iter()
         .collect();

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -793,28 +793,21 @@ mod manifest_drift_tests {
 
         // ── SDK-only baseline ───────────────────────────────────────────
         //
-        // Routes the SDK declares but the runner does not currently expose.
-        // These are real wire-through gaps captured as a *baseline snapshot*
-        // — none of them are the 5 friction-table entries from the
-        // 2026-05-03 plan (those have all been wired). They're long-tail
-        // SDK surface (annotations, design eval, intent registry, render-log
-        // file ops, etc.) that the runner has never plumbed through. Listed
-        // here so this test passes today and flags only NEW drift.
+        // Routes the SDK declares but the runner does not expose. The
+        // 2026-05-07 Bucket C plan wired through the 14 entries that were
+        // genuinely missing handlers — what remains here is intentional
+        // shape divergence (Bucket D) plus one deferred subsystem
+        // (spawn-headless, Bucket C7). Each remaining line documents the
+        // reason it's NOT a simple alias.
         //
-        // To remove an entry: implement the runner handler in the matching
-        // `mcp/ui_bridge/<family>.rs`, register in `route_entries()`, then
-        // delete the line below. The test will then assert end-to-end
-        // wiring forever after.
+        // To remove a future entry: implement the runner handler in the
+        // matching `mcp/ui_bridge/<family>.rs`, register in `routes()`
+        // AND `route_entries()`, then delete the line below. The test
+        // will then assert end-to-end wiring forever after.
         let sdk_only_baseline: HashSet<(&str, &str)> = [
-            // Render log file ops — no runner handler (clearRenderLog,
-            // getRenderLogPath, captureSnapshot are SDK-only today).
-            ("DELETE", "/ui-bridge/render-log"),
-            ("GET", "/ui-bridge/render-log/path"),
-            ("POST", "/ui-bridge/render-log/snapshot"),
-            // Intent name-in-URL forms — runner's /control/intents/execute
+            // Intent name-in-URL execute — runner's /control/intents/execute
             // takes the name in the JSON body (different shape from SDK's
-            // /control/intent/:name/execute). DELETE has no runner handler.
-            ("DELETE", "/ui-bridge/control/intent/{}"),
+            // /control/intent/:name/execute).
             ("POST", "/ui-bridge/control/intent/{}/execute"),
             // Cross-app analyze GET form — runner's analyze handlers are
             // POST-only (they accept a request body); SDK declares a GET
@@ -828,31 +821,10 @@ mod manifest_drift_tests {
             // wrapper handlers that hardcode the audit-type string.
             ("POST", "/ui-bridge/ai/media/audit/accessibility"),
             ("POST", "/ui-bridge/ai/media/audit/performance"),
-            // Misc /control/* the runner hasn't plumbed — each needs a real
-            // handler (no existing handler matches the SDK contract):
-            //   - getChangesSince (push-based change observation)
-            //   - getElementHistory / getElementReactState (per-element)
-            //   - getRoutes (page-route enumeration)
-            //   - executeBatchAction (different from /control/batch-actions
-            //     which is already runner-only)
-            //   - rankElements (element ranking)
-            //   - navigateByAdapter (adapter-based navigation)
-            //   - spawnHeadless (Phase 4.1 of plan; not yet wired)
-            //   - setViewportConstraints (viewport adjustment)
-            ("GET", "/ui-bridge/control/changes/since"),
-            ("GET", "/ui-bridge/control/element/{}/history"),
-            ("GET", "/ui-bridge/control/element/{}/react-state"),
-            ("GET", "/ui-bridge/control/page/routes"),
-            ("POST", "/ui-bridge/control/actions/batch"),
-            ("POST", "/ui-bridge/control/elements/rank"),
-            ("POST", "/ui-bridge/control/page/navigate-to"),
+            // Spawn-headless — deferred (Bucket C7 of the 2026-05-07 plan).
+            // Real subsystem (CLI subprocess orchestration), not a handler;
+            // tracked separately.
             ("POST", "/ui-bridge/control/sdk/spawn-headless"),
-            ("POST", "/ui-bridge/control/viewport-constraints"),
-            // Per-element debug history — needs a getElementHistory handler.
-            ("GET", "/ui-bridge/debug/element-history/{}"),
-            // Heartbeat — runner uses /pong + IPC plumbing for liveness; the
-            // SDK's receiveHeartbeat handler has no runner counterpart.
-            ("POST", "/ui-bridge/heartbeat"),
         ]
         .into_iter()
         .collect();

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -23,6 +23,21 @@ use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
 use super::helpers::{direct_webview_evaluate_with_result, evaluate_js_expression, safe_evaluate};
 use super::request::{ui_bridge_request_sync, wrap_ipc_result};
+use super::{ipc_handler_get, ipc_handler_post};
+
+// Macro-generated IPC forwarders for SDK-relayed page-control routes.
+// These forward `params` to the webview via `ui_bridge_request_sync` using the
+// IPC `kind` shown in each macro invocation. The matching React command
+// handlers live in
+// `D:\qontinui-root\ui-bridge\packages\ui-bridge\src\react\commandHandlers.ts`
+// (only `setViewportConstraints` is currently registered there; the other two
+// kinds will return "handler not found" until added).
+ipc_handler_post!(
+    ui_bridge_set_viewport_constraints_handler,
+    "set_viewport_constraints"
+);
+ipc_handler_get!(ui_bridge_page_get_routes_handler, "get_routes");
+ipc_handler_post!(ui_bridge_page_navigate_to_handler, "navigate_by_adapter");
 
 // ============================================================================
 // Request / response types
@@ -1357,6 +1372,18 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             post(ui_bridge_page_navigate_handler),
         )
         .route(
+            "/ui-bridge/control/page/navigate-to",
+            post(ui_bridge_page_navigate_to_handler),
+        )
+        .route(
+            "/ui-bridge/control/page/routes",
+            get(ui_bridge_page_get_routes_handler),
+        )
+        .route(
+            "/ui-bridge/control/viewport-constraints",
+            post(ui_bridge_set_viewport_constraints_handler),
+        )
+        .route(
             "/ui-bridge/control/page/back",
             post(ui_bridge_page_go_back_handler),
         )
@@ -1540,6 +1567,9 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/page/hard-refresh"),
         ("POST", "/ui-bridge/control/page/close-request"),
         ("POST", "/ui-bridge/control/page/navigate"),
+        ("POST", "/ui-bridge/control/page/navigate-to"),
+        ("GET", "/ui-bridge/control/page/routes"),
+        ("POST", "/ui-bridge/control/viewport-constraints"),
         ("POST", "/ui-bridge/control/page/back"),
         ("POST", "/ui-bridge/control/page/forward"),
         ("POST", "/ui-bridge/control/query-selector"),

--- a/src-tauri/src/mcp/ui_bridge/screenshots.rs
+++ b/src-tauri/src/mcp/ui_bridge/screenshots.rs
@@ -2051,9 +2051,13 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ui-bridge/control/annotations",
             get(ui_bridge_annotations_list_handler).post(ui_bridge_annotations_create_handler),
         )
+        // SDK declares POST /control/annotation/:id as setAnnotation
+        // (same action as PUT). Mounted alongside PUT so SDK callers
+        // using either method hit the same update handler.
         .route(
             "/ui-bridge/control/annotation/{id}",
             get(ui_bridge_annotations_get_handler)
+                .post(ui_bridge_annotations_update_handler)
                 .put(ui_bridge_annotations_update_handler)
                 .delete(ui_bridge_annotations_delete_handler),
         )
@@ -2064,6 +2068,27 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
         .route(
             "/ui-bridge/control/annotations/export",
             get(ui_bridge_annotations_export_handler),
+        )
+        // SDK top-level /annotations/* aliases — same handlers as the
+        // /control/annotation* family above. Mounted here for symmetry with
+        // the SDK contract (see UI_BRIDGE_ROUTES `path: '/annotations/...'`).
+        .route(
+            "/ui-bridge/annotations",
+            get(ui_bridge_annotations_list_handler),
+        )
+        .route(
+            "/ui-bridge/annotations/coverage",
+            get(ui_bridge_annotations_coverage_handler),
+        )
+        .route(
+            "/ui-bridge/annotations/export",
+            get(ui_bridge_annotations_export_handler),
+        )
+        .route(
+            "/ui-bridge/annotations/{id}",
+            get(ui_bridge_annotations_get_handler)
+                .put(ui_bridge_annotations_update_handler)
+                .delete(ui_bridge_annotations_delete_handler),
         )
         // Media routes
         .route(
@@ -2105,10 +2130,18 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("GET", "/ui-bridge/control/annotations"),
         ("POST", "/ui-bridge/control/annotations"),
         ("GET", "/ui-bridge/control/annotation/{id}"),
+        ("POST", "/ui-bridge/control/annotation/{id}"),
         ("PUT", "/ui-bridge/control/annotation/{id}"),
         ("DELETE", "/ui-bridge/control/annotation/{id}"),
         ("GET", "/ui-bridge/control/annotations/coverage"),
         ("GET", "/ui-bridge/control/annotations/export"),
+        // SDK top-level /annotations/* aliases
+        ("GET", "/ui-bridge/annotations"),
+        ("GET", "/ui-bridge/annotations/coverage"),
+        ("GET", "/ui-bridge/annotations/export"),
+        ("GET", "/ui-bridge/annotations/{id}"),
+        ("PUT", "/ui-bridge/annotations/{id}"),
+        ("DELETE", "/ui-bridge/annotations/{id}"),
         ("POST", "/ui-bridge/ai/media/find"),
         ("POST", "/ui-bridge/ai/media/audit/{audit_type}"),
         ("POST", "/ui-bridge/ai/media/snapshot"),

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -38,6 +38,13 @@ interface AuthProviderProps {
 
 const TOKEN_REFRESH_INTERVAL = 14 * 60 * 1000; // 14 minutes (tokens expire in 15 minutes)
 
+// Disarming window for the devAutoLoginPending failsafe. Re-armed on every
+// retry attempt; fires only when the retry chain has gone idle without
+// success. Must be strictly greater than the longest single retry interval
+// (10s for transient non-network errors) so an in-flight scheduled retry is
+// never pre-empted.
+const DEV_AUTO_LOGIN_PENDING_FAILSAFE_MS = 15000;
+
 // Development auto-login credentials (loaded from environment variables at
 // Vite build time). For temp test runners spawned by the supervisor, the
 // credentials are instead loaded at runtime from process env via the
@@ -72,6 +79,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const devLoginRetryTimer = useRef<number | null>(null);
   const devLoginRetryCount = useRef(0);
   const devLoginFailed = useRef(false);
+  // Bump on each retry attempt so the devAutoLoginPending failsafe effect
+  // re-arms its disarming timeout — without this, the failsafe fires after
+  // the first 10s window even though the retry chain is still in flight.
+  const [devLoginRetryTick, setDevLoginRetryTick] = useState(0);
   const MAX_DEV_LOGIN_RETRIES = 10;
 
   // Log mount/unmount
@@ -248,6 +259,75 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   /**
+   * Attempt the dev auto-login once, scheduling a retry on transient failure.
+   *
+   * The retry-timer must be able to re-invoke this function directly: relying
+   * on the auto-login useEffect to re-run does NOT work, because that effect's
+   * deps include `authStatus?.authenticated` as a boolean. A failed re-check
+   * that yields the same `false` value does not change the dep, so the effect
+   * does not fire — historically this meant the very first retry timer fired
+   * but never produced a second login attempt.
+   *
+   * To avoid a useCallback self-reference (which the react-hooks lint rule
+   * forbids), we route the recursive call through `attemptRef`.
+   */
+  const attemptRef = useRef<((email: string, password: string) => void) | null>(null);
+  const attemptDevAutoLogin = useCallback(
+    (email: string, password: string) => {
+      log.debug("Dev mode: Not authenticated, attempting auto-login...");
+      // Set pending flag BEFORE starting login so UI shows "Signing in..."
+      setDevAutoLoginPending(true);
+      // Bump the retry tick so the devAutoLoginPending failsafe effect
+      // re-arms its disarming timeout window for this attempt.
+      setDevLoginRetryTick((t) => t + 1);
+      login(email, password)
+        .then(() => {
+          // Login successful - the authStatus effect will clear devAutoLoginPending
+          log.debug("Dev mode auto-login succeeded");
+        })
+        .catch((err) => {
+          const errStr = String(err);
+          const isNetworkError =
+            errStr.includes("Network error") || errStr.includes("Failed to fetch");
+          const isTransientError =
+            isNetworkError || errStr.includes("Server error") || errStr.includes("Rate limit");
+          if (isTransientError && devLoginRetryCount.current < MAX_DEV_LOGIN_RETRIES) {
+            // Transient error (network, server, rate limit) — retry with backoff
+            devLoginRetryCount.current += 1;
+            const delay = isNetworkError ? 5000 : 10000;
+            log.warn(
+              `Dev mode auto-login failed (${isNetworkError ? "backend unavailable" : "transient error"}), retry ${devLoginRetryCount.current}/${MAX_DEV_LOGIN_RETRIES} in ${delay / 1000}s...`,
+            );
+            devLoginRetryTimer.current = window.setTimeout(() => {
+              devLoginRetryTimer.current = null;
+              // Re-invoke the attempt directly via the ref. Calling
+              // checkAuthStatus() alone would not retry: the auto-login
+              // effect bails when authStatus?.authenticated is unchanged
+              // (still false).
+              attemptRef.current?.(email, password);
+            }, delay);
+          } else {
+            if (isTransientError) {
+              log.error("Dev mode auto-login failed: max retries exceeded");
+            } else {
+              log.error("Dev mode auto-login failed (auth error):", err);
+            }
+            // Clear pending flag on non-retryable failure so user can see login screen
+            devLoginFailed.current = true;
+            setDevAutoLoginPending(false);
+          }
+        });
+    },
+    [login],
+  );
+  // Keep the ref pointing at the latest stable callback so timer-driven
+  // retries always invoke the current closure (which has the current
+  // `login` dep). Updated via effect so we never write the ref during render.
+  useEffect(() => {
+    attemptRef.current = attemptDevAutoLogin;
+  }, [attemptDevAutoLogin]);
+
+  /**
    * Auto-login with configured credentials
    * Automatically logs in when VITE_DEV_EMAIL/VITE_DEV_PASSWORD are set in .env
    * Works in both dev mode (Vite) and exe mode (embedded build)
@@ -304,50 +384,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
       return;
     }
 
-    // Auto-login in development
-    log.debug("Dev mode: Not authenticated, attempting auto-login...");
-    // Set pending flag BEFORE starting login so UI shows "Signing in..."
-    setDevAutoLoginPending(true);
-    login(autoLoginCreds.email, autoLoginCreds.password)
-      .then(() => {
-        // Login successful - the authStatus effect will clear devAutoLoginPending
-        log.debug("Dev mode auto-login succeeded");
-      })
-      .catch((err) => {
-        const errStr = String(err);
-        const isNetworkError =
-          errStr.includes("Network error") || errStr.includes("Failed to fetch");
-        const isTransientError =
-          isNetworkError || errStr.includes("Server error") || errStr.includes("Rate limit");
-        if (isTransientError && devLoginRetryCount.current < MAX_DEV_LOGIN_RETRIES) {
-          // Transient error (network, server, rate limit) — retry with backoff
-          devLoginRetryCount.current += 1;
-          const delay = isNetworkError ? 5000 : 10000;
-          log.warn(
-            `Dev mode auto-login failed (${isNetworkError ? "backend unavailable" : "transient error"}), retry ${devLoginRetryCount.current}/${MAX_DEV_LOGIN_RETRIES} in ${delay / 1000}s...`,
-          );
-          devLoginRetryTimer.current = window.setTimeout(() => {
-            devLoginRetryTimer.current = null;
-            checkAuthStatus();
-          }, delay);
-        } else {
-          if (isTransientError) {
-            log.error("Dev mode auto-login failed: max retries exceeded");
-          } else {
-            log.error("Dev mode auto-login failed (auth error):", err);
-          }
-          // Clear pending flag on non-retryable failure so user can see login screen
-          devLoginFailed.current = true;
-          setDevAutoLoginPending(false);
-        }
-      });
+    // First attempt — subsequent retries are driven by the retry timer
+    // re-invoking attemptDevAutoLogin directly (not by this effect re-running).
+    attemptDevAutoLogin(autoLoginCreds.email, autoLoginCreds.password);
   }, [
     loading,
     authStatus?.authenticated,
-    login,
-    checkAuthStatus,
     testAutoLoginProbed,
     autoLoginCreds,
+    attemptDevAutoLogin,
   ]);
 
   /**
@@ -368,9 +413,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [loading]);
 
   /**
-   * Failsafe timeout for devAutoLoginPending
-   * Covers the case where login() resolves quickly (clearing loading)
-   * but devAutoLoginPending stays stuck true due to a race condition
+   * Failsafe timeout for devAutoLoginPending.
+   *
+   * Contract: this timer is re-armed on every retry attempt (via the
+   * `devLoginRetryTick` dependency, which is bumped by `attemptDevAutoLogin`).
+   * It therefore fires only when the retry chain has gone idle without
+   * success — i.e., no fresh attempt has happened in the past
+   * DEV_AUTO_LOGIN_PENDING_FAILSAFE_MS milliseconds.
+   *
+   * The window must be strictly greater than the longest single retry
+   * interval (10s for non-network transient errors, 5s for network errors)
+   * so a still-scheduled retry attempt is never pre-empted by the failsafe.
+   * We do not want to remove the failsafe entirely: it covers the rare case
+   * where login() resolves but pending stays stuck due to a race or unmount
+   * during the retry chain.
    */
   useEffect(() => {
     if (!devAutoLoginPending) return;
@@ -378,10 +434,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
     const timeout = setTimeout(() => {
       log.warn("devAutoLoginPending timeout - forcing to false");
       setDevAutoLoginPending(false);
-    }, 10000);
+    }, DEV_AUTO_LOGIN_PENDING_FAILSAFE_MS);
 
     return () => clearTimeout(timeout);
-  }, [devAutoLoginPending]);
+  }, [devAutoLoginPending, devLoginRetryTick]);
 
   /**
    * Set up auto-refresh timer when authenticated


### PR DESCRIPTION
## Summary

Reopens `chore/registry-deps` for the 4 commits that landed after PR #53 (qontinui-types migration, already merged). Three of the four are the Bucket C handler/cleanup work from plan `qontinui-dev-notes/ui-bridge/docs/2026-05-07-ui-bridge-bucket-c-handlers-plan.md` (status: SHIPPED on this branch but not yet on main); the fourth is a one-line auth-retry bug fix.

The original PR #53 squash-merged on 2026-05-07 and closed; per Claude Code's `feedback_pr_close_push_no_sync` memory, pushes to a closed PR's head ref don't reopen it or fire CI — hence this fresh PR.

### Net-new commits (4)

- `51b988a` fix(auth): dev-mode auto-login retry loop now actually retries
- `ae6779c` ui-bridge: wire 14 missing runner handlers (Bucket C)
- `a8bd73f` chore(ui-bridge): cargo fmt for /ai/intents alias additions
- `f22ee14` chore(ui-bridge): shrink Phase 2a sdk_only_baseline allow-list (49 → 21)

### Cosmetic 5th commit (already on main as squash)

- `73316e8` chore: migrate qontinui-types to registry dep (phase 9b)

That commit was the entire content of merged PR #53 (squashed on main as `b992bcef9`). `git merge-tree` reports 0 conflicts between this branch and main, so the squash collapses cleanly. Recommend **squash-merge** for this PR — it'll fold the 5 commits down and de-duplicate the qontinui-types content automatically.

## Why this matters

The Bucket C plan SHIPPED status currently lives on a feature branch that never merged to main, so the runner's `/ui-bridge/control/elements/rank`, `/ui-bridge/control/element/{id}/react-state`, `/ui-bridge/heartbeat`, `/ui-bridge/control/intent/{name}` (DELETE), `/ui-bridge/control/viewport-constraints`, and 9 other Bucket C routes return 404 against any runner built from main. The follow-up plan `qontinui-dev-notes/ui-bridge/docs/2026-05-07-ui-bridge-react-handlers-followup-plan.md` (SHIPPED 2026-05-07 on `feat/coordinator-launch-controls` as commit `2b0ca681d`) wires the React-side IPC handlers that these routes forward to — but those handlers are dead code until this PR lands.

End-state once both PRs land on main: 5 of 7 Bucket C handlers go fully functional (the other 2, `get_changes_since` and `get_element_history`, are deferred behind an upstream `@qontinui/ui-bridge` SDK PR adding `ChangeTracker.peekBuffer()`).

## Test plan

- [ ] CI green on this PR
- [ ] After merge to main: rebase `feat/coordinator-launch-controls` (or wait for its next main-merge) so it picks up these routes
- [ ] Spawn a temp test runner from the resulting branch, smoke the 5 wired routes:
  - `POST /ui-bridge/heartbeat` → 200 + `data.received=true`
  - `POST /ui-bridge/control/elements/rank` `{text:"any"}` → 200 + array
  - `POST /ui-bridge/control/viewport-constraints` `{restore:true}` → 200; then `{width:800}` → 200 + `data.constrainedWidth=800`
  - `GET /ui-bridge/control/element/{id}/react-state` → 200 + `{props,fiberState,componentName}` (or fallback note)
  - `DELETE /ui-bridge/control/intent/{name}` after registering an intent → 200 + `data.deleted=true`