### PR TITLE
fix(file-registry): trim prompt before is_empty() short-circuit in run_ai_extractor

### DIFF
--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -586,9 +586,12 @@ async fn run_ai_extractor(enabled: bool, prompt: &str, cwd: &str) -> (Vec<String
     if !enabled {
         return (Vec::new(), AiStatus::Disabled);
     }
-    if prompt.is_empty() {
+    if prompt.trim().is_empty() {
         // No prompt to enrich. Not an AI failure — surface as Ok with 0
         // counts so the frontend doesn't render an unwarranted badge.
+        // `probe_conflicts` already trims at the boundary; defending here
+        // too so a direct caller (test or future code) passing whitespace
+        // doesn't burn an AI call on it.
         return (Vec::new(), AiStatus::Ok);
     }
 
@@ -1391,9 +1394,15 @@ mod tests {
         assert!(paths.is_empty());
         assert_eq!(status, AiStatus::Ok);
 
-        // Whitespace-only prompt is treated identically — the handler
-        // trims before calling.
-        let (paths, status) = run_ai_extractor(true, "", "/repo").await;
+        // Whitespace-only prompt is treated identically — `run_ai_extractor`
+        // trims defensively (mirrors the `probe_conflicts` boundary trim),
+        // so a direct caller passing whitespace doesn't burn an AI call.
+        let (paths, status) = run_ai_extractor(true, "   ", "/repo").await;
+        assert!(paths.is_empty());
+        assert_eq!(status, AiStatus::Ok);
+
+        // Tabs + newlines + spaces also count as whitespace.
+        let (paths, status) = run_ai_extractor(true, "\t \n  \r", "/repo").await;
         assert!(paths.is_empty());
         assert_eq!(status, AiStatus::Ok);
     }


### PR DESCRIPTION
Closes #87.

## Summary
`probe_conflicts` already trims the prompt at the boundary (`file_registry.rs:478`), so the production path is unaffected today. But the helper itself checked `prompt.is_empty()`, not `prompt.trim().is_empty()` — meaning a direct caller passing `"   "` would have skipped the short-circuit and burned an AI call on whitespace.

The accompanying test claimed to verify whitespace handling but passed `""` for both cases, never exercising the trim. Updated it to pass `"   "` and a tab/newline/space mix, which now actually covers the documented behavior.

## Diff
- `run_ai_extractor`: `prompt.is_empty()` → `prompt.trim().is_empty()` + a one-line comment explaining why the helper trims even though `probe_conflicts` already does.
- `probe_conflicts_ai_status_ok_when_prompt_empty`: second case now passes `"   "` (was `""` — duplicate of the first case); added a third case with `"\t \n  \r"` to lock down tab/newline/space coverage.

## Test plan
- [x] Locally: `cargo test --bin qontinui-runner --features custom-protocol probe_conflicts_ai_status_ok_when_prompt_empty` → 1 passed
- [ ] CI green