### PR TITLE
feat(file-activity): hot_files / hot_sessions + GET /file-activity/heatmap

### DIFF
--- a/src-tauri/src/database/pg/session_touched_files.rs
+++ b/src-tauri/src/database/pg/session_touched_files.rs
@@ -16,6 +16,34 @@
 //! existing `registry.register(...)` call.
 
 use super::PgDb;
+use serde::Serialize;
+
+/// One row of the windowed "hot files" aggregate. Returned by
+/// [`PgDb::hot_files`] for the file-activity heatmap.
+#[derive(Debug, Clone, Serialize)]
+pub struct HotFileRow {
+    pub file_path: String,
+    /// Distinct sessions that touched this file in the window. Counts
+    /// distinct `task_run_id`, not raw UPSERT rows — re-edits by the
+    /// same session don't inflate the count, which is the signal we
+    /// actually want ("how contested is this file").
+    pub distinct_sessions: i64,
+    /// Most recent recorded_at within the window for this file.
+    pub latest_recorded_at: chrono::DateTime<chrono::Utc>,
+    /// task_run_id of the most-recent toucher. Useful for the "latest
+    /// editor" column in the UI.
+    pub latest_task_run_id: String,
+}
+
+/// One row of the windowed "hot sessions" aggregate. Returned by
+/// [`PgDb::hot_sessions`].
+#[derive(Debug, Clone, Serialize)]
+pub struct HotSessionRow {
+    pub task_run_id: String,
+    /// Distinct files touched by this session in the window.
+    pub distinct_files: i64,
+    pub latest_recorded_at: chrono::DateTime<chrono::Utc>,
+}
 
 impl PgDb {
     /// Record that `file_path` was touched by `task_run_id`. Idempotent —
@@ -142,6 +170,98 @@ impl PgDb {
             .map_err(|e| format!("PG clear_files_touched: {}", e))?;
 
         Ok(n)
+    }
+
+    /// Top files by distinct-toucher count in the last `window_secs`
+    /// seconds. Ordered by `distinct_sessions DESC`, then most-recent
+    /// `recorded_at` for stable display. Capped at `limit` rows.
+    ///
+    /// Uses the existing `idx_session_touched_files_recorded_at` index;
+    /// `EXPLAIN` confirms a bitmap-index scan for windows ≤ 1 hour on
+    /// dev table sizes.
+    pub async fn hot_files(&self, window_secs: i64, limit: i64) -> Result<Vec<HotFileRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows = conn
+            .query(
+                r#"WITH windowed AS (
+                       SELECT file_path, task_run_id, recorded_at
+                       FROM coord.session_touched_files
+                       WHERE recorded_at >= NOW() - make_interval(secs => $1::double precision)
+                   ),
+                   per_file_latest AS (
+                       SELECT DISTINCT ON (file_path)
+                              file_path, task_run_id, recorded_at
+                       FROM windowed
+                       ORDER BY file_path, recorded_at DESC
+                   )
+                   SELECT w.file_path,
+                          COUNT(DISTINCT w.task_run_id)::bigint AS distinct_sessions,
+                          MAX(w.recorded_at) AS latest_recorded_at,
+                          (SELECT pfl.task_run_id
+                             FROM per_file_latest pfl
+                            WHERE pfl.file_path = w.file_path) AS latest_task_run_id
+                   FROM windowed w
+                   GROUP BY w.file_path
+                   ORDER BY distinct_sessions DESC, latest_recorded_at DESC
+                   LIMIT $2"#,
+                &[&(window_secs as f64), &limit],
+            )
+            .await
+            .map_err(|e| format!("PG hot_files: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| HotFileRow {
+                file_path: r.get(0),
+                distinct_sessions: r.get(1),
+                latest_recorded_at: r.get(2),
+                latest_task_run_id: r.get(3),
+            })
+            .collect())
+    }
+
+    /// Top sessions by distinct-file count in the last `window_secs`
+    /// seconds. Ordered by `distinct_files DESC`, then most-recent
+    /// `recorded_at`. Capped at `limit` rows.
+    pub async fn hot_sessions(
+        &self,
+        window_secs: i64,
+        limit: i64,
+    ) -> Result<Vec<HotSessionRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows = conn
+            .query(
+                r#"SELECT task_run_id,
+                          COUNT(DISTINCT file_path)::bigint AS distinct_files,
+                          MAX(recorded_at) AS latest_recorded_at
+                   FROM coord.session_touched_files
+                   WHERE recorded_at >= NOW() - make_interval(secs => $1::double precision)
+                   GROUP BY task_run_id
+                   ORDER BY distinct_files DESC, latest_recorded_at DESC
+                   LIMIT $2"#,
+                &[&(window_secs as f64), &limit],
+            )
+            .await
+            .map_err(|e| format!("PG hot_sessions: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| HotSessionRow {
+                task_run_id: r.get(0),
+                distinct_files: r.get(1),
+                latest_recorded_at: r.get(2),
+            })
+            .collect())
     }
 }
 

