### PR TITLE
feat(processes): slug/category/name resolution for HTTP route id

### DIFF
--- a/src-tauri/src/mcp/processes.rs
+++ b/src-tauri/src/mcp/processes.rs
@@ -93,7 +93,11 @@ pub async fn start_process(
         )
     })?;
 
-    manager.start_process(&id).await.map_err(|e| {
+    let resolved = manager
+        .resolve_process_id(&id)
+        .await
+        .unwrap_or_else(|| id.clone());
+    manager.start_process(&resolved).await.map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
             Json(api_error(format!("Failed to start process: {}", e))),
@@ -126,7 +130,11 @@ pub async fn stop_process(
         )
     })?;
 
-    manager.stop_process(&id).await.map_err(|e| {
+    let resolved = manager
+        .resolve_process_id(&id)
+        .await
+        .unwrap_or_else(|| id.clone());
+    manager.stop_process(&resolved).await.map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
             Json(api_error(format!("Failed to stop process: {}", e))),
@@ -159,7 +167,11 @@ pub async fn restart_process(
         )
     })?;
 
-    manager.restart_process(&id).await.map_err(|e| {
+    let resolved = manager
+        .resolve_process_id(&id)
+        .await
+        .unwrap_or_else(|| id.clone());
+    manager.restart_process(&resolved).await.map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
             Json(api_error(format!("Failed to restart process: {}", e))),
@@ -196,8 +208,12 @@ pub async fn rebuild_and_restart_process(
         )
     })?;
 
+    let resolved = manager
+        .resolve_process_id(&id)
+        .await
+        .unwrap_or_else(|| id.clone());
     manager
