### PR TITLE
ui-bridge: wire deferred Phase E handlers (get_changes_since + get_element_history)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,20 @@ jobs:
       #     qontinui-web/frontend/src/app at typecheck/build time. These are
       #     cross-repo file imports rather than npm deps, so the redesign
       #     doesn't migrate them.
-      # qontinui-schemas and qontinui-web are both public org-owned repos;
-      # the default github.token authenticates the clone, no PAT needed.
+      #   - ui-bridge: the SDK↔runner manifest diff test
+      #     (`sdk_manifest_routes_are_exposed_by_runner` in
+      #     `mcp/ui_bridge/mod.rs`) reads `UI_BRIDGE_ROUTES` from
+      #     `ui-bridge/packages/ui-bridge/src/server/types.ts`. Without this
+      #     clone the test hits its "file unreadable, skip" branch and
+      #     silently passes, so SDK-vs-runner drift would not be flagged.
+      # qontinui-schemas, qontinui-web, and ui-bridge are public org-owned
+      # repos; the default github.token authenticates the clone, no PAT needed.
       - name: Checkout sibling repos
         run: |
           cd "$GITHUB_WORKSPACE/.."
           git clone --depth 1 https://github.com/qontinui/qontinui-schemas.git
           git clone --depth 1 https://github.com/qontinui/qontinui-web.git
+          git clone --depth 1 https://github.com/qontinui/ui-bridge.git
         shell: bash
 
       - name: Setup pnpm

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.2.3",
-    "@qontinui/ui-bridge": "^0.3.4",
+    "@qontinui/ui-bridge": "^0.3.5",
     "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.3.4(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.3
         version: 0.2.3
       '@qontinui/ui-bridge':
-        specifier: ^0.3.4
-        version: 0.3.4(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.3.5
+        version: 0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1143,8 +1143,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  '@qontinui/ui-bridge@0.3.4':
-    resolution: {integrity: sha512-tUHk8LWauzDtQjxm3Iq+TTT/NktTqgGbJxeVVoheU73JfIDxNT6I5ZYd8THeFmzUpFOtoErelNQ/YM0ZLWG2Cg==}
+  '@qontinui/ui-bridge@0.3.5':
+    resolution: {integrity: sha512-8sGn/fiUZkDXgEa34OLtlX+g02BcBumASYTKkyJUu4qzadX9hJ9g1ilxEJ/YmcR1VM0gFFz/DAz7QVOT9RGXRA==}
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
       '@qontinui/ui-bridge-headless': '>=0.1.0'
@@ -6106,9 +6106,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.4(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.3.4(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.3': {}
@@ -6116,7 +6116,7 @@ snapshots:
   '@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       '@qontinui/shared-types': 0.2.3
-      '@qontinui/ui-bridge': 0.3.4(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - '@qontinui/ui-bridge-headless'
@@ -6135,7 +6135,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.3.4(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:

--- a/scripts/test-grid-endpoints.sh
+++ b/scripts/test-grid-endpoints.sh
@@ -43,17 +43,22 @@ curl -s -X POST "$RUNNER/ui-bridge/control/element/button-launch-menu/action" \
   -H "Content-Type: application/json" \
   -d '{"action": "click"}' > /dev/null
 sleep 1
-curl -s -X POST "$RUNNER/ui-bridge/control/element/button-1-0/action" \
+# `button-open-1-terminal-0` opens a single terminal from the launch menu.
+# (Previous attempt used `button-1-0` which doesn't match the runner's
+# generated ID scheme.)
+curl -s -X POST "$RUNNER/ui-bridge/control/element/button-open-1-terminal-0/action" \
   -H "Content-Type: application/json" \
   -d '{"action": "click"}' > /dev/null || true
 # Give PowerShell time to print its prompt.
 sleep 5
 
 # 2. Find a session id via React-fiber walk through page/evaluate.
+# `page/evaluate` wraps complex return types in `{value: ...}` and returns
+# bare values for primitives — handle both.
 SID=$(curl -s -X POST "$RUNNER/ui-bridge/control/page/evaluate" \
   -H "Content-Type: application/json" \
   -d '{"expression": "(()=>{const s=new Set();for(const el of document.querySelectorAll(\"*\")){for(const k of Object.keys(el)){if(k.startsWith(\"__reactFiber\")){let f=el[k],d=0;while(f&&d<5){if(f.memoizedProps&&f.memoizedProps.terminalId)s.add(f.memoizedProps.terminalId);f=f.return;d++;}break;}}}return [...s][0]||\"\";})()"}' \
-  | python -c "import sys,json; print(json.load(sys.stdin)['data']['result'])")
+  | python -c "import sys,json; r=json.load(sys.stdin)['data']['result']; print(r['value'] if isinstance(r,dict) and 'value' in r else r)")
 
 if [[ -z "$SID" ]]; then
   echo "FAIL: no terminal session found after launch"; exit 1
@@ -78,10 +83,15 @@ TEXT=$(curl -s "$RUNNER/ui-bridge/sdk/terminal/sessions/$SID/text" \
   | python -c "import sys,json; print(json.load(sys.stdin)['data']['text'])")
 echo "OK /text: $(echo \"$TEXT\" | head -c 80)"
 
-# 6. /search — substring match for any printable run of characters.
-NEEDLE=$(echo "$TEXT" | tr -d '[:space:]' | head -c 4)
+# 6. /search — substring match for any printable run of characters
+# from the rendered text. We extract the first contiguous non-whitespace
+# token from /text so the needle is guaranteed to exist verbatim in the
+# grid (with the same byte sequence — no whitespace stripping that would
+# desync needle vs. haystack).
+NEEDLE=$(echo "$TEXT" | python -c "import sys; t=sys.stdin.read(); import re; m=re.search(r'\S{2,}', t); sys.stdout.write(m.group(0) if m else '')")
 if [[ -n "$NEEDLE" ]]; then
-  SEARCH_HITS=$(curl -s "$RUNNER/ui-bridge/sdk/terminal/search?q=$NEEDLE&session_id=$SID" \
+  ENC_NEEDLE=$(python -c "import sys,urllib.parse; sys.stdout.write(urllib.parse.quote(sys.argv[1]))" "$NEEDLE")
+  SEARCH_HITS=$(curl -s "$RUNNER/ui-bridge/sdk/terminal/search?q=$ENC_NEEDLE&session_id=$SID" \
     | python -c "import sys,json; print(json.load(sys.stdin)['data']['totalHits'])")
   if [[ "$SEARCH_HITS" -lt 1 ]]; then
     echo "FAIL: /search returned 0 hits for needle '$NEEDLE' that exists in /text"; exit 1

--- a/specs/pages/terminal/notes.md
+++ b/specs/pages/terminal/notes.md
@@ -1,3 +1,28 @@
 # TerminalPage
 
-_(notes)_
+## Asserting on terminal cell content (Claude Code, vim, htop, etc.)
+
+DOM-search assertions in this spec (`assertionType: "exists"` with a
+`textContent` criterion) **only see the runner's own UI chrome** — tab
+bars, buttons, status indicators. They do **not** see what a TUI app
+draws inside an xterm pane, because xterm.js renders to a canvas /
+WebGL surface that's not in the DOM.
+
+To assert on terminal cell content, query the server-side cell grid:
+
+| Use case | Endpoint |
+|---|---|
+| Is text "Welcome" visible in any terminal? | `GET /ui-bridge/sdk/terminal/search?q=Welcome` |
+| Is text "Welcome" in this specific session? | `GET /ui-bridge/sdk/terminal/search?q=Welcome&session_id=<id>` |
+| Get the rendered text rows of a session | `GET /ui-bridge/sdk/terminal/sessions/<id>/buffer` |
+| Get full cell-level grid (fg/bg/attrs/cursor) | `GET /ui-bridge/sdk/terminal/sessions/<id>/grid` |
+| Compact text view for verifier prompts | `GET /ui-bridge/sdk/terminal/sessions/<id>/text` |
+| Diff two sessions row-by-row | `GET /ui-bridge/sdk/terminal/sessions/<a>/diff/<b>` |
+
+Full reference + worked examples:
+[`src/components/terminal/GRID_TESTING.md`](../../../src/components/terminal/GRID_TESTING.md).
+End-to-end smoke at `scripts/test-grid-endpoints.sh`.
+
+The assertions in `spec.uibridge.json` below cover the runner UI
+shell. Cell content lives on the HTTP side because the spec runner's
+DOM-search primitive can't reach it.

--- a/specs/pages/wrappers/spec.uibridge.json
+++ b/specs/pages/wrappers/spec.uibridge.json
@@ -1,5 +1,5 @@
 {
-  "description": "The Wrappers Library page lists installed wrapper extensions and lets users discover/install new ones from the public registry. Wrappers are first-class extensions that add typed actions to the runner — think MCP servers, but native. The page has two tabs (Installed / Browse) and is the entry point to per-wrapper detail views (Actions, Settings, Logs, About). Backed by the runner's HTTP endpoints under /wrappers/* (registry, install, lifecycle, dispatch).",
+  "description": "The Wrappers Library page lists installed wrapper extensions, lets users discover and install new ones from the public registry, and registers the qontinui-wrappers MCP server with installed AI clients. Three tabs: Installed (default), AI Clients, Browse.\n\n# WrappersLibraryPage\n\n_(notes)_",
   "groups": [
     {
       "assertions": [
@@ -97,7 +97,7 @@
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 0 for state Tab Navigation (Installed / Browse)",
+          "description": "Required element 0 for state Tab Navigation (Installed / AI Clients / Browse)",
           "enabled": true,
           "id": "tab-navigation-elem-0",
           "precondition": "At least one wrapper is installed",
@@ -109,14 +109,14 @@
               "tagName": "button",
               "textContent": "Installed"
             },
-            "label": "Required element for Tab Navigation (Installed / Browse)",
+            "label": "Required element for Tab Navigation (Installed / AI Clients / Browse)",
             "type": "search"
           }
         },
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 1 for state Tab Navigation (Installed / Browse)",
+          "description": "Required element 1 for state Tab Navigation (Installed / AI Clients / Browse)",
           "enabled": true,
           "id": "tab-navigation-elem-1",
           "precondition": "At least one wrapper is installed",
@@ -128,14 +128,14 @@
               "tagName": "button",
               "textContent": "Browse"
             },
-            "label": "Required element for Tab Navigation (Installed / Browse)",
+            "label": "Required element for Tab Navigation (Installed / AI Clients / Browse)",
             "type": "search"
           }
         },
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 2 for state Tab Navigation (Installed / Browse)",
+          "description": "Required element 2 for state Tab Navigation (Installed / AI Clients / Browse)",
           "enabled": true,
           "id": "tab-navigation-elem-2",
           "precondition": "At least one wrapper is installed",
@@ -147,14 +147,14 @@
               "tagName": "button",
               "textContent": "Browse"
             },
-            "label": "Required element for Tab Navigation (Installed / Browse)",
+            "label": "Required element for Tab Navigation (Installed / AI Clients / Browse)",
             "type": "search"
           }
         },
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 3 for state Tab Navigation (Installed / Browse)",
+          "description": "Required element 3 for state Tab Navigation (Installed / AI Clients / Browse)",
           "enabled": true,
           "id": "tab-navigation-elem-3",
           "precondition": "At least one wrapper is installed",
@@ -166,15 +166,34 @@
               "tagName": "button",
               "textContent": "Installed"
             },
-            "label": "Required element for Tab Navigation (Installed / Browse)",
+            "label": "Required element for Tab Navigation (Installed / AI Clients / Browse)",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 4 for state Tab Navigation (Installed / AI Clients / Browse)",
+          "enabled": true,
+          "id": "tab-navigation-elem-4",
+          "precondition": "At least one wrapper is installed",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "tagName": "button",
+              "textContent": "AI Clients"
+            },
+            "label": "Required element for Tab Navigation (Installed / AI Clients / Browse)",
             "type": "search"
           }
         }
       ],
       "category": "element-presence",
-      "description": "Two tabs at the top of the content area let users switch between viewing installed wrappers and browsing the public registry. The active tab is indicated by a cyan-400 underline and cyan-400 text color. The Installed tab also shows a count badge of installed wrappers when > 0.",
+      "description": "The wrappers page has three tabs in this order: Installed (default), AI Clients, and Browse. The active tab is highlighted with a cyan underline and cyan-400 text; inactive tabs use muted-foreground.",
       "id": "tab-navigation",
