### PR TITLE
fix(coordinator): sweep stale assignments on scheduler startup

### DIFF
--- a/src-tauri/src/coordinator/scheduler.rs
+++ b/src-tauri/src/coordinator/scheduler.rs
@@ -151,6 +151,14 @@ pub fn start_coordinator_scheduler(
         // flips back to us the metric counter increments.
         let mut held_lease_last_tick = false;
 
+        // Per-process stale-assignment sweep: tasks that were `assigned` to
+        // a worker session in a prior runner lifetime point at session ids
+        // that no longer exist; without a sweep, Rule B's "assign ready task"
+        // never fires and the queue stalls forever. Run once after the first
+        // successful lease takeover so the sweep runs from the lease holder
+        // (avoids a race where two sibling instances both try to reset).
+        let mut sweep_done = false;
+
         loop {
             tick.tick().await;
             iteration = iteration.wrapping_add(1);
@@ -199,6 +207,32 @@ pub fn start_coordinator_scheduler(
                         );
                     }
                     held_lease_last_tick = true;
+                    // First-lease-takeover stale-assignment sweep. Idempotent —
+                    // a fresh runner has no live sessions, so every
+                    // `assigned`/`needs_fix` row is eligible; subsequent
+                    // bounces of the lease within the same process find no
+                    // matches (sweep_done gates this anyway).
+                    if !sweep_done {
+                        sweep_done = true;
+                        match crate::mcp::coordinator::sweep_stale_assignments(&state, false).await
+                        {
+                            Ok(resp) => {
+                                if !resp.reset.is_empty() || !resp.skipped.is_empty() {
+                                    info!(
+                                        "Coordinator scheduler: startup stale-assignment sweep — reset={} skipped={}",
+                                        resp.reset.len(),
+                                        resp.skipped.len()
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "Coordinator scheduler: startup stale-assignment sweep failed: {} (proceeding; assignment may stall until next manual reset)",
+                                    e
+                                );
+                            }
+                        }
+                    }
                 }
                 Ok(false) => {
                     held_lease_last_tick = false;

--- a/src-tauri/src/mcp/coordinator.rs
+++ b/src-tauri/src/mcp/coordinator.rs
@@ -554,13 +554,16 @@ pub struct ResetStaleTasksResponse {
 /// `coord.tasks.assigned_session_id` and prevent the next coordinator
 /// iteration from picking the task back up.
 ///
+/// Reusable across the HTTP handler and the scheduler's startup sweep
+/// (`coordinator::scheduler::start_coordinator_scheduler`); both share the
+/// same classification + flip logic so behaviour stays consistent.
+///
 /// Idempotent: a second concurrent call will see the task already in
 /// `ready` and skip it with reason `status not assigned/needs_fix`.
-async fn reset_stale_tasks(
-    State(state): State<Arc<ApiState>>,
-    Query(query): Query<ResetStaleTasksQuery>,
-) -> Result<Json<ResetStaleTasksResponse>, (StatusCode, String)> {
-    let dry_run = query.dry_run;
+pub(crate) async fn sweep_stale_assignments(
+    state: &Arc<ApiState>,
+    dry_run: bool,
+) -> Result<ResetStaleTasksResponse, String> {
     let app = state.app_state.clone();
 
     // 1. Pull every non-terminal task — same source the dashboard uses.
@@ -568,12 +571,7 @@ async fn reset_stale_tasks(
         .pg_db
         .list_tasks_by_status(NON_TERMINAL_STATUSES)
         .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("list_tasks_by_status: {}", e),
-            )
-        })?;
+        .map_err(|e| format!("list_tasks_by_status: {}", e))?;
 
     // 2. Resolve the live session set. If SessionManager isn't registered
     //    (test harness, or runner shutting down), treat the live set as
@@ -690,11 +688,23 @@ async fn reset_stale_tasks(
         );
     }
 
-    Ok(Json(ResetStaleTasksResponse {
+    Ok(ResetStaleTasksResponse {
         reset: reset_ids,
         skipped,
         dry_run,
-    }))
+    })
+}
+
+/// Thin HTTP wrapper around [`sweep_stale_assignments`]. Mounts at
+/// `POST /coordinator/tasks/reset-stale`; query string supports `dry_run`.
+async fn reset_stale_tasks(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<ResetStaleTasksQuery>,
+) -> Result<Json<ResetStaleTasksResponse>, (StatusCode, String)> {
+    sweep_stale_assignments(&state, query.dry_run)
+        .await
+        .map(Json)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Rust scheduler now runs a one-time stale-assignment sweep on first lease takeover
- Extracts `reset_stale_tasks`'s body into a reusable `sweep_stale_assignments(state, dry_run)` so the HTTP handler and scheduler share one code path
- Same classification as the existing `POST /coordinator/tasks/reset-stale`: any task with status `assigned`/`needs_fix` whose `assigned_session_id` is not in the live `SessionManager` set gets flipped back to `ready`

## Why
Tasks left in `assigned` from a prior runner lifetime point at session ids that no longer exist. Rule B's "assign ready task" doesn't pick them up because they're not `status=ready`, so the queue stalls forever until someone manually fires the HTTP endpoint.

Discovered during the productivity-stack-followups §6 closeout test on the laptop — the coordinator was alive but `recentDecisions` stayed empty across multiple sweeps because every visible task was zombie-assigned.

## Test plan
- [x] `cargo check --bin qontinui-runner --features custom-protocol` — clean (10m 06s)
- [ ] Spawn a test runner with pre-decomposed plan fixtures; verify the startup sweep flips zombie-assigned tasks back to ready (visible via `GET /coordinator/state` `recentDecisions`)
- [ ] Verify idempotence: subsequent lease bounces within the same scheduler process do NOT re-sweep (gated on `sweep_done`)

Session-Id: e2e-pol2-laptop-2026-05-12