### PR TITLE
ci(macos): drop CARGO_BUILD_JOBS to 2 + 45-min step timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,14 @@ jobs:
       - name: Run Rust tests
         # Accessibility integration tests that require a real desktop session are
         # skipped in CI. Only pure unit tests (no system dependencies) run here.
+        #
+        # Step has a hard 45-minute timeout. Empirically Ubuntu finishes in
+        # ~30 min and Windows in ~50 min total job-time including this step;
+        # 45 min for the step alone is generous. Without the cap, macOS swap-
+        # thrash hangs ran for 80+ min before admin-cancel (PR #84 was the
+        # most recent — root-caused to CARGO_BUILD_JOBS=4 below). Fail fast
+        # is better than burning runner minutes on a known recurring pattern.
+        timeout-minutes: 45
         env:
           # `CARGO_BUILD_JOBS` reduces the parallel-rustc memory peak.
           # Empirically:
@@ -179,8 +187,17 @@ jobs:
           #   - Ubuntu OOM-killer is harsher: even with a 12 GB swapfile,
           #     JOBS=2 still trips the runner-agent shutdown. Drop Ubuntu
           #     to JOBS=1 for a single-threaded compile.
-          #   - macOS is on a fatter runner and stays at default 4.
-          CARGO_BUILD_JOBS: ${{ (matrix.platform == 'macos-latest' && 4) || 1 }}
+          #   - macOS: GitHub-hosted M1/aarch64 runners ship with only
+          #     ~7 GB RAM (NOT 16 GB like ubuntu/windows — the older
+          #     "fatter runner" comment was wrong). With JOBS=4 the
+          #     peak from two parallel large-crate rustc invocations
+          #     (qontinui_runner_lib + wrappers_mcp) exceeds RAM and
+          #     macOS swap-thrashes indefinitely (no OOM-killer like
+          #     Linux). PR #84's macOS leg hung 80+ min mid-compile of
+          #     exactly that pair before admin-cancel. Drop to JOBS=2
+          #     — still parallel, half the peak. JOBS=1 would be safer
+          #     but ~2x slower.
+          CARGO_BUILD_JOBS: ${{ (matrix.platform == 'macos-latest' && 2) || 1 }}
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             echo "=== free / df before cargo test ==="
@@ -189,6 +206,11 @@ jobs:
           elif [ "$RUNNER_OS" = "Windows" ]; then
             echo "=== Windows memory state before cargo test ==="
             powershell -NoProfile -Command "Get-CimInstance Win32_PageFileUsage | Format-List *; Get-CimInstance Win32_OperatingSystem | Select-Object FreePhysicalMemory,TotalVisibleMemorySize,TotalVirtualMemorySize,FreeVirtualMemory | Format-List"
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            echo "=== macOS memory state before cargo test ==="
+            sysctl -n hw.memsize | awk '{print "physical RAM:", $1/1024/1024/1024, "GB"}'
+            vm_stat
+            df -h
           fi
           cd src-tauri
           cargo test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,13 +166,15 @@ jobs:
         # Accessibility integration tests that require a real desktop session are
         # skipped in CI. Only pure unit tests (no system dependencies) run here.
         #
-        # Step has a hard 45-minute timeout. Empirically Ubuntu finishes in
-        # ~30 min and Windows in ~50 min total job-time including this step;
-        # 45 min for the step alone is generous. Without the cap, macOS swap-
-        # thrash hangs ran for 80+ min before admin-cancel (PR #84 was the
-        # most recent — root-caused to CARGO_BUILD_JOBS=4 below). Fail fast
-        # is better than burning runner minutes on a known recurring pattern.
-        timeout-minutes: 45
+        # Step has a hard 75-minute timeout. Ubuntu finishes ~43 min and
+        # Windows ~77 min on this step alone (single-threaded compile at
+        # JOBS=1 + test execution). macOS at JOBS=1 should land between
+        # the two given the M1's raw single-thread speed but with the
+        # 7GB-RAM swap-pressure penalty. 75 min covers worst case; without
+        # the cap, macOS swap-thrash hangs ran for 80+ min before admin-
+        # cancel (PR #84 was the most recent). Fail fast is better than
+        # burning runner minutes.
+        timeout-minutes: 75
         env:
           # `CARGO_BUILD_JOBS` reduces the parallel-rustc memory peak.
           # Empirically:
@@ -188,16 +190,19 @@ jobs:
           #     JOBS=2 still trips the runner-agent shutdown. Drop Ubuntu
           #     to JOBS=1 for a single-threaded compile.
           #   - macOS: GitHub-hosted M1/aarch64 runners ship with only
-          #     ~7 GB RAM (NOT 16 GB like ubuntu/windows — the older
-          #     "fatter runner" comment was wrong). With JOBS=4 the
-          #     peak from two parallel large-crate rustc invocations
-          #     (qontinui_runner_lib + wrappers_mcp) exceeds RAM and
-          #     macOS swap-thrashes indefinitely (no OOM-killer like
-          #     Linux). PR #84's macOS leg hung 80+ min mid-compile of
-          #     exactly that pair before admin-cancel. Drop to JOBS=2
-          #     — still parallel, half the peak. JOBS=1 would be safer
-          #     but ~2x slower.
-          CARGO_BUILD_JOBS: ${{ (matrix.platform == 'macos-latest' && 2) || 1 }}
+          #     7 GB RAM (confirmed via `sysctl hw.memsize` in the
+          #     pre-test diagnostic) — NOT 16 GB like ubuntu/windows.
+          #     The older "fatter runner" comment was wrong. With
+          #     JOBS=4 the peak from two parallel large-crate rustc
+          #     invocations (qontinui_runner_lib + wrappers_mcp)
+          #     exceeds RAM and macOS swap-thrashes indefinitely (no
+          #     OOM-killer like Linux). PR #84's macOS leg hung 80+
+          #     min mid-compile before admin-cancel. PR #86 first
+          #     tried JOBS=2 — also still swap-pressured, hit the 45-
+          #     min timeout. JOBS=1 matches ubuntu/windows: one rustc
+          #     at a time, ~no swap pressure, slower wall-clock but
+          #     deterministic.
+          CARGO_BUILD_JOBS: 1
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             echo "=== free / df before cargo test ==="


### PR DESCRIPTION
## Summary

Root-causes and fixes the recurring **test (macos-latest)** hang that admin-merges have papered over (most recently PR #84, also documented in `proj_macos_tauri_build_hangs` memory).

The hang was always assumed to be in a test. **It's not — it's in compilation.** Inspection of the cancelled job from PR #84 ([job 75336134749](https://github.com/qontinui/qontinui-runner/actions/runs/25665308712/job/75336134749)) shows:
- Orphan processes killed on cleanup: `rustc` ×2 + `cargo`
- Last visible compile commands started two huge parallel rustc invocations (`qontinui_runner_lib` + `wrappers_mcp`)
- 80 minutes of log silence before admin-cancel

Why: previous CI comment said "macOS is on a fatter runner and stays at default 4." **That was wrong.** GitHub-hosted macOS M1/aarch64 runners ship with ~7 GB RAM, not the 16 GB on ubuntu-22.04 / windows-latest. With `JOBS=4` the peak from two parallel large-crate rustc invocations blows out RAM and macOS swap-thrashes indefinitely — there's no OOM-killer to fire (unlike Linux, which kills the runner agent within seconds).

## Changes

1. **`CARGO_BUILD_JOBS: 4 → 2`** on macOS. Still parallel (faster than `JOBS=1`) but half the peak memory. `JOBS=1` would be safer; 2 is the calculated balance — if 2 also wedges we can drop to 1.
2. **`timeout-minutes: 45`** on the step. Ubuntu finishes the whole job in ~30 min, Windows in ~50 min; 45 min for the test step alone is generous. Without it, the step burns up to GitHub's 6-hour default on every hang and admin-merge becomes the only escape hatch.
3. Added a `vm_stat` / `sysctl hw.memsize` diagnostic on macOS to match the existing `free -h` / pagefile dump on the other platforms — so future hangs leave evidence of the pre-test memory state in the log.

## Test plan

- [ ] CI green on PR (including macos-latest now finishing in <45 min — first real signal)
- [ ] No regression on ubuntu-22.04 / windows-latest (unchanged code paths)
- [ ] If macOS still hangs at `JOBS=2`, follow-up patch drops to `JOBS=1` (same fix template)