### PR TITLE
test(path-extraction): route via OneshotLlm + add live-AI CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,13 +223,22 @@ jobs:
 
       - name: Live AI extractor smoke
         # Single live API call per PR — Haiku 4.5, ~$0.001 each. Ubuntu-only so the
-        # 3-platform matrix doesn't 3x the cost for no extra signal. continue-on-error:
-        # true because Haiku output is non-deterministic; we want the signal without
-        # flake-blocking PRs.
-        if: ${{ secrets.ANTHROPIC_API_KEY != '' && matrix.platform == 'ubuntu-22.04' }}
+        # 3-platform matrix doesn't 3x the cost for no extra signal. continue-on-error
+        # is true because Haiku output is non-deterministic; we want the signal
+        # without flake-blocking PRs.
+        #
+        # The secret presence check runs INSIDE the shell, not in `if:` — the
+        # `secrets` context is not available to step-level `if:` (only job-level
+        # `if:` and step `env:`/`run:`/`with:`). Setting an empty env var is
+        # safe; we early-exit before invoking cargo.
+        if: matrix.platform == 'ubuntu-22.04'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY secret not set — skipping live AI smoke test."
+            exit 0
+          fi
           cd src-tauri
           cargo test --bin qontinui-runner -- --ignored --exact \
             util::path_extraction::tests::test_extract_paths_via_ai_real_call

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,20 @@ jobs:
           cargo test --verbose
         shell: bash
 
+      - name: Live AI extractor smoke
+        # Single live API call per PR — Haiku 4.5, ~$0.001 each. Ubuntu-only so the
+        # 3-platform matrix doesn't 3x the cost for no extra signal. continue-on-error:
+        # true because Haiku output is non-deterministic; we want the signal without
+        # flake-blocking PRs.
+        if: ${{ secrets.ANTHROPIC_API_KEY != '' && matrix.platform == 'ubuntu-22.04' }}
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          cd src-tauri
+          cargo test --bin qontinui-runner -- --ignored --exact \
+            util::path_extraction::tests::test_extract_paths_via_ai_real_call
+        continue-on-error: true
+
       - name: Build Tauri app (development)
         # @tauri-apps/cli 2.11 changes that affect this step:
         #   1. Args after `--` are forwarded straight to `cargo build`, which

--- a/src-tauri/src/ai_provider/claude_api_warm.rs
+++ b/src-tauri/src/ai_provider/claude_api_warm.rs
@@ -74,9 +74,11 @@ impl WarmCredential {
 /// 1. Explicit API key via `ai_keychain().get("claude_api")`. Preferred when
 ///    present so production runners with a deliberately provisioned key bill
 ///    that key rather than silently falling through to the user's OAuth quota.
-/// 2. OAuth access token from the Claude CLI's `.credentials.json`, skipped
+/// 2. `$ANTHROPIC_API_KEY` env-var fallback. Useful for CI lanes and local dev
+///    where neither the OS keychain nor a Claude CLI OAuth file is set up.
+/// 3. OAuth access token from the Claude CLI's `.credentials.json`, skipped
 ///    if `expiresAt` is already in the past.
-/// 3. `None` — the warm provider is unavailable; the `auto` path should fall
+/// 4. `None` — the warm provider is unavailable; the `auto` path should fall
 ///    through to `Disabled`.
 pub(super) fn resolve_warm_credential() -> Option<WarmCredential> {
     // 1. Keychain API key wins when present.
@@ -96,7 +98,18 @@ pub(super) fn resolve_warm_credential() -> Option<WarmCredential> {
         }
     }
 
-    // 2. OAuth fallback via the Claude CLI credentials file.
+    // 2. ANTHROPIC_API_KEY env-var fallback. Useful for CI lanes and local dev
+    //    where neither the OS keychain nor a Claude CLI OAuth file is set up.
+    //    Keychain wins when both are present so production runners with a
+    //    deliberately provisioned key bill that key rather than the env var.
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        if !key.trim().is_empty() {
+            debug!("Warm credential: resolved from $ANTHROPIC_API_KEY env var");
+            return Some(WarmCredential::ApiKey(key));
+        }
+    }
+
+    // 3. OAuth fallback via the Claude CLI credentials file.
     let creds_path = crate::commands::ai_settings::find_claude_credentials_path()?;
     resolve_oauth_from_path(&creds_path).map(WarmCredential::OAuth)
 }

