### PR TITLE
runner: inject window.__QONTINUI_PORT__ at webview boot

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1682,6 +1682,22 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         builder = builder.data_directory(dir.clone());
                     }
 
+                    // Inject the intended API port as a global so the frontend's
+                    // synchronous port-resolution fast-path (`window.__QONTINUI_PORT__`,
+                    // used by useFileLockTracking / useRegistryAwareness /
+                    // useMidSessionProbe / LaunchMenu / useSessionManager / etc.)
+                    // resolves to the *actual* runner port on temp/secondary instances
+                    // instead of silently falling through to the hardcoded 9876.
+                    // Without this, hooks on a temp runner route their reads at the
+                    // primary. The async `get_api_port` IPC + `setApiPort` path
+                    // remains the source of truth if the bound port differs from the
+                    // intended one (port-fallback rare case).
+                    let intended_api_port = crate::mcp::types::get_mcp_api_port();
+                    builder = builder.initialization_script(&format!(
+                        "window.__QONTINUI_PORT__ = {};",
+                        intended_api_port
+                    ));
+
                     builder = placement.configure_builder(builder);
 
                     match builder.build() {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1693,7 +1693,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     // remains the source of truth if the bound port differs from the
                     // intended one (port-fallback rare case).
                     let intended_api_port = crate::mcp::types::get_mcp_api_port();
-                    builder = builder.initialization_script(&format!(
+                    builder = builder.initialization_script(format!(
                         "window.__QONTINUI_PORT__ = {};",
                         intended_api_port
                     ));


### PR DESCRIPTION
## Summary

Six frontend hooks read `window.__QONTINUI_PORT__` as their synchronous fast-path for resolving the runner's HTTP API port:

- `useFileLockTracking`
- `useRegistryAwareness`
- `useMidSessionProbe`
- `LaunchMenu.resolvePort()`
- `useSessionManager`
- `useReviewState`
- plus `fileActivityApi.resolveBase()`

The runner never set the global, so all of them silently fell through to the hardcoded `9876` fallback. On the primary runner that's a no-op. On temp/secondary runners (different port) it routed every read at the **primary's** port instead — affecting `useFileLockTracking` (already shipped) and every newer registry/lock feature identically.

## Fix

Chain `WebviewWindowBuilder::initialization_script` with `get_mcp_api_port()` (the same source `AppState.api_port` seeds from) on the runner's main window builder. The script runs before any page JS, so hooks see the right value on first read.

The async `get_api_port` IPC + `setApiPort` path remains the source of truth if the bound port ever differs from the intended one (port-fallback rare case).

## Test plan

- [x] `cargo check` clean
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (initial commit failed on a redundant `&` before `format!()` — fixed in follow-up commit)
- [x] Manual smoke on temp runner :9880 (rebuild=true via supervisor):
  - [x] `window.__QONTINUI_PORT__` evaluates to `9880` (number, not string)
  - [x] Matches the temp runner's actual port, not the primary's 9876
- [x] Primary runner case validated by inspection: `get_mcp_api_port()` returns `9876` when `QONTINUI_PORT` is unset, so existing primary behavior is preserved

## Follow-up

Now that the global is reliably set, the existing `|| 9876` fallback chains in the affected hooks can eventually be simplified — they're harmless but no longer load-bearing. Out of scope here.