-      "name": "Tab Navigation (Installed / Browse)",
+      "name": "Tab Navigation (Installed / AI Clients / Browse)",
       "source": "migrated"
     },
     {
@@ -909,16 +928,223 @@
       "id": "data-correctness",
       "name": "Data Correctness — Installed list reflects backend",
       "source": "migrated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 0 for state AI Clients Tab — Structure & Cards",
+          "enabled": true,
+          "id": "ai-clients-tab-structure-elem-0",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "heading",
+              "textContent": "Claude CLI"
+            },
+            "label": "Required element for AI Clients Tab — Structure & Cards",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 1 for state AI Clients Tab — Structure & Cards",
+          "enabled": true,
+          "id": "ai-clients-tab-structure-elem-1",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "heading",
+              "textContent": "Claude Desktop"
+            },
+            "label": "Required element for AI Clients Tab — Structure & Cards",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 2 for state AI Clients Tab — Structure & Cards",
+          "enabled": true,
+          "id": "ai-clients-tab-structure-elem-2",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "heading",
+              "textContent": "Cursor"
+            },
+            "label": "Required element for AI Clients Tab — Structure & Cards",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 3 for state AI Clients Tab — Structure & Cards",
+          "enabled": true,
+          "id": "ai-clients-tab-structure-elem-3",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "heading",
+              "textContent": "Continue"
+            },
+            "label": "Required element for AI Clients Tab — Structure & Cards",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 4 for state AI Clients Tab — Structure & Cards",
+          "enabled": true,
+          "id": "ai-clients-tab-structure-elem-4",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "heading",
+              "textContent": "Cline"
+            },
+            "label": "Required element for AI Clients Tab — Structure & Cards",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "When the AI Clients tab is active, the page renders a vertical stack of one card per supported client: Claude CLI, Claude Desktop, Cursor, Continue, Cline. Each card has a heading with the client's display name, a status pill, an action button (Connect / Disconnect / Reconnect), and a Details disclosure button. Detection (GET /wrappers/clients) marks a client installed if EITHER its config file exists OR its launcher binary is on PATH.",
+      "id": "ai-clients-tab-structure",
+      "name": "AI Clients Tab — Structure & Cards",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 0 for state AI Clients Tab — Status Pills",
+          "enabled": true,
+          "id": "ai-clients-status-pills-elem-0",
+          "precondition": "AI Clients tab is active and at least one card is rendered",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "button",
+              "textContains": "onnect"
+            },
+            "label": "Required element for AI Clients Tab — Status Pills",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The status pill on each card reflects the connection state returned by GET /wrappers/clients. Five visual variants exist: 'Connected' (emerald, kind=Connected), 'Connected (out of date)' (amber, kind=Drifted — entry exists but command path or env.QONTINUI_PRIMARY_PORT differs from the runner's current values), 'Not connected' (muted, kind=NotConnected), 'Invalid JSON' (red, kind=ConfigParseError — config file exists but doesn't parse), and 'Not detected' (muted, client not installed). Pill text is uppercase tracking-wider 10px font with a 1px border in the matching accent color and a 10% transparent fill.",
+      "id": "ai-clients-status-pills",
+      "name": "AI Clients Tab — Status Pills",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 0 for state AI Clients Tab — Action Buttons",
+          "enabled": true,
+          "id": "ai-clients-action-buttons-elem-0",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "button"
+            },
+            "label": "Required element for AI Clients Tab — Action Buttons",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 1 for state AI Clients Tab — Action Buttons",
+          "enabled": true,
+          "id": "ai-clients-action-buttons-elem-1",
+          "precondition": "AI Clients tab is active",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "button"
+            },
+            "label": "Required element for AI Clients Tab — Action Buttons",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The action button on each card reflects connection state and drives POST /wrappers/clients/{id}/{connect|disconnect}. Possible labels: 'Connect' (kind=NotConnected, enabled, cyan-to-purple gradient), 'Disconnect' (kind=Connected, enabled, neutral border), 'Reconnect' (kind=Drifted, enabled, amber-to-orange gradient), 'Connect' disabled with hover title (installed=false OR kind=ConfigParseError). Mid-request the label transitions to 'Connecting…' / 'Disconnecting…' / 'Reconnecting…' with a spinner. After Connect, the button transitions to 'Disconnect' on the next list refresh; after Disconnect, returns to 'Connect'. After every action the page calls listAiClients() and re-renders. POST /wrappers/clients/{id}/connect writes the qontinui-wrappers entry into the client's config via atomic temp-file-then-rename, with a single .qontinui-backup.<ts> backup the first time the file is written this session.",
+      "id": "ai-clients-action-buttons",
+      "name": "AI Clients Tab — Action Buttons",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 0 for state AI Clients Tab — Details Disclosure",
+          "enabled": true,
+          "id": "ai-clients-details-disclosure-elem-0",
+          "precondition": "AI Clients tab is active and a Details disclosure has been expanded",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "role": "button"
+            },
+            "label": "Required element for AI Clients Tab — Details Disclosure",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "Each card has a 'Details' disclosure button (chevron icon) that expands to reveal: (1) the absolute config file path under 'Config file:'; (2) for ConfigParseError state, a red 'Config error:' block with the path and the message 'Open this file and fix the JSON, or delete it to start fresh.'; (3) the JSON snippet that will be written or removed under the mcpServers key, with placeholders '<launcher path>' and '<port>' since the live values aren't fetched into the UI; (4) for Drifted state, the current (stale) command path and port shown alongside the new values that Reconnect will write. The note 'The runner fills in its own stable launcher path and current port.' is rendered below the JSON snippet.",
+      "id": "ai-clients-details-disclosure",
+      "name": "AI Clients Tab — Details Disclosure",
+      "source": "ai-generated"
     }
   ],
   "metadata": {
     "component": "wrappers",
     "tags": [
-      "wrappers",
+      "ai-clients",
+      "connect",
       "extensions",
-      "registry",
       "install",
-      "library"
+      "library",
+      "mcp",
+      "registry",
+      "wrappers"
     ]
   },
   "stateMachine": {
@@ -958,7 +1184,7 @@
         "transitions": []
       },
       {
-        "description": "Two tabs at the top of the content area let users switch between viewing installed wrappers and browsing the public registry. The active tab is indicated by a cyan-400 underline and cyan-400 text color. The Installed tab also shows a count badge of installed wrappers when > 0.",
+        "description": "The wrappers page has three tabs in this order: Installed (default), AI Clients, and Browse. The active tab is highlighted with a cyan underline and cyan-400 text; inactive tabs use muted-foreground.",
         "elements": [
           {
             "tagName": "button",
@@ -975,11 +1201,15 @@
           {
             "tagName": "button",
             "textContent": "Installed"
+          },
+          {
+            "tagName": "button",
+            "textContent": "AI Clients"
           }
         ],
         "id": "tab-navigation",
         "isInitial": false,
-        "name": "Tab Navigation (Installed / Browse)",
+        "name": "Tab Navigation (Installed / AI Clients / Browse)",
         "transitions": []
       },
       {
@@ -1190,6 +1420,75 @@
         "id": "data-correctness",
         "isInitial": false,
         "name": "Data Correctness — Installed list reflects backend",
+        "transitions": []
+      },
+      {
+        "description": "When the AI Clients tab is active, the page renders a vertical stack of one card per supported client: Claude CLI, Claude Desktop, Cursor, Continue, Cline. Each card has a heading with the client's display name, a status pill, an action button (Connect / Disconnect / Reconnect), and a Details disclosure button. Detection (GET /wrappers/clients) marks a client installed if EITHER its config file exists OR its launcher binary is on PATH.",
+        "elements": [
+          {
+            "role": "heading",
+            "textContent": "Claude CLI"
+          },
+          {
+            "role": "heading",
+            "textContent": "Claude Desktop"
+          },
+          {
+            "role": "heading",
+            "textContent": "Cursor"
+          },
+          {
+            "role": "heading",
+            "textContent": "Continue"
+          },
+          {
+            "role": "heading",
+            "textContent": "Cline"
+          }
+        ],
+        "id": "ai-clients-tab-structure",
+        "isInitial": false,
+        "name": "AI Clients Tab — Structure & Cards",
+        "transitions": []
+      },
+      {
+        "description": "The status pill on each card reflects the connection state returned by GET /wrappers/clients. Five visual variants exist: 'Connected' (emerald, kind=Connected), 'Connected (out of date)' (amber, kind=Drifted — entry exists but command path or env.QONTINUI_PRIMARY_PORT differs from the runner's current values), 'Not connected' (muted, kind=NotConnected), 'Invalid JSON' (red, kind=ConfigParseError — config file exists but doesn't parse), and 'Not detected' (muted, client not installed). Pill text is uppercase tracking-wider 10px font with a 1px border in the matching accent color and a 10% transparent fill.",
+        "elements": [
+          {
+            "role": "button",
+            "textContains": "onnect"
+          }
+        ],
+        "id": "ai-clients-status-pills",
+        "isInitial": false,
+        "name": "AI Clients Tab — Status Pills",
+        "transitions": []
+      },
+      {
+        "description": "The action button on each card reflects connection state and drives POST /wrappers/clients/{id}/{connect|disconnect}. Possible labels: 'Connect' (kind=NotConnected, enabled, cyan-to-purple gradient), 'Disconnect' (kind=Connected, enabled, neutral border), 'Reconnect' (kind=Drifted, enabled, amber-to-orange gradient), 'Connect' disabled with hover title (installed=false OR kind=ConfigParseError). Mid-request the label transitions to 'Connecting…' / 'Disconnecting…' / 'Reconnecting…' with a spinner. After Connect, the button transitions to 'Disconnect' on the next list refresh; after Disconnect, returns to 'Connect'. After every action the page calls listAiClients() and re-renders. POST /wrappers/clients/{id}/connect writes the qontinui-wrappers entry into the client's config via atomic temp-file-then-rename, with a single .qontinui-backup.<ts> backup the first time the file is written this session.",
+        "elements": [
+          {
+            "role": "button"
+          },
+          {
+            "role": "button"
+          }
+        ],
+        "id": "ai-clients-action-buttons",
+        "isInitial": false,
+        "name": "AI Clients Tab — Action Buttons",
+        "transitions": []
+      },
+      {
+        "description": "Each card has a 'Details' disclosure button (chevron icon) that expands to reveal: (1) the absolute config file path under 'Config file:'; (2) for ConfigParseError state, a red 'Config error:' block with the path and the message 'Open this file and fix the JSON, or delete it to start fresh.'; (3) the JSON snippet that will be written or removed under the mcpServers key, with placeholders '<launcher path>' and '<port>' since the live values aren't fetched into the UI; (4) for Drifted state, the current (stale) command path and port shown alongside the new values that Reconnect will write. The note 'The runner fills in its own stable launcher path and current port.' is rendered below the JSON snippet.",
+        "elements": [
+          {
+            "role": "button"
+          }
+        ],
+        "id": "ai-clients-details-disclosure",
+        "isInitial": false,
+        "name": "AI Clients Tab — Details Disclosure",
         "transitions": []
       }
     ]

--- a/specs/pages/wrappers/state-machine.derived.json
+++ b/specs/pages/wrappers/state-machine.derived.json
@@ -2,10 +2,27 @@
   "version": "1.0",
   "id": "wrappers",
   "name": "WrappersLibraryPage",
