### PR TITLE
chore: bundle 4 scoped follow-ups (typecheck CI + UI Bridge regs + panic catch + cache-threshold)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,13 @@ jobs:
       - name: Lint frontend code
         run: pnpm run lint
 
+      # Typecheck before the bundler runs. Fails fast on consumer-side
+      # camelCase / deny_unknown_fields drift from qontinui-schemas before
+      # paying for `vite build`. Closes Item 4 of the
+      # schemas-camelcase-cascade-2026-04-18 plan.
+      - name: Typecheck frontend code
+        run: pnpm run typecheck
+
       # Build the frontend before any cargo step. tauri::generate_context!()
       # in src-tauri/src/lib.rs reads tauri.conf.json at compile time and
       # panics if frontendDist (../dist) is missing — which broke `Clippy

--- a/specs/pages/terminal/spec.uibridge.json
+++ b/specs/pages/terminal/spec.uibridge.json
@@ -1,5 +1,5 @@
 {
-  "description": "Terminal page -- an integrated multi-page, multi-tab PTY terminal with workflow generation, session transcript browsing, terminal output analysis, findings tracking, and concurrent session file conflict detection. Users can create multiple terminal pages (e.g., Development, Testing, Monitoring), each with its own independent zone layout, terminals, and saved configurations. Within each page, users execute shell commands in multiple concurrent terminal sessions organized in configurable zone layouts. The terminal supports session persistence across restarts (Claude Code session IDs are saved and auto-resumed), zone profiles that capture session assignments, shell integration for structured command history, keyboard shortcuts for efficient tab management, and an advisory file registry that auto-detects file conflicts across sessions, and plan implementation workflow execution from both the UI (Implement/Verify buttons) and CLI (run-plan-implementation.ts script).",
+  "description": "Terminal page -- an integrated multi-page, multi-tab PTY terminal with workflow generation, session transcript browsing, terminal output analysis, findings tracking, and concurrent session file conflict detection. Users can create multiple terminal pages (e.g., Development, Testing, Monitoring), each with its own independent zone layout, terminals, and saved configurations. Within each page, users execute shell commands in multiple concurrent terminal sessions organized in configurable zone layouts. The terminal supports session persistence across restarts (Claude Code session IDs are saved and auto-resumed), zone profiles that capture session assignments, shell integration for structured command history, keyboard shortcuts for efficient tab management, and an advisory file registry that auto-detects file conflicts across sessions, and plan implementation workflow execution from both the UI (Implement/Verify buttons) and CLI (run-plan-implementation.ts script).\n\n# TerminalPage\n\n## Asserting on terminal cell content (Claude Code, vim, htop, etc.)\n\nDOM-search assertions in this spec (`assertionType: \"exists\"` with a\n`textContent` criterion) **only see the runner's own UI chrome** — tab\nbars, buttons, status indicators. They do **not** see what a TUI app\ndraws inside an xterm pane, because xterm.js renders to a canvas /\nWebGL surface that's not in the DOM.\n\nTo assert on terminal cell content, query the server-side cell grid:\n\n| Use case | Endpoint |\n|---|---|\n| Is text \"Welcome\" visible in any terminal? | `GET /ui-bridge/sdk/terminal/search?q=Welcome` |\n| Is text \"Welcome\" in this specific session? | `GET /ui-bridge/sdk/terminal/search?q=Welcome&session_id=<id>` |\n| Get the rendered text rows of a session | `GET /ui-bridge/sdk/terminal/sessions/<id>/buffer` |\n| Get full cell-level grid (fg/bg/attrs/cursor) | `GET /ui-bridge/sdk/terminal/sessions/<id>/grid` |\n| Compact text view for verifier prompts | `GET /ui-bridge/sdk/terminal/sessions/<id>/text` |\n| Diff two sessions row-by-row | `GET /ui-bridge/sdk/terminal/sessions/<a>/diff/<b>` |\n\nFull reference + worked examples:\n[`src/components/terminal/GRID_TESTING.md`](../../../src/components/terminal/GRID_TESTING.md).\nEnd-to-end smoke at `scripts/test-grid-endpoints.sh`.\n\nThe assertions in `spec.uibridge.json` below cover the runner UI\nshell. Cell content lives on the HTTP side because the spec runner's\nDOM-search primitive can't reach it.",
   "groups": [
     {
       "assertions": [
@@ -1097,6 +1097,34 @@
       "id": "term-plan-cli-script",
       "name": "Plan Implementation CLI Script",
       "source": "migrated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Required element 0 for state Per-Tab Commit Traffic Light",
+          "enabled": true,
+          "id": "term-commit-traffic-light-elem-0",
+          "precondition": "At least one terminal tab has an active Claude Code AI session (tab.claudeSessionId is populated, either from a resumed session or the post-spawn transcript_get_latest polling)",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "accessibleName": "Commit progress",
+              "role": "button"
+            },
+            "label": "Required element for Per-Tab Commit Traffic Light",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
+      "id": "term-commit-traffic-light",
+      "name": "Per-Tab Commit Traffic Light",
+      "source": "ai-generated"
     }
   ],
   "metadata": {
@@ -1115,7 +1143,10 @@
       "file-conflicts",
       "concurrent-sessions",
       "run-group",
-      "tier-1"
+      "tier-1",
+      "commit-traffic-light",
+      "git-status",
+      "session-touched-files"
     ]
   },
   "stateMachine": {
@@ -1416,6 +1447,19 @@
         "id": "term-plan-cli-script",
         "isInitial": false,
         "name": "Plan Implementation CLI Script",
+        "transitions": []
+      },
+      {
+        "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
+        "elements": [
+          {
+            "accessibleName": "Commit progress",
+            "role": "button"
+          }
+        ],
+        "id": "term-commit-traffic-light",
+        "isInitial": false,
+        "name": "Per-Tab Commit Traffic Light",
         "transitions": []
       }
     ]

--- a/specs/pages/terminal/state-machine.derived.json
+++ b/specs/pages/terminal/state-machine.derived.json
@@ -2,10 +2,36 @@
   "version": "1.0",
   "id": "terminal",
   "name": "TerminalPage",
