### PR TITLE
fix(ui-bridge): repair recurring SDK-manifest-drift (vision routes promoted by ui-bridge #21)

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -677,13 +677,16 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/invoke/{}"),
             ("POST", "/ui-bridge/pong"),
             ("POST", "/ui-bridge/ipc-response"),
-            ("POST", "/ui-bridge/vision/mutation-occurred"),
-            ("POST", "/ui-bridge/vision/extract"),
-            ("POST", "/ui-bridge/vision/describe"),
-            ("POST", "/ui-bridge/vision/analyze"),
-            ("POST", "/ui-bridge/vision/assert"),
-            ("POST", "/ui-bridge/vision/baseline"),
-            ("GET", "/ui-bridge/vision/baselines"),
+            // NOTE: the Phase 4/6 `/vision/*` routes (extract, describe,
+            // analyze, assert, baseline, baselines, mutation-occurred) used
+            // to be listed here as runner-only extensions. ui-bridge #21
+            // promoted them into UI_BRIDGE_ROUTES, and the runner exposes
+            // them via `vision_routes::route_entries()`. They are now wired
+            // end-to-end, so per the "promote … and remove from this list
+            // when wiring the SDK side" rule above they are no longer
+            // runner-only and must NOT be filtered out of the runner set —
+            // keeping them here re-introduced spurious "SDK declares but
+            // runner does not expose" drift.
             ("POST", "/ui-bridge/batch"),
             ("POST", "/ui-bridge/control/batch"),
             ("POST", "/ui-bridge/render-log"),


### PR DESCRIPTION
## Problem

`sdk_manifest_routes_are_exposed_by_runner` (`mcp/ui_bridge/mod.rs`) has been failing in CI and getting **admin-merged through** repeatedly — cited verbatim as `mcp/ui_bridge/mod.rs:899 SDK-manifest-drift` across:

- PR #133 (Row 9 Phase 3 IR catch-up)
- PR #139 (coord merge_proposals)
- PR #140 (Row 9 Phase 3 agent pusher)
- PR #143 (Row 9 Phase 4 Fleet Health panel)
- Waves 4.1 / 4.2 / 4.3

Each admin-merge masks the possibility that the merged PR's own diff carried a real regression. The count was growing ~2–3 per wave.

## Root cause — drift direction: **SDK caught up; runner test allow-list was stale**

`ui-bridge` #21 (`feat(vision): __UI_BRIDGE__.mutationOccurred() SDK helper + Phase 4/6 route manifest`) promoted the Phase 4/6 `/vision/*` routes into `UI_BRIDGE_ROUTES`. CI clones `ui-bridge` at `main`, so every runner PR after that point diffs against the new contract.

The runner **already exposes** all of them via `vision_routes::route_entries()` (wired in #135/#136, consumed via `@qontinui/ui-bridge@^0.8.0` in #138) — so they are wired end-to-end. But `runner_only_baseline` still listed 7 of them as "runner-only extensions". That list is subtracted from the runner route set *before* the SDK diff, so the test concluded the runner did **not** expose 7 SDK-declared routes and panicked.

This is neither a missing handler nor an SDK regression — it is exactly the staleness the file's own comment anticipates: *"Promote to UI_BRIDGE_ROUTES (and remove from this list) when wiring the SDK side."*

## Fix

Removed the 7 now-contracted entries from `runner_only_baseline`:

| Method | Path |
|---|---|
| POST | /ui-bridge/vision/extract |
| POST | /ui-bridge/vision/describe |
| POST | /ui-bridge/vision/analyze |
| POST | /ui-bridge/vision/assert |
| POST | /ui-bridge/vision/baseline |
| POST | /ui-bridge/vision/mutation-occurred |
| GET  | /ui-bridge/vision/baselines |

## Verification

The test's algorithm (bracket-balanced `UI_BRIDGE_ROUTES` scrape, multi-line tuple extraction across the exact `route_manifest()` module set, prefix allow-list, both baselines, identical canonicalisation + set-difference) was reproduced statically against `ui-bridge@origin/main` (`6e36a0e`) and `qontinui-runner@origin/main` (`0419c5d6`):

- **Before fix:** FAIL — exactly these 7 routes reported as "SDK declares but runner does not expose", 0 runner-extra.
- **After fix:** PASS — `sdk_filtered 189 == runner 189`, 0 missing, 0 extra.

CI runs the real `cargo test` (with frontend built first) and will confirm. If this PR's own CI admin-merges through the same breakage, the fix is incomplete — it should not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)