### PR TITLE
feat: Stream E flywheel foundation — spec_authoring + proposals (Steps 2-7)

### DIFF
--- a/atlas/schema.hcl
+++ b/atlas/schema.hcl
@@ -233,6 +233,86 @@ table "regression_assertion_executions" {
 }
 
 // ---------------------------------------------------------------
+// project.spec_proposals — Stream E (Flywheel) coverage-growth queue.
+// Stores `fullPage` and `patch` proposals discovered by
+// `/spec/proposals/scan`; lifecycle is driven by the supervisor cron + the
+// `/spec/proposals/{id}/execute` handler.
+// ---------------------------------------------------------------
+
+table "spec_proposals" {
+  schema = schema.project
+  column "id" {
+    null = false
+    type = text
+  }
+  column "kind" {
+    null = false
+    type = text
+  }
+  column "pathname" {
+    null = true
+    type = text
+  }
+  column "spec_id" {
+    null = true
+    type = text
+  }
+  column "status" {
+    null = false
+    type = text
+  }
+  column "created_at" {
+    null    = false
+    type    = timestamptz
+    default = sql("now()")
+  }
+  column "last_attempt_at" {
+    null = true
+    type = timestamptz
+  }
+  column "consecutive_greens" {
+    null    = false
+    type    = integer
+    default = 0
+  }
+  column "last_error" {
+    null = true
+    type = text
+  }
+  column "candidate_ir" {
+    null = true
+    type = jsonb
+  }
+  column "metadata" {
+    null    = false
+    type    = jsonb
+    default = sql("'{}'::jsonb")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  check "spec_proposals_kind_chk" {
+    expr = "kind IN ('fullPage', 'patch')"
+  }
+  // Dedup: a queued/in-flight proposal for a given target identity. Uses
+  // a functional unique index over (kind, COALESCE(pathname, spec_id)) so
+  // the same pathname (kind='fullPage') or spec_id (kind='patch') cannot
+  // be queued twice. Insertions use ON CONFLICT DO NOTHING.
+  index "spec_proposals_kind_target_uniq" {
+    unique = true
+    on {
+      column = column.kind
+    }
+    on {
+      expr = "COALESCE(pathname, spec_id)"
+    }
+  }
+  index "spec_proposals_status_idx" {
+    columns = [column.status]
+  }
+}
+
+// ---------------------------------------------------------------
 // coord.coordinator_shadow_decisions — soak comparison of shadow vs live
 // scheduler decisions. Created by Rust ensure_shadow_decisions_table; this
 // HCL is now source of truth.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,7 +45,7 @@ jsonschema = { version = "0.45", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-util = "0.7"
-uuid = { version = "1.0", features = ["v4", "v5", "serde"] }
+uuid = { version = "1.0", features = ["v4", "v5", "v7", "serde"] }
 thiserror = "2"
 anyhow = "1.0"
 async-trait = "0.1"
@@ -217,6 +217,15 @@ custom-protocol = ["tauri/custom-protocol"]
 # `cfg(debug_assertions)`; this feature is the explicit opt-in for
 # release-mode regression / smoke harnesses.
 test-fixtures = []
+# Stream E (Flywheel) — coverage-growth loop. Gates `spec_authoring`,
+# the proposals endpoints, and the supervisor cron. Off by default for
+# spec-check v1.0 ship; the user-facing `--enable-spec-authoring` alias
+# maps to this feature in the runner CLI/env layer.
+spec-authoring = []
+# PG-bound integration tests for the proposals subsystem (Stream E).
+# Off by default; enable with `--features spec-authoring,pg_integration_tests`
+# when a live PG (canonical or local) is available.
+pg_integration_tests = []
 
 [[bin]]
 name = "mock_claude_cli"

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -74,6 +74,7 @@ pub mod session_touched_files;
 pub mod settings;
 pub mod skills;
 pub mod spec_experimentation;
+pub mod spec_proposals;
 pub mod state_machine;
 pub mod step_type_knowledge;
 pub mod task_run_events;

--- a/src-tauri/src/database/pg/spec_proposals.rs
+++ b/src-tauri/src/database/pg/spec_proposals.rs
@@ -83,11 +83,7 @@ impl PgDb {
     /// Update only the status of a proposal. Does NOT touch
     /// `last_attempt_at` / `last_error` — use the more specific helpers when
     /// recording attempts or failures.
-    pub async fn update_proposal_status(
-        &self,
-        id: &str,
-        status: &str,
-    ) -> Result<(), String> {
+    pub async fn update_proposal_status(&self, id: &str, status: &str) -> Result<(), String> {
         let conn = self
             .pool
             .get()
@@ -198,10 +194,7 @@ impl PgDb {
     // -------------------------------------------------------------------------
 
     /// Fetch a single proposal by id. Returns `Ok(None)` if missing.
-    pub async fn find_proposal_by_id(
-        &self,
-        id: &str,
-    ) -> Result<Option<SpecProposalRow>, String> {
+    pub async fn find_proposal_by_id(&self, id: &str) -> Result<Option<SpecProposalRow>, String> {
         let conn = self
             .pool
             .get()

--- a/src-tauri/src/database/pg/spec_proposals.rs
+++ b/src-tauri/src/database/pg/spec_proposals.rs
@@ -1,0 +1,333 @@
+//! PostgreSQL CRUD for `project.spec_proposals` — Stream E (Flywheel) queue.
+//!
+//! The table is authored declaratively in `atlas/schema.hcl`; this module
+//! issues the queries directly via `tokio_postgres`, mirroring the
+//! `regression.rs` / `merge_proposals.rs` style. There is no self-heal helper
+//! here — Atlas owns the table shape and the runner expects it to be present
+//! when `feature = "spec-authoring"` is enabled.
+//!
+//! Lifecycle (`status` column) is driven by Stream E:
+//!   queued → inFlight → pendingValidation → pendingPromotion → promoted
+//!                                                                    failed
+//! See `spec_api/proposals.rs` for the execution handler that transitions
+//! `queued → inFlight → pendingPromotion | failed` and the supervisor cron
+//! (Step 10) for `pendingPromotion → promoted` after 2 consecutive greens.
+
+use super::PgDb;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// One row from `project.spec_proposals`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SpecProposalRow {
+    pub id: String,
+    pub kind: String,
+    pub pathname: Option<String>,
+    pub spec_id: Option<String>,
+    pub status: String,
+    pub created_at: String,
+    pub last_attempt_at: Option<String>,
+    pub consecutive_greens: i32,
+    pub last_error: Option<String>,
+    pub candidate_ir: Option<Value>,
+    pub metadata: Value,
+}
+
+impl PgDb {
+    // -------------------------------------------------------------------------
+    // Writes
+    // -------------------------------------------------------------------------
+
+    /// Insert a new proposal row. Returns `Ok(true)` if a row was inserted,
+    /// `Ok(false)` if the unique-on-(kind, COALESCE(pathname, spec_id))
+    /// constraint suppressed the insert via `ON CONFLICT DO NOTHING`.
+    ///
+    /// `kind` must be `"fullPage"` or `"patch"`; the CHECK constraint enforces
+    /// this server-side, but callers should validate upstream so the rejection
+    /// surfaces as a structured `SpecError` rather than a raw PG error.
+    pub async fn insert_proposal(
+        &self,
+        id: &str,
+        kind: &str,
+        pathname: Option<&str>,
+        spec_id: Option<&str>,
+        status: &str,
+        metadata: &Value,
+    ) -> Result<bool, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        // ON CONFLICT DO NOTHING with no target catches both the PK and the
+        // unique `spec_proposals_kind_target_uniq` index. The PK is a fresh
+        // UUIDv7-shaped id from `mint_proposal_id` so PK collisions are
+        // effectively zero — the only realistic conflict is the unique
+        // dedup index, which is the intended swallow.
+        let rows_affected = conn
+            .execute(
+                r#"
+                INSERT INTO spec_proposals (id, kind, pathname, spec_id, status, metadata)
+                VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+                ON CONFLICT DO NOTHING
+                "#,
+                &[&id, &kind, &pathname, &spec_id, &status, metadata],
+            )
+            .await
+            .map_err(|e| format!("PG insert_proposal: {}", e))?;
+
+        Ok(rows_affected == 1)
+    }
+
+    /// Update only the status of a proposal. Does NOT touch
+    /// `last_attempt_at` / `last_error` — use the more specific helpers when
+    /// recording attempts or failures.
+    pub async fn update_proposal_status(
+        &self,
+        id: &str,
+        status: &str,
+    ) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        conn.execute(
+            "UPDATE spec_proposals SET status = $2 WHERE id = $1",
+            &[&id, &status],
+        )
+        .await
+        .map_err(|e| format!("PG update_proposal_status: {}", e))?;
+        Ok(())
+    }
+
+    /// Mark an attempt without changing status — used to record the start of
+    /// an execute call before authoring kicks off.
+    pub async fn update_proposal_attempt_only(&self, id: &str) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        conn.execute(
+            "UPDATE spec_proposals SET last_attempt_at = now() WHERE id = $1",
+            &[&id],
+        )
+        .await
+        .map_err(|e| format!("PG update_proposal_attempt_only: {}", e))?;
+        Ok(())
+    }
+
+    /// Terminal-failure update: status='failed' + last_error populated +
+    /// last_attempt_at bumped. Idempotent.
+    pub async fn update_proposal_status_with_error(
+        &self,
+        id: &str,
+        status: &str,
+        last_error: &str,
+    ) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        conn.execute(
+            r#"UPDATE spec_proposals
+               SET status = $2,
+                   last_error = $3,
+                   last_attempt_at = now()
+               WHERE id = $1"#,
+            &[&id, &status, &last_error],
+        )
+        .await
+        .map_err(|e| format!("PG update_proposal_status_with_error: {}", e))?;
+        Ok(())
+    }
+
+    /// Set `consecutive_greens` to an absolute value (e.g. 0 on red, +1 on
+    /// green). The promotion sweep (Step 10) decides when to use this.
+    pub async fn update_proposal_greens(
+        &self,
+        id: &str,
+        consecutive_greens: i32,
+    ) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        conn.execute(
+            "UPDATE spec_proposals SET consecutive_greens = $2 WHERE id = $1",
+            &[&id, &consecutive_greens],
+        )
+        .await
+        .map_err(|e| format!("PG update_proposal_greens: {}", e))?;
+        Ok(())
+    }
+
+    /// Persist the authored candidate IR + transition to a new status
+    /// (typically `pendingValidation` or `pendingPromotion`).
+    pub async fn update_proposal_candidate_ir(
+        &self,
+        id: &str,
+        status: &str,
+        candidate_ir: &Value,
+    ) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        conn.execute(
+            r#"UPDATE spec_proposals
+               SET status = $2,
+                   candidate_ir = $3::jsonb,
+                   last_attempt_at = now(),
+                   last_error = NULL
+               WHERE id = $1"#,
+            &[&id, &status, candidate_ir],
+        )
+        .await
+        .map_err(|e| format!("PG update_proposal_candidate_ir: {}", e))?;
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // Reads
+    // -------------------------------------------------------------------------
+
+    /// Fetch a single proposal by id. Returns `Ok(None)` if missing.
+    pub async fn find_proposal_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<SpecProposalRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    id,
+                    kind,
+                    pathname,
+                    spec_id,
+                    status,
+                    created_at::TEXT,
+                    last_attempt_at::TEXT,
+                    consecutive_greens,
+                    last_error,
+                    candidate_ir,
+                    metadata
+                FROM spec_proposals
+                WHERE id = $1
+                "#,
+                &[&id],
+            )
+            .await
+            .map_err(|e| format!("PG find_proposal_by_id: {}", e))?;
+
+        Ok(rows.first().map(row_to_proposal))
+    }
+
+    /// Paginated list of proposals, ordered by `created_at DESC, id`.
+    pub async fn list_proposals(
+        &self,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<SpecProposalRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        let lim = limit.clamp(1, 1000);
+        let off = offset.max(0);
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    id,
+                    kind,
+                    pathname,
+                    spec_id,
+                    status,
+                    created_at::TEXT,
+                    last_attempt_at::TEXT,
+                    consecutive_greens,
+                    last_error,
+                    candidate_ir,
+                    metadata
+                FROM spec_proposals
+                ORDER BY created_at DESC, id
+                LIMIT $1 OFFSET $2
+                "#,
+                &[&lim, &off],
+            )
+            .await
+            .map_err(|e| format!("PG list_proposals: {}", e))?;
+
+        Ok(rows.iter().map(row_to_proposal).collect())
+    }
+
+    /// Proposals filtered by a single status value, ordered by
+    /// `created_at DESC`. Used by the supervisor cron to find
+    /// `pendingPromotion` candidates.
+    pub async fn list_proposals_by_status(
+        &self,
+        status: &str,
+        limit: i64,
+    ) -> Result<Vec<SpecProposalRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        let lim = limit.clamp(1, 1000);
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    id,
+                    kind,
+                    pathname,
+                    spec_id,
+                    status,
+                    created_at::TEXT,
+                    last_attempt_at::TEXT,
+                    consecutive_greens,
+                    last_error,
+                    candidate_ir,
+                    metadata
+                FROM spec_proposals
+                WHERE status = $1
+                ORDER BY created_at DESC, id
+                LIMIT $2
+                "#,
+                &[&status, &lim],
+            )
+            .await
+            .map_err(|e| format!("PG list_proposals_by_status: {}", e))?;
+
+        Ok(rows.iter().map(row_to_proposal).collect())
+    }
+}
+
+fn row_to_proposal(r: &tokio_postgres::Row) -> SpecProposalRow {
+    SpecProposalRow {
+        id: r.get(0),
+        kind: r.get(1),
+        pathname: r.get(2),
+        spec_id: r.get(3),
+        status: r.get(4),
+        created_at: r.get(5),
+        last_attempt_at: r.get(6),
+        consecutive_greens: r.get(7),
+        last_error: r.get(8),
+        candidate_ir: r.get(9),
+        metadata: r.get(10),
+    }
+}

--- a/src-tauri/src/spec_api/mod.rs
+++ b/src-tauri/src/spec_api/mod.rs
@@ -28,6 +28,9 @@ pub mod responses;
 pub mod storage;
 pub mod types;
 
+#[cfg(feature = "spec-authoring")]
+pub mod proposals;
+
 #[cfg(test)]
 mod tests;
 
@@ -42,7 +45,7 @@ use crate::mcp::types::ApiState;
 /// the Section 2 plan ("Spec API is consumed differently from the UI
 /// Bridge").
 pub fn routes() -> Router<Arc<ApiState>> {
-    Router::new()
+    let r = Router::new()
         .route("/spec/health", get(handlers::get_health))
         .route("/spec/get", get(handlers::get_file))
         .route("/spec/page/{id}", get(handlers::get_page))
@@ -53,5 +56,16 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/spec/diff", get(handlers::get_diff))
         .route("/spec/author", post(handlers::post_author))
         .route("/spec/validate", post(handlers::post_validate))
-        .route("/spec/subscribe", get(handlers::get_subscribe))
+        .route("/spec/subscribe", get(handlers::get_subscribe));
+
+    // Stream E (Flywheel) — coverage-growth queue endpoints. Gated behind
+    // `spec-authoring` so v1.0 release builds don't expose the proposals
+    // queue surface area.
+    #[cfg(feature = "spec-authoring")]
+    let r = r
+        .route("/spec/proposals/scan", post(proposals::post_scan))
+        .route("/spec/proposals", get(proposals::get_list))
+        .route("/spec/proposals/{id}/execute", post(proposals::post_execute));
+
+    r
 }

--- a/src-tauri/src/spec_api/mod.rs
+++ b/src-tauri/src/spec_api/mod.rs
@@ -65,7 +65,10 @@ pub fn routes() -> Router<Arc<ApiState>> {
     let r = r
         .route("/spec/proposals/scan", post(proposals::post_scan))
         .route("/spec/proposals", get(proposals::get_list))
-        .route("/spec/proposals/{id}/execute", post(proposals::post_execute));
+        .route(
+            "/spec/proposals/{id}/execute",
+            post(proposals::post_execute),
+        );
 
     r
 }

--- a/src-tauri/src/spec_api/proposals.rs
+++ b/src-tauri/src/spec_api/proposals.rs
@@ -106,7 +106,10 @@ pub async fn post_scan(
     let scanned_pathnames = full_page_rows.len();
     for pathname in full_page_rows {
         if on_disk_pathnames.contains(&pathname) {
-            debug!("post_scan: pathname {} already has a spec; skipping", pathname);
+            debug!(
+                "post_scan: pathname {} already has a spec; skipping",
+                pathname
+            );
             continue;
         }
         let proposal_id = mint_proposal_id();
@@ -307,7 +310,10 @@ pub async fn post_execute(
     // Transition to inFlight (best-effort; ignore errors so we still try to
     // author rather than wedging the queue).
     if let Err(e) = pg_db.update_proposal_status(&row.id, "inFlight").await {
-        warn!("post_execute: update_proposal_status (inFlight) failed: {}", e);
+        warn!(
+            "post_execute: update_proposal_status (inFlight) failed: {}",
+            e
+        );
     }
     let _ = pg_db.update_proposal_attempt_only(&row.id).await;
 
@@ -354,7 +360,8 @@ pub async fn post_execute(
             // Patch mode requires a fresh drift report — re-scan to get the
             // current delta (the queued row only carries the missing element
             // ids in `metadata`, not the full report shape).
-            let project_root = std::env::var("QONTINUI_PROJECT_ROOT").unwrap_or_else(|_| ".".into());
+            let project_root =
+                std::env::var("QONTINUI_PROJECT_ROOT").unwrap_or_else(|_| ".".into());
             let drift = match crate::commands::spec_drift::scan_spec_drift(project_root).await {
                 Ok(d) => d,
                 Err(e) => {
@@ -428,22 +435,23 @@ pub async fn post_execute(
 
     // TODO(Step 8): replace with full validator gate (round-trip + coverage +
     // b-green) and Step 9: replace with storage::write_pending_ir.
-    let staged_path = match stage_pending_ir_placeholder(&storage::resolve_specs_root(), &outcome.candidate) {
-        Ok(p) => p,
-        Err(e) => {
-            let _ = pg_db
-                .update_proposal_status_with_error(&row.id, "failed", &e)
-                .await;
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(SpecError::with_detail(
-                    "stage-pending-failed",
-                    json!({ "proposalId": row.id, "error": e }),
-                )),
-            )
-                .into_response();
-        }
-    };
+    let staged_path =
+        match stage_pending_ir_placeholder(&storage::resolve_specs_root(), &outcome.candidate) {
+            Ok(p) => p,
+            Err(e) => {
+                let _ = pg_db
+                    .update_proposal_status_with_error(&row.id, "failed", &e)
+                    .await;
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(SpecError::with_detail(
+                        "stage-pending-failed",
+                        json!({ "proposalId": row.id, "error": e }),
+                    )),
+                )
+                    .into_response();
+            }
+        };
 
     // Persist the candidate IR + flip to pendingPromotion (skipping the
     // pendingValidation hop that Step 8 will introduce).
@@ -484,7 +492,9 @@ pub async fn post_execute(
         .into_response()
 }
 
-fn authoring_error_reason(e: &crate::workflow_generation::spec_authoring::AuthoringError) -> &'static str {
+fn authoring_error_reason(
+    e: &crate::workflow_generation::spec_authoring::AuthoringError,
+) -> &'static str {
     use crate::workflow_generation::spec_authoring::AuthoringError::*;
     match e {
         NoDiscoveryArtifact { .. } => "no-discovery-artifact",
@@ -496,7 +506,9 @@ fn authoring_error_reason(e: &crate::workflow_generation::spec_authoring::Author
     }
 }
 
-fn authoring_error_detail(e: &crate::workflow_generation::spec_authoring::AuthoringError) -> String {
+fn authoring_error_detail(
+    e: &crate::workflow_generation::spec_authoring::AuthoringError,
+) -> String {
     use crate::workflow_generation::spec_authoring::AuthoringError::*;
     match e {
         NoDiscoveryArtifact { pathname } => {
@@ -576,10 +588,7 @@ impl From<SpecProposalRow> for ProposalListItem {
     }
 }
 
-pub async fn get_list(
-    State(state): State<Arc<ApiState>>,
-    Query(q): Query<ListQuery>,
-) -> Response {
+pub async fn get_list(State(state): State<Arc<ApiState>>, Query(q): Query<ListQuery>) -> Response {
     let limit = q.limit.unwrap_or(50);
     let offset = q.offset.unwrap_or(0);
     let pg_db = state.app_state.pg_db.clone();
@@ -740,7 +749,10 @@ mod tests {
 
     #[test]
     fn spec_id_to_pathname_simple() {
-        assert_eq!(spec_id_to_pathname("account-billing").as_deref(), Some("/account/billing"));
+        assert_eq!(
+            spec_id_to_pathname("account-billing").as_deref(),
+            Some("/account/billing")
+        );
         assert_eq!(spec_id_to_pathname("home").as_deref(), Some("/home"));
         assert_eq!(spec_id_to_pathname("index").as_deref(), Some("/"));
         assert_eq!(spec_id_to_pathname(""), None);
@@ -760,7 +772,10 @@ mod tests {
             line: 12,
             suggested_assertion: String::new(),
         };
-        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("account-billing"));
+        assert_eq!(
+            infer_target_spec_id(&elem).as_deref(),
+            Some("account-billing")
+        );
     }
 
     #[test]
@@ -788,7 +803,10 @@ mod tests {
             line: 12,
             suggested_assertion: String::new(),
         };
-        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("account-billing"));
+        assert_eq!(
+            infer_target_spec_id(&elem).as_deref(),
+            Some("account-billing")
+        );
     }
 
     #[test]
@@ -824,7 +842,10 @@ mod tests {
             line: 12,
             suggested_assertion: String::new(),
         };
-        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("account-billing"));
+        assert_eq!(
+            infer_target_spec_id(&elem).as_deref(),
+            Some("account-billing")
+        );
     }
 
     #[test]
@@ -851,7 +872,11 @@ mod tests {
             .join("demo-page")
             .join("_pending")
             .join("state-machine.derived.json");
-        assert!(target.exists(), "target file should exist: {}", target.display());
+        assert!(
+            target.exists(),
+            "target file should exist: {}",
+            target.display()
+        );
         let body = std::fs::read_to_string(&target).unwrap();
         assert!(body.contains("\"id\""));
         assert!(body.contains("demo-page"));
@@ -873,10 +898,9 @@ mod tests {
 
     #[test]
     fn scan_request_parses_full_payload() {
-        let req: ScanRequest = serde_json::from_str(
-            r#"{ "minObservations": 10, "lookbackDays": 30, "limit": 5 }"#,
-        )
-        .unwrap();
+        let req: ScanRequest =
+            serde_json::from_str(r#"{ "minObservations": 10, "lookbackDays": 30, "limit": 5 }"#)
+                .unwrap();
         assert_eq!(req.min_observations, Some(10));
         assert_eq!(req.lookback_days, Some(30));
         assert_eq!(req.limit, Some(5));
@@ -947,7 +971,9 @@ mod tests {
             .await
             .expect("insert");
             let rows = db.list_proposals(10, 0).await.expect("list");
-            assert!(rows.iter().any(|r| r.id == "prop_test_list" && r.status == "queued"));
+            assert!(rows
+                .iter()
+                .any(|r| r.id == "prop_test_list" && r.status == "queued"));
         }
     }
 }

--- a/src-tauri/src/spec_api/proposals.rs
+++ b/src-tauri/src/spec_api/proposals.rs
@@ -1,0 +1,953 @@
+//! Spec proposals — Stream E (Flywheel) coverage-growth queue.
+//!
+//! Three endpoints, mounted under `/spec/proposals/...` when the
+//! `spec-authoring` feature is enabled:
+//!
+//! - `POST /spec/proposals/scan` — discovers eligible `fullPage` candidates
+//!   (un-spec'd pathnames with ≥ N observations in the lookback window) and
+//!   `patch` candidates (drift-flagged specs), inserts them into
+//!   `project.spec_proposals` with `status = 'queued'`.
+//! - `POST /spec/proposals/{id}/execute` — drives one queued proposal through
+//!   `spec_authoring::author_candidate` and (in Step 8) the three-gate
+//!   validator. **This PR stubs the validator** — successful authoring lands
+//!   the candidate in `_pending/` via a placeholder writer; failures persist
+//!   the structured `AuthoringError` reason.
+//! - `GET /spec/proposals` — paginated list of all proposal rows.
+//!
+//! See `qontinui-dev-notes/spec-check-v1/05-flywheel.md` Steps 6–7 for the
+//! design context; the SQL trigger query is verbatim from the plan
+//! (§ Step 7 — "Full-page branch").
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::extract::{Path as AxPath, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use tracing::{debug, info, warn};
+
+use crate::commands::spec_drift::RegisteredElement;
+use crate::database::pg::spec_proposals::SpecProposalRow;
+use crate::mcp::types::ApiState;
+use crate::spec_api::responses::SpecError;
+use crate::spec_api::storage;
+
+// =============================================================================
+// Scan endpoint — POST /spec/proposals/scan
+// =============================================================================
+
+/// Default knobs for `/spec/proposals/scan`. All tunable via the request
+/// body. Defaults come from `05-flywheel.md` § Step 7 ("`N` (default 50) and
+/// 90-day window are baked into the SQL").
+const DEFAULT_MIN_OBSERVATIONS: i32 = 50;
+const DEFAULT_LOOKBACK_DAYS: i32 = 90;
+const DEFAULT_SCAN_LIMIT: i64 = 100;
+
+/// Request body for `/spec/proposals/scan`. All fields optional.
+#[derive(Debug, Deserialize, Default)]
+pub struct ScanRequest {
+    #[serde(rename = "minObservations")]
+    pub min_observations: Option<i32>,
+    #[serde(rename = "lookbackDays")]
+    pub lookback_days: Option<i32>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct QueuedProposalSummary {
+    #[serde(rename = "proposalId")]
+    proposal_id: String,
+    kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pathname: Option<String>,
+    #[serde(rename = "specId", skip_serializing_if = "Option::is_none")]
+    spec_id: Option<String>,
+}
+
+pub async fn post_scan(
+    State(state): State<Arc<ApiState>>,
+    body: Option<Json<ScanRequest>>,
+) -> Response {
+    let req = body.map(|Json(b)| b).unwrap_or_default();
+    let min_obs = req.min_observations.unwrap_or(DEFAULT_MIN_OBSERVATIONS);
+    let lookback = req.lookback_days.unwrap_or(DEFAULT_LOOKBACK_DAYS);
+    let limit = req.limit.unwrap_or(DEFAULT_SCAN_LIMIT);
+
+    let pg_db = state.app_state.pg_db.clone();
+    let root = storage::resolve_specs_root();
+
+    // ---- Full-page branch -------------------------------------------------
+    let full_page_rows = match query_eligible_pathnames(&pg_db, lookback, min_obs, limit).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!("post_scan: query_eligible_pathnames failed: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "scan-query-failed",
+                    json!({ "branch": "fullPage", "error": e }),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let on_disk = storage::list_pages(&root).unwrap_or_default();
+    let on_disk_pathnames: HashSet<String> = on_disk
+        .iter()
+        .filter_map(|id| spec_id_to_pathname(id))
+        .collect();
+
+    let mut queued: Vec<QueuedProposalSummary> = Vec::new();
+    let scanned_pathnames = full_page_rows.len();
+    for pathname in full_page_rows {
+        if on_disk_pathnames.contains(&pathname) {
+            debug!("post_scan: pathname {} already has a spec; skipping", pathname);
+            continue;
+        }
+        let proposal_id = mint_proposal_id();
+        let metadata = json!({
+            "minObservations": min_obs,
+            "lookbackDays": lookback,
+        });
+        match pg_db
+            .insert_proposal(
+                &proposal_id,
+                "fullPage",
+                Some(&pathname),
+                None,
+                "queued",
+                &metadata,
+            )
+            .await
+        {
+            Ok(true) => {
+                queued.push(QueuedProposalSummary {
+                    proposal_id,
+                    kind: "fullPage".to_string(),
+                    pathname: Some(pathname),
+                    spec_id: None,
+                });
+            }
+            Ok(false) => {
+                // Dedup hit — already queued.
+                debug!(
+                    "post_scan: fullPage pathname {} already queued (dedup)",
+                    pathname
+                );
+            }
+            Err(e) => {
+                warn!("post_scan: insert_proposal (fullPage) failed: {}", e);
+            }
+        }
+    }
+
+    // ---- Patch branch -----------------------------------------------------
+    let project_root = std::env::var("QONTINUI_PROJECT_ROOT").unwrap_or_else(|_| ".".into());
+    let mut scanned_drift_reports = 0usize;
+    match crate::commands::spec_drift::scan_spec_drift(project_root.clone()).await {
+        Ok(drift) => {
+            scanned_drift_reports = 1;
+            let mut per_spec: std::collections::BTreeMap<String, Vec<&RegisteredElement>> =
+                Default::default();
+            for elem in &drift.missing_from_spec {
+                if let Some(target_id) = infer_target_spec_id(elem) {
+                    per_spec.entry(target_id).or_default().push(elem);
+                }
+            }
+            for (target_spec_id, elems) in per_spec {
+                let proposal_id = mint_proposal_id();
+                let metadata = json!({
+                    "missingElementIds": elems.iter().map(|e| &e.id).collect::<Vec<_>>(),
+                    "missingCount": elems.len(),
+                });
+                match pg_db
+                    .insert_proposal(
+                        &proposal_id,
+                        "patch",
+                        None,
+                        Some(&target_spec_id),
+                        "queued",
+                        &metadata,
+                    )
+                    .await
+                {
+                    Ok(true) => {
+                        queued.push(QueuedProposalSummary {
+                            proposal_id,
+                            kind: "patch".to_string(),
+                            pathname: None,
+                            spec_id: Some(target_spec_id),
+                        });
+                    }
+                    Ok(false) => {
+                        debug!(
+                            "post_scan: patch spec_id {} already queued (dedup)",
+                            target_spec_id
+                        );
+                    }
+                    Err(e) => {
+                        warn!("post_scan: insert_proposal (patch) failed: {}", e);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            // Soft failure — drift scan can fail (e.g. project_root missing)
+            // without breaking the full-page branch. Surface in the response
+            // but don't 500.
+            warn!("post_scan: scan_spec_drift failed: {}", e);
+        }
+    }
+
+    let reason = if queued.is_empty() {
+        "no-eligible-pathnames".to_string()
+    } else {
+        format!("queued-{}-proposals", queued.len())
+    };
+
+    info!(
+        "post_scan: scanned_pathnames={} scanned_drift_reports={} queued={}",
+        scanned_pathnames,
+        scanned_drift_reports,
+        queued.len()
+    );
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "scannedPathnames": scanned_pathnames,
+            "scannedDriftReports": scanned_drift_reports,
+            "queuedProposals": queued,
+            "reason": reason,
+        })),
+    )
+        .into_response()
+}
+
+/// Run the verbatim SQL from `05-flywheel.md` § Step 7 against
+/// `co_occurrence_observations`. Returns pathnames sorted by observation
+/// count desc, capped at `limit`.
+async fn query_eligible_pathnames(
+    pg_db: &crate::database::pg::PgDb,
+    lookback_days: i32,
+    min_observations: i32,
+    limit: i64,
+) -> Result<Vec<String>, String> {
+    let conn = pg_db
+        .pool()
+        .get()
+        .await
+        .map_err(|e| format!("PG pool error: {}", e))?;
+    let rows = conn
+        .query(
+            r#"
+            SELECT
+                snapshot_metadata->>'pathname' AS pathname,
+                COUNT(*) AS obs
+            FROM co_occurrence_observations
+            WHERE captured_at >= now() - ($1::int || ' days')::interval
+              AND invalidated_at IS NULL
+              AND (snapshot_metadata->>'pathname') IS NOT NULL
+            GROUP BY pathname
+            HAVING COUNT(*) >= $2
+            ORDER BY obs DESC
+            LIMIT $3
+            "#,
+            &[&lookback_days, &(min_observations as i64), &limit],
+        )
+        .await
+        .map_err(|e| format!("PG query_eligible_pathnames: {}", e))?;
+
+    Ok(rows.iter().map(|r| r.get::<usize, String>(0)).collect())
+}
+
+// =============================================================================
+// Execute endpoint — POST /spec/proposals/{id}/execute
+// =============================================================================
+
+pub async fn post_execute(
+    State(state): State<Arc<ApiState>>,
+    AxPath(id): AxPath<String>,
+) -> Response {
+    let pg_db = state.app_state.pg_db.clone();
+    let app_state = state.app_state.clone();
+
+    // Look up the proposal.
+    let row = match pg_db.find_proposal_by_id(&id).await {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(SpecError::with_detail(
+                    "proposal-not-found",
+                    json!({ "proposalId": id }),
+                )),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            warn!("post_execute: find_proposal_by_id failed: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "proposal-lookup-failed",
+                    json!({ "proposalId": id, "error": e }),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    // Transition to inFlight (best-effort; ignore errors so we still try to
+    // author rather than wedging the queue).
+    if let Err(e) = pg_db.update_proposal_status(&row.id, "inFlight").await {
+        warn!("post_execute: update_proposal_status (inFlight) failed: {}", e);
+    }
+    let _ = pg_db.update_proposal_attempt_only(&row.id).await;
+
+    // Build the authoring mode from the row shape.
+    let mode = match row.kind.as_str() {
+        "fullPage" => {
+            let pathname = match row.pathname.clone() {
+                Some(p) => p,
+                None => {
+                    let msg = "fullPage proposal missing pathname".to_string();
+                    let _ = pg_db
+                        .update_proposal_status_with_error(&row.id, "failed", &msg)
+                        .await;
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(SpecError::with_detail(
+                            "proposal-shape-invalid",
+                            json!({ "proposalId": row.id, "reason": msg }),
+                        )),
+                    )
+                        .into_response();
+                }
+            };
+            crate::workflow_generation::spec_authoring::AuthoringMode::FullPage { pathname }
+        }
+        "patch" => {
+            let existing_spec_id = match row.spec_id.clone() {
+                Some(s) => s,
+                None => {
+                    let msg = "patch proposal missing spec_id".to_string();
+                    let _ = pg_db
+                        .update_proposal_status_with_error(&row.id, "failed", &msg)
+                        .await;
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(SpecError::with_detail(
+                            "proposal-shape-invalid",
+                            json!({ "proposalId": row.id, "reason": msg }),
+                        )),
+                    )
+                        .into_response();
+                }
+            };
+            // Patch mode requires a fresh drift report — re-scan to get the
+            // current delta (the queued row only carries the missing element
+            // ids in `metadata`, not the full report shape).
+            let project_root = std::env::var("QONTINUI_PROJECT_ROOT").unwrap_or_else(|_| ".".into());
+            let drift = match crate::commands::spec_drift::scan_spec_drift(project_root).await {
+                Ok(d) => d,
+                Err(e) => {
+                    let _ = pg_db
+                        .update_proposal_status_with_error(&row.id, "failed", &e)
+                        .await;
+                    return (
+                        StatusCode::OK,
+                        Json(json!({
+                            "ok": false,
+                            "proposalId": row.id,
+                            "outcome": "authoring-failed",
+                            "reason": "drift-scan-failed",
+                            "detail": e,
+                        })),
+                    )
+                        .into_response();
+                }
+            };
+            crate::workflow_generation::spec_authoring::AuthoringMode::Patch {
+                existing_spec_id,
+                drift,
+            }
+        }
+        other => {
+            let msg = format!("unknown proposal kind: {}", other);
+            let _ = pg_db
+                .update_proposal_status_with_error(&row.id, "failed", &msg)
+                .await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "proposal-shape-invalid",
+                    json!({ "proposalId": row.id, "reason": msg }),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    // Dispatch to spec_authoring. The sibling agent owns this module — at
+    // integration time, an unresolved import here means the sibling's PR
+    // hasn't landed yet.
+    let outcome = match crate::workflow_generation::spec_authoring::author_candidate(
+        pg_db.clone(),
+        app_state,
+        mode,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            let reason = authoring_error_reason(&e);
+            let detail = authoring_error_detail(&e);
+            let _ = pg_db
+                .update_proposal_status_with_error(&row.id, "failed", &detail)
+                .await;
+            return (
+                StatusCode::OK,
+                Json(json!({
+                    "ok": false,
+                    "proposalId": row.id,
+                    "outcome": "authoring-failed",
+                    "reason": reason,
+                    "detail": detail,
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // TODO(Step 8): replace with full validator gate (round-trip + coverage +
+    // b-green) and Step 9: replace with storage::write_pending_ir.
+    let staged_path = match stage_pending_ir_placeholder(&storage::resolve_specs_root(), &outcome.candidate) {
+        Ok(p) => p,
+        Err(e) => {
+            let _ = pg_db
+                .update_proposal_status_with_error(&row.id, "failed", &e)
+                .await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "stage-pending-failed",
+                    json!({ "proposalId": row.id, "error": e }),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    // Persist the candidate IR + flip to pendingPromotion (skipping the
+    // pendingValidation hop that Step 8 will introduce).
+    let candidate_json = match serde_json::to_value(&outcome.candidate) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("post_execute: serialize candidate failed: {}", e);
+            let msg = format!("serialize candidate: {}", e);
+            let _ = pg_db
+                .update_proposal_status_with_error(&row.id, "failed", &msg)
+                .await;
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "serialize-candidate-failed",
+                    json!({ "proposalId": row.id, "error": msg }),
+                )),
+            )
+                .into_response();
+        }
+    };
+    if let Err(e) = pg_db
+        .update_proposal_candidate_ir(&row.id, "pendingPromotion", &candidate_json)
+        .await
+    {
+        warn!("post_execute: update_proposal_candidate_ir failed: {}", e);
+    }
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "proposalId": row.id,
+            "outcome": "landed-in-pending",
+            "stagedPath": staged_path,
+        })),
+    )
+        .into_response()
+}
+
+fn authoring_error_reason(e: &crate::workflow_generation::spec_authoring::AuthoringError) -> &'static str {
+    use crate::workflow_generation::spec_authoring::AuthoringError::*;
+    match e {
+        NoDiscoveryArtifact { .. } => "no-discovery-artifact",
+        EmptyArtifact => "empty-artifact",
+        MalformedAiOutput(_) => "malformed-ai-output",
+        AiDispatchFailed(_) => "ai-dispatch-failed",
+        ExistingSpecMissing(_) => "existing-spec-missing",
+        Database(_) => "database-error",
+    }
+}
+
+fn authoring_error_detail(e: &crate::workflow_generation::spec_authoring::AuthoringError) -> String {
+    use crate::workflow_generation::spec_authoring::AuthoringError::*;
+    match e {
+        NoDiscoveryArtifact { pathname } => {
+            format!("no discovery artifact for pathname={}", pathname)
+        }
+        EmptyArtifact => "discovery artifact has zero states".to_string(),
+        MalformedAiOutput(s) => format!("malformed AI output: {}", s),
+        AiDispatchFailed(s) => format!("AI dispatch failed: {}", s),
+        ExistingSpecMissing(s) => format!("existing spec missing: {}", s),
+        Database(s) => format!("database error: {}", s),
+    }
+}
+
+/// Placeholder writer for the staged candidate IR. Bypasses the validator
+/// (Step 8) and the canonical `storage::write_pending_ir` helper (Step 9 will
+/// introduce that helper); writes the IR file to
+/// `specs/pages/<id>/_pending/state-machine.derived.json` and stops.
+///
+/// **Do not extend this** — Step 8/9 replace it entirely.
+fn stage_pending_ir_placeholder(
+    root: &Path,
+    candidate: &crate::spec_api::types::IrPageSpec,
+) -> Result<String, String> {
+    let page_dir = root.join("pages").join(&candidate.id).join("_pending");
+    std::fs::create_dir_all(&page_dir)
+        .map_err(|e| format!("create_dir_all {}: {}", page_dir.display(), e))?;
+    let target = page_dir.join("state-machine.derived.json");
+    let json = serde_json::to_string_pretty(candidate)
+        .map_err(|e| format!("serialize candidate: {}", e))?;
+    std::fs::write(&target, json.as_bytes())
+        .map_err(|e| format!("write {}: {}", target.display(), e))?;
+    Ok(target.display().to_string())
+}
+
+// =============================================================================
+// List endpoint — GET /spec/proposals
+// =============================================================================
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ListQuery {
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ProposalListItem {
+    #[serde(rename = "proposalId")]
+    proposal_id: String,
+    kind: String,
+    pathname: Option<String>,
+    #[serde(rename = "specId")]
+    spec_id: Option<String>,
+    status: String,
+    #[serde(rename = "createdAt")]
+    created_at: String,
+    #[serde(rename = "lastAttemptAt")]
+    last_attempt_at: Option<String>,
+    #[serde(rename = "consecutiveGreens")]
+    consecutive_greens: i32,
+    #[serde(rename = "lastError")]
+    last_error: Option<String>,
+}
+
+impl From<SpecProposalRow> for ProposalListItem {
+    fn from(r: SpecProposalRow) -> Self {
+        Self {
+            proposal_id: r.id,
+            kind: r.kind,
+            pathname: r.pathname,
+            spec_id: r.spec_id,
+            status: r.status,
+            created_at: r.created_at,
+            last_attempt_at: r.last_attempt_at,
+            consecutive_greens: r.consecutive_greens,
+            last_error: r.last_error,
+        }
+    }
+}
+
+pub async fn get_list(
+    State(state): State<Arc<ApiState>>,
+    Query(q): Query<ListQuery>,
+) -> Response {
+    let limit = q.limit.unwrap_or(50);
+    let offset = q.offset.unwrap_or(0);
+    let pg_db = state.app_state.pg_db.clone();
+
+    match pg_db.list_proposals(limit, offset).await {
+        Ok(rows) => {
+            let items: Vec<ProposalListItem> = rows.into_iter().map(Into::into).collect();
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "ok": true,
+                    "proposals": items,
+                })),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            warn!("get_list: list_proposals failed: {}", e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "list-proposals-failed",
+                    json!({ "error": e }),
+                )),
+            )
+                .into_response()
+        }
+    }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Generate a new proposal id of the form `prop_<UUIDv7>`.
+///
+/// Plan reference: `05-flywheel.md` § Step 6 ("ULID: there's no `ulid` crate.
+/// Use `format!("prop_{{}}", uuid::Uuid::now_v7())`"). UUIDv7 carries a
+/// millisecond timestamp prefix so the queue lists in roughly creation order
+/// even without `ORDER BY created_at`.
+fn mint_proposal_id() -> String {
+    format!("prop_{}", uuid::Uuid::now_v7())
+}
+
+/// Convert an on-disk page id (slug form, e.g. `account-billing`) back to
+/// its pathname (e.g. `/account/billing`). Inverse of `pathname_to_spec_id`
+/// owned by the sibling `workflow_generation::spec_authoring` module.
+///
+/// v1.0 slug shape: pathname segments joined with `-`, lowercased, leading
+/// slash dropped. Index pathnames (empty / `/`) map to `index`. Anything
+/// outside that shape returns `None`.
+fn spec_id_to_pathname(spec_id: &str) -> Option<String> {
+    if spec_id.is_empty() {
+        return None;
+    }
+    if spec_id == "index" {
+        return Some("/".to_string());
+    }
+    // Reject anything that wouldn't round-trip cleanly through the slug
+    // shape — e.g. uppercase, double-dashes (which would collapse on
+    // re-slug), leading/trailing dashes.
+    if spec_id.chars().any(|c| c.is_uppercase())
+        || spec_id.contains("--")
+        || spec_id.starts_with('-')
+        || spec_id.ends_with('-')
+    {
+        return None;
+    }
+    Some(format!("/{}", spec_id.replace('-', "/")))
+}
+
+/// Map a `RegisteredElement` (from `commands::spec_drift::DriftReport
+/// .missing_from_spec`) to a target `spec_id`, using `elem.file` as the
+/// pathname-routing input.
+///
+/// Heuristic v1.0: strip the conventional Next.js / Vite source-tree prefix
+/// (`src/pages/...`, `src/app/...`, `app/...`), drop the file extension and
+/// the `index` leaf, lowercase, and slugify by joining the remaining
+/// segments with `-`. Files outside these prefixes return `None` (the
+/// caller drops them — patch routing is best-effort).
+///
+/// Sibling-module symmetry: keeps the slug shape identical to the
+/// `pathname_to_spec_id` helper owned by `workflow_generation::spec_authoring`.
+/// If the sibling makes that helper `pub(crate)`, this should be deleted in
+/// favor of calling it directly.
+fn infer_target_spec_id(elem: &RegisteredElement) -> Option<String> {
+    let file = elem.file.replace('\\', "/");
+
+    // Strip the leading source-tree prefix; preserve order, longest first.
+    let candidates = [
+        "src/pages/",
+        "src/app/",
+        "pages/",
+        "app/",
+        "src/views/",
+        "src/routes/",
+    ];
+    let mut tail: Option<&str> = None;
+    for prefix in &candidates {
+        if let Some(idx) = file.find(prefix) {
+            tail = Some(&file[idx + prefix.len()..]);
+            break;
+        }
+    }
+    let tail = tail?;
+
+    // Drop extension and trim.
+    let no_ext = match tail.rsplit_once('.') {
+        Some((stem, _)) => stem,
+        None => tail,
+    };
+
+    let segments: Vec<String> = no_ext
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_lowercase())
+        .collect();
+
+    if segments.is_empty() {
+        return None;
+    }
+
+    // Drop trailing `index` (e.g. `account/billing/index.tsx` →
+    // `account/billing`). Index-at-root maps to "index".
+    let trimmed: Vec<String> = if segments.last().map(|s| s.as_str()) == Some("index") {
+        let n = segments.len();
+        if n == 1 {
+            return Some("index".to_string());
+        }
+        segments.into_iter().take(n - 1).collect()
+    } else {
+        segments
+    };
+
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    Some(trimmed.join("-"))
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_proposal_id_shape() {
+        let id = mint_proposal_id();
+        assert!(id.starts_with("prop_"), "expected prop_ prefix: {}", id);
+        // UUIDv7 string is 36 chars (8-4-4-4-12 plus 4 dashes); plus the
+        // 5-char prefix.
+        assert_eq!(id.len(), 5 + 36, "unexpected proposal id length: {}", id);
+    }
+
+    #[test]
+    fn spec_id_to_pathname_simple() {
+        assert_eq!(spec_id_to_pathname("account-billing").as_deref(), Some("/account/billing"));
+        assert_eq!(spec_id_to_pathname("home").as_deref(), Some("/home"));
+        assert_eq!(spec_id_to_pathname("index").as_deref(), Some("/"));
+        assert_eq!(spec_id_to_pathname(""), None);
+        // Reject non-roundtrippable shapes.
+        assert_eq!(spec_id_to_pathname("Account-Billing"), None);
+        assert_eq!(spec_id_to_pathname("-leading"), None);
+        assert_eq!(spec_id_to_pathname("trailing-"), None);
+        assert_eq!(spec_id_to_pathname("double--dash"), None);
+    }
+
+    #[test]
+    fn infer_target_spec_id_strips_src_pages() {
+        let elem = RegisteredElement {
+            id: "btn-save".into(),
+            label: None,
+            file: "src/pages/account/billing.tsx".into(),
+            line: 12,
+            suggested_assertion: String::new(),
+        };
+        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("account-billing"));
+    }
+
+    #[test]
+    fn infer_target_spec_id_strips_app_dir() {
+        let elem = RegisteredElement {
+            id: "btn-save".into(),
+            label: None,
+            file: "src/app/settings/general/page.tsx".into(),
+            line: 12,
+            suggested_assertion: String::new(),
+        };
+        // `page.tsx` is not the literal `index`, so it stays as a segment.
+        assert_eq!(
+            infer_target_spec_id(&elem).as_deref(),
+            Some("settings-general-page")
+        );
+    }
+
+    #[test]
+    fn infer_target_spec_id_drops_index_leaf() {
+        let elem = RegisteredElement {
+            id: "btn-save".into(),
+            label: None,
+            file: "src/pages/account/billing/index.tsx".into(),
+            line: 12,
+            suggested_assertion: String::new(),
+        };
+        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("account-billing"));
+    }
+
+    #[test]
+    fn infer_target_spec_id_root_index() {
+        let elem = RegisteredElement {
+            id: "btn-save".into(),
+            label: None,
+            file: "src/pages/index.tsx".into(),
+            line: 12,
+            suggested_assertion: String::new(),
+        };
+        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("index"));
+    }
+
+    #[test]
+    fn infer_target_spec_id_outside_known_prefixes() {
+        let elem = RegisteredElement {
+            id: "btn-save".into(),
+            label: None,
+            file: "src-tauri/src/main.rs".into(),
+            line: 12,
+            suggested_assertion: String::new(),
+        };
+        assert_eq!(infer_target_spec_id(&elem), None);
+    }
+
+    #[test]
+    fn infer_target_spec_id_tolerates_backslashes() {
+        let elem = RegisteredElement {
+            id: "btn-save".into(),
+            label: None,
+            file: "src\\pages\\account\\billing.tsx".into(),
+            line: 12,
+            suggested_assertion: String::new(),
+        };
+        assert_eq!(infer_target_spec_id(&elem).as_deref(), Some("account-billing"));
+    }
+
+    #[test]
+    fn stage_pending_ir_placeholder_writes_to_pending_dir() {
+        use crate::spec_api::types::IrPageSpec;
+        let tmp = tempfile::tempdir().unwrap();
+        let candidate = IrPageSpec {
+            version: "1.0".into(),
+            id: "demo-page".into(),
+            name: "Demo Page".into(),
+            description: None,
+            metadata: None,
+            provenance: None,
+            states: Vec::new(),
+            transitions: Vec::new(),
+            synthesized_groups: None,
+            initial_state: None,
+        };
+        let path = stage_pending_ir_placeholder(tmp.path(), &candidate).unwrap();
+        assert!(path.contains("_pending"));
+        let target = tmp
+            .path()
+            .join("pages")
+            .join("demo-page")
+            .join("_pending")
+            .join("state-machine.derived.json");
+        assert!(target.exists(), "target file should exist: {}", target.display());
+        let body = std::fs::read_to_string(&target).unwrap();
+        assert!(body.contains("\"id\""));
+        assert!(body.contains("demo-page"));
+    }
+
+    #[test]
+    fn scan_request_defaults() {
+        let req: ScanRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(
+            req.min_observations.unwrap_or(DEFAULT_MIN_OBSERVATIONS),
+            DEFAULT_MIN_OBSERVATIONS
+        );
+        assert_eq!(
+            req.lookback_days.unwrap_or(DEFAULT_LOOKBACK_DAYS),
+            DEFAULT_LOOKBACK_DAYS
+        );
+        assert_eq!(req.limit.unwrap_or(DEFAULT_SCAN_LIMIT), DEFAULT_SCAN_LIMIT);
+    }
+
+    #[test]
+    fn scan_request_parses_full_payload() {
+        let req: ScanRequest = serde_json::from_str(
+            r#"{ "minObservations": 10, "lookbackDays": 30, "limit": 5 }"#,
+        )
+        .unwrap();
+        assert_eq!(req.min_observations, Some(10));
+        assert_eq!(req.lookback_days, Some(30));
+        assert_eq!(req.limit, Some(5));
+    }
+
+    /// PG-bound tests are gated behind `pg_integration_tests` because the
+    /// shared dev DB is the only place the `project.spec_proposals` table
+    /// exists (Atlas-managed). Unit tests above cover the pure helpers
+    /// (slug, JSON shapes, placeholder writer).
+    ///
+    /// To run: `cargo test --features spec-authoring,pg_integration_tests -- proposals::tests::pg`
+    #[cfg(feature = "pg_integration_tests")]
+    mod pg {
+        use super::*;
+        use crate::database::pg::PgDb;
+
+        async fn fresh_db() -> std::sync::Arc<PgDb> {
+            // The integration DB must already have spec_proposals (Atlas).
+            let db = PgDb::new_blocking_for_test();
+            // Wipe any prior test rows so dedup behaves deterministically.
+            let conn = db.pool().get().await.expect("pg conn");
+            conn.execute("TRUNCATE TABLE spec_proposals", &[])
+                .await
+                .expect("truncate spec_proposals");
+            db
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn insert_dedupes_on_kind_and_target() {
+            let db = fresh_db().await;
+            let first = db
+                .insert_proposal(
+                    "prop_test_one",
+                    "fullPage",
+                    Some("/foo"),
+                    None,
+                    "queued",
+                    &serde_json::json!({}),
+                )
+                .await
+                .expect("first insert");
+            assert!(first, "first insert should succeed");
+            let second = db
+                .insert_proposal(
+                    "prop_test_two",
+                    "fullPage",
+                    Some("/foo"),
+                    None,
+                    "queued",
+                    &serde_json::json!({}),
+                )
+                .await
+                .expect("second insert");
+            assert!(!second, "second insert should be deduped");
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn list_round_trips_inserted_rows() {
+            let db = fresh_db().await;
+            db.insert_proposal(
+                "prop_test_list",
+                "fullPage",
+                Some("/bar"),
+                None,
+                "queued",
+                &serde_json::json!({}),
+            )
+            .await
+            .expect("insert");
+            let rows = db.list_proposals(10, 0).await.expect("list");
+            assert!(rows.iter().any(|r| r.id == "prop_test_list" && r.status == "queued"));
+        }
+    }
+}

--- a/src-tauri/src/workflow_generation/meta_workflow.rs
+++ b/src-tauri/src/workflow_generation/meta_workflow.rs
@@ -1375,8 +1375,7 @@ pub async fn build_spec_priming_context(
 
     // Pull self-improvement + GT-reference sections from the standard path
     // so verifier focus items still come from the workflow corpus.
-    let baseline =
-        build_historical_context_pg(pg_db, &skeleton.name, Some("spec-authoring")).await;
+    let baseline = build_historical_context_pg(pg_db, &skeleton.name, Some("spec-authoring")).await;
 
     let (improvement_section, verifier_focus_items, past_fixes_section, gt_reference_section) =
         match baseline {

--- a/src-tauri/src/workflow_generation/meta_workflow.rs
+++ b/src-tauri/src/workflow_generation/meta_workflow.rs
@@ -1262,6 +1262,149 @@ fn build_past_fixes_section() -> String {
     String::new()
 }
 
+// ---------------------------------------------------------------------------
+// Stream E (Flywheel) — spec-authoring priming context
+// ---------------------------------------------------------------------------
+//
+// Builds a HistoricalContext priming bundle tuned for spec-authoring rather
+// than workflow generation. The `spec_authoring` module composes the
+// skeleton + the AI fill-in via the meta-workflow template; this helper is
+// the priming-corpus loader for that second step. Selection is by Jaccard
+// similarity of cluster element fingerprints (state assertions / element
+// criteria identifiers). Reuses the standard `similar_workflows` formatters
+// so the prompt shape is identical to the workflow-generation path.
+//
+// Gated behind `spec-authoring` so the default build doesn't pull in
+// `spec_api::storage`/IR-walking helpers it doesn't otherwise need.
+#[cfg(feature = "spec-authoring")]
+pub async fn build_spec_priming_context(
+    pg_db: &std::sync::Arc<crate::database::pg::PgDb>,
+    skeleton: &qontinui_types::ir::IrPageSpec,
+    top_k: usize,
+) -> Option<HistoricalContext> {
+    use crate::spec_api::{storage, types::IrPageSpec};
+
+    // Build the skeleton's fingerprint set once. Each IrElementCriteria
+    // contributes its `id`/`aria_label`/`tag_name+text` (whichever is set,
+    // in stable priority order) as a token.
+    fn fingerprint_tokens(spec: &IrPageSpec) -> std::collections::BTreeSet<String> {
+        let mut out = std::collections::BTreeSet::new();
+        for state in &spec.states {
+            // assertions live in IrAssertion.target.criteria as free-form
+            // JSON; we only extract from `excluded_elements` since the
+            // skeleton stores discovered fingerprints there.
+            if let Some(excluded) = &state.excluded_elements {
+                for crit in excluded {
+                    if let Some(id) = &crit.id {
+                        out.insert(format!("id:{}", id));
+                    } else if let Some(aria) = &crit.aria_label {
+                        out.insert(format!("aria:{}", aria));
+                    } else if let (Some(tag), Some(text)) = (&crit.tag_name, &crit.text) {
+                        out.insert(format!("tag:{}:{}", tag, text));
+                    } else if let Some(role) = &crit.role {
+                        out.insert(format!("role:{}", role));
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    let skeleton_tokens = fingerprint_tokens(skeleton);
+    if skeleton_tokens.is_empty() {
+        // Fall back to the standard workflow path so we still get
+        // self-improvement context + GT references.
+        return build_historical_context_pg(pg_db, &skeleton.name, Some("spec-authoring")).await;
+    }
+
+    // List existing IR pages and rank by Jaccard similarity. We do a
+    // best-effort filesystem scan (cheap; <500 pages today) and skip any
+    // page that fails to read.
+    let root = storage::resolve_specs_root();
+    let candidates = storage::list_pages(&root).unwrap_or_default();
+
+    let mut scored: Vec<(f32, IrPageSpec)> = Vec::new();
+    for page_id in candidates {
+        if page_id == skeleton.id {
+            continue;
+        }
+        let Ok(Some(other)) = storage::read_ir(&root, &page_id) else {
+            continue;
+        };
+        let other_tokens = fingerprint_tokens(&other);
+        if other_tokens.is_empty() {
+            continue;
+        }
+        let intersection = skeleton_tokens.intersection(&other_tokens).count() as f32;
+        let union = skeleton_tokens.union(&other_tokens).count() as f32;
+        if union == 0.0 {
+            continue;
+        }
+        let jaccard = intersection / union;
+        if jaccard > 0.0 {
+            scored.push((jaccard, other));
+        }
+    }
+    scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(top_k);
+
+    // Reuse the standard similar_workflows formatter — we synthesize a
+    // SimilarWorkflow row per IR so the prompt shape is identical to the
+    // workflow-gen path. Step counts collapse to state/transition counts.
+    let similar: Vec<super::similar_workflows::SimilarWorkflow> = scored
+        .iter()
+        .map(|(score, ir)| super::similar_workflows::SimilarWorkflow {
+            id: ir.id.clone(),
+            name: ir.name.clone(),
+            description: ir.description.clone().unwrap_or_default(),
+            category: "spec-authoring".into(),
+            setup_step_count: ir.states.len(),
+            verification_step_count: 0,
+            agentic_step_count: ir.transitions.len(),
+            completion_step_count: 0,
+            similarity: *score,
+            full_json: None,
+        })
+        .collect();
+
+    let similar_section = if similar.is_empty() {
+        String::new()
+    } else {
+        super::similar_workflows::format_similar_workflows(&similar)
+    };
+
+    // Pull self-improvement + GT-reference sections from the standard path
+    // so verifier focus items still come from the workflow corpus.
+    let baseline =
+        build_historical_context_pg(pg_db, &skeleton.name, Some("spec-authoring")).await;
+
+    let (improvement_section, verifier_focus_items, past_fixes_section, gt_reference_section) =
+        match baseline {
+            Some(b) => (
+                b.improvement_section,
+                b.verifier_focus_items,
+                b.past_fixes_section,
+                b.gt_reference_section,
+            ),
+            None => (String::new(), Vec::new(), String::new(), String::new()),
+        };
+
+    if similar_section.is_empty()
+        && improvement_section.is_empty()
+        && gt_reference_section.is_empty()
+    {
+        return None;
+    }
+
+    Some(HistoricalContext {
+        improvement_section,
+        similar_section,
+        verifier_focus_items,
+        past_fixes_section,
+        gt_reference_section,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/workflow_generation/mod.rs
+++ b/src-tauri/src/workflow_generation/mod.rs
@@ -31,6 +31,10 @@ pub mod rules;
 pub mod schema_context;
 pub mod self_improve;
 pub mod similar_workflows;
+// Stream E (Flywheel) — coverage-growth loop. Gated behind the
+// `spec-authoring` Cargo feature so default builds never compile it.
+#[cfg(feature = "spec-authoring")]
+pub mod spec_authoring;
 pub mod spec_synthesis;
 pub mod specification;
 pub mod step_type_knowledge;

--- a/src-tauri/src/workflow_generation/spec_authoring.rs
+++ b/src-tauri/src/workflow_generation/spec_authoring.rs
@@ -347,10 +347,7 @@ fn project_cluster_to_state(cluster: &Cluster) -> IrState {
 
     IrState {
         id: cluster.id.clone(),
-        name: cluster
-            .name
-            .clone()
-            .unwrap_or_else(|| cluster.id.clone()),
+        name: cluster.name.clone().unwrap_or_else(|| cluster.id.clone()),
         description: None,
         assertions: Vec::new(),
         excluded_elements: if criteria.is_empty() {
@@ -447,8 +444,7 @@ async fn ai_fill_skeleton(
         parse_meta_workflow_output(&run_result).map_err(AuthoringError::MalformedAiOutput)?;
     stamp_provenance_ai_generated_proposed(&mut filled);
 
-    enforce_skeleton_invariants(&skeleton, &filled)
-        .map_err(AuthoringError::MalformedAiOutput)?;
+    enforce_skeleton_invariants(&skeleton, &filled).map_err(AuthoringError::MalformedAiOutput)?;
 
     Ok(filled)
 }
@@ -518,10 +514,7 @@ fn stamp_provenance_ai_generated_proposed(ir: &mut IrPageSpec) {
 
 /// Skeleton invariants the AI must not violate. The AI may add transitions,
 /// names, descriptions, metadata — but it may NOT delete states.
-fn enforce_skeleton_invariants(
-    skeleton: &IrPageSpec,
-    filled: &IrPageSpec,
-) -> Result<(), String> {
+fn enforce_skeleton_invariants(skeleton: &IrPageSpec, filled: &IrPageSpec) -> Result<(), String> {
     if filled.states.len() != skeleton.states.len() {
         return Err(format!(
             "state count drift: skeleton={}, filled={}",
@@ -809,8 +802,7 @@ pub(crate) async fn execute_meta_workflow_blocking(
     use crate::database::types::CreateTaskRunInput;
     use crate::unified_workflows::UnifiedWorkflowExt;
 
-    let mut create_request =
-        crate::unified_workflows::unified_workflow_to_create_request(&meta_wf);
+    let mut create_request = crate::unified_workflows::unified_workflow_to_create_request(&meta_wf);
     create_request.generated_by_task_run_id = None;
 
     let saved = pg_db
@@ -919,10 +911,7 @@ mod tests {
     fn skeleton_from_artifact(body: &serde_json::Value, observation_count: i32) -> IrPageSpec {
         // Helper that mirrors the projection path without touching PG.
         let clusters = extract_clusters(body).expect("clusters parse");
-        let mut states: Vec<IrState> = clusters
-            .iter()
-            .map(project_cluster_to_state)
-            .collect();
+        let mut states: Vec<IrState> = clusters.iter().map(project_cluster_to_state).collect();
         states.sort_by(|a, b| a.id.cmp(&b.id));
         IrPageSpec {
             version: "1.0".into(),
@@ -982,10 +971,7 @@ mod tests {
         ]);
         let spec = skeleton_from_artifact(&body, 12);
         assert_eq!(spec.states.len(), 3);
-        assert_eq!(
-            spec.provenance.as_ref().unwrap().source,
-            "build-plugin"
-        );
+        assert_eq!(spec.provenance.as_ref().unwrap().source, "build-plugin");
         assert_eq!(
             spec.provenance.as_ref().unwrap().status,
             Some(ProposalStatus::Proposed)
@@ -1084,8 +1070,14 @@ mod tests {
         });
         // ir.states[1].provenance is None initially.
         stamp_provenance_ai_generated_proposed(&mut ir);
-        assert_eq!(ir.states[0].provenance.as_ref().unwrap().source, "hand-authored");
-        assert_eq!(ir.states[1].provenance.as_ref().unwrap().source, "ai-generated");
+        assert_eq!(
+            ir.states[0].provenance.as_ref().unwrap().source,
+            "hand-authored"
+        );
+        assert_eq!(
+            ir.states[1].provenance.as_ref().unwrap().source,
+            "ai-generated"
+        );
         // Document-level always becomes ai-generated.
         assert_eq!(ir.provenance.as_ref().unwrap().source, "ai-generated");
     }
@@ -1217,7 +1209,9 @@ mod tests {
             .transitions
             .push(make_transition("tx-1", "s1", "s2"));
         let mut patch = IrPatch::default();
-        patch.add_transitions.push(make_transition("tx-1", "s1", "s2"));
+        patch
+            .add_transitions
+            .push(make_transition("tx-1", "s1", "s2"));
         let err = merge_patch_into_ir(existing, patch).unwrap_err();
         assert!(err.contains("collides with an existing transition"));
     }
@@ -1226,7 +1220,9 @@ mod tests {
     fn merge_patch_adds_transition_with_ai_generated_provenance() {
         let existing = make_skeleton(&["s1", "s2"]);
         let mut patch = IrPatch::default();
-        patch.add_transitions.push(make_transition("tx-new", "s1", "s2"));
+        patch
+            .add_transitions
+            .push(make_transition("tx-new", "s1", "s2"));
         let result = merge_patch_into_ir(existing, patch).expect("merge ok");
         assert_eq!(result.transitions.len(), 1);
         let prov = result.transitions[0]
@@ -1241,8 +1237,12 @@ mod tests {
     fn merge_patch_intra_patch_duplicate_transition_id_fails() {
         let existing = make_skeleton(&["s1", "s2"]);
         let mut patch = IrPatch::default();
-        patch.add_transitions.push(make_transition("tx-dup", "s1", "s2"));
-        patch.add_transitions.push(make_transition("tx-dup", "s1", "s2"));
+        patch
+            .add_transitions
+            .push(make_transition("tx-dup", "s1", "s2"));
+        patch
+            .add_transitions
+            .push(make_transition("tx-dup", "s1", "s2"));
         let err = merge_patch_into_ir(existing, patch).unwrap_err();
         assert!(err.contains("duplicate transition id"));
     }

--- a/src-tauri/src/workflow_generation/spec_authoring.rs
+++ b/src-tauri/src/workflow_generation/spec_authoring.rs
@@ -1,0 +1,1285 @@
+//! Spec authoring — composes the discovery pipeline with the meta-workflow
+//! to produce candidate `IrPageSpec`s for un-spec'd pages and patch deltas
+//! for drift-flagged specs.
+//!
+//! Composition only — every step calls an existing primitive:
+//! - skeleton projection: `state_discovery_artifacts` -> `IrPageSpec`
+//! - prompt priming: `meta_workflow::build_spec_priming_context`
+//! - AI fill-in: `meta_workflow::build_meta_workflow_template`
+//! - validation: `spec_api::handlers::post_author` (with the new gates)
+//!
+//! Stream E (Flywheel) — gated behind the `spec-authoring` Cargo feature.
+//! Public API: [`author_candidate`] (entrypoint), [`AuthoringMode`],
+//! [`AuthoringOutcome`], [`AuthoringError`], and [`pathname_to_spec_id`]
+//! (shared with `spec_api::proposals`).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+use crate::database::pg::PgDb;
+use crate::spec_api::types::{
+    IrElementCriteria, IrPageSpec, IrProvenance, IrState, IrTransition, ProposalStatus,
+};
+
+// ---------------------------------------------------------------------------
+// Public surface
+// ---------------------------------------------------------------------------
+
+/// The two authoring flavors.
+///
+/// `FullPage` constructs a fresh candidate from observations alone; `Patch`
+/// reconciles a drift report against an existing IR — only mutating the
+/// affected `IrState.requiredElements` / appending `IrTransition`s.
+///
+/// Not `Clone` because `crate::commands::spec_drift::DriftReport` is not
+/// `Clone`; the proposals path constructs an `AuthoringMode` once per
+/// execute call and consumes it on the way into `author_candidate`.
+#[derive(Debug)]
+pub enum AuthoringMode {
+    /// Build a fresh `IrPageSpec` for a pathname with no existing spec.
+    FullPage { pathname: String },
+    /// Mutate an existing IR to absorb a drift delta. Carries the existing
+    /// spec id + the drift report; emits only the minimal IR mutation.
+    Patch {
+        existing_spec_id: String,
+        drift: crate::commands::spec_drift::DriftReport,
+    },
+}
+
+/// Authoring result. Either a fully-formed candidate `IrPageSpec` or an
+/// [`AuthoringError`] with a structured reason (used by `proposals.rs` to
+/// distinguish retryable failures from terminal ones).
+#[derive(Debug)]
+pub struct AuthoringOutcome {
+    pub candidate: IrPageSpec,
+    /// Free-form: artifact id, meta-workflow run id, token counts.
+    /// Persisted in `spec_proposals.metadata` for diagnostics.
+    pub diagnostics: serde_json::Value,
+}
+
+/// Structured error for authoring failures. `proposals.rs` maps each
+/// variant to a `last_error` string + a status transition.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthoringError {
+    /// No discovery artifact exists for the pathname yet.
+    #[error("no discovery artifact for pathname '{pathname}'")]
+    NoDiscoveryArtifact { pathname: String },
+    /// Discovery artifact has zero states (under-observed page).
+    #[error("discovery artifact is empty")]
+    EmptyArtifact,
+    /// Meta-workflow returned but the result failed structural validation.
+    #[error("malformed AI output: {0}")]
+    MalformedAiOutput(String),
+    /// Bridge / AI provider error.
+    #[error("AI dispatch failed: {0}")]
+    AiDispatchFailed(String),
+    /// Drift mode: existing spec couldn't be read.
+    #[error("existing spec missing: {0}")]
+    ExistingSpecMissing(String),
+    /// Database error.
+    #[error("database error: {0}")]
+    Database(String),
+}
+
+/// Top-level entrypoint. `proposals.rs` calls this from the execute handler.
+///
+/// Runs the appropriate authoring flavor and returns either a candidate
+/// `IrPageSpec` (still un-validated — the validator gates are layered on top
+/// by the proposals handler) or a structured error.
+pub async fn author_candidate(
+    pg_db: Arc<PgDb>,
+    app_state: Arc<crate::commands::AppState>,
+    mode: AuthoringMode,
+) -> Result<AuthoringOutcome, AuthoringError> {
+    author_candidate_with_executor(pg_db, app_state, mode, &DefaultMetaWorkflowExecutor).await
+}
+
+/// Test seam: same as [`author_candidate`] but takes an explicit
+/// [`MetaWorkflowExecutor`] so unit tests can return canned AI output
+/// without spinning a real task run.
+pub async fn author_candidate_with_executor(
+    pg_db: Arc<PgDb>,
+    app_state: Arc<crate::commands::AppState>,
+    mode: AuthoringMode,
+    executor: &dyn MetaWorkflowExecutor,
+) -> Result<AuthoringOutcome, AuthoringError> {
+    match mode {
+        AuthoringMode::FullPage { pathname } => {
+            // 1. Project the artifact into a deterministic skeleton.
+            let skeleton = load_and_project_skeleton(&pg_db, &pathname).await?;
+            let skeleton_id = skeleton.id.clone();
+
+            // 2. AI fill-in via the meta-workflow.
+            let filled =
+                ai_fill_skeleton(pg_db.clone(), app_state.clone(), skeleton, executor).await?;
+
+            Ok(AuthoringOutcome {
+                candidate: filled,
+                diagnostics: serde_json::json!({
+                    "mode": "fullPage",
+                    "pathname": pathname,
+                    "skeleton_id": skeleton_id,
+                }),
+            })
+        }
+        AuthoringMode::Patch {
+            existing_spec_id,
+            drift,
+        } => {
+            let mutated =
+                author_patch(pg_db, app_state, &existing_spec_id, &drift, executor).await?;
+            Ok(AuthoringOutcome {
+                candidate: mutated,
+                diagnostics: serde_json::json!({
+                    "mode": "patch",
+                    "specId": existing_spec_id,
+                    "missing_count": drift.missing_from_spec.len(),
+                }),
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Slug helper — shared with sibling `spec_api::proposals`
+// ---------------------------------------------------------------------------
+
+/// Deterministic slug from a URL pathname. Lowercased ASCII; non-alphanumeric
+/// runs collapse to a single `-`; leading/trailing `-` are trimmed. Empty
+/// input maps to `"root"` so we always emit a usable id.
+///
+/// ```
+/// // (doc-test gated behind cargo feature so it's only compiled under
+/// //  --features spec-authoring; covered by the unit tests below.)
+/// // assert_eq!(
+/// //     qontinui_runner_lib::workflow_generation::spec_authoring::pathname_to_spec_id("/account/billing"),
+/// //     "account-billing"
+/// // );
+/// ```
+pub(crate) fn pathname_to_spec_id(pathname: &str) -> String {
+    let mut out = String::with_capacity(pathname.len());
+    let mut last_was_hyphen = true; // suppress leading hyphens
+    for ch in pathname.chars() {
+        let mapped = if ch.is_ascii_alphanumeric() {
+            Some(ch.to_ascii_lowercase())
+        } else {
+            None
+        };
+        match mapped {
+            Some(c) => {
+                out.push(c);
+                last_was_hyphen = false;
+            }
+            None => {
+                if !last_was_hyphen {
+                    out.push('-');
+                    last_was_hyphen = true;
+                }
+            }
+        }
+    }
+    // Trim trailing hyphen (leading is suppressed by `last_was_hyphen` init).
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        "root".to_string()
+    } else {
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — skeleton projection
+// ---------------------------------------------------------------------------
+
+/// Load the most recent (non-empty) `state_discovery_artifacts` row for the
+/// pathname-derived spec id and project it into a deterministic IR skeleton.
+///
+/// Determinism contract:
+/// - states ordered by id ascending
+/// - element criteria fields chosen by stable priority (`id > aria-label >
+///   tag+text > role`)
+/// - `IrElementCriteria.attributes` is a `BTreeMap` (already deterministic)
+async fn load_and_project_skeleton(
+    pg_db: &PgDb,
+    pathname: &str,
+) -> Result<IrPageSpec, AuthoringError> {
+    let candidate_id = pathname_to_spec_id(pathname);
+    let artifact = load_latest_artifact(pg_db, &candidate_id).await?;
+
+    let clusters = extract_clusters(&artifact.body)?;
+    if clusters.is_empty() {
+        return Err(AuthoringError::EmptyArtifact);
+    }
+
+    // Project each cluster, then sort states by id for determinism.
+    let mut states: Vec<IrState> = clusters
+        .iter()
+        .map(project_cluster_to_state)
+        .collect::<Vec<_>>();
+    states.sort_by(|a, b| a.id.cmp(&b.id));
+
+    Ok(IrPageSpec {
+        version: "1.0".into(),
+        id: candidate_id.clone(),
+        name: format!("Auto-discovered: {pathname}"),
+        description: Some(format!(
+            "Skeleton projected from {} observations over the last 90 days.",
+            artifact.observation_count
+        )),
+        metadata: None,
+        provenance: Some(IrProvenance {
+            source: "build-plugin".into(),
+            status: Some(ProposalStatus::Proposed),
+            ..Default::default()
+        }),
+        states,
+        transitions: Vec::new(),
+        synthesized_groups: None,
+        initial_state: None,
+    })
+}
+
+/// The "loaded artifact" shape we work with internally. We deliberately keep
+/// the raw JSON `body` around so consumers can re-extract additional fields
+/// without re-querying.
+struct LoadedArtifact {
+    #[allow(dead_code)]
+    artifact_id: String,
+    observation_count: i32,
+    body: serde_json::Value,
+}
+
+async fn load_latest_artifact(
+    pg_db: &PgDb,
+    spec_id: &str,
+) -> Result<LoadedArtifact, AuthoringError> {
+    let conn = pg_db
+        .pool()
+        .get()
+        .await
+        .map_err(|e| AuthoringError::Database(format!("PG pool error: {}", e)))?;
+
+    let rows = conn
+        .query(
+            r#"SELECT id::text, artifact, observation_count
+               FROM state_discovery_artifacts
+               WHERE spec_id = $1
+                 AND observation_count > 0
+               ORDER BY derived_at DESC
+               LIMIT 1"#,
+            &[&spec_id],
+        )
+        .await
+        .map_err(|e| AuthoringError::Database(format!("PG query: {}", e)))?;
+
+    let row = rows
+        .into_iter()
+        .next()
+        .ok_or_else(|| AuthoringError::NoDiscoveryArtifact {
+            pathname: spec_id.to_string(),
+        })?;
+    let artifact_id: String = row.get(0);
+    let body: serde_json::Value = row.get(1);
+    let observation_count: i32 = row.get(2);
+
+    Ok(LoadedArtifact {
+        artifact_id,
+        observation_count,
+        body,
+    })
+}
+
+/// One cluster of co-occurring elements, sourced from the
+/// `state_discovery_artifacts.artifact` JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Cluster {
+    /// Cluster id (deterministic from the discovery side).
+    id: String,
+    /// Human-readable name. Falls back to `id` when absent.
+    #[serde(default)]
+    name: Option<String>,
+    /// Fingerprint strings. Each is mapped to one `IrElementCriteria`.
+    /// Format is opaque to spec_authoring — we look for `id:<...>`,
+    /// `aria:<...>`, `tag:<tag>:<text>`, `role:<...>` prefixes and otherwise
+    /// fall back to `text`.
+    #[serde(default)]
+    fingerprints: Vec<String>,
+}
+
+fn extract_clusters(body: &serde_json::Value) -> Result<Vec<Cluster>, AuthoringError> {
+    let arr = body
+        .get("states")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            AuthoringError::MalformedAiOutput(
+                "discovery artifact missing 'states' array".to_string(),
+            )
+        })?;
+
+    let mut clusters = Vec::with_capacity(arr.len());
+    for entry in arr {
+        let cluster: Cluster = serde_json::from_value(entry.clone()).map_err(|e| {
+            AuthoringError::MalformedAiOutput(format!("cluster parse failed: {}", e))
+        })?;
+        clusters.push(cluster);
+    }
+    Ok(clusters)
+}
+
+/// Project one discovery cluster into an `IrState`.
+///
+/// Fingerprints land in `excluded_elements` (the only `Vec<IrElementCriteria>`
+/// slot in `IrState`) so the AI fill-in step has them in scope when emitting
+/// the final assertions. The slot name is a historical artifact — Stream E
+/// treats it as the "candidate criteria" channel for the skeleton, and the
+/// AI verification step relocates them onto `assertions` as appropriate.
+fn project_cluster_to_state(cluster: &Cluster) -> IrState {
+    let mut sorted = cluster.fingerprints.clone();
+    sorted.sort();
+    sorted.dedup();
+
+    let criteria: Vec<IrElementCriteria> = sorted.iter().map(fingerprint_to_criteria).collect();
+
+    IrState {
+        id: cluster.id.clone(),
+        name: cluster
+            .name
+            .clone()
+            .unwrap_or_else(|| cluster.id.clone()),
+        description: None,
+        assertions: Vec::new(),
+        excluded_elements: if criteria.is_empty() {
+            None
+        } else {
+            Some(criteria)
+        },
+        conditions: None,
+        is_initial: None,
+        is_terminal: None,
+        blocking: None,
+        group: None,
+        path_cost: None,
+        precondition: None,
+        element_ids: None,
+        incoming_transitions: None,
+        metadata: None,
+        provenance: Some(IrProvenance {
+            source: "build-plugin".into(),
+            status: Some(ProposalStatus::Proposed),
+            ..Default::default()
+        }),
+        cross_refs: None,
+    }
+}
+
+/// Stable priority order for fingerprint -> `IrElementCriteria` field
+/// selection: `id > aria-label > tag+text > role`. Unknown shapes degrade
+/// to `text`.
+fn fingerprint_to_criteria(fingerprint: &String) -> IrElementCriteria {
+    let mut out = IrElementCriteria::default();
+    if let Some(rest) = fingerprint.strip_prefix("id:") {
+        out.id = Some(rest.to_string());
+    } else if let Some(rest) = fingerprint.strip_prefix("aria:") {
+        out.aria_label = Some(rest.to_string());
+    } else if let Some(rest) = fingerprint.strip_prefix("tag:") {
+        // `tag:<tag>:<text>` — split on the first colon only.
+        let mut parts = rest.splitn(2, ':');
+        out.tag_name = parts.next().map(|s| s.to_string());
+        out.text = parts.next().map(|s| s.to_string());
+    } else if let Some(rest) = fingerprint.strip_prefix("role:") {
+        out.role = Some(rest.to_string());
+    } else {
+        out.text = Some(fingerprint.clone());
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — meta-workflow integration (AI fill-in)
+// ---------------------------------------------------------------------------
+
+/// Hand the skeleton + 5 most-similar existing IRs to the meta-workflow. The
+/// workflow fills in human-readable names/descriptions, infers transitions
+/// from element semantics, and the result is stamped `provenance.source:
+/// "ai-generated"`.
+async fn ai_fill_skeleton(
+    pg_db: Arc<PgDb>,
+    app_state: Arc<crate::commands::AppState>,
+    skeleton: IrPageSpec,
+    executor: &dyn MetaWorkflowExecutor,
+) -> Result<IrPageSpec, AuthoringError> {
+    use crate::workflow_generation::generator::GenerateWorkflowRequest;
+    use crate::workflow_generation::meta_workflow::{
+        build_meta_workflow_template, build_spec_priming_context,
+    };
+
+    let description = build_priming_description(&skeleton);
+    let historical = build_spec_priming_context(&pg_db, &skeleton, 5).await;
+
+    let request = GenerateWorkflowRequest {
+        description: description.clone(),
+        category: Some("spec-authoring".into()),
+        ..Default::default()
+    };
+    let resolved_contexts = format!(
+        "<<<SKELETON>>>\n{}\n<<<END SKELETON>>>",
+        serde_json::to_string_pretty(&skeleton).unwrap_or_default()
+    );
+
+    let meta_wf = build_meta_workflow_template(
+        &request,
+        &resolved_contexts,
+        historical.as_ref(),
+        Some(&*app_state),
+    );
+
+    let run_result = executor
+        .execute(app_state.clone(), pg_db.clone(), meta_wf)
+        .await
+        .map_err(AuthoringError::AiDispatchFailed)?;
+
+    let mut filled: IrPageSpec =
+        parse_meta_workflow_output(&run_result).map_err(AuthoringError::MalformedAiOutput)?;
+    stamp_provenance_ai_generated_proposed(&mut filled);
+
+    enforce_skeleton_invariants(&skeleton, &filled)
+        .map_err(AuthoringError::MalformedAiOutput)?;
+
+    Ok(filled)
+}
+
+fn build_priming_description(skeleton: &IrPageSpec) -> String {
+    let mut fingerprints: Vec<String> = Vec::new();
+    for state in &skeleton.states {
+        if let Some(excluded) = &state.excluded_elements {
+            for crit in excluded {
+                if let Some(id) = &crit.id {
+                    fingerprints.push(format!("id:{}", id));
+                } else if let Some(aria) = &crit.aria_label {
+                    fingerprints.push(format!("aria:{}", aria));
+                } else if let (Some(tag), Some(text)) = (&crit.tag_name, &crit.text) {
+                    fingerprints.push(format!("tag:{}:{}", tag, text));
+                } else if let Some(role) = &crit.role {
+                    fingerprints.push(format!("role:{}", role));
+                } else if let Some(text) = &crit.text {
+                    fingerprints.push(format!("text:{}", text));
+                }
+            }
+        }
+    }
+    fingerprints.sort();
+    fingerprints.dedup();
+    let listing = if fingerprints.is_empty() {
+        "(no fingerprints captured)".to_string()
+    } else {
+        fingerprints.join(", ")
+    };
+    format!(
+        "Spec-authoring for {}: project clusters {}.",
+        skeleton.name, listing
+    )
+}
+
+/// Stamp `provenance.source = "ai-generated"` and `status = Proposed` at the
+/// document level + on every state whose existing provenance is missing or
+/// `ai-generated`. States with `hand-authored` / `migrated` / `build-plugin`
+/// provenance are left untouched.
+fn stamp_provenance_ai_generated_proposed(ir: &mut IrPageSpec) {
+    let doc_prov = ir.provenance.get_or_insert_with(IrProvenance::default);
+    doc_prov.source = "ai-generated".to_string();
+    doc_prov.status = Some(ProposalStatus::Proposed);
+
+    for state in &mut ir.states {
+        match &state.provenance {
+            None => {
+                state.provenance = Some(IrProvenance {
+                    source: "ai-generated".into(),
+                    status: Some(ProposalStatus::Proposed),
+                    ..Default::default()
+                });
+            }
+            Some(p) if p.source == "ai-generated" || p.source.is_empty() => {
+                let mut clone = p.clone();
+                clone.source = "ai-generated".to_string();
+                clone.status = Some(ProposalStatus::Proposed);
+                state.provenance = Some(clone);
+            }
+            Some(_) => {
+                // Leave hand-authored / migrated / build-plugin alone.
+            }
+        }
+    }
+}
+
+/// Skeleton invariants the AI must not violate. The AI may add transitions,
+/// names, descriptions, metadata — but it may NOT delete states.
+fn enforce_skeleton_invariants(
+    skeleton: &IrPageSpec,
+    filled: &IrPageSpec,
+) -> Result<(), String> {
+    if filled.states.len() != skeleton.states.len() {
+        return Err(format!(
+            "state count drift: skeleton={}, filled={}",
+            skeleton.states.len(),
+            filled.states.len()
+        ));
+    }
+    let skel_ids: BTreeSet<&str> = skeleton.states.iter().map(|s| s.id.as_str()).collect();
+    let filled_ids: BTreeSet<&str> = filled.states.iter().map(|s| s.id.as_str()).collect();
+    if !skel_ids.is_subset(&filled_ids) {
+        let missing: Vec<&&str> = skel_ids.difference(&filled_ids).collect();
+        return Err(format!(
+            "filled IR is missing skeleton state ids: {:?}",
+            missing
+        ));
+    }
+    Ok(())
+}
+
+fn parse_meta_workflow_output(value: &serde_json::Value) -> Result<IrPageSpec, String> {
+    // Try the value as-is first.
+    if let Ok(ir) = serde_json::from_value::<IrPageSpec>(value.clone()) {
+        return Ok(ir);
+    }
+    // Common nesting shapes.
+    for key in ["ir", "spec", "result", "candidate"] {
+        if let Some(inner) = value.get(key) {
+            if let Ok(ir) = serde_json::from_value::<IrPageSpec>(inner.clone()) {
+                return Ok(ir);
+            }
+        }
+    }
+    Err(format!(
+        "could not parse meta-workflow output as IrPageSpec (top-level keys: {:?})",
+        value
+            .as_object()
+            .map(|o| o.keys().cloned().collect::<Vec<_>>())
+            .unwrap_or_default()
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Step 5 — patch authoring (drift reconciliation)
+// ---------------------------------------------------------------------------
+
+/// Per-state required-element additions + new transitions. RFC 7396-style.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct IrPatch {
+    #[serde(default)]
+    add_required_elements: BTreeMap<String, Vec<IrElementCriteria>>,
+    #[serde(default)]
+    add_transitions: Vec<IrTransition>,
+}
+
+async fn author_patch(
+    pg_db: Arc<PgDb>,
+    app_state: Arc<crate::commands::AppState>,
+    existing_spec_id: &str,
+    drift: &crate::commands::spec_drift::DriftReport,
+    executor: &dyn MetaWorkflowExecutor,
+) -> Result<IrPageSpec, AuthoringError> {
+    use crate::workflow_generation::generator::GenerateWorkflowRequest;
+    use crate::workflow_generation::meta_workflow::{
+        build_historical_context_pg, build_meta_workflow_template,
+    };
+
+    let root = crate::spec_api::storage::resolve_specs_root();
+    let existing: IrPageSpec = crate::spec_api::storage::read_ir(&root, existing_spec_id)
+        .map_err(AuthoringError::ExistingSpecMissing)?
+        .ok_or_else(|| {
+            AuthoringError::ExistingSpecMissing(format!(
+                "no IR found for spec_id={existing_spec_id}"
+            ))
+        })?;
+
+    let description = format!(
+        "Patch-authoring for spec '{}': reconcile {} missing element(s).",
+        existing_spec_id,
+        drift.missing_from_spec.len()
+    );
+    let request = GenerateWorkflowRequest {
+        description: description.clone(),
+        category: Some("spec-authoring".into()),
+        ..Default::default()
+    };
+    let resolved_contexts = build_patch_resolved_contexts(&existing, drift);
+
+    let historical =
+        build_historical_context_pg(&pg_db, &request.description, Some("spec-authoring")).await;
+    let meta_wf = build_meta_workflow_template(
+        &request,
+        &resolved_contexts,
+        historical.as_ref(),
+        Some(&*app_state),
+    );
+
+    let run_result = executor
+        .execute(app_state.clone(), pg_db.clone(), meta_wf)
+        .await
+        .map_err(AuthoringError::AiDispatchFailed)?;
+
+    let patch: IrPatch =
+        parse_patch_output(&run_result).map_err(AuthoringError::MalformedAiOutput)?;
+    merge_patch_into_ir(existing, patch).map_err(AuthoringError::MalformedAiOutput)
+}
+
+fn build_patch_resolved_contexts(
+    existing: &IrPageSpec,
+    drift: &crate::commands::spec_drift::DriftReport,
+) -> String {
+    let drift_payload = serde_json::json!({
+        "missingFromSpec": drift.missing_from_spec,
+        "orphansInSpec": drift.orphans_in_spec,
+    });
+    format!(
+        "<<<EXISTING_IR>>>\n{}\n<<<END_EXISTING_IR>>>\n\n<<<DRIFT>>>\n{}\n<<<END_DRIFT>>>",
+        serde_json::to_string_pretty(existing).unwrap_or_default(),
+        serde_json::to_string_pretty(&drift_payload).unwrap_or_default(),
+    )
+}
+
+fn parse_patch_output(value: &serde_json::Value) -> Result<IrPatch, String> {
+    if let Ok(patch) = serde_json::from_value::<IrPatch>(value.clone()) {
+        return Ok(patch);
+    }
+    for key in ["patch", "ir_patch", "result", "candidate"] {
+        if let Some(inner) = value.get(key) {
+            if let Ok(patch) = serde_json::from_value::<IrPatch>(inner.clone()) {
+                return Ok(patch);
+            }
+        }
+    }
+    Err(format!(
+        "could not parse meta-workflow output as IrPatch (top-level keys: {:?})",
+        value
+            .as_object()
+            .map(|o| o.keys().cloned().collect::<Vec<_>>())
+            .unwrap_or_default()
+    ))
+}
+
+/// Apply a patch to an existing IR.
+///
+/// Rules (load-bearing — pinning invariant per §6.5):
+/// - APPENDS new IrTransitions; rejects duplicates by id (also rejects ids
+///   that collide with an existing transition).
+/// - APPENDS new IrElementCriteria to `state.excluded_elements` ONLY for
+///   states whose provenance.source is "ai-generated" or absent. States
+///   with provenance.source in {"hand-authored", "migrated", "build-plugin"}
+///   are PINNED — patch additions hard-fail.
+/// - Newly added IrTransition / IrElementCriteria get
+///   `provenance: { source: "ai-generated", status: Proposed }`.
+fn merge_patch_into_ir(mut existing: IrPageSpec, patch: IrPatch) -> Result<IrPageSpec, String> {
+    // Validate transition ids first so we don't half-apply.
+    let mut existing_tx_ids: BTreeSet<String> =
+        existing.transitions.iter().map(|t| t.id.clone()).collect();
+    let mut new_tx_ids: BTreeSet<String> = BTreeSet::new();
+    for tx in &patch.add_transitions {
+        if existing_tx_ids.contains(&tx.id) {
+            return Err(format!(
+                "patch transition id '{}' collides with an existing transition",
+                tx.id
+            ));
+        }
+        if !new_tx_ids.insert(tx.id.clone()) {
+            return Err(format!(
+                "patch contains duplicate transition id '{}'",
+                tx.id
+            ));
+        }
+    }
+
+    // Validate every targeted state allows additions.
+    for (state_id, _criteria) in &patch.add_required_elements {
+        let target = existing
+            .states
+            .iter()
+            .find(|s| &s.id == state_id)
+            .ok_or_else(|| {
+                format!(
+                    "patch targets unknown state '{}' (not present in existing IR)",
+                    state_id
+                )
+            })?;
+        let source = target
+            .provenance
+            .as_ref()
+            .map(|p| p.source.as_str())
+            .unwrap_or("");
+        match source {
+            "" | "ai-generated" => { /* allowed */ }
+            "hand-authored" | "migrated" | "build-plugin" => {
+                return Err(format!(
+                    "patch targets pinned state '{}' (provenance.source='{}'); refusing to mutate",
+                    state_id, source
+                ));
+            }
+            other => {
+                return Err(format!(
+                    "patch targets state '{}' with unrecognized provenance.source='{}'",
+                    state_id, other
+                ));
+            }
+        }
+    }
+
+    // Apply criteria additions. New IrElementCriteria don't carry their own
+    // provenance (the type has no provenance field), so stamping happens at
+    // the wrapper IrPatch level — the criteria themselves are "ai-generated"
+    // by virtue of being added through this code path.
+    for (state_id, criteria) in patch.add_required_elements {
+        let state = existing
+            .states
+            .iter_mut()
+            .find(|s| s.id == state_id)
+            .expect("validated above");
+        let slot = state.excluded_elements.get_or_insert_with(Vec::new);
+        for crit in criteria {
+            slot.push(crit);
+        }
+    }
+
+    // Apply transition additions. Stamp provenance.
+    for mut tx in patch.add_transitions {
+        tx.provenance = Some(IrProvenance {
+            source: "ai-generated".into(),
+            status: Some(ProposalStatus::Proposed),
+            ..Default::default()
+        });
+        existing_tx_ids.insert(tx.id.clone());
+        existing.transitions.push(tx);
+    }
+
+    Ok(existing)
+}
+
+// ---------------------------------------------------------------------------
+// MetaWorkflowExecutor — production impl + test seam
+// ---------------------------------------------------------------------------
+
+/// Pluggable executor for the meta-workflow. Production uses
+/// [`DefaultMetaWorkflowExecutor`], which persists the workflow + creates
+/// a task run + polls it to terminal status. Tests substitute a canned
+/// implementation so they don't need a live PG / AI provider.
+#[async_trait::async_trait]
+pub trait MetaWorkflowExecutor: Send + Sync {
+    async fn execute(
+        &self,
+        app_state: Arc<crate::commands::AppState>,
+        pg_db: Arc<PgDb>,
+        meta_wf: crate::unified_workflows::UnifiedWorkflow,
+    ) -> Result<serde_json::Value, String>;
+}
+
+/// Default production executor. Mirrors the persistence path in
+/// `mcp::unified_workflows::generate_unified_workflow_async_handler` — persist
+/// the workflow, create a task run, then poll until terminal. Returns the
+/// final accumulated output blob as a `serde_json::Value`.
+pub struct DefaultMetaWorkflowExecutor;
+
+#[async_trait::async_trait]
+impl MetaWorkflowExecutor for DefaultMetaWorkflowExecutor {
+    async fn execute(
+        &self,
+        app_state: Arc<crate::commands::AppState>,
+        pg_db: Arc<PgDb>,
+        meta_wf: crate::unified_workflows::UnifiedWorkflow,
+    ) -> Result<serde_json::Value, String> {
+        execute_meta_workflow_blocking(app_state, pg_db, meta_wf).await
+    }
+}
+
+/// Persist the meta-workflow, create a task run, poll until terminal, return
+/// the accumulated output blob as a `serde_json::Value`.
+///
+/// Terminal task statuses are `complete` / `failed` / `stopped` (see
+/// `database::types::TaskRun::status`). Polls every 2s; 120s overall timeout
+/// (long enough for the meta-workflow's 4-phase cycle, short enough that a
+/// stuck proposal surfaces in the nightly cadence).
+pub(crate) async fn execute_meta_workflow_blocking(
+    app_state: Arc<crate::commands::AppState>,
+    pg_db: Arc<PgDb>,
+    meta_wf: crate::unified_workflows::UnifiedWorkflow,
+) -> Result<serde_json::Value, String> {
+    use crate::database::types::CreateTaskRunInput;
+    use crate::unified_workflows::UnifiedWorkflowExt;
+
+    let mut create_request =
+        crate::unified_workflows::unified_workflow_to_create_request(&meta_wf);
+    create_request.generated_by_task_run_id = None;
+
+    let saved = pg_db
+        .create_unified_workflow(&create_request)
+        .await
+        .map_err(|e| format!("create_unified_workflow: {}", e))?;
+
+    let task_run_id = uuid::Uuid::new_v4().to_string();
+    let simple_prompt: String = saved
+        .agentic_steps
+        .iter()
+        .filter_map(|step| step.get("content").and_then(|v| v.as_str()))
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+    let port = app_state
+        .api_port
+        .load(std::sync::atomic::Ordering::Relaxed);
+
+    let task_run_input = CreateTaskRunInput::new(&task_run_id, &saved.name)
+        .with_task_type("ai")
+        .with_prompt(&simple_prompt)
+        .with_workflow_type("unified")
+        .with_workflow_name(&saved.name)
+        .with_workflow_id(&saved.id)
+        .with_max_sessions(saved.iter_cap())
+        .with_auto_continue(true)
+        .with_runner_port(port);
+
+    pg_db
+        .create_task_run(&task_run_input)
+        .await
+        .map_err(|e| format!("create_task_run: {}", e))?;
+
+    // Poll for terminal status.
+    let deadline = std::time::Instant::now() + Duration::from_secs(120);
+    let mut interval = tokio::time::interval(Duration::from_secs(2));
+    // Skip the immediate first tick — the task was just created.
+    interval.tick().await;
+    loop {
+        if std::time::Instant::now() > deadline {
+            return Err(format!("meta-workflow task run {} timed out", task_run_id));
+        }
+        interval.tick().await;
+        let task = pg_db
+            .get_task_run(&task_run_id)
+            .await
+            .map_err(|e| format!("get_task_run: {}", e))?
+            .ok_or_else(|| format!("task run {} disappeared", task_run_id))?;
+        if matches!(task.status.as_str(), "complete" | "failed" | "stopped") {
+            if task.status == "failed" {
+                return Err(task
+                    .error_message
+                    .unwrap_or_else(|| "meta-workflow failed (no error message)".to_string()));
+            }
+            // Parse the output_log as JSON when possible; otherwise return
+            // it wrapped as a string blob so the parser can search for
+            // common envelope keys.
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&task.output_log) {
+                return Ok(parsed);
+            }
+            return Ok(serde_json::json!({ "output_log": task.output_log }));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec_api::hashing::canonical_hash;
+    use crate::spec_api::types::{IrAssertion, IrAssertionTarget};
+
+    #[test]
+    fn pathname_to_spec_id_basic() {
+        assert_eq!(pathname_to_spec_id("/account/billing"), "account-billing");
+        assert_eq!(pathname_to_spec_id("/"), "root");
+        assert_eq!(pathname_to_spec_id(""), "root");
+        assert_eq!(pathname_to_spec_id("/Foo/Bar/"), "foo-bar");
+        assert_eq!(pathname_to_spec_id("/foo--bar//baz"), "foo-bar-baz");
+        assert_eq!(pathname_to_spec_id("/settings/general"), "settings-general");
+        // Idempotent on canonical form.
+        let once = pathname_to_spec_id("/Account/Billing/");
+        let twice = pathname_to_spec_id(&format!("/{}", once));
+        assert_eq!(once, twice);
+    }
+
+    fn artifact_json(states: Vec<serde_json::Value>) -> serde_json::Value {
+        serde_json::json!({
+            "states": states,
+            "elements": [],
+            "elementToRenders": {},
+        })
+    }
+
+    fn cluster(id: &str, fingerprints: &[&str]) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "name": format!("cluster-{}", id),
+            "fingerprints": fingerprints,
+        })
+    }
+
+    fn skeleton_from_artifact(body: &serde_json::Value, observation_count: i32) -> IrPageSpec {
+        // Helper that mirrors the projection path without touching PG.
+        let clusters = extract_clusters(body).expect("clusters parse");
+        let mut states: Vec<IrState> = clusters
+            .iter()
+            .map(project_cluster_to_state)
+            .collect();
+        states.sort_by(|a, b| a.id.cmp(&b.id));
+        IrPageSpec {
+            version: "1.0".into(),
+            id: "account-billing".into(),
+            name: "Auto-discovered: /account/billing".into(),
+            description: Some(format!(
+                "Skeleton projected from {} observations over the last 90 days.",
+                observation_count
+            )),
+            metadata: None,
+            provenance: Some(IrProvenance {
+                source: "build-plugin".into(),
+                status: Some(ProposalStatus::Proposed),
+                ..Default::default()
+            }),
+            states,
+            transitions: Vec::new(),
+            synthesized_groups: None,
+            initial_state: None,
+        }
+    }
+
+    #[test]
+    fn skeleton_projection_deterministic_byte_identical() {
+        let body = artifact_json(vec![
+            cluster("state-c", &["id:btn-pay", "aria:cart"]),
+            cluster("state-a", &["id:btn-cancel"]),
+            cluster("state-b", &["tag:input:email", "role:textbox"]),
+        ]);
+        let s1 = skeleton_from_artifact(&body, 7);
+        let s2 = skeleton_from_artifact(&body, 7);
+        let h1 = canonical_hash(&s1).expect("hash");
+        let h2 = canonical_hash(&s2).expect("hash");
+        assert_eq!(h1, h2, "skeleton projection must be byte-identical");
+        // And ids sorted.
+        let ids: Vec<&str> = s1.states.iter().map(|s| s.id.as_str()).collect();
+        assert_eq!(ids, vec!["state-a", "state-b", "state-c"]);
+    }
+
+    #[test]
+    fn empty_artifact_returns_empty_error() {
+        let body = artifact_json(vec![]);
+        let err = extract_clusters(&body);
+        // extract_clusters returns Ok([]) for an empty array; the
+        // caller (load_and_project_skeleton) converts to EmptyArtifact.
+        // We test that conversion logic via a focused match.
+        let clusters = err.expect("parsed");
+        assert!(clusters.is_empty(), "empty cluster list expected");
+    }
+
+    #[test]
+    fn three_cluster_artifact_three_states_with_provenance() {
+        let body = artifact_json(vec![
+            cluster("s1", &["id:foo"]),
+            cluster("s2", &["aria:bar"]),
+            cluster("s3", &["role:button"]),
+        ]);
+        let spec = skeleton_from_artifact(&body, 12);
+        assert_eq!(spec.states.len(), 3);
+        assert_eq!(
+            spec.provenance.as_ref().unwrap().source,
+            "build-plugin"
+        );
+        assert_eq!(
+            spec.provenance.as_ref().unwrap().status,
+            Some(ProposalStatus::Proposed)
+        );
+        for state in &spec.states {
+            let p = state.provenance.as_ref().expect("state provenance");
+            assert_eq!(p.source, "build-plugin");
+            assert_eq!(p.status, Some(ProposalStatus::Proposed));
+        }
+    }
+
+    #[test]
+    fn fingerprint_priority_order() {
+        // id beats everything.
+        let crit = fingerprint_to_criteria(&"id:my-button".to_string());
+        assert_eq!(crit.id.as_deref(), Some("my-button"));
+        assert!(crit.aria_label.is_none());
+        // aria beats tag+text.
+        let crit = fingerprint_to_criteria(&"aria:Submit".to_string());
+        assert_eq!(crit.aria_label.as_deref(), Some("Submit"));
+        // tag+text via tag:<tag>:<text>.
+        let crit = fingerprint_to_criteria(&"tag:button:Save".to_string());
+        assert_eq!(crit.tag_name.as_deref(), Some("button"));
+        assert_eq!(crit.text.as_deref(), Some("Save"));
+        // role last.
+        let crit = fingerprint_to_criteria(&"role:dialog".to_string());
+        assert_eq!(crit.role.as_deref(), Some("dialog"));
+    }
+
+    // -----------------------------------------------------------------
+    // Step 4 invariant tests
+    // -----------------------------------------------------------------
+
+    fn make_state(id: &str) -> IrState {
+        IrState {
+            id: id.into(),
+            name: id.into(),
+            description: None,
+            assertions: vec![],
+            excluded_elements: None,
+            conditions: None,
+            is_initial: None,
+            is_terminal: None,
+            blocking: None,
+            group: None,
+            path_cost: None,
+            precondition: None,
+            element_ids: None,
+            incoming_transitions: None,
+            metadata: None,
+            provenance: None,
+            cross_refs: None,
+        }
+    }
+
+    fn make_skeleton(state_ids: &[&str]) -> IrPageSpec {
+        IrPageSpec {
+            version: "1.0".into(),
+            id: "test".into(),
+            name: "test".into(),
+            description: None,
+            metadata: None,
+            provenance: Some(IrProvenance {
+                source: "build-plugin".into(),
+                status: Some(ProposalStatus::Proposed),
+                ..Default::default()
+            }),
+            states: state_ids.iter().map(|id| make_state(id)).collect(),
+            transitions: vec![],
+            synthesized_groups: None,
+            initial_state: None,
+        }
+    }
+
+    #[test]
+    fn enforce_invariants_passes_on_matching_state_set() {
+        let skel = make_skeleton(&["a", "b", "c"]);
+        let filled = make_skeleton(&["a", "b", "c"]);
+        enforce_skeleton_invariants(&skel, &filled).expect("invariants hold");
+    }
+
+    #[test]
+    fn enforce_invariants_fails_when_ai_drops_a_state() {
+        let skel = make_skeleton(&["a", "b", "c"]);
+        let filled = make_skeleton(&["a", "b"]);
+        let err = enforce_skeleton_invariants(&skel, &filled).unwrap_err();
+        assert!(err.contains("state count drift"));
+    }
+
+    #[test]
+    fn stamp_provenance_skips_hand_authored_states() {
+        let mut ir = make_skeleton(&["keep", "stamp"]);
+        ir.states[0].provenance = Some(IrProvenance {
+            source: "hand-authored".into(),
+            ..Default::default()
+        });
+        // ir.states[1].provenance is None initially.
+        stamp_provenance_ai_generated_proposed(&mut ir);
+        assert_eq!(ir.states[0].provenance.as_ref().unwrap().source, "hand-authored");
+        assert_eq!(ir.states[1].provenance.as_ref().unwrap().source, "ai-generated");
+        // Document-level always becomes ai-generated.
+        assert_eq!(ir.provenance.as_ref().unwrap().source, "ai-generated");
+    }
+
+    // -----------------------------------------------------------------
+    // Mocked executor — AI dispatch + malformed-output paths
+    // -----------------------------------------------------------------
+
+    struct FailingExecutor;
+
+    #[async_trait::async_trait]
+    impl MetaWorkflowExecutor for FailingExecutor {
+        async fn execute(
+            &self,
+            _app_state: Arc<crate::commands::AppState>,
+            _pg_db: Arc<PgDb>,
+            _meta_wf: crate::unified_workflows::UnifiedWorkflow,
+        ) -> Result<serde_json::Value, String> {
+            Err("simulated bridge error".to_string())
+        }
+    }
+
+    /// Construct an output blob that omits the `version` field, so
+    /// IrPageSpec deserialization fails — exercising the MalformedAiOutput
+    /// path without needing a full mock workflow.
+    fn malformed_output() -> serde_json::Value {
+        serde_json::json!({ "id": "x", "name": "x", "states": [], "transitions": [] })
+    }
+
+    #[test]
+    fn parse_meta_workflow_output_handles_common_nestings() {
+        let ir = IrPageSpec {
+            version: "1.0".into(),
+            id: "x".into(),
+            name: "X".into(),
+            description: None,
+            metadata: None,
+            provenance: None,
+            states: vec![],
+            transitions: vec![],
+            synthesized_groups: None,
+            initial_state: None,
+        };
+        let bare = serde_json::to_value(&ir).unwrap();
+        assert!(parse_meta_workflow_output(&bare).is_ok());
+        let nested = serde_json::json!({ "ir": bare });
+        assert!(parse_meta_workflow_output(&nested).is_ok());
+        let other = serde_json::json!({ "spec": serde_json::to_value(&ir).unwrap() });
+        assert!(parse_meta_workflow_output(&other).is_ok());
+        let bad = malformed_output();
+        assert!(parse_meta_workflow_output(&bad).is_err());
+    }
+
+    // -----------------------------------------------------------------
+    // Step 5 — patch merge tests
+    // -----------------------------------------------------------------
+
+    fn make_existing_with(state_id: &str, source: &str) -> IrPageSpec {
+        let mut ir = make_skeleton(&[state_id]);
+        ir.states[0].provenance = Some(IrProvenance {
+            source: source.into(),
+            ..Default::default()
+        });
+        ir
+    }
+
+    fn make_criteria(id: &str) -> IrElementCriteria {
+        let mut c = IrElementCriteria::default();
+        c.id = Some(id.into());
+        c
+    }
+
+    fn make_transition(id: &str, from: &str, to: &str) -> IrTransition {
+        IrTransition {
+            id: id.into(),
+            name: id.into(),
+            description: None,
+            from_states: vec![from.into()],
+            activate_states: vec![to.into()],
+            exit_states: None,
+            actions: vec![],
+            path_cost: None,
+            bidirectional: None,
+            effect: None,
+            metadata: None,
+            provenance: None,
+            cross_refs: None,
+        }
+    }
+
+    #[test]
+    fn merge_patch_against_ai_generated_state_lands() {
+        let existing = make_existing_with("s1", "ai-generated");
+        let mut patch = IrPatch::default();
+        patch
+            .add_required_elements
+            .insert("s1".into(), vec![make_criteria("new-elem")]);
+        let result = merge_patch_into_ir(existing, patch).expect("merge ok");
+        let crit = result.states[0]
+            .excluded_elements
+            .as_ref()
+            .expect("criteria added")
+            .first()
+            .expect("at least one");
+        assert_eq!(crit.id.as_deref(), Some("new-elem"));
+    }
+
+    #[test]
+    fn merge_patch_against_hand_authored_state_fails() {
+        let existing_before = make_existing_with("s1", "hand-authored");
+        let snapshot = serde_json::to_value(&existing_before).unwrap();
+        let mut patch = IrPatch::default();
+        patch
+            .add_required_elements
+            .insert("s1".into(), vec![make_criteria("new-elem")]);
+        let err = merge_patch_into_ir(existing_before, patch).unwrap_err();
+        assert!(err.contains("pinned state 's1'"), "got: {}", err);
+        // The original snapshot should still match what we built — proves
+        // the function did not return a half-mutated IR.
+        // (snapshot was taken before moving `existing_before` into the
+        // function; we just confirm it's still a valid spec.)
+        assert!(snapshot.get("states").is_some());
+    }
+
+    #[test]
+    fn merge_patch_duplicate_transition_id_fails() {
+        let mut existing = make_skeleton(&["s1", "s2"]);
+        existing
+            .transitions
+            .push(make_transition("tx-1", "s1", "s2"));
+        let mut patch = IrPatch::default();
+        patch.add_transitions.push(make_transition("tx-1", "s1", "s2"));
+        let err = merge_patch_into_ir(existing, patch).unwrap_err();
+        assert!(err.contains("collides with an existing transition"));
+    }
+
+    #[test]
+    fn merge_patch_adds_transition_with_ai_generated_provenance() {
+        let existing = make_skeleton(&["s1", "s2"]);
+        let mut patch = IrPatch::default();
+        patch.add_transitions.push(make_transition("tx-new", "s1", "s2"));
+        let result = merge_patch_into_ir(existing, patch).expect("merge ok");
+        assert_eq!(result.transitions.len(), 1);
+        let prov = result.transitions[0]
+            .provenance
+            .as_ref()
+            .expect("provenance stamped");
+        assert_eq!(prov.source, "ai-generated");
+        assert_eq!(prov.status, Some(ProposalStatus::Proposed));
+    }
+
+    #[test]
+    fn merge_patch_intra_patch_duplicate_transition_id_fails() {
+        let existing = make_skeleton(&["s1", "s2"]);
+        let mut patch = IrPatch::default();
+        patch.add_transitions.push(make_transition("tx-dup", "s1", "s2"));
+        patch.add_transitions.push(make_transition("tx-dup", "s1", "s2"));
+        let err = merge_patch_into_ir(existing, patch).unwrap_err();
+        assert!(err.contains("duplicate transition id"));
+    }
+
+    #[test]
+    fn merge_patch_against_unknown_state_fails() {
+        let existing = make_skeleton(&["s1"]);
+        let mut patch = IrPatch::default();
+        patch
+            .add_required_elements
+            .insert("ghost".into(), vec![make_criteria("x")]);
+        let err = merge_patch_into_ir(existing, patch).unwrap_err();
+        assert!(err.contains("unknown state 'ghost'"));
+    }
+
+    // Silence unused-import warnings under cfg(test) for symbols referenced
+    // by the doc-test in pathname_to_spec_id (the doc-test is illustrative
+    // commentary in the doc-comment, but we still want to be sure the
+    // pulled-in IrAssertion + IrAssertionTarget paths compile.
+    #[test]
+    fn _ir_assertion_symbol_resolves() {
+        let _t = IrAssertionTarget {
+            kind: "search".into(),
+            criteria: serde_json::json!({}),
+            label: "x".into(),
+        };
+        let _a = IrAssertion {
+            id: "a".into(),
+            description: "d".into(),
+            category: "c".into(),
+            severity: "s".into(),
+            assertion_type: "at".into(),
+            target: _t,
+            source: "src".into(),
+            reviewed: false,
+            enabled: true,
+            precondition: None,
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Steps 2–7** of plan [`05-flywheel.md`](https://github.com/qontinui/qontinui-dev-notes/blob/main/spec-check-v1/05-flywheel.md) (Spec-Check v1, Stream E — the coverage-growth flywheel). Steps 8–11 follow in a separate PR.

All new surfaces are gated behind the `spec-authoring` Cargo feature (off by default for v1.0 ship). Default build behavior unchanged.

### What lands

**New modules (under `#[cfg(feature = "spec-authoring")]`):**
- `src-tauri/src/workflow_generation/spec_authoring.rs` (1285 LOC, 16 tests) — composes the discovery pipeline with the meta-workflow to produce candidate `IrPageSpec` docs. Two flavors: `FullPage` (fresh skeleton from `state_discovery_artifacts` → meta-workflow AI fill-in) and `Patch` (drift-report-driven minimal mutation with the hand-authored/migrated pinning rule).
- `src-tauri/src/spec_api/proposals.rs` (~950 LOC, 11 tests) — three new endpoints under `/spec/proposals/*`:
  - `POST /spec/proposals/scan` (trigger logic per §6.1)
  - `POST /spec/proposals/<id>/execute` (drives proposal through authoring; validator gate stubbed pending Step 8)
  - `GET /spec/proposals` (paginated list)
- `src-tauri/src/database/pg/spec_proposals.rs` — PG ops for the new `spec_proposals` table: insert with `ON CONFLICT DO NOTHING` dedup, list/find, status + greens + candidate_ir + last_error updates.

**Schema:**
- `atlas/schema.hcl` — new `project.spec_proposals` table with `UNIQUE (kind, COALESCE(pathname, spec_id))` for trigger idempotency, status index, JSONB columns for `candidate_ir` + `metadata`.

**Cargo:**
- `spec-authoring = []` feature added; `pg_integration_tests = []` feature added (gates PG-bound proposals tests).
- `uuid` features gain `"v7"` (for `Uuid::now_v7()` proposal IDs).

### Carryover for Step 8/9 follow-up session

1. **Skeleton fingerprint slot.** Currently stashes cluster fingerprints in `IrState.excluded_elements` because the plan's `requiredElements` field was deleted by Plan 02 (replaced with `IrState.assertions: Vec<IrAssertion>` — a different type that can't take raw `IrElementCriteria`). Step 4's AI fill-in pass relocates them onto canonical `assertions`; Step 8's validator gate-3 will surface any failure to do so. See `spec_authoring.rs:336-340` for the in-code rationale.
2. **Execute handler validator gate stubbed.** Currently skips the three-gate validator via `stage_pending_ir_placeholder`. Replace with `gate_b_execution_green` chain + `storage::write_pending_ir` when Step 8 + Step 9 land.

### Test plan

- [x] `cargo check --bin qontinui-runner` (default features) — passes
- [x] `cargo check --bin qontinui-runner --features spec-authoring` — passes
- [x] `cargo test --features spec-authoring workflow_generation::spec_authoring` — 16 tests, all green
- [x] `cargo test --features spec-authoring spec_api::proposals` — 11 tests, all green
- [ ] CI: cargo fmt + clippy + the broader test suite (let GitHub Actions confirm)
- [ ] Atlas schema diff applied to canonical PG (operator runs `atlas schema apply` separately; not blocking PR merge — table only used when `spec-authoring` feature is enabled, which won't happen until v1.1)
