### PR TITLE
feat(ui-bridge): terminal-sessions list endpoint + launch-action ids

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -38,6 +38,7 @@ pub mod screenshots;
 pub mod sdk_spec_sync;
 pub mod state_machine;
 pub mod stubs;
+pub mod terminals;
 pub mod toasts;
 pub mod types;
 
@@ -336,6 +337,7 @@ pub(super) fn route_manifest() -> &'static [(&'static str, &'static str)] {
         all.extend_from_slice(sdk_spec_sync::route_entries());
         all.extend_from_slice(state_machine::route_entries());
         all.extend_from_slice(stubs::route_entries());
+        all.extend_from_slice(terminals::route_entries());
         all.extend_from_slice(toasts::route_entries());
         all
     })
@@ -382,6 +384,7 @@ pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
         .merge(sdk_spec_sync::routes())
         .merge(state_machine::routes())
         .merge(stubs::routes())
+        .merge(terminals::routes())
         .merge(toasts::routes())
         // Tier 2.1 — safelisted Tauri command proxy
         .merge(crate::mcp::tauri_proxy::routes())

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -667,6 +667,11 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/control/element/{}/assert"),
             ("POST", "/ui-bridge/control/batch-actions"),
             ("POST", "/ui-bridge/circuit-breaker/reset"),
+            // Terminal sessions — runner-only (terminal tabs are a Tauri-host
+            // construct; SDK/web/supervisor consumers don't host PTY tabs).
+            // Pairs with `terminal-launch-menu` component actions.
+            ("GET", "/ui-bridge/control/terminal-sessions"),
+            ("GET", "/ui-bridge/control/terminal-sessions/{}"),
             // /control/ai/* aliases mirroring SDK /ai/* (runner-side dual mount)
             ("DELETE", "/ui-bridge/control/ai/bookmark/{}"),
             ("DELETE", "/ui-bridge/control/ai/bookmarks/{}"),

