### PR TITLE
fix(terminal): clip long tab titles instead of bleeding into adjacent tabs

### DIFF
--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -609,7 +609,7 @@ export function TerminalTabBar({
               }}
               className={`
               flex items-center gap-1.5 px-3 py-1 rounded-t text-xs font-medium min-h-[37px]
-              transition-colors whitespace-nowrap max-w-[260px] group cursor-grab active:cursor-grabbing
+              transition-colors whitespace-nowrap min-w-0 max-w-[260px] overflow-hidden group cursor-grab active:cursor-grabbing
               ${
                 isActive
                   ? "bg-[#1a1b26] text-[#c0caf5] border-t border-x border-[#2a2d3d] -mb-px"


### PR DESCRIPTION
## Summary

Fixes the terminal-tab overflow bug found during a `/manual-test` of the Terminal page: tabs with long working directories (e.g. full PowerShell exe paths) painted their text outside the tab box, overlapping the adjacent tab by ~53px.

**Root cause:** the tab `<button>` had `max-w-[260px]` + `whitespace-nowrap` but no `overflow-hidden` and no `min-w-0`. Default flex items have `min-width: auto`, so the button never shrank below its intrinsic content width, and `max-width` alone does not clip (`overflow: visible` by default). The inner title `truncate` never engaged because the flex-shrink chain was broken at the button.

**Fix (1 line):**
- `min-w-0` — lets the flex-shrink chain reach the existing `truncate` span so the title ellipsizes cleanly.
- `overflow-hidden` — hard guarantee nothing paints outside the 260px tab box regardless of flex quirks.

Branched off `origin/main` (not the originating session's checkout branch, which was an unrelated agent's WIP).

## Test plan

- [ ] CI build green (was blocked on the stale branch by the unrelated 2026-05-14 IR breakage; `origin/main` already has the IR consumer fix, so this branch builds clean).
- [ ] Visual: open the Terminal page with a long-cwd tab; confirm the title ellipsizes within the tab and no overlap onto the next tab. (Deferred live `visual-audit` per session decision; `no_overlap` / `text_fits_container` assertions cover this case.)