### PR TITLE
feat(wrappers-mcp): live tool refresh (per-list + tools.listChanged push)

### DIFF
--- a/src-tauri/src/bin/wrappers_mcp.rs
+++ b/src-tauri/src/bin/wrappers_mcp.rs
@@ -31,6 +31,10 @@
 //!     without restarting the MCP bin (which is the AI client's lifetime).
 //!   - On a `tools/call` for an unknown tool name (one retry), covering
 //!     clients that don't re-list before calling.
+//!   - On a push from the runner's `GET /wrappers/events` SSE stream — a
+//!     background thread long-polls that endpoint, refreshes the cache on
+//!     every event, and emits `notifications/tools/list_changed` upstream
+//!     so AI clients update their tool palettes without re-listing.
 //!
 //! If a refresh returns empty while we previously had tools, the existing
 //! cache is preserved — almost always a transient runner-down blip rather
@@ -38,6 +42,8 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -376,12 +382,22 @@ fn write_response(stdout: &mut impl Write, value: &Value) {
     let _ = stdout.flush();
 }
 
-fn handle_request(
-    base: &str,
-    tools: &mut Vec<ToolEntry>,
-    reverse_map: &mut HashMap<String, (String, String)>,
-    req: JsonRpcRequest,
-) -> Option<Value> {
+/// Bundles the mutable tool catalog so it can travel through an
+/// `Arc<Mutex<...>>` and be touched by both the stdin loop and the SSE
+/// consumer thread without manual two-field locking.
+struct ToolCache {
+    tools: Vec<ToolEntry>,
+    reverse_map: HashMap<String, (String, String)>,
+}
+
+impl ToolCache {
+    fn from_tools(tools: Vec<ToolEntry>) -> Self {
+        let reverse_map = build_reverse_map(&tools);
+        Self { tools, reverse_map }
+    }
+}
+
+fn handle_request(base: &str, cache: &Arc<Mutex<ToolCache>>, req: JsonRpcRequest) -> Option<Value> {
     let id = req.id.clone();
     match req.method.as_str() {
         "initialize" => Some(rpc_success(
@@ -389,7 +405,11 @@ fn handle_request(
             json!({
                 "protocolVersion": PROTOCOL_VERSION,
                 "serverInfo": { "name": SERVER_NAME, "version": SERVER_VERSION },
-                "capabilities": { "tools": {} },
+                // `tools.listChanged: true` advertises that we will push
+                // `notifications/tools/list_changed` when the catalog
+                // changes. The SSE consumer thread is the source of those
+                // pushes.
+                "capabilities": { "tools": { "listChanged": true } },
             }),
         )),
         "notifications/initialized" | "notifications/cancelled" => {
@@ -397,6 +417,8 @@ fn handle_request(
             None
         }
         "tools/list" => {
+            let mut guard = cache.lock().expect("tool cache mutex poisoned");
+            let ToolCache { tools, reverse_map } = &mut *guard;
             refresh_tools(base, tools, reverse_map);
             Some(rpc_success(id, tools_list_payload(tools)))
         }
@@ -411,6 +433,8 @@ fn handle_request(
                     ));
                 }
             };
+            let mut guard = cache.lock().expect("tool cache mutex poisoned");
+            let ToolCache { tools, reverse_map } = &mut *guard;
             // If the client never re-listed, a wrapper installed since
             // startup is invisible to our cache. Refresh once before
             // surfacing "unknown tool" so the call still resolves.
@@ -494,13 +518,21 @@ fn main() {
     let base = primary_base_url();
     eprintln!("[wrappers-mcp] runner base: {}", base);
 
-    let mut tools = fetch_tools(&base);
-    let mut reverse_map = build_reverse_map(&tools);
+    let cache = Arc::new(Mutex::new(ToolCache::from_tools(fetch_tools(&base))));
+    // Wrap stdout so the stdin loop and the SSE thread can both write
+    // without interleaving JSON-RPC frames.
+    let stdout = Arc::new(Mutex::new(std::io::stdout()));
+
+    // Spawn the SSE consumer. It loops forever, reconnecting with backoff
+    // on disconnect; the only way it stops is the process exiting.
+    {
+        let cache = Arc::clone(&cache);
+        let stdout = Arc::clone(&stdout);
+        let base = base.clone();
+        thread::spawn(move || sse_consumer_loop(&base, cache, stdout));
+    }
 
     let stdin = std::io::stdin();
-    let stdout = std::io::stdout();
-    let mut stdout = stdout.lock();
-
     for line in stdin.lock().lines() {
         let line = match line {
             Ok(l) => l,
@@ -518,21 +550,149 @@ fn main() {
             Err(e) => {
                 eprintln!("[wrappers-mcp] parse error: {} (line: {})", e, trimmed);
                 let err = rpc_error(None, ERR_PARSE, format!("parse error: {}", e));
-                write_response(&mut stdout, &err);
+                let mut out = stdout.lock().expect("stdout mutex poisoned");
+                write_response(&mut *out, &err);
                 continue;
             }
         };
         if req.method.is_empty() {
             let err = rpc_error(req.id, ERR_INVALID_REQUEST, "method is required");
-            write_response(&mut stdout, &err);
+            let mut out = stdout.lock().expect("stdout mutex poisoned");
+            write_response(&mut *out, &err);
             continue;
         }
-        if let Some(response) = handle_request(&base, &mut tools, &mut reverse_map, req) {
-            write_response(&mut stdout, &response);
+        if let Some(response) = handle_request(&base, &cache, req) {
+            let mut out = stdout.lock().expect("stdout mutex poisoned");
+            write_response(&mut *out, &response);
         }
     }
 
     eprintln!("[wrappers-mcp] stdin closed, shutting down");
+}
+
+// ---------------------------------------------------------------------------
+// SSE consumer
+// ---------------------------------------------------------------------------
+
+const SSE_BACKOFF_INITIAL_SECS: u64 = 1;
+const SSE_BACKOFF_MAX_SECS: u64 = 30;
+
+fn next_backoff(current: u64) -> u64 {
+    (current.saturating_mul(2)).min(SSE_BACKOFF_MAX_SECS)
+}
+
+/// Long-polls `<base>/wrappers/events`. On every `data:` line received,
+/// refreshes the tool cache and emits `notifications/tools/list_changed`
+/// to stdout. Reconnects with exponential backoff (1s → 2s → 4s → ... →
+/// 30s) on any disconnect or non-2xx response. Logs go to stderr.
+///
+/// We deliberately don't fight to stay connected during the AI client's
+/// initialize handshake: clients typically open a single MCP session
+/// per conversation, so a 1–2s delay before the first SSE attempt is
+/// invisible. If the runner is genuinely down we'll keep retrying at
+/// 30s intervals — cheap and the user gets a working push the moment
+/// the runner comes back up.
+fn sse_consumer_loop(
+    base: &str,
+    cache: Arc<Mutex<ToolCache>>,
+    stdout: Arc<Mutex<std::io::Stdout>>,
+) {
+    let url = format!("{}/wrappers/events", base);
+    let mut backoff = SSE_BACKOFF_INITIAL_SECS;
+
+    loop {
+        // SSE is a long-lived stream — disable per-request timeout. The
+        // server's keep-alive comments will keep TCP healthy; we only
+        // detect disconnect via stream EOF / read error.
+        let client = match reqwest::blocking::Client::builder().timeout(None).build() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!(
+                    "[wrappers-mcp] sse client init failed: {} (retrying in {}s)",
+                    e, backoff
+                );
+                thread::sleep(Duration::from_secs(backoff));
+                backoff = next_backoff(backoff);
+                continue;
+            }
+        };
+
+        let resp = match client
+            .get(&url)
+            .header("Accept", "text/event-stream")
+            .send()
+        {
+            Ok(r) if r.status().is_success() => r,
+            Ok(r) => {
+                eprintln!(
+                    "[wrappers-mcp] sse {} returned {} (retrying in {}s)",
+                    url,
+                    r.status(),
+                    backoff
+                );
+                thread::sleep(Duration::from_secs(backoff));
+                backoff = next_backoff(backoff);
+                continue;
+            }
+            Err(e) => {
+                eprintln!(
+                    "[wrappers-mcp] sse connect failed: {} (retrying in {}s)",
+                    e, backoff
+                );
+                thread::sleep(Duration::from_secs(backoff));
+                backoff = next_backoff(backoff);
+                continue;
+            }
+        };
+
+        eprintln!("[wrappers-mcp] sse connected to {}", url);
+        backoff = SSE_BACKOFF_INITIAL_SECS;
+
+        let reader = std::io::BufReader::new(resp);
+        for line in reader.lines() {
+            match line {
+                Ok(l) if is_sse_data_line(&l) => {
+                    handle_sse_event(base, &cache, &stdout);
+                }
+                Ok(_) => {
+                    // Comment (`:keep-alive`), `event:`, `id:`, blank — ignore.
+                }
+                Err(e) => {
+                    eprintln!("[wrappers-mcp] sse stream read error: {} (reconnecting)", e);
+                    break;
+                }
+            }
+        }
+
+        eprintln!(
+            "[wrappers-mcp] sse stream closed; reconnecting in {}s",
+            backoff
+        );
+        thread::sleep(Duration::from_secs(backoff));
+        backoff = next_backoff(backoff);
+    }
+}
+
+fn is_sse_data_line(line: &str) -> bool {
+    line.starts_with("data:")
+}
+
+fn handle_sse_event(
+    base: &str,
+    cache: &Arc<Mutex<ToolCache>>,
+    stdout: &Arc<Mutex<std::io::Stdout>>,
+) {
+    {
+        let mut guard = cache.lock().expect("tool cache mutex poisoned");
+        let ToolCache { tools, reverse_map } = &mut *guard;
+        refresh_tools(base, tools, reverse_map);
+    }
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/tools/list_changed",
+    });
+    let mut out = stdout.lock().expect("stdout mutex poisoned");
+    write_response(&mut *out, &notification);
 }
 
 #[cfg(test)]
