### PR TITLE
fix(repro-gate): build frontend before cargo so generate_context! finds dist/

### DIFF
--- a/.github/workflows/reproducibility-gate.yml
+++ b/.github/workflows/reproducibility-gate.yml
@@ -134,11 +134,13 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            src-tauri/target/
+            target/
           key: ${{ runner.os }}-repro-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      # First build: full compile (cold cache) or relink (warm cache).
-      # Either way, produces target/release/mock_claude_cli{,.exe}.
+      # qontinui-runner/Cargo.toml is the workspace root with src-tauri/
+      # as a member, so cargo invoked from src-tauri/ resolves the
+      # workspace upward and outputs to <workspace_root>/target/, NOT
+      # src-tauri/target/. All subsequent steps reference $GITHUB_WORKSPACE/target.
       - name: Build #1
         env:
           CARGO_BUILD_JOBS: 1
@@ -150,15 +152,14 @@ jobs:
       - name: Hash build #1 artifact
         id: hash1
         run: |
-          cd src-tauri
           if [ "$RUNNER_OS" = "Windows" ]; then
-            EXE=target/release/mock_claude_cli.exe
+            EXE="$GITHUB_WORKSPACE/target/release/mock_claude_cli.exe"
           else
-            EXE=target/release/mock_claude_cli
+            EXE="$GITHUB_WORKSPACE/target/release/mock_claude_cli"
           fi
           if [ ! -f "$EXE" ]; then
             echo "FAIL: expected artifact at $EXE not found"
-            ls -la target/release/ | head -30
+            ls -la "$GITHUB_WORKSPACE/target/release/" | head -30 || true
             exit 1
           fi
           HASH=$(sha256sum "$EXE" | awk '{print $1}')
@@ -190,11 +191,10 @@ jobs:
 
       - name: Hash build #2 artifact and compare
         run: |
-          cd src-tauri
           if [ "$RUNNER_OS" = "Windows" ]; then
-            EXE=target/release/mock_claude_cli.exe
+            EXE="$GITHUB_WORKSPACE/target/release/mock_claude_cli.exe"
           else
-            EXE=target/release/mock_claude_cli
+            EXE="$GITHUB_WORKSPACE/target/release/mock_claude_cli"
           fi
           HASH2=$(sha256sum "$EXE" | awk '{print $1}')
           HASH1='${{ steps.hash1.outputs.hash1 }}'

--- a/.github/workflows/reproducibility-gate.yml
+++ b/.github/workflows/reproducibility-gate.yml
@@ -102,6 +102,30 @@ jobs:
           sudo mkswap /swapfile
           sudo swapon /swapfile
 
+      # The runner's lib.rs calls tauri::generate_context!() at compile
+      # time, which reads tauri.conf.json and panics if frontendDist
+      # (../dist) is missing. mock_claude_cli is in the same package as
+      # the lib, so building --bin mock_claude_cli still triggers the lib
+      # compile path. Build the frontend first so dist/ exists. Same
+      # pattern as ci.yml's "Build frontend" step.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend (creates dist/ for tauri::generate_context!)
+        run: pnpm run build
+
       - name: Cache Rust dependencies
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Summary
The reproducibility gate landed in #125 has been failing on every PR since merge — every CI run errors at ~13 min with `tauri::generate_context!()` panic: "frontendDist configuration is set to ../dist but this path doesn't exist".

`mock_claude_cli` lives in the same package as the runner lib, so `cargo build --bin mock_claude_cli` drags the lib's compile path along, which means the proc macro fires and needs `dist/`.

`ci.yml` works around this with `pnpm install` + `pnpm run build` before the cargo step; this gate had no equivalent. Adding the same steps.

## Verification
- [x] Manual repro of the failure: [run 25861380672](https://github.com/qontinui/qontinui-runner/actions/runs/25861380672) — both Ubuntu and Windows died on the proc-macro panic, never reached the sha256 comparison.
- [ ] Post-merge: first triggered run should reach Build #2 + the hash comparison and (assuming /Brepro / --build-id=none are still wired correctly) report PASS.

## Context
Companion fix to #125 (Wave 0 Item 2). Caught after the IR-breakage on main was unblocked and Rust-touching PRs started running the gate cleanly enough to surface this skip.