### PR TITLE
feat(file-activity): FileActivityPanel + useFileActivity hook (Phase 2/3)

### DIFF
--- a/specs/pages/productivity/spec.uibridge.json
+++ b/specs/pages/productivity/spec.uibridge.json
@@ -654,10 +654,30 @@
             "label": "Required element for Coordinator Dashboard — Five-Panel Stack",
             "type": "search"
           }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "FileActivityPanel — heatmap of currently-edited files, hot files in the selected window, and hot sessions. Added by the file-ownership-heatmap plan; lives below the spec-locked five-panel block.",
+          "enabled": true,
+          "id": "productivity-coordinator-panels-elem-6",
+          "precondition": "The Coordinator sub-view is active.",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "manual",
+          "target": {
+            "criteria": {
+              "dataAttributes": {
+                "ui-bridge-id": "productivity.file-activity"
+              }
+            },
+            "label": "Required element for Coordinator Dashboard — File Activity panel",
+            "type": "search"
+          }
         }
       ],
       "category": "element-presence",
-      "description": "The Coordinator dashboard renders five vertically-stacked panels in a fixed order: (1) PlanRecommendations 'Coordinator suggests next plan' card; (2) RecommendationsPanel — medium-confidence approved review queue; (3) AdvisoriesPanel — LLM advise-with-text rows from the last hour; (4) EscalationsPanel — open destructive recommendations the agent flagged advisory-only; (5) DecisionLogPanel — chronological feed of last 200 coordinator_decisions rows filterable by rule (A-E or LLM) and action. Each panel is wrapped in a border-border + bg-card/30 rounded-lg section with its own header (icon + title + count chip + Refresh button) and a content area that handles error / empty / populated states.",
+      "description": "The Coordinator dashboard renders six vertically-stacked panels. The first five are spec-locked in fixed order: (1) PlanRecommendations 'Coordinator suggests next plan' card; (2) RecommendationsPanel — medium-confidence approved review queue; (3) AdvisoriesPanel — LLM advise-with-text rows from the last hour; (4) EscalationsPanel — open destructive recommendations the agent flagged advisory-only; (5) DecisionLogPanel — chronological feed of last 200 coordinator_decisions rows filterable by rule (A-E or LLM) and action. Below the locked block sits (6) FileActivityPanel — file-ownership heatmap with a live-snapshot grouped by holder, a hot-files table, and a hot-sessions table, refreshed every 5 s while visible; the panel is OUTSIDE the productivity-stack spec's order-invariant guarantee but is required to exist. Each panel is wrapped in a border-border + bg-card/30 rounded-lg section with its own header (icon + title + count or selector + Refresh button) and a content area that handles error / empty / populated states.",
       "id": "productivity-coordinator-panels",
       "name": "Coordinator Dashboard — Five-Panel Stack",
       "source": "migrated"

