### PR TITLE
refactor(runner): unify per-agent daemon spawn site + shared token

### DIFF
--- a/src-tauri/src/agent_daemons/mod.rs
+++ b/src-tauri/src/agent_daemons/mod.rs
@@ -1,0 +1,188 @@
+//! Unified per-agent daemon spawn site.
+//!
+//! Before this module, two long-lived per-agent Tokio daemons existed
+//! with **no shared spawn path**:
+//!
+//! - `agent_pusher` (Row 9 Phase 3) — periodic `git push` to the
+//!   coord-hosted origin. Built + `tick_once`-tested but its `spawn`
+//!   had **no production call site** (coordination plan §3.0 step 3:
+//!   PTY/spawn wiring not yet on disk).
+//! - `dirty_poller` (Coordination Phase 6) — 5s `git status` →
+//!   `POST /agents/:id/dirty-state`. Self-registered at
+//!   `/agents/allocate-local` via its own `spawn_and_register` +
+//!   private handle registry.
+//!
+//! Each carried its **own** `TokenSlot` and its **own** refresh loop,
+//! so an agent ran two independent refreshers hitting coord's
+//! `POST /agents/:id/refresh-token` — 2× the refresh load at 300
+//! agents and two independently-rotating jtis per agent.
+//!
+//! This module is the single spawn site: one
+//! [`crate::agent_token::SharedToken`] per agent, both daemons built
+//! against it (`*State::with_shared_token`), one combined handle held
+//! in one process-global registry keyed by `agent_id`. Re-allocating
+//! the same agent drops the prior [`AgentDaemons`] → both old daemons
+//! stop cleanly on their next tick.
+//!
+//! The unification also gives `agent_pusher` its first real spawn
+//! site: every worktree-mode allocation now starts the pusher too,
+//! not just the poller.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::agent_pusher::{self, PusherHandle, PusherState};
+use crate::agent_token;
+use crate::agent_worktree::AllocateResult;
+use crate::dirty_poller::{self, DirtyPollerHandle, DirtyPollerState};
+
+/// Both daemons for one agent. Dropping this stops both: each handle's
+/// `Drop` signals its task to exit on the next tick.
+#[derive(Default)]
+struct AgentDaemons {
+    pusher: Option<PusherHandle>,
+    poller: Option<DirtyPollerHandle>,
+}
+
+/// Process-global registry. Agents are long-lived; teardown is
+/// best-effort and dies with the runner (the trade-off `agent_pusher`
+/// documents). Keyed by `agent_id` so a re-allocation replaces — and
+/// thereby stops — the prior daemons.
+static REGISTRY: OnceLock<Mutex<HashMap<Uuid, AgentDaemons>>> = OnceLock::new();
+
+/// Spawn (and retain) the pusher + poller for one freshly-allocated
+/// agent, both sharing one refreshing token slot.
+///
+/// No-op when the allocation carried no JWT (coord JWT keys
+/// unconfigured / dev fallback): both daemons' coord calls are
+/// JWT-gated, so there is nothing to run. Best-effort throughout — a
+/// missing daemon degrades observability/durability, never
+/// correctness.
+pub fn spawn_for_agent(allocate: &AllocateResult, coord_http_base: String, machine_id: Uuid) {
+    let Some(token) = agent_token::from_allocate_result(allocate) else {
+        info!(
+            "agent_daemons: agent_id={} — no token in allocation; pusher+poller skipped (dev/no-JWT coord)",
+            allocate.agent_id
+        );
+        return;
+    };
+    let agent_id = match Uuid::parse_str(&allocate.agent_id) {
+        Ok(id) => id,
+        Err(e) => {
+            warn!(
+                "agent_daemons: unparseable agent_id {:?} ({e}) — daemons skipped",
+                allocate.agent_id
+            );
+            return;
+        }
+    };
+
+    let mut daemons = AgentDaemons::default();
+
+    match PusherState::with_shared_token(allocate, coord_http_base.clone(), token.clone()) {
+        Some(ps) => daemons.pusher = Some(agent_pusher::spawn(Arc::new(ps))),
+        None => info!("agent_daemons: agent_id={agent_id} pusher skipped (no push targets)"),
+    }
+    match DirtyPollerState::with_shared_token(allocate, coord_http_base, machine_id, token) {
+        Some(dp) => daemons.poller = Some(dirty_poller::spawn(Arc::new(dp))),
+        None => info!("agent_daemons: agent_id={agent_id} poller skipped (no worktrees)"),
+    }
+
+    let reg = REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(mut g) = reg.lock() {
+        // Insert drops any prior AgentDaemons for this agent → both
+        // old daemons observe cancellation and exit next tick.
+        g.insert(agent_id, daemons);
+        info!(
+            "agent_daemons: agent_id={agent_id} pusher+poller live (agents tracked={})",
+            g.len()
+        );
+    }
+}
+
+/// Test-only: is a specific agent currently tracked? Per-agent so
+/// parallel tests don't race on a shared total count.
+#[cfg(test)]
+fn tracked_contains(id: Uuid) -> bool {
+    REGISTRY
+        .get()
+        .and_then(|m| m.lock().ok().map(|g| g.contains_key(&id)))
+        .unwrap_or(false)
+}
+
+/// Test-only: how many `AgentDaemons` entries exist for `id` (a
+/// HashMap key is unique, so this is 0 or 1 — proves re-allocation
+/// replaces rather than accumulates).
+#[cfg(test)]
+fn entries_for(id: Uuid) -> usize {
+    REGISTRY
+        .get()
+        .and_then(|m| m.lock().ok())
+        .map(|g| g.keys().filter(|k| **k == id).count())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_worktree::MaterializedWorktree;
+
+    fn alloc(agent: &str, token: &str) -> AllocateResult {
+        AllocateResult {
+            agent_id: agent.to_string(),
+            worktrees: vec![MaterializedWorktree {
+                repo: "qontinui-coord".into(),
+                branch: "agent/m-a".into(),
+                parent_sha: "0".repeat(40),
+                worktree_path: std::env::temp_dir(),
+                push_ref: "refs/agent/m-a".into(),
+            }],
+            token: token.to_string(),
+            token_jti: Uuid::nil(),
+            token_exp: chrono::Utc::now().timestamp() + 4 * 3600,
+        }
+    }
+
+    /// No token ⇒ no daemons for that agent (per-agent assertion, so
+    /// parallel tests don't race a shared total).
+    #[tokio::test]
+    async fn tokenless_allocation_is_noop() {
+        let id = Uuid::parse_str("00000000-0000-0000-0000-0000000000aa").unwrap();
+        spawn_for_agent(
+            &alloc(&id.to_string(), ""),
+            "http://127.0.0.1:1".into(),
+            Uuid::nil(),
+        );
+        assert!(!tracked_contains(id), "tokenless alloc must not register");
+    }
+
+    /// A tokened allocation registers the agent; re-allocating the
+    /// same agent_id replaces in place (still exactly one entry — the
+    /// prior `AgentDaemons` is dropped, stopping both old daemons; the
+    /// Drop→stop path itself is covered by the handles' own tests).
+    /// Unreachable coord base ⇒ the spawned tasks just error+retry.
+    #[tokio::test]
+    async fn tokened_allocation_registers_then_replaces() {
+        let id = Uuid::parse_str("00000000-0000-0000-0000-0000000000bb").unwrap();
+        spawn_for_agent(
+            &alloc(&id.to_string(), "tok"),
+            "http://127.0.0.1:1".into(),
+            Uuid::nil(),
+        );
+        assert!(tracked_contains(id));
+        assert_eq!(entries_for(id), 1);
+        spawn_for_agent(
+            &alloc(&id.to_string(), "tok2"),
+            "http://127.0.0.1:1".into(),
+            Uuid::nil(),
+        );
+        assert_eq!(
+            entries_for(id),
+            1,
+            "re-allocation of the same agent must replace, not accumulate"
+        );
+    }
+}

