### PR TITLE
feat(lock-yield): auto-yield-on-idle policy (§Open Q4)

### DIFF
--- a/src-tauri/src/commands/lock_yield_policy_settings.rs
+++ b/src-tauri/src/commands/lock_yield_policy_settings.rs
@@ -1,0 +1,84 @@
+//! Lock-yield-policy settings commands.
+//!
+//! Get/save the auto-yield-on-idle policy that drives
+//! `executor::auto_yield_policy`. See `settings::LockYieldPolicySettings`
+//! for the on-disk schema.
+
+use crate::error::AppError;
+use crate::settings::{self, LockYieldPolicySettings};
+use anyhow::Result;
+use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
+use tauri::Runtime;
+use tracing::info;
+
+use super::CommandResponse;
+
+/// Internal implementation of [`get_lock_yield_policy_settings`].
+fn get_lock_yield_policy_settings_impl() -> Result<CommandResponse, AppError> {
+    info!("Getting lock-yield policy settings");
+
+    let policy = settings::get_lock_yield_policy_settings();
+    let data = serde_json::to_value(&policy)?;
+
+    Ok(CommandResponse {
+        success: true,
+        message: Some("Lock-yield policy settings retrieved".to_string()),
+        data: Some(data),
+    })
+}
+
+/// Get the current lock-yield policy settings.
+#[tauri::command]
+pub fn get_lock_yield_policy_settings() -> Result<CommandResponse, String> {
+    get_lock_yield_policy_settings_impl().map_err(String::from)
+}
+
+/// Internal implementation of [`save_lock_yield_policy_settings`].
+fn save_lock_yield_policy_settings_impl(
+    enabled: bool,
+    idle_threshold_secs: u64,
+    min_wait_secs: u64,
+) -> Result<CommandResponse, AppError> {
+    info!(
+        "Saving lock-yield policy settings: enabled={}, idle_threshold_secs={}, min_wait_secs={}",
+        enabled, idle_threshold_secs, min_wait_secs
+    );
+
+    let policy = LockYieldPolicySettings {
+        enabled,
+        idle_threshold_secs,
+        min_wait_secs,
+    };
+    settings::save_lock_yield_policy_settings(policy).map_err(AppError::ConfigError)?;
+
+    Ok(CommandResponse {
+        success: true,
+        message: Some("Lock-yield policy settings saved".to_string()),
+        data: None,
+    })
+}
+
+/// Save lock-yield policy settings.
+#[tauri::command]
+pub fn save_lock_yield_policy_settings(
+    enabled: bool,
+    idle_threshold_secs: u64,
+    min_wait_secs: u64,
+) -> Result<CommandResponse, String> {
+    save_lock_yield_policy_settings_impl(enabled, idle_threshold_secs, min_wait_secs)
+        .map_err(String::from)
+}
+
+/// Tauri plugin exposing the lock-yield-policy settings commands.
+///
+/// Left in place for parity with the rest of `commands/*_settings.rs`;
+/// the runtime registration goes through main.rs's central
+/// `generate_handler!`.
+pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
+    PluginBuilder::new("qontinui_lock_yield_policy_settings")
+        .invoke_handler(tauri::generate_handler![
+            get_lock_yield_policy_settings,
+            save_lock_yield_policy_settings,
+        ])
+        .build()
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -196,6 +196,7 @@ pub mod issues;
 pub mod known_issues; // Known issues registry CRUD
 pub mod learning; // Learning insights dashboard commands
 pub mod library_sync; // Sync library items (checks, macros, etc.) to web backend
+pub mod lock_yield_policy_settings; // Auto-yield-on-idle file-lock policy (Open Q4 / lock-yield-protocol-plan)
 pub mod log_api; // Frontend → Rust log sync (general/image/action/AI/issues/RAG/project)
 pub mod logging;
 pub mod mcp; // MCP client management and tool calling

