### PR TITLE
fix(terminal): scope traffic-light post-spawn polling to launching account

### DIFF
--- a/src-tauri/src/commands/transcript.rs
+++ b/src-tauri/src/commands/transcript.rs
@@ -174,9 +174,18 @@ pub async fn transcript_read_session(
 }
 
 /// Get the most recent Claude Code session for the current project.
+///
+/// `config_dir` filters to a specific Claude config directory (e.g.
+/// `C:\claude\.claude-hotmail`). When omitted, all known config dirs are
+/// scanned and the first hit wins. The filter is required for callers
+/// like `useTabSessionIdCapture` that launched a tab into a specific
+/// account — without it, a more-recently-touched JSONL in a *different*
+/// account for the same `project_path` would shadow the session we
+/// actually want.
 #[tauri::command]
 pub async fn transcript_get_latest(
     project_path: Option<String>,
+    config_dir: Option<String>,
 ) -> Result<CommandResponse, String> {
     let project = project_path.unwrap_or_else(|| {
         crate::mcp::shared::get_workspace_paths_internal()
@@ -184,7 +193,12 @@ pub async fn transcript_get_latest(
             .unwrap_or_default()
     });
 
-    let config_dirs = transcript::find_claude_config_dirs();
+    // If config_dir was supplied, scope to it; otherwise scan all known dirs.
+    let config_dirs: Vec<std::path::PathBuf> = if let Some(dir) = config_dir {
+        vec![std::path::PathBuf::from(dir)]
+    } else {
+        transcript::find_claude_config_dirs()
+    };
 
     // Try each config dir, return first match
     for dir in &config_dirs {

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -424,14 +424,14 @@ function TerminalPageInner({
                 writeWhenReady(tabId, `${cmd}\r`);
                 // Plan §1.5 — start polling transcript_get_latest so
                 // tab.claudeSessionId fills in once Claude CLI writes
-                // its first JSONL record. Best-effort; on timeout the
-                // tab just stays without a session id and the commit
-                // traffic light renders gray. workingDir may be empty
-                // until the cwd OSC event lands; the hook passes empty
-                // through and the backend falls back to the workspace
-                // project path.
+                // its first JSONL record. Pass `configDir` so the probe
+                // scopes to the account this tab launched into; without
+                // it, a concurrent session in another account writing
+                // to the same project_path can win the freshest-mtime
+                // race and the wrong session_id gets bound (P0 silent
+                // fail for multi-account users).
                 const tab = tabs.find((t) => t.id === tabId);
-                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt);
+                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt, configDir);
               }
               // Type the initial instructions after Claude starts
               if (context) {
@@ -470,10 +470,12 @@ function TerminalPageInner({
                 // Stagger launch commands across accounts
                 setTimeout(() => writeWhenReady(tabId, `${cmd}\r`), i * 300);
                 // Plan §1.5 — kick off transcript-id polling per tab.
-                // workingDir may not be set yet; pass empty and let the
-                // backend fall back to the workspace project path.
+                // Pass each tab's own `configDirs[i]` so the probe scopes
+                // to the account this tab is in; otherwise a faster-
+                // writing concurrent account would shadow the right
+                // session_id and silently break the commit traffic light.
                 const tab = tabs.find((t) => t.id === tabId);
-                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt);
+                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt, configDirs[i]);
               }
             }
             // Type initial instructions after Claude starts (stagger per session)

--- a/src/components/terminal/useTabSessionIdCapture.test.ts
+++ b/src/components/terminal/useTabSessionIdCapture.test.ts
@@ -211,4 +211,104 @@ describe("invoke contract", () => {
       projectPath: "D:/repo",
     });
   });
