### PR TITLE
fix(file-activity-panel): rename inner poll, drop unused abortRef

### DIFF
--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -18,7 +18,7 @@
  *     state — keep the last good snapshot, just age it.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /** Live entry from the in-process `FileRegistryManager.info()` snapshot. */
 export interface FileRegistryInfoEntry {
@@ -175,21 +175,21 @@ export function useFileActivity({
     return () => document.removeEventListener("visibilitychange", onVisChange);
   }, []);
 
-  // Stable ref for the currently in-flight request so we can abort it
-  // when the effect cleans up (component unmount, window change).
-  const abortRef = useRef<AbortController | null>(null);
-
   // Snapshot the most recent successful resolution time. Phase 3 spec:
   // stale flag flips on slow fetches, not just hard failures.
+  //
+  // Lifecycle: when any dep changes (or the component unmounts), React
+  // runs the cleanup below — `cancelled` blocks late `setState` calls
+  // and `ac.abort()` short-circuits the in-flight fetch. We don't need
+  // a ref-based abort because every controller is captured by its own
+  // effect-run closure.
   useEffect(() => {
     if (!enabled || !visible) return;
 
     let cancelled = false;
     const ac = new AbortController();
-    abortRef.current?.abort();
-    abortRef.current = ac;
 
-    const tick = async () => {
+    const poll = async () => {
       const start = performance.now();
       try {
         const payload = await fetchHeatmap(windowSecs, 25, ac.signal);
@@ -209,8 +209,8 @@ export function useFileActivity({
       }
     };
 
-    tick();
-    const id = window.setInterval(tick, pollIntervalMs);
+    poll();
+    const id = window.setInterval(poll, pollIntervalMs);
     return () => {
       cancelled = true;
       window.clearInterval(id);


### PR DESCRIPTION
Redo of PR #89 (which merged into the now-stale `feat/file-activity-panel` branch after #81 had already merged into main). Cherry-picked the same single commit onto a fresh branch off main so the cleanups actually land.

## Summary
Two cleanups in `useFileActivity` (`fileActivityApi.ts`):

- **Rename inner `tick` → `poll`.** The outer `useState<number>('tick', …)` for refresh-bumping uses the same name, which shadows the inner async function. JS scoping made the dep array `[..., tick]` resolve to the outer state (correct), but the shadowing was a footgun for readers and IDEs.
- **Drop the `abortRef` indirection.** Every `AbortController` is captured by its own effect-run closure; the cleanup at the bottom of the effect already calls `ac.abort()`. The pre-cleanup `abortRef.current?.abort()` was double-aborting the same controller the prior cleanup had already aborted — harmless but messy. Removes the `useRef` import.

No behavior change. Diff is 10/10 lines in one file.

## Timing note
#89 was opened against `feat/file-activity-panel` after #81 had already merged into main at the prior head. The merge of #89 into `feat/file-activity-panel` is now orphaned (branch still exists but doesn't gate anything). This PR is the actual fix.

## Test plan
- [x] Local `npx vitest run --run FileActivityPanel` → 14 passed (verified on prior PR)
- [ ] CI green