### PR TITLE
test: RAII cleanup + poison recovery for three env-var-mutating modules

### DIFF
--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -270,17 +270,32 @@ mod tests {
         assert_eq!(dev.auth.as_ref().unwrap().kind, "static-dev-token");
     }
 
+    /// RAII guard that restores `RUNNER_DATABASE_URL` to its pre-test
+    /// value on drop, including the panic path. Without this, a panic
+    /// in the test body between `remove_var` and the manual restore
+    /// would leak the unset state to any sibling test (current or
+    /// future) that reads the var.
+    struct DbUrlRestore {
+        prev: Option<String>,
+    }
+    impl Drop for DbUrlRestore {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("RUNNER_DATABASE_URL", v),
+                None => std::env::remove_var("RUNNER_DATABASE_URL"),
+            }
+        }
+    }
+
     #[test]
     fn legacy_fallback_uses_env_or_localhost_default() {
-        // SAFETY of env mutation in tests: we read-and-restore. Single-thread
-        // test runs avoid cross-test interference.
-        let prior = std::env::var("RUNNER_DATABASE_URL").ok();
+        let _restore = DbUrlRestore {
+            prev: std::env::var("RUNNER_DATABASE_URL").ok(),
+        };
         std::env::remove_var("RUNNER_DATABASE_URL");
         let p = legacy_env_fallback();
         assert_eq!(p.source, "legacy-env");
         assert!(p.database_url.contains("qontinui_user"));
-        if let Some(prev) = prior {
-            std::env::set_var("RUNNER_DATABASE_URL", prev);
-        }
+        // `_restore` drops here, including the panic path above.
     }
 }

--- a/src-tauri/src/scheduler_service.rs
+++ b/src-tauri/src/scheduler_service.rs
@@ -2323,8 +2323,24 @@ mod tests {
     // ========================================================================
 
     /// Serialize env-mutating tests. `Mutex<()>` is fine — we only need
-    /// mutual exclusion, not data sharing.
+    /// mutual exclusion, not data sharing. `unwrap_or_else(into_inner)`
+    /// recovers from poison so a panicking test doesn't cascade-fail the
+    /// rest of the module.
     static REMOTE_AGENT_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard: removes `QONTINUI_PORT` on drop, including the panic
+    /// path. Without this, each test would leak its mock's (now-closed)
+    /// random port into the process env, and any later test in this
+    /// binary that reads `QONTINUI_PORT` (via `launch_env::RunnerLaunchEnv::read`,
+    /// `mcp::types::get_mcp_api_port`, etc.) would see a dead port. The
+    /// `REMOTE_AGENT_TEST_LOCK` above gives intra-test serialization;
+    /// this guard gives inter-test cleanup.
+    struct QontinuiPortGuard;
+    impl Drop for QontinuiPortGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("QONTINUI_PORT");
+        }
+    }
 
     /// Spin up a tiny axum mock on a random localhost port that captures
     /// the most recent `/prompts/run` body and replies with `response`.