@@ -628,6 +788,43 @@ mod tests {
 
         assert!(tools.is_empty());
         assert!(reverse_map.is_empty());
+    }
+
+    #[test]
+    fn is_sse_data_line_matches_only_data_prefix() {
+        assert!(is_sse_data_line("data: {\"atMs\":1}"));
+        assert!(is_sse_data_line("data:nospace"));
+        assert!(!is_sse_data_line(":keep-alive"));
+        assert!(!is_sse_data_line("event: wrapper.changed"));
+        assert!(!is_sse_data_line("id: 42"));
+        assert!(!is_sse_data_line(""));
+        assert!(!is_sse_data_line("retry: 1000"));
+    }
+
+    #[test]
+    fn next_backoff_doubles_then_caps() {
+        assert_eq!(next_backoff(1), 2);
+        assert_eq!(next_backoff(2), 4);
+        assert_eq!(next_backoff(8), 16);
+        assert_eq!(next_backoff(16), SSE_BACKOFF_MAX_SECS);
+        assert_eq!(next_backoff(SSE_BACKOFF_MAX_SECS), SSE_BACKOFF_MAX_SECS);
+        // Saturating: u64::MAX shouldn't panic.
+        assert_eq!(next_backoff(u64::MAX), SSE_BACKOFF_MAX_SECS);
+    }
+
+    #[test]
+    fn tool_cache_from_tools_builds_reverse_map() {
+        let cache = ToolCache::from_tools(vec![ToolEntry {
+            name: "wrapper_v0__do_thing".to_string(),
+            wrapper_id: "v0".to_string(),
+            action_id: "do-thing".to_string(),
+            description: "x".to_string(),
+            input_schema: json!({}),
+        }]);
+        assert_eq!(cache.tools.len(), 1);
+        let (w, a) = cache.reverse_map.get("wrapper_v0__do_thing").unwrap();
+        assert_eq!(w, "v0");
+        assert_eq!(a, "do-thing");
     }
 
     #[test]

