### PR TITLE
feat(runner): worktree-per-agent spawn path (Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6217,10 +6217,14 @@ name = "qontinui-types"
 version = "0.1.3"
 dependencies = [
  "chrono",
+ "hex",
  "html-escape",
  "schemars 1.2.1",
  "serde",
+ "serde_jcs",
  "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
  "unicode-normalization",
  "uuid",
 ]

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -1,0 +1,305 @@
+//! Worktree-per-agent spawn path (Coordination Phase 1).
+//!
+//! Plan reference:
+//! `D:/qontinui-root/plans/2026-05-14-branch-per-agent-coordination-plan.md`
+//! §4.1. New code path that, on session creation, calls qontinui-coord's
+//! `POST /agents/allocate`, materializes the per-repo worktrees via
+//! `git worktree add`, and returns the agent_id + per-repo materialized
+//! paths so the caller (PTY-spawn, slash-command, UI) can use them as
+//! CWD.
+//!
+//! Gated behind the `QONTINUI_AGENT_WORKTREE_MODE` env var (default off).
+//! When off, this module is dead code — the existing shared-tree spawn
+//! path stays exclusively active. Reversible per the plan's Phase 7
+//! commit ("feature-flag-flip the new spawn path on for everyone,
+//! monitor a week, then delete").
+//!
+//! ## Scope (Phase 1)
+//!
+//! - Call coord `/agents/allocate` with `{ machine_id, repos: [{repo,
+//!   parent_sha}], intent? }`.
+//! - `git worktree add <suggested-path> -b <branch> <parent_sha>` for
+//!   each returned worktree row.
+//! - Return materialized rows.
+//!
+//! ## Not yet in scope
+//!
+//! - Cross-repo Cargo.toml path-dep rewriting. Memory
+//!   `feedback_worktree_path_dep_hooks` documents the gotcha for
+//!   committed rewrites; uncommitted rewrites get stashed by the
+//!   pre-commit cargo hook. Phase 1 surfaces the worktrees with the
+//!   path deps pointing at the **canonical** sibling tree (not the
+//!   sibling worktree). Cross-repo work that needs the sibling
+//!   worktree's HEAD is a follow-up (see tracker Row 5 "Cross-repo
+//!   path-deps").
+//! - Status lifecycle (`allocated → active`). Phase 1 writes the row
+//!   in `allocated` state via coord, and the runner doesn't yet
+//!   transition it. Phase 3+ (merge proposal API) drives the rest of
+//!   the state machine.
+//! - Cleanup of materialized worktrees. The sweeper on coord prunes
+//!   `coord.agent_worktrees` rows; pruning the on-disk worktree
+//!   directories is Phase 6+ territory.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+
+use crate::worktree::run_git_command;
+
+/// Env var that turns the new spawn path on. Default off — `feature
+/// flag agent_worktree_mode` per plan §5 Phase 1.
+const FLAG_ENV: &str = "QONTINUI_AGENT_WORKTREE_MODE";
+
+/// Returns true iff the worktree-per-agent spawn mode is enabled.
+/// Accepts the usual truthy values; anything else (including unset) is
+/// false.
+pub fn worktree_mode_enabled() -> bool {
+    matches!(
+        std::env::var(FLAG_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("YES")
+    )
+}
+
+/// A repo the caller wants a worktree for, paired with the commit the
+/// worktree should branch off of. The runner is the host so it
+/// resolves `parent_sha` from its own checkout — coord doesn't
+/// re-resolve.
+#[derive(Debug, Clone, Serialize)]
+pub struct RepoRequest {
+    pub repo: String,
+    pub parent_sha: String,
+}
+
+/// A single materialized worktree as returned by `allocate_and_materialize`.
+/// `worktree_path` is the actual on-disk path the runner created (matches
+/// coord's `suggested_path` in the happy path, but the runner is allowed
+/// to deviate — e.g. tighter disk).
+#[derive(Debug, Clone, Serialize)]
+pub struct MaterializedWorktree {
+    pub repo: String,
+    pub branch: String,
+    pub parent_sha: String,
+    pub worktree_path: PathBuf,
+}
+
+/// Result of a full allocate + materialize round-trip.
+#[derive(Debug, Clone, Serialize)]
+pub struct AllocateResult {
+    pub agent_id: String,
+    pub worktrees: Vec<MaterializedWorktree>,
+}
+
+/// Coord's JSON response shape for `POST /agents/allocate`. Mirrored
+/// here so we don't have to share a crate just for two structs.
+#[derive(Debug, Deserialize)]
+struct CoordAllocateResponse {
+    agent_id: String,
+    worktrees: Vec<CoordAllocatedWorktree>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CoordAllocatedWorktree {
+    repo: String,
+    branch: String,
+    parent_sha: String,
+    worktree_path: String,
+    #[allow(dead_code)]
+    status: String,
+}
+
+/// Call coord's `/agents/allocate` and then `git worktree add` for each
+/// returned row.
+///
+/// `coord_http_base` is the HTTP base URL of qontinui-coord (e.g.
+/// `http://localhost:9870`). The runner's profile stores `coord_url` as
+/// a `ws://` URL — callers should convert via [`coord_ws_to_http`]
+/// before calling here.
+///
+/// `repo_canonical_paths` maps `repo` slug to the canonical checkout
+/// path on the runner's host. The runner's host typically holds one
+/// canonical checkout per repo at `D:/qontinui-root/<repo>/`; this map
+/// is the dependency injection point so tests can substitute scratch
+/// repos.
+///
+/// On success returns `AllocateResult`. On any error, returns a
+/// caller-readable string. Partial failure is handled at the boundary:
+/// if any `git worktree add` fails after coord has minted rows, the
+/// partial materialization stops; coord's sweeper will eventually
+/// reclaim the unused rows once they age into `abandoned`.
+pub async fn allocate_and_materialize(
+    coord_http_base: &str,
+    machine_id: &uuid::Uuid,
+    repos: &[RepoRequest],
+    intent: Option<&str>,
+    repo_canonical_paths: &std::collections::HashMap<String, PathBuf>,
+) -> Result<AllocateResult, String> {
+    if !worktree_mode_enabled() {
+        return Err(format!(
+            "{} is not enabled; spawn path is disabled",
+            FLAG_ENV
+        ));
+    }
+    if repos.is_empty() {
+        return Err("repos must not be empty".to_string());
+    }
+
+    // Pre-flight: every requested repo must have a canonical path the
+    // runner can `git worktree add` from. Surface this before bothering
+    // coord with the request.
+    for r in repos {
+        if !repo_canonical_paths.contains_key(&r.repo) {
+            return Err(format!(
+                "no canonical checkout known for repo '{}' — pass it in \
+                 repo_canonical_paths",
+                r.repo
+            ));
+        }
+    }
+
+    let body = serde_json::json!({
+        "machine_id": machine_id.to_string(),
+        "repos": repos.iter().map(|r| serde_json::json!({
+            "repo": r.repo,
+            "parent_sha": r.parent_sha,
+        })).collect::<Vec<_>>(),
+        "intent": intent,
+    });
+
+    let url = format!("{}/agents/allocate", coord_http_base.trim_end_matches('/'));
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body_text = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "POST {url} returned {} — body: {}",
+            status.as_u16(),
+            body_text
+        ));
+    }
+    let coord_resp: CoordAllocateResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("decode coord response: {e}"))?;
+
+    info!(
+        "coord allocated agent_id={} repos={}",
+        coord_resp.agent_id,
+        coord_resp.worktrees.len()
+    );
+
+    let mut materialized: Vec<MaterializedWorktree> = Vec::with_capacity(repos.len());
+    for w in coord_resp.worktrees {
+        let canonical = repo_canonical_paths
+            .get(&w.repo)
+            .ok_or_else(|| format!("missing canonical path for repo '{}'", w.repo))?;
+        let target = PathBuf::from(&w.worktree_path);
+
+        // Ensure the parent dir exists. `git worktree add` will create
+        // the leaf, but the parent (`D:/qontinui-root.wt/<agent>/`)
+        // doesn't exist on first allocation.
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                format!(
+                    "create parent dir {} for worktree {}: {}",
+                    parent.display(),
+                    w.repo,
+                    e
+                )
+            })?;
+        }
+
+        // `git -C <canonical> worktree add <target> -b <branch> <parent_sha>`.
+        // Plan §4.1 step 4 spelled this exact command.
+        let target_str = target.to_string_lossy().to_string();
+        let args: [&str; 6] = [
+            "worktree",
+            "add",
+            &target_str,
+            "-b",
+            &w.branch,
+            &w.parent_sha,
+        ];
+        match run_git_command(canonical, &args) {
+            Ok(stdout) => {
+                info!(
+                    "git worktree add ok: repo={} branch={} path={} stdout={}",
+                    w.repo,
+                    w.branch,
+                    target.display(),
+                    stdout.trim()
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "git worktree add failed: repo={} branch={} path={}: {}",
+                    w.repo,
+                    w.branch,
+                    target.display(),
+                    e
+                );
+                return Err(format!(
+                    "git worktree add for repo '{}' (branch {}) failed: {}",
+                    w.repo, w.branch, e
+                ));
+            }
+        }
+
+        materialized.push(MaterializedWorktree {
+            repo: w.repo,
+            branch: w.branch,
+            parent_sha: w.parent_sha,
+            worktree_path: target,
+        });
+    }
+
+    Ok(AllocateResult {
+        agent_id: coord_resp.agent_id,
+        worktrees: materialized,
+    })
+}
+
+/// Convert a `ws://` or `wss://` coord URL into the matching HTTP base.
+/// Profiles store `coord_url` as a WebSocket URL because the `/ws`
+/// endpoint is the dominant runner-side use case; HTTP callers (this
+/// module, build_events POSTs) flip the scheme.
+pub fn coord_ws_to_http(coord_url: &str) -> String {
+    if let Some(rest) = coord_url.strip_prefix("ws://") {
+        format!("http://{}", rest)
+    } else if let Some(rest) = coord_url.strip_prefix("wss://") {
+        format!("https://{}", rest)
+    } else {
+        coord_url.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn flag_off_by_default() {
+        // Tests run with no env var set unless tested explicitly. We
+        // don't mutate process env here because the runner test
+        // harness mutates env globally (memory
+        // `feedback_env_var_tests_serialize`); this assertion holds
+        // as long as no test sets QONTINUI_AGENT_WORKTREE_MODE before
+        // this runs.
+        if std::env::var(FLAG_ENV).is_err() {
+            assert!(!worktree_mode_enabled());
+        }
+    }
+
+    #[test]
+    fn coord_ws_to_http_swaps_scheme() {
+        assert_eq!(coord_ws_to_http("ws://h:9870"), "http://h:9870");
+        assert_eq!(coord_ws_to_http("wss://h:9870"), "https://h:9870");
+        assert_eq!(coord_ws_to_http("http://h:9870"), "http://h:9870");
+        assert_eq!(coord_ws_to_http("https://h:9870"), "https://h:9870");
+    }
+}

--- a/src-tauri/src/coordinator/scheduler.rs
+++ b/src-tauri/src/coordinator/scheduler.rs
@@ -165,6 +165,17 @@ pub fn start_coordinator_scheduler(
             );
         }
 