--- a/src-tauri/src/mcp/ui_bridge/terminals.rs
+++ b/src-tauri/src/mcp/ui_bridge/terminals.rs
@@ -70,10 +70,8 @@ pub async fn ui_bridge_terminal_sessions_list_handler(
 pub(crate) fn classify_terminal_session_get_response(
     id: &str,
     data: serde_json::Value,
-) -> Result<
-    Json<ApiResponse<serde_json::Value>>,
-    (StatusCode, Json<ApiResponse<serde_json::Value>>),
-> {
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
+{
     match data.get("found").and_then(serde_json::Value::as_bool) {
         Some(true) => Ok(Json(ApiResponse::success(data))),
         Some(false) => {

--- a/src-tauri/src/mcp/ui_bridge/terminals.rs
+++ b/src-tauri/src/mcp/ui_bridge/terminals.rs
@@ -1,0 +1,250 @@
+//! Terminal-sessions HTTP handlers.
+//!
+//! `GET /ui-bridge/control/terminal-sessions` — list every PTY-backed
+//! terminal tab the runner currently has open (plain + AI sessions),
+//! together with the per-tab session-machine `state` and the
+//! Claude-Code `task_run_id` once it's been captured.
+//!
+//! `GET /ui-bridge/control/terminal-sessions/{id}` — single entry lookup
+//! keyed by `tab.id`. Returns HTTP 404 when the id isn't a known tab.
+//!
+//! The authoritative tab list lives in the frontend (`useTerminalManager`
+//! inside `TerminalCoreProvider`). The page publishes a snapshot to a
+//! module-level registry (`@/lib/terminal-sessions-registry`) on every
+//! render; the IPC handler in `useTerminalsEvents.ts` reads that
+//! snapshot. This keeps the substrate symmetric with `tabs_list` in
+//! `usePageEvents.ts`, which reads from `instanceStorage` for the same
+//! "frontend-owned data, stateless handler" reason.
+//!
+//! These two endpoints unblock autonomous testing of the
+//! lock-yield protocol: a caller can issue `create-best-account`,
+//! capture the returned `tab_ids`, then poll
+//! `/terminal-sessions/{tab_id}` until `state === "ready"` /
+//! `task_run_id` is non-null without resorting to screen scraping.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::Json,
+};
+use tracing::{error, info};
+
+use crate::mcp::types::{api_error, ApiResponse, ApiState};
+
+use super::request::ui_bridge_request_sync;
+
+/// `GET /ui-bridge/control/terminal-sessions`
+///
+/// Returns `{ sessions: TerminalSessionEntry[] }` covering every tab in
+/// the runner's terminal page. Empty array (not a 404) when no terminal
+/// tabs are open. The shape is fixed by `useTerminalsEvents.ts` —
+/// adding new fields requires matching changes on both sides.
+pub async fn ui_bridge_terminal_sessions_list_handler(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    info!("UI Bridge API: terminal_sessions_list");
+
+    match ui_bridge_request_sync(&state, "terminal_sessions_list", serde_json::json!({})).await {
+        Ok(data) => Ok(Json(ApiResponse::success(data))),
+        Err(e) => {
+            error!("UI Bridge API: terminal_sessions_list failed: {}", e);
+            Err((StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))
+        }
+    }
+}
+
+/// Classify a `terminal_session_get` IPC response into the
+/// (http_status, body) pair the handler should return. Pulled out so
+/// the 404/200 decision can be unit-tested without a live frontend.
+///
+/// Returns:
+/// - `Ok(success_body)` — frontend reported `found: true`. Body wraps
+///   the IPC `data` as a success ApiResponse.
+/// - `Err((NOT_FOUND, body))` — frontend reported `found: false`. Body
+///   carries `{error, knownIds, id}` so callers can recover from typos
+///   without a second list call.
+/// - `Err((INTERNAL_SERVER_ERROR, body))` — shape was unexpected (no
+///   `found` key); treat as a server-side bug.
+pub(crate) fn classify_terminal_session_get_response(
+    id: &str,
+    data: serde_json::Value,
+) -> Result<
+    Json<ApiResponse<serde_json::Value>>,
+    (StatusCode, Json<ApiResponse<serde_json::Value>>),
+> {
+    match data.get("found").and_then(serde_json::Value::as_bool) {
+        Some(true) => Ok(Json(ApiResponse::success(data))),
+        Some(false) => {
+            let known_ids = data
+                .get("knownIds")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!([]));
+            let body = ApiResponse {
+                success: false,
+                data: Some(serde_json::json!({
+                    "error": "unknown_terminal_session",
+                    "knownIds": known_ids,
+                    "id": id,
+                })),
+                error: Some(format!("unknown terminal session: \"{}\"", id)),
+                error_detail: None,
+                hint: None,
+            };
+            Err((StatusCode::NOT_FOUND, Json(body)))
+        }
+        None => {
+            // The frontend handler always sets `found`; missing key means
+            // a payload shape regression. Surface as 500 with the raw body
+            // for diagnosis rather than silently treating it as a hit.
+            let body = ApiResponse {
+                success: false,
+                data: Some(data),
+                error: Some(
+                    "terminal_session_get: missing `found` discriminator in IPC response"
+                        .to_string(),
+                ),
+                error_detail: None,
+                hint: None,
+            };
+            Err((StatusCode::INTERNAL_SERVER_ERROR, Json(body)))
+        }
+    }
+}
+
+/// `GET /ui-bridge/control/terminal-sessions/{id}`
+///
+/// Looks up a single terminal session by `tab.id`. Returns HTTP 404
+/// (with the known ids in the error body) when no match is found, so
+/// callers polling for a freshly-spawned tab can recover without
+/// dropping back to the list endpoint.
+pub async fn ui_bridge_terminal_session_get_handler(
+    State(state): State<Arc<ApiState>>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
+{
+    info!("UI Bridge API: terminal_session_get -> {}", id);
+
+    let payload = serde_json::json!({ "id": id });
+    match ui_bridge_request_sync(&state, "terminal_session_get", payload).await {
+        Ok(data) => classify_terminal_session_get_response(&id, data),
+        Err(e) => {
+            error!("UI Bridge API: terminal_session_get IPC failed: {}", e);
+            let body = ApiResponse {
+                success: false,
+                data: None,
+                error: Some(e),
+                error_detail: None,
+                hint: None,
+            };
+            Err((StatusCode::INTERNAL_SERVER_ERROR, Json(body)))
+        }
+    }
+}
+
+/// Terminal-session inspection routes.
+pub fn routes() -> axum::Router<Arc<ApiState>> {
+    use axum::routing::get;
+    axum::Router::new()
+        .route(
+            "/ui-bridge/control/terminal-sessions",
+            get(ui_bridge_terminal_sessions_list_handler),
+        )
+        .route(
+            "/ui-bridge/control/terminal-sessions/{id}",
+            get(ui_bridge_terminal_session_get_handler),
+        )
+}
+
+/// Static (method, path) tuples corresponding to every route registered
+/// by `routes()`. Concatenated into `route_manifest()` in `mod.rs`.
+pub fn route_entries() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("GET", "/ui-bridge/control/terminal-sessions"),
+        ("GET", "/ui-bridge/control/terminal-sessions/{id}"),
+    ]
+}
+
+#[cfg(test)]
+mod terminal_session_classifier_tests {
+    //! Unit tests for `classify_terminal_session_get_response`. The
+    //! handler delegates the success/404/500 decision to this pure
+    //! helper so we can lock down the wire shape without a live frontend
+    //! — same pattern as `tab_activate_tests` / `page_navigate_mode_tests`.
+
+    use super::classify_terminal_session_get_response;
+    use axum::http::StatusCode;
+
+    #[test]
+    fn found_true_returns_200_with_data_passthrough() {
+        let data = serde_json::json!({
+            "found": true,
+            "session": { "id": "tab-1", "title": "Terminal 1", "state": "idle" }
+        });
+        let resp = classify_terminal_session_get_response("tab-1", data.clone()).unwrap();
+        let body = resp.0;
+        assert!(body.success);
+        assert_eq!(body.data.as_ref().unwrap(), &data);
+    }
+
+    #[test]
+    fn found_false_returns_404_with_known_ids_hint() {
+        let data = serde_json::json!({
+            "found": false,
+            "knownIds": ["tab-1", "tab-2"]
+        });
+        let err = classify_terminal_session_get_response("missing", data).unwrap_err();
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+        let body = err.1 .0;
+        assert!(!body.success);
+        let body_data = body.data.expect("404 body carries data");
+        assert_eq!(body_data["error"], "unknown_terminal_session");
+        assert_eq!(body_data["id"], "missing");
+        assert_eq!(body_data["knownIds"], serde_json::json!(["tab-1", "tab-2"]));
+    }
+
+    #[test]
+    fn found_false_with_no_known_ids_still_404s() {
+        // The empty-tabs case: frontend just published `[]`, so `knownIds`
+        // is an empty array rather than missing. The 404 still fires and
+        // the body shape stays consistent.
+        let data = serde_json::json!({ "found": false, "knownIds": [] });
+        let err = classify_terminal_session_get_response("anything", data).unwrap_err();
+        assert_eq!(err.0, StatusCode::NOT_FOUND);
+        assert_eq!(err.1 .0.data.unwrap()["knownIds"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn missing_found_key_returns_500() {
+        // Payload-shape regression. Surface as 500 rather than guessing.
+        let data = serde_json::json!({ "session": { "id": "x" } });
+        let err = classify_terminal_session_get_response("x", data).unwrap_err();
+        assert_eq!(err.0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(err.1 .0.error.as_deref().unwrap().contains("found"));
+    }
+
+    /// Routes/route_entries drift guard. The `manifest_matches_route_calls`
+    /// test in `mod.rs` re-scans the source file to verify this, but a
+    /// local equality check catches the more common "forgot to add a
+    /// tuple" mistake earlier (and runs as part of `cargo test -p
+    /// qontinui-runner terminals::`).
+    #[test]
+    fn route_entries_match_route_count() {
+        // Build the router and count its `.route(...)` calls indirectly
+        // via `route_entries()` — every entry corresponds to one route.
+        // The constant matches the number of `.route(` calls in
+        // `routes()`; bumping one without the other fails compile via
+        // the manifest test, but this lower-bound check catches local
+        // edits before that broader test runs.
+        assert_eq!(super::route_entries().len(), 2);
+        for (method, path) in super::route_entries() {
+            assert_eq!(*method, "GET", "all terminal-session routes are GET");
+            assert!(
+                path.starts_with("/ui-bridge/control/terminal-sessions"),
+                "unexpected path prefix: {}",
+                path
+            );
+        }
+    }
+}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -37,6 +37,10 @@ import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { useTerminalInitialization } from "./useTerminalInitialization";
 import { useZoneActions } from "./useZoneActions";
 import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
+import {
+  setTerminalSessions,
+  type TerminalSessionEntry,
+} from "@/lib/terminal-sessions-registry";
 import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
 import { useCommitState } from "./useCommitState";
 import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
@@ -270,6 +274,37 @@ function TerminalPageInner({
   } = useZoneMetadata();
 
   const stateTracking = useSessionState();
+
+  // Publish a snapshot of the current tabs + per-tab session state to the
+  // module-level `terminal-sessions-registry`. The UI Bridge IPC handlers
+  // for `GET /control/terminal-sessions[/{id}]` read from there since the
+  // dispatcher (`useUIBridgeEventHandler`) sits above `TerminalCoreProvider`
+  // and can't reach into this context directly. On unmount we clear the
+  // snapshot so a stale view doesn't survive a route switch.
+  useEffect(() => {
+    const entries: TerminalSessionEntry[] = tabs.map((t) => ({
+      id: t.id,
+      title: t.title,
+      taskRunId: t.claudeSessionId ?? null,
+      claudeSessionId: t.claudeSessionId ?? null,
+      workingDir: t.workingDir ?? "",
+      // `sessionStates` keys are tab.id; tabs without a tracked state
+      // (plain pwsh, freshly-created AI tabs before the state machine
+      // observes them) fall through to "idle" so the field is always
+      // a valid `TerminalSessionState`.
+      state: stateTracking.sessionStates[t.id] ?? "idle",
+      isAlive: Boolean(t.isAlive),
+      exitCode: t.exitCode,
+      type: t.type ?? "terminal",
+      createdAt: t.createdAt ?? null,
+    }));
+    setTerminalSessions(entries);
+    return () => {
+      // Best-effort clear when TerminalPage unmounts so stale entries
+      // don't survive tab switches away from `/terminals`.
+      setTerminalSessions([]);
+    };
+  }, [tabs, stateTracking.sessionStates]);
 
   const transitionEffects = useTransitionEffects();
   const { handleRestartInZone } = transitionEffects;
@@ -514,6 +549,10 @@ function TerminalPageInner({
                 writeWhenReady(tabId, `${autoCommand}\r`);
               }
             }
+            // Returned ids surface in the UI Bridge action response so
+            // automation can immediately poll
+            // `/control/terminal-sessions/{id}` without screen-scraping.
+            return createdTabIds;
           }}
           onLaunchAiSession={async (count, configDir, context) => {
             const totalTabs = tabs.length + count;
@@ -561,6 +600,10 @@ function TerminalPageInner({
                 }, 8000);
               }
             }
+            // Returned ids surface in the UI Bridge action response so
+            // automation can immediately poll
+            // `/control/terminal-sessions/{id}` without screen-scraping.
+            return createdTabIds;
           }}
           onLaunchMultiAiSessions={async (configDirs, context) => {
             const count = configDirs.length;
@@ -604,6 +647,10 @@ function TerminalPageInner({
                 setTimeout(() => writeWhenReady(tabId, `${safeContext}\r`), j * 300 + 8000);
               }
             }
+            // Returned ids surface in the UI Bridge action response so
+            // automation can immediately poll
+            // `/control/terminal-sessions/{id}` without screen-scraping.
+            return createdTabIds;
           }}
           accountUsage={sessionManager.accountUsage}
           launchCommands={sessionManager.launchCommands}

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -21,9 +21,25 @@ interface TerminalTabBarProps {
   onRename: (id: string, title: string) => void;
   sessionStates?: Record<string, SessionState>;
   layoutPicker?: ReactNode;
-  onQuickLaunch?: (count: number, autoCommand?: string) => void;
-  onLaunchAiSession?: (count: number, configDir: string, context?: string) => void;
-  onLaunchMultiAiSessions?: (configDirs: string[], context?: string) => void;
+  /**
+   * Spawn N plain PTY terminals. Returns the created `tab.id`s in
+   * launch order so UI Bridge action handlers can surface them in the
+   * synchronous response — see `chore/uib-terminal-sessions-endpoint`.
+   * The user-click path through `<LaunchMenu>` ignores the return
+   * value (it's a fire-and-forget).
+   */
+  onQuickLaunch?: (count: number, autoCommand?: string) => Promise<string[]> | void;
+  /** Spawn N AI sessions for a single account; returns the new `tab.id`s. */
+  onLaunchAiSession?: (
+    count: number,
+    configDir: string,
+    context?: string,
+  ) => Promise<string[]> | void;
+  /** Spawn one AI session per `configDir`; returns the new `tab.id`s. */
+  onLaunchMultiAiSessions?: (
+    configDirs: string[],
+    context?: string,
+  ) => Promise<string[]> | void;
   accountUsage?: AccountUsageInfo[];
   launchCommands?: Record<string, string>;
   fileLocks?: import("./useSessionManager").FileLockInfo[];
@@ -321,13 +337,22 @@ export function TerminalTabBar({
         label: "Create Plain Terminal",
         description: "Spawn N blank terminals using the user's default shell.",
         paramSchema: { count: "number (>= 1, defaults to 1)" },
-        handler: (params?: unknown) => {
+        handler: async (params?: unknown) => {
           const { count = 1 } = (params ?? {}) as { count?: number };
           if (typeof count !== "number" || count < 1) {
             throw new Error("create-plain requires { count: number } where count >= 1");
           }
-          onQuickLaunch?.(count);
+          // PTY-only tabs never own a Claude task_run_id, so the parallel
+          // task_run_ids array is empty — callers polling
+          // `/control/terminal-sessions/{id}` for the readiness signal
+          // (`state` / `is_alive`) is the right pattern for these.
+          const tabIds = ((await onQuickLaunch?.(count)) ?? []) as string[];
           closeLaunchMenu();
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: [] as Array<string | null>,
+          };
         },
       },
       {
@@ -340,7 +365,7 @@ export function TerminalTabBar({
           configDir: "string (absolute path to a Claude Code config dir, required)",
           context: "string (optional initial prompt auto-typed after claude starts)",
         },
-        handler: (params?: unknown) => {
+        handler: async (params?: unknown) => {
           const {
             count = 1,
             configDir,
@@ -357,8 +382,19 @@ export function TerminalTabBar({
           if (typeof count !== "number" || count < 1) {
             throw new Error("create-ai-session: count must be a positive number");
           }
-          onLaunchAiSession?.(count, configDir, context);
+          // `task_run_id` (= Claude session_id) is captured asynchronously
+          // by `useTabSessionIdCapture` once Claude CLI writes its first
+          // JSONL record. At handler-return time the value is `null` for
+          // every fresh tab — callers correlate via
+          // `GET /control/terminal-sessions/{tab_id}` and watch for
+          // `task_run_id` to flip non-null.
+          const tabIds = ((await onLaunchAiSession?.(count, configDir, context)) ?? []) as string[];
           closeLaunchMenu();
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: tabIds.map(() => null) as Array<string | null>,
+          };
         },
       },
       {
@@ -370,7 +406,7 @@ export function TerminalTabBar({
           count: "number (>= 1, defaults to 1)",
           context: "string (optional initial prompt auto-typed after claude starts)",
         },
-        handler: (params?: unknown) => {
+        handler: async (params?: unknown) => {
           const { count = 1, context } = (params ?? {}) as {
             count?: number;
             context?: string;
@@ -380,8 +416,14 @@ export function TerminalTabBar({
           }
           const best = sortedAccountsForBridge[0];
           if (!best) throw new Error("No AI accounts available");
-          onLaunchAiSession?.(count, best.config_dir, context);
+          const tabIds = ((await onLaunchAiSession?.(count, best.config_dir, context)) ??
+            []) as string[];
           closeLaunchMenu();
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: tabIds.map(() => null) as Array<string | null>,
+          };
         },
       },
       {
@@ -393,7 +435,7 @@ export function TerminalTabBar({
           count: "number (>= 1, defaults to 1)",
           command: "string (the shell command to type + Enter, required)",
         },
-        handler: (params?: unknown) => {
+        handler: async (params?: unknown) => {
           const { count = 1, command } = (params ?? {}) as {
             count?: number;
             command?: string;
@@ -403,8 +445,16 @@ export function TerminalTabBar({
           if (typeof count !== "number" || count < 1) {
             throw new Error("create-with-command: count must be a positive number");
           }
-          onQuickLaunch?.(count, command);
+          // `create-with-command` reuses the plain-PTY path (no Claude
+          // CLI), so `task_run_ids` is empty by definition. Callers can
+          // still observe the spawned tabs via `terminal-sessions`.
+          const tabIds = ((await onQuickLaunch?.(count, command)) ?? []) as string[];
           closeLaunchMenu();
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: [] as Array<string | null>,
+          };
         },
       },
     ],

--- a/src/hooks/ui-bridge-events/index.ts
+++ b/src/hooks/ui-bridge-events/index.ts
@@ -9,6 +9,7 @@ export { useAISearchEvents } from "./useAISearchEvents";
 export { useWorkflowEvents } from "./useWorkflowEvents";
 export { useMediaEvents } from "./useMediaEvents";
 export { useAnnotationEvents } from "./useAnnotationEvents";
+export { useTerminalsEvents } from "./useTerminalsEvents";
 
 export type {
   UIBridgeRequestType,

--- a/src/hooks/ui-bridge-events/types.ts
+++ b/src/hooks/ui-bridge-events/types.ts
@@ -208,6 +208,9 @@ export type UIBridgeRequestType =
   // Tab control (F4 — first-class tab activation)
   | "tabs_list"
   | "tab_activate"
+  // Terminal session inspection (chore/uib-terminal-sessions-endpoint)
+  | "terminal_sessions_list"
+  | "terminal_session_get"
   // Page playbook (combined tab + component + intent + primary-action snapshot)
   | "get_playbook"
   // Network stubs (F2)
@@ -443,6 +446,14 @@ export type AnnotationEventTypes =
   | "annotations_export"
   | "annotations_import";
 
+/**
+ * Terminal session inspection — GET /control/terminal-sessions[/{id}].
+ * Reads from the module-level `terminal-sessions-registry` populated by
+ * `TerminalPageInner`, mirroring the "Rust asks, frontend answers"
+ * shape used by `tabs_list` / `tab_activate`.
+ */
+export type TerminalEventTypes = "terminal_sessions_list" | "terminal_session_get";
+
 /** Union of every variant claimed by a sub-hook. */
 export type AllHandledTypes =
   | ControlEventTypes
@@ -455,7 +466,8 @@ export type AllHandledTypes =
   | AISearchEventTypes
   | WorkflowEventTypes
   | MediaEventTypes
-  | AnnotationEventTypes;
+  | AnnotationEventTypes
+  | TerminalEventTypes;
 
 /**
  * Type-level assertion helper. `AssertEqual<X, Y>` is the literal type
@@ -544,6 +556,8 @@ export interface UIBridgeRequestPayload {
   maxTokens?: number;
   /** Target tab id for `tab_activate`. */
   tabId?: string;
+  /** Target id for `terminal_session_get` (== `tab.id` from `useTerminalManager`). */
+  id?: string;
   /** DOM-tree depth for `get_element_dom_tree` (clamped server-side to [1,6]). */
   depth?: number;
   /**

--- a/src/hooks/ui-bridge-events/useTerminalsEvents.test.ts
+++ b/src/hooks/ui-bridge-events/useTerminalsEvents.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for the terminal-sessions IPC handler.
+ *
+ * The vitest config uses `environment: "node"` (no jsdom, no
+ * `@testing-library/react`), so we exercise the load-bearing pieces
+ * by:
+ *   1. Driving the module-level registry directly and asserting on
+ *      `getTerminalSessions` / `getTerminalSession`.
+ *   2. Calling the pure `projectTerminalSessionEntry` projector and
+ *      asserting on the snake_case wire shape (the Rust side reads
+ *      `task_run_id`, not `taskRunId`).
+ *
+ * This matches the precedent in `LaunchMenu.test.tsx` — test the
+ * pure helpers, not the JSX wiring.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  setTerminalSessions,
+  getTerminalSessions,
+  getTerminalSession,
+  __resetTerminalSessionsForTest,
+  type TerminalSessionEntry,
+} from "@/lib/terminal-sessions-registry";
+import { projectTerminalSessionEntry } from "./useTerminalsEvents";
+
+function makeEntry(overrides: Partial<TerminalSessionEntry> = {}): TerminalSessionEntry {
+  return {
+    id: "tab-1",
+    title: "Terminal 1",
+    taskRunId: null,
+    claudeSessionId: null,
+    workingDir: "C:/work",
+    state: "idle",
+    isAlive: true,
+    exitCode: null,
+    type: "terminal",
+    createdAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe("terminal-sessions-registry", () => {
+  beforeEach(() => {
+    __resetTerminalSessionsForTest();
+  });
+
+  it("starts empty so a poll during runner startup returns []", () => {
+    expect(getTerminalSessions()).toEqual([]);
+    expect(getTerminalSession("nope")).toBeUndefined();
+  });
+
+  it("setTerminalSessions stores the snapshot in order", () => {
+    const entries = [makeEntry({ id: "a" }), makeEntry({ id: "b" })];
+    setTerminalSessions(entries);
+    expect(getTerminalSessions().map((e) => e.id)).toEqual(["a", "b"]);
+  });
+
+  it("getTerminalSession returns the entry by id or undefined", () => {
+    setTerminalSessions([
+      makeEntry({ id: "tab-1" }),
+      makeEntry({ id: "tab-2", title: "Terminal 2" }),
+    ]);
+    expect(getTerminalSession("tab-2")?.title).toBe("Terminal 2");
+    expect(getTerminalSession("missing")).toBeUndefined();
+  });
+
+  it("publishing a fresh snapshot replaces the prior one", () => {
+    setTerminalSessions([makeEntry({ id: "a" })]);
+    setTerminalSessions([makeEntry({ id: "b" })]);
+    const ids = getTerminalSessions().map((e) => e.id);
+    expect(ids).toEqual(["b"]);
+  });
+});
+
+describe("projectTerminalSessionEntry", () => {
+  it("renames every camelCase field to snake_case for the wire", () => {
+    const entry = makeEntry({
+      id: "tab-x",
+      title: "claude",
+      taskRunId: "task-abc",
+      claudeSessionId: "task-abc",
+      workingDir: "D:/repo",
+      state: "working",
+      isAlive: true,
+      exitCode: null,
+      createdAt: 1234567890,
+    });
+    expect(projectTerminalSessionEntry(entry)).toEqual({
+      id: "tab-x",
+      title: "claude",
+      task_run_id: "task-abc",
+      claude_session_id: "task-abc",
+      working_dir: "D:/repo",
+      state: "working",
+      is_alive: true,
+      exit_code: null,
+      type: "terminal",
+      created_at: 1234567890,
+    });
+  });
+
+  it("preserves null task_run_id / claude_session_id for fresh AI tabs", () => {
+    // Pre-JSONL-capture window: the tab exists but its Claude session id
+    // hasn't been observed yet. Callers detect this and poll until it
+    // flips non-null.
+    const projected = projectTerminalSessionEntry(makeEntry());
+    expect(projected.task_run_id).toBeNull();
+    expect(projected.claude_session_id).toBeNull();
+  });
+
+  it("passes through exit_code for dead tabs so callers can see the failure", () => {
+    const projected = projectTerminalSessionEntry(
+      makeEntry({ isAlive: false, exitCode: 137 }),
+    );
+    expect(projected.is_alive).toBe(false);
+    expect(projected.exit_code).toBe(137);
+  });
+
+  it("returns the plan tab type literally so callers can filter", () => {
+    expect(
+      projectTerminalSessionEntry(
+        makeEntry({ type: "plan", state: "idle", isAlive: true }),
+      ).type,
+    ).toBe("plan");
+  });
+});

--- a/src/hooks/ui-bridge-events/useTerminalsEvents.ts
+++ b/src/hooks/ui-bridge-events/useTerminalsEvents.ts
@@ -1,0 +1,148 @@
+/**
+ * useTerminalsEvents
+ *
+ * Handles `terminal_sessions_list` and `terminal_session_get` IPC
+ * requests issued by the new `GET /ui-bridge/control/terminal-sessions`
+ * + `GET /ui-bridge/control/terminal-sessions/{id}` HTTP routes in the
+ * Rust `mcp::ui_bridge::terminals` family.
+ *
+ * The hook reads from the module-level `terminal-sessions-registry`
+ * that `TerminalPageInner` publishes on every render. The registry
+ * scopes the response to the active terminal page; tabs from other
+ * `pageId`s (multi-window setups) would publish a different snapshot
+ * when they were on top, but the registry holds a single snapshot at
+ * a time — matching `instanceStorage[ACTIVE_TAB_STORAGE_KEY]`'s
+ * "current page wins" behaviour for `tabs_list`.
+ *
+ * The empty case (no terminal tabs open, or the page hasn't mounted
+ * yet) returns `{sessions: []}` — NOT an error — so a caller polling
+ * during runner startup gets a clean "nothing yet" signal.
+ */
+
+import { useCallback } from "react";
+import type { UIBridgeRequestPayload, UIBridgeEventContext, TerminalEventTypes } from "./types";
+import { createLogger } from "@/lib/logger";
+import {
+  getTerminalSession,
+  getTerminalSessions,
+  type TerminalSessionEntry,
+} from "@/lib/terminal-sessions-registry";
+
+const logger = createLogger("UIBridgeTerminalsEvents");
+
+const TERMINAL_EVENT_TYPES: ReadonlySet<TerminalEventTypes> = new Set<TerminalEventTypes>([
+  "terminal_sessions_list",
+  "terminal_session_get",
+]);
+
+function isTerminalEventType(type: string): type is TerminalEventTypes {
+  return TERMINAL_EVENT_TYPES.has(type as TerminalEventTypes);
+}
+
+/**
+ * Project a registry entry to the IPC wire shape. snake_case keys mirror
+ * the Rust DTO conventions for `/control/*` payload bodies (`task_run_id`,
+ * `working_dir`, `claude_session_id`, `created_at`) so downstream typed
+ * consumers in qontinui-types can decode the response without an
+ * additional rename layer. Exported for vitest.
+ */
+export function projectTerminalSessionEntry(entry: TerminalSessionEntry) {
+  return {
+    id: entry.id,
+    title: entry.title,
+    task_run_id: entry.taskRunId,
+    claude_session_id: entry.claudeSessionId,
+    working_dir: entry.workingDir,
+    state: entry.state,
+    is_alive: entry.isAlive,
+    exit_code: entry.exitCode,
+    type: entry.type,
+    created_at: entry.createdAt,
+  };
+}
+
+export function useTerminalsEvents(
+  context: Pick<UIBridgeEventContext, "sendResponse">,
+) {
+  const { sendResponse } = context;
+
+  return useCallback(
+    async (payload: UIBridgeRequestPayload): Promise<boolean> => {
+      const { requestId, type } = payload;
+
+      if (!isTerminalEventType(type)) {
+        return false;
+      }
+
+      switch (type) {
+        case "terminal_sessions_list": {
+          const sessions = getTerminalSessions().map(projectTerminalSessionEntry);
+          logger.debug(`terminal_sessions_list: returning ${sessions.length} entries`);
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: { sessions },
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+
+        case "terminal_session_get": {
+          // Path param is plumbed through `payload.id`; tolerate
+          // `payload.params.id` too in case future callers wrap the
+          // payload under `params` (the legacy convention for several
+          // /control/* handlers).
+          const rawId =
+            (payload as { id?: unknown }).id ??
+            (payload.params as { id?: unknown } | undefined)?.id;
+          if (typeof rawId !== "string" || rawId.length === 0) {
+            await sendResponse({
+              requestId,
+              type,
+              success: false,
+              error: "id is required (non-empty string)",
+              timestamp: Date.now(),
+            });
+            return true;
+          }
+          const entry = getTerminalSession(rawId);
+          if (!entry) {
+            const knownIds = getTerminalSessions().map((e) => e.id);
+            // Surface as a successful IPC response with `found: false`
+            // so the Rust handler can branch to HTTP 404 with the
+            // known-ids hint body. Returning an IPC `error` here would
+            // strip the `data` payload via `wrap_ipc_result`.
+            await sendResponse({
+              requestId,
+              type,
+              success: true,
+              data: { found: false, knownIds },
+              timestamp: Date.now(),
+            });
+            return true;
+          }
+          await sendResponse({
+            requestId,
+            type,
+            success: true,
+            data: { found: true, session: projectTerminalSessionEntry(entry) },
+            timestamp: Date.now(),
+          });
+          return true;
+        }
+
+        default: {
+          // Exhaustiveness guard — keeps `TerminalEventTypes` and the
+          // switch in lockstep at compile time. Adding a new variant
+          // to `TerminalEventTypes` without a matching `case` here
+          // fails the `never` check below.
+          const _exhaustive: never = type;
+          void _exhaustive;
+          return false;
+        }
+      }
+    },
+    [sendResponse],
+  );
+}

--- a/src/hooks/useUIBridgeEventHandler.ts
+++ b/src/hooks/useUIBridgeEventHandler.ts
@@ -46,6 +46,7 @@ import {
   useWorkflowEvents,
   useMediaEvents,
   useAnnotationEvents,
+  useTerminalsEvents,
 } from "./ui-bridge-events";
 
 import type { UIBridgeRequestPayload, UIBridgeResponsePayload } from "./ui-bridge-events/types";
@@ -129,6 +130,7 @@ export function useUIBridgeEventHandler(): void {
   const handleWorkflow = useWorkflowEvents(context);
   const handleMedia = useMediaEvents(context);
   const handleAnnotations = useAnnotationEvents(context);
+  const handleTerminals = useTerminalsEvents(context);
 
   /**
    * Handle incoming UI Bridge requests
@@ -166,6 +168,7 @@ export function useUIBridgeEventHandler(): void {
           handleWorkflow,
           handleMedia,
           handleAnnotations,
+          handleTerminals,
         ];
 
         for (const handler of handlers) {
@@ -205,6 +208,7 @@ export function useUIBridgeEventHandler(): void {
       handleWorkflow,
       handleMedia,
       handleAnnotations,
+      handleTerminals,
     ],
   );
 

--- a/src/lib/terminal-sessions-registry.ts
+++ b/src/lib/terminal-sessions-registry.ts
@@ -1,0 +1,90 @@
+/**
+ * Terminal Sessions Registry
+ *
+ * Module-level snapshot of the runner's terminal sessions (the tabs owned by
+ * `useTerminalManager`) plus their session-state-machine status, kept current
+ * by `TerminalPageInner` on every render. UI Bridge IPC handlers read from
+ * this registry to answer `GET /ui-bridge/control/terminal-sessions[/{id}]`
+ * — endpoints that need a frontend-owned view of the tab list without
+ * coupling to React mount order.
+ *
+ * Why a module singleton: the IPC dispatch path (`useUIBridgeEventHandler`)
+ * lives outside the terminal-page subtree, so it can't reach into
+ * `TerminalCoreContext` directly. Rather than threading the context through
+ * every sub-hook or fanning out a custom DOM event, the page publishes its
+ * snapshot here and the new `useTerminalsEvents` hook reads it. The
+ * registry mirrors how `instanceStorage[ACTIVE_TAB_STORAGE_KEY]` is used
+ * by `usePageEvents.ts` (`tabs_list`) — a tiny module-scope leak that
+ * lets stateless handlers serve frontend-owned data.
+ */
+
+/** Mirrors `SessionState` from `./components/terminal/useZoneLayout.ts`. */
+export type TerminalSessionState =
+  | "idle"
+  | "working"
+  | "needs-input"
+  | "completed"
+  | "error";
+
+/**
+ * A single terminal session entry as published to the UI Bridge.
+ *
+ * `taskRunId` / `claudeSessionId` are `null` for tabs that have not yet
+ * captured a Claude Code session id (fresh AI tabs in the bootstrap window,
+ * or plain pwsh tabs that never will). Callers correlate `tabId` ↔
+ * `taskRunId` by polling `/ui-bridge/control/terminal-sessions/{id}`.
+ */
+export interface TerminalSessionEntry {
+  /** Runner-internal tab id (matches `tab.id` from `useTerminalManager`). */
+  id: string;
+  /** Display title (== `holder_name` for file-lock events). */
+  title: string;
+  /** Claude Code task-run id (== `claudeSessionId` today). `null` until
+   *  captured by `useTabSessionIdCapture` (~JSONL first write). */
+  taskRunId: string | null;
+  /** Alias kept in lockstep with `taskRunId`; the two may diverge if the
+   *  runner adopts a separate task-runs surface in the future. */
+  claudeSessionId: string | null;
+  /** Tab's working directory. Empty string when the tab has not reported
+   *  one yet (preserves the `string` shape rather than threading nulls). */
+  workingDir: string;
+  /** Sourced from `useSessionStateTracking.sessionStates` for AI tabs;
+   *  defaults to `"idle"` for plain PTY tabs that never register a state. */
+  state: TerminalSessionState;
+  /** True when the underlying PTY is still alive (false after exit). */
+  isAlive: boolean;
+  /** Process exit code, when known. `null` while the PTY is running. */
+  exitCode: number | null;
+  /** Tab type discriminator from `useTerminalManager`. Defaults to
+   *  `"terminal"` when undefined. */
+  type: "terminal" | "plan";
+  /** Epoch ms when the tab was created. `null` when not yet recorded. */
+  createdAt: number | null;
+}
+
+let snapshot: readonly TerminalSessionEntry[] = [];
+
+/**
+ * Replace the registry's snapshot. Called by `TerminalPageInner` on every
+ * render that affects the published fields (tabs / session states).
+ */
+export function setTerminalSessions(next: readonly TerminalSessionEntry[]): void {
+  snapshot = next;
+}
+
+/** Read the current snapshot. Returns the same array reference between
+ *  publishes so callers can cheaply detect "nothing changed". */
+export function getTerminalSessions(): readonly TerminalSessionEntry[] {
+  return snapshot;
+}
+
+/** Look up a single entry by `tab.id`. Returns `undefined` when no match
+ *  exists — handlers turn that into HTTP 404. */
+export function getTerminalSession(id: string): TerminalSessionEntry | undefined {
+  return snapshot.find((entry) => entry.id === id);
+}
+
+/** Reset for tests. Not exported through the package barrel. */
+export function __resetTerminalSessionsForTest(): void {
+  snapshot = [];
+}


### PR DESCRIPTION
## Summary
Closes the autonomous-driving gap that surfaced during the lock-yield smoke (`/manual-test` 2026-05-12). When spawning AI sessions via `terminal-launch-menu/action/create-best-account` (et al.), the action returned only `{success: true}` — no way to identify the spawned tab, no endpoint to list sessions, no way to tell if Claude actually started. Autonomous tests had to wait blindly and infer state from side-effects.

This PR adds two endpoints + extends four action responses:

```http
GET /ui-bridge/control/terminal-sessions
GET /ui-bridge/control/terminal-sessions/{id}
```
Returns `{sessions: [{id, title, task_run_id, claude_session_id, working_dir, state, is_alive, exit_code, type, created_at}]}`. Per-id GET returns 404 with `{error: "unknown_terminal_session", knownIds: [...]}` so callers polling a freshly-spawned tab can recover.

`terminal-launch-menu` actions (`create-best-account`, `create-ai-session`, `create-with-command`, `create-plain`) now return:
```json
{"success": true, "tab_ids": ["..."], "task_run_ids": ["..." | null]}
```
`task_run_ids` parallel to `tab_ids`; `null` until the JSONL-capture window closes (~<2s after spawn). Caller pattern: capture `tab_ids[0]` synchronously, poll `/control/terminal-sessions/{tab_ids[0]}` until `state ∈ {"idle","working"}` and `task_run_id !== null`.

Data routed through the existing IPC bridge — the source is `useTerminalManager.tabs` + `SessionStateContext.sessionStates`, both frontend-owned. Mirrors the precedent at `src-tauri/src/mcp/ui_bridge/page.rs:1161` (`ui_bridge_tabs_list_handler`) + `src/hooks/ui-bridge-events/usePageEvents.ts:947` (`tabs_list` projection).

Docs update lands in [ui-bridge](https://github.com/qontinui/ui-bridge) at runner-features.md (separate small commit on `main`).

## Test plan
- [x] Rust: 5 unit tests in `terminals.rs#mod tests`, `cargo test ... manifest_matches_route_calls` passes.
- [x] `cargo check -p qontinui-runner` + `cargo clippy --bin qontinui-runner --tests -- -D warnings` clean.
- [x] TS: 8 vitest tests in `useTerminalsEvents.test.ts` (registry + projection). `npx tsc --noEmit` clean. ESLint clean for touched files.
- [x] End-to-end smoke against a fresh temp runner (supervisor `spawn-test {rebuild: true}` on port 9881):
  - empty list → `{sessions: []}`
  - `create-best-account {count: 1}` → returned `tab_ids: ["ed1b7734-..."]`, `task_run_ids: [null]`
  - `GET /control/terminal-sessions/ed1b7734-...` → 200, `state: "working"`, `is_alive: true`, `task_run_id: null`
  - list now contains the new tab
  - unknown id → 404 with `knownIds` hint body

## Defer-list
- Reading terminal stdout / cell-grid output via UI Bridge (P2 from the remediation plan) — not in this PR. The list endpoint covers the unblocking signal; output peek is a follow-up if telemetry shows it's needed.