### PR TITLE
fix(productivity): use resolvePort() in fetchLockInfo URL

### DIFF
--- a/src/components/productivity/fileActivityApi.ts
+++ b/src/components/productivity/fileActivityApi.ts
@@ -153,7 +153,7 @@ export async function fetchHeatmap(
 export async function fetchLockInfo(
   signal?: AbortSignal,
 ): Promise<FileLockInfoEntry[]> {
-  const url = `${apiBaseUrl()}/file-locks/info`;
+  const url = `http://127.0.0.1:${resolvePort()}/file-locks/info`;
   const resp = await fetch(url, { signal });
   if (!resp.ok) {
     throw new Error(`lock info fetch failed: HTTP ${resp.status}`);


### PR DESCRIPTION
## Summary
- One-line fix: `fileActivityApi.ts:156` calls `apiBaseUrl()` which isn't imported or defined anywhere in the codebase
- Replace with the sibling pattern from `fetchHeatmap` (line 131): `http://127.0.0.1:${resolvePort()}/...`
- `resolvePort` is already imported at line 22, no other changes needed

## Why
`tsc --noEmit` fails on `main` with:
```
src/components/productivity/fileActivityApi.ts(156,18): error TS2304: Cannot find name 'apiBaseUrl'.
```

Pre-commit hooks reject every commit that touches this file. Discovered while running the productivity-stack-followups §6 closeout test — the cherry-pick I needed to land was blocked.

The bug landed in the Lock-Yield Protocol Phase 4 commit that added `fetchLockInfo`. Probably the author intended to use a helper that was never written (or was removed elsewhere).

## Test plan
- [x] Local `pnpm tsc --noEmit` passes
- [x] Pre-commit hook passes (`Running TypeScript check... All pre-commit checks passed.`)
- [ ] CI Frontend Check passes
- [ ] After merge, a fresh cherry-pick on any branch no longer blocks at the same TypeScript error

Session-Id: e2e-pol2-laptop-2026-05-12