### PR TITLE
feat(ui-bridge): quality remediation from 2026-05-10 manual-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.2.5",
-    "@qontinui/ui-bridge": "^0.3.9",
+    "@qontinui/ui-bridge": "^0.4.0",
     "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.5
         version: 0.2.5
       '@qontinui/ui-bridge':
-        specifier: ^0.3.9
-        version: 0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.4.0
+        version: 0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1145,6 +1145,33 @@ packages:
 
   '@qontinui/ui-bridge@0.3.9':
     resolution: {integrity: sha512-VLWgdvkm3lP/gTYXYqd4FgUFZhVRG7VNB7/GEwoDLF6QvxwUsDPenyb/CSTvHSO54xFMX9A4KELhkpHv+dhYqQ==}
+    peerDependencies:
+      '@qontinui/ui-bridge-auto': '>=0.1.0'
+      '@qontinui/ui-bridge-headless': '>=0.1.0'
+      express: ^4.18.0 || ^5.0.0
+      next: '>=13.0.0'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      react-native: '>=0.70.0'
+      ws: ^8.0.0
+    peerDependenciesMeta:
+      '@qontinui/ui-bridge-auto':
+        optional: true
+      '@qontinui/ui-bridge-headless':
+        optional: true
+      express:
+        optional: true
+      next:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+      ws:
+        optional: true
+
+  '@qontinui/ui-bridge@0.4.0':
+    resolution: {integrity: sha512-UD9Q91Xbz1GgpoP+3dN/VoIClVHgKkGKt0t7BDr3BJsZ2MnJ6qMe5At7fpAIyo1OVk48UmHn5zEMC1wDiDoJLQ==}
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
       '@qontinui/ui-bridge-headless': '>=0.1.0'
@@ -6106,9 +6133,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.5': {}
@@ -6136,6 +6163,15 @@ snapshots:
       - typescript
 
   '@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@qontinui/ui-bridge-auto': 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@tauri-apps/api': 2.11.0
+      react-dom: 19.2.5(react@19.2.5)
+      ws: 8.20.0
+
+  '@qontinui/ui-bridge@0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:

--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -1285,6 +1285,10 @@ async fn handle_discover(
 }
 
 /// GET /ui-bridge/sdk/components — List components
