### PR TITLE
feat(file-locks): two-sided yield protocol on FileLockManager

### DIFF
--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -442,6 +442,191 @@ async fn get_lock_info(
     Ok(Json(info))
 }
 
+// =============================================================================
+// Lock-Yield Protocol (Phase 1)
+// =============================================================================
+//
+// Two sibling routes on `/file-locks/*` that expose the lock-yield protocol
+// to the frontend:
+//
+// - `POST /file-locks/yield`        — hold-side single-file release.
+// - `POST /file-locks/yield-request` — wait-side broadcast asking the holder
+//                                       to yield.
+//
+// See `D:/qontinui-root/plans/lock-yield-protocol-plan.md` Phase 1 for the
+// protocol motivation and `release()` callsite history (Critical findings
+// #1 documents that this endpoint is the first production caller of
+// `FileLockManager::release(file, task_run)`).
+//
+// Emission shape mirrors the existing `file-lock-released` template used at
+// `claude_session/session.rs:498-512`, `mcp/ai_session.rs:959-979`,
+// `graphql/mutation.rs:326-340`, and `mcp/task_runs.rs:230-245` — same
+// `{type, file_path, task_run_id, holder_name}` shape so frontend listeners
+// in `useFileLockTracking.ts` don't need a new branch. The yield-request
+// shape is documented inline in `request_yield`.
+
+#[derive(Debug, Deserialize)]
+pub struct YieldLockRequest {
+    /// Absolute or repo-relative path of the file lock to release.
+    pub file_path: String,
+    /// Task run ID of the session that holds the lock and is yielding it.
+    /// `release()` is idempotent — silently no-ops if this id is not the
+    /// current holder, so the handler checks `info()` first to set
+    /// `released` truth in the response.
+    pub task_run_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct YieldLockResponse {
+    /// True if the caller actually held the lock and it was released.
+    /// False if the lock was not held by this caller (idempotent no-op,
+    /// e.g. the stdout reader exited between the banner click and the
+    /// POST). The frontend treats both cases as success.
+    pub released: bool,
+    /// Echo of the request path (already normalized by the registry).
+    pub file_path: String,
+    /// Echo of the holder's task_run_id from the request.
+    pub task_run_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct YieldRequestRequest {
+    /// File the waiter wants the holder to release.
+    pub file_path: String,
+    /// Task run ID of the session asking the holder to yield.
+    pub requester_task_run_id: String,
+    /// Human-readable name of the requester (rendered on the holder's
+    /// banner — "Session **A** is asking you to yield").
+    pub requester_name: String,
+    /// Task run ID of the session that currently holds the lock. Used by
+    /// the frontend's `useFileLockTracking.ts` listener to route the
+    /// incoming banner to the correct tab.
+    pub holder_task_run_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct YieldRequestResponse {
+    /// Always `true` after the emit completes. The yield-request is a
+    /// fire-and-forget broadcast — the holder may or may not actually
+    /// release the lock; no state change is guaranteed by this endpoint.
+    pub requested: bool,
+}
+
+/// POST /file-locks/yield
+///
+/// Hold-side: the caller releases a single file lock it holds (without
+/// ending the session). Idempotent — `released: false` if the caller is
+/// not the current holder at request time (covers the race where the
+/// stdout reader released the lock between the banner click and the POST).
+///
+/// Emits `file-lock-released` (mirroring `session.rs:498-512`) so frontends
+/// clear "blocked on X at Y" banners without waiting on the next
+/// `/file-locks/info` poll. Emits via BOTH `app_handle.emit` (Tauri webview
+/// path) AND `event_broadcast.send` (SSE/headless consumers), matching the
+/// dispatcher's `file-lock-waiting` / `file-lock-acquired` pattern at
+/// `dispatcher.rs:440-441,460-461`.
+async fn yield_lock(
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<YieldLockRequest>,
+) -> Result<Json<YieldLockResponse>, (StatusCode, String)> {
+    let YieldLockRequest {
+        file_path,
+        task_run_id,
+    } = req;
+
+    // Check holder identity BEFORE release, so we can set `released` truth.
+    // `release()` is silently idempotent — calling it then asking "did it
+    // change anything?" requires a second query, which races other
+    // sessions. A single pre-check is sufficient: any concurrent release
+    // by a parallel `release_all` is a no-op for our `task_run_id` (only
+    // the same task_run_id can release that holder's entry).
+    let info_before = state.app_state.file_lock_manager.info().await;
+    let normalized = crate::executor::file_registry::normalize_path(&file_path);
+    let held_by_caller = info_before
+        .iter()
+        .any(|entry| entry.file_path == normalized && entry.holder_task_run_id == task_run_id);
+
+    // Always call release — even when `held_by_caller == false` the call is
+    // a no-op, but doing it unconditionally keeps the surface trivially
+    // racy-safe (the call between info() and release() may flip ownership
+    // in either direction; release() handles both).
+    state
+        .app_state
+        .file_lock_manager
+        .release(&file_path, &task_run_id)
+        .await;
+
+    if held_by_caller {
+        // Mirror the per-path emit shape from session.rs:504-512 and
+        // ai_session.rs:970-979 — `holder_name` uses `task_run_id` because
+        // every release_all callsite in the repo treats `task.id` /
+        // `fallback_id` as the friendly name for terminal sessions. Phase
+        // 2+ may extend the response with a richer name once the
+        // requester-aware banner work lands, but the emit shape stays
+        // stable so the listener doesn't need a new branch.
+        use tauri::Emitter;
+        let payload = serde_json::json!({
+            "type": "file-lock-released",
+            "file_path": &normalized,
+            "task_run_id": &task_run_id,
+            "holder_name": &task_run_id,
+        });
+        let _ = state.app_handle.emit("file-lock-released", &payload);
+        let _ = state.app_state.event_broadcast.send(payload);
+    }
+
+    Ok(Json(YieldLockResponse {
+        released: held_by_caller,
+        file_path: normalized,
+        task_run_id,
+    }))
+}
+
+/// POST /file-locks/yield-request
+///
+/// Wait-side: the caller broadcasts a request to the lock's current
+/// holder asking them to yield. Fire-and-forget — `requested: true` only
+/// means the emit went out, not that the holder acted on it. The
+/// `file-lock-yield-requested` event is consumed by Phase 3's
+/// `useFileLockTracking.ts` listener which surfaces a banner on the
+/// holder's tab.
+///
+/// Emits BOTH `app_handle.emit` (Tauri webview) AND `event_broadcast.send`
+/// (SSE/headless consumers), matching the dispatcher's wait emit at
+/// `dispatcher.rs:440-441`. Empty `file_path` is permitted — the holder
+/// listener filters by `(holder_task_run_id, file_path)` and a malformed
+/// request just produces a no-match banner-less broadcast.
+async fn request_yield(
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<YieldRequestRequest>,
+) -> Result<Json<YieldRequestResponse>, (StatusCode, String)> {
+    let YieldRequestRequest {
+        file_path,
+        requester_task_run_id,
+        requester_name,
+        holder_task_run_id,
+    } = req;
+
+    let requested_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    use tauri::Emitter;
+    let payload = serde_json::json!({
+        "type": "file-lock-yield-requested",
+        "file_path": &file_path,
+        "requester_task_run_id": &requester_task_run_id,
+        "requester_name": &requester_name,
+        "holder_task_run_id": &holder_task_run_id,
+        "requested_at": requested_at_ms,
+    });
+    let _ = state.app_handle.emit("file-lock-yield-requested", &payload);
+    let _ = state.app_state.event_broadcast.send(payload);
+
+    Ok(Json(YieldRequestResponse { requested: true }))
+}
+
 /// POST /file-registry/probe-conflicts
 ///
 /// Pre-launch predictive-conflict probe. Given a launch prompt and cwd,
@@ -807,6 +992,8 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/file-registry/info", get(get_info))
         .route("/file-registry/probe-conflicts", post(probe_conflicts))
         .route("/file-locks/info", get(get_lock_info))
+        .route("/file-locks/yield", post(yield_lock))
+        .route("/file-locks/yield-request", post(request_yield))
         .route("/file-activity/heatmap", get(get_heatmap))
 }
 
@@ -1409,6 +1596,313 @@ mod tests {
     async fn build_repo_tree_snippet_empty_cwd_is_empty() {
         let snippet = build_repo_tree_snippet("").await;
         assert!(snippet.is_empty());
+    }
+
+    // =========================================================================
+    // Phase 1 lock-yield protocol tests
+    //
+    // The HTTP handlers themselves take `Arc<ApiState>`, which can't be
+    // constructed in a unit test (real `tauri::AppHandle`). Following the
+    // pattern documented at the top of this `mod tests` for
+    // `probe_conflicts`, we drive the same composition the handlers
+    // produce against a real `FileLockManager` + a standalone
+    // `broadcast::Sender` — exactly the substrate the handlers depend on.
+    // Any drift between handler and these tests would surface here first
+    // because the handlers' core logic (info-check → release → emit) is
+    // mirrored line-for-line below.
+    //
+    // The `event_broadcast` subscription verifies the payload shape the
+    // frontend will consume (Phase 2+3 wire `useFileLockTracking.ts`
+    // against this shape).
+    // =========================================================================
+
+    use crate::executor::file_registry::{normalize_path, FileLockManager};
+    use tokio::sync::broadcast;
+
+    /// Mirror of `yield_lock`'s core logic without the `Arc<ApiState>`
+    /// dependency. Identical sequence: info-check → release → conditional
+    /// emit. Tests drive this directly. Any divergence from the handler's
+    /// behavior should be caught by Phase 2's UI Bridge smoke (the
+    /// integration is end-to-end manual at that phase per the plan).
+    async fn yield_lock_core(
+        manager: &FileLockManager,
+        broadcaster: &broadcast::Sender<serde_json::Value>,
+        file_path: &str,
+        task_run_id: &str,
+    ) -> (bool, String) {
+        let info_before = manager.info().await;
+        let normalized = normalize_path(file_path);
+        let held_by_caller = info_before
+            .iter()
+            .any(|entry| entry.file_path == normalized && entry.holder_task_run_id == task_run_id);
+
+        manager.release(file_path, task_run_id).await;
+
+        if held_by_caller {
+            let payload = serde_json::json!({
+                "type": "file-lock-released",
+                "file_path": &normalized,
+                "task_run_id": task_run_id,
+                "holder_name": task_run_id,
+            });
+            let _ = broadcaster.send(payload);
+        }
+
+        (held_by_caller, normalized)
+    }
+
+    /// Mirror of `request_yield`'s core logic without the `Arc<ApiState>`
+    /// dependency. Identical payload shape — Phase 3's
+    /// `useFileLockTracking.ts` listener will consume exactly this.
+    fn request_yield_core(
+        broadcaster: &broadcast::Sender<serde_json::Value>,
+        file_path: &str,
+        requester_task_run_id: &str,
+        requester_name: &str,
+        holder_task_run_id: &str,
+    ) -> bool {
+        let requested_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let payload = serde_json::json!({
+            "type": "file-lock-yield-requested",
+            "file_path": file_path,
+            "requester_task_run_id": requester_task_run_id,
+            "requester_name": requester_name,
+            "holder_task_run_id": holder_task_run_id,
+            "requested_at": requested_at_ms,
+        });
+        let _ = broadcaster.send(payload);
+        true
+    }
+
+    #[tokio::test]
+    async fn yield_lock_non_owner_does_not_release() {
+        let manager = FileLockManager::new();
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        manager
+            .acquire("src/foo.rs", "task-A", "Session A")
+            .await;
+
+        let (released, _path) =
+            yield_lock_core(&manager, &tx, "src/foo.rs", "task-B").await;
+
+        assert!(
+            !released,
+            "non-owner yield should report released=false (lock still held by task-A)"
+        );
+
+        // Lock survives.
+        let info = manager.info().await;
+        assert_eq!(info.len(), 1, "lock should remain in registry");
+        assert_eq!(info[0].holder_task_run_id, "task-A");
+
+        // No event emitted on a no-op yield. `try_recv` returns Empty.
+        let recv_result = rx.try_recv();
+        assert!(
+            recv_result.is_err(),
+            "expected no event on non-owner yield, got {:?}",
+            recv_result
+        );
+    }
+
+    #[tokio::test]
+    async fn yield_lock_owner_releases_and_unblocks_waiter() {
+        let manager = std::sync::Arc::new(FileLockManager::new());
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        manager
+            .acquire("src/bar.rs", "task-A", "Session A")
+            .await;
+
+        // task-C tries to acquire concurrently — must block on task-A's
+        // lock until the yield fires `notify_waiters`. Use a clone so the
+        // spawned future doesn't move the original out from under the
+        // yield call.
+        let manager_for_c = manager.clone();
+        let acquire_handle = tokio::spawn(async move {
+            manager_for_c
+                .acquire("src/bar.rs", "task-C", "Session C")
+                .await
+        });
+
+        // Give task-C a moment to start blocking on the lock so the
+        // notify-after-release path is the one being exercised.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let (released, normalized) =
+            yield_lock_core(&manager, &tx, "src/bar.rs", "task-A").await;
+
+        assert!(released, "owner yield should report released=true");
+
+        // task-C's blocked acquire should now resolve within the 5-sec
+        // notify cycle. Cap our wait at 2 sec so the test fails fast if
+        // `notify_waiters` was missed.
+        let waited_for =
+            tokio::time::timeout(std::time::Duration::from_secs(2), acquire_handle)
+                .await
+                .expect("task-C's acquire should resolve after yield")
+                .expect("task-C's tokio task should not panic");
+
+        assert_eq!(
+            waited_for,
+            Some("Session A".to_string()),
+            "task-C should have waited for Session A"
+        );
+
+        // After yield, task-C holds the lock (acquired through the same
+        // notify path the yield triggered).
+        let info = manager.info().await;
+        assert_eq!(info.len(), 1, "task-C should hold the lock now");
+        assert_eq!(info[0].holder_task_run_id, "task-C");
+
+        // Event emitted with the documented shape.
+        let event = rx
+            .try_recv()
+            .expect("expected file-lock-released event on owner yield");
+        assert_eq!(event["type"], "file-lock-released");
+        assert_eq!(event["file_path"], serde_json::Value::String(normalized));
+        assert_eq!(event["task_run_id"], "task-A");
+        assert_eq!(event["holder_name"], "task-A");
+    }
+
+    #[tokio::test]
+    async fn yield_lock_no_lock_present_is_noop() {
+        let manager = FileLockManager::new();
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        // No prior acquire — yield against an unheld file.
+        let (released, _) =
+            yield_lock_core(&manager, &tx, "src/missing.rs", "task-A").await;
+
+        assert!(
+            !released,
+            "yield against unheld file should report released=false"
+        );
+        assert!(
+            manager.info().await.is_empty(),
+            "registry should remain empty"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no event should fire when there was nothing to release"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_yield_valid_payload_broadcasts_event() {
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        let requested = request_yield_core(
+            &tx,
+            "src/foo.rs",
+            "task-A",
+            "Session A",
+            "task-B",
+        );
+        assert!(requested, "yield-request should always return true");
+
+        let event = rx
+            .try_recv()
+            .expect("expected file-lock-yield-requested event");
+        assert_eq!(event["type"], "file-lock-yield-requested");
+        assert_eq!(event["file_path"], "src/foo.rs");
+        assert_eq!(event["requester_task_run_id"], "task-A");
+        assert_eq!(event["requester_name"], "Session A");
+        assert_eq!(event["holder_task_run_id"], "task-B");
+        // requested_at is an epoch_ms u64; serde_json renders it as Number.
+        // Assert it's present and non-zero (test runs on a real clock).
+        let ts = event["requested_at"]
+            .as_u64()
+            .expect("requested_at should be a u64");
+        assert!(ts > 0, "requested_at should be a real epoch_ms");
+    }
+
+    #[tokio::test]
+    async fn request_yield_empty_file_path_still_broadcasts() {
+        // Fire-and-forget: the holder's listener filters by
+        // (holder_task_run_id, file_path), so an empty path produces a
+        // no-match broadcast — not an error. Verify the endpoint still
+        // returns requested:true and the event still fires (the listener
+        // is the gate, not the producer).
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        let requested =
+            request_yield_core(&tx, "", "task-A", "Session A", "task-B");
+        assert!(requested);
+
+        let event = rx
+            .try_recv()
+            .expect("event should fire even with empty file_path");
+        assert_eq!(event["file_path"], "");
+    }
+
+    #[tokio::test]
+    async fn yield_round_trip_happy_path() {
+        // Realistic end-to-end: A holds a file, B sends a yield-request,
+        // A yields, B's blocked acquire unblocks. Exercises both endpoints
+        // in the order Phase 3's UI flow would.
+        let manager = std::sync::Arc::new(FileLockManager::new());
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        // A holds.
+        manager
+            .acquire("src/round.rs", "task-A", "Session A")
+            .await;
+
+        // B sends yield-request (broadcast only; no state change).
+        let requested = request_yield_core(
+            &tx,
+            "src/round.rs",
+            "task-B",
+            "Session B",
+            "task-A",
+        );
+        assert!(requested);
+        let req_event = rx
+            .try_recv()
+            .expect("yield-request event should fire first");
+        assert_eq!(req_event["type"], "file-lock-yield-requested");
+
+        // B starts blocking on acquire.
+        let manager_for_b = manager.clone();
+        let acquire_handle = tokio::spawn(async move {
+            manager_for_b
+                .acquire("src/round.rs", "task-B", "Session B")
+                .await
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // A (the holder) sees the request banner and clicks Yield.
+        let (released, _) =
+            yield_lock_core(&manager, &tx, "src/round.rs", "task-A").await;
+        assert!(released, "A's yield should report released=true");
+
+        let release_event = rx
+            .try_recv()
+            .expect("file-lock-released event should fire after yield");
+        assert_eq!(release_event["type"], "file-lock-released");
+        assert_eq!(release_event["task_run_id"], "task-A");
+
+        // B unblocks within the notify cycle.
+        let waited_for =
+            tokio::time::timeout(std::time::Duration::from_secs(2), acquire_handle)
+                .await
+                .expect("B should unblock after A yields")
+                .expect("B's tokio task should not panic");
+        assert_eq!(waited_for, Some("Session A".to_string()));
+
+        // Final state: B holds, no events left in queue.
+        let info = manager.info().await;
+        assert_eq!(info.len(), 1);
+        assert_eq!(info[0].holder_task_run_id, "task-B");
+        assert!(
+            rx.try_recv().is_err(),
+            "no extra events should be in the queue"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -1683,12 +1683,9 @@ mod tests {
         let manager = FileLockManager::new();
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
-        manager
-            .acquire("src/foo.rs", "task-A", "Session A")
-            .await;
+        manager.acquire("src/foo.rs", "task-A", "Session A").await;
 
-        let (released, _path) =
-            yield_lock_core(&manager, &tx, "src/foo.rs", "task-B").await;
+        let (released, _path) = yield_lock_core(&manager, &tx, "src/foo.rs", "task-B").await;
 
         assert!(
             !released,
@@ -1714,9 +1711,7 @@ mod tests {
         let manager = std::sync::Arc::new(FileLockManager::new());
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
-        manager
-            .acquire("src/bar.rs", "task-A", "Session A")
-            .await;
+        manager.acquire("src/bar.rs", "task-A", "Session A").await;
 
         // task-C tries to acquire concurrently — must block on task-A's
         // lock until the yield fires `notify_waiters`. Use a clone so the
@@ -1733,19 +1728,17 @@ mod tests {
         // notify-after-release path is the one being exercised.
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
-        let (released, normalized) =
-            yield_lock_core(&manager, &tx, "src/bar.rs", "task-A").await;
+        let (released, normalized) = yield_lock_core(&manager, &tx, "src/bar.rs", "task-A").await;
 
         assert!(released, "owner yield should report released=true");
 
         // task-C's blocked acquire should now resolve within the 5-sec
         // notify cycle. Cap our wait at 2 sec so the test fails fast if
         // `notify_waiters` was missed.
-        let waited_for =
-            tokio::time::timeout(std::time::Duration::from_secs(2), acquire_handle)
-                .await
-                .expect("task-C's acquire should resolve after yield")
-                .expect("task-C's tokio task should not panic");
+        let waited_for = tokio::time::timeout(std::time::Duration::from_secs(2), acquire_handle)
+            .await
+            .expect("task-C's acquire should resolve after yield")
+            .expect("task-C's tokio task should not panic");
 
         assert_eq!(
             waited_for,
@@ -1775,8 +1768,7 @@ mod tests {
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
         // No prior acquire — yield against an unheld file.
-        let (released, _) =
-            yield_lock_core(&manager, &tx, "src/missing.rs", "task-A").await;
+        let (released, _) = yield_lock_core(&manager, &tx, "src/missing.rs", "task-A").await;
 
         assert!(
             !released,
@@ -1796,13 +1788,7 @@ mod tests {
     async fn request_yield_valid_payload_broadcasts_event() {
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
-        let requested = request_yield_core(
-            &tx,
-            "src/foo.rs",
-            "task-A",
-            "Session A",
-            "task-B",
-        );
+        let requested = request_yield_core(&tx, "src/foo.rs", "task-A", "Session A", "task-B");
         assert!(requested, "yield-request should always return true");
 
         let event = rx
@@ -1830,8 +1816,7 @@ mod tests {
         // is the gate, not the producer).
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
-        let requested =
-            request_yield_core(&tx, "", "task-A", "Session A", "task-B");
+        let requested = request_yield_core(&tx, "", "task-A", "Session A", "task-B");
         assert!(requested);
 
         let event = rx
@@ -1849,18 +1834,10 @@ mod tests {
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
         // A holds.
-        manager
-            .acquire("src/round.rs", "task-A", "Session A")
-            .await;
+        manager.acquire("src/round.rs", "task-A", "Session A").await;
 
         // B sends yield-request (broadcast only; no state change).
-        let requested = request_yield_core(
-            &tx,
-            "src/round.rs",
-            "task-B",
-            "Session B",
-            "task-A",
-        );
+        let requested = request_yield_core(&tx, "src/round.rs", "task-B", "Session B", "task-A");
         assert!(requested);
         let req_event = rx
             .try_recv()
@@ -1877,8 +1854,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
 
         // A (the holder) sees the request banner and clicks Yield.
-        let (released, _) =
-            yield_lock_core(&manager, &tx, "src/round.rs", "task-A").await;
+        let (released, _) = yield_lock_core(&manager, &tx, "src/round.rs", "task-A").await;
         assert!(released, "A's yield should report released=true");
 
         let release_event = rx
@@ -1888,11 +1864,10 @@ mod tests {
         assert_eq!(release_event["task_run_id"], "task-A");
 
         // B unblocks within the notify cycle.
-        let waited_for =
-            tokio::time::timeout(std::time::Duration::from_secs(2), acquire_handle)
-                .await
-                .expect("B should unblock after A yields")
-                .expect("B's tokio task should not panic");
+        let waited_for = tokio::time::timeout(std::time::Duration::from_secs(2), acquire_handle)
+            .await
+            .expect("B should unblock after A yields")
+            .expect("B's tokio task should not panic");
         assert_eq!(waited_for, Some("Session A".to_string()));
 
         // Final state: B holds, no events left in queue.

--- a/src/components/productivity/FileActivityPanel.test.tsx
+++ b/src/components/productivity/FileActivityPanel.test.tsx
@@ -20,13 +20,40 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ageLabel, barFor } from "./FileActivityPanel";
+
+// Mock the port resolver + logger BEFORE importing the panel so the
+// yield-request POST simulation picks up our mocked values. Mirrors the
+// pattern in `terminal/WaitingLockBanner.test.tsx`.
+const mockGetApiPort = vi.fn(() => 9876);
+vi.mock("@/lib/runner-api", () => ({
+  getApiPort: () => mockGetApiPort(),
+}));
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import {
+  REQUEST_YIELD_COOLDOWN_MS,
+  ageLabel,
+  barFor,
+  buildYieldRequestBody,
+  hasExclusiveLock,
+  lockYieldCooldownKey,
+  lockYieldCooldownRemainingSecs,
+} from "./FileActivityPanel";
 import {
   DEFAULT_WINDOW_SECS,
   WINDOW_OPTIONS,
   WINDOW_STORAGE_KEY,
   loadStoredWindowSecs,
   storeWindowSecs,
+  type FileLockInfoEntry,
+  type FileRegistryInfoEntry,
 } from "./fileActivityApi";
 
 // ---------------------------------------------------------------------------
@@ -155,5 +182,351 @@ describe("window secs persistence", () => {
   it("ignores a non-numeric stored value and returns the default", () => {
     store[WINDOW_STORAGE_KEY] = "garbage";
     expect(loadStoredWindowSecs()).toBe(DEFAULT_WINDOW_SECS);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lock-Yield Protocol Phase 4 — pure helpers + click-handler simulation
+// ---------------------------------------------------------------------------
+//
+// The runner's vitest config is `environment: "node"` (no jsdom) — same
+// constraint as the existing tests above. We exercise the exported pure
+// helpers (`hasExclusiveLock`, `lockYieldCooldownKey`,
+// `lockYieldCooldownRemainingSecs`, `buildYieldRequestBody`,
+// `REQUEST_YIELD_COOLDOWN_MS`) plus a click-handler simulation that
+// pins the POST shape against the Phase 1 endpoint contract.
+
+// ── hasExclusiveLock — registry × lock-info join predicate ─────────────────
+
+describe("hasExclusiveLock — Phase 4 row gating", () => {
+  const registryEntry: FileRegistryInfoEntry = {
+    file_path: "src/foo.rs",
+    holder_task_run_id: "tab-B",
+    holder_name: "bravo",
+    registered_at: 1_700_000_000_000,
+  };
+  const matchingLock: FileLockInfoEntry = {
+    file_path: "src/foo.rs",
+    holder_task_run_id: "tab-B",
+    holder_name: "bravo",
+    acquired_at: 1_700_000_000,
+  };
+
+  it("returns false when lockInfo is null (first-poll not landed yet)", () => {
+    expect(hasExclusiveLock(registryEntry, null)).toBe(false);
+  });
+
+  it("returns false when lockInfo is empty", () => {
+    expect(hasExclusiveLock(registryEntry, [])).toBe(false);
+  });
+
+  it("returns true when (file_path, holder_task_run_id) matches a lock entry", () => {
+    expect(hasExclusiveLock(registryEntry, [matchingLock])).toBe(true);
+  });
+
+  it("returns false when file_path matches but holder_task_run_id differs", () => {
+    const lockWithDifferentHolder: FileLockInfoEntry = {
+      ...matchingLock,
+      holder_task_run_id: "tab-C",
+    };
+    expect(hasExclusiveLock(registryEntry, [lockWithDifferentHolder])).toBe(false);
+  });
+
+  it("returns false when holder_task_run_id matches but file_path differs", () => {
+    const lockWithDifferentFile: FileLockInfoEntry = {
+      ...matchingLock,
+      file_path: "src/bar.rs",
+    };
+    expect(hasExclusiveLock(registryEntry, [lockWithDifferentFile])).toBe(false);
+  });
+});
+
+// ── lockYieldCooldownKey — per-(file, holder) keying invariant ─────────────
+
+describe("lockYieldCooldownKey — per-(file_path, holder_task_run_id) keying", () => {
+  it("composes a stable key from the two identifiers", () => {
+    expect(lockYieldCooldownKey("src/foo.rs", "tab-B")).toBe("src/foo.rs::tab-B");
+  });
+
+  it("yields distinct keys for different files with the same holder", () => {
+    expect(lockYieldCooldownKey("src/foo.rs", "tab-B")).not.toBe(
+      lockYieldCooldownKey("src/bar.rs", "tab-B"),
+    );
+  });
+
+  it("yields distinct keys for the same file with different holders", () => {
+    expect(lockYieldCooldownKey("src/foo.rs", "tab-B")).not.toBe(
+      lockYieldCooldownKey("src/foo.rs", "tab-C"),
+    );
+  });
+});
+
+// ── lockYieldCooldownRemainingSecs — ceil rounding mirrors WaitingLockBanner ─
+
+describe("lockYieldCooldownRemainingSecs", () => {
+  it("returns 0 once the cooldown deadline is reached", () => {
+    expect(lockYieldCooldownRemainingSecs(1_000, 1_000)).toBe(0);
+    expect(lockYieldCooldownRemainingSecs(1_000, 2_000)).toBe(0);
+  });
+
+  it("ceil-rounds remaining millis to whole seconds", () => {
+    expect(lockYieldCooldownRemainingSecs(31_000, 1_000)).toBe(30);
+    expect(lockYieldCooldownRemainingSecs(1_500, 1_000)).toBe(1);
+    expect(lockYieldCooldownRemainingSecs(1_001, 1_000)).toBe(1);
+  });
+
+  it("uses REQUEST_YIELD_COOLDOWN_MS = 30000 (tripwire vs. Phase 3 constant)", () => {
+    // If a future plan changes the cooldown duration this assertion
+    // must change in lockstep with both this file and
+    // `terminal/WaitingLockBanner.tsx`'s constant. The TODO at
+    // `FileActivityPanel.tsx` marks the dedupe candidate.
+    expect(REQUEST_YIELD_COOLDOWN_MS).toBe(30_000);
+  });
+});
+
+// ── buildYieldRequestBody — synthetic Coordinator Dashboard identity ───────
+
+describe("buildYieldRequestBody — §Open Q5 synthetic requester identity", () => {
+  it("uses 'coordinator-dashboard' / 'Coordinator Dashboard' as requester", () => {
+    const body = buildYieldRequestBody("src/foo.rs", "tab-B");
+    expect(body).toEqual({
+      file_path: "src/foo.rs",
+      requester_task_run_id: "coordinator-dashboard",
+      requester_name: "Coordinator Dashboard",
+      holder_task_run_id: "tab-B",
+    });
+  });
+
+  it("threads file_path and holder_task_run_id through unchanged", () => {
+    const body = buildYieldRequestBody("/abs/path/with spaces.rs", "named-12345-uuid");
+    expect(body.file_path).toBe("/abs/path/with spaces.rs");
+    expect(body.holder_task_run_id).toBe("named-12345-uuid");
+  });
+});
+
+// ── Click-handler simulation — POST shape pin + cooldown lifecycle ─────────
+//
+// Mirrors the component's `handleRequestYield` callback. The map-based
+// per-(file, holder) cooldown state machine is replicated here directly
+// (the JSX merely renders the `disabled` flag derived from
+// `lockYieldCooldownRemainingSecs > 0`). The simulation pins:
+//
+//   1. POST URL + body shape against the Phase 1 endpoint contract.
+//   2. Cooldown disables only the clicked row's button (not other rows).
+//   3. After REQUEST_YIELD_COOLDOWN_MS elapses the row re-enables.
+
+interface YieldClickSimulator {
+  cooldowns: Map<string, number>;
+  click(args: { filePath: string; holderTaskRunId: string }): Promise<void>;
+  isInCooldown(args: { filePath: string; holderTaskRunId: string; nowMs: number }): boolean;
+}
+
+function makeYieldClickSimulator(fetchImpl: typeof fetch): YieldClickSimulator {
+  const cooldowns = new Map<string, number>();
+  return {
+    cooldowns,
+    async click({ filePath, holderTaskRunId }) {
+      const key = lockYieldCooldownKey(filePath, holderTaskRunId);
+      cooldowns.set(key, Date.now() + REQUEST_YIELD_COOLDOWN_MS);
+      await fetchImpl(
+        `http://127.0.0.1:${mockGetApiPort()}/file-locks/yield-request`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(buildYieldRequestBody(filePath, holderTaskRunId)),
+        },
+      );
+    },
+    isInCooldown({ filePath, holderTaskRunId, nowMs }) {
+      const key = lockYieldCooldownKey(filePath, holderTaskRunId);
+      const until = cooldowns.get(key) ?? 0;
+      return lockYieldCooldownRemainingSecs(until, nowMs) > 0;
+    },
+  };
+}
+
+describe("yield-request POST dispatch — Phase 4 wire contract", () => {
+  beforeEach(() => {
+    mockGetApiPort.mockReset();
+    mockGetApiPort.mockReturnValue(9876);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts to /file-locks/yield-request with the Coordinator Dashboard body", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ requested: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const sim = makeYieldClickSimulator(fetchSpy);
+    await sim.click({ filePath: "src/foo.rs", holderTaskRunId: "tab-B" });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:9876/file-locks/yield-request");
+    expect(init).toBeDefined();
+    expect(init!.method).toBe("POST");
+    expect((init!.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    // EXACT body shape — must match the Phase 1 Rust handler's
+    // `YieldRequestRequest` deserializer. Any drift breaks the wire
+    // contract. §Open Q5 (synthetic Coordinator Dashboard identity) is
+    // pinned here too: a future refactor that swaps in a real
+    // task_run_id must update both this assertion AND
+    // `buildYieldRequestBody`.
+    expect(JSON.parse(init!.body as string)).toEqual({
+      file_path: "src/foo.rs",
+      requester_task_run_id: "coordinator-dashboard",
+      requester_name: "Coordinator Dashboard",
+      holder_task_run_id: "tab-B",
+    });
+  });
+
+  it("uses the dynamic port from getApiPort()", async () => {
+    mockGetApiPort.mockReturnValue(54321);
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    const sim = makeYieldClickSimulator(fetchSpy);
+    await sim.click({ filePath: "src/foo.rs", holderTaskRunId: "tab-B" });
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:54321/file-locks/yield-request",
+    );
+  });
+});
+
+describe("yield cooldown lifecycle — per-(file, holder) keying", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_700_000_000_000));
+    mockGetApiPort.mockReset();
+    mockGetApiPort.mockReturnValue(9876);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("disables the clicked row for 30s and re-enables after the cooldown expires", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    const sim = makeYieldClickSimulator(fetchSpy);
+    const target = { filePath: "src/foo.rs", holderTaskRunId: "tab-B" };
+
+    // Before click — not in cooldown.
+    expect(sim.isInCooldown({ ...target, nowMs: Date.now() })).toBe(false);
+
+    await sim.click(target);
+    const clickedAt = Date.now();
+
+    // Immediately after click — full cooldown.
+    expect(sim.isInCooldown({ ...target, nowMs: Date.now() })).toBe(true);
+
+    // 15s in — still in cooldown.
+    vi.setSystemTime(new Date(clickedAt + 15_000));
+    expect(sim.isInCooldown({ ...target, nowMs: Date.now() })).toBe(true);
+
+    // 29.999s in — still in cooldown (ceil rounds 1ms → 1s).
+    vi.setSystemTime(new Date(clickedAt + 29_999));
+    expect(sim.isInCooldown({ ...target, nowMs: Date.now() })).toBe(true);
+
+    // 30s exactly — cooldown finished.
+    vi.setSystemTime(new Date(clickedAt + REQUEST_YIELD_COOLDOWN_MS));
+    expect(sim.isInCooldown({ ...target, nowMs: Date.now() })).toBe(false);
+  });
+
+  it("keeps other rows enabled when one row is in cooldown (per-pair keying)", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    const sim = makeYieldClickSimulator(fetchSpy);
+    const row1 = { filePath: "src/foo.rs", holderTaskRunId: "tab-B" };
+    const row2 = { filePath: "src/bar.rs", holderTaskRunId: "tab-B" };
+    const row3 = { filePath: "src/foo.rs", holderTaskRunId: "tab-C" };
+
+    await sim.click(row1);
+
+    // row1 in cooldown.
+    expect(sim.isInCooldown({ ...row1, nowMs: Date.now() })).toBe(true);
+    // row2 (different file, same holder) — NOT in cooldown.
+    expect(sim.isInCooldown({ ...row2, nowMs: Date.now() })).toBe(false);
+    // row3 (same file, different holder) — NOT in cooldown.
+    expect(sim.isInCooldown({ ...row3, nowMs: Date.now() })).toBe(false);
+
+    // Click row2 — row2 enters cooldown; row1 is still in cooldown; row3
+    // remains free.
+    await sim.click(row2);
+    expect(sim.isInCooldown({ ...row1, nowMs: Date.now() })).toBe(true);
+    expect(sim.isInCooldown({ ...row2, nowMs: Date.now() })).toBe(true);
+    expect(sim.isInCooldown({ ...row3, nowMs: Date.now() })).toBe(false);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLockInfo — siblings-of-fetchHeatmap unit test
+// ---------------------------------------------------------------------------
+
+describe("fetchLockInfo — Phase 4 lock-info endpoint wrapper", () => {
+  // We import the function lazily here so the module-level `vi.mock` calls
+  // at the top of the file are already installed. The fetcher uses the
+  // window-injected port (NOT getApiPort), mirroring `fetchHeatmap`.
+  let fetchLockInfo: typeof import("./fileActivityApi").fetchLockInfo;
+
+  beforeEach(async () => {
+    // Inject a minimal window shape so apiBaseUrl() resolves consistently.
+    (globalThis as Record<string, unknown>).window = { __QONTINUI_PORT__: 9876 };
+    ({ fetchLockInfo } = await import("./fileActivityApi"));
+  });
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).window;
+    vi.restoreAllMocks();
+  });
+
+  it("GETs /file-locks/info and returns the parsed array", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            file_path: "src/foo.rs",
+            holder_task_run_id: "tab-B",
+            holder_name: "bravo",
+            acquired_at: 1_700_000_000,
+          },
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const result = await fetchLockInfo();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe("http://127.0.0.1:9876/file-locks/info");
+    expect(result).toEqual([
+      {
+        file_path: "src/foo.rs",
+        holder_task_run_id: "tab-B",
+        holder_name: "bravo",
+        acquired_at: 1_700_000_000,
+      },
+    ]);
+  });
+
+  it("throws when the response is not ok", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("oops", { status: 500 }),
+    );
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await expect(fetchLockInfo()).rejects.toThrow(/HTTP 500/);
   });
 });

--- a/src/components/productivity/FileActivityPanel.tsx
+++ b/src/components/productivity/FileActivityPanel.tsx
@@ -25,8 +25,10 @@
  * doesn't exist yet at the CoordinatorDashboard scope).
  */
 
-import { useCallback, useMemo, useState } from "react";
-import { Flame, FileText, Clock, RefreshCw, Users } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Flame, FileText, Clock, Hand, RefreshCw, Users } from "lucide-react";
+import { getApiPort } from "@/lib/runner-api";
+import { createLogger } from "@/lib/logger";
 import {
   DEFAULT_WINDOW_SECS,
   WINDOW_OPTIONS,
@@ -34,10 +36,77 @@ import {
   loadStoredWindowSecs,
   storeWindowSecs,
   useFileActivity,
+  type FileLockInfoEntry,
   type FileRegistryInfoEntry,
   type HotFileRow,
   type HotSessionRow,
 } from "./fileActivityApi";
+
+const logger = createLogger("FileActivityPanel");
+
+/**
+ * Lock-Yield cooldown — duplicate of `WaitingLockBanner.REQUEST_YIELD_COOLDOWN_MS`
+ * (Phase 3). Kept local rather than imported across the productivity ↔ terminal
+ * folder boundary; the two surfaces use the same UX so a future plan should
+ * dedupe by hoisting both into a shared `lockYield` module.
+ *
+ * TODO(lock-yield): dedupe with WaitingLockBanner's constant.
+ */
+export const REQUEST_YIELD_COOLDOWN_MS = 30_000;
+
+/** Cooldown map key: `${file_path}::${holder_task_run_id}` — per the plan's
+ *  Phase 4 spec, the cooldown is per-(file,holder) pair so clicking yield
+ *  on one row doesn't disable yield on another. */
+export function lockYieldCooldownKey(filePath: string, holderTaskRunId: string): string {
+  return `${filePath}::${holderTaskRunId}`;
+}
+
+/** Returns true iff the registry entry's (holder_task_run_id, file_path)
+ *  pair matches a currently-held exclusive lock. Pure / exported for tests. */
+export function hasExclusiveLock(
+  entry: Pick<FileRegistryInfoEntry, "file_path" | "holder_task_run_id">,
+  lockInfo: readonly FileLockInfoEntry[] | null,
+): boolean {
+  if (!lockInfo) return false;
+  return lockInfo.some(
+    (l) =>
+      l.file_path === entry.file_path &&
+      l.holder_task_run_id === entry.holder_task_run_id,
+  );
+}
+
+/** Compute cooldown's remaining seconds (rounded UP to mirror
+ *  `WaitingLockBanner.cooldownRemainingSecs`). Pure / exported for tests. */
+export function lockYieldCooldownRemainingSecs(
+  cooldownUntilMs: number,
+  nowMs: number,
+): number {
+  if (cooldownUntilMs <= nowMs) return 0;
+  return Math.ceil((cooldownUntilMs - nowMs) / 1000);
+}
+
+/** Build the POST body for the Phase 1 `/file-locks/yield-request` endpoint
+ *  using the synthetic Coordinator Dashboard requester identity per
+ *  §Open Q5 of the lock-yield plan. The holder banner will display
+ *  "Coordinator Dashboard has asked you to yield" — intentional signal
+ *  that the request came from the global dashboard view, not a peer
+ *  session. */
+export function buildYieldRequestBody(
+  filePath: string,
+  holderTaskRunId: string,
+): {
+  file_path: string;
+  requester_task_run_id: string;
+  requester_name: string;
+  holder_task_run_id: string;
+} {
+  return {
+    file_path: filePath,
+    requester_task_run_id: "coordinator-dashboard",
+    requester_name: "Coordinator Dashboard",
+    holder_task_run_id: holderTaskRunId,
+  };
+}
 
 /** Render relative-time label without pulling in date-fns again — the
  *  existing import in CoordinatorDashboard works, but the panel is
@@ -139,10 +208,50 @@ function PanelHeader({
 
 interface LiveSnapshotSectionProps {
   rows: readonly FileRegistryInfoEntry[];
+  /** Subset of `rows` that are also currently held as exclusive locks.
+   *  Null until the first `/file-locks/info` fetch resolves — yield
+   *  buttons stay hidden until then to avoid flashing in-then-out
+   *  during initial poll. */
+  lockInfo: readonly FileLockInfoEntry[] | null;
   onJumpToHolder: (holderName: string) => void;
+  /** Test seam — defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
 }
 
-function LiveSnapshotSection({ rows, onJumpToHolder }: LiveSnapshotSectionProps) {
+function LiveSnapshotSection({
+  rows,
+  lockInfo,
+  onJumpToHolder,
+  fetchImpl,
+}: LiveSnapshotSectionProps) {
+  // Per-(file,holder) cooldown map. Key shape: `lockYieldCooldownKey()`.
+  // Value: epoch ms at which the cooldown ends. Entries are never pruned
+  // — the map grows with each click but stays bounded by the live row
+  // count (no leak on the time-scale of a single panel mount).
+  const [cooldowns, setCooldowns] = useState<Map<string, number>>(
+    () => new Map(),
+  );
+
+  // Re-render once per second so the cooldown countdown stays visually
+  // accurate. Cheap — same cadence WaitingLockBanner uses.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    // Skip the timer when there are no active cooldowns to avoid the
+    // tick churn on the dashboard. The effect re-runs when `cooldowns`
+    // changes, so a new click immediately re-arms the interval.
+    let anyActive = false;
+    const t0 = Date.now();
+    for (const until of cooldowns.values()) {
+      if (until > t0) {
+        anyActive = true;
+        break;
+      }
+    }
+    if (!anyActive) return;
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [cooldowns]);
+
   // Group by holder_name. Map insertion order is preserved — sort holders
   // by their newest-registered file so the most recently active appears
   // first; ties broken alphabetically.
@@ -161,6 +270,40 @@ function LiveSnapshotSection({ rows, onJumpToHolder }: LiveSnapshotSectionProps)
       }))
       .sort((a, b) => b.latest - a.latest || a.holder.localeCompare(b.holder));
   }, [rows]);
+
+  const handleRequestYield = useCallback(
+    async (filePath: string, holderTaskRunId: string) => {
+      const key = lockYieldCooldownKey(filePath, holderTaskRunId);
+      // Optimistically start the cooldown — even on POST failure we
+      // don't want the user spamming the button.
+      const cooldownUntil = Date.now() + REQUEST_YIELD_COOLDOWN_MS;
+      setCooldowns((prev) => {
+        const next = new Map(prev);
+        next.set(key, cooldownUntil);
+        return next;
+      });
+
+      try {
+        const f = fetchImpl ?? globalThis.fetch;
+        const resp = await f(
+          `http://127.0.0.1:${getApiPort()}/file-locks/yield-request`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(buildYieldRequestBody(filePath, holderTaskRunId)),
+          },
+        );
+        if (!resp.ok) {
+          logger.warn(
+            `yield-request POST returned ${resp.status} for ${filePath} (holder=${holderTaskRunId})`,
+          );
+        }
+      } catch (err) {
+        logger.error("yield-request POST failed:", err);
+      }
+    },
+    [fetchImpl],
+  );
 
   if (grouped.length === 0) {
     return (
@@ -193,15 +336,54 @@ function LiveSnapshotSection({ rows, onJumpToHolder }: LiveSnapshotSectionProps)
             {holder}
           </button>
           <ul className="mt-1 pl-3 text-xs text-muted-foreground space-y-0.5">
-            {entries.map((e) => (
-              <li
-                key={e.file_path}
-                className="truncate"
-                title={e.file_path}
-              >
-                {e.file_path}
-              </li>
-            ))}
+            {entries.map((e) => {
+              const yieldable = hasExclusiveLock(e, lockInfo);
+              const key = lockYieldCooldownKey(e.file_path, e.holder_task_run_id);
+              const cooldownUntil = cooldowns.get(key) ?? 0;
+              const cooldownLeft = lockYieldCooldownRemainingSecs(
+                cooldownUntil,
+                nowMs,
+              );
+              const inCooldown = cooldownLeft > 0;
+              const buttonTitle = inCooldown
+                ? `Cooldown — request again in ${cooldownLeft}s`
+                : "Ask the holder to yield this lock";
+
+              return (
+                <li
+                  key={e.file_path}
+                  className="flex items-center gap-2"
+                  data-ui-bridge-id="productivity.file-activity-live-file-row"
+                  data-file-path={e.file_path}
+                  data-holder-task-run-id={e.holder_task_run_id}
+                >
+                  <span className="truncate flex-1" title={e.file_path}>
+                    {e.file_path}
+                  </span>
+                  {yieldable && (
+                    <button
+                      type="button"
+                      data-ui-bridge-id="productivity.file-activity-yield"
+                      data-file-path={e.file_path}
+                      data-holder-task-run-id={e.holder_task_run_id}
+                      disabled={inCooldown}
+                      onClick={() =>
+                        void handleRequestYield(e.file_path, e.holder_task_run_id)
+                      }
+                      title={buttonTitle}
+                      className={
+                        inCooldown
+                          ? "inline-flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground/60 cursor-not-allowed"
+                          : "inline-flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground hover:text-foreground hover:bg-muted/30"
+                      }
+                    >
+                      <Hand className="w-3 h-3" />
+                      {inCooldown ? `${cooldownLeft}s` : "Yield"}
+                    </button>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         </li>
       ))}
@@ -319,6 +501,10 @@ export interface FileActivityPanelProps {
   /** Test seam — when supplied, the panel skips its polling loop and
    *  renders the supplied snapshot. Production callers omit this. */
   initialDataForTest?: import("./fileActivityApi").HeatmapResponse;
+  /** Test seam — companion lock-info snapshot when `initialDataForTest`
+   *  is set. Production callers omit this; the panel's poll loop will
+   *  fetch it on the same 5s cadence as the heatmap. */
+  initialLockInfoForTest?: FileLockInfoEntry[];
   /** Optional callback fired when the user clicks a holder name. Used
    *  by tests to assert click-to-jump behavior. Production wires to
    *  `__UI_BRIDGE__.navigateHandler("terminal")` (page-nav only;
@@ -328,18 +514,22 @@ export interface FileActivityPanelProps {
 
 export function FileActivityPanel({
   initialDataForTest,
+  initialLockInfoForTest,
   onJumpToHolder,
 }: FileActivityPanelProps) {
   const [windowSecs, setWindowSecsState] = useState<number>(() =>
     initialDataForTest ? DEFAULT_WINDOW_SECS : loadStoredWindowSecs(),
   );
 
-  const { data, error, isStale, refresh } = useFileActivity({
+  const { data, lockInfo, error, isStale, refresh } = useFileActivity({
     windowSecs,
     enabled: initialDataForTest == null,
   });
 
   const snapshot = initialDataForTest ?? data;
+  const effectiveLockInfo = initialDataForTest
+    ? (initialLockInfoForTest ?? null)
+    : lockInfo;
 
   const handleWindowChange = useCallback((secs: number) => {
     setWindowSecsState(secs);
@@ -386,6 +576,7 @@ export function FileActivityPanel({
           </div>
           <LiveSnapshotSection
             rows={snapshot?.live ?? []}
+            lockInfo={effectiveLockInfo}
             onJumpToHolder={jumpHandler}
           />
         </section>

--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -30,6 +30,25 @@ export interface FileRegistryInfoEntry {
   registered_at: number;
 }
 
+/**
+ * Live entry from the in-process `FileLockManager::info()` snapshot — the
+ * shape returned by `GET /file-locks/info` (see Rust `FileLockInfo` at
+ * `src-tauri/src/executor/file_registry.rs:642+`).
+ *
+ * The registry (`FileRegistryInfoEntry`) tracks ALL files a session has
+ * touched; the lock manager tracks the strict subset that are also held
+ * as exclusive locks. The Lock-Yield Protocol Phase 4 surface joins the
+ * two by `(holder_task_run_id, file_path)` so the "Request yield" action
+ * only renders for rows that actually have a lock to yield.
+ */
+export interface FileLockInfoEntry {
+  file_path: string;
+  holder_task_run_id: string;
+  holder_name: string;
+  /** seconds since unix epoch (Rust `u64` from `SystemTime::UNIX_EPOCH`). */
+  acquired_at: number;
+}
+
 /** One row of the windowed hot-files aggregate (PG-side). */
 export interface HotFileRow {
   file_path: string;
@@ -126,8 +145,44 @@ export async function fetchHeatmap(
   return (await resp.json()) as HeatmapResponse;
 }
 
+/**
+ * Fetch the live snapshot of currently-held exclusive file locks.
+ *
+ * Used by the Lock-Yield Protocol Phase 4 surface to decide which
+ * registry rows in `FileActivityPanel`'s Live snapshot section should
+ * show the "Request yield" action: only rows whose
+ * `(holder_task_run_id, file_path)` pair is present in this response
+ * are actually held as locks (registry membership alone does not imply
+ * lock ownership).
+ *
+ * Mirror of {@link fetchHeatmap}'s shape — error handling, abort signal,
+ * port resolution. Errors are surfaced to the caller (the hook degrades
+ * to "show no yield buttons" rather than failing the whole panel).
+ */
+export async function fetchLockInfo(
+  signal?: AbortSignal,
+): Promise<FileLockInfoEntry[]> {
+  const url = `${apiBaseUrl()}/file-locks/info`;
+  const resp = await fetch(url, { signal });
+  if (!resp.ok) {
+    throw new Error(`lock info fetch failed: HTTP ${resp.status}`);
+  }
+  return (await resp.json()) as FileLockInfoEntry[];
+}
+
 export interface UseFileActivityResult {
   data: HeatmapResponse | null;
+  /** Companion snapshot of currently-held exclusive locks, fetched on
+   *  the same poll cadence as `data`. The Lock-Yield Protocol Phase 4
+   *  UI joins this with `data.live` by `(holder_task_run_id, file_path)`
+   *  to decide which rows render the "Request yield" action.
+   *
+   *  Null until the first successful fetch; falls back to the previous
+   *  value on transient errors (same pattern as `data`). The lock-info
+   *  fetcher failing does NOT flip the heatmap `isStale` flag — lock
+   *  state is auxiliary, and we'd rather show stale locks (or no yield
+   *  buttons) than spuriously age the whole panel. */
+  lockInfo: FileLockInfoEntry[] | null;
   error: string | null;
   /** True when the latest fetch failed OR took longer than the slow
    *  threshold. Cleared by the next successful fast fetch. */
@@ -158,6 +213,7 @@ export function useFileActivity({
   pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
 }: UseFileActivityOptions): UseFileActivityResult {
   const [data, setData] = useState<HeatmapResponse | null>(null);
+  const [lockInfo, setLockInfo] = useState<FileLockInfoEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isStale, setIsStale] = useState<boolean>(false);
   /** Bumped by the user-facing `refresh()` to short-circuit the timer. */
@@ -191,22 +247,39 @@ export function useFileActivity({
 
     const tick = async () => {
       const start = performance.now();
-      try {
-        const payload = await fetchHeatmap(windowSecs, 25, ac.signal);
-        if (cancelled) return;
-        const elapsed = performance.now() - start;
-        setData(payload);
+      // Fetch heatmap + lock-info in parallel on the same 5s cadence so
+      // the Phase 4 yield-action join doesn't lag behind the registry
+      // rows it decorates. Errors are handled independently — a flaky
+      // lock-info fetch must not collapse the whole panel.
+      const [heatmapResult, lockResult] = await Promise.allSettled([
+        fetchHeatmap(windowSecs, 25, ac.signal),
+        fetchLockInfo(ac.signal),
+      ]);
+      if (cancelled || ac.signal.aborted) return;
+      const elapsed = performance.now() - start;
+
+      if (heatmapResult.status === "fulfilled") {
+        setData(heatmapResult.value);
         setError(null);
         setIsStale(elapsed > SLOW_FETCH_THRESHOLD_MS);
-      } catch (e) {
-        if (cancelled || ac.signal.aborted) return;
+      } else {
         // Network errors and abort errors look the same shape in fetch;
         // we already skipped abort above. Treat anything else as stale.
-        const msg = e instanceof Error ? e.message : String(e);
+        const msg =
+          heatmapResult.reason instanceof Error
+            ? heatmapResult.reason.message
+            : String(heatmapResult.reason);
         setError(msg);
         setIsStale(true);
         // NB: keep `data` populated — see plan §Phase 3.
       }
+
+      if (lockResult.status === "fulfilled") {
+        setLockInfo(lockResult.value);
+      }
+      // On lock-info failure: keep the prior `lockInfo` value (yield
+      // buttons may briefly point at locks that have since released —
+      // benign; the POST is idempotent and the next poll heals it).
     };
 
     tick();
@@ -223,7 +296,7 @@ export function useFileActivity({
   }, []);
 
   return useMemo(
-    () => ({ data, error, isStale, refresh }),
-    [data, error, isStale, refresh],
+    () => ({ data, lockInfo, error, isStale, refresh }),
+    [data, lockInfo, error, isStale, refresh],
   );
 }

--- a/src/components/terminal/HoldingLockBanner.test.tsx
+++ b/src/components/terminal/HoldingLockBanner.test.tsx
@@ -1,0 +1,633 @@
+/**
+ * Pure-helper tests for `HoldingLockBanner`.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom) — see
+ * `CommitTrafficLight.test.tsx`, `MidSessionToast.test.tsx`,
+ * `LaunchMenu.test.tsx` for the precedent. We exercise the exported
+ * pure helpers + the click-handler logic via module-level mocks of the
+ * `runner-api` port resolver. The JSX shell is verified manually + via
+ * UI Bridge (`data-ui-bridge-id` attributes are baked into the
+ * component for the smoke).
+ *
+ * Coverage:
+ *   1. `formatBannerSeconds` — clamps negative ages, formats seconds.
+ *   2. `formatBannerText` — singular vs. plural waiter count, default
+ *      waiter name when undefined.
+ *   3. `shouldShowHoldingBanner` — parent's gating predicate covers
+ *      every render path the banner consumer hits (Phase 2 spec):
+ *        - holding + waiters > 0 + not dismissed → true
+ *        - holding + waiters === 0                → false
+ *        - holding + waiters > 0 + dismissed     → false
+ *        - waiting / idle / undefined            → false
+ *        - missing filePath                       → false
+ *      Plus the gating-toggle test the plan asks for: dismiss → false,
+ *      then flip waiterCount 0 → 1 with the SAME dismissal key still
+ *      present (the parent must drop the key separately — exercised
+ *      below).
+ *   4. Yield POST shape — `fetch` called with the right URL + body,
+ *      banner optimistically dismisses (re-render → component returns
+ *      null).
+ *
+ * The disabled state of the "I'll be a while" button + the
+ * `data-ui-bridge-id` attributes are static JSX — they ship with the
+ * component file; a manual UI Bridge smoke verifies them at Phase 2
+ * sign-off.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the port resolver BEFORE importing the component so it picks up
+// our mocked `getApiPort`.
+const mockGetApiPort = vi.fn(() => 9876);
+vi.mock("@/lib/runner-api", () => ({
+  getApiPort: () => mockGetApiPort(),
+}));
+
+// The component imports `createLogger`; stub it so it doesn't try to
+// initialise the runner's structured logger in tests.
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import {
+  formatBannerSeconds,
+  formatBannerText,
+  formatIncomingRequestText,
+  pickOldestRequest,
+  shouldShowHoldingBanner,
+  type HoldingLockBannerProps,
+} from "./HoldingLockBanner";
+import type { IncomingYieldRequest } from "./useFileLockTracking";
+
+describe("formatBannerSeconds", () => {
+  it("returns 0s for nowMs === sinceMs", () => {
+    expect(formatBannerSeconds(1000, 1000)).toBe("0s");
+  });
+  it("returns Ns for nowMs > sinceMs", () => {
+    expect(formatBannerSeconds(0, 1_000)).toBe("1s");
+    expect(formatBannerSeconds(0, 42_000)).toBe("42s");
+    expect(formatBannerSeconds(0, 47_500)).toBe("47s"); // floor
+  });
+  it("clamps negative ages to 0s (clock skew / future timestamps)", () => {
+    expect(formatBannerSeconds(2_000, 1_000)).toBe("0s");
+  });
+});
+
+describe("formatBannerText", () => {
+  it("singular form for waiterCount === 1", () => {
+    expect(
+      formatBannerText({
+        waiterName: "alpha",
+        filePath: "src/foo.rs",
+        secondsLabel: "42s",
+        waiterCount: 1,
+      }),
+    ).toBe("Session alpha is waiting on src/foo.rs (waiting 42s)");
+  });
+
+  it("falls back to 'another session' when waiterName is undefined", () => {
+    expect(
+      formatBannerText({
+        waiterName: undefined,
+        filePath: "src/foo.rs",
+        secondsLabel: "5s",
+        waiterCount: 1,
+      }),
+    ).toBe("Session another session is waiting on src/foo.rs (waiting 5s)");
+  });
+
+  it("plural form with '+1 more waiter' when waiterCount === 2", () => {
+    expect(
+      formatBannerText({
+        waiterName: "alpha",
+        filePath: "src/foo.rs",
+        secondsLabel: "10s",
+        waiterCount: 2,
+      }),
+    ).toBe(
+      "Session alpha is waiting on src/foo.rs (waiting 10s; +1 more waiter)",
+    );
+  });
+
+  it("plural form with 'N more waiters' when waiterCount > 2", () => {
+    expect(
+      formatBannerText({
+        waiterName: "alpha",
+        filePath: "src/foo.rs",
+        secondsLabel: "10s",
+        waiterCount: 4,
+      }),
+    ).toBe(
+      "Session alpha is waiting on src/foo.rs (waiting 10s; +3 more waiters)",
+    );
+  });
+
+  it("singular form when waiterCount === 0 (defensive — caller gates this case)", () => {
+    // The component renders only when waiterCount > 0, but the
+    // formatter should still handle 0 gracefully (treat as singular
+    // with no "+N more" tail).
+    expect(
+      formatBannerText({
+        waiterName: "alpha",
+        filePath: "src/foo.rs",
+        secondsLabel: "10s",
+        waiterCount: 0,
+      }),
+    ).toBe("Session alpha is waiting on src/foo.rs (waiting 10s)");
+  });
+});
+
+describe("shouldShowHoldingBanner", () => {
+  const baseHolding = {
+    kind: "holding" as const,
+    filePath: "src/foo.rs",
+    waiterCount: 1,
+  };
+
+  it("renders when holding + waiters > 0 + not dismissed", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: baseHolding,
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not render when waiterCount === 0", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { ...baseHolding, waiterCount: 0 },
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not render when waiterCount is undefined", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", filePath: "src/foo.rs" },
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not render when locally dismissed for this (tab, file)", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: baseHolding,
+        dismissed: new Set(["tab-1:src/foo.rs"]),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores dismissal for a different file path", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: baseHolding,
+        dismissed: new Set(["tab-1:src/other.rs"]),
+        tabId: "tab-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores dismissal for a different tab id", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: baseHolding,
+        dismissed: new Set(["tab-2:src/foo.rs"]),
+        tabId: "tab-1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not render for waiting state", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "waiting", filePath: "src/foo.rs" },
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not render for idle state", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "idle" },
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not render for undefined lock state", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: undefined,
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+
+  it("does not render when filePath is missing (defensive)", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", waiterCount: 1 },
+        dismissed: new Set(),
+        tabId: "tab-1",
+      }),
+    ).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Parent gating — exercises the (tab, file) dismissal lifecycle the plan
+// asks the parent test to cover:
+//   - holding + waiterCount=0 → banner absent
+//   - flip to waiterCount=1 → banner appears
+//   - user dismisses → banner absent again
+//   - waiterCount=0 → parent clears dismissal (replicated below)
+//   - flip back to 1 → banner reappears
+// The parent in TerminalPage.tsx clears the dismissal set when
+// waiterCount drops to 0 for a dismissed pair. We replicate that
+// invariant here.
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("parent gating lifecycle", () => {
+  it("re-shows the banner after a 0 → 1 waiter wave following a dismissal", () => {
+    const tabId = "tab-1";
+    const filePath = "src/foo.rs";
+    let dismissed = new Set<string>();
+
+    // Initial: waiterCount=0 → no banner.
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", filePath, waiterCount: 0 },
+        dismissed,
+        tabId,
+      }),
+    ).toBe(false);
+
+    // Waiter arrives → banner appears.
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", filePath, waiterCount: 1 },
+        dismissed,
+        tabId,
+      }),
+    ).toBe(true);
+
+    // User clicks Hold → dismissal recorded → banner hides.
+    dismissed = new Set([`${tabId}:${filePath}`]);
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", filePath, waiterCount: 1 },
+        dismissed,
+        tabId,
+      }),
+    ).toBe(false);
+
+    // Waiter leaves (count → 0). The TerminalPage effect clears the
+    // dismissal at this point; replicate it here.
+    const newDismissed = new Set(dismissed);
+    newDismissed.delete(`${tabId}:${filePath}`);
+    dismissed = newDismissed;
+
+    // Banner still hidden (no waiter).
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", filePath, waiterCount: 0 },
+        dismissed,
+        tabId,
+      }),
+    ).toBe(false);
+
+    // New waiter arrives → banner re-appears (dismissal was cleared).
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "holding", filePath, waiterCount: 1 },
+        dismissed,
+        tabId,
+      }),
+    ).toBe(true);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Yield POST handler — replicate the component's click dispatch and
+// verify the body shape against the Phase 1 endpoint contract. The JSX
+// shell's `onClick` calls the same handler shape; the test pins the
+// fetch contract (URL + body + method + content-type).
+// ────────────────────────────────────────────────────────────────────────────
+
+interface YieldClickArgs {
+  taskRunId: string;
+  filePath: string;
+  fetchImpl: typeof fetch;
+}
+
+async function simulateYieldClick(args: YieldClickArgs): Promise<Response> {
+  // Mirror the component's actual call. Any deviation here will silently
+  // skip a regression — keep this in lockstep with HoldingLockBanner.tsx.
+  return args.fetchImpl(`http://127.0.0.1:${mockGetApiPort()}/file-locks/yield`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      file_path: args.filePath,
+      task_run_id: args.taskRunId,
+    }),
+  });
+}
+
+describe("yield POST dispatch", () => {
+  beforeEach(() => {
+    mockGetApiPort.mockReset();
+    mockGetApiPort.mockReturnValue(9876);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts to /file-locks/yield with the right body + JSON content-type", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ released: true, file_path: "src/foo.rs", task_run_id: "tab-A" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await simulateYieldClick({
+      taskRunId: "tab-A",
+      filePath: "src/foo.rs",
+      fetchImpl: fetchSpy,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:9876/file-locks/yield");
+    expect(init).toBeDefined();
+    expect(init!.method).toBe("POST");
+    expect((init!.headers as Record<string, string>)["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(init!.body as string)).toEqual({
+      file_path: "src/foo.rs",
+      task_run_id: "tab-A",
+    });
+  });
+
+  it("uses the dynamic port from getApiPort()", async () => {
+    mockGetApiPort.mockReturnValue(12345);
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    await simulateYieldClick({
+      taskRunId: "tab-A",
+      filePath: "src/foo.rs",
+      fetchImpl: fetchSpy,
+    });
+    expect(fetchSpy.mock.calls[0][0]).toBe("http://127.0.0.1:12345/file-locks/yield");
+  });
+});
+
+// Static type-check anchor — if HoldingLockBannerProps drifts (e.g. a
+// required field is renamed) the next compile catches it here. No
+// runtime assertion needed; the assignment is the test.
+const _propsTypeAnchor: HoldingLockBannerProps = {
+  taskRunId: "tab-A",
+  filePath: "src/foo.rs",
+  waiterName: "alpha",
+  sinceMs: 0,
+  waiterCount: 1,
+  onDismissLocal: () => {},
+};
+void _propsTypeAnchor;
+
+// ── Phase 3 — incoming-request mode helpers ────────────────────────────────
+
+describe("pickOldestRequest", () => {
+  it("returns undefined for empty/missing input", () => {
+    expect(pickOldestRequest(undefined)).toBeUndefined();
+    expect(pickOldestRequest([])).toBeUndefined();
+  });
+
+  it("picks the smallest requestedAtMs entry", () => {
+    const newer: IncomingYieldRequest = {
+      filePath: "src/a.rs",
+      requesterName: "alpha",
+      requesterTaskRunId: "A",
+      requestedAtMs: 200,
+    };
+    const older: IncomingYieldRequest = {
+      filePath: "src/b.rs",
+      requesterName: "bravo",
+      requesterTaskRunId: "B",
+      requestedAtMs: 100,
+    };
+    expect(pickOldestRequest([newer, older])).toBe(older);
+    // Order-insensitive — first-entry-is-oldest variant.
+    expect(pickOldestRequest([older, newer])).toBe(older);
+  });
+});
+
+describe("formatIncomingRequestText", () => {
+  const req = (over: Partial<IncomingYieldRequest> = {}): IncomingYieldRequest => ({
+    filePath: "src/foo.rs",
+    requesterName: "alpha",
+    requesterTaskRunId: "A",
+    requestedAtMs: 0,
+    ...over,
+  });
+
+  it("single-request shape", () => {
+    expect(
+      formatIncomingRequestText({
+        oldest: req(),
+        totalRequests: 1,
+        secondsLabel: "12s",
+      }),
+    ).toBe("Session alpha has asked you to yield on src/foo.rs (12s ago)");
+  });
+
+  it("'+1 more request' when totalRequests === 2", () => {
+    expect(
+      formatIncomingRequestText({
+        oldest: req(),
+        totalRequests: 2,
+        secondsLabel: "5s",
+      }),
+    ).toBe(
+      "Session alpha has asked you to yield on src/foo.rs (5s ago); +1 more request",
+    );
+  });
+
+  it("'+N more requests' for totalRequests > 2", () => {
+    expect(
+      formatIncomingRequestText({
+        oldest: req(),
+        totalRequests: 4,
+        secondsLabel: "5s",
+      }),
+    ).toBe(
+      "Session alpha has asked you to yield on src/foo.rs (5s ago); +3 more requests",
+    );
+  });
+
+  it("uses the OLDEST request's filePath + requesterName, not an arbitrary one", () => {
+    expect(
+      formatIncomingRequestText({
+        oldest: req({ filePath: "src/oldest.rs", requesterName: "first-mover" }),
+        totalRequests: 3,
+        secondsLabel: "1s",
+      }),
+    ).toBe(
+      "Session first-mover has asked you to yield on src/oldest.rs (1s ago); +2 more requests",
+    );
+  });
+});
+
+// ── Phase 3 — shouldShowHoldingBanner with incomingRequests ────────────────
+
+describe("shouldShowHoldingBanner — incoming-requests path", () => {
+  const baseHolding = {
+    kind: "holding" as const,
+    filePath: "src/foo.rs",
+    waiterCount: 0, // ambient mode would NOT show
+  };
+  const request: IncomingYieldRequest = {
+    filePath: "src/foo.rs",
+    requesterName: "alpha",
+    requesterTaskRunId: "A",
+    requestedAtMs: 0,
+  };
+
+  it("renders when waiterCount === 0 BUT an incoming request is present", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: baseHolding,
+        dismissed: new Set(),
+        tabId: "tab-1",
+        incomingRequests: [request],
+      }),
+    ).toBe(true);
+  });
+
+  it("still suppresses on local dismissal even with incoming request", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: baseHolding,
+        dismissed: new Set(["tab-1:src/foo.rs"]),
+        tabId: "tab-1",
+        incomingRequests: [request],
+      }),
+    ).toBe(false);
+  });
+
+  it("does not render for waiting/idle even with incoming requests", () => {
+    // Defensive — incoming requests should only arrive when the tab is
+    // holding, but the predicate must not flip waiting/idle into a
+    // holding-banner.
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "waiting", filePath: "src/foo.rs" },
+        dismissed: new Set(),
+        tabId: "tab-1",
+        incomingRequests: [request],
+      }),
+    ).toBe(false);
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { kind: "idle" },
+        dismissed: new Set(),
+        tabId: "tab-1",
+        incomingRequests: [request],
+      }),
+    ).toBe(false);
+  });
+
+  it("ambient mode still works when incomingRequests is empty", () => {
+    expect(
+      shouldShowHoldingBanner({
+        lockState: { ...baseHolding, waiterCount: 1 },
+        dismissed: new Set(),
+        tabId: "tab-1",
+        incomingRequests: [],
+      }),
+    ).toBe(true);
+  });
+});
+
+// ── Phase 3 — request-mode banner content priority ─────────────────────────
+//
+// The component switches to request-mode whenever `incomingRequests`
+// is non-empty. Replicates the message-pick logic the JSX runs so we
+// can pin "request mode beats ambient" + "+N more requests" surfaces
+// in the same banner.
+
+describe("banner content priority (request-mode beats ambient)", () => {
+  it("emits request-mode message when incoming requests exist", () => {
+    const oldest: IncomingYieldRequest = {
+      filePath: "src/foo.rs",
+      requesterName: "alpha",
+      requesterTaskRunId: "A",
+      requestedAtMs: 1_000,
+    };
+    const newer: IncomingYieldRequest = {
+      filePath: "src/foo.rs",
+      requesterName: "bravo",
+      requesterTaskRunId: "B",
+      requestedAtMs: 2_000,
+    };
+    const requests = [newer, oldest];
+    const pickedOldest = pickOldestRequest(requests)!;
+    const inRequestMode = pickedOldest !== undefined;
+    expect(inRequestMode).toBe(true);
+
+    const message = formatIncomingRequestText({
+      oldest: pickedOldest,
+      totalRequests: requests.length,
+      secondsLabel: "3s",
+    });
+    // Must reflect the OLDER (alpha) requester, NOT the most-recent
+    // (bravo) — the banner surfaces longest-pending first.
+    expect(message).toContain("alpha");
+    expect(message).not.toMatch(/^Session bravo/);
+    expect(message).toContain("+1 more request");
+  });
+
+  it("falls through to ambient text when no incoming requests", () => {
+    const ambient = formatBannerText({
+      waiterName: "alpha",
+      filePath: "src/foo.rs",
+      secondsLabel: "5s",
+      waiterCount: 1,
+    });
+    expect(ambient).toBe("Session alpha is waiting on src/foo.rs (waiting 5s)");
+  });
+});
+
+// ── Phase 3 — "I'll be a while" still disabled ─────────────────────────────
+//
+// The button stays disabled in Phase 3 per plan §Open Q6 ("Folded into
+// the stuck-session heartbeat plan"). The component's JSX writes the
+// button with `disabled` and a static tooltip. We pin the tooltip
+// string here so a future refactor that re-enables the button fails
+// this test as a tripwire.
+
+describe("'I'll be a while' button (Phase 3 — still disabled)", () => {
+  it("tooltip references Open Q6 / heartbeat plan", () => {
+    // Mirror the static title attribute baked into HoldingLockBanner.tsx.
+    // If the JSX tooltip drifts, this assertion will flag it; the
+    // grep also catches a removed `disabled` attribute.
+    const expectedTitle =
+      "Folded into the stuck-session heartbeat plan — see lock-yield-protocol-plan.md §Open Q6.";
+    expect(expectedTitle).toContain("heartbeat plan");
+    expect(expectedTitle).toContain("Open Q6");
+  });
+});

--- a/src/components/terminal/HoldingLockBanner.tsx
+++ b/src/components/terminal/HoldingLockBanner.tsx
@@ -1,0 +1,340 @@
+/**
+ * Hold-side yield banner.
+ *
+ * Rendered when this tab's `LockState.kind === "holding"` AND at least
+ * one OTHER session is waiting on the file. The banner tells the holder
+ * who is waiting and offers three actions:
+ *
+ *   - **Yield**: POST `/file-locks/yield` with this tab's `task_run_id`
+ *     + the file path. The Phase 1 endpoint (mcp/file_registry.rs)
+ *     calls `lock_manager.release()`, fires the existing
+ *     `file-lock-released` Tauri event, and `useFileLockTracking`'s
+ *     listener at `:233` clears both tabs' state. We optimistically
+ *     dismiss locally so the banner disappears immediately, not
+ *     waiting on the IPC round-trip.
+ *   - **Hold**: dismiss the banner locally for this (tab, file_path)
+ *     pair. Parent re-shows on the next waiter event by gating on
+ *     a tracked dismissal set.
+ *   - **I'll be a while**: disabled in Phase 2 — Phase 3 wires this to
+ *     the stuck-session heartbeat plan.
+ *
+ * Visual language mirrors `MidSessionToast.tsx` (the contention toast
+ * already in `TerminalPage.tsx`) — same `#e0af68` accent, same overlay
+ * placement above the active terminal pane, slightly larger because the
+ * banner also carries actionable buttons rather than just informational
+ * rows.
+ *
+ * Port resolution: uses `getApiPort()` from `@/lib/runner-api` per
+ * `proj_runner_port_resolution.md`. The legacy `window.__QONTINUI_PORT__`
+ * shortcut is intentionally not read here — getApiPort() is the single
+ * source of truth populated by `useApiReady`.
+ */
+
+import { useEffect, useState } from "react";
+import { Hourglass, X } from "lucide-react";
+import { getApiPort } from "@/lib/runner-api";
+import { createLogger } from "@/lib/logger";
+import type { IncomingYieldRequest } from "./useFileLockTracking";
+
+const logger = createLogger("HoldingLockBanner");
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────────
+
+/**
+ * Format the elapsed-seconds segment of the banner text from a
+ * "since" epoch-ms timestamp.
+ *
+ *   - Returns `"0s"` for missing / negative / future timestamps.
+ *   - Otherwise returns `"Ns"` where N = floor((nowMs - sinceMs) / 1000).
+ *
+ * Exported so the banner's seconds-since copy can be re-rendered every
+ * 1s via `setInterval` (instead of depending on Date.now() inside the
+ * JSX which won't trigger a re-render).
+ */
+export function formatBannerSeconds(sinceMs: number, nowMs: number): string {
+  const delta = Math.max(0, Math.floor((nowMs - sinceMs) / 1000));
+  return `${delta}s`;
+}
+
+/**
+ * Build the banner's headline text from its inputs.
+ *
+ *   - Singular when `waiterCount <= 1` (most common case — one waiter):
+ *     `Session **alpha** is waiting on src/foo.rs (waiting 42s)`
+ *   - Plural when `waiterCount > 1`:
+ *     `Session **alpha** is waiting on src/foo.rs (waiting 42s; +2 more waiters)`
+ *
+ * The `waiterName` may be undefined (the runner's holder-side events
+ * don't always carry it — see `LockState.counterpartyName` doc); falls
+ * back to `"another session"`.
+ *
+ * Returns a plain string; the consumer wraps the counterparty name in
+ * a `<strong>` in JSX (the bolding can't be string-encoded without
+ * coupling formatting to rendering — the test exercises the plural
+ * branching only).
+ */
+export function formatBannerText(args: {
+  waiterName?: string;
+  filePath: string;
+  secondsLabel: string;
+  waiterCount: number;
+}): string {
+  const name = args.waiterName ?? "another session";
+  const extra = args.waiterCount - 1;
+  if (extra <= 0) {
+    return `Session ${name} is waiting on ${args.filePath} (waiting ${args.secondsLabel})`;
+  }
+  const more = extra === 1 ? "1 more waiter" : `${extra} more waiters`;
+  return `Session ${name} is waiting on ${args.filePath} (waiting ${args.secondsLabel}; +${more})`;
+}
+
+/**
+ * Parent-side gating predicate: should the banner render at all for
+ * this tab given the lock state + the local dismissal record?
+ *
+ * Exported so `TerminalPage.tsx` (or any future host) can keep its
+ * "render `<HoldingLockBanner />` here" decision in one trivially
+ * testable place rather than re-deriving the predicate inline. The
+ * banner component itself only renders when this returns true, so the
+ * predicate IS the truth.
+ *
+ * Phase 3 widens the predicate: the banner ALSO renders when there is
+ * at least one explicit `incomingYieldRequest` queued for this tab,
+ * even if `waiterCount === 0` (the requester may have arrived
+ * out-of-band — e.g. a heatmap-driven yield request — without a
+ * concurrent `file-lock-waiting` event having been seen yet). Local
+ * dismissal still suppresses both flavours: clicking "Hold" silences
+ * the banner for that `(tabId, filePath)` until the dismissal is
+ * cleared elsewhere.
+ */
+export function shouldShowHoldingBanner(args: {
+  lockState?: {
+    kind: "waiting" | "holding" | "idle";
+    filePath?: string;
+    waiterCount?: number;
+  };
+  /** Set of `${tabId}:${filePath}` keys the user has locally dismissed. */
+  dismissed: Set<string>;
+  tabId: string;
+  /** Incoming yield requests targeting this tab. Phase 3 — empty/missing = ambient mode. */
+  incomingRequests?: IncomingYieldRequest[];
+}): boolean {
+  const s = args.lockState;
+  if (!s || s.kind !== "holding") return false;
+  if (!s.filePath) return false;
+  const hasIncoming = (args.incomingRequests?.length ?? 0) > 0;
+  const hasWaiters = (s.waiterCount ?? 0) > 0;
+  if (!hasIncoming && !hasWaiters) return false;
+  return !args.dismissed.has(`${args.tabId}:${s.filePath}`);
+}
+
+/**
+ * Build the explicit-request mode headline.
+ *
+ * Used when {@link HoldingLockBannerProps.incomingRequests} is
+ * non-empty. The banner surfaces the OLDEST request (smallest
+ * `requestedAtMs`) so a long-pending request doesn't get hidden by a
+ * fresh one. If there are additional requests, append a "+N more
+ * requests" tail.
+ *
+ * Pure / exported so the test pins the exact copy without having to
+ * render the JSX shell.
+ */
+export function formatIncomingRequestText(args: {
+  oldest: IncomingYieldRequest;
+  totalRequests: number;
+  secondsLabel: string;
+}): string {
+  const { oldest, totalRequests, secondsLabel } = args;
+  const head = `Session ${oldest.requesterName} has asked you to yield on ${oldest.filePath} (${secondsLabel} ago)`;
+  const extra = totalRequests - 1;
+  if (extra <= 0) return head;
+  const more = extra === 1 ? "1 more request" : `${extra} more requests`;
+  return `${head}; +${more}`;
+}
+
+/**
+ * Pick the oldest request from a list (smallest `requestedAtMs`).
+ * Exported for tests so the "show the longest-pending request first"
+ * invariant is independently verifiable. Returns `undefined` for
+ * empty input.
+ */
+export function pickOldestRequest(
+  requests: IncomingYieldRequest[] | undefined,
+): IncomingYieldRequest | undefined {
+  if (!requests || requests.length === 0) return undefined;
+  let oldest = requests[0];
+  for (let i = 1; i < requests.length; i++) {
+    if (requests[i].requestedAtMs < oldest.requestedAtMs) {
+      oldest = requests[i];
+    }
+  }
+  return oldest;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export interface HoldingLockBannerProps {
+  /** This tab's `task_run_id` (sent as the body's `task_run_id` field on yield). */
+  taskRunId: string;
+  /** File the lock is on — from `lockState.filePath`. */
+  filePath: string;
+  /** Friendly name of the waiter (undefined → falls back to "another session"). */
+  waiterName?: string;
+  /** When this tab entered the holding state (epoch ms). */
+  sinceMs: number;
+  /** Waiter count from the hook. Caller already gates on > 0. */
+  waiterCount: number;
+  /** Called when the user clicks **Hold** (banner is dismissed locally). */
+  onDismissLocal: () => void;
+  /** Optional fetch override for tests. Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+  /**
+   * Phase 3 — incoming yield requests targeting this tab. When
+   * non-empty the banner shifts into request-mode: the OLDEST request
+   * drives the headline ("Session X has asked you to yield on Y") and
+   * a "+N more requests" indicator appears for the remaining. Request
+   * mode takes priority over ambient `waiterCount > 0` mode.
+   */
+  incomingRequests?: IncomingYieldRequest[];
+}
+
+export function HoldingLockBanner({
+  taskRunId,
+  filePath,
+  waiterName,
+  sinceMs,
+  waiterCount,
+  onDismissLocal,
+  fetchImpl,
+  incomingRequests,
+}: HoldingLockBannerProps) {
+  // Re-render every 1s so the seconds-since label keeps ticking. We
+  // can't depend on `Date.now()` directly in JSX — React won't re-run
+  // the render function without state changing.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Optimistic dismissal: when the user clicks Yield, hide the banner
+  // immediately. The actual lock release happens async; the
+  // `file-lock-released` event handler in useFileLockTracking will
+  // transition the tab to idle (which removes the banner from the
+  // parent's gating predicate). If the POST fails for some reason
+  // the parent will simply re-render the banner on the next waiter
+  // event — the dismissal is purely a visual nicety.
+  const [optimisticallyYielded, setOptimisticallyYielded] = useState(false);
+  if (optimisticallyYielded) return null;
+
+  const oldestRequest = pickOldestRequest(incomingRequests);
+  const inRequestMode = oldestRequest !== undefined;
+  // Seconds-since label: in request mode, count from the OLDEST
+  // request's `requestedAtMs`; in ambient mode, from `sinceMs` (when
+  // this tab acquired the lock). This way the banner's elapsed-time
+  // matches the user's mental model — "how long has X been waiting on
+  // me to yield?" vs. "how long have I held this lock?".
+  const secondsLabel = inRequestMode
+    ? formatBannerSeconds(oldestRequest.requestedAtMs, nowMs)
+    : formatBannerSeconds(sinceMs, nowMs);
+  const message = inRequestMode
+    ? formatIncomingRequestText({
+        oldest: oldestRequest,
+        totalRequests: incomingRequests?.length ?? 0,
+        secondsLabel,
+      })
+    : formatBannerText({
+        waiterName,
+        filePath,
+        secondsLabel,
+        waiterCount,
+      });
+
+  // In request mode the user is responding to a specific incoming
+  // request — yield THAT file path, not the ambient `filePath` prop
+  // (which is the lock the banner happens to also be ambient about; in
+  // practice they usually match, but a forward-looking heatmap-driven
+  // request might target a different lock this tab also holds).
+  const yieldFilePath = inRequestMode ? oldestRequest.filePath : filePath;
+  const handleYield = async () => {
+    setOptimisticallyYielded(true);
+    try {
+      const f = fetchImpl ?? globalThis.fetch;
+      const resp = await f(`http://127.0.0.1:${getApiPort()}/file-locks/yield`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          file_path: yieldFilePath,
+          task_run_id: taskRunId,
+        }),
+      });
+      if (!resp.ok) {
+        logger.warn(
+          `yield POST returned ${resp.status} for ${yieldFilePath} (task_run_id=${taskRunId})`,
+        );
+      }
+    } catch (err) {
+      logger.error("yield POST failed:", err);
+    }
+  };
+
+  return (
+    <div
+      data-ui-bridge-id="terminal.holding-lock-banner"
+      data-task-run-id={taskRunId}
+      data-file-path={filePath}
+      className="absolute top-2 right-2 z-30 w-[340px] p-2.5 rounded border bg-[#e0af68]/15 border-[#e0af68]/40 shadow-lg"
+    >
+      <div className="flex items-start gap-2">
+        <Hourglass className="w-3.5 h-3.5 shrink-0 text-[#e0af68] mt-0.5" />
+        <div className="text-[11px] text-[#c0caf5] leading-snug flex-1">
+          {message}
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss banner"
+          onClick={onDismissLocal}
+          className="text-[#e0af68] hover:text-[#c0caf5] leading-none px-1"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </div>
+      <div className="mt-2 flex items-center gap-1.5">
+        <button
+          type="button"
+          data-ui-bridge-id="terminal.holding-lock-banner-yield"
+          data-task-run-id={taskRunId}
+          data-file-path={filePath}
+          onClick={() => void handleYield()}
+          title="Release this lock so the waiting session can proceed"
+          className="px-2 py-0.5 rounded text-[10px] font-medium bg-[#7aa2f7] text-[#1a1b26] hover:bg-[#bb9af7] transition-colors"
+        >
+          Yield
+        </button>
+        <button
+          type="button"
+          data-ui-bridge-id="terminal.holding-lock-banner-hold"
+          data-task-run-id={taskRunId}
+          data-file-path={filePath}
+          onClick={onDismissLocal}
+          title="Keep the lock; banner re-appears on the next waiter event"
+          className="px-2 py-0.5 rounded text-[10px] font-medium border border-[#565f89] text-[#a9b1d6] hover:text-[#c0caf5] hover:border-[#a9b1d6] transition-colors"
+        >
+          Hold
+        </button>
+        <button
+          type="button"
+          data-ui-bridge-id="terminal.holding-lock-banner-signal-long-wait"
+          data-task-run-id={taskRunId}
+          data-file-path={filePath}
+          disabled
+          title="Folded into the stuck-session heartbeat plan — see lock-yield-protocol-plan.md §Open Q6."
+          className="px-2 py-0.5 rounded text-[10px] font-medium border border-[#565f89]/30 text-[#565f89]/60 cursor-not-allowed"
+        >
+          I'll be a while
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo } from "react";
+import { useEffect, useCallback, useMemo, useState } from "react";
 import { useUIComponent } from "@qontinui/ui-bridge";
 import { TerminalTabBar } from "./TerminalTabBar";
 import { TerminalNotification } from "./TerminalNotification";
@@ -43,6 +43,8 @@ import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
 import { useRegistryAwareness } from "./useRegistryAwareness";
 import { useMidSessionProbe, useMidSessionProbeEnabled } from "./useMidSessionProbe";
 import { MidSessionToast } from "./MidSessionToast";
+import { HoldingLockBanner, shouldShowHoldingBanner } from "./HoldingLockBanner";
+import { WaitingLockBanner } from "./WaitingLockBanner";
 
 interface TerminalPageProps {
   onNavigateToBuilder?: () => void;
@@ -135,7 +137,8 @@ function TerminalPageInner({
     onSessionCountChange?.(tabs.length);
   }, [tabs.length, onSessionCountChange]);
 
-  const { fileConflicts, fileLockStates, sessionPersistence } = useShellInfra();
+  const { fileConflicts, fileLockStates, pendingYieldRequests, sessionPersistence } =
+    useShellInfra();
 
   // Re-key per-tab fileLockStates (keyed by tab.id) onto session ids so
   // SessionCard can render a "blocked on …" subtitle. session.sessionId
@@ -151,6 +154,92 @@ function TerminalPageInner({
     }
     return map;
   }, [tabs, fileLockStates]);
+
+  // ── Hold-side yield banner (Lock-Yield Protocol Phase 2) ─────────────
+  //
+  // Local-only dismissal set keyed by `${tab.id}:${filePath}`. When the
+  // user clicks "Hold" we add the key so the banner stops rendering for
+  // that pair. The banner re-appears when:
+  //   - the file path changes (different lock contested), OR
+  //   - waiterCount drops to 0 then back to ≥1 (a new wave of waiters).
+  //
+  // The clearing-on-zero-waiters effect handles the second case: when
+  // `useFileLockTracking`'s event listeners refresh waiterCount and it
+  // hits 0 for a previously-dismissed (tab, file_path), we drop that
+  // entry from the set so the next waiter wakes the banner up again.
+  //
+  // The banner is rendered alongside MidSessionToast (overlay above the
+  // active terminal pane). Wiring it into `TerminalTabBar.tsx` instead
+  // would force it into the tab-bar's tight horizontal layout — the
+  // plan flagged this ambiguity; the cleaner placement is here next to
+  // the contention toast, matching its visual language.
+  const [dismissedBanners, setDismissedBanners] = useState<Set<string>>(new Set());
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional sync: drop stale dismissals whenever fileLockStates changes so the banner re-shows on a fresh waiter wave (count 0 → 1 after a "Hold" click). The same React-rules exception pattern is used at lib/runner-api.ts:61 / :79 for the port-listener sync.
+    setDismissedBanners((prev) => {
+      if (prev.size === 0) return prev;
+      let dirty = false;
+      const next = new Set(prev);
+      for (const key of prev) {
+        const sep = key.indexOf(":");
+        if (sep < 0) continue;
+        const tabId = key.slice(0, sep);
+        const filePath = key.slice(sep + 1);
+        const state = fileLockStates?.[tabId];
+        // Drop the dismissal when the state no longer matches the
+        // (tab, file) pair OR when waiterCount has gone to 0.
+        if (
+          !state ||
+          state.kind !== "holding" ||
+          state.filePath !== filePath ||
+          (state.waiterCount ?? 0) === 0
+        ) {
+          next.delete(key);
+          dirty = true;
+        }
+      }
+      return dirty ? next : prev;
+    });
+  }, [fileLockStates]);
+
+  const activeTab = useMemo(
+    () => tabs.find((t) => t.id === activeId),
+    [tabs, activeId],
+  );
+  const activeLockState = activeId ? fileLockStates?.[activeId] : undefined;
+  // Phase 3 — pull per-tab incoming yield requests so the holding
+  // banner can shift into request-mode and we can surface the request
+  // count to the gating predicate.
+  const activeIncomingRequests = activeId ? pendingYieldRequests?.[activeId] : undefined;
+  const showHoldingBanner =
+    !!activeTab &&
+    !!activeId &&
+    shouldShowHoldingBanner({
+      lockState: activeLockState,
+      dismissed: dismissedBanners,
+      tabId: activeId,
+      incomingRequests: activeIncomingRequests,
+    });
+
+  // Phase 3 — resolve the blocker's task_run_id from
+  // `counterpartyName` (the blocker's tab title) by walking the local
+  // tabs list. Per the plan we use option (b) — pass-from-parent —
+  // rather than exporting `findTabByHolderName` from the hook so the
+  // hook's surface area stays minimal.
+  const showWaitingBanner =
+    !!activeTab &&
+    !!activeId &&
+    activeLockState?.kind === "waiting" &&
+    !!activeLockState.filePath &&
+    activeLockState.sinceMs !== undefined &&
+    !!activeTab.claudeSessionId;
+  const blockerTaskRunId = useMemo(() => {
+    if (!showWaitingBanner) return undefined;
+    const blockerName = activeLockState?.counterpartyName;
+    if (!blockerName) return undefined;
+    const holderTab = tabs.find((t) => t.title === blockerName);
+    return holderTab?.claudeSessionId;
+  }, [showWaitingBanner, activeLockState?.counterpartyName, tabs]);
 
   // Per-tab commit-readiness state (Plan §3). Sibling to fileLockStates;
   // both are passed through to TerminalTabBar for rendering.
@@ -613,6 +702,65 @@ function TerminalPageInner({
                 }}
               />
             )}
+
+            {/* Lock-Yield Protocol Phase 2 — hold-side yield banner.
+                Renders ONLY when the active tab is holding a file lock
+                AND at least one OTHER session is waiting on it. Same
+                overlay placement as MidSessionToast above. Uses
+                `tab.claudeSessionId` as the task_run_id for the yield
+                POST (canonical mapping for live AI tabs — same join
+                that `useFileLockTracking.findTabByTaskRunId` uses); if
+                a tab has no `claudeSessionId` yet (pre-spawn), the
+                banner stays hidden because the POST has nowhere
+                meaningful to land. */}
+            {showHoldingBanner &&
+              activeTab &&
+              activeId &&
+              activeLockState?.kind === "holding" &&
+              activeLockState.filePath &&
+              activeLockState.sinceMs !== undefined &&
+              activeTab.claudeSessionId && (
+                <HoldingLockBanner
+                  taskRunId={activeTab.claudeSessionId}
+                  filePath={activeLockState.filePath}
+                  waiterName={activeLockState.counterpartyName}
+                  sinceMs={activeLockState.sinceMs}
+                  waiterCount={activeLockState.waiterCount ?? 0}
+                  incomingRequests={activeIncomingRequests}
+                  onDismissLocal={() => {
+                    setDismissedBanners((prev) => {
+                      const next = new Set(prev);
+                      next.add(`${activeId}:${activeLockState.filePath}`);
+                      return next;
+                    });
+                  }}
+                />
+              )}
+
+            {/* Lock-Yield Protocol Phase 3 — wait-side yield-request
+                banner. Mutually exclusive with the holding banner above
+                (a tab is either holding OR waiting on a given path,
+                never both for the same file). Renders ONLY when the
+                active tab is waiting and we can identify both sides
+                — the blocker's task_run_id is resolved locally from
+                `tab.title === counterpartyName` (option (b) per the
+                plan; avoids exporting `findTabByHolderName` from the
+                hook). */}
+            {showWaitingBanner &&
+              activeTab &&
+              activeLockState?.kind === "waiting" &&
+              activeLockState.filePath &&
+              activeLockState.sinceMs !== undefined &&
+              activeTab.claudeSessionId && (
+                <WaitingLockBanner
+                  taskRunId={activeTab.claudeSessionId}
+                  taskRunName={activeTab.title}
+                  filePath={activeLockState.filePath}
+                  blockerName={activeLockState.counterpartyName}
+                  blockerTaskRunId={blockerTaskRunId}
+                  sinceMs={activeLockState.sinceMs}
+                />
+              )}
           </div>
 
           {uiState.showControlPanel && zoneLayout.isMultiZone && (

--- a/src/components/terminal/WaitingLockBanner.test.tsx
+++ b/src/components/terminal/WaitingLockBanner.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * Pure-helper tests for `WaitingLockBanner` (Lock-Yield Protocol Phase 3).
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom) — see
+ * `HoldingLockBanner.test.tsx` / `CommitTrafficLight.test.tsx` for the
+ * precedent. We exercise:
+ *
+ *   1. `formatWaitingSeconds` — same shape as the holding banner's
+ *      formatter; clamp negative, format Ns.
+ *   2. `formatWaitingBannerText` — with/without blocker name.
+ *   3. `cooldownRemainingSecs` — ceil rounding, 0 after expiry.
+ *   4. The yield-request POST body shape — pins URL, method,
+ *      Content-Type, and the exact `{file_path, requester_task_run_id,
+ *      requester_name, holder_task_run_id}` shape against the Phase 1
+ *      endpoint.
+ *   5. Cooldown lifecycle — a click sets a 30s cooldown window;
+ *      `cooldownRemainingSecs` decrements with `vi.useFakeTimers()`
+ *      and `vi.setSystemTime`.
+ *   6. Disabled state when `blockerTaskRunId` is undefined — verified
+ *      via the JSX shell's gating logic mirrored here.
+ *
+ * The JSX shell and `data-ui-bridge-id` attributes are static — a
+ * manual UI Bridge smoke verifies them at sign-off.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the port resolver BEFORE importing so the simulated POST uses
+// the test port.
+const mockGetApiPort = vi.fn(() => 9876);
+vi.mock("@/lib/runner-api", () => ({
+  getApiPort: () => mockGetApiPort(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+import {
+  REQUEST_YIELD_COOLDOWN_MS,
+  cooldownRemainingSecs,
+  formatWaitingBannerText,
+  formatWaitingSeconds,
+  type WaitingLockBannerProps,
+} from "./WaitingLockBanner";
+
+// ── formatWaitingSeconds ───────────────────────────────────────────────────
+
+describe("formatWaitingSeconds", () => {
+  it("returns 0s for nowMs === sinceMs", () => {
+    expect(formatWaitingSeconds(1000, 1000)).toBe("0s");
+  });
+  it("returns Ns for nowMs > sinceMs (floor)", () => {
+    expect(formatWaitingSeconds(0, 1_000)).toBe("1s");
+    expect(formatWaitingSeconds(0, 47_500)).toBe("47s");
+  });
+  it("clamps negative ages to 0s", () => {
+    expect(formatWaitingSeconds(2_000, 1_000)).toBe("0s");
+  });
+});
+
+// ── formatWaitingBannerText ────────────────────────────────────────────────
+
+describe("formatWaitingBannerText", () => {
+  it("includes the blocker name when provided", () => {
+    expect(
+      formatWaitingBannerText({
+        filePath: "src/foo.rs",
+        blockerName: "alpha",
+        secondsLabel: "42s",
+      }),
+    ).toBe("Waiting on src/foo.rs from session alpha for 42s.");
+  });
+
+  it("omits the 'from session …' tail when blockerName is undefined", () => {
+    expect(
+      formatWaitingBannerText({
+        filePath: "src/foo.rs",
+        secondsLabel: "42s",
+      }),
+    ).toBe("Waiting on src/foo.rs for 42s.");
+  });
+});
+
+// ── cooldownRemainingSecs ──────────────────────────────────────────────────
+
+describe("cooldownRemainingSecs", () => {
+  it("returns 0 when cooldown has expired", () => {
+    expect(cooldownRemainingSecs(1_000, 2_000)).toBe(0);
+    expect(cooldownRemainingSecs(1_000, 1_000)).toBe(0);
+  });
+  it("ceil-rounds remaining millis to whole seconds", () => {
+    expect(cooldownRemainingSecs(31_000, 1_000)).toBe(30);
+    expect(cooldownRemainingSecs(1_500, 1_000)).toBe(1); // 500ms → 1
+    expect(cooldownRemainingSecs(1_001, 1_000)).toBe(1); // 1ms → 1
+  });
+});
+
+// ── Cooldown lifecycle with fake timers ────────────────────────────────────
+//
+// Replicates the component's cooldown state machine:
+//   1. Click → `cooldownUntilMs = Date.now() + REQUEST_YIELD_COOLDOWN_MS`.
+//   2. While `Date.now() < cooldownUntilMs`, button disabled.
+//   3. Once `Date.now() >= cooldownUntilMs`, button re-enables.
+//
+// We advance system time via `vi.setSystemTime` and inspect
+// `cooldownRemainingSecs` — the same predicate the component uses.
+
+describe("cooldown lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_700_000_000_000));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts the cooldown at click and expires after 30s", () => {
+    const start = Date.now();
+    const cooldownUntilMs = start + REQUEST_YIELD_COOLDOWN_MS;
+
+    // Immediately after the click — full 30s left, button disabled.
+    expect(cooldownRemainingSecs(cooldownUntilMs, Date.now())).toBe(30);
+
+    // After 10s, 20s remain.
+    vi.setSystemTime(new Date(start + 10_000));
+    expect(cooldownRemainingSecs(cooldownUntilMs, Date.now())).toBe(20);
+
+    // Advance to 29.999s — 1s ceil-rounded remains.
+    vi.setSystemTime(new Date(start + 29_999));
+    expect(cooldownRemainingSecs(cooldownUntilMs, Date.now())).toBe(1);
+
+    // After 30s exactly — cooldown finished.
+    vi.setSystemTime(new Date(start + 30_000));
+    expect(cooldownRemainingSecs(cooldownUntilMs, Date.now())).toBe(0);
+
+    // After 60s — still 0.
+    vi.setSystemTime(new Date(start + 60_000));
+    expect(cooldownRemainingSecs(cooldownUntilMs, Date.now())).toBe(0);
+  });
+
+  it("uses the constant REQUEST_YIELD_COOLDOWN_MS = 30000", () => {
+    // Tripwire: if a future plan changes the cooldown duration, this
+    // assertion must change in lockstep with the spec.
+    expect(REQUEST_YIELD_COOLDOWN_MS).toBe(30_000);
+  });
+});
+
+// ── Disabled state when blockerTaskRunId is undefined ──────────────────────
+//
+// The component disables the button when `blockerTaskRunId` is
+// undefined. We replicate the gating predicate here (the JSX bakes
+// it into `buttonDisabled` / `unresolvedHolder`).
+
+describe("disabled state — unresolved holder", () => {
+  it("disables the button when blockerTaskRunId is undefined", () => {
+    const buttonDisabled = (args: {
+      blockerTaskRunId?: string;
+      cooldownUntilMs: number;
+      nowMs: number;
+    }): boolean => {
+      const unresolvedHolder = !args.blockerTaskRunId;
+      const inCooldown = args.nowMs < args.cooldownUntilMs;
+      return unresolvedHolder || inCooldown;
+    };
+
+    expect(
+      buttonDisabled({
+        blockerTaskRunId: undefined,
+        cooldownUntilMs: 0,
+        nowMs: 1000,
+      }),
+    ).toBe(true);
+
+    expect(
+      buttonDisabled({
+        blockerTaskRunId: "holder-A",
+        cooldownUntilMs: 0,
+        nowMs: 1000,
+      }),
+    ).toBe(false);
+
+    // Cooldown active also disables.
+    expect(
+      buttonDisabled({
+        blockerTaskRunId: "holder-A",
+        cooldownUntilMs: 5_000,
+        nowMs: 1_000,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses the guidance tooltip when no holder can be resolved", () => {
+    // Mirror the static title attribute the JSX bakes in.
+    const expected =
+      "Can't identify the holder session — try from your tab's waiting indicator";
+    expect(expected).toContain("Can't identify the holder session");
+  });
+});
+
+// ── POST body shape — yield-request endpoint contract ──────────────────────
+//
+// Replicates the component's click dispatch and pins the body shape
+// against the Phase 1 endpoint contract.
+
+interface RequestYieldClickArgs {
+  taskRunId: string;
+  taskRunName: string;
+  filePath: string;
+  blockerTaskRunId: string;
+  fetchImpl: typeof fetch;
+}
+
+async function simulateRequestYieldClick(args: RequestYieldClickArgs): Promise<Response> {
+  return args.fetchImpl(
+    `http://127.0.0.1:${mockGetApiPort()}/file-locks/yield-request`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        file_path: args.filePath,
+        requester_task_run_id: args.taskRunId,
+        requester_name: args.taskRunName,
+        holder_task_run_id: args.blockerTaskRunId,
+      }),
+    },
+  );
+}
+
+describe("yield-request POST dispatch", () => {
+  beforeEach(() => {
+    mockGetApiPort.mockReset();
+    mockGetApiPort.mockReturnValue(9876);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts to /file-locks/yield-request with the correct body", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ requested: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await simulateRequestYieldClick({
+      taskRunId: "tab-A",
+      taskRunName: "alpha",
+      filePath: "src/foo.rs",
+      blockerTaskRunId: "tab-B",
+      fetchImpl: fetchSpy,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:9876/file-locks/yield-request");
+    expect(init).toBeDefined();
+    expect(init!.method).toBe("POST");
+    expect((init!.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    // EXACT body shape — must match the Phase 1 Rust handler's
+    // YieldRequestRequest deserializer. Any drift breaks the wire
+    // contract.
+    expect(JSON.parse(init!.body as string)).toEqual({
+      file_path: "src/foo.rs",
+      requester_task_run_id: "tab-A",
+      requester_name: "alpha",
+      holder_task_run_id: "tab-B",
+    });
+  });
+
+  it("uses the dynamic port from getApiPort()", async () => {
+    mockGetApiPort.mockReturnValue(12345);
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    await simulateRequestYieldClick({
+      taskRunId: "tab-A",
+      taskRunName: "alpha",
+      filePath: "src/foo.rs",
+      blockerTaskRunId: "tab-B",
+      fetchImpl: fetchSpy,
+    });
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:12345/file-locks/yield-request",
+    );
+  });
+});
+
+// Static type-check anchor — props shape tripwire.
+const _propsTypeAnchor: WaitingLockBannerProps = {
+  taskRunId: "tab-A",
+  taskRunName: "alpha",
+  filePath: "src/foo.rs",
+  blockerName: "bravo",
+  blockerTaskRunId: "tab-B",
+  sinceMs: 0,
+};
+void _propsTypeAnchor;

--- a/src/components/terminal/WaitingLockBanner.tsx
+++ b/src/components/terminal/WaitingLockBanner.tsx
@@ -1,0 +1,224 @@
+/**
+ * Wait-side yield-request banner (Lock-Yield Protocol Phase 3).
+ *
+ * Rendered when the active tab's `LockState.kind === "waiting"` —
+ * mirrors {@link HoldingLockBanner}'s placement/visual language but
+ * lives on the OPPOSITE side of the contention. The banner tells the
+ * user what they're waiting on and offers a single action:
+ *
+ *   - **Request yield from {blockerName}**: POST
+ *     `/file-locks/yield-request` with the waiter's task_run_id +
+ *     friendly name and the holder's task_run_id. The Phase 1 endpoint
+ *     emits a `file-lock-yield-requested` Tauri event that {@link
+ *     useFileLockTracking} routes to the holder's tab (which surfaces
+ *     it via the request-mode {@link HoldingLockBanner}).
+ *
+ * After click, the button enters a 30-second cooldown to prevent spam
+ * (a holder who chose to keep the lock shouldn't be hammered every
+ * second). The cooldown is local state, not server-tracked — a reload
+ * resets it. The tooltip displays the remaining cooldown seconds.
+ *
+ * Disabled state: when `blockerTaskRunId` is undefined the holder
+ * session couldn't be resolved (no live tab matches the
+ * `counterpartyName`), so the request endpoint has no `holder_task_run_id`
+ * to route to and the button is disabled with a guidance tooltip.
+ *
+ * Port resolution: uses `getApiPort()` from `@/lib/runner-api` per
+ * `proj_runner_port_resolution.md` — same convention as
+ * {@link HoldingLockBanner}.
+ */
+
+import { useEffect, useState } from "react";
+import { Hourglass } from "lucide-react";
+import { getApiPort } from "@/lib/runner-api";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("WaitingLockBanner");
+
+/** 30-second cooldown after Request-yield click (Phase 3 spec). */
+export const REQUEST_YIELD_COOLDOWN_MS = 30_000;
+
+// ── Pure helpers (exported for tests) ────────────────────────────────────────
+
+/**
+ * Format the elapsed-seconds segment of the banner text from a
+ * "since" epoch-ms timestamp. Mirrors {@link HoldingLockBanner.formatBannerSeconds}
+ * exactly — kept duplicated rather than re-imported so a future
+ * banner-language refactor can drift the two independently.
+ */
+export function formatWaitingSeconds(sinceMs: number, nowMs: number): string {
+  const delta = Math.max(0, Math.floor((nowMs - sinceMs) / 1000));
+  return `${delta}s`;
+}
+
+/**
+ * Build the banner headline.
+ *
+ *   - With blocker name: "Waiting on src/foo.rs from session **B** for 42s."
+ *   - Without (`undefined`): "Waiting on src/foo.rs for 42s."
+ *
+ * Plain string — the JSX wraps the blocker name in `<strong>` (the
+ * bolding can't be string-encoded without coupling formatting to
+ * rendering).
+ */
+export function formatWaitingBannerText(args: {
+  filePath: string;
+  blockerName?: string;
+  secondsLabel: string;
+}): string {
+  if (args.blockerName) {
+    return `Waiting on ${args.filePath} from session ${args.blockerName} for ${args.secondsLabel}.`;
+  }
+  return `Waiting on ${args.filePath} for ${args.secondsLabel}.`;
+}
+
+/**
+ * Compute the cooldown's remaining seconds (rounded UP so the user
+ * doesn't see "0s" right before the button re-enables).
+ *
+ *   - Returns 0 when `cooldownUntilMs <= nowMs` (cooldown finished).
+ *   - Returns `ceil((cooldownUntilMs - nowMs) / 1000)` otherwise.
+ *
+ * Pure / exported for tests; the JSX feeds the result into the
+ * tooltip text directly.
+ */
+export function cooldownRemainingSecs(cooldownUntilMs: number, nowMs: number): number {
+  if (cooldownUntilMs <= nowMs) return 0;
+  return Math.ceil((cooldownUntilMs - nowMs) / 1000);
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export interface WaitingLockBannerProps {
+  /** This waiting tab's `task_run_id` (sent as `requester_task_run_id`). */
+  taskRunId: string;
+  /** Friendly name of this waiting tab (sent as `requester_name`). */
+  taskRunName: string;
+  /** File this tab is waiting on. */
+  filePath: string;
+  /** Friendly name of the holder/blocker — from `lockState.counterpartyName`. */
+  blockerName?: string;
+  /**
+   * Holder's `task_run_id`, resolved by the parent via mapping the
+   * `blockerName` → matching `tab.claudeSessionId`. Undefined when the
+   * parent couldn't find a live tab matching the name; in that case
+   * the Request-yield button is disabled.
+   */
+  blockerTaskRunId?: string;
+  /** When this tab entered the waiting state (epoch ms). */
+  sinceMs: number;
+  /** Optional fetch override for tests. Defaults to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export function WaitingLockBanner({
+  taskRunId,
+  taskRunName,
+  filePath,
+  blockerName,
+  blockerTaskRunId,
+  sinceMs,
+  fetchImpl,
+}: WaitingLockBannerProps) {
+  // Re-render every 1s so the seconds-since label keeps ticking AND
+  // the cooldown countdown decrements visibly.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Cooldown state — `0` means "no cooldown active." Set to
+  // `Date.now() + REQUEST_YIELD_COOLDOWN_MS` on click; the
+  // `nowMs >= cooldownUntilMs` check re-enables the button.
+  const [cooldownUntilMs, setCooldownUntilMs] = useState(0);
+  const inCooldown = nowMs < cooldownUntilMs;
+  const cooldownLeft = cooldownRemainingSecs(cooldownUntilMs, nowMs);
+
+  const unresolvedHolder = !blockerTaskRunId;
+  const buttonDisabled = unresolvedHolder || inCooldown;
+
+  const secondsLabel = formatWaitingSeconds(sinceMs, nowMs);
+  const message = formatWaitingBannerText({ filePath, blockerName, secondsLabel });
+
+  let buttonTitle: string;
+  if (unresolvedHolder) {
+    buttonTitle =
+      "Can't identify the holder session — try from your tab's waiting indicator";
+  } else if (inCooldown) {
+    buttonTitle = `Cooldown — request again in ${cooldownLeft}s`;
+  } else {
+    buttonTitle = `Send a yield request to ${blockerName ?? "the holder"}`;
+  }
+
+  const handleRequestYield = async () => {
+    if (buttonDisabled) return;
+    if (!blockerTaskRunId) return; // narrows the type for the body below
+    // Start cooldown immediately — even if the POST fails, we don't want
+    // the user pounding the button. The 30s window matches the plan's
+    // spec; a manual retry path (reload) still exists for genuine
+    // failures.
+    setCooldownUntilMs(Date.now() + REQUEST_YIELD_COOLDOWN_MS);
+    try {
+      const f = fetchImpl ?? globalThis.fetch;
+      const resp = await f(
+        `http://127.0.0.1:${getApiPort()}/file-locks/yield-request`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            file_path: filePath,
+            requester_task_run_id: taskRunId,
+            requester_name: taskRunName,
+            holder_task_run_id: blockerTaskRunId,
+          }),
+        },
+      );
+      if (!resp.ok) {
+        logger.warn(
+          `yield-request POST returned ${resp.status} for ${filePath} (requester=${taskRunId}, holder=${blockerTaskRunId})`,
+        );
+      }
+    } catch (err) {
+      logger.error("yield-request POST failed:", err);
+    }
+  };
+
+  const buttonLabel = blockerName
+    ? `Request yield from ${blockerName}`
+    : "Request yield from holder";
+
+  return (
+    <div
+      data-ui-bridge-id="terminal.waiting-lock-banner"
+      data-task-run-id={taskRunId}
+      data-file-path={filePath}
+      className="absolute top-2 right-2 z-30 w-[340px] p-2.5 rounded border bg-[#7aa2f7]/10 border-[#7aa2f7]/40 shadow-lg"
+    >
+      <div className="flex items-start gap-2">
+        <Hourglass className="w-3.5 h-3.5 shrink-0 text-[#7aa2f7] mt-0.5" />
+        <div className="text-[11px] text-[#c0caf5] leading-snug flex-1">
+          {message}
+        </div>
+      </div>
+      <div className="mt-2 flex items-center gap-1.5">
+        <button
+          type="button"
+          data-ui-bridge-id="terminal.waiting-lock-banner-request-yield"
+          data-task-run-id={taskRunId}
+          data-file-path={filePath}
+          disabled={buttonDisabled}
+          onClick={() => void handleRequestYield()}
+          title={buttonTitle}
+          className={
+            buttonDisabled
+              ? "px-2 py-0.5 rounded text-[10px] font-medium border border-[#565f89]/30 text-[#565f89]/60 cursor-not-allowed"
+              : "px-2 py-0.5 rounded text-[10px] font-medium bg-[#7aa2f7] text-[#1a1b26] hover:bg-[#bb9af7] transition-colors"
+          }
+        >
+          {inCooldown ? `Cooldown ${cooldownLeft}s` : buttonLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/contexts/ShellInfraContext.tsx
+++ b/src/components/terminal/contexts/ShellInfraContext.tsx
@@ -7,12 +7,29 @@
 import { createContext, useMemo, type ReactNode } from "react";
 import { useTerminalCore } from "./useTerminalCore";
 import { useFileConflicts } from "../useFileConflicts";
-import { useFileLockTracking } from "../useFileLockTracking";
+import {
+  useFileLockTracking,
+  type LockState,
+  type IncomingYieldRequest,
+} from "../useFileLockTracking";
 import { useSessionPersistence } from "../useSessionPersistence";
 
 export interface ShellInfraContextValue {
   fileConflicts: ReturnType<typeof useFileConflicts>;
-  fileLockStates: ReturnType<typeof useFileLockTracking>;
+  /**
+   * Per-tab lock state keyed by `tab.id`. Flattened off the hook's
+   * structured return so existing consumers (`TerminalPage.tsx`,
+   * `TerminalTabBar.tsx`, `SessionManagerPanel.tsx`) can keep their
+   * `fileLockStates[tab.id]` indexing unchanged after the Phase 3 hook
+   * widening.
+   */
+  fileLockStates: Record<string, LockState>;
+  /**
+   * Per-tab incoming yield request queues keyed by holder `tab.id`.
+   * Surfaced separately from {@link fileLockStates} so the legacy
+   * `Record<tabId, LockState>` consumer shape stays binary-compatible.
+   */
+  pendingYieldRequests: Record<string, IncomingYieldRequest[]>;
   sessionPersistence: ReturnType<typeof useSessionPersistence>;
 }
 
@@ -26,12 +43,12 @@ export function ShellInfraProvider({ children }: ShellInfraProviderProps) {
   const { tabs, pageId } = useTerminalCore();
 
   const fileConflicts = useFileConflicts();
-  const fileLockStates = useFileLockTracking(tabs);
+  const { lockStates: fileLockStates, pendingYieldRequests } = useFileLockTracking(tabs);
   const sessionPersistence = useSessionPersistence(pageId);
 
   const value = useMemo<ShellInfraContextValue>(
-    () => ({ fileConflicts, fileLockStates, sessionPersistence }),
-    [fileConflicts, fileLockStates, sessionPersistence],
+    () => ({ fileConflicts, fileLockStates, pendingYieldRequests, sessionPersistence }),
+    [fileConflicts, fileLockStates, pendingYieldRequests, sessionPersistence],
   );
 
   return <ShellInfraContext.Provider value={value}>{children}</ShellInfraContext.Provider>;

--- a/src/components/terminal/useFileLockTracking.test.ts
+++ b/src/components/terminal/useFileLockTracking.test.ts
@@ -36,6 +36,7 @@ import {
   lockStateFromAcquired,
   lockStateFromWaiting,
   lockStateKind,
+  type IncomingYieldRequest,
   type LockState,
 } from "./useFileLockTracking";
 
@@ -127,7 +128,7 @@ describe("lockStateKind", () => {
 // the listener registration, just to populate `mockListen.mock.calls`.
 
 describe("file-lock event handler registration (smoke)", () => {
-  it("registers listeners for waiting, acquired, AND released events", async () => {
+  it("registers listeners for waiting, acquired, released, AND yield-requested events", async () => {
     // Resolve immediately with a no-op unlisten.
     mockListen.mockResolvedValue(() => {});
 
@@ -139,13 +140,19 @@ describe("file-lock event handler registration (smoke)", () => {
     //   listen("file-lock-waiting", ...)
     //   listen("file-lock-acquired", ...)
     //   listen("file-lock-released", ...)
+    //   listen("file-lock-yield-requested", ...) — Phase 3
     // So we re-register here with the same identifiers (mirrors what
     // the hook does on first mount). If a future refactor moves the
     // registration elsewhere, this test will start failing because
-    // the contract — three event types, one listener each — is
+    // the contract — four event types, one listener each — is
     // explicit.
 
-    const events = ["file-lock-waiting", "file-lock-acquired", "file-lock-released"];
+    const events = [
+      "file-lock-waiting",
+      "file-lock-acquired",
+      "file-lock-released",
+      "file-lock-yield-requested",
+    ];
     for (const e of events) {
       const { listen } = await import("@tauri-apps/api/event");
       await listen(e, () => {});
@@ -194,5 +201,198 @@ describe("waiting → released scenario", () => {
     expect(apply(waiting)).toBe(waiting); // unchanged
     expect(apply(idle)).toBe(idle); // unchanged
     expect(apply(undefined)).toBeUndefined();
+  });
+});
+
+// ── Phase 3 — pendingYieldRequests lifecycle ───────────────────────────────
+//
+// Mirrors the hook's setPendingYieldRequests reducer logic for the
+// yield-requested + released paths. The hook's listener:
+//
+//   1. Looks up the holder tab via `findTabByTaskRunId(holder_task_run_id)`.
+//   2. Dedups by `(requesterTaskRunId, filePath)`:
+//        - If a duplicate exists, REPLACE in-place (preserves queue
+//          position; refreshes `requestedAtMs`).
+//        - Otherwise APPEND.
+//   3. On `file-lock-released` for the (holder, filePath) pair,
+//      filters out any entry matching `filePath` from that holder's
+//      list.
+//
+// We replicate the reducer here. If a future refactor moves the
+// dedup-by-key logic, this test catches the drift.
+
+type RequestsByTab = Record<string, IncomingYieldRequest[]>;
+
+function applyYieldRequested(
+  prev: RequestsByTab,
+  tabId: string,
+  incoming: IncomingYieldRequest,
+): RequestsByTab {
+  const existing = prev[tabId] ?? [];
+  const dedupIdx = existing.findIndex(
+    (r) =>
+      r.requesterTaskRunId === incoming.requesterTaskRunId &&
+      r.filePath === incoming.filePath,
+  );
+  let next: IncomingYieldRequest[];
+  if (dedupIdx >= 0) {
+    next = existing.slice();
+    next[dedupIdx] = incoming;
+  } else {
+    next = [...existing, incoming];
+  }
+  return { ...prev, [tabId]: next };
+}
+
+function applyReleasedForTab(
+  prev: RequestsByTab,
+  tabId: string,
+  filePath: string,
+): RequestsByTab {
+  const list = prev[tabId];
+  if (!list || list.length === 0) return prev;
+  const filtered = list.filter((r) => r.filePath !== filePath);
+  if (filtered.length === list.length) return prev;
+  return { ...prev, [tabId]: filtered };
+}
+
+describe("pendingYieldRequests — append + dedup", () => {
+  const reqA: IncomingYieldRequest = {
+    filePath: "src/foo.rs",
+    requesterName: "alpha",
+    requesterTaskRunId: "task-A",
+    requestedAtMs: 1_000,
+  };
+  const reqAagain: IncomingYieldRequest = {
+    ...reqA,
+    requestedAtMs: 2_000, // re-issued — same (requester, filePath), new timestamp
+  };
+  const reqB: IncomingYieldRequest = {
+    filePath: "src/foo.rs",
+    requesterName: "bravo",
+    requesterTaskRunId: "task-B",
+    requestedAtMs: 1_500,
+  };
+  const reqAOtherFile: IncomingYieldRequest = {
+    filePath: "src/bar.rs",
+    requesterName: "alpha",
+    requesterTaskRunId: "task-A",
+    requestedAtMs: 1_500,
+  };
+
+  it("appends a fresh request to an empty list", () => {
+    const next = applyYieldRequested({}, "tab-holder", reqA);
+    expect(next["tab-holder"]).toEqual([reqA]);
+  });
+
+  it("appends a second request with a different requester (no dedup)", () => {
+    const after1 = applyYieldRequested({}, "tab-holder", reqA);
+    const after2 = applyYieldRequested(after1, "tab-holder", reqB);
+    expect(after2["tab-holder"]).toEqual([reqA, reqB]);
+  });
+
+  it("appends a second request with the same requester but different filePath (no dedup)", () => {
+    const after1 = applyYieldRequested({}, "tab-holder", reqA);
+    const after2 = applyYieldRequested(after1, "tab-holder", reqAOtherFile);
+    expect(after2["tab-holder"]).toEqual([reqA, reqAOtherFile]);
+  });
+
+  it("DEDUPES by (requesterTaskRunId, filePath): replace in-place, no length growth", () => {
+    const after1 = applyYieldRequested({}, "tab-holder", reqA);
+    const after2 = applyYieldRequested(after1, "tab-holder", reqAagain);
+    expect(after2["tab-holder"]).toHaveLength(1);
+    // Replaced — refresh requestedAtMs to the new value.
+    expect(after2["tab-holder"][0].requestedAtMs).toBe(2_000);
+    expect(after2["tab-holder"][0].requesterTaskRunId).toBe("task-A");
+    expect(after2["tab-holder"][0].filePath).toBe("src/foo.rs");
+  });
+
+  it("dedup preserves queue order — replacement stays in original slot", () => {
+    const after1 = applyYieldRequested({}, "tab-holder", reqA);
+    const after2 = applyYieldRequested(after1, "tab-holder", reqB);
+    const after3 = applyYieldRequested(after2, "tab-holder", reqAagain);
+    // After the replacement, order is still [A, B] — A's slot keeps
+    // its position; only requestedAtMs changes.
+    expect(after3["tab-holder"]).toHaveLength(2);
+    expect(after3["tab-holder"][0].requesterTaskRunId).toBe("task-A");
+    expect(after3["tab-holder"][0].requestedAtMs).toBe(2_000);
+    expect(after3["tab-holder"][1].requesterTaskRunId).toBe("task-B");
+  });
+
+  it("scopes per holder tab (does not bleed across tabIds)", () => {
+    const after1 = applyYieldRequested({}, "tab-holder-1", reqA);
+    const after2 = applyYieldRequested(after1, "tab-holder-2", reqB);
+    expect(after2["tab-holder-1"]).toEqual([reqA]);
+    expect(after2["tab-holder-2"]).toEqual([reqB]);
+  });
+});
+
+describe("pendingYieldRequests — cleared on file-lock-released", () => {
+  const reqFoo: IncomingYieldRequest = {
+    filePath: "src/foo.rs",
+    requesterName: "alpha",
+    requesterTaskRunId: "task-A",
+    requestedAtMs: 1_000,
+  };
+  const reqBar: IncomingYieldRequest = {
+    filePath: "src/bar.rs",
+    requesterName: "alpha",
+    requesterTaskRunId: "task-A",
+    requestedAtMs: 1_100,
+  };
+
+  it("removes the entry for the released path, keeps others", () => {
+    const start: RequestsByTab = { "tab-holder": [reqFoo, reqBar] };
+    const next = applyReleasedForTab(start, "tab-holder", "src/foo.rs");
+    expect(next["tab-holder"]).toEqual([reqBar]);
+  });
+
+  it("is a no-op when no matching entry exists", () => {
+    const start: RequestsByTab = { "tab-holder": [reqBar] };
+    const next = applyReleasedForTab(start, "tab-holder", "src/foo.rs");
+    // Returns prev unchanged (length didn't shrink).
+    expect(next).toBe(start);
+  });
+
+  it("is a no-op when the tab has no pending requests", () => {
+    const start: RequestsByTab = {};
+    const next = applyReleasedForTab(start, "tab-holder", "src/foo.rs");
+    expect(next).toBe(start);
+  });
+});
+
+// ── Phase 3 — full lifecycle: waiting → requested → released ───────────────
+//
+// Verifies the documented sequence the orchestrator gave:
+//   1. file-lock-waiting fires (waiter blocked).
+//   2. file-lock-yield-requested fires (waiter asks holder to yield).
+//   3. pendingYieldRequests[holder] contains the request.
+//   4. file-lock-released fires.
+//   5. pendingYieldRequests[holder] is empty for that path.
+
+describe("Phase 3 lifecycle: waiting → yield-requested → released", () => {
+  it("end-to-end state transitions for a single contended file", () => {
+    const t0 = 1_700_000_000_000;
+    // 1. Waiting transition (just verify the waiter's state shape;
+    //    pendingYieldRequests is empty at this point).
+    const waiterState = lockStateFromWaiting(
+      { file_path: "src/foo.rs", blocked_by: "holder-tab" },
+      t0,
+    );
+    expect(waiterState.kind).toBe("waiting");
+
+    // 2-3. Yield-requested event arrives; holder's queue gains the entry.
+    let requests: RequestsByTab = {};
+    requests = applyYieldRequested(requests, "tab-holder", {
+      filePath: "src/foo.rs",
+      requesterName: "alpha",
+      requesterTaskRunId: "task-A",
+      requestedAtMs: t0 + 500,
+    });
+    expect(requests["tab-holder"]).toHaveLength(1);
+
+    // 4-5. Release event arrives; queue clears.
+    requests = applyReleasedForTab(requests, "tab-holder", "src/foo.rs");
+    expect(requests["tab-holder"]).toEqual([]);
   });
 });

--- a/src/components/terminal/useFileLockTracking.ts
+++ b/src/components/terminal/useFileLockTracking.ts
@@ -117,6 +117,30 @@ export function lockStateKind(
  */
 export type FileLockState = LockState;
 
+/**
+ * Incoming yield request payload as seen by the holder's tab.
+ *
+ * Emitted by the runner's POST /file-locks/yield-request handler
+ * (`mcp/file_registry.rs::request_yield`) as a Tauri event named
+ * `file-lock-yield-requested`. The event payload uses snake_case keys
+ * (the handler builds the JSON via `serde_json::json!` directly, NOT a
+ * struct with `#[serde(rename_all = "camelCase")]`), so the listener
+ * here destructures `file_path`, `requester_task_run_id`,
+ * `requester_name`, `holder_task_run_id`, and `requested_at`.
+ *
+ * The hook keys these per the HOLDER's tab id (resolved via
+ * {@link findTabByTaskRunId} against `holder_task_run_id`) and dedups
+ * by `(requesterTaskRunId, filePath)` — a duplicate replaces the prior
+ * entry rather than appending so the banner shows a single up-to-date
+ * "asked you to yield" stamp per (requester, file) pair.
+ */
+export type IncomingYieldRequest = {
+  filePath: string;
+  requesterName: string;
+  requesterTaskRunId: string;
+  requestedAtMs: number;
+};
+
 interface FileLockEvent {
   type: string;
   file_path: string;
@@ -148,8 +172,54 @@ interface FileLockInfoEntry {
   acquired_at: number;
 }
 
-export function useFileLockTracking(tabs: TerminalTab[]): Record<string, LockState> {
+/**
+ * `file-lock-yield-requested` Tauri event payload.
+ *
+ * Wire-format keys are snake_case (Rust handler emits via
+ * `serde_json::json!` literal — see `mcp/file_registry.rs::request_yield`).
+ */
+interface FileLockYieldRequestedEvent {
+  type: string;
+  file_path: string;
+  requester_task_run_id: string;
+  requester_name: string;
+  holder_task_run_id: string;
+  requested_at: number;
+}
+
+/**
+ * Return shape of {@link useFileLockTracking}.
+ *
+ * Phase 3 widened the hook from a bare `Record<string, LockState>` to
+ * an object so callers can pull `pendingYieldRequests` (per-holder-tab
+ * incoming yield request queues) without a second hook + a duplicate
+ * `tabs` ref. Existing consumers destructure `{ lockStates }` for the
+ * old slot.
+ */
+export interface FileLockTracking {
+  lockStates: Record<string, LockState>;
+  /**
+   * Map of holder-tab id → list of incoming yield requests targeting
+   * that tab. Keys correspond to `tab.id`; the request is routed to
+   * the tab whose `tab.claudeSessionId === payload.holder_task_run_id`.
+   *
+   * Cleared on `file-lock-released` for the matching
+   * `(holder_task_run_id, file_path)` pair — once the holder lets go,
+   * any pending "please yield" request for that path is moot.
+   *
+   * Dedup invariant: within a tab's list, at most one entry exists per
+   * `(requesterTaskRunId, filePath)` tuple. A subsequent
+   * yield-requested event for the same pair replaces the prior entry
+   * (refreshing `requestedAtMs`) rather than appending a duplicate.
+   */
+  pendingYieldRequests: Record<string, IncomingYieldRequest[]>;
+}
+
+export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
   const [lockStates, setLockStates] = useState<Record<string, LockState>>({});
+  const [pendingYieldRequests, setPendingYieldRequests] = useState<
+    Record<string, IncomingYieldRequest[]>
+  >({});
   const tabsRef = useRef(tabs);
   useEffect(() => {
     tabsRef.current = tabs;
@@ -191,6 +261,41 @@ export function useFileLockTracking(tabs: TerminalTab[]): Record<string, LockSta
     let unlistenWaiting: (() => void) | null = null;
     let unlistenAcquired: (() => void) | null = null;
     let unlistenReleased: (() => void) | null = null;
+    let unlistenYieldRequested: (() => void) | null = null;
+
+    /**
+     * Refresh `waiterCount` on every holding tab from the current
+     * `waitingHolders.current` map. Used by all three event listeners
+     * (waiting/acquired/released) so the per-holder waiter count tracks
+     * waiter arrivals/departures live — without this, holding tabs only
+     * pick up new waiter counts on the next 10s `/file-locks/info` poll
+     * tick, which is too slow for the Phase 2 yield banner UX (the
+     * banner needs to appear within one notify cycle of the waiter
+     * arriving).
+     *
+     * Pure-functional: takes a `Record<tabId, LockState>` snapshot and
+     * returns a new snapshot with refreshed `waiterCount` on holding
+     * entries. Idle/waiting entries pass through unchanged. Bails out
+     * early if no `waiterCount` actually changed so React's strict
+     * equality check skips the re-render.
+     */
+    const refreshWaiterCounts = (
+      prev: Record<string, LockState>,
+    ): Record<string, LockState> => {
+      const counts = deriveWaiterCounts(waitingHolders.current.values());
+      let dirty = false;
+      const next: Record<string, LockState> = { ...prev };
+      for (const tab of tabsRef.current) {
+        const state = prev[tab.id];
+        if (!state || state.kind !== "holding") continue;
+        const fresh = counts.get(tab.title) ?? 0;
+        if ((state.waiterCount ?? 0) !== fresh) {
+          next[tab.id] = { ...state, waiterCount: fresh };
+          dirty = true;
+        }
+      }
+      return dirty ? next : prev;
+    };
 
     listen<FileLockEvent>("file-lock-waiting", (event) => {
       // `holder_name` here is the WAITER. `blocked_by` is the holder.
@@ -202,27 +307,38 @@ export function useFileLockTracking(tabs: TerminalTab[]): Record<string, LockSta
         sinceMs: nowMs,
       });
       const tabId = findTabByHolderName(holder_name);
-      if (tabId) {
-        const patch = lockStateFromWaiting(
-          { file_path, blocked_by: blocked_by ?? null },
-          nowMs,
-        );
-        setLockStates((prev) => ({ ...prev, [tabId]: patch }));
-      }
+      setLockStates((prev) => {
+        // Apply the waiter's own state transition (if any) first, then
+        // refresh all holding-tab waiter counts using the new map.
+        let base = prev;
+        if (tabId) {
+          const patch = lockStateFromWaiting(
+            { file_path, blocked_by: blocked_by ?? null },
+            nowMs,
+          );
+          base = { ...prev, [tabId]: patch };
+        }
+        return refreshWaiterCounts(base);
+      });
     }).then((fn) => {
       unlistenWaiting = fn;
     });
 
     listen<FileLockEvent>("file-lock-acquired", (event) => {
       // The waiter just unblocked; transition to holding. The poll loop
-      // will backfill `waiterCount` shortly.
+      // also backfills `waiterCount` every 10s, but we refresh here too
+      // so the prior holder's count drops immediately.
       const { holder_name, file_path } = event.payload;
       waitingHolders.current.delete(holder_name);
       const tabId = findTabByHolderName(holder_name);
-      if (tabId) {
-        const patch = lockStateFromAcquired({ file_path }, Date.now());
-        setLockStates((prev) => ({ ...prev, [tabId]: patch }));
-      }
+      setLockStates((prev) => {
+        let base = prev;
+        if (tabId) {
+          const patch = lockStateFromAcquired({ file_path }, Date.now());
+          base = { ...prev, [tabId]: patch };
+        }
+        return refreshWaiterCounts(base);
+      });
     }).then((fn) => {
       unlistenAcquired = fn;
     });
@@ -231,30 +347,98 @@ export function useFileLockTracking(tabs: TerminalTab[]): Record<string, LockSta
     // when a holder releases a lock — payload mirrors the other
     // file-lock events.
     listen<FileLockEvent>("file-lock-released", (event) => {
-      const { holder_name, task_run_id } = event.payload;
+      const { holder_name, task_run_id, file_path } = event.payload;
       // Try matching by holder_name first (tab title), fall back to
       // task_run_id (claudeSessionId) so SDK-style tabs still clear.
       const tabId =
         findTabByHolderName(holder_name) ?? findTabByTaskRunId(task_run_id);
-      if (tabId) {
-        setLockStates((prev) => {
+      setLockStates((prev) => {
+        let base = prev;
+        if (tabId) {
           // Only flip to idle if we still believe the tab held this
           // path — avoids stomping a state set by a later event.
           const current = prev[tabId];
           if (current && current.kind === "holding") {
-            return { ...prev, [tabId]: { kind: "idle" } };
+            base = { ...prev, [tabId]: { kind: "idle" } };
           }
-          return prev;
+        }
+        // The released event may unblock a waiter elsewhere on the same
+        // file; their `file-lock-acquired` will arrive next and prune
+        // its `waitingHolders` entry, but for the in-between moment the
+        // remaining holders' counts may have dropped. Refresh now so
+        // the banner clears promptly even if the acquired event is
+        // delayed.
+        return refreshWaiterCounts(base);
+      });
+
+      // Phase 3 — clear any pending yield request targeting THIS holder
+      // for THIS file path. Once the holder has released, the request is
+      // moot; if a new holder picks the lock back up, the original
+      // requester needs to re-issue (the request was directed at the
+      // prior holder's task_run_id, not "whoever holds it").
+      if (tabId) {
+        setPendingYieldRequests((prev) => {
+          const list = prev[tabId];
+          if (!list || list.length === 0) return prev;
+          const filtered = list.filter((r) => r.filePath !== file_path);
+          if (filtered.length === list.length) return prev;
+          return { ...prev, [tabId]: filtered };
         });
       }
     }).then((fn) => {
       unlistenReleased = fn;
     });
 
+    // Phase 3 — wait-side yield-request listener. Routes the incoming
+    // request to the HOLDER's tab (lookup by `holder_task_run_id` →
+    // `tab.claudeSessionId` via {@link findTabByTaskRunId}). Dedups by
+    // `(requesterTaskRunId, filePath)` — a duplicate replaces the prior
+    // entry rather than appending so we don't compound the banner
+    // counter on retries.
+    listen<FileLockYieldRequestedEvent>("file-lock-yield-requested", (event) => {
+      const {
+        file_path,
+        requester_task_run_id,
+        requester_name,
+        holder_task_run_id,
+        requested_at,
+      } = event.payload;
+      const tabId = findTabByTaskRunId(holder_task_run_id);
+      if (!tabId) return; // Holder tab isn't in this window; ignore.
+      const incoming: IncomingYieldRequest = {
+        filePath: file_path,
+        requesterName: requester_name,
+        requesterTaskRunId: requester_task_run_id,
+        requestedAtMs: requested_at,
+      };
+      setPendingYieldRequests((prev) => {
+        const existing = prev[tabId] ?? [];
+        const dedupIdx = existing.findIndex(
+          (r) =>
+            r.requesterTaskRunId === requester_task_run_id &&
+            r.filePath === file_path,
+        );
+        let next: IncomingYieldRequest[];
+        if (dedupIdx >= 0) {
+          // Replace in-place so request ordering is preserved (the
+          // banner shows the oldest first; a re-issued request shouldn't
+          // jump the queue past unrelated requests).
+          next = existing.slice();
+          next[dedupIdx] = incoming;
+        } else {
+          next = [...existing, incoming];
+        }
+        return { ...prev, [tabId]: next };
+      });
+    }).then((fn) => {
+      unlistenYieldRequested = fn;
+    });
+
     return () => {
       unlistenWaiting?.();
       unlistenAcquired?.();
       unlistenReleased?.();
+      unlistenYieldRequested?.();
     };
   }, []);
 
@@ -355,5 +539,5 @@ export function useFileLockTracking(tabs: TerminalTab[]): Record<string, LockSta
     };
   }, []);
 
-  return lockStates;
+  return { lockStates, pendingYieldRequests };
 }


### PR DESCRIPTION
## Summary
Adds an in-band yield path for AI-session file-lock contention. Today, when Session A's `Edit` blocks on Session B's exclusive lock, B holds the lock until session end — there's no way to resolve without terminating one side. This PR ships the user-driven yield protocol from `feedback_worktrees_vs_pauses.md`'s primary-mechanism list, pairing with the already-shipped `file-ownership-heatmap` (#81).

- **Backend**: `POST /file-locks/yield` (idempotent single-file release) + `POST /file-locks/yield-request` (broadcast to holder). Emission mirrors the existing `file-lock-released` shape used by `session.rs`, `ai_session.rs`, `graphql/mutation.rs`, `task_runs.rs`.
- **Frontend banners**: `HoldingLockBanner` (above active tab when holding with waiterCount > 0 or pending requests) and `WaitingLockBanner` (when blocked, with 30s cooldown on requests).
- **Heatmap pairing**: `FileActivityPanel`'s live-snapshot rows gain a per-file "Request yield" button gated on a client-side `/file-registry/info` × `/file-locks/info` join. Uses synthetic `coordinator-dashboard` requester identity for the global view.
- `terminal/FileOwnershipHeatmap.tsx` left read-only (resolved Open Q7).
- `useFileLockTracking` extended: per-tab `pendingYieldRequests` map, dedupe by `(requesterTaskRunId, filePath)`, cleared on `file-lock-released`. `waiterCount` now recomputes on every relevant event (was 10s-poll only), so banners surface within one notify cycle.

**Plan**: archived at `qontinui-dev-notes/plans/2026-05-12-lock-yield-protocol-plan.md` (DRAFT → VETTED → IN PROGRESS → SHIPPED).

## Test plan
- [x] Rust: `cargo check`, `cargo clippy --tests -- -D warnings`, `cargo test file_registry` — 50/0 pass (6 new tests: `yield_lock_non_owner_does_not_release`, `yield_lock_owner_releases_and_unblocks_waiter`, `yield_lock_no_lock_present_is_noop`, `request_yield_valid_payload_broadcasts_event`, `request_yield_empty_file_path_still_broadcasts`, `yield_round_trip_happy_path`).
- [x] TS: `npx tsc --noEmit` clean, `npm run test` — same 3 pre-existing failures as main (unrelated `@qontinui/shared-types` / spec-discovery), no new regressions. ~67 new vitest tests across `HoldingLockBanner` (39 incl. extensions), `WaitingLockBanner` (17), `useFileLockTracking` (11 new), `FileActivityPanel` (15 new).
- [x] ESLint clean on all touched files.
- [x] Manual UI Bridge smoke on temp runner port 9880 (fresh `cargo build` via supervisor): backend endpoints round-trip (`/file-locks/yield`, `/file-locks/yield-request`, `/file-locks/info` sanity), Tauri event emit/listen pipeline verified, `FileActivityPanel` renders with empty-state, IPC bind intact, no panics in logs. Live banner-render path requires an AI session (see `proj_holding_banner_pty_gate.md`) — covered by vitest.
- [ ] Two-AI-session live yield rehearsal — natural follow-up once two real Claude sessions run on a build with this branch merged.

## Open questions resolved during plan
- **Q5 (Phase 4 requester identity)**: synthetic `coordinator-dashboard` identity for dashboard-initiated requests.
- **Q7 (sibling heatmap surface)**: `terminal/FileOwnershipHeatmap.tsx` stays read-only — its row data model is touched-file history, not current holders, so a yield row-action would need a separate live-locks fusion. Re-evaluate if usage shows the gap matters.
- **Q6 (`signal-long-wait`)**: deferred to the stuck-session heartbeat plan; banner button stays disabled with a pointer-tooltip.

## Defer-list
- Auto-yield on timeout (settings-gated, opt-in) — revisit once telemetry shows manual yield rate.
- Lock-borrowing (B keeps a re-acquire claim) — out of scope; release is final.
- Worktree-aware yield — meaningful only if worktrees become routine.