### PR TITLE
test(clorinde): smoke-test canonical baseline after #116

### DIFF
--- a/src-tauri/queries/settings.sql
+++ b/src-tauri/queries/settings.sql
@@ -1,4 +1,7 @@
 --- Settings and config storage operations.
+--- (No-op comment edit to exercise the clorinde auto-regen CI gate
+--- against the post-#116 canonical baseline. Expected: clorinde-verify
+--- and schema-fresh-verify both pass with "no drift" trivially.)
 
 --! get_setting
 SELECT value FROM settings WHERE key = :key;


### PR DESCRIPTION
## Purpose

Acceptance criterion #4 from [PLAN_restate_sdk_upgrade_and_canonical_regen](https://github.com/qontinui/qontinui-dev-notes/blob/main/PLAN_restate_sdk_upgrade_and_canonical_regen.md): after the canonical Clorinde/schema baseline landed in #116, open a no-op queries/** PR to confirm the auto-regen workflow's happy path stays green.

## What this PR does

Adds three comment lines to the top of `src-tauri/queries/settings.sql`. No SQL change; the regen against canonical PG should produce byte-equal bindings.

## Expected workflow behaviour (the happy path)

1. `detect` job marks `bindings_relevant=true` (queries/** touched).
2. `clorinde-verify` spins up Postgres + applies alembic chain + runs `clorinde live --search-path "project,public"`.
3. `git diff` on `src-tauri/clorinde/` is empty → `drift=false`.
4. No auto-commit fires. `clorinde-fresh` shim passes trivially.
5. Same for `schema-fresh-verify`: no drift, no artifact uploaded.

If the workflow fires an auto-commit, that signals canonical drift snuck in after #116 — investigate.

## Cleanup

Close without merging once verified — the comment is intentionally non-canonical and we don't want it lingering in the codebase.