### PR TITLE
feat(terminal): mid-session + always-on conflict awareness for PTY AI tabs

### DIFF
--- a/src/components/terminal/LaunchMenu.test.tsx
+++ b/src/components/terminal/LaunchMenu.test.tsx
@@ -32,6 +32,7 @@ import {
   CONFIDENCE_TIER_CLASS,
   COLLISION_DIM_THRESHOLD,
   PROBE_DEBOUNCE_MS,
+  buildProbeBody,
   buildProbeUrl,
   confidenceTier,
   formatHoldingAge,
@@ -415,6 +416,72 @@ describe("probe fetch wire shape", () => {
     const [, init] = fetchMock.mock.calls[0]!;
     const sentBody = JSON.parse((init as RequestInit).body as string);
     expect(sentBody.prompt).toBeNull();
+  });
+
+  // ── cwd plumbing (Phase 1) ────────────────────────────────────────────────
+  //
+  // These three cases lock the `cwd?: string` prop's contract end-to-end:
+  // a provided cwd shows up in the wire body; an undefined prop defaults
+  // to ""; and an explicit "" survives unmodified (no coercion to
+  // undefined / no field-drop). Driven through the same `fetch` mock
+  // pattern as the wire-shape tests above, exercising the pure
+  // `buildProbeBody` helper that the component's runProbe uses.
+
+  it("posts the provided cwd in the JSON body when LaunchMenu has cwd='/repo'", async () => {
+    const port = resolvePort();
+    const url = buildProbeUrl(port);
+
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildProbeBody("edit src/foo.rs", "/repo"),
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0]!;
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody.cwd).toBe("/repo");
+  });
+
+  it("defaults undefined cwd to empty string (first-tab / no-active case)", async () => {
+    // When TerminalPage's `tabs.find((t) => t.id === activeId)?.workingDir`
+    // returns undefined (no active tab, or tab has no workingDir yet),
+    // LaunchMenu's prop is undefined and the wire body must still carry
+    // cwd="" — the legacy hardcoded behavior the backend handler already
+    // expects.
+    const port = resolvePort();
+    const url = buildProbeUrl(port);
+
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildProbeBody("edit src/foo.rs", undefined),
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    // The field is present in the body (not dropped) and equals "".
+    expect(sentBody).toHaveProperty("cwd");
+    expect(sentBody.cwd).toBe("");
+  });
+
+  it("preserves an explicit empty-string cwd (does not drop or undefined-coerce)", async () => {
+    // A caller passing cwd="" explicitly must get cwd="" in the wire
+    // body — not dropped (which would risk a JSON-shape regression on
+    // the backend) and not coerced to undefined.
+    const port = resolvePort();
+    const url = buildProbeUrl(port);
+
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: buildProbeBody("edit src/foo.rs", ""),
+    });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const sentBody = JSON.parse((init as RequestInit).body as string);
+    expect(sentBody).toHaveProperty("cwd");
+    expect(sentBody.cwd).toBe("");
   });
 });
 

