### PR TITLE
docs(contributing): point Rust env-var-mutating tests at startup_panic.rs precedent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,14 @@ cd python-bridge
 pytest
 ```
 
+### Rust unit tests — env-var hygiene
+
+Cargo runs tests within a binary in parallel by default. Two tests in the same binary that touch the same process-wide env var will race: one mutates it, the other reads it expecting the unset (or differently-set) state. The race is OS-sensitive — macOS/Windows tend to finish the env-toggling test fast enough to hide the leak; Ubuntu CI exposes it routinely.
+
+**Canonical pattern: [`src-tauri/src/startup_panic.rs::tests`](src-tauri/src/startup_panic.rs).** That module ships the full shape — module-local `static ENV_LOCK: Mutex<()>` for inter-test serialization, an `EnvGuard` RAII `Drop` that clears the touched vars on every exit path (including panics), and `.lock().unwrap_or_else(|e| e.into_inner())` poison recovery so a panicking test doesn't cascade-fail siblings. Copy that shape verbatim before reaching for `serial_test` or rolling your own. If your test mutates a different env var, name the guard accordingly (e.g. `QontinuiPortGuard` in `scheduler_service.rs::tests`); if multiple modules touch the same var, promote the lock to a shared module.
+
+Avoid the half-pattern (lock without RAII, or RAII without poison recovery): the env state leaks across tests on every panic. See PRs #82 and #95 for examples of retrofitting the full shape onto modules that had one or both halves missing.
+
 ## CI & Merge Readiness
 
 A PR is ready to merge when every required workflow is green on the PR's HEAD commit. Don't merge through red, and don't assume someone else's red is "fine" because `main` is also red — that's how `main` ended up with a 685-run failure streak going back to 2025-09-24.


### PR DESCRIPTION
8-line addition to `CONTRIBUTING.md`'s **Testing** section. Adds a "Rust unit tests — env-var hygiene" subsection pointing at `src-tauri/src/startup_panic.rs::tests` as the canonical template.

## Why
The full pattern (module-local `Mutex<()>` + RAII `Drop` cleanup + `unwrap_or_else(into_inner)` poison recovery) shipped in `3c5f0c5d4` on **2026-04-24**, three weeks before #82 had to rediscover it for the ubuntu-22.04 flake in #74. Two days *after* `startup_panic.rs` landed, `scheduler_service.rs::tests` shipped with only the inter-test lock and no RAII cleanup — caught and retrofitted in #95.

The pattern was invented but never codified anywhere greppable. A single-paragraph reference in `CONTRIBUTING.md` would have collapsed the whole #74→#82→#95 chain into one import-and-go on day two. This PR is that reference.

## What changes
One new subsection under `## Testing`:
- Names the race (parallel test runner + shared env var, OS-sensitive).
- Points readers at `src-tauri/src/startup_panic.rs::tests` as the canonical shape.
- Lists the three pieces — module-local `static ENV_LOCK: Mutex<()>`, RAII `Drop` guard, `unwrap_or_else(|e| e.into_inner())` poison recovery — so the half-pattern (lock without guard, or guard without poison recovery) is recognizable.
- Cites #82 and #95 as retrofit examples for anyone who wants to see the diff.

No code changes. Docs-only PR; pre-push cargo gate skipped via `QONTINUI_PREPUSH_SKIP=1`.

## Test plan
- [x] Markdown renders correctly (preview locally)
- [ ] CI green (only the docs-relevant subset)