### PR TITLE
ci: drop CARGO_BUILD_JOBS to 1 on windows-latest (rustc-LLVM OOM)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,14 +167,20 @@ jobs:
         # skipped in CI. Only pure unit tests (no system dependencies) run here.
         env:
           # `CARGO_BUILD_JOBS` reduces the parallel-rustc memory peak.
-          # Empirically (run 25336049561):
-          #   - Windows passes at JOBS=2 with a 16 GB pagefile — Windows
-          #     pagefile commits lazily so peak fits.
+          # Empirically:
+          #   - Windows: was passing at JOBS=2 with a 16 GB pagefile (run
+          #     25336049561), but cumulative dep growth through PRs #59-#62
+          #     pushed peak past the threshold — runs 25612844640 +
+          #     75193978255 (PR #65) both OOM'd with `rustc-LLVM ERROR:
+          #     out of memory / Allocation failed`, exit `0xc000001d`
+          #     (STATUS_ILLEGAL_INSTRUCTION = the rustc allocator
+          #     aborting). Dropped to JOBS=1 for single-threaded compile,
+          #     matching Ubuntu's mitigation.
           #   - Ubuntu OOM-killer is harsher: even with a 12 GB swapfile,
           #     JOBS=2 still trips the runner-agent shutdown. Drop Ubuntu
           #     to JOBS=1 for a single-threaded compile.
           #   - macOS is on a fatter runner and stays at default 4.
-          CARGO_BUILD_JOBS: ${{ (matrix.platform == 'ubuntu-22.04' && 1) || (matrix.platform == 'macos-latest' && 4) || 2 }}
+          CARGO_BUILD_JOBS: ${{ (matrix.platform == 'macos-latest' && 4) || 1 }}
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             echo "=== free / df before cargo test ==="


### PR DESCRIPTION
## Summary

PRs #59-#62 added enough Rust dep volume to push the windows-latest test build past its memory budget. Symptom on PR #65 (run [25612844640](https://github.com/qontinui/qontinui-runner/actions/runs/25612844640) + the same run's first attempt, both reproducible across two attempts on the same HEAD):

```
rustc-LLVM ERROR: out of memory
Allocation failed
process didn't exit successfully: ... (exit code: 0xc000001d, STATUS_ILLEGAL_INSTRUCTION)
```

This is the rustc allocator aborting; the OS reports the abort, not a real CPU instruction-set fault. Same pathology `Cargo.toml:5-9` and the runner `CONTRIBUTING.md` "Platform escape valve" section already document — but the JOBS=2 mitigation that worked at the time of PR #30 no longer fits.

PR #65's content (10/-10 line `@qontinui/ui-bridge` dep bump) cannot itself cause this; reproduces deterministically across both run attempts on the same HEAD.

## Change

Lower `CARGO_BUILD_JOBS` from 2 → 1 on Windows (single-threaded compile), mirroring Ubuntu's existing mitigation. Conditional simplified to `(macos && 4) || 1` since both Linux and Windows now share JOBS=1.

## Test plan

- [ ] CI matrix on this PR completes — verify windows-latest test job no longer OOMs.
- [ ] If windows still OOMs after this change, escalate via follow-up: bump pagefile 16GB → 24-32GB via configure-pagefile-action, OR add `[profile.test] codegen-units = 1` to spread the rustc memory peak.
- [ ] After this lands, rerun PR #65's checks; should now pass.