### PR TITLE
chore(repro): add /Brepro + --build-id=none for byte-identical builds

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,6 +1,28 @@
 # Increase linker stack size to prevent STATUS_STACK_BUFFER_OVERRUN
-# when linking the large test binary on Windows.
-# Default MSVC stack is 1MB; this binary needs more due to deep
-# async-graphql type expansion and Tauri codegen.
+# when linking the large test binary on Windows. Default MSVC stack is
+# 1 MB; this binary needs more due to deep async-graphql type expansion
+# and Tauri codegen.
+#
+# /Brepro tells link.exe to zero the PE COFF timestamp and the RSDS
+# debug GUID so identical inputs produce byte-identical .exe / .pdb
+# outputs. Required by the content-addressed build cache rolled out in
+# Row 10 / Wave 0 — without it, two cargo builds of the same source
+# differ in 16 bytes at PE offset 107636 (the RSDS GUID is regenerated
+# per link), defeating cross-worktree CAS dedup. Spike artifacts at
+# tmp_spike_bazel_remote/ + memory `proj_canonical_diff_hash_recipe`
+# document the empirical proof.
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "link-args=/STACK:8388608"]
+rustflags = ["-C", "link-args=/STACK:8388608 /Brepro"]
+
+# Linux equivalent of /Brepro. ld embeds a per-link build-id by default,
+# which varies across builds of identical inputs. --build-id=none drops
+# the .note.gnu.build-id section so two builds produce byte-identical
+# ELFs. The build-id is only used by debuginfo-lookup tooling; ELFs
+# without it run normally, and the workspace profile already strips
+# debuginfo so nothing downstream depends on it. Same Row 10 / Wave 0
+# rationale.
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,--build-id=none"]
+
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,--build-id=none"]


### PR DESCRIPTION
## Summary
- Adds `/Brepro` to the Windows linker rustflags and `-Wl,--build-id=none` to the Linux linker rustflags in `src-tauri/.cargo/config.toml`.
- Required by the content-addressed build cache (Row 10 / Wave 0): without these, two cargo `--release` builds of the same source differ at the PE RSDS GUID (Windows, 16 bytes at offset 107636) / `.note.gnu.build-id` (Linux). That defeats cross-worktree CAS dedup because the `diff_sha` cache key collides while the artifact sha drifts.

## Verification
Two cargo `--release` builds of `mock_claude_cli` into separate target dirs on this branch produced byte-identical executables:
```
b37a1f9836ed4891346c8f2cb15589ce41e6bc2cb0fd2c18eaf52b135a0d3ecc *target-repro-A/release/mock_claude_cli.exe
b37a1f9836ed4891346c8f2cb15589ce41e6bc2cb0fd2c18eaf52b135a0d3ecc *target-repro-B/release/mock_claude_cli.exe
```

## Test plan
- [x] Local two-build sha256 check (Windows) — see Verification.
- [ ] CI: existing `Build Tauri app` step still passes with the added linker flags (validates the Windows STACK + Brepro combo).
- [ ] PR #2 (`ci/reproducibility-gate`) lands behind this and enforces this property going forward.

## Context
- Tracker: `plans/2026-05-14-row-10-implementation-tracker.md` Item 1.
- Spike artifacts: `tmp_spike_bazel_remote/` (repro recipe).
- Memory: `proj_canonical_diff_hash_recipe`.