### PR TITLE
feat(terminal): frontend mirror of worker-tab title suppression (Phase 2)

### DIFF
--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1079,8 +1079,31 @@ pub async fn spawn_worker_session(
         terminal_manager.clone(),
     );
     let worker_arc = Arc::new(worker);
-    if let Err(e) = session_manager.register_worker(worker_arc.clone()) {
-        warn!("spawn_worker_session: register_worker failed: {}", e);
+    let register_ok = match session_manager.register_worker(worker_arc.clone()) {
+        Ok(()) => true,
+        Err(e) => {
+            warn!("spawn_worker_session: register_worker failed: {}", e);
+            false
+        }
+    };
+
+    // Phase 2 frontend mirror of `set_title_unless_worker`: tell the
+    // React tree which terminalId is worker-backed so `ZoneGrid::onTitleChange`
+    // can skip OSC 0/2 `renameTab` (and the paired `terminal_set_title`
+    // invoke) for this tab. The backend gate alone keeps `/terminals` and
+    // `GET /workers` pinned at `Worker N`, but without this event the
+    // operator-facing tab strip drifts to the Claude CLI's OSC 0 title
+    // because the FE has no listener for `terminal-title-changed`.
+    // Race-safe: the FE's `useTerminalManager` buffers marks that arrive
+    // before their `terminal-created` event lands.
+    if register_ok {
+        let payload = serde_json::json!({
+            "terminalId": info.id.clone(),
+            "taskRunId": task_run_id.clone(),
+        });
+        if let Err(e) = app_handle.emit("worker-registered", &payload) {
+            warn!("spawn_worker_session: emit worker-registered failed: {}", e);
+        }
     }
 
     // "Coord as Deconflicter, not Dispatcher" Phase 1 (§4.3): create an

--- a/src/components/terminal/ZoneGrid.tsx
+++ b/src/components/terminal/ZoneGrid.tsx
@@ -161,11 +161,25 @@ export function ZoneGrid({
    * Skip empty / whitespace-only titles defensively. The TerminalInstance
    * de-dupes against its last-reported value, so this fires at most once
    * per real title change despite the 200ms idle repaint cadence.
+   *
+   * Worker tabs (presence of `taskRunId`) are pinned at `Worker N` per the
+   * Phase 1 backend gate (`set_title_unless_worker`); skip the local rename
+   * *and* the backend invoke for those so OSC 0 emissions from the embedded
+   * Claude CLI don't clobber the operator-facing identifier.
    */
+  // tabsRef keeps the worker-marker lookup current without re-creating
+  // onTitleChange on every tab mutation (TerminalInstance refs onto the
+  // latest callback, so this ref pattern also avoids re-render thrash).
+  const tabsRef = useRef(tabs);
+  useEffect(() => {
+    tabsRef.current = tabs;
+  }, [tabs]);
   const onTitleChange = useCallback(
     (tabId: string, title: string) => {
       const trimmed = title.trim();
       if (!trimmed) return;
+      const tab = tabsRef.current.find((t) => t.id === tabId);
+      if (tab?.taskRunId) return;
       renameTab(tabId, trimmed);
       // Phase 2: bi-directional title sync. The local React rename above
       // updates UI immediately; fire-and-forget the backend write so other

--- a/src/components/terminal/useTerminalManager.test.ts
+++ b/src/components/terminal/useTerminalManager.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for `useTerminalManager`'s worker-marker decision logic (Phase 2
+ * of the worker-tab title suppression plan; Phase 1 backend gate ships in
+ * `terminal/manager.rs::set_title_unless_worker`).
+ *
+ * The runner's vitest config is `environment: "node"` and React Testing
+ * Library is not in scope (see `useCommitState.test.ts` /
+ * `useFileLockTracking.test.ts` for the precedent). Rather than render
+ * the hook, this file targets the extracted pure helper `applyWorkerMark`
+ * — the only place where race-safety + idempotency live. The hook's
+ * `markAsWorker` callback is a thin `setTabs(prev => applyWorkerMark(prev, …))`
+ * wrapper whose side effect (the `pendingWorkerMarks` ref write) is the
+ * literal `buffered === true` branch covered below.
+ */
+
+import { describe, it, expect } from "vitest";
+import { applyWorkerMark, type TerminalTab } from "./useTerminalManager";
+
+const tab = (id: string, overrides: Partial<TerminalTab> = {}): TerminalTab => ({
+  id,
+  title: id,
+  pid: 1,
+  isAlive: true,
+  exitCode: null,
+  ...overrides,
+});
+
+describe("applyWorkerMark", () => {
+  it("buffers the mark when the tab record hasn't arrived yet", () => {
+    const tabs = [tab("a"), tab("b")];
+    const result = applyWorkerMark(tabs, "ghost", "task-1");
+    expect(result.buffered).toBe(true);
+    expect(result.tabs).toBe(tabs);
+  });
+
+  it("stamps taskRunId onto the matching tab and returns a fresh array", () => {
+    const tabs = [tab("a"), tab("worker-tab")];
+    const result = applyWorkerMark(tabs, "worker-tab", "task-1");
+    expect(result.buffered).toBe(false);
+    expect(result.tabs).not.toBe(tabs);
+    expect(result.tabs[1].taskRunId).toBe("task-1");
+    expect(result.tabs[0].taskRunId).toBeUndefined();
+  });
+
+  it("is idempotent: re-marking with the same taskRunId returns the same array identity", () => {
+    const tabs = [tab("worker-tab", { taskRunId: "task-1" })];
+    const result = applyWorkerMark(tabs, "worker-tab", "task-1");
+    expect(result.buffered).toBe(false);
+    expect(result.tabs).toBe(tabs);
+  });
+
+  it("does not mutate the input array", () => {
+    const tabs = [tab("worker-tab")];
+    applyWorkerMark(tabs, "worker-tab", "task-1");
+    expect(tabs[0].taskRunId).toBeUndefined();
+  });
+
+  it("overwrites a stale taskRunId when a different one arrives", () => {
+    const tabs = [tab("worker-tab", { taskRunId: "task-old" })];
+    const result = applyWorkerMark(tabs, "worker-tab", "task-new");
+    expect(result.buffered).toBe(false);
+    expect(result.tabs[0].taskRunId).toBe("task-new");
+  });
+});

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -25,6 +25,42 @@ export interface TerminalTab {
   claudeSessionId?: string;
   /** Claude config dir for the session (set on resume). */
   claudeConfigDir?: string;
+  /**
+   * Coordinator `task_run_id` for tabs backed by a registered `WorkerSession`.
+   * Presence is the worker marker — `ZoneGrid::onTitleChange` skips the local
+   * `renameTab` + backend `terminal_set_title` invoke so worker tabs stay
+   * pinned at `Worker N` in the tab strip. Mirrors the Phase 1 backend gate
+   * (`set_title_unless_worker`) on the frontend side.
+   */
+  taskRunId?: string;
+}
+
+/** Tauri event payload from `commands::productivity::spawn_worker_session`. */
+interface WorkerRegisteredPayload {
+  terminalId: string;
+  taskRunId: string;
+}
+
+/**
+ * Pure helper: decide whether `tabs` should be replaced when applying a
+ * worker mark for `terminalId`. Returns the next tabs array (same identity
+ * if no change), and a `buffered` flag the caller uses to record the mark
+ * in `pendingWorkerMarks` when the tab record hasn't arrived yet.
+ *
+ * Exported so `useTerminalManager.test.ts` can drive the race-safety + idempotency
+ * contract without booting React.
+ */
+export function applyWorkerMark(
+  tabs: TerminalTab[],
+  terminalId: string,
+  taskRunId: string,
+): { tabs: TerminalTab[]; buffered: boolean } {
+  const idx = tabs.findIndex((t) => t.id === terminalId);
+  if (idx < 0) return { tabs, buffered: true };
+  if (tabs[idx].taskRunId === taskRunId) return { tabs, buffered: false };
+  const next = tabs.slice();
+  next[idx] = { ...tabs[idx], taskRunId };
+  return { tabs: next, buffered: false };
 }
 
 // `TerminalInfo` is imported from `@qontinui/shared-types/tauri-events` —
@@ -38,6 +74,25 @@ export function useTerminalManager(pageId: string = "default") {
   const [activeId, setActiveId] = useState<string | null>(null);
   const nextTitleNum = useRef(1);
   const [initialized, setInitialized] = useState(false);
+  /**
+   * Worker marks (`terminalId → taskRunId`) received from the Rust side
+   * before their tab record exists in React state. The Tauri command path
+   * emits `terminal-created` then `worker-registered` in order, but their
+   * arrival order at the webview is not strictly guaranteed; on reconnect
+   * we also call `list_workers` while `terminal_list` is mid-flight, so a
+   * buffer is the simplest race-safe shape.
+   */
+  const pendingWorkerMarks = useRef<Map<string, string>>(new Map());
+
+  const markAsWorker = useCallback((terminalId: string, taskRunId: string) => {
+    setTabs((prev) => {
+      const result = applyWorkerMark(prev, terminalId, taskRunId);
+      if (result.buffered) {
+        pendingWorkerMarks.current.set(terminalId, taskRunId);
+      }
+      return result.tabs;
+    });
+  }, []);
 
   // Listen for terminals created externally (e.g. via HTTP API) and add them as tabs.
   // Deduplicates by checking if the terminal ID already exists in state.
@@ -45,6 +100,13 @@ export function useTerminalManager(pageId: string = "default") {
     let unlisten: (() => void) | null = null;
     listen<TerminalInfo>("terminal-created", (event) => {
       const info = event.payload;
+      // Drain the race buffer OUTSIDE the reducer so the `setTabs` updater
+      // stays pure (React StrictMode double-invokes updaters in dev; a
+      // delete-inside-reducer would miss on the second pass).
+      const pendingTaskRunId = pendingWorkerMarks.current.get(info.id);
+      if (pendingTaskRunId !== undefined) {
+        pendingWorkerMarks.current.delete(info.id);
+      }
       setTabs((prev) => {
         if (prev.some((t) => t.id === info.id)) return prev;
         logger.info(`External terminal created: ${info.id} (${info.title})`);
@@ -58,6 +120,7 @@ export function useTerminalManager(pageId: string = "default") {
             exitCode: info.exitCode ?? null,
             workingDir: info.workingDir || undefined,
             createdAt: info.createdAt,
+            taskRunId: pendingTaskRunId,
           },
         ];
       });
@@ -68,6 +131,25 @@ export function useTerminalManager(pageId: string = "default") {
       unlisten?.();
     };
   }, []);
+
+  // Mirror the Phase 1 backend worker gate on the frontend. The Rust side
+  // emits `worker-registered` right after `SessionManager::register_worker`
+  // succeeds in `commands::productivity::spawn_worker_session`; consuming
+  // it here lets `ZoneGrid::onTitleChange` skip OSC 0/2 `renameTab` for
+  // worker pty tabs.
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    listen<WorkerRegisteredPayload>("worker-registered", (event) => {
+      const { terminalId, taskRunId } = event.payload;
+      if (!terminalId || !taskRunId) return;
+      markAsWorker(terminalId, taskRunId);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [markAsWorker]);
 
   /**
    * Reconnect to existing Rust PTY sessions that survived a React remount.
@@ -119,12 +201,31 @@ export function useTerminalManager(pageId: string = "default") {
       setTabs(reconnectedTabs);
       // Select the last tab (most recently created)
       setActiveId(reconnectedTabs[reconnectedTabs.length - 1].id);
+
+      // Backfill the Phase 2 worker marker for reconnected tabs. The Rust
+      // `SessionManager` keeps `WorkerSession` registrations across reloads
+      // of the React tree, so a `worker-registered` event won't re-fire for
+      // these tabs — we have to ask. Fire-and-forget; if it fails the
+      // worker tabs simply lose the gate on the frontend (backend gate
+      // still holds).
+      invoke<Array<{ terminal_id: string; task_run_id: string }>>("list_workers")
+        .then((workers) => {
+          for (const w of workers) {
+            if (w.terminal_id && w.task_run_id) {
+              markAsWorker(w.terminal_id, w.task_run_id);
+            }
+          }
+        })
+        .catch((err) => {
+          logger.warn(`list_workers backfill failed: ${err}`);
+        });
+
       return reconnectedTabs.map((t) => t.id);
     } catch (err) {
       console.error("[TerminalManager] Failed to reconnect:", err);
       return null;
     }
-  }, [pageId]);
+  }, [pageId, markAsWorker]);
 
   /** Mark a tab as having completed reconnection (buffer replayed). */
   const markReconnected = useCallback((id: string) => {
@@ -240,5 +341,6 @@ export function useTerminalManager(pageId: string = "default") {
     updateTab,
     reconnectToExistingSessions,
     markReconnected,
+    markAsWorker,
   };
 }


### PR DESCRIPTION
## Summary

Phase 2 of the [worker-tab title suppression plan](../plans/2026-05-12-claude-auto-title-suppression-worker-tabs-plan.md). Phase 1 (#113, `set_title_unless_worker`) pinned the **backend** `TerminalSession.title` at `Worker N`, but the **React tab strip** still drifted to the Claude CLI's OSC 0 title and never recovered.

**Gate exercised & fired (2026-05-15).** Manual smoke against the running primary runner (port 9876, build `06c625ee6`, confirmed to contain `e2a1fc709`):

- Backend `GET /terminals` → `title: "Worker 1"` (Phase 1 gate holding) ✅
- React tab strip → `✳ Add data attributes to reflection toggle button` ❌

The plan's gate text predicted a *transient flicker*; the real symptom is **permanent drift** — there is no `terminal-title-changed` listener and no recurring `terminal_list` re-poll in the frontend, so once `ZoneGrid::onTitleChange` calls the local `renameTab`, nothing ever resets it. Phase 2's frontend mirror is required a fortiori.

## Changes

- **Rust** (`spawn_worker_session`): emit a `worker-registered` Tauri event (`{terminalId, taskRunId}`) right after `register_worker` succeeds.
- **`useTerminalManager`**: consume `worker-registered` → `markAsWorker`, stamping a new `taskRunId` field on `TerminalTab`. Race-safe `pendingWorkerMarks` buffer for marks that beat their `terminal-created` event; buffer drain kept out of the `setTabs` reducer so it stays React-StrictMode-safe. Reconnect path backfilled via the existing `list_workers` command.
- **`ZoneGrid::onTitleChange`**: skip both the local `renameTab` and the paired `terminal_set_title` invoke when the tab has a `taskRunId`.

### Plumbing note (divergence from plan's Option B)

The plan's Option B sketch had `CoordinatorDashboard` capture `LaunchResult` and call a `useTerminalManager` setter. That isn't reachable: `CoordinatorDashboard` is mounted **outside** `TerminalCoreProvider` (provider lives only inside `TerminalPage`). The Rust-emitted-event approach is frontend-consumed, touches **no shared schema** (`qontinui-schemas`) so the "minimum schema churn" intent of Option B is preserved, and additionally covers **all** worker-spawn paths (dashboard + programmatic coordinator spawns), not just the dashboard one.

## Test plan

- [x] `npx vitest run src/components/terminal/` — 226/226 pass (incl. 5 new `useTerminalManager.test.ts` cases: buffering, idempotency, no-mutation, overwrite)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` (changed files) — clean
- [x] `npx prettier --check` (changed files) — clean
- [x] `cargo check -p qontinui-runner` — clean
- [x] pre-push `cargo fmt --check` + `clippy -D warnings` — Passed
- [ ] CI green
- [ ] Post-merge: re-smoke a worker tab during OSC 0 — tab strip stays `Worker N`