--- a/src-tauri/src/agent_pusher/mod.rs
+++ b/src-tauri/src/agent_pusher/mod.rs
@@ -58,8 +58,13 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use tokio::process::Command;
-use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+
+use crate::agent_token::{self, SharedToken};
+// Re-exported so existing `agent_pusher::TokenSlot` /
+// `TOKEN_REFRESH_MARGIN_SECS` references (incl. this module's tests)
+// keep resolving after the token logic moved to `crate::agent_token`.
+pub use crate::agent_token::{TokenSlot, TOKEN_REFRESH_MARGIN_SECS};
 
 /// Default cadence — 5 minutes per §3.2. Tunable for tests.
 const DEFAULT_PUSH_INTERVAL_SECS: u64 = 300;
@@ -67,12 +72,6 @@ const DEFAULT_PUSH_INTERVAL_SECS: u64 = 300;
 /// ±jitter window applied to each tick. §3.2's "spread to ~1/sec
 /// sustained at 300 agents" math depends on this.
 const DEFAULT_JITTER_SECS: u64 = 60;
-
-/// Refresh the JWT proactively when this much time-to-expiry remains.
-/// Tokens are 4h per §3.3; refreshing at 30min remaining means the
-/// pusher gets ~7 refresh opportunities per token's lifetime in the
-/// happy path.
-const TOKEN_REFRESH_MARGIN_SECS: i64 = 30 * 60;
 
 /// One worktree the pusher pushes for. Mirrors the shape coord
 /// returns from `POST /agents/allocate`, less the suggested-path
