### PR TITLE
fix(file-activity-panel): rename inner poll, drop unused abortRef (follow-up to #81)

### DIFF
--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -18,7 +18,7 @@
  *     state — keep the last good snapshot, just age it.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /** Live entry from the in-process `FileRegistryManager.info()` snapshot. */
 export interface FileRegistryInfoEntry {
@@ -175,21 +175,21 @@ export function useFileActivity({
     return () => document.removeEventListener("visibilitychange", onVisChange);
   }, []);
 
-  // Stable ref for the currently in-flight request so we can abort it
-  // when the effect cleans up (component unmount, window change).
-  const abortRef = useRef<AbortController | null>(null);
-
   // Snapshot the most recent successful resolution time. Phase 3 spec:
   // stale flag flips on slow fetches, not just hard failures.
+  //
+  // Lifecycle: when any dep changes (or the component unmounts), React
+  // runs the cleanup below — `cancelled` blocks late `setState` calls
+  // and `ac.abort()` short-circuits the in-flight fetch. We don't need
+  // a ref-based abort because every controller is captured by its own
+  // effect-run closure.
   useEffect(() => {
     if (!enabled || !visible) return;
 
     let cancelled = false;
     const ac = new AbortController();
-    abortRef.current?.abort();
-    abortRef.current = ac;
 
-    const tick = async () => {
+    const poll = async () => {
       const start = performance.now();
       try {
         const payload = await fetchHeatmap(windowSecs, 25, ac.signal);
@@ -209,8 +209,8 @@ export function useFileActivity({
       }
     };
 
-    tick();
-    const id = window.setInterval(tick, pollIntervalMs);
+    poll();
+    const id = window.setInterval(poll, pollIntervalMs);
     return () => {
       cancelled = true;
       window.clearInterval(id);


### PR DESCRIPTION
Follow-up to #81. Targets `feat/file-activity-panel` so merging this lands the cleanups directly on the existing PR's branch.

Cleanups in `useFileActivity` (`fileActivityApi.ts`):
- **Rename inner `tick` → `poll`** to stop shadowing the outer `useState<number>('tick', …)` used for refresh-bumping. JS scoping made the dep array `[..., tick]` resolve to the outer state (correct), but the shadowing was a footgun.
- **Drop the `abortRef` indirection.** Every `AbortController` is captured by its own effect-run closure; the cleanup at the bottom of the effect already calls `ac.abort()`. The pre-cleanup `abortRef.current?.abort()` was double-aborting the same controller that the prior cleanup had already aborted — harmless but messy. Drops the `useRef` import.

No behavior change. Diff is 10/10 lines in one file.

## Re: the "no useFileActivity lifecycle test" finding
After looking more carefully, I'm withdrawing that one. The runner's vitest config is `environment: "node"` (no jsdom, no `@testing-library/react`) — see `useCommitState.test.ts:1-20` and `CompletionReportSections.test.tsx:24` for the precedent. Hook tests in this project extract *pure decision logic* as small testable functions and test those; the React-lifecycle parts are intentionally not exercised. `useFileActivity`'s pure decisions (`elapsed > SLOW_FETCH_THRESHOLD_MS`, error-message normalization) are trivial one-liners not worth their own helpers. Matching the project's convention.

## Test plan
- [x] Local `npx vitest run --run FileActivityPanel` → 14 passed
- [ ] CI green