--- a/src-tauri/src/wrappers/events.rs
+++ b/src-tauri/src/wrappers/events.rs
@@ -1,0 +1,58 @@
+//! Wrapper-change event broadcaster.
+//!
+//! A single broadcast channel per process. Registry mutations
+//! (`rescan`, `rescan_all`, `remove`) emit a [`WrapperChanged`] event
+//! here, and the SSE handler at `GET /wrappers/events` forwards each
+//! event to every subscriber.
+//!
+//! Primary consumer: the stdio MCP bin (`bin/wrappers_mcp.rs`), which
+//! uses these events to push `notifications/tools/list_changed` to its
+//! AI-client peer so newly-installed wrappers surface as tools without
+//! the user restarting the AI session.
+//!
+//! Mirror of `spec_api::events` — same one-channel pattern.
+
+use std::sync::OnceLock;
+use tokio::sync::broadcast;
+
+use serde::{Deserialize, Serialize};
+
+/// Single event variant — the bin only needs to know "something
+/// changed, refetch /wrappers". A richer payload would be over-coupling
+/// for today's only consumer; future consumers can read the full list
+/// from `GET /wrappers` after the wakeup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WrapperChanged {
+    /// Epoch milliseconds the event was emitted at.
+    pub at_ms: u64,
+}
+
+/// Broadcast capacity. Slow subscribers that fall this far behind will
+/// Lag; the SSE handler logs and continues. 256 is plenty for the
+/// install/uninstall cadence we expect (a handful per session at most).
+const CAPACITY: usize = 256;
+
+static SENDER: OnceLock<broadcast::Sender<WrapperChanged>> = OnceLock::new();
+
+fn sender() -> &'static broadcast::Sender<WrapperChanged> {
+    SENDER.get_or_init(|| broadcast::channel::<WrapperChanged>(CAPACITY).0)
+}
+
+pub fn subscribe() -> broadcast::Receiver<WrapperChanged> {
+    sender().subscribe()
+}
+
+/// Emit a change event. No-op when there are no subscribers (the
+/// channel just drops the message — that's the broadcast-channel
+/// contract and what we want here).
+pub fn emit() {
+    let _ = sender().send(WrapperChanged { at_ms: now_ms() });
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/src-tauri/src/wrappers/mod.rs
+++ b/src-tauri/src/wrappers/mod.rs
@@ -27,6 +27,7 @@
 pub mod clients;
 pub mod credentials;
 pub mod dispatch;
+pub mod events;
 pub mod install;
 pub mod launcher;
 pub mod manager;

--- a/src-tauri/src/wrappers/registry.rs
+++ b/src-tauri/src/wrappers/registry.rs
@@ -226,7 +226,8 @@ impl WrapperRegistry {
     pub async fn rescan(&self, id: &str) -> Result<(), RegistryError> {
         let wrapper_dir = self.root.join(id);
         if !wrapper_dir.is_dir() {
-            // Directory gone — treat as uninstall.
+            // Directory gone — treat as uninstall. `remove` already emits
+            // a change event so we don't emit again here.
             self.remove(id).await;
             return Ok(());
         }
@@ -244,13 +245,16 @@ impl WrapperRegistry {
                 idx.wrappers.insert(wrapper.id.clone(), wrapper);
                 drop(idx);
                 self.save_index().await?;
+                super::events::emit();
                 Ok(())
             }
             Err(e) => Err(e),
         }
     }
 
-    /// Re-scan every subdirectory of the wrappers root.
+    /// Re-scan every subdirectory of the wrappers root. Emits a single
+    /// change event after the scan completes if the cache contents
+    /// changed (added entries, removed entries, or updated_at moved).
     pub async fn rescan_all(&self) -> Result<(), RegistryError> {
         let entries = match std::fs::read_dir(&self.root) {
             Ok(e) => e,
@@ -300,16 +304,20 @@ impl WrapperRegistry {
         idx.wrappers.retain(|id, _| seen.iter().any(|s| s == id));
         drop(idx);
         self.save_index().await?;
+        super::events::emit();
         Ok(())
     }
 
     /// Drop a wrapper from the cache (used by uninstall).
     pub async fn remove(&self, id: &str) {
         let mut idx = self.inner.write().await;
-        idx.wrappers.remove(id);
+        let was_present = idx.wrappers.remove(id).is_some();
         drop(idx);
         if let Err(e) = self.save_index().await {
             warn!("wrappers: save_index after remove('{}') failed: {}", id, e);
+        }
+        if was_present {
+            super::events::emit();
         }
     }
 

--- a/src-tauri/src/wrappers/routes.rs
+++ b/src-tauri/src/wrappers/routes.rs
@@ -105,15 +105,28 @@ pub fn router() -> Router<Arc<ApiState>> {
 /// event. Subscribers refetch `GET /wrappers` after a wakeup; the event
 /// payload itself only carries an `atMs` timestamp.
 ///
-/// Primary-only: secondaries never own a wrapper registry, so there's
-/// no event source for them to forward. The MCP bin always points at
-/// the primary's port, so this is fine. (We don't proxy this in
-/// `primary_proxy.rs` — secondaries that hit `/wrappers/events` get an
-/// empty stream; explicit reject would log noise per AI-session
-/// reconnect.)
+/// Primary-only. On a secondary the wrapper subsystem isn't initialized
+/// (see `mcp_api.rs` — `WrapperState::new_default()` is gated on
+/// `!is_secondary()`), and our broadcaster is a per-process `OnceLock`
+/// so a secondary's channel has no producer. Returning 503 here makes
+/// the bin's reconnect-with-backoff surface the misroute in stderr;
+/// silently serving an empty stream (older behavior) looked like a
+/// healthy connection but received no events. The bin should always
+/// point at the primary's port via `QONTINUI_PRIMARY_PORT`.
 async fn events_stream(
     State(_state): State<Arc<ApiState>>,
-) -> Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>> {
+) -> Result<
+    Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>,
+    (StatusCode, Json<ApiResponse<()>>),
+> {
+    if primary_proxy::is_secondary() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(api_error(
+                "wrapper change-events are primary-only — point QONTINUI_PRIMARY_PORT at the primary",
+            )),
+        ));
+    }
     let rx = events::subscribe();
     let stream = BroadcastStream::new(rx).filter_map(|res| async move {
         match res {
@@ -127,7 +140,7 @@ async fn events_stream(
             Err(_) => None,
         }
     });
-    Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(30)))
+    Ok(Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(30))))
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/wrappers/routes.rs
+++ b/src-tauri/src/wrappers/routes.rs
@@ -21,20 +21,28 @@
 //! | PUT    | `/wrappers/:id/credentials/:name`               | set_credential     |
 //! | DELETE | `/wrappers/:id/credentials/:name`               | delete_credential  |
 
