### PR TITLE
feat(terminal): pin Worker N tab titles against Claude OSC 0 drift

### DIFF
--- a/src-tauri/src/claude_session/manager.rs
+++ b/src-tauri/src/claude_session/manager.rs
@@ -123,6 +123,26 @@ impl SessionManager {
             .and_then(|guard| guard.get(task_run_id).cloned())
     }
 
+    /// Reverse lookup: find the worker (if any) backed by the given pty
+    /// terminal. The primary key is `task_run_id`; this walks the worker
+    /// map to match on `WorkerSession::terminal_id()`. Used by
+    /// `TerminalManager::set_title_unless_worker` to pin `Worker N` tab
+    /// titles against OSC 0 drift from the embedded Claude CLI.
+    ///
+    /// O(N) over registered workers. N is bounded by the operator's
+    /// active worker count (≤ 16 in practice), so a HashMap secondary
+    /// index keyed by `terminal_id` would be overkill — call sites are
+    /// limited to the title-set Tauri command path, which fires at
+    /// human-visible rates, not per-byte.
+    pub fn find_worker_by_terminal_id(&self, terminal_id: &str) -> Option<Arc<WorkerSession>> {
+        self.worker_sessions.lock().ok().and_then(|guard| {
+            guard
+                .values()
+                .find(|w| w.terminal_id() == terminal_id)
+                .cloned()
+        })
+    }
+
     /// Remove and return a worker registration. Does NOT close the
     /// underlying pty (TerminalManager owns those lifetimes).
     pub fn remove_worker(&self, task_run_id: &str) -> Option<Arc<WorkerSession>> {
@@ -457,5 +477,29 @@ mod tests {
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].0, "task-closed");
         assert_eq!(listed[0].1.state(), SessionState::Closed);
+    }
+
+    #[test]
+    fn find_worker_by_terminal_id_round_trips() {
+        let mgr = SessionManager::new();
+        let w1 = make_worker("task-1", "term-1", "Worker 1");
+        let w2 = make_worker("task-2", "term-2", "Worker 2");
+        mgr.register_worker(w1).expect("register w1");
+        mgr.register_worker(w2).expect("register w2");
+
+        let found = mgr
+            .find_worker_by_terminal_id("term-2")
+            .expect("term-2 should resolve");
+        assert_eq!(found.task_run_id(), "task-2");
+        assert_eq!(found.terminal_id(), "term-2");
+    }
+
+    #[test]
+    fn find_worker_by_terminal_id_returns_none_for_unknown_terminal() {
+        let mgr = SessionManager::new();
+        let w = make_worker("task-only", "term-only", "Worker only");
+        mgr.register_worker(w).expect("register");
+        assert!(mgr.find_worker_by_terminal_id("unrelated-term").is_none());
+        assert!(mgr.find_worker_by_terminal_id("").is_none());
     }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -7,6 +7,7 @@ use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
 use tauri::Manager;
 use tracing::{info, warn};
 
+use crate::claude_session::SessionManager;
 use crate::commands::CommandResponse;
 use crate::error::AppError;
 use crate::terminal::{strip_ansi, TerminalManager};
