### PR TITLE
test: clorinde auto-regen smoke (trivial queries/** touch)

### DIFF
--- a/src-tauri/queries/activity_timeline.sql
+++ b/src-tauri/queries/activity_timeline.sql
@@ -1,4 +1,5 @@
 --- Activity Timeline CRUD and search operations (screenpipe-inspired capture history).
+--- (smoke-test for clorinde auto-regen workflow happy path — PR #116 acceptance criterion #4)
 
 --- Row types with nullable field annotations (? suffix = Option<T> in Rust).
 --: SearchTimelineRow(app_name?, window_title?, url?, screenshot_path?, element_count?, confidence?)


### PR DESCRIPTION
## Summary

Acceptance criterion #4 of [PLAN_restate_sdk_upgrade_and_canonical_regen](https://github.com/qontinui/qontinui-runner/blob/main/qontinui-dev-notes/PLAN_restate_sdk_upgrade_and_canonical_regen.md) (shipped via #116).

Adds a single SQL comment line to `src-tauri/queries/activity_timeline.sql` to confirm the auto-regen workflow (`clorinde-bindings-fresh.yml`, established by #110/#115) now stays trivially green against the canonical baseline.

## Expected CI behavior

- `clorinde-verify` runs, regenerates bindings, finds no drift, exits clean — **no auto-commit fires**
- `schema-fresh-verify` is satisfied trivially (no schema-relevant paths touched)
- `forbid-runner-schema`, `security`, `test (ubuntu/macos/windows)` all green
- PR mergeable on first CI run, no follow-up regen needed

## Test plan

- [ ] CI green on first run with no auto-commit on the branch
- [ ] After merge: workflow remains primed for the next real `queries/**` PR