@@ -101,29 +100,9 @@ pub struct PusherState {
     pub coord_http_base: String,
     pub origin_repo_alias: String,
     pub targets: Vec<PushTarget>,
-    pub token: RwLock<TokenSlot>,
-}
-
-/// Mutable token + bookkeeping. Lives behind an `RwLock` so the
-/// pusher can refresh without dropping in-flight push attempts.
-#[derive(Debug, Clone)]
-pub struct TokenSlot {
-    pub token: String,
-    pub jti: uuid::Uuid,
-    /// Unix-seconds expiry. Refresh fires when `exp - now() <
-    /// TOKEN_REFRESH_MARGIN_SECS`.
-    pub exp: i64,
-}
-
-impl TokenSlot {
-    /// Seconds until expiry from `now`.
-    pub fn ttl_secs(&self, now_unix: i64) -> i64 {
-        self.exp - now_unix
-    }
-
-    pub fn needs_refresh(&self, now_unix: i64) -> bool {
-        self.ttl_secs(now_unix) < TOKEN_REFRESH_MARGIN_SECS
-    }
+    /// Shared with every other daemon spawned for this agent (one
+    /// refresh path, not one per daemon). See [`crate::agent_token`].
+    pub token: SharedToken,
 }
 
 impl PusherState {
@@ -136,9 +115,18 @@ impl PusherState {
         allocate: &crate::agent_worktree::AllocateResult,
         coord_http_base: String,
     ) -> Option<Self> {
-        if allocate.token.is_empty() {
-            return None;
-        }
+        let token = agent_token::from_allocate_result(allocate)?;
+        Self::with_shared_token(allocate, coord_http_base, token)
+    }
+
+    /// Same as [`from_allocate_result`] but the caller supplies the
+    /// shared token slot — used by `agent_daemons::spawn_for_agent`
+    /// so the pusher and the dirty-poller refresh through one slot.
+    pub fn with_shared_token(
+        allocate: &crate::agent_worktree::AllocateResult,
+        coord_http_base: String,
+        token: SharedToken,
+    ) -> Option<Self> {
         let agent_id = uuid::Uuid::from_str(&allocate.agent_id).ok()?;
         // §3.4 pilot has only qontinui-coord.git; the alias is the
         // repo slug. We collect targets from the materialized worktree
@@ -163,11 +151,7 @@ impl PusherState {
             coord_http_base,
             origin_repo_alias,
             targets,
-            token: RwLock::new(TokenSlot {
-                token: allocate.token.clone(),
-                jti: allocate.token_jti,
-                exp: allocate.token_exp,
-            }),
+            token,
         })
     }
 }