+use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     extract::{Path as AxumPath, State},
     http::StatusCode,
-    response::Json,
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        Json,
+    },
     routing::{get, post, put},
     Router,
 };
+use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+use tokio_stream::wrappers::BroadcastStream;
 
 use super::clients::{self, AiClientId, ClientError, ClientInfo};
 use super::credentials::CredentialStore;
 use super::dispatch::dispatch_handler;
+use super::events;
 use super::install::{install, uninstall, update, InstallError, InstallRequest, InstallResponse};
 use super::manager::WrapperStatus;
 use super::primary_proxy::{self, into_http as proxy_error_to_http};
@@ -81,6 +89,45 @@ pub fn router() -> Router<Arc<ApiState>> {
         .route("/wrappers/clients", get(list_clients))
         .route("/wrappers/clients/{id}/connect", post(connect_client))
         .route("/wrappers/clients/{id}/disconnect", post(disconnect_client))
+        // Change-event SSE stream — consumed by `bin/wrappers_mcp.rs` so
+        // newly-installed wrappers surface as MCP tools without an AI
+        // session restart.
+        .route("/wrappers/events", get(events_stream))
+}
+
+// ---------------------------------------------------------------------------
+// Change-event stream
+// ---------------------------------------------------------------------------
+
+/// `GET /wrappers/events` — SSE stream of `wrapper.changed` events.
+///
+/// Each registry mutation (`rescan`, `rescan_all`, `remove`) emits one
+/// event. Subscribers refetch `GET /wrappers` after a wakeup; the event
+/// payload itself only carries an `atMs` timestamp.
+///
+/// Primary-only: secondaries never own a wrapper registry, so there's
+/// no event source for them to forward. The MCP bin always points at
+/// the primary's port, so this is fine. (We don't proxy this in
+/// `primary_proxy.rs` — secondaries that hit `/wrappers/events` get an
+/// empty stream; explicit reject would log noise per AI-session
+/// reconnect.)
+async fn events_stream(
+    State(_state): State<Arc<ApiState>>,
+) -> Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>> {
+    let rx = events::subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|res| async move {
+        match res {
+            Ok(ev) => match Event::default().event("wrapper.changed").json_data(&ev) {
+                Ok(e) => Some(Ok::<Event, Infallible>(e)),
+                Err(_) => None,
+            },
+            // Lag means a slow subscriber fell behind. Drop the lag
+            // marker silently — the next genuine event still triggers a
+            // refresh, which catches up.
+            Err(_) => None,
+        }
+    });
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(30)))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the post-install UX cliff in the wrapper → AI-client chain: a wrapper installed mid-session now surfaces in the AI client without any re-list, restart, or user action.

