### PR TITLE
deps(ui-bridge): consume @qontinui/ui-bridge@^0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.2.5",
-    "@qontinui/ui-bridge": "^0.7.0",
+    "@qontinui/ui-bridge": "^0.8.0",
     "@qontinui/ui-bridge-auto": "^0.1.5",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,13 +22,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.7.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.8.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.2.5
         version: 0.2.5
       '@qontinui/ui-bridge':
-        specifier: ^0.7.0
-        version: 0.7.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.8.0
+        version: 0.8.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.5
         version: 0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1170,8 +1170,8 @@ packages:
       ws:
         optional: true
 
-  '@qontinui/ui-bridge@0.7.0':
-    resolution: {integrity: sha512-ODXnVffL7ULlsK+njLsLQ3caeHv6lKBKhWVtvWmYAdcbrIakLuCOQYtqT7uKihuRx0iGgm8RjUdNaSf4uixy1w==}
+  '@qontinui/ui-bridge@0.8.0':
+    resolution: {integrity: sha512-2aci0OE8pkWp6Ixo0yzc1IoIlMkfx1/+jzlVXqs6LnkcNzA6dbap/h3ptvjLJKRmNLEmxc8AdQOFH5UwEeTLBg==}
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
       '@qontinui/ui-bridge-headless': '>=0.1.0'
@@ -6133,9 +6133,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.7.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.8.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.7.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.8.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.2.5': {}
@@ -6171,7 +6171,7 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       ws: 8.20.0
 
-  '@qontinui/ui-bridge@0.7.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.8.0(@qontinui/ui-bridge-auto@0.1.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       dom-accessibility-api: 0.5.16
       react: 19.2.5


### PR DESCRIPTION
Bumps the runner's \`@qontinui/ui-bridge\` dep from \`^0.7.0\` to \`^0.8.0\`. New SDK ships:

1. \`window.__UI_BRIDGE__.mutationOccurred()\` helper — fire-and-forget client for the runner's mutation-counter signal endpoint. Closes Phase 6 Gap B.
2. Catch-up of \`UI_BRIDGE_ROUTES\` manifest declaring all 7 Phase 3.3/4/6 runner-direct routes (extract, describe, analyze, assert, baseline, baselines, mutation-occurred). Unblocks the \`sdk_manifest_routes_are_exposed_by_runner\` drift test.

## Test plan
- [x] typecheck clean
- [x] pnpm-lock has 0.8.0 pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)