--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -4,13 +4,14 @@
 //! AI terminal sessions) use these to register files they're working on,
 //! check for conflicts, and release registrations.
 
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use crate::database::pg::session_touched_files::{HotFileRow, HotSessionRow};
 use crate::executor::file_registry::{FileConflict, FileLockInfo, FileRegistryInfo};
 use crate::mcp::types::ApiState;
 
@@ -181,6 +182,83 @@ async fn get_info(
     Ok(Json(info))
 }
 
+// =============================================================================
+// File Activity Heatmap
+// =============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct HeatmapQuery {
+    /// Time window for the windowed aggregates, in seconds. Defaults to
+    /// 3600 (1 hour). Clamped to a sane upper bound below.
+    #[serde(default)]
+    pub window_secs: Option<i64>,
+    /// Cap on the number of hot rows returned in each list. Defaults to
+    /// 25. Clamped to 100 to keep responses bounded.
+    #[serde(default)]
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HeatmapResponse {
+    /// Live `FileRegistryManager.info()` snapshot, pass-through. Always
+    /// reflects the current process; not affected by `window_secs`.
+    pub live: Vec<FileRegistryInfo>,
+    /// Top files by distinct-toucher count in the window.
+    pub hot_files: Vec<HotFileRow>,
+    /// Top sessions by distinct-file count in the window.
+    pub hot_sessions: Vec<HotSessionRow>,
+    /// Echo of the resolved window for the UI's selector.
+    pub window_secs: i64,
+    /// Echo of the resolved limit.
+    pub limit: i64,
+}
+
+/// GET /file-activity/heatmap?window_secs=3600&limit=25
+///
+/// Composes the live `FileRegistryManager.info()` snapshot with two
+/// windowed aggregates over `coord.session_touched_files`:
+///   - top files by distinct-toucher count
+///   - top sessions by distinct-file count
+///
+/// The aggregates use a >= NOW() - INTERVAL filter that exploits
+/// `idx_session_touched_files_recorded_at`. PG returns empty lists when
+/// no rows fall in the window — caller renders the empty-state copy.
+async fn get_heatmap(
+    State(state): State<Arc<ApiState>>,
+    Query(q): Query<HeatmapQuery>,
+) -> Result<Json<HeatmapResponse>, (StatusCode, String)> {
+    let window_secs = q.window_secs.unwrap_or(3600).clamp(60, 86_400);
+    let limit = q.limit.unwrap_or(25).clamp(1, 100);
+
+    let live = state.app_state.file_registry_manager.info().await;
+
+    let hot_files = state
+        .app_state
+        .pg_db
+        .hot_files(window_secs, limit)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("hot_files: {e}")))?;
+    let hot_sessions = state
+        .app_state
+        .pg_db
+        .hot_sessions(window_secs, limit)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("hot_sessions: {e}"),
+            )
+        })?;
+
+    Ok(Json(HeatmapResponse {
+        live,
+        hot_files,
+        hot_sessions,
+        window_secs,
+        limit,
+    }))
+}
+
 /// GET /file-locks/info
 ///
 /// Get a snapshot of all currently held exclusive file locks.
@@ -203,4 +281,5 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/file-registry/check-conflicts", post(check_conflicts))
         .route("/file-registry/info", get(get_info))
         .route("/file-locks/info", get(get_lock_info))
+        .route("/file-activity/heatmap", get(get_heatmap))
 }


### PR DESCRIPTION
## Summary

- Adds `PgDb::hot_files` and `PgDb::hot_sessions` windowed aggregates over `coord.session_touched_files` (Phase 1 of `plans/file-ownership-heatmap-plan.md`).
- Wires `GET /file-activity/heatmap?window_secs=N&limit=M` that fuses `FileRegistryManager.info()` with the two aggregates.
- Test workload: this PR is the live workload from a coord-validation run; observation report at `D:/qontinui-root/tmp_coord_test/observation-report.md`. Phase 2 (the React panel) is deferred.

## Test plan

- [ ] `cargo check --lib` — passes (verified locally)
- [ ] Hit `GET /file-activity/heatmap?window_secs=3600` against a runner with sessions touching files; confirm `live`, `hot_files`, `hot_sessions` populate
- [ ] EXPLAIN the windowed query under load; confirm `idx_session_touched_files_recorded_at` is used
- [ ] Empty-window case → empty `hot_files` / `hot_sessions` arrays, not 500
- [ ] Phase 2 (UI panel) lands in a follow-up — this PR is backend-only