### PR TITLE
fix(scripted-output): cache-firing on Haiku 4.5 + observability follow-ups from warm-emitter vet pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "schemars 1.2.1",

--- a/src-tauri/src/ai_provider/cache_aware_builder.rs
+++ b/src-tauri/src/ai_provider/cache_aware_builder.rs
@@ -10,12 +10,14 @@
 //! - Header: `anthropic-beta: prompt-caching-2024-07-31`
 //! - Place `"cache_control": {"type": "ephemeral"}` on content blocks in the
 //!   `system` array or in `messages[].content[]`.
-//! - Minimum block size depends on the model — see [`min_cacheable_chars`].
-//!   Haiku 4.5: 4096 tokens. Haiku 3.5: 2048 tokens. Sonnet/Opus: 1024 tokens.
-//!   Sub-threshold blocks are silently NOT cached (Anthropic returns 0 cache
-//!   reads with no error). Source:
-//!   <https://docs.claude.com/en/docs/build-with-claude/prompt-caching>
-//! - Cache TTL: 5 minutes default; 1-hour ephemeral tier available at 2x cost.
+//! - Minimum cacheable block is per-model — see [`min_cacheable_chars`].
+//!   Sonnet/Opus floor at 1024 tokens (~4096 chars); Haiku 3.5 floors at
+//!   2048 tokens (~8192 chars); Haiku 4.5 floors at 4096 tokens
+//!   (~16384 chars). Sub-threshold `cache_control` markers are silently
+//!   ignored by Anthropic — they don't error, they just don't cache.
+//!   Source: <https://docs.claude.com/en/docs/build-with-claude/prompt-caching>.
+//! - Cache TTL: 5 minutes default (extended on each hit); 1-hour ephemeral
+//!   tier available at 2x cost on cache-creation tokens.
 //! - Pricing: write = 1.25x base input; read = 0.1x base input.
 
 use serde::Serialize;
@@ -125,24 +127,33 @@ pub struct CacheAwareRequestBuilder {
     system_blocks: Vec<SystemBlock>,
 }
 
-/// Minimum cacheable block size in characters, per Claude model family.
+/// Per-model minimum block size in characters for `cache_control: ephemeral`
+/// to actually fire. Blocks below the per-model threshold are silently
+/// passed through uncached by Anthropic — the marker is accepted but
+/// ignored, returning 0 cache reads with no error. We work in characters
+/// (not tokens) because the builder operates on `String::len()`. Threshold
+/// = documented_token_min × 4 chars/token (English/code average; Claude's
+/// tokenizer trends ~3.5 chars/token, so a block at the char threshold is
+/// typically ≥ the token threshold).
 ///
-/// Anthropic silently returns 0 cache reads for blocks smaller than the
-/// model's documented token minimum; the `cache_control` marker is parsed
-/// and discarded. We work in characters (not tokens) because the builder
-/// operates on `String::len()`. Threshold = documented_token_min × 4
-/// chars-per-token (English/code average; Claude's tokenizer trends ~3.5
-/// chars/token, so a block at the char threshold is typically ≥ the token
-/// threshold).
+/// Source: <https://docs.claude.com/en/docs/build-with-claude/prompt-caching>.
 ///
