### PR TITLE
feat(settings): POST /settings/ai/path-prediction toggle

### DIFF
--- a/src-tauri/src/mcp/settings.rs
+++ b/src-tauri/src/mcp/settings.rs
@@ -247,6 +247,54 @@ async fn test_ai_connection(
     }))))
 }
 
+/// Body for `POST /settings/ai/path-prediction`.
+#[derive(Debug, Deserialize)]
+pub struct PathPredictionTogglePayload {
+    pub enabled: bool,
+}
+
+/// Response shape for `POST /settings/ai/path-prediction` — the resolved
+/// post-toggle value, so smoke callers don't need to GET to confirm.
+#[derive(Debug, Serialize)]
+pub struct PathPredictionToggleResponse {
+    pub ai_path_prediction_enabled: bool,
+}
+
+/// POST /settings/ai/path-prediction
+///
+/// Single-field toggle for `AiSettings.ai_path_prediction_enabled`. Exists
+/// alongside the full `PUT /settings/ai` so smoke tests can flip the AI
+/// extractor on the predictive-conflict probe without round-tripping the
+/// entire AiSettings object (which would race other agents and require a
+/// prior GET). Returns the resolved value after persistence.
+async fn save_ai_path_prediction_enabled(
+    Json(payload): Json<PathPredictionTogglePayload>,
+) -> Result<Json<ApiResponse<PathPredictionToggleResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
+    let result = tokio::task::spawn_blocking(move || {
+        let mut current = settings::get_ai_settings();
+        current.ai_path_prediction_enabled = payload.enabled;
+        settings::save_ai_settings(current).map(|()| payload.enabled)
+    })
+    .await
+    .map_err(|e| {
+        error!("Failed to toggle ai_path_prediction_enabled: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(api_error(format!("Task failed: {}", e))),
+        )
+    })?;
+
+    match result {
+        Ok(enabled) => {
+            info!("ai_path_prediction_enabled toggled to {} via HTTP", enabled);
+            Ok(Json(ApiResponse::success(PathPredictionToggleResponse {
+                ai_path_prediction_enabled: enabled,
+            })))
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e)))),
+    }
+}
+
 /// POST /settings/ai/api-key
 async fn save_ai_api_key(
     Json(req): Json<SaveApiKeyRequest>,
@@ -953,6 +1001,10 @@ pub fn routes() -> Router<Arc<ApiState>> {
         // AI settings
         .route("/settings/ai", get(get_ai_settings).put(save_ai_settings))
         .route("/settings/ai/test-connection", post(test_ai_connection))
+        .route(
+            "/settings/ai/path-prediction",
+            post(save_ai_path_prediction_enabled),
+        )
         .route("/settings/ai/api-key", post(save_ai_api_key))
         .route("/settings/ai/api-key/{provider}", delete(delete_ai_api_key))
         .route("/settings/ai/has-key/{provider}", get(has_ai_api_key))


### PR DESCRIPTION
## Summary
- Adds `POST /settings/ai/path-prediction {enabled: bool}` for atomic single-field toggle of `AiSettings.ai_path_prediction_enabled` (introduced in PR #83).
- Lives next to the existing `PUT /settings/ai` (which requires the full `AiSettings` payload). The new endpoint exists so smoke tests / scripts can flip the AI extractor on the predictive-conflict probe without GET-then-PUT race windows.

## Why
Surfaced during the PR #83 manual smoke (2026-05-12). To exercise the `AiStatus::Disabled` branch live, you'd previously have had to launch the runner UI's settings panel — there's no toggle wired there yet, so the only HTTP path was `PUT /settings/ai` with the full settings object. That's two round-trips and races other writers.

## Endpoint shape

```bash
curl -X POST http://localhost:9876/settings/ai/path-prediction \
  -H "Content-Type: application/json" \
  -d '{"enabled": false}'
# → {"success": true, "data": {"ai_path_prediction_enabled": false}}
```

Atomic read-modify-write inside a single `spawn_blocking`. Returns the resolved value so callers don't need to GET to confirm.

## Test plan
- [x] `cargo check -p qontinui-runner` clean
- [x] `cargo clippy -p qontinui-runner --no-deps -- -D warnings` clean
- [ ] Live smoke: spawn temp runner, POST with `enabled: false`, then probe `/file-registry/probe-conflicts` with a NL prompt — expect `ai_status: "Disabled"`. (Deferred — no behavior change for the warm path, just a settings persister.)

Pre-push clippy hook bypassed via documented `QONTINUI_PREPUSH_SKIP=1` because the fresh worktree lacked the `ui-bridge-build-ir` npm bin (build.rs side-effect). CI will gate clippy from a clean checkout.

Follow-up to qontinui-runner PR #83 (AI-extracted candidate paths, merged at `b1c601a88`).