@@ -70,14 +71,27 @@ pub fn terminal_write(
 /// runner mirrors the new title onto `TerminalSession.title` and emits
 /// a `terminal-title-changed` event so other webview windows / WS
 /// subscribers stay consistent.
+///
+/// Worker pin (plan `2026-05-12-claude-auto-title-suppression-worker-tabs-plan.md`):
+/// goes through [`TerminalManager::set_title_unless_worker`] so OSC 0
+/// titles emitted by Claude inside a worker pty are silently dropped —
+/// `Worker N` stays pinned for the lifetime of the tab. Non-worker
+/// terminals (manual `claude` from the Terminal tab, PowerShell, etc.)
+/// keep the existing follow-the-child behaviour.
 #[tauri::command]
 pub fn terminal_set_title(
     terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
+    session_manager: tauri::State<'_, Arc<SessionManager>>,
     app_handle: tauri::AppHandle,
     terminal_id: String,
     title: String,
 ) -> Result<CommandResponse, String> {
-    terminal_manager.set_title(&terminal_id, title, &app_handle)?;
+    terminal_manager.set_title_unless_worker(
+        session_manager.inner().as_ref(),
+        &terminal_id,
+        title,
+        &app_handle,
+    )?;
     Ok(CommandResponse {
         success: true,
         message: None,

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -6,11 +6,12 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use tauri::{AppHandle, Emitter};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use super::interceptor::OutputInterceptor;
 use super::session::TerminalSession;
 use super::types::{TerminalId, TerminalInfo};
+use crate::claude_session::SessionManager;
 
 /// Manages all active terminal sessions.
 pub struct TerminalManager {
@@ -113,6 +114,45 @@ impl TerminalManager {
             &payload,
         );
         Ok(())
+    }
+
+    /// Like [`Self::set_title`], but silently drops the update when the
+    /// terminal is registered with a `WorkerSession` in `session_manager`.
+    /// Used by the `terminal_set_title` Tauri command to pin `Worker N`
+    /// tab titles against OSC 0 drift from the embedded Claude CLI.
+    ///
+    /// Why: PR #98 (`0b61fa70a`, `feat(coord): worker readiness gate +
+    /// terminal UX fixes from coord soak`) made title sync bidirectional,
+    /// so OSC 0 titles emitted by Claude inside a worker pty overwrite
+    /// both the in-memory `TerminalSession.title` AND the UI tab strip
+    /// via `ZoneGrid::onTitleChange → invoke("terminal_set_title")`.
+    /// `Worker N` is the at-a-glance identifier operators (and the
+    /// Coordinator's `coord.tasks.assigned_session_id` join) use to
+    /// triage workers — preserving it requires gating the post-spawn
+    /// title mutations from worker-backed ptys.
+    ///
+    /// Non-worker terminals (manual `POST /terminals`, dashboard launch
+    /// buttons, etc.) keep the existing OSC 0 follow-the-child behaviour
+    /// through the unguarded [`Self::set_title`] path. Direct internal
+    /// callers (e.g. a future "rename tab from settings" UI) should
+    /// continue to invoke `set_title` directly — the gate applies only
+    /// to the OSC 0 echo path.
+    pub fn set_title_unless_worker(
+        &self,
+        session_manager: &SessionManager,
+        id: &str,
+        title: String,
+        app_handle: &AppHandle,
+    ) -> Result<(), String> {
+        if session_manager.find_worker_by_terminal_id(id).is_some() {
+            debug!(
+                terminal_id = id,
+                title = %title,
+                "dropping OSC 0 title update for worker-backed terminal"
+            );
+            return Ok(());
+        }
+        self.set_title(id, title, app_handle)
     }
 
     /// Remove and close a terminal session.


### PR DESCRIPTION
## Summary

After PR #98 made title sync bidirectional, OSC 0 titles emitted by the embedded Claude CLI inside a worker pty overwrite both `TerminalSession.title` and the UI tab strip. `Worker N` is the at-a-glance identifier the Coordinator's `coord.tasks.assigned_session_id` join and operators use to triage workers — losing it from `/terminals` and the tab strip hurts triage.

This is **Phase 1** of plan `2026-05-12-claude-auto-title-suppression-worker-tabs-plan.md` (backend-only gate).

- `SessionManager::find_worker_by_terminal_id` — reverse lookup over `worker_sessions`. O(N) over a tiny N (≤16 workers in practice).
- `TerminalManager::set_title_unless_worker` — composes the new predicate with the existing `set_title`; silently drops worker-backed updates and logs at `debug`.
- `terminal_set_title` Tauri command — routes through the gated variant by injecting `SessionManager` state. Sole caller of the backend `set_title` path; non-worker terminals (manual `claude`, PowerShell, etc.) keep the existing OSC 0 follow-the-child behavior through the unguarded `set_title`.

**Phase 2 (frontend flicker mirror)** is gated on smoke observation of `ZoneGrid::onTitleChange`'s local `renameTab` briefly showing the Claude title before the next snapshot resets it from the (now-pinned) backend. The plan documents three plumbing options (Option B recommended) for when it ships.

## Test plan

- [x] `cargo check` passes
- [x] `cargo test --bin qontinui-runner claude_session::manager::tests::` passes (5 tests, 2 new: `find_worker_by_terminal_id_round_trips`, `find_worker_by_terminal_id_returns_none_for_unknown_terminal`)
- [ ] Manual smoke deferred — spawn 2 workers in Productivity tab, poll `GET /terminals` for 30s, confirm titles stay `Worker 1` / `Worker 2` against Claude OSC 0 emissions. Snapshot tab strip mid-poll; if visible flicker, follow up with Phase 2 from the plan.