### PR TITLE
feat(ui-bridge): snapshot ?withDisabledOnly=true passthrough

### DIFF
--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -1154,15 +1154,39 @@ async fn handle_snapshot(
 ) -> impl IntoResponse {
     // Phase 1 wrapper framework: if the active app registered via WebSocket,
     // dispatch getControlSnapshot over its socket.
-    let ws_payload = match query.get("recency") {
-        Some(r) => serde_json::json!({ "recency": r }),
-        None => serde_json::json!({}),
+    //
+    // Manual-test remediation 2026-05-10 (Item 2): forward the
+    // `withDisabledOnly` filter to the SDK so the WS-transport snapshot path
+    // honours it. Without this the SDK app would receive an empty payload
+    // and silently return the unfiltered snapshot, while the runner-direct
+    // /ui-bridge/control/snapshot route (which applies the filter Rust-side)
+    // would honour it. We accept both camelCase and snake_case spellings to
+    // mirror the SDK's alias surface.
+    let truthy = |v: &String| {
+        let s = v.trim();
+        s == "1" || s.eq_ignore_ascii_case("true")
     };
-    // Forward recency query param to the SDK app for cache control
-    let path = if let Some(recency) = query.get("recency") {
-        format!("/control/snapshot?recency={}", urlencoding::encode(recency))
-    } else {
+    let want_disabled_only = query.get("withDisabledOnly").is_some_and(truthy)
+        || query.get("with_disabled_only").is_some_and(truthy);
+    let mut ws_payload = serde_json::json!({});
+    if let Some(r) = query.get("recency") {
+        ws_payload["recency"] = serde_json::Value::String(r.clone());
+    }
+    if want_disabled_only {
+        ws_payload["withDisabledOnly"] = serde_json::Value::Bool(true);
+    }
+    // Forward recency + withDisabledOnly query params to the SDK app
+    let mut query_parts: Vec<String> = Vec::new();
+    if let Some(recency) = query.get("recency") {
+        query_parts.push(format!("recency={}", urlencoding::encode(recency)));
+    }
+    if want_disabled_only {
+        query_parts.push("withDisabledOnly=true".to_string());
+    }
+    let path = if query_parts.is_empty() {
         "/control/snapshot".to_string()
+    } else {
+        format!("/control/snapshot?{}", query_parts.join("&"))
     };
 
     // Per-app-id dispatch: route to the named registered app and skip

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -1586,6 +1586,14 @@ pub async fn ui_bridge_get_last_discovered_handler(
 ///     standard SPA every registered element belongs to the current route, so
 ///     this is usually a no-op, but we forward it consistently for callers
 ///     that rely on the filter existing end-to-end.
+///   - `?withDisabledOnly=true` (manual-test remediation 2026-05-10
+///     Item 2) — keep only elements that report disabled by ANY signal in
+///     `state`: `disabled === true`, `ariaDisabled === "true"`, or
+///     `enabled === false`. Lets agents find a disabled target without
+///     walking the full snapshot. Companion to the SDK-side filter in
+///     `@qontinui/ui-bridge` (handlers.ts `getControlSnapshot`); both
+///     paths apply the same predicate so the runner-direct HTTP route and
+///     the SDK-WS route stay observationally identical.
 ///
 /// Filtering happens in this Rust handler (not via a special SDK code path),
 /// because `get_snapshot` participates in the dedup cache keyed by type, and
@@ -1600,10 +1608,14 @@ pub async fn ui_bridge_get_snapshot_handler(
     };
     let visible_only = query.get("visibleOnly").is_some_and(truthy);
     let current_route_only = query.get("currentRouteOnly").is_some_and(truthy);
+    // Manual-test remediation 2026-05-10 (Item 2). Both camelCase and
+    // snake_case spellings are accepted to match the SDK's alias surface.
+    let with_disabled_only = query.get("withDisabledOnly").is_some_and(truthy)
+        || query.get("with_disabled_only").is_some_and(truthy);
 
     info!(
-        "UI Bridge API: Getting snapshot (visibleOnly={}, currentRouteOnly={})",
-        visible_only, current_route_only
+        "UI Bridge API: Getting snapshot (visibleOnly={}, currentRouteOnly={}, withDisabledOnly={})",
+        visible_only, current_route_only, with_disabled_only
     );
 
     // Try to get snapshot; if elements are empty, auto-discover once and retry.
@@ -1647,7 +1659,7 @@ pub async fn ui_bridge_get_snapshot_handler(
             // disagrees with the snapshot's top-level `page.pathname`. This is
             // a no-op in SPAs where the registry only holds current-route
             // elements, but we forward it so the filter works end-to-end.
-            if visible_only || current_route_only {
+            if visible_only || current_route_only || with_disabled_only {
                 let snapshot_pathname = data
                     .get("page")
                     .and_then(|p| p.get("pathname"))
@@ -1682,12 +1694,41 @@ pub async fn ui_bridge_get_snapshot_handler(
                                         }
                                     }
                                 }
+                                if with_disabled_only {
+                                    // Manual-test remediation 2026-05-10
+                                    // (Item 2). Mirror the SDK predicate in
+                                    // `@qontinui/ui-bridge` handlers.ts:
+                                    // keep elements that report disabled by
+                                    // ANY of the three signals the SDK
+                                    // might emit. Today's
+                                    // `serializeRegisteredElement` writes
+                                    // `state.enabled` (not `state.disabled`),
+                                    // so checking only `disabled` would let
+                                    // the filter return zero rows on every
+                                    // current-shape snapshot.
+                                    let state = el.get("state");
+                                    let disabled_true = state
+                                        .and_then(|s| s.get("disabled"))
+                                        .and_then(|v| v.as_bool())
+                                        == Some(true);
+                                    let aria_disabled_true = state
+                                        .and_then(|s| s.get("ariaDisabled"))
+                                        .and_then(|v| v.as_str())
+                                        == Some("true");
+                                    let enabled_false = state
+                                        .and_then(|s| s.get("enabled"))
+                                        .and_then(|v| v.as_bool())
+                                        == Some(false);
+                                    if !(disabled_true || aria_disabled_true || enabled_false) {
+                                        return false;
+                                    }
+                                }
                                 true
                             });
                             let after = arr.len();
                             debug!(
-                                "UI Bridge snapshot filter: visibleOnly={} currentRouteOnly={} kept {}/{} elements",
-                                visible_only, current_route_only, after, before
+                                "UI Bridge snapshot filter: visibleOnly={} currentRouteOnly={} withDisabledOnly={} kept {}/{} elements",
+                                visible_only, current_route_only, with_disabled_only, after, before
                             );
                         }
                     }


### PR DESCRIPTION
## Summary

Companion to ui-bridge#16 — forwards the new `withDisabledOnly` query param so the snapshot disabled filter applies through the runner's direct HTTP path AND the SDK-WS-transport wrapper, not just the SDK direct path.

Without this companion, an agent calling `GET /ui-bridge/control/snapshot?withDisabledOnly=true` against the runner would silently get the unfiltered snapshot back: the runner's HTTP handler in `mcp/ui_bridge/elements.rs` parses query params Rust-side and only forwards an empty `{}` IPC payload to the SDK frontend. So even though the SDK's handler now understands the flag, it never sees it in this transport. The `mcp/sdk_client.rs` snapshot wrapper (used for WS-transport SDK apps) had the same gap.

This PR closes both:

1. **`mcp/ui_bridge/elements.rs`** — `ui_bridge_get_snapshot_handler` now parses `withDisabledOnly` / `with_disabled_only` (truthy = `1` or case-insensitive `true`) and applies the same predicate the SDK uses (`state.disabled === true || state.ariaDisabled === "true" || state.enabled === false`) to the snapshot it gets back via IPC. The third branch is required because today's `serializeRegisteredElement` writes `state.enabled` rather than `state.disabled` — without it the filter would return zero rows on every current-shape snapshot.
2. **`mcp/sdk_client.rs`** — `handle_snapshot` now also forwards the param to the WS-transport SDK app via both the IPC payload (`ws_payload.withDisabledOnly`) and the path query string, joined alongside the existing `recency` forwarding.

Source plan: `D:/qontinui-root/plans/manual-test-remediation-2026-05-10.md` (Item 2).

## Test plan

- [x] `cargo check --features custom-protocol` — clean (only the pre-existing unrelated `qontinui-runner@1.0.0: build-ir failed` warning).
- [x] `cargo fmt -- --check` — clean.
- [x] `cargo test manifest_matches_route_calls` — 1/1 passed (internal route-manifest drift guard).
- [x] `cargo test sdk_manifest_routes_are_exposed_by_runner` — 1/1 passed (SDK manifest ↔ runner routes drift guard).
- [x] Pre-push `cargo fmt + clippy` gate passed during push.