### PR TITLE
fix(scripts+schema): gen-events-drift on Windows + close envelope drift it surfaces

### DIFF
--- a/src-tauri/scripts/generate_types.sh
+++ b/src-tauri/scripts/generate_types.sh
@@ -80,7 +80,12 @@ cargo run --bin export_schemas --release -- --pretty > "$SCHEMAS_JSON"
 DISCR_SCRIPT="$PROJECT_ROOT/../../qontinui-schemas/scripts/add_discriminators.py"
 if [ -f "$DISCR_SCRIPT" ] && command -v python >/dev/null 2>&1; then
     echo "==> Annotating oneOf unions with discriminator keyword..."
-    python "$DISCR_SCRIPT" "$SCHEMAS_JSON"
+    # Convert MSYS paths to Windows form for native python.exe — same
+    # rationale as the node + datamodel-codegen calls below.
+    # Without this the pre-push gen-events-drift hook fails on Windows
+    # worktrees with FileNotFoundError on the /d/... path. See
+    # `proj_runner_gen_events_drift_windows_bug` for the symptom history.
+    python "$(to_native_path "$DISCR_SCRIPT")" "$(to_native_path "$SCHEMAS_JSON")"
 fi
 
 if [ "$DRY_RUN" = true ]; then

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -71,6 +71,17 @@ pub fn export_all_schemas() -> Value {
     // Wire-format canvas panel struct carried inside AppEvent::CanvasUpdate's
     // `data.panel` field. Mirrors the runner's `mcp::canvas::StoredPanel`.
     add!("CanvasPanel", qae::CanvasPanel);
+    // Typed UI Bridge IPC envelopes. The structs live in
+    // `qontinui-schemas/rust/src/app_events.rs` (added by schemas commit
+    // `2aca16e feat(events): typed UI Bridge request/response envelopes`)
+    // and are serialized live by the runner at
+    // `mcp/ui_bridge/request.rs:292` and `mcp/ui_bridge/screenshots.rs:1597`.
+    // Registering them here keeps the `.d.ts` bindings already checked in at
+    // `qontinui-schemas/ts/src/generated/` matching the runner's regen
+    // output — without these, the gen-events-drift hook reports a
+    // delete-only diff against the checked-in TS files.
+    add!("UiBridgeRequestEnvelope", qae::UiBridgeRequestEnvelope);
+    add!("UiBridgeResponseEnvelope", qae::UiBridgeResponseEnvelope);
 
     // ── qontinui-types: ai_workflows ──
     add!("ExecutionStep", qaw::ExecutionStep);

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -686,7 +686,7 @@ mod tests {
         );
         assert!(obj.contains_key("AppEvent"), "Missing AppEvent schema");
         assert!(obj.contains_key("FlowEvent"), "Missing FlowEvent schema");
-        assert_eq!(obj.len(), 429, "Expected 429 schema entries");
+        assert_eq!(obj.len(), 431, "Expected 431 schema entries");
 
         // Sanity-check that qontinui_types re-exports are present
         assert!(


### PR DESCRIPTION
## Summary

Two-commit bundled fix:

1. **Windows path fix** (commit `0b6512e0d`) — the gen-events-drift pre-push hook called `python` with raw MSYS-style `/d/...` paths in the discriminator-annotation step of `src-tauri/scripts/generate_types.sh`. Wrapped both args in the existing `to_native_path()` helper (which the same script already used for `node` + `datamodel-codegen`). 6-line script change.

2. **Schema-export gap fix** (commit `fb47220a5`) — once the hook actually runs to completion on Windows, it surfaced pre-existing drift: `UiBridgeRequestEnvelope.d.ts` and `UiBridgeResponseEnvelope.d.ts` were checked into `qontinui-schemas/ts/src/generated/` but the runner's `schema_export.rs` didn't register the underlying Rust types. Added two `add!()` lines next to the existing `qae::FlowEvent` / `qae::AppEvent` / `qae::CanvasPanel` cluster (`schema_export.rs:69-73`). The structs are already serialized live by the runner at `mcp/ui_bridge/request.rs:292` and `screenshots.rs:1597`, so canonical export from runner-side aligns runtime with schema. 11-line change (2 lines of registration + 8-line comment explaining lineage + 1 line trailing context).

## Verification

Ran the pre-push hook against current branch HEAD on a Windows worktree:

- **Before commit 1:** `[gen-events-drift] ERROR: generate_types.sh failed.` within ~1s of starting.
- **After commit 1:** completes the discriminator step (`annotated 40 oneOf union(s)`) and TS regen (`Emitted 429 .d.ts files`), but trips the drift check:
  ```
  ts/src/generated/UiBridgeRequestEnvelope.d.ts  | 45 ------
  ts/src/generated/UiBridgeResponseEnvelope.d.ts | 66 ------
  ts/src/generated/index.ts                      |  2 -
  ```
- **After commit 2:** `[gen-events-drift] OK — generated bindings match checked-in output.`

Closes the SKIP=gen-events-drift recurring workaround on Windows worktrees.

## Test plan

- [ ] CI green (Linux platform tests + `qontinui-types-drift` check-drift workflow)
- [ ] Squash-merge once approved

## Memory note

`proj_runner_gen_events_drift_windows_bug.md` updated locally with the fix-in-flight status; will fold in once this lands.