@@ -280,7 +264,13 @@ async fn run(
 /// Public for the integration test — doesn't depend on the spawn
 /// machinery.
 pub async fn tick_once(state: &Arc<PusherState>) -> Result<()> {
-    maybe_refresh_token(state).await?;
+    agent_token::maybe_refresh(
+        &state.token,
+        &state.coord_http_base,
+        state.agent_id,
+        "agent_pusher",
+    )
+    .await?;
     let token_clone = {
         let guard = state.token.read().await;
         guard.clone()
@@ -302,77 +292,6 @@ pub async fn tick_once(state: &Arc<PusherState>) -> Result<()> {
         }
     }
     Ok(())
-}
-
-/// Refresh the cached token if it's within `TOKEN_REFRESH_MARGIN_SECS`
-/// of expiry. Best-effort: a failed refresh logs a warning and
-/// returns Ok — the next tick will retry.
-async fn maybe_refresh_token(state: &Arc<PusherState>) -> Result<()> {
-    let now = chrono::Utc::now().timestamp();
-    let needs = {
-        let guard = state.token.read().await;
-        guard.needs_refresh(now)
-    };
-    if !needs {
-        return Ok(());
-    }
-    info!(
-        "agent_pusher: agent_id={} refreshing token (ttl_secs={})",
-        state.agent_id,
-        state.token.read().await.ttl_secs(now)
-    );
-    let url = format!(
-        "{}/agents/{}/refresh-token",
-        state.coord_http_base.trim_end_matches('/'),
-        state.agent_id
-    );
-    let current = state.token.read().await.token.clone();
-    let resp = match reqwest::Client::new()
-        .post(&url)
-        .bearer_auth(&current)
-        .send()
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("agent_pusher: refresh request failed: {e} — will retry on next tick");
-            return Ok(());
-        }
-    };
-    if !resp.status().is_success() {
-        warn!(
-            "agent_pusher: refresh returned {} — will retry next tick",
-            resp.status()
-        );
-        return Ok(());
-    }
-    let body: RefreshResponseBody = match resp.json().await {
-        Ok(b) => b,
-        Err(e) => {
-            warn!("agent_pusher: refresh body decode failed: {e}");
-            return Ok(());
-        }
-    };
-    let mut guard = state.token.write().await;
-    *guard = TokenSlot {
-        token: body.token,
-        jti: body.jti,
-        exp: body.exp,
-    };
-    info!(
-        "agent_pusher: agent_id={} token refreshed jti={} exp={}",
-        state.agent_id, guard.jti, guard.exp
-    );
-    Ok(())
-}
-
-#[derive(Debug, Deserialize)]
-struct RefreshResponseBody {
-    token: String,
-    #[allow(dead_code)]
-    agent_id: uuid::Uuid,
-    jti: uuid::Uuid,
-    exp: i64,
 }
 
 /// Push one branch to coord-origin via `git push`. Returns
@@ -580,11 +499,11 @@ mod tests {
             coord_http_base: "http://invalid:1".into(),
             origin_repo_alias: "qontinui-coord".into(),
             targets: vec![],
-            token: RwLock::new(TokenSlot {
+            token: Arc::new(tokio::sync::RwLock::new(TokenSlot {
                 token: "x".into(),
                 jti: uuid::Uuid::nil(),
                 exp: chrono::Utc::now().timestamp() + 4 * 3600,
-            }),
+            })),
         });
         let handle = spawn(state);
         // Drop immediately — should not hang or panic.