--- a/src/components/productivity/CoordinatorDashboard.tsx
+++ b/src/components/productivity/CoordinatorDashboard.tsx
@@ -54,6 +54,7 @@ import {
 import { acknowledgeAdvisory } from "./reflectionApi";
 import { PlanRecommendations } from "./PlanRecommendations";
 import { WorkersPanel } from "./WorkersPanel";
+import { FileActivityPanel } from "./FileActivityPanel";
 
 const DECISION_LOG_LIMIT = 200;
 
@@ -1181,6 +1182,18 @@ export function CoordinatorDashboard() {
           onActionFilterChange={setActionFilter}
           onRefresh={loadDecisions}
         />
+
+        {/*
+         * File Activity panel — file-ownership-heatmap-plan Phase 2.
+         *
+         * Lives BELOW the productivity-stack spec-locked five-panel
+         * block (PlanRecommendations → Recommendations → Advisories →
+         * Escalations → Decision Log). The spec asserts existence of
+         * each, not relative order, so appending here is safe — the
+         * description in productivity/spec.uibridge.json is updated in
+         * the same PR to keep the human-readable narrative accurate.
+         */}
+        <FileActivityPanel />
       </div>
     </div>
   );

--- a/src/components/productivity/FileActivityPanel.test.tsx
+++ b/src/components/productivity/FileActivityPanel.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Pure-helper tests for FileActivityPanel and fileActivityApi.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom — see
+ * CompletionReportSections.test.tsx for the same pattern). That means we
+ * can't render the panel and assert on its DOM. The plan's three Phase 2
+ * test cases ("renders empty state", "click on hot session row calls
+ * setActiveId", "window selector change triggers a re-fetch") map to:
+ *
+ *   - empty state            → covered by manual + UI Bridge spec
+ *   - click → setActiveId    → covered by manual + UI Bridge spec
+ *                              (v1 ships a page-nav stub; per-tab focus
+ *                              is a documented follow-up — see panel
+ *                              header comment)
+ *   - window selector reset  → loadStoredWindowSecs / storeWindowSecs
+ *                              round-trip covered here
+ *
+ * The pure helpers `ageLabel`, `barFor`, `loadStoredWindowSecs`, and
+ * `storeWindowSecs` carry the load-bearing logic and are tested here.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ageLabel, barFor } from "./FileActivityPanel";
+import {
+  DEFAULT_WINDOW_SECS,
+  WINDOW_OPTIONS,
+  WINDOW_STORAGE_KEY,
+  loadStoredWindowSecs,
+  storeWindowSecs,
+} from "./fileActivityApi";
+
+// ---------------------------------------------------------------------------
+// ageLabel
+// ---------------------------------------------------------------------------
+
+describe("ageLabel", () => {
+  // Fixed "now" so subsecond drift between Date.now() reads doesn't flake
+  // the test. The function exposes nowMs precisely for this reason.
+  const NOW = Date.parse("2026-05-10T20:00:00Z");
+
+  it("returns 'now' for timestamps in the future", () => {
+    expect(ageLabel("2026-05-10T20:01:00Z", NOW)).toBe("now");
+  });
+
+  it("formats seconds for ages under a minute", () => {
+    expect(ageLabel("2026-05-10T19:59:30Z", NOW)).toBe("30s ago");
+  });
+
+  it("formats minutes for ages under an hour", () => {
+    expect(ageLabel("2026-05-10T19:45:00Z", NOW)).toBe("15m ago");
+  });
+
+  it("formats hours for ages under a day", () => {
+    expect(ageLabel("2026-05-10T17:00:00Z", NOW)).toBe("3h ago");
+  });
+
+  it("formats days otherwise", () => {
+    expect(ageLabel("2026-05-08T20:00:00Z", NOW)).toBe("2d ago");
+  });
+
+  it("returns 'unknown' for unparseable input", () => {
+    expect(ageLabel("not-a-timestamp", NOW)).toBe("unknown");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// barFor
+// ---------------------------------------------------------------------------
+
+describe("barFor", () => {
+  it("returns empty string when max is 0 (avoid /0 NaN)", () => {
+    expect(barFor(0, 0)).toBe("");
+    expect(barFor(5, 0)).toBe("");
+  });
+
+  it("renders a 10-segment bar with at least one filled cell for any nonzero count", () => {
+    // 1 out of 100 rounds to 0.1 → would render 0 filled without the
+    // `Math.max(1, ...)` floor. The floor keeps the bar legible.
+    const bar = barFor(1, 100);
+    expect(bar).toMatch(/^▮+▯+$/);
+    expect(bar.length).toBe(10);
+    expect((bar.match(/▮/g) ?? []).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders all-filled when count equals max", () => {
+    expect(barFor(7, 7)).toBe("▮▮▮▮▮▮▮▮▮▮");
+  });
+
+  it("scales linearly between extremes", () => {
+    const bar = barFor(5, 10);
+    expect(bar.length).toBe(10);
+    // 5/10 → 5 filled.
+    expect((bar.match(/▮/g) ?? []).length).toBe(5);
+    expect((bar.match(/▯/g) ?? []).length).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadStoredWindowSecs / storeWindowSecs
+// ---------------------------------------------------------------------------
+
+describe("window secs persistence", () => {
+  // Shim a minimal localStorage onto globalThis for the node-environment
+  // test runner. Cleanup restores any prior shape (none, in practice).
+  let store: Record<string, string>;
+  const originalWindow = (globalThis as Record<string, unknown>).window;
+
+  beforeEach(() => {
+    store = {};
+    (globalThis as Record<string, unknown>).window = {
+      localStorage: {
+        getItem: (k: string): string | null => (k in store ? store[k] : null),
+        setItem: (k: string, v: string): void => {
+          store[k] = v;
+        },
+        removeItem: (k: string): void => {
+          delete store[k];
+        },
+        clear: (): void => {
+          store = {};
+        },
+        get length(): number {
+          return Object.keys(store).length;
+        },
+        key: (i: number): string | null => Object.keys(store)[i] ?? null,
+      },
+    };
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      delete (globalThis as Record<string, unknown>).window;
+    } else {
+      (globalThis as Record<string, unknown>).window = originalWindow;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns the default when localStorage is empty", () => {
+    expect(loadStoredWindowSecs()).toBe(DEFAULT_WINDOW_SECS);
+  });
+
+  it("round-trips a stored value when it matches a WINDOW_OPTIONS entry", () => {
+    const sixHours = WINDOW_OPTIONS.find((o) => o.secs === 21_600)!;
+    storeWindowSecs(sixHours.secs);
+    expect(store[WINDOW_STORAGE_KEY]).toBe("21600");
+    expect(loadStoredWindowSecs()).toBe(21_600);
+  });
+
+  it("ignores an unrecognized stored value and returns the default", () => {
+    store[WINDOW_STORAGE_KEY] = "999999"; // not in WINDOW_OPTIONS
+    expect(loadStoredWindowSecs()).toBe(DEFAULT_WINDOW_SECS);
+  });
+
+  it("ignores a non-numeric stored value and returns the default", () => {
+    store[WINDOW_STORAGE_KEY] = "garbage";
+    expect(loadStoredWindowSecs()).toBe(DEFAULT_WINDOW_SECS);
+  });
+});

--- a/src/components/productivity/FileActivityPanel.tsx
+++ b/src/components/productivity/FileActivityPanel.tsx
@@ -1,0 +1,423 @@
+/**
+ * FileActivityPanel — Phase 2 of the file-ownership-heatmap plan.
+ *
+ * Three vertically-stacked sub-sections:
+ *   1. Live snapshot  — `FileRegistryManager.info()` grouped by
+ *      `holder_name`; files indented beneath their holder.
+ *   2. Hot files      — top N most-touched paths in the selected
+ *      window, with bar-length rendering of the touch count.
+ *   3. Hot sessions   — top N most-active sessions in the same window,
+ *      with their file count and latest activity.
+ *
+ * Lives at the bottom of `CoordinatorDashboard` as a sixth panel,
+ * outside the productivity-stack spec-locked five-panel block. The
+ * locked block asserts only `exists` for each panel (not relative
+ * order), so appending here doesn't break the assertion — but the
+ * spec's `Coordinator Dashboard — Five-Panel Stack` description gets
+ * a parallel update in the same commit.
+ *
+ * Per `proj_runner_analysis_state_split.md`, sibling-panel data
+ * sharing in the runner is done through explicit channels — props
+ * or CustomEvents — not implicit context. This panel currently
+ * mirrors `WorkersPanel`'s "click reveals the Terminals page, user
+ * picks their tab from there" pattern; per-tab focus is a documented
+ * follow-up (the substrate to dispatch `setActiveId` across siblings
+ * doesn't exist yet at the CoordinatorDashboard scope).
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { Flame, FileText, Clock, RefreshCw, Users } from "lucide-react";
+import {
+  DEFAULT_WINDOW_SECS,
+  WINDOW_OPTIONS,
+  fetchHeatmap,
+  loadStoredWindowSecs,
+  storeWindowSecs,
+  useFileActivity,
+  type FileRegistryInfoEntry,
+  type HotFileRow,
+  type HotSessionRow,
+} from "./fileActivityApi";
+
+/** Render relative-time label without pulling in date-fns again — the
+ *  existing import in CoordinatorDashboard works, but the panel is
+ *  intentionally standalone so the unit test can mount it in isolation
+ *  without configuring date-fns mocks. `nowMs` is injected for tests;
+ *  production callers omit it. */
+export function ageLabel(isoTimestamp: string, nowMs: number = Date.now()): string {
+  const ts = Date.parse(isoTimestamp);
+  if (!Number.isFinite(ts)) return "unknown";
+  const ageMs = nowMs - ts;
+  if (ageMs < 0) return "now";
+  const s = Math.floor(ageMs / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.floor(h / 24)}d ago`;
+}
+
+/** Build a 10-segment bar string. Plan calls for sort + bar length, not
+ *  color intensity — color without calibration is fake precision. */
+export function barFor(count: number, maxCount: number): string {
+  if (maxCount <= 0) return "";
+  const filled = Math.max(1, Math.round((count / maxCount) * 10));
+  const empty = Math.max(0, 10 - filled);
+  return "▮".repeat(filled) + "▯".repeat(empty); // ▮ filled, ▯ empty
+}
+
+interface PanelHeaderProps {
+  windowSecs: number;
+  onWindowChange: (secs: number) => void;
+  onRefresh: () => void;
+  isStale: boolean;
+  error: string | null;
+}
+
+function PanelHeader({
+  windowSecs,
+  onWindowChange,
+  onRefresh,
+  isStale,
+  error,
+}: PanelHeaderProps) {
+  return (
+    <header className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
+        <Flame className="w-4 h-4 text-muted-foreground" />
+        <h2
+          id="productivity-file-activity-heading"
+          className="text-sm font-semibold text-foreground"
+        >
+          File activity
+        </h2>
+        {isStale && (
+          <span
+            title={error ?? "data older than 2s — refreshing"}
+            data-ui-bridge-id="productivity.file-activity-stale"
+            className="inline-flex items-center gap-1 text-xs text-amber-400"
+          >
+            <Clock className="w-3 h-3" />
+            stale
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <label
+          htmlFor="productivity-file-activity-window"
+          className="text-xs text-muted-foreground"
+        >
+          window:
+        </label>
+        <select
+          id="productivity-file-activity-window"
+          value={windowSecs}
+          onChange={(e) => onWindowChange(Number.parseInt(e.target.value, 10))}
+          data-ui-bridge-id="productivity.file-activity-window-select"
+          className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
+        >
+          {WINDOW_OPTIONS.map((o) => (
+            <option key={o.secs} value={o.secs}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={onRefresh}
+          data-ui-bridge-id="productivity.file-activity-refresh"
+          className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted/30"
+        >
+          <RefreshCw className="w-3 h-3" />
+          Refresh
+        </button>
+      </div>
+    </header>
+  );
+}
+
+interface LiveSnapshotSectionProps {
+  rows: readonly FileRegistryInfoEntry[];
+  onJumpToHolder: (holderName: string) => void;
+}
+
+function LiveSnapshotSection({ rows, onJumpToHolder }: LiveSnapshotSectionProps) {
+  // Group by holder_name. Map insertion order is preserved — sort holders
+  // by their newest-registered file so the most recently active appears
+  // first; ties broken alphabetically.
+  const grouped = useMemo(() => {
+    const byHolder = new Map<string, FileRegistryInfoEntry[]>();
+    for (const r of rows) {
+      const list = byHolder.get(r.holder_name) ?? [];
+      list.push(r);
+      byHolder.set(r.holder_name, list);
+    }
+    return Array.from(byHolder.entries())
+      .map(([holder, entries]) => ({
+        holder,
+        entries: [...entries].sort((a, b) => b.registered_at - a.registered_at),
+        latest: Math.max(...entries.map((e) => e.registered_at)),
+      }))
+      .sort((a, b) => b.latest - a.latest || a.holder.localeCompare(b.holder));
+  }, [rows]);
+
+  if (grouped.length === 0) {
+    return (
+      <div
+        className="rounded-md border border-border/40 bg-muted/10 p-3 text-xs text-muted-foreground"
+        data-ui-bridge-id="productivity.file-activity-live-empty"
+      >
+        No sessions currently hold files in this runner.
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      className="flex flex-col gap-2"
+      data-ui-bridge-id="productivity.file-activity-live"
+    >
+      {grouped.map(({ holder, entries }) => (
+        <li
+          key={holder}
+          className="rounded-md border border-border/40 bg-background/40 p-2"
+        >
+          <button
+            type="button"
+            onClick={() => onJumpToHolder(holder)}
+            className="text-xs font-mono text-foreground hover:underline"
+            data-ui-bridge-id="productivity.file-activity-holder-row"
+            data-holder-name={holder}
+          >
+            {holder}
+          </button>
+          <ul className="mt-1 pl-3 text-xs text-muted-foreground space-y-0.5">
+            {entries.map((e) => (
+              <li
+                key={e.file_path}
+                className="truncate"
+                title={e.file_path}
+              >
+                {e.file_path}
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface HotFilesSectionProps {
+  rows: readonly HotFileRow[];
+}
+
+function HotFilesSection({ rows }: HotFilesSectionProps) {
+  const max = rows.length === 0 ? 0 : Math.max(...rows.map((r) => r.distinct_sessions));
+  if (rows.length === 0) {
+    return (
+      <div
+        className="rounded-md border border-border/40 bg-muted/10 p-3 text-xs text-muted-foreground"
+        data-ui-bridge-id="productivity.file-activity-hot-files-empty"
+      >
+        No file activity in this window.
+      </div>
+    );
+  }
+  return (
+    <table
+      className="w-full text-xs"
+      data-ui-bridge-id="productivity.file-activity-hot-files"
+    >
+      <thead className="text-muted-foreground">
+        <tr>
+          <th className="text-left font-normal pb-1">Path</th>
+          <th className="text-left font-normal pb-1 w-32">Touches</th>
+          <th className="text-left font-normal pb-1 w-24">Latest</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr
+            key={r.file_path}
+            data-ui-bridge-id="productivity.file-activity-hot-file-row"
+            data-file-path={r.file_path}
+          >
+            <td className="text-foreground truncate max-w-[18rem]" title={r.file_path}>
+              {r.file_path}
+            </td>
+            <td>
+              <span className="font-mono text-foreground/90 mr-2">
+                {r.distinct_sessions}
+              </span>
+              <span className="font-mono text-muted-foreground">
+                {barFor(r.distinct_sessions, max)}
+              </span>
+            </td>
+            <td className="text-muted-foreground">{ageLabel(r.latest_recorded_at)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+interface HotSessionsSectionProps {
+  rows: readonly HotSessionRow[];
+}
+
+function HotSessionsSection({ rows }: HotSessionsSectionProps) {
+  const max = rows.length === 0 ? 0 : Math.max(...rows.map((r) => r.distinct_files));
+  if (rows.length === 0) {
+    return (
+      <div
+        className="rounded-md border border-border/40 bg-muted/10 p-3 text-xs text-muted-foreground"
+        data-ui-bridge-id="productivity.file-activity-hot-sessions-empty"
+      >
+        No session activity in this window.
+      </div>
+    );
+  }
+  return (
+    <table
+      className="w-full text-xs"
+      data-ui-bridge-id="productivity.file-activity-hot-sessions"
+    >
+      <thead className="text-muted-foreground">
+        <tr>
+          <th className="text-left font-normal pb-1">Session</th>
+          <th className="text-left font-normal pb-1 w-32">Files</th>
+          <th className="text-left font-normal pb-1 w-24">Latest</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr
+            key={r.task_run_id}
+            data-ui-bridge-id="productivity.file-activity-hot-session-row"
+            data-task-run-id={r.task_run_id}
+          >
+            <td className="font-mono text-foreground truncate max-w-[18rem]" title={r.task_run_id}>
+              {r.task_run_id}
+            </td>
+            <td>
+              <span className="font-mono text-foreground/90 mr-2">{r.distinct_files}</span>
+              <span className="font-mono text-muted-foreground">
+                {barFor(r.distinct_files, max)}
+              </span>
+            </td>
+            <td className="text-muted-foreground">{ageLabel(r.latest_recorded_at)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export interface FileActivityPanelProps {
+  /** Test seam — when supplied, the panel skips its polling loop and
+   *  renders the supplied snapshot. Production callers omit this. */
+  initialDataForTest?: import("./fileActivityApi").HeatmapResponse;
+  /** Optional callback fired when the user clicks a holder name. Used
+   *  by tests to assert click-to-jump behavior. Production wires to
+   *  `__UI_BRIDGE__.navigateHandler("terminal")` (page-nav only;
+   *  per-tab focus is a follow-up — see panel header comment). */
+  onJumpToHolder?: (holderName: string) => void;
+}
+
+export function FileActivityPanel({
+  initialDataForTest,
+  onJumpToHolder,
+}: FileActivityPanelProps) {
+  const [windowSecs, setWindowSecsState] = useState<number>(() =>
+    initialDataForTest ? DEFAULT_WINDOW_SECS : loadStoredWindowSecs(),
+  );
+
+  const { data, error, isStale, refresh } = useFileActivity({
+    windowSecs,
+    enabled: initialDataForTest == null,
+  });
+
+  const snapshot = initialDataForTest ?? data;
+
+  const handleWindowChange = useCallback((secs: number) => {
+    setWindowSecsState(secs);
+    storeWindowSecs(secs);
+  }, []);
+
+  const defaultJumpHandler = useCallback((_holderName: string) => {
+    // Mirror WorkersPanel: page-nav to Terminals; per-tab focus is a
+    // documented follow-up (the dashboard scope doesn't currently own
+    // `setActiveId`).
+    const handler = (
+      window as unknown as {
+        __UI_BRIDGE__?: { navigateHandler?: (url: string) => void };
+      }
+    )?.__UI_BRIDGE__?.navigateHandler;
+    handler?.("terminal");
+  }, []);
+
+  const jumpHandler = onJumpToHolder ?? defaultJumpHandler;
+
+  return (
+    <section
+      role="region"
+      aria-labelledby="productivity-file-activity-heading"
+      className="flex flex-col rounded-lg border border-border bg-card/30 p-4 gap-3"
+      data-ui-bridge-id="productivity.file-activity"
+    >
+      <PanelHeader
+        windowSecs={windowSecs}
+        onWindowChange={handleWindowChange}
+        onRefresh={refresh}
+        isStale={isStale}
+        error={error}
+      />
+
+      <div className="flex flex-col gap-3">
+        <section
+          aria-label="Live file holdings"
+          data-ui-bridge-id="productivity.file-activity-live-section"
+        >
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+            <Users className="w-3 h-3" />
+            Currently editing
+          </div>
+          <LiveSnapshotSection
+            rows={snapshot?.live ?? []}
+            onJumpToHolder={jumpHandler}
+          />
+        </section>
+
+        <section
+          aria-label="Hot files"
+          data-ui-bridge-id="productivity.file-activity-hot-files-section"
+        >
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+            <FileText className="w-3 h-3" />
+            Most touched files
+          </div>
+          <HotFilesSection rows={snapshot?.hot_files ?? []} />
+        </section>
+
+        <section
+          aria-label="Hot sessions"
+          data-ui-bridge-id="productivity.file-activity-hot-sessions-section"
+        >
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+            <Flame className="w-3 h-3" />
+            Most active sessions
+          </div>
+          <HotSessionsSection rows={snapshot?.hot_sessions ?? []} />
+        </section>
+      </div>
+    </section>
+  );
+}
+
+export default FileActivityPanel;
+
+// Re-export the raw fetcher so the unit test (and a future server-side
+// renderer) can drive the panel without the React lifecycle.
+export { fetchHeatmap };

--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -1,0 +1,229 @@
+/**
+ * File Activity heatmap — types, fetcher, and `useFileActivity` hook.
+ *
+ * Backend: `GET /file-activity/heatmap?window_secs=N&limit=M` (runner
+ * MCP API, shipped as Phase 1 of the file-ownership-heatmap plan). The
+ * endpoint composes:
+ *   - `FileRegistryManager.info()` live snapshot
+ *   - `PgDb::hot_files`  windowed aggregate
+ *   - `PgDb::hot_sessions` windowed aggregate
+ *
+ * Phase 3 lifecycle:
+ *   - 5 s `setInterval` while mounted; cleared on unmount.
+ *   - Polling pauses while `document.visibilityState !== "visible"` to
+ *     avoid background PG load. A `visibilitychange` listener resumes it.
+ *   - On fetch failure or response slower than 2 s, the prior data is
+ *     kept and `isStale` flips to `true` (UI renders a clock icon). The
+ *     plan is explicit: do *not* replace stale data with a loading
+ *     state — keep the last good snapshot, just age it.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+/** Live entry from the in-process `FileRegistryManager.info()` snapshot. */
+export interface FileRegistryInfoEntry {
+  file_path: string;
+  worktree_id?: string;
+  holder_task_run_id: string;
+  holder_name: string;
+  /** ms since unix epoch. */
+  registered_at: number;
+}
+
+/** One row of the windowed hot-files aggregate (PG-side). */
+export interface HotFileRow {
+  file_path: string;
+  /** distinct sessions that touched this file in the window. */
+  distinct_sessions: number;
+  /** ISO 8601 timestamp of the most recent touch in the window. */
+  latest_recorded_at: string;
+  latest_task_run_id: string;
+}
+
+/** One row of the windowed hot-sessions aggregate (PG-side). */
+export interface HotSessionRow {
+  task_run_id: string;
+  /** distinct files this session touched in the window. */
+  distinct_files: number;
+  latest_recorded_at: string;
+}
+
+export interface HeatmapResponse {
+  live: FileRegistryInfoEntry[];
+  hot_files: HotFileRow[];
+  hot_sessions: HotSessionRow[];
+  /** echo of the window the server resolved (after clamping). */
+  window_secs: number;
+  /** echo of the per-list cap the server resolved (after clamping). */
+  limit: number;
+}
+
+/** Dropdown options for the window selector. Plan calls for fixed
+ *  values, not a slider — 4 options keeps the UI honest about what's
+ *  meaningful. */
+export const WINDOW_OPTIONS: readonly { label: string; secs: number }[] = [
+  { label: "15 min", secs: 900 },
+  { label: "1 hr", secs: 3600 },
+  { label: "6 hr", secs: 21600 },
+  { label: "24 hr", secs: 86400 },
+];
+
+export const DEFAULT_WINDOW_SECS = 3600;
+export const WINDOW_STORAGE_KEY = "fileActivity.windowSecs";
+
+/** Default poll interval matches the plan's Phase 3 spec. */
+export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/** Beyond this latency a fetch is considered slow and triggers the
+ *  stale indicator even if it eventually returns. */
+const SLOW_FETCH_THRESHOLD_MS = 2_000;
+
+/** Load the user's stored window choice. Falls back to 1 hour. Defensive
+ *  against `localStorage` being unavailable (Tauri sandboxes, SSR). */
+export function loadStoredWindowSecs(): number {
+  if (typeof window === "undefined") return DEFAULT_WINDOW_SECS;
+  try {
+    const raw = window.localStorage.getItem(WINDOW_STORAGE_KEY);
+    if (!raw) return DEFAULT_WINDOW_SECS;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n)) return DEFAULT_WINDOW_SECS;
+    if (!WINDOW_OPTIONS.some((o) => o.secs === n)) return DEFAULT_WINDOW_SECS;
+    return n;
+  } catch {
+    return DEFAULT_WINDOW_SECS;
+  }
+}
+
+export function storeWindowSecs(secs: number): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(WINDOW_STORAGE_KEY, String(secs));
+  } catch {
+    /* localStorage unavailable; no-op. */
+  }
+}
+
+/** Resolve the runner MCP API base URL the same way `useFileLockTracking`
+ *  does. The runner injects `__QONTINUI_PORT__` on its window object at
+ *  boot; we fall back to the canonical 9876 port when missing. */
+function apiBaseUrl(): string {
+  if (typeof window === "undefined") return "http://127.0.0.1:9876";
+  const port = (window as unknown as Record<string, unknown>).__QONTINUI_PORT__;
+  const parsed = typeof port === "number" ? port : Number.parseInt(String(port ?? ""), 10);
+  return `http://127.0.0.1:${Number.isFinite(parsed) && parsed > 0 ? parsed : 9876}`;
+}
+
+export async function fetchHeatmap(
+  windowSecs: number,
+  limit = 25,
+  signal?: AbortSignal,
+): Promise<HeatmapResponse> {
+  const url = `${apiBaseUrl()}/file-activity/heatmap?window_secs=${windowSecs}&limit=${limit}`;
+  const resp = await fetch(url, { signal });
+  if (!resp.ok) {
+    throw new Error(`heatmap fetch failed: HTTP ${resp.status}`);
+  }
+  return (await resp.json()) as HeatmapResponse;
+}
+
+export interface UseFileActivityResult {
+  data: HeatmapResponse | null;
+  error: string | null;
+  /** True when the latest fetch failed OR took longer than the slow
+   *  threshold. Cleared by the next successful fast fetch. */
+  isStale: boolean;
+  /** Force-refresh now. Does not reset `isStale` optimistically — that
+   *  flips back when the refresh completes successfully. */
+  refresh: () => void;
+}
+
+interface UseFileActivityOptions {
+  windowSecs: number;
+  /** When `false`, polling is suspended (mount-time + visibility gate).
+   *  Defaults to `true`. */
+  enabled?: boolean;
+  /** Override the 5 s poll cadence; useful for tests. */
+  pollIntervalMs?: number;
+}
+
+/**
+ * Encapsulates the windowed fetch, the visibility-gated poll lifecycle,
+ * and the stale flag. The hook deliberately keeps the previous payload
+ * across failures (per plan's Phase 3 rule "don't replace stale data
+ * with loading").
+ */
+export function useFileActivity({
+  windowSecs,
+  enabled = true,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+}: UseFileActivityOptions): UseFileActivityResult {
+  const [data, setData] = useState<HeatmapResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isStale, setIsStale] = useState<boolean>(false);
+  /** Bumped by the user-facing `refresh()` to short-circuit the timer. */
+  const [tick, setTick] = useState<number>(0);
+
+  // Track document visibility so polling pauses in background tabs.
+  const [visible, setVisible] = useState<boolean>(
+    typeof document === "undefined" || document.visibilityState === "visible",
+  );
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onVisChange = () => setVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", onVisChange);
+    return () => document.removeEventListener("visibilitychange", onVisChange);
+  }, []);
+
+  // Stable ref for the currently in-flight request so we can abort it
+  // when the effect cleans up (component unmount, window change).
+  const abortRef = useRef<AbortController | null>(null);
+
+  // Snapshot the most recent successful resolution time. Phase 3 spec:
+  // stale flag flips on slow fetches, not just hard failures.
+  useEffect(() => {
+    if (!enabled || !visible) return;
+
+    let cancelled = false;
+    const ac = new AbortController();
+    abortRef.current?.abort();
+    abortRef.current = ac;
+
+    const tick = async () => {
+      const start = performance.now();
+      try {
+        const payload = await fetchHeatmap(windowSecs, 25, ac.signal);
+        if (cancelled) return;
+        const elapsed = performance.now() - start;
+        setData(payload);
+        setError(null);
+        setIsStale(elapsed > SLOW_FETCH_THRESHOLD_MS);
+      } catch (e) {
+        if (cancelled || ac.signal.aborted) return;
+        // Network errors and abort errors look the same shape in fetch;
+        // we already skipped abort above. Treat anything else as stale.
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+        setIsStale(true);
+        // NB: keep `data` populated — see plan §Phase 3.
+      }
+    };
+
+    tick();
+    const id = window.setInterval(tick, pollIntervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+      ac.abort();
+    };
+  }, [windowSecs, enabled, visible, pollIntervalMs, tick]);
+
+  const refresh = useCallback(() => {
+    setTick((t) => t + 1);
+  }, []);
+
+  return useMemo(
+    () => ({ data, error, isStale, refresh }),
+    [data, error, isStale, refresh],
+  );
+}


### PR DESCRIPTION
## Summary

- Phases 2 + 3 of `plans/file-ownership-heatmap-plan.md`. Backend Phase 1 already shipped in #73.
- New `FileActivityPanel` rendered below the productivity-stack spec-locked block on `CoordinatorDashboard`. Three sub-sections: Live snapshot grouped by holder, Hot files (count + 10-segment bar), Hot sessions.
- `useFileActivity` hook owns the Phase 3 lifecycle: 5 s polling, `document.visibilityState` pause, 2 s slow-fetch threshold flips `isStale` without discarding prior data.
- `findTabByHolderName` lifted to a module-level export on `useFileLockTracking.ts` for sibling reuse.
- Spec assertion `productivity-coordinator-panels` grows from 5 to 6 required elements; description updated to call out the order-invariant boundary.
- Drive-by: dedupe an accidentally-merged duplicate `mod tests` block in `mcp/file_registry.rs` (was failing `cargo clippy --tests` on main).

## Scope notes called out in the plan stamp

- The plan asked for `setActiveId(tabId)` click-to-jump. `setActiveId` lives in `useTerminalManager`, which `CoordinatorDashboard` doesn't instantiate. v1 mirrors `WorkersPanel`'s page-nav-only behaviour; per-tab focus is a follow-up.
- Vitest config is `environment: "node"` — no jsdom. Tests cover the pure helpers (`ageLabel`, `barFor`, `loadStoredWindowSecs` / `storeWindowSecs`); JSX is gated by manual + UI Bridge spec assertion. Same trade-off as the rest of the productivity panels.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` on changed files — clean
- [x] `pnpm vitest run` — 14 new cases pass; pre-existing failures on main reproduce without these changes
- [x] `cargo clippy --tests --no-deps -- -D warnings` — clean (was failing on main, fixed by the dedup commit)
- [ ] Manual UI Bridge smoke (per `feedback_primary_runner_restart.md`): spawn temp runner, populate `coord.session_touched_files`, observe panel — follow-up
- [ ] `EXPLAIN` the windowed aggregate under non-trivial load — follow-up