@@ -2383,7 +2399,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_launch_remote_agent_posts_full_body_when_all_fields_set() {
-        let _guard = REMOTE_AGENT_TEST_LOCK.lock().unwrap();
+        let _lock = REMOTE_AGENT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _env = QontinuiPortGuard;
 
         let (port, captured) = spawn_prompts_run_mock(ok_response(serde_json::json!({
             "session_id": "sid-123"
@@ -2426,7 +2445,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_launch_remote_agent_omits_optional_fields_when_none() {
-        let _guard = REMOTE_AGENT_TEST_LOCK.lock().unwrap();
+        let _lock = REMOTE_AGENT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _env = QontinuiPortGuard;
 
         let (port, captured) = spawn_prompts_run_mock(ok_response(serde_json::json!({
             "session_id": "sid-456"
@@ -2458,7 +2480,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_launch_remote_agent_extracts_session_id_from_data_envelope() {
-        let _guard = REMOTE_AGENT_TEST_LOCK.lock().unwrap();
+        let _lock = REMOTE_AGENT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _env = QontinuiPortGuard;
 
         // /prompts/run wraps successful responses in
         // `{ "success": true, "data": { ... } }`.
@@ -2479,7 +2504,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_launch_remote_agent_500_returns_err() {
-        let _guard = REMOTE_AGENT_TEST_LOCK.lock().unwrap();
+        let _lock = REMOTE_AGENT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _env = QontinuiPortGuard;
 
         let err_resp = axum::response::Response::builder()
             .status(500)
@@ -2506,7 +2534,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_launch_remote_agent_missing_session_id_returns_err() {
-        let _guard = REMOTE_AGENT_TEST_LOCK.lock().unwrap();
+        let _lock = REMOTE_AGENT_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let _env = QontinuiPortGuard;
 
         // 200 OK but no session_id anywhere.
         let (port, _captured) = spawn_prompts_run_mock(ok_response(serde_json::json!({

--- a/src-tauri/src/verification/mode.rs
+++ b/src-tauri/src/verification/mode.rs
@@ -172,18 +172,35 @@ mod tests {
     /// race if run in parallel. Serialize through this mutex.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn with_env<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+    /// RAII guard that restores `key` to its pre-test value on drop,
+    /// including the panic path. Without this, a panic inside `f()` would
+    /// leave the env var pointing at the test's mutated value, leaking
+    /// state to any sibling test that reads the same key.
+    struct EnvRestore {
+        key: &'static str,
+        prev: Option<String>,
+    }
+    impl Drop for EnvRestore {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => env::set_var(self.key, v),
+                None => env::remove_var(self.key),
+            }
+        }
+    }
+
+    fn with_env<F: FnOnce()>(key: &'static str, value: Option<&str>, f: F) {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev = env::var(key).ok();
+        let _restore = EnvRestore {
+            key,
+            prev: env::var(key).ok(),
+        };
         match value {
             Some(v) => env::set_var(key, v),
             None => env::remove_var(key),
         }
         f();
-        match prev {
-            Some(v) => env::set_var(key, v),
-            None => env::remove_var(key),
-        }
+        // `_restore` drops here — runs whether or not `f()` panicked.
     }
 
     #[test]


### PR DESCRIPTION
Follow-up audit after PR #82 (timeout_config.rs flake fix). Found one real leak and two panic-safety holes across six env-mutating modules. All three follow the same pattern shipped in #82.

## scheduler_service.rs — real bug

The five `test_launch_remote_agent_*` tests each `set_var("QONTINUI_PORT", port.to_string())` for a random port bound via `tokio::net::TcpListener::bind("127.0.0.1:0")`. **None of them unset the var.** After the suite runs, `QONTINUI_PORT` is left pointing at a now-closed port from whichever test ran last. Any later test in the same binary that reads `QONTINUI_PORT` (`launch_env.rs::RunnerLaunchEnv::read`, `mcp/types.rs::get_mcp_api_port`, `orchestration_loop/loop_engine.rs`) would see a dead port. The `REMOTE_AGENT_TEST_LOCK` mutex prevented *inter-scheduler-test* races but didn't help with the cleanup.

**Fix:** `QontinuiPortGuard` RAII guard removes `QONTINUI_PORT` on drop (including panic path), and the five `.lock().unwrap()` calls switch to `.lock().unwrap_or_else(|e| e.into_inner())` so a panic in one test doesn't cascade-fail the rest.

## verification/mode.rs — panic-safety hole

`with_env` saves the prior value, sets the new one, runs `f()`, restores. **If `f()` panics the restore lines never run** and the env var leaks to subsequent tests. The `ENV_LOCK` mutex correctly recovers from poison, but state leakage is independent.

**Fix:** Replace the manual restore with an `EnvRestore` RAII struct whose `Drop` impl runs whether or not the closure panics. Key parameter narrowed from `&str` to `&'static str` since every call site already passes a `&'static` constant.

## profiles.rs — panic-safety hole

`legacy_fallback_uses_env_or_localhost_default` reads-and-restores `RUNNER_DATABASE_URL`. The comment claimed *"Single-thread test runs avoid cross-test interference"* but cargo defaults to parallel. A panic between `remove_var` and the manual restore leaks the unset state.

**Fix:** `DbUrlRestore` RAII guard matching the pattern in the other two modules.

## Modules NOT touched (audit findings)

- `api_config.rs` — single test, no sibling readers; safe as-is.
- `commands/dev_findings.rs` — bundled-into-one-test pattern with documented prior CI race; safe.
- `spec_api/tests.rs` — already uses `scopeguard::guard` for RAII cleanup; safe.
- `startup_panic.rs` — already has the full pattern (`ENV_LOCK`, `EnvGuard`, poison recovery); gold-standard, predates and matches #82.
- `timeout_config.rs` — fixed in #82.

## Test plan
- [x] `cargo test --bin qontinui-runner --features custom-protocol test_launch_remote_agent` → 5 passed
- [x] `cargo test --bin qontinui-runner --features custom-protocol verification::mode::tests` → 8 passed
- [x] `cargo test --lib profiles::tests::legacy_fallback` → 1 passed
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] CI green across the three OS jobs