--- a/src-tauri/src/agent_token/mod.rs
+++ b/src-tauri/src/agent_token/mod.rs
@@ -1,0 +1,176 @@
+//! Shared per-agent JWT slot + proactive refresh.
+//!
+//! Row 9 §3.3 tokens live 4h; long agent sessions outlive a single
+//! token, so every per-agent daemon (`agent_pusher`, `dirty_poller`,
+//! …) must refresh proactively. Before the spawn-site unification each
+//! daemon carried its **own** `TokenSlot` + its own refresh loop —
+//! correct, but at 300 agents that's 2× the `POST
+//! /agents/:id/refresh-token` load and two independently-rotating jtis
+//! per agent. This module is the single source of truth: one
+//! `Arc<RwLock<TokenSlot>>` per agent, shared by every daemon
+//! `agent_daemons::spawn_for_agent` starts, and one `maybe_refresh`
+//! implementation.
+//!
+//! Standalone use (the modules' own unit/integration tests) still
+//! builds a private token via [`from_allocate_result`]; only the
+//! production spawn path shares one.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::Deserialize;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+/// Refresh the JWT proactively when this much time-to-expiry remains.
+/// Tokens are 4h per §3.3; 30min margin ⇒ ~7 refresh opportunities
+/// per token lifetime in the happy path.
+pub const TOKEN_REFRESH_MARGIN_SECS: i64 = 30 * 60;
+
+/// Mutable token + bookkeeping. Behind an `RwLock` (in
+/// [`SharedToken`]) so a refresh never drops an in-flight push/poll.
+#[derive(Debug, Clone)]
+pub struct TokenSlot {
+    pub token: String,
+    pub jti: Uuid,
+    /// Unix-seconds expiry. Refresh fires when
+    /// `exp - now() < TOKEN_REFRESH_MARGIN_SECS`.
+    pub exp: i64,
+}
+
+impl TokenSlot {
+    /// Seconds until expiry from `now`.
+    pub fn ttl_secs(&self, now_unix: i64) -> i64 {
+        self.exp - now_unix
+    }
+
+    pub fn needs_refresh(&self, now_unix: i64) -> bool {
+        self.ttl_secs(now_unix) < TOKEN_REFRESH_MARGIN_SECS
+    }
+}
+
+/// One token slot shared by every daemon spawned for an agent.
+pub type SharedToken = Arc<RwLock<TokenSlot>>;
+
+/// Build a fresh shared token from a coord allocation. `None` when
+/// the allocation carried no token (coord JWT keys unconfigured / dev
+/// fallback) — callers skip daemon spawn and log + continue.
+pub fn from_allocate_result(
+    allocate: &crate::agent_worktree::AllocateResult,
+) -> Option<SharedToken> {
+    if allocate.token.is_empty() {
+        return None;
+    }
+    Some(Arc::new(RwLock::new(TokenSlot {
+        token: allocate.token.clone(),
+        jti: allocate.token_jti,
+        exp: allocate.token_exp,
+    })))
+}
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponseBody {
+    token: String,
+    #[allow(dead_code)]
+    agent_id: Uuid,
+    jti: Uuid,
+    exp: i64,
+}
+
+/// Refresh the shared token if it's within
+/// `TOKEN_REFRESH_MARGIN_SECS` of expiry. Best-effort: a failed
+/// refresh logs + returns `Ok` so the caller's next tick retries.
+/// `who` is a short caller label for log lines
+/// (`"agent_pusher"` / `"dirty_poller"`); behaviour is identical
+/// regardless. Idempotent across daemons sharing the slot — the first
+/// daemon to tick after the margin refreshes; the rest observe the
+/// already-fresh token and no-op.
+pub async fn maybe_refresh(
+    token: &SharedToken,
+    coord_http_base: &str,
+    agent_id: Uuid,
+    who: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().timestamp();
+    let (needs, ttl) = {
+        let g = token.read().await;
+        (g.needs_refresh(now), g.ttl_secs(now))
+    };
+    if !needs {
+        return Ok(());
+    }
+    info!("{who}: agent_id={agent_id} refreshing token (ttl_secs={ttl})");
+    let url = format!(
+        "{}/agents/{}/refresh-token",
+        coord_http_base.trim_end_matches('/'),
+        agent_id
+    );
+    let current = token.read().await.token.clone();
+    let resp = match reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(&current)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("{who}: token refresh request failed: {e} — retry next tick");
+            return Ok(());
+        }
+    };
+    if !resp.status().is_success() {
+        warn!(
+            "{who}: token refresh returned {} — retry next tick",
+            resp.status()
+        );
+        return Ok(());
+    }
+    let body: RefreshResponseBody = match resp.json().await {
+        Ok(b) => b,
+        Err(e) => {
+            warn!("{who}: token refresh body decode failed: {e}");
+            return Ok(());
+        }
+    };
+    let mut g = token.write().await;
+    *g = TokenSlot {
+        token: body.token,
+        jti: body.jti,
+        exp: body.exp,
+    };
+    info!(
+        "{who}: agent_id={agent_id} token refreshed jti={} exp={}",
+        g.jti, g.exp
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn needs_refresh_threshold() {
+        let now = 1_700_000_000;
+        let fresh = TokenSlot {
+            token: "x".into(),
+            jti: Uuid::nil(),
+            exp: now + 4 * 3600,
+        };
+        assert!(!fresh.needs_refresh(now));
+        let stale = TokenSlot {
+            token: "x".into(),
+            jti: Uuid::nil(),
+            exp: now + 600,
+        };
+        assert!(stale.needs_refresh(now));
+        // Exactly one second under the margin → refresh.
+        let edge = TokenSlot {
+            token: "x".into(),
+            jti: Uuid::nil(),
+            exp: now + TOKEN_REFRESH_MARGIN_SECS - 1,
+        };
+        assert!(edge.needs_refresh(now));
+    }
+}

