### PR TITLE
ci(macos): bump Run Rust tests cap from 75 to 90 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,15 +166,21 @@ jobs:
         # Accessibility integration tests that require a real desktop session are
         # skipped in CI. Only pure unit tests (no system dependencies) run here.
         #
-        # Step has a hard 75-minute timeout. Ubuntu finishes ~43 min and
-        # Windows ~77 min on this step alone (single-threaded compile at
-        # JOBS=1 + test execution). macOS at JOBS=1 should land between
-        # the two given the M1's raw single-thread speed but with the
-        # 7GB-RAM swap-pressure penalty. 75 min covers worst case; without
-        # the cap, macOS swap-thrash hangs ran for 80+ min before admin-
-        # cancel (PR #84 was the most recent). Fail fast is better than
-        # burning runner minutes.
-        timeout-minutes: 75
+        # Step has a hard 90-minute timeout. Empirical durations from
+        # main-branch runs on 2026-05-11/12 (10-run sample): Ubuntu p50
+        # ~43 min, Windows p50 ~70 min, macOS p50 ~58 min / p90 ~70 min /
+        # max(success) ~72 min. The earlier 75-min cap sat at p90+5 min;
+        # PR #104 and PR #105 (both content-trivial — terminal-sessions
+        # endpoint additions / JSON spec) blew it three times in 36 h
+        # with `Run Rust tests` landing at 75.2 / 75.4 / 75.5 min.
+        # Variance is dominated by GitHub-hosted macOS runner load +
+        # cache state (cold-cache runs land at 65-72 min, warm-cache at
+        # 30-40 min). 90 min = p90 + 20 min headroom covers the slow
+        # tail without hiding genuine regressions. The original cap
+        # rationale ("fail fast on swap-thrash hangs") is preserved —
+        # JOBS=1 below prevents the 80+ min swap-thrash scenario from
+        # PR #84, so the cap is just bounding normal variance now.
+        timeout-minutes: 90
         env:
           # `CARGO_BUILD_JOBS` reduces the parallel-rustc memory peak.
           # Empirically:


### PR DESCRIPTION
## Summary

The macOS `Run Rust tests` step cap at 75 min sat at **p90+5 min** of the actual distribution. PR #104 and PR #105 (both content-trivial — terminal-sessions endpoint additions and a JSON-only spec) blew it three times in 36 hours, with the step landing at **75.2 / 75.4 / 75.5 min** all on infrastructure variance, not content.

10-run empirical sample on main from 2026-05-11/12:

| OS | p50 | p90 | max(success) | Step cap (before this PR) |
|---|---|---|---|---|
| Ubuntu | 43 min | — | — | 75 min |
| Windows | 70 min | — | — | 75 min |
| **macOS** | **58 min** | **70 min** | **72 min** | **75 min** ← p90+5, too tight |

Variance on macOS is dominated by GitHub-hosted runner load and cache state (cold-cache 65-72 min, warm-cache 30-40 min). Bumping to **90 min = p90 + 20 min** clears the current intermittent-failure pattern without hiding genuine regressions.

The original cap rationale (fail fast on `JOBS>1` swap-thrash hangs from PR #84) is preserved — `JOBS=1` already prevents that scenario, so the cap is now just bounding normal variance.

## Test plan

- [x] `yamllint` / `actionlint` -compatible diff (1 numeric value + comment block).
- [ ] CI itself is the verification — the cap kicks in on this PR's macOS leg. If the leg lands between 75 and 90 min on this very PR, the bump is doing its job.
- [ ] Roll back / tighten if 90 min turns out to hide a real regression (the comment block above describes how to recompute the baseline).