### PR TITLE
runner: filter transcript_get_latest by sinceMs + ms-precision mtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5828,6 +5828,7 @@ dependencies = [
  "deadpool-postgres",
  "dirs 6.0.0",
  "erased-serde",
+ "filetime",
  "flate2",
  "futures",
  "futures-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -269,6 +269,9 @@ regex_creation_in_loops = "allow"
 [dev-dependencies]
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }
+# Deterministic mtime control for tests (e.g. transcript::get_latest_session_id
+# `since` filter coverage). Cross-platform; on Windows wraps SetFileTime.
+filetime = "0.2"
 
 ## Profile overrides moved to the workspace root Cargo.toml — cargo
 ## ignores [profile.*] in package manifests when a workspace exists.

--- a/src-tauri/src/commands/transcript.rs
+++ b/src-tauri/src/commands/transcript.rs
@@ -182,10 +182,18 @@ pub async fn transcript_read_session(
 /// account — without it, a more-recently-touched JSONL in a *different*
 /// account for the same `project_path` would shadow the session we
 /// actually want.
+///
+/// `since_ms` (epoch milliseconds, matches `Date.now()` on the JS side as
+/// camelCase `sinceMs`) filters out sessions whose `last_modified` is at
+/// or before the supplied threshold. This lets the frontend lift its
+/// freshness check into the backend so the `.claude.json` shortcut and
+/// mtime fallback are filtered consistently — see Phase 1 of
+/// `plans/traffic-light-session-id-followups.md`.
 #[tauri::command]
 pub async fn transcript_get_latest(
     project_path: Option<String>,
     config_dir: Option<String>,
+    since_ms: Option<i64>,
 ) -> Result<CommandResponse, String> {
     let project = project_path.unwrap_or_else(|| {
         crate::mcp::shared::get_workspace_paths_internal()
@@ -200,9 +208,14 @@ pub async fn transcript_get_latest(
         transcript::find_claude_config_dirs()
     };
 
+    // Convert the epoch-millis threshold to a UTC timestamp for the backend
+    // helper. `from_timestamp_millis` returns `None` for out-of-range
+    // values; in that case we behave as if no filter was supplied.
+    let since = since_ms.and_then(chrono::DateTime::<chrono::Utc>::from_timestamp_millis);
+
     // Try each config dir, return first match
     for dir in &config_dirs {
-        if let Some(session) = transcript::get_latest_session_id(dir, &project) {
+        if let Some(session) = transcript::get_latest_session_id(dir, &project, since) {
             return Ok(CommandResponse {
                 success: true,
                 message: Some(format!("Latest session: {}", session.session_id)),

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -219,8 +219,12 @@ pub fn list_sessions(
         let session_id = stem.to_string();
         let last_modified = mtime
             .map(|t| {
+                // Millisecond precision so `get_latest_session_id`'s `since` filter
+                // can compare against `Date.now()`-derived spawn timestamps without
+                // a second-boundary truncation race that drops fresh sessions whose
+                // mtime falls in the same wall-clock second as the spawn.
                 chrono::DateTime::<chrono::Utc>::from(t)
-                    .format("%Y-%m-%dT%H:%M:%SZ")
+                    .format("%Y-%m-%dT%H:%M:%S%.3fZ")
                     .to_string()
             })
             .unwrap_or_default();
@@ -684,8 +688,42 @@ pub fn extract_text_from_messages(messages: &[TranscriptMessage]) -> String {
     parts.join("\n\n---\n\n")
 }
 
+/// Parse a `last_modified` string back into a `DateTime<Utc>`.
+///
+/// Accepts both RFC 3339 (the format produced by Claude Code's own JSONL
+/// records) and the `"%Y-%m-%dT%H:%M:%SZ"` shape this module emits via
+/// `chrono::DateTime::format`. Returns `None` for unparseable input — the
+/// caller decides whether that is "stale" or "drop".
+fn parse_session_timestamp(s: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .ok()
+        .or_else(|| {
+            // Fallback for the "%Y-%m-%dT%H:%M:%SZ" format used in this module.
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%SZ")
+                .ok()
+                .map(|ndt| {
+                    chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(ndt, chrono::Utc)
+                })
+        })
+}
+
 /// Get the most recent session ID from `.claude.json` or by file modification time.
-pub fn get_latest_session_id(config_dir: &Path, project_path: &str) -> Option<TranscriptSession> {
+///
+/// `since` (optional) filters out sessions whose `last_modified` is at or
+/// before the supplied threshold. Both branches honour the filter:
+///
+/// - The `.claude.json` `lastSessionId` shortcut falls through (instead of
+///   early-returning) when its session's mtime is `<= since`. Records with
+///   unparseable timestamps are also treated as stale so the mtime fallback
+///   can still find a fresher session.
+/// - The mtime-sorted fallback drops sessions whose `last_modified` is `<=
+///   since` (or unparseable when `since` is `Some`).
+pub fn get_latest_session_id(
+    config_dir: &Path,
+    project_path: &str,
+    since: Option<chrono::DateTime<chrono::Utc>>,
+) -> Option<TranscriptSession> {
     // Try reading .claude.json for lastSessionId
     let claude_json = PathBuf::from(project_path).join(".claude.json");
     if let Ok(content) = fs::read_to_string(&claude_json) {
@@ -704,49 +742,82 @@ pub fn get_latest_session_id(config_dir: &Path, project_path: &str) -> Option<Tr
                         .as_ref()
                         .and_then(|m| m.modified().ok())
                         .map(|t| {
+                            // Millisecond precision: see comment in `list_sessions`.
                             chrono::DateTime::<chrono::Utc>::from(t)
-                                .format("%Y-%m-%dT%H:%M:%SZ")
+                                .format("%Y-%m-%dT%H:%M:%S%.3fZ")
                                 .to_string()
                         })
                         .unwrap_or_default();
 
-                    let content = fs::read_to_string(&session_file).unwrap_or_default();
-                    let message_count = content
-                        .lines()
-                        .filter(|l| {
-                            l.contains("\"type\":\"user\"")
-                                || l.contains("\"type\": \"user\"")
-                                || l.contains("\"type\":\"assistant\"")
-                                || l.contains("\"type\": \"assistant\"")
-                        })
-                        .count();
-                    let has_plans = content.contains("\"planContent\"");
-                    let first_message_preview = extract_first_user_preview(&content);
-                    let started_at = extract_first_timestamp(&content);
-                    let display_name =
-                        generate_display_name(&first_message_preview, &last_modified);
+                    // Honour `since`: if the shortcut record is not strictly
+                    // newer than the threshold (or its timestamp is
+                    // unparseable), fall through to the mtime fallback so
+                    // it can find a fresher session. Treating unparseable
+                    // timestamps as "stale enough to fall through" is safer
+                    // than binding the wrong session.
+                    let shortcut_is_stale = match since {
+                        Some(threshold) => match parse_session_timestamp(&last_modified) {
+                            Some(parsed) => parsed <= threshold,
+                            None => true,
+                        },
+                        None => false,
+                    };
 
-                    return Some(TranscriptSession {
-                        session_id: session_id.to_string(),
-                        project_path: project_path.to_string(),
-                        config_dir: config_dir.to_string_lossy().to_string(),
-                        message_count,
-                        last_modified,
-                        started_at,
-                        first_message_preview,
-                        has_plans,
-                        display_name,
-                        // Real on-disk session — no override.
-                        injected_live_status: None,
-                    });
+                    if !shortcut_is_stale {
+                        let content = fs::read_to_string(&session_file).unwrap_or_default();
+                        let message_count = content
+                            .lines()
+                            .filter(|l| {
+                                l.contains("\"type\":\"user\"")
+                                    || l.contains("\"type\": \"user\"")
+                                    || l.contains("\"type\":\"assistant\"")
+                                    || l.contains("\"type\": \"assistant\"")
+                            })
+                            .count();
+                        let has_plans = content.contains("\"planContent\"");
+                        let first_message_preview = extract_first_user_preview(&content);
+                        let started_at = extract_first_timestamp(&content);
+                        let display_name =
+                            generate_display_name(&first_message_preview, &last_modified);
+
+                        return Some(TranscriptSession {
+                            session_id: session_id.to_string(),
+                            project_path: project_path.to_string(),
+                            config_dir: config_dir.to_string_lossy().to_string(),
+                            message_count,
+                            last_modified,
+                            started_at,
+                            first_message_preview,
+                            has_plans,
+                            display_name,
+                            // Real on-disk session — no override.
+                            injected_live_status: None,
+                        });
+                    }
                 }
             }
         }
     }
 
-    // Fallback: return the most recently modified session
+    // Fallback: return the most recently modified session that satisfies
+    // the `since` filter. `list_sessions` already sorts newest-first, so
+    // the first surviving entry is the freshest post-`since` session.
     match list_sessions(config_dir, project_path) {
-        Ok(sessions) if !sessions.is_empty() => Some(sessions[0].clone()),
+        Ok(sessions) => {
+            for session in sessions {
+                if let Some(threshold) = since {
+                    match parse_session_timestamp(&session.last_modified) {
+                        Some(parsed) if parsed > threshold => return Some(session),
+                        // Drop entries that don't parse — better to miss
+                        // than to bind the wrong session.
+                        _ => continue,
+                    }
+                } else {
+                    return Some(session);
+                }
+            }
+            None
+        }
         _ => None,
     }
 }
@@ -857,10 +928,14 @@ fn generate_display_name(first_preview: &Option<String>, last_modified: &str) ->
         }
     }
 
-    // Fallback: date-based name
+    // Fallback: date-based name. Accepts both the legacy second-precision
+    // and the current millisecond-precision (`%.3f`) formats — see the
+    // formatter comment in `list_sessions`.
     if !last_modified.is_empty() {
         let iso = last_modified.trim_end_matches('Z');
-        if let Ok(dt) = chrono::NaiveDateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S") {
+        let parsed = chrono::NaiveDateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S%.3f")
+            .or_else(|_| chrono::NaiveDateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S"));
+        if let Ok(dt) = parsed {
             return format!("Session {}", dt.format("%b %-d, %H:%M"));
         }
     }
@@ -1017,8 +1092,9 @@ pub fn session_digest(
         .ok()
         .and_then(|m| m.modified().ok())
         .map(|t| {
+            // Millisecond precision: see comment in `list_sessions`.
             chrono::DateTime::<chrono::Utc>::from(t)
-                .format("%Y-%m-%dT%H:%M:%SZ")
+                .format("%Y-%m-%dT%H:%M:%S%.3fZ")
                 .to_string()
         })
         .unwrap_or_default();
@@ -1653,5 +1729,162 @@ mod tests {
         assert_eq!(touched[0].tool, ToolKind::Write);
         assert_eq!(touched[0].file_path, "/new/file.rs");
         assert_eq!(touched[0].session_id, "sess-I");
+    }
+
+    // ── get_latest_session_id `since` filter (Phase 1.5) ─────────────────────
+    //
+    // These cover the two new behaviours added by
+    // `plans/traffic-light-session-id-followups.md` Phase 1:
+    // - the mtime-sorted fallback drops sessions whose mtime is `<= since`
+    // - the `.claude.json` shortcut falls through (instead of early-returning)
+    //   when its session's mtime is `<= since`
+
+    /// One JSONL record with a single user message — enough for `list_sessions`
+    /// to consider the session non-empty (`message_count == 1`) and produce a
+    /// real `TranscriptSession`. Workflow-marker free.
+    fn minimal_user_jsonl() -> &'static str {
+        r#"{"type":"user","uuid":"u1","timestamp":"2026-01-01T00:00:00Z","message":{"role":"user","content":"hello"}}"#
+    }
+
+    /// Write a synthetic JSONL session at `<config_dir>/projects/<encoded>/<id>.jsonl`
+    /// and force its mtime via `filetime::set_file_mtime`. Returns the file path.
+    fn write_session_with_mtime(
+        config_dir: &Path,
+        project_path: &str,
+        session_id: &str,
+        mtime: chrono::DateTime<chrono::Utc>,
+    ) -> PathBuf {
+        let encoded = encode_project_path(project_path);
+        let project_dir = config_dir.join("projects").join(&encoded);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let file_path = project_dir.join(format!("{}.jsonl", session_id));
+        std::fs::write(&file_path, minimal_user_jsonl()).unwrap();
+
+        // Preserve sub-second precision — the clock-skew boundary test needs
+        // mtime resolution finer than 1 second.
+        let ft = filetime::FileTime::from_unix_time(
+            mtime.timestamp(),
+            mtime.timestamp_subsec_nanos(),
+        );
+        filetime::set_file_mtime(&file_path, ft).unwrap();
+        file_path
+    }
+
+    /// Clear cached entries that may shadow our fixture mtimes. The shared
+    /// `SESSION_CACHE` is process-wide and other tests in this binary touch
+    /// it; if a stale entry lingers under our tempdir's prefix, `list_sessions`
+    /// can return a cached `TranscriptSession` whose `last_modified` doesn't
+    /// match the freshly-set fixture mtime.
+    fn clear_cache_under(prefix: &Path) {
+        let mut cache = SESSION_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        cache.retain(|p, _| !p.starts_with(prefix));
+    }
+
+    #[test]
+    fn get_latest_session_id_filters_by_since() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path().to_path_buf();
+        // Use a project path that won't have a real .claude.json sitting on
+        // disk — the lookup below would otherwise read the user's actual
+        // workspace `.claude.json` and pick a foreign session.
+        let project_path = temp.path().join("fake_project").to_string_lossy().to_string();
+        std::fs::create_dir_all(temp.path().join("fake_project")).unwrap();
+
+        let before = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let after = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_001_000, 0).unwrap();
+        let since = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_500, 0).unwrap();
+
+        let _ = write_session_with_mtime(&config_dir, &project_path, "old-session", before);
+        let _ = write_session_with_mtime(&config_dir, &project_path, "new-session", after);
+        clear_cache_under(temp.path());
+
+        // No filter → freshest wins.
+        let latest = get_latest_session_id(&config_dir, &project_path, None).unwrap();
+        assert_eq!(latest.session_id, "new-session");
+
+        // Filter excludes old-session, keeps new-session.
+        let filtered = get_latest_session_id(&config_dir, &project_path, Some(since)).unwrap();
+        assert_eq!(filtered.session_id, "new-session");
+
+        // Filter excludes BOTH → None.
+        let strict = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_002_000, 0).unwrap();
+        assert!(get_latest_session_id(&config_dir, &project_path, Some(strict)).is_none());
+    }
+
+    #[test]
+    fn get_latest_session_id_skips_claude_json_when_stale() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path().to_path_buf();
+        let project_dir = temp.path().join("fake_project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let project_path = project_dir.to_string_lossy().to_string();
+
+        let before = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let after = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_001_000, 0).unwrap();
+        let since = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_500, 0).unwrap();
+
+        let _ = write_session_with_mtime(&config_dir, &project_path, "old-session", before);
+        let _ = write_session_with_mtime(&config_dir, &project_path, "new-session", after);
+        clear_cache_under(temp.path());
+
+        // Point .claude.json's lastSessionId at the OLDER (pre-since) session
+        // — this is the shadowing case the plan calls out.
+        let claude_json = project_dir.join(".claude.json");
+        std::fs::write(
+            &claude_json,
+            serde_json::json!({ "lastSessionId": "old-session" }).to_string(),
+        )
+        .unwrap();
+
+        // Without `since` → shortcut wins, returns old-session as-is.
+        let no_filter = get_latest_session_id(&config_dir, &project_path, None).unwrap();
+        assert_eq!(
+            no_filter.session_id, "old-session",
+            "without `since`, .claude.json shortcut should win"
+        );
+
+        // With `since` past old-session's mtime → shortcut falls through,
+        // mtime fallback returns new-session.
+        let filtered =
+            get_latest_session_id(&config_dir, &project_path, Some(since)).unwrap();
+        assert_eq!(
+            filtered.session_id, "new-session",
+            ".claude.json shortcut must NOT shadow a fresher session when stale"
+        );
+    }
+
+    /// Regression: a hook spawn at `t = T.345` (millis) and a Claude write at
+    /// `t = T.789` BOTH truncate to the same wall-clock second `T`. With
+    /// second-precision timestamps, the strict `parsed > since` filter would
+    /// drop the legitimate fresh session. With millisecond-precision
+    /// timestamps the filter accepts it.
+    ///
+    /// Verifies the formatter at `list_sessions` emits `%.3fZ` so that the
+    /// JSONL mtime, parsed back, retains enough precision to win the strict
+    /// `>` comparison against `Date.now()`-derived spawn timestamps.
+    #[test]
+    fn get_latest_session_id_clock_skew_boundary() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_dir = temp.path().to_path_buf();
+        let project_dir = temp.path().join("fake_project");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let project_path = project_dir.to_string_lossy().to_string();
+
+        // Spawn at .345s, JSONL mtime at .789s of the same wall-clock second.
+        let spawn = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1_700_000_000_345)
+            .unwrap();
+        let mtime = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1_700_000_000_789)
+            .unwrap();
+
+        let _ = write_session_with_mtime(&config_dir, &project_path, "fresh-session", mtime);
+        clear_cache_under(temp.path());
+
+        let result = get_latest_session_id(&config_dir, &project_path, Some(spawn));
+        assert!(
+            result.is_some(),
+            "session whose mtime is in the same second as `since` (789ms vs 345ms) \
+             must NOT be dropped — that's the common hook-spawn case"
+        );
+        assert_eq!(result.unwrap().session_id, "fresh-session");
     }
 }

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -1762,10 +1762,8 @@ mod tests {
 
         // Preserve sub-second precision — the clock-skew boundary test needs
         // mtime resolution finer than 1 second.
-        let ft = filetime::FileTime::from_unix_time(
-            mtime.timestamp(),
-            mtime.timestamp_subsec_nanos(),
-        );
+        let ft =
+            filetime::FileTime::from_unix_time(mtime.timestamp(), mtime.timestamp_subsec_nanos());
         filetime::set_file_mtime(&file_path, ft).unwrap();
         file_path
     }