This was the **option (b)** prerequisite the AI Clients tab plan named in its sequencing (`PLAN-mcp-client-connect-ux.md` step 1), plus **option (c)** push refresh on top so tool palettes update the moment a wrapper installs.

## What changed

### Commit 1 — `feat(wrappers-mcp): refresh tool catalog on every tools/list` (5a7c0f2d4)

- `tools/list` refreshes from `GET /wrappers` before responding (loopback HTTP, ~5ms).
- `tools/call` refreshes once if the requested tool name isn't in the cache, so a wrapper installed since startup still resolves on first call.
- `refresh_tools` preserves the existing cache when a fresh fetch comes back empty — almost always a transient runner-down blip rather than the user truly uninstalling everything.
- 2 unit tests cover the preserve-on-empty guard.

### Commit 2 — `feat(wrappers-mcp): push tool list updates via SSE (tools.listChanged)` (2805fcd4e)

**Runner side**

- `wrappers/events.rs` (new) — broadcast channel mirroring `spec_api/events.rs`. Single `WrapperChanged` event variant; consumers refetch `/wrappers` on wakeup.
- `registry.rs` — `rescan`, `rescan_all`, `remove` emit. `prune_orphans` stays silent (boot-time, no subscribers yet). `remove` only emits when the entry was actually present.
- `routes.rs` — `GET /wrappers/events` SSE handler with 30s keep-alive. Lag silently dropped (next genuine event catches up).