--- a/src-tauri/src/ai_provider/oneshot.rs
+++ b/src-tauri/src/ai_provider/oneshot.rs
@@ -423,9 +423,9 @@ impl OneshotLlm for OneshotClaudeApiWarm {
                 &system,
                 &user,
                 &claude_api_settings,
-                model_override,      // pinned by with_overrides, else use settings default
-                None,                // doctor_handle
-                Some(0.0),           // deterministic
+                model_override, // pinned by with_overrides, else use settings default
+                None,           // doctor_handle
+                Some(0.0),      // deterministic
                 max_tokens_override, // pinned by with_overrides, else use settings default
                 &schema_owned,
                 &schema_name_owned,

--- a/src-tauri/src/ai_provider/oneshot.rs
+++ b/src-tauri/src/ai_provider/oneshot.rs
@@ -361,11 +361,28 @@ fn parse_payload(output: &str) -> Result<Value, OneshotError> {
 /// This is the recommended default for one-shot calls when the user has
 /// either an Anthropic API key in the keychain or a Claude CLI OAuth token.
 /// Reference call template: `coordinator/llm_decide.rs:153-166`.
-pub struct OneshotClaudeApiWarm;
+pub struct OneshotClaudeApiWarm {
+    model_override: Option<&'static str>,
+    max_tokens_override: Option<u32>,
+}
 
 impl OneshotClaudeApiWarm {
     pub fn new() -> Self {
-        Self
+        Self {
+            model_override: None,
+            max_tokens_override: None,
+        }
+    }
+
+    /// Pin a specific model + max_tokens for this adapter, overriding the
+    /// values from `settings::get_ai_settings()`. Used by callers like the
+    /// path-extractor that need Haiku 4.5 for cache savings regardless of
+    /// the user's configured default.
+    pub fn with_overrides(model: &'static str, max_tokens: u32) -> Self {
+        Self {
+            model_override: Some(model),
+            max_tokens_override: Some(max_tokens),
+        }
     }
 }
 
@@ -394,6 +411,10 @@ impl OneshotLlm for OneshotClaudeApiWarm {
         let user = user_prompt.to_string();
         let schema_owned = schema.clone();
         let schema_name_owned = schema_name.to_string();
+        // Capture overrides into locals before the `move` closure so we don't
+        // borrow `self` across the `spawn_blocking` boundary.
+        let model_override = self.model_override;
+        let max_tokens_override = self.max_tokens_override;
 
         // run_claude_api_warm_with_structured_output uses reqwest::blocking,
         // so bounce off the tokio reactor.
@@ -402,10 +423,10 @@ impl OneshotLlm for OneshotClaudeApiWarm {
                 &system,
                 &user,
                 &claude_api_settings,
-                None,      // model_override — use settings default
-                None,      // doctor_handle
-                Some(0.0), // deterministic
-                None,      // max_tokens — use settings default
+                model_override,      // pinned by with_overrides, else use settings default
+                None,                // doctor_handle
+                Some(0.0),           // deterministic
+                max_tokens_override, // pinned by with_overrides, else use settings default
                 &schema_owned,
                 &schema_name_owned,
             )

--- a/src-tauri/src/util/path_extraction.rs
+++ b/src-tauri/src/util/path_extraction.rs
@@ -154,8 +154,12 @@ async fn extract_paths_via_ai_inner(
         user_message.len(),
     );
 
-    let call_future =
-        provider.call_json(&system_prefix, &user_message, schema, AI_EXTRACT_SCHEMA_NAME);
+    let call_future = provider.call_json(
+        &system_prefix,
+        &user_message,
+        schema,
+        AI_EXTRACT_SCHEMA_NAME,
+    );
 
     let output_value = match tokio::time::timeout(AI_EXTRACT_TIMEOUT, call_future).await {
         Ok(Ok(v)) => v,
@@ -1216,7 +1220,11 @@ mod tests {
         let fake = FakeOneshotLlm::returning(Err(OneshotError::NoCredentials));
         let result =
             extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
-        assert!(matches!(result, Err(ExtractError::Offline)), "got {:?}", result);
+        assert!(
+            matches!(result, Err(ExtractError::Offline)),
+            "got {:?}",
+            result
+        );
     }
 
     #[tokio::test]
@@ -1224,7 +1232,11 @@ mod tests {
         let fake = FakeOneshotLlm::returning(Err(OneshotError::Disabled));
         let result =
             extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
-        assert!(matches!(result, Err(ExtractError::Offline)), "got {:?}", result);
+        assert!(
+            matches!(result, Err(ExtractError::Offline)),
+            "got {:?}",
+            result
+        );
     }
 
     #[tokio::test]
@@ -1260,7 +1272,11 @@ mod tests {
         )));
         let result =
             extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
-        assert!(matches!(result, Err(ExtractError::Offline)), "got {:?}", result);
+        assert!(
+            matches!(result, Err(ExtractError::Offline)),
+            "got {:?}",
+            result
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/util/path_extraction.rs
+++ b/src-tauri/src/util/path_extraction.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use serde_json::{json, Value};
 use tracing::{debug, info, warn};
 
-use crate::ai_provider::claude_api_warm::{self, WARM_NO_CREDENTIAL_MARKER};
+use crate::ai_provider::{OneshotClaudeApiWarm, OneshotError, OneshotLlm};
 use crate::executor::file_registry::normalize_path;
 
 /// Substrings that, if present in a normalized path, disqualify it as a
@@ -130,8 +130,15 @@ pub async fn extract_paths_via_ai(
     prompt: &str,
     bundle: &AiContextBundle,
 ) -> Result<Vec<String>, ExtractError> {
-    let claude_api_settings = crate::settings::get_ai_settings().claude_api;
+    let provider = OneshotClaudeApiWarm::with_overrides(AI_EXTRACT_MODEL, AI_EXTRACT_MAX_TOKENS);
+    extract_paths_via_ai_inner(prompt, bundle, &provider).await
+}
 
+async fn extract_paths_via_ai_inner(
+    prompt: &str,
+    bundle: &AiContextBundle,
+    provider: &dyn OneshotLlm,
+) -> Result<Vec<String>, ExtractError> {
     let system_prefix = build_system_prefix();
     let user_message = build_user_message(prompt, bundle);
     let schema = ai_extract_schema();
@@ -147,27 +154,34 @@ pub async fn extract_paths_via_ai(
         user_message.len(),
     );
 
-    // The warm path uses `reqwest::blocking::Client`; bounce off the tokio
-    // reactor for the round-trip (reference: coordinator/llm_decide.rs:173).
-    let join_future = tauri::async_runtime::spawn_blocking(move || {
-        claude_api_warm::run_claude_api_warm_with_structured_output(
-            &system_prefix,
-            &user_message,
-            &claude_api_settings,
-            Some(AI_EXTRACT_MODEL),
-            None,      // no doctor handle — short synthetic call
-            Some(0.0), // deterministic
-            Some(AI_EXTRACT_MAX_TOKENS),
-            &schema,
-            AI_EXTRACT_SCHEMA_NAME,
-        )
-    });
+    let call_future =
+        provider.call_json(&system_prefix, &user_message, schema, AI_EXTRACT_SCHEMA_NAME);
 
-    let response = match tokio::time::timeout(AI_EXTRACT_TIMEOUT, join_future).await {
-        Ok(Ok(resp)) => resp,
-        Ok(Err(join_err)) => {
-            warn!("path_extraction.ai_join_error: {}", join_err);
-            return Err(ExtractError::Other(format!("spawn join: {}", join_err)));
+    let output_value = match tokio::time::timeout(AI_EXTRACT_TIMEOUT, call_future).await {
+        Ok(Ok(v)) => v,
+        Ok(Err(OneshotError::NoCredentials)) => {
+            info!("path_extraction.ai_disabled reason=no_credentials");
+            return Err(ExtractError::Offline);
+        }
+        Ok(Err(OneshotError::Disabled)) => {
+            info!("path_extraction.ai_disabled reason=provider_disabled");
+            return Err(ExtractError::Offline);
+        }
+        Ok(Err(OneshotError::BudgetExhausted)) => {
+            info!("path_extraction.ai_rate_limited reason=budget");
+            return Err(ExtractError::RateLimited);
+        }
+        Ok(Err(OneshotError::ProviderTransport(msg))) => {
+            let lower = msg.to_ascii_lowercase();
+            if lower.contains("rate") && lower.contains("limit") {
+                info!("path_extraction.ai_rate_limited");
+                return Err(ExtractError::RateLimited);
+            }
+            warn!("path_extraction.ai_transport_error: {}", msg);
+            return Err(ExtractError::Offline);
+        }
+        Ok(Err(OneshotError::SchemaParse(msg))) => {
+            return Err(ExtractError::ParseFailure(msg));
         }
         Err(_elapsed) => {
             info!(
@@ -178,36 +192,15 @@ pub async fn extract_paths_via_ai(
         }
     };
 
-    if !response.success {
-        // The warm provider stuffs the credential marker into the `error`
-        // field (see `claude_api_warm.rs:385`); HTTP/transport errors land
-        // there too. Output is usually empty on failure but we check both
-        // to be defensive.
-        let error_str = response.error.as_deref().unwrap_or("");
-        let combined = format!("{}|{}", response.output, error_str);
-        let lower = combined.to_ascii_lowercase();
+    // `OneshotLlm::call_json` returns a parsed JSON `Value`. Serialize back
+    // to a string so the existing `parse_ai_paths_response(&str, &cwd)`
+    // post-processor (slash-normalize → cwd-resolve → blacklist → dedupe →
+    // cap) stays untouched. The downstream pipeline expects a stringy input
+    // and we don't want to dual-track string vs Value parsers.
+    let output = serde_json::to_string(&output_value)
+        .map_err(|e| ExtractError::ParseFailure(format!("re-serialize: {}", e)))?;
 
-        if combined.contains(WARM_NO_CREDENTIAL_MARKER) {
-            info!("path_extraction.ai_disabled reason=no_warm_credentials");
-            return Err(ExtractError::Offline);
-        }
-        if lower.contains("rate") && lower.contains("limit") {
-            info!("path_extraction.ai_rate_limited");
-            return Err(ExtractError::RateLimited);
-        }
-        warn!(
-            "path_extraction.ai_failed error={} output_len={}",
-            error_str,
-            response.output.len()
-        );
-        return Err(ExtractError::Other(if error_str.is_empty() {
-            response.output
-        } else {
-            error_str.to_string()
-        }));
-    }
-
-    let paths = parse_ai_paths_response(&response.output, &cwd)?;
+    let paths = parse_ai_paths_response(&output, &cwd)?;
     debug!(
         "path_extraction.ai_call_succeeded returned={} cwd_resolved={}",
         paths.len(),
@@ -1143,12 +1136,144 @@ mod tests {
         assert_eq!(paths, vec![normalize_path("src/main.rs")]);
     }
 
+    use crate::ai_provider::{OneshotError, OneshotLlm};
+    use serde_json::Value;
+    use std::sync::Mutex;
+
+    /// Test-only fake provider. Each call consumes the response by move
+    /// (`OneshotError` is `Debug` but not `Clone`); construct one fake per
+    /// test rather than reusing. Optional `delay` is applied before the
+    /// response, so a `with_delay(TIMEOUT+1s)` fake exercises the timeout
+    /// branch of `extract_paths_via_ai_inner`.
+    struct FakeOneshotLlm {
+        response: Mutex<Option<Result<Value, OneshotError>>>,
+        delay: Duration,
+    }
+
+    impl FakeOneshotLlm {
+        fn returning(response: Result<Value, OneshotError>) -> Self {
+            Self {
+                response: Mutex::new(Some(response)),
+                delay: Duration::from_millis(0),
+            }
+        }
+
+        fn with_delay(delay: Duration) -> Self {
+            Self {
+                response: Mutex::new(Some(Ok(serde_json::json!({"paths": []})))),
+                delay,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl OneshotLlm for FakeOneshotLlm {
+        fn name(&self) -> &'static str {
+            "fake"
+        }
+
+        async fn call_json(
+            &self,
+            _system_prompt: &str,
+            _user_prompt: &str,
+            _schema: Value,
+            _schema_name: &str,
+        ) -> Result<Value, OneshotError> {
+            if !self.delay.is_zero() {
+                tokio::time::sleep(self.delay).await;
+            }
+            self.response
+                .lock()
+                .expect("FakeOneshotLlm poisoned")
+                .take()
+                .expect("FakeOneshotLlm::call_json invoked twice — construct a fresh fake per test")
+        }
+    }
+
     #[tokio::test]
-    #[ignore = "requires injectable warm provider — extractor calls run_claude_api_warm_with_structured_output directly; mocking it would mean refactoring out a trait, which belongs to a follow-up plan. The 5s tokio::time::timeout in extract_paths_via_ai → ExtractError::Offline is exercised indirectly by the no-credentials path in test_extract_paths_via_ai_real_call."]
     async fn test_extract_paths_via_ai_timeout() {
-        // Intentionally empty body — see ignore message above. Kept as a
-        // documented placeholder so a future contributor adding a trait-based
-        // mock has a slot to fill in.
+        // Fake that sleeps past AI_EXTRACT_TIMEOUT. The plan called for
+        // `start_paused = true` to keep this <1ms wall-clock, but that
+        // attribute requires tokio's `test-util` feature which isn't
+        // enabled in this crate's Cargo.toml (tokio = features = ["full"]
+        // — `full` does NOT include `test-util`). To keep this PR scoped
+        // to the three planned source files, the test uses a real delay
+        // and pays the ~AI_EXTRACT_TIMEOUT wall-clock cost. A follow-up
+        // adding `tokio` to dev-dependencies with the `test-util` feature
+        // is the right way to speed this back up.
+        let fake = FakeOneshotLlm::with_delay(AI_EXTRACT_TIMEOUT + Duration::from_secs(1));
+        let bundle = AiContextBundle::default();
+        let result = extract_paths_via_ai_inner("anything", &bundle, &fake).await;
+        assert!(
+            matches!(result, Err(ExtractError::Offline)),
+            "expected Err(Offline), got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_credentials_maps_to_offline() {
+        let fake = FakeOneshotLlm::returning(Err(OneshotError::NoCredentials));
+        let result =
+            extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
+        assert!(matches!(result, Err(ExtractError::Offline)), "got {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_disabled_maps_to_offline() {
+        let fake = FakeOneshotLlm::returning(Err(OneshotError::Disabled));
+        let result =
+            extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
+        assert!(matches!(result, Err(ExtractError::Offline)), "got {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_budget_exhausted_maps_to_rate_limited() {
+        let fake = FakeOneshotLlm::returning(Err(OneshotError::BudgetExhausted));
+        let result =
+            extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
+        assert!(
+            matches!(result, Err(ExtractError::RateLimited)),
+            "got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transport_rate_limit_maps_to_rate_limited() {
+        let fake = FakeOneshotLlm::returning(Err(OneshotError::ProviderTransport(
+            "HTTP 429: rate limit exceeded".to_string(),
+        )));
+        let result =
+            extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
+        assert!(
+            matches!(result, Err(ExtractError::RateLimited)),
+            "got {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
+    async fn test_transport_generic_maps_to_offline() {
+        let fake = FakeOneshotLlm::returning(Err(OneshotError::ProviderTransport(
+            "connection refused".to_string(),
+        )));
+        let result =
+            extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
+        assert!(matches!(result, Err(ExtractError::Offline)), "got {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn test_schema_parse_maps_to_parse_failure() {
+        let fake = FakeOneshotLlm::returning(Err(OneshotError::SchemaParse(
+            "missing field `paths`".to_string(),
+        )));
+        let result =
+            extract_paths_via_ai_inner("anything", &AiContextBundle::default(), &fake).await;
+        match result {
+            Err(ExtractError::ParseFailure(msg)) => assert!(msg.contains("missing field")),
+            other => panic!("expected ParseFailure, got {:?}", other),
+        }
     }
 
     #[tokio::test]
@@ -1176,7 +1301,16 @@ mod tests {
                 );
             }
             Err(ExtractError::Offline) => {
-                // Acceptable: no credentials available in the test env.
+                // Acceptable ONLY when no credential was supplied. If
+                // ANTHROPIC_API_KEY is set in the env, an Offline result means the
+                // env-var fallback in resolve_warm_credential regressed — fail loud
+                // so the CI lane catches it instead of silently passing.
+                if std::env::var("ANTHROPIC_API_KEY")
+                    .map(|v| !v.trim().is_empty())
+                    .unwrap_or(false)
+                {
+                    panic!("Offline result despite ANTHROPIC_API_KEY being set — env-var fallback regression?");
+                }
             }
             Err(e) => panic!("unexpected extractor error: {:?}", e),
         }


### PR DESCRIPTION
## Summary

- Refactors `extract_paths_via_ai` to dispatch through the existing `OneshotLlm` trait (`ai_provider/oneshot.rs:137`) so a fake provider can drive tests for the 5s timeout path and the full `OneshotError → ExtractError` mapping table. Closes both `#[ignore]`'d tests left behind by the original `ai-extracted-candidate-paths` PR.
- Adds `OneshotClaudeApiWarm::with_overrides(model, max_tokens)` so the path-extractor keeps its Haiku 4.5 + 1024-token pin instead of falling back to settings defaults (which currently route to Sonnet 4 + 4096 tokens).
- Adds an `$ANTHROPIC_API_KEY` env-var fallback to `resolve_warm_credential` between the OS keychain and the Claude CLI OAuth-file checks. Without this, Ubuntu CI runners have no usable credential source and the new live lane would silently report Offline → the test's tolerant arm would mark it passing without ever making a real call.
- New `Live AI extractor smoke` step in `ci.yml`: ubuntu-22.04 only, gated on `secrets.ANTHROPIC_API_KEY`, runs `test_extract_paths_via_ai_real_call` with `--ignored --exact`, `continue-on-error: true` since Haiku output is non-deterministic. Tightened the test's `Err(Offline)` arm to panic when `ANTHROPIC_API_KEY` is set, so a regression in the env-var fallback can't silently mute the lane.

Plan (with full design notes + the vet pass that surfaced the credential gap): `qontinui-dev-notes/plans/2026-05-12-ai-extracted-paths-test-injection-plan.md`.

## Test plan

- [x] `cargo test path_extraction` → 33 passed, 1 ignored (the live test, exercised by the new CI step)
- [x] `cargo clippy --no-deps -- -D warnings` clean
- [x] `cargo fmt` clean
- [ ] CI's new `Live AI extractor smoke` step runs and reports green (informational) on a PR build with the `ANTHROPIC_API_KEY` secret set
- [ ] CI's `Live AI extractor smoke` step is skipped (green) on PRs from forks or when the secret is unset