@@ -1787,7 +1785,11 @@ mod tests {
         // Use a project path that won't have a real .claude.json sitting on
         // disk — the lookup below would otherwise read the user's actual
         // workspace `.claude.json` and pick a foreign session.
-        let project_path = temp.path().join("fake_project").to_string_lossy().to_string();
+        let project_path = temp
+            .path()
+            .join("fake_project")
+            .to_string_lossy()
+            .to_string();
         std::fs::create_dir_all(temp.path().join("fake_project")).unwrap();
 
         let before = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap();
@@ -1845,8 +1847,7 @@ mod tests {
 
         // With `since` past old-session's mtime → shortcut falls through,
         // mtime fallback returns new-session.
-        let filtered =
-            get_latest_session_id(&config_dir, &project_path, Some(since)).unwrap();
+        let filtered = get_latest_session_id(&config_dir, &project_path, Some(since)).unwrap();
         assert_eq!(
             filtered.session_id, "new-session",
             ".claude.json shortcut must NOT shadow a fresher session when stale"
@@ -1871,10 +1872,10 @@ mod tests {
         let project_path = project_dir.to_string_lossy().to_string();
 
         // Spawn at .345s, JSONL mtime at .789s of the same wall-clock second.
-        let spawn = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1_700_000_000_345)
-            .unwrap();
-        let mtime = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1_700_000_000_789)
-            .unwrap();
+        let spawn =
+            chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1_700_000_000_345).unwrap();
+        let mtime =
+            chrono::DateTime::<chrono::Utc>::from_timestamp_millis(1_700_000_000_789).unwrap();
 
         let _ = write_session_with_mtime(&config_dir, &project_path, "fresh-session", mtime);
         clear_cache_under(temp.path());

--- a/src/components/terminal/useTabSessionIdCapture.test.ts
+++ b/src/components/terminal/useTabSessionIdCapture.test.ts
@@ -5,19 +5,21 @@
  *
  * Same constraint as `useCommitState.test.ts`: the runner's vitest
  * environment is `node`, so we mock the IPC surface and exercise the
- * decision logic directly. The branches that matter:
+ * decision logic directly.
+ *
+ * Freshness is enforced backend-side via `sinceMs`. The hook trusts
+ * any non-null payload returned by `transcript_get_latest`. The
+ * branches that still matter on the frontend:
  *
  *   1. Latest unclaimed session matching workingDir →
  *      `updateTab({ claudeSessionId, claudeConfigDir })` is called once.
  *   2. Two tabs spawn into the same workdir → the first one wins;
  *      the second sees the session id as already-claimed and refuses
  *      to bind it.
- *   3. Timeout (no JSONL appears within 15 s) → `updateTab` is never
+ *   3. Backend returns null (filtered by sinceMs because no fresh
+ *      JSONL exists yet) → poll keeps ticking, no claim.
+ *   4. Timeout (no JSONL appears within 15 s) → `updateTab` is never
  *      called for that tab.
- *
- * The polling driver itself (the 500 ms tick scheduler) is exercised
- * via a small reproduction of the decision logic so we don't need
- * fake-timer plumbing in a node-environment vitest project.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -37,19 +39,16 @@ interface TranscriptSessionPayload {
 }
 
 // Decision helper that mirrors the hook's per-tick claim logic.
-// Returns the update payload to apply (if any) given a poll response.
+// Freshness (last_modified > spawnTimestamp) is enforced backend-side
+// via `sinceMs`; the hook trusts any non-null payload it receives.
 function decideClaim(
   tab: TerminalTab | undefined,
   payload: TranscriptSessionPayload | null,
-  spawnTimestamp: number,
   alreadyClaimed: Set<string>,
 ): { claudeSessionId: string; claudeConfigDir: string } | null {
   if (!tab) return null;
   if (tab.claudeSessionId) return null;
   if (!payload) return null;
-  const lastModifiedMs = Date.parse(payload.last_modified);
-  if (!Number.isFinite(lastModifiedMs)) return null;
-  if (lastModifiedMs <= spawnTimestamp) return null;
   if (alreadyClaimed.has(payload.session_id)) return null;
   return {
     claudeSessionId: payload.session_id,
@@ -68,17 +67,15 @@ const tab = (id: string, workingDir: string, claudeSessionId?: string): Terminal
 });
 
 describe("decideClaim — happy path", () => {
-  it("binds the session when payload is fresh + unclaimed", () => {
-    const spawnAt = 1_700_000_000_000;
+  it("binds the session when payload is unclaimed", () => {
     const result = decideClaim(
       tab("tab-1", "D:/repo"),
       {
         session_id: "session-A",
         config_dir: "C:/claude/.claude-default",
         project_path: "D:/repo",
-        last_modified: new Date(spawnAt + 1000).toISOString(),
+        last_modified: new Date().toISOString(),
       },
-      spawnAt,
       new Set(),
     );
     expect(result).toEqual({
@@ -87,24 +84,7 @@ describe("decideClaim — happy path", () => {
     });
   });
 
-  it("rejects a stale session (last_modified <= spawn timestamp)", () => {
-    const spawnAt = 1_700_000_000_000;
-    const result = decideClaim(
-      tab("tab-1", "D:/repo"),
-      {
-        session_id: "session-old",
-        config_dir: "C:/claude/.claude-default",
-        project_path: "D:/repo",
-        last_modified: new Date(spawnAt - 5_000).toISOString(),
-      },
-      spawnAt,
-      new Set(),
-    );
-    expect(result).toBeNull();
-  });
-
   it("rejects when the session id is already claimed", () => {
-    const spawnAt = 1_700_000_000_000;
     const claimed = new Set(["session-A"]);
     const result = decideClaim(
       tab("tab-2", "D:/repo"),
@@ -112,9 +92,8 @@ describe("decideClaim — happy path", () => {
         session_id: "session-A", // claimed by tab-1 already
         config_dir: "C:/claude/.claude-default",
         project_path: "D:/repo",
-        last_modified: new Date(spawnAt + 1000).toISOString(),
+        last_modified: new Date().toISOString(),
       },
-      spawnAt,
       claimed,
     );
     expect(result).toBeNull();
@@ -123,39 +102,36 @@ describe("decideClaim — happy path", () => {
 
 describe("decideClaim — concurrent same-workdir spawn defense", () => {
   it("first tab wins, second tab times out (no claim)", () => {
-    const spawnAt = 1_700_000_000_000;
     const claimed = new Set<string>();
     const payload: TranscriptSessionPayload = {
       session_id: "session-shared",
       config_dir: "C:/claude/.claude-default",
       project_path: "D:/repo",
-      last_modified: new Date(spawnAt + 1000).toISOString(),
+      last_modified: new Date().toISOString(),
     };
 
     // Tab 1 polls first → wins.
-    const claim1 = decideClaim(tab("tab-1", "D:/repo"), payload, spawnAt, claimed);
+    const claim1 = decideClaim(tab("tab-1", "D:/repo"), payload, claimed);
     expect(claim1).not.toBeNull();
     if (claim1) claimed.add(claim1.claudeSessionId);
 
     // Tab 2 polls same workdir → sees the same session_id, but it's
     // claimed now → rejected.
-    const claim2 = decideClaim(tab("tab-2", "D:/repo"), payload, spawnAt, claimed);
+    const claim2 = decideClaim(tab("tab-2", "D:/repo"), payload, claimed);
     expect(claim2).toBeNull();
   });
 });
 
 describe("decideClaim — already-bound and missing-tab cases", () => {
   it("skips a tab that already has a claudeSessionId (resume path beat us)", () => {
-    const spawnAt = 1_700_000_000_000;
     const result = decideClaim(
       tab("tab-1", "D:/repo", "session-RESUME"),
       {
         session_id: "session-NEW",
         config_dir: "C:/claude/.claude-default",
         project_path: "D:/repo",
-        last_modified: new Date(spawnAt + 1000).toISOString(),
+        last_modified: new Date().toISOString(),
       },
-      spawnAt,
       new Set(),
     );
     expect(result).toBeNull();
@@ -171,30 +147,13 @@ describe("decideClaim — already-bound and missing-tab cases", () => {
           project_path: "D:/repo",
           last_modified: new Date().toISOString(),
         },
-        Date.now(),
         new Set(),
       ),
     ).toBeNull();
   });
 
-  it("returns null when the probe payload is null (no transcript yet)", () => {
-    expect(decideClaim(tab("tab-1", "D:/repo"), null, Date.now(), new Set())).toBeNull();
-  });
-
-  it("returns null when last_modified is unparseable", () => {
-    expect(
-      decideClaim(
-        tab("tab-1", "D:/repo"),
-        {
-          session_id: "session-A",
-          config_dir: "C:/claude/.claude-default",
-          project_path: "D:/repo",
-          last_modified: "not-a-date",
-        },
-        Date.now(),
-        new Set(),
-      ),
-    ).toBeNull();
+  it("returns null when the probe payload is null (filtered by backend or no JSONL yet)", () => {
+    expect(decideClaim(tab("tab-1", "D:/repo"), null, new Set())).toBeNull();
   });
 });
 
@@ -203,16 +162,21 @@ describe("invoke contract", () => {
     mockInvoke.mockReset();
   });
 
-  it("transcript_get_latest is invoked with camelCase projectPath", async () => {
+  it("transcript_get_latest is invoked with camelCase projectPath + sinceMs", async () => {
     mockInvoke.mockResolvedValueOnce({ success: true, data: null });
     const { invoke } = await import("@tauri-apps/api/core");
-    await invoke("transcript_get_latest", { projectPath: "D:/repo" });
+    const spawnAt = Date.now();
+    await invoke("transcript_get_latest", {
+      sinceMs: spawnAt,
+      projectPath: "D:/repo",
+    });
     expect(mockInvoke).toHaveBeenCalledWith("transcript_get_latest", {
+      sinceMs: spawnAt,
       projectPath: "D:/repo",
     });
   });
 
-  it("transcript_get_latest accepts configDir alongside projectPath", async () => {
+  it("transcript_get_latest accepts configDir alongside projectPath + sinceMs", async () => {
     mockInvoke.mockResolvedValueOnce({
       success: true,
       data: {
@@ -223,14 +187,33 @@ describe("invoke contract", () => {
       },
     });
     const { invoke } = await import("@tauri-apps/api/core");
+    const spawnAt = Date.now();
     await invoke("transcript_get_latest", {
+      sinceMs: spawnAt,
       projectPath: "D:/repo",
       configDir: "C:/claude/.claude-hotmail",
     });
     expect(mockInvoke).toHaveBeenCalledWith("transcript_get_latest", {
+      sinceMs: spawnAt,
       projectPath: "D:/repo",
       configDir: "C:/claude/.claude-hotmail",
     });
+  });
+
+  it("backend returning null (filtered by sinceMs) leaves the hook unbound", async () => {
+    // After the since-filter migration, "stale" is a backend concept: the
+    // backend returns `data: null` when no session passes the filter. The
+    // hook must not bind anything in that case — it just keeps ticking.
+    mockInvoke.mockResolvedValueOnce({ success: true, data: null });
+    const { invoke } = await import("@tauri-apps/api/core");
+    const resp = (await invoke("transcript_get_latest", {
+      sinceMs: Date.now(),
+      projectPath: "D:/repo",
+    })) as { success: boolean; data: TranscriptSessionPayload | null };
+
+    const data = resp.success ? resp.data : null;
+    const claim = decideClaim(tab("tab-1", "D:/repo"), data, new Set());
+    expect(claim).toBeNull();
   });
 });
 
@@ -255,7 +238,6 @@ describe("invoke contract", () => {
  */
 describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
   it("accepts a session whose config_dir matches the launching account", () => {
-    const spawnAt = 1_700_000_000_000;
     // Backend was called with configDir filter, so it returns ONLY
     // the hotmail session — even though gmail had a fresher mtime.
     const result = decideClaim(
@@ -264,9 +246,8 @@ describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
         session_id: "session-hotmail",
         config_dir: "C:/claude/.claude-hotmail",
         project_path: "D:/repo",
-        last_modified: new Date(spawnAt + 500).toISOString(),
+        last_modified: new Date().toISOString(),
       },
-      spawnAt,
       new Set(),
     );
     expect(result).toEqual({
@@ -276,7 +257,6 @@ describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
   });
 
   it("two tabs in different accounts each bind their own session", () => {
-    const spawnAt = 1_700_000_000_000;
     const claimed = new Set<string>();
 
     // Hotmail tab: backend filtered to hotmail, returns hotmail session.
@@ -286,9 +266,8 @@ describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
         session_id: "session-hotmail",
         config_dir: "C:/claude/.claude-hotmail",
         project_path: "D:/repo",
-        last_modified: new Date(spawnAt + 500).toISOString(),
+        last_modified: new Date().toISOString(),
       },
-      spawnAt,
       claimed,
     );
     expect(hotmailClaim?.claudeSessionId).toBe("session-hotmail");
@@ -304,9 +283,8 @@ describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
         session_id: "session-gmail",
         config_dir: "C:/claude/.claude-gmail",
         project_path: "D:/repo",
-        last_modified: new Date(spawnAt + 700).toISOString(),
+        last_modified: new Date().toISOString(),
       },
-      spawnAt,
       claimed,
     );
     expect(gmailClaim?.claudeSessionId).toBe("session-gmail");

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -12,15 +12,25 @@
  * called, the consumer fires `startCapture(tabId, workingDir,
  * spawnTimestamp)`. The hook polls the existing `transcript_get_latest`
  * Tauri command (in `commands/transcript.rs:178`) every ~500 ms for up
- * to ~15 s. When it finds a `TranscriptSession` whose `last_modified`
- * is fresher than the spawn timestamp AND whose `session_id` isn't
- * already claimed by another tab, it calls
+ * to ~15 s. Freshness gating (last_modified > spawnTimestamp) is now
+ * enforced backend-side via the `sinceMs` argument; if the backend
+ * returns a non-null payload it's already known fresher than the
+ * spawn. The frontend just checks the session id isn't already claimed
+ * by another tab and then calls
  * `updateTab(tabId, { claudeSessionId, claudeConfigDir })`.
  *
  * Concurrency defense: a `claimedSessionIds` ref tracks every session id
  * we've already bound to a tab; the polling loop refuses to claim an
- * already-claimed id. This prevents two concurrent spawns into the same
- * working directory from latching onto the same JSONL.
+ * already-claimed id. This is the intra-tab dedup line of defense for
+ * the case where two concurrent spawns into the same working directory
+ * (and same config dir) race on a single JSONL — backend-side `sinceMs`
+ * cannot disambiguate them.
+ *
+ * Diagnostics: set `localStorage["debug:tabSidCapture"] = "1"` to emit
+ * `logger.debug("[tabSidCapture] <tag>", payload)` at every rejection
+ * branch (`tab-not-found`, `already-bound`, `timed-out`, `probe-null`,
+ * `already-claimed`, `probe-error`). Off by default; same affordance
+ * pattern as `UI_BRIDGE_DEBUG_FIND`.
  *
  * On timeout the tab simply stays without a session id — the user can
  * still use the terminal, just no commit indicator.
@@ -127,6 +137,17 @@ export function useTabSessionIdCapture({
     // capture-start time. Empty string is treated as "let the backend
     // fall back to its workspace default".
     (tabId, workingDir, spawnTimestamp, configDir) => {
+      // Re-read on every emission so tests that stub localStorage at
+      // arbitrary points still get the latest value. Production cost
+      // is a single getItem per debug call site.
+      const debug = (): boolean =>
+        typeof localStorage !== "undefined" &&
+        localStorage.getItem("debug:tabSidCapture") === "1";
+
+      if (debug()) {
+        logger.debug("[tabSidCapture] start", { tabId, workingDir, configDir, spawnTimestamp });
+      }
+
       // Already polling this tab? Don't double-up.
       if (inFlight.current.has(tabId)) return;
       const handle = { cancelled: false };
@@ -141,11 +162,18 @@ export function useTabSessionIdCapture({
         const tab = tabsRef.current.find((t) => t.id === tabId);
         if (!tab) {
           // Tab was closed — stop.
+          if (debug()) logger.debug("[tabSidCapture] tab-not-found", { tabId });
           handle.cancelled = true;
           inFlight.current.delete(tabId);
           return;
         }
         if (tab.claudeSessionId) {
+          if (debug()) {
+            logger.debug("[tabSidCapture] already-bound", {
+              tabId,
+              sessionId: tab.claudeSessionId,
+            });
+          }
           handle.cancelled = true;
           inFlight.current.delete(tabId);
           return;
@@ -153,41 +181,53 @@ export function useTabSessionIdCapture({
 
         // Timed out?
         if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
+          if (debug()) {
+            logger.debug("[tabSidCapture] timed-out", {
+              tabId,
+              elapsedMs: Date.now() - startedAt,
+            });
+          }
           handle.cancelled = true;
           inFlight.current.delete(tabId);
           return;
         }
 
         try {
-          // Pass workingDir + configDir when known. Both fall back
-          // server-side: empty workingDir → workspace project path;
-          // missing configDir → scan all known config dirs (the bug
-          // path that motivated adding configDir — see hook docstring).
-          const args: Record<string, string> = {};
+          // Pass workingDir + configDir when known, plus sinceMs so the
+          // backend can drop pre-spawn JSONLs before answering. Both
+          // workingDir/configDir fall back server-side: empty workingDir
+          // → workspace project path; missing configDir → scan all known
+          // config dirs (the bug path that motivated adding configDir —
+          // see hook docstring).
+          const args: Record<string, string | number> = { sinceMs: spawnTimestamp };
           if (workingDir) args.projectPath = workingDir;
           if (configDir) args.configDir = configDir;
           const resp = await invoke<CommandResponse>("transcript_get_latest", args);
           if (handle.cancelled) return;
 
           const data = resp.success ? (resp.data as TranscriptSessionPayload | null) : null;
-          if (data) {
-            const lastModifiedMs = Date.parse(data.last_modified);
-            const fresh = Number.isFinite(lastModifiedMs) && lastModifiedMs > spawnTimestamp;
-            const unclaimed = !claimedSessionIds.current.has(data.session_id);
-            if (fresh && unclaimed) {
-              claimedSessionIds.current.add(data.session_id);
-              updateTab(tabId, {
-                claudeSessionId: data.session_id,
-                claudeConfigDir: data.config_dir,
+          if (!data) {
+            if (debug()) logger.debug("[tabSidCapture] probe-null", { tabId });
+          } else if (claimedSessionIds.current.has(data.session_id)) {
+            if (debug()) {
+              logger.debug("[tabSidCapture] already-claimed", {
+                tabId,
+                sessionId: data.session_id,
               });
-              handle.cancelled = true;
-              inFlight.current.delete(tabId);
-              return;
             }
+          } else {
+            claimedSessionIds.current.add(data.session_id);
+            updateTab(tabId, {
+              claudeSessionId: data.session_id,
+              claudeConfigDir: data.config_dir,
+            });
+            handle.cancelled = true;
+            inFlight.current.delete(tabId);
+            return;
           }
         } catch (err) {
           // Probe error: keep trying; runner may be transiently busy.
-          logger.debug("transcript_get_latest probe failed:", err);
+          if (debug()) logger.debug("[tabSidCapture] probe-error", { tabId, err });
         }
 
         // Schedule next tick.


### PR DESCRIPTION
## Summary

Two follow-ups to PR #70 (cross-account session-id capture). Both surfaced during the live verification of `7894d70ec` — neither was a P0 regression and neither belonged in #70.

- **Issue 1 — intra-account collision.** When multiple Claude sessions are active in the same config dir, `transcript_get_latest({ configDir })` still returned the freshest-mtime session. External CLI sessions never enter `claimedSessionIds`, so they could win the race against a hook-spawned tab. Fixed by lifting freshness filtering server-side: new `sinceMs` parameter on `transcript_get_latest` (Tauri auto-converts to `since_ms: Option<i64>` on the Rust side) applied to **both** branches of `get_latest_session_id` — the `.claude.json` `lastSessionId` shortcut and the `list_sessions` mtime fallback. The frontend hook now passes `Date.now()` at spawn time and drops its local freshness check.

- **Issue 2 — diagnostic logging.** Frontend never recorded `claudeSessionId` on the just-spawned hotmail tab during verification. Three possible causes (timeout, claim conflict, polling never fired) were not distinguishable. Added tagged `logger.debug` calls at every rejection branch in `useTabSessionIdCapture` (`start`, `tab-not-found`, `already-bound`, `timed-out`, `probe-null`, `already-claimed`, `probe-error`), gated by `localStorage["debug:tabSidCapture"] === "1"`. Permanent diagnostic affordance, same pattern as `UI_BRIDGE_DEBUG_FIND`.

## Side effects & edge-case fix

Bumped on-disk mtime formatting from `%Y-%m-%dT%H:%M:%SZ` (second precision) to `%Y-%m-%dT%H:%M:%S%.3fZ` (millisecond precision) so a session whose mtime falls in the same wall-clock second as the spawn isn't dropped by the strict `parsed > since` filter — that's the common hook-spawn case. `/vet-plan` flagged this mid-implementation; without it the manual smoke could have looked clean while production still hit `probe-null`. Display-name fallback parser accepts both legacy and new formats.

## Plan

`qontinui-dev-notes/plans/2026-05-10-traffic-light-session-id-followups.md` (archived as SHIPPED).

## Test plan

- [x] 30 Rust tests pass in `terminal::transcript`, including new regressions:
  - [x] `get_latest_session_id_filters_by_since` — basic `since` filter on the mtime fallback
  - [x] `get_latest_session_id_skips_claude_json_when_stale` — `.claude.json` shortcut must fall through when stale
  - [x] `get_latest_session_id_clock_skew_boundary` — the same-second case from `/vet-plan`
- [x] 12 frontend tests pass in `useTabSessionIdCapture.test.ts`:
  - [x] `decideClaim` helper updated to mirror the new (backend-gated) frontend logic
  - [x] Invoke-contract tests assert `sinceMs` is forwarded with every probe
  - [x] New "backend-null-as-stale" case
- [x] Manual smoke on temp runner port 9878 (rebuild=true):
  - [x] `sinceMs=0` returns a session (note mtime now `…484Z` — ms precision)
  - [x] `sinceMs=Date.now()+60s` returns `data: null` (filter active)
  - [x] No-filter probe still returns the freshest cross-account session (#70 P0 fix intact)
  - [x] `sinceMs=24h ago + configDir=hotmail` returns the hotmail session (cross-account scoping intact)
- [x] `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean