### PR TITLE
Coordination Phase 5 (runner side): refs/agent push + out-of-tree Cargo override

### DIFF
--- a/src-tauri/src/agent_pusher/mod.rs
+++ b/src-tauri/src/agent_pusher/mod.rs
@@ -82,6 +82,13 @@ pub struct PushTarget {
     pub repo: String,
     pub branch: String,
     pub worktree_path: PathBuf,
+    /// Coordination Phase 5 / bottleneck Row 4 — the non-`heads`
+    /// remote ref to push to (`refs/agent/<m>-<a>`). The local side
+    /// stays `refs/heads/<branch>` (a normal checked-out branch); only
+    /// the origin side moves namespace so default `refs/heads/*`
+    /// fetches skip the ~10K agent refs.
+    #[serde(default)]
+    pub push_ref: String,
 }
 
 /// State shared between the pusher task and any caller that needs to
@@ -143,6 +150,11 @@ impl PusherState {
                 repo: w.repo.clone(),
                 branch: w.branch.clone(),
                 worktree_path: w.worktree_path.clone(),
+                push_ref: if w.push_ref.is_empty() {
+                    crate::agent_worktree::remote_agent_ref(&w.branch)
+                } else {
+                    w.push_ref.clone()
+                },
             })
             .collect();
         let origin_repo_alias = targets.first().map(|t| t.repo.clone()).unwrap_or_default();
@@ -368,10 +380,21 @@ struct RefreshResponseBody {
 /// date", and `Err` for actual failures.
 async fn push_one(state: &Arc<PusherState>, target: &PushTarget, token: &str) -> Result<bool> {
     let origin_url = build_origin_url(&state.coord_http_base, &target.repo, token)?;
+    // Coordination Phase 5 / Row 4: push the local branch
+    // (`refs/heads/<branch>` — a normal checked-out branch in the
+    // worktree) to the non-`heads` remote ref `refs/agent/<m>-<a>`.
+    // Defensive fallback if push_ref is somehow empty (older
+    // serialized PushTarget).
+    let push_ref = if target.push_ref.is_empty() {
+        crate::agent_worktree::remote_agent_ref(&target.branch)
+    } else {
+        target.push_ref.clone()
+    };
+    let refspec = format!("refs/heads/{}:{}", target.branch, push_ref);
     debug!(
-        "agent_pusher: pushing repo={} branch={} from {}",
+        "agent_pusher: pushing repo={} refspec={} from {}",
         target.repo,
-        target.branch,
+        refspec,
         target.worktree_path.display()
     );
     let out = Command::new("git")
@@ -381,7 +404,7 @@ async fn push_one(state: &Arc<PusherState>, target: &PushTarget, token: &str) ->
         .arg("--porcelain")
         .arg("--no-verify")
         .arg(&origin_url)
-        .arg(format!("{}:{}", target.branch, target.branch))
+        .arg(&refspec)
         .output()
         .await
         .with_context(|| format!("invoking git push for {}", target.branch))?;
@@ -488,6 +511,44 @@ mod tests {
     fn build_origin_url_rejects_non_http() {
         assert!(build_origin_url("ws://h:9870", "qontinui-coord", "x").is_err());
         assert!(build_origin_url("ftp://h", "r", "t").is_err());
+    }
+
+    #[test]
+    fn push_target_refspec_is_heads_to_agent_namespace() {
+        // Coordination Phase 5 / Row 4: local refs/heads/<branch>
+        // (a real checked-out branch) → remote refs/agent/<m>-<a>.
+        let t = PushTarget {
+            repo: "qontinui-coord".into(),
+            branch: "agent/m12-a34".into(),
+            worktree_path: PathBuf::from("/tmp/wt"),
+            push_ref: crate::agent_worktree::remote_agent_ref("agent/m12-a34"),
+        };
+        let effective = if t.push_ref.is_empty() {
+            crate::agent_worktree::remote_agent_ref(&t.branch)
+        } else {
+            t.push_ref.clone()
+        };
+        let refspec = format!("refs/heads/{}:{}", t.branch, effective);
+        assert_eq!(refspec, "refs/heads/agent/m12-a34:refs/agent/m12-a34");
+        let (src, dst) = refspec.split_once(':').unwrap();
+        assert!(src.starts_with("refs/heads/"));
+        assert!(dst.starts_with("refs/agent/") && !dst.starts_with("refs/heads/"));
+    }
+
+    #[test]
+    fn push_target_empty_push_ref_falls_back() {
+        let t = PushTarget {
+            repo: "qontinui-coord".into(),
+            branch: "agent/x-y".into(),
+            worktree_path: PathBuf::from("/tmp/wt"),
+            push_ref: String::new(), // pre-Phase-5 coord
+        };
+        let effective = if t.push_ref.is_empty() {
+            crate::agent_worktree::remote_agent_ref(&t.branch)
+        } else {
+            t.push_ref.clone()
+        };
+        assert_eq!(effective, "refs/agent/x-y");
     }
 
     #[test]

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -81,6 +81,23 @@ pub struct MaterializedWorktree {
     pub branch: String,
     pub parent_sha: String,
     pub worktree_path: PathBuf,
+    /// Coordination Phase 5 / bottleneck Row 4 — the non-`heads`
+    /// remote ref this worktree's branch pushes to
+    /// (`refs/agent/<m>-<a>`). Source of truth is coord's allocate
+    /// response; [`remote_agent_ref`] recomputes it as a fallback
+    /// when talking to a pre-Phase-5 coord.
+    pub push_ref: String,
+}
+
+/// Mirror of `qontinui-coord::ref_namespace::remote_agent_ref` — kept
+/// in lockstep (no shared crate). Logical branch `agent/<m>-<a>` maps
+/// to the non-`heads` remote ref `refs/agent/<m>-<a>` so the default
+/// `+refs/heads/*:...` fetch refspec skips the ~10K agent refs at
+/// fleet scale (Row 4). A non-agent branch maps verbatim under the
+/// prefix (defensive — allocated agents always start with `agent/`).
+pub fn remote_agent_ref(branch: &str) -> String {
+    let rest = branch.strip_prefix("agent/").unwrap_or(branch);
+    format!("refs/agent/{rest}")
 }
 
 /// Result of a full allocate + materialize round-trip.
@@ -115,6 +132,19 @@ struct CoordAllocateResponse {
     token_jti: Option<uuid::Uuid>,
     #[serde(default)]
     token_exp: Option<i64>,
+    /// Coordination Phase 5 — per-agent out-of-tree Cargo path-dep
+    /// override. Absent (pre-Phase-5 coord) or null (single-repo
+    /// agent) → no override written.
+    #[serde(default)]
+    cargo_config: Option<CoordCargoConfig>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CoordCargoConfig {
+    /// Absolute target path —
+    /// `<COORD_WORKTREE_ROOT>/<agent_id>/.cargo/config.toml`.
+    path: String,
+    contents: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -125,6 +155,12 @@ struct CoordAllocatedWorktree {
     worktree_path: String,
     #[allow(dead_code)]
     status: String,
+    /// Coordination Phase 5 — non-`heads` push ref. `#[serde(default)]`
+    /// so a pre-Phase-5 coord (no field) still deserializes; the
+    /// empty string triggers the [`remote_agent_ref`] fallback at
+    /// materialization.
+    #[serde(default)]
+    push_ref: String,
 }
 
 /// Call coord's `/agents/allocate` and then `git worktree add` for each
@@ -269,12 +305,46 @@ pub async fn allocate_and_materialize(
             }
         }
 
+        let push_ref = if w.push_ref.is_empty() {
+            remote_agent_ref(&w.branch)
+        } else {
+            w.push_ref
+        };
         materialized.push(MaterializedWorktree {
             repo: w.repo,
             branch: w.branch,
             parent_sha: w.parent_sha,
             worktree_path: target,
+            push_ref,
         });
+    }
+
+    // Coordination Phase 5 / Row 5 — write coord's per-agent Cargo
+    // path-dep override. It lands at
+    // <COORD_WORKTREE_ROOT>/<agent_id>/.cargo/config.toml, i.e. the
+    // PARENT of the per-repo worktree dirs — outside every git repo,
+    // so it never merges and pre-commit cargo hooks never see it
+    // (feedback_worktree_path_dep_hooks). Best-effort: a write
+    // failure logs + continues (the agent then builds against the
+    // canonical sibling, i.e. today's non-deterministic behaviour —
+    // degraded, not broken).
+    if let Some(cc) = &coord_resp.cargo_config {
+        if let Some(parent) = std::path::Path::new(&cc.path).parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                warn!(
+                    "phase5 cargo override: mkdir {} failed: {e}",
+                    parent.display()
+                );
+            }
+        }
+        match std::fs::write(&cc.path, &cc.contents) {
+            Ok(()) => info!(
+                "phase5 cargo override written: {} ({} bytes)",
+                cc.path,
+                cc.contents.len()
+            ),
+            Err(e) => warn!("phase5 cargo override: write {} failed: {e}", cc.path),
+        }
     }
 
     Ok(AllocateResult {
@@ -323,5 +393,17 @@ mod tests {
         assert_eq!(coord_ws_to_http("wss://h:9870"), "https://h:9870");
         assert_eq!(coord_ws_to_http("http://h:9870"), "http://h:9870");
         assert_eq!(coord_ws_to_http("https://h:9870"), "https://h:9870");
+    }
+
+    #[test]
+    fn remote_agent_ref_mirrors_coord_mapping() {
+        // Must stay byte-identical to
+        // qontinui-coord::ref_namespace::remote_agent_ref.
+        assert_eq!(remote_agent_ref("agent/m12-a34"), "refs/agent/m12-a34");
+        // No redundant agent/agent/ segment.
+        assert!(!remote_agent_ref("agent/x-y").contains("agent/agent"));
+        // Result is outside refs/heads/* — the whole Row 4 point.
+        assert!(!remote_agent_ref("agent/x-y").starts_with("refs/heads/"));
+        assert_eq!(remote_agent_ref("weird"), "refs/agent/weird");
     }
 }


### PR DESCRIPTION
Runner-side lockstep changes for **Coordination Phase 5** (coord: qontinui-coord#16).

## Branch namespacing (bottleneck Row 4)
- `agent_worktree::remote_agent_ref` — byte-identical mirror of `qontinui-coord::ref_namespace::remote_agent_ref` (no shared crate; parity unit-tested).
- `MaterializedWorktree` / `CoordAllocatedWorktree` carry `push_ref` (`#[serde(default)]` → pre-Phase-5 coord still deserializes; empty string triggers the local fallback).
- `agent_pusher`: `PushTarget.push_ref`; push refspec `{branch}:{branch}` → `refs/heads/{branch}:{push_ref}`. Local side stays a real checked-out branch; origin side is the non-`heads` `refs/agent/*` ref so default `refs/heads/*` fetches skip the ~10K agent refs.

## Path-dep rewriting (bottleneck Row 5)
- `CoordAllocateResponse.cargo_config`; at materialization the runner writes it to `<COORD_WORKTREE_ROOT>/<agent_id>/.cargo/config.toml` — the **parent** of the per-repo worktree dirs, outside every git repo, so it never merges and pre-commit cargo hooks never see it (sidesteps `feedback_worktree_path_dep_hooks` entirely). Best-effort: write failure logs + continues (degraded, not broken).

Tests: `remote_agent_ref` mirror-parity, refspec shape, empty-push_ref fallback. `cargo check --bin qontinui-runner --tests` clean.

Session-Id: 63cf7d5d-1ac4-494d-8519-5b552732c744