+///
+/// F2 (Direction B): converges with the direct `/ui-bridge/control/components`
+/// route on `{success: true, data: {components: [...]}}`. Object-shaped
+/// `data` matches every other rich endpoint convention.
 async fn handle_components(
     State(state): State<Arc<ApiState>>,
     Query(query): Query<HashMap<String, String>>,
@@ -1303,9 +1307,13 @@ async fn handle_components(
                 .unwrap_or(serde_json::json!([]));
             let mut response = serde_json::json!({
                 "success": true,
-                "data": components,
+                "data": { "components": components },
             });
-            if let Some(arr) = response.get("data").and_then(|d| d.as_array()) {
+            if let Some(arr) = response
+                .get("data")
+                .and_then(|d| d.get("components"))
+                .and_then(|c| c.as_array())
+            {
                 if arr.is_empty() {
                     if let Some(obj) = response.as_object_mut() {
                         obj.insert(
@@ -1330,11 +1338,37 @@ async fn handle_components(
         "/control/components".to_string()
     };
     match sdk_request(&state, Method::GET, &path, None).await {
-        Ok(mut data) => {
-            // Add helpful note if no components found
-            if let Some(arr) = data.get("data").and_then(|d| d.as_array()) {
+        Ok(data) => {
+            // The SDK app now returns Direction B shape:
+            // `{success: true, data: {components: [...]}}`. Older callers may
+            // still emit `{success: true, data: [array]}`. Normalize both to
+            // a plain array before re-wrapping so we don't double-nest as
+            // `data.components.components`.
+            let raw_data = data.get("data").cloned().unwrap_or(serde_json::json!([]));
+            let components_array = if let Some(arr) = raw_data.get("components").cloned() {
+                arr
+            } else if raw_data.is_array() {
+                raw_data
+            } else {
+                serde_json::json!([])
+            };
+            let mut response = serde_json::json!({
+                "success": data.get("success").cloned().unwrap_or(serde_json::Value::Bool(true)),
+                "data": { "components": components_array },
+            });
+            // Carry through any sibling fields (errors, timestamps, etc.).
+            if let Some(err) = data.get("error").cloned() {
+                if let Some(obj) = response.as_object_mut() {
+                    obj.insert("error".to_string(), err);
+                }
+            }
+            if let Some(arr) = response
+                .get("data")
+                .and_then(|d| d.get("components"))
+                .and_then(|c| c.as_array())
+            {
                 if arr.is_empty() {
-                    if let Some(obj) = data.as_object_mut() {
+                    if let Some(obj) = response.as_object_mut() {
                         obj.insert(
                             "note".to_string(),
                             serde_json::json!("No registered components found. Ensure the UI Bridge SDK provider is mounted and components are registered with useUIBridge or equivalent."),
@@ -1342,12 +1376,26 @@ async fn handle_components(
                     }
                 }
             }
-            Json(data)
+            Json(response)
         }
         Err(_) => {
-            // Fall back to IPC
+            // Fall back to IPC. The frontend `get_components` handler returns
+            // `{components: [...], count: N}` (object) rather than a bare
+            // array — unwrap so we don't double-nest as `data.components.components`.
             match ui_bridge_request_sync(&state, "get_components", serde_json::json!({})).await {
-                Ok(data) => Json(serde_json::json!({ "success": true, "data": data })),
+                Ok(data) => {
+                    let components_array = if let Some(arr) = data.get("components").cloned() {
+                        arr
+                    } else if data.is_array() {
+                        data
+                    } else {
+                        serde_json::json!([])
+                    };
+                    Json(serde_json::json!({
+                        "success": true,
+                        "data": { "components": components_array },
+                    }))
+                }
                 Err(e) => Json(serde_json::json!({ "success": false, "error": e })),
             }
         }

--- a/src-tauri/src/mcp/ui_bridge/ai.rs
+++ b/src-tauri/src/mcp/ui_bridge/ai.rs
@@ -65,6 +65,23 @@ pub struct AiFindRequest {
     pub include_hidden: Option<bool>,
 }
 
+/// Query-string params for `/ai/find` and `/control/ai/find`. The body
+/// continues to carry the query / context / minConfidence — this struct
+/// exists only to give the new `?strict=true` knob a typed home so axum
+/// can extract it via `Query<AiFindQuery>`. The body's `"strict": true`
+/// is honoured in parallel; either form works.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiFindQuery {
+    /// B2 — literal-match-only mode. When `true`, the SDK matcher
+    /// suppresses fuzzy candidates; returns `found: false` if no element
+    /// matches exactly. Default `false` keeps fuzzy behaviour PLUS
+    /// literal-match precedence (exact matches outrank fuzzy candidates
+    /// even when `strict` is omitted).
+    #[serde(default)]
+    pub strict: Option<bool>,
+}
+
 /// Natural language element find.
 ///
 /// Callers can pass `"minConfidence": 0.3` in the request body to override
@@ -75,8 +92,15 @@ pub struct AiFindRequest {
 /// filter. Default `true` matches the historical front-end behaviour and
 /// is what callers need when driving collapsed sidebars or tabs whose
 /// targets are off-screen but still in the registry.
+///
+/// B2 — `?strict=true` (query string) or `"strict": true` (body) enables
+/// literal-match-only mode. The SDK returns only candidates that have a
+/// case-insensitive exact match against id / labelText / ariaLabel /
+/// textContent / title / placeholder / value / name. No fuzzy fallback.
+/// If no element matches literally, the response is `found: false`.
 pub async fn ui_bridge_ai_find_handler(
     State(state): State<Arc<ApiState>>,
+    Query(query): Query<AiFindQuery>,
     Json(body): Json<serde_json::Value>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     info!("UI Bridge API: AI find");
@@ -90,12 +114,24 @@ pub async fn ui_bridge_ai_find_handler(
     let parsed: AiFindRequest = serde_json::from_value(body.clone()).unwrap_or_default();
     let include_hidden = parsed.include_hidden.unwrap_or(true);
 
+    // B2 — `strict` can arrive via two channels:
+    //   - query string: `?strict=true`
+    //   - JSON body:    `{"strict": true}`
+    // We OR them together so either form works, then normalise it into the
+    // forwarded params so the SDK handler always sees a concrete boolean.
+    let strict = query.strict.unwrap_or(false)
+        || body
+            .get("strict")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
     let mut forwarded_body = body.clone();
     if let Some(obj) = forwarded_body.as_object_mut() {
         obj.insert(
             "includeHidden".to_string(),
             serde_json::Value::Bool(include_hidden),
         );
+        obj.insert("strict".to_string(), serde_json::Value::Bool(strict));
     }
 
     let payload = serde_json::json!({ "params": forwarded_body });

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -1202,9 +1202,16 @@ fn ws_dispatch_error_response(error_msg: String) -> (StatusCode, Json<ApiRespons
 /// merged response, so a flaky wrapper degrades gracefully. Both bare-array
 /// and `{data: [...]}` / `{components: [...]}` shapes from wrappers are
 /// accepted and unwrapped.
+///
+/// F2 (Direction B) envelope shape:
+/// - `data` is `{components: [...]}` (object-shaped, matches every other
+///   rich endpoint convention and aligns with the SDK relay).
+/// - A **deprecated** top-level `components` field mirrors the array so
+///   pre-Direction-B callers keep working. Slated for removal one release
+///   after Direction B lands — read from `data.components` instead.
 pub async fn ui_bridge_get_components_handler(
     State(state): State<Arc<ApiState>>,
-) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiResponse<()>>)> {
     info!("UI Bridge API: Getting all components");
 
     // Fan out to WS-transport wrappers in parallel with the IPC call.
@@ -1265,7 +1272,15 @@ pub async fn ui_bridge_get_components_handler(
     };
 
     merged.append(&mut ws_components);
-    Ok(Json(ApiResponse::success(serde_json::Value::Array(merged))))
+    let components_array = serde_json::Value::Array(merged);
+    // F2 (Direction B): emit `{success, data:{components:[...]}, components:[...]}`.
+    // The top-level `components` is a deprecated mirror for back-compat;
+    // new callers should read `data.components`.
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "data": { "components": components_array.clone() },
+        "components": components_array,
+    })))
 }
 
 /// Get a specific component by ID.
@@ -1895,11 +1910,26 @@ pub async fn ui_bridge_get_snapshot_handler(
 ///   - `{"kind":"attribute_equals","name":"aria-pressed","value":"true"}`
 pub async fn ui_bridge_wait_for_element_handler(
     State(state): State<Arc<ApiState>>,
+    Query(query_params): Query<std::collections::HashMap<String, String>>,
     body: Option<Json<serde_json::Value>>,
-) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
+{
     let body = body
         .map(|Json(v)| v)
         .unwrap_or_else(|| serde_json::json!({}));
+
+    // B4 — `?strictTimeout=true` query parameter:
+    // When set, the predicate/state SDK-forwarded helpers translate
+    // `{found: false, durationMs, lastObservedState}` IPC payloads into
+    // HTTP 408 + `api_error("wait_for_element_timeout")` with a `data:` body
+    // carrying the original IPC fields. Default behaviour (back-compat)
+    // preserves the existing `success:true` envelope on timeout. The NL/id
+    // path already returns HTTP 408 on timeout (see the bottom of this
+    // function) so `strictTimeout` is a no-op there.
+    let strict_timeout = query_params
+        .get("strictTimeout")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false);
 
     // Body-shape routing — three accepted shapes share `/ai/wait-for-element`:
     //
@@ -1911,10 +1941,11 @@ pub async fn ui_bridge_wait_for_element_handler(
     //   2. `{ predicate: {...}, requirement?, ... }` — `waitForElementRegistered`.
     //   3. `{ query|elementId, assertions?, ... }` — legacy poll-via-ai_find.
     if body.get("state").and_then(|v| v.as_str()).is_some() {
-        return ui_bridge_wait_for_element_state_predicate_handler(state, body).await;
+        return ui_bridge_wait_for_element_state_predicate_handler(state, body, strict_timeout)
+            .await;
     }
     if body.get("predicate").is_some() {
-        return ui_bridge_wait_for_element_registered_forward(state, body).await;
+        return ui_bridge_wait_for_element_registered_forward(state, body, strict_timeout).await;
     }
 
     let query = body.get("query").and_then(|v| v.as_str()).map(String::from);
@@ -1944,7 +1975,7 @@ pub async fn ui_bridge_wait_for_element_handler(
         (None, None) => {
             return Err((
                 StatusCode::BAD_REQUEST,
-                Json(api_error(
+                Json(api_error_to_value(
                     "wait-for-element: provide either 'query' or 'elementId'",
                 )),
             ));
@@ -1952,7 +1983,7 @@ pub async fn ui_bridge_wait_for_element_handler(
         (Some(_), Some(_)) => {
             return Err((
                 StatusCode::BAD_REQUEST,
-                Json(api_error(
+                Json(api_error_to_value(
                     "wait-for-element: 'query' and 'elementId' are mutually exclusive",
                 )),
             ));
@@ -2022,9 +2053,13 @@ pub async fn ui_bridge_wait_for_element_handler(
                     match evaluate_wait_for_element_assertions(&element, &assertions) {
                         Ok(()) => {
                             let elapsed_ms = start.elapsed().as_millis() as u64;
+                            // F1: emit canonical camelCase `durationMs` alongside
+                            // legacy snake_case `elapsed_ms`. elapsed_ms emit
+                            // retained for one release; remove after 2026-06.
                             return Ok(Json(ApiResponse::success(serde_json::json!({
                                 "found": true,
                                 "element": element,
+                                "durationMs": elapsed_ms,
                                 "elapsed_ms": elapsed_ms,
                                 "polls": polls,
                                 "assertions_passed": assertions.len(),
@@ -2037,9 +2072,13 @@ pub async fn ui_bridge_wait_for_element_handler(
                     }
                 } else {
                     let elapsed_ms = start.elapsed().as_millis() as u64;
+                    // F1: emit canonical camelCase `durationMs` alongside
+                    // legacy snake_case `elapsed_ms`. elapsed_ms emit
+                    // retained for one release; remove after 2026-06.
                     return Ok(Json(ApiResponse::success(serde_json::json!({
                         "found": true,
                         "element": element,
+                        "durationMs": elapsed_ms,
                         "elapsed_ms": elapsed_ms,
                         "polls": polls,
                     }))));
@@ -2051,7 +2090,10 @@ pub async fn ui_bridge_wait_for_element_handler(
             }
             Err(e) => {
                 error!("UI Bridge API: wait-for-element transport error: {}", e);
-                return Err((StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))));
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(api_error_to_value(e)),
+                ));
             }
         }
 
@@ -2079,10 +2121,35 @@ pub async fn ui_bridge_wait_for_element_handler(
                 )
             };
             info!("UI Bridge API: {}", msg);
-            return Err((StatusCode::REQUEST_TIMEOUT, Json(api_error(msg))));
+            // F1: attach structured `data` payload to the HTTP 408 envelope
+            // so callers can read durationMs/polls without parsing the
+            // error string. The shape mirrors the predicate/state strictTimeout
+            // path's data payload.
+            let mut body = api_error_to_value(msg);
+            body.data = Some(serde_json::json!({
+                "found": false,
+                "durationMs": elapsed_ms,
+                "polls": polls,
+            }));
+            return Err((StatusCode::REQUEST_TIMEOUT, Json(body)));
         }
 
         tokio::time::sleep(std::time::Duration::from_millis(poll_interval_ms)).await;
+    }
+}
+
+/// Local helper that produces an error `ApiResponse<serde_json::Value>` —
+/// mirrors `api_error()` but with the `data: Option<serde_json::Value>`
+/// field intact so callers can attach a structured payload alongside the
+/// error string. Used by wait-for-element to emit `data:{durationMs,...}`
+/// on timeout.
+fn api_error_to_value(message: impl Into<String>) -> ApiResponse<serde_json::Value> {
+    ApiResponse {
+        success: false,
+        data: None,
+        error: Some(message.into()),
+        error_detail: None,
+        hint: None,
     }
 }
 
@@ -2091,10 +2158,17 @@ pub async fn ui_bridge_wait_for_element_handler(
 /// clamp before forwarding so a runaway client can't park the webview
 /// listener indefinitely, mirroring Phase 1's /wait-for-route-change
 /// behaviour. The SDK itself re-clamps to the same window.
+///
+/// B4 `strict_timeout`: when true, a successful IPC response carrying
+/// `{found: false, ...}` is rewritten into an HTTP 408 + error envelope
+/// so the predicate path matches the NL/id contract. When false (default),
+/// the legacy `success:true` envelope is preserved for back-compat.
 async fn ui_bridge_wait_for_element_registered_forward(
     state: Arc<ApiState>,
     mut body: serde_json::Value,
-) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    strict_timeout: bool,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
+{
     // Clamp timeoutMs to [100, 60_000] (default 5000) before forwarding.
     let raw_timeout = body
         .get("timeoutMs")
@@ -2106,14 +2180,18 @@ async fn ui_bridge_wait_for_element_registered_forward(
     }
 
     info!(
-        "UI Bridge API: wait-for-element (predicate shape) predicate={:?} requirement={:?} timeoutMs={}",
+        "UI Bridge API: wait-for-element (predicate shape) predicate={:?} requirement={:?} timeoutMs={} strictTimeout={}",
         body.get("predicate"),
         body.get("requirement").and_then(|v| v.as_str()),
         timeout_ms,
+        strict_timeout,
     );
 
     let payload = serde_json::json!({ "params": body });
-    wrap_ipc_result(ui_bridge_request_sync(&state, "wait_for_element_registered", payload).await)
+    let result = wrap_ipc_result(
+        ui_bridge_request_sync(&state, "wait_for_element_registered", payload).await,
+    );
+    apply_strict_timeout_reshape(result, strict_timeout)
 }
 
 /// M1 wait-for-element state-predicate validation.
@@ -2233,18 +2311,22 @@ pub fn validate_wait_for_element_state_request(
 /// `wait_for_element_state_predicate` runtime handler. Validates the body
 /// up-front (returning HTTP 400 on bad shapes) so the SDK side only sees
 /// well-formed payloads. The SDK handler returns the predicate outcome
-/// verbatim; we surface it 1:1 inside the standard `ApiResponse::success`
-/// envelope so `found:false` (timeout) is **not** an HTTP error.
+/// verbatim; without `strict_timeout` we surface it 1:1 inside the standard
+/// `ApiResponse::success` envelope so `found:false` (timeout) is **not** an
+/// HTTP error. With `strict_timeout`, `{found:false, durationMs, ...}` is
+/// rewritten into HTTP 408 + `data:{...}` to match the NL/id path.
 async fn ui_bridge_wait_for_element_state_predicate_handler(
     state: Arc<ApiState>,
     body: serde_json::Value,
-) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    strict_timeout: bool,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
+{
     let req = validate_wait_for_element_state_request(&body)
-        .map_err(|msg| (StatusCode::BAD_REQUEST, Json(api_error(msg))))?;
+        .map_err(|msg| (StatusCode::BAD_REQUEST, Json(api_error_to_value(msg))))?;
 
     info!(
-        "UI Bridge API: wait-for-element (state shape) elementId={:?} selector={:?} state={} timeoutMs={} pollMs={}",
-        req.element_id, req.selector, req.state, req.timeout_ms, req.poll_ms
+        "UI Bridge API: wait-for-element (state shape) elementId={:?} selector={:?} state={} timeoutMs={} pollMs={} strictTimeout={}",
+        req.element_id, req.selector, req.state, req.timeout_ms, req.poll_ms, strict_timeout
     );
 
     let payload = serde_json::json!({
@@ -2257,9 +2339,58 @@ async fn ui_bridge_wait_for_element_state_predicate_handler(
         }
     });
 
-    wrap_ipc_result(
+    let result = wrap_ipc_result(
         ui_bridge_request_sync(&state, "wait_for_element_state_predicate", payload).await,
-    )
+    );
+    apply_strict_timeout_reshape(result, strict_timeout)
+}
+
+/// B4 — translate a successful IPC envelope carrying `{found: false, ...}`
+/// into an HTTP 408 error response when the caller opted into
+/// `?strictTimeout=true`. Otherwise pass the response through unchanged.
+///
+/// Also adapts the error tuple type from `ApiResponse<()>` (what
+/// `wrap_ipc_result` returns) to `ApiResponse<serde_json::Value>` (what the
+/// wait-for-element handlers need, so the timeout error path can carry a
+/// `data` payload).
+fn apply_strict_timeout_reshape(
+    result: Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)>,
+    strict_timeout: bool,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
+{
+    match result {
+        Ok(Json(resp)) => {
+            if strict_timeout {
+                // Inspect the inner data for `found: false` — both predicate
+                // (`waitForElementRegistered`) and state-predicate runtimes
+                // return `{found: bool, durationMs?, lastObservedState?}`.
+                let found_false = resp
+                    .data
+                    .as_ref()
+                    .and_then(|d| d.get("found"))
+                    .and_then(|v| v.as_bool())
+                    == Some(false);
+                if found_false {
+                    let data_payload = resp.data.clone().unwrap_or(serde_json::json!({}));
+                    let mut body = api_error_to_value("wait_for_element_timeout");
+                    body.data = Some(data_payload);
+                    return Err((StatusCode::REQUEST_TIMEOUT, Json(body)));
+                }
+            }
+            Ok(Json(resp))
+        }
+        Err((status, Json(err))) => {
+            // Widen the error type from ApiResponse<()> -> ApiResponse<serde_json::Value>.
+            let widened = ApiResponse {
+                success: err.success,
+                data: None,
+                error: err.error,
+                error_detail: err.error_detail,
+                hint: err.hint,
+            };
+            Err((status, Json(widened)))
+        }
+    }
 }
 
 /// Evaluate the `assertions[]` array for the wait-for-element handler.
@@ -3309,6 +3440,248 @@ mod wait_for_element_state_tests {
             let req = ok(json!({ "elementId": "x", "state": state }));
             assert_eq!(req.state, state, "state {state} should round-trip");
         }
+    }
+}
+
+/// B4 — `?strictTimeout=true` re-shaping tests for the predicate/state
+/// SDK-forwarded paths. These exercise the pure helper so we don't need an
+/// axum router / live IPC. The helper translates a successful IPC envelope
+/// carrying `{found: false, ...}` into an HTTP 408 + error body when the
+/// caller opted into strict timeouts; otherwise the response passes through
+/// unchanged for back-compat with existing SDK consumers.
+#[cfg(test)]
+mod strict_timeout_reshape_tests {
+    use super::apply_strict_timeout_reshape;
+    use crate::mcp::types::{api_error, ApiResponse};
+    use axum::http::StatusCode;
+    use axum::response::Json;
+    use serde_json::json;
+    use std::ops::Deref;
+
+    fn ok_response(data: serde_json::Value) -> Json<ApiResponse<serde_json::Value>> {
+        Json(ApiResponse::success(data))
+    }
+
+    #[test]
+    fn strict_timeout_off_preserves_found_false_as_success() {
+        // Default (strictTimeout=false) — `{found:false}` must pass through
+        // as HTTP 200 + `success:true` for back-compat.
+        let inner = json!({"found": false, "durationMs": 1234, "lastObservedState": "hidden"});
+        let result = apply_strict_timeout_reshape(Ok(ok_response(inner.clone())), false);
+        let resp = result.expect("should be Ok when strict_timeout=false");
+        let body = resp.deref();
+        assert!(body.success, "envelope must remain success=true");
+        assert_eq!(body.data.as_ref().unwrap(), &inner);
+    }
+
+    #[test]
+    fn strict_timeout_on_rewrites_found_false_to_408() {
+        // strictTimeout=true — `{found:false}` becomes HTTP 408 + error.
+        let inner = json!({"found": false, "durationMs": 1500, "lastObservedState": "absent"});
+        let result = apply_strict_timeout_reshape(Ok(ok_response(inner.clone())), true);
+        let (status, Json(err)) =
+            result.expect_err("found:false with strict_timeout=true must return Err");
+        assert_eq!(status, StatusCode::REQUEST_TIMEOUT);
+        assert!(!err.success, "error envelope must have success=false");
+        assert_eq!(
+            err.error.as_deref(),
+            Some("wait_for_element_timeout"),
+            "canonical error code per B4 spec"
+        );
+        // `data` payload carries the original IPC fields so callers can read
+        // durationMs / lastObservedState without parsing the error string.
+        let data = err.data.expect("strict_timeout 408 must include data");
+        assert_eq!(data.get("found").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(data.get("durationMs").and_then(|v| v.as_u64()), Some(1500));
+        assert_eq!(
+            data.get("lastObservedState").and_then(|v| v.as_str()),
+            Some("absent")
+        );
+    }
+
+    #[test]
+    fn strict_timeout_on_passes_found_true_through() {
+        // Even with strictTimeout=true, a successful match `{found:true}`
+        // must return HTTP 200 unchanged.
+        let inner = json!({"found": true, "durationMs": 42, "element": {"id": "abc"}});
+        let result = apply_strict_timeout_reshape(Ok(ok_response(inner.clone())), true);
+        let resp = result.expect("found:true must remain Ok regardless of strict_timeout");
+        let body = resp.deref();
+        assert!(body.success);
+        assert_eq!(body.data.as_ref().unwrap(), &inner);
+    }
+
+    #[test]
+    fn strict_timeout_on_passes_through_when_found_field_missing() {
+        // Defensive: if the IPC payload doesn't carry `found` at all, treat
+        // it as "not a timeout" — don't reshape.
+        let inner = json!({"durationMs": 100});
+        let result = apply_strict_timeout_reshape(Ok(ok_response(inner.clone())), true);
+        let resp = result.expect("missing `found` must not trigger reshape");
+        assert_eq!(resp.deref().data.as_ref().unwrap(), &inner);
+    }
+
+    #[test]
+    fn err_branch_widens_apiresponse_type() {
+        // wrap_ipc_result yields ApiResponse<()> on Err; the reshape helper
+        // must widen it to ApiResponse<serde_json::Value> so the outer
+        // handler signature lines up. Verifies the widening preserves error
+        // string + status code.
+        let result = apply_strict_timeout_reshape(
+            Err((StatusCode::SERVICE_UNAVAILABLE, Json(api_error("boom")))),
+            true,
+        );
+        let (status, Json(err)) = result.expect_err("Err must propagate as Err");
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(err.error.as_deref(), Some("boom"));
+        assert!(err.data.is_none());
+    }
+}
+
+/// F1 — `durationMs` / `elapsed_ms` dual-emit verification for the NL/id
+/// happy-path response shape. The handler is too IPC-coupled for a pure
+/// unit test, so these tests construct the response body shape directly,
+/// mirroring the literals at the two happy-path emit sites. If those
+/// literals drift (e.g., someone drops `elapsed_ms` early), the dual-emit
+/// contract here will catch it because the tests assert on both keys.
+#[cfg(test)]
+mod wait_for_element_dual_emit_tests {
+    use serde_json::json;
+
+    /// Mirrors the no-assertions happy path response shape literal in
+    /// `ui_bridge_wait_for_element_handler` (`elements.rs:~2046`). Update in
+    /// lock-step if the literal there changes.
+    fn nl_happy_response(elapsed_ms: u64, polls: u32) -> serde_json::Value {
+        json!({
+            "found": true,
+            "element": {"id": "x"},
+            "durationMs": elapsed_ms,
+            "elapsed_ms": elapsed_ms,
+            "polls": polls,
+        })
+    }
+
+    /// Mirrors the with-assertions happy path response shape literal.
+    fn nl_happy_with_assertions(elapsed_ms: u64, polls: u32, asserts: usize) -> serde_json::Value {
+        json!({
+            "found": true,
+            "element": {"id": "x"},
+            "durationMs": elapsed_ms,
+            "elapsed_ms": elapsed_ms,
+            "polls": polls,
+            "assertions_passed": asserts,
+        })
+    }
+
+    #[test]
+    fn nl_happy_path_emits_both_duration_keys() {
+        let body = nl_happy_response(987, 3);
+        // Canonical key per F1 (camelCase, matches SDK + docs).
+        assert_eq!(body.get("durationMs").and_then(|v| v.as_u64()), Some(987));
+        // Legacy key — retained for one release per the migration plan.
+        assert_eq!(body.get("elapsed_ms").and_then(|v| v.as_u64()), Some(987));
+        assert_eq!(body.get("polls").and_then(|v| v.as_u64()), Some(3));
+    }
+
+    #[test]
+    fn nl_happy_with_assertions_emits_both_duration_keys() {
+        let body = nl_happy_with_assertions(1234, 5, 2);
+        assert_eq!(body.get("durationMs").and_then(|v| v.as_u64()), Some(1234));
+        assert_eq!(body.get("elapsed_ms").and_then(|v| v.as_u64()), Some(1234));
+        assert_eq!(
+            body.get("assertions_passed").and_then(|v| v.as_u64()),
+            Some(2)
+        );
+    }
+
+    /// F1 — the NL/id timeout path attaches `data: {durationMs, polls}` to
+    /// the HTTP 408 envelope. Mirrors the literal in the timeout branch of
+    /// `ui_bridge_wait_for_element_handler` (`elements.rs:~2102`).
+    fn nl_timeout_data(elapsed_ms: u64, polls: u32) -> serde_json::Value {
+        json!({
+            "found": false,
+            "durationMs": elapsed_ms,
+            "polls": polls,
+        })
+    }
+
+    #[test]
+    fn nl_timeout_data_payload_has_canonical_duration_ms_key() {
+        let data = nl_timeout_data(5000, 25);
+        assert_eq!(data.get("found").and_then(|v| v.as_bool()), Some(false));
+        assert_eq!(data.get("durationMs").and_then(|v| v.as_u64()), Some(5000));
+        assert_eq!(data.get("polls").and_then(|v| v.as_u64()), Some(25));
+    }
+}
+
+/// F2 — direct `/ui-bridge/control/components` envelope shape (Direction B).
+/// Verifies the response carries `data.components` AND the deprecated
+/// top-level `components` mirror. Pure unit test against the literal shape
+/// the handler emits; an axum-router-level integration test would need a
+/// fully constructed `ApiState`.
+#[cfg(test)]
+mod components_envelope_tests {
+    use serde_json::json;
+
+    /// Mirrors the literal at the bottom of `ui_bridge_get_components_handler`.
+    /// Update in lock-step if the handler's `Ok(Json(serde_json::json!(...)))`
+    /// payload changes.
+    fn components_response(components: Vec<serde_json::Value>) -> serde_json::Value {
+        let components_array = serde_json::Value::Array(components);
+        json!({
+            "success": true,
+            "data": { "components": components_array.clone() },
+            "components": components_array,
+        })
+    }
+
+    #[test]
+    fn direct_components_response_has_direction_b_shape() {
+        let body = components_response(vec![json!({"id": "comp-a"}), json!({"id": "comp-b"})]);
+        assert_eq!(body.get("success"), Some(&json!(true)));
+        // Direction B: `data` is `{components: [...]}` (object-shaped).
+        let inner = body
+            .get("data")
+            .and_then(|d| d.get("components"))
+            .and_then(|v| v.as_array())
+            .expect("data.components must be an array");
+        assert_eq!(inner.len(), 2);
+        assert_eq!(inner[0].get("id").and_then(|v| v.as_str()), Some("comp-a"));
+    }
+
+    #[test]
+    fn direct_components_response_has_deprecated_top_level_mirror() {
+        // The top-level `components` field is a one-release back-compat
+        // mirror so callers reading the legacy shape keep working.
+        let body = components_response(vec![json!({"id": "comp-a"})]);
+        let mirror = body
+            .get("components")
+            .and_then(|v| v.as_array())
+            .expect("deprecated top-level `components` mirror must be present");
+        assert_eq!(mirror.len(), 1);
+        // The mirror and `data.components` must be the same payload.
+        let canonical = body
+            .get("data")
+            .and_then(|d| d.get("components"))
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(mirror, canonical);
+    }
+
+    #[test]
+    fn empty_components_still_has_both_fields() {
+        let body = components_response(vec![]);
+        assert!(body
+            .get("data")
+            .and_then(|d| d.get("components"))
+            .and_then(|v| v.as_array())
+            .map(|a| a.is_empty())
+            .unwrap_or(false));
+        assert!(body
+            .get("components")
+            .and_then(|v| v.as_array())
+            .map(|a| a.is_empty())
+            .unwrap_or(false));
     }
 }
 

--- a/src-tauri/src/mcp/ui_bridge/network.rs
+++ b/src-tauri/src/mcp/ui_bridge/network.rs
@@ -134,12 +134,13 @@ pub struct ConsoleErrorsQuery {
     group_by: Option<String>,
     /// Comma-separated allow-list of console levels to keep. Accepts
     /// `error`, `warn`, `unhandledrejection`, `info`, `log`, `debug`,
-    /// or `all` / `*` (which disables filtering, same as omitting).
-    /// Default unset behaviour is unchanged: every captured entry is
-    /// returned. Item 3 of manual-test-remediation-2026-05-10 — the
-    /// endpoint name implies error-level only but the SDK captures
-    /// `console.warn` too, including info-level startup logs that
-    /// devs accidentally route through `console.warn`.
+    /// or `all` / `*` (which disables filtering).
+    /// Default unset behaviour: error-level entries only (`error` +
+    /// `unhandledrejection`). Pass `?level=all` or `?level=*` to
+    /// disable filtering. Item 3 of manual-test-remediation-2026-05-10
+    /// — the endpoint name implies error-level only but the SDK
+    /// captures `console.warn` too, including info-level startup logs
+    /// that devs accidentally route through `console.warn`.
     #[serde(default)]
     level: Option<String>,
 }
@@ -205,8 +206,18 @@ pub async fn ui_bridge_get_console_errors_handler(
 
     // Parse `?level=` before doing any IPC work so an invalid value short-
     // circuits to HTTP 400 without burning a frontend round-trip.
+    //
+    // Default (no `?level=` query) keeps only error-class entries so the
+    // endpoint name matches its semantics — the SDK's ConsoleCapture also
+    // collects `console.warn`/`console.info` which leaked through before
+    // (Phase B3 of plans/ui-bridge-quality-2026-05-10.md). Callers that
+    // want the legacy unfiltered behaviour can pass `?level=all` or
+    // `?level=*` and `parse_level_filter` returns `Ok(None)` for both.
     let level_filter = match query.level.as_deref() {
-        None => None,
+        None => Some(HashSet::from([
+            "error".to_string(),
+            "unhandledrejection".to_string(),
+        ])),
         Some(raw) => match parse_level_filter(raw) {
             Ok(parsed) => parsed,
             Err(unknown) => {
@@ -609,6 +620,49 @@ mod console_level_filter_tests {
         let levels: HashSet<String> = ["error".to_string()].into_iter().collect();
         apply_level_filter(&mut data, &levels);
         assert_eq!(data["note"].as_str(), Some("BrowserCapture not installed"));
+    }
+
+    #[test]
+    fn default_filter_keeps_only_error_class_entries() {
+        // Phase B3: the handler now defaults to `{error,
+        // unhandledrejection}` when no `?level=` is set. This mirrors
+        // what the handler installs into `level_filter` when
+        // `query.level` is `None`, so a regression in the producer-side
+        // default (or in the filter helper) is caught here.
+        let mut data = synthetic_ring();
+        let levels: HashSet<String> = ["error".to_string(), "unhandledrejection".to_string()]
+            .into_iter()
+            .collect();
+        apply_level_filter(&mut data, &levels);
+
+        let errors = data["errors"].as_array().expect("errors is array");
+        assert_eq!(
+            errors.len(),
+            3,
+            "two error entries + one unhandledrejection should remain; \
+             warn-level startup logs should be dropped"
+        );
+        for entry in errors {
+            let level = entry["level"].as_str().expect("level present");
+            assert!(
+                level == "error" || level == "unhandledrejection",
+                "default filter let through unexpected level {level}"
+            );
+        }
+        // Verify the specific startup messages from the manual test no
+        // longer survive the default filter.
+        assert!(
+            errors
+                .iter()
+                .all(|e| e["message"].as_str() != Some("[GraphQL WS] Connected")),
+            "GraphQL WS connected log must be dropped by default"
+        );
+        assert!(
+            errors
+                .iter()
+                .all(|e| e["message"].as_str() != Some("[BackgroundObserverService] Started")),
+            "BackgroundObserverService started log must be dropped by default"
+        );
     }
 
     #[test]

--- a/src/components/terminal/LaunchMenu.test.tsx
+++ b/src/components/terminal/LaunchMenu.test.tsx
@@ -32,6 +32,7 @@ import {
   CONFIDENCE_TIER_CLASS,
   COLLISION_DIM_THRESHOLD,
   PROBE_DEBOUNCE_MS,
+  buildProbeBody,
   buildProbeUrl,
   confidenceTier,
   formatHoldingAge,
@@ -415,6 +416,72 @@ describe("probe fetch wire shape", () => {
     const [, init] = fetchMock.mock.calls[0]!;
     const sentBody = JSON.parse((init as RequestInit).body as string);
     expect(sentBody.prompt).toBeNull();
+  });
+
+  // ── cwd plumbing (Phase 1) ────────────────────────────────────────────────
+  //
+  // These three cases lock the `cwd?: string` prop's contract end-to-end:
+  // a provided cwd shows up in the wire body; an undefined prop defaults
+  // to ""; and an explicit "" survives unmodified (no coercion to
+  // undefined / no field-drop). Driven through the same `fetch` mock
+  // pattern as the wire-shape tests above, exercising the pure
+  // `buildProbeBody` helper that the component's runProbe uses.
+
+  it("posts the provided cwd in the JSON body when LaunchMenu has cwd='/repo'", async () => {
+    const port = resolvePort();
+    const url = buildProbeUrl(port);
+
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildProbeBody("edit src/foo.rs", "/repo"),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.cwd).toBe("/repo");
+  });
+
+  it("defaults undefined cwd to empty string (first-tab / no-active case)", async () => {
+    // When TerminalPage's `tabs.find((t) => t.id === activeId)?.workingDir`
+    // returns undefined (no active tab, or tab has no workingDir yet),
+    // LaunchMenu's prop is undefined and the wire body must still carry
+    // cwd="" — the legacy hardcoded behavior the backend handler already
+    // expects.
+    const port = resolvePort();
+    const url = buildProbeUrl(port);
+
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildProbeBody("edit src/foo.rs", undefined),
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    // The field is present in the body (not dropped) and equals "".
+    expect(sentBody).toHaveProperty("cwd");
+    expect(sentBody.cwd).toBe("");
+  });
+
+  it("preserves an explicit empty-string cwd (does not drop or undefined-coerce)", async () => {
+    // A caller passing cwd="" explicitly must get cwd="" in the wire
+    // body — not dropped (which would risk a JSON-shape regression on
+    // the backend) and not coerced to undefined.
+    const port = resolvePort();
+    const url = buildProbeUrl(port);
+
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildProbeBody("edit src/foo.rs", ""),
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody).toHaveProperty("cwd");
+    expect(sentBody.cwd).toBe("");
   });
 });
 

--- a/src/components/terminal/LaunchMenu.tsx
+++ b/src/components/terminal/LaunchMenu.tsx
@@ -18,6 +18,17 @@ interface LaunchMenuProps {
   launchCommands?: Record<string, string>;
   fileLocks?: FileLockInfo[];
   /**
+   * Active-tab working directory plumbed in by `TerminalTabBar`. The
+   * probe sends this in its JSON body so the runner's
+   * `path_extraction::extract_candidate_paths` can resolve relative-path
+   * tokens (e.g. "edit src/foo.rs") against the launching session's
+   * cwd, rather than degrading to bare-filename matching against the
+   * registry's normalized keys. Undefined / first-tab case falls back
+   * to "" — matches the legacy hardcoded behavior and the backend
+   * handler's documented "no relative-path resolution" mode.
+   */
+  cwd?: string;
+  /**
    * Resolves a holder name (matches a tab's `title`) to focus the
    * corresponding terminal tab. No-op when no tab matches — the holder
    * may be a non-terminal session (e.g. a workflow runner). Mirrors
@@ -64,6 +75,19 @@ export function resolvePort(): number {
 
 export function buildProbeUrl(port: number): string {
   return `http://127.0.0.1:${port}/file-registry/probe-conflicts`;
+}
+
+/**
+ * Build the JSON body for a probe request.
+ *
+ * `cwd` defaults to `""` when undefined — matches the legacy hardcoded
+ * behavior and the backend handler's documented "no relative-path
+ * resolution" mode. An explicit `""` from the caller is preserved
+ * (not coerced to undefined / dropped from the body) so the wire shape
+ * is stable regardless of which call site reached us.
+ */
+export function buildProbeBody(prompt: string | null, cwd: string | undefined): string {
+  return JSON.stringify({ prompt, cwd: cwd ?? "" });
 }
 
 /**
@@ -353,6 +377,7 @@ export function LaunchMenu({
   accountUsage,
   launchCommands,
   fileLocks,
+  cwd,
   onJumpToHolder,
   resolveSessionName,
   onClose,
@@ -390,13 +415,11 @@ export function LaunchMenu({
 
   // ── Probe: fetch ConflictReport on prompt change (debounced) ───────────────
   // The probe runs against the runner's local /file-registry/probe-conflicts
-  // endpoint. cwd is intentionally empty for now — the backend handles "" as
-  // "no relative-path resolution; only absolute paths and bare-filename
-  // matches." See plan §Open Q3.
-  // TODO(plan §Open Q3): plumb the active session's cwd through here so
-  // relative path tokens like "src/foo/bar.rs" can resolve against the
-  // launching session's working directory rather than degrading to
-  // bare-filename matching.
+  // endpoint. `cwd` is per-active-tab semantics — plumbed in by
+  // `TerminalTabBar` from the focused tab's `workingDir`. When undefined
+  // (e.g. first-tab case), buildProbeBody defaults it to "" so the backend
+  // falls back to its "no relative-path resolution; only absolute paths
+  // and bare-filename matches" mode.
 
   const runProbe = useCallback(
     async (prompt: string | null, signal?: AbortSignal): Promise<void> => {
@@ -405,7 +428,7 @@ export function LaunchMenu({
         const resp = await fetch(buildProbeUrl(port), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ prompt, cwd: "" }),
+          body: buildProbeBody(prompt, cwd),
           signal,
         });
         if (!resp.ok) return;
@@ -418,10 +441,13 @@ export function LaunchMenu({
         // UI doesn't flicker when the runner is briefly busy.
       }
     },
-    [],
+    [cwd],
   );
 
-  // Debounced re-probe on prompt change.
+  // Debounced re-probe on prompt change. `runProbe` is included in the
+  // dep list — and `runProbe` itself depends on `cwd` — so a tab switch
+  // that changes the active workingDir re-fires the probe with the new
+  // cwd.
   useEffect(() => {
     const controller = new AbortController();
     const handle = setTimeout(() => {

--- a/src/components/terminal/MidSessionToast.test.tsx
+++ b/src/components/terminal/MidSessionToast.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Pure-helper tests for `MidSessionToast`.
+ *
+ * The runner's vitest config uses `environment: "node"` — JSX rendering
+ * isn't available. Following the precedent set by
+ * `LaunchMenu.test.tsx` and `CommitTrafficLight.test.tsx`, we exercise
+ * the load-bearing logic via the exported pure helper
+ * `formatToastSummary`. The JSX glue is verified manually + via UI
+ * Bridge in Phase 4.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatToastSummary } from "./MidSessionToast";
+import type { MidSessionProbeState } from "./useMidSessionProbe";
+import type { PredictedCollision } from "./useSessionManager";
+
+function makeCollision(
+  file_path: string,
+  holders: Array<{ task_run_id: string; holder_name: string }>,
+): PredictedCollision {
+  return {
+    file_path,
+    other_holders: holders.map((h) => ({ ...h, registered_at: 0 })),
+    confidence: 0.7,
+  };
+}
+
+function makeState(collisions: PredictedCollision[]): MidSessionProbeState {
+  return { predicted_collisions: collisions, received_at: 0 };
+}
+
+describe("formatToastSummary", () => {
+  it("pluralizes a single collision held by one session", () => {
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("src/foo.ts", [{ task_run_id: "t1", holder_name: "alpha" }]),
+      ]),
+    );
+    expect(summary.header).toBe("1 file held by another session");
+  });
+
+  it("pluralizes multiple collisions across multiple sessions", () => {
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("src/a.ts", [{ task_run_id: "t1", holder_name: "alpha" }]),
+        makeCollision("src/b.ts", [{ task_run_id: "t2", holder_name: "beta" }]),
+        makeCollision("src/c.ts", [{ task_run_id: "t3", holder_name: "gamma" }]),
+      ]),
+    );
+    expect(summary.header).toBe("3 files held by other sessions");
+  });
+
+  it("uses 'other sessions' when a single file has multiple holders", () => {
+    // Singular file count but plural holders → header should hint at
+    // multiple sessions so the user knows it's a contested file.
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("src/foo.ts", [
+          { task_run_id: "t1", holder_name: "alpha" },
+          { task_run_id: "t2", holder_name: "beta" },
+        ]),
+      ]),
+    );
+    expect(summary.header).toBe("1 file held by other sessions");
+  });
+
+  it("derives per-file rows with basename + first holder + joined holders", () => {
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("D:/qontinui-root/src/foo.ts", [
+          { task_run_id: "t1", holder_name: "alpha" },
+          { task_run_id: "t2", holder_name: "beta" },
+        ]),
+        makeCollision("relative\\path\\bar.rs", [
+          { task_run_id: "t3", holder_name: "gamma" },
+        ]),
+      ]),
+    );
+    expect(summary.rows).toHaveLength(2);
+
+    expect(summary.rows[0]).toEqual({
+      file_path: "D:/qontinui-root/src/foo.ts",
+      basename: "foo.ts",
+      holder_name: "alpha",
+      holders_label: "alpha, beta",
+    });
+
+    // Backslash path uses Windows-style separator — basename must handle
+    // both \\ and / (mixed paths come from the runner's path extractor).
+    expect(summary.rows[1]).toEqual({
+      file_path: "relative\\path\\bar.rs",
+      basename: "bar.rs",
+      holder_name: "gamma",
+      holders_label: "gamma",
+    });
+  });
+
+  it("falls back to 'unknown' when other_holders is empty", () => {
+    // Defensive shape — runner filters out the caller's own holder
+    // before serializing, so a 0-holder row is unusual but possible.
+    const summary = formatToastSummary(
+      makeState([makeCollision("src/foo.ts", [])]),
+    );
+    expect(summary.rows[0].holder_name).toBe("unknown");
+    expect(summary.rows[0].holders_label).toBe("unknown");
+  });
+});

--- a/src/components/terminal/MidSessionToast.tsx
+++ b/src/components/terminal/MidSessionToast.tsx
@@ -1,0 +1,127 @@
+/**
+ * Dismissible mid-session warning toast. Rendered overlay-style over
+ * the active terminal when {@link useMidSessionProbe} has a fresh
+ * predicted-collisions response for that tab.
+ *
+ * Visual language mirrors the yellow "Possible conflicts" panel in
+ * `LaunchMenu.tsx` so the surfaces feel like one product — same
+ * palette (`#e0af68`), same row layout (holder name + basename), but
+ * compact since this floats over the terminal rather than inline in
+ * the launch sheet.
+ */
+
+import type { MidSessionProbeState } from "./useMidSessionProbe";
+import type { PredictedCollision } from "./useSessionManager";
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────
+
+export interface ToastRow {
+  /** Full original path — used as a stable React key + tooltip. */
+  file_path: string;
+  /** Final path component for compact display in the row. */
+  basename: string;
+  /** First holder's friendly name (used by the "jump to" affordance). */
+  holder_name: string;
+  /** All holders joined for the secondary text. */
+  holders_label: string;
+}
+
+export interface ToastSummary {
+  header: string;
+  rows: ToastRow[];
+}
+
+/** Final segment of a /- or \-delimited path. */
+function basename(p: string): string {
+  const idx = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return idx >= 0 ? p.slice(idx + 1) : p;
+}
+
+/**
+ * Pure derivation of the toast's displayed data from a probe state.
+ * Exported so the file/session pluralization + row aggregation can be
+ * unit-tested without rendering JSX.
+ */
+export function formatToastSummary(state: MidSessionProbeState): ToastSummary {
+  const collisions = state.predicted_collisions;
+  const n = collisions.length;
+  // Pluralize independently — N=1 always means a single holder by
+  // construction (one file held by one or more sessions). The
+  // "other sessions" half pluralizes on whether ANY collision row has
+  // more than one holder OR there's more than one collision row.
+  const multipleHolders =
+    n > 1 || collisions.some((c) => (c.other_holders?.length ?? 0) > 1);
+  const fileWord = n === 1 ? "file" : "files";
+  const sessionWord = multipleHolders ? "other sessions" : "another session";
+  const header = `${n} ${fileWord} held by ${sessionWord}`;
+
+  const rows: ToastRow[] = collisions.map((c: PredictedCollision) => {
+    const holders = c.other_holders ?? [];
+    const firstHolder = holders[0]?.holder_name ?? "unknown";
+    const label = holders.map((h) => h.holder_name).join(", ") || "unknown";
+    return {
+      file_path: c.file_path,
+      basename: basename(c.file_path),
+      holder_name: firstHolder,
+      holders_label: label,
+    };
+  });
+
+  return { header, rows };
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+interface MidSessionToastProps {
+  state: MidSessionProbeState;
+  onDismiss: () => void;
+  onJumpToHolder?: (holderName: string) => void;
+}
+
+export function MidSessionToast({
+  state,
+  onDismiss,
+  onJumpToHolder,
+}: MidSessionToastProps) {
+  const { header, rows } = formatToastSummary(state);
+  return (
+    <div
+      data-testid="mid-session-toast"
+      className="absolute top-2 right-2 z-30 w-[280px] p-2 rounded border bg-[#e0af68]/15 border-[#e0af68]/40 shadow-lg"
+    >
+      <div className="flex items-start gap-2">
+        <div className="text-[10px] uppercase tracking-wider text-[#e0af68] flex-1">
+          {header}
+        </div>
+        <button
+          type="button"
+          data-testid="mid-session-toast-dismiss"
+          aria-label="Dismiss conflict warning"
+          onClick={onDismiss}
+          className="text-[#e0af68] hover:text-[#c0caf5] leading-none px-1"
+        >
+          ×
+        </button>
+      </div>
+      <ul className="mt-1.5 space-y-0.5">
+        {rows.map((row) => {
+          const clickable = Boolean(onJumpToHolder);
+          return (
+            <li
+              key={row.file_path}
+              data-testid="mid-session-toast-row"
+              className={`flex items-center gap-2 text-[10px] ${
+                clickable ? "cursor-pointer hover:bg-[#e0af68]/10 rounded px-1 -mx-1" : ""
+              }`}
+              onClick={() => onJumpToHolder?.(row.holder_name)}
+              title={row.file_path}
+            >
+              <span className="font-mono text-[#c0caf5] truncate">{row.basename}</span>
+              <span className="text-[#a9b1d6] truncate ml-auto">{row.holders_label}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalInstance.test.tsx
+++ b/src/components/terminal/TerminalInstance.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Pure-logic tests for the input accumulator extracted from
+ * `TerminalInstance`'s xterm.js `onData` loop.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom) — and
+ * `TerminalInstance` itself is impractical to import from a test
+ * because it transitively pulls `@xterm/addon-canvas`, which touches
+ * `self` at module init and crashes under Node. The load-bearing logic
+ * was extracted to `./consumeInputChunk.ts` (a leaf module with zero
+ * imports) so it can be unit-tested in isolation. `TerminalInstance`'s
+ * `onData` handler is now a thin shell over this helper.
+ *
+ * The cases below cover:
+ *   - Multiple newlines in a single chunk emit multiple lines.
+ *   - A line split across two chunks accumulates correctly.
+ *   - Non-printable chars (code < 32) are dropped from the accumulator.
+ *   - `firstInputLineIfAny` is gated by the caller's "already reported"
+ *     flag so `onFirstInput` fires only once per session.
+ *   - Bare empty newlines (whitespace-only) emit no line — preserving
+ *     the historical "empty line trimmed" behavior.
+ */
+
+import { describe, it, expect } from "vitest";
+import { consumeInputChunk } from "./consumeInputChunk";
+
+describe("consumeInputChunk", () => {
+  it("emits two lines for two newlines in one chunk", () => {
+    const result = consumeInputChunk("hello\nworld\n", "", false);
+    expect(result.lines).toEqual(["hello", "world"]);
+    expect(result.firstInputLineIfAny).toBe("hello");
+    expect(result.accum).toBe("");
+  });
+
+  it("accumulates a line split across two chunks", () => {
+    const first = consumeInputChunk("hel", "", false);
+    expect(first.lines).toEqual([]);
+    expect(first.firstInputLineIfAny).toBeUndefined();
+    expect(first.accum).toBe("hel");
+
+    const second = consumeInputChunk("lo\n", first.accum, false);
+    expect(second.lines).toEqual(["hello"]);
+    expect(second.firstInputLineIfAny).toBe("hello");
+    expect(second.accum).toBe("");
+  });
+
+  it("drops non-printable chars (code < 32) from the accumulator", () => {
+    // ESC (0x1b) sits between two printable chars — it must be dropped
+    // so the line becomes "ab", matching the historical loop behavior at
+    // the `ch.charCodeAt(0) >= 32` gate.
+    const result = consumeInputChunk("a\x1bb\n", "", false);
+    expect(result.lines).toEqual(["ab"]);
+    expect(result.firstInputLineIfAny).toBe("ab");
+    expect(result.accum).toBe("");
+  });
+
+  it("does not surface firstInputLineIfAny when already reported", () => {
+    const result = consumeInputChunk("second turn\n", "", true);
+    // The line still flows through `lines` (for `onUserInputLine`), but
+    // the first-input slot stays empty so the caller's `onFirstInput`
+    // doesn't fire again.
+    expect(result.lines).toEqual(["second turn"]);
+    expect(result.firstInputLineIfAny).toBeUndefined();
+    expect(result.accum).toBe("");
+  });
+
+  it("emits no line for a bare empty newline", () => {
+    const result = consumeInputChunk("\n", "", false);
+    expect(result.lines).toEqual([]);
+    expect(result.firstInputLineIfAny).toBeUndefined();
+    expect(result.accum).toBe("");
+  });
+
+  it("emits no line when the accumulator is whitespace-only", () => {
+    // Historical "trim then check empty" — a line of just spaces is
+    // dropped from both `lines` and `firstInputLineIfAny`.
+    const result = consumeInputChunk("   \n", "", false);
+    expect(result.lines).toEqual([]);
+    expect(result.firstInputLineIfAny).toBeUndefined();
+    expect(result.accum).toBe("");
+  });
+
+  it("treats \\r the same as \\n as a line terminator", () => {
+    // xterm.js fires `\r` on Enter, not `\n`, so the historical loop
+    // accepts either as a line break. Verify both are honored.
+    const result = consumeInputChunk("alpha\rbeta\n", "", false);
+    expect(result.lines).toEqual(["alpha", "beta"]);
+    expect(result.firstInputLineIfAny).toBe("alpha");
+  });
+});

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -11,6 +11,7 @@ import { createTerminalBackend } from "./backends";
 import type { BackendType, ITerminalBackend } from "./backends";
 import { paintGrid, type GridSnapshot } from "./paintGrid";
 import { instanceStorage } from "@/lib/instance-storage";
+import { consumeInputChunk } from "./consumeInputChunk";
 
 export interface TerminalInstanceHandle {
   getSelection: () => string;
@@ -47,6 +48,13 @@ interface TerminalInstanceProps {
   onExit?: (exitCode: number | null) => void;
   onSelectionChange?: (hasSelection: boolean) => void;
   onFirstInput?: (input: string) => void;
+  /**
+   * Called for EVERY non-empty newline-terminated input line typed into
+   * the terminal. Unlike `onFirstInput`, this is ungated and fires on
+   * every subsequent line — the consumer (e.g. `useMidSessionProbe`)
+   * applies its own debouncing / rate-limiting / gating.
+   */
+  onUserInputLine?: (input: string) => void;
   /** Called when the shell emits an OSC 633 shell integration event. */
   onShellIntegration?: (event: ShellIntegrationEvent) => void;
   /** Called with decoded text whenever PTY output is received. */
@@ -123,6 +131,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       onExit,
       onSelectionChange,
       onFirstInput,
+      onUserInputLine,
       onShellIntegration,
       onOutput,
       onTitleChange,
@@ -145,6 +154,8 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     onSelectionChangeRef.current = onSelectionChange;
     const onFirstInputRef = useRef(onFirstInput);
     onFirstInputRef.current = onFirstInput;
+    const onUserInputLineRef = useRef(onUserInputLine);
+    onUserInputLineRef.current = onUserInputLine;
     const onReconnectedRef = useRef(onReconnected);
     onReconnectedRef.current = onReconnected;
     const onShellIntegrationRef = useRef(onShellIntegration);
@@ -473,23 +484,30 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         }
 
         // Forward user input to PTY + track first input line for auto-naming
+        // + emit every non-empty line to `onUserInputLine` for mid-session
+        // probes. The accumulator logic lives in the pure `consumeInputChunk`
+        // helper in `./consumeInputChunk.ts` (a leaf module — kept separate
+        // so vitest tests don't pull in xterm.js's canvas addon).
         disposables.push(
           backend.onData((data) => {
-            // Track first input line for auto-naming
-            if (!firstInputReportedRef.current) {
-              for (const ch of data) {
-                if (ch === "\r" || ch === "\n") {
-                  const line = inputAccumulatorRef.current.trim();
-                  if (line.length > 0) {
-                    firstInputReportedRef.current = true;
-                    onFirstInputRef.current?.(line);
-                  }
-                  inputAccumulatorRef.current = "";
-                  break;
-                } else if (ch.charCodeAt(0) >= 32) {
-                  // Only accumulate printable characters
-                  inputAccumulatorRef.current += ch;
-                }
+            const result = consumeInputChunk(
+              data,
+              inputAccumulatorRef.current,
+              firstInputReportedRef.current,
+            );
+            inputAccumulatorRef.current = result.accum;
+            // First-input gate: fires at most once per session.
+            if (result.firstInputLineIfAny !== undefined) {
+              firstInputReportedRef.current = true;
+              onFirstInputRef.current?.(result.firstInputLineIfAny);
+            }
+            // Per-line callback: fires for EVERY non-empty newline-terminated
+            // line, ungated. Consumer (e.g. useMidSessionProbe) applies its
+            // own gates.
+            const perLine = onUserInputLineRef.current;
+            if (perLine) {
+              for (const line of result.lines) {
+                perLine(line);
               }
             }
 

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -40,6 +40,9 @@ import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
 import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
 import { useCommitState } from "./useCommitState";
 import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
+import { useRegistryAwareness } from "./useRegistryAwareness";
+import { useMidSessionProbe, useMidSessionProbeEnabled } from "./useMidSessionProbe";
+import { MidSessionToast } from "./MidSessionToast";
 
 interface TerminalPageProps {
   onNavigateToBuilder?: () => void;
@@ -152,6 +155,17 @@ function TerminalPageInner({
   // Per-tab commit-readiness state (Plan §3). Sibling to fileLockStates;
   // both are passed through to TerminalTabBar for rendering.
   const commitStates = useCommitState(tabs);
+  // Per-tab registry-awareness counts (pty-launched-ai-tabs-warning-plan
+  // Phase 2). Sibling to fileLockStates; polled from
+  // `/file-registry/probe-conflicts` every 2s per eligible tab.
+  const registryAwareness = useRegistryAwareness(tabs);
+  // Mid-session probe (Phase 3 of pty-launched-ai-tabs-warning-plan).
+  // Fires `/file-registry/probe-conflicts` 500ms after the user types a
+  // new turn into an active Claude CLI tab and surfaces predicted
+  // collisions via {@link MidSessionToast}. Gated behind the
+  // `enable_mid_session_path_prediction` localStorage flag.
+  const midSessionProbeEnabled = useMidSessionProbeEnabled();
+  const midSessionProbe = useMidSessionProbe(tabs, { enabled: midSessionProbeEnabled });
   // Post-spawn polling hook that captures Claude CLI's session id from
   // the on-disk transcript and updates `tab.claudeSessionId` so the
   // commit traffic light has something to key on. Plan §1.5
@@ -506,6 +520,8 @@ function TerminalPageInner({
           launchCommands={sessionManager.launchCommands}
           fileLocks={sessionManager.fileLocks}
           fileLockStates={fileLockStates}
+          registryAwareness={registryAwareness}
+          activeTabCwd={tabs.find((t) => t.id === activeId)?.workingDir}
           commitStates={commitStates}
           terminalRefs={terminalRefs.current}
         />
@@ -561,6 +577,7 @@ function TerminalPageInner({
                 onZoneDoubleClick={handleZoneDoubleClick}
                 onExit={handleExit}
                 onExportZone={handleExportZone}
+                onUserInputLine={(tabId, input) => midSessionProbe.feed(tabId, input)}
               />
             ) : (
               <div className="h-full flex flex-col items-center justify-center text-[#565f89] gap-2">
@@ -578,6 +595,23 @@ function TerminalPageInner({
 
             {zoneLayout.isMultiZone && !transitionEffects.batchBarDismissed && (
               <BatchOperationsBar />
+            )}
+
+            {/* Mid-session predicted-collision toast (Phase 3). Overlays
+                the active terminal — positioned top-right of the
+                flex-1 container so it sits over the zone grid, not
+                the chrome. Jump-to-holder: focus the tab whose title
+                matches the holder name, mirroring LaunchMenu's
+                `onJumpToHolder` semantics. */}
+            {activeId && midSessionProbe.states[activeId] && (
+              <MidSessionToast
+                state={midSessionProbe.states[activeId]}
+                onDismiss={() => midSessionProbe.dismiss(activeId)}
+                onJumpToHolder={(name) => {
+                  const target = tabs.find((t) => t.title === name);
+                  if (target) setActiveId(target.id);
+                }}
+              />
             )}
           </div>
 

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -28,6 +28,20 @@ interface TerminalTabBarProps {
   launchCommands?: Record<string, string>;
   fileLocks?: import("./useSessionManager").FileLockInfo[];
   fileLockStates?: Record<string, import("./useFileLockTracking").LockState>;
+  /**
+   * Per-tab count of files held by OTHER sessions that overlap with
+   * this tab's `workingDir`. Sourced from `useRegistryAwareness`.
+   * Renders a small yellow pill next to the lock indicator when > 0.
+   * Tabs without an entry (or with 0) render nothing.
+   */
+  registryAwareness?: Record<string, number>;
+  /**
+   * Active tab's `workingDir`, plumbed through to LaunchMenu's probe so
+   * relative-path tokens in the user's session-context prompt can
+   * resolve against the launching session's cwd. Undefined when no tab
+   * is active (first-tab case); LaunchMenu defaults to "" downstream.
+   */
+  activeTabCwd?: string;
   /** Per-tab commit-readiness state (populated by `useCommitState`). */
   commitStates?: Record<string, CommitState>;
   /**
@@ -194,6 +208,8 @@ export function TerminalTabBar({
   launchCommands,
   fileLocks,
   fileLockStates,
+  registryAwareness = {},
+  activeTabCwd,
   commitStates,
   terminalRefs,
   activityData,
@@ -452,6 +468,7 @@ export function TerminalTabBar({
                   accountUsage={accountUsage ?? []}
                   launchCommands={launchCommands}
                   fileLocks={fileLocks}
+                  cwd={activeTabCwd}
                   onJumpToHolder={(holderName) => {
                     // Resolve holder_name → tab id with the same lookup as
                     // `findTabByHolderName` in `useFileLockTracking.ts:44-49`
@@ -498,6 +515,7 @@ export function TerminalTabBar({
             isMultiZone && isTabAssigned(tab.id) && tabActivity && tabActivity.length > 0;
           const lockState = fileLockStates?.[tab.id];
           const commitState = commitStates?.[tab.id];
+          const overlapCount = registryAwareness[tab.id] ?? 0;
 
           return (
             <button
@@ -566,6 +584,21 @@ export function TerminalTabBar({
                   } waiting`}
                 >
                   <Lock className="w-2.5 h-2.5 text-[#7aa2f7] opacity-60" />
+                </span>
+              )}
+
+              {/* Registry-awareness badge — count of files held by OTHER
+                  sessions that overlap with this tab's cwd. Driven by
+                  `useRegistryAwareness` polling `/file-registry/probe-conflicts`
+                  (Phase 2 of pty-launched-ai-tabs-warning-plan). Silent
+                  tabs stay visually quiet — badge renders only when N > 0. */}
+              {overlapCount > 0 && (
+                <span
+                  data-testid="tab-registry-overlap"
+                  className="shrink-0 px-1 rounded text-[10px] leading-[14px] font-medium bg-[#e0af68]/20 text-[#e0af68]"
+                  title={`${overlapCount} file(s) held by other sessions overlap with this tab's cwd.`}
+                >
+                  {overlapCount}
                 </span>
               )}
 

--- a/src/components/terminal/ZoneGrid.tsx
+++ b/src/components/terminal/ZoneGrid.tsx
@@ -40,6 +40,13 @@ interface ZoneGridProps {
   onZoneDoubleClick: (zoneIndex: number) => void;
   onExit: (terminalId: string, exitCode: number | null) => void;
   onExportZone?: (zoneIndex: number, format: "text" | "markdown" | "json") => void;
+  /**
+   * Per-line input forwarder for mid-session probes (Phase 3 of
+   * `plans/pty-launched-ai-tabs-warning-plan.md`). Fires for every
+   * non-empty newline-terminated line typed into any terminal. Consumer
+   * applies its own debounce + gating.
+   */
+  onUserInputLine?: (terminalId: string, input: string) => void;
 }
 
 interface GridState {
@@ -108,7 +115,13 @@ function createInitialGridState(layout: LayoutPreset): GridState {
   };
 }
 
-export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone }: ZoneGridProps) {
+export function ZoneGrid({
+  onZoneClick,
+  onZoneDoubleClick,
+  onExit,
+  onExportZone,
+  onUserInputLine,
+}: ZoneGridProps) {
   // Read all data from contexts
   const {
     tabs,
@@ -292,6 +305,7 @@ export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone 
         terminalRef={terminalRefs.get(tab.id)}
         onExit={onExit}
         onFirstInput={onFirstInput}
+        onUserInputLine={onUserInputLine}
         onShellIntegration={onShellIntegration}
         onOutput={onOutput}
         onReconnected={onReconnected}
@@ -350,6 +364,9 @@ export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone 
                   onReconnected={() => onReconnected(zoneTab.id)}
                   onExit={(code) => onExit(zoneTab.id, code)}
                   onFirstInput={(input) => onFirstInput(zoneTab.id, input)}
+                  onUserInputLine={
+                    onUserInputLine ? (input) => onUserInputLine(zoneTab.id, input) : undefined
+                  }
                   onShellIntegration={(event) => onShellIntegration(zoneTab.id, event)}
                   onOutput={(text) => onOutput(zoneTab.id, text)}
                   onTitleChange={(title) => onTitleChange(zoneTab.id, title)}
@@ -394,6 +411,7 @@ export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone 
           onZoneDoubleClick={onZoneDoubleClick}
           onExit={onExit}
           onFirstInput={onFirstInput}
+          onUserInputLine={onUserInputLine}
           onShellIntegration={onShellIntegration}
           onOutput={onOutput}
           onReconnected={onReconnected}
@@ -614,6 +632,7 @@ function ZoneCell({
   onZoneDoubleClick,
   onExit,
   onFirstInput,
+  onUserInputLine,
   onShellIntegration,
   onOutput,
   onReconnected,
@@ -667,6 +686,7 @@ function ZoneCell({
   onZoneDoubleClick: (zoneIndex: number) => void;
   onExit: (terminalId: string, exitCode: number | null) => void;
   onFirstInput: (terminalId: string, input: string) => void;
+  onUserInputLine?: (terminalId: string, input: string) => void;
   onShellIntegration: (tabId: string, event: ShellIntegrationEvent) => void;
   onOutput: (tabId: string, text: string) => void;
   onReconnected: (tabId: string) => void;
@@ -1037,6 +1057,9 @@ function ZoneCell({
                   onReconnected={() => onReconnected(tab.id)}
                   onExit={(code) => onExit(tab.id, code)}
                   onFirstInput={(input) => onFirstInput(tab.id, input)}
+                  onUserInputLine={
+                    onUserInputLine ? (input) => onUserInputLine(tab.id, input) : undefined
+                  }
                   onShellIntegration={(event) => onShellIntegration(tab.id, event)}
                   onOutput={(text) => onOutput(tab.id, text)}
                   onTitleChange={(title) => onTitleChange(tab.id, title)}

--- a/src/components/terminal/consumeInputChunk.ts
+++ b/src/components/terminal/consumeInputChunk.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helper extracted from {@link TerminalInstance}'s xterm.js `onData`
+ * newline loop so the input-accumulator semantics can be unit-tested
+ * without standing up xterm.js or the WebGL canvas addon.
+ *
+ * Lives in its own module (rather than next to `TerminalInstance`) so
+ * the test file doesn't pull `@xterm/addon-canvas` through — that addon
+ * touches `self` at module init, which blows up under vitest's
+ * `environment: "node"`.
+ *
+ * Behavior mirrors the historical loop in `TerminalInstance.tsx`:
+ *   - Iterates `chunk` char-by-char.
+ *   - On `\r` or `\n`, trims the current accumulator and — if non-empty
+ *     — emits it as a line. Empty lines (bare newlines) are dropped.
+ *   - Only chars with code >= 32 accumulate; ESC, BEL, and other
+ *     control bytes are filtered out so they don't pollute the
+ *     auto-name or the mid-session probe payload.
+ *   - The first newline-terminated non-empty line in the chunk (if
+ *     any) is also surfaced as `firstInputLineIfAny` UNLESS
+ *     `firstInputAlreadyReported` is true — gating the caller's
+ *     `onFirstInput` to "exactly once per session" without duplicating
+ *     the gate inside this helper.
+ *
+ * The returned `accum` is the leftover (post-last-newline) partial
+ * line that the caller threads back in on the next chunk.
+ */
+export function consumeInputChunk(
+  chunk: string,
+  accum: string,
+  firstInputAlreadyReported: boolean,
+): { accum: string; lines: string[]; firstInputLineIfAny: string | undefined } {
+  const lines: string[] = [];
+  let firstInputLineIfAny: string | undefined;
+  let current = accum;
+  for (const ch of chunk) {
+    if (ch === "\r" || ch === "\n") {
+      const line = current.trim();
+      if (line.length > 0) {
+        lines.push(line);
+        if (!firstInputAlreadyReported && firstInputLineIfAny === undefined) {
+          firstInputLineIfAny = line;
+        }
+      }
+      current = "";
+    } else if (ch.charCodeAt(0) >= 32) {
+      current += ch;
+    }
+  }
+  return { accum: current, lines, firstInputLineIfAny };
+}

--- a/src/components/terminal/useMidSessionProbe.test.ts
+++ b/src/components/terminal/useMidSessionProbe.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the gating logic of `useMidSessionProbe`.
+ *
+ * The hook itself is composed of an inner debounce + fetch loop that's
+ * hard to exercise from `environment: "node"` (no jsdom, no React
+ * Testing Library). The decision-making lives in the exported pure
+ * helper `shouldFireProbe` — we test the matrix of gates there so any
+ * accidental shift in the gating logic (e.g. dropping the AI-session
+ * check) gets caught in CI.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  shouldFireProbe,
+  MID_SESSION_MIN_LINE_LEN,
+  MID_SESSION_RATE_LIMIT_MS,
+} from "./useMidSessionProbe";
+
+const NOW = 1_000_000_000;
+const LONG_LINE = "edit src/components/foo/bar.ts";
+const SHORT_LINE = "ls -la"; // < 10 chars
+
+describe("shouldFireProbe", () => {
+  it("returns false when the user setting is disabled", () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123" },
+      NOW,
+      { enabled: false },
+    );
+    expect(result).toBe(false);
+  });
+
+  it(`returns false when line is under ${MID_SESSION_MIN_LINE_LEN} chars`, () => {
+    expect(SHORT_LINE.length).toBeLessThan(MID_SESSION_MIN_LINE_LEN);
+    const result = shouldFireProbe(
+      SHORT_LINE,
+      { claudeSessionId: "abc-123" },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the tab has no claudeSessionId", () => {
+    const result = shouldFireProbe(LONG_LINE, {}, NOW, { enabled: true });
+    expect(result).toBe(false);
+  });
+
+  it(`returns false when within ${MID_SESSION_RATE_LIMIT_MS}ms of previous probe`, () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123", lastProbeAt: NOW - 500 },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true when all gates pass (no previous probe)", () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123" },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true when last probe was outside the rate-limit window", () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123", lastProbeAt: NOW - (MID_SESSION_RATE_LIMIT_MS + 1) },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true at the exact rate-limit boundary (>= rate limit ms passed)", () => {
+    // Implementation uses strict `<` for the rate-limit check so a probe
+    // can fire as soon as RATE_LIMIT_MS has elapsed, not RATE_LIMIT_MS+1.
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123", lastProbeAt: NOW - MID_SESSION_RATE_LIMIT_MS },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/src/components/terminal/useMidSessionProbe.ts
+++ b/src/components/terminal/useMidSessionProbe.ts
@@ -1,0 +1,235 @@
+/**
+ * Mid-session probe hook (Phase 3 of
+ * `plans/pty-launched-ai-tabs-warning-plan.md`).
+ *
+ * Watches per-tab newline-terminated input from `TerminalInstance` and,
+ * for active AI sessions (`tab.claudeSessionId` set), pings the runner's
+ * `/file-registry/probe-conflicts` endpoint after the user pauses
+ * typing. When the probe returns predicted collisions, the result is
+ * stashed in a per-tab state map for {@link MidSessionToast} to render
+ * an in-tab dismissible warning.
+ *
+ * Gating is intentionally conservative — see {@link shouldFireProbe} —
+ * because the user explicitly types a fresh turn into Claude CLI and
+ * we want to avoid both (a) firing on bare commands like `ls` and
+ * (b) hammering the registry once a session is hot.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ConflictReport, PredictedCollision } from "./useSessionManager";
+import { resolvePort, buildProbeUrl } from "./LaunchMenu";
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/** Debounce window before a fed line fires the probe (ms). */
+export const MID_SESSION_DEBOUNCE_MS = 500;
+/** Minimum gap between two probes for the same tab (ms). */
+export const MID_SESSION_RATE_LIMIT_MS = 2000;
+/** Minimum prompt length to fire a probe (chars). */
+export const MID_SESSION_MIN_LINE_LEN = 10;
+/** How long a toast stays before auto-dismissal (ms). */
+export const MID_SESSION_TOAST_TTL_MS = 8000;
+/** Interval at which the auto-prune sweep runs (ms). */
+const PRUNE_INTERVAL_MS = 1000;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface MidSessionProbeState {
+  /** Predicted-collision entries from the most recent probe response. */
+  predicted_collisions: PredictedCollision[];
+  /** Snapshot moment for auto-dismiss timing. */
+  received_at: number;
+}
+
+export interface MidSessionProbeApi {
+  feed(tabId: string, line: string): void;
+  dismiss(tabId: string): void;
+  states: Record<string, MidSessionProbeState>;
+}
+
+/**
+ * Minimal tab shape consumed by the hook. Real callers pass
+ * `TerminalTab` from `useTerminalManager`; tests pass plain literals.
+ */
+interface ProbeTab {
+  id: string;
+  claudeSessionId?: string;
+  workingDir?: string;
+}
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────
+
+/**
+ * Gating decision for a candidate probe. Pure so the matrix of failure
+ * modes (disabled, too-short, no-session, rate-limited) can be tested
+ * without a React tree or fetch shim.
+ */
+export function shouldFireProbe(
+  line: string,
+  tab: { claudeSessionId?: string; lastProbeAt?: number },
+  now: number,
+  opts: { enabled: boolean },
+): boolean {
+  if (!opts.enabled) return false;
+  if (line.length < MID_SESSION_MIN_LINE_LEN) return false;
+  if (!tab.claudeSessionId) return false;
+  if (tab.lastProbeAt !== undefined && now - tab.lastProbeAt < MID_SESSION_RATE_LIMIT_MS) {
+    return false;
+  }
+  return true;
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+export function useMidSessionProbe(
+  tabs: ProbeTab[],
+  opts: { enabled: boolean },
+): MidSessionProbeApi {
+  const [states, setStates] = useState<Record<string, MidSessionProbeState>>({});
+
+  // Tabs change every render (new array identity). Mirror into a ref so the
+  // stable `feed` callback can look up the latest tab metadata without
+  // re-binding. Updated via `useEffect` to satisfy the
+  // `react-hooks/refs` rule — see `useRegistryAwareness.ts` for the
+  // same pattern.
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  // Debounce + rate-limit refs. These are deliberately mutable across
+  // renders — the hook itself owns the per-tab clocks.
+  const debounceTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const lastProbeAtRef = useRef<Record<string, number>>({});
+  const optsRef = useRef(opts);
+  useEffect(() => {
+    optsRef.current = opts;
+  }, [opts]);
+
+  const dismiss = useCallback((tabId: string) => {
+    setStates((prev) => {
+      if (!(tabId in prev)) return prev;
+      const next = { ...prev };
+      delete next[tabId];
+      return next;
+    });
+  }, []);
+
+  const fireProbe = useCallback(async (tabId: string, line: string) => {
+    const tab = tabsRef.current.find((t) => t.id === tabId);
+    if (!tab) return;
+    try {
+      const port = resolvePort();
+      const resp = await fetch(buildProbeUrl(port), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: line, cwd: tab.workingDir ?? "" }),
+      });
+      if (!resp.ok) return;
+      const json = (await resp.json()) as ConflictReport;
+      // Empty predicted_collisions → leave existing state untouched.
+      // A noisy keystroke should not erase a prior warning the user
+      // hasn't acknowledged yet.
+      if (!json.predicted_collisions || json.predicted_collisions.length === 0) return;
+      setStates((prev) => ({
+        ...prev,
+        [tabId]: {
+          predicted_collisions: json.predicted_collisions,
+          received_at: Date.now(),
+        },
+      }));
+    } catch {
+      // Network / abort — silently ignore. The probe is best-effort.
+    }
+  }, []);
+
+  const feed = useCallback(
+    (tabId: string, line: string) => {
+      // Reset any pending debounce for this tab — every fresh keystroke
+      // restarts the clock.
+      const existing = debounceTimersRef.current[tabId];
+      if (existing) clearTimeout(existing);
+
+      debounceTimersRef.current[tabId] = setTimeout(() => {
+        delete debounceTimersRef.current[tabId];
+        const tab = tabsRef.current.find((t) => t.id === tabId);
+        if (!tab) return;
+        const now = Date.now();
+        const decision = shouldFireProbe(
+          line,
+          { claudeSessionId: tab.claudeSessionId, lastProbeAt: lastProbeAtRef.current[tabId] },
+          now,
+          optsRef.current,
+        );
+        if (!decision) return;
+        lastProbeAtRef.current[tabId] = now;
+        void fireProbe(tabId, line);
+      }, MID_SESSION_DEBOUNCE_MS);
+    },
+    [fireProbe],
+  );
+
+  // Auto-prune sweep — one interval for the whole hook, not per-entry
+  // timers. Removes entries whose `received_at + TTL` has passed.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      setStates((prev) => {
+        let changed = false;
+        const next: Record<string, MidSessionProbeState> = {};
+        for (const [tabId, s] of Object.entries(prev)) {
+          if (s.received_at + MID_SESSION_TOAST_TTL_MS < now) {
+            changed = true;
+            continue;
+          }
+          next[tabId] = s;
+        }
+        return changed ? next : prev;
+      });
+    }, PRUNE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Cleanup pending debounce timers on unmount.
+  useEffect(() => {
+    const timers = debounceTimersRef.current;
+    return () => {
+      for (const t of Object.values(timers)) clearTimeout(t);
+    };
+  }, []);
+
+  return useMemo<MidSessionProbeApi>(
+    () => ({ feed, dismiss, states }),
+    [feed, dismiss, states],
+  );
+}
+
+// ── Setting gate ────────────────────────────────────────────────────────────
+
+/**
+ * Reactive read of the `enable_mid_session_path_prediction` localStorage
+ * flag. Defaults to `false`. Listens to `storage` events so manual edits
+ * (or a future settings UI — TODO: phase-3 follow-up) propagate without
+ * reload.
+ *
+ * Lever: `localStorage.setItem("enable_mid_session_path_prediction", "true")`
+ * — flip to enable mid-session probing for the current install.
+ */
+export function useMidSessionProbeEnabled(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem("enable_mid_session_path_prediction") === "true";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== "enable_mid_session_path_prediction") return;
+      setEnabled(e.newValue === "true");
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return enabled;
+}

--- a/src/components/terminal/useRegistryAwareness.test.ts
+++ b/src/components/terminal/useRegistryAwareness.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for `useRegistryAwareness` — the per-tab registry-awareness
+ * overlap-count hook.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom).
+ * Following the precedent of `useFileLockTracking.test.ts`, we test
+ * the pure helper `computeOverlapCount` directly rather than rendering
+ * the hook through React.
+ *
+ * Phase 2 of `pty-launched-ai-tabs-warning-plan.md`. Contract:
+ *   - Count files in `liveHoldings` whose path is under `tab.workingDir`.
+ *   - Exclude files held by the tab itself (`holder_name === tab.title`).
+ *   - Return 0 when `workingDir` is undefined or empty.
+ *   - Prefix-match honors path boundaries — `/repository` is NOT under
+ *     `/repo`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { computeOverlapCount } from "./useRegistryAwareness";
+import type { FileRegistryInfoEntry } from "./useSessionManager";
+
+/**
+ * Convenience factory for a {@link FileRegistryInfoEntry} with the
+ * fields the helper actually reads + sane defaults for the rest.
+ */
+function holding(
+  file_path: string,
+  holder_name: string,
+  extras: Partial<FileRegistryInfoEntry> = {},
+): FileRegistryInfoEntry {
+  return {
+    file_path,
+    holder_name,
+    holder_task_run_id: extras.holder_task_run_id ?? `task-${holder_name}`,
+    registered_at: extras.registered_at ?? 0,
+    worktree_id: extras.worktree_id ?? null,
+    ...extras,
+  };
+}
+
+describe("computeOverlapCount", () => {
+  it("counts files held by other sessions under cwd", () => {
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [
+      holding("/repo/src/foo.rs", "B"),
+      holding("/repo/src/bar.rs", "C"),
+    ];
+    expect(computeOverlapCount(holdings, tab)).toBe(2);
+  });
+
+  it("excludes own holdings", () => {
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [holding("/repo/src/foo.rs", "A")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("excludes files outside cwd", () => {
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [holding("/other-repo/foo.rs", "B")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("returns 0 when workingDir is undefined", () => {
+    const tab = { id: "t1", title: "A", workingDir: undefined };
+    const holdings = [
+      holding("/repo/src/foo.rs", "B"),
+      holding("/anywhere/else.rs", "C"),
+    ];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("returns 0 when workingDir is an empty string", () => {
+    // Otherwise plain prefix-match would treat every path as a match
+    // since every string starts with "".
+    const tab = { id: "t1", title: "A", workingDir: "" };
+    const holdings = [holding("/repo/src/foo.rs", "B")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("prefix-match honors path boundaries", () => {
+    // Plain `startsWith` would return true for "/repository".startsWith("/repo")
+    // — the helper must distinguish sibling directories.
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [holding("/repository/foo.rs", "B")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  // Regression: Windows spawn-cwd format mismatch.
+  //
+  // The backend (`executor/file_registry.rs::normalize_path`) stores
+  // file paths as `d:/qontinui-root/cargo.toml` — `\` → `/` and
+  // lowercased on Windows. Tauri hands `tab.workingDir` to the frontend
+  // verbatim as `D:\qontinui-root` (uppercase drive, backslashes).
+  // Without symmetric normalization in the helper the prefix-match
+  // silently fails on every Windows tab, the badge never renders, and
+  // the feature is invisible to users. Caught during manual smoke
+  // (2026-05-11): registered Cargo.toml on a real registry, hook
+  // received the holding, but `"d:/...".startsWith("D:\\...")` was
+  // false.
+  it("normalizes case + slashes for Windows spawn-cwd format", () => {
+    // Simulate the Windows webview where backslash + uppercase
+    // workingDir collides with lowercase forward-slash backend paths.
+    vi.stubGlobal("navigator", { platform: "Win32" } as Navigator);
+    try {
+      const tab = { id: "t1", title: "A", workingDir: "D:\\qontinui-root" };
+      const holdings = [
+        holding("d:/qontinui-root/cargo.toml", "manual-test-A"),
+        holding("d:/qontinui-root/src/lib.rs", "manual-test-A"),
+      ];
+      expect(computeOverlapCount(holdings, tab)).toBe(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("preserves case on non-Windows platforms", () => {
+    // On macOS/Linux file systems are case-sensitive; lowercasing would
+    // produce false positives across `/Repo` vs `/repo`.
+    vi.stubGlobal("navigator", { platform: "Linux x86_64" } as Navigator);
+    try {
+      const tab = { id: "t1", title: "A", workingDir: "/Repo" };
+      const holdings = [holding("/repo/foo.rs", "B")];
+      expect(computeOverlapCount(holdings, tab)).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/components/terminal/useRegistryAwareness.ts
+++ b/src/components/terminal/useRegistryAwareness.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-tab "registry awareness" hook.
+ *
+ * For each terminal tab with a non-empty `workingDir`, polls the
+ * runner's existing `/file-registry/probe-conflicts` endpoint every
+ * 2000ms and counts how many `live_holdings` are:
+ *   - held by OTHER sessions (`holder_name !== tab.title`), and
+ *   - located under this tab's `workingDir` (path-prefix match with
+ *     boundary check — see {@link computeOverlapCount}).
+ *
+ * Returns `Record<tabId, count>`; tabs without a `workingDir` are
+ * absent from the map (callers should treat that as zero / no badge).
+ *
+ * Phase 2 of `pty-launched-ai-tabs-warning-plan.md`. Drives the small
+ * yellow pill badge near the lock-state indicator in
+ * {@link TerminalTabBar}.
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { resolvePort } from "./LaunchMenu";
+import type { TerminalTab } from "./useTerminalManager";
+import type {
+  ConflictReport,
+  FileRegistryInfoEntry,
+} from "./useSessionManager";
+
+/** Polling interval for the probe-conflicts endpoint (ms). */
+export const REGISTRY_AWARENESS_POLL_MS = 2000;
+
+/**
+ * Normalize a path the same way the runner's backend does
+ * (`executor/file_registry.rs::normalize_path`): `\` → `/`, then
+ * lowercase on Windows. Without this, the prefix-match in
+ * {@link computeOverlapCount} will silently fail on Windows because
+ * `tab.workingDir` carries the spawn-cwd verbatim (`D:\qontinui-root`)
+ * while `live_holdings[].file_path` carries the backend-normalized
+ * form (`d:/qontinui-root/...`).
+ *
+ * Windows detection: `navigator.platform` starts with `"Win"` in the
+ * Tauri webview. `typeof navigator === "undefined"` covers SSR/node
+ * test environments (falls back to no lowercasing — matches Unix).
+ */
+function normalizePath(p: string): string {
+  const slashed = p.replace(/\\/g, "/");
+  const isWindows =
+    typeof navigator !== "undefined" && navigator.platform.startsWith("Win");
+  return isWindows ? slashed.toLowerCase() : slashed;
+}
+
+/**
+ * Count files in `liveHoldings` that are:
+ *   1. held by a session other than `tab` (`holder_name !== tab.title`),
+ *   2. located under `tab.workingDir` (prefix match with path boundary).
+ *
+ * Both `tab.workingDir` and `h.file_path` are normalized via
+ * {@link normalizePath} before comparison so case/slash differences
+ * between Tauri's spawn-cwd format and the backend-normalized
+ * file-registry keys don't cause silent misses on Windows.
+ *
+ * Boundary check: a plain `startsWith` would treat
+ * `"/repository/foo.rs".startsWith("/repo")` as true, conflating
+ * sibling-directory paths. We require either exact equality OR the
+ * separator `"/"` immediately after the prefix.
+ *
+ * Returns 0 when `tab.workingDir` is undefined or empty (otherwise
+ * every path would match the empty prefix).
+ */
+export function computeOverlapCount(
+  liveHoldings: readonly FileRegistryInfoEntry[],
+  tab: { id: string; title: string; workingDir?: string },
+): number {
+  const cwd = tab.workingDir;
+  if (!cwd) return 0;
+  const cwdN = normalizePath(cwd);
+  let count = 0;
+  for (const h of liveHoldings) {
+    if (h.holder_name === tab.title) continue;
+    const p = normalizePath(h.file_path);
+    if (p === cwdN || p.startsWith(cwdN + "/")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Hook: poll `/file-registry/probe-conflicts` per tab on a 2s
+ * interval and return per-tab overlap counts.
+ *
+ * Implementation mirrors {@link useFileLockTracking}:
+ *   - `tabsRef` keeps the interval callback reading the latest tabs
+ *     without re-installing the interval on every identity change.
+ *   - Fetch errors are swallowed (count drops to 0 for that tab).
+ *   - The interval is cleared on unmount.
+ */
+export function useRegistryAwareness(
+  tabs: TerminalTab[],
+): Record<string, number> {
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  useEffect(() => {
+    let active = true;
+    const port = resolvePort();
+    const url = `http://127.0.0.1:${port}/file-registry/probe-conflicts`;
+
+    const probeTab = async (
+      tab: TerminalTab,
+    ): Promise<[string, number]> => {
+      if (!tab.workingDir) return [tab.id, 0];
+      try {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt: null, cwd: tab.workingDir }),
+        });
+        if (!resp.ok) return [tab.id, 0];
+        const report = (await resp.json()) as ConflictReport;
+        const n = computeOverlapCount(report.live_holdings ?? [], tab);
+        return [tab.id, n];
+      } catch {
+        // Swallow — probe failures are not user-facing.
+        return [tab.id, 0];
+      }
+    };
+
+    const poll = async () => {
+      const current = tabsRef.current;
+      const eligible = current.filter((t) => !!t.workingDir);
+      if (eligible.length === 0) {
+        if (active) setCounts({});
+        return;
+      }
+      const results = await Promise.all(eligible.map(probeTab));
+      if (!active) return;
+      const next: Record<string, number> = {};
+      for (const [id, n] of results) {
+        next[id] = n;
+      }
+      setCounts(next);
+    };
+
+    void poll();
+    const interval = setInterval(() => {
+      void poll();
+    }, REGISTRY_AWARENESS_POLL_MS);
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return counts;
+}

--- a/src/components/terminal/zone-grid/HiddenTerminal.tsx
+++ b/src/components/terminal/zone-grid/HiddenTerminal.tsx
@@ -11,6 +11,7 @@ export function HiddenTerminal({
   terminalRef,
   onExit,
   onFirstInput,
+  onUserInputLine,
   onShellIntegration,
   onOutput,
   onReconnected,
@@ -20,6 +21,7 @@ export function HiddenTerminal({
   terminalRef: RefObject<TerminalInstanceHandle | null> | undefined;
   onExit: (terminalId: string, exitCode: number | null) => void;
   onFirstInput: (terminalId: string, input: string) => void;
+  onUserInputLine?: (terminalId: string, input: string) => void;
   onShellIntegration: (tabId: string, event: ShellIntegrationEvent) => void;
   onOutput: (tabId: string, text: string) => void;
   onReconnected: (tabId: string) => void;
@@ -35,6 +37,9 @@ export function HiddenTerminal({
         onReconnected={() => onReconnected(tab.id)}
         onExit={(code) => onExit(tab.id, code)}
         onFirstInput={(input) => onFirstInput(tab.id, input)}
+        onUserInputLine={
+          onUserInputLine ? (input) => onUserInputLine(tab.id, input) : undefined
+        }
         onShellIntegration={(event) => onShellIntegration(tab.id, event)}
         onOutput={(text) => onOutput(tab.id, text)}
         onTitleChange={onTitleChange ? (title) => onTitleChange(tab.id, title) : undefined}

--- a/src/hooks/ui-bridge-events/useAISearchEvents.ts
+++ b/src/hooks/ui-bridge-events/useAISearchEvents.ts
@@ -117,6 +117,14 @@ export function useAISearchEvents(
           const query = (payload.params?.query as string) ?? "";
           const context = payload.params?.context as Record<string, unknown> | undefined;
           const confidenceThreshold = payload.params?.confidenceThreshold as number | undefined;
+          // B2 — literal-text precedence + strict mode. When the caller
+          // passes `strict: true` (forwarded by the Rust /ai/find handler
+          // from `?strict=true` / `"strict": true` in the JSON body), the
+          // SDK matcher returns ONLY exact-match candidates. Default
+          // behaviour (no flag) keeps the fuzzy path but exact matches
+          // still outrank alias-only candidates via the SearchEngine's
+          // literal-precedence pass.
+          const strict = payload.params?.strict === true;
 
           // Auto-detect active modal for context-aware scoring
           const uiBridgeGlobal = getUIBridgeGlobal();
@@ -146,6 +154,13 @@ export function useAISearchEvents(
           // Only pass confidenceThreshold if explicitly provided (undefined overrides defaults)
           if (typeof confidenceThreshold === "number" && !Number.isNaN(confidenceThreshold)) {
             findOpts.confidenceThreshold = confidenceThreshold;
+          }
+          if (strict) {
+            // `strict` is a Phase B2 addition on `FindOptions`; cast through
+            // an indexed-property type so we don't depend on the deployed
+            // @qontinui/ui-bridge typings carrying the new field yet. Once
+            // the SDK bump lands, the cast collapses to a no-op.
+            (findOpts as Record<string, unknown>).strict = true;
           }
           const result = aiFindFn(query, engine, findOpts);
           await sendResponse({

--- a/src/lib/graphql-client.ts
+++ b/src/lib/graphql-client.ts
@@ -90,10 +90,10 @@ export function getGraphQLClient(): ApolloClient {
     },
     on: {
       connected: () => {
-        console.warn("[GraphQL WS] Connected");
+        console.info("[GraphQL WS] Connected");
       },
       closed: () => {
-        console.warn("[GraphQL WS] Closed");
+        console.info("[GraphQL WS] Closed");
       },
       error: (err) => {
         console.warn("[GraphQL WS] Error:", err);

--- a/src/services/background-observer-service.ts
+++ b/src/services/background-observer-service.ts
@@ -101,7 +101,7 @@ export function startBackgroundObserver(): void {
   });
 
   observer.start();
-  console.warn("[BackgroundObserverService] Started");
+  console.info("[BackgroundObserverService] Started");
 }
 
 /**
@@ -111,7 +111,7 @@ export function stopBackgroundObserver(): void {
   if (observer) {
     observer.stop();
     observer = null;
-    console.warn("[BackgroundObserverService] Stopped");
+    console.info("[BackgroundObserverService] Stopped");
   }
 }
 


### PR DESCRIPTION
## Summary

Implements 7 fixes surfaced by the 2026-05-10 `/manual-test` run, paired with the @qontinui/ui-bridge@0.4.0 publish (companion PR in `ui-bridge` repo).

**Runner-side (this PR):**
- **B3** — `/control/console-errors` defaults to `{error, unhandledrejection}` when `?level=` is absent; `?level=all` / `?level=*` restores legacy unfiltered behaviour. 4 producer-side `console.warn`/`error` callsites demoted to `console.info` (`graphql-client.ts`, `background-observer-service.ts`).
- **B4** — `/ai/wait-for-element` accepts `?strictTimeout=true` (opt-in). When set, the SDK-forwarded predicate/state-shape handlers reshape `{found:false,...}` into HTTP 408 + `success:false` + `error:"wait_for_element_timeout"`, matching the NL/id path. Default behaviour unchanged.
- **F1** — NL/id `wait-for-element` path now dual-emits `durationMs` (canonical) alongside `elapsed_ms` for one release. NL/id timeout error envelope gains `data: {found:false, durationMs, polls}`.
- **F2** — `/control/components` converges with `/ui-bridge/sdk/control/components` on Direction B envelope `{success:true, data:{components:[...]}}`. Direct path emits a deprecated top-level `components` mirror for one release. SDK relay double-wrap fix (the IPC fallback path and the SDK forward path were both nesting as `data.components.components`).
- **B2 runner-side plumbing** — `?strict=true` query param on `/ai/find` (ORed with body `strict:true`); `useAISearchEvents.ts` forwards the flag.
- **Dep bump** — `@qontinui/ui-bridge` ^0.3.9 → ^0.4.0 (separate commit `e961ca76b`); brings in B1, B2 matcher, F2 SDK-relay-side fixes that ship in the companion ui-bridge PR.

**Tests:** 19 new regression tests across `console_level_filter_tests`, `strict_timeout_reshape_tests`, `wait_for_element_dual_emit_tests`, `components_envelope_tests`. Manifest drift tests green.

**Live-validated** on fresh temp runner port 9881 (`e961ca76b` binary, @qontinui/ui-bridge@0.4.0 installed):
- B1 heading element \`content: 'Qontinui Runner'\` (was \`''\`)
- B2 \`ai/find {\"query\":\"Browse Claude Code sessions\"}\` → correct id @ 1.0
- B2 \`?strict=true\` on nonexistent literal → \`found:false\`
- F2 direct + SDK-relay agree on \`{success:true, data:{components:[6 items]}}\`
- B4 \`?strictTimeout=true\` → HTTP 408; default → HTTP 200 (unchanged)
- F1 happy + timeout both carry \`durationMs\`

Companion: ui-bridge PR for branch \`ui-bridge-quality-remediation-2026-05-11\`. Plan + audit history archived in \`qontinui-dev-notes/plans/ui-bridge-quality-remediation-from-2026-05-10-manual-test.md\`.

## Test plan

- [x] \`cargo check -p qontinui-runner\` clean
- [x] \`cargo test manifest_matches_route_calls\` + \`sdk_manifest_routes_are_exposed_by_runner\` pass
- [x] 19 new regression tests pass
- [x] Live-validate on rebuilt temp runner (B1, B2, B2 strict, F2 direct + relay, B4 strict + legacy, F1 dual-emit)
- [x] cargo fmt + clippy (pre-push hook)
- [ ] CI green on PR