--- a/src-tauri/src/dirty_poller/mod.rs
+++ b/src-tauri/src/dirty_poller/mod.rs
@@ -70,17 +70,19 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tokio::process::Command;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+use crate::agent_token::{self, SharedToken};
+// Re-exported so existing `dirty_poller::TokenSlot` references (incl.
+// this module's tests) keep resolving after the token logic moved to
+// `crate::agent_token` (shared with `agent_pusher`).
+pub use crate::agent_token::TokenSlot;
+
 /// Default cadence — 5 s per §4.8.
 const DEFAULT_POLL_INTERVAL_SECS: u64 = 5;
-
-/// Refresh the JWT proactively when this much time-to-expiry remains.
-/// Mirrors `agent_pusher::TOKEN_REFRESH_MARGIN_SECS` (30 min).
-const TOKEN_REFRESH_MARGIN_SECS: i64 = 30 * 60;
 
 /// One worktree the poller watches.
 #[derive(Debug, Clone)]
@@ -90,25 +92,6 @@ pub struct DirtyTarget {
     pub worktree_path: PathBuf,
 }
 
-/// Mutable token + bookkeeping. Same shape as
-/// `agent_pusher::TokenSlot`; kept local so the poller doesn't depend
-/// on the (not-yet-wired) pusher spawn machinery.
-#[derive(Debug, Clone)]
-pub struct TokenSlot {
-    pub token: String,
-    pub jti: uuid::Uuid,
-    pub exp: i64,
-}
-
-impl TokenSlot {
-    pub fn ttl_secs(&self, now_unix: i64) -> i64 {
-        self.exp - now_unix
-    }
-    pub fn needs_refresh(&self, now_unix: i64) -> bool {
-        self.ttl_secs(now_unix) < TOKEN_REFRESH_MARGIN_SECS
-    }
-}
-
 /// State shared between the poller task and its handle.
 #[derive(Debug)]
 pub struct DirtyPollerState {
@@ -116,7 +99,9 @@ pub struct DirtyPollerState {
     pub machine_id: uuid::Uuid,
     pub coord_http_base: String,
     pub targets: Vec<DirtyTarget>,
-    pub token: RwLock<TokenSlot>,
+    /// Shared with every other daemon spawned for this agent (one
+    /// refresh path, not one per daemon). See [`crate::agent_token`].
+    pub token: SharedToken,
     /// Per-repo fingerprint of the last *sent* state. `tick_once`
     /// compares against this to decide change-vs-heartbeat and to
     /// drive the monotonic `seq`.
@@ -144,9 +129,19 @@ impl DirtyPollerState {
         coord_http_base: String,
         machine_id: uuid::Uuid,
     ) -> Option<Self> {
-        if allocate.token.is_empty() {
-            return None;
-        }
+        let token = agent_token::from_allocate_result(allocate)?;
+        Self::with_shared_token(allocate, coord_http_base, machine_id, token)
+    }
+
+    /// Same as [`from_allocate_result`] but the caller supplies the
+    /// shared token slot — used by `agent_daemons::spawn_for_agent`
+    /// so the poller and the pusher refresh through one slot.
+    pub fn with_shared_token(
+        allocate: &crate::agent_worktree::AllocateResult,
+        coord_http_base: String,
+        machine_id: uuid::Uuid,
+        token: SharedToken,
+    ) -> Option<Self> {
         let agent_id = uuid::Uuid::from_str(&allocate.agent_id).ok()?;
         let targets: Vec<DirtyTarget> = allocate
             .worktrees
@@ -165,11 +160,7 @@ impl DirtyPollerState {
             machine_id,
             coord_http_base,
             targets,
-            token: RwLock::new(TokenSlot {
-                token: allocate.token.clone(),
-                jti: allocate.token_jti,
-                exp: allocate.token_exp,
-            }),
+            token,
             seen: RwLock::new(SeenState::default()),
         })
     }
@@ -210,32 +201,10 @@ impl Drop for DirtyPollerHandle {
     }
 }
 
