### PR TITLE
feat(coord-pg): ensure coord.merge_proposals tables (Phase 3 §4.5)

### DIFF
--- a/src-tauri/src/coordinator/scheduler.rs
+++ b/src-tauri/src/coordinator/scheduler.rs
@@ -176,6 +176,19 @@ pub fn start_coordinator_scheduler(
             );
         }
 
+        // Coordination Phase 3 (merge proposal API): self-heal
+        // coord.merge_proposals + coord.merge_proposal_repos. Idempotent.
+        // Logs but doesn't fail — runner doesn't write these tables
+        // directly today, but the local-coord harness does, and a
+        // fresh dev DB whose alembic chain hasn't reached Phase 3 yet
+        // benefits from the self-heal.
+        if let Err(e) = state.app_state.pg_db.ensure_merge_proposals_tables().await {
+            warn!(
+                "Coordinator scheduler: ensure_merge_proposals_tables failed: {} — /merge/* endpoints may fail until alembic upgrade",
+                e
+            );
+        }
+
         info!(
             "Coordinator (Rust) scheduler started: instance_id={} interval={}s rule_version={} max_llm_calls_per_hour={} auto_review_enabled={} shadow_mode_enabled={} initial_enabled={}",
             instance_id,

--- a/src-tauri/src/database/pg/merge_proposals.rs
+++ b/src-tauri/src/database/pg/merge_proposals.rs
@@ -1,0 +1,96 @@
+//! Self-heal helper for `coord.merge_proposals` + `coord.merge_proposal_repos`.
+//!
+//! Plan reference:
+//! `D:/qontinui-root/plans/2026-05-14-branch-per-agent-coordination-plan.md`
+//! §4.5 (Merge proposal API). The schema is authored authoritatively in
+//! alembic revision `coord_phase_3_01_merge_proposals`; this module mirrors
+//! it via the self-heal pattern documented in memory
+//! [[proj_pg_dual_schema_runner_public]] — the runner can ensure the
+//! tables exist without waiting for qontinui-web's alembic upgrade to run.
+//!
+//! Unlike `agent_worktrees.rs`, the runner does NOT execute write paths
+//! against these tables — `POST /merge/propose` and its siblings live
+//! entirely in qontinui-coord. The ensure_* helper is provided so a
+//! runner-driven local-coord harness (or a fresh dev database whose
+//! alembic chain hasn't reached Phase 3 yet) can still allocate the
+//! tables before coord first writes to them. Schema must stay
+//! byte-equivalent to the alembic migration — downstream phases (Phase
+//! 4 scheduler) depend on the column shape.
+
+use super::PgDb;
+
+impl PgDb {
+    /// Self-heal `coord.merge_proposals` + `coord.merge_proposal_repos`.
+    /// Idempotent — `CREATE TABLE IF NOT EXISTS` + `ADD CONSTRAINT IF
+    /// NOT EXISTS` pattern, matching the convention in
+    /// `ensure_agent_worktrees_table`.
+    ///
+    /// Allowed `status` values are kept in sync with the alembic CHECK
+    /// constraint and the Rust enum in `qontinui-coord/src/merge.rs`.
+    pub async fn ensure_merge_proposals_tables(&self) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        conn.batch_execute(
+            r#"
+            CREATE SCHEMA IF NOT EXISTS coord;
+
+            CREATE TABLE IF NOT EXISTS coord.merge_proposals (
+                proposal_id        UUID PRIMARY KEY,
+                agent_id           UUID NOT NULL,
+                description        TEXT,
+                requires_clean_ci  BOOLEAN NOT NULL DEFAULT true,
+                status             TEXT NOT NULL DEFAULT 'queued',
+                error              TEXT,
+                cancelled_at       TIMESTAMPTZ,
+                merged_at          TIMESTAMPTZ,
+                created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+                updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+            );
+
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conname = 'merge_proposals_status_chk'
+                ) THEN
+                    ALTER TABLE coord.merge_proposals
+                        ADD CONSTRAINT merge_proposals_status_chk
+                        CHECK (status IN (
+                            'queued', 'dry-rebasing', 'awaiting-ci',
+                            'landing', 'blocked-by-overlap', 'conflict',
+                            'merged', 'cancelled'
+                        ));
+                END IF;
+            END$$;
+
+            CREATE INDEX IF NOT EXISTS idx_merge_proposals_status
+                ON coord.merge_proposals (status, proposal_id DESC);
+            CREATE INDEX IF NOT EXISTS idx_merge_proposals_agent_id
+                ON coord.merge_proposals (agent_id);
+
+            CREATE TABLE IF NOT EXISTS coord.merge_proposal_repos (
+                proposal_id     UUID NOT NULL REFERENCES coord.merge_proposals(proposal_id)
+                                ON DELETE CASCADE,
+                repo            TEXT NOT NULL,
+                branch          TEXT NOT NULL,
+                head_sha        TEXT NOT NULL,
+                rebase_result   JSONB,
+                conflict_diff   TEXT,
+                ci_run_url      TEXT,
+                overlap_paths   TEXT[],
+                created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (proposal_id, repo)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_merge_proposal_repos_head_sha
+                ON coord.merge_proposal_repos (repo, head_sha);
+            "#,
+        )
+        .await
+        .map_err(|e| format!("Failed to ensure coord.merge_proposal* tables: {}", e))
+    }
+}

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -45,6 +45,7 @@ pub mod learned_patterns_ops;
 pub mod learning;
 pub mod log_sources;
 pub mod memory_query_cache;
+pub mod merge_proposals;
 pub mod meta_optimizer;
 pub mod misc_crud;
 pub mod observations;


### PR DESCRIPTION
## Summary
- New `ensure_merge_proposals_tables` self-heal helper mirroring the alembic migration `coord_phase_3_01_merge_proposals` (qontinui-web PR #119).
- Wired into `coordinator/scheduler.rs` boot path alongside `ensure_agent_worktrees_table`.
- Schema must stay byte-equivalent to the alembic migration — verified against canonical PG.

The runner doesn't write `coord.merge_proposals` directly; the helper exists so a runner-driven local-coord harness (and dev DBs whose alembic chain isn't at Phase 3 yet) can still allocate the tables before coord first writes to them.

Companion PRs: qontinui-web #119 (alembic migration), qontinui-coord (endpoints + JetStream fanout).

## Test plan
- [x] `cargo fmt` clean
- [x] Compile verified via coord's worktree (no path-dep against runner from coord)
- [ ] Live-DB smoke-test post-merge

Session-Id: 320f8e97-3fb9-4456-a41d-96c7482134a0