--- a/src/components/terminal/LaunchMenu.test.tsx
+++ b/src/components/terminal/LaunchMenu.test.tsx
@@ -191,6 +191,8 @@ describe("summarizeFileLocksByHolder", () => {
 describe("resolvePort", () => {
   it("falls back to 9876 when __QONTINUI_PORT__ is absent", () => {
     // In Node test env, window may or may not exist; the helper handles both.
+    // `getApiPort()` from `@/lib/runner-api` defaults to 9876 in its
+    // initial state — the helper delegates here when the global is unset.
     const original = (globalThis as unknown as { window?: unknown }).window;
     (globalThis as unknown as { window?: unknown }).window = {};
     try {
@@ -208,6 +210,42 @@ describe("resolvePort", () => {
     try {
       expect(resolvePort()).toBe(9123);
     } finally {
+      (globalThis as unknown as { window?: unknown }).window = original;
+    }
+  });
+
+  it("falls through to setApiPort()'s value when the global is unset", async () => {
+    // Regression: secondary / temp runners on non-default ports never
+    // had `__QONTINUI_PORT__` set in the webview, so `resolvePort()`
+    // used to silently fall back to 9876 — routing all probes from
+    // the temp runner to the primary's registry and dropping the
+    // hook's own data. Fix: delegate to `getApiPort()`, which
+    // `useApiReady` populates from the `api-ready` Tauri event.
+    const { setApiPort } = await import("@/lib/runner-api");
+    const original = (globalThis as unknown as { window?: unknown }).window;
+    (globalThis as unknown as { window?: unknown }).window = {};
+    try {
+      setApiPort(9878);
+      expect(resolvePort()).toBe(9878);
+    } finally {
+      setApiPort(9876); // restore module-level default
+      (globalThis as unknown as { window?: unknown }).window = original;
+    }
+  });
+
+  it("prefers __QONTINUI_PORT__ over getApiPort() when both are set", async () => {
+    // The global override path is the manual-test escape hatch.
+    // Setting it must win regardless of what `useApiReady` populated.
+    const { setApiPort } = await import("@/lib/runner-api");
+    const original = (globalThis as unknown as { window?: unknown }).window;
+    (globalThis as unknown as { window?: { __QONTINUI_PORT__?: number } }).window = {
+      __QONTINUI_PORT__: 9123,
+    };
+    try {
+      setApiPort(9878);
+      expect(resolvePort()).toBe(9123);
+    } finally {
+      setApiPort(9876);
       (globalThis as unknown as { window?: unknown }).window = original;
     }
   });

--- a/src/components/terminal/LaunchMenu.tsx
+++ b/src/components/terminal/LaunchMenu.tsx
@@ -18,6 +18,17 @@ interface LaunchMenuProps {
   launchCommands?: Record<string, string>;
   fileLocks?: FileLockInfo[];
   /**
+   * Active-tab working directory plumbed in by `TerminalTabBar`. The
+   * probe sends this in its JSON body so the runner's
+   * `path_extraction::extract_candidate_paths` can resolve relative-path
+   * tokens (e.g. "edit src/foo.rs") against the launching session's
+   * cwd, rather than degrading to bare-filename matching against the
+   * registry's normalized keys. Undefined / first-tab case falls back
+   * to "" — matches the legacy hardcoded behavior and the backend
+   * handler's documented "no relative-path resolution" mode.
+   */
+  cwd?: string;
+  /**
    * Resolves a holder name (matches a tab's `title`) to focus the
    * corresponding terminal tab. No-op when no tab matches — the holder
    * may be a non-terminal session (e.g. a workflow runner). Mirrors
@@ -64,6 +75,19 @@ export function resolvePort(): number {
 
 export function buildProbeUrl(port: number): string {
   return `http://127.0.0.1:${port}/file-registry/probe-conflicts`;
+}
+
+/**
+ * Build the JSON body for a probe request.
+ *
+ * `cwd` defaults to `""` when undefined — matches the legacy hardcoded
+ * behavior and the backend handler's documented "no relative-path
+ * resolution" mode. An explicit `""` from the caller is preserved
+ * (not coerced to undefined / dropped from the body) so the wire shape
+ * is stable regardless of which call site reached us.
+ */
+export function buildProbeBody(prompt: string | null, cwd: string | undefined): string {
+  return JSON.stringify({ prompt, cwd: cwd ?? "" });
 }
 
 /**
@@ -353,6 +377,7 @@ export function LaunchMenu({
   accountUsage,
   launchCommands,
   fileLocks,
+  cwd,
   onJumpToHolder,
   resolveSessionName,
   onClose,
@@ -390,13 +415,11 @@ export function LaunchMenu({
 
   // ── Probe: fetch ConflictReport on prompt change (debounced) ───────────────
   // The probe runs against the runner's local /file-registry/probe-conflicts
-  // endpoint. cwd is intentionally empty for now — the backend handles "" as
-  // "no relative-path resolution; only absolute paths and bare-filename
-  // matches." See plan §Open Q3.
-  // TODO(plan §Open Q3): plumb the active session's cwd through here so
-  // relative path tokens like "src/foo/bar.rs" can resolve against the
-  // launching session's working directory rather than degrading to
-  // bare-filename matching.
+  // endpoint. `cwd` is per-active-tab semantics — plumbed in by
+  // `TerminalTabBar` from the focused tab's `workingDir`. When undefined
+  // (e.g. first-tab case), buildProbeBody defaults it to "" so the backend
+  // falls back to its "no relative-path resolution; only absolute paths
+  // and bare-filename matches" mode.
 
   const runProbe = useCallback(
     async (prompt: string | null, signal?: AbortSignal): Promise<void> => {
@@ -405,7 +428,7 @@ export function LaunchMenu({
         const resp = await fetch(buildProbeUrl(port), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ prompt, cwd: "" }),
+          body: buildProbeBody(prompt, cwd),
           signal,
         });
         if (!resp.ok) return;
@@ -418,10 +441,13 @@ export function LaunchMenu({
         // UI doesn't flicker when the runner is briefly busy.
       }
     },
-    [],
+    [cwd],
   );
 
-  // Debounced re-probe on prompt change.
+  // Debounced re-probe on prompt change. `runProbe` is included in the
+  // dep list — and `runProbe` itself depends on `cwd` — so a tab switch
+  // that changes the active workingDir re-fires the probe with the new
+  // cwd.
   useEffect(() => {
     const controller = new AbortController();
     const handle = setTimeout(() => {

--- a/src/components/terminal/LaunchMenu.tsx
+++ b/src/components/terminal/LaunchMenu.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { Star, Terminal, Play, Loader2, Lock } from "lucide-react";
+import { getApiPort } from "@/lib/runner-api";
 import type {
   AccountUsageInfo,
   ConflictReport,
@@ -63,14 +64,28 @@ export const PROBE_POLL_INTERVAL_MS = 2000;
 // ── Pure helpers (exported for tests) ────────────────────────────────────────
 
 /**
- * Resolve the runner HTTP port. Mirrors the pattern from
- * `useFileLockTracking.ts:90-95` so probe traffic lands on the same
- * port as the rest of the runner's local control surface.
+ * Resolve the runner HTTP port for local-control-surface traffic
+ * (`/file-registry/...`, `/file-locks/...`, etc.).
+ *
+ * Resolution order:
+ *   1. `window.__QONTINUI_PORT__` if explicitly set — manual-test
+ *      override and the historical fallback hatch.
+ *   2. `getApiPort()` from `@/lib/runner-api` — the centralized port
+ *      populated by `useApiReady` from Tauri's `api-ready` event and
+ *      the `get_api_port` IPC. Defaults to 9876 when the API isn't
+ *      bound yet, so first-poll on a secondary runner can still
+ *      briefly hit the primary; the next 2s poll cycle picks up the
+ *      correct port once `setApiPort` runs.
+ *
+ * The hardcoded `9876` fallback is intentionally absent here — it
+ * lives inside `getApiPort()`'s default state so it's a single source
+ * of truth for the entire frontend.
  */
 export function resolvePort(): number {
-  if (typeof window === "undefined") return 9876;
+  if (typeof window === "undefined") return getApiPort();
   const fromGlobal = (window as unknown as Record<string, unknown>).__QONTINUI_PORT__;
-  return fromGlobal ? Number(fromGlobal) : 9876;
+  if (fromGlobal) return Number(fromGlobal);
+  return getApiPort();
 }
 
 export function buildProbeUrl(port: number): string {

--- a/src/components/terminal/MidSessionToast.test.tsx
+++ b/src/components/terminal/MidSessionToast.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Pure-helper tests for `MidSessionToast`.
+ *
+ * The runner's vitest config uses `environment: "node"` — JSX rendering
+ * isn't available. Following the precedent set by
+ * `LaunchMenu.test.tsx` and `CommitTrafficLight.test.tsx`, we exercise
+ * the load-bearing logic via the exported pure helper
+ * `formatToastSummary`. The JSX glue is verified manually + via UI
+ * Bridge in Phase 4.
+ */
+
+import { describe, it, expect } from "vitest";
+import { formatToastSummary } from "./MidSessionToast";
+import type { MidSessionProbeState } from "./useMidSessionProbe";
+import type { PredictedCollision } from "./useSessionManager";
+
+function makeCollision(
+  file_path: string,
+  holders: Array<{ task_run_id: string; holder_name: string }>,
+): PredictedCollision {
+  return {
+    file_path,
+    other_holders: holders.map((h) => ({ ...h, registered_at: 0 })),
+    confidence: 0.7,
+  };
+}
+
+function makeState(collisions: PredictedCollision[]): MidSessionProbeState {
+  return { predicted_collisions: collisions, received_at: 0 };
+}
+
+describe("formatToastSummary", () => {
+  it("pluralizes a single collision held by one session", () => {
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("src/foo.ts", [{ task_run_id: "t1", holder_name: "alpha" }]),
+      ]),
+    );
+    expect(summary.header).toBe("1 file held by another session");
+  });
+
+  it("pluralizes multiple collisions across multiple sessions", () => {
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("src/a.ts", [{ task_run_id: "t1", holder_name: "alpha" }]),
+        makeCollision("src/b.ts", [{ task_run_id: "t2", holder_name: "beta" }]),
+        makeCollision("src/c.ts", [{ task_run_id: "t3", holder_name: "gamma" }]),
+      ]),
+    );
+    expect(summary.header).toBe("3 files held by other sessions");
+  });
+
+  it("uses 'other sessions' when a single file has multiple holders", () => {
+    // Singular file count but plural holders → header should hint at
+    // multiple sessions so the user knows it's a contested file.
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("src/foo.ts", [
+          { task_run_id: "t1", holder_name: "alpha" },
+          { task_run_id: "t2", holder_name: "beta" },
+        ]),
+      ]),
+    );
+    expect(summary.header).toBe("1 file held by other sessions");
+  });
+
+  it("derives per-file rows with basename + first holder + joined holders", () => {
+    const summary = formatToastSummary(
+      makeState([
+        makeCollision("D:/qontinui-root/src/foo.ts", [
+          { task_run_id: "t1", holder_name: "alpha" },
+          { task_run_id: "t2", holder_name: "beta" },
+        ]),
+        makeCollision("relative\\path\\bar.rs", [
+          { task_run_id: "t3", holder_name: "gamma" },
+        ]),
+      ]),
+    );
+    expect(summary.rows).toHaveLength(2);
+
+    expect(summary.rows[0]).toEqual({
+      file_path: "D:/qontinui-root/src/foo.ts",
+      basename: "foo.ts",
+      holder_name: "alpha",
+      holders_label: "alpha, beta",
+    });
+
+    // Backslash path uses Windows-style separator — basename must handle
+    // both \\ and / (mixed paths come from the runner's path extractor).
+    expect(summary.rows[1]).toEqual({
+      file_path: "relative\\path\\bar.rs",
+      basename: "bar.rs",
+      holder_name: "gamma",
+      holders_label: "gamma",
+    });
+  });
+
+  it("falls back to 'unknown' when other_holders is empty", () => {
+    // Defensive shape — runner filters out the caller's own holder
+    // before serializing, so a 0-holder row is unusual but possible.
+    const summary = formatToastSummary(
+      makeState([makeCollision("src/foo.ts", [])]),
+    );
+    expect(summary.rows[0].holder_name).toBe("unknown");
+    expect(summary.rows[0].holders_label).toBe("unknown");
+  });
+});

