### PR TITLE
feat(coord): worker readiness gate + terminal UX fixes from coord soak

### DIFF
--- a/src-tauri/src/claude_session/manager.rs
+++ b/src-tauri/src/claude_session/manager.rs
@@ -216,6 +216,13 @@ impl SessionManager {
     /// List all active session task_run_ids — union of ClaudeSessions and
     /// Workers whose state is non-Closed. Phase 6: workers participate in
     /// `Observation.live_sessions` so Rule B can assign them tasks.
+    ///
+    /// Broad-by-default: includes `Initializing` workers (Phase 1 of the
+    /// 2026-05-11 dispatch-fix plan). Callers that need dispatch-eligible
+    /// sessions only (i.e. `Ready` and not currently assigned) MUST filter
+    /// the returned ids via [`Self::get_state`]. See
+    /// `mcp::reflection::compute_plan_recommendations` for the canonical
+    /// `idle_session_count` pattern.
     pub fn list_active(&self) -> Vec<String> {
         let mut active: Vec<String> = self
             .sessions

--- a/src-tauri/src/claude_session/worker_session.rs
+++ b/src-tauri/src/claude_session/worker_session.rs
@@ -11,8 +11,13 @@
 //! Workers carry their own `Arc<AtomicU8>` for state (see
 //! [`SessionManager`](super::SessionManager) for the sibling-map
 //! registration shape — Option B′ from the Phase 6 worker plan).
-//! Workers track only `Ready ⇄ Processing → Closed`; they never enter
-//! the `Created`/`Initializing`/`Interrupting`/`Promoting` states.
+//! Workers track `Initializing → Ready ⇄ Processing → Closed`. They
+//! start in `Initializing` so dispatchers (Rule B `assign-task`) can
+//! gate on readline visibility before sending the brief; the
+//! readline-observer task in `commands::productivity::spawn_worker_session`
+//! transitions them to `Ready` once the embedded Claude CLI has set its
+//! OSC 0 title (or after the 8 s fallback timeout). Workers never enter
+//! the `Created`/`Interrupting`/`Promoting` states.
 
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
@@ -21,15 +26,17 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::state::SessionState;
 use crate::terminal::TerminalManager;
 
-// Compact u8 encoding for the three states a worker can hold. Round-trips
+// Compact u8 encoding for the four states a worker can hold. Round-trips
 // only the states the worker lifecycle uses; other variants map back to
 // `Closed` on read so a corrupt write fails closed rather than open.
+const STATE_INITIALIZING: u8 = 1;
 const STATE_READY: u8 = 2;
 const STATE_PROCESSING: u8 = 3;
 const STATE_CLOSED: u8 = 7;
 
 fn state_to_u8(state: SessionState) -> u8 {
     match state {
+        SessionState::Initializing => STATE_INITIALIZING,
         SessionState::Ready => STATE_READY,
         SessionState::Processing => STATE_PROCESSING,
         SessionState::Closed => STATE_CLOSED,
@@ -42,6 +49,7 @@ fn state_to_u8(state: SessionState) -> u8 {
 
 fn state_from_u8(value: u8) -> SessionState {
     match value {
+        STATE_INITIALIZING => SessionState::Initializing,
         STATE_READY => SessionState::Ready,
         STATE_PROCESSING => SessionState::Processing,
         _ => SessionState::Closed,
@@ -59,8 +67,13 @@ pub struct WorkerSession {
 }
 
 impl WorkerSession {
-    /// Build a new worker. State starts as `Ready` — workers are immediately
-    /// available to Rule B once registered.
+    /// Build a new worker. State starts as `Initializing` — the worker is
+    /// registered but NOT yet eligible for assignment. A readline-observer
+    /// task spawned by `spawn_worker_session` transitions to `Ready` once
+    /// the embedded Claude CLI emits an OSC 0 title (its standard startup
+    /// signal) or after an 8 s fallback timeout, whichever fires first.
+    /// See plan `2026-05-11-runner-dispatch-and-terminal-ux-fixes-plan.md`
+    /// Phase 1 for the dispatch-race motivation.
     pub fn new(
         task_run_id: String,
         terminal_id: String,
@@ -75,7 +88,7 @@ impl WorkerSession {
             task_run_id,
             terminal_id,
             title,
-            state: Arc::new(AtomicU8::new(STATE_READY)),
+            state: Arc::new(AtomicU8::new(STATE_INITIALIZING)),
             terminal_manager,
             created_at_unix,
         }
@@ -105,14 +118,17 @@ impl WorkerSession {
     /// Returns the worker's logical state. Workers are NEVER `Closed`
     /// unless we explicitly call [`Self::close`] — the pty might outlive
     /// the worker registration if the user closed the tab. We track
-    /// `Ready ⇄ Processing`.
+    /// `Initializing → Ready ⇄ Processing`.
     pub fn state(&self) -> SessionState {
         state_from_u8(self.state.load(Ordering::Acquire))
     }
 
-    /// Set state. Used by `observe.rs` Phase 2c wiring (Processing→Ready
-    /// when the assigned task transitions to `done`/`cancelled`) and by
-    /// [`Self::send_user_message`] (Ready→Processing on dispatch).
+    /// Set state. Used by:
+    /// - `spawn_worker_session`'s readline-observer task
+    ///   (Initializing→Ready when OSC 0 lands or the 8 s fallback fires).
+    /// - `observe.rs` Phase 2c wiring (Processing→Ready when the assigned
+    ///   task transitions to `done`/`cancelled`).
+    /// - [`Self::send_user_message`] (Ready→Processing on dispatch).
     pub fn set_state(&self, new_state: SessionState) {
         let encoded = state_to_u8(new_state);
         if encoded == STATE_CLOSED && !matches!(new_state, SessionState::Closed) {
@@ -185,6 +201,13 @@ mod tests {
 
     #[test]
     fn state_round_trip() {
+        // Initializing now round-trips — Phase 1 of the dispatch-fix plan
+        // requires workers to be observable in this state so dispatchers
+        // can gate on Ready before sending briefs.
+        assert_eq!(
+            state_from_u8(state_to_u8(SessionState::Initializing)),
+            SessionState::Initializing
+        );
         assert_eq!(
             state_from_u8(state_to_u8(SessionState::Ready)),
             SessionState::Ready
@@ -197,9 +220,17 @@ mod tests {
             state_from_u8(state_to_u8(SessionState::Closed)),
             SessionState::Closed
         );
-        // Unsupported state encodes to Closed.
+        // Truly unsupported variants still collapse to Closed.
         assert_eq!(
-            state_from_u8(state_to_u8(SessionState::Initializing)),
+            state_from_u8(state_to_u8(SessionState::Created)),
+            SessionState::Closed
+        );
+        assert_eq!(
+            state_from_u8(state_to_u8(SessionState::Interrupting)),
+            SessionState::Closed
+        );
+        assert_eq!(
+            state_from_u8(state_to_u8(SessionState::Promoting)),
             SessionState::Closed
         );
     }
@@ -223,7 +254,47 @@ mod tests {
     }
 
     #[test]
+    fn new_starts_in_initializing_and_is_active() {
+        // Phase 1 contract: workers spawn in Initializing and stay
+        // "active" so existing observability paths (cleanup_closed,
+        // list_active, list_all_with_state) keep surfacing them while
+        // they wait for the readline-observer task to flip them Ready.
+        let tm = Arc::new(TerminalManager::new());
+        let w = WorkerSession::new(
+            "task-init".to_string(),
+            "term-init".to_string(),
+            "Worker init".to_string(),
+            tm,
+        );
+        assert_eq!(w.state(), SessionState::Initializing);
+        assert!(
+            w.state().is_active(),
+            "Initializing workers must be considered active"
+        );
+    }
+
+    #[test]
+    fn initializing_to_ready_transition_round_trips() {
+        // The spawn_worker_session readline-observer task drives this
+        // exact transition. Guard it explicitly.
+        let tm = Arc::new(TerminalManager::new());
+        let w = WorkerSession::new(
+            "task-ir".to_string(),
+            "term-ir".to_string(),
+            "Worker ir".to_string(),
+            tm,
+        );
+        assert_eq!(w.state(), SessionState::Initializing);
+        w.set_state(SessionState::Ready);
+        assert_eq!(w.state(), SessionState::Ready);
+    }
+
+    #[test]
     fn unsupported_set_state_is_ignored() {
+        // Initializing, Ready, Processing, and Closed are all accepted.
+        // Created / Interrupting / Promoting collapse to STATE_CLOSED on
+        // encoding and trigger the set_state guard, leaving the previous
+        // state intact.
         let tm = Arc::new(TerminalManager::new());
         let w = WorkerSession::new(
             "task-1".to_string(),
@@ -231,12 +302,18 @@ mod tests {
             "Worker 1".to_string(),
             tm,
         );
+        assert_eq!(w.state(), SessionState::Initializing);
+        // Created is unsupported — set_state should refuse and leave the
+        // previous state in place.
+        w.set_state(SessionState::Created);
+        assert_eq!(w.state(), SessionState::Initializing);
+        w.set_state(SessionState::Interrupting);
+        assert_eq!(w.state(), SessionState::Initializing);
+        w.set_state(SessionState::Promoting);
+        assert_eq!(w.state(), SessionState::Initializing);
+        // Ready, Processing, and Closed are accepted.
+        w.set_state(SessionState::Ready);
         assert_eq!(w.state(), SessionState::Ready);
-        // Initializing isn't representable for a worker; set_state should
-        // refuse and leave the previous state in place.
-        w.set_state(SessionState::Initializing);
-        assert_eq!(w.state(), SessionState::Ready);
-        // Processing and Closed are accepted.
         w.set_state(SessionState::Processing);
         assert_eq!(w.state(), SessionState::Processing);
         w.set_state(SessionState::Ready);

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1008,12 +1008,20 @@ pub async fn spawn_worker_session(
     // Coordinator's flag for the same reason).
     let initial_command = "claude --dangerously-skip-permissions".to_string();
 
+    // Phase 4: pre-size the worker PTY to match the dominant existing
+    // zone so worker briefs land on a grid the same size the user will
+    // eventually see (rather than the 120×30 default, which produces
+    // mis-wrapped output until the user activates the tab and fit-addon
+    // resizes the PTY). Falls back to (120, 30) when no other terminals
+    // exist — same as `terminal_manager.create(None, None)` historically.
+    let (dom_cols, dom_rows) = terminal_manager.dominant_zone_dims();
+
     let info = terminal_manager.create(
         Some(title.clone()),
         Some(repo_path),
         None,
-        None,
-        None,
+        Some(dom_cols),
+        Some(dom_rows),
         app_handle.clone(),
     )?;
 

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1023,9 +1023,63 @@ pub async fn spawn_worker_session(
         title,
         terminal_manager.clone(),
     );
-    if let Err(e) = session_manager.register_worker(Arc::new(worker)) {
+    let worker_arc = Arc::new(worker);
+    if let Err(e) = session_manager.register_worker(worker_arc.clone()) {
         warn!("spawn_worker_session: register_worker failed: {}", e);
     }
+
+    // Phase 1: readline-observer task. Workers register in `Initializing`
+    // (see `WorkerSession::new`); Coordinator's `idle_session_count`
+    // reader filters Ready-only. We flip to Ready once one of:
+    //   - the embedded Claude CLI emits its OSC 0 title (`"✳ Claude
+    //     Code"` on startup, observed by the reader thread's grid parser
+    //     in `terminal/session.rs` and surfaced via
+    //     `subscribe_first_osc_title`); or
+    //   - 8 s elapses (defensive fallback for Claude binaries that fail
+    //     to emit an OSC 0 — e.g. auth prompts, missing binary). The
+    //     Coordinator's Rule A "stuck session" detector then catches the
+    //     downstream failure.
+    let osc_title_rx = terminal_manager
+        .get(&info.id)
+        .and_then(|s| s.subscribe_first_osc_title());
+    let observer_worker = worker_arc.clone();
+    let observer_terminal_id = info.id.clone();
+    tokio::spawn(async move {
+        let trigger = match osc_title_rx {
+            Some(rx) => {
+                tokio::select! {
+                    res = rx => {
+                        match res {
+                            Ok(()) => "osc_title",
+                            // Sender dropped (session closed before any
+                            // OSC fired). Don't flip Ready in that case;
+                            // the worker will be cleaned up by
+                            // close_all_sessions / cleanup_closed.
+                            Err(_) => "closed",
+                        }
+                    }
+                    _ = tokio::time::sleep(Duration::from_secs(8)) => "timeout",
+                }
+            }
+            // No receiver available means the OSC already fired (or the
+            // session vanished before we could subscribe). Either way,
+            // skip the wait and let the worker proceed.
+            None => "already_subscribed",
+        };
+        if trigger == "closed" {
+            tracing::warn!(
+                terminal_id = %observer_terminal_id,
+                "spawn_worker_session: PTY closed before readline; worker stays Initializing"
+            );
+            return;
+        }
+        tracing::info!(
+            terminal_id = %observer_terminal_id,
+            trigger = trigger,
+            "spawn_worker_session: worker transition Initializing → Ready"
+        );
+        observer_worker.set_state(crate::claude_session::state::SessionState::Ready);
+    });
 
     schedule_initial_command(terminal_manager, info.id.clone(), initial_command);
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -60,6 +60,31 @@ pub fn terminal_write(
     })
 }
 
+/// Update a terminal session's display title.
+///
+/// Phase 2 of the bi-directional title sync (plan
+/// `2026-05-11-runner-dispatch-and-terminal-ux-fixes-plan.md`): the
+/// frontend's xterm.js `onTitleChange` handler (see
+/// `components/terminal/ZoneGrid.tsx`) invokes this whenever it
+/// observes a new OSC 0/2 title in a `terminal-output` paint. The
+/// runner mirrors the new title onto `TerminalSession.title` and emits
+/// a `terminal-title-changed` event so other webview windows / WS
+/// subscribers stay consistent.
+#[tauri::command]
+pub fn terminal_set_title(
+    terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
+    app_handle: tauri::AppHandle,
+    terminal_id: String,
+    title: String,
+) -> Result<CommandResponse, String> {
+    terminal_manager.set_title(&terminal_id, title, &app_handle)?;
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: None,
+    })
+}
+
 /// Resize a terminal's PTY dimensions.
 #[tauri::command]
 pub fn terminal_resize(
@@ -508,6 +533,7 @@ pub fn plugin() -> TauriPlugin<tauri::Wry> {
             terminal_create,
             terminal_write,
             terminal_resize,
+            terminal_set_title,
             terminal_close,
             terminal_list,
             terminal_ack,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1347,6 +1347,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::terminal::terminal_list,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_save_scrollback,
+            commands::terminal::terminal_set_title,
             commands::terminal::terminal_write,
             commands::terminal_analysis::analyze_architecture,
             commands::terminal_analysis::analyze_change_impact,

--- a/src-tauri/src/mcp/reflection.rs
+++ b/src-tauri/src/mcp/reflection.rs
@@ -261,12 +261,24 @@ pub async fn compute_plan_recommendations(
     let active_info = app_state.file_registry_manager.info().await;
     let active_paths: HashSet<String> = active_info.into_iter().map(|i| i.file_path).collect();
 
-    // Idle session count — sessions not currently assigned to any task.
-    // Cheap pass over the SessionManager: every active session that the
-    // task table doesn't list as `assigned_session_id` for an in-flight
-    // task is idle.
+    // Idle session count — Ready (not Initializing) sessions not currently
+    // assigned to any task. `list_active` returns every non-Closed session
+    // by design (broad-by-default so cleanup / observability callers see
+    // them); the dispatch-eligibility filter belongs here. Initializing
+    // workers exist but their embedded Claude CLI hasn't surfaced its
+    // readline yet — including them would re-introduce the Phase 1
+    // dispatch race the worker state machine just plugged.
     let live_sessions: Vec<String> = match &session_manager {
-        Some(sm) => sm.list_active(),
+        Some(sm) => sm
+            .list_active()
+            .into_iter()
+            .filter(|id| {
+                matches!(
+                    sm.get_state(id),
+                    Some(crate::claude_session::state::SessionState::Ready)
+                )
+            })
+            .collect(),
         None => Vec::new(),
     };
 

--- a/src-tauri/src/productivity/workers.rs
+++ b/src-tauri/src/productivity/workers.rs
@@ -34,10 +34,10 @@ pub struct WorkerInfo {
     /// has been removed from the manager (the worker registration outlived
     /// its pty — surfaces as a stale row the user can clean up).
     pub terminal_title: Option<String>,
-    /// One of `"ready"`, `"processing"`, `"closed"`. Workers never
-    /// logically enter the other `SessionState` variants; defensively map
-    /// anything unexpected to `"closed"` so the dashboard doesn't have to
-    /// handle a wider variant set.
+    /// One of `"initializing"`, `"ready"`, `"processing"`, `"closed"`.
+    /// Workers never logically enter the other `SessionState` variants;
+    /// defensively map anything unexpected to `"closed"` so the dashboard
+    /// doesn't have to handle a wider variant set.
     pub state: String,
     /// The `coord.tasks.id` (uuid string) currently assigned to this
     /// worker, if any. `None` when the worker is idle or when the lookup
@@ -50,12 +50,13 @@ pub struct WorkerInfo {
     pub created_at_ms: i64,
 }
 
-/// Map a `SessionState` to the wire-format string. Workers track only
-/// `Ready ⇄ Processing → Closed`; any other variant falls through to
-/// `"closed"` so the dashboard handles a closed pseudo-state instead of
-/// rendering a foreign string.
+/// Map a `SessionState` to the wire-format string. Workers track
+/// `Initializing → Ready ⇄ Processing → Closed`; any other variant falls
+/// through to `"closed"` so the dashboard handles a closed pseudo-state
+/// instead of rendering a foreign string.
 fn state_string(state: SessionState) -> &'static str {
     match state {
+        SessionState::Initializing => "initializing",
         SessionState::Ready => "ready",
         SessionState::Processing => "processing",
         SessionState::Closed => "closed",
@@ -118,12 +119,14 @@ mod tests {
 
     #[test]
     fn state_string_maps_supported_variants() {
+        assert_eq!(state_string(SessionState::Initializing), "initializing");
         assert_eq!(state_string(SessionState::Ready), "ready");
         assert_eq!(state_string(SessionState::Processing), "processing");
         assert_eq!(state_string(SessionState::Closed), "closed");
         // Unsupported variants fall through to "closed" rather than
         // expanding the wire surface.
-        assert_eq!(state_string(SessionState::Initializing), "closed");
         assert_eq!(state_string(SessionState::Created), "closed");
+        assert_eq!(state_string(SessionState::Interrupting), "closed");
+        assert_eq!(state_string(SessionState::Promoting), "closed");
     }
 }

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -158,6 +158,43 @@ impl TerminalManager {
         self.sessions.lock().map(|s| s.len()).unwrap_or(0)
     }
 
+    /// Return the `(cols, rows)` of the largest currently-registered
+    /// terminal — "largest" measured by `cols * rows` cell count. Falls
+    /// back to `(120, 30)` (the historical `create()` default) when no
+    /// sessions exist.
+    ///
+    /// Phase 4 of the 2026-05-11 dispatch-fix plan: worker tabs spawned
+    /// into a zone where another tab is currently visible mount under
+    /// `display: none`. xterm.js's fit-addon then can't measure the
+    /// container, so the backend PTY stays at the 120×30 default until
+    /// the user activates the tab. Pre-sizing the new PTY to the
+    /// dominant zone dims means Coordinator dispatch lands on a PTY
+    /// matching the eventual visible size (Claude doesn't have to wrap
+    /// twice). Fallback dims match what `create()` would have used on
+    /// `None, None`, so behaviour is identical when there's no signal to
+    /// crib from.
+    pub fn dominant_zone_dims(&self) -> (u16, u16) {
+        let sessions = match self.sessions.lock() {
+            Ok(s) => s,
+            Err(e) => {
+                error!("Sessions lock poisoned in dominant_zone_dims: {}", e);
+                return (120, 30);
+            }
+        };
+        let mut best: Option<(u16, u16, u32)> = None;
+        for sess in sessions.values() {
+            let info = sess.info();
+            let area = (info.cols as u32).saturating_mul(info.rows as u32);
+            if area == 0 {
+                continue;
+            }
+            if best.map(|(_, _, a)| area > a).unwrap_or(true) {
+                best = Some((info.cols, info.rows, area));
+            }
+        }
+        best.map(|(c, r, _)| (c, r)).unwrap_or((120, 30))
+    }
+
     /// Snapshot of `(session_id, Arc<TerminalSession>)` pairs for
     /// callers that need to iterate every active session — e.g. the
     /// cross-session grid search endpoint. Sorted by creation time

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -95,12 +95,7 @@ impl TerminalManager {
     /// user sees in the UI. Without this, `TerminalSession.title` was
     /// frozen at spawn time and drifted from the OSC 0 title the child
     /// emits at runtime.
-    pub fn set_title(
-        &self,
-        id: &str,
-        title: String,
-        app_handle: &AppHandle,
-    ) -> Result<(), String> {
+    pub fn set_title(&self, id: &str, title: String, app_handle: &AppHandle) -> Result<(), String> {
         let session = self
             .get(id)
             .ok_or_else(|| format!("Terminal session not found: {}", id))?;

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -84,6 +84,42 @@ impl TerminalManager {
         self.sessions.lock().ok().and_then(|s| s.get(id).cloned())
     }
 
+    /// Update the title of a terminal session and emit a
+    /// `terminal-title-changed` Tauri event so other webview windows
+    /// (and the backend relay's WS subscribers) stay in sync.
+    ///
+    /// Phase 2 of the bi-directional title sync (plan
+    /// `2026-05-11-runner-dispatch-and-terminal-ux-fixes-plan.md`): the
+    /// frontend's xterm.js `onTitleChange` callback now invokes
+    /// `terminal_set_title` so backend `/terminals` titles match what the
+    /// user sees in the UI. Without this, `TerminalSession.title` was
+    /// frozen at spawn time and drifted from the OSC 0 title the child
+    /// emits at runtime.
+    pub fn set_title(
+        &self,
+        id: &str,
+        title: String,
+        app_handle: &AppHandle,
+    ) -> Result<(), String> {
+        let session = self
+            .get(id)
+            .ok_or_else(|| format!("Terminal session not found: {}", id))?;
+        session.set_title(title.clone());
+        let payload = serde_json::json!({ "id": id, "title": title });
+        if let Err(e) = app_handle.emit("terminal-title-changed", &payload) {
+            error!("Failed to emit terminal-title-changed: {}", e);
+        }
+        // Mirror to the backend WS relay so remote mobile viewers stay
+        // consistent (same pattern as the reader thread's terminal-output
+        // mirror in session.rs).
+        crate::event_system::broadcast_ws_notification(
+            app_handle,
+            "terminal-title-changed",
+            &payload,
+        );
+        Ok(())
+    }
+
     /// Remove and close a terminal session.
     pub fn close(&self, id: &str) -> Result<(), String> {
         let session = {

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -83,8 +83,10 @@ pub(crate) fn build_submit_payload(message: &str) -> Vec<u8> {
 pub struct TerminalSession {
     /// Unique identifier for this terminal.
     id: TerminalId,
-    /// Display title.
-    title: String,
+    /// Display title. Mutated post-spawn by [`Self::set_title`] (Phase 2 of
+    /// the bi-directional title sync — frontend OSC 0 observers in xterm.js
+    /// call back via `terminal_set_title` Tauri command).
+    title: Arc<Mutex<String>>,
     /// Working directory the shell was started in.
     working_dir: String,
     /// Which terminal page this session belongs to.
@@ -447,7 +449,7 @@ impl TerminalSession {
 
         Ok(Self {
             id,
-            title,
+            title: Arc::new(Mutex::new(title)),
             working_dir: cwd,
             page_id,
             writer,
@@ -627,9 +629,17 @@ impl TerminalSession {
 
     /// Get terminal info for the frontend.
     pub fn info(&self) -> TerminalInfo {
+        // Phase 2: title is now `Arc<Mutex<String>>`. Clone under the lock
+        // so the returned snapshot doesn't observe a torn write from a
+        // concurrent `set_title`.
+        let title = self
+            .title
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_else(|e| e.into_inner().clone());
         TerminalInfo {
             id: self.id.clone(),
-            title: self.title.clone(),
+            title,
             pid: self.child_pid,
             cols: self.cols.load(Ordering::Relaxed),
             rows: self.rows.load(Ordering::Relaxed),
@@ -639,6 +649,22 @@ impl TerminalSession {
             created_at: self.created_at,
             total_bytes_produced: self.total_bytes_produced.load(Ordering::Relaxed),
             page_id: self.page_id.clone(),
+        }
+    }
+
+    /// Update the session's display title. Phase 2 of bi-directional
+    /// title sync: the frontend's xterm.js `onTitleChange` handler relays
+    /// observed OSC 0/2 titles back to the runner via the
+    /// `terminal_set_title` Tauri command, which routes through
+    /// `TerminalManager::set_title` to here. Subsequent `info()` calls
+    /// (and `GET /terminals`) see the new value; other observers get the
+    /// `terminal-title-changed` event emitted by the manager.
+    pub fn set_title(&self, title: String) {
+        match self.title.lock() {
+            Ok(mut g) => *g = title,
+            // Poisoned: recover and overwrite. Title is a pure-text field
+            // with no invariants to preserve, so this is safe.
+            Err(e) => *e.into_inner() = title,
         }
     }
 
@@ -844,7 +870,7 @@ mod tests {
         let (osc_title_tx, osc_title_rx) = oneshot::channel::<()>();
         TerminalSession {
             id: "test".to_string(),
-            title: "test".to_string(),
+            title: Arc::new(Mutex::new("test".to_string())),
             working_dir: ".".to_string(),
             page_id: "default".to_string(),
             writer: Arc::new(Mutex::new(writer)),
@@ -910,6 +936,20 @@ mod tests {
             "submit_prompt must not emit LF bytes; got {:?}",
             written
         );
+    }
+
+    #[test]
+    fn set_title_updates_info() {
+        // Phase 2: bi-directional title sync. set_title must be visible
+        // via info() so subsequent /terminals reads see the new value.
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let session = make_test_session(buf);
+        assert_eq!(session.info().title, "test");
+        session.set_title("✳ Claude Code".to_string());
+        assert_eq!(session.info().title, "✳ Claude Code");
+        // Idempotent overwrite.
+        session.set_title("Worker 1".to_string());
+        assert_eq!(session.info().title, "Worker 1");
     }
 
     #[test]

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot};
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
@@ -119,6 +119,21 @@ pub struct TerminalSession {
     output_tx: broadcast::Sender<String>,
     /// Server-side cell grid produced by the VT parser tee in the reader thread.
     grid: Arc<Mutex<Grid>>,
+    /// One-shot sender fired by the reader thread when it observes the
+    /// first OSC 0 / OSC 2 title from the child process. Used by
+    /// `spawn_worker_session` (Phase 1) to gate `Initializing → Ready` on
+    /// readline visibility: Claude Code's CLI emits an OSC 0 title
+    /// (`"✳ Claude Code"`) on startup, so this resolves ~150–300 ms after
+    /// child spawn. Wrapped in `Mutex<Option<...>>` because the sender is
+    /// consumed (`take()`'d) on first fire — subsequent OSC 0s do not
+    /// re-fire.
+    first_osc_title_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    /// One-shot receiver, taken at most once by
+    /// [`Self::subscribe_first_osc_title`]. After the take, callers that
+    /// ask again get `None` and should treat the worker as already ready
+    /// (the OSC may have fired before they could subscribe, in which case
+    /// the sender already consumed the slot above).
+    first_osc_title_rx: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
 }
 
 impl TerminalSession {
@@ -222,6 +237,15 @@ impl TerminalSession {
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
+        // Phase 1: one-shot fired by the reader thread on the first OSC
+        // 0/2 title transition. The session owns the receiver until a
+        // caller (`spawn_worker_session`) takes it via
+        // `subscribe_first_osc_title`; the reader owns the sender via
+        // an Arc<Mutex<Option<...>>> slot and `take`s it on first fire.
+        let (osc_title_tx, osc_title_rx) = oneshot::channel::<()>();
+        let first_osc_title_tx = Arc::new(Mutex::new(Some(osc_title_tx)));
+        let first_osc_title_rx: Arc<Mutex<Option<oneshot::Receiver<()>>>> =
+            Arc::new(Mutex::new(Some(osc_title_rx)));
 
         // Get a reader from the master PTY
         let mut reader = pair
@@ -239,6 +263,7 @@ impl TerminalSession {
         let reader_total_bytes = total_bytes_produced.clone();
         let reader_output_tx = output_tx.clone();
         let reader_grid = grid.clone();
+        let reader_osc_title_tx = first_osc_title_tx.clone();
         let reader_handle = thread::Builder::new()
             .name(format!("terminal-reader-{}", &id))
             .spawn(move || {
@@ -278,9 +303,41 @@ impl TerminalSession {
                             reader_total_bytes.fetch_add(data.len() as u64, Ordering::Relaxed);
 
                             // Tee through the VT parser into the per-session cell grid.
+                            // Detect the first OSC 0/2 title transition by
+                            // checking whether the grid's title became
+                            // `Some` *during* this parser advance. The
+                            // sender lives in an `Arc<Mutex<Option<...>>>`
+                            // slot we drain on first fire — subsequent
+                            // title changes don't re-fire. Worker dispatch
+                            // gating in `spawn_worker_session` only needs
+                            // the one-shot signal.
+                            let title_was_none = reader_grid
+                                .lock()
+                                .ok()
+                                .map(|g| g.title().is_none())
+                                .unwrap_or(false);
                             if let Ok(mut g) = reader_grid.lock() {
                                 let mut perf = GridPerformer::new(&mut g);
                                 parser.advance(&mut perf, &data);
+                            }
+                            if title_was_none {
+                                let title_is_now_some = reader_grid
+                                    .lock()
+                                    .ok()
+                                    .map(|g| g.title().is_some())
+                                    .unwrap_or(false);
+                                if title_is_now_some {
+                                    if let Ok(mut slot) = reader_osc_title_tx.lock() {
+                                        if let Some(tx) = slot.take() {
+                                            // Receiver may have been
+                                            // dropped (caller didn't
+                                            // subscribe). Ignore — the
+                                            // sender simply discards the
+                                            // signal.
+                                            let _ = tx.send(());
+                                        }
+                                    }
+                                }
                             }
 
                             let encoded = STANDARD.encode(&data);
@@ -409,6 +466,8 @@ impl TerminalSession {
             created_at,
             output_tx,
             grid,
+            first_osc_title_tx,
+            first_osc_title_rx,
         })
     }
 
@@ -581,6 +640,26 @@ impl TerminalSession {
             total_bytes_produced: self.total_bytes_produced.load(Ordering::Relaxed),
             page_id: self.page_id.clone(),
         }
+    }
+
+    /// Take the one-shot receiver that resolves when the reader thread
+    /// observes the first OSC 0/2 title from the child process. Returns
+    /// `None` if a previous caller already took the receiver — callers
+    /// should treat that as "already initialized" and skip the wait.
+    /// `Some(rx)` resolves to `Ok(())` when the title lands, or
+    /// `Err(oneshot::error::RecvError)` if the session closes before any
+    /// OSC 0/2 arrives (caller should fall back to a timeout regardless).
+    ///
+    /// Used by `spawn_worker_session` (Phase 1) to gate
+    /// `Initializing → Ready` on Claude CLI readline visibility — the CLI
+    /// emits its OSC 0 title (`"✳ Claude Code"`) ~150–300 ms after
+    /// startup, so the rx resolves well before the 8 s fallback timeout
+    /// the dispatcher uses.
+    pub fn subscribe_first_osc_title(&self) -> Option<oneshot::Receiver<()>> {
+        self.first_osc_title_rx
+            .lock()
+            .ok()
+            .and_then(|mut slot| slot.take())
     }
 
     /// Get the scrollback buffer contents and the byte offset where the data starts.
@@ -762,6 +841,7 @@ mod tests {
     fn make_test_session(buf: Arc<Mutex<Vec<u8>>>) -> TerminalSession {
         let writer: Box<dyn Write + Send> = Box::new(CapturingWriter(buf));
         let (output_tx, _) = broadcast::channel::<String>(1);
+        let (osc_title_tx, osc_title_rx) = oneshot::channel::<()>();
         TerminalSession {
             id: "test".to_string(),
             title: "test".to_string(),
@@ -785,6 +865,8 @@ mod tests {
             created_at: 0,
             output_tx,
             grid: Arc::new(Mutex::new(Grid::new(80, 24))),
+            first_osc_title_tx: Arc::new(Mutex::new(Some(osc_title_tx))),
+            first_osc_title_rx: Arc::new(Mutex::new(Some(osc_title_rx))),
         }
     }
 
@@ -828,5 +910,16 @@ mod tests {
             "submit_prompt must not emit LF bytes; got {:?}",
             written
         );
+    }
+
+    #[test]
+    fn subscribe_first_osc_title_returns_some_once() {
+        // The receiver can be taken at most once. Subsequent takes return
+        // `None` — `spawn_worker_session` interprets that as "already
+        // ready, skip the wait".
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let session = make_test_session(buf);
+        assert!(session.subscribe_first_osc_title().is_some());
+        assert!(session.subscribe_first_osc_title().is_none());
     }
 }

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -499,8 +499,15 @@ export function TerminalTabBar({
         )}
       </div>
 
-      {/* Scrollable tab area */}
-      <div className="flex items-center gap-0.5 px-1 overflow-x-auto scrollbar-none flex-1 min-w-0 h-full">
+      {/* Scrollable tab area.
+          Phase 3: `items-end` (was `items-center`) anchors every tab to
+          the bottom edge of the strip where the active tab's `-mb-px`
+          overlap happens, so the taller active tab grows UPWARD without
+          dragging the inactive tabs along (active renders extra rows for
+          tags + working-dir; inactives don't). Pair with `min-h-[37px]`
+          on each tab below to give inactives a baseline matching the
+          observed active-tab height. */}
+      <div className="flex items-end gap-0.5 px-1 overflow-x-auto scrollbar-none flex-1 min-w-0 h-full">
         {tabs.map((tab) => {
           const isActive = tab.id === activeId;
           const isDead = !tab.isAlive;
@@ -534,7 +541,7 @@ export function TerminalTabBar({
                 e.dataTransfer.effectAllowed = "move";
               }}
               className={`
-              flex items-center gap-1.5 px-3 py-1 rounded-t text-xs font-medium
+              flex items-center gap-1.5 px-3 py-1 rounded-t text-xs font-medium min-h-[37px]
               transition-colors whitespace-nowrap max-w-[260px] group cursor-grab active:cursor-grabbing
               ${
                 isActive

--- a/src/components/terminal/ZoneGrid.tsx
+++ b/src/components/terminal/ZoneGrid.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useReducer, useRef, useEffect, type RefObject } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import type { TerminalTab } from "./useTerminalManager";
 import type { SessionState, ZoneAssignments } from "./useZoneLayout";
 import { instanceStorage } from "@/lib/instance-storage";
@@ -166,6 +167,14 @@ export function ZoneGrid({
       const trimmed = title.trim();
       if (!trimmed) return;
       renameTab(tabId, trimmed);
+      // Phase 2: bi-directional title sync. The local React rename above
+      // updates UI immediately; fire-and-forget the backend write so other
+      // observers (`GET /terminals`, multi-window setups) see the same
+      // value. Failures are non-fatal — at worst the backend keeps the
+      // spawn-time title; we still rendered the new one locally.
+      invoke("terminal_set_title", { terminalId: tabId, title: trimmed }).catch((e) => {
+        console.warn(`[ZoneGrid] terminal_set_title failed for ${tabId}:`, e);
+      });
     },
     [renameTab],
   );


### PR DESCRIPTION
## Summary

Four root-cause fixes from a 2026-05-11 multi-worker coord soak that showed all 3 Coordinator-dispatched workers stuck at "brief in input pane, never submitted." Plan: [archived in qontinui-dev-notes](https://github.com/qontinui/qontinui-dev-notes/blob/main/plans/2026-05-11-runner-dispatch-and-terminal-ux-fixes-plan.md).

**Phase 1 — Worker `Initializing` state gates dispatch** (5b323ce73)
`WorkerSession::new` now spawns in `SessionState::Initializing`. A new `TerminalSession::subscribe_first_osc_title()` oneshot fires when the child emits its first OSC 0/2 title; `spawn_worker_session` `tokio::spawn`s a readline observer that awaits the oneshot OR an 8 s fallback (whichever fires first) then transitions the worker to `Ready`. `compute_plan_recommendations.idle_session_count` filters live_sessions to Ready-only via `SessionManager::get_state`. `state_string(Initializing)` now returns `"initializing"` instead of `"closed"`.

**Phase 2 — Bi-directional title sync** (fd4026455 + 4961a72dc)
`TerminalSession.title` is now `Arc<Mutex<String>>`; new `TerminalSession::set_title` + `TerminalManager::set_title` forwarder emit a `terminal-title-changed` Tauri event. New `terminal_set_title` command registered in main's central `generate_handler!`. `ZoneGrid.tsx::onTitleChange` now invokes the command alongside the existing local `renameTab`, so `/terminals` and the React tab title stay in sync after Claude's OSC 0 prompt changes.

**Phase 3 — Tab strip vertical alignment** (5d498c168)
`TerminalTabBar.tsx` strip switched from `items-center` → `items-end` with `min-h-[37px]` on each tab button. Active tab's extra cwd/tags rows grow upward; inactives bottom-align with the active tab's title row baseline. Preserves `-mb-px` active-tab overlap.

**Phase 4 — Pre-sized worker PTYs** (04450ff0f)
Reframed in vet pass (original "vertically centered" symptom was not reproducible). New `TerminalManager::dominant_zone_dims()` returns the largest `(cols, rows)` pair across existing sessions; `spawn_worker_session` passes those to `create()` instead of `None, None`. Workers spawn matching the visible neighbors (~114×44) instead of the spawn-default 120×30, so Claude inside the worker wraps consistently with what the user sees after activation. Live UI Bridge probe at vet time confirmed hidden-at-spawn workers were stuck at 120×30 (xterm screen 80×95 px) because `display:none` blocks fit-addon measurement; this avoids the issue at spawn rather than retrofitting another fit layer.

Plus `00eaba192 style: cargo fmt set_title signature`.

## Test plan

- [ ] Manual smoke: spawn N workers from the Coordinator, confirm `coord.session_touched_files` rows appear within ~30 s without any `\x1b[201~\r` unstick.
- [ ] `curl /terminals | jq '.[].title'` after Claude has set OSC 0 — titles should match what the UI renders.
- [ ] Snapshot tab-button `rect.y` across the strip — all identical (`/control/snapshot` + `evaluate`).
- [ ] Spawn a worker, immediately `curl /terminals` — `cols`/`rows` should match the dominant visible tab, not 120×30.
- [ ] `cargo test -p qontinui-runner` — new tests `new_starts_in_initializing_and_is_active`, `initializing_to_ready_transition_round_trips`, `unsupported_set_state_is_ignored`, `set_title_updates_info`, `subscribe_first_osc_title_returns_some_once` all pass.

Session-Id: 61599db8-3b0e-4051-94e5-6c63bb470053