-/// Process-global registry holding live poller handles so they aren't
-/// `Drop`ped (which would stop the poller) the moment the allocation
-/// handler returns. Agents are long-lived; teardown is best-effort and
-/// dies with the runner — same trade-off `agent_pusher` documents.
-/// Keyed by `agent_id` so a re-allocation of the same agent replaces
-/// (and thereby stops) the prior poller.
-static DIRTY_POLLERS: std::sync::OnceLock<
-    std::sync::Mutex<HashMap<uuid::Uuid, DirtyPollerHandle>>,
-> = std::sync::OnceLock::new();
-
-/// Spawn a poller for `state` and retain its handle for the runner's
-/// lifetime. Replaces any prior poller for the same `agent_id`.
-pub fn spawn_and_register(state: Arc<DirtyPollerState>) {
-    let agent_id = state.agent_id;
-    let handle = spawn(state);
-    let map = DIRTY_POLLERS.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
-    if let Ok(mut guard) = map.lock() {
-        // Inserting drops any prior handle → its poller stops cleanly.
-        guard.insert(agent_id, handle);
-        info!(
-            "dirty_poller: registered agent_id={} (live pollers={})",
-            agent_id,
-            guard.len()
-        );
-    }
-}
+// The process-global handle registry moved to `crate::agent_daemons`,
+// which now owns the single per-agent spawn site (pusher + poller).
+// `dirty_poller::spawn` stays the standalone primitive (used by
+// `agent_daemons` and the integration test).
 
 async fn run(state: Arc<DirtyPollerState>, interval_secs: u64, cancel: Arc<tokio::sync::Notify>) {
     info!(
@@ -300,7 +269,13 @@ pub struct DirtyStateReq {
 /// Returns the `heartbeat` flag that was sent (true = no change since
 /// the prior tick) so tests can assert change-detection.
 pub async fn tick_once(state: &Arc<DirtyPollerState>) -> Result<bool> {
-    maybe_refresh_token(state).await?;
+    agent_token::maybe_refresh(
+        &state.token,
+        &state.coord_http_base,
+        state.agent_id,
+        "dirty_poller",
+    )
+    .await?;
 
     let mut worktrees = Vec::with_capacity(state.targets.len());
     let mut new_fps: HashMap<String, u64> = HashMap::new();
@@ -429,62 +404,6 @@ async fn post_dirty_state(state: &Arc<DirtyPollerState>, req: &DirtyStateReq) ->
         req.seq,
         req.worktrees.len()
     );
-    Ok(())
-}
-
-/// Token refresh — same contract as `agent_pusher::maybe_refresh_token`.
-/// Best-effort: a failed refresh logs + returns Ok; next tick retries.
-async fn maybe_refresh_token(state: &Arc<DirtyPollerState>) -> Result<()> {
-    let now = chrono::Utc::now().timestamp();
-    if !state.token.read().await.needs_refresh(now) {
-        return Ok(());
-    }
-    let url = format!(
-        "{}/agents/{}/refresh-token",
-        state.coord_http_base.trim_end_matches('/'),
-        state.agent_id
-    );
-    let current = state.token.read().await.token.clone();
-    let resp = match reqwest::Client::new()
-        .post(&url)
-        .bearer_auth(&current)
-        .send()
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            warn!("dirty_poller: token refresh request failed: {e} — retry next tick");
-            return Ok(());
-        }
-    };
-    if !resp.status().is_success() {
-        warn!(
-            "dirty_poller: token refresh returned {} — retry next tick",
-            resp.status()
-        );
-        return Ok(());
-    }
-    #[derive(Deserialize)]
-    struct RefreshBody {
-        token: String,
-        jti: uuid::Uuid,
-        exp: i64,
-    }
-    match resp.json::<RefreshBody>().await {
-        Ok(b) => {
-            let mut guard = state.token.write().await;
-            *guard = TokenSlot {
-                token: b.token,
-                jti: b.jti,
-                exp: b.exp,
-            };
-            info!(
-                "dirty_poller: agent_id={} token refreshed jti={}",
-                state.agent_id, guard.jti
-            );
-        }
-        Err(e) => warn!("dirty_poller: refresh body decode failed: {e}"),
-    }
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,9 @@
 #![allow(clippy::too_many_arguments)]
 
 mod action_service;
+mod agent_daemons;
 mod agent_pusher;
+mod agent_token;
 mod agent_worktree;
 mod agentic_verification;
 mod ai_pricing;

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -127,24 +127,15 @@ pub async fn post_allocate_local(
                 result.agent_id,
                 result.worktrees.len()
             );
-            // Coordination Phase 6 — spawn the per-worktree live-state
-            // poller for this agent (5s `git status` → coord
-            // dirty-state). No-op when the allocation carried no JWT
-            // (dev fallback, coord JWT keys unconfigured) — the
-            // dirty-state endpoint is JWT-gated, so there's nothing to
-            // push without a token. Best-effort: a missing poller
-            // degrades the heatmap, never correctness.
-            match crate::dirty_poller::DirtyPollerState::from_allocate_result(
-                &result,
-                coord_http_base.clone(),
-                machine_id,
-            ) {
-                Some(st) => crate::dirty_poller::spawn_and_register(std::sync::Arc::new(st)),
-                None => info!(
-                    "/agents/allocate-local: dirty_poller skipped for agent_id={} (no token)",
-                    result.agent_id
-                ),
-            }
+            // Spawn this agent's long-lived daemons (Row 9 Phase 3
+            // pusher + Coordination Phase 6 dirty-poller) through the
+            // single unified site. One shared, self-refreshing token
+            // serves both. No-op when the allocation carried no JWT
+            // (dev fallback / coord JWT keys unconfigured) — both
+            // daemons' coord calls are JWT-gated. Best-effort: a
+            // missing daemon degrades observability/durability, never
+            // correctness.
+            crate::agent_daemons::spawn_for_agent(&result, coord_http_base.clone(), machine_id);
             Ok(Json(ApiResponse::success(json!({
                 "agent_id": result.agent_id,
                 "worktrees": result.worktrees.iter().map(|w| json!({


### PR DESCRIPTION
Follow-up to Coordination Phase 6 (runner PR #148). Closes the
spawn-site gap flagged in that report.

## Problem
`agent_pusher` (Row 9 P3) and `dirty_poller` (Coord P6) are two
long-lived per-agent daemons that had **no shared spawn path**:
- `agent_pusher::spawn` had **no production call site** (plan §3.0
  step 3 — PTY/spawn wiring not on disk).
- `dirty_poller` self-registered at `/agents/allocate-local`.
- Each carried its **own** `TokenSlot` + refresh loop → 2× the
  `POST /agents/:id/refresh-token` load and two independently-rotating
  jtis per agent at 300-agent scale.

## Change
- **`agent_token`** (new): `TokenSlot`, `SharedToken =
  Arc<RwLock<TokenSlot>>`, one `maybe_refresh`, `from_allocate_result`.
  First daemon past the 30-min margin refreshes; the rest observe the
  fresh token and no-op.
- **`agent_pusher` / `dirty_poller`**: deleted duplicated `TokenSlot`
  + refresh fn + (poller) its private handle registry; `*State.token`
  is now `SharedToken`; `TokenSlot` re-exported so existing
  refs/tests resolve; new `with_shared_token` constructor.
- **`agent_daemons::spawn_for_agent`** (new): one shared token, spawns
  pusher + poller against it, one `agent_id`-keyed registry
  (re-allocation replaces → both old daemons stop). Wired at
  `/agents/allocate-local` — **`agent_pusher`'s first real spawn
  site**.

Behaviour per daemon is unchanged; only wiring + token ownership
consolidated.

## Verification
18/18 unit tests (agent_token 1, agent_pusher 10, dirty_poller 5,
agent_daemons 2: tokenless-noop, register-then-replace). `cargo check`
clean. rustfmt applied to only the touched files (no drift).