### PR TITLE
test(timeout-config): serialize env-var tests + RAII cleanup guard

### DIFF
--- a/src-tauri/src/timeout_config.rs
+++ b/src-tauri/src/timeout_config.rs
@@ -254,9 +254,30 @@ impl Timeouts {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Tests in this module read or mutate process-wide `QONTINUI_TIMEOUT_*`
+    // env vars. Cargo runs tests within a binary in parallel by default, so
+    // without serialization `test_optional_timeout_disabled_by_default` can
+    // observe the env var set by `test_env_override` mid-run and assert
+    // against leaked state. Recover-from-poison so a panicking test doesn't
+    // cascade-fail the rest of the module.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard: removes the named env var on drop, including the panic
+    /// path. Without this, a future failing assertion inside
+    /// `test_env_override` after `set_var` would leak the var into the
+    /// process and break sibling tests once the mutex is released.
+    struct EnvVarGuard(&'static str);
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            env::remove_var(self.0);
+        }
+    }
 
     #[test]
     fn test_optional_timeout_disabled_by_default() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // User-facing operations should be disabled by default
         assert!(Timeouts::action_execution().is_none());
         assert!(Timeouts::python_command().is_none());
@@ -265,6 +286,7 @@ mod tests {
 
     #[test]
     fn test_required_timeout_has_default() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // System health operations should have defaults
         assert!(Timeouts::python_startup().as_secs() > 0);
         assert!(Timeouts::health_ping_interval().as_secs() > 0);
@@ -273,11 +295,13 @@ mod tests {
 
     #[test]
     fn test_env_override() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _env = EnvVarGuard("QONTINUI_TIMEOUT_ACTION_EXECUTION");
         // Test that environment variables can override defaults
         env::set_var("QONTINUI_TIMEOUT_ACTION_EXECUTION", "300");
         let timeout = Timeouts::action_execution();
         assert!(timeout.is_some());
         assert_eq!(timeout.unwrap().as_secs(), 300);
-        env::remove_var("QONTINUI_TIMEOUT_ACTION_EXECUTION");
+        // env var auto-removed by EnvVarGuard on drop
     }
 }


### PR DESCRIPTION
## Summary

Fixes the flaky `test_optional_timeout_disabled_by_default` failure on `ubuntu-22.04` CI seen on #74 (passed cleanly on rerun, which is the smoking gun for an ordering race).

## Root cause

`test_env_override` writes `QONTINUI_TIMEOUT_ACTION_EXECUTION=300` to the process-wide env then removes it. `test_optional_timeout_disabled_by_default` asserts `Timeouts::action_execution().is_none()`, which reads the same env var. Cargo runs tests within a binary in parallel by default — when the assertion test wakes up while the env-toggling test has the var set, the assertion fails with:

```
thread 'timeout_config::tests::test_optional_timeout_disabled_by_default' panicked at src-tauri/src/timeout_config.rs:261:9:
assertion failed: Timeouts::action_execution().is_none()
```

macOS and Windows happen to finish the env-toggling test fast enough that the assertion test rarely sees the leaked state. Ubuntu doesn't.

A separate panic-safety hole: if any assertion in `test_env_override` ever fails between `set_var` and `remove_var`, the var leaks into the rest of the process and breaks subsequent tests permanently for that run.

## Fix

- **Module-local `static ENV_LOCK: Mutex<()>`** serializes all three tests that touch `QONTINUI_TIMEOUT_*`. Lock acquires use `unwrap_or_else(|e| e.into_inner())` so a panic inside the critical section poisons the lock without cascade-failing every sibling test.
- **`EnvVarGuard(&'static str)`** removes the var on `Drop`, including the panic path. The auto-cleanup replaces the explicit `env::remove_var` at the bottom of `test_env_override`.

A grep across `src-tauri/src/**` for `env::set_var.*QONTINUI_TIMEOUT_` turns up only this module, so a local Mutex (rather than a global one or pulling in `serial_test`) is sufficient. If someone later adds another module that mutates `QONTINUI_TIMEOUT_*` env vars, that module should use the same pattern.

## Verification

- `cargo test --bin qontinui-runner --features custom-protocol timeout_config::tests -- --test-threads=4` — 3 passed locally
- **Stress test: 20/20 iterations pass** (the pre-fix branch would intermittently fail at rates that varied with system load)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Test plan
- [ ] CI passes (ubuntu-22.04 specifically — the test that was failing)
- [ ] Re-run ubuntu-22.04 a couple times if possible to confirm the flake is gone