### PR TITLE
chore(lock-yield): dedupe cooldown constant + fix fetchLockInfo undefined ref

### DIFF
--- a/src/components/productivity/FileActivityPanel.test.tsx
+++ b/src/components/productivity/FileActivityPanel.test.tsx
@@ -27,6 +27,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetApiPort = vi.fn(() => 9876);
 vi.mock("@/lib/runner-api", () => ({
   getApiPort: () => mockGetApiPort(),
+  // `fetchHeatmap` + `fetchLockInfo` (`fileActivityApi.ts`) use
+  // `resolvePort()` for port lookup so the synthetic window global
+  // wins over `getApiPort()` in test runs; mock to the same value
+  // for parity.
+  resolvePort: () => mockGetApiPort(),
 }));
 vi.mock("@/lib/logger", () => ({
   createLogger: () => ({

--- a/src/components/productivity/FileActivityPanel.tsx
+++ b/src/components/productivity/FileActivityPanel.tsx
@@ -42,17 +42,15 @@ import {
   type HotSessionRow,
 } from "./fileActivityApi";
 
+import { REQUEST_YIELD_COOLDOWN_MS } from "@/lib/lock-yield";
+
 const logger = createLogger("FileActivityPanel");
 
-/**
- * Lock-Yield cooldown — duplicate of `WaitingLockBanner.REQUEST_YIELD_COOLDOWN_MS`
- * (Phase 3). Kept local rather than imported across the productivity ↔ terminal
- * folder boundary; the two surfaces use the same UX so a future plan should
- * dedupe by hoisting both into a shared `lockYield` module.
- *
- * TODO(lock-yield): dedupe with WaitingLockBanner's constant.
- */
-export const REQUEST_YIELD_COOLDOWN_MS = 30_000;
+// Canonical home for the cooldown lives at `@/lib/lock-yield` — both this
+// dashboard surface and the per-tab WaitingLockBanner consume the same
+// constant. Re-exported for backwards compatibility with the tripwire
+// test in this file's sibling `.test.tsx`.
+export { REQUEST_YIELD_COOLDOWN_MS };
 
 /** Cooldown map key: `${file_path}::${holder_task_run_id}` — per the plan's
  *  Phase 4 spec, the cooldown is per-(file,holder) pair so clicking yield

--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -153,7 +153,7 @@ export async function fetchHeatmap(
 export async function fetchLockInfo(
   signal?: AbortSignal,
 ): Promise<FileLockInfoEntry[]> {
-  const url = `${apiBaseUrl()}/file-locks/info`;
+  const url = `http://127.0.0.1:${resolvePort()}/file-locks/info`;
   const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(`lock info fetch failed: HTTP ${resp.status}`);

--- a/src/components/terminal/WaitingLockBanner.tsx
+++ b/src/components/terminal/WaitingLockBanner.tsx
@@ -32,11 +32,13 @@ import { useEffect, useState } from "react";
 import { Hourglass } from "lucide-react";
 import { getApiPort } from "@/lib/runner-api";
 import { createLogger } from "@/lib/logger";
+import { REQUEST_YIELD_COOLDOWN_MS } from "@/lib/lock-yield";
 
 const logger = createLogger("WaitingLockBanner");
 
-/** 30-second cooldown after Request-yield click (Phase 3 spec). */
-export const REQUEST_YIELD_COOLDOWN_MS = 30_000;
+// Re-exported for backwards compatibility with consumers that imported
+// it from this file (test tripwires + downstream usage).
+export { REQUEST_YIELD_COOLDOWN_MS };
 
 // ── Pure helpers (exported for tests) ────────────────────────────────────────
 

--- a/src/lib/lock-yield.ts
+++ b/src/lib/lock-yield.ts
@@ -1,0 +1,19 @@
+/**
+ * Shared constants for the lock-yield protocol UI (lock-yield-protocol-plan
+ * SHIPPED 2026-05-12, archived in qontinui-dev-notes/plans/).
+ *
+ * Hoisted out of WaitingLockBanner.tsx and FileActivityPanel.tsx so both
+ * surfaces — the per-tab waiting banner in `components/terminal/` and the
+ * dashboard row action in `components/productivity/` — share one source of
+ * truth without crossing the productivity ↔ terminal folder boundary.
+ */
+
+/**
+ * Cooldown applied after a "Request yield" click, in milliseconds.
+ * Prevents the requester from spamming yield-request POSTs at the holder.
+ *
+ * The same value is asserted by tripwire tests in both
+ * `WaitingLockBanner.test.tsx` and `FileActivityPanel.test.tsx` — if you
+ * change this, update both tripwires in lockstep.
+ */
+export const REQUEST_YIELD_COOLDOWN_MS = 30_000;


### PR DESCRIPTION
## Summary
Two small follow-ups from lock-yield-protocol (#93):

1. **Dedupe `REQUEST_YIELD_COOLDOWN_MS`** between `WaitingLockBanner.tsx` and `FileActivityPanel.tsx` — hoisted to a new `src/lib/lock-yield.ts`. Both component files re-export the constant so existing tripwire tests (which import from the component files) keep working without churn.

2. **Fix pre-existing bug from PR #93**: `fileActivityApi.ts::fetchLockInfo()` referenced an undefined `apiBaseUrl()` symbol — see [the function before the fix](https://github.com/qontinui/qontinui-runner/blob/7cdcade4475/src/components/productivity/fileActivityApi.ts#L153-L162). It type-checked at integration time (likely cached `tsc` state), but `npx tsc --noEmit` on a clean checkout flagged it today. Replaced with the same `http://127.0.0.1:${resolvePort()}/...` pattern used by `fetchHeatmap()`. Test mock now exposes `resolvePort` alongside `getApiPort` so the fetchLockInfo unit tests exercise the real code path.

`window.__QONTINUI_PORT__` propagation was already addressed by PR #90 + the `resolvePort()` helper in `@/lib/runner-api`. The four consumers flagged in the heatmap-plan smoke (`fileActivityApi.ts`, `LaunchMenu.tsx`, `useFileLockTracking.ts`, `useReviewState.ts`) already use `resolvePort()`. Nothing more to do there.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run FileActivityPanel WaitingLockBanner` — 46/46 pass (no new failures).
- [x] `npx eslint` clean on all five touched files.
- [x] `cargo` untouched (frontend-only change).