### PR TITLE
feat(ui-bridge): allowlist terminal_set_title + spawn_worker_session

### DIFF
--- a/src-tauri/src/ui_bridge_invoke.rs
+++ b/src-tauri/src/ui_bridge_invoke.rs
@@ -342,6 +342,26 @@ pub const UI_BRIDGE_COMMANDS: &[ProxyableCommand] = &[
         // Read-only — empty args is the canonical call shape.
         probe_with_empty_args: true,
     },
+    // Coord/terminal smoke commands — bi-directional title sync (Phase 2
+    // of runner-dispatch-and-terminal-ux-fixes-plan) + worker spawn.
+    ProxyableCommand {
+        name: "terminal_set_title",
+        description: "Update a terminal session's display title. Mirrors OSC 0/2 titles emitted by the PTY into TerminalSession.title and broadcasts terminal-title-changed to other webviews / WS subscribers. Pair to ZoneGrid's onTitleChange handler.",
+        args_schema: r#"{"type":"object","required":["terminalId","title"],"properties":{"terminalId":{"type":"string"},"title":{"type":"string"}},"additionalProperties":false}"#,
+        response_schema: r#"{"type":"object","required":["success"],"properties":{"success":{"type":"boolean"},"message":{"type":["string","null"]},"data":{"type":["object","null"]}}}"#,
+        // Required `terminalId` + `title`; empty-args probe would always
+        // fail, and a real call would mutate session state.
+        probe_with_empty_args: false,
+    },
+    ProxyableCommand {
+        name: "spawn_worker_session",
+        description: "Spawn a Claude-Code-backed worker PTY pre-sized to the dominant zone dimensions and register it under a fresh task_run_id in SessionManager.worker_sessions. Used by the Productivity tab Workers panel and coord soak smokes.",
+        args_schema: r#"{"type":"object","properties":{"titleHint":{"type":["string","null"]}},"additionalProperties":false}"#,
+        response_schema: r#"{"type":"object","required":["mode"],"properties":{"mode":{"type":"string"},"terminalId":{"type":["string","null"]},"taskRunId":{"type":["string","null"]}}}"#,
+        // Spawns a PTY child process — side-effectful even with empty
+        // args. Probe must skip.
+        probe_with_empty_args: false,
+    },
 ];
 
 /// Whether a command name is in the UI Bridge invoke allowlist.
@@ -449,6 +469,12 @@ mod tests {
         assert!(is_allowlisted("report_ui_error"));
         assert!(is_allowlisted("clear_ui_error"));
         assert!(is_allowlisted("get_ui_error"));
+    }
+
+    #[test]
+    fn is_allowlisted_recognizes_coord_terminal_commands() {
+        assert!(is_allowlisted("terminal_set_title"));
+        assert!(is_allowlisted("spawn_worker_session"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `terminal_set_title` and `spawn_worker_session` to the UI Bridge `/invoke` allowlist (`UI_BRIDGE_COMMANDS` in `src-tauri/src/ui_bridge_invoke.rs`).
- Both commands are now reachable via `POST /ui-bridge/invoke/<cmd>` and listed in `GET /ui-bridge/commands` (24 entries total, up from 22). No frontend wireup needed — `useUIBridgeInvokeHandler.ts` dispatches generically.
- Closes the gap surfaced by the post-PR #98 manual smoke: external testing tools (coord soak, CI smoke scripts) can now drive both commands without going through the bundled React frontend.

### Why these two?

| Command | Source | Why allowlist now |
|---|---|---|
| `terminal_set_title` | PR #98 (`commands/terminal.rs:73`) | Phase 2 of bi-directional OSC 0/2 title sync. Currently only reachable via the in-app xterm `onTitleChange` handler; external smokes hit the 400 wall. |
| `spawn_worker_session` | Productivity tab (`commands/productivity.rs:966`) | Coord soak smokes need to spin up worker PTYs without rendering the Workers panel. |

Both entries set `probe_with_empty_args: false` — `terminal_set_title` has required args (`terminalId`, `title`); `spawn_worker_session` is side-effectful (spawns a PTY child) even with empty args.

### Security note

`spawn_worker_session` widens the surface for in-process callers on this machine, but the HTTP listener binds loopback-only (`mcp_api.rs:1742`), so it is not LAN-reachable. Flagged for awareness; consistent with how the rest of the allowlist treats write/destructive commands.

## Test plan

- [x] `cargo test ui_bridge_invoke::tests` — all 10 tests pass, incl. new `is_allowlisted_recognizes_coord_terminal_commands` and the existing `allowlist_is_not_empty_and_schemas_are_populated` invariant.
- [x] Live smoke against a temp runner (`POST /runners/spawn-test {rebuild:true}` → `:9877`):
  - [x] `GET /ui-bridge/commands` lists 24 entries including both new ones.
  - [x] Created a terminal via `POST /terminals` → invoked `terminal_set_title` → `GET /terminals` confirms `title` went from `smoke` to `Smoke Test`.
  - [x] `spawn_worker_session` returned `success:true` with `mode=worker` + `terminalId` + `taskRunId`.
  - [x] `list_workers` shows the new worker after spawn (`state: ready`, terminal title `✳ Claude Code`).

## Plan

`qontinui-dev-notes/plans/2026-05-12-ui-bridge-invoke-allowlist-coord-commands-plan.md` (archived at `302cb47`).