### PR TITLE
fix(file-activity): port fetchLockInfo from dropped apiBaseUrl() to resolvePort()

### DIFF
--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -153,7 +153,7 @@ export async function fetchHeatmap(
 export async function fetchLockInfo(
   signal?: AbortSignal,
 ): Promise<FileLockInfoEntry[]> {
-  const url = `${apiBaseUrl()}/file-locks/info`;
+  const url = `http://127.0.0.1:${resolvePort()}/file-locks/info`;
   const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(`lock info fetch failed: HTTP ${resp.status}`);


### PR DESCRIPTION
Main is red — `tsc --noEmit` fails on every platform with:

    src/components/productivity/fileActivityApi.ts(156,18):
    error TS2304: Cannot find name 'apiBaseUrl'.

## Root cause: merge-race between two sibling PRs

| Time (UTC, 2026-05-12) | SHA | PR | What |
|---|---|---|---|
| 06:05:53 | `7cdcade44` | #93 | Adds `fetchLockInfo` calling `apiBaseUrl()` — a function that existed when its branch's CI ran |
| 06:07:35 | `56affd9b5` | #92 | Drops `apiBaseUrl()`, ports every then-existing caller (just `fetchHeatmap`) to `resolvePort()`. CI was clean on its own branch because #93's new caller hadn't merged yet at the time #92's branch HEAD was last tested |

GitHub merged both without re-running CI on the post-#93 state of #92, so main shipped with a dangling reference. I caught it because PR #100 (docs-only) inherited the failure on every OS test job.

## Fix
One-line change — same shape PR #92 used for the other caller (`fetchHeatmap` at line 131): inline the `http://127.0.0.1:${resolvePort()}/...` form. `resolvePort` is already imported at line 22.

```diff
-  const url = `${apiBaseUrl()}/file-locks/info`;
+  const url = `http://127.0.0.1:${resolvePort()}/file-locks/info`;
```

## Test plan
- [x] Local `npx tsc --noEmit` clean
- [ ] CI green on all three OS jobs
- [ ] Once merged, PR #100's CI should auto-recover (no rerun needed since it's a fresh PR that'll pick up the new main when its checks fire next)

## Why this kind of race happens
PR-level CI checks the branch HEAD at approval time, not at merge time. When two PRs both pass CI individually and merge in quick succession, GitHub's branch-protection rules don't re-verify the post-merge state. Branches that drop a symbol the merged-sibling branch added a caller of slip through. Mitigation options for the maintainer (not addressed in this PR): enable "require branches to be up to date before merging" on the branch protection rule, or use a merge queue.