+        // Coordination Phase 1 (branch-per-agent): self-heal
+        // coord.agent_worktrees. Idempotent. Logs but doesn't fail —
+        // when the table is missing, /agents/allocate-local will
+        // surface the error from coord rather than from the runner.
+        if let Err(e) = state.app_state.pg_db.ensure_agent_worktrees_table().await {
+            warn!(
+                "Coordinator scheduler: ensure_agent_worktrees_table failed: {} — agent worktree allocation may fail until alembic upgrade",
+                e
+            );
+        }
+
         info!(
             "Coordinator (Rust) scheduler started: instance_id={} interval={}s rule_version={} max_llm_calls_per_hour={} auto_review_enabled={} shadow_mode_enabled={} initial_enabled={}",
             instance_id,

--- a/src-tauri/src/database/pg/agent_worktrees.rs
+++ b/src-tauri/src/database/pg/agent_worktrees.rs
@@ -117,7 +117,7 @@ impl PgDb {
                 created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
                 updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
                 PRIMARY KEY (agent_id, repo),
-                CONSTRAINT agent_worktrees_branch_uq UNIQUE (branch)
+                CONSTRAINT agent_worktrees_repo_branch_uq UNIQUE (repo, branch)
             );
 
             DO $$

--- a/src-tauri/src/database/pg/agent_worktrees.rs
+++ b/src-tauri/src/database/pg/agent_worktrees.rs
@@ -1,0 +1,206 @@
+//! PostgreSQL CRUD for `coord.agent_worktrees` — the per-(agent, repo)
+//! durable row that backs the worktree-per-agent spawn model.
+//!
+//! Plan reference:
+//! `D:/qontinui-root/plans/2026-05-14-branch-per-agent-coordination-plan.md`
+//! §4.1 + §4.2. The schema is defined authoritatively in alembic revision
+//! `coord_phase_1_01_agent_worktrees`; this module mirrors it via the
+//! self-heal pattern documented in memory
+//! [[proj_pg_dual_schema_runner_public]] — the runner can write rows
+//! without waiting for qontinui-web's alembic upgrade to run.
+//!
+//! Column shapes match §4.2 exactly. Downstream phases (merge proposals,
+//! merge scheduler, observability heatmap) read this table, so the names
+//! and types here are a contract.
+
+use super::PgDb;
+use serde::{Deserialize, Serialize};
+
+/// Status enum mapped to TEXT in PG with a CHECK constraint. We hold the
+/// string form in Rust because it makes JSON encoding / WS event payloads
+/// transparent. Allowed transitions: `Allocated` → `Active` → `Merging`
+/// → `Merged` / `Abandoned`. The runner only ever writes `Allocated` and
+/// `Active`; coord's merge scheduler advances to the terminal states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentWorktreeStatus {
+    Allocated,
+    Active,
+    Merging,
+    Merged,
+    Abandoned,
+}
+
+impl AgentWorktreeStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AgentWorktreeStatus::Allocated => "allocated",
+            AgentWorktreeStatus::Active => "active",
+            AgentWorktreeStatus::Merging => "merging",
+            AgentWorktreeStatus::Merged => "merged",
+            AgentWorktreeStatus::Abandoned => "abandoned",
+        }
+    }
+}
+
+/// One row from `coord.agent_worktrees`. UUIDs surface as TEXT because
+/// `tokio-postgres` in this crate doesn't always enable `with-uuid-1`
+/// (same convention as `coordinator_shadow_decisions.rs`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentWorktreeRow {
+    pub agent_id: String,
+    pub machine_id: Option<String>,
+    pub repo: String,
+    pub branch: String,
+    pub parent_sha: String,
+    pub worktree_path: String,
+    pub status: String,
+    pub intent: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+const SELECT_COLS: &str = r#"
+    agent_id::text, machine_id::text, repo, branch, parent_sha,
+    worktree_path, status, intent, created_at::text, updated_at::text
+"#;
+
+fn row_to_aw(r: &tokio_postgres::Row) -> AgentWorktreeRow {
+    AgentWorktreeRow {
+        agent_id: r.get(0),
+        machine_id: r.get(1),
+        repo: r.get(2),
+        branch: r.get(3),
+        parent_sha: r.get(4),
+        worktree_path: r.get(5),
+        status: r.get(6),
+        intent: r.get(7),
+        created_at: r.get(8),
+        updated_at: r.get(9),
+    }
+}
+
+impl PgDb {
+    /// Self-heal `coord.agent_worktrees` on PG instances where the
+    /// alembic migration hasn't been applied yet. Idempotent — uses
+    /// `CREATE TABLE IF NOT EXISTS` plus a DO-block that conditionally
+    /// adds the CHECK constraint. Mirrors the
+    /// `ensure_shadow_decisions_table` / `ensure_coord_tasks_emergent_columns`
+    /// self-heal helpers already in this crate.
+    ///
+    /// Schema must stay byte-equivalent to the alembic migration
+    /// `coord_phase_1_01_agent_worktrees`. Both shapes are the §4.2
+    /// contract; downstream phases will fail in interesting ways if
+    /// the two drift.
+    pub async fn ensure_agent_worktrees_table(&self) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        conn.batch_execute(
+            r#"
+            CREATE SCHEMA IF NOT EXISTS coord;
+
+            CREATE TABLE IF NOT EXISTS coord.agent_worktrees (
+                agent_id       UUID NOT NULL,
+                machine_id     UUID REFERENCES coord.machines(machine_id)
+                                   ON DELETE SET NULL,
+                repo           TEXT NOT NULL,
+                branch         TEXT NOT NULL,
+                parent_sha     TEXT NOT NULL,
+                worktree_path  TEXT NOT NULL,
+                status         TEXT NOT NULL DEFAULT 'allocated',
+                intent         TEXT,
+                created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (agent_id, repo),
+                CONSTRAINT agent_worktrees_branch_uq UNIQUE (branch)
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'agent_worktrees_status_chk'
+                ) THEN
+                    ALTER TABLE coord.agent_worktrees
+                        ADD CONSTRAINT agent_worktrees_status_chk
+                        CHECK (status IN ('allocated','active','merging','merged','abandoned'));
+                END IF;
+            END$$;
+
+            CREATE INDEX IF NOT EXISTS idx_agent_worktrees_status
+                ON coord.agent_worktrees (status, updated_at DESC);
+            CREATE INDEX IF NOT EXISTS idx_agent_worktrees_machine_status
+                ON coord.agent_worktrees (machine_id, status)
+                WHERE machine_id IS NOT NULL;
+            "#,
+        )
+        .await
+        .map_err(|e| format!("Failed to ensure coord.agent_worktrees: {}", e))
+    }
+
+    /// Fetch all worktree rows for a given agent. Ordered by repo for
+    /// deterministic iteration when the spawn path materializes the
+    /// worktrees one-by-one.
+    pub async fn list_agent_worktrees(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<AgentWorktreeRow>, String> {
+        let agent_uuid = uuid::Uuid::parse_str(agent_id)
+            .map_err(|e| format!("agent_id is not a valid UUID: {}", e))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        let rows = conn
+            .query(
+                &format!(
+                    "SELECT {} FROM coord.agent_worktrees \
+                     WHERE agent_id = $1 ORDER BY repo",
+                    SELECT_COLS
+                ),
+                &[&agent_uuid],
+            )
+            .await
+            .map_err(|e| format!("Failed to list agent_worktrees: {}", e))?;
+        Ok(rows.iter().map(row_to_aw).collect())
+    }
+
+    /// Transition a single worktree row's status. Used by the runner
+    /// when it materializes the worktree (`allocated` → `active`) and
+    /// when the merge scheduler later advances it. Returns the post-
+    /// update row, or an error if no row matched.
+    pub async fn update_agent_worktree_status(
+        &self,
+        agent_id: &str,
+        repo: &str,
+        new_status: AgentWorktreeStatus,
+    ) -> Result<AgentWorktreeRow, String> {
+        let agent_uuid = uuid::Uuid::parse_str(agent_id)
+            .map_err(|e| format!("agent_id is not a valid UUID: {}", e))?;
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        let row = conn
+            .query_one(
+                &format!(
+                    "UPDATE coord.agent_worktrees \
+                     SET status = $3, updated_at = now() \
+                     WHERE agent_id = $1 AND repo = $2 \
+                     RETURNING {}",
+                    SELECT_COLS
+                ),
+                &[&agent_uuid, &repo, &new_status.as_str()],
+            )
+            .await
+            .map_err(|e| format!("Failed to update agent_worktree status: {}", e))?;
+        Ok(row_to_aw(&row))
+    }
+}

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod activity_timeline;
 pub mod adaptive_learning;
