### PR TITLE
chore: consolidate resolvePort + drop bespoke port logic

### DIFF
--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -19,6 +19,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { resolvePort } from "@/lib/runner-api";
 
 /** Live entry from the in-process `FileRegistryManager.info()` snapshot. */
 export interface FileRegistryInfoEntry {
@@ -103,22 +104,12 @@ export function storeWindowSecs(secs: number): void {
   }
 }
 
-/** Resolve the runner MCP API base URL the same way `useFileLockTracking`
- *  does. The runner injects `__QONTINUI_PORT__` on its window object at
- *  boot; we fall back to the canonical 9876 port when missing. */
-function apiBaseUrl(): string {
-  if (typeof window === "undefined") return "http://127.0.0.1:9876";
-  const port = (window as unknown as Record<string, unknown>).__QONTINUI_PORT__;
-  const parsed = typeof port === "number" ? port : Number.parseInt(String(port ?? ""), 10);
-  return `http://127.0.0.1:${Number.isFinite(parsed) && parsed > 0 ? parsed : 9876}`;
-}
-
 export async function fetchHeatmap(
   windowSecs: number,
   limit = 25,
   signal?: AbortSignal,
 ): Promise<HeatmapResponse> {
-  const url = `${apiBaseUrl()}/file-activity/heatmap?window_secs=${windowSecs}&limit=${limit}`;
+  const url = `http://127.0.0.1:${resolvePort()}/file-activity/heatmap?window_secs=${windowSecs}&limit=${limit}`;
   const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(`heatmap fetch failed: HTTP ${resp.status}`);

--- a/src/components/terminal/LaunchMenu.test.tsx
+++ b/src/components/terminal/LaunchMenu.test.tsx
@@ -38,9 +38,9 @@ import {
   confidenceTier,
   formatHoldingAge,
   groupHoldingsByHolder,
-  resolvePort,
   summarizeFileLocksByHolder,
 } from "./LaunchMenu";
+import { resolvePort } from "@/lib/runner-api";
 import type {
   ConflictReport,
   FileLockInfo,

--- a/src/components/terminal/LaunchMenu.tsx
+++ b/src/components/terminal/LaunchMenu.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import type { JSX } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { Star, Terminal, Play, Loader2, Lock } from "lucide-react";
-import { getApiPort } from "@/lib/runner-api";
+import { resolvePort } from "@/lib/runner-api";
 import type {
   AccountUsageInfo,
   AiStatus,
@@ -64,31 +64,6 @@ export const PROBE_DEBOUNCE_MS = 300;
 export const PROBE_POLL_INTERVAL_MS = 2000;
 
 // ── Pure helpers (exported for tests) ────────────────────────────────────────
-
-/**
- * Resolve the runner HTTP port for local-control-surface traffic
- * (`/file-registry/...`, `/file-locks/...`, etc.).
- *
- * Resolution order:
- *   1. `window.__QONTINUI_PORT__` if explicitly set — manual-test
- *      override and the historical fallback hatch.
- *   2. `getApiPort()` from `@/lib/runner-api` — the centralized port
- *      populated by `useApiReady` from Tauri's `api-ready` event and
- *      the `get_api_port` IPC. Defaults to 9876 when the API isn't
- *      bound yet, so first-poll on a secondary runner can still
- *      briefly hit the primary; the next 2s poll cycle picks up the
- *      correct port once `setApiPort` runs.
- *
- * The hardcoded `9876` fallback is intentionally absent here — it
- * lives inside `getApiPort()`'s default state so it's a single source
- * of truth for the entire frontend.
- */
-export function resolvePort(): number {
-  if (typeof window === "undefined") return getApiPort();
-  const fromGlobal = (window as unknown as Record<string, unknown>).__QONTINUI_PORT__;
-  if (fromGlobal) return Number(fromGlobal);
-  return getApiPort();
-}
 
 export function buildProbeUrl(port: number): string {
   return `http://127.0.0.1:${port}/file-registry/probe-conflicts`;

--- a/src/components/terminal/useFileLockTracking.ts
+++ b/src/components/terminal/useFileLockTracking.ts
@@ -21,7 +21,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { resolvePort } from "./LaunchMenu";
+import { resolvePort } from "@/lib/runner-api";
 import type { TerminalTab } from "./useTerminalManager";
 
 // ── Pure helpers (exported for tests) ────────────────────────────────────────

--- a/src/components/terminal/useMidSessionProbe.ts
+++ b/src/components/terminal/useMidSessionProbe.ts
@@ -17,7 +17,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ConflictReport, PredictedCollision } from "./useSessionManager";
-import { resolvePort, buildProbeUrl } from "./LaunchMenu";
+import { resolvePort } from "@/lib/runner-api";
+import { buildProbeUrl } from "./LaunchMenu";
 
 // ── Constants ───────────────────────────────────────────────────────────────
 

--- a/src/components/terminal/useRegistryAwareness.ts
+++ b/src/components/terminal/useRegistryAwareness.ts
@@ -17,7 +17,7 @@
  */
 
 import { useState, useEffect, useRef } from "react";
-import { resolvePort } from "./LaunchMenu";
+import { resolvePort } from "@/lib/runner-api";
 import type { TerminalTab } from "./useTerminalManager";
 import type {
   ConflictReport,

--- a/src/components/terminal/useReviewState.ts
+++ b/src/components/terminal/useReviewState.ts
@@ -14,7 +14,7 @@
 
 import { useEffect, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { resolvePort } from "./LaunchMenu";
+import { resolvePort } from "@/lib/runner-api";
 
 /** Verdict tag emitted by `/auto-review`. Mirrors the wire format from
  *  `pg::reviews::ReviewRow`. */

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -12,7 +12,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { instanceStorage } from "@/lib/instance-storage";
-import { resolvePort } from "./LaunchMenu";
+import { resolvePort } from "@/lib/runner-api";
 import type { TranscriptSession } from "./useTranscriptSessions";
 import type { TerminalTab } from "./useTerminalManager";
 import type { SessionState } from "./useZoneLayout";

--- a/src/lib/runner-api.ts
+++ b/src/lib/runner-api.ts
@@ -46,6 +46,30 @@ export function getWsBase(): string {
 }
 
 /**
+ * Resolve the runner HTTP port for local-control-surface traffic
+ * (`/file-registry/...`, `/file-locks/...`, `/file-activity/...`, etc.).
+ *
+ * Resolution order:
+ *   1. `window.__QONTINUI_PORT__` if explicitly set — manual-test override
+ *      and the fast-path the runner now injects at webview boot (PR #90,
+ *      `WebviewWindowBuilder::initialization_script`). On temp/secondary
+ *      runners this resolves to the correct port before any page JS runs.
+ *   2. `getApiPort()` — the async-populated centralized port from
+ *      `useApiReady` via Tauri's `api-ready` event and the `get_api_port`
+ *      IPC. Remains the source of truth if the bound port ever differs
+ *      from the intended one (port-fallback rare case).
+ *
+ * The hardcoded `9876` fallback lives inside `getApiPort()`'s default
+ * state so it's a single source of truth for the entire frontend.
+ */
+export function resolvePort(): number {
+  if (typeof window === "undefined") return getApiPort();
+  const fromGlobal = (window as unknown as Record<string, unknown>).__QONTINUI_PORT__;
+  if (fromGlobal) return Number(fromGlobal);
+  return getApiPort();
+}
+
+/**
  * React hook that returns the current API base URL and re-renders the
  * component whenever `setApiPort` runs. Use this in components whose props
  * (e.g. a polling URL passed to a hook) must track the resolved port —


### PR DESCRIPTION
## Summary

Follow-up to #90 (now merged): now that `window.__QONTINUI_PORT__` is reliably set at webview boot, the per-consumer port-resolution scaffolding can collapse to one source of truth.

- Move `resolvePort()` from `LaunchMenu.tsx` → `src/lib/runner-api.ts`, next to `getApiPort` / `getApiBase`. UI components shouldn't own API primitives.
- Drop `fileActivityApi.ts::apiBaseUrl()` — its bespoke `window` read + hardcoded `9876` fallback bypassed `getApiPort()` entirely, so it was always broken on temp/secondary runners (regardless of #90). Now uses the shared `resolvePort()`.
- Five consumers updated to import from `@/lib/runner-api`: `useFileLockTracking`, `useMidSessionProbe`, `useRegistryAwareness`, `useReviewState`, `useSessionManager`. Plus `LaunchMenu.test.tsx`.
- `buildProbeUrl`, `buildProbeBody`, etc. remain in `LaunchMenu.tsx` — probe-specific, not port-specific.

## Diff overview

```
 src/components/productivity/fileActivityApi.ts  | 13 ++----------
 src/components/terminal/LaunchMenu.test.tsx     |  2 +-
 src/components/terminal/LaunchMenu.tsx          | 27 +------------------------
 src/components/terminal/useFileLockTracking.ts  |  2 +-
 src/components/terminal/useMidSessionProbe.ts   |  3 ++-
 src/components/terminal/useRegistryAwareness.ts |  2 +-
 src/components/terminal/useReviewState.ts       |  2 +-
 src/components/terminal/useSessionManager.ts    |  2 +-
 src/lib/runner-api.ts                           | 24 ++++++++++++++++++++++
 9 files changed, 34 insertions(+), 43 deletions(-)
```

No behavioral change: `resolvePort()`'s body is identical to the old one.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint <edited files>` clean
- [x] `pnpm exec vitest run LaunchMenu.test.tsx FileActivityPanel.test.tsx` — 53/53 pass
- [ ] CI green