### PR TITLE
feat(ui-bridge): capture console.debug/info/log + revert tabSidCapture warn workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.2.5",
-    "@qontinui/ui-bridge": "^0.4.0",
+    "@qontinui/ui-bridge": "^0.5.0",
     "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.5.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.5
         version: 0.2.5
       '@qontinui/ui-bridge':
-        specifier: ^0.4.0
-        version: 0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1170,8 +1170,8 @@ packages:
       ws:
         optional: true
 
-  '@qontinui/ui-bridge@0.4.0':
-    resolution: {integrity: sha512-UD9Q91Xbz1GgpoP+3dN/VoIClVHgKkGKt0t7BDr3BJsZ2MnJ6qMe5At7fpAIyo1OVk48UmHn5zEMC1wDiDoJLQ==}
+  '@qontinui/ui-bridge@0.5.0':
+    resolution: {integrity: sha512-QYOgEjUEu5O9gf5k9K0+G2L/chgm+sDsftv2/wq8uE9jF4vW4I8FUd1MkSfmeD/BAFMG3zVqtt3qZiHamqMs2A==}
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
       '@qontinui/ui-bridge-headless': '>=0.1.0'
@@ -6133,9 +6133,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.5.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.5.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.5': {}
@@ -6171,7 +6171,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       ws: 8.20.0
 
-  '@qontinui/ui-bridge@0.4.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.5.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -828,7 +828,10 @@ export default function App() {
       <BuildRefreshBanner />
       <UIBridgeProvider
         features={{ renderLog: true, control: true, debug: true }}
-        browserCaptureConfig={{ console: true }}
+        browserCaptureConfig={{
+          console: true,
+          consoleLevels: ['error', 'warn', 'debug', 'info', 'log'],
+        }}
       >
         <UIBridgeEventHandler />
         <UIBridgeInvokeHandler />

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -27,19 +27,10 @@
  * cannot disambiguate them.
  *
  * Diagnostics: set `localStorage["debug:tabSidCapture"] = "1"` to emit
- * `logger.warn("[tabSidCapture] <tag>", payload)` at every rejection
+ * `logger.debug("[tabSidCapture] <tag>", payload)` at every rejection
  * branch (`tab-not-found`, `already-bound`, `timed-out`, `probe-null`,
  * `already-claimed`, `probe-error`). Off by default; same affordance
  * pattern as `UI_BRIDGE_DEBUG_FIND`.
- *
- * Emission level is `warn` (not `debug`) so the UI Bridge SDK's
- * `installConsoleCapture` picks the lines up — the SDK only wraps
- * `console.warn`/`console.error`/`unhandledrejection`, so debug-level
- * diagnostics are invisible to `/ui-bridge/control/console-errors`. The
- * `localStorage` gate keeps the surface silent in production by default,
- * so the louder level is a no-op for users who haven't opted in.
- * See plans/2026-05-13-ui-bridge-console-capture-extension.md for the
- * strategic fix that lets future diagnostics use `logger.debug` again.
  *
  * On timeout the tab simply stays without a session id — the user can
  * still use the terminal, just no commit indicator.
@@ -154,7 +145,7 @@ export function useTabSessionIdCapture({
         localStorage.getItem("debug:tabSidCapture") === "1";
 
       if (debug()) {
-        logger.warn("[tabSidCapture] start", { tabId, workingDir, configDir, spawnTimestamp });
+        logger.debug("[tabSidCapture] start", { tabId, workingDir, configDir, spawnTimestamp });
       }
 
       // Already polling this tab? Don't double-up.
@@ -171,14 +162,14 @@ export function useTabSessionIdCapture({
         const tab = tabsRef.current.find((t) => t.id === tabId);
         if (!tab) {
           // Tab was closed — stop.
-          if (debug()) logger.warn("[tabSidCapture] tab-not-found", { tabId });
+          if (debug()) logger.debug("[tabSidCapture] tab-not-found", { tabId });
           handle.cancelled = true;
           inFlight.current.delete(tabId);
           return;
         }
         if (tab.claudeSessionId) {
           if (debug()) {
-            logger.warn("[tabSidCapture] already-bound", {
+            logger.debug("[tabSidCapture] already-bound", {
               tabId,
               sessionId: tab.claudeSessionId,
             });
@@ -191,7 +182,7 @@ export function useTabSessionIdCapture({
         // Timed out?
         if (Date.now() - startedAt > POLL_TIMEOUT_MS) {
           if (debug()) {
-            logger.warn("[tabSidCapture] timed-out", {
+            logger.debug("[tabSidCapture] timed-out", {
               tabId,
               elapsedMs: Date.now() - startedAt,
             });
@@ -216,10 +207,10 @@ export function useTabSessionIdCapture({
 
           const data = resp.success ? (resp.data as TranscriptSessionPayload | null) : null;
           if (!data) {
-            if (debug()) logger.warn("[tabSidCapture] probe-null", { tabId });
+            if (debug()) logger.debug("[tabSidCapture] probe-null", { tabId });
           } else if (claimedSessionIds.current.has(data.session_id)) {
             if (debug()) {
-              logger.warn("[tabSidCapture] already-claimed", {
+              logger.debug("[tabSidCapture] already-claimed", {
                 tabId,
                 sessionId: data.session_id,
               });
@@ -236,7 +227,7 @@ export function useTabSessionIdCapture({
           }
         } catch (err) {
           // Probe error: keep trying; runner may be transiently busy.
-          if (debug()) logger.warn("[tabSidCapture] probe-error", { tabId, err });
+          if (debug()) logger.debug("[tabSidCapture] probe-error", { tabId, err });
         }
 
         // Schedule next tick.


### PR DESCRIPTION
## Summary

- Opt the runner into the SDK's debug/info/log capture by passing `consoleLevels: ['error','warn','debug','info','log']` to `<UIBridgeProvider>` in `App.tsx`.
- Revert the tactical `logger.debug → logger.warn` workaround in `useTabSessionIdCapture.ts` (7 sites + docstring) — added 2026-05-13 in `06c625ee6` because the pre-0.5 SDK only captured warn/error. Now obsolete with @qontinui/ui-bridge@0.5.0.
- Bumps `@qontinui/ui-bridge` dep `^0.4.0 → ^0.5.0`.

## Paired with

- SDK: https://github.com/qontinui/ui-bridge/pull/20 (needs to publish 0.5.0 to npm before this PR's CI install can succeed)

## Test plan

- [x] `npx tsc --noEmit` clean (against locally-installed 0.5.0 dist)
- [x] `npx eslint` clean on touched files
- [x] End-to-end smoke on supervisor temp runner (:9880, fresh build with this change): `GET /ui-bridge/control/console-errors?level=debug` returns 128 debug entries on idle startup (was 0); `?level=info` returns 6; `?level=warn` returns 0; default returns 0
- [ ] CI green once SDK publishes — expected to fail at npm install until then

## Plan

`plans/2026-05-13-ui-bridge-console-capture-extension.md` (will archive to `qontinui-dev-notes/plans/` on merge).