### PR TITLE
ci(clorinde): use `live` subcommand with explicit search-path

### DIFF
--- a/.github/workflows/clorinde-bindings-fresh.yml
+++ b/.github/workflows/clorinde-bindings-fresh.yml
@@ -208,26 +208,25 @@ jobs:
         if: steps.cache-clorinde.outputs.cache-hit != 'true'
         run: cargo install clorinde --locked
 
-      # Run `clorinde --help` so workflow logs document the real CLI
-      # surface. If the invocation below is wrong, this output points
-      # at the right flags for the next iteration.
-      - name: Show clorinde --help
-        run: clorinde --help || true
+      # Document the actual CLI surface in workflow logs. `clorinde live`
+      # is the subcommand we use; the top-level help shows there are
+      # also `schema` and `fresh` variants we don't need here.
+      - name: Show clorinde live --help
+        run: clorinde live --help || true
 
-      # Run Clorinde codegen in-place. The destination (`clorinde/`)
-      # comes from `src-tauri/clorinde.toml`; the queries directory
-      # (`queries/`) comes from the same toml. Connection is via
-      # standard libpq env vars + DATABASE_URL.
+      # Run Clorinde codegen in-place. `clorinde live` reads
+      # DATABASE_URL from env (clap `[env: DATABASE_URL=]` binding),
+      # then uses `clorinde.toml` in the working directory for the
+      # queries-path + destination + sync/async settings. The
+      # `--search-path` matches the canonical PG runtime config in
+      # `database/pg/mod.rs` so queries resolve table references in
+      # both `project` (alembic-managed) and `public` schemas the same
+      # way the runner does at runtime.
       - name: Run Clorinde codegen
         working-directory: qontinui-runner/src-tauri
         env:
           DATABASE_URL: postgresql://qontinui_user:qontinui_dev_password@localhost:5433/qontinui_db
-          PGHOST: localhost
-          PGPORT: "5433"
-          PGUSER: qontinui_user
-          PGPASSWORD: qontinui_dev_password
-          PGDATABASE: qontinui_db
-        run: clorinde
+        run: clorinde live --search-path "project,public"
 
       # Drift detection: if `git diff` on src-tauri/clorinde/ is empty,
       # the checked-in bindings match a fresh regen. Otherwise we have


### PR DESCRIPTION
## Summary

Fix the Clorinde codegen invocation in `.github/workflows/clorinde-bindings-fresh.yml` after the smoke-test PR (#114) surfaced that bare `clorinde` requires a subcommand and exits with code 2.

The workflow's discovery step (`clorinde --help`) captured the exact CLI surface; running `clorinde live --help` locally confirmed the right invocation.

## Changes

- `clorinde` → `clorinde live --search-path "project,public"`
- `clorinde --help` (discovery) → `clorinde live --help` (more useful)

## Why `--search-path "project,public"`

Matches the canonical runtime config at `qontinui-runner/src-tauri/src/database/pg/mod.rs:168`, which sets `SET search_path TO project, public` on every connection. Queries reference tables by unqualified name (e.g., `settings`, `configs`), so codegen needs the same search path or it can't resolve them.

## Why `live`

The CLI has three subcommands:
- `live` — generate against your own DB (reads `DATABASE_URL` from env, reads `clorinde.toml` for the rest)
- `schema` — generate from schema files
- `fresh` — generate against schema files using a fresh database

`live` matches our flow: alembic has already applied against the workflow's Postgres service before codegen runs.

## Test plan

After merge, smoke-test PR #114 should rerun the workflow. Expected: `clorinde live` succeeds against the workflow's Postgres + applied alembic chain, detects the diff introduced by the smoke-test's new `count_settings` query, auto-commits the regenerated `clorinde/` tree, and the PAT-triggered new run on the auto-commit SHA goes green.