+  "description": "The Wrappers Library page lists installed wrapper extensions, lets users discover and install new ones from the public registry, and registers the qontinui-wrappers MCP server with installed AI clients. Three tabs: Installed (default), AI Clients, Browse.",
+  "metadata": {
+    "tags": [
+      "ai-clients",
+      "connect",
+      "extensions",
+      "install",
+      "library",
+      "mcp",
+      "registry",
+      "wrappers"
+    ]
+  },
+  "provenance": {
+    "source": "migrated"
+  },
   "states": [
     {
       "id": "page-structure",
       "name": "Page Structure & Layout",
+      "description": "The page uses a centered max-width container with a header, tab bar, and content area. Layout is consistent with other refined runner pages (UI Bridge, etc.) — max-w-[1024px] container, padded content, dark theme.",
       "requiredElements": [
         {
           "attributes": {
@@ -20,7 +37,6 @@
           "textContains": "Install wrapper extensions to give the runner"
         }
       ],
-      "description": "The page uses a centered max-width container with a header, tab bar, and content area. Layout is consistent with other refined runner pages (UI Bridge, etc.) — max-w-[1024px] container, padded content, dark theme.",
       "provenance": {
         "source": "migrated"
       }
@@ -28,13 +44,13 @@
     {
       "id": "header-icon-tile",
       "name": "Header Icon Tile",
+      "description": "The header includes a 36×36 cyan-tinted icon tile holding a Package icon — this matches the 'icon-tile' visual pattern established on the UI Bridge integration page.",
       "requiredElements": [
         {
           "role": "heading",
           "text": "Wrappers"
         }
       ],
-      "description": "The header includes a 36×36 cyan-tinted icon tile holding a Package icon — this matches the 'icon-tile' visual pattern established on the UI Bridge integration page.",
       "precondition": "The Wrappers page is active",
       "provenance": {
         "source": "migrated"
@@ -42,7 +58,8 @@
     },
     {
       "id": "tab-navigation",
-      "name": "Tab Navigation (Installed / Browse)",
+      "name": "Tab Navigation (Installed / AI Clients / Browse)",
+      "description": "The wrappers page has three tabs in this order: Installed (default), AI Clients, and Browse. The active tab is highlighted with a cyan underline and cyan-400 text; inactive tabs use muted-foreground.",
       "requiredElements": [
         {
           "tagName": "button",
@@ -59,9 +76,12 @@
         {
           "tagName": "button",
           "text": "Installed"
+        },
+        {
+          "tagName": "button",
+          "text": "AI Clients"
         }
       ],
-      "description": "Two tabs at the top of the content area let users switch between viewing installed wrappers and browsing the public registry. The active tab is indicated by a cyan-400 underline and cyan-400 text color. The Installed tab also shows a count badge of installed wrappers when > 0.",
       "precondition": "At least one wrapper is installed",
       "provenance": {
         "source": "migrated"
@@ -70,6 +90,7 @@
     {
       "id": "installed-tab-empty-state",
       "name": "Installed Tab — Empty State",
+      "description": "When no wrappers are installed, the Installed tab renders an empty-state card with a dashed border, a Package icon-tile, the heading 'No wrappers installed yet', and a hint pointing the user to the Browse tab.",
       "requiredElements": [
         {
           "role": "heading",
@@ -79,7 +100,6 @@
           "textContains": "Switch to the Browse tab to discover wrappers"
         }
       ],
-      "description": "When no wrappers are installed, the Installed tab renders an empty-state card with a dashed border, a Package icon-tile, the heading 'No wrappers installed yet', and a hint pointing the user to the Browse tab.",
       "precondition": "No wrappers are installed and the Installed tab is active",
       "provenance": {
         "source": "migrated"
@@ -88,6 +108,7 @@
     {
       "id": "installed-tab-loading-error",
       "name": "Installed Tab — Loading & Error States",
+      "description": "While the wrapper list is being fetched from GET /wrappers, a centered spinner with the text 'Loading installed wrappers…' is shown. If the fetch fails, an error card is shown with a Retry button that re-runs the fetch.",
       "requiredElements": [
         {
           "textContains": "Loading installed wrappers"
@@ -100,7 +121,6 @@
           "text": "Retry"
         }
       ],
-      "description": "While the wrapper list is being fetched from GET /wrappers, a centered spinner with the text 'Loading installed wrappers…' is shown. If the fetch fails, an error card is shown with a Retry button that re-runs the fetch.",
       "precondition": "GET /wrappers is in flight",
       "provenance": {
         "source": "migrated"
@@ -109,6 +129,7 @@
     {
       "id": "installed-tab-card-grid",
       "name": "Installed Tab — Wrapper Card Grid",
+      "description": "When wrappers are installed, the Installed tab renders a 1- or 2-column grid (responsive on md+) of wrapper cards. Each card displays the wrapper's display name, package name + version, description (line-clamped to 2 lines), transport badge, status badge, action count, a three-dot menu for lifecycle actions, and an Open button.",
       "requiredElements": [
         {
           "role": "heading",
@@ -137,7 +158,6 @@
           "text": "Wrappers"
         }
       ],
-      "description": "When wrappers are installed, the Installed tab renders a 1- or 2-column grid (responsive on md+) of wrapper cards. Each card displays the wrapper's display name, package name + version, description (line-clamped to 2 lines), transport badge, status badge, action count, a three-dot menu for lifecycle actions, and an Open button.",
       "precondition": "At least one wrapper is installed and the Installed tab is active",
       "provenance": {
         "source": "migrated"
@@ -146,6 +166,7 @@
     {
       "id": "browse-tab-search",
       "name": "Browse Tab — Search & Refresh",
+      "description": "The Browse tab has a search input (with a Search icon prefix) and a Refresh button next to it. Search filters the registry entries by id, package, displayName, description, categories, or author name (case-insensitive substring match). Refresh forces a re-fetch of the registry, bypassing the 24h cache.",
       "requiredElements": [
         {},
         {},
@@ -154,7 +175,6 @@
           "text": "Refresh"
         }
       ],
-      "description": "The Browse tab has a search input (with a Search icon prefix) and a Refresh button next to it. Search filters the registry entries by id, package, displayName, description, categories, or author name (case-insensitive substring match). Refresh forces a re-fetch of the registry, bypassing the 24h cache.",
       "precondition": "The Browse tab is active",
       "provenance": {
         "source": "migrated"
@@ -163,6 +183,7 @@
     {
       "id": "browse-tab-states",
       "name": "Browse Tab — Loading / Error / Empty States",
+      "description": "The Browse tab handles three non-populated states: a loading spinner while fetching the registry, an error card if the fetch fails, and an empty/no-results state when the registry is empty or the search query matches nothing.",
       "requiredElements": [
         {
           "textContains": "Loading registry"
@@ -174,7 +195,6 @@
           "textContains": "registry is empty"
         }
       ],
-      "description": "The Browse tab handles three non-populated states: a loading spinner while fetching the registry, an error card if the fetch fails, and an empty/no-results state when the registry is empty or the search query matches nothing.",
       "precondition": "Registry fetch is in flight",
       "provenance": {
         "source": "migrated"
@@ -183,6 +203,7 @@
     {
       "id": "browse-tab-entries",
       "name": "Browse Tab — Registry Entries",
+      "description": "Each registry entry is rendered as a list item showing the wrapper's displayName, an optional 'verified' badge (with ShieldCheck icon, emerald-tinted), the author name, the npm package name + version (monospace), description, category chips, an optional repo link (with ExternalLink icon), a TransportBadge, and an Install button.",
       "requiredElements": [
         {
           "tagName": "li"
@@ -208,7 +229,6 @@
           "text": "repo"
         }
       ],
-      "description": "Each registry entry is rendered as a list item showing the wrapper's displayName, an optional 'verified' badge (with ShieldCheck icon, emerald-tinted), the author name, the npm package name + version (monospace), description, category chips, an optional repo link (with ExternalLink icon), a TransportBadge, and an Install button.",
       "precondition": "The Browse tab is active and at least one registry entry is loaded",
       "provenance": {
         "source": "migrated"
@@ -217,6 +237,7 @@
     {
       "id": "visual-typography",
       "name": "Visual Design — Typography",
+      "description": "Heading hierarchy: h1 'Wrappers' is text-2xl + font-bold + tracking-tight. Section headings (e.g., 'No wrappers installed yet') are h3 + text-sm + font-semibold. Body text is text-xs muted. Package names are font-mono.",
       "requiredElements": [
         {
           "role": "heading",
@@ -226,7 +247,6 @@
           "textContains": "Install wrapper extensions"
         }
       ],
-      "description": "Heading hierarchy: h1 'Wrappers' is text-2xl + font-bold + tracking-tight. Section headings (e.g., 'No wrappers installed yet') are h3 + text-sm + font-semibold. Body text is text-xs muted. Package names are font-mono.",
       "provenance": {
         "source": "migrated"
       }
@@ -234,6 +254,7 @@
     {
       "id": "visual-color-scheme",
       "name": "Visual Design — Color Scheme",
+      "description": "Cyan-400 is the primary accent (active tab, icon-tile borders, links, ring highlights). Cyan-to-purple gradient is reserved for primary action buttons (Install). Status badges use semantic colors: green for running, red for error, yellow for degraded.",
       "requiredElements": [
         {
           "tagName": "button",
@@ -244,7 +265,6 @@
           "text": "Install"
         }
       ],
-      "description": "Cyan-400 is the primary accent (active tab, icon-tile borders, links, ring highlights). Cyan-to-purple gradient is reserved for primary action buttons (Install). Status badges use semantic colors: green for running, red for error, yellow for degraded.",
       "precondition": "The Installed tab is active",
       "provenance": {
         "source": "migrated"
@@ -253,6 +273,7 @@
     {
       "id": "visual-spacing-layout",
       "name": "Visual Design — Spacing & Layout",
+      "description": "The content is constrained to a centered max-w-[1024px] container with px-4/sm:px-6 horizontal padding and py-8 vertical padding. Inside the container, a flex column with gap-4 spaces the header / tab bar / content. Wrapper cards in the Installed grid use gap-4 and switch from 1 column to 2 columns at md+.",
       "requiredElements": [
         {
           "role": "heading",
@@ -263,7 +284,6 @@
           "text": "Wrappers"
         }
       ],
-      "description": "The content is constrained to a centered max-w-[1024px] container with px-4/sm:px-6 horizontal padding and py-8 vertical padding. Inside the container, a flex column with gap-4 spaces the header / tab bar / content. Wrapper cards in the Installed grid use gap-4 and switch from 1 column to 2 columns at md+.",
       "precondition": "At least 2 wrappers are installed",
       "provenance": {
         "source": "migrated"
@@ -272,6 +292,7 @@
     {
       "id": "data-correctness",
       "name": "Data Correctness — Installed list reflects backend",
+      "description": "The Installed tab is the user's window into the runner's wrapper subsystem. What the page shows MUST match what the backend reports. These assertions specify the contract between the UI and GET /wrappers / GET /wrappers/:id/status.",
       "requiredElements": [
         {
           "role": "heading",
@@ -290,25 +311,88 @@
           "text": "Browse"
         }
       ],
-      "description": "The Installed tab is the user's window into the runner's wrapper subsystem. What the page shows MUST match what the backend reports. These assertions specify the contract between the UI and GET /wrappers / GET /wrappers/:id/status.",
       "precondition": "The Installed tab is active and the runner is reachable",
       "provenance": {
         "source": "migrated"
       }
+    },
+    {
+      "id": "ai-clients-tab-structure",
+      "name": "AI Clients Tab — Structure & Cards",
+      "description": "When the AI Clients tab is active, the page renders a vertical stack of one card per supported client: Claude CLI, Claude Desktop, Cursor, Continue, Cline. Each card has a heading with the client's display name, a status pill, an action button (Connect / Disconnect / Reconnect), and a Details disclosure button. Detection (GET /wrappers/clients) marks a client installed if EITHER its config file exists OR its launcher binary is on PATH.",
+      "requiredElements": [
+        {
+          "role": "heading",
+          "text": "Claude CLI"
+        },
+        {
+          "role": "heading",
+          "text": "Claude Desktop"
+        },
+        {
+          "role": "heading",
+          "text": "Cursor"
+        },
+        {
+          "role": "heading",
+          "text": "Continue"
+        },
+        {
+          "role": "heading",
+          "text": "Cline"
+        }
+      ],
+      "precondition": "AI Clients tab is active",
+      "provenance": {
+        "source": "ai-generated"
+      }
+    },
+    {
+      "id": "ai-clients-status-pills",
+      "name": "AI Clients Tab — Status Pills",
+      "description": "The status pill on each card reflects the connection state returned by GET /wrappers/clients. Five visual variants exist: 'Connected' (emerald, kind=Connected), 'Connected (out of date)' (amber, kind=Drifted — entry exists but command path or env.QONTINUI_PRIMARY_PORT differs from the runner's current values), 'Not connected' (muted, kind=NotConnected), 'Invalid JSON' (red, kind=ConfigParseError — config file exists but doesn't parse), and 'Not detected' (muted, client not installed). Pill text is uppercase tracking-wider 10px font with a 1px border in the matching accent color and a 10% transparent fill.",
+      "requiredElements": [
+        {
+          "role": "button",
+          "textContains": "onnect"
+        }
+      ],
+      "precondition": "AI Clients tab is active and at least one card is rendered",
+      "provenance": {
+        "source": "ai-generated"
+      }
+    },
+    {
+      "id": "ai-clients-action-buttons",
+      "name": "AI Clients Tab — Action Buttons",
+      "description": "The action button on each card reflects connection state and drives POST /wrappers/clients/{id}/{connect|disconnect}. Possible labels: 'Connect' (kind=NotConnected, enabled, cyan-to-purple gradient), 'Disconnect' (kind=Connected, enabled, neutral border), 'Reconnect' (kind=Drifted, enabled, amber-to-orange gradient), 'Connect' disabled with hover title (installed=false OR kind=ConfigParseError). Mid-request the label transitions to 'Connecting…' / 'Disconnecting…' / 'Reconnecting…' with a spinner. After Connect, the button transitions to 'Disconnect' on the next list refresh; after Disconnect, returns to 'Connect'. After every action the page calls listAiClients() and re-renders. POST /wrappers/clients/{id}/connect writes the qontinui-wrappers entry into the client's config via atomic temp-file-then-rename, with a single .qontinui-backup.<ts> backup the first time the file is written this session.",
+      "requiredElements": [
+        {
+          "role": "button"
+        },
+        {
+          "role": "button"
+        }
+      ],
+      "precondition": "AI Clients tab is active",
+      "provenance": {
+        "source": "ai-generated"
+      }
+    },
+    {
+      "id": "ai-clients-details-disclosure",
+      "name": "AI Clients Tab — Details Disclosure",
+      "description": "Each card has a 'Details' disclosure button (chevron icon) that expands to reveal: (1) the absolute config file path under 'Config file:'; (2) for ConfigParseError state, a red 'Config error:' block with the path and the message 'Open this file and fix the JSON, or delete it to start fresh.'; (3) the JSON snippet that will be written or removed under the mcpServers key, with placeholders '<launcher path>' and '<port>' since the live values aren't fetched into the UI; (4) for Drifted state, the current (stale) command path and port shown alongside the new values that Reconnect will write. The note 'The runner fills in its own stable launcher path and current port.' is rendered below the JSON snippet.",
+      "requiredElements": [
+        {
+          "role": "button"
+        }
+      ],
+      "precondition": "AI Clients tab is active and a Details disclosure has been expanded",
+      "provenance": {
+        "source": "ai-generated"
+      }
     }
   ],
-  "transitions": [],
-  "provenance": {
-    "source": "migrated"
-  },
-  "description": "The Wrappers Library page lists installed wrapper extensions and lets users discover/install new ones from the public registry. Wrappers are first-class extensions that add typed actions to the runner — think MCP servers, but native. The page has two tabs (Installed / Browse) and is the entry point to per-wrapper detail views (Actions, Settings, Logs, About). Backed by the runner's HTTP endpoints under /wrappers/* (registry, install, lifecycle, dispatch).",
-  "metadata": {
-    "tags": [
-      "wrappers",
-      "extensions",
-      "registry",
-      "install",
-      "library"
-    ]
-  }
+  "transitions": []
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -236,7 +236,14 @@ pub fn terminal_grid_diff(
         .ok_or_else(|| format!("Terminal not found: {}", b_terminal_id))?;
     let a_grid_handle = a.grid();
     let b_grid_handle = b.grid();
-    let diff = {
+    // Self-diff would deadlock on a single-mutex re-lock — detect via
+    // Arc::ptr_eq and take one lock instead.
+    let diff = if Arc::ptr_eq(&a_grid_handle, &b_grid_handle) {
+        let grid = a_grid_handle
+            .lock()
+            .map_err(|e| format!("Grid lock poisoned: {}", e))?;
+        grid.diff_lines(&grid)
+    } else {
         let ag = a_grid_handle
             .lock()
             .map_err(|e| format!("Grid A lock poisoned: {}", e))?;

--- a/src-tauri/src/database/pg/completion_reports.rs
+++ b/src-tauri/src/database/pg/completion_reports.rs
@@ -27,6 +27,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::time::Instant;
+use tracing::debug;
+use uuid::Uuid;
 
 // ============================================================================
 // Wire types — match the §2 "Rust schema" exactly.
@@ -368,6 +371,8 @@ impl PgDb {
         let report_json =
             serde_json::to_value(report).map_err(|e| format!("serialize report: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -377,7 +382,7 @@ impl PgDb {
                     updated_at = NOW()
                 WHERE id = $3::uuid
                 "#,
-                &[&report_json, &source.as_str(), &task_id],
+                &[&report_json, &source.as_str(), &task_uuid],
             )
             .await
             .map_err(|e| format!("write_completion_report: {}", e))?;
@@ -401,6 +406,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 r#"
@@ -408,7 +415,7 @@ impl PgDb {
                 FROM coord.tasks
                 WHERE id = $1::uuid
                 "#,
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("get_completion_report: {}", e))?;
@@ -465,6 +472,10 @@ impl PgDb {
         // does not enable `with-uuid-1`, so we cast the array element-wise
         // to text in the SELECT and decode as Vec<String> — same convention
         // as `tasks.depends_on` in `database/pg/tasks.rs`.
+        let proposed_upstream_uuid = Uuid::parse_str(proposed_upstream_id)
+            .map_err(|e| format!("invalid proposed_upstream_id uuid: {}", e))?;
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let row_opt = conn
             .query_opt(
                 r#"
@@ -497,7 +508,7 @@ impl PgDb {
                 WHERE upstream_id = $2::uuid
                 LIMIT 1
                 "#,
-                &[&proposed_upstream_id, &task_id],
+                &[&proposed_upstream_uuid, &task_uuid],
             )
             .await
             .map_err(|e| format!("detect_dependency_cycle: {}", e))?;
@@ -525,6 +536,10 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let upstream_uuid = Uuid::parse_str(upstream_task_id)
+            .map_err(|e| format!("invalid upstream_task_id uuid: {}", e))?;
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -533,7 +548,7 @@ impl PgDb {
                     updated_at = NOW()
                 WHERE id = $2::uuid
                 "#,
-                &[&upstream_task_id, &task_id],
+                &[&upstream_uuid, &task_uuid],
             )
             .await
             .map_err(|e| format!("add_task_dependency: {}", e))?;
@@ -558,6 +573,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -566,7 +583,7 @@ impl PgDb {
                     updated_at = NOW()
                 WHERE id = $2::uuid
                 "#,
-                &[&extras, &task_id],
+                &[&extras, &task_uuid],
             )
             .await
             .map_err(|e| format!("write_assignment_brief_extras: {}", e))?;
@@ -587,6 +604,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         conn.execute(
             r#"
             UPDATE coord.tasks
@@ -594,7 +613,7 @@ impl PgDb {
                 updated_at = NOW()
             WHERE id = $1::uuid
             "#,
-            &[&task_id],
+            &[&task_uuid],
         )
         .await
         .map_err(|e| format!("clear_assignment_brief_extras: {}", e))?;
@@ -616,6 +635,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 r#"
@@ -623,7 +644,7 @@ impl PgDb {
                 FROM coord.tasks
                 WHERE id = $1::uuid
                 "#,
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("get_assignment_brief_extras: {}", e))?;
@@ -644,13 +665,37 @@ impl PgDb {
         &self,
         task_id: &str,
     ) -> Result<UnblockEvaluation, String> {
+        // Per-tick telemetry — see `flip_telemetry` block at the function
+        // exit. Plan §9 explicitly accepted the N+1 round-trip cost as
+        // "fine at current scale; flag for telemetry"; this debug! emits
+        // the counts so the cost is observable in logs once N grows.
+        let started_at = Instant::now();
+
         // Reload the task row inside this call so we have a fresh snapshot of
         // depends_on. The scheduler's observation could be 10s stale.
         let task = match self.get_task_by_id(task_id).await? {
             Some(t) => t,
             None => return Err(format!("no task with id {}", task_id)),
         };
+        let upstream_count = task.depends_on.len();
+        let log_telemetry = |outcome: &'static str, upstream_loads: usize, report_loads: usize| {
+            // Round-trip count is the load-candidate (1) + per-upstream
+            // task loads + per-upstream report loads + (Flipped only) the
+            // final UPDATE (1). Caller can derive total from the fields.
+            debug!(
+                target: "qontinui_runner::coord::rule_e",
+                task_id = %task_id,
+                upstream_count,
+                upstream_loads,
+                report_loads,
+                elapsed_ms = started_at.elapsed().as_millis() as u64,
+                outcome,
+                "evaluate_and_flip_unblocked_task: per-task telemetry"
+            );
+        };
+
         if task.status != "pending" {
+            log_telemetry("skipped_not_pending", 0, 0);
             return Ok(UnblockEvaluation::Skipped {
                 reason: format!("task status is {}, not pending", task.status),
             });
@@ -658,19 +703,28 @@ impl PgDb {
 
         // Gather every upstream's status + completion_report in one fan-out.
         // depends_on can legitimately be empty — empty deps are trivially
-        // unblocked, no upstream reports to attach.
+        // unblocked, no upstream reports to attach. Each iteration costs 2
+        // PG round-trips (task row + completion report) — the N+1 the
+        // telemetry exposes.
         let mut upstream_pairs: Vec<(String, Option<CompletionReport>)> =
-            Vec::with_capacity(task.depends_on.len());
+            Vec::with_capacity(upstream_count);
+        let mut upstream_loads = 0usize;
+        let mut report_loads = 0usize;
         for dep_id in &task.depends_on {
             let dep = match self.get_task_by_id(dep_id).await? {
-                Some(d) => d,
+                Some(d) => {
+                    upstream_loads += 1;
+                    d
+                }
                 None => {
+                    log_telemetry("skipped_upstream_missing", upstream_loads, report_loads);
                     return Ok(UnblockEvaluation::Skipped {
                         reason: format!("upstream {} not found", dep_id),
                     });
                 }
             };
             if dep.status != "done" {
+                log_telemetry("skipped_upstream_not_done", upstream_loads, report_loads);
                 return Ok(UnblockEvaluation::Skipped {
                     reason: format!("upstream {} is {}", dep.id, dep.status),
                 });
@@ -679,6 +733,7 @@ impl PgDb {
                 .get_completion_report(&dep.id)
                 .await?
                 .map(|(r, _src)| r);
+            report_loads += 1;
             upstream_pairs.push((dep.id.clone(), report));
         }
 
@@ -691,6 +746,7 @@ impl PgDb {
             .map(|(id, _)| id.clone())
             .collect();
         if !missing.is_empty() {
+            log_telemetry("missing_report", upstream_loads, report_loads);
             return Ok(UnblockEvaluation::MissingReport {
                 upstream_ids: missing,
             });
@@ -714,6 +770,7 @@ impl PgDb {
             }
         }
         if !blockers.is_empty() {
+            log_telemetry("blocked_followups", upstream_loads, report_loads);
             return Ok(UnblockEvaluation::Blocked { blockers });
         }
 
@@ -741,6 +798,8 @@ impl PgDb {
             .get()
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -751,15 +810,17 @@ impl PgDb {
                 WHERE id = $1::uuid
                   AND status = 'pending'
                 "#,
-                &[&task_id, &extras],
+                &[&task_uuid, &extras],
             )
             .await
             .map_err(|e| format!("evaluate_and_flip_unblocked_task: {}", e))?;
         if n == 0 {
+            log_telemetry("skipped_concurrent_flip", upstream_loads, report_loads);
             return Ok(UnblockEvaluation::Skipped {
                 reason: "row was flipped concurrently".to_string(),
             });
         }
+        log_telemetry("flipped", upstream_loads, report_loads);
         Ok(UnblockEvaluation::Flipped)
     }
 
@@ -782,6 +843,8 @@ impl PgDb {
             .get()
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let rows = conn
             .query(
                 r#"
@@ -797,7 +860,7 @@ impl PgDb {
                       )
                   )
                 "#,
-                &[&plan_id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("mark_ready_for_unblocked_with_briefs select: {}", e))?;
@@ -914,8 +977,10 @@ impl PgDb {
             "#
         };
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
-            .execute(sql, &[&task_id, &from, &to])
+            .execute(sql, &[&task_uuid, &from, &to])
             .await
             .map_err(|e| format!("transition_task_status_unchecked: {}", e))?;
 
@@ -953,6 +1018,8 @@ impl PgDb {
         // text[] parameter. completion_report itself must be non-null —
         // the WHERE clause guards against that case.
         let path: Vec<String> = vec!["artifacts".to_string(), key.to_string()];
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -966,7 +1033,7 @@ impl PgDb {
                     updated_at = NOW()
                 WHERE id = $1::uuid AND completion_report IS NOT NULL
                 "#,
-                &[&task_id, &path, &value],
+                &[&task_uuid, &path, &value],
             )
             .await
             .map_err(|e| format!("write_completion_report_artifact: {}", e))?;
@@ -1037,10 +1104,12 @@ impl PgDb {
 
         // First confirm the row exists. Avoids a silent no-op on a typo'd
         // task_id that would mask a bug at the call site.
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let exists = conn
             .query_opt(
                 r#"SELECT 1 FROM coord.tasks WHERE id = $1::uuid"#,
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("force_task_status_to_done lookup: {}", e))?;
@@ -1057,7 +1126,7 @@ impl PgDb {
                     updated_at = NOW()
                 WHERE id = $1::uuid AND status <> 'done'
                 "#,
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("force_task_status_to_done: {}", e))?;
@@ -1518,8 +1587,12 @@ mod tests {
         assert!(!path.is_empty(), "cycle path must contain at least 1 step");
 
         // Cleanup so re-runs don't accumulate.
+        let plan_cleanup_uuid = Uuid::parse_str(&plan_id).expect("test plan_id must be uuid");
         let _ = conn
-            .execute("DELETE FROM coord.plans WHERE id = $1::uuid", &[&plan_id])
+            .execute(
+                "DELETE FROM coord.plans WHERE id = $1::uuid",
+                &[&plan_cleanup_uuid],
+            )
             .await;
     }
 
@@ -1579,8 +1652,12 @@ mod tests {
             .expect("detect_dependency_cycle");
         assert!(cycle.is_none(), "A -> D must be safe (D is a leaf)");
 
+        let plan_cleanup_uuid = Uuid::parse_str(&plan_id).expect("test plan_id must be uuid");
         let _ = conn
-            .execute("DELETE FROM coord.plans WHERE id = $1::uuid", &[&plan_id])
+            .execute(
+                "DELETE FROM coord.plans WHERE id = $1::uuid",
+                &[&plan_cleanup_uuid],
+            )
             .await;
     }
 }

--- a/src-tauri/src/database/pg/coordinator_decisions.rs
+++ b/src-tauri/src/database/pg/coordinator_decisions.rs
@@ -15,6 +15,7 @@
 
 use super::PgDb;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// One row from `coordinator_decisions`. The TS contract in
 /// productivity-stack §8 lists this as `CoordinatorDecision` with
@@ -127,13 +128,15 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let decision_uuid =
+            Uuid::parse_str(decision_id).map_err(|e| format!("invalid decision_id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 &format!(
                     "SELECT {} FROM coord.coordinator_decisions WHERE id = $1::uuid",
                     SELECT_COLS
                 ),
-                &[&decision_id],
+                &[&decision_uuid],
             )
             .await
             .map_err(|e| format!("Failed to load coordinator decision: {}", e))?;
@@ -256,6 +259,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let decision_uuid =
+            Uuid::parse_str(decision_id).map_err(|e| format!("invalid decision_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -266,7 +271,7 @@ impl PgDb {
                 WHERE id = $1::uuid
                   AND resolved = FALSE
                 "#,
-                &[&decision_id, &resolution],
+                &[&decision_uuid, &resolution],
             )
             .await
             .map_err(|e| format!("Failed to resolve coordinator decision: {}", e))?;

--- a/src-tauri/src/database/pg/plans.rs
+++ b/src-tauri/src/database/pg/plans.rs
@@ -13,6 +13,7 @@
 
 use super::PgDb;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// A row from the `plans` table.
 ///
@@ -125,6 +126,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 r#"
@@ -133,7 +136,7 @@ impl PgDb {
                 FROM coord.plans
                 WHERE id = $1::uuid
                 "#,
-                &[&plan_id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("Failed to load plan by id: {}", e))?;
@@ -225,10 +228,12 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let task_count: i64 = conn
             .query_one(
                 "SELECT COUNT(*)::bigint FROM coord.tasks WHERE plan_id = $1::uuid",
-                &[&plan_id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("Failed to count tasks for plan: {}", e))?
@@ -250,6 +255,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -257,7 +264,7 @@ impl PgDb {
                 SET status = $2, updated_at = NOW()
                 WHERE id = $1::uuid
                 "#,
-                &[&plan_id, &status],
+                &[&plan_uuid, &status],
             )
             .await
             .map_err(|e| format!("Failed to update plan status: {}", e))?;
@@ -274,12 +281,14 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
                 DELETE FROM coord.plans WHERE id = $1::uuid
                 "#,
-                &[&plan_id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("Failed to delete plan: {}", e))?;

--- a/src-tauri/src/database/pg/productivity_knowledge.rs
+++ b/src-tauri/src/database/pg/productivity_knowledge.rs
@@ -22,6 +22,7 @@ use crate::database::embeddings::{
 };
 use serde::{Deserialize, Serialize};
 use tracing::warn;
+use uuid::Uuid;
 
 /// A row from the `productivity_knowledge` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -138,13 +139,15 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let id_uuid =
+            Uuid::parse_str(id).map_err(|e| format!("invalid knowledge id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 &format!(
                     "SELECT {} FROM productivity_knowledge WHERE id = $1::uuid",
                     SELECT_COLUMNS
                 ),
-                &[&id],
+                &[&id_uuid],
             )
             .await
             .map_err(|e| format!("Failed to get knowledge: {}", e))?;

--- a/src-tauri/src/database/pg/reviews.rs
+++ b/src-tauri/src/database/pg/reviews.rs
@@ -17,6 +17,7 @@
 
 use super::PgDb;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// One row from `reviews`. The TS contract in productivity-stack §8 lists
 /// this as `ReviewRow` with `camelCase` fields; the `serde(rename_all)`
@@ -145,6 +146,8 @@ impl PgDb {
             .await
             .map_err(|e| InsertReviewError::Db(format!("PG pool error: {}", e)))?;
 
+        let task_uuid = Uuid::parse_str(input.task_id)
+            .map_err(|e| InsertReviewError::Db(format!("invalid task_id uuid: {}", e)))?;
         let row = conn
             .query_one(
                 &format!(
@@ -162,7 +165,7 @@ impl PgDb {
                     SELECT_COLS
                 ),
                 &[
-                    &input.task_id,
+                    &task_uuid,
                     &input.reviewer_session_id,
                     &input.reviewed_session_id,
                     &input.verdict,
@@ -186,13 +189,15 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let review_uuid =
+            Uuid::parse_str(review_id).map_err(|e| format!("invalid review_id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 &format!(
                     "SELECT {} FROM coord.reviews WHERE id = $1::uuid",
                     SELECT_COLS
                 ),
-                &[&review_id],
+                &[&review_uuid],
             )
             .await
             .map_err(|e| format!("Failed to get review: {}", e))?;
@@ -242,6 +247,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let rows = conn
             .query(
                 &format!(
@@ -253,7 +260,7 @@ impl PgDb {
                     "#,
                     SELECT_COLS
                 ),
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("Failed to list reviews for task: {}", e))?;
@@ -304,6 +311,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let row = conn
             .query_one(
                 r#"
@@ -311,7 +320,7 @@ impl PgDb {
                 FROM coord.reviews
                 WHERE task_id = $1::uuid AND verdict = 'needs_fix'
                 "#,
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("Failed to count needs_fix reviews: {}", e))?;
@@ -371,6 +380,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let review_uuid =
+            Uuid::parse_str(review_id).map_err(|e| format!("invalid review_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -380,7 +391,7 @@ impl PgDb {
                 WHERE id = $1::uuid
                   AND user_decision IS NULL
                 "#,
-                &[&review_id, &decision],
+                &[&review_uuid, &decision],
             )
             .await
             .map_err(|e| format!("Failed to record review decision: {}", e))?;

--- a/src-tauri/src/database/pg/tasks.rs
+++ b/src-tauri/src/database/pg/tasks.rs
@@ -17,6 +17,7 @@
 
 use super::PgDb;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// A row from the `tasks` table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -113,6 +114,11 @@ impl PgDb {
 
         // Deps come in as Vec<String>; cast to UUID[] inside the query.
         let depends_on_owned: Vec<String> = input.depends_on.to_vec();
+        // Parse plan_id to Uuid for binding ($1::uuid). tokio-postgres infers
+        // Type::UUID for `$1::uuid` and rejects `&str` with
+        // "error serializing parameter 0".
+        let plan_uuid =
+            Uuid::parse_str(input.plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let row = conn
             .query_one(
                 &format!(
@@ -132,7 +138,7 @@ impl PgDb {
                     SELECT_TASK_COLUMNS
                 ),
                 &[
-                    &input.plan_id,
+                    &plan_uuid,
                     &input.plan_version_hash,
                     &input.phase_name,
                     &input.sequence_in_phase,
@@ -158,13 +164,15 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let row = conn
             .query_opt(
                 &format!(
                     "SELECT {} FROM coord.tasks WHERE id = $1::uuid",
                     SELECT_TASK_COLUMNS
                 ),
-                &[&task_id],
+                &[&task_uuid],
             )
             .await
             .map_err(|e| format!("Failed to get task: {}", e))?;
@@ -180,6 +188,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let rows = conn
             .query(
                 &format!(
@@ -191,7 +201,7 @@ impl PgDb {
                     "#,
                     SELECT_TASK_COLUMNS
                 ),
-                &[&plan_id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("Failed to list tasks for plan: {}", e))?;
@@ -208,6 +218,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let rows = conn
             .query(
                 &format!(
@@ -220,7 +232,7 @@ impl PgDb {
                     "#,
                     SELECT_TASK_COLUMNS
                 ),
-                &[&plan_id, &NON_TERMINAL_STATUSES],
+                &[&plan_uuid, &NON_TERMINAL_STATUSES],
             )
             .await
             .map_err(|e| format!("Failed to list active tasks: {}", e))?;
@@ -268,6 +280,8 @@ impl PgDb {
         // A pending task is unblocked when every dep id is present in the
         // set of done-tasks in the same plan. Empty depends_on counts as
         // unblocked too.
+        let plan_uuid =
+            Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let rows = conn
             .query(
                 r#"
@@ -284,7 +298,7 @@ impl PgDb {
                   )
                 RETURNING id::text
                 "#,
-                &[&plan_id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("Failed to mark tasks ready: {}", e))?;
@@ -309,6 +323,8 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
             .execute(
                 r#"
@@ -319,7 +335,7 @@ impl PgDb {
                     updated_at = NOW()
                 WHERE id = $1::uuid
                 "#,
-                &[&task_id, &session_id],
+                &[&task_uuid, &session_id],
             )
             .await
             .map_err(|e| format!("Failed to assign task: {}", e))?;
@@ -381,8 +397,10 @@ impl PgDb {
             }
         };
 
+        let task_uuid =
+            Uuid::parse_str(task_id).map_err(|e| format!("invalid task_id uuid: {}", e))?;
         let n = conn
-            .execute(sql, &[&task_id, &from, &to])
+            .execute(sql, &[&task_uuid, &from, &to])
             .await
             .map_err(|e| format!("Failed to transition task status: {}", e))?;
 
@@ -448,5 +466,87 @@ mod tests {
         // Illegal — skipping states
         assert!(!is_valid_transition("pending", "running"));
         assert!(!is_valid_transition("ready", "running"));
+    }
+
+    /// Regression test for the "error serializing parameter 0" bug — passing a
+    /// `&str` to `WHERE id = $1::uuid` fails because tokio-postgres infers
+    /// Type::UUID for `$1::uuid` and rejects `String::to_sql` for that type.
+    /// The fix parses the string to `uuid::Uuid` before binding. This test
+    /// proves a real round-trip insert→get→list exercises the fixed path.
+    ///
+    /// Marked `#[ignore]` because it needs a live PG fixture; run manually
+    /// with `cargo test -p qontinui-runner database::pg::tasks::tests::uuid_param_round_trip -- --ignored --nocapture`
+    /// against a temp DB whose alembic head includes v28+.
+    #[tokio::test]
+    #[ignore = "needs PG fixture (DATABASE_URL with v28+ tasks/plans applied)"]
+    async fn uuid_param_round_trip() {
+        let pg = PgDb::new_blocking_for_test();
+        let conn = pg.pool().get().await.expect("conn");
+
+        // Insert a synthetic plan we can clean up after.
+        let plan_row = conn
+            .query_one(
+                r#"
+                INSERT INTO coord.plans (markdown_path, plan_version_hash, status)
+                VALUES ($1, $2, $3)
+                RETURNING id::text, plan_version_hash
+                "#,
+                &[&"/tmp/uuid-param-round-trip.md", &"deadbe11", &"decomposed"],
+            )
+            .await
+            .expect("insert plan");
+        let plan_id: String = plan_row.get(0);
+        let plan_version_hash: String = plan_row.get(1);
+
+        // 1. insert_task — exercises the $1::uuid bind in INSERT.
+        let task = pg
+            .insert_task(&InsertTaskInput {
+                plan_id: &plan_id,
+                plan_version_hash: &plan_version_hash,
+                phase_name: "P",
+                sequence_in_phase: 1,
+                description: "round-trip-uuid",
+                expected_file_claims: &[],
+                expected_dirs: &[],
+                depends_on: &[],
+                status: "pending",
+                notes: None,
+            })
+            .await
+            .expect("insert_task should round-trip plan_id uuid");
+
+        // 2. get_task_by_id — exercises the WHERE id = $1::uuid bind in SELECT.
+        let fetched = pg
+            .get_task_by_id(&task.id)
+            .await
+            .expect("get_task_by_id should round-trip task_id uuid")
+            .expect("row exists");
+        assert_eq!(fetched.id, task.id);
+        assert_eq!(fetched.plan_id, plan_id);
+
+        // 3. list_tasks_for_plan — the smoke-test path that surfaced the bug.
+        let listed = pg
+            .list_tasks_for_plan(&plan_id)
+            .await
+            .expect("list_tasks_for_plan should round-trip plan_id uuid");
+        assert!(listed.iter().any(|r| r.id == task.id));
+
+        // Sanity: an obviously-bogus uuid string should now error early at the
+        // parse step, not silently submit a malformed query.
+        let bogus = pg.get_task_by_id("not-a-uuid").await;
+        assert!(
+            bogus.is_err(),
+            "non-uuid task_id must error at parse, got {:?}",
+            bogus
+        );
+
+        // Cleanup so re-runs don't accumulate.
+        let plan_cleanup_uuid = uuid::Uuid::parse_str(&plan_id).expect("test plan_id must be uuid");
+        let _ = conn
+            .execute(
+                "DELETE FROM coord.plans WHERE id = $1::uuid",
+                &[&plan_cleanup_uuid],
+            )
+            .await;
     }
 }

--- a/src-tauri/src/mcp/completion_reports.rs
+++ b/src-tauri/src/mcp/completion_reports.rs
@@ -43,6 +43,13 @@ use crate::mcp::types::ApiState;
 
 /// Extract the calling session's `task_run_id` from the `task_run_id` header.
 /// Returns 400 on missing/malformed header.
+///
+/// Per plan §9.5 hygiene rules, the value is UUID-parsed before being
+/// returned: the field stores `coord.tasks.assigned_session_id`, which is a
+/// `uuid` column. A non-UUID header value can never match the column and used
+/// to silently fall through to the 403 ownership check, masking the actual
+/// "garbage header" failure mode. We now reject with 400 + a descriptive
+/// message so callers see why their request was rejected.
 fn extract_task_run_id(headers: &HeaderMap) -> Result<String, (StatusCode, String)> {
     let raw = headers.get("task_run_id").ok_or((
         StatusCode::BAD_REQUEST,
@@ -63,6 +70,13 @@ fn extract_task_run_id(headers: &HeaderMap) -> Result<String, (StatusCode, Strin
             "empty task_run_id header".to_string(),
         ));
     }
+    // UUID-validate: a malformed header is a 400, not a 403.
+    Uuid::parse_str(s).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("invalid task_run_id header uuid: {}", e),
+        )
+    })?;
     Ok(s.to_string())
 }
 
@@ -443,9 +457,41 @@ mod tests {
     #[test]
     fn extract_task_run_id_ok() {
         let mut h = HeaderMap::new();
-        h.insert("task_run_id", "abc-123".parse().unwrap());
+        let valid = "11111111-2222-3333-4444-555555555555";
+        h.insert("task_run_id", valid.parse().unwrap());
         let s = extract_task_run_id(&h).unwrap();
-        assert_eq!(s, "abc-123");
+        assert_eq!(s, valid);
+    }
+
+    #[test]
+    fn extract_task_run_id_rejects_garbage_non_uuid() {
+        let mut h = HeaderMap::new();
+        h.insert("task_run_id", "abc-123".parse().unwrap());
+        let err = extract_task_run_id(&h).expect_err("garbage non-uuid header");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(
+            err.1.starts_with("invalid task_run_id header uuid:"),
+            "got: {}",
+            err.1
+        );
+    }
+
+    #[test]
+    fn extract_task_run_id_rejects_uuid_with_trailing_garbage() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "task_run_id",
+            "11111111-2222-3333-4444-555555555555-extra"
+                .parse()
+                .unwrap(),
+        );
+        let err = extract_task_run_id(&h).expect_err("malformed uuid");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(
+            err.1.starts_with("invalid task_run_id header uuid:"),
+            "got: {}",
+            err.1
+        );
     }
 
     /// Validation surface: oversize summary should reject. Exercises the

--- a/src-tauri/src/mcp/completion_sources.rs
+++ b/src-tauri/src/mcp/completion_sources.rs
@@ -233,6 +233,22 @@ async fn github_merge(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
+    // Dashboard's task-detail listener subscribes to
+    // `completion-report-written` (Phase 1 contract); emit it AND the
+    // `coordinator-wakeup` so the panel re-fetches the task and the
+    // scheduler observes the state change without waiting for its tick.
+    if let Err(e) = state.app_handle.emit(
+        "completion-report-written",
+        serde_json::json!({
+            "taskId": task.id,
+            "source": CompletionSource::GithubMerge.as_str(),
+        }),
+    ) {
+        warn!(
+            "emit completion-report-written (github-merge) failed: {}",
+            e
+        );
+    }
     if let Err(e) = state.app_handle.emit(
         "coordinator-wakeup",
         serde_json::json!({
@@ -342,6 +358,22 @@ async fn manual_user_fire(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
+    // Dashboard's task-detail listener subscribes to
+    // `completion-report-written` (Phase 1 contract); emit it AND the
+    // `coordinator-wakeup` so the panel re-fetches the task and the
+    // scheduler observes the state change without waiting for its tick.
+    if let Err(e) = state.app_handle.emit(
+        "completion-report-written",
+        serde_json::json!({
+            "taskId": task.id,
+            "source": CompletionSource::ManualUserFire.as_str(),
+        }),
+    ) {
+        warn!(
+            "emit completion-report-written (manual-user-fire) failed: {}",
+            e
+        );
+    }
     if let Err(e) = state.app_handle.emit(
         "coordinator-wakeup",
         serde_json::json!({

--- a/src-tauri/src/mcp/completion_sources.rs
+++ b/src-tauri/src/mcp/completion_sources.rs
@@ -862,12 +862,16 @@ mod tests {
         assert_eq!(ids[0], task.id);
 
         // Cleanup.
+        let plan_cleanup_uuid = Uuid::parse_str(&plan_id).expect("plan_id must be uuid");
         let _ = pg
             .pool()
             .get()
             .await
             .expect("conn")
-            .execute("DELETE FROM coord.plans WHERE id = $1::uuid", &[&plan_id])
+            .execute(
+                "DELETE FROM coord.plans WHERE id = $1::uuid",
+                &[&plan_cleanup_uuid],
+            )
             .await;
     }
 }

--- a/src-tauri/src/mcp/reflection.rs
+++ b/src-tauri/src/mcp/reflection.rs
@@ -26,6 +26,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tauri::Manager;
 use tracing::warn;
+use uuid::Uuid;
 
 use crate::commands::AppState;
 use crate::mcp::types::ApiState;
@@ -94,6 +95,10 @@ pub async fn compute_reflection(
         .await
         .map_err(|e| format!("PG pool error: {}", e))?;
 
+    // tokio-postgres infers Type::UUID for `$1::uuid` and rejects `&str`. Parse
+    // once and reuse for every WHERE plan_id = $1::uuid below.
+    let plan_uuid = Uuid::parse_str(plan_id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
+
     let task_counts_row = conn
         .query_one(
             r#"
@@ -104,7 +109,7 @@ pub async fn compute_reflection(
             FROM coord.tasks
             WHERE plan_id = $1::uuid
             "#,
-            &[&plan_id],
+            &[&plan_uuid],
         )
         .await
         .map_err(|e| format!("Failed to compute task tallies: {}", e))?;
@@ -123,7 +128,7 @@ pub async fn compute_reflection(
             JOIN coord.tasks  t ON t.id = r.task_id
             WHERE t.plan_id = $1::uuid
             "#,
-            &[&plan_id],
+            &[&plan_uuid],
         )
         .await
         .map_err(|e| format!("Failed to compute avg confidence: {}", e))?;
@@ -140,7 +145,7 @@ pub async fn compute_reflection(
             JOIN coord.tasks t ON t.id = k.task_id
             WHERE t.plan_id = $1::uuid
             "#,
-            &[&plan_id],
+            &[&plan_uuid],
         )
         .await
         .map_err(|e| format!("Failed to count knowledge: {}", e))?;
@@ -158,7 +163,7 @@ pub async fn compute_reflection(
             ORDER BY k.created_at DESC
             LIMIT 5
             "#,
-            &[&plan_id],
+            &[&plan_uuid],
         )
         .await
         .map_err(|e| format!("Failed to list top knowledge: {}", e))?;
@@ -182,7 +187,7 @@ pub async fn compute_reflection(
             WHERE t.plan_id = $1::uuid
             ORDER BY r.created_at DESC
             "#,
-            &[&plan_id],
+            &[&plan_uuid],
         )
         .await
         .map_err(|e| format!("Failed to list review trail: {}", e))?;
@@ -298,6 +303,8 @@ pub async fn compute_plan_recommendations(
     let mut candidates: Vec<PlanRecommendation> = Vec::new();
     for plan in plans {
         // Ready / not-yet-assigned tasks on this plan.
+        let plan_uuid =
+            Uuid::parse_str(&plan.id).map_err(|e| format!("invalid plan_id uuid: {}", e))?;
         let ready_row = conn
             .query_one(
                 r#"
@@ -307,7 +314,7 @@ pub async fn compute_plan_recommendations(
                   AND status IN ('ready', 'pending')
                   AND assigned_session_id IS NULL
                 "#,
-                &[&plan.id],
+                &[&plan_uuid],
             )
             .await
             .map_err(|e| format!("Failed to count ready tasks: {}", e))?;

--- a/src-tauri/src/mcp/sdk_terminal_buffer.rs
+++ b/src-tauri/src/mcp/sdk_terminal_buffer.rs
@@ -297,7 +297,21 @@ pub async fn handle_terminal_diff(
             Json(api_error(format!("terminal session '{}' not found", b_id))),
         )
     })?;
-    let diff = {
+    // Self-diff would deadlock if we naively locked `a.grid()` and
+    // `b.grid()` separately when they point to the same Mutex. Detect
+    // that case via Arc::ptr_eq and take a single lock — diff against
+    // itself is a no-op (always 0 changes), useful as a smoke check
+    // from automated tests.
+    let diff = if Arc::ptr_eq(&a.grid(), &b.grid()) {
+        let g = a.grid();
+        let grid = g.lock().map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(api_error(format!("Grid lock poisoned: {}", e))),
+            )
+        })?;
+        grid.diff_lines(&grid)
+    } else {
         let a_grid = a.grid();
         let b_grid = b.grid();
         let ag = a_grid.lock().map_err(|e| {

--- a/src-tauri/src/unified_workflow_executor/agentic_verification_loop.rs
+++ b/src-tauri/src/unified_workflow_executor/agentic_verification_loop.rs
@@ -509,10 +509,16 @@ impl LoopController {
                         // Stash the pair for the canvas panel builder.
                         wsm_pre_for_panel = Some(pre.clone());
                         wsm_post_for_panel = Some(post.clone());
+                        // `terminal_context: None` for now — when an action
+                        // targets a terminal/TUI, future code can populate
+                        // this from the relevant `Grid::text_snapshot()`
+                        // PRE/POST pair to give the WSM judge an authoritative
+                        // text view that screenshots can't deliver. See
+                        // `verification::TerminalContext`.
                         let result = wsm
                             .as_ref()
                             .unwrap()
-                            .verify(pre, &post, &prev_worker_intent, Some(&goal))
+                            .verify(pre, &post, &prev_worker_intent, Some(&goal), None)
                             .await;
                         let dur = wsm_start.elapsed().as_millis() as u64;
                         match result {

--- a/src-tauri/src/verification/mod.rs
+++ b/src-tauri/src/verification/mod.rs
@@ -11,4 +11,4 @@ pub mod world_state_verifier;
 
 pub use mode::{parse_mode, WsvConfig, WsvMode};
 pub use retry_policy::{RefusalRetryTracker, RetryDecision};
-pub use world_state_verifier::{VerifierError, WorldStateVerifier};
+pub use world_state_verifier::{TerminalContext, VerifierError, WorldStateVerifier};

--- a/src-tauri/src/verification/world_state_verifier.rs
+++ b/src-tauri/src/verification/world_state_verifier.rs
@@ -22,6 +22,28 @@ use tracing::{debug, warn};
 
 use crate::agentic_verification::{VerificationIssue, VerificationStatus, VerificationVerdict};
 
+/// Optional terminal context for actions that target a TUI / PTY rather than
+/// (or in addition to) a screenshot-able GUI surface. When provided, the WSM
+/// judge prompt includes the rendered text of the terminal *before* and
+/// *after* the action — sourced from `Grid::text_snapshot().text` per the
+/// terminal grid snapshot architecture.
+///
+/// The text is rendered cell content, not raw bytes — TUI apps that scroll,
+/// use alt-screen, or DEC 2026 sync output produce coherent text here that
+/// they would NOT produce from a wholesale byte-stream replay. See
+/// `memory/proj_terminal_grid_snapshot.md`.
+#[derive(Clone, Debug)]
+pub struct TerminalContext {
+    /// Stable identifier of the terminal session (UUID). Helps the judge
+    /// disambiguate when the agent has multiple terminals open.
+    pub session_id: String,
+    /// `\n`-joined rendered grid text BEFORE the action. Empty string is
+    /// allowed for "nothing in the terminal yet."
+    pub pre_text: String,
+    /// `\n`-joined rendered grid text AFTER the action.
+    pub post_text: String,
+}
+
 /// Errors returned by the WorldStateVerifier. Callers should fall back
 /// to the existing text-based verifier agent on any error.
 #[derive(Debug, Error)]
@@ -104,12 +126,14 @@ impl WorldStateVerifier {
         post_screenshot_b64: &str,
         intent: &str,
         goal_context: Option<&str>,
+        terminal_context: Option<&TerminalContext>,
     ) -> Result<VerificationVerdict, VerifierError> {
         let payload = self.build_payload(
             pre_screenshot_b64,
             post_screenshot_b64,
             intent,
             goal_context,
+            terminal_context,
         );
 
         let url = format!(
@@ -138,9 +162,10 @@ impl WorldStateVerifier {
         post_b64: &str,
         intent: &str,
         goal_context: Option<&str>,
+        terminal_context: Option<&TerminalContext>,
     ) -> serde_json::Value {
         let system_prompt = WSM_SYSTEM_PROMPT;
-        let user_text = build_user_text(intent, goal_context);
+        let user_text = build_user_text(intent, goal_context, terminal_context);
 
         json!({
             "model": self.model,
@@ -173,8 +198,10 @@ impl WorldStateVerifier {
 
 const WSM_SYSTEM_PROMPT: &str = "You are a GUI world-state verifier. You receive two screenshots \
 (PRE and POST) of an application and a text intent describing what action the agent attempted. \
-Your job is to judge, by comparing the two screenshots, whether the POST state reflects that the \
-intended action was actually performed on the correct target.\n\n\
+For terminal-based actions you may also receive PRE and POST blocks of rendered terminal text — \
+treat that text as authoritative for terminal content (it's sourced from a server-side VT parser, \
+not a screenshot). Your job is to judge whether the POST state reflects that the intended action \
+was actually performed on the correct target.\n\n\
 Output STRICT JSON matching this schema — no prose before or after:\n\
 ```json\n\
 {\n\
@@ -196,7 +223,11 @@ use refused when the agent appears to have acted on the wrong element.\n\n\
 Confidence must be calibrated: use high values (>0.8) only when you can clearly see the \
 intended change or the clear absence of it. Use middle values (0.5-0.7) when you are unsure.";
 
-fn build_user_text(intent: &str, goal_context: Option<&str>) -> String {
+fn build_user_text(
+    intent: &str,
+    goal_context: Option<&str>,
+    terminal_context: Option<&TerminalContext>,
+) -> String {
     let mut s = String::new();
     if let Some(goal) = goal_context {
         if !goal.is_empty() {
@@ -207,7 +238,30 @@ fn build_user_text(intent: &str, goal_context: Option<&str>) -> String {
     }
     s.push_str("## Action Intent (what the worker just attempted)\n");
     s.push_str(intent);
-    s.push_str("\n\nThe first image is PRE (before the action). The second image is POST (after the action). Compare them and return the JSON verdict.");
+    s.push_str("\n\n");
+    if let Some(tc) = terminal_context {
+        s.push_str(
+            "## Terminal output\n\
+            The action targeted a terminal/TUI session. The text below is the \
+            **rendered cell content** of that terminal (sourced from a server-\
+            side VT parser, so cursor positioning, alt-screen, and synchronized \
+            output are already resolved). Use it as additional evidence \
+            alongside the screenshots.\n\n",
+        );
+        s.push_str(&format!("Terminal session: `{}`\n\n", tc.session_id));
+        s.push_str("### PRE (terminal contents before the action)\n```\n");
+        s.push_str(&tc.pre_text);
+        if !tc.pre_text.ends_with('\n') {
+            s.push('\n');
+        }
+        s.push_str("```\n\n### POST (terminal contents after the action)\n```\n");
+        s.push_str(&tc.post_text);
+        if !tc.post_text.ends_with('\n') {
+            s.push('\n');
+        }
+        s.push_str("```\n\n");
+    }
+    s.push_str("The first image is PRE (before the action). The second image is POST (after the action). Compare them and return the JSON verdict.");
     s
 }
 
@@ -419,5 +473,46 @@ mod tests {
     fn parse_judgement_rejects_empty() {
         assert!(parse_judgement("").is_err());
         assert!(parse_judgement("no json here at all").is_err());
+    }
+
+    #[test]
+    fn build_user_text_omits_terminal_block_when_none() {
+        let s = build_user_text("click submit", Some("complete the form"), None);
+        assert!(s.contains("Action Intent"));
+        assert!(s.contains("complete the form"));
+        assert!(!s.contains("Terminal output"));
+        assert!(!s.contains("Terminal session"));
+    }
+
+    #[test]
+    fn build_user_text_includes_terminal_block_when_provided() {
+        let tc = TerminalContext {
+            session_id: "abc-123".into(),
+            pre_text: "PS D:\\repo>".into(),
+            post_text: "PS D:\\repo>\nWelcome to Claude Code".into(),
+        };
+        let s = build_user_text(
+            "type 'claude' and press Enter",
+            Some("launch claude"),
+            Some(&tc),
+        );
+        assert!(s.contains("Terminal output"));
+        assert!(s.contains("Terminal session: `abc-123`"));
+        assert!(s.contains("PS D:\\repo>"));
+        assert!(s.contains("Welcome to Claude Code"));
+        assert!(s.contains("PRE"));
+        assert!(s.contains("POST"));
+    }
+
+    #[test]
+    fn build_user_text_handles_empty_terminal_text() {
+        let tc = TerminalContext {
+            session_id: "fresh".into(),
+            pre_text: String::new(),
+            post_text: "first line".into(),
+        };
+        let s = build_user_text("spawn", None, Some(&tc));
+        assert!(s.contains("Terminal output"));
+        assert!(s.contains("first line"));
     }
 }

--- a/src/components/productivity/CompletionReportSections.test.tsx
+++ b/src/components/productivity/CompletionReportSections.test.tsx
@@ -11,6 +11,29 @@
  * `productivity.spec.uibridge.json` element-presence assertions.
  */
 
+/**
+ * TEST COVERAGE NOTE — accepted test-only debt.
+ *
+ * This file covers ONLY pure helpers exported from `CompletionReportSections.tsx`
+ * (completionSourceLabel, deliverableHref, truncatePreview, validateManualFireDraft,
+ * buildReportFromDraft, etc.). The four subcomponents themselves —
+ * <CompletionReportSection>, <UpstreamReportsPreview>, <BriefingPreview>,
+ * <ManualFireForm> — are NOT exercised by render-and-assert tests.
+ *
+ * Reason: the runner's Vitest config uses `environment: "node"` (no jsdom),
+ * so `@testing-library/react` and `render(<Component />)` aren't viable here.
+ * The matching pattern in this repo is the `WebIntegrationAuthBanner.test.ts`
+ * precedent: extract pure helpers, test those, leave JSX gating to manual-test
+ * + Playwright passes.
+ *
+ * If a render-test environment is added later (e.g. a separate vitest project
+ * with `environment: "jsdom"`), the gating logic worth covering is:
+ *   - <CompletionReportSection> returns null when `report` is null.
+ *   - <UpstreamReportsPreview> requires status === "pending" AND deps.length > 0.
+ *   - <BriefingPreview> renders when `detail.hasAssignmentBriefExtras` is true.
+ *   - <ManualFireForm> hides for status === "done".
+ */
+
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   buildReportFromDraft,

--- a/src/components/productivity/PlanTaskBoard.tsx
+++ b/src/components/productivity/PlanTaskBoard.tsx
@@ -20,6 +20,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import {
   RefreshCw,
   ChevronDown,
@@ -1134,6 +1135,45 @@ export function PlanTaskBoard() {
     window.addEventListener("productivity-select-task", onSelectTask);
     return () => window.removeEventListener("productivity-select-task", onSelectTask);
   }, []);
+
+  // Listen for `completion-report-written` Tauri events emitted by
+  // mcp/completion_reports.rs (worker self-report) and
+  // mcp/completion_sources.rs (github-merge / manual-user-fire). Refreshes
+  // both the task list and the currently-selected task's detail. Without
+  // this, external triggers (manual-user-fire from the dashboard form,
+  // a github-merge webhook, etc.) wrote the report but the panel kept
+  // showing stale "Ready" state until the user clicked refresh.
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const u = await listen<{ taskId?: string; source?: string }>(
+          "completion-report-written",
+          (event) => {
+            if (cancelled) return;
+            if (selectedPlanId) void fetchTasks(selectedPlanId);
+            const eventTaskId = event.payload?.taskId;
+            if (eventTaskId && eventTaskId === selectedTaskId) {
+              void fetchDetail(selectedTaskId);
+            }
+          },
+        );
+        if (cancelled) {
+          u();
+        } else {
+          unlisten = u;
+        }
+      } catch {
+        // listen() can fail in non-Tauri contexts (storybook, vitest);
+        // ignore — the form-driven onReloadDetail path still works.
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (unlisten) unlisten();
+    };
+  }, [selectedPlanId, fetchTasks, selectedTaskId, fetchDetail]);
 
   const selectedPlan = useMemo(
     () => plans.find((p) => p.id === selectedPlanId) ?? null,

--- a/src/hooks/changeTrackingHandler.test.ts
+++ b/src/hooks/changeTrackingHandler.test.ts
@@ -361,6 +361,120 @@ describe("handleChangeTrackingCommand (runner/snake_case)", () => {
       const result = await handleChangeTrackingCommand(ct, "get_change_buffer_size", {}, deps);
       expect(result).toEqual({ size: 5, enabled: true });
     });
+
+    // -----------------------------------------------------------------------
+    // Phase E (plan 2026-05-07): get_changes_since + get_element_history
+    // back ChangeTracker.changeBuffer via peekBuffer().
+    // -----------------------------------------------------------------------
+
+    it("get_changes_since filters by recordedAt and respects limit", async () => {
+      const fixture = [
+        { recordedAt: 1, sequence: 0 },
+        { recordedAt: 5, sequence: 1 },
+        { recordedAt: 10, sequence: 2 },
+        { recordedAt: 15, sequence: 3 },
+      ];
+      ct.peekBuffer = vi.fn().mockReturnValue(fixture);
+
+      const result = (await handleChangeTrackingCommand(
+        ct,
+        "get_changes_since",
+        { params: { since: "5", limit: "10" } },
+        deps,
+      )) as { events: Array<{ recordedAt: number }>; count: number };
+
+      expect(result.count).toBe(2);
+      expect(result.events.map((e) => e.recordedAt)).toEqual([10, 15]);
+    });
+
+    it("get_changes_since defaults to since=0, limit=100 when params missing", async () => {
+      const fixture = [
+        { recordedAt: 1, sequence: 0 },
+        { recordedAt: 2, sequence: 1 },
+      ];
+      ct.peekBuffer = vi.fn().mockReturnValue(fixture);
+
+      const result = (await handleChangeTrackingCommand(
+        ct,
+        "get_changes_since",
+        {},
+        deps,
+      )) as { events: unknown[]; count: number };
+
+      expect(result.count).toBe(2);
+    });
+
+    it("get_changes_since returns empty when peekBuffer is unavailable", async () => {
+      // Older SDK builds — peekBuffer not on the tracker. The handler
+      // falls back to [] and never throws.
+      delete (ct as { peekBuffer?: unknown }).peekBuffer;
+
+      const result = (await handleChangeTrackingCommand(
+        ct,
+        "get_changes_since",
+        { params: { since: 0, limit: 50 } },
+        deps,
+      )) as { events: unknown[]; count: number };
+
+      expect(result).toEqual({ events: [], count: 0 });
+    });
+
+    it("get_element_history returns BufferedChange entries that mention the element id", async () => {
+      const target = "btn-save";
+      const fixture = [
+        // Matches via diff.changes.modified
+        {
+          recordedAt: 100,
+          diff: {
+            changes: { modified: [{ elementId: target }], appeared: [], disappeared: [] },
+          },
+        },
+        // Matches via diff.contentChanges.textChanges
+        {
+          recordedAt: 200,
+          diff: {
+            changes: {},
+            contentChanges: {
+              textChanges: [{ elementId: target }],
+              metricChanges: [],
+              statusChanges: [],
+            },
+          },
+        },
+        // Different element — must be excluded
+        {
+          recordedAt: 300,
+          diff: {
+            changes: { modified: [{ elementId: "other-id" }] },
+          },
+        },
+        // Route-change — must be excluded by type discriminator
+        {
+          recordedAt: 400,
+          type: "route-change",
+          from: "/a",
+          to: "/b",
+        },
+      ];
+      ct.peekBuffer = vi.fn().mockReturnValue(fixture);
+
+      const result = (await handleChangeTrackingCommand(
+        ct,
+        "get_element_history",
+        { params: { id: target } },
+        deps,
+      )) as Array<{ recordedAt: number }>;
+
+      expect(result).toHaveLength(2);
+      expect(result.map((e) => e.recordedAt)).toEqual([100, 200]);
+    });
+
+    it("get_element_history throws when id is missing", async () => {
+      ct.peekBuffer = vi.fn().mockReturnValue([]);
+      await expect(
+        handleChangeTrackingCommand(ct, "get_element_history", {}, deps),
+      ).rejects.toThrow(/requires an 'id' parameter/);
+    });
   });
 
   // =========================================================================

--- a/src/hooks/changeTrackingHandler.ts
+++ b/src/hooks/changeTrackingHandler.ts
@@ -34,6 +34,14 @@ export interface ChangeTrackerLike {
   isBufferEnabled(): boolean;
   /** P1.3 — push a SPA route-change entry into the change buffer. */
   pushRouteChange?(from: string, to: string, at?: number): void;
+  /**
+   * Phase E (plan 2026-05-07) — non-draining read of the registry-level
+   * change buffer. Returns a shallow copy; safe to call repeatedly.
+   * Backs `get_changes_since` and `get_element_history`. Optional so
+   * older SDKs (pre-0.3.5) still typecheck — the handlers fall back to
+   * `[]` when the method is absent.
+   */
+  peekBuffer?(): unknown[];
 }
 
 /** Dependencies needed only for the `structured_changes` command. */
@@ -171,6 +179,74 @@ export async function handleChangeTrackingCommand(
         size: ct.getBufferSize(),
         enabled: ct.isBufferEnabled(),
       };
+    case "get_changes_since": {
+      // Rust handler ui_bridge_get_changes_since_handler forwards
+      // `{ params: { since, limit } }` where the values arrive as
+      // strings from the URL query (Query<HashMap<String, String>>),
+      // so coerce explicitly with Number() rather than relying on
+      // `typeof === "number"`. SDK-shape divergence note: the SDK's
+      // getChangesSince reads from a separate DOMChangeEvent buffer
+      // (relay-handlers.ts:1609); the runner exposes the
+      // ChangeTracker.changeBuffer view — entries carry `recordedAt`,
+      // not `timestamp`.
+      const params =
+        (payload.params as { since?: string | number; limit?: string | number } | undefined) ?? {};
+      const since = Number(params.since ?? 0);
+      const limit = Number(params.limit ?? 100);
+      const buffer = (ct.peekBuffer?.() ?? []) as Array<{ recordedAt: number }>;
+      const events = buffer.filter((e) => e.recordedAt > since).slice(-limit);
+      return { events, count: events.length };
+    }
+    case "get_element_history": {
+      // Rust handler ui_bridge_get_element_history_handler uses the
+      // `ipc_handler_path_get!` macro with param "id", so the React
+      // side receives `{ params: { id: <id-from-path> } }`.
+      const params = (payload.params as { id?: string } | undefined) ?? {};
+      const id = typeof params.id === "string" ? params.id : null;
+      if (!id) {
+        throw new Error("get_element_history requires an 'id' parameter");
+      }
+
+      // BufferEntry = BufferedChange | BufferedRouteChange. Element IDs
+      // are reachable only via nested SemanticDiff arrays on the
+      // BufferedChange side (ai/types.ts:951-985 + 646-679). Skip
+      // route-change entries via the `type` discriminator.
+      type ElIdHolder = { elementId?: string };
+      type DiffShape = {
+        changes?: {
+          appeared?: ElIdHolder[];
+          disappeared?: ElIdHolder[];
+          modified?: ElIdHolder[];
+        };
+        contentChanges?: {
+          textChanges?: ElIdHolder[];
+          metricChanges?: ElIdHolder[];
+          statusChanges?: ElIdHolder[];
+        };
+      };
+      type CandidateEntry = {
+        type?: string;
+        diff?: DiffShape;
+      };
+
+      const mentionsId = (diff: DiffShape | undefined): boolean => {
+        if (!diff) return false;
+        const lists: ElIdHolder[][] = [
+          diff.changes?.appeared ?? [],
+          diff.changes?.disappeared ?? [],
+          diff.changes?.modified ?? [],
+          diff.contentChanges?.textChanges ?? [],
+          diff.contentChanges?.metricChanges ?? [],
+          diff.contentChanges?.statusChanges ?? [],
+        ];
+        return lists.some((list) => list.some((e) => e.elementId === id));
+      };
+
+      const buffer = (ct.peekBuffer?.() ?? []) as CandidateEntry[];
+      return buffer.filter(
+        (e) => e.type !== "route-change" && mentionsId(e.diff),
+      );
+    }
     default:
       return undefined;
   }

--- a/src/hooks/ui-bridge-events/types.ts
+++ b/src/hooks/ui-bridge-events/types.ts
@@ -220,7 +220,15 @@ export type UIBridgeRequestType =
   // Toast ring buffer (GET /control/toasts)
   | "get_toast_buffer"
   // Spec execution (POST /control/spec/{id}/run)
-  | "run_spec";
+  | "run_spec"
+  // Bucket C follow-up (plan 2026-05-07): 5 of 7 handlers wired here.
+  // get_changes_since and get_element_history are deferred pending an
+  // upstream SDK PR adding ChangeTracker.peekBuffer().
+  | "receive_heartbeat"
+  | "delete_intent"
+  | "rank_elements"
+  | "set_viewport_constraints"
+  | "get_element_react_state";
 
 // ============================================================
 // N1 — Compile-time exhaustiveness registry for the chained
@@ -252,7 +260,8 @@ export type ControlEventTypes =
   | "navigate_tab"
   | "assert_element"
   | "resolve_stable_ref"
-  | "clear_storage";
+  | "clear_storage"
+  | "receive_heartbeat";
 
 export type DiscoveryEventTypes =
   | "discover"
@@ -311,7 +320,8 @@ export type DesignEventTypes =
   | "design_evaluate"
   | "design_evaluate_baseline"
   | "design_evaluate_contexts"
-  | "design_evaluate_diff";
+  | "design_evaluate_diff"
+  | "set_viewport_constraints";
 
 export type ChangeTrackingEventTypes =
   | "wait_for_route_change"
@@ -363,7 +373,8 @@ export type DebugInspectEventTypes =
   | "get_element_dom_tree"
   | "highlight_element"
   | "get_toast_buffer"
-  | "run_spec";
+  | "run_spec"
+  | "get_element_react_state";
 
 export type NetworkIdleEventTypes =
   | "get_network_requests"
@@ -400,7 +411,9 @@ export type AISearchEventTypes =
   | "register_intent"
   | "find_intent"
   | "execute_intent"
-  | "execute_intent_from_query";
+  | "execute_intent_from_query"
+  | "delete_intent"
+  | "rank_elements";
 
 export type WorkflowEventTypes = "get_workflows" | "run_workflow" | "get_workflow_status";
 

--- a/src/hooks/ui-bridge-events/types.ts
+++ b/src/hooks/ui-bridge-events/types.ts
@@ -222,13 +222,16 @@ export type UIBridgeRequestType =
   // Spec execution (POST /control/spec/{id}/run)
   | "run_spec"
   // Bucket C follow-up (plan 2026-05-07): 5 of 7 handlers wired here.
-  // get_changes_since and get_element_history are deferred pending an
-  // upstream SDK PR adding ChangeTracker.peekBuffer().
   | "receive_heartbeat"
   | "delete_intent"
   | "rank_elements"
   | "set_viewport_constraints"
-  | "get_element_react_state";
+  | "get_element_react_state"
+  // Bucket C deferred (plan 2026-05-07-ui-bridge-change-buffer-peek):
+  // both back the runner's view of ChangeTracker.changeBuffer via
+  // peekBuffer() (SDK 0.3.5).
+  | "get_changes_since"
+  | "get_element_history";
 
 // ============================================================
 // N1 — Compile-time exhaustiveness registry for the chained
@@ -340,7 +343,9 @@ export type ChangeTrackingEventTypes =
   | "enable_change_buffer"
   | "disable_change_buffer"
   | "drain_change_buffer"
-  | "get_change_buffer_size";
+  | "get_change_buffer_size"
+  | "get_changes_since"
+  | "get_element_history";
 
 export type DebugInspectEventTypes =
   | "get_console_errors"

--- a/src/hooks/ui-bridge-events/useAISearchEvents.ts
+++ b/src/hooks/ui-bridge-events/useAISearchEvents.ts
@@ -158,6 +158,34 @@ export function useAISearchEvents(
           return true;
         }
 
+        case "rank_elements": {
+          const { findElements } = await import("@qontinui/ui-bridge");
+          const registry = (
+            currentBridge as unknown as {
+              registry?: { getAllElements: () => Array<unknown> } | null;
+            }
+          ).registry;
+          const elements = (registry?.getAllElements?.() ?? []) as Parameters<
+            typeof findElements
+          >[0];
+          const query = (payload.params || {}) as Parameters<typeof findElements>[1];
+          const matches = findElements(elements, query);
+          const ranked = matches.map((m) => ({
+            id: m.id,
+            score: m.score,
+            reasons: m.reasons,
+            element: m.element,
+          }));
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: ranked,
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+
         case "wait_for_element_registered": {
           // SDK-shape wait-for-element: body carries a `predicate` object
           // (id, label, testId, selector) plus optional `requirement` and
@@ -1164,6 +1192,40 @@ export function useAISearchEvents(
               timestamp: Date.now(),
             });
           }
+          return true;
+        }
+
+        case "delete_intent": {
+          const { name } = (payload.params || {}) as { name?: string };
+          if (!name) {
+            await sendResponse({
+              requestId,
+              type,
+              success: false,
+              error: "name is required",
+              timestamp: Date.now(),
+            });
+            return true;
+          }
+          const uiBridgeGlobal = getUIBridgeGlobal();
+          const intentRegistry = uiBridgeGlobal?.intentRegistry as
+            | { delete?: (name: string) => boolean; remove?: (name: string) => boolean }
+            | undefined;
+          const removedFromRegistry =
+            intentRegistry?.delete?.(name) ?? intentRegistry?.remove?.(name) ?? false;
+          const beforeLen = localIntentStore.length;
+          for (let i = localIntentStore.length - 1; i >= 0; i--) {
+            const entry = localIntentStore[i] as { name?: string; id?: string };
+            if (entry.name === name || entry.id === name) localIntentStore.splice(i, 1);
+          }
+          const removedFromLocal = localIntentStore.length < beforeLen;
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: { deleted: removedFromRegistry || removedFromLocal },
+            timestamp: Date.now(),
+          });
           return true;
         }
 

--- a/src/hooks/ui-bridge-events/useChangeTrackingEvents.ts
+++ b/src/hooks/ui-bridge-events/useChangeTrackingEvents.ts
@@ -291,7 +291,9 @@ export function useChangeTrackingEvents(
         case "enable_change_buffer":
         case "disable_change_buffer":
         case "drain_change_buffer":
-        case "get_change_buffer_size": {
+        case "get_change_buffer_size":
+        case "get_changes_since":
+        case "get_element_history": {
           const {
             ChangeTracker,
             createSnapshotManager,

--- a/src/hooks/ui-bridge-events/useControlEvents.ts
+++ b/src/hooks/ui-bridge-events/useControlEvents.ts
@@ -502,6 +502,17 @@ export function useControlEvents(
           return true;
         }
 
+        case "receive_heartbeat": {
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: { received: true },
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+
         case "clear_storage": {
           // Clear all localStorage keys for the current instance port namespace
           const port = getApiPort();

--- a/src/hooks/ui-bridge-events/useDebugInspectEvents.ts
+++ b/src/hooks/ui-bridge-events/useDebugInspectEvents.ts
@@ -506,6 +506,57 @@ export function useDebugInspectEvents(
           return true;
         }
 
+        case "get_element_react_state": {
+          const { id } = (payload.params || {}) as { id?: string };
+          if (!id) {
+            await sendResponse({
+              requestId,
+              type,
+              success: false,
+              error: "id is required",
+              timestamp: Date.now(),
+            });
+            return true;
+          }
+          const stateEl = currentBridge.getElement(id);
+          if (!stateEl) {
+            await sendResponse({
+              requestId,
+              type,
+              success: false,
+              error: `Element not found: ${id}`,
+              timestamp: Date.now(),
+            });
+            return true;
+          }
+          const node = (stateEl as { element?: HTMLElement }).element ?? null;
+          if (!node) {
+            await sendResponse({
+              requestId,
+              type,
+              success: false,
+              error: `Element ${id} has no DOM node`,
+              timestamp: Date.now(),
+            });
+            return true;
+          }
+          const { extractReactState } = await import("@qontinui/ui-bridge");
+          const reactState = extractReactState(node);
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: reactState ?? {
+              props: {},
+              fiberState: [],
+              componentName: undefined,
+              note: "No React internals found on this element",
+            },
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+
         case "get_forms": {
           const formsResult = await discoverBridgeForms(currentBridge);
           await sendResponse({

--- a/src/hooks/ui-bridge-events/useDesignEvents.ts
+++ b/src/hooks/ui-bridge-events/useDesignEvents.ts
@@ -446,6 +446,39 @@ export function useDesignEvents(
           return true;
         }
 
+        case "set_viewport_constraints": {
+          const { width, restore } = (payload.params || {}) as {
+            width?: number;
+            restore?: boolean;
+          };
+          const docEl = document.documentElement;
+          if (restore) {
+            docEl.style.removeProperty("width");
+            docEl.style.removeProperty("min-width");
+            docEl.style.removeProperty("max-width");
+            docEl.style.removeProperty("overflow");
+          } else if (typeof width === "number") {
+            docEl.style.width = `${width}px`;
+            docEl.style.minWidth = `${width}px`;
+            docEl.style.maxWidth = `${width}px`;
+            docEl.style.overflow = "hidden";
+          }
+          void docEl.offsetHeight;
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: {
+              success: true,
+              viewportWidth: window.innerWidth,
+              constrainedWidth: width ?? window.innerWidth,
+              timestamp: Date.now(),
+            },
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+
         default:
           return false;
       }


### PR DESCRIPTION
## Summary

- Wires the 2 React-side IPC handlers the parent Bucket C plan deferred — `get_changes_since` and `get_element_history` — closing the cross-repo loop kicked off by `plans/2026-05-07-ui-bridge-change-buffer-peek-plan.md`.
- Bumps `@qontinui/ui-bridge` `^0.3.3 → ^0.3.5` to consume the new non-draining `ChangeTracker.peekBuffer()` accessor (released in [@qontinui/ui-bridge#10](https://github.com/qontinui/ui-bridge/pull/10)).
- Adds 5 unit tests covering the `recordedAt` filter, default params, missing-`peekBuffer` fallback, nested `SemanticDiff` element-id match, and the missing-id error path.

## Why now

The Rust handlers shipped in the parent Bucket C plan (commit `ae6779cca` on `chore/registry-deps`) forward two routes via IPC that had no React responder, so calls returned "no IPC handler". Both needed buffer reads with filtering across multiple HTTP calls — `drainBuffer` clears state, so it could not back either route. The new SDK accessor `peekBuffer()` (ui-bridge `0.3.5`) returns a non-draining shallow copy.

## Notable shape choices

- `get_changes_since` filters `peekBuffer()` entries by `recordedAt` — `BufferEntry = BufferedChange | BufferedRouteChange` has **no** top-level `timestamp`. The SDK's own `getChangesSince` reads from a separate `DOMChangeEvent` ring buffer (`relay-handlers.ts:1609`); runner shape divergence is intentional and called out in the plan.
- Rust handler `Query<HashMap<String, String>>` means params arrive as **strings**. Coerced with `Number()`.
- `get_element_history` walks the nested `SemanticDiff` (`changes.{appeared,disappeared,modified}[].elementId` + `contentChanges.{textChanges,metricChanges,statusChanges}[].elementId`). `BufferedRouteChange` entries are filtered out via the `type: 'route-change'` discriminator.
- `peekBuffer` is declared optional on `ChangeTrackerLike` with a `[]` fallback so the runner stays robust if a future test fixture mocks the tracker without it.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `vitest src/hooks/changeTrackingHandler.test.ts` — 30/30 (5 new)
- [x] `vitest src/hooks/ui-bridge-events/` — 13/13
- [ ] **Pending parent-plan merge:** Once `chore/registry-deps` (Rust handlers) and `feat/coordinator-launch-controls` (parent React handlers) land on main, the SDK↔runner manifest diff allow-list at `mod.rs:851,853` should drop the two corresponding entries (`/ui-bridge/control/changes/since`, `/ui-bridge/control/element/{}/history`). Phase 5 smoke verify (`scripts/contract-smoke.ps1`) runs end-to-end at that point.