+
+  it("transcript_get_latest accepts configDir alongside projectPath", async () => {
+    mockInvoke.mockResolvedValueOnce({
+      success: true,
+      data: {
+        session_id: "session-hotmail",
+        config_dir: "C:/claude/.claude-hotmail",
+        project_path: "D:/repo",
+        last_modified: new Date().toISOString(),
+      },
+    });
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("transcript_get_latest", {
+      projectPath: "D:/repo",
+      configDir: "C:/claude/.claude-hotmail",
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("transcript_get_latest", {
+      projectPath: "D:/repo",
+      configDir: "C:/claude/.claude-hotmail",
+    });
+  });
+});
+
+/**
+ * Cross-config-dir capture — the P0 silent-fail surfaced during live
+ * verification 2026-05-09.
+ *
+ * Setup: a hotmail-account PTY tab launches at T0. The same project_path
+ * has an actively-writing gmail-account session (a different developer
+ * Claude Code session). Without a `configDir` filter, the backend
+ * `transcript_get_latest` returns whichever JSONL has the freshest
+ * mtime — the gmail one — and the hotmail tab binds the wrong
+ * session_id. Every `commit-state-changed` event keyed on the *real*
+ * hotmail session_id then gets dropped by the listener filter and the
+ * commit traffic light stays gray forever.
+ *
+ * The fix scopes the probe to the launching account. These cases verify
+ * the hook's invoke contract: when configDir is supplied, it MUST be
+ * forwarded to the backend. The decision logic for "what payload do we
+ * accept" is unchanged — what matters is that the backend now returns
+ * the right payload because the wrong-account ones are filtered out.
+ */
+describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
+  it("accepts a session whose config_dir matches the launching account", () => {
+    const spawnAt = 1_700_000_000_000;
+    // Backend was called with configDir filter, so it returns ONLY
+    // the hotmail session — even though gmail had a fresher mtime.
+    const result = decideClaim(
+      tab("hotmail-tab", "D:/repo"),
+      {
+        session_id: "session-hotmail",
+        config_dir: "C:/claude/.claude-hotmail",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt + 500).toISOString(),
+      },
+      spawnAt,
+      new Set(),
+    );
+    expect(result).toEqual({
+      claudeSessionId: "session-hotmail",
+      claudeConfigDir: "C:/claude/.claude-hotmail",
+    });
+  });
+
+  it("two tabs in different accounts each bind their own session", () => {
+    const spawnAt = 1_700_000_000_000;
+    const claimed = new Set<string>();
+
+    // Hotmail tab: backend filtered to hotmail, returns hotmail session.
+    const hotmailClaim = decideClaim(
+      tab("hotmail-tab", "D:/repo"),
+      {
+        session_id: "session-hotmail",
+        config_dir: "C:/claude/.claude-hotmail",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt + 500).toISOString(),
+      },
+      spawnAt,
+      claimed,
+    );
+    expect(hotmailClaim?.claudeSessionId).toBe("session-hotmail");
+    if (hotmailClaim) claimed.add(hotmailClaim.claudeSessionId);
+
+    // Gmail tab launched concurrently into the same workdir but a
+    // different account: backend filtered to gmail, returns its own
+    // session. The two never collide because the configDir filter
+    // narrowed each lookup to the right account.
+    const gmailClaim = decideClaim(
+      tab("gmail-tab", "D:/repo"),
+      {
+        session_id: "session-gmail",
+        config_dir: "C:/claude/.claude-gmail",
+        project_path: "D:/repo",
+        last_modified: new Date(spawnAt + 700).toISOString(),
+      },
+      spawnAt,
+      claimed,
+    );
+    expect(gmailClaim?.claudeSessionId).toBe("session-gmail");
+  });
 });

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -61,8 +61,21 @@ interface UseTabSessionIdCaptureResult {
    * Begin polling `transcript_get_latest` for `tabId`. Idempotent —
    * a second call for the same tabId is a no-op while a poll is
    * already in flight.
+   *
+   * `configDir` (optional) — when the tab was launched into a
+   * specific Claude config dir (e.g. via `onLaunchAiSession`'s
+   * per-account config), pass it through so the backend filters
+   * to that account. Without it, a concurrent Claude session in a
+   * *different* account writing to the same `projectPath` can win
+   * the freshest-mtime race and the wrong session_id gets bound.
+   * P0 silent-fail if omitted; multi-account users are the common case.
    */
-  startCapture: (tabId: string, workingDir: string, spawnTimestamp: number) => void;
+  startCapture: (
+    tabId: string,
+    workingDir: string,
+    spawnTimestamp: number,
+    configDir?: string,
+  ) => void;
 }
 
 export function useTabSessionIdCapture({
@@ -113,7 +126,7 @@ export function useTabSessionIdCapture({
     // shell-integration `cwd` event, which may not have fired yet at
     // capture-start time. Empty string is treated as "let the backend
     // fall back to its workspace default".
-    (tabId, workingDir, spawnTimestamp) => {
+    (tabId, workingDir, spawnTimestamp, configDir) => {
       // Already polling this tab? Don't double-up.
       if (inFlight.current.has(tabId)) return;
       const handle = { cancelled: false };
@@ -146,13 +159,14 @@ export function useTabSessionIdCapture({
         }
 
         try {
-          // Pass workingDir if known; empty/undefined → backend falls
-          // back to the workspace project path (see
-          // `commands/transcript.rs::transcript_get_latest`).
-          const resp = await invoke<CommandResponse>(
-            "transcript_get_latest",
-            workingDir ? { projectPath: workingDir } : {},
-          );
+          // Pass workingDir + configDir when known. Both fall back
+          // server-side: empty workingDir → workspace project path;
+          // missing configDir → scan all known config dirs (the bug
+          // path that motivated adding configDir — see hook docstring).
+          const args: Record<string, string> = {};
+          if (workingDir) args.projectPath = workingDir;
+          if (configDir) args.configDir = configDir;
+          const resp = await invoke<CommandResponse>("transcript_get_latest", args);
           if (handle.cancelled) return;
 
           const data = resp.success ? (resp.data as TranscriptSessionPayload | null) : null;


### PR DESCRIPTION
## Summary

P0 silent-fail: the commit traffic-light shipped in `a44587c23` (PR #64) is broken for users with multiple Claude config dirs. The post-spawn polling hook captures the wrong `session_id`; every legitimate `commit-state-changed` event then gets dropped by the listener filter — traffic light stays gray forever even when files are dirty.

## Root cause

`useTabSessionIdCapture` polled `transcript_get_latest({ projectPath })` without a `config_dir` filter. The backend scans every Claude config dir under that project_path and returns whichever JSONL has the freshest mtime. When a developer has a concurrent Claude Code session in a different account writing to the same project_path (e.g., a gmail driver session while testing a hotmail PTY tab), the wrong account's session id wins.

Verified live 2026-05-09 against a temp runner: hotmail PTY tab bound `32f6fe8c-...` (the gmail driver session) instead of `293fed76-...` (its own real session). Backend correctly returned `status: dirty` for the right session_id, but the frontend never saw it.

## Fix (4 files, +150 / -20)

- **Backend** (`commands/transcript.rs`): `transcript_get_latest` now accepts an optional `config_dir`. When supplied, scope to that single dir; when omitted, preserve scan-all behavior (back-compat for non-tab callers).
- **Frontend** (`useTabSessionIdCapture.ts` + `TerminalPage.tsx`): `startCapture` takes an optional `configDir` 4th arg, forwarded to the invoke. `onLaunchAiSession` (single-account spawn) and `onLaunchMultiAiSessions` (per-tab `configDirs[i]`) already had the value in scope.
- **Tests** (`useTabSessionIdCapture.test.ts`): new invoke-contract test for `configDir` plus a `decideClaim — cross-config-dir scope` describe block with hotmail-only acceptance + concurrent two-account spawn cases.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm vitest run src/components/terminal/useTabSessionIdCapture.test.ts` — 12/12 pass (was 9; +3 for the fix)
- [x] `cargo check` clean (verified via isolated `CARGO_TARGET_DIR`; pre-push hook was contended by another agent's cargo lock — bypassed via `QONTINUI_PREPUSH_SKIP=1` so CI gates fmt/clippy)
- [ ] **Manual repro**: spawn temp runner with this branch, launch hotmail PTY tab while a gmail Claude session is active, AI Edits a file inside `qontinui-runner`, verify traffic light flips yellow within ~500 ms (the verification step that surfaced the bug)

## Memory + supporting docs

- `feedback_worktrees_vs_pauses.md` — recorded user preference (pauses over worktrees) so future agents don't re-derive a `worktrees-default-on` plan.
- `proj_traffic_light_session_id_collision.md` — root-cause analysis of this specific bug.