-/// - Haiku 4.x (e.g. `claude-haiku-4-5-*`): 4096 tokens → 16384 chars
-/// - Haiku 3.x (e.g. `claude-haiku-3-5-*`): 2048 tokens → 8192 chars
-/// - Sonnet / Opus / unknown: 1024 tokens → 4096 chars
-pub(super) fn min_cacheable_chars(model: &str) -> usize {
-    let m = model.to_lowercase();
+/// | Model family | Token floor | Char floor (this fn) |
+/// |---|---|---|
+/// | Haiku 4.x (e.g. `claude-haiku-4-5-*`) | 4096 | **16384** |
+/// | Haiku 3.x (e.g. `claude-haiku-3-5-*`) | 2048 | **8192** |
+/// | Sonnet / Opus / others | 1024 | **4096** |
+///
+/// Match is case-insensitive substring-style. The `haiku-4` check runs
+/// first so a `claude-haiku-4-9-*` future bump inherits the 16384-char
+/// floor rather than falling through to the haiku-3 case. Unknown future
+/// haiku families (e.g. `haiku-5`) fall to the 4096-char default — flag
+/// for review when that ships rather than guessing the floor.
+pub(crate) fn min_cacheable_chars(model: &str) -> usize {
+    let m = model.to_ascii_lowercase();
     if m.contains("haiku-4") {
         16384
-    } else if m.contains("haiku") {
+    } else if m.contains("haiku-3") {
         8192
     } else {
         4096
@@ -168,8 +179,11 @@ impl CacheAwareRequestBuilder {
 
     /// Add a system block that should be cached (stable across iterations).
     ///
-    /// Only applies `cache_control` if the block is large enough to benefit.
-    /// Small blocks are still added to the system prompt but without the marker.
+    /// Only applies `cache_control` if the block crosses the model's
+    /// per-model cacheable minimum (see [`min_cacheable_chars`]). Small
+    /// blocks are still added to the system prompt but without the
+    /// marker — sub-threshold markers are silently ignored by Anthropic
+    /// and would just produce misleading telemetry.
     pub fn add_cached_system_block(&mut self, text: String) {
         if text.is_empty() {
             return;
@@ -400,7 +414,7 @@ mod tests {
     #[test]
     fn test_builder_basic() {
         let mut builder = CacheAwareRequestBuilder::new("claude-sonnet-4-20250514", 4096);
-        // 5000 chars passes Sonnet's 4096-char threshold.
+        // 5000 chars > Sonnet's 4096 cacheable floor.
         builder.add_cached_system_block("x".repeat(5000));
         builder.add_dynamic_system_block("dynamic context".to_string());
         let body = builder.build("Hello");
@@ -487,6 +501,9 @@ mod tests {
     #[test]
     fn test_from_structured_prompt() {
         let prompt = StructuredPrompt {
+            // Each block 5000 chars > Sonnet's 4096 cacheable floor; they
+            // pass through merge_small_blocks unmerged (each is already
+            // big enough on its own).
             cached_system_blocks: vec!["x".repeat(5000), "y".repeat(5000)],
             dynamic_system_blocks: vec!["dynamic".to_string()],
             user_message: "task".to_string(),
@@ -508,7 +525,9 @@ mod tests {
 
     #[test]
     fn test_builder_haiku_4_higher_threshold() {
-        // 5000 chars passes Sonnet's 4096-char threshold but NOT Haiku 4.5's 16384.
+        // 5000 chars passes Sonnet's 4096-char threshold but NOT Haiku 4.5's
+        // 16384 — same builder, same input size, different model → different
+        // cache decision.
         let mut b = CacheAwareRequestBuilder::new("claude-haiku-4-5-20251001", 4096);
         b.add_cached_system_block("x".repeat(5000));
         let body = b.build("Hello");
@@ -521,12 +540,42 @@ mod tests {
 
     #[test]
     fn test_min_cacheable_chars_per_model() {
+        // Sonnet/Opus and unknown families: 4096 chars (~1024 tokens).
         assert_eq!(min_cacheable_chars("claude-sonnet-4-20250514"), 4096);
         assert_eq!(min_cacheable_chars("claude-opus-4-5-20251101"), 4096);
+        assert_eq!(min_cacheable_chars("claude-opus-4-7"), 4096);
+        assert_eq!(min_cacheable_chars("some-other-model"), 4096);
+        // Haiku 3.x family: 8192 chars (~2048 tokens).
         assert_eq!(min_cacheable_chars("claude-haiku-3-5-20241022"), 8192);
+        // Haiku 4.x family: 16384 chars (~4096 tokens). Match is
+        // case-insensitive substring-style so future bumps within the
+        // family inherit the floor without code changes.
         assert_eq!(min_cacheable_chars("claude-haiku-4-5-20251001"), 16384);
         assert_eq!(min_cacheable_chars("Claude-Haiku-4-5"), 16384);
-        assert_eq!(min_cacheable_chars("some-other-model"), 4096);
+        assert_eq!(min_cacheable_chars("claude-haiku-4-9-20260101"), 16384);
+    }
+
+    #[test]
+    fn test_haiku_4_blocks_below_floor_are_uncached() {
+        // 8192-char block is comfortably above Sonnet's 4096 floor and
+        // Haiku 3's 8192 floor, but BELOW Haiku 4's 16384 floor — so
+        // the same block crosses the threshold on Sonnet and Haiku 3
+        // but not on Haiku 4. Cross-checks `add_cached_system_block`
+        // is reading `self.model` at decision time, not at construction.
+        let block = "x".repeat(8192);
+
+        let mut sonnet = CacheAwareRequestBuilder::new("claude-sonnet-4-20250514", 4096);
+        sonnet.add_cached_system_block(block.clone());
+        let body = sonnet.build("hi");
+        assert!(body["system"][0]["cache_control"].is_object());
+
+        let mut haiku4 = CacheAwareRequestBuilder::new("claude-haiku-4-5-20251001", 4096);
+        haiku4.add_cached_system_block(block);
+        let body = haiku4.build("hi");
+        assert!(
+            body["system"][0]["cache_control"].is_null(),
+            "8192-char block should NOT receive cache_control on Haiku 4 (floor 16384)"
+        );
     }
 
     #[test]

--- a/src-tauri/src/ai_provider/claude_api_warm.rs
+++ b/src-tauri/src/ai_provider/claude_api_warm.rs
@@ -209,11 +209,13 @@ fn sanitize_tool_name(schema_name: &str) -> String {
 
 /// Build the `system` array for the request body.
 ///
-/// Only attaches `cache_control: ephemeral` when `system_prefix.len() >=
-/// min_cacheable_chars(model)`. Below that per-model threshold, Anthropic
-/// silently ignores the marker and sending it anyway would be misleading
-/// telemetry. If the prefix is empty we return an empty array — the caller
-/// will typically send the message-only body.
+/// Only attaches `cache_control: ephemeral` when `system_prefix.len()
+/// >= min_cacheable_chars(model)` — see [`min_cacheable_chars`] for the
+/// per-model floors (Haiku 4.x: 16384, Haiku 3.x: 8192, else: 4096).
+/// Below that per-model threshold, Anthropic silently ignores the
+/// marker and sending it anyway would just produce misleading telemetry.
+/// If the prefix is empty we return an empty array — the caller will
+/// typically send the message-only body.
 fn build_system_array(system_prefix: &str, model: &str) -> Value {
     if system_prefix.is_empty() {
         return serde_json::json!([]);
@@ -358,9 +360,9 @@ pub(crate) fn run_claude_api_warm(
 /// - Authenticates with `WarmCredential` (API key or OAuth).
 /// - Takes a split `(system_prefix, user_message)` prompt. The stable
 ///   `system_prefix` is marked with `cache_control: ephemeral` *only when it
-///   crosses [`min_cacheable_chars`]* (per-model threshold) — sub-threshold
-///   blocks skip the marker so telemetry doesn't lie about cache
-///   participation. The `user_message`
+///   crosses [`min_cacheable_chars`]* (per-model floor — Haiku 4.x: 16384,
+///   Haiku 3.x: 8192, else: 4096) — sub-threshold blocks skip the marker so
+///   telemetry doesn't lie about cache participation. The `user_message`
 ///   carries per-call dynamic payload (goal, schemaHint, outputPreview) and
 ///   is never cached.
 pub(crate) fn run_claude_api_warm_with_structured_output(

--- a/src-tauri/src/commands/activity_timeline.rs
+++ b/src-tauri/src/commands/activity_timeline.rs
@@ -221,40 +221,69 @@ pub async fn get_scripted_output_stats(
         cache_read_tokens: 0,
     };
 
-    for (text_content, metadata_json) in rows {
+    for (text_content, metadata_json, occurrences) in rows {
         // Parse metadata lazily — many events have None or unparseable JSON.
         let meta: Option<serde_json::Value> = metadata_json
             .as_deref()
             .and_then(|s| serde_json::from_str(s).ok());
 
+        // Each row in activity_timeline can represent multiple emit
+        // occurrences when content-hash dedup collapsed identical
+        // events within the 30-s window (see
+        // `database::pg::activity_timeline::insert_activity_entry`). The
+        // `occurrences` field is `1 + duplicate_count`, i.e. how many
+        // emits this row stands for. Multiply per-row counts and per-row
+        // signals (token sums) by `occurrences` to recover the true
+        // total. Pre-fix this was 1 unconditionally — under rapid-fire
+        // emits with identical metadata (e.g. several
+        // `scripted_output.llm_ok` events from the warm provider's
+        // cache-read path) the panel under-reported by 60-90 %.
         match text_content.as_str() {
-            "scripted_output.attempted" => stats.attempted += 1,
-            "scripted_output.cache_hit" => stats.cache_hit += 1,
-            "scripted_output.worker_ok" => stats.worker_ok += 1,
+            "scripted_output.attempted" => {
+                stats.attempted = stats.attempted.saturating_add(occurrences)
+            }
+            "scripted_output.cache_hit" => {
+                stats.cache_hit = stats.cache_hit.saturating_add(occurrences)
+            }
+            "scripted_output.worker_ok" => {
+                stats.worker_ok = stats.worker_ok.saturating_add(occurrences)
+            }
             "scripted_output.bytes_avoided" => {
                 if let Some(n) = meta.as_ref().and_then(read_bytes_avoided) {
-                    stats.bytes_avoided = stats.bytes_avoided.saturating_add(n);
+                    stats.bytes_avoided = stats
+                        .bytes_avoided
+                        .saturating_add(n.saturating_mul(occurrences));
                 }
             }
             "scripted_output.llm_ok" => {
-                stats.llm_ok += 1;
+                stats.llm_ok = stats.llm_ok.saturating_add(occurrences);
                 if let Some(m) = meta.as_ref() {
                     if let Some(n) = m.get("tokens_in").and_then(|v| v.as_u64()) {
-                        stats.total_tokens_in = stats.total_tokens_in.saturating_add(n);
+                        stats.total_tokens_in = stats
+                            .total_tokens_in
+                            .saturating_add(n.saturating_mul(occurrences));
                     }
                     if let Some(n) = m.get("tokens_out").and_then(|v| v.as_u64()) {
-                        stats.total_tokens_out = stats.total_tokens_out.saturating_add(n);
+                        stats.total_tokens_out = stats
+                            .total_tokens_out
+                            .saturating_add(n.saturating_mul(occurrences));
                     }
                     if let Some(n) = m.get("cache_creation_tokens").and_then(|v| v.as_u64()) {
-                        stats.cache_creation_tokens = stats.cache_creation_tokens.saturating_add(n);
+                        stats.cache_creation_tokens = stats
+                            .cache_creation_tokens
+                            .saturating_add(n.saturating_mul(occurrences));
                     }
                     if let Some(n) = m.get("cache_read_tokens").and_then(|v| v.as_u64()) {
-                        stats.cache_read_tokens = stats.cache_read_tokens.saturating_add(n);
+                        stats.cache_read_tokens = stats
+                            .cache_read_tokens
+                            .saturating_add(n.saturating_mul(occurrences));
                     }
                     // Some Phase-B builds may roll `bytes_avoided` into the
                     // llm_ok event. Include it here defensively.
                     if let Some(n) = read_bytes_avoided(m) {
-                        stats.bytes_avoided = stats.bytes_avoided.saturating_add(n);
+                        stats.bytes_avoided = stats
+                            .bytes_avoided
+                            .saturating_add(n.saturating_mul(occurrences));
                     }
                 }
             }
@@ -265,7 +294,7 @@ pub async fn get_scripted_output_stats(
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown")
                     .to_string();
-                *stats.fallbacks.entry(reason).or_insert(0) += 1;
+                *stats.fallbacks.entry(reason).or_insert(0) += occurrences;
             }
             _ => {
                 // Ignore unknown `scripted_output.*` events — forward compat.

--- a/src-tauri/src/commands/script_emitter.rs
+++ b/src-tauri/src/commands/script_emitter.rs
@@ -10,17 +10,21 @@ use serde::Serialize;
 use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
 use tauri::Runtime;
 
-use crate::step_output::script_emitter::{self, EmitError, EmitResult};
+use crate::step_output::script_emitter::{self, DisabledReason, EmitError, EmitResult};
 
 /// Structured error shape returned to the TS shim on rejection. The shim
 /// maps any failure onto the truncation fallback; differentiating the
 /// reason lets the base handler emit the right `scripted_output.fallback`
-/// sub-event on the TS side.
+/// sub-event on the TS side, and lets manual-test agents see at a glance
+/// which gate is closed.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EmitExtractionScriptError {
-    /// Short machine token: `cost_cap`, `token_budget`, `timeout`,
-    /// `breaker_open`, `disabled`, `llm_error`, `invalid_response`.
+    /// Short machine token. Stable values: `cost_cap`, `token_budget`,
+    /// `timeout`, `breaker_open`, `llm_error`, `invalid_response`, plus
+    /// the three flavours of disabled — `disabled_env` (env kill
+    /// switch), `disabled_settings` (`scripted_output.enabled = false`),
+    /// `disabled_no_credentials` (Auto cascade exhausted).
     pub kind: String,
     /// Human-readable message (already safe to log).
     pub message: String,
@@ -33,7 +37,7 @@ impl From<EmitError> for EmitExtractionScriptError {
             EmitError::TokenBudget { .. } => ("token_budget", err.to_string()),
             EmitError::Timeout { .. } => ("timeout", err.to_string()),
             EmitError::BreakerOpen => ("breaker_open", err.to_string()),
-            EmitError::Disabled => ("disabled", err.to_string()),
+            EmitError::Disabled { reason } => (disabled_kind(reason), err.to_string()),
             EmitError::LlmError(_) => ("llm_error", err.to_string()),
             EmitError::InvalidResponse(_) => ("invalid_response", err.to_string()),
         };
@@ -41,6 +45,17 @@ impl From<EmitError> for EmitExtractionScriptError {
             kind: kind.to_string(),
             message,
         }
+    }
+}
+
+/// Map a `DisabledReason` to the wire-level `kind` discriminator. Kept
+/// separate so callers grepping for the canonical token list above find
+/// the strings here too.
+fn disabled_kind(reason: &DisabledReason) -> &'static str {
+    match reason {
+        DisabledReason::EnvKillSwitch => "disabled_env",
+        DisabledReason::SettingsFlag => "disabled_settings",
+        DisabledReason::NoCredentials => "disabled_no_credentials",
     }
 }
 

--- a/src-tauri/src/database/pg/activity_timeline.rs
+++ b/src-tauri/src/database/pg/activity_timeline.rs
@@ -10,9 +10,31 @@ use super::PgDb;
 use crate::database::types::*;
 
 /// Compute normalized SHA-256 hash for consecutive-frame deduplication.
-fn content_hash(text: &str) -> String {
+///
+/// Hashes `(text_content, metadata_json)` together so events that share the
+/// same `text_content` but carry distinct metadata are NOT deduped.
+/// Screenshot-style callers (BackgroundObserver, Python bridge) pass
+/// `metadata_json: None` and so retain their original dedup behavior — two
+/// identical text captures within 30 s still collapse into one row.
+/// Event-stream callers (e.g. `scripted_output.llm_ok` from
+/// [`crate::step_output::script_emitter::spawn_activity_event`]) carry the
+/// real signal — token counts, cache stats — in `metadata_json`; including
+/// it here means three back-to-back emit events with different cache_read
+/// totals are stored as three distinct rows instead of being silently
+/// coalesced into one with an incremented `duplicate_count`.
+///
+/// `text_content` is normalized (trim + lowercase) to match the original
+/// screenshot dedup intent. `metadata_json` is hashed verbatim — JSON is
+/// case-sensitive and a re-emit produced by the same code path will be
+/// byte-identical (serde_json::to_string is deterministic for stable maps).
+fn content_hash(text: &str, metadata_json: Option<&str>) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text.trim().to_lowercase().as_bytes());
+    // Separator that can't appear in normalized text or in the metadata
+    // body — any 0x00 byte is invalid in JSON and the lowercase
+    // text_content is unicode-printable.
+    hasher.update(b"\0meta:");
+    hasher.update(metadata_json.unwrap_or("").as_bytes());
     format!("{:x}", hasher.finalize())
 }
 
@@ -53,7 +75,7 @@ impl PgDb {
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
 
-        let hash = content_hash(&input.text_content);
+        let hash = content_hash(&input.text_content, input.metadata_json.as_deref());
 
         // Check for recent duplicate (30-second window)
         let dup = qontinui_db::queries::activity_timeline::find_recent_duplicate()
@@ -303,18 +325,28 @@ impl PgDb {
     }
 
     /// Return every `scripted_output` activity-timeline row's event name
-    /// (`text_content`) and `metadata_json`, optionally scoped to a single
-    /// `task_run_id`. Returns tuples `(text_content, metadata_json)` with
-    /// `metadata_json` as an optional JSON string.
+    /// (`text_content`), `metadata_json`, and `duplicate_count`, optionally
+    /// scoped to a single `task_run_id`. Returns tuples
+    /// `(text_content, metadata_json, occurrence_count)` where
+    /// `occurrence_count = 1 + duplicate_count` represents how many times the
+    /// row's event was emitted (one original + N suppressed dupes).
+    ///
+    /// `occurrence_count` is critical because [`insert_activity_entry`]
+    /// content-hash-dedups entries within a 30-s window: two identical
+    /// `(text, metadata)` events arrive as one row with `duplicate_count = 1`,
+    /// not as two separate rows. The aggregator must multiply per-row signals
+    /// by `occurrence_count` to recover accurate counts; otherwise rapid
+    /// emit calls with identical metadata (e.g. several
+    /// `scripted_output.llm_ok` events from the warm provider's cache-read
+    /// path) silently under-report.
     ///
     /// Used by the LLM-analytics scripted-output widget to aggregate per-run
-    /// counters. The query is a single indexed scan on `source_type`; the
-    /// caller aggregates in memory so we don't have to codegen a bespoke
-    /// clorinde query for a one-off dashboard surface.
+    /// counters. Single indexed scan on `source_type`; the caller aggregates
+    /// in memory.
     pub async fn get_scripted_output_rows(
         &self,
         task_run_id: Option<&str>,
-    ) -> Result<Vec<(String, Option<String>)>, String> {
+    ) -> Result<Vec<(String, Option<String>, u64)>, String> {
         let conn = self
             .pool
             .get()
@@ -323,7 +355,7 @@ impl PgDb {
 
         let rows = if let Some(tr) = task_run_id {
             conn.query(
-                "SELECT text_content, metadata_json \
+                "SELECT text_content, metadata_json, duplicate_count \
                  FROM activity_timeline \
                  WHERE source_type = 'scripted_output' \
                    AND NOT is_deleted \
@@ -334,7 +366,7 @@ impl PgDb {
             .map_err(|e| format!("PG get_scripted_output_rows(task_run): {}", e))?
         } else {
             conn.query(
-                "SELECT text_content, metadata_json \
+                "SELECT text_content, metadata_json, duplicate_count \
                  FROM activity_timeline \
                  WHERE source_type = 'scripted_output' \
                    AND NOT is_deleted",
@@ -349,7 +381,12 @@ impl PgDb {
             .map(|row| {
                 let text: String = row.get(0);
                 let meta: Option<String> = row.get(1);
-                (text, meta)
+                let dup: i32 = row.get(2);
+                // occurrence_count = 1 (the original) + N suppressed dupes.
+                // Saturate at i32::MAX cast — a row representing >2B emits
+                // is implausible but we don't want to panic on overflow.
+                let occurrences = 1u64.saturating_add(dup.max(0) as u64);
+                (text, meta, occurrences)
             })
             .collect())
     }
@@ -377,22 +414,82 @@ mod tests {
 
     #[test]
     fn test_content_hash_deterministic() {
-        let h1 = content_hash("Hello world");
-        let h2 = content_hash("Hello world");
+        let h1 = content_hash("Hello world", None);
+        let h2 = content_hash("Hello world", None);
         assert_eq!(h1, h2);
     }
 
     #[test]
     fn test_content_hash_normalized() {
-        let h1 = content_hash("  Hello World  ");
-        let h2 = content_hash("hello world");
+        let h1 = content_hash("  Hello World  ", None);
+        let h2 = content_hash("hello world", None);
         assert_eq!(h1, h2);
     }
 
     #[test]
     fn test_content_hash_different() {
-        let h1 = content_hash("Hello");
-        let h2 = content_hash("World");
+        let h1 = content_hash("Hello", None);
+        let h2 = content_hash("World", None);
         assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn test_content_hash_metadata_distinguishes_same_text() {
+        // The bug this fixes: three rapid `scripted_output.llm_ok` events
+        // share text_content but carry distinct cache_read_tokens in
+        // metadata_json. Pre-fix they collided on the 30-s dedup and
+        // calls 2..N were silently coalesced; post-fix they produce
+        // distinct hashes.
+        let text = "scripted_output.llm_ok";
+        let h_creation = content_hash(
+            text,
+            Some(r#"{"cache_creation_tokens":6697,"cache_read_tokens":0}"#),
+        );
+        let h_read = content_hash(
+            text,
+            Some(r#"{"cache_creation_tokens":0,"cache_read_tokens":6697}"#),
+        );
+        assert_ne!(
+            h_creation, h_read,
+            "events with same text but different metadata must NOT dedup"
+        );
+    }
+
+    #[test]
+    fn test_content_hash_identical_metadata_still_dedups() {
+        // Truly identical re-emits (same text, same metadata) still
+        // collapse — preserves the original 30-s screenshot-dedup intent.
+        let h1 = content_hash("scripted_output.cache_hit", Some(r#"{"tier":1}"#));
+        let h2 = content_hash("scripted_output.cache_hit", Some(r#"{"tier":1}"#));
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_content_hash_none_metadata_preserves_screenshot_dedup() {
+        // BackgroundObserver and the Python bridge both pass
+        // metadata_json: None — two identical text captures within 30 s
+        // must still produce the same hash so they dedup.
+        let h1 = content_hash("captured screen text", None);
+        let h2 = content_hash("captured screen text", None);
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn test_content_hash_none_vs_empty_metadata_are_equivalent() {
+        // None and Some("") both represent "no metadata"; they must hash
+        // identically so a caller migrating from one to the other
+        // doesn't accidentally suppress dedup.
+        let h_none = content_hash("event", None);
+        let h_empty = content_hash("event", Some(""));
+        assert_eq!(h_none, h_empty);
+    }
+
+    #[test]
+    fn test_content_hash_separator_prevents_field_smushing() {
+        // Without a delimiter, ("ab", None) and ("a", Some("b"))
+        // could collide. The "\0meta:" separator prevents that.
+        let h_smushed = content_hash("ab", None);
+        let h_split = content_hash("a", Some("b"));
+        assert_ne!(h_smushed, h_split);
     }
 }

--- a/src-tauri/src/step_output/script_emitter.rs
+++ b/src-tauri/src/step_output/script_emitter.rs
@@ -144,15 +144,59 @@ pub enum EmitError {
     /// The shared Claude API circuit breaker is Open.
     #[error("LLM circuit breaker is open")]
     BreakerOpen,
-    /// The global kill switch (env var or settings flag) is off.
-    #[error("scripted output path is disabled")]
-    Disabled,
+    /// The emitter cannot run for one of three reasons. Split out from a
+    /// single opaque `Disabled` so testing agents (and the panel) can
+    /// distinguish "feature off via env" from "feature off via settings"
+    /// from "Auto path tried every credential lane and found nothing
+    /// usable" — those have different remediations.
+    #[error("scripted output path is disabled: {reason}")]
+    Disabled {
+        /// Stable machine token; mirrored verbatim into the
+        /// `EmitExtractionScriptError.kind` wire field.
+        reason: DisabledReason,
+    },
     /// LLM returned an error response (network, auth, etc.).
     #[error("LLM error: {0}")]
     LlmError(String),
     /// LLM response didn't include a usable `expression` field.
     #[error("invalid LLM response: {0}")]
     InvalidResponse(String),
+}
+
+/// The specific reason an emitter call returned `EmitError::Disabled`.
+///
+/// `Display` gives the human-readable form (used in `error.message`);
+/// the serialized lowercase tag is the stable machine discriminator
+/// surfaced as `EmitExtractionScriptError.kind`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DisabledReason {
+    /// `QONTINUI_SCRIPTED_OUTPUT` env var is not `"1"`. Set the env var
+    /// at process spawn (e.g. `extra_env` on the supervisor's
+    /// `POST /runners/spawn-test`) and respawn — env vars are not
+    /// hot-reloadable.
+    EnvKillSwitch,
+    /// `scripted_output.enabled` setting is `false`. Flip it on via
+    /// Settings UI / `set_setting` Tauri command — no respawn needed.
+    SettingsFlag,
+    /// `Auto` provider mode tried every credential lane (warm Claude,
+    /// Gemma local) and found none usable. Provision an
+    /// `ANTHROPIC_API_KEY`, log into the Claude CLI to populate
+    /// `.credentials.json`, or start a local llama.cpp Gemma server.
+    NoCredentials,
+}
+
+impl std::fmt::Display for DisabledReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            DisabledReason::EnvKillSwitch => "env kill switch QONTINUI_SCRIPTED_OUTPUT is not '1'",
+            DisabledReason::SettingsFlag => "scripted_output.enabled setting is false",
+            DisabledReason::NoCredentials => {
+                "no Claude credential or Gemma local endpoint available on the Auto cascade"
+            }
+        };
+        f.write_str(s)
+    }
 }
 
 // ============================================================================
@@ -211,12 +255,16 @@ pub async fn emit_extraction_script(
     if !env_kill_switch_on() {
         debug!("scripted-output emitter disabled via env kill switch");
         emit_fallback_event(&task_run_id, "disabled");
-        return Err(EmitError::Disabled);
+        return Err(EmitError::Disabled {
+            reason: DisabledReason::EnvKillSwitch,
+        });
     }
     if !settings_flag_on() {
         debug!("scripted-output emitter disabled via settings flag");
         emit_fallback_event(&task_run_id, "disabled");
-        return Err(EmitError::Disabled);
+        return Err(EmitError::Disabled {
+            reason: DisabledReason::SettingsFlag,
+        });
     }
 
     // -------------------------------------------------------- 2. Tier 1 cache
@@ -363,7 +411,9 @@ pub async fn emit_extraction_script(
                         }
                     );
                     emit_fallback_event(&task_run_id, "disabled");
-                    return Err(EmitError::Disabled);
+                    return Err(EmitError::Disabled {
+                        reason: DisabledReason::NoCredentials,
+                    });
                 }
                 ScriptedOutputProviderMode::ClaudeApiWarm => {
                     warn!(

--- a/src-tauri/src/step_output/script_emitter.rs
+++ b/src-tauri/src/step_output/script_emitter.rs
@@ -797,30 +797,38 @@ fn response_schema() -> serde_json::Value {
 /// Compose the prompt as a `(system_prefix, user_message)` pair.
 ///
 /// The `system_prefix` is stable across emit calls and is deliberately
-/// fattened with worked examples so it crosses Anthropic's Haiku caching
-/// minimum. Haiku 3.x accepted ~1024 tokens (~4000 chars); Haiku 4.x
-/// raised the floor to ~2048 tokens (~8000 chars). Below that threshold
-/// `cache_control: ephemeral` is silently ignored and the warm provider
-/// pays the uncached rate on every call — confirmed empirically against
-/// `claude-haiku-4-5-20251001` on 2026-04-22 (cache_marker=true but
-/// `cache_read_input_tokens=0` on repeat calls).
+/// fattened with worked examples so it crosses Anthropic's per-model
+/// caching minimum on the warm emitter's pinned model (Haiku 4.x by
+/// default — see [`DEFAULT_MODEL`]). Per Anthropic's published table
+/// (<https://docs.claude.com/en/docs/build-with-claude/prompt-caching>),
+/// the per-model floors are: Sonnet/Opus 1024 tokens (~4096 chars),
+/// Haiku 3.x 2048 tokens (~8192 chars), Haiku 4.x 4096 tokens
+/// (~16384 chars). Below the floor, `cache_control: ephemeral` is
+/// silently ignored and the warm provider pays the uncached rate on
+/// every call — the threshold check itself lives in
+/// [`crate::ai_provider::cache_aware_builder::min_cacheable_chars`],
+/// and the test below pins the prefix length to that function so the
+/// prompt and the threshold can't drift apart.
 ///
 /// The `user_message` carries the per-call dynamic payload — goal,
 /// schema hint, output preview — which changes every call and must not
 /// be part of the cached prefix.
 ///
-/// **Versioning.** The trailing `Emitter system v2` line makes intentional
+/// **Versioning.** The trailing `Emitter system v3` line makes intentional
 /// preamble bumps invalidate the cache cleanly (distinct bytes → distinct
-/// cache key) instead of waiting for the 5-minute TTL.
+/// cache key) instead of waiting for the 5-minute TTL. v3 was the
+/// fattening pass that crossed Haiku 4.5's 16384-char floor.
 fn build_prompt_split(
     goal: &str,
     schema_hint: &serde_json::Value,
     output_preview: &str,
 ) -> (String, String) {
-    // The stable prefix. Fattened with 13 worked examples to cross the
-    // ~2048-token (~8000 char) Haiku 4.x caching minimum with margin.
-    // Counted once at write time and asserted in tests — don't shrink
-    // without rechecking the bound against current Haiku cache telemetry.
+    // The stable prefix. Fattened with 27 worked examples to cross
+    // Haiku 4.x's 16384-char (~4096-token) caching minimum with margin.
+    // Counted once at write time and asserted in `tests::
+    // build_prompt_split_meets_cache_threshold` against
+    // `min_cacheable_chars(DEFAULT_MODEL)` — don't shrink without
+    // rechecking that the bound still passes for the pinned model.
     let system_prefix = concat!(
         "You synthesize a single-line JavaScript expression that, given a ",
         "variable `output` (a string containing the raw stdout of a shell/step ",
@@ -911,6 +919,76 @@ fn build_prompt_split(
         "schemaHint: {\"keys\": {\"error_ips\": \"string[]\", \"error_ip_count\": \"number\"}}\n",
         "outputPreview: \"10.0.0.12 - - [21/Apr/2026:09:02:10] \\\"GET /api/a HTTP/1.1\\\" 200 1244\\n10.0.0.55 - - [21/Apr/2026:09:02:11] \\\"GET /api/b HTTP/1.1\\\" 502 41\\n10.0.0.12 - - [21/Apr/2026:09:02:13] \\\"GET /api/c HTTP/1.1\\\" 503 44\\n10.0.0.91 - - [21/Apr/2026:09:02:14] \\\"GET /api/d HTTP/1.1\\\" 200 1200\\n10.0.0.55 - - [21/Apr/2026:09:02:15] \\\"GET /api/b HTTP/1.1\\\" 500 47\\n\"\n",
         "expression: (((ips) => ({error_ips: ips, error_ip_count: ips.length}))(Array.from(new Set(output.split(/\\r?\\n/).filter(l => /\"\\s+5\\d{2}\\s/.test(l)).map(l => (l.match(/^(\\d+\\.\\d+\\.\\d+\\.\\d+)/) || [])[1]).filter(Boolean))).slice(0, 50)))\n\n",
+        "### Example 14 — extract sha256 hashes from a checksum file\n",
+        "goal: collect every sha256 digest, paired with its filename\n",
+        "schemaHint: {\"keys\": {\"sums\": \"Array<{file: string, sha256: string}>\"}}\n",
+        "outputPreview: \"5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8  README.md\\n2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae  build.sh\\n# blank lines and comments are tolerated\\n\\n9b71d224bd62f3785d96d46ad3ea3d73319bfbc2890caadae2dff72519673ca7  dist/index.js\\n\"\n",
+        "expression: ({sums: output.split(/\\r?\\n/).map(l => l.match(/^([0-9a-f]{64})\\s+(.+)$/i)).filter(Boolean).map(m => ({file: m[2].trim(), sha256: m[1].toLowerCase()})).slice(0, 50)})\n\n",
+        "### Example 15 — CSV second-column values\n",
+        "goal: list every value in the `email` column from a CSV (header row first)\n",
+        "schemaHint: {\"keys\": {\"emails\": \"string[]\"}}\n",
+        "outputPreview: \"id,email,role\\n12,alice@example.com,admin\\n47,bob@example.com,member\\n91,carol@example.com,member\\n\"\n",
+        "expression: (((rows, hdr) => ({emails: (() => { const i = hdr.indexOf('email'); return i < 0 ? [] : rows.slice(1).map(r => (r.split(',')[i] || '').trim()).filter(Boolean).slice(0, 50); })()}))((output.split(/\\r?\\n/).filter(Boolean)), ((output.split(/\\r?\\n/)[0] || '').split(',').map(s => s.trim()))))\n\n",
+        "### Example 16 — total size from `du -sh *`\n",
+        "goal: sum the human-readable sizes (assume MB only) into a single number\n",
+        "schemaHint: {\"keys\": {\"total_mb\": \"number\"}}\n",
+        "outputPreview: \"12M\\tdist\\n4.2M\\tnode_modules\\n  812K\\tsrc\\n0\\ttmp\\n98M\\ttarget\\n\"\n",
+        "expression: ({total_mb: Number(output.split(/\\r?\\n/).map(l => l.trim().match(/^([\\d.]+)([KMG]?)/)).filter(Boolean).reduce((acc, m) => acc + (Number(m[1]) * (m[2] === 'G' ? 1024 : m[2] === 'K' ? 1/1024 : m[2] === 'M' ? 1 : 0)), 0).toFixed(2))})\n\n",
+        "### Example 17 — last N lines of output (tail emulation)\n",
+        "goal: return the last 5 non-empty lines as an array, oldest first\n",
+        "schemaHint: {\"keys\": {\"tail\": \"string[]\"}}\n",
+        "outputPreview: \"line a\\nline b\\nline c\\n\\nline d\\nline e\\nline f\\nline g\\nline h\\n\"\n",
+        "expression: ({tail: output.split(/\\r?\\n/).filter(l => l.length > 0).slice(-5)})\n\n",
+        "### Example 18 — strip ANSI color codes\n",
+        "goal: return the raw output with all ANSI escape sequences removed\n",
+        "schemaHint: {\"keys\": {\"plain\": \"string\"}}\n",
+        "outputPreview: \"\\u001b[32mPASS\\u001b[0m tests/api.test.ts\\n\\u001b[31mFAIL\\u001b[0m tests/db.test.ts\\n\"\n",
+        "expression: ({plain: output.replace(/\\u001b\\[[0-9;]*[A-Za-z]/g, '').slice(0, 4000)})\n\n",
+        "### Example 19 — service health from `systemctl status`\n",
+        "goal: report whether the Active line says `active (running)` and the loaded unit path\n",
+        "schemaHint: {\"keys\": {\"active\": \"boolean\", \"unit_path\": \"string\"}}\n",
+        "outputPreview: \"\\u25cf nginx.service - A high performance web server\\n     Loaded: loaded (/lib/systemd/system/nginx.service; enabled; preset: enabled)\\n     Active: active (running) since Mon 2026-04-21 09:00:11 UTC; 2h ago\\n\"\n",
+        "expression: ({active: /\\bActive:\\s*active\\s*\\(running\\)/i.test(output), unit_path: (((output.match(/Loaded:\\s+loaded\\s*\\(([^;]+);/) || [])[1]) || '').trim()})\n\n",
+        "### Example 20 — memory %used from `free -m`\n",
+        "goal: compute used / total memory as a 0-100 integer percent\n",
+        "schemaHint: {\"keys\": {\"used_pct\": \"number\"}}\n",
+        "outputPreview: \"               total        used        free      shared  buff/cache   available\\nMem:           15891        9234        1102         210        5555        6201\\nSwap:           2047           0        2047\\n\"\n",
+        "expression: ({used_pct: (((m) => m && m[2] && m[1] ? Math.round((Number(m[2]) / Number(m[1])) * 100) : 0))(output.split(/\\r?\\n/).find(l => /^Mem:/.test(l))?.match(/^Mem:\\s+(\\d+)\\s+(\\d+)/) || null)})\n\n",
+        "### Example 21 — sum a numeric column\n",
+        "goal: sum the third whitespace-delimited column across all data rows (skip header)\n",
+        "schemaHint: {\"keys\": {\"total\": \"number\"}}\n",
+        "outputPreview: \"name        kind   bytes\\nalpha       file   1024\\nbeta        file    512\\ngamma       dir       0\\ndelta       file   2048\\n\"\n",
+        "expression: ({total: output.split(/\\r?\\n/).slice(1).map(l => Number((l.trim().split(/\\s+/)[2] || '0'))).filter(n => Number.isFinite(n)).reduce((a, b) => a + b, 0)})\n\n",
+        "### Example 22 — top-3 most frequent log levels\n",
+        "goal: count occurrences of each log level and return the top 3 levels by count\n",
+        "schemaHint: {\"keys\": {\"top\": \"Array<{level: string, count: number}>\"}}\n",
+        "outputPreview: \"2026-04-21 INFO  ready\\n2026-04-21 WARN  slow\\n2026-04-21 INFO  ok\\n2026-04-21 ERROR fail\\n2026-04-21 INFO  ok\\n2026-04-21 WARN  slow\\n2026-04-21 INFO  ok\\n2026-04-21 DEBUG trace\\n\"\n",
+        "expression: ({top: Object.entries(output.split(/\\r?\\n/).map(l => (l.match(/\\b(DEBUG|INFO|WARN|ERROR|FATAL)\\b/) || [])[1]).filter(Boolean).reduce((acc, lvl) => { acc[lvl] = (acc[lvl] || 0) + 1; return acc; }, {})).map(([level, count]) => ({level, count})).sort((a, b) => b.count - a.count).slice(0, 3)})\n\n",
+        "### Example 23 — first ISO-8601 timestamp\n",
+        "goal: return the first ISO-8601 timestamp in the output (with or without timezone)\n",
+        "schemaHint: {\"keys\": {\"timestamp\": \"string\"}}\n",
+        "outputPreview: \"started job at 2026-04-21T09:02:10.451Z (took 1.2s)\\nfinished at 2026-04-21T09:02:11.701+00:00\\n\"\n",
+        "expression: ({timestamp: ((output.match(/\\b(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:?\\d{2})?)\\b/) || [])[1]) || ''})\n\n",
+        "### Example 24 — strip a fixed prefix from each line\n",
+        "goal: return every line with the leading `[runner] ` prefix removed (preserve other lines verbatim)\n",
+        "schemaHint: {\"keys\": {\"lines\": \"string[]\"}}\n",
+        "outputPreview: \"[runner] booting\\n[runner] connected\\n[supervisor] ok\\n[runner] ready\\n\"\n",
+        "expression: ({lines: output.split(/\\r?\\n/).filter(Boolean).map(l => l.startsWith('[runner] ') ? l.slice(9) : l).slice(0, 50)})\n\n",
+        "### Example 25 — tar listing (file paths only, no metadata)\n",
+        "goal: list the file paths from `tar -tvf` output (skip directories ending in `/`)\n",
+        "schemaHint: {\"keys\": {\"paths\": \"string[]\"}}\n",
+        "outputPreview: \"-rw-r--r-- jq/jq        1024 2026-04-21 09:00 dist/index.js\\ndrwxr-xr-x jq/jq           0 2026-04-21 09:00 dist/\\n-rw-r--r-- jq/jq         512 2026-04-21 09:00 dist/style.css\\n\"\n",
+        "expression: ({paths: output.split(/\\r?\\n/).filter(l => l.startsWith('-')).map(l => l.trim().split(/\\s+/).slice(5).join(' ')).filter(p => p && !p.endsWith('/')).slice(0, 50)})\n\n",
+        "### Example 26 — SQL EXPLAIN total cost\n",
+        "goal: extract the topmost `cost=...rows=...` totals from a Postgres EXPLAIN block\n",
+        "schemaHint: {\"keys\": {\"cost\": \"number\", \"rows\": \"number\"}}\n",
+        "outputPreview: \"Seq Scan on big_table  (cost=0.00..38421.50 rows=120000 width=64)\\n  Filter: (created_at > now() - '7 days'::interval)\\n\"\n",
+        "expression: ({cost: Number(((output.match(/cost=[\\d.]+\\.\\.([\\d.]+)\\s+rows=/) || [])[1]) || 0), rows: Number(((output.match(/cost=[^\\s]+\\s+rows=(\\d+)/) || [])[1]) || 0)})\n\n",
+        "### Example 27 — listening ports from `ss -tlnp`\n",
+        "goal: collect every TCP port the host is listening on, deduped and sorted ascending\n",
+        "schemaHint: {\"keys\": {\"ports\": \"number[]\"}}\n",
+        "outputPreview: \"State    Recv-Q Send-Q  Local Address:Port    Peer Address:Port\\nLISTEN   0      128            0.0.0.0:22             0.0.0.0:*\\nLISTEN   0      128                  *:443                  *:*\\nLISTEN   0      128          127.0.0.1:5432           0.0.0.0:*\\nLISTEN   0      128                  *:80                   *:*\\n\"\n",
+        "expression: ({ports: Array.from(new Set(output.split(/\\r?\\n/).slice(1).map(l => Number(((l.match(/[:.](\\d+)\\s+/) || [])[1]) || 0)).filter(n => n > 0))).sort((a, b) => a - b).slice(0, 50)})\n\n",
         "## Response format\n\n",
         "Respond ONLY with a single JSON object matching {\"expression\": \"<js>\"} via the supplied tool. Do not wrap in prose. Do not emit multiple tool calls. Keep the expression on a single line.\n\n",
         "## Anti-patterns to avoid\n\n",
@@ -918,8 +996,12 @@ fn build_prompt_split(
         "- Do not use `eval`, `Function`, or dynamic code construction — the sandbox disallows them.\n",
         "- Do not access globals like `process`, `require`, `fetch`, `window`, `document` — they are not in scope.\n",
         "- Do not assume the preview is the full `output` at runtime — `output` may be longer.\n",
-        "- Do not rely on regex flags other than `g`, `i`, `m`, `s`, `u` — other flags are not guaranteed.\n\n",
-        "Emitter system v2"
+        "- Do not rely on regex flags other than `g`, `i`, `m`, `s`, `u` — other flags are not guaranteed.\n",
+        "- Do not return `undefined` or `null` for missing fields when the schema asks for a string — use `''`. Same for arrays — return `[]`, not `undefined`.\n",
+        "- Do not call `String.prototype.matchAll` without spreading the result — the sandbox returns an iterator that won't auto-serialise. Use `Array.from(s.matchAll(...))` if you need every match.\n",
+        "- Do not assume any specific locale for number parsing — `Number('1,234')` is `NaN`. Strip non-digits first if the source uses thousands separators.\n",
+        "- Do not call `output.match` then index without `||`-fallback — if the regex misses, `match` returns `null` and any `[1]` access throws.\n\n",
+        "Emitter system v3"
     );
 
     let user_message = format!(
@@ -1267,34 +1349,39 @@ mod tests {
     fn build_prompt_split_meets_cache_threshold() {
         let hint = serde_json::json!({"keys": {"a": "string"}});
         let (system_prefix, _user) = build_prompt_split("some goal", &hint, "some preview");
-        // Plan decision 4: the system_prefix must cross Anthropic's
-        // Haiku caching minimum or `cache_control: ephemeral` is a no-op.
-        // Haiku 3.x was ~1024 tokens (~4000 chars); Haiku 4.x raised the
-        // floor to ~2048 tokens (~8000 chars) — confirmed against
-        // `claude-haiku-4-5-20251001` on 2026-04-22 where a 5943-char
-        // prefix produced `cache_read_input_tokens=0` on repeat calls.
-        // If a future Haiku revision raises the minimum again and real
-        // telemetry shows a zero cache_read rate, bump examples further
-        // and update this bound.
+        // Decision 4 / Option A: the system_prefix must cross Anthropic's
+        // per-model caching minimum (per <https://docs.claude.com/en/docs/
+        // build-with-claude/prompt-caching>) for the model the warm
+        // emitter pins to, or `cache_control: ephemeral` is silently
+        // ignored and the warm provider pays the uncached rate every call.
+        //
+        // Pin the assertion to `min_cacheable_chars(DEFAULT_MODEL)` so the
+        // prefix length and the threshold check stay in sync — if anyone
+        // changes DEFAULT_MODEL to a family with a different floor, this
+        // test catches it without needing a manual edit.
+        let threshold = crate::ai_provider::cache_aware_builder::min_cacheable_chars(DEFAULT_MODEL);
         assert!(
-            system_prefix.len() >= 8000,
-            "system_prefix length {} is under the 8000-char Haiku 4.x cache threshold",
-            system_prefix.len()
+            system_prefix.len() >= threshold,
+            "system_prefix length {} is under the {}-char cache threshold for DEFAULT_MODEL={:?}",
+            system_prefix.len(),
+            threshold,
+            DEFAULT_MODEL
         );
     }
 
     #[test]
     fn build_prompt_split_contains_version_suffix() {
         let (system_prefix, _user) = build_prompt_split("g", &serde_json::json!({}), "p");
-        // The trailing `Emitter system v2` marker lets intentional
+        // The trailing `Emitter system v3` marker lets intentional
         // preamble bumps invalidate the cache cleanly instead of
-        // waiting for the 5-minute TTL.
+        // waiting for the 5-minute TTL. v3 = the fattening pass that
+        // crossed Haiku 4.5's 16384-char floor.
         assert!(
-            system_prefix.trim_end().ends_with("Emitter system v2"),
+            system_prefix.trim_end().ends_with("Emitter system v3"),
             "system_prefix should end with the version suffix; got tail: {:?}",
             &system_prefix[system_prefix.len().saturating_sub(64)..]
         );
-        assert!(system_prefix.contains("Emitter system v2"));
+        assert!(system_prefix.contains("Emitter system v3"));
     }
 
     #[test]

--- a/src/components/llm-observability/ScriptedOutputPanel.tsx
+++ b/src/components/llm-observability/ScriptedOutputPanel.tsx
@@ -199,6 +199,22 @@ export function ScriptedOutputPanel({ taskRunId }: ScriptedOutputPanelProps) {
               subtitle={`${stats.llmOk.toLocaleString()} calls`}
             />
             <MetricCard
+              title="Tier 1 miss rate"
+              value={
+                workerCalls > 0
+                  ? formatRate(stats.llmOk, workerCalls)
+                  : "—"
+              }
+              subtitle={
+                workerCalls === 0
+                  ? "no completed emits yet"
+                  : "llm_ok / (cache_hit + llm_ok)"
+              }
+              variant={
+                workerCalls > 0 && stats.llmOk / workerCalls >= 0.4 ? "warning" : "default"
+              }
+            />
+            <MetricCard
               title="Worker-OK rate"
               value={workerCalls > 0 ? formatRate(stats.workerOk, workerCalls) : "—"}
               subtitle={


### PR DESCRIPTION
## Summary

Four commits closing out the open items from the 2026-05-10 vet pass on `plans/warm-emitter-provider-2026-04-21.md`. All scoped to the scripted-output / warm-emitter subsystem and live-verified end-to-end on a temp runner against `claude-haiku-4-5-20251001`.

### 1. `fix(ai-provider): warm emitter prefix was below Haiku 4.5's cache floor`

Anthropic's Haiku 4.5 minimum cacheable block is 4096 tokens (~16384 chars); the warm emitter's ~8000-char `system_prefix` was below it, so `cache_control` was silently ignored.

- New `pub(crate) fn min_cacheable_chars(model)` in `cache_aware_builder.rs`: Haiku 4.x → 16384, Haiku 3.x → 8192, else → 4096. Threaded through `add_cached_system_block`, `merge_small_blocks`, and the warm provider's `build_system_array` (both call sites).
- `build_prompt_split` fattened to **16431 chars** with 27 worked examples covering common qontinui-relevant stdout patterns.
- Version suffix bumped `Emitter system v2 → v3` for clean cache invalidation.
- `meets_cache_threshold` test pinned to `min_cacheable_chars(DEFAULT_MODEL)` so retargeting the default model auto-validates the prompt size.

### 2. `fix(activity-timeline): metadata-aware dedup + occurrences in stats`

`get_scripted_output_stats` was under-reporting by 60-90% on rapid-fire emit telemetry — root-caused to two layers:

1. `insert_activity_entry`'s `content_hash` hashed `text_content` only. The 30-s dedup collapsed events with the same name regardless of metadata — three rapid `scripted_output.llm_ok` events with distinct cache_read_tokens collapsed into one row keyed to the first call's metadata.
2. `get_scripted_output_stats` summed signals one-per-row and ignored `duplicate_count` even when dedup recorded N occurrences.

- `content_hash` now takes `(text, metadata_json)`. Screenshot-style callers (BackgroundObserver, Python bridge) pass `metadata_json: None` and keep their original dedup behavior; event-stream callers with distinct metadata get distinct hashes. 5 new unit tests.
- `get_scripted_output_rows` returns `(text, metadata_json, occurrences)` where `occurrences = 1 + duplicate_count`.
- `get_scripted_output_stats` multiplies per-row counters and signals by `occurrences` (saturating).

### 3. `feat(scripted-output): split EmitError::Disabled into 3 reasons + Tier 1 miss-rate tile`

`EmitError::Disabled` was opaque — manual-test agents couldn't tell which gate was closed (env kill switch / settings flag / Auto cascade with no credentials). Phase D's gate condition (≥40% Tier 1 miss rate sustained for a week) wasn't visible on the panel either.

- New `DisabledReason` enum (`EnvKillSwitch` / `SettingsFlag` / `NoCredentials`) payloaded onto `EmitError::Disabled`.
- The Tauri wrapper maps each variant to a stable wire-level `kind`: `disabled_env` / `disabled_settings` / `disabled_no_credentials`.
- `ScriptedOutputPanel` adds a "Tier 1 miss rate" tile, value = `llm_ok / (cache_hit + llm_ok)`, warning variant at ≥40 %.

### 4. `chore(deps): bump qontinui-types lock entry 0.1.2 → 0.1.3`

Cargo.lock-only sync. The local `qontinui-schemas/rust/Cargo.toml` is at 0.1.3; without this commit, every cargo run on a clone of `main` regenerates Cargo.lock during the pre-push hook and fails the "no auto-fixes" check. No source changes.

## Live verification

Manual-test on a fresh temp runner (`rebuild: true` + `extra_env: {QONTINUI_SCRIPTED_OUTPUT: "1"}`):

| Behavior | Result |
|---|---|
| Anthropic prompt-cache fires on Haiku 4.5 | ✅ call 1 cache_creation=6697; calls 2-3 cache_read=6697 (~6.2× input savings) |
| Per-call latency | ✅ 1075–1277 ms (under <2s p95 target) |
| Activity-timeline aggregator captures all events under rapid-fire | ✅ 3 emits → llm_ok +3, cache_read +20091 (= 3 × 6697); pre-fix showed +1 |

## Test plan

- [x] `cargo test --bin qontinui-runner cache_aware_builder` → 13/13 pass (incl. new `test_min_cacheable_chars_per_model` + `test_haiku_4_blocks_below_floor_are_uncached`)
- [x] `cargo test --bin qontinui-runner script_emitter` → 17/17 pass
- [x] `cargo test --bin qontinui-runner activity_timeline` → 8/8 pass (incl. 5 new metadata-aware hash tests)
- [x] `cargo test --bin qontinui-runner ai_provider` → 126/126 pass
- [x] `npx tsc --noEmit` → clean (panel tile typechecks)
- [x] Live cache-firing verified on temp runner against `claude-haiku-4-5-20251001`
- [x] Pre-push hook (cargo fmt + clippy) → passed