### PR TITLE
chore(deps): bump @qontinui/ui-bridge ^0.3.7 -> ^0.3.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.2.5",
-    "@qontinui/ui-bridge": "^0.3.7",
+    "@qontinui/ui-bridge": "^0.3.9",
     "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.3.7(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.5
         version: 0.2.5
       '@qontinui/ui-bridge':
-        specifier: ^0.3.7
-        version: 0.3.7(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.3.9
+        version: 0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1143,8 +1143,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  '@qontinui/ui-bridge@0.3.7':
-    resolution: {integrity: sha512-wjk75cIXjkY6v6RU69iNmT9LlDLut+GROP+ZGpbbLe7nieoroqDjdT3OJsS0ycCRKf5oFL76ndp9fceSoTNIFg==}
+  '@qontinui/ui-bridge@0.3.9':
+    resolution: {integrity: sha512-VLWgdvkm3lP/gTYXYqd4FgUFZhVRG7VNB7/GEwoDLF6QvxwUsDPenyb/CSTvHSO54xFMX9A4KELhkpHv+dhYqQ==}
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
       '@qontinui/ui-bridge-headless': '>=0.1.0'
@@ -6106,9 +6106,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.7(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.3.7(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.5': {}
@@ -6116,7 +6116,7 @@ snapshots:
   '@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       '@qontinui/shared-types': 0.2.5
-      '@qontinui/ui-bridge': 0.3.7(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - '@qontinui/ui-bridge-headless'
@@ -6135,7 +6135,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.3.7(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Bumps `@qontinui/ui-bridge` from `^0.3.7` to `^0.3.9`.
- Pulls in `window.__UI_BRIDGE__.version` reflection (ui-bridge#15) and the snapshot `?withDisabledOnly=true` filter (ui-bridge#16).
- Pairs with today's runner-side passthroughs #71 (`console-errors ?level=`) and #72 (`?withDisabledOnly` passthrough) so the SDK honours the same params end-to-end.

Same pattern as #65 (the 0.3.6 → 0.3.7 dep-bump from yesterday). Lockfile delta is 10 lines, all `0.3.7` → `0.3.9` references.

## Test plan
- [ ] CI passes (typecheck, lint, schema drift, etc.)
- [ ] Manual test against a fresh runner: `window.__UI_BRIDGE__.version` reads `0.3.9`
- [ ] `/ui-bridge/control/snapshot?withDisabledOnly=true` returns only disabled elements