--- a/src/components/terminal/MidSessionToast.tsx
+++ b/src/components/terminal/MidSessionToast.tsx
@@ -1,0 +1,127 @@
+/**
+ * Dismissible mid-session warning toast. Rendered overlay-style over
+ * the active terminal when {@link useMidSessionProbe} has a fresh
+ * predicted-collisions response for that tab.
+ *
+ * Visual language mirrors the yellow "Possible conflicts" panel in
+ * `LaunchMenu.tsx` so the surfaces feel like one product — same
+ * palette (`#e0af68`), same row layout (holder name + basename), but
+ * compact since this floats over the terminal rather than inline in
+ * the launch sheet.
+ */
+
+import type { MidSessionProbeState } from "./useMidSessionProbe";
+import type { PredictedCollision } from "./useSessionManager";
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────
+
+export interface ToastRow {
+  /** Full original path — used as a stable React key + tooltip. */
+  file_path: string;
+  /** Final path component for compact display in the row. */
+  basename: string;
+  /** First holder's friendly name (used by the "jump to" affordance). */
+  holder_name: string;
+  /** All holders joined for the secondary text. */
+  holders_label: string;
+}
+
+export interface ToastSummary {
+  header: string;
+  rows: ToastRow[];
+}
+
+/** Final segment of a /- or \-delimited path. */
+function basename(p: string): string {
+  const idx = Math.max(p.lastIndexOf("/"), p.lastIndexOf("\\"));
+  return idx >= 0 ? p.slice(idx + 1) : p;
+}
+
+/**
+ * Pure derivation of the toast's displayed data from a probe state.
+ * Exported so the file/session pluralization + row aggregation can be
+ * unit-tested without rendering JSX.
+ */
+export function formatToastSummary(state: MidSessionProbeState): ToastSummary {
+  const collisions = state.predicted_collisions;
+  const n = collisions.length;
+  // Pluralize independently — N=1 always means a single holder by
+  // construction (one file held by one or more sessions). The
+  // "other sessions" half pluralizes on whether ANY collision row has
+  // more than one holder OR there's more than one collision row.
+  const multipleHolders =
+    n > 1 || collisions.some((c) => (c.other_holders?.length ?? 0) > 1);
+  const fileWord = n === 1 ? "file" : "files";
+  const sessionWord = multipleHolders ? "other sessions" : "another session";
+  const header = `${n} ${fileWord} held by ${sessionWord}`;
+
+  const rows: ToastRow[] = collisions.map((c: PredictedCollision) => {
+    const holders = c.other_holders ?? [];
+    const firstHolder = holders[0]?.holder_name ?? "unknown";
+    const label = holders.map((h) => h.holder_name).join(", ") || "unknown";
+    return {
+      file_path: c.file_path,
+      basename: basename(c.file_path),
+      holder_name: firstHolder,
+      holders_label: label,
+    };
+  });
+
+  return { header, rows };
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+interface MidSessionToastProps {
+  state: MidSessionProbeState;
+  onDismiss: () => void;
+  onJumpToHolder?: (holderName: string) => void;
+}
+
+export function MidSessionToast({
+  state,
+  onDismiss,
+  onJumpToHolder,
+}: MidSessionToastProps) {
+  const { header, rows } = formatToastSummary(state);
+  return (
+    <div
+      data-testid="mid-session-toast"
+      className="absolute top-2 right-2 z-30 w-[280px] p-2 rounded border bg-[#e0af68]/15 border-[#e0af68]/40 shadow-lg"
+    >
+      <div className="flex items-start gap-2">
+        <div className="text-[10px] uppercase tracking-wider text-[#e0af68] flex-1">
+          {header}
+        </div>
+        <button
+          type="button"
+          data-testid="mid-session-toast-dismiss"
+          aria-label="Dismiss conflict warning"
+          onClick={onDismiss}
+          className="text-[#e0af68] hover:text-[#c0caf5] leading-none px-1"
+        >
+          ×
+        </button>
+      </div>
+      <ul className="mt-1.5 space-y-0.5">
+        {rows.map((row) => {
+          const clickable = Boolean(onJumpToHolder);
+          return (
+            <li
+              key={row.file_path}
+              data-testid="mid-session-toast-row"
+              className={`flex items-center gap-2 text-[10px] ${
+                clickable ? "cursor-pointer hover:bg-[#e0af68]/10 rounded px-1 -mx-1" : ""
+              }`}
+              onClick={() => onJumpToHolder?.(row.holder_name)}
+              title={row.file_path}
+            >
+              <span className="font-mono text-[#c0caf5] truncate">{row.basename}</span>
+              <span className="text-[#a9b1d6] truncate ml-auto">{row.holders_label}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalInstance.test.tsx
+++ b/src/components/terminal/TerminalInstance.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Pure-logic tests for the input accumulator extracted from
+ * `TerminalInstance`'s xterm.js `onData` loop.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom) — and
+ * `TerminalInstance` itself is impractical to import from a test
+ * because it transitively pulls `@xterm/addon-canvas`, which touches
+ * `self` at module init and crashes under Node. The load-bearing logic
+ * was extracted to `./consumeInputChunk.ts` (a leaf module with zero
+ * imports) so it can be unit-tested in isolation. `TerminalInstance`'s
+ * `onData` handler is now a thin shell over this helper.
+ *
+ * The cases below cover:
+ *   - Multiple newlines in a single chunk emit multiple lines.
+ *   - A line split across two chunks accumulates correctly.
+ *   - Non-printable chars (code < 32) are dropped from the accumulator.
+ *   - `firstInputLineIfAny` is gated by the caller's "already reported"
+ *     flag so `onFirstInput` fires only once per session.
+ *   - Bare empty newlines (whitespace-only) emit no line — preserving
+ *     the historical "empty line trimmed" behavior.
+ */
+
+import { describe, it, expect } from "vitest";
+import { consumeInputChunk } from "./consumeInputChunk";
+
+describe("consumeInputChunk", () => {
+  it("emits two lines for two newlines in one chunk", () => {
+    const result = consumeInputChunk("hello\nworld\n", "", false);
+    expect(result.lines).toEqual(["hello", "world"]);
+    expect(result.firstInputLineIfAny).toBe("hello");
+    expect(result.accum).toBe("");
+  });
+
+  it("accumulates a line split across two chunks", () => {
+    const first = consumeInputChunk("hel", "", false);
+    expect(first.lines).toEqual([]);
+    expect(first.firstInputLineIfAny).toBeUndefined();
+    expect(first.accum).toBe("hel");
+
+    const second = consumeInputChunk("lo\n", first.accum, false);
+    expect(second.lines).toEqual(["hello"]);
+    expect(second.firstInputLineIfAny).toBe("hello");
+    expect(second.accum).toBe("");
+  });
+
+  it("drops non-printable chars (code < 32) from the accumulator", () => {
+    // ESC (0x1b) sits between two printable chars — it must be dropped
+    // so the line becomes "ab", matching the historical loop behavior at
+    // the `ch.charCodeAt(0) >= 32` gate.
+    const result = consumeInputChunk("a\x1bb\n", "", false);
+    expect(result.lines).toEqual(["ab"]);
+    expect(result.firstInputLineIfAny).toBe("ab");
+    expect(result.accum).toBe("");
+  });
+
+  it("does not surface firstInputLineIfAny when already reported", () => {
+    const result = consumeInputChunk("second turn\n", "", true);
+    // The line still flows through `lines` (for `onUserInputLine`), but
+    // the first-input slot stays empty so the caller's `onFirstInput`
+    // doesn't fire again.
+    expect(result.lines).toEqual(["second turn"]);
+    expect(result.firstInputLineIfAny).toBeUndefined();
+    expect(result.accum).toBe("");
+  });
+
+  it("emits no line for a bare empty newline", () => {
+    const result = consumeInputChunk("\n", "", false);
+    expect(result.lines).toEqual([]);
+    expect(result.firstInputLineIfAny).toBeUndefined();
+    expect(result.accum).toBe("");
+  });
+
+  it("emits no line when the accumulator is whitespace-only", () => {
+    // Historical "trim then check empty" — a line of just spaces is
+    // dropped from both `lines` and `firstInputLineIfAny`.
+    const result = consumeInputChunk("   \n", "", false);
+    expect(result.lines).toEqual([]);
+    expect(result.firstInputLineIfAny).toBeUndefined();
+    expect(result.accum).toBe("");
+  });
+
+  it("treats \\r the same as \\n as a line terminator", () => {
+    // xterm.js fires `\r` on Enter, not `\n`, so the historical loop
+    // accepts either as a line break. Verify both are honored.
+    const result = consumeInputChunk("alpha\rbeta\n", "", false);
+    expect(result.lines).toEqual(["alpha", "beta"]);
+    expect(result.firstInputLineIfAny).toBe("alpha");
+  });
+});

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -11,6 +11,7 @@ import { createTerminalBackend } from "./backends";
 import type { BackendType, ITerminalBackend } from "./backends";
 import { paintGrid, type GridSnapshot } from "./paintGrid";
 import { instanceStorage } from "@/lib/instance-storage";
+import { consumeInputChunk } from "./consumeInputChunk";
 
 export interface TerminalInstanceHandle {
   getSelection: () => string;
@@ -47,6 +48,13 @@ interface TerminalInstanceProps {
   onExit?: (exitCode: number | null) => void;
   onSelectionChange?: (hasSelection: boolean) => void;
   onFirstInput?: (input: string) => void;
+  /**
+   * Called for EVERY non-empty newline-terminated input line typed into
+   * the terminal. Unlike `onFirstInput`, this is ungated and fires on
+   * every subsequent line — the consumer (e.g. `useMidSessionProbe`)
+   * applies its own debouncing / rate-limiting / gating.
+   */
+  onUserInputLine?: (input: string) => void;
   /** Called when the shell emits an OSC 633 shell integration event. */
   onShellIntegration?: (event: ShellIntegrationEvent) => void;
   /** Called with decoded text whenever PTY output is received. */
@@ -123,6 +131,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       onExit,
       onSelectionChange,
       onFirstInput,
+      onUserInputLine,
       onShellIntegration,
       onOutput,
       onTitleChange,
@@ -145,6 +154,8 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     onSelectionChangeRef.current = onSelectionChange;
     const onFirstInputRef = useRef(onFirstInput);
     onFirstInputRef.current = onFirstInput;
+    const onUserInputLineRef = useRef(onUserInputLine);
+    onUserInputLineRef.current = onUserInputLine;
     const onReconnectedRef = useRef(onReconnected);
     onReconnectedRef.current = onReconnected;
     const onShellIntegrationRef = useRef(onShellIntegration);
@@ -473,23 +484,30 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         }
 
         // Forward user input to PTY + track first input line for auto-naming
+        // + emit every non-empty line to `onUserInputLine` for mid-session
+        // probes. The accumulator logic lives in the pure `consumeInputChunk`
+        // helper in `./consumeInputChunk.ts` (a leaf module — kept separate
+        // so vitest tests don't pull in xterm.js's canvas addon).
         disposables.push(
           backend.onData((data) => {
-            // Track first input line for auto-naming
-            if (!firstInputReportedRef.current) {
-              for (const ch of data) {
-                if (ch === "\r" || ch === "\n") {
-                  const line = inputAccumulatorRef.current.trim();
-                  if (line.length > 0) {
-                    firstInputReportedRef.current = true;
-                    onFirstInputRef.current?.(line);
-                  }
-                  inputAccumulatorRef.current = "";
-                  break;
-                } else if (ch.charCodeAt(0) >= 32) {
-                  // Only accumulate printable characters
-                  inputAccumulatorRef.current += ch;
-                }
+            const result = consumeInputChunk(
+              data,
+              inputAccumulatorRef.current,
+              firstInputReportedRef.current,
+            );
+            inputAccumulatorRef.current = result.accum;
+            // First-input gate: fires at most once per session.
+            if (result.firstInputLineIfAny !== undefined) {
+              firstInputReportedRef.current = true;
+              onFirstInputRef.current?.(result.firstInputLineIfAny);
+            }
+            // Per-line callback: fires for EVERY non-empty newline-terminated
+            // line, ungated. Consumer (e.g. useMidSessionProbe) applies its
+            // own gates.
+            const perLine = onUserInputLineRef.current;
+            if (perLine) {
+              for (const line of result.lines) {
+                perLine(line);
               }
             }
 

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -40,6 +40,9 @@ import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
 import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
 import { useCommitState } from "./useCommitState";
 import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
+import { useRegistryAwareness } from "./useRegistryAwareness";
+import { useMidSessionProbe, useMidSessionProbeEnabled } from "./useMidSessionProbe";
+import { MidSessionToast } from "./MidSessionToast";
 
 interface TerminalPageProps {
   onNavigateToBuilder?: () => void;
@@ -152,6 +155,17 @@ function TerminalPageInner({
   // Per-tab commit-readiness state (Plan §3). Sibling to fileLockStates;
   // both are passed through to TerminalTabBar for rendering.
   const commitStates = useCommitState(tabs);
+  // Per-tab registry-awareness counts (pty-launched-ai-tabs-warning-plan
+  // Phase 2). Sibling to fileLockStates; polled from
+  // `/file-registry/probe-conflicts` every 2s per eligible tab.
+  const registryAwareness = useRegistryAwareness(tabs);
+  // Mid-session probe (Phase 3 of pty-launched-ai-tabs-warning-plan).
+  // Fires `/file-registry/probe-conflicts` 500ms after the user types a
+  // new turn into an active Claude CLI tab and surfaces predicted
+  // collisions via {@link MidSessionToast}. Gated behind the
+  // `enable_mid_session_path_prediction` localStorage flag.
+  const midSessionProbeEnabled = useMidSessionProbeEnabled();
+  const midSessionProbe = useMidSessionProbe(tabs, { enabled: midSessionProbeEnabled });
   // Post-spawn polling hook that captures Claude CLI's session id from
   // the on-disk transcript and updates `tab.claudeSessionId` so the
   // commit traffic light has something to key on. Plan §1.5
@@ -506,6 +520,8 @@ function TerminalPageInner({
           launchCommands={sessionManager.launchCommands}
           fileLocks={sessionManager.fileLocks}
           fileLockStates={fileLockStates}
+          registryAwareness={registryAwareness}
+          activeTabCwd={tabs.find((t) => t.id === activeId)?.workingDir}
           commitStates={commitStates}
           terminalRefs={terminalRefs.current}
         />
@@ -561,6 +577,7 @@ function TerminalPageInner({
                 onZoneDoubleClick={handleZoneDoubleClick}
                 onExit={handleExit}
                 onExportZone={handleExportZone}
+                onUserInputLine={(tabId, input) => midSessionProbe.feed(tabId, input)}
               />
             ) : (
               <div className="h-full flex flex-col items-center justify-center text-[#565f89] gap-2">
@@ -578,6 +595,23 @@ function TerminalPageInner({
 
             {zoneLayout.isMultiZone && !transitionEffects.batchBarDismissed && (
               <BatchOperationsBar />
+            )}
+
+            {/* Mid-session predicted-collision toast (Phase 3). Overlays
+                the active terminal — positioned top-right of the
+                flex-1 container so it sits over the zone grid, not
+                the chrome. Jump-to-holder: focus the tab whose title
+                matches the holder name, mirroring LaunchMenu's
+                `onJumpToHolder` semantics. */}
+            {activeId && midSessionProbe.states[activeId] && (
+              <MidSessionToast
+                state={midSessionProbe.states[activeId]}
+                onDismiss={() => midSessionProbe.dismiss(activeId)}
+                onJumpToHolder={(name) => {
+                  const target = tabs.find((t) => t.title === name);
+                  if (target) setActiveId(target.id);
+                }}
+              />
             )}
           </div>
 

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -28,6 +28,20 @@ interface TerminalTabBarProps {
   launchCommands?: Record<string, string>;
   fileLocks?: import("./useSessionManager").FileLockInfo[];
   fileLockStates?: Record<string, import("./useFileLockTracking").LockState>;
+  /**
+   * Per-tab count of files held by OTHER sessions that overlap with
+   * this tab's `workingDir`. Sourced from `useRegistryAwareness`.
+   * Renders a small yellow pill next to the lock indicator when > 0.
+   * Tabs without an entry (or with 0) render nothing.
+   */
+  registryAwareness?: Record<string, number>;
+  /**
+   * Active tab's `workingDir`, plumbed through to LaunchMenu's probe so
+   * relative-path tokens in the user's session-context prompt can
+   * resolve against the launching session's cwd. Undefined when no tab
+   * is active (first-tab case); LaunchMenu defaults to "" downstream.
+   */
+  activeTabCwd?: string;
   /** Per-tab commit-readiness state (populated by `useCommitState`). */
   commitStates?: Record<string, CommitState>;
   /**
@@ -194,6 +208,8 @@ export function TerminalTabBar({
   launchCommands,
   fileLocks,
   fileLockStates,
+  registryAwareness = {},
+  activeTabCwd,
   commitStates,
   terminalRefs,
   activityData,
@@ -452,6 +468,7 @@ export function TerminalTabBar({
                   accountUsage={accountUsage ?? []}
                   launchCommands={launchCommands}
                   fileLocks={fileLocks}
+                  cwd={activeTabCwd}
                   onJumpToHolder={(holderName) => {
                     // Resolve holder_name → tab id with the same lookup as
                     // `findTabByHolderName` in `useFileLockTracking.ts:44-49`
@@ -498,6 +515,7 @@ export function TerminalTabBar({
             isMultiZone && isTabAssigned(tab.id) && tabActivity && tabActivity.length > 0;
           const lockState = fileLockStates?.[tab.id];
           const commitState = commitStates?.[tab.id];
+          const overlapCount = registryAwareness[tab.id] ?? 0;
 
           return (
             <button
@@ -566,6 +584,21 @@ export function TerminalTabBar({
                   } waiting`}
                 >
                   <Lock className="w-2.5 h-2.5 text-[#7aa2f7] opacity-60" />
+                </span>
+              )}
+
+              {/* Registry-awareness badge — count of files held by OTHER
+                  sessions that overlap with this tab's cwd. Driven by
+                  `useRegistryAwareness` polling `/file-registry/probe-conflicts`
+                  (Phase 2 of pty-launched-ai-tabs-warning-plan). Silent
+                  tabs stay visually quiet — badge renders only when N > 0. */}
+              {overlapCount > 0 && (
+                <span
+                  data-testid="tab-registry-overlap"
+                  className="shrink-0 px-1 rounded text-[10px] leading-[14px] font-medium bg-[#e0af68]/20 text-[#e0af68]"
+                  title={`${overlapCount} file(s) held by other sessions overlap with this tab's cwd.`}
+                >
+                  {overlapCount}
                 </span>
               )}
 

--- a/src/components/terminal/ZoneGrid.tsx
+++ b/src/components/terminal/ZoneGrid.tsx
@@ -40,6 +40,13 @@ interface ZoneGridProps {
   onZoneDoubleClick: (zoneIndex: number) => void;
   onExit: (terminalId: string, exitCode: number | null) => void;
   onExportZone?: (zoneIndex: number, format: "text" | "markdown" | "json") => void;
+  /**
+   * Per-line input forwarder for mid-session probes (Phase 3 of
+   * `plans/pty-launched-ai-tabs-warning-plan.md`). Fires for every
+   * non-empty newline-terminated line typed into any terminal. Consumer
+   * applies its own debounce + gating.
+   */
+  onUserInputLine?: (terminalId: string, input: string) => void;
 }
 
 interface GridState {
@@ -108,7 +115,13 @@ function createInitialGridState(layout: LayoutPreset): GridState {
   };
 }
 
-export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone }: ZoneGridProps) {
+export function ZoneGrid({
+  onZoneClick,
+  onZoneDoubleClick,
+  onExit,
+  onExportZone,
+  onUserInputLine,
+}: ZoneGridProps) {
   // Read all data from contexts
   const {
     tabs,
@@ -292,6 +305,7 @@ export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone 
         terminalRef={terminalRefs.get(tab.id)}
         onExit={onExit}
         onFirstInput={onFirstInput}
+        onUserInputLine={onUserInputLine}
         onShellIntegration={onShellIntegration}
         onOutput={onOutput}
         onReconnected={onReconnected}
@@ -350,6 +364,9 @@ export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone 
                   onReconnected={() => onReconnected(zoneTab.id)}
                   onExit={(code) => onExit(zoneTab.id, code)}
                   onFirstInput={(input) => onFirstInput(zoneTab.id, input)}
+                  onUserInputLine={
+                    onUserInputLine ? (input) => onUserInputLine(zoneTab.id, input) : undefined
+                  }
                   onShellIntegration={(event) => onShellIntegration(zoneTab.id, event)}
                   onOutput={(text) => onOutput(zoneTab.id, text)}
                   onTitleChange={(title) => onTitleChange(zoneTab.id, title)}
@@ -394,6 +411,7 @@ export function ZoneGrid({ onZoneClick, onZoneDoubleClick, onExit, onExportZone 
           onZoneDoubleClick={onZoneDoubleClick}
           onExit={onExit}
           onFirstInput={onFirstInput}
+          onUserInputLine={onUserInputLine}
           onShellIntegration={onShellIntegration}
           onOutput={onOutput}
           onReconnected={onReconnected}
@@ -614,6 +632,7 @@ function ZoneCell({
   onZoneDoubleClick,
   onExit,
   onFirstInput,
+  onUserInputLine,
   onShellIntegration,
   onOutput,
   onReconnected,
@@ -667,6 +686,7 @@ function ZoneCell({
   onZoneDoubleClick: (zoneIndex: number) => void;
   onExit: (terminalId: string, exitCode: number | null) => void;
   onFirstInput: (terminalId: string, input: string) => void;
+  onUserInputLine?: (terminalId: string, input: string) => void;
   onShellIntegration: (tabId: string, event: ShellIntegrationEvent) => void;
   onOutput: (tabId: string, text: string) => void;
   onReconnected: (tabId: string) => void;
@@ -1037,6 +1057,9 @@ function ZoneCell({
                   onReconnected={() => onReconnected(tab.id)}
                   onExit={(code) => onExit(tab.id, code)}
                   onFirstInput={(input) => onFirstInput(tab.id, input)}
+                  onUserInputLine={
+                    onUserInputLine ? (input) => onUserInputLine(tab.id, input) : undefined
+                  }
                   onShellIntegration={(event) => onShellIntegration(tab.id, event)}
                   onOutput={(text) => onOutput(tab.id, text)}
                   onTitleChange={(title) => onTitleChange(tab.id, title)}

--- a/src/components/terminal/consumeInputChunk.ts
+++ b/src/components/terminal/consumeInputChunk.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure helper extracted from {@link TerminalInstance}'s xterm.js `onData`
+ * newline loop so the input-accumulator semantics can be unit-tested
+ * without standing up xterm.js or the WebGL canvas addon.
+ *
+ * Lives in its own module (rather than next to `TerminalInstance`) so
+ * the test file doesn't pull `@xterm/addon-canvas` through — that addon
+ * touches `self` at module init, which blows up under vitest's
+ * `environment: "node"`.
+ *
+ * Behavior mirrors the historical loop in `TerminalInstance.tsx`:
+ *   - Iterates `chunk` char-by-char.
+ *   - On `\r` or `\n`, trims the current accumulator and — if non-empty
+ *     — emits it as a line. Empty lines (bare newlines) are dropped.
+ *   - Only chars with code >= 32 accumulate; ESC, BEL, and other
+ *     control bytes are filtered out so they don't pollute the
+ *     auto-name or the mid-session probe payload.
+ *   - The first newline-terminated non-empty line in the chunk (if
+ *     any) is also surfaced as `firstInputLineIfAny` UNLESS
+ *     `firstInputAlreadyReported` is true — gating the caller's
+ *     `onFirstInput` to "exactly once per session" without duplicating
+ *     the gate inside this helper.
+ *
+ * The returned `accum` is the leftover (post-last-newline) partial
+ * line that the caller threads back in on the next chunk.
+ */
+export function consumeInputChunk(
+  chunk: string,
+  accum: string,
+  firstInputAlreadyReported: boolean,
+): { accum: string; lines: string[]; firstInputLineIfAny: string | undefined } {
+  const lines: string[] = [];
+  let firstInputLineIfAny: string | undefined;
+  let current = accum;
+  for (const ch of chunk) {
+    if (ch === "\r" || ch === "\n") {
+      const line = current.trim();
+      if (line.length > 0) {
+        lines.push(line);
+        if (!firstInputAlreadyReported && firstInputLineIfAny === undefined) {
+          firstInputLineIfAny = line;
+        }
+      }
+      current = "";
+    } else if (ch.charCodeAt(0) >= 32) {
+      current += ch;
+    }
+  }
+  return { accum: current, lines, firstInputLineIfAny };
+}

--- a/src/components/terminal/useFileLockTracking.ts
+++ b/src/components/terminal/useFileLockTracking.ts
@@ -21,6 +21,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
+import { resolvePort } from "./LaunchMenu";
 import type { TerminalTab } from "./useTerminalManager";
 
 // ── Pure helpers (exported for tests) ────────────────────────────────────────
@@ -263,11 +264,14 @@ export function useFileLockTracking(tabs: TerminalTab[]): Record<string, LockSta
 
     const poll = async () => {
       try {
-        const port =
-          typeof window !== "undefined" &&
-          (window as unknown as Record<string, unknown>).__QONTINUI_PORT__
-            ? Number((window as unknown as Record<string, unknown>).__QONTINUI_PORT__)
-            : 9876;
+        // Resolve the port at each poll (not once at mount): on secondary
+        // runners `useApiReady` populates `getApiPort()` asynchronously
+        // via the `api-ready` Tauri event, so a hook that mounted
+        // before the event fires would otherwise keep polling 9876
+        // (the primary) forever. Re-reading here lets us catch up by
+        // the second tick. `__QONTINUI_PORT__` still wins when set
+        // (manual-test override).
+        const port = resolvePort();
         const resp = await fetch(`http://127.0.0.1:${port}/file-locks/info`);
         if (!resp.ok || !active) return;
         const locks = (await resp.json()) as FileLockInfoEntry[];

--- a/src/components/terminal/useMidSessionProbe.test.ts
+++ b/src/components/terminal/useMidSessionProbe.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the gating logic of `useMidSessionProbe`.
+ *
+ * The hook itself is composed of an inner debounce + fetch loop that's
+ * hard to exercise from `environment: "node"` (no jsdom, no React
+ * Testing Library). The decision-making lives in the exported pure
+ * helper `shouldFireProbe` — we test the matrix of gates there so any
+ * accidental shift in the gating logic (e.g. dropping the AI-session
+ * check) gets caught in CI.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  shouldFireProbe,
+  MID_SESSION_MIN_LINE_LEN,
+  MID_SESSION_RATE_LIMIT_MS,
+} from "./useMidSessionProbe";
+
+const NOW = 1_000_000_000;
+const LONG_LINE = "edit src/components/foo/bar.ts";
+const SHORT_LINE = "ls -la"; // < 10 chars
+
+describe("shouldFireProbe", () => {
+  it("returns false when the user setting is disabled", () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123" },
+      NOW,
+      { enabled: false },
+    );
+    expect(result).toBe(false);
+  });
+
+  it(`returns false when line is under ${MID_SESSION_MIN_LINE_LEN} chars`, () => {
+    expect(SHORT_LINE.length).toBeLessThan(MID_SESSION_MIN_LINE_LEN);
+    const result = shouldFireProbe(
+      SHORT_LINE,
+      { claudeSessionId: "abc-123" },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the tab has no claudeSessionId", () => {
+    const result = shouldFireProbe(LONG_LINE, {}, NOW, { enabled: true });
+    expect(result).toBe(false);
+  });
+
+  it(`returns false when within ${MID_SESSION_RATE_LIMIT_MS}ms of previous probe`, () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123", lastProbeAt: NOW - 500 },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(false);
+  });
+
+  it("returns true when all gates pass (no previous probe)", () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123" },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true when last probe was outside the rate-limit window", () => {
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123", lastProbeAt: NOW - (MID_SESSION_RATE_LIMIT_MS + 1) },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(true);
+  });
+
+  it("returns true at the exact rate-limit boundary (>= rate limit ms passed)", () => {
+    // Implementation uses strict `<` for the rate-limit check so a probe
+    // can fire as soon as RATE_LIMIT_MS has elapsed, not RATE_LIMIT_MS+1.
+    const result = shouldFireProbe(
+      LONG_LINE,
+      { claudeSessionId: "abc-123", lastProbeAt: NOW - MID_SESSION_RATE_LIMIT_MS },
+      NOW,
+      { enabled: true },
+    );
+    expect(result).toBe(true);
+  });
+});

--- a/src/components/terminal/useMidSessionProbe.ts
+++ b/src/components/terminal/useMidSessionProbe.ts
@@ -1,0 +1,235 @@
+/**
+ * Mid-session probe hook (Phase 3 of
+ * `plans/pty-launched-ai-tabs-warning-plan.md`).
+ *
+ * Watches per-tab newline-terminated input from `TerminalInstance` and,
+ * for active AI sessions (`tab.claudeSessionId` set), pings the runner's
+ * `/file-registry/probe-conflicts` endpoint after the user pauses
+ * typing. When the probe returns predicted collisions, the result is
+ * stashed in a per-tab state map for {@link MidSessionToast} to render
+ * an in-tab dismissible warning.
+ *
+ * Gating is intentionally conservative — see {@link shouldFireProbe} —
+ * because the user explicitly types a fresh turn into Claude CLI and
+ * we want to avoid both (a) firing on bare commands like `ls` and
+ * (b) hammering the registry once a session is hot.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ConflictReport, PredictedCollision } from "./useSessionManager";
+import { resolvePort, buildProbeUrl } from "./LaunchMenu";
+
+// ── Constants ───────────────────────────────────────────────────────────────
+
+/** Debounce window before a fed line fires the probe (ms). */
+export const MID_SESSION_DEBOUNCE_MS = 500;
+/** Minimum gap between two probes for the same tab (ms). */
+export const MID_SESSION_RATE_LIMIT_MS = 2000;
+/** Minimum prompt length to fire a probe (chars). */
+export const MID_SESSION_MIN_LINE_LEN = 10;
+/** How long a toast stays before auto-dismissal (ms). */
+export const MID_SESSION_TOAST_TTL_MS = 8000;
+/** Interval at which the auto-prune sweep runs (ms). */
+const PRUNE_INTERVAL_MS = 1000;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface MidSessionProbeState {
+  /** Predicted-collision entries from the most recent probe response. */
+  predicted_collisions: PredictedCollision[];
+  /** Snapshot moment for auto-dismiss timing. */
+  received_at: number;
+}
+
+export interface MidSessionProbeApi {
+  feed(tabId: string, line: string): void;
+  dismiss(tabId: string): void;
+  states: Record<string, MidSessionProbeState>;
+}
+
+/**
+ * Minimal tab shape consumed by the hook. Real callers pass
+ * `TerminalTab` from `useTerminalManager`; tests pass plain literals.
+ */
+interface ProbeTab {
+  id: string;
+  claudeSessionId?: string;
+  workingDir?: string;
+}
+
+// ── Pure helpers (exported for tests) ───────────────────────────────────────
+
+/**
+ * Gating decision for a candidate probe. Pure so the matrix of failure
+ * modes (disabled, too-short, no-session, rate-limited) can be tested
+ * without a React tree or fetch shim.
+ */
+export function shouldFireProbe(
+  line: string,
+  tab: { claudeSessionId?: string; lastProbeAt?: number },
+  now: number,
+  opts: { enabled: boolean },
+): boolean {
+  if (!opts.enabled) return false;
+  if (line.length < MID_SESSION_MIN_LINE_LEN) return false;
+  if (!tab.claudeSessionId) return false;
+  if (tab.lastProbeAt !== undefined && now - tab.lastProbeAt < MID_SESSION_RATE_LIMIT_MS) {
+    return false;
+  }
+  return true;
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+export function useMidSessionProbe(
+  tabs: ProbeTab[],
+  opts: { enabled: boolean },
+): MidSessionProbeApi {
+  const [states, setStates] = useState<Record<string, MidSessionProbeState>>({});
+
+  // Tabs change every render (new array identity). Mirror into a ref so the
+  // stable `feed` callback can look up the latest tab metadata without
+  // re-binding. Updated via `useEffect` to satisfy the
+  // `react-hooks/refs` rule — see `useRegistryAwareness.ts` for the
+  // same pattern.
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  // Debounce + rate-limit refs. These are deliberately mutable across
+  // renders — the hook itself owns the per-tab clocks.
+  const debounceTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const lastProbeAtRef = useRef<Record<string, number>>({});
+  const optsRef = useRef(opts);
+  useEffect(() => {
+    optsRef.current = opts;
+  }, [opts]);
+
+  const dismiss = useCallback((tabId: string) => {
+    setStates((prev) => {
+      if (!(tabId in prev)) return prev;
+      const next = { ...prev };
+      delete next[tabId];
+      return next;
+    });
+  }, []);
+
+  const fireProbe = useCallback(async (tabId: string, line: string) => {
+    const tab = tabsRef.current.find((t) => t.id === tabId);
+    if (!tab) return;
+    try {
+      const port = resolvePort();
+      const resp = await fetch(buildProbeUrl(port), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt: line, cwd: tab.workingDir ?? "" }),
+      });
+      if (!resp.ok) return;
+      const json = (await resp.json()) as ConflictReport;
+      // Empty predicted_collisions → leave existing state untouched.
+      // A noisy keystroke should not erase a prior warning the user
+      // hasn't acknowledged yet.
+      if (!json.predicted_collisions || json.predicted_collisions.length === 0) return;
+      setStates((prev) => ({
+        ...prev,
+        [tabId]: {
+          predicted_collisions: json.predicted_collisions,
+          received_at: Date.now(),
+        },
+      }));
+    } catch {
+      // Network / abort — silently ignore. The probe is best-effort.
+    }
+  }, []);
+
+  const feed = useCallback(
+    (tabId: string, line: string) => {
+      // Reset any pending debounce for this tab — every fresh keystroke
+      // restarts the clock.
+      const existing = debounceTimersRef.current[tabId];
+      if (existing) clearTimeout(existing);
+
+      debounceTimersRef.current[tabId] = setTimeout(() => {
+        delete debounceTimersRef.current[tabId];
+        const tab = tabsRef.current.find((t) => t.id === tabId);
+        if (!tab) return;
+        const now = Date.now();
+        const decision = shouldFireProbe(
+          line,
+          { claudeSessionId: tab.claudeSessionId, lastProbeAt: lastProbeAtRef.current[tabId] },
+          now,
+          optsRef.current,
+        );
+        if (!decision) return;
+        lastProbeAtRef.current[tabId] = now;
+        void fireProbe(tabId, line);
+      }, MID_SESSION_DEBOUNCE_MS);
+    },
+    [fireProbe],
+  );
+
+  // Auto-prune sweep — one interval for the whole hook, not per-entry
+  // timers. Removes entries whose `received_at + TTL` has passed.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const now = Date.now();
+      setStates((prev) => {
+        let changed = false;
+        const next: Record<string, MidSessionProbeState> = {};
+        for (const [tabId, s] of Object.entries(prev)) {
+          if (s.received_at + MID_SESSION_TOAST_TTL_MS < now) {
+            changed = true;
+            continue;
+          }
+          next[tabId] = s;
+        }
+        return changed ? next : prev;
+      });
+    }, PRUNE_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Cleanup pending debounce timers on unmount.
+  useEffect(() => {
+    const timers = debounceTimersRef.current;
+    return () => {
+      for (const t of Object.values(timers)) clearTimeout(t);
+    };
+  }, []);
+
+  return useMemo<MidSessionProbeApi>(
+    () => ({ feed, dismiss, states }),
+    [feed, dismiss, states],
+  );
+}
+
+// ── Setting gate ────────────────────────────────────────────────────────────
+
+/**
+ * Reactive read of the `enable_mid_session_path_prediction` localStorage
+ * flag. Defaults to `false`. Listens to `storage` events so manual edits
+ * (or a future settings UI — TODO: phase-3 follow-up) propagate without
+ * reload.
+ *
+ * Lever: `localStorage.setItem("enable_mid_session_path_prediction", "true")`
+ * — flip to enable mid-session probing for the current install.
+ */
+export function useMidSessionProbeEnabled(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem("enable_mid_session_path_prediction") === "true";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== "enable_mid_session_path_prediction") return;
+      setEnabled(e.newValue === "true");
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  return enabled;
+}

--- a/src/components/terminal/useRegistryAwareness.test.ts
+++ b/src/components/terminal/useRegistryAwareness.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for `useRegistryAwareness` — the per-tab registry-awareness
+ * overlap-count hook.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom).
+ * Following the precedent of `useFileLockTracking.test.ts`, we test
+ * the pure helper `computeOverlapCount` directly rather than rendering
+ * the hook through React.
+ *
+ * Phase 2 of `pty-launched-ai-tabs-warning-plan.md`. Contract:
+ *   - Count files in `liveHoldings` whose path is under `tab.workingDir`.
+ *   - Exclude files held by the tab itself (`holder_name === tab.title`).
+ *   - Return 0 when `workingDir` is undefined or empty.
+ *   - Prefix-match honors path boundaries — `/repository` is NOT under
+ *     `/repo`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { computeOverlapCount } from "./useRegistryAwareness";
+import type { FileRegistryInfoEntry } from "./useSessionManager";
+
+/**
+ * Convenience factory for a {@link FileRegistryInfoEntry} with the
+ * fields the helper actually reads + sane defaults for the rest.
+ */
+function holding(
+  file_path: string,
+  holder_name: string,
+  extras: Partial<FileRegistryInfoEntry> = {},
+): FileRegistryInfoEntry {
+  return {
+    file_path,
+    holder_name,
+    holder_task_run_id: extras.holder_task_run_id ?? `task-${holder_name}`,
+    registered_at: extras.registered_at ?? 0,
+    worktree_id: extras.worktree_id ?? null,
+    ...extras,
+  };
+}
+
+describe("computeOverlapCount", () => {
+  it("counts files held by other sessions under cwd", () => {
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [
+      holding("/repo/src/foo.rs", "B"),
+      holding("/repo/src/bar.rs", "C"),
+    ];
+    expect(computeOverlapCount(holdings, tab)).toBe(2);
+  });
+
+  it("excludes own holdings", () => {
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [holding("/repo/src/foo.rs", "A")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("excludes files outside cwd", () => {
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [holding("/other-repo/foo.rs", "B")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("returns 0 when workingDir is undefined", () => {
+    const tab = { id: "t1", title: "A", workingDir: undefined };
+    const holdings = [
+      holding("/repo/src/foo.rs", "B"),
+      holding("/anywhere/else.rs", "C"),
+    ];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("returns 0 when workingDir is an empty string", () => {
+    // Otherwise plain prefix-match would treat every path as a match
+    // since every string starts with "".
+    const tab = { id: "t1", title: "A", workingDir: "" };
+    const holdings = [holding("/repo/src/foo.rs", "B")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  it("prefix-match honors path boundaries", () => {
+    // Plain `startsWith` would return true for "/repository".startsWith("/repo")
+    // — the helper must distinguish sibling directories.
+    const tab = { id: "t1", title: "A", workingDir: "/repo" };
+    const holdings = [holding("/repository/foo.rs", "B")];
+    expect(computeOverlapCount(holdings, tab)).toBe(0);
+  });
+
+  // Regression: Windows spawn-cwd format mismatch.
+  //
+  // The backend (`executor/file_registry.rs::normalize_path`) stores
+  // file paths as `d:/qontinui-root/cargo.toml` — `\` → `/` and
+  // lowercased on Windows. Tauri hands `tab.workingDir` to the frontend
+  // verbatim as `D:\qontinui-root` (uppercase drive, backslashes).
+  // Without symmetric normalization in the helper the prefix-match
+  // silently fails on every Windows tab, the badge never renders, and
+  // the feature is invisible to users. Caught during manual smoke
+  // (2026-05-11): registered Cargo.toml on a real registry, hook
+  // received the holding, but `"d:/...".startsWith("D:\\...")` was
+  // false.
+  it("normalizes case + slashes for Windows spawn-cwd format", () => {
+    // Simulate the Windows webview where backslash + uppercase
+    // workingDir collides with lowercase forward-slash backend paths.
+    vi.stubGlobal("navigator", { platform: "Win32" } as Navigator);
+    try {
+      const tab = { id: "t1", title: "A", workingDir: "D:\\qontinui-root" };
+      const holdings = [
+        holding("d:/qontinui-root/cargo.toml", "manual-test-A"),
+        holding("d:/qontinui-root/src/lib.rs", "manual-test-A"),
+      ];
+      expect(computeOverlapCount(holdings, tab)).toBe(2);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("preserves case on non-Windows platforms", () => {
+    // On macOS/Linux file systems are case-sensitive; lowercasing would
+    // produce false positives across `/Repo` vs `/repo`.
+    vi.stubGlobal("navigator", { platform: "Linux x86_64" } as Navigator);
+    try {
+      const tab = { id: "t1", title: "A", workingDir: "/Repo" };
+      const holdings = [holding("/repo/foo.rs", "B")];
+      expect(computeOverlapCount(holdings, tab)).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/src/components/terminal/useRegistryAwareness.ts
+++ b/src/components/terminal/useRegistryAwareness.ts
@@ -1,0 +1,158 @@
+/**
+ * Per-tab "registry awareness" hook.
+ *
+ * For each terminal tab with a non-empty `workingDir`, polls the
+ * runner's existing `/file-registry/probe-conflicts` endpoint every
+ * 2000ms and counts how many `live_holdings` are:
+ *   - held by OTHER sessions (`holder_name !== tab.title`), and
+ *   - located under this tab's `workingDir` (path-prefix match with
+ *     boundary check — see {@link computeOverlapCount}).
+ *
+ * Returns `Record<tabId, count>`; tabs without a `workingDir` are
+ * absent from the map (callers should treat that as zero / no badge).
+ *
+ * Phase 2 of `pty-launched-ai-tabs-warning-plan.md`. Drives the small
+ * yellow pill badge near the lock-state indicator in
+ * {@link TerminalTabBar}.
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { resolvePort } from "./LaunchMenu";
+import type { TerminalTab } from "./useTerminalManager";
+import type {
+  ConflictReport,
+  FileRegistryInfoEntry,
+} from "./useSessionManager";
+
+/** Polling interval for the probe-conflicts endpoint (ms). */
+export const REGISTRY_AWARENESS_POLL_MS = 2000;
+
+/**
+ * Normalize a path the same way the runner's backend does
+ * (`executor/file_registry.rs::normalize_path`): `\` → `/`, then
+ * lowercase on Windows. Without this, the prefix-match in
+ * {@link computeOverlapCount} will silently fail on Windows because
+ * `tab.workingDir` carries the spawn-cwd verbatim (`D:\qontinui-root`)
+ * while `live_holdings[].file_path` carries the backend-normalized
+ * form (`d:/qontinui-root/...`).
+ *
+ * Windows detection: `navigator.platform` starts with `"Win"` in the
+ * Tauri webview. `typeof navigator === "undefined"` covers SSR/node
+ * test environments (falls back to no lowercasing — matches Unix).
+ */
+function normalizePath(p: string): string {
+  const slashed = p.replace(/\\/g, "/");
+  const isWindows =
+    typeof navigator !== "undefined" && navigator.platform.startsWith("Win");
+  return isWindows ? slashed.toLowerCase() : slashed;
+}
+
+/**
+ * Count files in `liveHoldings` that are:
+ *   1. held by a session other than `tab` (`holder_name !== tab.title`),
+ *   2. located under `tab.workingDir` (prefix match with path boundary).
+ *
+ * Both `tab.workingDir` and `h.file_path` are normalized via
+ * {@link normalizePath} before comparison so case/slash differences
+ * between Tauri's spawn-cwd format and the backend-normalized
+ * file-registry keys don't cause silent misses on Windows.
+ *
+ * Boundary check: a plain `startsWith` would treat
+ * `"/repository/foo.rs".startsWith("/repo")` as true, conflating
+ * sibling-directory paths. We require either exact equality OR the
+ * separator `"/"` immediately after the prefix.
+ *
+ * Returns 0 when `tab.workingDir` is undefined or empty (otherwise
+ * every path would match the empty prefix).
+ */
+export function computeOverlapCount(
+  liveHoldings: readonly FileRegistryInfoEntry[],
+  tab: { id: string; title: string; workingDir?: string },
+): number {
+  const cwd = tab.workingDir;
+  if (!cwd) return 0;
+  const cwdN = normalizePath(cwd);
+  let count = 0;
+  for (const h of liveHoldings) {
+    if (h.holder_name === tab.title) continue;
+    const p = normalizePath(h.file_path);
+    if (p === cwdN || p.startsWith(cwdN + "/")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Hook: poll `/file-registry/probe-conflicts` per tab on a 2s
+ * interval and return per-tab overlap counts.
+ *
+ * Implementation mirrors {@link useFileLockTracking}:
+ *   - `tabsRef` keeps the interval callback reading the latest tabs
+ *     without re-installing the interval on every identity change.
+ *   - Fetch errors are swallowed (count drops to 0 for that tab).
+ *   - The interval is cleared on unmount.
+ */
+export function useRegistryAwareness(
+  tabs: TerminalTab[],
+): Record<string, number> {
+  const [counts, setCounts] = useState<Record<string, number>>({});
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
+
+  useEffect(() => {
+    let active = true;
+    const port = resolvePort();
+    const url = `http://127.0.0.1:${port}/file-registry/probe-conflicts`;
+
+    const probeTab = async (
+      tab: TerminalTab,
+    ): Promise<[string, number]> => {
+      if (!tab.workingDir) return [tab.id, 0];
+      try {
+        const resp = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ prompt: null, cwd: tab.workingDir }),
+        });
+        if (!resp.ok) return [tab.id, 0];
+        const report = (await resp.json()) as ConflictReport;
+        const n = computeOverlapCount(report.live_holdings ?? [], tab);
+        return [tab.id, n];
+      } catch {
+        // Swallow — probe failures are not user-facing.
+        return [tab.id, 0];
+      }
+    };
+
+    const poll = async () => {
+      const current = tabsRef.current;
+      const eligible = current.filter((t) => !!t.workingDir);
+      if (eligible.length === 0) {
+        if (active) setCounts({});
+        return;
+      }
+      const results = await Promise.all(eligible.map(probeTab));
+      if (!active) return;
+      const next: Record<string, number> = {};
+      for (const [id, n] of results) {
+        next[id] = n;
+      }
+      setCounts(next);
+    };
+
+    void poll();
+    const interval = setInterval(() => {
+      void poll();
+    }, REGISTRY_AWARENESS_POLL_MS);
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return counts;
+}

--- a/src/components/terminal/useRegistryAwareness.ts
+++ b/src/components/terminal/useRegistryAwareness.ts
@@ -104,14 +104,18 @@ export function useRegistryAwareness(
 
   useEffect(() => {
     let active = true;
-    const port = resolvePort();
-    const url = `http://127.0.0.1:${port}/file-registry/probe-conflicts`;
 
     const probeTab = async (
       tab: TerminalTab,
     ): Promise<[string, number]> => {
       if (!tab.workingDir) return [tab.id, 0];
       try {
+        // Resolve the port per-poll (not once at mount): on secondary
+        // runners `useApiReady` populates the port asynchronously via
+        // the `api-ready` Tauri event, so a hook that mounted before
+        // the event would otherwise keep polling the primary forever.
+        // Re-reading here catches up by the second tick.
+        const url = `http://127.0.0.1:${resolvePort()}/file-registry/probe-conflicts`;
         const resp = await fetch(url, {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/src/components/terminal/useReviewState.ts
+++ b/src/components/terminal/useReviewState.ts
@@ -14,6 +14,7 @@
 
 import { useEffect, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { resolvePort } from "./LaunchMenu";
 
 /** Verdict tag emitted by `/auto-review`. Mirrors the wire format from
  *  `pg::reviews::ReviewRow`. */
@@ -125,16 +126,12 @@ function projectReview(row: ReviewRowWire): ReviewState | null {
   };
 }
 
-/** Poll URL for the runner. Mirrors `useFileLockTracking`'s pattern of
- *  reading `__QONTINUI_PORT__` off `window` and falling back to the
- *  default dev port. */
+/** Poll URL for the runner. Resolves the port via the centralized
+ *  helper so secondary/temp runners on non-default ports get their
+ *  actually-bound port (populated asynchronously by `useApiReady` via
+ *  the `api-ready` Tauri event). */
 function runnerBaseUrl(): string {
-  const port =
-    typeof window !== "undefined" &&
-    (window as unknown as Record<string, unknown>).__QONTINUI_PORT__
-      ? Number((window as unknown as Record<string, unknown>).__QONTINUI_PORT__)
-      : 9876;
-  return `http://127.0.0.1:${port}`;
+  return `http://127.0.0.1:${resolvePort()}`;
 }
 
 /** Hook: returns the latest review state for a session, or `null` when

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -12,6 +12,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { instanceStorage } from "@/lib/instance-storage";
+import { resolvePort } from "./LaunchMenu";
 import type { TranscriptSession } from "./useTranscriptSessions";
 import type { TerminalTab } from "./useTerminalManager";
 import type { SessionState } from "./useZoneLayout";
@@ -517,11 +518,10 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
 
   const fetchFileLocks = useCallback(async () => {
     try {
-      const port =
-        typeof window !== "undefined" &&
-        (window as unknown as Record<string, unknown>).__QONTINUI_PORT__
-          ? Number((window as unknown as Record<string, unknown>).__QONTINUI_PORT__)
-          : 9876;
+      // Resolve at call time so secondary runners pick up the
+      // actually-bound port once `useApiReady` populates it (the
+      // `api-ready` event may arrive after this hook mounts).
+      const port = resolvePort();
       const resp = await fetch(`http://127.0.0.1:${port}/file-locks/info`);
       if (resp.ok) {
         const data = (await resp.json()) as FileLockInfo[];

--- a/src/components/terminal/zone-grid/HiddenTerminal.tsx
+++ b/src/components/terminal/zone-grid/HiddenTerminal.tsx
@@ -11,6 +11,7 @@ export function HiddenTerminal({
   terminalRef,
   onExit,
   onFirstInput,
+  onUserInputLine,
   onShellIntegration,
   onOutput,
   onReconnected,
@@ -20,6 +21,7 @@ export function HiddenTerminal({
   terminalRef: RefObject<TerminalInstanceHandle | null> | undefined;
   onExit: (terminalId: string, exitCode: number | null) => void;
   onFirstInput: (terminalId: string, input: string) => void;
+  onUserInputLine?: (terminalId: string, input: string) => void;
   onShellIntegration: (tabId: string, event: ShellIntegrationEvent) => void;
   onOutput: (tabId: string, text: string) => void;
   onReconnected: (tabId: string) => void;
@@ -35,6 +37,9 @@ export function HiddenTerminal({
         onReconnected={() => onReconnected(tab.id)}
         onExit={(code) => onExit(tab.id, code)}
         onFirstInput={(input) => onFirstInput(tab.id, input)}
+        onUserInputLine={
+          onUserInputLine ? (input) => onUserInputLine(tab.id, input) : undefined
+        }
         onShellIntegration={(event) => onShellIntegration(tab.id, event)}
         onOutput={(text) => onOutput(tab.id, text)}
         onTitleChange={onTitleChange ? (title) => onTitleChange(tab.id, title) : undefined}


### PR DESCRIPTION
## Summary

Three follow-up surfaces to the launch-time predictive-conflict warning shipped in #77, plus a related port-resolution fix surfaced during manual smoke.

- **Phase 1 — cwd plumbing.** The shipped probe hardcoded `cwd: ""`, so relative-path tokens like `"edit src/foo.rs"` never resolved against the launching session's cwd. `TerminalPage` now plumbs the active tab's `workingDir` through `TerminalTabBar` → `LaunchMenu` so the probe receives a real cwd.
- **Phase 2 — per-tab registry-awareness badge.** New `useRegistryAwareness` hook polls `/file-registry/probe-conflicts` every 2s per tab with a `workingDir` and renders a small yellow pill (next to the existing lock-state indicator) when other sessions hold files under that cwd. Frontend `normalizePath()` mirrors the backend's `executor/file_registry.rs::normalize_path` (`\` → `/`, lowercase on Windows) so Tauri's spawn-cwd format prefix-matches backend-normalized registry keys.
- **Phase 3 — mid-session probe + dismissible toast (opt-in).** Extends `TerminalInstance`'s existing input-line accumulator with a new `onUserInputLine` callback that fires on every newline (preserving `onFirstInput`'s once-only semantics). `useMidSessionProbe` debounces 500ms per-tab, gates on `>= 10` chars + `claudeSessionId` set + 2s rate-limit, then probes; non-empty `predicted_collisions` render `MidSessionToast` above the terminal with 8s auto-dismiss. Gated by `localStorage.enable_mid_session_path_prediction = "true"`.
- **`__QONTINUI_PORT__` resolution fix.** Five terminal hooks read `window.__QONTINUI_PORT__` directly with a hardcoded `9876` fallback — but nothing in the runner ever sets that global. On the primary it accidentally matched; on secondary / temp runners every poll silently routed to the primary, hiding the secondary's own data from its own UI. Migrated all 5 sites to the canonical `getApiPort()` source populated by `useApiReady` from the `api-ready` Tauri event. Resolution happens at poll-time (not mount-time) so a late-arriving event is picked up by the next tick.

## Plan

`plans/pty-launched-ai-tabs-warning-plan.md` — archived as SHIPPED in `qontinui-dev-notes@af27e41`.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — 0 new warnings (only pre-existing in untouched files)
- [x] `pnpm vitest run src/components/terminal/` — 115/115 passing
  - 35 `LaunchMenu` wire-shape cases (+2 regression cases for the port-resolution fix)
  - 8 `useRegistryAwareness` count/overlap (+2 Windows-normalize regressions caught during smoke)
  - 7 `useMidSessionProbe` gating
  - 7 `TerminalInstance` accumulator
  - 5 `MidSessionToast` summary
- [x] Manual smoke on a temp runner — Phase 1 cwd verified end-to-end via fetch-patch capture; Phase 2 badge verified end-to-end on temp runner port 9880 after the port-resolution fix (both tabs render the "1" pill when another session registers a file under their cwd)
- [ ] Reviewer: try a 3-tab scenario with `enable_mid_session_path_prediction=true` on a fresh primary build to validate the Phase 3 toast end-to-end