### PR TITLE
ci(clorinde): auto-regenerate Rust bindings when queries or schema change

### DIFF
--- a/.github/workflows/clorinde-bindings-fresh.yml
+++ b/.github/workflows/clorinde-bindings-fresh.yml
@@ -1,0 +1,340 @@
+name: clorinde bindings freshness
+
+# Auto-regenerate Clorinde Rust bindings when `queries/**`, `clorinde.toml`,
+# or the cross-repo alembic chain changes, and auto-commit the result back
+# to the PR branch. Mirrors `schema-pg-sql-fresh.yml`'s structure (detect /
+# verify / required-shim) and is the bindings-side analog of that gate.
+#
+# Motivation
+# ----------
+# Clorinde codegen requires a live Postgres with the latest alembic
+# revisions applied. Without CI automation, every PR that touches
+# `queries/**` (or rides an upstream schema change) needs a human on a
+# machine with canonical Postgres to regen + commit before the runner
+# will compile. That gates downstream sessions on a single machine,
+# which is a problem for distributed multi-machine work.
+#
+# Posture
+# -------
+# On drift: regenerate, commit + push back to the PR branch using a PAT
+# stored as `CLORINDE_AUTOCOMMIT_TOKEN`. PAT pushes (unlike GITHUB_TOKEN
+# pushes) DO trigger downstream workflow runs, so dependent checks like
+# `cargo check` re-run on the new SHA against the fresh bindings.
+#
+# Fallback: if the PAT is missing (first-run before secret is configured)
+# or the push fails for any reason (e.g., user pushed concurrently and
+# the branch advanced), the regenerated bindings are uploaded as a build
+# artifact `clorinde-bindings-fresh` so the contributor can download and
+# commit manually.
+#
+# Required-check shim: `clorinde-fresh` always runs and reflects the
+# verify outcome (or trivially passes on no-relevant-changes PRs).
+# Registered as a required check in branch protection — the same
+# "ghost required check" trap that schema-pg-sql-fresh avoids by always
+# running a shim job applies here.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+# Workflow-level permissions for the GITHUB_TOKEN fallback path. The
+# auto-commit uses CLORINDE_AUTOCOMMIT_TOKEN (a PAT) for the push so
+# downstream workflows re-trigger; these permissions only matter if the
+# PAT is unavailable and we surface a check failure.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # ---------------------------------------------------------------------
+  # detect: short-circuit when the PR doesn't touch Clorinde-relevant
+  # paths. Matches schema-pg-sql-fresh.yml's pattern — we don't use a
+  # trigger-level `paths:` filter because that would skip the entire
+  # workflow (including the required-check shim) on non-relevant PRs.
+  # ---------------------------------------------------------------------
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      bindings_relevant: ${{ steps.changes.outputs.bindings_relevant }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect Clorinde-relevant changes
+        id: changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "bindings_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Non-PR trigger (${{ github.event_name }}); running full verification."
+            exit 0
+          fi
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+          # Trigger paths:
+          #   - queries/**          (new or modified SQL queries)
+          #   - clorinde.toml       (codegen config)
+          #   - clorinde/**         (manual edits — forbidden but caught)
+          # Cross-repo qontinui-web alembic changes also affect bindings
+          # (a column type change upstream re-shapes the generated row
+          # types), but we can't reliably detect that from runner-side
+          # paths alone. Conservative fallback: also trigger on
+          # `schema.pg.sql.generated` changes, which encode the upstream
+          # schema state and ratchet whenever migrations land.
+          if git diff --name-only "$base_sha" "$head_sha" -- \
+              'src-tauri/queries/' \
+              'src-tauri/clorinde.toml' \
+              'src-tauri/clorinde/' \
+              'src-tauri/schema.pg.sql.generated' \
+              | grep -q .; then
+            echo "bindings_relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Clorinde-relevant paths changed; running full verification."
+          else
+            echo "bindings_relevant=false" >> "$GITHUB_OUTPUT"
+            echo "No relevant changes; verification will be skipped (required check satisfied trivially)."
+          fi
+
+  # ---------------------------------------------------------------------
+  # clorinde-verify: spin up Postgres, apply the full alembic chain from
+  # the sibling qontinui-web checkout, run Clorinde codegen in-place,
+  # detect drift via `git diff`, auto-commit + push if drifted.
+  # ---------------------------------------------------------------------
+  clorinde-verify:
+    needs: detect
+    if: needs.detect.outputs.bindings_relevant == 'true'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: qontinui_user
+          POSTGRES_PASSWORD: qontinui_dev_password
+          POSTGRES_DB: qontinui_db
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U qontinui_user -d qontinui_db"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      # Checkout with the PAT so subsequent `git push` from this job is
+      # authenticated with a token that triggers downstream workflows.
+      # If the secret is unset (first-run before configuration), fall
+      # back to the default GITHUB_TOKEN — push will succeed but won't
+      # re-trigger CI, which is detected later as a soft failure with
+      # an artifact upload.
+      - name: Checkout qontinui-runner
+        uses: actions/checkout@v5
+        with:
+          path: qontinui-runner
+          ref: ${{ github.head_ref || github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.CLORINDE_AUTOCOMMIT_TOKEN || secrets.GITHUB_TOKEN }}
+
+      # Resolve which qontinui-web ref to use: prefer the same branch
+      # name as this PR (so coordinated cross-repo changes are tested
+      # together), fall back to `main`. Same logic as schema-pg-sql-fresh.
+      - name: Resolve qontinui-web ref
+        id: resolve_ref
+        shell: bash
+        run: |
+          branch="${{ github.head_ref || github.ref_name }}"
+          if [ -n "$branch" ] && git ls-remote --heads https://github.com/qontinui/qontinui-web.git "$branch" | grep -q .; then
+            echo "Using qontinui-web ref: $branch (matches this PR's branch)"
+            echo "ref=$branch" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using qontinui-web ref: main (PR branch '$branch' does not exist on qontinui-web)"
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout qontinui-web (sibling)
+        uses: actions/checkout@v5
+        with:
+          repository: qontinui/qontinui-web
+          path: qontinui-web
+          ref: ${{ steps.resolve_ref.outputs.ref }}
+
+      # qontinui-web/backend depends on sibling repos via path-deps; the
+      # alembic env.py imports the full backend model graph. Mirror the
+      # canonical install pattern from schema-pg-sql-fresh.yml so alembic
+      # can actually load.
+      - name: Checkout sibling repos (qontinui-schemas, qontinui)
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          git clone --depth 1 https://github.com/qontinui/qontinui-schemas.git
+          git clone --depth 1 https://github.com/qontinui/qontinui.git
+        shell: bash
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install backend dependencies (poetry, default groups only)
+        working-directory: qontinui-web/backend
+        run: poetry install --no-interaction --no-root
+
+      - name: Apply alembic chain
+        working-directory: qontinui-web/backend
+        env:
+          DATABASE_URL: postgresql://qontinui_user:qontinui_dev_password@localhost:5433/qontinui_db
+        run: poetry run alembic upgrade head
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      # Cache the clorinde CLI binary so subsequent runs skip the ~5min
+      # cargo install step. The cache key is fixed because clorinde
+      # versions rarely change for our purposes; bump the suffix to
+      # invalidate when needed.
+      - name: Cache clorinde CLI
+        id: cache-clorinde
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/clorinde
+          key: clorinde-cli-${{ runner.os }}-v1
+
+      - name: Install clorinde CLI
+        if: steps.cache-clorinde.outputs.cache-hit != 'true'
+        run: cargo install clorinde --locked
+
+      # Run `clorinde --help` so workflow logs document the real CLI
+      # surface. If the invocation below is wrong, this output points
+      # at the right flags for the next iteration.
+      - name: Show clorinde --help
+        run: clorinde --help || true
+
+      # Run Clorinde codegen in-place. The destination (`clorinde/`)
+      # comes from `src-tauri/clorinde.toml`; the queries directory
+      # (`queries/`) comes from the same toml. Connection is via
+      # standard libpq env vars + DATABASE_URL.
+      - name: Run Clorinde codegen
+        working-directory: qontinui-runner/src-tauri
+        env:
+          DATABASE_URL: postgresql://qontinui_user:qontinui_dev_password@localhost:5433/qontinui_db
+          PGHOST: localhost
+          PGPORT: "5433"
+          PGUSER: qontinui_user
+          PGPASSWORD: qontinui_dev_password
+          PGDATABASE: qontinui_db
+        run: clorinde
+
+      # Drift detection: if `git diff` on src-tauri/clorinde/ is empty,
+      # the checked-in bindings match a fresh regen. Otherwise we have
+      # drift.
+      - name: Detect drift
+        id: drift
+        working-directory: qontinui-runner
+        run: |
+          if git diff --quiet -- src-tauri/clorinde/; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "Clorinde bindings are up to date."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Clorinde bindings are stale; auto-commit will run."
+            echo "Files changed:"
+            git diff --stat -- src-tauri/clorinde/
+          fi
+
+      # Auto-commit + push the regenerated bindings back to the PR
+      # branch. Uses CLORINDE_AUTOCOMMIT_TOKEN if set (PAT — triggers
+      # downstream workflow re-runs). Skips on forked PRs because we
+      # can't push to a fork from CI.
+      - name: Auto-commit regenerated bindings
+        id: autocommit
+        if: |
+          steps.drift.outputs.drift == 'true' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        working-directory: qontinui-runner
+        env:
+          PAT_AVAILABLE: ${{ secrets.CLORINDE_AUTOCOMMIT_TOKEN != '' }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src-tauri/clorinde/
+          git commit -m "chore(clorinde): regenerate bindings against current schema"
+          if [ "$PAT_AVAILABLE" = "true" ]; then
+            echo "Pushing with PAT (downstream workflows will re-trigger)."
+          else
+            echo "::warning::CLORINDE_AUTOCOMMIT_TOKEN not set; pushing with GITHUB_TOKEN (downstream workflows will NOT re-trigger)."
+            echo "::warning::Configure a fine-grained PAT with 'Contents: write' permission on qontinui-runner and add as 'CLORINDE_AUTOCOMMIT_TOKEN' secret."
+          fi
+          if ! git push origin HEAD:${{ github.head_ref }}; then
+            echo "::error::Push failed (concurrent update on branch?). Falling back to artifact upload."
+            exit 1
+          fi
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      # Fallback: if drift exists but auto-commit didn't succeed (no
+      # PAT, fork PR, push conflict), upload the regenerated bindings
+      # as an artifact so the contributor can download + commit manually.
+      - name: Upload regenerated bindings on push failure
+        if: |
+          steps.drift.outputs.drift == 'true' &&
+          (steps.autocommit.outputs.pushed != 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: clorinde-bindings-fresh
+          path: qontinui-runner/src-tauri/clorinde/
+          if-no-files-found: error
+
+      # If we auto-committed successfully, fail this run so the
+      # required-check shim reflects the regen as "needs re-verification
+      # on the new SHA". The PAT-triggered downstream run on the new
+      # commit will be the one that goes green. Without this, the PR
+      # could merge against the OLD SHA's check status, which never
+      # validated the regenerated bindings.
+      - name: Surface auto-commit as a check failure
+        if: steps.autocommit.outputs.pushed == 'true'
+        run: |
+          echo "::error::Clorinde bindings were regenerated and auto-committed."
+          echo "::error::This run is intentionally failed; the new commit will be checked separately."
+          exit 1
+
+      # Final guard: if we got here without drift, we're done.
+      - name: Confirm no drift
+        if: steps.drift.outputs.drift == 'false'
+        run: echo "Clorinde bindings verified fresh; no action taken."
+
+  # ---------------------------------------------------------------------
+  # clorinde-fresh: required-check shim. Always runs and reflects the
+  # verify outcome (or trivially passes when no relevant paths changed).
+  # Register this job name as a required status check in branch
+  # protection — NOT clorinde-verify, which doesn't run on every PR.
+  # ---------------------------------------------------------------------
+  clorinde-fresh:
+    needs: [detect, clorinde-verify]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate verification result
+        shell: bash
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          VERIFY_RESULT: ${{ needs.clorinde-verify.result }}
+          BINDINGS_RELEVANT: ${{ needs.detect.outputs.bindings_relevant }}
+        run: |
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "::error::detect job did not succeed (result=$DETECT_RESULT); cannot determine path-change scope."
+            exit 1
+          fi
+          if [ "$BINDINGS_RELEVANT" = "true" ]; then
+            if [ "$VERIFY_RESULT" = "success" ]; then
+              echo "Clorinde bindings verification succeeded."
+              exit 0
+            fi
+            echo "::error::clorinde-verify result=$VERIFY_RESULT"
+            echo "::error::If drift was detected and auto-committed, the new commit's run is the one that will pass."
+            exit 1
+          fi
+          echo "::notice::No Clorinde-relevant paths changed. Required check satisfied trivially."


### PR DESCRIPTION
## Summary

Add a CI workflow that regenerates Clorinde Rust bindings in CI when `src-tauri/queries/**`, `clorinde.toml`, or the cross-repo alembic chain changes, and **auto-commits the result back to the PR branch**. Eliminates the "someone with canonical Postgres has to regen + commit" choke point that currently blocks distributed multi-machine work on runner DB changes.

Mirrors the existing `schema-pg-sql-fresh.yml` workflow's three-job layout (detect / verify / required-shim) and Postgres+alembic setup pattern, so the operational model is identical.

## Behaviour on drift

1. Workflow spins up Postgres + applies alembic chain from the sibling qontinui-web checkout (matching this PR's branch name if it exists, else main).
2. Runs `clorinde` codegen in-place.
3. `git diff` detects whether the regen produced anything different from the checked-in `src-tauri/clorinde/` tree.
4. If drift exists, commits with `github-actions[bot]` identity and pushes back to the PR branch using `CLORINDE_AUTOCOMMIT_TOKEN` (PAT) so downstream workflows re-trigger.
5. The verify job intentionally fails after a successful auto-commit so the required-check shim reflects "needs re-verification on the new SHA" — the new commit's run is the one that goes green.

## Fallback path

If the PAT secret isn't configured, or the push fails (concurrent update, fork PR), the regenerated bindings are uploaded as a build artifact named `clorinde-bindings-fresh` so the contributor can download + commit manually.

## Required setup (one-time)

1. **Create a fine-grained PAT** with:
   - Repository access: `qontinui/qontinui-runner`
   - Permissions: `Contents: write`
2. **Add as a repo secret** named `CLORINDE_AUTOCOMMIT_TOKEN` (Settings → Secrets and variables → Actions → New repository secret).
3. **After this PR merges**, register `clorinde-fresh` (the shim — NOT `clorinde-verify`) as a required status check in branch protection for `main`.

Without the PAT, the workflow still works but falls back to the artifact-download mode — same UX as `schema.pg.sql.generated-fresh` today.

## CLI discovery note

Clorinde's CLI documentation is sparse, so the workflow includes a `clorinde --help` step that runs unconditionally — its output in the first CI run documents the real flag surface. If the active invocation (`clorinde` with libpq env vars + DATABASE_URL) is wrong, the next iteration is a single-line edit guided by that help output.

## Test plan

- [ ] Add the `CLORINDE_AUTOCOMMIT_TOKEN` secret before merging.
- [ ] After merge, open a small PR that adds a comment to one `queries/*.sql` file (touches a relevant path, no real schema change). Workflow should detect "no drift" and pass trivially.
- [ ] Open a follow-up PR that adds a real new query. Workflow should detect drift, regen, auto-commit, and the new SHA's run should go green.
- [ ] Verify branch protection requires `clorinde-fresh` (not `clorinde-verify`).