### PR TITLE
chore(deps): bump @qontinui/ui-bridge ^0.3.5 -> ^0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.2.3",
-    "@qontinui/ui-bridge": "^0.3.5",
+    "@qontinui/ui-bridge": "^0.3.6",
     "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.3.6(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.3
         version: 0.2.3
       '@qontinui/ui-bridge':
-        specifier: ^0.3.5
-        version: 0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.3.6
+        version: 0.3.6(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1143,8 +1143,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  '@qontinui/ui-bridge@0.3.5':
-    resolution: {integrity: sha512-8sGn/fiUZkDXgEa34OLtlX+g02BcBumASYTKkyJUu4qzadX9hJ9g1ilxEJ/YmcR1VM0gFFz/DAz7QVOT9RGXRA==}
+  '@qontinui/ui-bridge@0.3.6':
+    resolution: {integrity: sha512-MG4teARFRKZsl6PEmfbd5D6auSiD+92Zc0xADrYZbR0ChGUWgQWfOQztQTJvXr4FHWX2TbTb7hgvcNdnEyaU3g==}
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
       '@qontinui/ui-bridge-headless': '>=0.1.0'
@@ -6106,9 +6106,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.6(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.6(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.3': {}
@@ -6116,7 +6116,7 @@ snapshots:
   '@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       '@qontinui/shared-types': 0.2.3
-      '@qontinui/ui-bridge': 0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.6(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - '@qontinui/ui-bridge-headless'
@@ -6135,7 +6135,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.3.5(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.3.6(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:


### PR DESCRIPTION
## Summary

Bumps the runner's `@qontinui/ui-bridge` pin floor from `^0.3.5` to `^0.3.6`. The previous caret already accepted 0.3.6 transitively, so consumers running `pnpm install` were already picking up the fix; this just makes the floor explicit in `package.json` + `pnpm-lock.yaml`.

## What 0.3.6 contains

Single fix from [ui-bridge#11](https://github.com/qontinui/ui-bridge/pull/11): `safeSerialize` (used internally by `extractReactState`) now has a recursion depth cap (`SAFE_SERIALIZE_MAX_DEPTH=6`) and short-circuits `Element` / `Document` / `Window` instances. Without it, `extractReactState` walked through every registered element's `__reactFiber\$` back-references into the parent fiber tree, blowing the 10s `ui_bridge_request_sync` IPC timeout before returning.

## Verification

Smoke-tested before opening this PR:

- Built a temp test runner from `ca8bdf575` (current main) with `^0.3.6` locally + fresh `pnpm install` + frontend rebuild
- Hit `GET /ui-bridge/control/element/button-browse-claude-code-sessions/react-state`
- Result: HTTP 200 in **337 ms** with the documented `{ props, fiberState, componentName }` shape
- `useRef` pointing at a DOM node correctly stringified to `"[HTMLButtonElement]"`; deeply-nested console-capture buffer entries correctly bottomed out at `"[MaxDepth]"`

Before 0.3.6 (against the same runner code): same route returned HTTP 500 with `"UI Bridge request timed out after 10000ms"` on every call.

## Test plan

- [ ] CI green
- [ ] Squash-merge once approved