+pub mod agent_worktrees;
 pub mod agentic_metrics;
 pub mod ai_sessions;
 pub mod approval_gates;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod action_service;
+mod agent_worktree;
 mod agentic_verification;
 mod ai_pricing;
 mod ai_provider;

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -1,0 +1,205 @@
+//! HTTP endpoint that drives the worktree-per-agent spawn path
+//! (Coordination Phase 1).
+//!
+//! `POST /agents/allocate-local` — runner-side wrapper that:
+//!
+//! 1. Calls qontinui-coord `POST /agents/allocate` (HTTP).
+//! 2. Runs `git worktree add` for each returned per-repo row.
+//! 3. Returns `{ agent_id, worktrees: [{repo, branch, parent_sha,
+//!    worktree_path}] }` so the caller (PTY-spawn, slash-command, UI)
+//!    can use `worktrees[].worktree_path` as the terminal CWD.
+//!
+//! Gated behind env var `QONTINUI_AGENT_WORKTREE_MODE` (default off).
+//! When off, the endpoint returns 503 with an actionable message.
+//!
+//! The endpoint exists only on the runner because each runner is the
+//! "spawning host" in plan §4.1 — it owns the canonical checkouts and
+//! the filesystem the worktrees live on. Cross-machine spawn is Phase 5
+//! territory and uses the same coord `/agents/allocate` underneath.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde::Deserialize;
+use serde_json::json;
+use tracing::{info, warn};
+
+use crate::agent_worktree::{
+    allocate_and_materialize, coord_ws_to_http, worktree_mode_enabled, RepoRequest,
+};
+use crate::mcp::types::{api_error, ApiResponse, ApiState};
+
+/// Body of `POST /agents/allocate-local`.
+#[derive(Debug, Deserialize)]
+pub struct AllocateLocalRequest {
+    /// One per repo the agent will work in. The runner reads
+    /// `parent_sha` from the caller (so callers that depend on a
+    /// specific HEAD can pin it). Empty list → 400.
+    pub repos: Vec<AllocateLocalRepo>,
+    /// Optional opaque human-readable intent. Echoed back into
+    /// `coord.agent_worktrees.intent`.
+    #[serde(default)]
+    pub intent: Option<String>,
+    /// Optional override of the canonical-checkout path for each repo.
+    /// Map of `repo` slug to absolute path. When not provided for a
+    /// given repo, defaults to `D:/qontinui-root/<repo>/` (Windows)
+    /// or `$HOME/qontinui-root/<repo>/` (POSIX).
+    #[serde(default)]
+    pub repo_canonical_paths: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AllocateLocalRepo {
+    pub repo: String,
+    pub parent_sha: String,
+}
+
+/// `POST /agents/allocate-local` handler.
+pub async fn post_allocate_local(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<AllocateLocalRequest>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    if !worktree_mode_enabled() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(api_error(
+                "agent_worktree_mode is off (set QONTINUI_AGENT_WORKTREE_MODE=1 \
+                 on the runner to enable)",
+            )),
+        ));
+    }
+    if req.repos.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(api_error("repos must not be empty")),
+        ));
+    }
+
+    let machine_id = read_machine_id().map_err(|e| {
+        warn!("/agents/allocate-local: machine_id load failed: {e}");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(api_error(format!(
+                "machine_id not available: {} — run `qontinui_profile machine init`",
+                e
+            ))),
+        )
+    })?;
+
+    let coord_http_base = coord_http_base().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(api_error(format!("coord URL not configured: {}", e))),
+        )
+    })?;
+
+    let canonical_paths = build_canonical_paths(&req.repos, &req.repo_canonical_paths);
+    let repo_reqs: Vec<RepoRequest> = req
+        .repos
+        .iter()
+        .map(|r| RepoRequest {
+            repo: r.repo.clone(),
+            parent_sha: r.parent_sha.clone(),
+        })
+        .collect();
+
+    match allocate_and_materialize(
+        &coord_http_base,
+        &machine_id,
+        &repo_reqs,
+        req.intent.as_deref(),
+        &canonical_paths,
+    )
+    .await
+    {
+        Ok(result) => {
+            info!(
+                "/agents/allocate-local ok: agent_id={} repos={}",
+                result.agent_id,
+                result.worktrees.len()
+            );
+            Ok(Json(ApiResponse::success(json!({
+                "agent_id": result.agent_id,
+                "worktrees": result.worktrees.iter().map(|w| json!({
+                    "repo": w.repo,
+                    "branch": w.branch,
+                    "parent_sha": w.parent_sha,
+                    "worktree_path": w.worktree_path.to_string_lossy(),
+                })).collect::<Vec<_>>(),
+            }))))
+        }
+        Err(e) => {
+            warn!("/agents/allocate-local failed: {e}");
+            Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(api_error(format!("allocate_and_materialize: {}", e))),
+            ))
+        }
+    }
+}
+
+fn read_machine_id() -> Result<uuid::Uuid, String> {
+    let path = dirs::home_dir()
+        .map(|h| h.join(".qontinui").join("machine.json"))
+        .ok_or_else(|| "no HOME dir".to_string())?;
+    let bytes = std::fs::read(&path)
+        .map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let id_str = v
+        .get("machine_id")
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| format!("{}: missing machine_id", path.display()))?;
+    uuid::Uuid::parse_str(id_str).map_err(|e| format!("invalid UUID: {}", e))
+}
+
+fn coord_http_base() -> Result<String, String> {
+    // Source-of-truth chain: env `COORD_HTTP_URL` → profile `coord_url`
+    // (ws→http) → default `http://localhost:9870`.
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        if !v.is_empty() {
+            return Ok(v);
+        }
+    }
+    let profile = qontinui_runner_lib::profiles::load();
+    if let Some(ws) = profile.coord_url.as_deref() {
+        return Ok(coord_ws_to_http(ws));
+    }
+    Ok("http://localhost:9870".to_string())
+}
+
+fn build_canonical_paths(
+    repos: &[AllocateLocalRepo],
+    override_map: &HashMap<String, String>,
+) -> HashMap<String, PathBuf> {
+    let mut out: HashMap<String, PathBuf> = HashMap::new();
+    for r in repos {
+        let path = if let Some(p) = override_map.get(&r.repo) {
+            PathBuf::from(p)
+        } else {
+            default_canonical_path(&r.repo)
+        };
+        out.insert(r.repo.clone(), path);
+    }
+    out
+}
+
+#[cfg(target_os = "windows")]
+fn default_canonical_path(repo: &str) -> PathBuf {
+    PathBuf::from(format!("D:/qontinui-root/{}", repo))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn default_canonical_path(repo: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(format!("{}/qontinui-root/{}", home, repo))
+}
+
+pub fn routes() -> axum::Router<Arc<ApiState>> {
+    use axum::routing::post;
+    axum::Router::new().route("/agents/allocate-local", post(post_allocate_local))
+}

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -146,10 +146,9 @@ fn read_machine_id() -> Result<uuid::Uuid, String> {
     let path = dirs::home_dir()
         .map(|h| h.join(".qontinui").join("machine.json"))
         .ok_or_else(|| "no HOME dir".to_string())?;
-    let bytes = std::fs::read(&path)
-        .map_err(|e| format!("read {}: {}", path.display(), e))?;
-    let v: serde_json::Value = serde_json::from_slice(&bytes)
-        .map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let bytes = std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let v: serde_json::Value =
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {}", path.display(), e))?;
     let id_str = v
         .get("machine_id")
         .and_then(|s| s.as_str())

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -15,6 +15,7 @@
 pub mod accessibility;
 pub mod action_plan_cache;
 pub mod adb_helper;
+pub mod agent_worktrees;
 pub mod ai_generation;
 pub mod ai_network_probe;
 pub mod ai_session;

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1628,6 +1628,7 @@ pub fn create_router(
         .merge(crate::mcp::websocket::routes())
         .merge(crate::mcp::window_manager::routes())
         .merge(crate::mcp::worktrees::routes())
+        .merge(crate::mcp::agent_worktrees::routes())
         .merge(crate::mcp::token_analytics::routes())
         .merge(crate::mcp::otel_status::routes())
         .merge(crate::mcp::container_status::routes())


### PR DESCRIPTION
## Summary
- Implements §4.1 of the [branch-per-agent coordination plan](D:/qontinui-root/plans/2026-05-14-branch-per-agent-coordination-plan.md): `POST /agents/allocate-local` calls coord `/agents/allocate`, runs `git worktree add` per returned row, returns `worktree_path`s the caller can set as terminal CWD
- Gated behind `QONTINUI_AGENT_WORKTREE_MODE` env var (default off). Old spawn path stays exclusively active when flag is off — fully reversible per plan §5
- `ensure_agent_worktrees_table` self-heal mirrors the alembic schema; called from the coordinator scheduler boot path alongside the existing `ensure_*` helpers
- `coord_ws_to_http` profile helper turns `ws://` → `http://` for the HTTP client

## Companion PRs
- qontinui-web `coord-phase-1-agent-worktrees` — alembic migration  
- qontinui-coord `coord-phase-1-agent-worktrees` — `POST /agents/allocate` endpoint + sweeper

## Compile note
- 5 pre-existing main errors remain (qontinui_types::ir spec-check API drift, documented in session memory). My modules add zero new errors. Lib-only test compile clean.

## Phase 1 scope (intentional follow-ups)
- Cross-repo path-dep rewriting (tracker Row 5) — see commit msg
- `allocated → active` lifecycle transition — Phase 3+ territory
- On-disk worktree cleanup — Phase 6+