**MCP bin side**

- `ToolCache` struct bundles `tools + reverse_map`; one `Arc<Mutex<...>>` covers both fields.
- Background SSE consumer thread spawned at startup. Long-poll → `data:` line → refresh cache → emit `notifications/tools/list_changed`. Stdout is wrapped in `Mutex` so the stdin-loop responses and SSE-thread notifications never interleave a frame.
- Reconnects with exponential backoff (1s → 30s capped) on disconnect or non-2xx response.
- `initialize` declares `capabilities.tools.listChanged: true` so clients know to honor the push.
- 3 new unit tests (`is_sse_data_line`, `next_backoff` cap+saturate, `ToolCache::from_tools`).

## Test plan

- [x] `cargo check --bin wrappers_mcp` clean
- [x] `cargo clippy --bin wrappers_mcp -- -D warnings` clean
- [x] `cargo clippy --lib -- -D warnings` clean
- [x] `cargo test --bin wrappers_mcp` — 12/12 pass (9 prior + 3 new)
- [ ] Live: with `wrappers_mcp.exe` registered in a Claude session, install a wrapper via Wrappers → Browse; AI client tool palette updates without re-list/restart. Stderr shows `[wrappers-mcp] sse connected to <url>`; stdout emits `notifications/tools/list_changed` per install.
- [ ] Live: kill the runner mid-session; bin retries with backoff (1s, 2s, 4s, … 30s capped). When runner restarts, bin reconnects and resumes emitting notifications.
- [ ] Live: install/uninstall multiple wrappers in quick succession; each emits exactly one `notifications/tools/list_changed`.

## Notes

- Primary-only by design. Secondaries don't own the wrapper registry, so `/wrappers/events` is not proxied (the MCP bin always points at the primary's port via `QONTINUI_PRIMARY_PORT`).
- No Cargo.toml changes — `tokio-stream` (with `sync`), `axum` 0.8 SSE, and `reqwest` blocking are already dependencies.