-        .rebuild_and_restart_process(&id)
+        .rebuild_and_restart_process(&resolved)
         .await
         .map_err(|e| {
             (
@@ -243,7 +259,11 @@ pub async fn get_output(
         )
     })?;
 
-    let output = manager.get_output(&id, tail).await.map_err(|e| {
+    let resolved = manager
+        .resolve_process_id(&id)
+        .await
+        .unwrap_or_else(|| id.clone());
+    let output = manager.get_output(&resolved, tail).await.map_err(|e| {
         (
             StatusCode::NOT_FOUND,
             Json(api_error(format!("Failed to get output: {}", e))),

--- a/src-tauri/src/process_capture/manager.rs
+++ b/src-tauri/src/process_capture/manager.rs
@@ -359,6 +359,29 @@ impl ProcessCaptureManager {
             .map(|p| p.config.id.clone())
     }
 
+    /// Resolve a process identifier (UUID, category slug, or name substring) to a
+    /// canonical process id. Returns `None` if no unambiguous match exists.
+    ///
+    /// HTTP routes like `POST /processes/{id}/restart` accept any of these forms
+    /// so callers can use the convenient slug (`frontend`, `backend`) instead of
+    /// looking up the UUID first. Resolution order: exact id, exact category
+    /// (single match), name substring (single match). Multi-match resolutions
+    /// return `None` to avoid silently restarting the wrong service.
+    pub async fn resolve_process_id(&self, input: &str) -> Option<String> {
+        let processes = self.processes.read().await;
+        let entries: Vec<(&str, &str, &str)> = processes
+            .values()
+            .map(|p| {
+                (
+                    p.config.id.as_str(),
+                    p.config.name.as_str(),
+                    p.config.category.as_str(),
+                )
+            })
+            .collect();
+        resolve_process_id_from_entries(&entries, input)
+    }
+
     /// The event loop for a single process: handles output, errors, health, exit.
     ///
     /// Responsibilities:
@@ -850,5 +873,106 @@ impl ProcessCaptureManager {
 
     fn emit_state_change(&self, status: &ProcessStatus) {
         let _ = tauri::Emitter::emit(&self.app_handle, "process-state-changed", status);
+    }
+}
+
+/// Pure resolution helper backing [`ProcessCaptureManager::resolve_process_id`].
+///
+/// Each entry is `(id, name, category)`. Match precedence:
+/// 1. Exact id (case-sensitive — these are UUIDs)
+/// 2. Exact category (case-insensitive, requires single match)
+/// 3. Name substring (case-insensitive, requires single match)
+fn resolve_process_id_from_entries(entries: &[(&str, &str, &str)], input: &str) -> Option<String> {
+    if let Some((id, _, _)) = entries.iter().find(|(id, _, _)| *id == input) {
+        return Some((*id).to_string());
+    }
+    let input_lower = input.to_lowercase();
+    let category_matches: Vec<&(&str, &str, &str)> = entries
+        .iter()
+        .filter(|(_, _, cat)| cat.to_lowercase() == input_lower)
+        .collect();
+    if category_matches.len() == 1 {
+        return Some(category_matches[0].0.to_string());
+    }
+    let name_matches: Vec<&(&str, &str, &str)> = entries
+        .iter()
+        .filter(|(_, name, _)| name.to_lowercase().contains(&input_lower))
+        .collect();
+    if name_matches.len() == 1 {
+        return Some(name_matches[0].0.to_string());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_process_id_from_entries;
+
+    fn fixture() -> Vec<(&'static str, &'static str, &'static str)> {
+        vec![
+            ("uuid-frontend", "Frontend (Next.js)", "frontend"),
+            ("uuid-backend", "FastAPI Backend", "backend"),
+            (
+                "uuid-embed",
+                "Embedding Service (MiniLM-L6-v2)",
+                "infrastructure",
+            ),
+        ]
+    }
+
+    #[test]
+    fn exact_uuid_match_wins() {
+        let e = fixture();
+        assert_eq!(
+            resolve_process_id_from_entries(&e, "uuid-frontend"),
+            Some("uuid-frontend".to_string())
+        );
+    }
+
+    #[test]
+    fn category_slug_resolves_to_unique_match() {
+        let e = fixture();
+        assert_eq!(
+            resolve_process_id_from_entries(&e, "frontend"),
+            Some("uuid-frontend".to_string())
+        );
+        assert_eq!(
+            resolve_process_id_from_entries(&e, "BACKEND"),
+            Some("uuid-backend".to_string())
+        );
+    }
+
+    #[test]
+    fn name_substring_resolves_when_unique() {
+        let e = fixture();
+        assert_eq!(
+            resolve_process_id_from_entries(&e, "fastapi"),
+            Some("uuid-backend".to_string())
+        );
+        assert_eq!(
+            resolve_process_id_from_entries(&e, "MiniLM"),
+            Some("uuid-embed".to_string())
+        );
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let e = fixture();
+        assert_eq!(resolve_process_id_from_entries(&e, "mobile"), None);
+        assert_eq!(resolve_process_id_from_entries(&e, ""), None);
+    }
+
+    #[test]
+    fn ambiguous_substring_returns_none() {
+        // Two processes whose names share a substring (e.g., "service") must
+        // refuse to resolve rather than restart the wrong one.
+        let e = vec![
+            ("uuid-a", "Auth Service", "backend"),
+            ("uuid-b", "Notification Service", "backend"),
+        ];
+        assert_eq!(resolve_process_id_from_entries(&e, "service"), None);
+        // But the category itself is also ambiguous (both are "backend"),
+        // so the category lookup also returns None.
+        assert_eq!(resolve_process_id_from_entries(&e, "backend"), None);
     }
 }


### PR DESCRIPTION
## Summary

`POST /processes/{id}/restart` (and start/stop/rebuild-and-restart/output)
now accepts:
- exact UUID (unchanged)
- category slug — `frontend` resolves to the process whose `config.category` is `"frontend"`
- name substring — `fastapi` resolves to `"FastAPI Backend"`

Ambiguous matches (two processes in the same category, or two names sharing the substring) deliberately return `None` so the handler falls through to the existing not-found error. Better than silently restarting the wrong service.

Surfaced by the 2026-05-13 `/manual-test web` session — the slash-command prompt documents `POST /processes/frontend/restart` as the preferred restart path but only the UUID form worked previously.

Plan: [`qontinui-dev-notes/plans/2026-05-13-web-manual-test-remediation.md`](https://github.com/qontinui/qontinui-dev-notes/blob/main/plans/2026-05-13-web-manual-test-remediation.md) (pending push).

## Test plan
- [x] `cargo check --tests` clean
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] 5 unit tests in `process_capture::manager::tests` (exact UUID, slug, substring, no-match, ambiguous)
- [ ] Live smoke from a temp runner: `curl -X POST http://localhost:9876/processes/frontend/restart` returns `{"success":true,"data":"restarted"}` once the next manual-test session has an opportunity to verify