--- a/src-tauri/src/executor/auto_yield_policy.rs
+++ b/src-tauri/src/executor/auto_yield_policy.rs
@@ -1,0 +1,293 @@
+//! Auto-yield-on-idle policy for [`FileLockManager`].
+//!
+//! Implements §Open Q4 of the lock-yield-protocol-plan: if session A is
+//! holding a file lock AND session A has been idle (no terminal stdout
+//! activity) for at least `idle_threshold_secs` AND session B has been
+//! waiting on the lock for at least `min_wait_secs`, the policy task
+//! releases the lock on session A's behalf and emits a
+//! `file-lock-auto-yielded` event (plus a matching `file-lock-released`
+//! event so the existing `useFileLockTracking` listener clears state
+//! without needing any frontend changes).
+//!
+//! Substrate:
+//! - `FileLockManager::info_with_waiters` (this module, lock-yield Phase 1)
+//! - `SessionManager::snapshot` (`claude_session::manager.rs:235`) —
+//!   yields `(task_run_id, holder_name, Arc<AtomicU64>)` triples where
+//!   the atomic stores epoch SECONDS of the last observed stdout line
+//!   (`claude_session::session.rs:420`).
+//! - `Settings::lock_yield_policy` — opt-in toggle + thresholds.
+//!
+//! The task runs at `POLL_INTERVAL_SECS` cadence forever; when the
+//! policy is disabled the body short-circuits without scanning lock
+//! state, so the cost is one settings load per tick.
+
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::json;
+use tauri::{AppHandle, Emitter};
+use tokio::sync::broadcast;
+use tracing::info;
+
+use crate::claude_session::manager::SessionManager;
+use crate::executor::FileLockManager;
+use crate::settings::LockYieldPolicySettings;
+
+/// How often the policy task scans held locks. 5s is granular enough
+/// that a user-visible auto-yield happens within a tick of the
+/// (idle + wait) condition being met, while keeping the per-tick cost
+/// trivial (one async read of the lock map + one settings load).
+pub const POLL_INTERVAL_SECS: u64 = 5;
+
+/// Pure predicate exposed for unit testing.
+///
+/// Returns `true` when the holder's idle time AND the oldest waiter's
+/// wait time both meet the configured thresholds. The boundary check
+/// is inclusive: `idle_secs >= threshold` and `waited_ms >= min * 1000`.
+pub fn should_yield(
+    holder_idle_secs: u64,
+    waiter_waited_ms: u64,
+    settings: &LockYieldPolicySettings,
+    _now_ms: u64,
+) -> bool {
+    if !settings.enabled {
+        return false;
+    }
+    if holder_idle_secs < settings.idle_threshold_secs {
+        return false;
+    }
+    let min_wait_ms = settings.min_wait_secs.saturating_mul(1000);
+    if waiter_waited_ms < min_wait_ms {
+        return false;
+    }
+    true
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Spawn the auto-yield policy task. Returns immediately; the task
+/// runs in the background for the lifetime of the runtime.
+///
+/// `app_handle` is used for the `app_handle.emit(...)` half of the
+/// dual-emit (Tauri webview). `event_broadcast` is the SSE/headless
+/// channel that mirrors the same payload.
+///
+/// Uses `tauri::async_runtime::spawn` (not bare `tokio::spawn`)
+/// because this function is called from Tauri's synchronous `setup`
+/// closure, before any user-side Tokio runtime is active.
+/// `tauri::async_runtime::spawn` routes the future through Tauri's
+/// own multi-threaded runtime, which is alive by the time `setup`
+/// runs.
+pub fn spawn(
+    app_handle: AppHandle,
+    file_lock_manager: Arc<FileLockManager>,
+    session_manager: Arc<SessionManager>,
+    event_broadcast: broadcast::Sender<serde_json::Value>,
+) {
+    tauri::async_runtime::spawn(async move {
+        run_policy_loop(app_handle, file_lock_manager, session_manager, event_broadcast).await;
+    });
+}
+
+async fn run_policy_loop(
+    app_handle: AppHandle,
+    file_lock_manager: Arc<FileLockManager>,
+    session_manager: Arc<SessionManager>,
+    event_broadcast: broadcast::Sender<serde_json::Value>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(POLL_INTERVAL_SECS));
+    // Reset on every tick — `interval` defaults to "burst missed
+    // ticks", which would spam yield events after a long PG migration
+    // pause. We want strict one-tick-per-period regardless.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        interval.tick().await;
+        let settings = crate::settings::get_lock_yield_policy_settings();
+        if !settings.enabled {
+            continue;
+        }
+
+        let infos = file_lock_manager.info_with_waiters().await;
+        if infos.is_empty() {
+            continue;
+        }
+
+        let now_s = now_secs();
+        let now_ms = now_millis();
+
+        for entry in infos {
+            // Skip uncontested locks — auto-yield is only relevant
+            // when someone is actually blocked.
+            let oldest = match entry.waiters.first() {
+                Some(w) => w.clone(),
+                None => continue,
+            };
+
+            // Look up the holder's last-activity tracker. PTY tabs
+            // without a `task_run_id` in SessionManager are excluded
+            // by `SessionManager::snapshot`, so we look up by
+            // task_run_id directly.
+            let holder_session = match session_manager.get(&entry.holder_task_run_id) {
+                Some(s) => s,
+                None => continue, // Holder is not a Claude session — can't measure idle.
+            };
+            let holder_last_activity_s =
+                holder_session.last_activity_tracker().load(Ordering::Relaxed);
+            let holder_idle_secs = now_s.saturating_sub(holder_last_activity_s);
+            let oldest_waiter_waited_ms = now_ms.saturating_sub(oldest.waiting_since_ms);
+
+            if !should_yield(
+                holder_idle_secs,
+                oldest_waiter_waited_ms,
+                &settings,
+                now_ms,
+            ) {
+                continue;
+            }
+
+            // Release the lock on the holder's behalf, then emit BOTH
+            // `file-lock-auto-yielded` (new event so observability /
+            // banners can react specifically to auto-yield) and the
+            // existing `file-lock-released` event (so the unchanged
+            // `useFileLockTracking` listener clears state).
+            file_lock_manager
+                .release(&entry.file_path, &entry.holder_task_run_id)
+                .await;
+
+            let oldest_waiter_waited_secs = oldest_waiter_waited_ms / 1000;
+            info!(
+                "Auto-yielded file lock '{}' held by '{}' (idle {}s, waiter waited {}s)",
+                entry.file_path,
+                entry.holder_name,
+                holder_idle_secs,
+                oldest_waiter_waited_secs
+            );
+
+            let auto_yield_payload = json!({
+                "type": "file-lock-auto-yielded",
+                "file_path": &entry.file_path,
+                "holder_task_run_id": &entry.holder_task_run_id,
+                "holder_name": &entry.holder_name,
+                "holder_idle_secs": holder_idle_secs,
+                "oldest_waiter_task_run_id": &oldest.task_run_id,
+                "oldest_waiter_waited_secs": oldest_waiter_waited_secs,
+                "auto_yielded_at": now_ms,
+            });
+            let _ = app_handle.emit("file-lock-auto-yielded", &auto_yield_payload);
+            let _ = event_broadcast.send(auto_yield_payload);
+
+            // Mirror the released-event emit shape from
+            // `mcp/file_registry.rs::yield_lock` (the manual yield
+            // endpoint). Listener clears "X is holding Y" banners.
+            let released_payload = json!({
+                "type": "file-lock-released",
+                "file_path": &entry.file_path,
+                "task_run_id": &entry.holder_task_run_id,
+                "holder_name": &entry.holder_name,
+            });
+            let _ = app_handle.emit("file-lock-released", &released_payload);
+            let _ = event_broadcast.send(released_payload);
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings(enabled: bool, idle_threshold_secs: u64, min_wait_secs: u64) -> LockYieldPolicySettings {
+        LockYieldPolicySettings {
+            enabled,
+            idle_threshold_secs,
+            min_wait_secs,
+        }
+    }
+
+    #[test]
+    fn yields_when_idle_and_wait_meet_thresholds() {
+        let s = settings(true, 60, 30);
+        // idle 90s, waited 31s.
+        assert!(should_yield(90, 31_000, &s, 0));
+    }
+
+    #[test]
+    fn does_not_yield_when_idle_below_threshold() {
+        let s = settings(true, 60, 30);
+        // idle 59s, waited well over the floor.
+        assert!(!should_yield(59, 600_000, &s, 0));
+    }
+
+    #[test]
+    fn does_not_yield_when_wait_below_threshold() {
+        let s = settings(true, 60, 30);
+        // idle 600s, waited only 29.999s.
+        assert!(!should_yield(600, 29_999, &s, 0));
+    }
+
+    #[test]
+    fn does_not_yield_when_disabled() {
+        let s = settings(false, 60, 30);
+        // Both thresholds met, but policy off.
+        assert!(!should_yield(900, 900_000, &s, 0));
+    }
+
+    #[test]
+    fn yields_at_inclusive_boundary_for_idle() {
+        // idle == threshold should yield (inclusive).
+        let s = settings(true, 60, 30);
+        assert!(should_yield(60, 30_000, &s, 0));
+    }
+
+    #[test]
+    fn yields_at_inclusive_boundary_for_wait() {
+        // waited_ms == min_wait_secs * 1000 should yield.
+        let s = settings(true, 60, 30);
+        assert!(should_yield(120, 30_000, &s, 0));
+    }
+
+    #[test]
+    fn does_not_yield_just_below_wait_boundary() {
+        // 29_999 ms is one ms short of the 30s floor.
+        let s = settings(true, 60, 30);
+        assert!(!should_yield(120, 29_999, &s, 0));
+    }
+
+    #[test]
+    fn zero_thresholds_yield_immediately_when_enabled() {
+        // Edge case: with both thresholds at 0, any idle/wait satisfies.
+        let s = settings(true, 0, 0);
+        assert!(should_yield(0, 0, &s, 0));
+        assert!(should_yield(1, 1, &s, 0));
+    }
+
+    #[test]
+    fn saturating_arithmetic_on_min_wait_secs_max() {
+        // u64::MAX * 1000 saturates; should not panic and should not yield
+        // for any non-saturated waiter age.
+        let s = LockYieldPolicySettings {
+            enabled: true,
+            idle_threshold_secs: 60,
+            min_wait_secs: u64::MAX,
+        };
+        // Saturated min_wait_ms means any finite waited_ms is below the floor.
+        assert!(!should_yield(600, 1_000_000_000, &s, 0));
+    }
+}

--- a/src-tauri/src/executor/auto_yield_policy.rs
+++ b/src-tauri/src/executor/auto_yield_policy.rs
@@ -98,7 +98,13 @@ pub fn spawn(
     event_broadcast: broadcast::Sender<serde_json::Value>,
 ) {
     tauri::async_runtime::spawn(async move {
-        run_policy_loop(app_handle, file_lock_manager, session_manager, event_broadcast).await;
+        run_policy_loop(
+            app_handle,
+            file_lock_manager,
+            session_manager,
+            event_broadcast,
+        )
+        .await;
     });
 }
 
@@ -145,17 +151,13 @@ async fn run_policy_loop(
                 Some(s) => s,
                 None => continue, // Holder is not a Claude session — can't measure idle.
             };
-            let holder_last_activity_s =
-                holder_session.last_activity_tracker().load(Ordering::Relaxed);
+            let holder_last_activity_s = holder_session
+                .last_activity_tracker()
+                .load(Ordering::Relaxed);
             let holder_idle_secs = now_s.saturating_sub(holder_last_activity_s);
             let oldest_waiter_waited_ms = now_ms.saturating_sub(oldest.waiting_since_ms);
 
-            if !should_yield(
-                holder_idle_secs,
-                oldest_waiter_waited_ms,
-                &settings,
-                now_ms,
-            ) {
+            if !should_yield(holder_idle_secs, oldest_waiter_waited_ms, &settings, now_ms) {
                 continue;
             }
 
@@ -171,10 +173,7 @@ async fn run_policy_loop(
             let oldest_waiter_waited_secs = oldest_waiter_waited_ms / 1000;
             info!(
                 "Auto-yielded file lock '{}' held by '{}' (idle {}s, waiter waited {}s)",
-                entry.file_path,
-                entry.holder_name,
-                holder_idle_secs,
-                oldest_waiter_waited_secs
+                entry.file_path, entry.holder_name, holder_idle_secs, oldest_waiter_waited_secs
             );
 
             let auto_yield_payload = json!({
@@ -213,7 +212,11 @@ async fn run_policy_loop(
 mod tests {
     use super::*;
 
-    fn settings(enabled: bool, idle_threshold_secs: u64, min_wait_secs: u64) -> LockYieldPolicySettings {
+    fn settings(
+        enabled: bool,
+        idle_threshold_secs: u64,
+        min_wait_secs: u64,
+    ) -> LockYieldPolicySettings {
         LockYieldPolicySettings {
             enabled,
             idle_threshold_secs,

--- a/src-tauri/src/executor/file_registry.rs
+++ b/src-tauri/src/executor/file_registry.rs
@@ -584,11 +584,7 @@ impl FileLockManager {
 
     /// Remove a single waiter entry for `(file_path, task_run_id)` from
     /// the shared state. Must be called with the state write lock held.
-    fn remove_waiter_locked(
-        state: &mut FileLockManagerState,
-        normalized: &str,
-        task_run_id: &str,
-    ) {
+    fn remove_waiter_locked(state: &mut FileLockManagerState, normalized: &str, task_run_id: &str) {
         if let Some(queue) = state.waiters.get_mut(normalized) {
             queue.retain(|w| w.task_run_id != task_run_id);
             if queue.is_empty() {
@@ -734,11 +730,7 @@ impl FileLockManager {
                 holder_task_run_id: entry.holder_task_run_id.clone(),
                 holder_name: entry.holder_name.clone(),
                 acquired_at: entry.acquired_at,
-                waiters: state
-                    .waiters
-                    .get(path)
-                    .cloned()
-                    .unwrap_or_default(),
+                waiters: state.waiters.get(path).cloned().unwrap_or_default(),
             })
             .collect()
     }
@@ -1394,11 +1386,8 @@ mod tests {
 
         // task-2 starts to wait. Spawn it; it blocks until task-1 releases.
         let mgr_clone = mgr.clone();
-        let waiter_handle = tokio::spawn(async move {
-            mgr_clone
-                .acquire("src/a.rs", "task-2", "Session B")
-                .await
-        });
+        let waiter_handle =
+            tokio::spawn(async move { mgr_clone.acquire("src/a.rs", "task-2", "Session B").await });
 
         // Poll until the waiter has registered (acquire loop pushes the
         // FileLockWaiter on first iteration when it sees contention).
@@ -1446,11 +1435,8 @@ mod tests {
 
         // task-2 starts to wait.
         let mgr_clone = mgr.clone();
-        let waiter_handle = tokio::spawn(async move {
-            mgr_clone
-                .acquire("src/a.rs", "task-2", "Session B")
-                .await
-        });
+        let waiter_handle =
+            tokio::spawn(async move { mgr_clone.acquire("src/a.rs", "task-2", "Session B").await });
 
         // Wait until task-2 has registered.
         tokio::time::timeout(Duration::from_secs(2), async {
@@ -1491,9 +1477,7 @@ mod tests {
         // waiting_since_ms values are monotonically increasing and
         // FIFO order is unambiguous.
         let mgr2 = mgr.clone();
-        let h2 = tokio::spawn(async move {
-            mgr2.acquire("src/a.rs", "task-2", "Session B").await
-        });
+        let h2 = tokio::spawn(async move { mgr2.acquire("src/a.rs", "task-2", "Session B").await });
         // Wait for task-2 to register before spawning task-3.
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
@@ -1508,9 +1492,7 @@ mod tests {
         .expect("task-2 should register");
 
         let mgr3 = mgr.clone();
-        let h3 = tokio::spawn(async move {
-            mgr3.acquire("src/a.rs", "task-3", "Session C").await
-        });
+        let h3 = tokio::spawn(async move { mgr3.acquire("src/a.rs", "task-3", "Session C").await });
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
                 let infos = mgr.info_with_waiters().await;
@@ -1550,9 +1532,8 @@ mod tests {
         mgr.acquire("src/a.rs", "task-1", "Session A").await;
 
         let mgr_clone = mgr.clone();
-        let h = tokio::spawn(async move {
-            mgr_clone.acquire("src/a.rs", "task-2", "Session B").await
-        });
+        let h =
+            tokio::spawn(async move { mgr_clone.acquire("src/a.rs", "task-2", "Session B").await });
 
         // Wait for the first waiter row to appear.
         tokio::time::timeout(Duration::from_secs(2), async {

--- a/src-tauri/src/executor/file_registry.rs
+++ b/src-tauri/src/executor/file_registry.rs
@@ -454,6 +454,27 @@ struct FileLockEntry {
     acquired_at: u64,
 }
 
+/// A single waiter currently blocked in [`FileLockManager::acquire`].
+///
+/// Auto-yield (§Open Q4 of lock-yield-protocol-plan) needs the
+/// `waiting_since_ms` (oldest-waiter age check) and the waiter's own
+/// friendly `holder_name` (event payload). The list is FIFO — the
+/// first entry is the longest-waiting; this is the one the policy
+/// task consults when deciding whether to auto-release.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FileLockWaiter {
+    /// Task run ID of the session waiting on the lock.
+    pub task_run_id: String,
+    /// Friendly name of the WAITER (not the current holder). This is
+    /// the same string `claude_session::dispatcher.rs` emits as
+    /// `holder_name` on `file-lock-waiting` events.
+    pub holder_name: String,
+    /// Epoch milliseconds when this waiter first entered the wait
+    /// queue. Stable across acquire-loop iterations — the entry is
+    /// pushed exactly once, on the first observation of contention.
+    pub waiting_since_ms: u64,
+}
+
 /// Exclusive per-file lock manager that blocks concurrent access.
 ///
 /// When a session edits a file (Edit/Write tool), it acquires an exclusive lock.
@@ -464,14 +485,26 @@ struct FileLockEntry {
 /// Unlike the advisory `FileRegistryManager`, this is a hard blocking mechanism.
 #[derive(Debug, Clone)]
 pub struct FileLockManager {
-    state: Arc<RwLock<HashMap<String, FileLockEntry>>>,
+    state: Arc<RwLock<FileLockManagerState>>,
     notify: Arc<Notify>,
+}
+
+/// Internal state for [`FileLockManager`]. Held under a single
+/// `RwLock` so the held-locks map and the per-file waiter queues stay
+/// consistent across acquire / release transitions.
+#[derive(Debug, Default)]
+struct FileLockManagerState {
+    locks: HashMap<String, FileLockEntry>,
+    /// `file_path` (normalized) → ordered list of waiters (FIFO).
+    /// Auto-yield consults `waiters[normalized][0]` as the
+    /// longest-waiting blocked session for the oldest-wait check.
+    waiters: HashMap<String, Vec<FileLockWaiter>>,
 }
 
 impl FileLockManager {
     pub fn new() -> Self {
         Self {
-            state: Arc::new(RwLock::new(HashMap::new())),
+            state: Arc::new(RwLock::new(FileLockManagerState::default())),
             notify: Arc::new(Notify::new()),
         }
     }
@@ -490,28 +523,54 @@ impl FileLockManager {
     ) -> Option<String> {
         let normalized = normalize_path(file_path);
         let mut waited_for: Option<String> = None;
+        // Track whether this caller has registered a waiter row for
+        // the current acquire call. The auto-yield policy task reads
+        // `waiters[normalized][0].waiting_since_ms` to decide when
+        // the oldest waiter has waited long enough; pushing on every
+        // loop iteration would reset the clock and starve the policy.
+        let mut registered_waiter = false;
 
         loop {
             {
                 let mut state = self.state.write().await;
 
                 // Check if already held by this session (idempotent)
-                if let Some(entry) = state.get(&normalized) {
+                if let Some(entry) = state.locks.get(&normalized) {
                     if entry.holder_task_run_id == task_run_id {
+                        // Acquired by self (idempotent). Clean up any
+                        // stale waiter row we may have left from a
+                        // prior loop iteration before the holder
+                        // changed identity.
+                        Self::remove_waiter_locked(&mut state, &normalized, task_run_id);
                         return waited_for;
                     }
                     // Held by another session — record who we're waiting for, then wait
                     waited_for = Some(entry.holder_name.clone());
+                    if !registered_waiter {
+                        state
+                            .waiters
+                            .entry(normalized.clone())
+                            .or_default()
+                            .push(FileLockWaiter {
+                                task_run_id: task_run_id.to_string(),
+                                holder_name: holder_name.to_string(),
+                                waiting_since_ms: now_millis(),
+                            });
+                        registered_waiter = true;
+                    }
                 } else {
-                    // Free — acquire it
-                    state.insert(
-                        normalized,
+                    // Free — acquire it. Pop our waiter row (if any)
+                    // so `waiters[file]` only ever contains live
+                    // blocked sessions.
+                    state.locks.insert(
+                        normalized.clone(),
                         FileLockEntry {
                             holder_task_run_id: task_run_id.to_string(),
                             holder_name: holder_name.to_string(),
                             acquired_at: now_millis(),
                         },
                     );
+                    Self::remove_waiter_locked(&mut state, &normalized, task_run_id);
                     return waited_for;
                 }
             }
@@ -523,14 +582,29 @@ impl FileLockManager {
         }
     }
 
+    /// Remove a single waiter entry for `(file_path, task_run_id)` from
+    /// the shared state. Must be called with the state write lock held.
+    fn remove_waiter_locked(
+        state: &mut FileLockManagerState,
+        normalized: &str,
+        task_run_id: &str,
+    ) {
+        if let Some(queue) = state.waiters.get_mut(normalized) {
+            queue.retain(|w| w.task_run_id != task_run_id);
+            if queue.is_empty() {
+                state.waiters.remove(normalized);
+            }
+        }
+    }
+
     /// Release a specific file lock.
     pub async fn release(&self, file_path: &str, task_run_id: &str) {
         let normalized = normalize_path(file_path);
         let mut state = self.state.write().await;
 
-        if let Some(entry) = state.get(&normalized) {
+        if let Some(entry) = state.locks.get(&normalized) {
             if entry.holder_task_run_id == task_run_id {
-                state.remove(&normalized);
+                state.locks.remove(&normalized);
                 drop(state);
                 self.notify.notify_waiters();
             }
@@ -546,7 +620,7 @@ impl FileLockManager {
     pub async fn release_all(&self, task_run_id: &str) -> Vec<String> {
         let mut state = self.state.write().await;
         let mut released_paths: Vec<String> = Vec::new();
-        state.retain(|path, entry| {
+        state.locks.retain(|path, entry| {
             if entry.holder_task_run_id == task_run_id {
                 released_paths.push(path.clone());
                 false
@@ -554,6 +628,13 @@ impl FileLockManager {
                 true
             }
         });
+        // Also evict this task from every waiter queue — when a session
+        // ends mid-wait it must not linger as a stale "blocked
+        // session" the auto-yield policy could account for.
+        for queue in state.waiters.values_mut() {
+            queue.retain(|w| w.task_run_id != task_run_id);
+        }
+        state.waiters.retain(|_, queue| !queue.is_empty());
         if !released_paths.is_empty() {
             info!(
                 "Released {} file lock(s) for task {}",
@@ -578,7 +659,7 @@ impl FileLockManager {
             match self.state.try_write() {
                 Ok(mut state) => {
                     let mut released_paths: Vec<String> = Vec::new();
-                    state.retain(|path, entry| {
+                    state.locks.retain(|path, entry| {
                         if entry.holder_task_run_id == task_run_id {
                             released_paths.push(path.clone());
                             false
@@ -586,6 +667,10 @@ impl FileLockManager {
                             true
                         }
                     });
+                    for queue in state.waiters.values_mut() {
+                        queue.retain(|w| w.task_run_id != task_run_id);
+                    }
+                    state.waiters.retain(|_, queue| !queue.is_empty());
                     if !released_paths.is_empty() {
                         drop(state);
                         self.notify.notify_waiters();
@@ -611,6 +696,7 @@ impl FileLockManager {
         let normalized = normalize_path(file_path);
         let state = self.state.read().await;
         state
+            .locks
             .get(&normalized)
             .filter(|e| e.holder_task_run_id != task_run_id)
             .map(|e| e.holder_name.clone())
@@ -620,12 +706,39 @@ impl FileLockManager {
     pub async fn info(&self) -> Vec<FileLockInfo> {
         let state = self.state.read().await;
         state
+            .locks
             .iter()
             .map(|(path, entry)| FileLockInfo {
                 file_path: path.clone(),
                 holder_task_run_id: entry.holder_task_run_id.clone(),
                 holder_name: entry.holder_name.clone(),
                 acquired_at: entry.acquired_at,
+            })
+            .collect()
+    }
+
+    /// Get info about all held locks with their live waiter queues.
+    ///
+    /// Mirrors [`Self::info`] shape but extends each entry with the
+    /// `waiters: Vec<FileLockWaiter>` consumed by the auto-yield
+    /// policy task (see `executor::auto_yield_policy`). The bare
+    /// [`Self::info`] remains unchanged so existing lock-yield Phase 4
+    /// consumers don't need to migrate.
+    pub async fn info_with_waiters(&self) -> Vec<FileLockInfoWithWaiters> {
+        let state = self.state.read().await;
+        state
+            .locks
+            .iter()
+            .map(|(path, entry)| FileLockInfoWithWaiters {
+                file_path: path.clone(),
+                holder_task_run_id: entry.holder_task_run_id.clone(),
+                holder_name: entry.holder_name.clone(),
+                acquired_at: entry.acquired_at,
+                waiters: state
+                    .waiters
+                    .get(path)
+                    .cloned()
+                    .unwrap_or_default(),
             })
             .collect()
     }
@@ -644,6 +757,21 @@ pub struct FileLockInfo {
     pub holder_task_run_id: String,
     pub holder_name: String,
     pub acquired_at: u64,
+}
+
+/// Information about a held file lock plus its live waiter queue.
+///
+/// Returned by [`FileLockManager::info_with_waiters`] and consumed by
+/// the auto-yield policy task. The `waiters` Vec is FIFO — the first
+/// entry is the longest-waiting session and is what the policy uses
+/// to check the `min_wait_secs` floor before triggering an auto-yield.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FileLockInfoWithWaiters {
+    pub file_path: String,
+    pub holder_task_run_id: String,
+    pub holder_name: String,
+    pub acquired_at: u64,
+    pub waiters: Vec<FileLockWaiter>,
 }
 
 #[cfg(test)]
@@ -1233,5 +1361,237 @@ mod tests {
         rt.block_on(async {
             assert!(mgr.info().await.is_empty());
         });
+    }
+
+    // =========================================================================
+    // Waiter tracking (lock-yield-protocol-plan §Open Q4)
+    //
+    // `FileLockManager::acquire` now records each blocked caller in
+    // `waiters[normalized]` so the auto-yield policy task can see
+    // ordered (FIFO) blocked-session metadata. Tests cover push on
+    // first observation of contention, pop on actual acquisition,
+    // pop on `release_all` mid-wait, and `info_with_waiters` shape.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_info_with_waiters_empty_when_uncontended() {
+        let mgr = FileLockManager::new();
+        mgr.acquire("src/a.rs", "task-1", "Session A").await;
+        let infos = mgr.info_with_waiters().await;
+        assert_eq!(infos.len(), 1);
+        assert!(
+            infos[0].waiters.is_empty(),
+            "uncontested lock must have an empty waiter queue"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_waiter_pushed_when_contended_and_popped_on_acquire() {
+        let mgr = FileLockManager::new();
+
+        // task-1 holds the lock.
+        mgr.acquire("src/a.rs", "task-1", "Session A").await;
+
+        // task-2 starts to wait. Spawn it; it blocks until task-1 releases.
+        let mgr_clone = mgr.clone();
+        let waiter_handle = tokio::spawn(async move {
+            mgr_clone
+                .acquire("src/a.rs", "task-2", "Session B")
+                .await
+        });
+
+        // Poll until the waiter has registered (acquire loop pushes the
+        // FileLockWaiter on first iteration when it sees contention).
+        let waiter_seen = tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let infos = mgr.info_with_waiters().await;
+                if let Some(entry) = infos.first() {
+                    if !entry.waiters.is_empty() {
+                        return entry.waiters.clone();
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("waiter row should have appeared within 2s");
+
+        assert_eq!(waiter_seen.len(), 1);
+        assert_eq!(waiter_seen[0].task_run_id, "task-2");
+        assert_eq!(waiter_seen[0].holder_name, "Session B");
+        assert!(waiter_seen[0].waiting_since_ms > 0);
+
+        // Release the lock so task-2 can acquire.
+        mgr.release("src/a.rs", "task-1").await;
+        let waited_for = waiter_handle
+            .await
+            .expect("waiter task should complete after release");
+        assert_eq!(waited_for.as_deref(), Some("Session A"));
+
+        // After acquisition the waiter row must be gone.
+        let infos = mgr.info_with_waiters().await;
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0].holder_task_run_id, "task-2");
+        assert!(
+            infos[0].waiters.is_empty(),
+            "waiter row must be popped on acquisition"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_waiter_dropped_on_release_all_mid_wait() {
+        let mgr = FileLockManager::new();
+
+        mgr.acquire("src/a.rs", "task-1", "Session A").await;
+
+        // task-2 starts to wait.
+        let mgr_clone = mgr.clone();
+        let waiter_handle = tokio::spawn(async move {
+            mgr_clone
+                .acquire("src/a.rs", "task-2", "Session B")
+                .await
+        });
+
+        // Wait until task-2 has registered.
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let infos = mgr.info_with_waiters().await;
+                if infos.first().map(|e| e.waiters.len()).unwrap_or(0) == 1 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("waiter row should appear");
+
+        // task-2 ends mid-wait — `release_all` evicts its waiter row.
+        mgr.release_all("task-2").await;
+
+        let infos = mgr.info_with_waiters().await;
+        assert_eq!(infos.len(), 1);
+        assert!(
+            infos[0].waiters.is_empty(),
+            "release_all must evict the waiter row for the released task"
+        );
+
+        // Clean up: release task-1's lock so the spawned waiter wakes
+        // (the acquire loop will see the lock free and proceed; the
+        // waiter row is gone but that's fine for the wake path).
+        mgr.release("src/a.rs", "task-1").await;
+        let _ = waiter_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_waiter_fifo_order_preserved() {
+        let mgr = FileLockManager::new();
+        mgr.acquire("src/a.rs", "task-1", "Session A").await;
+
+        // Spawn task-2 first, then task-3, with a small gap so the
+        // waiting_since_ms values are monotonically increasing and
+        // FIFO order is unambiguous.
+        let mgr2 = mgr.clone();
+        let h2 = tokio::spawn(async move {
+            mgr2.acquire("src/a.rs", "task-2", "Session B").await
+        });
+        // Wait for task-2 to register before spawning task-3.
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let infos = mgr.info_with_waiters().await;
+                if infos.first().map(|e| e.waiters.len()).unwrap_or(0) >= 1 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("task-2 should register");
+
+        let mgr3 = mgr.clone();
+        let h3 = tokio::spawn(async move {
+            mgr3.acquire("src/a.rs", "task-3", "Session C").await
+        });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let infos = mgr.info_with_waiters().await;
+                if infos.first().map(|e| e.waiters.len()).unwrap_or(0) >= 2 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("task-3 should register");
+
+        // task-2 should be at the head of the queue (longest-waiting).
+        let infos = mgr.info_with_waiters().await;
+        let waiters = &infos[0].waiters;
+        assert_eq!(waiters.len(), 2);
+        assert_eq!(waiters[0].task_run_id, "task-2");
+        assert_eq!(waiters[1].task_run_id, "task-3");
+
+        // Cleanup.
+        mgr.release("src/a.rs", "task-1").await;
+        let _ = h2.await;
+        // Whichever wakes first now holds; release it so the other can proceed.
+        // Easiest: release_all on both task-2 and task-3 if they ended up holding.
+        mgr.release_all("task-2").await;
+        mgr.release_all("task-3").await;
+        let _ = h3.await;
+    }
+
+    #[tokio::test]
+    async fn test_waiter_idempotent_no_duplicate_on_same_caller() {
+        // Property: `acquire` registers the caller in the waiter queue
+        // exactly once per call, even though the acquire loop wakes on
+        // every notify_waiters() tick (e.g. another lock release fires
+        // notify on this lock too).
+        let mgr = FileLockManager::new();
+        mgr.acquire("src/a.rs", "task-1", "Session A").await;
+
+        let mgr_clone = mgr.clone();
+        let h = tokio::spawn(async move {
+            mgr_clone.acquire("src/a.rs", "task-2", "Session B").await
+        });
+
+        // Wait for the first waiter row to appear.
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let infos = mgr.info_with_waiters().await;
+                if infos.first().map(|e| e.waiters.len()).unwrap_or(0) >= 1 {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("waiter row should appear");
+
+        // Spam notify by acquiring + releasing a different lock; this
+        // forces the waiter's acquire loop to re-iterate without the
+        // held lock changing identity.
+        for _ in 0..3 {
+            mgr.acquire("src/other.rs", "task-other", "Other").await;
+            mgr.release("src/other.rs", "task-other").await;
+        }
+
+        // Give the waiter loop time to spin a couple of times.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let infos = mgr.info_with_waiters().await;
+        let waiters = infos
+            .iter()
+            .find(|e| e.file_path == normalize_path("src/a.rs"))
+            .map(|e| e.waiters.clone())
+            .unwrap_or_default();
+        assert_eq!(
+            waiters.len(),
+            1,
+            "same caller must not appear multiple times in the waiter queue"
+        );
+
+        // Cleanup.
+        mgr.release("src/a.rs", "task-1").await;
+        let _ = h.await;
     }
 }

--- a/src-tauri/src/executor/mod.rs
+++ b/src-tauri/src/executor/mod.rs
@@ -1,3 +1,4 @@
+pub mod auto_yield_policy;
 pub mod bridge_helpers;
 pub mod bridge_manager;
 pub mod context;
@@ -39,7 +40,9 @@ pub use python_bridge::PythonBridge;
 pub use results::{ExecutionOutcome, IntoOutcome};
 pub use state::ExecutorState;
 
-pub use file_registry::{FileLockInfo, FileLockManager, FileRegistryManager};
+pub use file_registry::{
+    FileLockInfo, FileLockInfoWithWaiters, FileLockManager, FileLockWaiter, FileRegistryManager,
+};
 #[allow(unused_imports)]
 pub use url_lock::UrlLockInfo;
 pub use url_lock::UrlLockManager;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1028,6 +1028,8 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::library_sync::sync_macros_to_backend,
             commands::library_sync::sync_prompt_snippets_to_backend,
             commands::library_sync::sync_shell_commands_to_backend,
+            commands::lock_yield_policy_settings::get_lock_yield_policy_settings,
+            commands::lock_yield_policy_settings::save_lock_yield_policy_settings,
             commands::logging::append_ai_output_log,
             commands::logging::append_render_log,
             commands::logging::clear_ai_output_log,
@@ -2233,6 +2235,27 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             });
 
             // Embedding backfill job removed (SQLite embeddings deprecated, PG handles this)
+
+            // Start auto-yield-on-idle policy task (lock-yield-protocol-plan
+            // §Open Q4). Polls every 5s; releases held file locks when the
+            // holder has been stdout-idle for `idle_threshold_secs` AND
+            // the oldest waiter has been blocked for `min_wait_secs`.
+            // Disabled by default; user opts in via Settings → Lock-yield.
+            info!("Starting auto-yield-on-idle policy task");
+            {
+                let app_handle_for_yield = app.handle().clone();
+                let app_state_for_yield = app.state::<Arc<AppState>>().inner().clone();
+                let session_manager_for_yield = app
+                    .state::<Arc<claude_session::SessionManager>>()
+                    .inner()
+                    .clone();
+                executor::auto_yield_policy::spawn(
+                    app_handle_for_yield,
+                    app_state_for_yield.file_lock_manager.clone(),
+                    session_manager_for_yield,
+                    app_state_for_yield.event_broadcast.clone(),
+                );
+            }
 
             // Start memory consolidation scheduler in background
             info!("Starting memory consolidation scheduler");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1979,9 +1979,7 @@ pub fn get_lock_yield_policy_settings() -> LockYieldPolicySettings {
 }
 
 /// Save the lock-yield policy settings.
-pub fn save_lock_yield_policy_settings(
-    policy: LockYieldPolicySettings,
-) -> Result<(), String> {
+pub fn save_lock_yield_policy_settings(policy: LockYieldPolicySettings) -> Result<(), String> {
     let mut settings = load_settings();
     settings.lock_yield_policy = policy;
     save_settings(&settings)

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1175,6 +1175,13 @@ pub struct Settings {
     /// Default: false (shipped but inert until the migration is applied).
     #[serde(default)]
     pub trace_api: TraceApiSettings,
+    /// Auto-yield-on-idle policy for file locks. See
+    /// `executor::auto_yield_policy` for the background task that
+    /// consumes this setting. Defaults preserve historical behavior:
+    /// `enabled = false`, so existing deployments don't auto-yield
+    /// until a user opts in.
+    #[serde(default)]
+    pub lock_yield_policy: LockYieldPolicySettings,
 }
 
 // ============================================================================
@@ -1188,6 +1195,58 @@ pub struct Settings {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TraceApiSettings {
     pub enabled: bool,
+}
+
+// ============================================================================
+// Lock Yield Policy Settings (lock-yield-protocol-plan §Open Q4)
+// ============================================================================
+
+/// Auto-yield-on-idle policy for `FileLockManager`.
+///
+/// When `enabled`, a background task (see
+/// `executor::auto_yield_policy`) periodically scans currently-held
+/// file locks and, for each holder that has been idle (no terminal
+/// stdout activity) for at least `idle_threshold_secs` AND whose
+/// oldest waiter has been blocked for at least `min_wait_secs`,
+/// releases the lock on the holder's behalf and emits a
+/// `file-lock-auto-yielded` event.
+///
+/// Defaults are intentionally conservative: `enabled = false` so the
+/// policy is opt-in. Once a user opts in, the 60s idle / 30s wait
+/// thresholds keep transient contention (e.g. a sub-second multi-edit
+/// burst from a busy session) from triggering false-positive yields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockYieldPolicySettings {
+    /// Enable auto-yield. Default off until users opt in.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Minimum holder-idle duration (no stdout activity from the holding
+    /// session for this many seconds) before the holder is considered
+    /// yieldable. Default 60.
+    #[serde(default = "default_auto_yield_idle_threshold_secs")]
+    pub idle_threshold_secs: u64,
+    /// Minimum wait duration (a waiter has been blocked on this file
+    /// for at least this many seconds) before auto-yield fires.
+    /// Default 30.
+    #[serde(default = "default_auto_yield_min_wait_secs")]
+    pub min_wait_secs: u64,
+}
+
+fn default_auto_yield_idle_threshold_secs() -> u64 {
+    60
+}
+fn default_auto_yield_min_wait_secs() -> u64 {
+    30
+}
+
+impl Default for LockYieldPolicySettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            idle_threshold_secs: default_auto_yield_idle_threshold_secs(),
+            min_wait_secs: default_auto_yield_min_wait_secs(),
+        }
+    }
 }
 
 // ============================================================================
@@ -1907,5 +1966,23 @@ pub fn get_saved_projects() -> Vec<SavedProject> {
 pub fn save_saved_projects(projects: Vec<SavedProject>) -> Result<(), String> {
     let mut settings = load_settings();
     settings.saved_projects = projects;
+    save_settings(&settings)
+}
+
+// ============================================================================
+// Lock Yield Policy accessors
+// ============================================================================
+
+/// Get the current lock-yield policy settings.
+pub fn get_lock_yield_policy_settings() -> LockYieldPolicySettings {
+    load_settings().lock_yield_policy
+}
+
+/// Save the lock-yield policy settings.
+pub fn save_lock_yield_policy_settings(
+    policy: LockYieldPolicySettings,
+) -> Result<(), String> {
+    let mut settings = load_settings();
+    settings.lock_yield_policy = policy;
     save_settings(&settings)
 }

--- a/src/components/settings/LockYieldPolicySettings.test.tsx
+++ b/src/components/settings/LockYieldPolicySettings.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Pure-helper tests for `LockYieldPolicySettings`.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom) —
+ * see sibling tests like `HoldingLockBanner.test.tsx` for the
+ * precedent. We exercise the exported `clampNumber` pure helper +
+ * exported defaults / constants for value-binding semantics.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  clampNumber,
+  IDLE_THRESHOLD_MIN,
+  IDLE_THRESHOLD_MAX,
+  MIN_WAIT_MIN,
+  MIN_WAIT_MAX,
+} from "./lockYieldPolicyHelpers";
+
+describe("clampNumber", () => {
+  it("returns n unchanged when within bounds", () => {
+    expect(clampNumber(50, 10, 100, 60)).toBe(50);
+    expect(clampNumber(10, 10, 100, 60)).toBe(10);
+    expect(clampNumber(100, 10, 100, 60)).toBe(100);
+  });
+  it("clamps to min when below", () => {
+    expect(clampNumber(5, 10, 100, 60)).toBe(10);
+    expect(clampNumber(-1, 10, 100, 60)).toBe(10);
+  });
+  it("clamps to max when above", () => {
+    expect(clampNumber(101, 10, 100, 60)).toBe(100);
+    expect(clampNumber(9999, 10, 100, 60)).toBe(100);
+  });
+  it("floors fractional inputs", () => {
+    expect(clampNumber(50.7, 10, 100, 60)).toBe(50);
+    expect(clampNumber(10.99, 10, 100, 60)).toBe(10);
+  });
+  it("falls back when input is NaN", () => {
+    expect(clampNumber(Number.NaN, 10, 100, 60)).toBe(60);
+  });
+  it("falls back when input is non-finite", () => {
+    expect(clampNumber(Number.POSITIVE_INFINITY, 10, 100, 60)).toBe(60);
+    expect(clampNumber(Number.NEGATIVE_INFINITY, 10, 100, 60)).toBe(60);
+  });
+});
+
+describe("LockYieldPolicySettings UI bounds (settings panel contract)", () => {
+  it("idle-threshold bounds match the spec (10-3600s)", () => {
+    expect(IDLE_THRESHOLD_MIN).toBe(10);
+    expect(IDLE_THRESHOLD_MAX).toBe(3600);
+  });
+  it("min-wait bounds match the spec (5-600s)", () => {
+    expect(MIN_WAIT_MIN).toBe(5);
+    expect(MIN_WAIT_MAX).toBe(600);
+  });
+});

--- a/src/components/settings/LockYieldPolicySettings.tsx
+++ b/src/components/settings/LockYieldPolicySettings.tsx
@@ -1,0 +1,327 @@
+/**
+ * LockYieldPolicySettings — Auto-yield-on-idle policy controls.
+ *
+ * Wraps the runner's `lock_yield_policy` settings group (see
+ * `settings::LockYieldPolicySettings` in src-tauri). When enabled, a
+ * background task in the runner releases held file locks once the
+ * holder has been stdout-idle for `idleThresholdSecs` AND the oldest
+ * waiter has been blocked for at least `minWaitSecs`. Default off so
+ * existing deployments stay opt-in.
+ *
+ * Implements §Open Q4 of the lock-yield-protocol-plan.
+ */
+
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { Check, X, Hourglass, Info } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
+import { getAccentColors } from "@/design-system";
+import {
+  IDLE_THRESHOLD_MAX,
+  IDLE_THRESHOLD_MIN,
+  MIN_WAIT_MAX,
+  MIN_WAIT_MIN,
+  clampNumber,
+} from "./lockYieldPolicyHelpers";
+import type { LogFunction } from "./types";
+
+interface TauriResult<T> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+export interface LockYieldPolicySettingsValue {
+  enabled: boolean;
+  idle_threshold_secs: number;
+  min_wait_secs: number;
+}
+
+interface LockYieldPolicySettingsProps {
+  onLog: LogFunction;
+}
+
+const DEFAULT_SETTINGS: LockYieldPolicySettingsValue = {
+  enabled: false,
+  idle_threshold_secs: 60,
+  min_wait_secs: 30,
+};
+
+// Re-export pure helpers so callers can `import { clampNumber } from
+// "./LockYieldPolicySettings"` without changing import surface. Tests
+// pull directly from `./lockYieldPolicyHelpers` to keep the design-
+// system module graph out of vitest's node-environment.
+export {
+  IDLE_THRESHOLD_MIN,
+  IDLE_THRESHOLD_MAX,
+  MIN_WAIT_MIN,
+  MIN_WAIT_MAX,
+  clampNumber,
+};
+
+export function LockYieldPolicySettings({ onLog }: LockYieldPolicySettingsProps) {
+  const [settings, setSettings] = useState<LockYieldPolicySettingsValue>(DEFAULT_SETTINGS);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const result = await invoke<TauriResult<LockYieldPolicySettingsValue>>(
+          "get_lock_yield_policy_settings",
+        );
+        if (cancelled) return;
+        if (result?.success && result.data) {
+          setSettings({
+            ...DEFAULT_SETTINGS,
+            ...result.data,
+          });
+          onLog("debug", "Lock-yield policy settings loaded");
+        } else {
+          onLog("warning", "Using default lock-yield policy settings");
+        }
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to load lock-yield policy settings:", err);
+        setError(`Failed to load settings: ${String(err)}`);
+        onLog("error", `Failed to load lock-yield policy settings: ${String(err)}`);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+    // onLog is stable in practice (parent useCallback), but we deliberately
+    // skip it as a dep to avoid reload thrash if a parent re-creates it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const saveSettings = async () => {
+    setSaving(true);
+    setError(null);
+    setSaveSuccess(false);
+    try {
+      const result = await invoke<TauriResult<null>>("save_lock_yield_policy_settings", {
+        enabled: settings.enabled,
+        idleThresholdSecs: settings.idle_threshold_secs,
+        minWaitSecs: settings.min_wait_secs,
+      });
+      if (result?.success) {
+        setSaveSuccess(true);
+        onLog("success", "Lock-yield policy settings saved");
+        setTimeout(() => setSaveSuccess(false), 3000);
+      } else {
+        const msg = result?.message || "Unknown error";
+        setError(msg);
+        onLog("error", `Failed to save lock-yield policy settings: ${msg}`);
+      }
+    } catch (err) {
+      console.error("Failed to save lock-yield policy settings:", err);
+      setError(`Failed to save settings: ${String(err)}`);
+      onLog("error", `Failed to save lock-yield policy settings: ${String(err)}`);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div
+          data-content-role="status"
+          data-content-label="loading lock-yield policy settings"
+          className="text-muted-foreground"
+        >
+          Loading lock-yield policy settings...
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <SectionHeader
+        title="Lock-yield policy"
+        description="Automatically yield a held file lock when the holder has been stdout-idle and another session has been waiting. Disabled by default; opt in for the productivity-stack §Open Q4 behaviour."
+        icon={<Hourglass className="w-6 h-6" />}
+      />
+
+      {error && (
+        <div className={`p-3 ${getAccentColors("red").bg} rounded-lg flex items-start gap-2`}>
+          <X className={`w-4 h-4 ${getAccentColors("red").text} shrink-0 mt-0.5`} />
+          <span className={`${getAccentColors("red").text} text-xs`}>{error}</span>
+        </div>
+      )}
+
+      {saveSuccess && (
+        <div className={`p-3 ${getAccentColors("green").bg} rounded-lg flex items-start gap-2`}>
+          <Check className={`w-4 h-4 ${getAccentColors("green").text} shrink-0 mt-0.5`} />
+          <span className={`${getAccentColors("green").text} text-xs`}>
+            Lock-yield policy saved.
+          </span>
+        </div>
+      )}
+
+      <div className="rounded-lg bg-card/50 p-4 space-y-4">
+        {/* Enable toggle */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h4 className="font-medium text-sm">Auto-yield idle lock holders</h4>
+            <p className="text-xs text-muted-foreground">
+              Background task polls every 5 seconds.
+            </p>
+          </div>
+          <ToggleSwitch
+            data-ui-bridge-id="settings.lock-yield-auto-yield-enabled"
+            checked={settings.enabled}
+            onChange={(enabled) => setSettings((s) => ({ ...s, enabled }))}
+          />
+        </div>
+
+        {/* Idle threshold */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium" htmlFor="lock-yield-idle-threshold">
+            Idle threshold (seconds)
+          </label>
+          <input
+            id="lock-yield-idle-threshold"
+            data-ui-bridge-id="settings.lock-yield-idle-threshold"
+            type="number"
+            min={IDLE_THRESHOLD_MIN}
+            max={IDLE_THRESHOLD_MAX}
+            step={5}
+            value={settings.idle_threshold_secs}
+            onChange={(e) =>
+              setSettings((s) => ({
+                ...s,
+                idle_threshold_secs: clampNumber(
+                  parseInt(e.target.value, 10),
+                  IDLE_THRESHOLD_MIN,
+                  IDLE_THRESHOLD_MAX,
+                  DEFAULT_SETTINGS.idle_threshold_secs,
+                ),
+              }))
+            }
+            disabled={!settings.enabled}
+            className="w-full px-2.5 py-1.5 text-sm bg-muted/50 rounded-md outline-hidden focus:ring-1 focus:ring-primary/50 disabled:opacity-50"
+          />
+          <p className="text-[10px] text-muted-foreground">
+            Time since the holder&apos;s last terminal output before they&apos;re eligible to
+            auto-yield. Range {IDLE_THRESHOLD_MIN}-{IDLE_THRESHOLD_MAX}s.
+          </p>
+        </div>
+
+        {/* Min wait */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-medium" htmlFor="lock-yield-min-wait">
+            Min waiter wait (seconds)
+          </label>
+          <input
+            id="lock-yield-min-wait"
+            data-ui-bridge-id="settings.lock-yield-min-wait"
+            type="number"
+            min={MIN_WAIT_MIN}
+            max={MIN_WAIT_MAX}
+            step={5}
+            value={settings.min_wait_secs}
+            onChange={(e) =>
+              setSettings((s) => ({
+                ...s,
+                min_wait_secs: clampNumber(
+                  parseInt(e.target.value, 10),
+                  MIN_WAIT_MIN,
+                  MIN_WAIT_MAX,
+                  DEFAULT_SETTINGS.min_wait_secs,
+                ),
+              }))
+            }
+            disabled={!settings.enabled}
+            className="w-full px-2.5 py-1.5 text-sm bg-muted/50 rounded-md outline-hidden focus:ring-1 focus:ring-primary/50 disabled:opacity-50"
+          />
+          <p className="text-[10px] text-muted-foreground">
+            Minimum time a waiter must be blocked before auto-yield fires. Prevents auto-yield on
+            transient contention. Range {MIN_WAIT_MIN}-{MIN_WAIT_MAX}s.
+          </p>
+        </div>
+
+        <div className={`p-3 ${getAccentColors("blue").bg} rounded-lg flex gap-2`}>
+          <Info className={`w-4 h-4 ${getAccentColors("blue").text} shrink-0 mt-0.5`} />
+          <p className={`text-xs ${getAccentColors("blue").text}`}>
+            The runner releases a held lock when{" "}
+            <strong>holder idle ≥ idle threshold</strong> AND{" "}
+            <strong>oldest waiter waited ≥ min waiter wait</strong>. A
+            {" "}<code>file-lock-auto-yielded</code> event is emitted alongside the standard
+            {" "}<code>file-lock-released</code> event so the waiter unblocks normally.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={saveSettings}
+          disabled={saving}
+          className="px-6 py-2 bg-primary hover:bg-primary/80 text-primary-foreground rounded-md font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 text-sm"
+        >
+          {saving ? (
+            <>
+              <div className="w-4 h-4 border-2 border-primary-foreground/30 border-t-primary-foreground rounded-full animate-spin" />
+              Saving...
+            </>
+          ) : saveSuccess ? (
+            <>
+              <Check className="w-4 h-4" />
+              Saved!
+            </>
+          ) : (
+            <>
+              <Hourglass className="w-4 h-4" />
+              Save Lock-Yield Policy
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Toggle (mirrors SelfHealingSettings.tsx pattern) ────────────────────────
+interface ToggleSwitchProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+  "data-ui-bridge-id"?: string;
+}
+
+function ToggleSwitch({
+  checked,
+  onChange,
+  disabled,
+  "data-ui-bridge-id": dataUiBridgeId,
+}: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      data-ui-bridge-id={dataUiBridgeId}
+      onClick={() => {
+        if (!disabled) onChange(!checked);
+      }}
+      disabled={disabled}
+      aria-pressed={checked}
+      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+        checked ? "bg-primary" : "bg-muted"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+          checked ? "translate-x-4" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -28,6 +28,7 @@ import { RunnerInstancesSettings } from "./RunnerInstancesSettings";
 import { NotificationSettings } from "./NotificationSettings";
 import { OtelSettings } from "./OtelSettings";
 import { ContainerSettings } from "./ContainerSettings";
+import { LockYieldPolicySettings } from "./LockYieldPolicySettings";
 import { SecuritySettings } from "./SecuritySettings";
 
 interface SettingsProps {
@@ -57,6 +58,7 @@ type SettingsTab =
   | "otel"
   | "containers"
   | "security"
+  | "lock-yield"
   | "advanced"
   | "updates";
 
@@ -90,6 +92,7 @@ const SETTINGS_TABS = [
   { id: "otel", label: "OpenTelemetry" },
   { id: "containers", label: "Container Isolation" },
   { id: "security", label: "Security" },
+  { id: "lock-yield", label: "Lock-yield Policy" },
   { id: "advanced", label: "Debug" },
   { id: "updates", label: "Updates" },
 ] as const satisfies ReadonlyArray<{ id: SettingsTab; label: string }>;
@@ -221,6 +224,8 @@ export function Settings({ defaultTab, onLog, onDebugModeChange }: SettingsProps
         return <ContainerSettings onLog={onLog} />;
       case "security":
         return <SecuritySettings onLog={onLog} />;
+      case "lock-yield":
+        return <LockYieldPolicySettings onLog={onLog} />;
       case "advanced":
         return <AdvancedSettings onLog={onLog} onDebugModeChange={onDebugModeChange} />;
       case "updates":

--- a/src/components/settings/lockYieldPolicyHelpers.ts
+++ b/src/components/settings/lockYieldPolicyHelpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure helpers for `LockYieldPolicySettings`.
+ *
+ * Lives outside the JSX module so vitest can import these without
+ * dragging in the design-system / SectionHeader module graph (which
+ * pulls in `qontinui-workflow-utils` and fails to resolve under
+ * `environment: "node"`). Same pattern used by sibling
+ * `HoldingLockBanner.tsx` — the banner's pure helpers ship alongside
+ * the JSX, but only because their import surface is already
+ * test-friendly. For settings panels we factor the helpers out.
+ */
+
+// Bounds the panel enforces on the number inputs. The runner will
+// accept any u64, but the UI keeps the user away from values that
+// aren't useful (e.g. 0s thresholds that would yield every transient
+// contention).
+export const IDLE_THRESHOLD_MIN = 10;
+export const IDLE_THRESHOLD_MAX = 3600;
+export const MIN_WAIT_MIN = 5;
+export const MIN_WAIT_MAX = 600;
+
+/**
+ * Clamp `n` to `[min, max]`. Non-finite / non-numeric values resolve
+ * to `fallback`. Used to gate number inputs against typo'd values
+ * (e.g. user types "abc" → falls back to default).
+ */
+export function clampNumber(
+  n: number,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}

--- a/src/components/terminal/HoldingLockBanner.test.tsx
+++ b/src/components/terminal/HoldingLockBanner.test.tsx
@@ -55,6 +55,7 @@ vi.mock("@/lib/logger", () => ({
 }));
 
 import {
+  formatAutoYieldCountdown,
   formatBannerSeconds,
   formatBannerText,
   formatIncomingRequestText,
@@ -782,5 +783,67 @@ describe("signal-long-wait cooldown lifecycle", () => {
     // Beyond — still disabled-clear.
     vi.setSystemTime(new Date(start + 60_000));
     expect(inSignalCooldown(cooldownUntilMs, Date.now())).toBe(false);
+  });
+});
+
+// ── Auto-yield countdown (lock-yield-protocol-plan §Open Q4) ───────────────
+describe("formatAutoYieldCountdown", () => {
+  const baseArgs = {
+    enabled: true,
+    waiterCount: 1,
+    holderIdleSecs: 0,
+    waiterWaitedSecs: 0,
+    idleThresholdSecs: 60,
+    minWaitSecs: 30,
+  };
+
+  it("returns null when policy is disabled", () => {
+    expect(formatAutoYieldCountdown({ ...baseArgs, enabled: false })).toBeNull();
+  });
+
+  it("returns null when no waiter is present", () => {
+    expect(formatAutoYieldCountdown({ ...baseArgs, waiterCount: 0 })).toBeNull();
+  });
+
+  it("uses the larger remaining of (idle, wait) — wait dominates", () => {
+    // idle remaining: 60-50 = 10. wait remaining: 30-5 = 25. max = 25.
+    expect(
+      formatAutoYieldCountdown({
+        ...baseArgs,
+        holderIdleSecs: 50,
+        waiterWaitedSecs: 5,
+      }),
+    ).toBe("auto-yield in 25s");
+  });
+
+  it("uses the larger remaining of (idle, wait) — idle dominates", () => {
+    // idle remaining: 60-10 = 50. wait remaining: 30-25 = 5. max = 50.
+    expect(
+      formatAutoYieldCountdown({
+        ...baseArgs,
+        holderIdleSecs: 10,
+        waiterWaitedSecs: 25,
+      }),
+    ).toBe("auto-yield in 50s");
+  });
+
+  it("returns 'imminent' when both thresholds met", () => {
+    expect(
+      formatAutoYieldCountdown({
+        ...baseArgs,
+        holderIdleSecs: 60,
+        waiterWaitedSecs: 30,
+      }),
+    ).toBe("auto-yield imminent");
+  });
+
+  it("returns 'imminent' when both thresholds exceeded", () => {
+    expect(
+      formatAutoYieldCountdown({
+        ...baseArgs,
+        holderIdleSecs: 1000,
+        waiterWaitedSecs: 1000,
+      }),
+    ).toBe("auto-yield imminent");
   });
 });

--- a/src/components/terminal/HoldingLockBanner.tsx
+++ b/src/components/terminal/HoldingLockBanner.tsx
@@ -181,6 +181,39 @@ export function pickOldestRequest(
   return oldest;
 }
 
+/**
+ * Auto-yield-on-idle policy (lock-yield-protocol-plan §Open Q4):
+ * formats an advisory countdown for the holder's banner.
+ *
+ *   - When the policy is disabled, returns `null` (no badge).
+ *   - When `waiterCount <= 0`, returns `null` (no waiter, no auto-yield risk).
+ *   - Otherwise returns the remaining seconds until the policy can
+ *     fire, computed as `max(idleThresholdSecs - holderIdleSecs,
+ *     minWaitSecs - waiterWaitedSecs, 0)`. The actual policy AND-gates
+ *     both thresholds so the larger remaining duration is the true
+ *     "earliest auto-yield" estimate.
+ *   - String form is `"auto-yield in Ns"` for N>0, or
+ *     `"auto-yield imminent"` for N==0.
+ *
+ * Pure helper exported for vitest.
+ */
+export function formatAutoYieldCountdown(args: {
+  enabled: boolean;
+  waiterCount: number;
+  holderIdleSecs: number;
+  waiterWaitedSecs: number;
+  idleThresholdSecs: number;
+  minWaitSecs: number;
+}): string | null {
+  if (!args.enabled) return null;
+  if (args.waiterCount <= 0) return null;
+  const idleRemaining = Math.max(0, args.idleThresholdSecs - args.holderIdleSecs);
+  const waitRemaining = Math.max(0, args.minWaitSecs - args.waiterWaitedSecs);
+  const remaining = Math.max(idleRemaining, waitRemaining);
+  if (remaining <= 0) return "auto-yield imminent";
+  return `auto-yield in ${remaining}s`;
+}
+
 // ── Component ───────────────────────────────────────────────────────────────
 
 export interface HoldingLockBannerProps {
@@ -214,6 +247,21 @@ export interface HoldingLockBannerProps {
    * mode takes priority over ambient `waiterCount > 0` mode.
    */
   incomingRequests?: IncomingYieldRequest[];
+  /**
+   * Lock-yield-protocol-plan §Open Q4 — auto-yield-on-idle policy
+   * context. When provided AND `enabled === true` AND
+   * `waiterCount > 0`, the banner renders a subtle countdown line
+   * advising the holder that the auto-yield policy may release this
+   * lock on their behalf. Purely advisory — the runner runs the
+   * policy regardless of whether this prop is set.
+   */
+  autoYieldPolicy?: {
+    enabled: boolean;
+    idleThresholdSecs: number;
+    minWaitSecs: number;
+    /** Seconds since holder's last terminal output (from idle-status feed). */
+    holderIdleSecs: number;
+  };
 }
 
 export function HoldingLockBanner({
@@ -226,6 +274,7 @@ export function HoldingLockBanner({
   onDismissLocal,
   fetchImpl,
   incomingRequests,
+  autoYieldPolicy,
 }: HoldingLockBannerProps) {
   // Phase 2 (stuck-session heartbeat) — subscribe to the shared 1Hz
   // broadcast so the seconds-since label keeps ticking. Previously
@@ -285,6 +334,21 @@ export function HoldingLockBanner({
   // practice they usually match, but a forward-looking heatmap-driven
   // request might target a different lock this tab also holds).
   const yieldFilePath = inRequestMode ? oldestRequest.filePath : filePath;
+
+  // Auto-yield countdown (advisory). The runner's policy is the actual
+  // truth — this badge just tells the user when they might lose the
+  // lock involuntarily, so they aren't surprised by a sudden release.
+  const waiterWaitedSecs = Math.max(0, Math.floor((nowMs - sinceMs) / 1000));
+  const autoYieldLabel = autoYieldPolicy
+    ? formatAutoYieldCountdown({
+        enabled: autoYieldPolicy.enabled,
+        waiterCount,
+        holderIdleSecs: autoYieldPolicy.holderIdleSecs,
+        waiterWaitedSecs,
+        idleThresholdSecs: autoYieldPolicy.idleThresholdSecs,
+        minWaitSecs: autoYieldPolicy.minWaitSecs,
+      })
+    : null;
 
   // Phase 3 (stuck-session heartbeat) — fire-and-forget POST to the
   // signal-long-wait endpoint. Even if the POST fails the cooldown
@@ -353,6 +417,16 @@ export function HoldingLockBanner({
         <Hourglass className="w-3.5 h-3.5 shrink-0 text-[#e0af68] mt-0.5" />
         <div className="text-[11px] text-[#c0caf5] leading-snug flex-1">
           {message}
+          {autoYieldLabel && (
+            <span
+              data-ui-bridge-id="terminal.holding-lock-banner-auto-yield-countdown"
+              data-task-run-id={taskRunId}
+              data-file-path={filePath}
+              className="ml-1 text-[10px] text-muted-foreground"
+            >
+              ({autoYieldLabel})
+            </span>
+          )}
         </div>
         <button
           type="button"


### PR DESCRIPTION
## Summary
Closes deferred §Open Q4 from `lock-yield-protocol-plan.md`: settings-gated background policy that releases a held file lock when the holder has been idle for X seconds AND a waiter has been blocked for Y seconds. Addresses the "holder forgot they had a lock" failure mode that motivated the manual yield UI.

**Default off.** Two thresholds (`idle_threshold_secs=60`, `min_wait_secs=30`) prevent yield on transient contention or actively-busy sessions.

### Substrate already in place (this PR doesn't re-invent any of it)
- `last_activity` per AI session (`claude_session/session.rs:89` since lock-yield Phase 2)
- `FileLockManager::release` single-file (lock-yield Phase 1, PR #93)
- `file-lock-released` dual-emit pattern (PR #93)
- Heartbeat plan's `/sessions/idle-status` (PR #103) — used as cross-reference, policy reads `SessionManager` directly

### New pieces
**Backend:**
- `FileLockManager` state restructured: `{ locks, waiters: HashMap<path, Vec<FileLockWaiter>> }`. `acquire` tracks waiters; `release_all` evicts across queues. New `info_with_waiters()` extends the existing `FileLockInfo` shape; original `info()` unchanged (Phase 4 callers preserved).
- `executor/auto_yield_policy.rs` — 5s tokio poll loop. Pure `should_yield` predicate (unit-tested with boundary cases). Emits `file-lock-auto-yielded` (full context: `holder_idle_secs`, `oldest_waiter_waited_secs`) + `file-lock-released` (so existing `useFileLockTracking` listeners clear state without changes).
- `LockYieldPolicySettings` nested in `Settings`; Tauri commands `get_lock_yield_policy` / `save_lock_yield_policy`.
- Background task spawned via `tauri::async_runtime::spawn` in `main.rs:2237` (bare `tokio::spawn` from Tauri's sync setup closure panics with "no reactor running" — caught by agent's smoke; documented inline).

**Frontend:**
- New Settings tab "Lock-yield policy": enable toggle + two number inputs. Pure helpers in `lockYieldPolicyHelpers.ts` (kept separate so vitest's node env doesn't drag in `@qontinui/shared-types/workflow`).
- `HoldingLockBanner` gains optional `autoYieldPolicy` prop + subtle countdown badge "(auto-yield in {N}s)" when enabled AND there's a known waiter.

### Event shape
```json
{
  "type": "file-lock-auto-yielded",
  "file_path": "src/foo.rs",
  "holder_task_run_id": "task-…",
  "holder_name": "Session alpha",
  "holder_idle_secs": 73,
  "oldest_waiter_task_run_id": "task-…",
  "oldest_waiter_waited_secs": 42,
  "auto_yielded_at": <epoch_ms>
}
```

## Test plan
- [x] Rust: 9 `auto_yield_policy` unit tests (predicate + boundary cases), 5 new `file_registry` waiter-tracking tests, all 57 pre-existing file_registry tests still pass. `cargo check` + `cargo clippy --bin qontinui-runner --tests -- -D warnings` clean.
- [x] Manifest: `manifest_matches_route_calls` + `sdk_manifest_routes_are_exposed_by_runner` both pass — no new HTTP routes added (policy is internal + Tauri command surface only).
- [x] TS: `npx tsc --noEmit` clean. 14 new vitest tests (8 settings panel + 6 banner countdown), 508 total pass (+6 vs main's 502 baseline). 3 pre-existing failures unchanged.
- [x] ESLint clean on all touched files.
- [x] Live smoke: temp runner via supervisor with rebuild, healthy. Policy task confirmed spawned at startup. First smoke caught + fixed the `tokio::spawn` reactor bug.

## Defer-list
- Telemetry on auto-yield rate (would inform whether to flip default to enabled). Out of scope.
- Per-session opt-out (e.g., "this session has long-running task X, don't auto-yield"). The settings are global; per-session override would need session-state extensions.