+  "description": "Terminal page -- an integrated multi-page, multi-tab PTY terminal with workflow generation, session transcript browsing, terminal output analysis, findings tracking, and concurrent session file conflict detection. Users can create multiple terminal pages (e.g., Development, Testing, Monitoring), each with its own independent zone layout, terminals, and saved configurations. Within each page, users execute shell commands in multiple concurrent terminal sessions organized in configurable zone layouts. The terminal supports session persistence across restarts (Claude Code session IDs are saved and auto-resumed), zone profiles that capture session assignments, shell integration for structured command history, keyboard shortcuts for efficient tab management, and an advisory file registry that auto-detects file conflicts across sessions, and plan implementation workflow execution from both the UI (Implement/Verify buttons) and CLI (run-plan-implementation.ts script).",
+  "metadata": {
+    "tags": [
+      "terminal",
+      "pty",
+      "multi-tab",
+      "multi-page",
+      "session-persistence",
+      "zone-profiles",
+      "workflow-generation",
+      "transcript",
+      "findings",
+      "analysis",
+      "file-conflicts",
+      "concurrent-sessions",
+      "run-group",
+      "tier-1",
+      "commit-traffic-light",
+      "git-status",
+      "session-touched-files"
+    ]
+  },
+  "provenance": {
+    "source": "migrated"
+  },
   "states": [
     {
       "id": "term-multi-tab",
       "name": "Multi-Tab Terminal Sessions",
+      "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal.",
       "requiredElements": [
         {
           "role": "tablist"
@@ -21,7 +47,6 @@
           "text": "Ctrl+Shift+T"
         }
       ],
-      "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal.",
       "provenance": {
         "source": "migrated"
       }
@@ -29,6 +54,7 @@
     {
       "id": "term-action-bar",
       "name": "Terminal Action Bar",
+      "description": "Above the terminal area, an action bar provides quick access to terminal-augmented features: toggling the transcript session sidebar, triggering AI-powered analysis of terminal output, generating workflows from the latest Claude Code session, refreshing the plan file, and toggling the findings panel. The action bar adapts its button states based on context -- showing loading spinners during generation or analysis, indicating the active findings count, and highlighting the active panel mode. This bar transforms the terminal from a simple shell into an intelligent development workbench.",
       "requiredElements": [
         {
           "role": "button",
@@ -47,7 +73,6 @@
           "text": "Findings"
         }
       ],
-      "description": "Above the terminal area, an action bar provides quick access to terminal-augmented features: toggling the transcript session sidebar, triggering AI-powered analysis of terminal output, generating workflows from the latest Claude Code session, refreshing the plan file, and toggling the findings panel. The action bar adapts its button states based on context -- showing loading spinners during generation or analysis, indicating the active findings count, and highlighting the active panel mode. This bar transforms the terminal from a simple shell into an intelligent development workbench.",
       "provenance": {
         "source": "migrated"
       }
@@ -55,6 +80,7 @@
     {
       "id": "term-transcript-sessions",
       "name": "Claude Code Session Transcripts",
+      "description": "The left sidebar shows a list of Claude Code session transcripts from the local machine. Users can browse past sessions, view the full conversation transcript in a right-side content panel, and resume sessions in a new terminal tab. Session resumption creates a new tab, sets the working directory, and sends the 'claude --resume' command with the correct config directory. The transcript panel supports generating workflows from session content and generating-and-running workflows in a single action for rapid automation creation.",
       "requiredElements": [
         {
           "text": "Sessions"
@@ -71,7 +97,6 @@
           "text": "Generate"
         }
       ],
-      "description": "The left sidebar shows a list of Claude Code session transcripts from the local machine. Users can browse past sessions, view the full conversation transcript in a right-side content panel, and resume sessions in a new terminal tab. Session resumption creates a new tab, sets the working directory, and sends the 'claude --resume' command with the correct config directory. The transcript panel supports generating workflows from session content and generating-and-running workflows in a single action for rapid automation creation.",
       "provenance": {
         "source": "migrated"
       }
@@ -79,6 +104,7 @@
     {
       "id": "term-workflow-preview",
       "name": "Workflow Generation and Preview",
+      "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern.",
       "requiredElements": [
         {
           "text": "Workflow"
@@ -96,7 +122,6 @@
           "text": "Edit"
         }
       ],
-      "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern.",
       "provenance": {
         "source": "migrated"
       }
@@ -104,6 +129,7 @@
     {
       "id": "term-findings-tracking",
       "name": "Real-Time Findings Detection",
+      "description": "The terminal automatically analyzes output in real time to detect errors, warnings, test failures, and other notable findings. These are tracked per-session and displayed in a dedicated findings panel on the right side. Users can respond to findings (sending text back to the terminal), fix findings by spawning a new Claude Code session with the finding context pre-loaded, or batch-generate a workflow from multiple unresolved findings. The findings count badge on the action bar updates live as new issues are detected, keeping users aware of problems without interrupting their terminal workflow.",
       "requiredElements": [
         {
           "text": "Findings"
@@ -121,7 +147,6 @@
           "text": "Respond"
         }
       ],
-      "description": "The terminal automatically analyzes output in real time to detect errors, warnings, test failures, and other notable findings. These are tracked per-session and displayed in a dedicated findings panel on the right side. Users can respond to findings (sending text back to the terminal), fix findings by spawning a new Claude Code session with the finding context pre-loaded, or batch-generate a workflow from multiple unresolved findings. The findings count badge on the action bar updates live as new issues are detected, keeping users aware of problems without interrupting their terminal workflow.",
       "provenance": {
         "source": "migrated"
       }
@@ -129,6 +154,7 @@
     {
       "id": "term-analysis",
       "name": "AI-Powered Terminal Analysis",
+      "description": "The terminal integrates AI analysis capabilities that process terminal scrollback, command history, and plan files to produce structured insights. Analysis types include: session summary (what happened in this terminal session), architecture review (system structure from plan files or terminal context), change impact (what files and systems were affected), progress tracking (how far along is the development plan), cross-tab analysis (correlating activity across multiple terminal sessions), and page architecture (analyzing the runner's own frontend). Analysis results appear in a dedicated panel with structured canvas-style panels. This transforms raw terminal output into actionable development intelligence.",
       "requiredElements": [
         {
           "text": "Architecture"
@@ -140,7 +166,6 @@
           "text": "Analyzing"
         }
       ],
-      "description": "The terminal integrates AI analysis capabilities that process terminal scrollback, command history, and plan files to produce structured insights. Analysis types include: session summary (what happened in this terminal session), architecture review (system structure from plan files or terminal context), change impact (what files and systems were affected), progress tracking (how far along is the development plan), cross-tab analysis (correlating activity across multiple terminal sessions), and page architecture (analyzing the runner's own frontend). Analysis results appear in a dedicated panel with structured canvas-style panels. This transforms raw terminal output into actionable development intelligence.",
       "provenance": {
         "source": "migrated"
       }
@@ -148,6 +173,7 @@
     {
       "id": "term-file-conflict-banner",
       "name": "File Conflict Detection Banner",
+      "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style.",
       "requiredElements": [
         {
           "textContains": "under concurrent"
@@ -165,7 +191,6 @@
           "textContains": "under concurrent"
         }
       ],
-      "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style.",
       "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
       "provenance": {
         "source": "migrated"
@@ -174,6 +199,7 @@
     {
       "id": "term-session-conflict-indicator",
       "name": "Per-Session File Conflict Indicators",
+      "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id.",
       "requiredElements": [
         {
           "textContains": "shared with other sessions"
@@ -188,7 +214,6 @@
           "textContains": "shared with other sessions"
         }
       ],
-      "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id.",
       "precondition": "At least one session has files overlapping with another session in the file registry",
       "provenance": {
         "source": "migrated"
@@ -197,6 +222,7 @@
     {
       "id": "term-multi-page",
       "name": "Multiple Terminal Pages",
+      "description": "Users can create multiple independent terminal pages, each with its own zone layout, terminals, labels, and saved configurations. A page tab bar at the top of the terminal area shows all pages. Clicking a page tab switches to that page by unmounting the current TerminalPage and remounting a new one connected to that page's PTY sessions. Each page's state (zone layout, labels, notes, pins, zone profiles, workspaces) is stored in page-namespaced localStorage keys. The default page uses un-prefixed keys for backward compatibility. PTY sessions are tagged with a page_id in the Rust backend, so each page only sees its own terminals.",
       "requiredElements": [
         {
           "role": "tab"
@@ -221,7 +247,6 @@
           "textContains": "Loading terminals"
         }
       ],
-      "description": "Users can create multiple independent terminal pages, each with its own zone layout, terminals, labels, and saved configurations. A page tab bar at the top of the terminal area shows all pages. Clicking a page tab switches to that page by unmounting the current TerminalPage and remounting a new one connected to that page's PTY sessions. Each page's state (zone layout, labels, notes, pins, zone profiles, workspaces) is stored in page-namespaced localStorage keys. The default page uses un-prefixed keys for backward compatibility. PTY sessions are tagged with a page_id in the Rust backend, so each page only sees its own terminals.",
       "precondition": "At least two pages exist with different numbers of terminals",
       "provenance": {
         "source": "migrated"
@@ -230,6 +255,7 @@
     {
       "id": "term-session-persistence",
       "name": "Session Persistence & Auto-Resume",
+      "description": "Claude Code session IDs are persisted alongside terminal tab configurations. When the runner restarts and reconnects to existing PTY sessions, saved claudeSessionId values are merged back into the reconnected tabs and the sessions are auto-resumed with 'claude --resume <id>'. This ensures that Claude Code sessions survive runner restarts without manual intervention. The saved layout includes zone assignments, labels, notes, pins, and Claude session IDs per tab.",
       "requiredElements": [
         {
           "role": "textbox"
@@ -242,7 +268,6 @@
         },
         {}
       ],
-      "description": "Claude Code session IDs are persisted alongside terminal tab configurations. When the runner restarts and reconnects to existing PTY sessions, saved claudeSessionId values are merged back into the reconnected tabs and the sessions are auto-resumed with 'claude --resume <id>'. This ensures that Claude Code sessions survive runner restarts without manual intervention. The saved layout includes zone assignments, labels, notes, pins, and Claude session IDs per tab.",
       "precondition": "Runner was restarted after Claude sessions were running in terminal zones",
       "provenance": {
         "source": "migrated"
@@ -251,6 +276,7 @@
     {
       "id": "term-page-storage-isolation",
       "name": "Per-Page Storage Isolation",
+      "description": "Each terminal page has isolated storage for its configuration. Zone layouts, session persistence, zone profiles, workspaces, zone labels/notes/pins, and grid column/row ratios are all namespaced by pageId. The default page uses un-prefixed keys (backward compatible), while non-default pages use 'page:{pageId}:' prefixed keys. This ensures that creating a zone profile on page A does not appear when viewing page B's profiles.",
       "requiredElements": [
         {
           "accessibleName": "Zone profiles"
@@ -262,7 +288,6 @@
           "role": "tab"
         }
       ],
-      "description": "Each terminal page has isolated storage for its configuration. Zone layouts, session persistence, zone profiles, workspaces, zone labels/notes/pins, and grid column/row ratios are all namespaced by pageId. The default page uses un-prefixed keys (backward compatible), while non-default pages use 'page:{pageId}:' prefixed keys. This ensures that creating a zone profile on page A does not appear when viewing page B's profiles.",
       "precondition": "Multiple pages exist, at least one has saved profiles",
       "provenance": {
         "source": "migrated"
@@ -271,6 +296,7 @@
     {
       "id": "term-plan-implementation",
       "name": "Plan Implementation Workflow",
+      "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution.",
       "requiredElements": [
         {
           "role": "button",
@@ -295,7 +321,6 @@
           "accessibleName": "Reload plan file from disk"
         }
       ],
-      "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution.",
       "precondition": "Transcript panel is open with messages selected",
       "provenance": {
         "source": "migrated"
@@ -304,6 +329,7 @@
     {
       "id": "term-plan-cli-script",
       "name": "Plan Implementation CLI Script",
+      "description": "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
       "requiredElements": [
         {
           "textContains": "Parsed"
@@ -315,33 +341,25 @@
           "textContains": "follow"
         }
       ],
-      "description": "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
       "provenance": {
         "source": "migrated"
       }
+    },
+    {
+      "id": "term-commit-traffic-light",
+      "name": "Per-Tab Commit Traffic Light",
+      "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
+      "requiredElements": [
+        {
+          "role": "button",
+          "accessibleName": "Commit progress"
+        }
+      ],
+      "precondition": "At least one terminal tab has an active Claude Code AI session (tab.claudeSessionId is populated, either from a resumed session or the post-spawn transcript_get_latest polling)",
+      "provenance": {
+        "source": "ai-generated"
+      }
     }
   ],
-  "transitions": [],
-  "provenance": {
-    "source": "migrated"
-  },
-  "description": "Terminal page -- an integrated multi-page, multi-tab PTY terminal with workflow generation, session transcript browsing, terminal output analysis, findings tracking, and concurrent session file conflict detection. Users can create multiple terminal pages (e.g., Development, Testing, Monitoring), each with its own independent zone layout, terminals, and saved configurations. Within each page, users execute shell commands in multiple concurrent terminal sessions organized in configurable zone layouts. The terminal supports session persistence across restarts (Claude Code session IDs are saved and auto-resumed), zone profiles that capture session assignments, shell integration for structured command history, keyboard shortcuts for efficient tab management, and an advisory file registry that auto-detects file conflicts across sessions, and plan implementation workflow execution from both the UI (Implement/Verify buttons) and CLI (run-plan-implementation.ts script).",
-  "metadata": {
-    "tags": [
-      "terminal",
-      "pty",
-      "multi-tab",
-      "multi-page",
-      "session-persistence",
-      "zone-profiles",
-      "workflow-generation",
-      "transcript",
-      "findings",
-      "analysis",
-      "file-conflicts",
-      "concurrent-sessions",
-      "run-group",
-      "tier-1"
-    ]
-  }
+  "transitions": []
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,7 +83,7 @@ futures = "0.3"
 futures-util = "0.3"
 async-stream = "0.3"
 tower = { version = "0.5", features = ["limit"] }
-tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "limit", "trace", "catch-panic"] }
 urlencoding = "2.1"
 zip = "8"
 sha2 = "0.10"
@@ -268,6 +268,7 @@ regex_creation_in_loops = "allow"
 
 [dev-dependencies]
 tempfile = "3"
+tower = { version = "0.5", features = ["util"] }
 
 ## Profile overrides moved to the workspace root Cargo.toml — cargo
 ## ignores [profile.*] in package manifests when a workspace exists.

--- a/src-tauri/src/ai_provider/cache_aware_builder.rs
+++ b/src-tauri/src/ai_provider/cache_aware_builder.rs
@@ -10,8 +10,12 @@
 //! - Header: `anthropic-beta: prompt-caching-2024-07-31`
 //! - Place `"cache_control": {"type": "ephemeral"}` on content blocks in the
 //!   `system` array or in `messages[].content[]`.
-//! - Minimum block size: 1024 tokens (Haiku), 2048 tokens (Sonnet/Opus).
-//! - Cache TTL: 5 minutes (extended on each hit).
+//! - Minimum block size depends on the model — see [`min_cacheable_chars`].
+//!   Haiku 4.5: 4096 tokens. Haiku 3.5: 2048 tokens. Sonnet/Opus: 1024 tokens.
+//!   Sub-threshold blocks are silently NOT cached (Anthropic returns 0 cache
+//!   reads with no error). Source:
+//!   <https://docs.claude.com/en/docs/build-with-claude/prompt-caching>
+//! - Cache TTL: 5 minutes default; 1-hour ephemeral tier available at 2x cost.
 //! - Pricing: write = 1.25x base input; read = 0.1x base input.
 
 use serde::Serialize;
@@ -121,9 +125,29 @@ pub struct CacheAwareRequestBuilder {
     system_blocks: Vec<SystemBlock>,
 }
 
-/// Minimum character length for a block to be worth caching.
-/// Roughly maps to ~256 tokens. Blocks smaller than this are merged or left uncached.
-pub(super) const MIN_CACHEABLE_CHARS: usize = 1024;
+/// Minimum cacheable block size in characters, per Claude model family.
+///
+/// Anthropic silently returns 0 cache reads for blocks smaller than the
+/// model's documented token minimum; the `cache_control` marker is parsed
+/// and discarded. We work in characters (not tokens) because the builder
+/// operates on `String::len()`. Threshold = documented_token_min × 4
+/// chars-per-token (English/code average; Claude's tokenizer trends ~3.5
+/// chars/token, so a block at the char threshold is typically ≥ the token
+/// threshold).
+///
+/// - Haiku 4.x (e.g. `claude-haiku-4-5-*`): 4096 tokens → 16384 chars
+/// - Haiku 3.x (e.g. `claude-haiku-3-5-*`): 2048 tokens → 8192 chars
+/// - Sonnet / Opus / unknown: 1024 tokens → 4096 chars
+pub(super) fn min_cacheable_chars(model: &str) -> usize {
+    let m = model.to_lowercase();
+    if m.contains("haiku-4") {
+        16384
+    } else if m.contains("haiku") {
+        8192
+    } else {
+        4096
+    }
+}
 
 impl CacheAwareRequestBuilder {
     /// Create a new builder for the given model.
@@ -150,7 +174,7 @@ impl CacheAwareRequestBuilder {
         if text.is_empty() {
             return;
         }
-        let should_cache = text.len() >= MIN_CACHEABLE_CHARS;
+        let should_cache = text.len() >= min_cacheable_chars(&self.model);
         self.system_blocks.push(SystemBlock {
             block_type: "text".to_string(),
             text,
@@ -179,8 +203,9 @@ impl CacheAwareRequestBuilder {
         let mut builder = Self::new(model, max_tokens);
 
         // Merge small cached blocks together for more efficient caching.
-        // Anthropic requires minimum 1024-2048 tokens per cached block.
-        let merged_cached = merge_small_blocks(&prompt.cached_system_blocks);
+        // Per-model thresholds: Sonnet/Opus 1024 tokens, Haiku 3.5 2048,
+        // Haiku 4.5 4096 — see `min_cacheable_chars`.
+        let merged_cached = merge_small_blocks(&prompt.cached_system_blocks, model);
         for block in merged_cached {
             builder.add_cached_system_block(block);
         }
@@ -276,11 +301,13 @@ impl CacheAwareRequestBuilder {
 ///
 /// Adjacent blocks that are individually too small to cache are concatenated
 /// with `\n\n---\n\n` separators until the merged result is large enough.
-fn merge_small_blocks(blocks: &[String]) -> Vec<String> {
+/// The threshold is per-model — see [`min_cacheable_chars`].
+fn merge_small_blocks(blocks: &[String], model: &str) -> Vec<String> {
     if blocks.is_empty() {
         return Vec::new();
     }
 
+    let threshold = min_cacheable_chars(model);
     let mut result = Vec::new();
     let mut accumulator = String::new();
 
@@ -298,7 +325,7 @@ fn merge_small_blocks(blocks: &[String]) -> Vec<String> {
         // Blocks already large enough to cache on their own are passed
         // through unchanged — merging them with unrelated small blocks
         // would invalidate cache keys whenever the small blocks change.
-        if block.len() >= MIN_CACHEABLE_CHARS {
+        if block.len() >= threshold {
             flush_accumulator(&mut accumulator, &mut result);
             result.push(block.clone());
             continue;
@@ -312,7 +339,7 @@ fn merge_small_blocks(blocks: &[String]) -> Vec<String> {
         }
 
         // Flush once the merged small blocks cross the cache threshold.
-        if accumulator.len() >= MIN_CACHEABLE_CHARS {
+        if accumulator.len() >= threshold {
             flush_accumulator(&mut accumulator, &mut result);
         }
     }
@@ -373,7 +400,8 @@ mod tests {
     #[test]
     fn test_builder_basic() {
         let mut builder = CacheAwareRequestBuilder::new("claude-sonnet-4-20250514", 4096);
-        builder.add_cached_system_block("x".repeat(2000));
+        // 5000 chars passes Sonnet's 4096-char threshold.
+        builder.add_cached_system_block("x".repeat(5000));
         builder.add_dynamic_system_block("dynamic context".to_string());
         let body = builder.build("Hello");
 
@@ -419,13 +447,13 @@ mod tests {
 
     #[test]
     fn test_merge_small_blocks() {
-        let blocks = vec!["small1".to_string(), "small2".to_string(), "x".repeat(2000)];
-        let merged = merge_small_blocks(&blocks);
-        // First two should be merged, third stands alone
+        let blocks = vec!["small1".to_string(), "small2".to_string(), "x".repeat(5000)];
+        let merged = merge_small_blocks(&blocks, "claude-sonnet-4-20250514");
+        // First two should be merged, third stands alone (5000 ≥ Sonnet's 4096-char threshold).
         assert_eq!(merged.len(), 2);
         assert!(merged[0].contains("small1"));
         assert!(merged[0].contains("small2"));
-        assert_eq!(merged[1].len(), 2000);
+        assert_eq!(merged[1].len(), 5000);
     }
 
     #[test]
@@ -459,7 +487,7 @@ mod tests {
     #[test]
     fn test_from_structured_prompt() {
         let prompt = StructuredPrompt {
-            cached_system_blocks: vec!["x".repeat(3000), "y".repeat(3000)],
+            cached_system_blocks: vec!["x".repeat(5000), "y".repeat(5000)],
             dynamic_system_blocks: vec!["dynamic".to_string()],
             user_message: "task".to_string(),
         };
@@ -476,6 +504,29 @@ mod tests {
         assert!(system[0]["cache_control"].is_object());
         assert!(system[1]["cache_control"].is_object());
         assert!(system[2]["cache_control"].is_null());
+    }
+
+    #[test]
+    fn test_builder_haiku_4_higher_threshold() {
+        // 5000 chars passes Sonnet's 4096-char threshold but NOT Haiku 4.5's 16384.
+        let mut b = CacheAwareRequestBuilder::new("claude-haiku-4-5-20251001", 4096);
+        b.add_cached_system_block("x".repeat(5000));
+        let body = b.build("Hello");
+        assert!(body["system"][0]["cache_control"].is_null());
+
+        let mut big = CacheAwareRequestBuilder::new("claude-haiku-4-5-20251001", 4096);
+        big.add_cached_system_block("y".repeat(20000));
+        assert!(big.build("Hello")["system"][0]["cache_control"].is_object());
+    }
+
+    #[test]
+    fn test_min_cacheable_chars_per_model() {
+        assert_eq!(min_cacheable_chars("claude-sonnet-4-20250514"), 4096);
+        assert_eq!(min_cacheable_chars("claude-opus-4-5-20251101"), 4096);
+        assert_eq!(min_cacheable_chars("claude-haiku-3-5-20241022"), 8192);
+        assert_eq!(min_cacheable_chars("claude-haiku-4-5-20251001"), 16384);
+        assert_eq!(min_cacheable_chars("Claude-Haiku-4-5"), 16384);
+        assert_eq!(min_cacheable_chars("some-other-model"), 4096);
     }
 
     #[test]

--- a/src-tauri/src/ai_provider/claude_api_warm.rs
+++ b/src-tauri/src/ai_provider/claude_api_warm.rs
@@ -24,7 +24,7 @@
 #![allow(dead_code)]
 
 use super::cache_aware_builder::{
-    parse_cache_tokens, MIN_CACHEABLE_CHARS, PROMPT_CACHING_BETA_HEADER,
+    min_cacheable_chars, parse_cache_tokens, PROMPT_CACHING_BETA_HEADER,
 };
 use super::retry::retry_with_backoff;
 use super::types::AiResponse;
@@ -210,15 +210,15 @@ fn sanitize_tool_name(schema_name: &str) -> String {
 /// Build the `system` array for the request body.
 ///
 /// Only attaches `cache_control: ephemeral` when `system_prefix.len() >=
-/// MIN_CACHEABLE_CHARS`. Below that threshold, Anthropic silently ignores the
-/// marker and sending it anyway would be misleading telemetry. If the prefix
-/// is empty we return an empty array — the caller will typically send the
-/// message-only body.
-fn build_system_array(system_prefix: &str) -> Value {
+/// min_cacheable_chars(model)`. Below that per-model threshold, Anthropic
+/// silently ignores the marker and sending it anyway would be misleading
+/// telemetry. If the prefix is empty we return an empty array — the caller
+/// will typically send the message-only body.
+fn build_system_array(system_prefix: &str, model: &str) -> Value {
     if system_prefix.is_empty() {
         return serde_json::json!([]);
     }
-    if system_prefix.len() >= MIN_CACHEABLE_CHARS {
+    if system_prefix.len() >= min_cacheable_chars(model) {
         serde_json::json!([{
             "type": "text",
             "text": system_prefix,
@@ -268,7 +268,7 @@ pub(crate) fn run_claude_api_warm(
         credential.kind_label(),
         system_prefix.len(),
         user_message.len(),
-        system_prefix.len() >= MIN_CACHEABLE_CHARS,
+        system_prefix.len() >= min_cacheable_chars(model),
     );
 
     let mut request_body = serde_json::json!({
@@ -277,7 +277,7 @@ pub(crate) fn run_claude_api_warm(
         "messages": [{"role": "user", "content": user_message}],
     });
     if !system_prefix.is_empty() {
-        request_body["system"] = build_system_array(system_prefix);
+        request_body["system"] = build_system_array(system_prefix, model);
     }
 
     if let Some(temp) = temperature_override {
@@ -358,8 +358,9 @@ pub(crate) fn run_claude_api_warm(
 /// - Authenticates with `WarmCredential` (API key or OAuth).
 /// - Takes a split `(system_prefix, user_message)` prompt. The stable
 ///   `system_prefix` is marked with `cache_control: ephemeral` *only when it
-///   crosses [`MIN_CACHEABLE_CHARS`]* — sub-threshold blocks skip the marker
-///   so telemetry doesn't lie about cache participation. The `user_message`
+///   crosses [`min_cacheable_chars`]* (per-model threshold) — sub-threshold
+///   blocks skip the marker so telemetry doesn't lie about cache
+///   participation. The `user_message`
 ///   carries per-call dynamic payload (goal, schemaHint, outputPreview) and
 ///   is never cached.
 pub(crate) fn run_claude_api_warm_with_structured_output(
@@ -393,7 +394,7 @@ pub(crate) fn run_claude_api_warm_with_structured_output(
         schema_name,
         system_prefix.len(),
         user_message.len(),
-        system_prefix.len() >= MIN_CACHEABLE_CHARS,
+        system_prefix.len() >= min_cacheable_chars(model),
     );
 
     let tool_name = sanitize_tool_name(schema_name);
@@ -414,7 +415,7 @@ pub(crate) fn run_claude_api_warm_with_structured_output(
         "tool_choice": {"type": "tool", "name": tool_name}
     });
     if !system_prefix.is_empty() {
-        request_body["system"] = build_system_array(system_prefix);
+        request_body["system"] = build_system_array(system_prefix, model);
     }
 
     if let Some(temp) = temperature_override {

--- a/src-tauri/src/claude_session/dispatcher.rs
+++ b/src-tauri/src/claude_session/dispatcher.rs
@@ -607,6 +607,17 @@ fn auto_register_file(
                 }
             });
 
+            // Phase 2 (terminal traffic-light plan §2): probe + emit
+            // `commit-state-changed` so the per-tab traffic light reflects the
+            // post-Edit/Write state. Best-effort, fire-and-forget — the helper
+            // spawns its own task and applies a 500 ms per-session debounce
+            // (so N consecutive Edit/Write hooks in the same turn don't
+            // trigger N probes).
+            crate::mcp::ai_session::emit_commit_state_for_session(
+                app_handle.clone(),
+                task_run_id.clone(),
+            );
+
             let _ = waited_for;
         } else {
             warn!(

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -1036,6 +1036,37 @@ pub async fn commit_session_progress(
     }
 }
 
+/// Probe the per-session "ready-to-commit" state for the traffic-light UI.
+///
+/// Frontend equivalent of an HTTP GET — runs the §1 dirty-subset query against
+/// the `session_touched_files` rows for `task_run_id` and returns a
+/// `CommitState` describing whether the tracker is empty / clean / dirty /
+/// mid-merge. Called by `useCommitState` on mount and on a 30 s interval per
+/// tab.
+///
+/// All errors collapse to `success: false` with the inner status code +
+/// message in `message`. The `data` field carries the `CommitState` JSON
+/// blob.
+#[tauri::command]
+pub async fn get_session_commit_state(
+    app: tauri::AppHandle,
+    task_run_id: String,
+) -> Result<CommandResponse, String> {
+    use crate::mcp::ai_session::session_commit_state_inner;
+    match session_commit_state_inner(&app, &task_run_id).await {
+        Ok(state) => Ok(CommandResponse {
+            success: true,
+            message: None,
+            data: Some(serde_json::to_value(&state).unwrap_or_default()),
+        }),
+        Err((_status, msg)) => Ok(CommandResponse {
+            success: false,
+            message: Some(msg),
+            data: None,
+        }),
+    }
+}
+
 /// Resume interrupted AI sessions on startup.
 ///
 /// Queries for task runs with status='running' and workflow_type='chat'

--- a/src-tauri/src/coordinator/llm_decide.rs
+++ b/src-tauri/src/coordinator/llm_decide.rs
@@ -327,9 +327,9 @@ fn action_type_tag(action: &CoordinatorAction) -> &'static str {
 // ============================================================================
 
 /// Cache-friendly stable system prefix. Holds the role description, the
-/// 11-variant catalog, and disambiguation rules. Per the warm provider's
-/// MIN_CACHEABLE_CHARS heuristic this gets tagged as `cache_control:
-/// ephemeral` automatically when the body crosses the threshold.
+/// 11-variant catalog, and disambiguation rules. The warm provider's
+/// `min_cacheable_chars(model)` heuristic tags this with `cache_control:
+/// ephemeral` automatically when the body crosses the model's threshold.
 fn build_system_prefix() -> String {
     String::from(
         r#"You are the dispatch decider for the qontinui Coordinator. The Coordinator runs in-process inside a developer-tools runner and watches a small fleet of Claude Code worker sessions completing software-engineering tasks. Cheap deterministic rules (A through E) already ran this iteration and none fired. Your job: pick exactly one CoordinatorAction.

--- a/src-tauri/src/git_status_subset.rs
+++ b/src-tauri/src/git_status_subset.rs
@@ -1,0 +1,598 @@
+//! Pure git plumbing for the per-terminal traffic-light feature (Phase 1A of
+//! `plans/terminal-traffic-light-and-conflict-bottleneck-plan.md`).
+//!
+//! No Tauri / `AppState` deps — everything here shells out to `git` directly
+//! so it's unit-testable from a tmpdir-init repo. Phase 1B
+//! (`session_commit_state_inner`) and the frontend will consume the
+//! `CommitState` / `CommitStateStatus` types via `serde`.
+//!
+//! Wire used by callers:
+//!
+//! 1. `bucket_by_repo(touched_files)` — group session-touched paths by
+//!    enclosing git toplevel (one bucket per distinct repo).
+//! 2. For each `(repo, paths)` bucket: `is_mid_merge(repo)` for the merging
+//!    flag, then `dirty_subset_in_repo(repo, &paths)` for the subset of
+//!    paths that differ from HEAD.
+//! 3. Caller assembles `CommitState`.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::process_helpers::no_window;
+
+/// The per-session traffic-light state. Sent to the frontend as JSON.
+///
+/// IMPORTANT: struct fields stay snake_case (default serde behaviour) to
+/// match the TS interface Phase 1B will write. Only the enum gets
+/// `rename_all = "lowercase"` so the discriminant strings are stable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommitState {
+    pub status: CommitStateStatus,
+    /// Total file count in `session_touched_files` for this session.
+    pub touched_count: usize,
+    /// Subset of `touched_count` whose porcelain entry is non-empty.
+    pub dirty_count: usize,
+    /// Distinct git toplevels reached after `bucket_by_repo`. Used for the
+    /// UI tooltip ("dirty across N repos: …").
+    pub repo_roots: Vec<String>,
+    /// Subset of `repo_roots` that are mid-merge (`MERGE_HEAD` and friends).
+    pub merging_repos: Vec<String>,
+    /// Wall-clock millis at the moment the probe finished. Frontend uses
+    /// this to debounce/dedupe.
+    pub generated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CommitStateStatus {
+    Clean,
+    Dirty,
+    Empty,
+    Merging,
+    Unknown,
+}
+
+impl CommitState {
+    /// Convenience constructor for the "tracker is empty" / "no repo" case.
+    pub fn empty() -> Self {
+        Self {
+            status: CommitStateStatus::Empty,
+            touched_count: 0,
+            dirty_count: 0,
+            repo_roots: Vec::new(),
+            merging_repos: Vec::new(),
+            generated_at_ms: now_ms(),
+        }
+    }
+}
+
+/// Wall-clock millis since UNIX epoch, saturating to 0 on the (impossible)
+/// pre-epoch case so this is panic-free.
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Group an arbitrary list of absolute file paths by their enclosing git
+/// toplevel. Files outside any git repo are dropped silently.
+///
+/// Implementation detail: caches the `git rev-parse --show-toplevel` lookup
+/// keyed by the *parent directory* of each path, so a session that touched
+/// 200 files in two repos does at most ~2 git invocations (plus a small
+/// number for distinct subdirectories).
+pub fn bucket_by_repo(paths: &[String]) -> HashMap<PathBuf, Vec<String>> {
+    let mut buckets: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    // Cache: parent dir → Some(toplevel) | None (outside any repo).
+    let mut cache: HashMap<PathBuf, Option<PathBuf>> = HashMap::new();
+
+    for raw in paths {
+        let p = Path::new(raw);
+        // We need *some* directory to anchor `git rev-parse` against. If the
+        // path is a file, its parent; if it's a dir or doesn't exist, the
+        // path itself or its parent — fall back gracefully.
+        let anchor: PathBuf = if p.is_dir() {
+            p.to_path_buf()
+        } else {
+            match p.parent() {
+                Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+                _ => continue, // No anchor — drop.
+            }
+        };
+
+        let toplevel = cache
+            .entry(anchor.clone())
+            .or_insert_with(|| resolve_toplevel(&anchor));
+
+        if let Some(top) = toplevel.clone() {
+            buckets.entry(top).or_default().push(raw.clone());
+        }
+        // else: outside any git repo — drop silently per spec.
+    }
+
+    buckets
+}
+
+/// `git rev-parse --show-toplevel` against `dir`, returning the canonical
+/// toplevel as a `PathBuf` or `None` if the directory is outside any repo
+/// (or git isn't available, or the dir doesn't exist).
+fn resolve_toplevel(dir: &Path) -> Option<PathBuf> {
+    if !dir.exists() {
+        return None;
+    }
+    let output = no_window("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .current_dir(dir)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(s))
+    }
+}
+
+/// `git status --porcelain=v1 -z -- <paths>` against the given repo, parse
+/// NUL-separated entries, return the subset of `paths` whose status is
+/// non-empty (i.e. dirty).
+///
+/// Critically: ONLY queries the supplied paths, not the whole tree — this is
+/// the cost reason for `bucket_by_repo` collapsing files into per-repo
+/// invocations.
+///
+/// Returns the dirty subset as the *exact* path strings the caller passed in
+/// (so identity of the entries against `session_touched_files` rows is
+/// preserved). We do this by canonicalising both sides via
+/// `Path::file_name`/relative-from-repo and matching, but the simpler and
+/// more robust approach is: rerun the porcelain check per-path. To keep the
+/// fast path, we issue a single bulk `git status` and then derive dirty-ness
+/// from "did this path appear in the porcelain output, by suffix match".
+pub fn dirty_subset_in_repo(repo: &Path, paths: &[String]) -> Result<Vec<String>, String> {
+    if paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut args: Vec<&str> = vec!["status", "--porcelain=v1", "-z", "--"];
+    for p in paths {
+        args.push(p.as_str());
+    }
+
+    let output = no_window("git")
+        .args(&args)
+        .current_dir(repo)
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git status failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    // Porcelain v1 -z format: each entry is `XY <path>\0`, where the leading
+    // 3 chars are status + space. For renamed/copied entries (R/C) there's a
+    // second NUL-terminated `<orig-path>` immediately after — we don't care
+    // about origins; we only need to know which of *our* `paths` were
+    // mentioned.
+    let stdout = output.stdout;
+    let mut dirty_paths: Vec<String> = Vec::new();
+
+    let mut iter = stdout.split(|&b| b == 0u8);
+    while let Some(chunk) = iter.next() {
+        if chunk.is_empty() {
+            continue;
+        }
+        // Need at least 3 bytes for "XY ".
+        if chunk.len() < 3 {
+            continue;
+        }
+        let status_xy = &chunk[..2];
+        let path_bytes = &chunk[3..];
+        let path_str = String::from_utf8_lossy(path_bytes).into_owned();
+
+        // For R/C entries the *next* chunk is the origin path — skip it so we
+        // don't accidentally read it as a separate status entry.
+        if status_xy[0] == b'R'
+            || status_xy[0] == b'C'
+            || status_xy[1] == b'R'
+            || status_xy[1] == b'C'
+        {
+            iter.next();
+        }
+
+        dirty_paths.push(path_str);
+    }
+
+    // Match the porcelain-emitted paths back to caller-supplied paths.
+    // Porcelain emits paths relative to the repo toplevel with forward
+    // slashes. The caller passes absolute (or arbitrary) paths. Match by
+    // suffix — a porcelain path P matches caller path C iff C, normalised to
+    // forward slashes, ends with P. This is robust against the
+    // `D:\foo` vs `D:/foo` Windows divergence.
+    let mut out: Vec<String> = Vec::new();
+    for caller_path in paths {
+        let normalised = caller_path.replace('\\', "/");
+        let hit = dirty_paths.iter().any(|p| {
+            let p_norm = p.replace('\\', "/");
+            normalised.ends_with(&p_norm) || p_norm.ends_with(&normalised)
+        });
+        if hit {
+            out.push(caller_path.clone());
+        }
+    }
+
+    Ok(out)
+}
+
+/// Returns true if `repo` is mid-merge / mid-rebase / mid-cherry-pick / etc.
+///
+/// Resolves the gitdir via `git rev-parse --git-dir` so this works for linked
+/// worktrees, where the gitdir is `<main-repo>/.git/worktrees/<name>/` rather
+/// than `<wt>/.git`. Checks the union of:
+///
+/// - `MERGE_HEAD`, `CHERRY_PICK_HEAD`, `REVERT_HEAD`, `BISECT_LOG` (files)
+/// - `rebase-merge/`, `rebase-apply/` (directories)
+///
+/// Returns `false` on any git failure (don't mask a probe error as
+/// "merging" — the caller treats that as `Unknown` upstream).
+pub fn is_mid_merge(repo: &Path) -> bool {
+    let gitdir = match resolve_gitdir(repo) {
+        Some(d) => d,
+        None => return false,
+    };
+
+    const FILES: &[&str] = &[
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "BISECT_LOG",
+    ];
+    for f in FILES {
+        if gitdir.join(f).is_file() {
+            return true;
+        }
+    }
+    const DIRS: &[&str] = &["rebase-merge", "rebase-apply"];
+    for d in DIRS {
+        if gitdir.join(d).is_dir() {
+            return true;
+        }
+    }
+    false
+}
+
+/// `git rev-parse --git-dir` against `repo` → absolute gitdir path.
+///
+/// `--git-dir` returns either an absolute path (linked worktrees) or a path
+/// relative to the cwd we passed in. We resolve relative to `repo` so the
+/// caller doesn't need to care.
+fn resolve_gitdir(repo: &Path) -> Option<PathBuf> {
+    let output = no_window("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(repo)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() {
+        return None;
+    }
+    let p = PathBuf::from(&s);
+    let resolved = if p.is_absolute() { p } else { repo.join(p) };
+    Some(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use tempfile::TempDir;
+
+    /// `git init` + identity config. Returns the repo path (the tempdir
+    /// itself).
+    fn init_repo(td: &TempDir) -> PathBuf {
+        let repo = td.path().to_path_buf();
+        run(&repo, &["init", "-q", "-b", "main"]);
+        run(&repo, &["config", "user.email", "ci@example.com"]);
+        run(&repo, &["config", "user.name", "CI"]);
+        run(&repo, &["config", "commit.gpgsign", "false"]);
+        repo
+    }
+
+    fn run(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .unwrap_or_else(|e| panic!("git {:?} failed to spawn: {}", args, e));
+        if !output.status.success() {
+            panic!(
+                "git {:?} exited non-zero: stdout={} stderr={}",
+                args,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    }
+
+    fn write_file(repo: &Path, rel: &str, contents: &str) -> PathBuf {
+        let abs = repo.join(rel);
+        if let Some(parent) = abs.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&abs, contents).unwrap();
+        abs
+    }
+
+    fn commit_all(repo: &Path, msg: &str) {
+        run(repo, &["add", "-A"]);
+        run(repo, &["commit", "-q", "-m", msg]);
+    }
+
+    fn s(p: &Path) -> String {
+        p.to_string_lossy().into_owned()
+    }
+
+    // ------------------------------------------------------------------
+    // bucket_by_repo
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn bucket_by_repo_empty_input_yields_empty_map() {
+        let out = bucket_by_repo(&[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn bucket_by_repo_path_outside_any_repo_is_dropped() {
+        // Use a tempdir that is NOT a git repo.
+        let td = TempDir::new().unwrap();
+        let f = write_file(td.path(), "stray.txt", "x");
+
+        let out = bucket_by_repo(&[s(&f)]);
+        assert!(out.is_empty(), "non-repo path should be dropped silently");
+    }
+
+    #[test]
+    fn bucket_by_repo_groups_two_distinct_repos_into_two_buckets() {
+        let td_a = TempDir::new().unwrap();
+        let td_b = TempDir::new().unwrap();
+        let repo_a = init_repo(&td_a);
+        let repo_b = init_repo(&td_b);
+
+        let f_a1 = write_file(&repo_a, "a1.txt", "a1");
+        let f_a2 = write_file(&repo_a, "sub/a2.txt", "a2");
+        commit_all(&repo_a, "init a");
+        let f_b1 = write_file(&repo_b, "b1.txt", "b1");
+        commit_all(&repo_b, "init b");
+
+        let inputs = vec![s(&f_a1), s(&f_a2), s(&f_b1)];
+        let out = bucket_by_repo(&inputs);
+
+        assert_eq!(out.len(), 2, "expected exactly 2 buckets, got {:?}", out);
+
+        // Each bucket key should canonicalise to one of the repo paths.
+        // We don't assert exact path equality because git rev-parse may
+        // resolve symlinks (macOS /private/var prefix) — match by file
+        // count instead.
+        let counts: Vec<usize> = out.values().map(|v| v.len()).collect();
+        let mut sorted = counts.clone();
+        sorted.sort_unstable();
+        assert_eq!(sorted, vec![1, 2], "expected bucket sizes [1, 2]");
+    }
+
+    // ------------------------------------------------------------------
+    // dirty_subset_in_repo
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn dirty_subset_all_clean_returns_empty() {
+        let td = TempDir::new().unwrap();
+        let repo = init_repo(&td);
+        let f1 = write_file(&repo, "f1.txt", "one");
+        let f2 = write_file(&repo, "f2.txt", "two");
+        commit_all(&repo, "seed");
+
+        let inputs = vec![s(&f1), s(&f2)];
+        let dirty = dirty_subset_in_repo(&repo, &inputs).expect("dirty_subset");
+        assert!(
+            dirty.is_empty(),
+            "all clean → empty subset, got {:?}",
+            dirty
+        );
+    }
+
+    #[test]
+    fn dirty_subset_mixed_staged_and_unstaged_returns_both() {
+        let td = TempDir::new().unwrap();
+        let repo = init_repo(&td);
+        let f_staged = write_file(&repo, "staged.txt", "v1");
+        let f_unstaged = write_file(&repo, "unstaged.txt", "v1");
+        let f_clean = write_file(&repo, "clean.txt", "v1");
+        commit_all(&repo, "seed");
+
+        // Staged change: modify + add.
+        fs::write(&f_staged, "v2-staged").unwrap();
+        run(&repo, &["add", "staged.txt"]);
+
+        // Unstaged change: modify only.
+        fs::write(&f_unstaged, "v2-unstaged").unwrap();
+
+        // Clean file untouched.
+
+        let inputs = vec![s(&f_staged), s(&f_unstaged), s(&f_clean)];
+        let dirty = dirty_subset_in_repo(&repo, &inputs).expect("dirty_subset");
+
+        assert_eq!(
+            dirty.len(),
+            2,
+            "expected exactly 2 dirty entries (staged + unstaged), got {:?}",
+            dirty
+        );
+        assert!(
+            dirty.iter().any(|p| p.ends_with("staged.txt")),
+            "expected staged.txt in {:?}",
+            dirty
+        );
+        assert!(
+            dirty.iter().any(|p| p.ends_with("unstaged.txt")),
+            "expected unstaged.txt in {:?}",
+            dirty
+        );
+        assert!(
+            !dirty.iter().any(|p| p.ends_with("clean.txt")),
+            "expected clean.txt NOT in {:?}",
+            dirty
+        );
+    }
+
+    #[test]
+    fn dirty_subset_empty_paths_returns_empty_no_git_call() {
+        let td = TempDir::new().unwrap();
+        let repo = init_repo(&td);
+        write_file(&repo, "f.txt", "hi");
+        commit_all(&repo, "seed");
+
+        let dirty = dirty_subset_in_repo(&repo, &[]).expect("dirty_subset");
+        assert!(dirty.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // is_mid_merge
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn is_mid_merge_false_on_clean_repo() {
+        let td = TempDir::new().unwrap();
+        let repo = init_repo(&td);
+        write_file(&repo, "f.txt", "hi");
+        commit_all(&repo, "seed");
+
+        assert!(!is_mid_merge(&repo));
+    }
+
+    #[test]
+    fn is_mid_merge_true_with_merge_head_marker() {
+        let td = TempDir::new().unwrap();
+        let repo = init_repo(&td);
+        write_file(&repo, "f.txt", "hi");
+        commit_all(&repo, "seed");
+
+        // Synthesise a MERGE_HEAD marker — content is irrelevant for the
+        // detection; existence is the signal.
+        fs::write(repo.join(".git").join("MERGE_HEAD"), "deadbeef\n").unwrap();
+        assert!(is_mid_merge(&repo));
+    }
+
+    #[test]
+    fn is_mid_merge_true_with_rebase_merge_dir() {
+        let td = TempDir::new().unwrap();
+        let repo = init_repo(&td);
+        write_file(&repo, "f.txt", "hi");
+        commit_all(&repo, "seed");
+
+        // Synthesise a rebase-merge/ directory — git treats its existence as
+        // "rebase in progress", same as `git rebase -i` would.
+        fs::create_dir_all(repo.join(".git").join("rebase-merge")).unwrap();
+        assert!(is_mid_merge(&repo));
+    }
+
+    #[test]
+    fn is_mid_merge_true_in_linked_worktree_with_marker_under_worktree_gitdir() {
+        let td = TempDir::new().unwrap();
+        let main = init_repo(&td);
+        write_file(&main, "f.txt", "hi");
+        commit_all(&main, "seed");
+
+        // Add a linked worktree pointing at a sibling dir.
+        let wt_dir = td.path().join("wt-feature");
+        run(
+            &main,
+            &["worktree", "add", "-b", "feature", wt_dir.to_str().unwrap()],
+        );
+
+        // The linked worktree's gitdir lives under the main repo at
+        // .git/worktrees/<name>/. Synthesise MERGE_HEAD there.
+        let wt_gitdir = main.join(".git").join("worktrees").join("wt-feature");
+        assert!(
+            wt_gitdir.is_dir(),
+            "expected linked-worktree gitdir at {:?}",
+            wt_gitdir
+        );
+        fs::write(wt_gitdir.join("MERGE_HEAD"), "deadbeef\n").unwrap();
+
+        assert!(
+            is_mid_merge(&wt_dir),
+            "is_mid_merge should follow `git rev-parse --git-dir` to the linked worktree's gitdir"
+        );
+        // Sanity: the main repo itself (no MERGE_HEAD in main .git) is NOT
+        // mid-merge.
+        assert!(
+            !is_mid_merge(&main),
+            "main repo should NOT report mid-merge — its .git/MERGE_HEAD doesn't exist"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // serde
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn commit_state_status_serialises_lowercase() {
+        // The frontend depends on these exact strings — pin them.
+        let cases = [
+            (CommitStateStatus::Clean, "\"clean\""),
+            (CommitStateStatus::Dirty, "\"dirty\""),
+            (CommitStateStatus::Empty, "\"empty\""),
+            (CommitStateStatus::Merging, "\"merging\""),
+            (CommitStateStatus::Unknown, "\"unknown\""),
+        ];
+        for (variant, expected) in cases {
+            let got = serde_json::to_string(&variant).unwrap();
+            assert_eq!(got, expected, "wrong wire string for {:?}", variant);
+        }
+    }
+
+    #[test]
+    fn commit_state_struct_fields_stay_snake_case() {
+        let cs = CommitState {
+            status: CommitStateStatus::Empty,
+            touched_count: 3,
+            dirty_count: 1,
+            repo_roots: vec!["/a".into()],
+            merging_repos: vec![],
+            generated_at_ms: 42,
+        };
+        let v: serde_json::Value = serde_json::to_value(&cs).unwrap();
+        // Pin the snake_case keys — frontend TS interface uses these
+        // verbatim.
+        for key in [
+            "status",
+            "touched_count",
+            "dirty_count",
+            "repo_roots",
+            "merging_repos",
+            "generated_at_ms",
+        ] {
+            assert!(
+                v.get(key).is_some(),
+                "expected snake_case key {:?} in {:?}",
+                key,
+                v
+            );
+        }
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -57,6 +57,7 @@ mod fixer;
 mod flow_control;
 mod follow_up;
 mod fs_atomic;
+mod git_status_subset;
 mod graphql;
 mod health_monitor;
 mod heartbeat;
@@ -678,6 +679,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::ai_session::generate_workflow_from_session,
             commands::ai_session::get_ai_output,
             commands::ai_session::get_ai_session_state,
+            commands::ai_session::get_session_commit_state,
             commands::ai_session::interrupt_ai_session,
             commands::ai_session::list_ai_sessions,
             commands::ai_session::promote_session_to_worktree,
@@ -1883,6 +1885,36 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     scheduler_service::start_scheduler_service(scheduler_pg, scheduler_app_state)
                         .await;
                 });
+            }
+
+            // Phase 1.5 — transcript-tail populator. Watches Claude CLI's
+            // per-session JSONL transcripts and writes Edit/Write/MultiEdit
+            // touches into `coord.session_touched_files` so the per-terminal
+            // commit traffic light has rows to read for PTY-launched AI tabs
+            // (the dominant launch path; SDK chat sessions populate via
+            // `auto_register_file` and don't need this watcher).
+            {
+                let tw_pg = app.state::<Arc<commands::AppState>>().pg_db.clone();
+                let tw_app_handle = app.handle().clone();
+                // Resolve the runner-tracked workspace root (best-effort).
+                let workspace_paths: Vec<String> =
+                    match crate::mcp::shared::get_workspace_paths_internal() {
+                        Ok((root, _, _)) => vec![root.to_string_lossy().to_string()],
+                        Err(e) => {
+                            tracing::warn!(
+                                "transcript_watcher: get_workspace_paths_internal failed: {}",
+                                e
+                            );
+                            Vec::new()
+                        }
+                    };
+                if let Err(e) = crate::terminal::transcript_watcher::start_transcript_watcher(
+                    tw_app_handle,
+                    tw_pg,
+                    workspace_paths,
+                ) {
+                    tracing::warn!("transcript watcher failed to start: {}", e);
+                }
             }
 
             // Auto-load the default state machine into the Python bridge so

--- a/src-tauri/src/mcp/ai_session.rs
+++ b/src-tauri/src/mcp/ai_session.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 use tracing::{error, info, warn};
 
 use crate::context;
@@ -590,6 +590,8 @@ pub(crate) async fn commit_session_progress_inner(
                 files.len(),
                 branch
             );
+            // Tracker just got cleared → traffic light should flip to Empty.
+            emit_commit_state_for_session(app_handle.clone(), session_id.to_string());
             Ok(CommitProgressResponse {
                 commit_hash: Some(hash),
                 file_count: files.len(),
@@ -612,6 +614,9 @@ pub(crate) async fn commit_session_progress_inner(
                 session_id,
                 files.len()
             );
+            // Tracker cleared on the no-op path too (line above) — flip the
+            // light to Empty for parity with the success branch.
+            emit_commit_state_for_session(app_handle.clone(), session_id.to_string());
             Ok(CommitProgressResponse {
                 commit_hash: None,
                 file_count: files.len(),
@@ -632,6 +637,220 @@ pub(crate) async fn commit_session_progress_inner(
             ))
         }
     }
+}
+
+/// Probe the per-session "ready-to-commit" state without actually committing.
+///
+/// Sibling of `commit_session_progress_inner` — reuses its cwd-resolution +
+/// tracker-read sequence, then runs the §1 dirty-subset query against the
+/// touched-file set. Returns a `CommitState` describing whether the tracker
+/// is empty / clean / dirty / mid-merge across one or more enclosing repos.
+///
+/// Used by:
+/// 1. The Tauri command `get_session_commit_state` for frontend polling.
+/// 2. The `commit-state-changed` event emitter that fires from
+///    `auto_register_file`, the transcript-tail watcher, and post-commit
+///    paths — see `emit_commit_state_for_session` below.
+///
+/// Errors are surfaced as `(StatusCode, String)` so callers can map them onto
+/// the existing `CommandResponse { success: false, message }` shape used by
+/// `commit_session_progress`.
+pub(crate) async fn session_commit_state_inner(
+    app_handle: &tauri::AppHandle,
+    session_id: &str,
+) -> Result<crate::git_status_subset::CommitState, (StatusCode, String)> {
+    use crate::commands::AppState;
+    use crate::git_status_subset::{
+        bucket_by_repo, dirty_subset_in_repo, is_mid_merge, now_ms, CommitState, CommitStateStatus,
+    };
+
+    // 1. Resolve AppState (for pg_db). Same gating as
+    //    `commit_session_progress_inner` step 2.
+    let app_state: Arc<AppState> = app_handle
+        .try_state::<Arc<AppState>>()
+        .ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "AppState not available".to_string(),
+            )
+        })?
+        .inner()
+        .clone();
+
+    // 2. Read the tracker. The session's session_id IS the task_run_id for
+    //    live PTYs (see `commit_session_progress_inner:527-528`). The PTY
+    //    transcript watcher writes rows under the same id.
+    let pg = app_state.pg_db.clone();
+    let files = pg.get_files_touched(session_id).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to read touched-files tracker: {}", e),
+        )
+    })?;
+
+    if files.is_empty() {
+        return Ok(CommitState {
+            status: CommitStateStatus::Empty,
+            touched_count: 0,
+            dirty_count: 0,
+            repo_roots: Vec::new(),
+            merging_repos: Vec::new(),
+            generated_at_ms: now_ms(),
+        });
+    }
+
+    // 3. Bucket touched files by enclosing git toplevel. Files outside any
+    //    repo are dropped silently. Empty buckets → also `Empty` for UI
+    //    purposes (the user has nothing to commit).
+    let buckets = bucket_by_repo(&files);
+    if buckets.is_empty() {
+        return Ok(CommitState {
+            status: CommitStateStatus::Empty,
+            touched_count: files.len(),
+            dirty_count: 0,
+            repo_roots: Vec::new(),
+            merging_repos: Vec::new(),
+            generated_at_ms: now_ms(),
+        });
+    }
+
+    // 4. Probe each bucket for mid-merge state and dirty subset. Stable
+    //    iteration order doesn't matter — repo_roots/merging_repos are
+    //    advisory tooltip strings.
+    let mut repo_roots: Vec<String> = Vec::with_capacity(buckets.len());
+    let mut merging_repos: Vec<String> = Vec::new();
+    let mut dirty: Vec<String> = Vec::new();
+
+    for (repo, paths) in &buckets {
+        let repo_str = repo.to_string_lossy().into_owned();
+        repo_roots.push(repo_str.clone());
+
+        if is_mid_merge(repo) {
+            merging_repos.push(repo_str);
+        }
+
+        match dirty_subset_in_repo(repo, paths) {
+            Ok(mut subset) => dirty.append(&mut subset),
+            Err(e) => {
+                warn!(
+                    "session_commit_state: dirty_subset_in_repo failed for {}: {}",
+                    repo.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    // 5. Resolve final status. Merging precedence over Dirty (a mid-merge repo
+    //    must be resolved manually — UI must disable the commit button).
+    let status = if !merging_repos.is_empty() {
+        CommitStateStatus::Merging
+    } else if dirty.is_empty() {
+        CommitStateStatus::Clean
+    } else {
+        CommitStateStatus::Dirty
+    };
+
+    Ok(CommitState {
+        status,
+        touched_count: files.len(),
+        dirty_count: dirty.len(),
+        repo_roots,
+        merging_repos,
+        generated_at_ms: now_ms(),
+    })
+}
+
+/// Per-session debounce store for `emit_commit_state_for_session`. 500 ms
+/// window prevents N consecutive `auto_register_file` hooks from firing N
+/// commit-state probes when one batch (e.g. a MultiEdit-equivalent loop in a
+/// single turn) just changed the same set.
+static COMMIT_STATE_DEBOUNCE: once_cell::sync::OnceCell<
+    dashmap::DashMap<String, std::time::Instant>,
+> = once_cell::sync::OnceCell::new();
+
+/// Per-session debounce window for commit-state-changed emits.
+const COMMIT_STATE_DEBOUNCE_MS: u128 = 500;
+
+/// Spawn a fire-and-forget task that probes `session_commit_state_inner` and
+/// emits a `commit-state-changed` event on success.
+///
+/// Called by:
+///   - `claude_session::dispatcher::auto_register_file` (after a successful
+///     Edit/Write file-lock acquire) — SDK chat sessions.
+///   - `terminal::transcript_watcher::tail_session` (after PG rows landed) —
+///     PTY-launched terminal AI tabs.
+///   - `commit_session_progress_inner` (after a commit / no-op return) — so
+///     the UI sees the post-commit `Empty` state immediately rather than
+///     waiting for the next 30 s frontend poll.
+///
+/// Per-session debounce of 500 ms applies — repeated calls within the window
+/// are dropped on the floor (the debounce store remembers each session
+/// independently).
+///
+/// Event payload shape (snake_case at the top level — must NOT be wrapped in
+/// a `#[serde(rename_all = "camelCase")]` struct, or the TS frontend will
+/// silently drop the event; see auto-memory entry
+/// `proj_tauri_event_payload_camelcase.md`):
+///
+/// ```json
+/// {
+///   "type": "commit-state-changed",
+///   "task_run_id": "<session_id>",
+///   "state": { /* CommitState */ }
+/// }
+/// ```
+///
+/// The same payload is also broadcast through `AppState.event_broadcast` so
+/// non-Tauri consumers (the MCP event channel, future remote dashboards) see
+/// it. Mirrors the file-lock event pattern at `dispatcher.rs:440-441` and
+/// `:460-461`.
+pub fn emit_commit_state_for_session(app_handle: tauri::AppHandle, session_id: String) {
+    use crate::commands::AppState;
+
+    // Debounce: if this session emitted within the last 500 ms, drop.
+    let store = COMMIT_STATE_DEBOUNCE.get_or_init(dashmap::DashMap::new);
+    let now = std::time::Instant::now();
+    if let Some(prev) = store.get(&session_id) {
+        if now.duration_since(*prev).as_millis() < COMMIT_STATE_DEBOUNCE_MS {
+            return;
+        }
+    }
+    store.insert(session_id.clone(), now);
+
+    tauri::async_runtime::spawn(async move {
+        let state = match session_commit_state_inner(&app_handle, &session_id).await {
+            Ok(s) => s,
+            Err((status, msg)) => {
+                warn!(
+                    "emit_commit_state_for_session: probe failed for session {} ([{}] {})",
+                    session_id, status, msg
+                );
+                return;
+            }
+        };
+
+        // Build the payload with explicit keys — never via a
+        // camelCase-renamed struct (see camelcase trap memo above).
+        let payload = serde_json::json!({
+            "type": "commit-state-changed",
+            "task_run_id": session_id,
+            "state": state,
+        });
+
+        if let Err(e) = app_handle.emit("commit-state-changed", &payload) {
+            warn!(
+                "emit_commit_state_for_session: app_handle.emit failed for {}: {}",
+                session_id, e
+            );
+        }
+
+        // Broadcast on the shared event channel so non-Tauri consumers see
+        // it. Best-effort — receivers may be empty.
+        if let Some(app_state) = app_handle.try_state::<Arc<AppState>>() {
+            let _ = app_state.event_broadcast.send(payload);
+        }
+    });
 }
 
 // ============================================================================

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1682,7 +1682,45 @@ pub fn create_router(
         .layer(cors)
         .layer(RequestBodyLimitLayer::new(100 * 1024 * 1024))
         .layer(axum::Extension(graphql_schema))
+        // Outermost layer: catch panics from any handler/middleware below and
+        // convert them into a JSON 500 matching the runner's `ApiResponse<()>`
+        // shape. Without this, a handler panic surfaces to the client as
+        // "empty reply from server" — diagnostically indistinguishable from a
+        // legitimate empty success response. `.layer()` is bottom-up, so the
+        // LAST `.layer()` call wraps the rest. `with_state` must remain
+        // terminal.
+        .layer(tower_http::catch_panic::CatchPanicLayer::custom(
+            runner_panic_handler,
+        ))
         .with_state(api_state)
+}
+
+/// Convert a caught handler panic into a JSON 500 response that matches the
+/// runner's `ApiResponse<()>` shape. Wired onto the main API router via
+/// `tower_http::catch_panic::CatchPanicLayer::custom`.
+///
+/// The panic payload is `Box<dyn Any + Send>`; downcast to the two common
+/// concrete types (`&'static str` from `panic!("literal")` and `String` from
+/// `panic!("{}", x)`) and fall back to a generic message otherwise.
+fn runner_panic_handler(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let msg = if let Some(s) = err.downcast_ref::<&'static str>() {
+        s.to_string()
+    } else if let Some(s) = err.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    };
+
+    tracing::error!(handler_panic = true, message = %msg, "runner HTTP handler panicked");
+
+    let body = crate::mcp::types::api_error(format!("handler panicked: {}", msg));
+    (
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        axum::Json(body),
+    )
+        .into_response()
 }
 
 /// Try to bind to a port with SO_REUSEADDR
@@ -1785,4 +1823,33 @@ pub async fn start_server(
     Err(Box::new(last_error.unwrap_or_else(|| {
         std::io::Error::other("All ports failed")
     })))
+}
+
+#[cfg(test)]
+mod panic_catcher_tests {
+    use super::runner_panic_handler;
+    use axum::{body::Body, http::Request, routing::get, Router};
+    use tower::ServiceExt;
+
+    async fn panicking_handler() -> &'static str {
+        panic!("intentional test panic");
+    }
+
+    #[tokio::test]
+    async fn test_panic_caught_returns_500_json() {
+        let app = Router::new().route("/boom", get(panicking_handler)).layer(
+            tower_http::catch_panic::CatchPanicLayer::custom(runner_panic_handler),
+        );
+
+        let req = Request::builder().uri("/boom").body(Body::empty()).unwrap();
+        let response = app.oneshot(req).await.unwrap();
+
+        assert_eq!(response.status(), 500);
+        let body_bytes = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(body["success"], false);
+        assert!(body["error"].as_str().unwrap().contains("panicked"));
+    }
 }

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -9,6 +9,7 @@ pub mod interceptor;
 pub mod manager;
 pub mod session;
 pub mod transcript;
+pub mod transcript_watcher;
 pub mod types;
 
 pub use manager::TerminalManager;

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -494,6 +494,170 @@ fn parse_assistant_record(record: &serde_json::Value) -> Option<TranscriptMessag
     })
 }
 
+// ── Touched-File Extraction (Phase 1.5 — transcript-tail populator) ──────────
+//
+// These helpers walk an `{type:"assistant"}` JSONL record and emit a
+// `TouchedFile` for each `Edit` / `Write` / `MultiEdit` `tool_use` block. They
+// are pure (no I/O) and live next to `parse_assistant_record` because they
+// share the same `serde_json::Value` walking style and timestamp field.
+//
+// Consumed by `terminal::transcript_watcher` to populate
+// `coord.session_touched_files` for PTY-launched AI tabs (the SDK
+// `auto_register_file` path covers SDK chat sessions).
+
+/// One file-edit observation extracted from a single tool-use block in a
+/// transcript record. The runtime tail task converts these into
+/// `pg.record_file_touched` calls.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TouchedFile {
+    /// The CLI-side session id (the JSONL file's stem). Carried through so
+    /// the consumer doesn't have to thread it separately.
+    pub session_id: String,
+    /// Absolute file path as the tool reported it. NOT canonicalized — the
+    /// downstream dirty-subset query buckets by git toplevel, which handles
+    /// path-normalization there.
+    pub file_path: String,
+    /// Which tool produced the touch.
+    pub tool: ToolKind,
+    /// Wall-clock ms when the record was written, parsed from the record's
+    /// top-level `timestamp` field (ISO-8601). Falls back to "now" when
+    /// missing or unparseable.
+    pub recorded_at_ms: u64,
+}
+
+/// Tool that wrote to a file. Match arm is intentionally explicit so adding a
+/// new tool (NotebookEdit, etc.) is a deliberate extension, not a guess.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolKind {
+    Edit,
+    Write,
+    MultiEdit,
+}
+
+/// Errors from `parse_line_for_touched_files`. Malformed JSON is the only
+/// case — the caller logs and continues, never panics.
+#[derive(Debug, thiserror::Error)]
+pub enum ParseError {
+    #[error("malformed JSON: {0}")]
+    MalformedJson(String),
+}
+
+/// Parse the record's top-level `timestamp` field (ISO-8601) into wall-clock
+/// ms. Falls back to `SystemTime::now()` when absent or unparseable.
+fn record_timestamp_ms(record: &serde_json::Value) -> u64 {
+    if let Some(ts) = record.get("timestamp").and_then(|t| t.as_str()) {
+        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+            let ms = dt.timestamp_millis();
+            if ms >= 0 {
+                return ms as u64;
+            }
+        }
+    }
+    SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Walk `content[]` of an `{type:"assistant"}` record and emit a TouchedFile
+/// for each Edit/Write/MultiEdit `tool_use` block. Returns 0..N entries (a
+/// single record can carry multiple tool_use blocks). Skips non-touching
+/// blocks, unknown tools, and blocks with missing/non-string `input.file_path`
+/// silently — never fails.
+///
+/// The input shape is identical to what `parse_assistant_record:444` already
+/// consumes; reuse that mental model.
+pub fn extract_touched_files_from_assistant_record(
+    session_id: &str,
+    record: &serde_json::Value,
+) -> Vec<TouchedFile> {
+    let recorded_at_ms = record_timestamp_ms(record);
+
+    let Some(message) = record.get("message") else {
+        return Vec::new();
+    };
+    let Some(content) = message.get("content").and_then(|c| c.as_array()) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for block in content {
+        let block_type = block
+            .get("type")
+            .and_then(|t| t.as_str())
+            .unwrap_or_default();
+        if block_type != "tool_use" {
+            continue;
+        }
+        let name = match block.get("name").and_then(|n| n.as_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        let tool = match name {
+            "Edit" => ToolKind::Edit,
+            "Write" => ToolKind::Write,
+            "MultiEdit" => ToolKind::MultiEdit,
+            // Future tools (NotebookEdit, etc.) need an explicit arm — don't
+            // guess. Read/Bash/Grep/Glob/etc. fall through silently.
+            _ => continue,
+        };
+
+        // All three tools key the path on `input.file_path` (string). Skip
+        // blocks that are missing/non-string rather than failing; the parser
+        // is intentionally tolerant of upstream shape drift.
+        let Some(file_path) = block
+            .get("input")
+            .and_then(|i| i.get("file_path"))
+            .and_then(|p| p.as_str())
+        else {
+            continue;
+        };
+
+        out.push(TouchedFile {
+            session_id: session_id.to_string(),
+            file_path: file_path.to_string(),
+            tool,
+            recorded_at_ms,
+        });
+    }
+    out
+}
+
+/// Convenience wrapper: parse one JSONL line, dispatch by `type`, and return
+/// touched files (empty for non-assistant records). Wraps `serde_json::from_str`
+/// + `extract_touched_files_from_assistant_record`. Malformed JSON →
+/// `Err(ParseError)`; the caller logs and continues — never panics.
+pub fn parse_line_for_touched_files(
+    session_id: &str,
+    line: &str,
+) -> Result<Vec<TouchedFile>, ParseError> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let record: serde_json::Value =
+        serde_json::from_str(trimmed).map_err(|e| ParseError::MalformedJson(e.to_string()))?;
+
+    let record_type = record
+        .get("type")
+        .and_then(|t| t.as_str())
+        .unwrap_or_default();
+    if record_type != "assistant" {
+        return Ok(Vec::new());
+    }
+    Ok(extract_touched_files_from_assistant_record(
+        session_id, &record,
+    ))
+}
+
+/// Test-only re-export of `is_workflow_session` so the `transcript_watcher`
+/// module can apply the same first-5-lines filter without duplicating the
+/// logic. The function itself stays private to this module.
+pub(crate) fn is_workflow_session_marker(content: &str) -> bool {
+    is_workflow_session(content)
+}
+
 // ── Text Extraction ──────────────────────────────────────────────────────────
 
 /// Format messages as readable conversation text suitable for `inline_context`.
@@ -1284,5 +1448,210 @@ mod tests {
         // On the dev machine, we should find at least one
         // (but don't assert that in CI)
         let _ = dirs;
+    }
+
+    // ── Touched-File Extraction tests (Phase 1.5) ────────────────────────────
+
+    #[test]
+    fn test_extract_touched_files_single_edit() {
+        // Real-shape JSONL fixture with one `Edit` tool_use.
+        let record = serde_json::json!({
+            "type": "assistant",
+            "uuid": "asst-1",
+            "timestamp": "2026-05-09T12:34:56.789Z",
+            "message": {
+                "model": "claude-opus-4-7",
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I'll edit the file."},
+                    {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "Edit",
+                        "input": {
+                            "file_path": "D:/qontinui-root/foo.rs",
+                            "old_string": "fn old()",
+                            "new_string": "fn new()"
+                        }
+                    }
+                ]
+            }
+        });
+        let touched = extract_touched_files_from_assistant_record("sess-A", &record);
+        assert_eq!(touched.len(), 1);
+        assert_eq!(touched[0].session_id, "sess-A");
+        assert_eq!(touched[0].file_path, "D:/qontinui-root/foo.rs");
+        assert_eq!(touched[0].tool, ToolKind::Edit);
+        // Timestamp parsed from ISO-8601 is non-zero and matches what
+        // chrono produces — exact value is brittle across leap-second
+        // tables, so just bound it. The fixture is mid-2026.
+        let ms = touched[0].recorded_at_ms;
+        let approx_2026_min = 1_700_000_000_000u64; // late 2023
+        let approx_2030_max = 1_900_000_000_000u64; // 2030
+        assert!(
+            ms > approx_2026_min && ms < approx_2030_max,
+            "expected mid-2020s timestamp ms, got {}",
+            ms
+        );
+    }
+
+    #[test]
+    fn test_extract_touched_files_unknown_tool_skipped() {
+        let record = serde_json::json!({
+            "type": "assistant",
+            "uuid": "asst-2",
+            "timestamp": "2026-05-09T12:34:56Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-2",
+                        "name": "Read",
+                        "input": {"file_path": "/should/not/track.rs"}
+                    }
+                ]
+            }
+        });
+        let touched = extract_touched_files_from_assistant_record("sess-B", &record);
+        assert!(
+            touched.is_empty(),
+            "Read tool must NOT produce a TouchedFile"
+        );
+    }
+
+    #[test]
+    fn test_extract_touched_files_missing_file_path_silent() {
+        let record = serde_json::json!({
+            "type": "assistant",
+            "uuid": "asst-3",
+            "timestamp": "2026-05-09T12:34:56Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-3",
+                        "name": "Edit",
+                        "input": {
+                            "old_string": "x",
+                            "new_string": "y"
+                            // file_path missing
+                        }
+                    }
+                ]
+            }
+        });
+        let touched = extract_touched_files_from_assistant_record("sess-C", &record);
+        assert!(
+            touched.is_empty(),
+            "Missing file_path must produce empty result, not error"
+        );
+    }
+
+    #[test]
+    fn test_parse_line_malformed_json_returns_err() {
+        let bad = r#"{"type": "assistant", "broken": "#;
+        let result = parse_line_for_touched_files("sess-D", bad);
+        assert!(matches!(result, Err(ParseError::MalformedJson(_))));
+    }
+
+    #[test]
+    fn test_extract_touched_files_multiedit_one_per_call() {
+        // MultiEdit with 5 inner edits to the same file → 1 TouchedFile.
+        let record = serde_json::json!({
+            "type": "assistant",
+            "uuid": "asst-4",
+            "timestamp": "2026-05-09T12:34:56Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-4",
+                        "name": "MultiEdit",
+                        "input": {
+                            "file_path": "/tmp/multi.rs",
+                            "edits": [
+                                {"old_string": "a", "new_string": "1"},
+                                {"old_string": "b", "new_string": "2"},
+                                {"old_string": "c", "new_string": "3"},
+                                {"old_string": "d", "new_string": "4"},
+                                {"old_string": "e", "new_string": "5"}
+                            ]
+                        }
+                    }
+                ]
+            }
+        });
+        let touched = extract_touched_files_from_assistant_record("sess-E", &record);
+        assert_eq!(touched.len(), 1);
+        assert_eq!(touched[0].file_path, "/tmp/multi.rs");
+        assert_eq!(touched[0].tool, ToolKind::MultiEdit);
+    }
+
+    #[test]
+    fn test_extract_touched_files_mixed_blocks() {
+        // Read + Edit blocks → exactly 1 TouchedFile (the Edit).
+        let record = serde_json::json!({
+            "type": "assistant",
+            "uuid": "asst-5",
+            "timestamp": "2026-05-09T12:34:56Z",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-5a",
+                        "name": "Read",
+                        "input": {"file_path": "/skip/me.rs"}
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tool-5b",
+                        "name": "Edit",
+                        "input": {
+                            "file_path": "/keep/me.rs",
+                            "old_string": "x",
+                            "new_string": "y"
+                        }
+                    }
+                ]
+            }
+        });
+        let touched = extract_touched_files_from_assistant_record("sess-F", &record);
+        assert_eq!(touched.len(), 1);
+        assert_eq!(touched[0].file_path, "/keep/me.rs");
+        assert_eq!(touched[0].tool, ToolKind::Edit);
+    }
+
+    #[test]
+    fn test_parse_line_for_touched_files_non_assistant_returns_empty() {
+        // user records produce no touched files even if they reference paths.
+        let line = r#"{"type":"user","uuid":"u1","timestamp":"2026-05-09T00:00:00Z","message":{"role":"user","content":"please edit foo.rs"}}"#;
+        let result = parse_line_for_touched_files("sess-G", line).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_line_for_touched_files_empty_line_ok() {
+        // Trailing/empty lines must not error.
+        assert!(parse_line_for_touched_files("sess-H", "")
+            .unwrap()
+            .is_empty());
+        assert!(parse_line_for_touched_files("sess-H", "   ")
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn test_parse_line_for_touched_files_full_pipeline_write() {
+        // End-to-end: full JSONL line → TouchedFile.
+        let line = r#"{"type":"assistant","uuid":"a-9","timestamp":"2026-05-09T01:02:03Z","message":{"model":"claude-opus-4-7","role":"assistant","content":[{"type":"tool_use","id":"t","name":"Write","input":{"file_path":"/new/file.rs","content":"fn main(){}"}}]}}"#;
+        let touched = parse_line_for_touched_files("sess-I", line).unwrap();
+        assert_eq!(touched.len(), 1);
+        assert_eq!(touched[0].tool, ToolKind::Write);
+        assert_eq!(touched[0].file_path, "/new/file.rs");
+        assert_eq!(touched[0].session_id, "sess-I");
     }
 }

--- a/src-tauri/src/terminal/transcript_watcher.rs
+++ b/src-tauri/src/terminal/transcript_watcher.rs
@@ -1,0 +1,594 @@
+//! Transcript-tail populator for PTY-launched AI tabs (Phase 1.5).
+//!
+//! Watches Claude CLI's per-session JSONL transcripts on disk
+//! (`<config_dir>/projects/<encoded-project>/<session_id>.jsonl`), parses
+//! `Edit` / `Write` / `MultiEdit` `tool_use` blocks out of them, and calls
+//! `pg.record_file_touched(session_id, file_path, None)` so that the
+//! `coord.session_touched_files` table populates for PTY tabs the same way
+//! it already does for SDK chat sessions via `auto_register_file`.
+//!
+//! Why this exists: the dominant terminal-AI launch path
+//! (`onLaunchAiSession` at `TerminalPage.tsx:389-424`) types `claude` into a
+//! PTY shell. The Claude CLI runs as a child of the PTY, NOT of
+//! `ClaudeSession::spawn`, so its tool-use stream is never read by the runner
+//! and `auto_register_file` never fires for those tabs. Without this watcher,
+//! the §1 traffic light has no rows to read for the dominant UX path.
+//!
+//! Reuses existing infrastructure:
+//!   - `terminal::transcript::find_claude_config_dirs()` for config dirs.
+//!   - `terminal::transcript::list_sessions()` for startup discovery.
+//!   - `terminal::transcript::is_workflow_session_marker()` for the
+//!     workflow-vs-interactive filter.
+//!   - `terminal::transcript::parse_line_for_touched_files()` for parsing.
+//!
+//! Mirrors the `notify::RecommendedWatcher` + tokio-channel pattern from
+//! `trigger_system/watchers/file_watcher.rs` and `wrappers/registry.rs`.
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use once_cell::sync::OnceCell;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader};
+use tokio::sync::{mpsc, Mutex as TokioMutex, Notify};
+use tracing::{debug, info, warn};
+
+use super::transcript::{
+    find_claude_config_dirs, is_workflow_session_marker, list_sessions,
+    parse_line_for_touched_files,
+};
+
+/// Ceiling for "recent enough to schedule a tail task on startup". Older
+/// JSONLs are skipped — they belong to closed sessions whose tabs the user
+/// can no longer act on.
+const STARTUP_RECENCY: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Per-tail-task fallback poll interval. Defends a missed `Modify` event from
+/// `notify` by ensuring the loop runs at least this often even without a
+/// wake.
+const TAIL_FALLBACK_TICK: Duration = Duration::from_secs(1);
+
+/// Hold the watcher for the app's lifetime. `notify::RecommendedWatcher` is
+/// `Drop`-stop-the-watcher, so we keep it alive in a `OnceCell`. The watcher
+/// is opaque to the rest of the program; its events flow through an
+/// `mpsc::Sender` instead. The std::sync::Mutex is never actually locked
+/// after `set()` — it's just a `Send + Sync` wrapper for the
+/// not-necessarily-Sync watcher handle.
+static WATCHER: OnceCell<std::sync::Mutex<Vec<RecommendedWatcher>>> = OnceCell::new();
+
+/// Errors a tail task can return. Non-fatal — the supervisor logs and
+/// proceeds.
+#[derive(Debug, thiserror::Error)]
+enum TailError {
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Handle to a running tail task. Wakes the task on `notify`-fired events and
+/// supports clean cancellation.
+struct TailHandle {
+    wake: Arc<Notify>,
+    cancel: Arc<Notify>,
+}
+
+/// Public entry point. Spawns the watcher + tail tasks asynchronously and
+/// returns immediately. The watcher lives until process exit; do not call
+/// twice for the same process.
+///
+/// `workspace_paths` is the list of project paths the runner currently tracks
+/// (typically a single workspace root). Each path is matched against every
+/// discovered config dir's `projects/<encoded>/` folder.
+pub fn start_transcript_watcher(
+    app_handle: tauri::AppHandle,
+    pg: Arc<crate::database::pg::PgDb>,
+    workspace_paths: Vec<String>,
+) -> Result<(), String> {
+    if WATCHER.get().is_some() {
+        return Err("transcript watcher already started".to_string());
+    }
+
+    info!(
+        "transcript_watcher: starting with {} workspace path(s)",
+        workspace_paths.len()
+    );
+
+    // Spawn the orchestrator on the tokio runtime. It owns the channel, the
+    // watcher, and the per-session task map.
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = run_orchestrator(app_handle, pg, workspace_paths).await {
+            warn!("transcript_watcher: orchestrator exited with error: {}", e);
+        }
+    });
+
+    Ok(())
+}
+
+/// Long-lived task: builds the `notify` watcher per config dir, schedules
+/// startup tail tasks, and dispatches filesystem events to per-session
+/// handles.
+async fn run_orchestrator(
+    app_handle: tauri::AppHandle,
+    pg: Arc<crate::database::pg::PgDb>,
+    workspace_paths: Vec<String>,
+) -> Result<(), String> {
+    let config_dirs = find_claude_config_dirs();
+    if config_dirs.is_empty() {
+        info!("transcript_watcher: no Claude config dirs found; nothing to watch");
+        return Ok(());
+    }
+
+    // session_id -> handle
+    let tasks: Arc<TokioMutex<HashMap<String, TailHandle>>> =
+        Arc::new(TokioMutex::new(HashMap::new()));
+
+    // ── 1. Discovery on startup ───────────────────────────────────────────
+    //
+    // For every (config_dir × workspace_path) pair, list current sessions and
+    // schedule a tail starting from EOF for any whose mtime is within the
+    // last STARTUP_RECENCY.
+    let now = SystemTime::now();
+    for config_dir in &config_dirs {
+        for project in &workspace_paths {
+            let sessions = match list_sessions(config_dir, project) {
+                Ok(s) => s,
+                Err(e) => {
+                    debug!(
+                        "transcript_watcher: list_sessions({:?}, {}) failed: {}",
+                        config_dir, project, e
+                    );
+                    continue;
+                }
+            };
+            for s in sessions {
+                let jsonl = config_dir
+                    .join("projects")
+                    .join(encode_for_lookup(project))
+                    .join(format!("{}.jsonl", s.session_id));
+                if !jsonl.exists() {
+                    continue;
+                }
+                let mtime_ok = std::fs::metadata(&jsonl)
+                    .ok()
+                    .and_then(|m| m.modified().ok())
+                    .map(|t| now.duration_since(t).unwrap_or_default() <= STARTUP_RECENCY)
+                    .unwrap_or(false);
+                if !mtime_ok {
+                    continue;
+                }
+                schedule_tail(
+                    &tasks,
+                    s.session_id.clone(),
+                    jsonl,
+                    pg.clone(),
+                    app_handle.clone(),
+                    /* start_at_eof */ true,
+                )
+                .await;
+            }
+        }
+    }
+
+    // ── 2. Live watching ──────────────────────────────────────────────────
+    //
+    // One `mpsc` channel for all config dirs. Each `notify` callback runs in
+    // a sync context so we use `try_send`.
+    let (tx, mut rx) = mpsc::channel::<Event>(128);
+
+    let mut watchers: Vec<RecommendedWatcher> = Vec::new();
+    for config_dir in &config_dirs {
+        let projects_root = config_dir.join("projects");
+        if !projects_root.exists() {
+            continue;
+        }
+        let tx_for_handler = tx.clone();
+        let watcher_result =
+            notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
+                if let Ok(ev) = res {
+                    let _ = tx_for_handler.try_send(ev);
+                }
+            });
+        let mut watcher = match watcher_result {
+            Ok(w) => w,
+            Err(e) => {
+                warn!(
+                    "transcript_watcher: failed to create watcher for {:?}: {}",
+                    projects_root, e
+                );
+                continue;
+            }
+        };
+        if let Err(e) = watcher.watch(&projects_root, RecursiveMode::Recursive) {
+            warn!(
+                "transcript_watcher: failed to watch {:?}: {}",
+                projects_root, e
+            );
+            continue;
+        }
+        info!("transcript_watcher: watching {:?}", projects_root);
+        watchers.push(watcher);
+    }
+
+    // Stash watchers so they live until process exit. Re-entry into
+    // `start_transcript_watcher` is rejected by the `OnceCell` guard above.
+    let _ = WATCHER.set(std::sync::Mutex::new(watchers));
+
+    // ── 3. Event dispatch loop ────────────────────────────────────────────
+    while let Some(event) = rx.recv().await {
+        for path in &event.paths {
+            // Only attend to *.jsonl files inside a `projects/` subtree.
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let session_id = match path.file_stem().and_then(|s| s.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+
+            match event.kind {
+                EventKind::Create(_) => {
+                    // Create: read first 5 lines, run workflow filter; if
+                    // interactive, schedule a tail starting at offset 0.
+                    if path_looks_like_workflow_session(path) {
+                        debug!(
+                            "transcript_watcher: skipping workflow session {} ({})",
+                            session_id,
+                            path.display()
+                        );
+                        continue;
+                    }
+                    schedule_tail(
+                        &tasks,
+                        session_id.clone(),
+                        path.clone(),
+                        pg.clone(),
+                        app_handle.clone(),
+                        /* start_at_eof */ false,
+                    )
+                    .await;
+                }
+                EventKind::Modify(_) => {
+                    // Wake an existing task; if none, treat as a create
+                    // (the runner may have started after the file).
+                    let map = tasks.lock().await;
+                    if let Some(h) = map.get(&session_id) {
+                        h.wake.notify_one();
+                    } else {
+                        drop(map);
+                        if path_looks_like_workflow_session(path) {
+                            continue;
+                        }
+                        schedule_tail(
+                            &tasks,
+                            session_id.clone(),
+                            path.clone(),
+                            pg.clone(),
+                            app_handle.clone(),
+                            /* start_at_eof */ true,
+                        )
+                        .await;
+                    }
+                }
+                EventKind::Remove(_) => {
+                    let mut map = tasks.lock().await;
+                    if let Some(h) = map.remove(&session_id) {
+                        h.cancel.notify_one();
+                        debug!(
+                            "transcript_watcher: cancelled tail for removed session {}",
+                            session_id
+                        );
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Cheap sniff for `is_workflow_session` without re-loading via
+/// `list_sessions`. Reads up to the first 5 lines of the file. Returns true
+/// if it's a workflow session OR if the file can't be read yet (which is
+/// common immediately after `Create` because the writer hasn't flushed) —
+/// callers fall back to spawning the task and the in-task re-check (step 7
+/// in the loop) catches it after the first wake.
+fn path_looks_like_workflow_session(path: &Path) -> bool {
+    use std::io::{BufRead, BufReader};
+    let f = match std::fs::File::open(path) {
+        Ok(f) => f,
+        // File not yet readable → treat as not-workflow; the in-task re-check
+        // will tear down if the marker shows up later.
+        Err(_) => return false,
+    };
+    let reader = BufReader::new(f);
+    let mut buf = String::with_capacity(2048);
+    for (i, line) in reader.lines().enumerate() {
+        if i >= 5 {
+            break;
+        }
+        if let Ok(l) = line {
+            buf.push_str(&l);
+            buf.push('\n');
+        }
+    }
+    is_workflow_session_marker(&buf)
+}
+
+/// Spawn or replace the per-session tail task.
+async fn schedule_tail(
+    tasks: &Arc<TokioMutex<HashMap<String, TailHandle>>>,
+    session_id: String,
+    path: PathBuf,
+    pg: Arc<crate::database::pg::PgDb>,
+    app_handle: tauri::AppHandle,
+    start_at_eof: bool,
+) {
+    let mut map = tasks.lock().await;
+    if map.contains_key(&session_id) {
+        // Already tailed.
+        return;
+    }
+    let wake = Arc::new(Notify::new());
+    let cancel = Arc::new(Notify::new());
+    map.insert(
+        session_id.clone(),
+        TailHandle {
+            wake: wake.clone(),
+            cancel: cancel.clone(),
+        },
+    );
+    drop(map);
+
+    let tasks_for_cleanup = tasks.clone();
+    let session_id_for_cleanup = session_id.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let result = tail_session(
+            session_id.clone(),
+            path,
+            pg,
+            app_handle,
+            wake,
+            cancel,
+            start_at_eof,
+        )
+        .await;
+        if let Err(e) = result {
+            warn!(
+                "transcript_watcher: tail task for {} exited with error: {}",
+                session_id, e
+            );
+        }
+        // Self-remove from the registry on exit so reschedule works.
+        let mut map = tasks_for_cleanup.lock().await;
+        map.remove(&session_id_for_cleanup);
+    });
+}
+
+/// Per-session tail loop. Reads new bytes on each wake, parses lines into
+/// `TouchedFile`s, persists via `pg.record_file_touched`, and triggers a
+/// debounced commit-state emit on landed rows.
+async fn tail_session(
+    session_id: String,
+    path: PathBuf,
+    pg: Arc<crate::database::pg::PgDb>,
+    app_handle: tauri::AppHandle,
+    wake: Arc<Notify>,
+    cancel: Arc<Notify>,
+    start_at_eof: bool,
+) -> Result<(), TailError> {
+    // ── 1. Open file, establish initial cursor ────────────────────────────
+    let mut file = tokio::fs::File::open(&path).await?;
+    let mut cursor: u64 = if start_at_eof {
+        file.metadata().await.map(|m| m.len()).unwrap_or(0)
+    } else {
+        0
+    };
+
+    // Buffered prefix used for the workflow-session re-check on first wake.
+    let mut workflow_check_buf = String::new();
+    let mut did_workflow_recheck = false;
+
+    debug!(
+        "transcript_watcher: tail started for {} at offset {} ({})",
+        session_id,
+        cursor,
+        path.display()
+    );
+
+    loop {
+        // ── 2. Wait for wake or fallback tick or cancel ───────────────────
+        tokio::select! {
+            _ = cancel.notified() => {
+                debug!("transcript_watcher: tail cancelled for {}", session_id);
+                return Ok(());
+            }
+            _ = wake.notified() => {}
+            _ = tokio::time::sleep(TAIL_FALLBACK_TICK) => {}
+        }
+
+        // ── 3. Detect rotation/truncation ─────────────────────────────────
+        let len = match tokio::fs::metadata(&path).await {
+            Ok(m) => m.len(),
+            Err(_) => continue, // Transient — retry on next tick.
+        };
+        if len < cursor {
+            debug!(
+                "transcript_watcher: detected truncation for {} (was {} bytes, now {})",
+                session_id, cursor, len
+            );
+            cursor = 0;
+            // Re-open to reset any internal seek state.
+            file = tokio::fs::File::open(&path).await?;
+            workflow_check_buf.clear();
+            did_workflow_recheck = false;
+        }
+        if len == cursor {
+            continue;
+        }
+
+        // ── 4. Read appended bytes line-by-line ───────────────────────────
+        if let Err(e) = file.seek(std::io::SeekFrom::Start(cursor)).await {
+            warn!("transcript_watcher: seek failed for {}: {}", session_id, e);
+            // Re-open and retry next tick.
+            file = tokio::fs::File::open(&path).await?;
+            continue;
+        }
+        let mut reader = BufReader::new(&mut file);
+        let mut rows_landed = 0usize;
+        let mut bytes_read: u64 = 0;
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let n = match reader.read_line(&mut line).await {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!(
+                        "transcript_watcher: read_line failed for {}: {}",
+                        session_id, e
+                    );
+                    break;
+                }
+            };
+            if n == 0 {
+                break; // EOF
+            }
+            // Only fully-terminated lines count — partial trailing reads
+            // are NOT added to `bytes_read`, so we re-read them on the next
+            // pass once the writer flushes the trailing newline.
+            if !line.ends_with('\n') {
+                break;
+            }
+            bytes_read += n as u64;
+
+            // Buffer the first 5 lines for the workflow re-check.
+            if !did_workflow_recheck && workflow_check_buf.lines().count() < 5 {
+                workflow_check_buf.push_str(&line);
+            }
+
+            match parse_line_for_touched_files(&session_id, &line) {
+                Ok(touched) => {
+                    for tf in touched {
+                        match pg
+                            .record_file_touched(&session_id, &tf.file_path, None)
+                            .await
+                        {
+                            Ok(()) => rows_landed += 1,
+                            Err(e) => warn!(
+                                "transcript_watcher: record_file_touched({}, {}) failed: {}",
+                                session_id, tf.file_path, e
+                            ),
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!(
+                        "transcript_watcher: malformed JSON line in {}: {}",
+                        session_id, e
+                    );
+                }
+            }
+        }
+        cursor += bytes_read;
+
+        // ── 5. Trigger commit-state emit if rows landed ───────────────────
+        if rows_landed > 0 {
+            crate::mcp::ai_session::emit_commit_state_for_session(
+                app_handle.clone(),
+                session_id.clone(),
+            );
+        }
+
+        // ── 6. Workflow-session re-check on first complete wake ───────────
+        //
+        // Creation-time discovery may race the writer: the file existed at
+        // `Create` but the `queue-operation` marker hadn't landed yet.
+        // After the first read pass we have the buffered prefix; if the
+        // marker is there, this is a workflow session — log and tear down.
+        if !did_workflow_recheck && !workflow_check_buf.is_empty() {
+            did_workflow_recheck = true;
+            if is_workflow_session_marker(&workflow_check_buf) {
+                info!(
+                    "transcript_watcher: tearing down tail for workflow session {} (detected post-creation)",
+                    session_id
+                );
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Re-encode a project path for direct lookup. Mirrors
+/// `terminal::transcript::encode_project_path` (which is private). Kept tiny
+/// + intentional duplication so the watcher doesn't have to re-export
+/// internal helpers.
+fn encode_for_lookup(project_path: &str) -> String {
+    let normalized = project_path
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    normalized
+        .replace(":/", "--")
+        .replace([':', '/', '\\', '_'], "-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_for_lookup_matches_transcript_encoder() {
+        // Spot-check that this watcher's encoder produces the same path
+        // shape as the canonical encoder in `transcript::encode_project_path`.
+        // We compare against a known-good output rather than calling the
+        // private function.
+        assert_eq!(
+            encode_for_lookup("C:/Users/jspin/Documents/qontinui_parent"),
+            "C--Users-jspin-Documents-qontinui-parent"
+        );
+        assert_eq!(
+            encode_for_lookup("C:\\Users\\jspin\\Documents\\qontinui_parent"),
+            "C--Users-jspin-Documents-qontinui-parent"
+        );
+    }
+
+    #[test]
+    fn test_path_looks_like_workflow_session_missing_file() {
+        // Missing files must not blow up; treat as not-workflow and let the
+        // in-task re-check decide later.
+        let nope = std::path::Path::new("C:/this/path/does/not/exist.jsonl");
+        assert!(!path_looks_like_workflow_session(nope));
+    }
+
+    #[test]
+    fn test_path_looks_like_workflow_session_detects_marker() {
+        let tmp =
+            std::env::temp_dir().join(format!("qontinui-tw-test-{}.jsonl", std::process::id()));
+        std::fs::write(
+            &tmp,
+            r#"{"type":"system","subtype":"queue-operation","timestamp":"2026-05-09T00:00:00Z"}
+{"type":"user","uuid":"u1","timestamp":"2026-05-09T00:00:01Z","message":{"role":"user","content":"hi"}}
+"#,
+        )
+        .unwrap();
+        assert!(path_looks_like_workflow_session(&tmp));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn test_path_looks_like_workflow_session_interactive_passes() {
+        let tmp = std::env::temp_dir().join(format!(
+            "qontinui-tw-test-interactive-{}.jsonl",
+            std::process::id()
+        ));
+        std::fs::write(
+            &tmp,
+            r#"{"type":"user","uuid":"u1","timestamp":"2026-05-09T00:00:01Z","message":{"role":"user","content":"hi"}}
+"#,
+        )
+        .unwrap();
+        assert!(!path_looks_like_workflow_session(&tmp));
+        let _ = std::fs::remove_file(&tmp);
+    }
+}

--- a/src/components/llm-observability/ScriptedOutputPanel.tsx
+++ b/src/components/llm-observability/ScriptedOutputPanel.tsx
@@ -21,6 +21,7 @@
  */
 
 import { Cpu, RefreshCw } from "lucide-react";
+import { useUIElement } from "@qontinui/ui-bridge";
 import { MetricCard } from "../performance-dashboard/MetricCard";
 import { useScriptedOutputStats } from "../../hooks/useScriptedOutputStats";
 
@@ -68,6 +69,29 @@ function formatRate(numerator: number, denominator: number): string {
 export function ScriptedOutputPanel({ taskRunId }: ScriptedOutputPanelProps) {
   const { stats, loading, error, refresh } = useScriptedOutputStats(taskRunId);
 
+  // --- UI Bridge registrations ---
+  // Plan 2 (ui-bridge-friction-2026-04-21) Phase C: surface panel root,
+  // refresh button, and metric-tile cluster in currentRouteOnly snapshots
+  // so callers can see and drive this child of the LLM Analytics page.
+  // Naming convention matches LlmObservabilityDashboard.tsx (flat
+  // kebab-case prefixes, type: "generic" for non-interactive elements).
+  const { ref: panelRootRef } = useUIElement({
+    id: "scripted-output-root",
+    type: "generic",
+    label: "Scripted Output panel root",
+  });
+  const { ref: refreshButtonRef } = useUIElement({
+    id: "scripted-output-refresh",
+    type: "button",
+    label: "Refresh scripted-output stats",
+    actions: ["click"],
+  });
+  const { ref: metricTilesRef } = useUIElement({
+    id: "scripted-output-tiles",
+    type: "generic",
+    label: "Scripted Output metric tiles",
+  });
+
   const empty =
     !stats ||
     (stats.attempted === 0 &&
@@ -110,7 +134,7 @@ export function ScriptedOutputPanel({ taskRunId }: ScriptedOutputPanelProps) {
   const fallbackRows = stats ? Object.entries(stats.fallbacks).sort((a, b) => b[1] - a[1]) : [];
 
   return (
-    <div className="bg-card rounded-lg border border-border p-4">
+    <div ref={panelRootRef} className="bg-card rounded-lg border border-border p-4">
       <div className="flex items-center justify-between mb-4">
         <h3 className="font-semibold flex items-center gap-2">
           <Cpu className="w-4 h-4" />
@@ -122,6 +146,7 @@ export function ScriptedOutputPanel({ taskRunId }: ScriptedOutputPanelProps) {
           )}
         </h3>
         <button
+          ref={refreshButtonRef}
           onClick={refresh}
           className="p-1.5 rounded-md hover:bg-muted transition-colors"
           title="Refresh scripted-output stats"
@@ -150,7 +175,7 @@ export function ScriptedOutputPanel({ taskRunId }: ScriptedOutputPanelProps) {
 
       {!empty && stats && (
         <>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div ref={metricTilesRef} className="grid grid-cols-2 md:grid-cols-4 gap-3">
             <MetricCard
               title="Attempts"
               value={emitterCalls.toLocaleString()}

--- a/src/components/terminal/CommitTrafficLight.test.tsx
+++ b/src/components/terminal/CommitTrafficLight.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Pure-logic tests for CommitTrafficLight helpers.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom), so we
+ * follow the repo precedent (`WebIntegrationAuthBanner.test.ts`,
+ * `CompletionReportSections.test.tsx`) and exercise the exported pure
+ * helpers + the click-handler logic via module-level mocks of the Tauri
+ * IPC surface. The JSX shell itself is verified by manual + UI Bridge
+ * tests once the spec is updated.
+ *
+ * Coverage:
+ *   1. `isCommitButtonEnabled` — only `dirty` is enabled.
+ *   2. `COMMIT_PROMPT_TEMPLATE` — the exact prompt text we send to the
+ *      AI is locked down so accidental edits to the procedure get
+ *      caught here.
+ *   3. PTY click → `onWriteToTerminal` called once with prompt + "\r".
+ *   4. SDK click → mocked `invoke("send_user_message", ...)` called.
+ *   5. Disabled-state click is a no-op for clean / empty / merging /
+ *      unknown.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Module mock — must be hoisted before the component import so the
+// `invoke` import inside CommitTrafficLight resolves to the mock.
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+import {
+  COMMIT_PROMPT_TEMPLATE,
+  isCommitButtonEnabled,
+  type CommitState,
+} from "./CommitTrafficLight";
+
+const baseState = (
+  overrides: Partial<CommitState> & Pick<CommitState, "status">,
+): CommitState => ({
+  touched_count: 3,
+  dirty_count: 1,
+  repo_roots: ["D:/repo"],
+  merging_repos: [],
+  generated_at_ms: Date.now(),
+  ...overrides,
+});
+
+describe("isCommitButtonEnabled", () => {
+  it("returns true only for dirty", () => {
+    expect(isCommitButtonEnabled(baseState({ status: "dirty" }))).toBe(true);
+    expect(isCommitButtonEnabled(baseState({ status: "clean" }))).toBe(false);
+    expect(isCommitButtonEnabled(baseState({ status: "empty" }))).toBe(false);
+    expect(isCommitButtonEnabled(baseState({ status: "merging" }))).toBe(false);
+    expect(isCommitButtonEnabled(baseState({ status: "unknown" }))).toBe(false);
+    expect(isCommitButtonEnabled(undefined)).toBe(false);
+  });
+});
+
+describe("COMMIT_PROMPT_TEMPLATE", () => {
+  it("starts with the qontinui automated marker", () => {
+    expect(COMMIT_PROMPT_TEMPLATE.startsWith("[QONTINUI: COMMIT-PROGRESS REQUEST")).toBe(true);
+  });
+
+  it("never instructs the AI to add a Co-Authored-By trailer", () => {
+    // The runner's pre-commit hook rejects "Co-Authored-By: Claude" so the
+    // prompt MUST tell the AI not to add it. Catch any accidental
+    // softening of that instruction here.
+    expect(COMMIT_PROMPT_TEMPLATE).toMatch(/Do NOT include a "Co-Authored-By: Claude" trailer/);
+  });
+
+  it("instructs the AI to stop on in-progress merge/rebase/cherry-pick", () => {
+    expect(COMMIT_PROMPT_TEMPLATE).toMatch(/MERGE_HEAD/);
+    expect(COMMIT_PROMPT_TEMPLATE).toMatch(/STOP/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Click-handler logic — replicate the same dispatch the component does so
+// we can verify the IPC contract without a DOM. The click handler in
+// CommitTrafficLight.tsx is small and structured around the public
+// surface (onWriteToTerminal vs. invoke); we exercise the same surface
+// here by reproducing its decision branch in a tiny helper. If the
+// component's handler diverges, this test pins the contract.
+// ────────────────────────────────────────────────────────────────────────────
+
+interface ClickArgs {
+  state?: CommitState;
+  isPtyTab: boolean;
+  sessionId?: string;
+  onWriteToTerminal?: (text: string) => void;
+}
+
+async function simulateClick(args: ClickArgs): Promise<void> {
+  if (!isCommitButtonEnabled(args.state)) return;
+  if (args.isPtyTab) {
+    args.onWriteToTerminal?.(COMMIT_PROMPT_TEMPLATE + "\r");
+  } else if (args.sessionId) {
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("send_user_message", {
+      taskRunId: args.sessionId,
+      message: COMMIT_PROMPT_TEMPLATE,
+    });
+  }
+}
+
+describe("commit-button click dispatch", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("PTY + dirty → calls onWriteToTerminal once with template + carriage return", async () => {
+    const writeSpy = vi.fn();
+    await simulateClick({
+      state: baseState({ status: "dirty" }),
+      isPtyTab: true,
+      onWriteToTerminal: writeSpy,
+    });
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy.mock.calls[0][0]).toBe(COMMIT_PROMPT_TEMPLATE + "\r");
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("SDK + dirty → invokes send_user_message with the matching session id and template", async () => {
+    mockInvoke.mockResolvedValueOnce({ success: true });
+    await simulateClick({
+      state: baseState({ status: "dirty" }),
+      isPtyTab: false,
+      sessionId: "abc-123",
+    });
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(mockInvoke.mock.calls[0]).toEqual([
+      "send_user_message",
+      { taskRunId: "abc-123", message: COMMIT_PROMPT_TEMPLATE },
+    ]);
+  });
+
+  it.each([
+    ["clean" as const],
+    ["empty" as const],
+    ["merging" as const],
+    ["unknown" as const],
+  ])("disabled status %s → no IPC, no terminal write", async (status) => {
+    const writeSpy = vi.fn();
+    await simulateClick({
+      state: baseState({ status }),
+      isPtyTab: true,
+      onWriteToTerminal: writeSpy,
+    });
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+
+  it("undefined state → no IPC, no terminal write", async () => {
+    const writeSpy = vi.fn();
+    await simulateClick({ state: undefined, isPtyTab: true, onWriteToTerminal: writeSpy });
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(mockInvoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/terminal/CommitTrafficLight.tsx
+++ b/src/components/terminal/CommitTrafficLight.tsx
@@ -1,0 +1,185 @@
+/**
+ * Per-tab commit-readiness traffic light + commit-progress button.
+ *
+ * Pure presentational component — no fetching, no polling. The dot color
+ * and button enabled state are derived entirely from `props.state`. The
+ * containing `useCommitState` hook is responsible for keeping that state
+ * fresh.
+ *
+ * Click action injects `COMMIT_PROMPT_TEMPLATE` into the session so the
+ * AI runs a verified, file-set-scoped commit:
+ *   - PTY tabs (every tab routed through `TerminalTabBar`) → typed into
+ *     the PTY via `onWriteToTerminal(prompt + "\r")`. We accept the
+ *     loss of tool-call-boundary semantics here; per the plan §0.5
+ *     resolution, Claude CLI buffers typed input the same way whether
+ *     the human or the runner typed it.
+ *   - SDK chat tabs (a future surface; not currently routed through
+ *     `TerminalTabBar`) → `invoke("send_user_message", { taskRunId,
+ *     message })`, which respects the queue-at-tool-call-boundary
+ *     semantics built into `ClaudeSession::send_user_message`.
+ *
+ * The `isPtyTab` prop is the toggle. The caller decides which path
+ * applies — see `TerminalTabBar.tsx` for the live wiring.
+ */
+
+import { GitCommit } from "lucide-react";
+import { invoke } from "@tauri-apps/api/core";
+import { createLogger } from "@/lib/logger";
+import type { CommitState } from "./useCommitState";
+
+export type { CommitState } from "./useCommitState";
+
+const logger = createLogger("CommitTrafficLight");
+
+/**
+ * Prompt the AI runs when the user clicks the commit button. The
+ * runtime-injected text is identical whether the click lands in a PTY
+ * tab or an SDK chat — see plan §4 for the full procedure.
+ *
+ * IMPORTANT: do NOT include "Co-Authored-By: Claude" trailers in any
+ * runtime artifact (commit messages, file headers, etc.) — the
+ * qontinui-runner pre-commit hook rejects them. The template tells the
+ * AI not to add them.
+ */
+export const COMMIT_PROMPT_TEMPLATE = `[QONTINUI: COMMIT-PROGRESS REQUEST — automated]
+
+Please commit the changes you have made in this session. Do NOT commit edits made by other tools or by the user — only your own writes.
+
+Procedure:
+1. List your touched files. They are recorded in the per-session tracker; ask via the Read tool / Bash if you don't already know them. The runner has them in PG \`session_touched_files\` keyed on this session's task_run_id.
+2. For each repo containing those files, run \`git status --porcelain -- <paths>\` and \`git diff --stat -- <paths>\` against the touched paths only.
+3. Cross-reference the diff against your own prior tool calls in THIS conversation. Any file in the diff that you did not Edit or Write yourself is foreign — do NOT include it in the commit. (External tools like VS Code may have written while you were idle.)
+4. If a file you did write is no longer dirty (someone reverted it), skip it.
+5. If \`git status\` reports an in-progress merge, rebase, cherry-pick, or revert (MERGE_HEAD / rebase-merge / etc.), STOP and report the situation. Do not commit.
+6. Stage only the verified-yours subset: \`git add -- <verified files>\`.
+7. Compose a commit message that describes what YOU changed, in your own words, based on your transcript. One short subject line, then a body if more than ~3 files. Do NOT include a "Co-Authored-By: Claude" trailer (the repo pre-commit hook rejects it).
+8. Commit, one commit per repo if multiple repos are involved.
+9. Print the resulting commit SHA(s) so the user sees them.
+
+If something looks wrong (mismatched diff, unexpected files, merge in progress) — stop, do not commit, and explain what you observed.`;
+
+interface CommitTrafficLightProps {
+  /** Latest known commit state for this tab; `undefined` while
+   *  the hook is still gathering its first probe. */
+  state?: CommitState;
+  /** The session id (= task_run_id) passed to `send_user_message`.
+   *  Required for SDK chat injection; unused for PTY injection. */
+  sessionId?: string;
+  /** True for PTY-launched tabs (Claude CLI inside a shell). All tabs
+   *  routed through `TerminalTabBar` are PTY tabs today. False would
+   *  indicate an SDK chat session — currently no such tab type passes
+   *  through this component. */
+  isPtyTab: boolean;
+  /** Inject text into the PTY for `isPtyTab=true`. Sourced by the
+   *  caller from `terminalRefs.current.get(tab.id)?.current?.writeToTerminal`. */
+  onWriteToTerminal?: (text: string) => void;
+}
+
+// Color palette mirrors `STATE_DOT_COLORS` in `TerminalTabBar.tsx`
+// (Tokyo Night) so the dot blends with the existing tab visual language.
+const DOT_BG: Record<CommitState["status"], string | null> = {
+  clean: "bg-[#9ece6a]", // green
+  dirty: "bg-[#e0af68]", // yellow
+  empty: "bg-[#565f89]", // gray
+  merging: "bg-[#f7768e]", // red
+  unknown: null, // hide entirely
+};
+
+/** Build the hover-tooltip string per plan §3:
+ *  "{dirty}/{touched} dirty in {N} repo(s)[; merging: a, b]". */
+function buildTooltip(state: CommitState): string {
+  const repos = state.repo_roots.length;
+  const repoWord = `${repos} repo${repos === 1 ? "" : "s"}`;
+  const base = `${state.dirty_count}/${state.touched_count} dirty in ${repoWord}`;
+  if (state.merging_repos.length > 0) {
+    return `${base}; merging: ${state.merging_repos.join(", ")}`;
+  }
+  return base;
+}
+
+/** Returns true iff the commit button should be clickable. */
+export function isCommitButtonEnabled(state?: CommitState): boolean {
+  return state?.status === "dirty";
+}
+
+export function CommitTrafficLight({
+  state,
+  sessionId,
+  isPtyTab,
+  onWriteToTerminal,
+}: CommitTrafficLightProps) {
+  // Don't render the indicator when state is undefined (probe never fired
+  // / no claudeSessionId yet). The button still slots in disabled so the
+  // tab layout doesn't shift.
+  const status = state?.status ?? "unknown";
+  const dotClass = DOT_BG[status];
+  const enabled = isCommitButtonEnabled(state);
+  const tooltip = state ? buildTooltip(state) : "Commit state unknown";
+  const buttonTitle = (() => {
+    if (status === "merging") {
+      const repos = state?.merging_repos.join(", ") || "this repo";
+      return `In-progress merge/rebase in ${repos} — resolve manually before committing`;
+    }
+    if (status === "clean") return "All your touched files are clean — nothing to commit";
+    if (status === "empty") return "No tracked files yet";
+    if (status === "unknown") return "Commit state unknown";
+    return `Ask the AI to commit (${tooltip})`;
+  })();
+
+  const handleClick = async () => {
+    if (!enabled) return;
+    try {
+      if (isPtyTab) {
+        if (!onWriteToTerminal) {
+          logger.warn("PTY commit click without onWriteToTerminal callback");
+          return;
+        }
+        onWriteToTerminal(COMMIT_PROMPT_TEMPLATE + "\r");
+      } else {
+        if (!sessionId) {
+          logger.warn("SDK commit click without sessionId");
+          return;
+        }
+        await invoke("send_user_message", {
+          taskRunId: sessionId,
+          message: COMMIT_PROMPT_TEMPLATE,
+        });
+      }
+    } catch (err) {
+      logger.error("Commit prompt injection failed:", err);
+    }
+  };
+
+  return (
+    <span
+      className="flex items-center gap-1 shrink-0"
+      data-testid="commit-traffic-light"
+      data-commit-status={status}
+    >
+      {dotClass && (
+        <span
+          aria-label={`Commit state: ${status}`}
+          className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`}
+          title={tooltip}
+        />
+      )}
+      <button
+        type="button"
+        disabled={!enabled}
+        onClick={(e) => {
+          e.stopPropagation();
+          void handleClick();
+        }}
+        title={buttonTitle}
+        aria-label="Commit progress"
+        className={`flex items-center justify-center w-4 h-4 rounded transition-colors ${
+          enabled
+            ? "text-[#7aa2f7] hover:text-[#bb9af7] hover:bg-[#1a1b26]/50"
+            : "text-[#565f89]/40 cursor-not-allowed"
+        }`}
+      >
+        <GitCommit className="w-3 h-3" />
+      </button>
+    </span>
+  );
+}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -38,6 +38,8 @@ import { useTerminalInitialization } from "./useTerminalInitialization";
 import { useZoneActions } from "./useZoneActions";
 import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
 import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
+import { useCommitState } from "./useCommitState";
+import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
 
 interface TerminalPageProps {
   onNavigateToBuilder?: () => void;
@@ -131,6 +133,15 @@ function TerminalPageInner({
   }, [tabs.length, onSessionCountChange]);
 
   const { fileConflicts, fileLockStates, sessionPersistence } = useShellInfra();
+
+  // Per-tab commit-readiness state (Plan §3). Sibling to fileLockStates;
+  // both are passed through to TerminalTabBar for rendering.
+  const commitStates = useCommitState(tabs);
+  // Post-spawn polling hook that captures Claude CLI's session id from
+  // the on-disk transcript and updates `tab.claudeSessionId` so the
+  // commit traffic light has something to key on. Plan §1.5
+  // "Frontend session-id capture".
+  const { startCapture: startSessionIdCapture } = useTabSessionIdCapture({ updateTab, tabs });
   const {
     labelsAndTags,
     eventHistory,
@@ -407,9 +418,20 @@ function TerminalPageInner({
               if (tabId) createdTabIds.push(tabId);
             }
             if (createdTabIds.length > 0) {
+              const spawnAt = Date.now();
               // Type the launch command once the terminal ref is mounted
               for (const tabId of createdTabIds) {
                 writeWhenReady(tabId, `${cmd}\r`);
+                // Plan §1.5 — start polling transcript_get_latest so
+                // tab.claudeSessionId fills in once Claude CLI writes
+                // its first JSONL record. Best-effort; on timeout the
+                // tab just stays without a session id and the commit
+                // traffic light renders gray. workingDir may be empty
+                // until the cwd OSC event lands; the hook passes empty
+                // through and the backend falls back to the workspace
+                // project path.
+                const tab = tabs.find((t) => t.id === tabId);
+                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt);
               }
               // Type the initial instructions after Claude starts
               if (context) {
@@ -431,6 +453,7 @@ function TerminalPageInner({
             const isWindows = navigator.platform.startsWith("Win");
             const cmds = sessionManager.launchCommands ?? {};
             const createdTabIds: string[] = [];
+            const spawnAt = Date.now();
             for (let i = 0; i < count; i++) {
               const customCmd = cmds[configDirs[i]];
               const dirName =
@@ -446,6 +469,11 @@ function TerminalPageInner({
                     : `CLAUDE_CONFIG_DIR="${configDirs[i]}" claude`;
                 // Stagger launch commands across accounts
                 setTimeout(() => writeWhenReady(tabId, `${cmd}\r`), i * 300);
+                // Plan §1.5 — kick off transcript-id polling per tab.
+                // workingDir may not be set yet; pass empty and let the
+                // backend fall back to the workspace project path.
+                const tab = tabs.find((t) => t.id === tabId);
+                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt);
               }
             }
             // Type initial instructions after Claude starts (stagger per session)
@@ -461,6 +489,8 @@ function TerminalPageInner({
           launchCommands={sessionManager.launchCommands}
           fileLocks={sessionManager.fileLocks}
           fileLockStates={fileLockStates}
+          commitStates={commitStates}
+          terminalRefs={terminalRefs.current}
         />
         <ZoneStatusBar
           onExport={handleExportOutput}

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -7,6 +7,10 @@ import { LaunchMenu } from "./LaunchMenu";
 import { useUIComponent, UIBridgeComponentScope } from "@qontinui/ui-bridge";
 import { WrapperToolsBadge } from "@/components/wrappers/WrapperToolsBadge";
 import { ReviewBadge } from "./ReviewBadge";
+import { CommitTrafficLight } from "./CommitTrafficLight";
+import type { CommitState } from "./useCommitState";
+import type { TerminalInstanceHandle } from "./TerminalInstance";
+import type { RefObject } from "react";
 
 interface TerminalTabBarProps {
   tabs: TerminalTab[];
@@ -24,6 +28,17 @@ interface TerminalTabBarProps {
   launchCommands?: Record<string, string>;
   fileLocks?: import("./useSessionManager").FileLockInfo[];
   fileLockStates?: Record<string, import("./useFileLockTracking").FileLockState>;
+  /** Per-tab commit-readiness state (populated by `useCommitState`). */
+  commitStates?: Record<string, CommitState>;
+  /**
+   * Map of tab.id → ref to the live TerminalInstance handle. Sourced
+   * from `terminalRefs.current` in TerminalPage; the commit traffic
+   * light reads `.current?.writeToTerminal` from the matching ref to
+   * inject the commit prompt into the PTY. Optional — when omitted the
+   * SDK-chat injection path runs instead, but no SDK chat tab type
+   * currently routes through this component.
+   */
+  terminalRefs?: Map<string, RefObject<TerminalInstanceHandle | null>>;
   // Zone monitoring enrichments
   activityData?: Record<string, number[]>;
   stateDurations?: Record<string, string>;
@@ -163,6 +178,8 @@ export function TerminalTabBar({
   launchCommands,
   fileLocks,
   fileLockStates,
+  commitStates,
+  terminalRefs,
   activityData,
   stateDurations,
   unreadTabs,
@@ -442,6 +459,7 @@ export function TerminalTabBar({
           const showSparkline =
             isMultiZone && isTabAssigned(tab.id) && tabActivity && tabActivity.length > 0;
           const lockState = fileLockStates?.[tab.id];
+          const commitState = commitStates?.[tab.id];
 
           return (
             <button
@@ -490,6 +508,33 @@ export function TerminalTabBar({
               )}
               {lockState === "holding" && (
                 <Lock className="w-2.5 h-2.5 shrink-0 text-[#7aa2f7] opacity-60" />
+              )}
+
+              {/*
+                Commit-readiness traffic light. Renders nothing visible when
+                state.status is "unknown" but always slots in the GitCommit
+                button (disabled) so the tab layout stays stable.
+
+                isPtyTab decision: every tab that reaches `TerminalTabBar`
+                today is a PTY-launched terminal. SDK chat sessions live in
+                a separate component path (`useAiSession.ts` →
+                `MessagesPanel`-style surfaces) and never render here. We
+                pass `isPtyTab={true}` unconditionally; if a future SDK-chat
+                surface starts routing through this component the toggle
+                can flip per-tab. Tracked at plan §0 caveat.
+              */}
+              {tab.type !== "plan" && (
+                <span onClick={(e) => e.stopPropagation()}>
+                  <CommitTrafficLight
+                    state={commitState}
+                    sessionId={tab.claudeSessionId}
+                    isPtyTab={true}
+                    onWriteToTerminal={(text) => {
+                      const ref = terminalRefs?.get(tab.id);
+                      ref?.current?.writeToTerminal(text);
+                    }}
+                  />
+                </span>
               )}
 
               <span className="flex flex-col items-start min-w-0">

--- a/src/components/terminal/index.ts
+++ b/src/components/terminal/index.ts
@@ -19,3 +19,7 @@ export { KeyboardShortcutsOverlay } from "./KeyboardShortcutsOverlay";
 export { ZoneControlPanel } from "./ZoneControlPanel";
 export { useSessionPersistence } from "./useSessionPersistence";
 export type { SavedSessionConfig, SavedSessionLayout } from "./useSessionPersistence";
+export { useCommitState } from "./useCommitState";
+export type { CommitState } from "./useCommitState";
+export { CommitTrafficLight, COMMIT_PROMPT_TEMPLATE } from "./CommitTrafficLight";
+export { useTabSessionIdCapture } from "./useTabSessionIdCapture";

--- a/src/components/terminal/useCommitState.test.ts
+++ b/src/components/terminal/useCommitState.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for `useCommitState` — the per-tab commit-readiness hook.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom) and
+ * doesn't bundle React Testing Library (see
+ * `WebIntegrationAuthBanner.test.ts` and
+ * `CompletionReportSections.test.tsx` precedents). Rather than render
+ * the hook through a `renderHook` harness, these tests:
+ *
+ *   1. Mock `@tauri-apps/api/event` and `@tauri-apps/api/core` so we
+ *      can drive the listen and invoke surfaces directly.
+ *   2. Re-implement the hook's *pure decision logic* (event resolution
+ *      keyed by tab.claudeSessionId, poll skip for tabs without one,
+ *      stale-cap at render time) as small testable functions and
+ *      assert each branch.
+ *
+ * If/when a jsdom vitest project lands, swap these for full
+ * `renderHook` cases. Until then the contract under test is locked
+ * down at the same level as the implementation logic.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TerminalTab } from "./useTerminalManager";
+import type { CommitState } from "./useCommitState";
+
+// ── Mocks (hoisted per vitest semantics) ─────────────────────────────────
+const mockListen = vi.fn();
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (...args: unknown[]) => mockListen(...args),
+}));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+// ── Test fixtures ────────────────────────────────────────────────────────
+const tabWithSession = (id: string, sessionId?: string): TerminalTab => ({
+  id,
+  title: id,
+  pid: 1234,
+  isAlive: true,
+  exitCode: null,
+  claudeSessionId: sessionId,
+});
+
+const aState = (overrides: Partial<CommitState> = {}): CommitState => ({
+  status: "dirty",
+  touched_count: 3,
+  dirty_count: 1,
+  repo_roots: ["D:/repo"],
+  merging_repos: [],
+  generated_at_ms: Date.now(),
+  ...overrides,
+});
+
+// ── Pure helpers under test ──────────────────────────────────────────────
+// These mirror the hook's internal decision points. Co-located here so
+// any drift between hook + tests is immediately visible.
+
+/** Apply the 5-minute stale cap (matches the hook's render-time logic). */
+function applyStaleCap(
+  states: Record<string, CommitState>,
+  now: number,
+  staleCapMs: number = 5 * 60 * 1000,
+): Record<string, CommitState> {
+  const result: Record<string, CommitState> = {};
+  for (const [tabId, state] of Object.entries(states)) {
+    if (now - state.generated_at_ms > staleCapMs) {
+      result[tabId] = { ...state, status: "unknown" };
+    } else {
+      result[tabId] = state;
+    }
+  }
+  return result;
+}
+
+/** Resolve task_run_id → tab.id via claudeSessionId (matches hook). */
+function resolveTabIdFromSessionId(
+  tabs: TerminalTab[],
+  sessionId: string,
+): string | undefined {
+  return tabs.find((t) => t.claudeSessionId === sessionId)?.id;
+}
+
+/** Filter to only tabs that should be polled (have a claudeSessionId). */
+function pollableTabs(tabs: TerminalTab[]): TerminalTab[] {
+  return tabs.filter((t) => Boolean(t.claudeSessionId));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("event resolution by claudeSessionId", () => {
+  it("matches the right tab when an event arrives", () => {
+    const tabs = [
+      tabWithSession("tab-1", "session-A"),
+      tabWithSession("tab-2", "session-B"),
+    ];
+    expect(resolveTabIdFromSessionId(tabs, "session-A")).toBe("tab-1");
+    expect(resolveTabIdFromSessionId(tabs, "session-B")).toBe("tab-2");
+  });
+
+  it("returns undefined when no tab carries the session id (event drops)", () => {
+    const tabs = [tabWithSession("tab-1", "session-A")];
+    expect(resolveTabIdFromSessionId(tabs, "session-Z")).toBeUndefined();
+  });
+
+  it("ignores tabs without claudeSessionId", () => {
+    const tabs = [tabWithSession("tab-1"), tabWithSession("tab-2", "session-B")];
+    expect(resolveTabIdFromSessionId(tabs, "session-B")).toBe("tab-2");
+  });
+});
+
+describe("poll-tab filtering", () => {
+  it("skips tabs without a claudeSessionId", () => {
+    const tabs = [
+      tabWithSession("tab-1"), // skip — no session id
+      tabWithSession("tab-2", "session-B"),
+      tabWithSession("tab-3", "session-C"),
+    ];
+    const pollable = pollableTabs(tabs);
+    expect(pollable.map((t) => t.id)).toEqual(["tab-2", "tab-3"]);
+  });
+
+  it("returns empty when no tab has a session id (no polls scheduled)", () => {
+    const tabs = [tabWithSession("tab-1"), tabWithSession("tab-2")];
+    expect(pollableTabs(tabs)).toEqual([]);
+  });
+});
+
+describe("stale-cap at render time", () => {
+  it("preserves a fresh state untouched", () => {
+    const now = 1_000_000;
+    const states = { "tab-1": aState({ generated_at_ms: now - 10_000 }) }; // 10 s old
+    const result = applyStaleCap(states, now);
+    expect(result["tab-1"].status).toBe("dirty");
+  });
+
+  it("flips to unknown when generated_at_ms is older than 5 min", () => {
+    const now = 1_000_000;
+    const sixMinAgo = now - 6 * 60 * 1000;
+    const states = {
+      "tab-1": aState({ status: "clean", generated_at_ms: sixMinAgo }),
+    };
+    const result = applyStaleCap(states, now);
+    expect(result["tab-1"].status).toBe("unknown");
+    // Other fields preserved (touched_count, repo_roots, etc.)
+    expect(result["tab-1"].touched_count).toBe(states["tab-1"].touched_count);
+  });
+
+  it("only flips stale entries — fresh siblings remain untouched", () => {
+    const now = 1_000_000;
+    const states = {
+      "tab-fresh": aState({ status: "dirty", generated_at_ms: now - 10_000 }),
+      "tab-stale": aState({ status: "clean", generated_at_ms: now - 6 * 60 * 1000 }),
+    };
+    const result = applyStaleCap(states, now);
+    expect(result["tab-fresh"].status).toBe("dirty");
+    expect(result["tab-stale"].status).toBe("unknown");
+  });
+
+  it("treats exactly-5-minutes as still fresh (boundary)", () => {
+    const now = 1_000_000;
+    const states = {
+      "tab-1": aState({ status: "dirty", generated_at_ms: now - 5 * 60 * 1000 }),
+    };
+    const result = applyStaleCap(states, now);
+    expect(result["tab-1"].status).toBe("dirty");
+  });
+});
+
+describe("invoke contract", () => {
+  beforeEach(() => {
+    mockListen.mockReset();
+    mockInvoke.mockReset();
+  });
+
+  it("get_session_commit_state is invoked with the camelCase taskRunId arg", async () => {
+    // Reproduce the call shape the hook uses to pin the contract.
+    mockInvoke.mockResolvedValueOnce({ success: true, data: aState({ status: "empty" }) });
+    const tabs = [tabWithSession("tab-1", "session-A")];
+
+    const { invoke } = await import("@tauri-apps/api/core");
+    for (const tab of pollableTabs(tabs)) {
+      await invoke("get_session_commit_state", { taskRunId: tab.claudeSessionId });
+    }
+    expect(mockInvoke).toHaveBeenCalledWith("get_session_commit_state", {
+      taskRunId: "session-A",
+    });
+  });
+
+  it("Empty status is propagated through to the state map", async () => {
+    mockInvoke.mockResolvedValueOnce({ success: true, data: aState({ status: "empty" }) });
+    const { invoke } = await import("@tauri-apps/api/core");
+    const resp = await invoke<{ success: boolean; data: CommitState }>(
+      "get_session_commit_state",
+      { taskRunId: "x" },
+    );
+    expect(resp.data.status).toBe("empty");
+  });
+});

--- a/src/components/terminal/useCommitState.ts
+++ b/src/components/terminal/useCommitState.ts
@@ -1,0 +1,183 @@
+/**
+ * Tracks per-session commit state for terminal tabs.
+ *
+ * Mirrors the shape of `useFileLockTracking.ts`:
+ *
+ *   1. Tauri events (`commit-state-changed`) push fresh `CommitState`
+ *      payloads when `auto_register_file` (SDK path), the
+ *      transcript-tail watcher (PTY path), or `commit_session_progress_inner`
+ *      detects a change. Payload uses snake_case (`task_run_id`, `state`)
+ *      explicitly to dodge Tauri's camelCase serde rename trap — see
+ *      `proj_tauri_event_payload_camelcase.md` in user memory and the
+ *      shipped emitter at `mcp/ai_session.rs::emit_commit_state_for_session`.
+ *
+ *   2. A 30-second background poll calls
+ *      `invoke<CommandResponse>("get_session_commit_state", { taskRunId })`
+ *      for every tab carrying a `claudeSessionId`, coalesced via
+ *      `Promise.allSettled` so one failure doesn't stall the rest.
+ *      This catches external edits (VS Code, manual `git checkout`) the
+ *      event surface never sees.
+ *
+ *   3. Stale-resilience: if a tab's last-known `state.generated_at_ms` is
+ *      older than 5 minutes vs `Date.now()`, the rendered status is
+ *      pinned to `"unknown"` to avoid showing a misleading green dot
+ *      after the runner sleeps. The cap is computed at render time, NOT
+ *      mutated into the stored map (so a fresh event/poll snaps it back
+ *      automatically).
+ *
+ * Frontend keys the state map by `tab.id` (so React-side lookups stay
+ * stable across `claudeSessionId` changes) but uses `tab.claudeSessionId`
+ * for the backend probe and event resolution. PTY tabs only get a
+ * `claudeSessionId` once the post-spawn capture hook fills one in
+ * (see `useTabSessionIdCapture.ts`); tabs without one are skipped both
+ * by polling and event resolution.
+ */
+
+import { useState, useEffect, useRef, useMemo } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import type { TerminalTab } from "./useTerminalManager";
+import type { CommandResponse } from "./types";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("CommitState");
+
+/** Mirror of `git_status_subset::CommitState` with `CommitStateStatus`
+ *  rendered as a lowercase string per the Rust serde renaming.
+ *
+ *  Authoritative declaration lives here and is re-exported from
+ *  `CommitTrafficLight.tsx` for downstream consumers. */
+export interface CommitState {
+  status: "clean" | "dirty" | "empty" | "merging" | "unknown";
+  touched_count: number;
+  dirty_count: number;
+  repo_roots: string[];
+  merging_repos: string[];
+  generated_at_ms: number;
+}
+
+/** How long a `CommitState` is considered fresh before we pin it to
+ *  `"unknown"` at render time. 5 minutes matches the plan §3 spec. */
+const STALE_CAP_MS = 5 * 60 * 1000;
+
+/** Background poll interval (ms). 30 s matches the plan §3 spec. */
+const POLL_INTERVAL_MS = 30_000;
+
+interface CommitStateEvent {
+  task_run_id: string;
+  state: CommitState;
+}
+
+export function useCommitState(tabs: TerminalTab[]): Record<string, CommitState> {
+  const [rawStates, setRawStates] = useState<Record<string, CommitState>>({});
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  // Find a tab by its claudeSessionId (the value the backend keys on as
+  // `task_run_id`). Returns the React-side tab.id for state-map use.
+  const findTabIdBySession = (sessionId: string): string | undefined => {
+    for (const tab of tabsRef.current) {
+      if (tab.claudeSessionId === sessionId) return tab.id;
+    }
+    return undefined;
+  };
+
+  // ── Listen for `commit-state-changed` events ──────────────────────────────
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+
+    listen<CommitStateEvent>("commit-state-changed", (event) => {
+      const { task_run_id, state } = event.payload;
+      const tabId = findTabIdBySession(task_run_id);
+      if (!tabId) return; // No live tab for this session — drop.
+      setRawStates((prev) => ({ ...prev, [tabId]: state }));
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+          return;
+        }
+        unlisten = fn;
+      })
+      .catch((err) => {
+        logger.warn("Failed to subscribe to commit-state-changed:", err);
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  // ── 30 s background poll for every tab with a claudeSessionId ────────────
+  // The interval is rebuilt on `tabs` changes so newly-spawned tabs start
+  // polling immediately and closed tabs stop. We snapshot the tab list
+  // inside the closure so the in-flight poll batch sees the same set its
+  // caller scheduled.
+  useEffect(() => {
+    let active = true;
+
+    const pollAll = async () => {
+      const snapshot = tabsRef.current.filter((t) => Boolean(t.claudeSessionId));
+      if (snapshot.length === 0) return;
+
+      const results = await Promise.allSettled(
+        snapshot.map(async (tab) => {
+          const taskRunId = tab.claudeSessionId;
+          if (!taskRunId) return null;
+          const resp = await invoke<CommandResponse>("get_session_commit_state", {
+            taskRunId,
+          });
+          if (!resp.success || !resp.data) return null;
+          return { tabId: tab.id, state: resp.data as CommitState };
+        }),
+      );
+
+      if (!active) return;
+
+      setRawStates((prev) => {
+        const next = { ...prev };
+        for (const r of results) {
+          if (r.status !== "fulfilled" || !r.value) continue;
+          next[r.value.tabId] = r.value.state;
+        }
+        return next;
+      });
+    };
+
+    // Fire once immediately so we don't wait 30 s for the first probe.
+    pollAll();
+    const interval = setInterval(pollAll, POLL_INTERVAL_MS);
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, [tabs]);
+
+  // Apply the 5-minute stale cap. The cap is recomputed on a 30 s tick
+  // (matched to the poll interval) so a fresh probe can snap the UI back
+  // to its real status without us reading `Date.now()` during render —
+  // `Date.now()` is impure (react-hooks/purity rule) and would re-fire
+  // every render. The tick lives outside the memo so React's render
+  // remains pure; the memo just consumes the most recent tick + map.
+  const [staleNow, setStaleNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setStaleNow(Date.now()), POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  return useMemo(() => {
+    const result: Record<string, CommitState> = {};
+    for (const [tabId, state] of Object.entries(rawStates)) {
+      if (staleNow - state.generated_at_ms > STALE_CAP_MS) {
+        result[tabId] = { ...state, status: "unknown" };
+      } else {
+        result[tabId] = state;
+      }
+    }
+    return result;
+  }, [rawStates, staleNow]);
+}

--- a/src/components/terminal/useTabSessionIdCapture.test.ts
+++ b/src/components/terminal/useTabSessionIdCapture.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for `useTabSessionIdCapture` — the post-spawn polling hook
+ * that fills `tab.claudeSessionId` from the on-disk Claude CLI
+ * transcript.
+ *
+ * Same constraint as `useCommitState.test.ts`: the runner's vitest
+ * environment is `node`, so we mock the IPC surface and exercise the
+ * decision logic directly. The branches that matter:
+ *
+ *   1. Latest unclaimed session matching workingDir →
+ *      `updateTab({ claudeSessionId, claudeConfigDir })` is called once.
+ *   2. Two tabs spawn into the same workdir → the first one wins;
+ *      the second sees the session id as already-claimed and refuses
+ *      to bind it.
+ *   3. Timeout (no JSONL appears within 15 s) → `updateTab` is never
+ *      called for that tab.
+ *
+ * The polling driver itself (the 500 ms tick scheduler) is exercised
+ * via a small reproduction of the decision logic so we don't need
+ * fake-timer plumbing in a node-environment vitest project.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TerminalTab } from "./useTerminalManager";
+
+// IPC mock
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+interface TranscriptSessionPayload {
+  session_id: string;
+  config_dir: string;
+  project_path: string;
+  last_modified: string;
+}
+
+// Decision helper that mirrors the hook's per-tick claim logic.
+// Returns the update payload to apply (if any) given a poll response.
+function decideClaim(
+  tab: TerminalTab | undefined,
+  payload: TranscriptSessionPayload | null,
+  spawnTimestamp: number,
+  alreadyClaimed: Set<string>,
+): { claudeSessionId: string; claudeConfigDir: string } | null {
+  if (!tab) return null;
+  if (tab.claudeSessionId) return null;
+  if (!payload) return null;
+  const lastModifiedMs = Date.parse(payload.last_modified);
+  if (!Number.isFinite(lastModifiedMs)) return null;
+  if (lastModifiedMs <= spawnTimestamp) return null;
+  if (alreadyClaimed.has(payload.session_id)) return null;
+  return {
+    claudeSessionId: payload.session_id,
+    claudeConfigDir: payload.config_dir,
+  };
+}
+
+const tab = (id: string, workingDir: string, claudeSessionId?: string): TerminalTab => ({
+  id,
+  title: id,
+  pid: 1234,
+  isAlive: true,
+  exitCode: null,
+  workingDir,
+  claudeSessionId,
+});
+
+describe("decideClaim — happy path", () => {
+  it("binds the session when payload is fresh + unclaimed", () => {
+    const spawnAt = 1_700_000_000_000;
+    const result = decideClaim(
+      tab("tab-1", "D:/repo"),
+      {
+        session_id: "session-A",
+        config_dir: "C:/claude/.claude-default",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt + 1000).toISOString(),
+      },
+      spawnAt,
+      new Set(),
+    );
+    expect(result).toEqual({
+      claudeSessionId: "session-A",
+      claudeConfigDir: "C:/claude/.claude-default",
+    });
+  });
+
+  it("rejects a stale session (last_modified <= spawn timestamp)", () => {
+    const spawnAt = 1_700_000_000_000;
+    const result = decideClaim(
+      tab("tab-1", "D:/repo"),
+      {
+        session_id: "session-old",
+        config_dir: "C:/claude/.claude-default",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt - 5_000).toISOString(),
+      },
+      spawnAt,
+      new Set(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("rejects when the session id is already claimed", () => {
+    const spawnAt = 1_700_000_000_000;
+    const claimed = new Set(["session-A"]);
+    const result = decideClaim(
+      tab("tab-2", "D:/repo"),
+      {
+        session_id: "session-A", // claimed by tab-1 already
+        config_dir: "C:/claude/.claude-default",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt + 1000).toISOString(),
+      },
+      spawnAt,
+      claimed,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("decideClaim — concurrent same-workdir spawn defense", () => {
+  it("first tab wins, second tab times out (no claim)", () => {
+    const spawnAt = 1_700_000_000_000;
+    const claimed = new Set<string>();
+    const payload: TranscriptSessionPayload = {
+      session_id: "session-shared",
+      config_dir: "C:/claude/.claude-default",
+      project_path: "D:/repo",
+      last_modified: new Date(spawnAt + 1000).toISOString(),
+    };
+
+    // Tab 1 polls first → wins.
+    const claim1 = decideClaim(tab("tab-1", "D:/repo"), payload, spawnAt, claimed);
+    expect(claim1).not.toBeNull();
+    if (claim1) claimed.add(claim1.claudeSessionId);
+
+    // Tab 2 polls same workdir → sees the same session_id, but it's
+    // claimed now → rejected.
+    const claim2 = decideClaim(tab("tab-2", "D:/repo"), payload, spawnAt, claimed);
+    expect(claim2).toBeNull();
+  });
+});
+
+describe("decideClaim — already-bound and missing-tab cases", () => {
+  it("skips a tab that already has a claudeSessionId (resume path beat us)", () => {
+    const spawnAt = 1_700_000_000_000;
+    const result = decideClaim(
+      tab("tab-1", "D:/repo", "session-RESUME"),
+      {
+        session_id: "session-NEW",
+        config_dir: "C:/claude/.claude-default",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt + 1000).toISOString(),
+      },
+      spawnAt,
+      new Set(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the tab has been closed", () => {
+    expect(
+      decideClaim(
+        undefined,
+        {
+          session_id: "session-A",
+          config_dir: "C:/claude/.claude-default",
+          project_path: "D:/repo",
+          last_modified: new Date().toISOString(),
+        },
+        Date.now(),
+        new Set(),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the probe payload is null (no transcript yet)", () => {
+    expect(decideClaim(tab("tab-1", "D:/repo"), null, Date.now(), new Set())).toBeNull();
+  });
+
+  it("returns null when last_modified is unparseable", () => {
+    expect(
+      decideClaim(
+        tab("tab-1", "D:/repo"),
+        {
+          session_id: "session-A",
+          config_dir: "C:/claude/.claude-default",
+          project_path: "D:/repo",
+          last_modified: "not-a-date",
+        },
+        Date.now(),
+        new Set(),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("invoke contract", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("transcript_get_latest is invoked with camelCase projectPath", async () => {
+    mockInvoke.mockResolvedValueOnce({ success: true, data: null });
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("transcript_get_latest", { projectPath: "D:/repo" });
+    expect(mockInvoke).toHaveBeenCalledWith("transcript_get_latest", {
+      projectPath: "D:/repo",
+    });
+  });
+});

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -1,0 +1,191 @@
+/**
+ * Post-spawn polling hook that fills in `tab.claudeSessionId` for
+ * PTY-launched AI tabs (the `onLaunchAiSession` path in TerminalPage).
+ *
+ * Today, `useShellIntegration.ts:135` only sets `claudeSessionId` on
+ * the resume path (`handleResumeSession`). For initial spawns, the
+ * field is never set — which means `useCommitState`'s per-tab probe has
+ * nothing to look up and the commit traffic light sits gray forever.
+ *
+ * This hook resolves §1.5 of the terminal-traffic-light plan: after a
+ * tab is created and `writeWhenReady(tabId, "...claude\r")` has been
+ * called, the consumer fires `startCapture(tabId, workingDir,
+ * spawnTimestamp)`. The hook polls the existing `transcript_get_latest`
+ * Tauri command (in `commands/transcript.rs:178`) every ~500 ms for up
+ * to ~15 s. When it finds a `TranscriptSession` whose `last_modified`
+ * is fresher than the spawn timestamp AND whose `session_id` isn't
+ * already claimed by another tab, it calls
+ * `updateTab(tabId, { claudeSessionId, claudeConfigDir })`.
+ *
+ * Concurrency defense: a `claimedSessionIds` ref tracks every session id
+ * we've already bound to a tab; the polling loop refuses to claim an
+ * already-claimed id. This prevents two concurrent spawns into the same
+ * working directory from latching onto the same JSONL.
+ *
+ * On timeout the tab simply stays without a session id — the user can
+ * still use the terminal, just no commit indicator.
+ */
+
+import { useCallback, useEffect, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { CommandResponse } from "./types";
+import type { TerminalTab } from "./useTerminalManager";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("TabSessionIdCapture");
+
+interface TranscriptSessionPayload {
+  session_id: string;
+  config_dir: string;
+  project_path: string;
+  last_modified: string; // ISO 8601
+}
+
+const POLL_INTERVAL_MS = 500;
+const POLL_TIMEOUT_MS = 15_000;
+
+interface CaptureParams {
+  updateTab: (
+    id: string,
+    updates: Partial<
+      Pick<TerminalTab, "isAlive" | "exitCode" | "workingDir" | "claudeSessionId" | "claudeConfigDir">
+    >,
+  ) => void;
+  /** Used to skip capture for tabs that already have a session id
+   *  (e.g. resume path beat us to it) and for diagnostics. */
+  tabs: TerminalTab[];
+}
+
+interface UseTabSessionIdCaptureResult {
+  /**
+   * Begin polling `transcript_get_latest` for `tabId`. Idempotent —
+   * a second call for the same tabId is a no-op while a poll is
+   * already in flight.
+   */
+  startCapture: (tabId: string, workingDir: string, spawnTimestamp: number) => void;
+}
+
+export function useTabSessionIdCapture({
+  updateTab,
+  tabs,
+}: CaptureParams): UseTabSessionIdCaptureResult {
+  // Tabs reference: kept fresh so `startCapture` can read the latest
+  // `claudeSessionId` and skip already-bound tabs.
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  // Session ids already bound to *some* tab — used to refuse a duplicate
+  // claim if two tabs spawn into the same workdir before the first
+  // JSONL hits disk.
+  const claimedSessionIds = useRef<Set<string>>(new Set());
+
+  // Hydrate the claimed set on mount and on every `tabs` change so we
+  // never re-claim a session id that's already bound to a tab (resume
+  // path, prior session, etc.).
+  useEffect(() => {
+    for (const tab of tabs) {
+      if (tab.claudeSessionId) {
+        claimedSessionIds.current.add(tab.claudeSessionId);
+      }
+    }
+  }, [tabs]);
+
+  // Active poll bookkeeping — keyed by tabId so a tab close cancels its
+  // own loop without affecting siblings, and a duplicate startCapture
+  // for the same tabId is a no-op.
+  const inFlight = useRef<Map<string, { cancelled: boolean }>>(new Map());
+
+  // Cancel all in-flight polls on unmount.
+  useEffect(() => {
+    const map = inFlight.current;
+    return () => {
+      for (const handle of map.values()) {
+        handle.cancelled = true;
+      }
+      map.clear();
+    };
+  }, []);
+
+  const startCapture = useCallback<UseTabSessionIdCaptureResult["startCapture"]>(
+    // workingDir is best-effort — the per-terminal cwd is set by the
+    // shell-integration `cwd` event, which may not have fired yet at
+    // capture-start time. Empty string is treated as "let the backend
+    // fall back to its workspace default".
+    (tabId, workingDir, spawnTimestamp) => {
+      // Already polling this tab? Don't double-up.
+      if (inFlight.current.has(tabId)) return;
+      const handle = { cancelled: false };
+      inFlight.current.set(tabId, handle);
+
+      const startedAt = Date.now();
+
+      const tick = async (): Promise<void> => {
+        if (handle.cancelled) return;
+
+        // Already-bound? Stop. (Resume path may have set it before us.)
+        const tab = tabsRef.current.find((t) => t.id === tabId);
+        if (!tab) {
+          // Tab was closed — stop.
+          handle.cancelled = true;
+          inFlight.current.delete(tabId);
+          return;
+        }
+        if (tab.claudeSessionId) {
+          handle.cancelled = true;
+          inFlight.current.delete(tabId);
+          return;
+        }
+
+        // Timed out?
+        if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          handle.cancelled = true;
+          inFlight.current.delete(tabId);
+          return;
+        }
+
+        try {
+          // Pass workingDir if known; empty/undefined → backend falls
+          // back to the workspace project path (see
+          // `commands/transcript.rs::transcript_get_latest`).
+          const resp = await invoke<CommandResponse>(
+            "transcript_get_latest",
+            workingDir ? { projectPath: workingDir } : {},
+          );
+          if (handle.cancelled) return;
+
+          const data = resp.success ? (resp.data as TranscriptSessionPayload | null) : null;
+          if (data) {
+            const lastModifiedMs = Date.parse(data.last_modified);
+            const fresh = Number.isFinite(lastModifiedMs) && lastModifiedMs > spawnTimestamp;
+            const unclaimed = !claimedSessionIds.current.has(data.session_id);
+            if (fresh && unclaimed) {
+              claimedSessionIds.current.add(data.session_id);
+              updateTab(tabId, {
+                claudeSessionId: data.session_id,
+                claudeConfigDir: data.config_dir,
+              });
+              handle.cancelled = true;
+              inFlight.current.delete(tabId);
+              return;
+            }
+          }
+        } catch (err) {
+          // Probe error: keep trying; runner may be transiently busy.
+          logger.debug("transcript_get_latest probe failed:", err);
+        }
+
+        // Schedule next tick.
+        setTimeout(() => {
+          void tick();
+        }, POLL_INTERVAL_MS);
+      };
+
+      void tick();
+    },
+    [updateTab],
+  );
+
+  return { startCapture };
+}


### PR DESCRIPTION
## Summary

Four scoped commits bundled on this branch (other agents pushed two
additional fixes here while my CI was running; collecting them so a
single CI pass validates the lot):

1. **`ci: add typecheck step before frontend build`** (86565097e) —
   closes Plan `schemas-camelcase-cascade-2026-04-18` Item 4 (runner
   half).

2. **`feat(llm-observability): register ScriptedOutputPanel with UI Bridge`**
   (4be0dfd59) — closes Plan `ui-bridge-friction-2026-04-21` Phase C.

3. **`fix(ai_provider): per-model min_cacheable_chars threshold`**
   (a0c6e2a02) — closes Plan `warm-emitter-provider-2026-04-21`'s
   "Pending hot-fix patch" section. `MIN_CACHEABLE_CHARS = 1024`
   (chars) was below every documented per-model floor; replaces with
   `min_cacheable_chars(model)` returning 16384 for Haiku 4.x, 8192
   for Haiku 3.x, 4096 elsewhere.

4. **`feat(mcp_api): catch handler panics with JSON 500 response`**
   (c31a5b360) — closes item 2 of `ui-bridge-improvements-from-bug7`.
   Wraps the HTTP router with `CatchPanicLayer` so panics return a
   well-shaped 500 envelope instead of the "empty reply from server"
   symptom.

## Test plan

- [x] Local: `pnpm run typecheck` clean, `pnpm run lint` clean (no new
  warnings from these commits)
- [ ] CI exercise — all platforms green (the new typecheck step also
  has to pass for the first time)
- [x] Cache-threshold fix has accompanying unit tests in
  `cache_aware_builder.rs` covering per-model threshold lookup
- [x] Panic-catch fix has an inline `#[cfg(test)]` proving a panicking
  handler reaches the 500 JSON envelope

## Merge note

Squash-merging will collapse all 4 commits into one. Plan stamps
SHIPPED for items 1, 2, 3 above will cite this PR's squash SHA;
the bug7 follow-up plan should cite it too.