### PR TITLE
fix(ui-bridge): rank_elements uses createSnapshot, not registry getAll

### DIFF
--- a/src/hooks/ui-bridge-events/useAISearchEvents.ts
+++ b/src/hooks/ui-bridge-events/useAISearchEvents.ts
@@ -160,14 +160,19 @@ export function useAISearchEvents(
 
         case "rank_elements": {
           const { findElements } = await import("@qontinui/ui-bridge");
-          const registry = (
-            currentBridge as unknown as {
-              registry?: { getAllElements: () => Array<unknown> } | null;
-            }
-          ).registry;
-          const elements = (registry?.getAllElements?.() ?? []) as Parameters<
-            typeof findElements
-          >[0];
+          // Source elements from `createSnapshot()` — NOT `registry.getAllElements()`.
+          // `findElements()` echoes each input back as `m.element`; if we
+          // pass live `RegisteredElement[]` (which carry an
+          // `element: HTMLElement` field), the response contains DOM nodes
+          // that can't be JSON-serialized through the IPC boundary, the
+          // React handler never `sendResponse`s, and the Rust side hits the
+          // 10s `ui_bridge_request_sync` timeout on every non-empty result.
+          // `BridgeSnapshot.elements` is the same set as the registry but
+          // pre-serialized to flat FindableElement-shaped POJOs, matching
+          // the SDK relay-handlers.ts:472-491 pattern (which uses
+          // `latestControlSnapshot.elements`).
+          const snapshot = currentBridge.createSnapshot();
+          const elements = snapshot.elements as Parameters<typeof findElements>[0];
           const query = (payload.params || {}) as Parameters<typeof findElements>[1];
           const matches = findElements(elements, query);
           const ranked = matches.map((m) => ({


### PR DESCRIPTION
## Summary

Fixes a P1 timeout that left `POST /ui-bridge/control/elements/rank` non-functional whenever its query matched 1+ registered elements. Surfaced during the manual-test smoke that followed `@qontinui/ui-bridge@0.3.6` (the safeSerialize fix); not a regression from that release — yesterday's smoke just happened to use a query that returned zero matches and masked it.

## Root cause

The React-side handler at `qontinui-runner/src/hooks/ui-bridge-events/useAISearchEvents.ts:161-187` sourced elements from `currentBridge.registry.getAllElements()`, which returns `RegisteredElement[]` — entries that carry a live `element: HTMLElement` field. `findElements()` then echoes each input back verbatim as `m.element`, so the response payload contained DOM nodes. Tauri's IPC layer can't JSON-serialize `HTMLElement` (cycles + React's `__reactFiber\$` back-references), the React handler never `sendResponse`s, and the Rust side hits the 10s `ui_bridge_request_sync` timeout.

## Fix

Switch to `currentBridge.createSnapshot().elements`, which is the same registered set but pre-serialized to flat `FindableElement`-shaped POJOs (`id`/`type`/`label`/`state`/`bbox`/`identifier`/etc — no DOM refs). Mirrors the SDK's own pattern at `relay-handlers.ts:472-491` (which uses `latestControlSnapshot.elements`).

Net diff: 13 insertions / 8 deletions in one file.

## Verification

Spawned a temp test runner from main with the fix applied:

| Query | Before | After |
|---|---|---|
| `{"text":"button"}` (10 matches) | 500 TIMEOUT @ 10000ms | **200 in 235ms**, 10 matches |
| `{"text":"completely-unrelated-token-xyz"}` (zero matches) | 200 in 213ms `[]` | 200 in 213ms `[]` (unchanged) |

Each match's `element` payload now has 10 flat keys: `actions`, `bbox`, `category`, `id`, `identifier`, `kind`, `label`, `origin`, `route`, `stableRef` — no DOM refs.

`pnpm tsc --noEmit` and `pnpm exec eslint` both clean on the changed file.

## History note

This bug shipped as part of the 5-React-handlers recreation in qontinui-runner#57 (after the earlier wrap-everything PR #56 was abandoned). Until today's smoke, no test had hit it with non-empty results.

## Test plan

- [ ] CI green
- [ ] Squash-merge once approved