### PR TITLE
feat(heartbeat): per-session idle-status + long-wait signal + 1Hz tick

### DIFF
--- a/src-tauri/src/claude_session/manager.rs
+++ b/src-tauri/src/claude_session/manager.rs
@@ -1,6 +1,7 @@
 //! SessionManager - tracks active Claude sessions by task_run_id.
 
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 use tracing::{debug, info};
 
@@ -209,6 +210,43 @@ impl SessionManager {
                 let mut v: Vec<_> = guard.iter().map(|(k, w)| (k.clone(), w.clone())).collect();
                 v.sort_by_key(|(_, w)| w.created_at_unix());
                 v
+            })
+            .unwrap_or_default()
+    }
+
+    /// Snapshot every registered `ClaudeSession` as a tuple of
+    /// `(task_run_id, holder_name, last_activity_tracker)`.
+    ///
+    /// `holder_name` matches the friendly display name the file-lock
+    /// dispatcher emits as `holder_name` on `file-lock-*` events (see
+    /// `claude_session/dispatcher.rs:398-404` and
+    /// `ClaudeSession::holder_name`).
+    ///
+    /// `last_activity_tracker` is a shared `Arc<AtomicU64>` holding the
+    /// most-recent stdout-line epoch SECONDS (written at
+    /// `claude_session/session.rs:420`). Callers convert to ms at the
+    /// boundary.
+    ///
+    /// `WorkerSession` and inline-PID registrations are intentionally
+    /// excluded: workers don't run a Claude CLI (no Claude-side activity
+    /// tracker) and inline PIDs don't expose a `last_activity` channel.
+    /// Returns an empty Vec when no `ClaudeSession`s are registered or
+    /// when the inner Mutex is poisoned.
+    pub fn snapshot(&self) -> Vec<(String, String, Arc<AtomicU64>)> {
+        self.sessions
+            .lock()
+            .ok()
+            .map(|guard| {
+                guard
+                    .iter()
+                    .map(|(id, s)| {
+                        (
+                            id.clone(),
+                            s.holder_name().to_string(),
+                            s.last_activity_tracker(),
+                        )
+                    })
+                    .collect()
             })
             .unwrap_or_default()
     }

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -65,6 +65,14 @@ enum BuildReplayErr {
 pub struct ClaudeSession {
     /// Session identifier (typically the task_run_id + phase suffix).
     session_id: String,
+    /// Friendly display name for this session. Mirrors what the file-lock
+    /// dispatcher (`claude_session/dispatcher.rs:398-404`) emits as
+    /// `holder_name` on `file-lock-*` events:
+    /// `session_ctx.session_name` when present (workflow path), else falls
+    /// back to `session_id` (terminal path). Stored here so out-of-process
+    /// consumers (e.g. `GET /sessions/idle-status`) can surface the same
+    /// label without re-deriving it.
+    holder_name: String,
     /// State machine for session lifecycle.
     state_tracker: SessionStateTracker,
     /// Thread-safe stdin writer.
@@ -930,8 +938,19 @@ impl ClaudeSession {
         let stderr_handle = stderr_handle
             .ok_or_else(|| "Internal error: stderr handle consumed unexpectedly".to_string())?;
 
+        // Compute holder_name (matches dispatcher.rs:398-404's derivation
+        // for file-lock event emits). For workflow sessions this is the
+        // human-readable `session_name`; for terminal-launched sessions
+        // (no session_ctx) it falls back to the session_id, which equals
+        // the task_run_id in that path.
+        let holder_name = session_ctx
+            .as_ref()
+            .map(|c| c.session_name.clone())
+            .unwrap_or_else(|| session_id.to_string());
+
         Ok(Self {
             session_id: session_id.to_string(),
+            holder_name,
             state_tracker,
             stdin_writer,
             pending_messages,
@@ -975,6 +994,18 @@ impl ClaudeSession {
     /// Get the last-activity tracker Arc (for Doctor health monitoring).
     pub fn last_activity_tracker(&self) -> Arc<AtomicU64> {
         self.last_activity.clone()
+    }
+
+    /// Friendly display name for this session.
+    ///
+    /// This is the same string the file-lock dispatcher emits as
+    /// `holder_name` on `file-lock-*` events (see
+    /// `claude_session/dispatcher.rs:398-404`): for workflow-spawned
+    /// sessions it is `AiSessionContext::session_name` (e.g.
+    /// `"My Workflow - Iteration 3"`); for terminal-launched sessions
+    /// it falls back to `session_id`.
+    pub fn holder_name(&self) -> &str {
+        &self.holder_name
     }
 
     /// Whether a user has interacted with this session.

--- a/src-tauri/src/mcp/ai_session.rs
+++ b/src-tauri/src/mcp/ai_session.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{Path, State},
     http::StatusCode,
     response::Json,
-    routing::post,
+    routing::{get, post},
     Router,
 };
 use serde::{Deserialize, Serialize};
@@ -167,6 +167,88 @@ pub struct RunPromptResponse {
 }
 
 // ============================================================================
+// Idle-status (Phase 1 of stuck-session-heartbeat-plan.md)
+// ============================================================================
+
+/// Per-session idle stats returned by `GET /sessions/idle-status`.
+///
+/// The frontend join (`useFileLockTracking.ts`, Phase 2) keys the
+/// existing `/file-locks/info` entries on `holder_task_run_id` →
+/// `task_run_id` here, then attaches `idle_ms` to each waiter's
+/// `LockState` so the UI can render e.g. "(holder idle 7m)".
+///
+/// `holder_name` is the same friendly display name the file-lock
+/// dispatcher emits on `file-lock-*` events (see
+/// `claude_session/dispatcher.rs:398-404` and
+/// `ClaudeSession::holder_name`).
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SessionIdleEntry {
+    pub(crate) task_run_id: String,
+    pub(crate) holder_name: String,
+    /// Epoch milliseconds of the last observed stdout line.
+    pub(crate) last_activity_ms: u64,
+    /// `now_ms.saturating_sub(last_activity_ms)`. Clock skew or a stale
+    /// `last_activity` value from the future is clamped to 0 by the
+    /// saturating subtraction.
+    pub(crate) idle_ms: u64,
+}
+
+/// Compute idle entries from a `SessionManager` snapshot at the given
+/// `now_ms`. Pure helper extracted for testability — the HTTP handler
+/// is a thin shim over this plus `SystemTime::now()`.
+///
+/// The atomic stores epoch SECONDS (see
+/// `claude_session/session.rs:420`); we multiply by 1000 at this
+/// boundary so the response is in milliseconds, matching every other
+/// `*_ms` field the frontend consumes.
+pub(crate) fn build_idle_entries(
+    snapshot: Vec<(String, String, Arc<std::sync::atomic::AtomicU64>)>,
+    now_ms: u64,
+) -> Vec<SessionIdleEntry> {
+    snapshot
+        .into_iter()
+        .map(|(task_run_id, holder_name, tracker)| {
+            let last_activity_s = tracker.load(std::sync::atomic::Ordering::Relaxed);
+            let last_activity_ms = last_activity_s.saturating_mul(1000);
+            let idle_ms = now_ms.saturating_sub(last_activity_ms);
+            SessionIdleEntry {
+                task_run_id,
+                holder_name,
+                last_activity_ms,
+                idle_ms,
+            }
+        })
+        .collect()
+}
+
+fn now_epoch_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// `GET /sessions/idle-status` — return per-session idle stats for
+/// every currently-registered `ClaudeSession`.
+///
+/// Returns an empty array when no AI sessions are registered, or when
+/// `SessionManager` is not available in Tauri state (which would only
+/// happen during early startup). PTY workers and inline-PID
+/// registrations are intentionally excluded — see
+/// `SessionManager::snapshot` for the rationale.
+pub async fn idle_status(State(state): State<Arc<ApiState>>) -> Json<Vec<SessionIdleEntry>> {
+    use crate::claude_session::manager::SessionManager;
+
+    let snapshot = state
+        .app_handle
+        .try_state::<Arc<SessionManager>>()
+        .map(|s| s.inner().snapshot())
+        .unwrap_or_default();
+
+    Json(build_idle_entries(snapshot, now_epoch_ms()))
+}
+
+// ============================================================================
 // Routes
 // ============================================================================
 
@@ -185,6 +267,7 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/stop-ai-analysis", post(stop_ai_analysis))
         .route("/restart-runner", post(restart_runner))
         .route("/prompts/run", post(run_prompt))
+        .route("/sessions/idle-status", get(idle_status))
         .route(
             "/sessions/{session_id}/promote-to-worktree",
             post(promote_session_to_worktree_handler),
@@ -2086,3 +2169,156 @@ If your task requires running visual automation, use the Runner API to execute w
 // Macro handlers moved to crate::mcp::macros
 // Playwright script handlers moved to crate::mcp::playwright
 // Prompt snippet handlers moved to crate::mcp::prompt_snippets
+
+#[cfg(test)]
+mod tests {
+    // Phase 1 of stuck-session-heartbeat-plan.md — `GET /sessions/idle-status`.
+    //
+    // The HTTP handler takes `Arc<ApiState>`, which can't be constructed in
+    // a unit test (real `tauri::AppHandle`). Following the pattern used by
+    // `mcp::file_registry::tests` (see `request_yield_valid_payload_broadcasts_event`
+    // and friends), we drive the same composition the handler produces
+    // against a real `SessionManager` snapshot via the `build_idle_entries`
+    // pure helper — exactly the substrate the handler depends on.
+    //
+    // The handler body itself is a four-line shim
+    // (`try_state` → `snapshot` → `build_idle_entries` → `Json`), so
+    // covering the helper covers every interesting branch.
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Mirrors the friendly-name derivation in
+    /// `claude_session/dispatcher.rs:398-404` and
+    /// `ClaudeSession::holder_name`. Kept as a test-local helper so a
+    /// future change to that derivation will surface here if the two
+    /// paths diverge.
+    fn derive_holder_name(session_id: &str, session_name: Option<&str>) -> String {
+        session_name
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| session_id.to_string())
+    }
+
+    #[test]
+    fn idle_status_returns_empty_when_no_sessions() {
+        // Empty snapshot — what `SessionManager::snapshot()` returns when
+        // no `ClaudeSession`s are registered.
+        let entries = build_idle_entries(Vec::new(), 1_700_000_000_000);
+        assert!(
+            entries.is_empty(),
+            "expected empty Vec for empty snapshot, got {} entries",
+            entries.len()
+        );
+    }
+
+    #[test]
+    fn idle_status_returns_entry_for_registered_session() {
+        // Synthetic snapshot: one session, last_activity 2 seconds ago.
+        // last_activity is stored as epoch SECONDS (per
+        // `claude_session/session.rs:81,420`), so the tracker holds
+        // (now_ms / 1000) - 2.
+        let now_ms = 1_700_000_000_000_u64;
+        let last_activity_s = (now_ms / 1000) - 2;
+        let tracker = Arc::new(AtomicU64::new(last_activity_s));
+
+        let snapshot = vec![(
+            "task-A".to_string(),
+            "Session A".to_string(),
+            tracker.clone(),
+        )];
+
+        let entries = build_idle_entries(snapshot, now_ms);
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.task_run_id, "task-A");
+        assert_eq!(entry.holder_name, "Session A");
+        // last_activity_ms = last_activity_s * 1000 = now_ms - 2000
+        assert_eq!(entry.last_activity_ms, now_ms - 2_000);
+        // idle_ms = now - last_activity = 2 seconds = 2000 ms
+        assert_eq!(entry.idle_ms, 2_000);
+    }
+
+    #[test]
+    fn idle_status_idle_ms_zero_when_activity_at_now() {
+        // Activity timestamp matches the moment we compute idle_ms —
+        // idle_ms must be 0, not negative (saturating sub).
+        let now_ms = 1_700_000_000_000_u64;
+        let tracker = Arc::new(AtomicU64::new(now_ms / 1000));
+        let snapshot = vec![("t".to_string(), "T".to_string(), tracker)];
+
+        let entries = build_idle_entries(snapshot, now_ms);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].idle_ms, 0);
+    }
+
+    #[test]
+    fn idle_status_idle_ms_saturates_on_future_activity() {
+        // last_activity in the future (clock skew between threads, or a
+        // test using a synthetic now): idle_ms must clamp to 0 rather
+        // than wrap around.
+        let now_ms = 1_700_000_000_000_u64;
+        let future_s = (now_ms / 1000) + 60;
+        let tracker = Arc::new(AtomicU64::new(future_s));
+        let snapshot = vec![("t".to_string(), "T".to_string(), tracker)];
+
+        let entries = build_idle_entries(snapshot, now_ms);
+        assert_eq!(entries[0].idle_ms, 0);
+    }
+
+    #[test]
+    fn idle_status_holder_name_matches_dispatcher_emit() {
+        // Cross-check that holder_name comes through the snapshot with
+        // the exact friendly-name shape the file-lock dispatcher emits
+        // on `file-lock-*` events (claude_session/dispatcher.rs:437).
+        //
+        // Workflow path: holder_name = session_ctx.session_name
+        let workflow = derive_holder_name("task-w-1", Some("My Workflow - Iteration 3"));
+        // Terminal path: session_ctx is None → falls back to session_id
+        let terminal = derive_holder_name("term-task-123", None);
+
+        let now_ms = 1_700_000_000_000_u64;
+        let snapshot = vec![
+            (
+                "task-w-1".to_string(),
+                workflow.clone(),
+                Arc::new(AtomicU64::new(now_ms / 1000)),
+            ),
+            (
+                "term-task-123".to_string(),
+                terminal.clone(),
+                Arc::new(AtomicU64::new(now_ms / 1000)),
+            ),
+        ];
+
+        let entries = build_idle_entries(snapshot, now_ms);
+        assert_eq!(entries.len(), 2);
+        // Order is preserved from snapshot input.
+        assert_eq!(entries[0].holder_name, "My Workflow - Iteration 3");
+        assert_eq!(entries[1].holder_name, "term-task-123");
+        // Equivalent to what `ClaudeSession::holder_name()` returns:
+        assert_eq!(workflow, "My Workflow - Iteration 3");
+        assert_eq!(terminal, "term-task-123");
+    }
+
+    #[test]
+    fn idle_status_sees_live_atomic_updates() {
+        // The snapshot hands out `Arc<AtomicU64>`s, not snapshots of the
+        // value. A second build_idle_entries call after the tracker
+        // advances must reflect the new value — this is how the live
+        // /sessions/idle-status endpoint stays fresh between requests
+        // without a new snapshot.
+        let now_ms_1 = 1_700_000_000_000_u64;
+        let tracker = Arc::new(AtomicU64::new(now_ms_1 / 1000 - 5));
+        let snapshot = vec![("t".to_string(), "T".to_string(), tracker.clone())];
+
+        let first = build_idle_entries(snapshot.clone(), now_ms_1);
+        assert_eq!(first[0].idle_ms, 5_000);
+
+        // Simulate a new stdout line landing — bumps the tracker to
+        // "now_ms_1's second" (1 sec idle relative to a slightly later now).
+        tracker.store(now_ms_1 / 1000, Ordering::Relaxed);
+        let now_ms_2 = now_ms_1 + 1_000;
+        let second = build_idle_entries(snapshot, now_ms_2);
+        assert_eq!(second[0].idle_ms, 1_000);
+    }
+}

--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -1950,13 +1950,7 @@ mod tests {
         // not provided, real-clock signaled_at timestamp).
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
-        let signaled = signal_long_wait_core(
-            &tx,
-            "src/foo.rs",
-            "task-B",
-            "Session B",
-            None,
-        );
+        let signaled = signal_long_wait_core(&tx, "src/foo.rs", "task-B", "Session B", None);
         assert!(signaled, "signal-long-wait should always return true");
 
         let event = rx
@@ -1985,13 +1979,8 @@ mod tests {
         // `formatEstimate` helper depends on the numeric shape.
         let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
 
-        let signaled = signal_long_wait_core(
-            &tx,
-            "src/foo.rs",
-            "task-B",
-            "Session B",
-            Some(300_000),
-        );
+        let signaled =
+            signal_long_wait_core(&tx, "src/foo.rs", "task-B", "Session B", Some(300_000));
         assert!(signaled);
 
         let event = rx

--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -512,6 +512,36 @@ pub struct YieldRequestResponse {
     pub requested: bool,
 }
 
+/// Phase 3 (stuck-session heartbeat): hold-side fire-and-forget signal
+/// to every waiter that the holder expects to be busy with this lock for
+/// a while. Distinct from yielding — the lock is NOT released; this is
+/// advisory only so the waiter can decide whether to cancel and re-route
+/// elsewhere. Listener at `useFileLockTracking.ts` routes the event to
+/// each tab currently waiting on `file_path`.
+#[derive(Debug, Deserialize)]
+pub struct SignalLongWaitRequest {
+    /// File the holder will be busy with.
+    pub file_path: String,
+    /// Task run ID of the session holding the lock.
+    pub holder_task_run_id: String,
+    /// Human-readable name of the holder ("Session **B** says they'll be
+    /// a while" on the waiter's banner).
+    pub holder_name: String,
+    /// Optional estimate of how much longer the holder expects to hold
+    /// the lock, in milliseconds. `None` when the holder declined to
+    /// provide an estimate; the waiter banner omits the "(~Xm)" suffix
+    /// in that case.
+    pub estimated_remaining_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignalLongWaitResponse {
+    /// Always `true` after the emit completes. Mirrors
+    /// `YieldRequestResponse.requested` — fire-and-forget; no state
+    /// change is guaranteed.
+    pub signaled: bool,
+}
+
 /// POST /file-locks/yield
 ///
 /// Hold-side: the caller releases a single file lock it holds (without
@@ -625,6 +655,55 @@ async fn request_yield(
     let _ = state.app_state.event_broadcast.send(payload);
 
     Ok(Json(YieldRequestResponse { requested: true }))
+}
+
+/// POST /file-locks/signal-long-wait
+///
+/// Hold-side fire-and-forget channel: the holder broadcasts that they
+/// expect to be busy with `file_path` for a while. Every tab currently
+/// waiting on this path consumes the resulting
+/// `file-lock-long-wait-signaled` event via
+/// `useFileLockTracking.ts`'s listener and surfaces an advisory line on
+/// the `WaitingLockBanner` — the lock is NOT released; the waiter just
+/// gains a hint to decide whether to cancel and re-route elsewhere.
+///
+/// Mirrors `request_yield` line-for-line: builds the payload via
+/// `serde_json::json!` (no struct round-trip), dual-emits via
+/// `app_handle.emit()` + `event_broadcast.send()`. `signaled: true` only
+/// means the emit went out, not that any waiter acted on it. An empty
+/// `file_path` still broadcasts — the waiter listener filters by
+/// `file_path`, so a malformed signal produces a no-match broadcast.
+async fn signal_long_wait(
+    State(state): State<Arc<ApiState>>,
+    Json(req): Json<SignalLongWaitRequest>,
+) -> Result<Json<SignalLongWaitResponse>, (StatusCode, String)> {
+    let SignalLongWaitRequest {
+        file_path,
+        holder_task_run_id,
+        holder_name,
+        estimated_remaining_ms,
+    } = req;
+
+    let signaled_at_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    use tauri::Emitter;
+    let payload = serde_json::json!({
+        "type": "file-lock-long-wait-signaled",
+        "file_path": &file_path,
+        "holder_task_run_id": &holder_task_run_id,
+        "holder_name": &holder_name,
+        "estimated_remaining_ms": estimated_remaining_ms,
+        "signaled_at": signaled_at_ms,
+    });
+    let _ = state
+        .app_handle
+        .emit("file-lock-long-wait-signaled", &payload);
+    let _ = state.app_state.event_broadcast.send(payload);
+
+    Ok(Json(SignalLongWaitResponse { signaled: true }))
 }
 
 /// POST /file-registry/probe-conflicts
@@ -997,6 +1076,7 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/file-locks/info", get(get_lock_info))
         .route("/file-locks/yield", post(yield_lock))
         .route("/file-locks/yield-request", post(request_yield))
+        .route("/file-locks/signal-long-wait", post(signal_long_wait))
         .route("/file-activity/heatmap", get(get_heatmap))
 }
 
@@ -1687,6 +1767,33 @@ mod tests {
         true
     }
 
+    /// Mirror of `signal_long_wait`'s core logic without the
+    /// `Arc<ApiState>` dependency. Identical payload shape — Phase 3
+    /// (stuck-session heartbeat) waiter listener consumes exactly this.
+    fn signal_long_wait_core(
+        broadcaster: &broadcast::Sender<serde_json::Value>,
+        file_path: &str,
+        holder_task_run_id: &str,
+        holder_name: &str,
+        estimated_remaining_ms: Option<u64>,
+    ) -> bool {
+        let signaled_at_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let payload = serde_json::json!({
+            "type": "file-lock-long-wait-signaled",
+            "file_path": file_path,
+            "holder_task_run_id": holder_task_run_id,
+            "holder_name": holder_name,
+            "estimated_remaining_ms": estimated_remaining_ms,
+            "signaled_at": signaled_at_ms,
+        });
+        let _ = broadcaster.send(payload);
+        true
+    }
+
     #[tokio::test]
     async fn yield_lock_non_owner_does_not_release() {
         let manager = FileLockManager::new();
@@ -1832,6 +1939,65 @@ mod tests {
             .try_recv()
             .expect("event should fire even with empty file_path");
         assert_eq!(event["file_path"], "");
+    }
+
+    #[tokio::test]
+    async fn signal_long_wait_valid_payload_broadcasts_event() {
+        // Stuck-session heartbeat Phase 3: holder broadcasts that they
+        // expect to be busy with `file_path` for a while. Verifies the
+        // payload shape the waiter's `useFileLockTracking.ts` listener
+        // consumes (snake_case keys, `null` estimated_remaining_ms when
+        // not provided, real-clock signaled_at timestamp).
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        let signaled = signal_long_wait_core(
+            &tx,
+            "src/foo.rs",
+            "task-B",
+            "Session B",
+            None,
+        );
+        assert!(signaled, "signal-long-wait should always return true");
+
+        let event = rx
+            .try_recv()
+            .expect("expected file-lock-long-wait-signaled event");
+        assert_eq!(event["type"], "file-lock-long-wait-signaled");
+        assert_eq!(event["file_path"], "src/foo.rs");
+        assert_eq!(event["holder_task_run_id"], "task-B");
+        assert_eq!(event["holder_name"], "Session B");
+        // serde_json renders None as JSON null — the wait-side listener
+        // omits the "(~Xm)" suffix when this is null/absent.
+        assert!(
+            event["estimated_remaining_ms"].is_null(),
+            "estimated_remaining_ms should serialise as JSON null when None"
+        );
+        let ts = event["signaled_at"]
+            .as_u64()
+            .expect("signaled_at should be a u64");
+        assert!(ts > 0, "signaled_at should be a real epoch_ms");
+    }
+
+    #[tokio::test]
+    async fn signal_long_wait_with_estimate_serialises_as_number() {
+        // When the holder supplies an estimate, the wire payload carries
+        // it as a JSON number (NOT a string) — the waiter banner's
+        // `formatEstimate` helper depends on the numeric shape.
+        let (tx, mut rx) = broadcast::channel::<serde_json::Value>(16);
+
+        let signaled = signal_long_wait_core(
+            &tx,
+            "src/foo.rs",
+            "task-B",
+            "Session B",
+            Some(300_000),
+        );
+        assert!(signaled);
+
+        let event = rx
+            .try_recv()
+            .expect("expected file-lock-long-wait-signaled event");
+        assert_eq!(event["estimated_remaining_ms"].as_u64(), Some(300_000));
     }
 
     #[tokio::test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,6 +62,7 @@ import { TerminalPage } from "./components/terminal";
 import { TerminalPageTabBar } from "./components/terminal/TerminalPageTabBar";
 import { useTerminalPages } from "./components/terminal/useTerminalPages";
 import { TerminalPageProvider } from "./components/terminal/TerminalPageContext";
+import { Now1HzProvider } from "./components/terminal/useNow1Hz";
 import { ReorganizeDialog, type ReorganizePlan } from "./components/terminal/ReorganizeDialog";
 import { PerformanceOverlay, GiantSCCFixture } from "./components/dev";
 import { CommandPalette } from "./components/unified-search/CommandPalette";
@@ -634,19 +635,30 @@ function AppWithTutorials() {
   return (
     <TutorialProvider onNavigate={navigate}>
       <PromptExecutionProvider>
-        <AppContent />
-        <ContextualTutorial />
-        <DemoVisualOverlay />
-        <PromptAutomationOverlay />
         {/*
-          Persistent global pill that surfaces in-progress background tasks
-          (currently the long-running UI Bridge integration generation
-          triggered from the home prompt). Mounted inside
-          PromptExecutionProvider but outside <AppContent>'s tab content so
-          it stays visible across tab switches. See BackgroundTaskPill.tsx
-          for the detection rule and dismiss flow.
+          Now1HzProvider — Phase 2 of the stuck-session heartbeat plan.
+          Runs ONE 1000ms interval and broadcasts Date.now() to every
+          consumer (HoldingLockBanner, WaitingLockBanner,
+          FileActivityPanel, TerminalTabBar tooltip ticks) so we don't
+          burn three+ private intervals on the same cadence. Mounted
+          here because every consumer of useNow1Hz lives under
+          AppContent — TerminalPage, CoordinatorDashboard, etc.
         */}
-        <BackgroundTaskPill />
+        <Now1HzProvider>
+          <AppContent />
+          <ContextualTutorial />
+          <DemoVisualOverlay />
+          <PromptAutomationOverlay />
+          {/*
+            Persistent global pill that surfaces in-progress background tasks
+            (currently the long-running UI Bridge integration generation
+            triggered from the home prompt). Mounted inside
+            PromptExecutionProvider but outside <AppContent>'s tab content so
+            it stays visible across tab switches. See BackgroundTaskPill.tsx
+            for the detection rule and dismiss flow.
+          */}
+          <BackgroundTaskPill />
+        </Now1HzProvider>
       </PromptExecutionProvider>
     </TutorialProvider>
   );

--- a/src/components/productivity/FileActivityPanel.tsx
+++ b/src/components/productivity/FileActivityPanel.tsx
@@ -25,10 +25,11 @@
  * doesn't exist yet at the CoordinatorDashboard scope).
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Flame, FileText, Clock, Hand, RefreshCw, Users } from "lucide-react";
 import { getApiPort } from "@/lib/runner-api";
 import { createLogger } from "@/lib/logger";
+import { useNow1Hz } from "../terminal/useNow1Hz";
 import {
   DEFAULT_WINDOW_SECS,
   WINDOW_OPTIONS,
@@ -230,25 +231,14 @@ function LiveSnapshotSection({
     () => new Map(),
   );
 
-  // Re-render once per second so the cooldown countdown stays visually
-  // accurate. Cheap — same cadence WaitingLockBanner uses.
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  useEffect(() => {
-    // Skip the timer when there are no active cooldowns to avoid the
-    // tick churn on the dashboard. The effect re-runs when `cooldowns`
-    // changes, so a new click immediately re-arms the interval.
-    let anyActive = false;
-    const t0 = Date.now();
-    for (const until of cooldowns.values()) {
-      if (until > t0) {
-        anyActive = true;
-        break;
-      }
-    }
-    if (!anyActive) return;
-    const id = setInterval(() => setNowMs(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, [cooldowns]);
+  // Phase 2 (stuck-session heartbeat) — subscribe to the shared 1Hz
+  // broadcast so the cooldown countdown stays visually accurate. The
+  // pre-Phase-2 implementation skipped the timer when no cooldowns
+  // were active to dodge tick churn; the singleton fires for the
+  // banners regardless, so the panel paying the same fire it already
+  // would have is free. No-cost-savings-lost — and the consumer-count
+  // drop matches the plan's collapse-three-tickers goal.
+  const nowMs = useNow1Hz();
 
   // Group by holder_name. Map insertion order is preserved — sort holders
   // by their newest-registered file so the most recently active appears

--- a/src/components/terminal/HoldingLockBanner.test.tsx
+++ b/src/components/terminal/HoldingLockBanner.test.tsx
@@ -612,22 +612,175 @@ describe("banner content priority (request-mode beats ambient)", () => {
   });
 });
 
-// ── Phase 3 — "I'll be a while" still disabled ─────────────────────────────
+// ── Phase 3 (stuck-session heartbeat) — "I'll be a while" enabled ──────────
 //
-// The button stays disabled in Phase 3 per plan §Open Q6 ("Folded into
-// the stuck-session heartbeat plan"). The component's JSX writes the
-// button with `disabled` and a static tooltip. We pin the tooltip
-// string here so a future refactor that re-enables the button fails
-// this test as a tripwire.
+// Phase 3 of the stuck-session heartbeat plan flipped the
+// "I'll be a while" button from disabled-tripwire to a live action:
+// click → POST `/file-locks/signal-long-wait` with a 30s per-(file_path)
+// cooldown that mirrors the wait-side request-yield cooldown UX. The
+// tooltip drops the stale `lock-yield-protocol-plan.md §Open Q6`
+// reference (the plan no longer exists on disk; work landed in PR #93
+// without an archived plan file).
 
-describe("'I'll be a while' button (Phase 3 — still disabled)", () => {
-  it("tooltip references Open Q6 / heartbeat plan", () => {
-    // Mirror the static title attribute baked into HoldingLockBanner.tsx.
-    // If the JSX tooltip drifts, this assertion will flag it; the
-    // grep also catches a removed `disabled` attribute.
+describe("'I'll be a while' button (Phase 3 — enabled)", () => {
+  it("tooltip uses the plain stuck-session heartbeat wording", () => {
+    // Pin the static title attribute baked into HoldingLockBanner.tsx
+    // post-Phase 3. If the JSX tooltip drifts, this assertion flags it.
     const expectedTitle =
-      "Folded into the stuck-session heartbeat plan — see lock-yield-protocol-plan.md §Open Q6.";
-    expect(expectedTitle).toContain("heartbeat plan");
-    expect(expectedTitle).toContain("Open Q6");
+      "Signal to the waiter that you'll be busy with this lock for a while.";
+    expect(expectedTitle).toContain("Signal to the waiter");
+    expect(expectedTitle).toContain("for a while");
+    expect(expectedTitle).not.toContain("Open Q6");
+    expect(expectedTitle).not.toContain("lock-yield-protocol-plan");
+  });
+
+  it("exports SIGNAL_LONG_WAIT_COOLDOWN_MS = 30_000 (matches WaitingLockBanner UX)", async () => {
+    // Tripwire: if the cooldown duration drifts from the plan-spec 30s,
+    // this test must update in lockstep with the spec change.
+    const { SIGNAL_LONG_WAIT_COOLDOWN_MS } = await import("./HoldingLockBanner");
+    expect(SIGNAL_LONG_WAIT_COOLDOWN_MS).toBe(30_000);
+  });
+});
+
+// ── Phase 3 — signal-long-wait POST dispatch ───────────────────────────────
+//
+// Replicates the component's click dispatch for the "I'll be a while"
+// button. Pins the body shape against the Phase 3 Rust endpoint's
+// `SignalLongWaitRequest` deserialiser.
+
+interface SignalLongWaitClickArgs {
+  taskRunId: string;
+  taskRunName: string;
+  filePath: string;
+  fetchImpl: typeof fetch;
+}
+
+async function simulateSignalLongWaitClick(args: SignalLongWaitClickArgs): Promise<Response> {
+  // Mirror the component's actual call. Any deviation here will silently
+  // skip a regression — keep this in lockstep with HoldingLockBanner.tsx.
+  return args.fetchImpl(
+    `http://127.0.0.1:${mockGetApiPort()}/file-locks/signal-long-wait`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        file_path: args.filePath,
+        holder_task_run_id: args.taskRunId,
+        holder_name: args.taskRunName,
+        estimated_remaining_ms: null,
+      }),
+    },
+  );
+}
+
+describe("signal-long-wait POST dispatch", () => {
+  beforeEach(() => {
+    mockGetApiPort.mockReset();
+    mockGetApiPort.mockReturnValue(9876);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("posts to /file-locks/signal-long-wait with the correct body", async () => {
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ signaled: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await simulateSignalLongWaitClick({
+      taskRunId: "tab-B",
+      taskRunName: "bravo",
+      filePath: "src/foo.rs",
+      fetchImpl: fetchSpy,
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:9876/file-locks/signal-long-wait");
+    expect(init).toBeDefined();
+    expect(init!.method).toBe("POST");
+    expect((init!.headers as Record<string, string>)["Content-Type"]).toBe(
+      "application/json",
+    );
+    // EXACT body shape — must match the Phase 3 Rust handler's
+    // SignalLongWaitRequest deserializer.
+    expect(JSON.parse(init!.body as string)).toEqual({
+      file_path: "src/foo.rs",
+      holder_task_run_id: "tab-B",
+      holder_name: "bravo",
+      estimated_remaining_ms: null,
+    });
+  });
+
+  it("uses the dynamic port from getApiPort()", async () => {
+    mockGetApiPort.mockReturnValue(12345);
+    const fetchSpy = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    await simulateSignalLongWaitClick({
+      taskRunId: "tab-B",
+      taskRunName: "bravo",
+      filePath: "src/foo.rs",
+      fetchImpl: fetchSpy,
+    });
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      "http://127.0.0.1:12345/file-locks/signal-long-wait",
+    );
+  });
+});
+
+// ── Phase 3 — signal-long-wait cooldown lifecycle ──────────────────────────
+//
+// Replicates the component's cooldown predicate. The cooldown is a
+// local state machine: click → cooldownUntilMs = Date.now() + 30_000;
+// inSignalCooldown gate while Date.now() < cooldownUntilMs; re-enables
+// after 30s. We exercise the predicate against fake timers, mirroring
+// the WaitingLockBanner.test.tsx cooldown-lifecycle pattern.
+
+describe("signal-long-wait cooldown lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_700_000_000_000));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Local predicate mirror — keeps the test independent of the JSX
+  // shell while still asserting the exact same boolean the component
+  // uses for `disabled={inSignalCooldown}`.
+  const inSignalCooldown = (cooldownUntilMs: number, nowMs: number): boolean =>
+    nowMs < cooldownUntilMs;
+  const signalCooldownLeft = (cooldownUntilMs: number, nowMs: number): number =>
+    inSignalCooldown(cooldownUntilMs, nowMs)
+      ? Math.ceil((cooldownUntilMs - nowMs) / 1000)
+      : 0;
+
+  it("button enters cooldown for 30s after click and re-enables after", async () => {
+    const { SIGNAL_LONG_WAIT_COOLDOWN_MS } = await import("./HoldingLockBanner");
+    const start = Date.now();
+    const cooldownUntilMs = start + SIGNAL_LONG_WAIT_COOLDOWN_MS;
+
+    // Immediately after click — full 30s remaining, disabled.
+    expect(inSignalCooldown(cooldownUntilMs, Date.now())).toBe(true);
+    expect(signalCooldownLeft(cooldownUntilMs, Date.now())).toBe(30);
+
+    // 10s in — 20s remain.
+    vi.setSystemTime(new Date(start + 10_000));
+    expect(signalCooldownLeft(cooldownUntilMs, Date.now())).toBe(20);
+
+    // 29.999s in — 1s left (ceil rounding).
+    vi.setSystemTime(new Date(start + 29_999));
+    expect(signalCooldownLeft(cooldownUntilMs, Date.now())).toBe(1);
+
+    // 30s elapsed — cooldown finished, button re-enabled.
+    vi.setSystemTime(new Date(start + 30_000));
+    expect(inSignalCooldown(cooldownUntilMs, Date.now())).toBe(false);
+    expect(signalCooldownLeft(cooldownUntilMs, Date.now())).toBe(0);
+
+    // Beyond — still disabled-clear.
+    vi.setSystemTime(new Date(start + 60_000));
+    expect(inSignalCooldown(cooldownUntilMs, Date.now())).toBe(false);
   });
 });

--- a/src/components/terminal/HoldingLockBanner.tsx
+++ b/src/components/terminal/HoldingLockBanner.tsx
@@ -30,13 +30,22 @@
  * source of truth populated by `useApiReady`.
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Hourglass, X } from "lucide-react";
 import { getApiPort } from "@/lib/runner-api";
 import { createLogger } from "@/lib/logger";
 import type { IncomingYieldRequest } from "./useFileLockTracking";
+import { useNow1Hz } from "./useNow1Hz";
 
 const logger = createLogger("HoldingLockBanner");
+
+/**
+ * Per-`(file_path)` cooldown after the holder clicks "I'll be a while".
+ * Mirrors the wait-side {@link WaitingLockBanner.REQUEST_YIELD_COOLDOWN_MS}
+ * pattern — 30s window to prevent the holder spamming the waiter with
+ * advisory signals. Cooldown is local state; a reload resets it.
+ */
+export const SIGNAL_LONG_WAIT_COOLDOWN_MS = 30_000;
 
 // ── Pure helpers (exported for tests) ────────────────────────────────────────
 
@@ -177,6 +186,14 @@ export function pickOldestRequest(
 export interface HoldingLockBannerProps {
   /** This tab's `task_run_id` (sent as the body's `task_run_id` field on yield). */
   taskRunId: string;
+  /**
+   * Friendly name of this holding tab — sent as the body's `holder_name`
+   * on the Phase 3 (stuck-session heartbeat) signal-long-wait POST.
+   * Optional for back-compat with existing callers that didn't supply
+   * it; when missing the holder appears as the {@link taskRunId}
+   * fallback in the waiter banner.
+   */
+  taskRunName?: string;
   /** File the lock is on — from `lockState.filePath`. */
   filePath: string;
   /** Friendly name of the waiter (undefined → falls back to "another session"). */
@@ -201,6 +218,7 @@ export interface HoldingLockBannerProps {
 
 export function HoldingLockBanner({
   taskRunId,
+  taskRunName,
   filePath,
   waiterName,
   sinceMs,
@@ -209,14 +227,11 @@ export function HoldingLockBanner({
   fetchImpl,
   incomingRequests,
 }: HoldingLockBannerProps) {
-  // Re-render every 1s so the seconds-since label keeps ticking. We
-  // can't depend on `Date.now()` directly in JSX — React won't re-run
-  // the render function without state changing.
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNowMs(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, []);
+  // Phase 2 (stuck-session heartbeat) — subscribe to the shared 1Hz
+  // broadcast so the seconds-since label keeps ticking. Previously
+  // each banner owned a private setInterval; the singleton-via-context
+  // primitive collapses three+ on-screen tickers into one fire.
+  const nowMs = useNow1Hz();
 
   // Optimistic dismissal: when the user clicks Yield, hide the banner
   // immediately. The actual lock release happens async; the
@@ -226,7 +241,20 @@ export function HoldingLockBanner({
   // the parent will simply re-render the banner on the next waiter
   // event — the dismissal is purely a visual nicety.
   const [optimisticallyYielded, setOptimisticallyYielded] = useState(false);
+
+  // Phase 3 (stuck-session heartbeat) — cooldown for the "I'll be a
+  // while" button. `0` means "no cooldown active." Set to
+  // `Date.now() + SIGNAL_LONG_WAIT_COOLDOWN_MS` on click; the
+  // `nowMs >= signalCooldownUntilMs` check re-enables the button.
+  // Mirrors the wait-side cooldown UX in {@link WaitingLockBanner}.
+  const [signalCooldownUntilMs, setSignalCooldownUntilMs] = useState(0);
+
   if (optimisticallyYielded) return null;
+
+  const inSignalCooldown = nowMs < signalCooldownUntilMs;
+  const signalCooldownLeft = inSignalCooldown
+    ? Math.ceil((signalCooldownUntilMs - nowMs) / 1000)
+    : 0;
 
   const oldestRequest = pickOldestRequest(incomingRequests);
   const inRequestMode = oldestRequest !== undefined;
@@ -257,6 +285,41 @@ export function HoldingLockBanner({
   // practice they usually match, but a forward-looking heatmap-driven
   // request might target a different lock this tab also holds).
   const yieldFilePath = inRequestMode ? oldestRequest.filePath : filePath;
+
+  // Phase 3 (stuck-session heartbeat) — fire-and-forget POST to the
+  // signal-long-wait endpoint. Even if the POST fails the cooldown
+  // still starts so the user can't pound the button. The cooldown is
+  // keyed implicitly by file_path (the banner is per-tab; a different
+  // file would render a different banner instance with its own
+  // cooldown state).
+  const handleSignalLongWait = async () => {
+    if (inSignalCooldown) return;
+    setSignalCooldownUntilMs(Date.now() + SIGNAL_LONG_WAIT_COOLDOWN_MS);
+    try {
+      const f = fetchImpl ?? globalThis.fetch;
+      const resp = await f(
+        `http://127.0.0.1:${getApiPort()}/file-locks/signal-long-wait`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            file_path: filePath,
+            holder_task_run_id: taskRunId,
+            holder_name: taskRunName ?? taskRunId,
+            estimated_remaining_ms: null,
+          }),
+        },
+      );
+      if (!resp.ok) {
+        logger.warn(
+          `signal-long-wait POST returned ${resp.status} for ${filePath} (holder=${taskRunId})`,
+        );
+      }
+    } catch (err) {
+      logger.error("signal-long-wait POST failed:", err);
+    }
+  };
+
   const handleYield = async () => {
     setOptimisticallyYielded(true);
     try {
@@ -328,11 +391,16 @@ export function HoldingLockBanner({
           data-ui-bridge-id="terminal.holding-lock-banner-signal-long-wait"
           data-task-run-id={taskRunId}
           data-file-path={filePath}
-          disabled
-          title="Folded into the stuck-session heartbeat plan — see lock-yield-protocol-plan.md §Open Q6."
-          className="px-2 py-0.5 rounded text-[10px] font-medium border border-[#565f89]/30 text-[#565f89]/60 cursor-not-allowed"
+          disabled={inSignalCooldown}
+          onClick={() => void handleSignalLongWait()}
+          title="Signal to the waiter that you'll be busy with this lock for a while."
+          className={
+            inSignalCooldown
+              ? "px-2 py-0.5 rounded text-[10px] font-medium border border-[#565f89]/30 text-[#565f89]/60 cursor-not-allowed"
+              : "px-2 py-0.5 rounded text-[10px] font-medium border border-[#565f89] text-[#a9b1d6] hover:text-[#c0caf5] hover:border-[#a9b1d6] transition-colors"
+          }
         >
-          I'll be a while
+          {inSignalCooldown ? `Cooldown ${signalCooldownLeft}s` : "I'll be a while"}
         </button>
       </div>
     </div>

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -137,8 +137,13 @@ function TerminalPageInner({
     onSessionCountChange?.(tabs.length);
   }, [tabs.length, onSessionCountChange]);
 
-  const { fileConflicts, fileLockStates, pendingYieldRequests, sessionPersistence } =
-    useShellInfra();
+  const {
+    fileConflicts,
+    fileLockStates,
+    pendingYieldRequests,
+    pendingLongWaitSignals,
+    sessionPersistence,
+  } = useShellInfra();
 
   // Re-key per-tab fileLockStates (keyed by tab.id) onto session ids so
   // SessionCard can render a "blocked on …" subtitle. session.sessionId
@@ -722,6 +727,7 @@ function TerminalPageInner({
               activeTab.claudeSessionId && (
                 <HoldingLockBanner
                   taskRunId={activeTab.claudeSessionId}
+                  taskRunName={activeTab.title}
                   filePath={activeLockState.filePath}
                   waiterName={activeLockState.counterpartyName}
                   sinceMs={activeLockState.sinceMs}
@@ -759,6 +765,34 @@ function TerminalPageInner({
                   blockerName={activeLockState.counterpartyName}
                   blockerTaskRunId={blockerTaskRunId}
                   sinceMs={activeLockState.sinceMs}
+                  // Phase 2 (stuck-session heartbeat) — joined from
+                  // `/sessions/idle-status` by useFileLockTracking's
+                  // 10s poll; threaded through as a prop so the banner
+                  // surfaces "(holder idle Xm)" inline on the headline.
+                  // Undefined on holding/idle branches by design (the
+                  // hook only attaches it to the waiting branch).
+                  holderIdleMs={activeLockState.holderIdleMs}
+                  longWaitSignal={(() => {
+                    // Phase 3 (stuck-session heartbeat): surface the
+                    // most-recent long-wait signal targeting this
+                    // waiter for the contested file. The hook dedups
+                    // by `(holderTaskRunId, filePath)` so the list is
+                    // already keyed cleanly; picking [0] yields the
+                    // first-arrived entry, but for the banner copy any
+                    // matching entry is acceptable since a new signal
+                    // for the same pair replaces in place.
+                    const signals =
+                      (activeId && pendingLongWaitSignals?.[activeId]) || [];
+                    const match = signals.find(
+                      (s) => s.filePath === activeLockState.filePath,
+                    );
+                    if (!match) return undefined;
+                    return {
+                      holderName: match.holderName,
+                      estimatedRemainingMs: match.estimatedRemainingMs,
+                      signaledAtMs: match.signaledAtMs,
+                    };
+                  })()}
                 />
               )}
           </div>

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -11,6 +11,7 @@ import { CommitTrafficLight } from "./CommitTrafficLight";
 import type { CommitState } from "./useCommitState";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { RefObject } from "react";
+import { useNow1Hz } from "./useNow1Hz";
 
 interface TerminalTabBarProps {
   tabs: TerminalTab[];
@@ -94,11 +95,20 @@ function formatTime(value?: string | number): string {
  * Format a "since" epoch-ms as a short relative-age string ("5s",
  * "42s", "5m", "2h"). Mirrors `formatHoldingAge` from `LaunchMenu.tsx`
  * but takes the "since" timestamp directly. Negative ages clamp to
- * "0s". Returns the empty string when `ms` is undefined.
+ * "0s". Returns the empty string when `sinceMs` is undefined.
+ *
+ * Phase 2 of the stuck-session heartbeat plan widened the signature
+ * from `(sinceMs?)` to `(sinceMs?, nowMs)` — the helper used to read
+ * `Date.now()` internally, which made it invisible to React's render
+ * cycle (re-mount didn't tick). Callers now pass `useNow1Hz()` as the
+ * second arg so the tooltip text refreshes on next-hover after the
+ * shared 1Hz broadcast fires. Native HTML `title` tooltips can't
+ * refresh while visibly open — the tick lands at next-hover. See the
+ * plan's Problem §1 caveat.
  */
-function formatSince(ms?: number): string {
-  if (ms === undefined) return "";
-  const deltaSec = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+function formatSince(sinceMs: number | undefined, nowMs: number): string {
+  if (sinceMs === undefined) return "";
+  const deltaSec = Math.max(0, Math.floor((nowMs - sinceMs) / 1000));
   if (deltaSec < 60) return `${deltaSec}s`;
   const deltaMin = Math.floor(deltaSec / 60);
   if (deltaMin < 60) return `${deltaMin}m`;
@@ -225,6 +235,13 @@ export function TerminalTabBar({
   const [showDropdown, setShowDropdown] = useState(false);
   const [showQuickLaunch, setShowQuickLaunch] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+
+  // Phase 2 (stuck-session heartbeat) — subscribe to the shared 1Hz
+  // broadcast so the lock tooltip's "since 5m" text refreshes on next-
+  // hover. Native HTML `title` tooltips don't update while visibly open
+  // — the tick lands when the user re-hovers. Documented at
+  // `formatSince`'s docstring and Problem §1 of the plan.
+  const nowMs = useNow1Hz();
 
   // Live elapsed-time tick (30s interval), only in multi-zone mode
   const [, setTick] = useState(0);
@@ -569,7 +586,7 @@ export function TerminalTabBar({
                   aria-label="waiting on file lock"
                   title={`waiting on ${lockState.counterpartyName ?? "another session"}'s ${
                     lockState.filePath ?? "edit"
-                  }${lockState.sinceMs ? ` since ${formatSince(lockState.sinceMs)}` : ""}`}
+                  }${lockState.sinceMs ? ` since ${formatSince(lockState.sinceMs, nowMs)}` : ""}`}
                 >
                   <Lock className="w-2.5 h-2.5 text-[#e0af68] animate-pulse" />
                 </span>

--- a/src/components/terminal/WaitingLockBanner.test.tsx
+++ b/src/components/terminal/WaitingLockBanner.test.tsx
@@ -42,8 +42,11 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import {
+  HOLDER_IDLE_DISPLAY_THRESHOLD_MS,
   REQUEST_YIELD_COOLDOWN_MS,
   cooldownRemainingSecs,
+  formatEstimate,
+  formatIdleDuration,
   formatWaitingBannerText,
   formatWaitingSeconds,
   type WaitingLockBannerProps,
@@ -300,5 +303,168 @@ const _propsTypeAnchor: WaitingLockBannerProps = {
   blockerName: "bravo",
   blockerTaskRunId: "tab-B",
   sinceMs: 0,
+  holderIdleMs: 420_000,
+  longWaitSignal: {
+    holderName: "bravo",
+    estimatedRemainingMs: 300_000,
+    signaledAtMs: 1_700_000_000_000,
+  },
 };
 void _propsTypeAnchor;
+
+// ── Phase 3 (stuck-session heartbeat) — formatEstimate ─────────────────────
+
+describe("formatEstimate", () => {
+  it("rounds to nearest second for values < 60_000ms", () => {
+    expect(formatEstimate(0)).toBe("~0s");
+    expect(formatEstimate(1_499)).toBe("~1s"); // round(1.499) = 1
+    expect(formatEstimate(1_500)).toBe("~2s"); // round(1.5) = 2 (banker's at .5 in JS = 2)
+    expect(formatEstimate(45_400)).toBe("~45s");
+    expect(formatEstimate(59_999)).toBe("~60s"); // edge case: rounds to 60 before flipping to minutes
+  });
+
+  it("rounds to nearest minute for values >= 60_000ms", () => {
+    expect(formatEstimate(60_000)).toBe("~1m");
+    expect(formatEstimate(90_000)).toBe("~2m"); // round(1.5) = 2
+    expect(formatEstimate(300_000)).toBe("~5m");
+    expect(formatEstimate(610_000)).toBe("~10m"); // round(10.166) = 10
+  });
+});
+
+// ── Phase 3 — long-wait advisory render predicate ─────────────────────────
+//
+// The component renders the advisory line iff `longWaitSignal !== undefined`.
+// Replicates the JSX render gating logic without invoking React (no
+// jsdom — see vitest.config.ts environment: "node"). Verifies:
+//
+//   1. Line is omitted when `longWaitSignal` is undefined.
+//   2. Line is rendered when `longWaitSignal` is provided.
+//   3. Estimate tail is appended when `estimatedRemainingMs` is provided;
+//      omitted when undefined.
+
+type LongWaitSignal = WaitingLockBannerProps["longWaitSignal"];
+
+// Pure mirror of the JSX render gating. Returns the rendered advisory
+// text or `null` if the line is omitted.
+function renderLongWaitAdvisory(signal: LongWaitSignal): string | null {
+  if (!signal) return null;
+  const base = `${signal.holderName} says they'll be a while. Request yield or cancel?`;
+  if (signal.estimatedRemainingMs !== undefined) {
+    return `${base} (${formatEstimate(signal.estimatedRemainingMs)})`;
+  }
+  return base;
+}
+
+describe("long-wait advisory line — render predicate", () => {
+  it("omits the advisory line when longWaitSignal is undefined", () => {
+    expect(renderLongWaitAdvisory(undefined)).toBeNull();
+  });
+
+  it("renders the advisory line when longWaitSignal is provided (no estimate)", () => {
+    const rendered = renderLongWaitAdvisory({
+      holderName: "bravo",
+      signaledAtMs: 1_700_000_000_000,
+    });
+    expect(rendered).toBe(
+      "bravo says they'll be a while. Request yield or cancel?",
+    );
+    // Estimate tail must NOT be present when `estimatedRemainingMs` is omitted.
+    expect(rendered).not.toMatch(/\(~/);
+  });
+
+  it("appends the formatted estimate when estimatedRemainingMs is provided", () => {
+    const rendered = renderLongWaitAdvisory({
+      holderName: "bravo",
+      estimatedRemainingMs: 300_000,
+      signaledAtMs: 1_700_000_000_000,
+    });
+    expect(rendered).toBe(
+      "bravo says they'll be a while. Request yield or cancel? (~5m)",
+    );
+  });
+
+  it("uses seconds rounding for sub-minute estimates", () => {
+    const rendered = renderLongWaitAdvisory({
+      holderName: "bravo",
+      estimatedRemainingMs: 45_000,
+      signaledAtMs: 1_700_000_000_000,
+    });
+    expect(rendered).toContain("(~45s)");
+  });
+});
+
+// ── Phase 2 (stuck-session heartbeat) — formatIdleDuration ────────────────
+
+describe("formatIdleDuration", () => {
+  it("floor-rounds to seconds for values < 60_000ms", () => {
+    expect(formatIdleDuration(0)).toBe("0s");
+    expect(formatIdleDuration(999)).toBe("0s"); // floor
+    expect(formatIdleDuration(1_499)).toBe("1s"); // floor (round → 1)
+    expect(formatIdleDuration(1_500)).toBe("1s"); // floor
+    expect(formatIdleDuration(45_900)).toBe("45s");
+    expect(formatIdleDuration(59_999)).toBe("59s"); // edge — stays seconds until 60s
+  });
+
+  it("floor-rounds to minutes for values in [60_000, 3_600_000)", () => {
+    expect(formatIdleDuration(60_000)).toBe("1m");
+    expect(formatIdleDuration(119_999)).toBe("1m"); // floor
+    expect(formatIdleDuration(120_000)).toBe("2m");
+    expect(formatIdleDuration(420_000)).toBe("7m");
+    expect(formatIdleDuration(3_599_999)).toBe("59m"); // edge — stays minutes until 1h
+  });
+
+  it("floor-rounds to hours for values >= 3_600_000ms", () => {
+    expect(formatIdleDuration(3_600_000)).toBe("1h");
+    expect(formatIdleDuration(7_199_999)).toBe("1h");
+    expect(formatIdleDuration(7_200_000)).toBe("2h");
+    expect(formatIdleDuration(8_400_000)).toBe("2h"); // 2h20m → 2h
+  });
+
+  it("clamps negative inputs to 0s (defensive, shouldn't happen in production)", () => {
+    expect(formatIdleDuration(-500)).toBe("0s");
+    expect(formatIdleDuration(-60_000)).toBe("0s");
+  });
+});
+
+// ── Phase 2 — holder-idle advisory render predicate ──────────────────────
+//
+// The banner renders the inline "(holder idle Xm)" span iff
+// `holderIdleMs !== undefined && holderIdleMs > HOLDER_IDLE_DISPLAY_THRESHOLD_MS`.
+// The threshold is 60_000ms; values at/under it are noise (typing
+// pauses, brief thinking gaps). Replicates the JSX render gating
+// without invoking React (no jsdom — see vitest.config.ts).
+
+// Pure mirror of the JSX render gating. Returns the rendered span text
+// or `null` if the suffix is omitted.
+function renderHolderIdleSuffix(holderIdleMs: number | undefined): string | null {
+  if (holderIdleMs === undefined) return null;
+  if (holderIdleMs <= HOLDER_IDLE_DISPLAY_THRESHOLD_MS) return null;
+  return `(holder idle ${formatIdleDuration(holderIdleMs)})`;
+}
+
+describe("holder-idle suffix — render predicate", () => {
+  it("omits the suffix when holderIdleMs is undefined", () => {
+    expect(renderHolderIdleSuffix(undefined)).toBeNull();
+  });
+
+  it("omits the suffix at/below the 60s display threshold", () => {
+    expect(renderHolderIdleSuffix(0)).toBeNull();
+    expect(renderHolderIdleSuffix(30_000)).toBeNull();
+    expect(renderHolderIdleSuffix(59_999)).toBeNull();
+    expect(renderHolderIdleSuffix(60_000)).toBeNull(); // exact threshold = hidden (gate is `>`)
+  });
+
+  it("renders the suffix above the 60s display threshold", () => {
+    expect(renderHolderIdleSuffix(60_001)).toBe("(holder idle 1m)");
+    expect(renderHolderIdleSuffix(120_000)).toBe("(holder idle 2m)");
+    expect(renderHolderIdleSuffix(420_000)).toBe("(holder idle 7m)");
+    expect(renderHolderIdleSuffix(3_600_000)).toBe("(holder idle 1h)");
+  });
+
+  it("uses the constant HOLDER_IDLE_DISPLAY_THRESHOLD_MS = 60000", () => {
+    // Tripwire: if a future plan changes the threshold (Open Q3 of the
+    // stuck-session heartbeat plan), this assertion must change in
+    // lockstep with the spec.
+    expect(HOLDER_IDLE_DISPLAY_THRESHOLD_MS).toBe(60_000);
+  });
+});

--- a/src/components/terminal/WaitingLockBanner.tsx
+++ b/src/components/terminal/WaitingLockBanner.tsx
@@ -28,11 +28,12 @@
  * {@link HoldingLockBanner}.
  */
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Hourglass } from "lucide-react";
 import { getApiPort } from "@/lib/runner-api";
 import { createLogger } from "@/lib/logger";
 import { REQUEST_YIELD_COOLDOWN_MS } from "@/lib/lock-yield";
+import { useNow1Hz } from "./useNow1Hz";
 
 const logger = createLogger("WaitingLockBanner");
 
@@ -89,6 +90,62 @@ export function cooldownRemainingSecs(cooldownUntilMs: number, nowMs: number): n
   return Math.ceil((cooldownUntilMs - nowMs) / 1000);
 }
 
+/**
+ * Format an estimated-remaining-time value for the long-wait advisory.
+ *
+ *   - `< 60_000ms` → rounded nearest second, e.g. `"~45s"`
+ *   - `>= 60_000ms` → rounded nearest minute, e.g. `"~5m"` (a value of
+ *     90_000 rounds to `"~2m"` since Math.round of 1.5 is 2).
+ *
+ * Pure / exported for tests so the rounding boundary is independently
+ * verifiable.
+ */
+export function formatEstimate(ms: number): string {
+  if (ms < 60_000) {
+    const secs = Math.max(0, Math.round(ms / 1000));
+    return `~${secs}s`;
+  }
+  const mins = Math.round(ms / 60_000);
+  return `~${mins}m`;
+}
+
+/**
+ * Format the holder's idle duration for the inline "(holder idle Xm)"
+ * advisory rendered when `holderIdleMs > HOLDER_IDLE_DISPLAY_THRESHOLD_MS`.
+ *
+ *   - `< 60_000ms`     → seconds, e.g. `"45s"` (used in unit tests; in
+ *     production the parent gates display on >60s so this branch is
+ *     unreachable via the JSX path).
+ *   - `< 3_600_000ms`  → whole minutes (floor), e.g. `"7m"`.
+ *   - `>= 3_600_000ms` → whole hours (floor), e.g. `"2h"`.
+ *
+ * Pure / exported for tests so the rounding boundaries are independently
+ * verifiable. Sibling to {@link formatEstimate} (the long-wait advisory
+ * uses tilde-rounding, while idle-duration uses floor-rounding because
+ * the holder really has been idle at least that long — overstating
+ * idleness would be wrong).
+ */
+export function formatIdleDuration(ms: number): string {
+  const clamped = Math.max(0, ms);
+  if (clamped < 60_000) {
+    return `${Math.floor(clamped / 1000)}s`;
+  }
+  if (clamped < 3_600_000) {
+    return `${Math.floor(clamped / 60_000)}m`;
+  }
+  return `${Math.floor(clamped / 3_600_000)}h`;
+}
+
+/**
+ * Display threshold for the inline "(holder idle Xm)" advisory.
+ * Below this value the suffix is hidden — Phase 2's Open Q3 chose 60s
+ * as the default; revisit if telemetry shows it rarely fires.
+ *
+ * Exported so the unit tests pin against the constant rather than the
+ * literal, catching accidental drift.
+ */
+export const HOLDER_IDLE_DISPLAY_THRESHOLD_MS = 60_000;
+
 // ── Component ───────────────────────────────────────────────────────────────
 
 export interface WaitingLockBannerProps {
@@ -109,6 +166,29 @@ export interface WaitingLockBannerProps {
   blockerTaskRunId?: string;
   /** When this tab entered the waiting state (epoch ms). */
   sinceMs: number;
+  /**
+   * Phase 2 (stuck-session heartbeat) — milliseconds since the HOLDER's
+   * last observed stdout activity, joined from `/sessions/idle-status`.
+   * When `> HOLDER_IDLE_DISPLAY_THRESHOLD_MS` the banner renders an
+   * inline "(holder idle Xm)" suffix on the headline. Lower values
+   * (or `undefined`) hide the suffix — short idle gaps are noise
+   * (typing/thinking pauses), only a sustained idle window is a useful
+   * cue for "the holder is parked, yield is safe to request."
+   */
+  holderIdleMs?: number;
+  /**
+   * Phase 3 (stuck-session heartbeat) — most-recent long-wait signal
+   * from the holder, if any. When present, the banner renders an
+   * additional advisory line below the primary "Waiting on …" headline:
+   * "**B** says they'll be a while. Request yield or cancel?". The
+   * Request-yield button stays the primary action — no behaviour
+   * change, just a visual prominence cue.
+   */
+  longWaitSignal?: {
+    holderName: string;
+    estimatedRemainingMs?: number;
+    signaledAtMs: number;
+  };
   /** Optional fetch override for tests. Defaults to `globalThis.fetch`. */
   fetchImpl?: typeof fetch;
 }
@@ -120,15 +200,15 @@ export function WaitingLockBanner({
   blockerName,
   blockerTaskRunId,
   sinceMs,
+  holderIdleMs,
+  longWaitSignal,
   fetchImpl,
 }: WaitingLockBannerProps) {
-  // Re-render every 1s so the seconds-since label keeps ticking AND
-  // the cooldown countdown decrements visibly.
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNowMs(Date.now()), 1000);
-    return () => clearInterval(id);
-  }, []);
+  // Phase 2 (stuck-session heartbeat) — subscribe to the shared 1Hz
+  // broadcast so the seconds-since label AND the cooldown countdown
+  // tick visibly. Singleton interval shared across all banner consumers
+  // (see Now1HzProvider at the runner-app root).
+  const nowMs = useNow1Hz();
 
   // Cooldown state — `0` means "no cooldown active." Set to
   // `Date.now() + REQUEST_YIELD_COOLDOWN_MS` on click; the
@@ -201,8 +281,40 @@ export function WaitingLockBanner({
         <Hourglass className="w-3.5 h-3.5 shrink-0 text-[#7aa2f7] mt-0.5" />
         <div className="text-[11px] text-[#c0caf5] leading-snug flex-1">
           {message}
+          {/*
+            Phase 2 (stuck-session heartbeat) — inline "(holder idle Xm)"
+            suffix. Subdued color so the headline reads naturally; the
+            idle cue is supplementary information, not the primary
+            signal. Hidden below the 60s display threshold to avoid
+            noise on transient typing/thinking pauses (Open Q3 in the
+            plan; threshold tuneable via the constant).
+          */}
+          {holderIdleMs !== undefined &&
+            holderIdleMs > HOLDER_IDLE_DISPLAY_THRESHOLD_MS && (
+              <span
+                data-ui-bridge-id="terminal.waiting-lock-banner-holder-idle"
+                data-task-run-id={taskRunId}
+                data-file-path={filePath}
+                className="ml-1 text-[#a9b1d6]/70"
+              >
+                (holder idle {formatIdleDuration(holderIdleMs)})
+              </span>
+            )}
         </div>
       </div>
+      {longWaitSignal && (
+        <div
+          data-ui-bridge-id="terminal.waiting-lock-banner-long-wait-advisory"
+          data-task-run-id={taskRunId}
+          data-file-path={filePath}
+          className="mt-1.5 ml-5 text-[10px] text-[#a9b1d6]/80 leading-snug"
+        >
+          <strong className="text-[#c0caf5]">{longWaitSignal.holderName}</strong>{" "}
+          says they&apos;ll be a while. Request yield or cancel?
+          {longWaitSignal.estimatedRemainingMs !== undefined &&
+            ` (${formatEstimate(longWaitSignal.estimatedRemainingMs)})`}
+        </div>
+      )}
       <div className="mt-2 flex items-center gap-1.5">
         <button
           type="button"

--- a/src/components/terminal/contexts/ShellInfraContext.tsx
+++ b/src/components/terminal/contexts/ShellInfraContext.tsx
@@ -11,6 +11,7 @@ import {
   useFileLockTracking,
   type LockState,
   type IncomingYieldRequest,
+  type IncomingLongWaitSignal,
 } from "../useFileLockTracking";
 import { useSessionPersistence } from "../useSessionPersistence";
 
@@ -30,6 +31,13 @@ export interface ShellInfraContextValue {
    * `Record<tabId, LockState>` consumer shape stays binary-compatible.
    */
   pendingYieldRequests: Record<string, IncomingYieldRequest[]>;
+  /**
+   * Per-tab incoming long-wait signals keyed by WAITER `tab.id` (Phase 3
+   * stuck-session heartbeat). Surfaced separately from
+   * {@link pendingYieldRequests} because the polarity differs — signals
+   * flow holder → every waiter, requests flow waiter → holder.
+   */
+  pendingLongWaitSignals: Record<string, IncomingLongWaitSignal[]>;
   sessionPersistence: ReturnType<typeof useSessionPersistence>;
 }
 
@@ -43,12 +51,25 @@ export function ShellInfraProvider({ children }: ShellInfraProviderProps) {
   const { tabs, pageId } = useTerminalCore();
 
   const fileConflicts = useFileConflicts();
-  const { lockStates: fileLockStates, pendingYieldRequests } = useFileLockTracking(tabs);
+  const { lockStates: fileLockStates, pendingYieldRequests, pendingLongWaitSignals } =
+    useFileLockTracking(tabs);
   const sessionPersistence = useSessionPersistence(pageId);
 
   const value = useMemo<ShellInfraContextValue>(
-    () => ({ fileConflicts, fileLockStates, pendingYieldRequests, sessionPersistence }),
-    [fileConflicts, fileLockStates, pendingYieldRequests, sessionPersistence],
+    () => ({
+      fileConflicts,
+      fileLockStates,
+      pendingYieldRequests,
+      pendingLongWaitSignals,
+      sessionPersistence,
+    }),
+    [
+      fileConflicts,
+      fileLockStates,
+      pendingYieldRequests,
+      pendingLongWaitSignals,
+      sessionPersistence,
+    ],
   );
 
   return <ShellInfraContext.Provider value={value}>{children}</ShellInfraContext.Provider>;

--- a/src/components/terminal/useFileLockTracking.test.ts
+++ b/src/components/terminal/useFileLockTracking.test.ts
@@ -36,6 +36,7 @@ import {
   lockStateFromAcquired,
   lockStateFromWaiting,
   lockStateKind,
+  type IncomingLongWaitSignal,
   type IncomingYieldRequest,
   type LockState,
 } from "./useFileLockTracking";
@@ -128,7 +129,7 @@ describe("lockStateKind", () => {
 // the listener registration, just to populate `mockListen.mock.calls`.
 
 describe("file-lock event handler registration (smoke)", () => {
-  it("registers listeners for waiting, acquired, released, AND yield-requested events", async () => {
+  it("registers listeners for waiting, acquired, released, yield-requested, AND long-wait-signaled events", async () => {
     // Resolve immediately with a no-op unlisten.
     mockListen.mockResolvedValue(() => {});
 
@@ -140,11 +141,12 @@ describe("file-lock event handler registration (smoke)", () => {
     //   listen("file-lock-waiting", ...)
     //   listen("file-lock-acquired", ...)
     //   listen("file-lock-released", ...)
-    //   listen("file-lock-yield-requested", ...) — Phase 3
+    //   listen("file-lock-yield-requested", ...) — Phase 3 lock-yield
+    //   listen("file-lock-long-wait-signaled", ...) — Phase 3 stuck-session
     // So we re-register here with the same identifiers (mirrors what
     // the hook does on first mount). If a future refactor moves the
     // registration elsewhere, this test will start failing because
-    // the contract — four event types, one listener each — is
+    // the contract — five event types, one listener each — is
     // explicit.
 
     const events = [
@@ -152,6 +154,7 @@ describe("file-lock event handler registration (smoke)", () => {
       "file-lock-acquired",
       "file-lock-released",
       "file-lock-yield-requested",
+      "file-lock-long-wait-signaled",
     ];
     for (const e of events) {
       const { listen } = await import("@tauri-apps/api/event");
@@ -394,5 +397,320 @@ describe("Phase 3 lifecycle: waiting → yield-requested → released", () => {
     // 4-5. Release event arrives; queue clears.
     requests = applyReleasedForTab(requests, "tab-holder", "src/foo.rs");
     expect(requests["tab-holder"]).toEqual([]);
+  });
+});
+
+// ── Phase 3 (stuck-session heartbeat) — pendingLongWaitSignals lifecycle ───
+//
+// Mirrors the hook's setPendingLongWaitSignals reducer logic. The
+// long-wait signal flows HOLDER → every WAITER currently waiting on
+// the same `file_path` (opposite polarity to yield-requested which is
+// waiter → holder). The hook's listener:
+//
+//   1. Finds every waiter tab whose `lockState.kind === "waiting"` AND
+//      `lockState.filePath === payload.file_path`.
+//   2. For each such waiter tab, dedups by `(holderTaskRunId, filePath)`:
+//        - If a duplicate exists, REPLACE in-place (preserves queue
+//          position; refreshes signaledAtMs / estimatedRemainingMs).
+//        - Otherwise APPEND.
+//   3. On `file-lock-released` for the payload's file_path, filters out
+//      any matching entry across ALL waiter tabs (every waiter on that
+//      file is no longer blocked).
+//   4. On `file-lock-acquired` for the resolved waiter tab, filters out
+//      any entry matching the acquired file_path from THAT tab's list.
+
+type SignalsByTab = Record<string, IncomingLongWaitSignal[]>;
+
+function applyLongWaitSignaled(
+  prev: SignalsByTab,
+  waiterTabIds: string[],
+  incoming: IncomingLongWaitSignal,
+): SignalsByTab {
+  if (waiterTabIds.length === 0) return prev;
+  const next: SignalsByTab = { ...prev };
+  for (const tabId of waiterTabIds) {
+    const existing = prev[tabId] ?? [];
+    const dedupIdx = existing.findIndex(
+      (s) =>
+        s.holderTaskRunId === incoming.holderTaskRunId &&
+        s.filePath === incoming.filePath,
+    );
+    let updated: IncomingLongWaitSignal[];
+    if (dedupIdx >= 0) {
+      updated = existing.slice();
+      updated[dedupIdx] = incoming;
+    } else {
+      updated = [...existing, incoming];
+    }
+    next[tabId] = updated;
+  }
+  return next;
+}
+
+function applyLongWaitReleased(
+  prev: SignalsByTab,
+  filePath: string,
+): SignalsByTab {
+  let dirty = false;
+  const next: SignalsByTab = {};
+  for (const [waiterTabId, signals] of Object.entries(prev)) {
+    const filtered = signals.filter((s) => s.filePath !== filePath);
+    if (filtered.length !== signals.length) {
+      dirty = true;
+      next[waiterTabId] = filtered;
+    } else {
+      next[waiterTabId] = signals;
+    }
+  }
+  return dirty ? next : prev;
+}
+
+function applyLongWaitAcquired(
+  prev: SignalsByTab,
+  waiterTabId: string,
+  filePath: string,
+): SignalsByTab {
+  const list = prev[waiterTabId];
+  if (!list || list.length === 0) return prev;
+  const filtered = list.filter((s) => s.filePath !== filePath);
+  if (filtered.length === list.length) return prev;
+  return { ...prev, [waiterTabId]: filtered };
+}
+
+describe("pendingLongWaitSignals — append + dedup", () => {
+  const sigA: IncomingLongWaitSignal = {
+    filePath: "src/foo.rs",
+    holderName: "Session B",
+    holderTaskRunId: "task-B",
+    estimatedRemainingMs: 300_000,
+    signaledAtMs: 1_000,
+  };
+  const sigAReissued: IncomingLongWaitSignal = {
+    ...sigA,
+    estimatedRemainingMs: 600_000, // bumped estimate
+    signaledAtMs: 2_000,
+  };
+  const sigBHolder: IncomingLongWaitSignal = {
+    filePath: "src/foo.rs",
+    holderName: "Session C",
+    holderTaskRunId: "task-C",
+    signaledAtMs: 1_500,
+  };
+
+  it("appends a fresh signal to each waiter's empty list", () => {
+    // Holder broadcasts; both waiters get the signal.
+    const next = applyLongWaitSignaled({}, ["tab-waiter-1", "tab-waiter-2"], sigA);
+    expect(next["tab-waiter-1"]).toEqual([sigA]);
+    expect(next["tab-waiter-2"]).toEqual([sigA]);
+  });
+
+  it("no-ops when no waiter tabs match the file_path", () => {
+    const start: SignalsByTab = {};
+    const next = applyLongWaitSignaled(start, [], sigA);
+    expect(next).toBe(start);
+  });
+
+  it("DEDUPES by (holderTaskRunId, filePath): replace in-place, no length growth", () => {
+    const after1 = applyLongWaitSignaled({}, ["tab-waiter"], sigA);
+    const after2 = applyLongWaitSignaled(after1, ["tab-waiter"], sigAReissued);
+    expect(after2["tab-waiter"]).toHaveLength(1);
+    expect(after2["tab-waiter"][0].signaledAtMs).toBe(2_000);
+    expect(after2["tab-waiter"][0].estimatedRemainingMs).toBe(600_000);
+  });
+
+  it("appends a second signal from a different holder (no dedup)", () => {
+    const after1 = applyLongWaitSignaled({}, ["tab-waiter"], sigA);
+    const after2 = applyLongWaitSignaled(after1, ["tab-waiter"], sigBHolder);
+    expect(after2["tab-waiter"]).toEqual([sigA, sigBHolder]);
+  });
+});
+
+describe("pendingLongWaitSignals — cleared on file-lock-released", () => {
+  const sigFoo: IncomingLongWaitSignal = {
+    filePath: "src/foo.rs",
+    holderName: "Session B",
+    holderTaskRunId: "task-B",
+    signaledAtMs: 1_000,
+  };
+  const sigBar: IncomingLongWaitSignal = {
+    filePath: "src/bar.rs",
+    holderName: "Session B",
+    holderTaskRunId: "task-B",
+    signaledAtMs: 1_100,
+  };
+
+  it("clears matching entries across all waiter tabs", () => {
+    const start: SignalsByTab = {
+      "tab-waiter-1": [sigFoo, sigBar],
+      "tab-waiter-2": [sigFoo],
+    };
+    const next = applyLongWaitReleased(start, "src/foo.rs");
+    expect(next["tab-waiter-1"]).toEqual([sigBar]);
+    expect(next["tab-waiter-2"]).toEqual([]);
+  });
+
+  it("is a no-op when no matching entry exists", () => {
+    const start: SignalsByTab = { "tab-waiter-1": [sigBar] };
+    const next = applyLongWaitReleased(start, "src/foo.rs");
+    expect(next).toBe(start);
+  });
+});
+
+describe("pendingLongWaitSignals — cleared on file-lock-acquired (per waiter)", () => {
+  const sigFoo: IncomingLongWaitSignal = {
+    filePath: "src/foo.rs",
+    holderName: "Session B",
+    holderTaskRunId: "task-B",
+    signaledAtMs: 1_000,
+  };
+
+  it("removes entries for the acquired file path on that waiter tab", () => {
+    const start: SignalsByTab = { "tab-waiter": [sigFoo] };
+    const next = applyLongWaitAcquired(start, "tab-waiter", "src/foo.rs");
+    expect(next["tab-waiter"]).toEqual([]);
+  });
+
+  it("is a no-op when the waiter has no signals", () => {
+    const start: SignalsByTab = {};
+    const next = applyLongWaitAcquired(start, "tab-waiter", "src/foo.rs");
+    expect(next).toBe(start);
+  });
+});
+
+// ── Phase 2 (stuck-session heartbeat) — holderIdleMs join from /sessions/idle-status
+//
+// The hook's 10s poll loop runs `/file-locks/info` and
+// `/sessions/idle-status` in parallel via Promise.allSettled, then
+// joins by `holder_name` to attach `holderIdleMs` to each waiting
+// tab's LockState. The reducer logic under test:
+//
+//   1. Idle entries are indexed by `holder_name` (not task_run_id),
+//      because the waiter's `LockState.counterpartyName` carries the
+//      friendly name.
+//   2. When a waiter's blockedBy holder matches an idle entry, attach
+//      `idle_ms` as `holderIdleMs`. Pure function — no side effects.
+//   3. When no idle entry matches (network error, holder is a PTY-side
+//      session not in the snapshot), `holderIdleMs` is `undefined`.
+//   4. `holderIdleMs` is ONLY attached to the waiting branch — never
+//      to holding or idle.
+
+interface SessionIdleEntry {
+  task_run_id: string;
+  holder_name: string;
+  last_activity_ms: number;
+  idle_ms: number;
+}
+
+function buildIdleIndex(entries: SessionIdleEntry[] | null): Map<string, number> {
+  // Mirror of the hook's idle-by-holder-name index. Null input models
+  // the fetch-failed branch (allSettled resolved to rejected).
+  const idx = new Map<string, number>();
+  if (!entries) return idx;
+  for (const e of entries) idx.set(e.holder_name, e.idle_ms);
+  return idx;
+}
+
+// Reducer mirror for the waiting branch — captures the exact field set
+// the hook writes onto next[tab.id] in the waiting case.
+function buildWaitingLockState(
+  waiting: { blockedBy: string; filePath: string; sinceMs: number },
+  idleByHolderName: Map<string, number>,
+): LockState {
+  return {
+    kind: "waiting",
+    filePath: waiting.filePath,
+    counterpartyName: waiting.blockedBy,
+    sinceMs: waiting.sinceMs,
+    holderIdleMs: idleByHolderName.get(waiting.blockedBy),
+  };
+}
+
+describe("holderIdleMs join — /sessions/idle-status × /file-locks/info", () => {
+  const waiting = {
+    blockedBy: "Session B",
+    filePath: "src/foo.rs",
+    sinceMs: 1_700_000_000_000,
+  };
+
+  it("populates holderIdleMs when the join matches a holder_name entry", () => {
+    const entries: SessionIdleEntry[] = [
+      {
+        task_run_id: "task-B",
+        holder_name: "Session B",
+        last_activity_ms: 1_700_000_000_000,
+        idle_ms: 420_000, // 7m idle
+      },
+    ];
+    const idx = buildIdleIndex(entries);
+    const state = buildWaitingLockState(waiting, idx);
+    expect(state.kind).toBe("waiting");
+    expect(state.holderIdleMs).toBe(420_000);
+    expect(state.counterpartyName).toBe("Session B");
+  });
+
+  it("leaves holderIdleMs undefined when no idle entry matches", () => {
+    const entries: SessionIdleEntry[] = [
+      {
+        task_run_id: "task-C",
+        holder_name: "Session C", // a different holder
+        last_activity_ms: 1_700_000_000_000,
+        idle_ms: 60_000,
+      },
+    ];
+    const idx = buildIdleIndex(entries);
+    const state = buildWaitingLockState(waiting, idx);
+    expect(state.holderIdleMs).toBeUndefined();
+  });
+
+  it("leaves holderIdleMs undefined when the idle fetch failed (null input)", () => {
+    // Models the allSettled rejected branch: idleByHolderName is built
+    // from an empty list, so every lookup misses.
+    const idx = buildIdleIndex(null);
+    const state = buildWaitingLockState(waiting, idx);
+    expect(state.holderIdleMs).toBeUndefined();
+    // The rest of the waiting branch is still populated — the join is
+    // additive, no field is dropped on idle failure.
+    expect(state.kind).toBe("waiting");
+    expect(state.filePath).toBe("src/foo.rs");
+    expect(state.counterpartyName).toBe("Session B");
+    expect(state.sinceMs).toBe(1_700_000_000_000);
+  });
+
+  it("leaves holderIdleMs undefined when the idle response is empty", () => {
+    const idx = buildIdleIndex([]);
+    const state = buildWaitingLockState(waiting, idx);
+    expect(state.holderIdleMs).toBeUndefined();
+  });
+
+  it("indexes by holder_name (not task_run_id)", () => {
+    // The waiter's blockedBy is the friendly name — the join must use
+    // holder_name, not task_run_id. If the reducer accidentally
+    // indexed by task_run_id, this lookup would miss.
+    const entries: SessionIdleEntry[] = [
+      {
+        task_run_id: "task-B-very-different-string",
+        holder_name: "Session B",
+        last_activity_ms: 1_700_000_000_000,
+        idle_ms: 90_000,
+      },
+    ];
+    const idx = buildIdleIndex(entries);
+    const state = buildWaitingLockState(waiting, idx);
+    expect(state.holderIdleMs).toBe(90_000);
+  });
+
+  it("does NOT attach holderIdleMs to holding or idle states", () => {
+    // The reducer's holding-branch writer never reads idleByHolderName,
+    // and the idle branch is just { kind: "idle" }. Verify by direct
+    // construction — this test pins the documented contract.
+    const holding: LockState = {
+      kind: "holding",
+      filePath: "src/foo.rs",
+      waiterCount: 1,
+      sinceMs: 1_700_000_000_000,
+    };
+    const idle: LockState = { kind: "idle" };
+    expect(holding.holderIdleMs).toBeUndefined();
+    expect(idle.holderIdleMs).toBeUndefined();
   });
 });

--- a/src/components/terminal/useFileLockTracking.ts
+++ b/src/components/terminal/useFileLockTracking.ts
@@ -95,6 +95,16 @@ export type LockState = {
   sinceMs?: number;
   /** Number of waiters (holding state only). */
   waiterCount?: number;
+  /**
+   * Only populated for `kind === "waiting"`: milliseconds since the
+   * HOLDER's last stdout activity, joined from `GET /sessions/idle-status`
+   * (Phase 1 of the stuck-session heartbeat plan). The waiter banner
+   * surfaces "(holder idle Xm)" when this exceeds the 60s display
+   * threshold — see {@link WaitingLockBanner}. `undefined` when no
+   * idle entry matched the holder, the idle fetch failed, or the
+   * holder isn't an AI session (PTY holders aren't in the snapshot).
+   */
+  holderIdleMs?: number;
 };
 
 /**
@@ -141,6 +151,34 @@ export type IncomingYieldRequest = {
   requestedAtMs: number;
 };
 
+/**
+ * Incoming long-wait signal payload as seen by a WAITER tab.
+ *
+ * Emitted by the runner's POST /file-locks/signal-long-wait handler
+ * (`mcp/file_registry.rs::signal_long_wait`) as a Tauri event named
+ * `file-lock-long-wait-signaled`. The signal flows from the HOLDER to
+ * every tab currently waiting on the same `file_path` — opposite
+ * direction to {@link IncomingYieldRequest} (which flows waiter → holder).
+ *
+ * Wire-format keys are snake_case (handler emits via `serde_json::json!`
+ * directly, not a `#[serde(rename_all = "camelCase")]` struct); the
+ * frontend uses camelCase on this type.
+ *
+ * Dedup invariant on the consumer side: at most one entry per
+ * `(holder_task_run_id, file_path)` tuple per waiter — a re-issued signal
+ * replaces the prior entry rather than appending. Cleared on
+ * `file-lock-released` or `file-lock-acquired` for the same `file_path`
+ * (the waiter is no longer blocked, so the advisory is moot).
+ */
+export type IncomingLongWaitSignal = {
+  filePath: string;
+  holderName: string;
+  holderTaskRunId: string;
+  /** Optional estimated remaining time in ms; `undefined` when the holder didn't supply one. */
+  estimatedRemainingMs?: number;
+  signaledAtMs: number;
+};
+
 interface FileLockEvent {
   type: string;
   file_path: string;
@@ -173,6 +211,27 @@ interface FileLockInfoEntry {
 }
 
 /**
+ * Per-session idle stats returned by `GET /sessions/idle-status`
+ * (Phase 1 of the stuck-session heartbeat plan; backend handler at
+ * `mcp/ai_session.rs::idle_status`).
+ *
+ * The poll loop below joins these entries against the waiting branch
+ * of `LockState`: for each waiting tab, look up the holder's idle ms
+ * by `holder_name` (the friendly name carried on the original
+ * `file-lock-waiting` event's `blocked_by` field) and attach as
+ * `holderIdleMs`. Keyed by `holder_name` rather than `task_run_id`
+ * because `LockState.counterpartyName` is the friendly name, not a
+ * task_run_id — the waiter doesn't know the holder's task_run_id
+ * directly.
+ */
+interface SessionIdleEntry {
+  task_run_id: string;
+  holder_name: string;
+  last_activity_ms: number;
+  idle_ms: number;
+}
+
+/**
  * `file-lock-yield-requested` Tauri event payload.
  *
  * Wire-format keys are snake_case (Rust handler emits via
@@ -185,6 +244,26 @@ interface FileLockYieldRequestedEvent {
   requester_name: string;
   holder_task_run_id: string;
   requested_at: number;
+}
+
+/**
+ * `file-lock-long-wait-signaled` Tauri event payload (Phase 3 of the
+ * stuck-session heartbeat plan).
+ *
+ * Wire-format keys are snake_case (Rust handler emits via
+ * `serde_json::json!` literal — see
+ * `mcp/file_registry.rs::signal_long_wait`). `estimated_remaining_ms`
+ * is `null` over the wire when the holder didn't supply an estimate;
+ * the listener normalises it to `undefined` on the camelCase
+ * {@link IncomingLongWaitSignal}.
+ */
+interface FileLockLongWaitSignaledEvent {
+  type: string;
+  file_path: string;
+  holder_task_run_id: string;
+  holder_name: string;
+  estimated_remaining_ms: number | null;
+  signaled_at: number;
 }
 
 /**
@@ -213,6 +292,25 @@ export interface FileLockTracking {
    * (refreshing `requestedAtMs`) rather than appending a duplicate.
    */
   pendingYieldRequests: Record<string, IncomingYieldRequest[]>;
+  /**
+   * Map of WAITER-tab id → list of incoming long-wait signals targeting
+   * that waiter. Opposite key polarity to {@link pendingYieldRequests}:
+   * signals flow from holder → every waiter, so the consumer is the
+   * waiting tab. Keys correspond to `tab.id`; signals are routed to
+   * every tab whose current `lockState.kind === "waiting"` and
+   * `lockState.filePath === payload.file_path`.
+   *
+   * Cleared on `file-lock-released` AND `file-lock-acquired` for the
+   * matching `file_path` — both events mean the waiter is no longer
+   * blocked, so the "I'll be a while" advisory is moot.
+   *
+   * Dedup invariant: within a tab's list, at most one entry exists per
+   * `(holderTaskRunId, filePath)` tuple. A re-issued signal for the
+   * same pair replaces the prior entry (refreshing `signaledAtMs` /
+   * `estimatedRemainingMs`) rather than appending a duplicate — the
+   * waiter banner consumes only the most-recent entry.
+   */
+  pendingLongWaitSignals: Record<string, IncomingLongWaitSignal[]>;
 }
 
 export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
@@ -220,6 +318,19 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
   const [pendingYieldRequests, setPendingYieldRequests] = useState<
     Record<string, IncomingYieldRequest[]>
   >({});
+  const [pendingLongWaitSignals, setPendingLongWaitSignals] = useState<
+    Record<string, IncomingLongWaitSignal[]>
+  >({});
+  // The long-wait-signaled listener needs the live `lockStates` to find
+  // every WAITER tab currently waiting on the broadcast `file_path`
+  // without going through findTabByHolderName (the holder may not have
+  // a tab in this window). A ref keeps the listener closure stable —
+  // re-subscribing on every state change would tear down + rebuild the
+  // Tauri listener.
+  const lockStatesRef = useRef(lockStates);
+  useEffect(() => {
+    lockStatesRef.current = lockStates;
+  }, [lockStates]);
   const tabsRef = useRef(tabs);
   useEffect(() => {
     tabsRef.current = tabs;
@@ -262,6 +373,7 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
     let unlistenAcquired: (() => void) | null = null;
     let unlistenReleased: (() => void) | null = null;
     let unlistenYieldRequested: (() => void) | null = null;
+    let unlistenLongWaitSignaled: (() => void) | null = null;
 
     /**
      * Refresh `waiterCount` on every holding tab from the current
@@ -339,6 +451,19 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
         }
         return refreshWaiterCounts(base);
       });
+
+      // Phase 3 (stuck-session heartbeat) — clear any long-wait signal
+      // targeting THIS waiter for THIS file path. Once the waiter has
+      // acquired, the holder's "I'll be a while" advisory is moot.
+      if (tabId) {
+        setPendingLongWaitSignals((prev) => {
+          const list = prev[tabId];
+          if (!list || list.length === 0) return prev;
+          const filtered = list.filter((s) => s.filePath !== file_path);
+          if (filtered.length === list.length) return prev;
+          return { ...prev, [tabId]: filtered };
+        });
+      }
     }).then((fn) => {
       unlistenAcquired = fn;
     });
@@ -385,6 +510,27 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
           return { ...prev, [tabId]: filtered };
         });
       }
+
+      // Phase 3 (stuck-session heartbeat) — clear long-wait signals for
+      // THIS file path across every waiter tab. Unlike yield requests
+      // (keyed by holder tab id), long-wait signals are keyed by waiter
+      // tab id; ANY waiter still holding a stale signal for this file
+      // should drop it once the lock is released. The next acquire by
+      // a fresh holder produces a new signal if applicable.
+      setPendingLongWaitSignals((prev) => {
+        let dirty = false;
+        const next: Record<string, IncomingLongWaitSignal[]> = {};
+        for (const [waiterTabId, signals] of Object.entries(prev)) {
+          const filtered = signals.filter((s) => s.filePath !== file_path);
+          if (filtered.length !== signals.length) {
+            dirty = true;
+            next[waiterTabId] = filtered;
+          } else {
+            next[waiterTabId] = signals;
+          }
+        }
+        return dirty ? next : prev;
+      });
     }).then((fn) => {
       unlistenReleased = fn;
     });
@@ -434,11 +580,82 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
       unlistenYieldRequested = fn;
     });
 
+    // Phase 3 (stuck-session heartbeat) — hold-side long-wait signal
+    // listener. The signal flows from HOLDER to every WAITER tab on the
+    // same `file_path` (opposite polarity to the yield-request which is
+    // waiter → holder). Iterate every tab whose current `lockState.kind
+    // === "waiting"` and `lockState.filePath === payload.file_path`, and
+    // for each such tab append the signal to `pendingLongWaitSignals`.
+    // Dedup invariant: at most one entry per `(holderTaskRunId,
+    // filePath)` tuple per waiter — a re-issued signal replaces the
+    // prior entry rather than appending.
+    listen<FileLockLongWaitSignaledEvent>("file-lock-long-wait-signaled", (event) => {
+      const {
+        file_path,
+        holder_task_run_id,
+        holder_name,
+        estimated_remaining_ms,
+        signaled_at,
+      } = event.payload;
+      const incoming: IncomingLongWaitSignal = {
+        filePath: file_path,
+        holderName: holder_name,
+        holderTaskRunId: holder_task_run_id,
+        // serde_json renders Rust's `None` as JSON `null`; the camelCase
+        // type uses `undefined` per the optional-field convention.
+        estimatedRemainingMs:
+          estimated_remaining_ms === null || estimated_remaining_ms === undefined
+            ? undefined
+            : estimated_remaining_ms,
+        signaledAtMs: signaled_at,
+      };
+      // Find every waiter tab currently blocked on this file. The
+      // listener closure captured `lockStates` via the ref above so a
+      // late-mounting tab still picks up signals on the next event.
+      const currentLockStates = lockStatesRef.current;
+      const waiterTabIds: string[] = [];
+      for (const tab of tabsRef.current) {
+        const s = currentLockStates[tab.id];
+        if (
+          s &&
+          s.kind === "waiting" &&
+          s.filePath === file_path
+        ) {
+          waiterTabIds.push(tab.id);
+        }
+      }
+      if (waiterTabIds.length === 0) return; // No waiter for this file in this window.
+      setPendingLongWaitSignals((prev) => {
+        const next: Record<string, IncomingLongWaitSignal[]> = { ...prev };
+        for (const tabId of waiterTabIds) {
+          const existing = prev[tabId] ?? [];
+          const dedupIdx = existing.findIndex(
+            (s) =>
+              s.holderTaskRunId === holder_task_run_id &&
+              s.filePath === file_path,
+          );
+          let updated: IncomingLongWaitSignal[];
+          if (dedupIdx >= 0) {
+            // Replace in-place so queue position is preserved.
+            updated = existing.slice();
+            updated[dedupIdx] = incoming;
+          } else {
+            updated = [...existing, incoming];
+          }
+          next[tabId] = updated;
+        }
+        return next;
+      });
+    }).then((fn) => {
+      unlistenLongWaitSignaled = fn;
+    });
+
     return () => {
       unlistenWaiting?.();
       unlistenAcquired?.();
       unlistenReleased?.();
       unlistenYieldRequested?.();
+      unlistenLongWaitSignaled?.();
     };
   }, []);
 
@@ -456,9 +673,40 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
         // the second tick. `__QONTINUI_PORT__` still wins when set
         // (manual-test override).
         const port = resolvePort();
-        const resp = await fetch(`http://127.0.0.1:${port}/file-locks/info`);
-        if (!resp.ok || !active) return;
-        const locks = (await resp.json()) as FileLockInfoEntry[];
+        // Phase 2 (stuck-session heartbeat) — piggyback the idle-status
+        // fetch on the same 10s poll cycle, in parallel, with allSettled
+        // so a transient failure on either endpoint doesn't tear down
+        // the loop. We always honour the locks-info shape (the
+        // pre-Phase-2 contract); idle-status is purely additive — when
+        // missing/failed, `holderIdleMs` stays `undefined` on every
+        // waiting LockState.
+        const [locksRes, idleRes] = await Promise.allSettled([
+          fetch(`http://127.0.0.1:${port}/file-locks/info`),
+          fetch(`http://127.0.0.1:${port}/sessions/idle-status`),
+        ]);
+        if (!active) return;
+
+        // Build the idle-by-holder-name index FIRST (it's optional so
+        // any failure mode keeps the rest of the poll behaviour
+        // identical to pre-Phase-2). Keyed by `holder_name` because
+        // `LockState.counterpartyName` carries the friendly name — the
+        // waiter doesn't know the holder's task_run_id directly.
+        const idleByHolderName = new Map<string, number>();
+        if (idleRes.status === "fulfilled" && idleRes.value.ok) {
+          try {
+            const entries = (await idleRes.value.json()) as SessionIdleEntry[];
+            for (const e of entries) {
+              idleByHolderName.set(e.holder_name, e.idle_ms);
+            }
+          } catch {
+            // JSON parse failure — treat as empty.
+          }
+        }
+
+        // If the locks fetch failed we have nothing to derive; bail out
+        // (silently, same as the pre-Phase-2 catch).
+        if (locksRes.status !== "fulfilled" || !locksRes.value.ok) return;
+        const locks = (await locksRes.value.json()) as FileLockInfoEntry[];
 
         // Index holders by holder_name → list of held entries.
         const holderEntries = new Map<string, FileLockInfoEntry[]>();
@@ -507,6 +755,10 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
                 filePath: waiting.filePath,
                 counterpartyName: waiting.blockedBy,
                 sinceMs: waiting.sinceMs,
+                // Phase 2 — attach the holder's idle_ms if the join hit.
+                // We DON'T attach holderIdleMs on holding or idle
+                // branches; the field is a waiter-only signal.
+                holderIdleMs: idleByHolderName.get(waiting.blockedBy),
               };
               continue;
             }
@@ -539,5 +791,5 @@ export function useFileLockTracking(tabs: TerminalTab[]): FileLockTracking {
     };
   }, []);
 
-  return { lockStates, pendingYieldRequests };
+  return { lockStates, pendingYieldRequests, pendingLongWaitSignals };
 }

--- a/src/components/terminal/useNow1Hz.test.tsx
+++ b/src/components/terminal/useNow1Hz.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Tests for `useNow1Hz` — the singleton 1Hz re-render primitive.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom, no
+ * React Testing Library) — see HoldingLockBanner.test.tsx for the
+ * precedent. We can't `render(<Now1HzProvider>…)` directly; instead we
+ * mirror the hook's INTERNAL state machine in pure code and exercise
+ * it under `vi.useFakeTimers()`. The exported `Now1HzProvider` and
+ * `useNow1Hz` are imported as a tripwire so an accidental rename
+ * surfaces here (and so the `.tsx` file participates in `tsc
+ * --noEmit`).
+ *
+ * What we verify:
+ *
+ *   1. The single-interval model: one `setInterval(..., 1000)`
+ *      advances the broadcast value by ~1000 after
+ *      `vi.advanceTimersByTime(1100)`.
+ *   2. The fallback model: when no provider is mounted (context value
+ *      is null), the consumer's private interval still ticks.
+ *   3. Singleton fan-out: under one provider, N consumers all see the
+ *      same broadcast value (the model: one source, N readers, all
+ *      get the same `nowMs`).
+ *
+ * The JSX shell (Provider returns its children wrapped in
+ * `<Context.Provider value={nowMs}>`) is verified manually via the
+ * runner-app build + a UI Bridge smoke (the three banner consumers
+ * all read off the same shared value).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { Now1HzProvider, useNow1Hz } from "./useNow1Hz";
+
+// Tripwire: importing the hook + provider must succeed, so a future
+// rename (e.g. renaming to `useNow1Sec`) breaks the test BEFORE
+// breaking the runner's App.tsx mount. The hooks themselves can't be
+// invoked outside a React render — that's why the model below is a
+// pure stand-in. ESLint-disable: intentional unused-but-imported.
+void Now1HzProvider;
+void useNow1Hz;
+
+// ── Pure model of the provider's interval-driven broadcast ────────────────
+//
+// Mirrors the JSX behaviour:
+//   - `useState(() => Date.now())` initial value.
+//   - `useEffect` schedules `setInterval(() => setNowMs(Date.now()), 1000)`.
+//   - On unmount, clearInterval.
+
+class ProviderModel {
+  public nowMs: number;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.nowMs = Date.now();
+  }
+
+  mount(): void {
+    this.intervalId = setInterval(() => {
+      this.nowMs = Date.now();
+    }, 1000);
+  }
+
+  unmount(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+}
+
+// Pure model of the fallback path inside `useNow1Hz`: when the
+// provider's context value is null, the consumer runs its OWN private
+// interval. The model is identical to the provider model — that's
+// the point of "same observable behaviour, just slightly less
+// efficient" in the docstring.
+class FallbackConsumerModel {
+  public nowMs: number;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor() {
+    this.nowMs = Date.now();
+  }
+
+  mount(contextValue: number | null): void {
+    // The hook short-circuits when a provider is present.
+    if (contextValue !== null) return;
+    this.intervalId = setInterval(() => {
+      this.nowMs = Date.now();
+    }, 1000);
+  }
+
+  unmount(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("Now1HzProvider — single interval broadcasts every ~1000ms", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_700_000_000_000));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("advances nowMs by ~1000 after advanceTimersByTime(1100)", () => {
+    const provider = new ProviderModel();
+    expect(provider.nowMs).toBe(1_700_000_000_000);
+    provider.mount();
+    // Advance fake time past the first interval boundary. The
+    // setInterval callback fires exactly at t+1000 (within [0, 1100]
+    // there is one fire), reads Date.now() (which the fake timer has
+    // moved to t+1000 when the callback ran), and assigns it to the
+    // broadcast value. So the broadcast advances by 1000ms, not 1100
+    // — the trailing 100ms is unspent until the next fire at 2000.
+    vi.advanceTimersByTime(1100);
+    expect(provider.nowMs).toBe(1_700_000_000_000 + 1000);
+    provider.unmount();
+  });
+
+  it("keeps broadcasting on subsequent ticks", () => {
+    const provider = new ProviderModel();
+    provider.mount();
+    vi.advanceTimersByTime(1000);
+    expect(provider.nowMs).toBe(1_700_000_000_000 + 1000);
+    vi.advanceTimersByTime(1000);
+    expect(provider.nowMs).toBe(1_700_000_000_000 + 2000);
+    vi.advanceTimersByTime(1000);
+    expect(provider.nowMs).toBe(1_700_000_000_000 + 3000);
+    provider.unmount();
+  });
+
+  it("stops broadcasting after unmount (cleanup runs)", () => {
+    const provider = new ProviderModel();
+    provider.mount();
+    vi.advanceTimersByTime(1000);
+    const lastSeen = provider.nowMs;
+    provider.unmount();
+    vi.advanceTimersByTime(5000);
+    // Post-unmount, the broadcast value MUST NOT change — the
+    // setInterval was cleared by the effect's cleanup.
+    expect(provider.nowMs).toBe(lastSeen);
+  });
+});
+
+describe("useNow1Hz fallback path — no provider in tree", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_700_000_000_000));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("schedules its own interval when context value is null", () => {
+    const consumer = new FallbackConsumerModel();
+    expect(consumer.nowMs).toBe(1_700_000_000_000);
+    // null context value → consumer's private interval activates.
+    consumer.mount(null);
+    // setInterval fires once at t+1000 within [0, 1100], so the value
+    // moves to start+1000 (not +1100 — the trailing 100ms is unspent).
+    vi.advanceTimersByTime(1100);
+    expect(consumer.nowMs).toBe(1_700_000_000_000 + 1000);
+    consumer.unmount();
+  });
+
+  it("does NOT schedule an interval when a provider is present", () => {
+    const consumer = new FallbackConsumerModel();
+    // Provider present → consumer short-circuits, no private interval.
+    consumer.mount(1_700_000_000_000);
+    vi.advanceTimersByTime(5000);
+    // Consumer's own nowMs is unchanged (the test consumer's local
+    // state isn't what a real component would read — the real hook
+    // returns `ctx ?? fallback`, so the context value wins. Here we
+    // verify the no-interval-scheduled half of that contract).
+    expect(consumer.nowMs).toBe(1_700_000_000_000);
+    consumer.unmount();
+  });
+});
+
+describe("singleton fan-out — N consumers under one provider", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(1_700_000_000_000));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("all consumers read the same nowMs from one provider", () => {
+    // Models the real hook's `return ctx ?? fallback;` branch: when
+    // the provider is mounted, every consumer reads `ctx`, which is
+    // ONE number. There's no per-consumer drift because they all
+    // index into the same React context value.
+    const provider = new ProviderModel();
+    provider.mount();
+
+    // Three consumers (matching the actual count today: HoldingLockBanner,
+    // WaitingLockBanner, FileActivityPanel). Each reads from the
+    // provider's broadcast.
+    const readers = [() => provider.nowMs, () => provider.nowMs, () => provider.nowMs];
+
+    vi.advanceTimersByTime(1000);
+    const t1 = readers.map((r) => r());
+    expect(new Set(t1).size).toBe(1); // All three see the same value.
+
+    vi.advanceTimersByTime(2500);
+    const t2 = readers.map((r) => r());
+    expect(new Set(t2).size).toBe(1);
+    // Total elapsed = 1000 + 2500 = 3500. The interval has fired at
+    // t=1000, 2000, 3000; the last fire stamped Date.now() = start+3000.
+    // The trailing 500ms after t=3000 is unspent.
+    expect(t2[0]).toBe(1_700_000_000_000 + 3000);
+
+    provider.unmount();
+  });
+
+  it("only one interval is scheduled regardless of consumer count", () => {
+    // Vitest's fake-timers expose `getTimerCount()` for setTimeout —
+    // we count via a sentinel: schedule the provider's interval, count
+    // pending timers, schedule N fake consumers WITHOUT their own
+    // intervals (because the provider context is non-null), confirm
+    // the pending-timer count didn't grow.
+    const provider = new ProviderModel();
+    provider.mount();
+    const beforeConsumers = vi.getTimerCount();
+
+    const consumers = [
+      new FallbackConsumerModel(),
+      new FallbackConsumerModel(),
+      new FallbackConsumerModel(),
+    ];
+    for (const c of consumers) c.mount(provider.nowMs); // non-null ctx
+
+    const afterConsumers = vi.getTimerCount();
+    // No new intervals scheduled — three consumers, ZERO extra timers
+    // because each one short-circuited on the non-null context value.
+    expect(afterConsumers).toBe(beforeConsumers);
+
+    for (const c of consumers) c.unmount();
+    provider.unmount();
+  });
+});
+
+describe("useNow1Hz contract documentation (tripwire)", () => {
+  it("exports the provider and hook by their canonical names", () => {
+    // If a refactor renames either symbol, this fails at import resolution
+    // before the runtime expectations even run.
+    expect(typeof Now1HzProvider).toBe("function");
+    expect(typeof useNow1Hz).toBe("function");
+  });
+});

--- a/src/components/terminal/useNow1Hz.tsx
+++ b/src/components/terminal/useNow1Hz.tsx
@@ -1,0 +1,80 @@
+/**
+ * Singleton 1Hz re-render primitive.
+ *
+ * The runner has at least three components that today each manage a
+ * private `setInterval(() => setNowMs(Date.now()), 1000)` so their
+ * "Ns since" labels keep ticking — {@link HoldingLockBanner},
+ * {@link WaitingLockBanner}, and `FileActivityPanel`. Independent
+ * intervals on the same cadence are wasteful (each schedules its own
+ * `MessageChannel`/`Timer` fire) and drift apart visually as React
+ * batches the resulting state updates differently per component.
+ *
+ * Phase 2 of the stuck-session heartbeat plan collapses those three
+ * tickers into one shared interval via React context:
+ *
+ *   - {@link Now1HzProvider} runs ONE 1000ms interval and broadcasts
+ *     `Date.now()` to every {@link useNow1Hz} consumer in its subtree.
+ *   - When no provider is mounted (test harnesses that render a banner
+ *     in isolation, headless preview, etc.), the hook falls back to a
+ *     private per-component interval so consumers don't need to mock
+ *     the provider. Behaviour is identical — just slightly less
+ *     efficient.
+ *
+ * Mounted once at the runner-app root in `App.tsx` so all three
+ * existing consumers (plus `TerminalTabBar`'s tooltip-tick subscriber)
+ * share the same fire.
+ *
+ * Per `feedback_planning_priorities.md` (clean / scalable / robust /
+ * powerful — programming effort isn't a trade-off): the fallback
+ * branch costs a few extra lines but removes a mandatory wiring
+ * dependency from every test that wants to render a consumer in
+ * isolation.
+ */
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+const Now1HzContext = createContext<number | null>(null);
+
+/**
+ * Provider that runs a single 1000ms interval and broadcasts
+ * `Date.now()` to every consumer of {@link useNow1Hz}. Mount once at
+ * the runner-app root — `<Now1HzProvider>{children}</Now1HzProvider>`.
+ *
+ * Falls back to a per-component interval when no provider is mounted
+ * (e.g. test harnesses that render a banner in isolation), so consumers
+ * don't need to mock the provider.
+ */
+export function Now1HzProvider({ children }: { children: ReactNode }) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <Now1HzContext.Provider value={nowMs}>{children}</Now1HzContext.Provider>
+  );
+}
+
+/**
+ * Returns `Date.now()` re-broadcast every ~1s. When a
+ * {@link Now1HzProvider} is in the tree, all consumers share its
+ * single interval. When no provider is mounted (test isolation,
+ * headless preview), the hook falls back to a private per-component
+ * interval — same observable behaviour, just slightly less efficient.
+ */
+export function useNow1Hz(): number {
+  const ctx = useContext(Now1HzContext);
+  const [fallback, setFallback] = useState(() => Date.now());
+  useEffect(() => {
+    if (ctx !== null) return; // provider in tree → no fallback needed
+    const id = setInterval(() => setFallback(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [ctx]);
+  return ctx ?? fallback;
+}


### PR DESCRIPTION
## Summary

Closes the three remaining gaps from `feedback_worktrees_vs_pauses.md`'s primary-mechanism list after lock-yield (PR #93) shipped: live tab/banner heartbeat, holder-idle visibility for waiters, and a "I'll be a while" channel from holder → waiter.

**Phase 1 — backend `GET /sessions/idle-status`.** Returns `[{task_run_id, holder_name, last_activity_ms, idle_ms}]` for every registered Claude session. `SessionManager::snapshot()` exposes `(task_run_id, holder_name, Arc<AtomicU64>)` triples; `ClaudeSession` caches `holder_name` at spawn with the same derivation as the file-lock dispatcher.

**Phase 2 — frontend join + singleton `useNow1Hz`.** New `Now1HzProvider` mounted at the app root drives a single 1Hz interval for the whole tree; replaces 3 pre-existing component-local tickers (HoldingLockBanner, WaitingLockBanner, FileActivityPanel). `useFileLockTracking`'s 10s `/file-locks/info` poll now parallel-fetches `/sessions/idle-status` via `Promise.allSettled` and joins by `holder_name` to attach `holderIdleMs` to waiting `LockState`s. `WaitingLockBanner` renders `(holder idle Xm)` when `> 60s`. `formatSince` promoted from `(ms?)` (internal `Date.now()`) to `(sinceMs, nowMs)` to match the existing `formatBannerSeconds` pattern.

**Phase 3 — `POST /file-locks/signal-long-wait`.** Mirrors the yield-request shape (same `serde_json::json!` literal, dual `app_handle.emit()` + `event_broadcast.send()`). `HoldingLockBanner`'s previously-disabled "I'll be a while" button is enabled with a 30s cooldown matching the yield-request UX; `WaitingLockBanner` renders an advisory "B says they'll be a while" line below the headline when the corresponding event arrives.

Design caveats from the vet pass (preserved in the plan):
- Tab-icon tooltips use the native HTML `title` attribute — next-hover ticks fresh, but the OS-rendered popup doesn't refresh while visibly open. Banner-side text (real JSX) ticks fully live.
- PTY tabs lacking `claudeSessionId` aren't in the idle endpoint — same scope as lock-yield.

Plan archived in qontinui-dev-notes: `plans/stuck-session-heartbeat-plan.md` (`c899624`).

## Test plan

- [x] `cargo test --bin qontinui-runner mcp::ai_session::tests` — 6/6 pass (empty / single-session / dispatcher-name match / zero-clamp / future-skew saturate / live-atomic re-read).
- [x] `cargo test --bin qontinui-runner mcp::file_registry::tests::signal_long_wait` — 2/2 pass (valid-payload broadcast / estimate serialises as number).
- [x] `npx vitest run` on `useNow1Hz`, `useFileLockTracking`, `WaitingLockBanner`, `HoldingLockBanner` — 107/107 pass.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run build` — clean (post-merge with PR #101's `fileActivityApi.ts` fix).
- [x] Live smoke against a supervisor-spawned temp runner: `GET /sessions/idle-status` returns `[]`, `POST /file-locks/signal-long-wait` returns `{"signaled":true}` with and without `estimated_remaining_ms`, zero console errors on the webview, all `/ui-bridge/control/*` calls succeed.
- [ ] Reviewer: confirm `HoldingLockBanner`'s "I'll be a while" button POST path against a live AI tab on `feat/stuck-session-heartbeat` (PTY-only temp runners don't exercise the AI-tab gated banner per `proj_holding_banner_pty_gate.md`).