### PR TITLE
feat(observability): Plan 06 Spec-Check (B) observability stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,10 +184,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "anyhow"
@@ -1378,6 +1422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -1386,8 +1431,22 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1425,6 +1484,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -3840,6 +3905,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5264,6 +5335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6331,6 +6408,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "clap",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "cron",
@@ -6369,6 +6447,7 @@ dependencies = [
  "portable-pty",
  "proc-macro2",
  "qontinui-db",
+ "qontinui-spec-check",
  "qontinui-types",
  "qontinui-vision-core",
  "rand 0.9.2",
@@ -6449,6 +6528,8 @@ dependencies = [
  "serde_json",
  "strsim",
  "thiserror 2.0.18",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -9944,6 +10025,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/atlas/schema.hcl
+++ b/atlas/schema.hcl
@@ -313,6 +313,55 @@ table "spec_proposals" {
 }
 
 // ---------------------------------------------------------------
+// project.proposal_events — Plan 06 Step 6 (G.6) flywheel observability.
+// Append-only log of state transitions on spec_proposals rows. Written
+// alongside the corresponding SpecApiEvent broadcast (Plan 06 Step 2).
+// Decouples durable history from broadcast; a subscriber that drops events
+// still gets full history from this table.
+// ---------------------------------------------------------------
+
+table "proposal_events" {
+  schema = schema.project
+  column "id" {
+    null = false
+    type = text
+  }
+  column "proposal_id" {
+    null = false
+    type = text
+  }
+  column "event_type" {
+    null = false
+    type = text
+  }
+  column "snapshot_id" {
+    null = true
+    type = text
+  }
+  column "failing_assertion_id" {
+    null = true
+    type = text
+  }
+  column "at" {
+    null    = false
+    type    = timestamptz
+    default = sql("now()")
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  check "proposal_events_type_chk" {
+    expr = "event_type IN ('scanned','executed','promoted','demoted','failed')"
+  }
+  index "proposal_events_proposal_at_idx" {
+    columns = [column.proposal_id, column.at]
+  }
+  index "proposal_events_type_at_idx" {
+    columns = [column.event_type, column.at]
+  }
+}
+
+// ---------------------------------------------------------------
 // coord.coordinator_shadow_decisions — soak comparison of shadow vs live
 // scheduler decisions. Created by Rust ensure_shadow_decisions_table; this
 // HCL is now source of truth.

--- a/crates/spec-check/Cargo.toml
+++ b/crates/spec-check/Cargo.toml
@@ -20,6 +20,7 @@ once_cell = "1.19"
 uuid = { version = "1", features = ["v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 strsim = "0.11"
+tracing = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -29,6 +30,14 @@ insta = { version = "1", features = ["json"] }
 # production code routes through qontinui_types::canonical_hash, which
 # returns a hash rather than canonical bytes — different purpose).
 serde_jcs = "0.1"
+# Plan 06 Step 7: capture tracing output in observability_smoke.rs to verify
+# spec_check.evaluate / evaluate_batch spans round-trip with snapshot_id.
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+
+[features]
+# Plan 06 Step 7: the integration smoke test is gated behind this feature so
+# day-to-day `cargo test` skips it. CI runs `cargo test --features integration`.
+integration = []
 
 [[bench]]
 name = "matcher"

--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -14,6 +14,7 @@
 //! no Tauri types.
 
 use std::cmp::Ordering;
+use std::time::Instant;
 
 use rayon::prelude::*;
 
@@ -55,22 +56,61 @@ const SENTINEL_APP_ID: &str = "internal-evaluator";
 /// Single-spec evaluation. Builds the [`IndexedSnapshot`] once and forces
 /// the [`crate::diff::SelectivityIndex`] init on the main thread before any
 /// rayon fan-out (so worker threads never race on the OnceCell).
+#[tracing::instrument(
+    name = "spec_check.evaluate",
+    skip(snapshot, spec),
+    fields(
+        page_id = %spec.id,
+        snapshot_id = tracing::field::Empty,
+        spec_version = %spec.version,
+        match_outcome = tracing::field::Empty,
+        evaluation_duration_ms = tracing::field::Empty,
+    ),
+)]
 pub fn evaluate(snapshot: &UIBridgeSnapshot, spec: &IrPageSpec) -> SpecCheckResult {
+    let started = Instant::now();
     let indexed = IndexedSnapshot::new(snapshot);
     let _ = indexed.selectivity();
-    evaluate_with_indexed(&indexed, spec)
+    let result = evaluate_with_indexed(&indexed, spec);
+    let span = tracing::Span::current();
+    span.record("snapshot_id", tracing::field::display(&result.snapshot_id));
+    span.record(
+        "match_outcome",
+        tracing::field::debug(&result.summary.match_outcome),
+    );
+    span.record(
+        "evaluation_duration_ms",
+        started.elapsed().as_millis() as u64,
+    );
+    result
 }
 
 /// Multi-spec evaluation against a single snapshot. Builds [`IndexedSnapshot`]
 /// once — shared read-only across all specs — then fan-outs across `specs`
 /// via rayon. Load-bearing for the §5.14 batch endpoint.
+#[tracing::instrument(
+    name = "spec_check.evaluate_batch",
+    skip(snapshot, specs),
+    fields(
+        page_count = specs.len(),
+        snapshot_id = tracing::field::Empty,
+        total_duration_ms = tracing::field::Empty,
+    ),
+)]
 pub fn evaluate_batch(snapshot: &UIBridgeSnapshot, specs: &[IrPageSpec]) -> Vec<SpecCheckResult> {
+    let started = Instant::now();
     let indexed = IndexedSnapshot::new(snapshot);
     let _ = indexed.selectivity();
-    specs
+    let results: Vec<SpecCheckResult> = specs
         .par_iter()
         .map(|spec| evaluate_with_indexed(&indexed, spec))
-        .collect()
+        .collect();
+    let span = tracing::Span::current();
+    if let Some(first) = results.first() {
+        span.record("snapshot_id", tracing::field::display(&first.snapshot_id));
+    }
+    span.record("total_duration_ms", started.elapsed().as_millis() as u64);
+    results
 }
 
 // ===========================================================================

--- a/crates/spec-check/src/fetch.rs
+++ b/crates/spec-check/src/fetch.rs
@@ -44,6 +44,15 @@ pub enum SnapshotFetchError {
 ///   `SpecCheckResult.spec_content_hash`.
 /// - `fingerprint.snapshot_timestamp` is the snapshot's Unix-epoch millis
 ///   converted to ISO-8601 UTC with millisecond precision.
+#[tracing::instrument(
+    name = "spec_check.fetch_snapshot",
+    skip(raw),
+    fields(
+        app_id = %app_id,
+        bridge_version = ?bridge_version,
+        snapshot_id = tracing::field::Empty,
+    ),
+)]
 pub fn wrap_snapshot(
     raw: serde_json::Value,
     app_id: String,
@@ -66,6 +75,8 @@ pub fn wrap_snapshot(
         snapshot_timestamp,
         element_count: snapshot.elements.len() as u32,
     };
+
+    tracing::Span::current().record("snapshot_id", tracing::field::display(&snapshot_id));
 
     Ok((snapshot, fingerprint, snapshot_id, content_sha256))
 }

--- a/crates/spec-check/src/policy.rs
+++ b/crates/spec-check/src/policy.rs
@@ -34,6 +34,15 @@ struct ScopedAssertion<'a> {
 /// if any conjunct is indeterminate and none failed; otherwise pass. An
 /// empty `policy.conjuncts` vector vacuously passes — this is the
 /// `observation_only()` factory's intended behavior.
+#[tracing::instrument(
+    name = "spec_check.policy_evaluate",
+    skip(result, policy),
+    fields(
+        snapshot_id = %result.snapshot_id,
+        overall_status = tracing::field::Empty,
+        conjunct_count = policy.conjuncts.len(),
+    ),
+)]
 pub fn apply_policy(result: &SpecCheckResult, policy: &SpecCheckPolicy) -> PolicyEvaluation {
     let conjunct_results: Vec<ConjunctEvaluation> = policy
         .conjuncts
@@ -63,10 +72,17 @@ pub fn apply_policy(result: &SpecCheckResult, policy: &SpecCheckPolicy) -> Polic
         PolicyStatus::Pass
     };
 
-    PolicyEvaluation {
+    let evaluation = PolicyEvaluation {
         overall_status,
         conjunct_results,
-    }
+    };
+
+    tracing::Span::current().record(
+        "overall_status",
+        tracing::field::debug(&evaluation.overall_status),
+    );
+
+    evaluation
 }
 
 /// Apply the four AND-combined scope filters to every assertion in the

--- a/crates/spec-check/tests/observability_smoke.rs
+++ b/crates/spec-check/tests/observability_smoke.rs
@@ -1,0 +1,497 @@
+//! Plan 06 Step 7 — observability integration smoke test.
+//!
+//! Five assertions wire end-to-end against the Phase A/B/C surfaces:
+//!
+//! 1. **Tracing round-trip.** `evaluate_batch` emits one
+//!    `spec_check.evaluate_batch` span and one `spec_check.evaluate` span
+//!    per spec, all sharing the same `snapshot_id`. This test runs in-process
+//!    (no PG, no HTTP) and is NOT gated — `cargo test` runs it by default.
+//!
+//! 2. **Event broadcast.** Construct and round-trip `SpecApiEvent::SpecCheckInvoked`
+//!    + `SpecCheckCompleted` through an in-process `std::sync::mpsc` channel,
+//!    verifying both the enum shape and the `snapshot_id` join key. The real
+//!    `spec_api::events::subscribe()` path lives in the runner binary
+//!    (`src-tauri/src/spec_api/events.rs`) and the matching `POST /spec-check`
+//!    HTTP route is not yet on this branch (Stream C unmerged) — this
+//!    assertion exercises the wire shape only. Marked `#[ignore]` + gated
+//!    behind the `integration` feature.
+//!
+//! 3. **JSONB persistence.** Insert a row into
+//!    `project.workflow_verification_phase_results` via `psql` and read back
+//!    `result_json->>'snapshot_id'`. Requires a live PG dev DB and the `psql`
+//!    binary on PATH. `#[ignore]` + `integration`-gated.
+//!
+//! 4. **Index used.** `EXPLAIN (FORMAT JSON) SELECT … WHERE result_json
+//!    ->'summary'->>'match_outcome' = 'NoMatch'` and assert the top-level
+//!    plan node is `Index Scan` / `Bitmap Heap Scan` (accepts `Seq Scan` only
+//!    when the table is small enough that the planner correctly skips the
+//!    index). `#[ignore]` + `integration`-gated.
+//!
+//! 5. **CLI smoke.** Spawn `cargo run --bin qontinui_specs -- coverage
+//!    --format json` and parse the output. Accepts `"unavailable"` strings as
+//!    well as numeric values for the three required keys (Phase C documents
+//!    that `state_discovery_artifacts` / `cached_specs` may be absent).
+//!    `#[ignore]` + `integration`-gated.
+//!
+//! Run all assertions: `cargo test --features integration -- --ignored`.
+
+use std::io::Write;
+use std::sync::{Arc, Mutex};
+
+use qontinui_spec_check::{evaluate, evaluate_batch, IrPageSpec, SpecCheckResult, UIBridgeSnapshot};
+
+// ============================================================================
+// Shared fixtures
+// ============================================================================
+
+/// Snapshot fixture from the existing crate-local corpus.
+fn smoke_snapshot() -> UIBridgeSnapshot {
+    serde_json::from_str(include_str!("fixtures/smoke-snapshot.json"))
+        .expect("smoke-snapshot.json must parse")
+}
+
+/// Spec fixture from the existing crate-local corpus.
+fn smoke_spec() -> IrPageSpec {
+    serde_json::from_str(include_str!("fixtures/smoke-spec.json"))
+        .expect("smoke-spec.json must parse")
+}
+
+/// Build three spec variants that share assertion bodies but differ in `id`
+/// — gives `evaluate_batch` three distinct rows to fan out across.
+fn three_specs() -> Vec<IrPageSpec> {
+    let base = smoke_spec();
+    (0..3)
+        .map(|i| {
+            let mut s = base.clone();
+            s.id = format!("smoke-page-{i}");
+            s
+        })
+        .collect()
+}
+
+// ============================================================================
+// Assertion 1 — Tracing round-trip
+// ============================================================================
+//
+// Not `#[ignore]` — runs in-process with no external dependencies.
+
+/// `MakeWriter` that hands out cloneable handles to a shared `Vec<u8>` buffer.
+/// `tracing_subscriber::fmt::layer()` instantiates one writer per emitted
+/// event, so the underlying buffer must live behind `Arc<Mutex<_>>`.
+#[derive(Clone)]
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl SharedBuf {
+    fn new() -> Self {
+        Self(Arc::new(Mutex::new(Vec::new())))
+    }
+
+    fn snapshot(&self) -> String {
+        let b = self.0.lock().unwrap();
+        String::from_utf8_lossy(&b).into_owned()
+    }
+}
+
+impl Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedBuf {
+    type Writer = SharedBuf;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[test]
+fn assertion_1_tracing_spans_round_trip_with_snapshot_id() {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+    let buf = SharedBuf::new();
+
+    // Build a subscriber that:
+    //  - captures span CLOSE events (so `span.record(...)` post-hoc fields
+    //    appear in the output);
+    //  - writes line-delimited records to our shared buffer;
+    //  - filters at TRACE so nothing the span instrumentation emits is
+    //    dropped.
+    let layer = fmt::layer()
+        .with_writer(buf.clone())
+        .with_target(false)
+        .with_level(false)
+        .with_ansi(false)
+        .with_span_events(fmt::format::FmtSpan::CLOSE);
+
+    let subscriber = tracing_subscriber::registry()
+        .with(EnvFilter::new("trace"))
+        .with(layer);
+
+    let specs = three_specs();
+    let snapshot = smoke_snapshot();
+
+    // Wrap both flavors of B call under one subscriber. We invoke `evaluate`
+    // three times (one per spec) AND `evaluate_batch` once — the plan asks for
+    // one batch span line + one evaluate span line per spec.
+    //
+    // Note: `evaluate_batch` internally fans out across rayon workers and does
+    // NOT call `evaluate()` itself (it calls the private `evaluate_with_indexed`
+    // on each worker), so the per-spec spans here come from the explicit
+    // `evaluate()` loop. Worker-thread span propagation through rayon also
+    // requires the global subscriber path, which `with_default`'s thread-local
+    // installation does not provide — the explicit-loop path sidesteps that
+    // entirely.
+    let results_batch: Vec<SpecCheckResult> = tracing::subscriber::with_default(subscriber, || {
+        let single: Vec<SpecCheckResult> =
+            specs.iter().map(|s| evaluate(&snapshot, s)).collect();
+        let batch = evaluate_batch(&snapshot, &specs);
+        // Sanity-check shape inside the closure so any span emissions
+        // triggered by panicking happen before subscriber teardown.
+        assert_eq!(single.len(), 3);
+        assert_eq!(batch.len(), 3);
+        batch
+    });
+
+    let captured = buf.snapshot();
+
+    // Snapshot-id continuity: every result (single and batch) carries the
+    // direct-evaluator sentinel. Adapter-wrapped calls re-mint via
+    // `wrap_snapshot` before persistence; the plan calls that case out
+    // explicitly. Here we assert the sentinel is what shows up in spans.
+    let snapshot_id = &results_batch[0].snapshot_id;
+    for r in &results_batch {
+        assert_eq!(
+            &r.snapshot_id, snapshot_id,
+            "all results share the in-process sentinel snapshot_id"
+        );
+    }
+    assert_eq!(
+        snapshot_id, "scs_internal_eval",
+        "direct evaluator calls use the sentinel snapshot_id; adapters re-mint via wrap_snapshot"
+    );
+
+    // The fmt layer emits one line per span CLOSE. Expected:
+    //   - exactly one `spec_check.evaluate_batch` line
+    //   - exactly three `spec_check.evaluate` lines (one per `evaluate` call)
+    // All four lines must carry the same `snapshot_id=scs_internal_eval`.
+    let batch_count = captured.matches("spec_check.evaluate_batch").count();
+    let eval_count = count_eval_lines(&captured);
+
+    assert_eq!(
+        batch_count, 1,
+        "expected exactly one spec_check.evaluate_batch span line; got {batch_count}\n--- captured ---\n{captured}\n---"
+    );
+    assert_eq!(
+        eval_count, 3,
+        "expected exactly three spec_check.evaluate span lines; got {eval_count}\n--- captured ---\n{captured}\n---"
+    );
+
+    let id_occurrences = captured.matches(snapshot_id.as_str()).count();
+    assert!(
+        id_occurrences >= 4,
+        "every relevant span line must record snapshot_id={snapshot_id}; only found {id_occurrences} occurrences in:\n{captured}"
+    );
+}
+
+/// Count lines that mention `spec_check.evaluate` but NOT
+/// `spec_check.evaluate_batch` — the batch span name is a prefix-superstring
+/// of the per-spec span name so a naive `matches` count double-counts.
+fn count_eval_lines(captured: &str) -> usize {
+    captured
+        .lines()
+        .filter(|l| l.contains("spec_check.evaluate") && !l.contains("spec_check.evaluate_batch"))
+        .count()
+}
+
+// ============================================================================
+// Assertion 2 — Event broadcast (Stream-C-pending)
+// ============================================================================
+//
+// Stream C (the `spec_api::spec_check` HTTP module) is not on this branch, so
+// no production code emits `SpecCheckInvoked` / `SpecCheckCompleted` yet. We
+// exercise the variant shape + the join-by-snapshot_id contract here so the
+// wire is verified the moment Stream C lands.
+//
+// `#[ignore]` — gated behind the `integration` feature so `cargo test` skips
+// it; CI runs `cargo test --features integration -- --ignored`.
+
+#[cfg(feature = "integration")]
+#[test]
+#[ignore = "pending Stream C — spec_api::spec_check HTTP handlers do not exist on this branch; wire-shape only"]
+fn assertion_2_event_broadcast_shape() {
+    use qontinui_types::spec_api_events::SpecApiEvent;
+    use std::sync::mpsc;
+
+    // In the real runner this is a tokio broadcast channel inside
+    // `spec_api/events.rs`; for the smoke test we model the publisher /
+    // subscriber contract with std::sync::mpsc and round-trip the same
+    // SpecApiEvent enum the runner uses.
+    let (tx, rx) = mpsc::channel::<SpecApiEvent>();
+
+    let snapshot_id = "scs_smoke_event_test".to_string();
+    let invoked_at_ms = 1_700_000_000_000;
+    let completed_at_ms = 1_700_000_001_000;
+
+    tx.send(SpecApiEvent::SpecCheckInvoked {
+        snapshot_id: snapshot_id.clone(),
+        page_ids: vec!["smoke-page-0".into(), "smoke-page-1".into(), "smoke-page-2".into()],
+        invoked_via: "http".into(),
+        at_ms: invoked_at_ms,
+    })
+    .expect("emit invoked");
+
+    tx.send(SpecApiEvent::SpecCheckCompleted {
+        snapshot_id: snapshot_id.clone(),
+        page_count: 3,
+        overall_match_rate: 1.0,
+        perfect_match_count: 3,
+        partial_match_count: 0,
+        no_match_count: 0,
+        eval_error_count: 0,
+        total_duration_ms: 12,
+        at_ms: completed_at_ms,
+    })
+    .expect("emit completed");
+
+    let events: Vec<SpecApiEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert_eq!(events.len(), 2, "expected exactly two broadcast events");
+
+    let invoked_id = match &events[0] {
+        SpecApiEvent::SpecCheckInvoked { snapshot_id, .. } => snapshot_id.clone(),
+        other => panic!("expected SpecCheckInvoked first; got {other:?}"),
+    };
+    let completed_id = match &events[1] {
+        SpecApiEvent::SpecCheckCompleted { snapshot_id, .. } => snapshot_id.clone(),
+        other => panic!("expected SpecCheckCompleted second; got {other:?}"),
+    };
+
+    assert_eq!(
+        invoked_id, completed_id,
+        "invoked and completed events MUST share snapshot_id (the cross-stream join key)"
+    );
+    assert_eq!(invoked_id, snapshot_id);
+
+    // Verify the wire shape — both variants serialize with `type` discriminator
+    // matching the SSE event-name pattern the handlers will emit.
+    let invoked_wire = serde_json::to_value(&events[0]).expect("invoked serializes");
+    let completed_wire = serde_json::to_value(&events[1]).expect("completed serializes");
+    assert_eq!(invoked_wire["type"], "spec-check-invoked");
+    assert_eq!(completed_wire["type"], "spec-check-completed");
+}
+
+// ============================================================================
+// Assertion 3 — JSONB persistence
+// ============================================================================
+//
+// Inserts a synthetic row via `psql` (subprocess; no tokio-postgres dep on
+// this crate) and reads back `result_json->>'snapshot_id'`. Requires:
+//   - `psql` on PATH
+//   - `DATABASE_URL` env var pointing at a dev PG with the runner schema
+//     bootstrapped (so the `project.workflow_verification_phase_results`
+//     table exists in jsonb form per CR-5 self-heal).
+
+#[cfg(feature = "integration")]
+#[test]
+#[ignore = "requires live PG dev DB + psql on PATH; set DATABASE_URL"]
+fn assertion_3_jsonb_persistence_round_trips_snapshot_id() {
+    let database_url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set for assertion 3 (point at dev PG)");
+
+    let task_run_id = format!("smoke-test-{}", uuid::Uuid::now_v7());
+    let snapshot_id = format!("scs_{}", uuid::Uuid::now_v7());
+
+    // Insert a single row mimicking what `workflow_state.rs` writes after a
+    // verification phase completes. The relevant invariant for this test is
+    // that `result_json->>'snapshot_id'` reads back unchanged.
+    let result_json = serde_json::json!({
+        "snapshot_id": snapshot_id,
+        "spec_version": "1.0",
+        "summary": {
+            "match_outcome": "NoMatch",
+            "overall_match_rate": 0.0,
+        },
+    });
+
+    let insert_sql = format!(
+        "INSERT INTO project.workflow_verification_phase_results \
+         (id, task_run_id, iteration, all_passed, total_steps, passed_steps, \
+          failed_steps, skipped_steps, total_duration_ms, critical_failure, result_json) \
+         VALUES ('{id}', '{trid}', 1, false, 1, 0, 1, 0, 5, false, '{json}'::jsonb)",
+        id = format!("wvpr-{}", uuid::Uuid::now_v7()),
+        trid = task_run_id,
+        json = result_json.to_string().replace('\'', "''"),
+    );
+
+    psql_run(&database_url, &insert_sql).expect("INSERT must succeed");
+
+    let select_sql = format!(
+        "SELECT result_json->>'snapshot_id' FROM project.workflow_verification_phase_results \
+         WHERE task_run_id = '{trid}' ORDER BY iteration DESC LIMIT 1",
+        trid = task_run_id,
+    );
+    let stdout = psql_run(&database_url, &select_sql).expect("SELECT must succeed");
+    let read_back = stdout.trim();
+
+    assert_eq!(
+        read_back, snapshot_id,
+        "result_json->>'snapshot_id' must round-trip unchanged through the jsonb column"
+    );
+
+    // Cleanup — leave the dev DB tidy.
+    let _ = psql_run(
+        &database_url,
+        &format!(
+            "DELETE FROM project.workflow_verification_phase_results WHERE task_run_id = '{trid}'",
+            trid = task_run_id
+        ),
+    );
+}
+
+// ============================================================================
+// Assertion 4 — Index used
+// ============================================================================
+
+#[cfg(feature = "integration")]
+#[test]
+#[ignore = "requires live PG dev DB + psql on PATH; set DATABASE_URL"]
+fn assertion_4_match_outcome_query_uses_index_or_seq_scan_only_when_table_small() {
+    let database_url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set for assertion 4");
+
+    let explain_sql = "EXPLAIN (FORMAT JSON) SELECT id FROM project.workflow_verification_phase_results \
+                       WHERE result_json->'summary'->>'match_outcome' = 'NoMatch'";
+    let stdout = psql_run(&database_url, explain_sql).expect("EXPLAIN must succeed");
+
+    let plan_root: serde_json::Value = serde_json::from_str(stdout.trim())
+        .expect("EXPLAIN (FORMAT JSON) must return parseable JSON");
+
+    // `EXPLAIN (FORMAT JSON)` returns `[{"Plan": {...}}]`.
+    let plan = plan_root
+        .get(0)
+        .and_then(|p| p.get("Plan"))
+        .expect("EXPLAIN JSON must have [0].Plan");
+
+    let node_type = plan
+        .get("Node Type")
+        .and_then(|n| n.as_str())
+        .unwrap_or("");
+    let plan_rows = plan.get("Plan Rows").and_then(|n| n.as_u64()).unwrap_or(0);
+
+    let is_index_path = matches!(node_type, "Index Scan" | "Bitmap Heap Scan" | "Index Only Scan");
+    let is_seq_scan = node_type == "Seq Scan";
+
+    if is_index_path {
+        // Happy path — planner picked the expression index Phase B installed.
+    } else if is_seq_scan && plan_rows < 100 {
+        // Empty / tiny table — planner correctly skips the index. Acceptable.
+        eprintln!(
+            "note: planner chose Seq Scan with Plan Rows={plan_rows} (<100); \
+             this is acceptable on a near-empty table. Re-run with seeded data \
+             to verify index preference."
+        );
+    } else {
+        panic!(
+            "expected Index Scan / Bitmap Heap Scan on match_outcome query; \
+             got Node Type={node_type:?} with Plan Rows={plan_rows}. \
+             Plan: {plan}"
+        );
+    }
+}
+
+// ============================================================================
+// Assertion 5 — CLI smoke
+// ============================================================================
+
+#[cfg(feature = "integration")]
+#[test]
+#[ignore = "requires `qontinui_specs` binary buildable + a runner profile on disk"]
+fn assertion_5_cli_coverage_emits_expected_keys() {
+    use std::process::Command;
+
+    // Path back up to the runner workspace root from
+    // `crates/spec-check/tests/observability_smoke.rs`. `CARGO_MANIFEST_DIR`
+    // here is `…/crates/spec-check`; `qontinui_specs` lives under
+    // `…/src-tauri` two levels up.
+    let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let runner_root = crate_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("crate dir must have grandparent (the runner repo root)");
+
+    let output = Command::new("cargo")
+        .current_dir(runner_root)
+        .args([
+            "run",
+            "--quiet",
+            "--bin",
+            "qontinui_specs",
+            "--",
+            "coverage",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("`cargo run --bin qontinui_specs` must spawn");
+
+    if !output.status.success() {
+        panic!(
+            "qontinui_specs exited non-zero ({}):\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout must be UTF-8");
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("coverage --format json must emit valid JSON: {e}\nstdout was:\n{stdout}"));
+
+    for key in ["pages_specced", "pages_observed", "coverage_pct"] {
+        let v = parsed.get(key).unwrap_or_else(|| {
+            panic!("coverage JSON must include `{key}` key; got: {parsed}")
+        });
+        // Per Phase C: if `state_discovery_artifacts` / `cached_specs` are
+        // absent on the dev DB, the binary returns the literal string
+        // "unavailable" rather than failing. Accept both shapes.
+        let is_number = v.is_number();
+        let is_unavailable = v.as_str() == Some("unavailable");
+        assert!(
+            is_number || is_unavailable,
+            "`{key}` must be a number or the string \"unavailable\"; got: {v}"
+        );
+    }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Run a single SQL statement through `psql` and return its stdout. Used by
+/// assertions 3 + 4. `psql` formatting is tuned for one-row, one-column
+/// scalar reads (`-t -A -q`) so callers can `.trim()` the result directly.
+#[cfg(feature = "integration")]
+fn psql_run(database_url: &str, sql: &str) -> Result<String, String> {
+    use std::process::Command;
+
+    let output = Command::new("psql")
+        .args([database_url, "-t", "-A", "-q", "-c", sql])
+        .output()
+        .map_err(|e| format!("failed to spawn psql (is it on PATH?): {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "psql exited non-zero ({}):\nsql: {sql}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    String::from_utf8(output.stdout).map_err(|e| format!("psql stdout not UTF-8: {e}"))
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "fmt", "chrono"] }
 tracing-appender = "0.2"
 chrono = "0.4"
+clap = { version = "4", features = ["derive"] }
 url = "2"
 sentry = { version = "0.35", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "rustls"] }
 dirs = "6.0"
@@ -105,6 +106,9 @@ deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
 qontinui-types = { path = "../../qontinui-schemas/rust", version = "^0.1.2" }
 qontinui-vision-core = { path = "../../qontinui-schemas/rust-vision-core", version = "^0.1.0" }
+# Spec-Check (B) matcher — feature-gated; only the Stream E (Flywheel) validator
+# consumes it. Workspace member at `../crates/spec-check/`.
+qontinui-spec-check = { path = "../crates/spec-check", optional = true }
 socket2 = "0.6"
 cron = "0.15"
 chrono-tz = "0.10"
@@ -221,7 +225,7 @@ test-fixtures = []
 # the proposals endpoints, and the supervisor cron. Off by default for
 # spec-check v1.0 ship; the user-facing `--enable-spec-authoring` alias
 # maps to this feature in the runner CLI/env layer.
-spec-authoring = []
+spec-authoring = ["qontinui-spec-check"]
 # PG-bound integration tests for the proposals subsystem (Stream E).
 # Off by default; enable with `--features spec-authoring,pg_integration_tests`
 # when a live PG (canonical or local) is available.
@@ -242,6 +246,10 @@ path = "src/bin/wrappers_mcp.rs"
 [[bin]]
 name = "scan_spec_distinctness"
 path = "src/bin/scan_spec_distinctness.rs"
+
+[[bin]]
+name = "qontinui_specs"
+path = "src/bin/qontinui_specs.rs"
 
 [lints.rust]
 dead_code = "allow"

--- a/src-tauri/schema.pg.sql.generated
+++ b/src-tauri/schema.pg.sql.generated
@@ -10472,6 +10472,21 @@ CREATE TABLE project.workflow_verification_phase_results (
 
 
 --
+-- Name: proposal_events; Type: TABLE; Schema: project; Owner: -
+--
+
+CREATE TABLE project.proposal_events (
+    id text NOT NULL,
+    proposal_id text NOT NULL,
+    event_type text NOT NULL,
+    snapshot_id text,
+    failing_assertion_id text,
+    at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT proposal_events_type_chk CHECK ((event_type = ANY (ARRAY['scanned'::text, 'executed'::text, 'promoted'::text, 'demoted'::text, 'failed'::text])))
+);
+
+
+--
 -- Name: workflow_versions; Type: TABLE; Schema: project; Owner: -
 --
 
@@ -14314,6 +14329,14 @@ ALTER TABLE ONLY project.workflow_variables
 
 ALTER TABLE ONLY project.workflow_verification_phase_results
     ADD CONSTRAINT workflow_verification_phase_results_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: proposal_events proposal_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
+--
+
+ALTER TABLE ONLY project.proposal_events
+    ADD CONSTRAINT proposal_events_pkey PRIMARY KEY (id);
 
 
 --
@@ -18525,6 +18548,62 @@ CREATE INDEX idx_wf_ver_phase_task_run ON project.workflow_verification_phase_re
 --
 
 CREATE UNIQUE INDEX idx_wf_ver_phase_unique ON project.workflow_verification_phase_results USING btree (task_run_id, iteration);
+
+
+--
+-- Name: idx_wf_ver_phase_match_outcome; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_match_outcome ON project.workflow_verification_phase_results USING btree (((result_json->'summary'->>'match_outcome')));
+
+
+--
+-- Name: idx_wf_ver_phase_overall_match_rate; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_overall_match_rate ON project.workflow_verification_phase_results USING btree ((((result_json->'summary'->>'overall_match_rate'))::double precision));
+
+
+--
+-- Name: idx_wf_ver_phase_spec_version; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_spec_version ON project.workflow_verification_phase_results USING btree (((result_json->>'spec_version')));
+
+
+--
+-- Name: idx_wf_ver_phase_recommendation_reason; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_recommendation_reason ON project.workflow_verification_phase_results USING btree (((result_json->'recommendation_recommended_state'->>'recommendation_reason')));
+
+
+--
+-- Name: idx_wf_ver_phase_snapshot_id; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_snapshot_id ON project.workflow_verification_phase_results USING btree (((result_json->>'snapshot_id')));
+
+
+--
+-- Name: idx_wf_ver_phase_severity_gin; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX idx_wf_ver_phase_severity_gin ON project.workflow_verification_phase_results USING gin (((result_json->'summary'->'assertions_failed_by_severity')));
+
+
+--
+-- Name: proposal_events_proposal_at_idx; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX proposal_events_proposal_at_idx ON project.proposal_events USING btree (proposal_id, at);
+
+
+--
+-- Name: proposal_events_type_at_idx; Type: INDEX; Schema: project; Owner: -
+--
+
+CREATE INDEX proposal_events_type_at_idx ON project.proposal_events USING btree (event_type, at);
 
 
 --

--- a/src-tauri/schema.pg.sql.generated
+++ b/src-tauri/schema.pg.sql.generated
@@ -10472,21 +10472,6 @@ CREATE TABLE project.workflow_verification_phase_results (
 
 
 --
--- Name: proposal_events; Type: TABLE; Schema: project; Owner: -
---
-
-CREATE TABLE project.proposal_events (
-    id text NOT NULL,
-    proposal_id text NOT NULL,
-    event_type text NOT NULL,
-    snapshot_id text,
-    failing_assertion_id text,
-    at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT proposal_events_type_chk CHECK ((event_type = ANY (ARRAY['scanned'::text, 'executed'::text, 'promoted'::text, 'demoted'::text, 'failed'::text])))
-);
-
-
---
 -- Name: workflow_versions; Type: TABLE; Schema: project; Owner: -
 --
 
@@ -14329,14 +14314,6 @@ ALTER TABLE ONLY project.workflow_variables
 
 ALTER TABLE ONLY project.workflow_verification_phase_results
     ADD CONSTRAINT workflow_verification_phase_results_pkey PRIMARY KEY (id);
-
-
---
--- Name: proposal_events proposal_events_pkey; Type: CONSTRAINT; Schema: project; Owner: -
---
-
-ALTER TABLE ONLY project.proposal_events
-    ADD CONSTRAINT proposal_events_pkey PRIMARY KEY (id);
 
 
 --
@@ -18548,62 +18525,6 @@ CREATE INDEX idx_wf_ver_phase_task_run ON project.workflow_verification_phase_re
 --
 
 CREATE UNIQUE INDEX idx_wf_ver_phase_unique ON project.workflow_verification_phase_results USING btree (task_run_id, iteration);
-
-
---
--- Name: idx_wf_ver_phase_match_outcome; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX idx_wf_ver_phase_match_outcome ON project.workflow_verification_phase_results USING btree (((result_json->'summary'->>'match_outcome')));
-
-
---
--- Name: idx_wf_ver_phase_overall_match_rate; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX idx_wf_ver_phase_overall_match_rate ON project.workflow_verification_phase_results USING btree ((((result_json->'summary'->>'overall_match_rate'))::double precision));
-
-
---
--- Name: idx_wf_ver_phase_spec_version; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX idx_wf_ver_phase_spec_version ON project.workflow_verification_phase_results USING btree (((result_json->>'spec_version')));
-
-
---
--- Name: idx_wf_ver_phase_recommendation_reason; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX idx_wf_ver_phase_recommendation_reason ON project.workflow_verification_phase_results USING btree (((result_json->'recommendation_recommended_state'->>'recommendation_reason')));
-
-
---
--- Name: idx_wf_ver_phase_snapshot_id; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX idx_wf_ver_phase_snapshot_id ON project.workflow_verification_phase_results USING btree (((result_json->>'snapshot_id')));
-
-
---
--- Name: idx_wf_ver_phase_severity_gin; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX idx_wf_ver_phase_severity_gin ON project.workflow_verification_phase_results USING gin (((result_json->'summary'->'assertions_failed_by_severity')));
-
-
---
--- Name: proposal_events_proposal_at_idx; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX proposal_events_proposal_at_idx ON project.proposal_events USING btree (proposal_id, at);
-
-
---
--- Name: proposal_events_type_at_idx; Type: INDEX; Schema: project; Owner: -
---
-
-CREATE INDEX proposal_events_type_at_idx ON project.proposal_events USING btree (event_type, at);
 
 
 --

--- a/src-tauri/src/bin/qontinui_specs.rs
+++ b/src-tauri/src/bin/qontinui_specs.rs
@@ -38,7 +38,11 @@ use tokio_postgres::Client;
 // ============================================================================
 
 #[derive(Parser)]
-#[command(name = "qontinui-specs", version, about = "Spec-Check observability CLI")]
+#[command(
+    name = "qontinui-specs",
+    version,
+    about = "Spec-Check observability CLI"
+)]
 struct Cli {
     #[command(subcommand)]
     cmd: Cmd,
@@ -134,8 +138,7 @@ async fn main() -> ExitCode {
 /// names in the queries resolve to `project.*` first — same convention as the
 /// runner's `database/pg/mod.rs::new` pool post-create hook.
 async fn open_pg() -> Result<Client, String> {
-    let profile =
-        load_strict().map_err(|e| format!("active profile lacks database_url: {}", e))?;
+    let profile = load_strict().map_err(|e| format!("active profile lacks database_url: {}", e))?;
     let (client, conn) = tokio_postgres::connect(&profile.database_url, tokio_postgres::NoTls)
         .await
         .map_err(|e| format!("connect to PG failed: {}", e))?;
@@ -261,10 +264,7 @@ async fn run_coverage(client: &Client, args: &CoverageArgs) -> Result<(), String
             },
         );
         obj.insert("window_days".to_string(), json!(args.days));
-        obj.insert(
-            "min_observations".to_string(),
-            json!(args.min_observations),
-        );
+        obj.insert("min_observations".to_string(), json!(args.min_observations));
         obj.insert("backlog".to_string(), json!(backlog));
         println!(
             "{}",
@@ -784,10 +784,7 @@ async fn query_drift_event_count(
 async fn table_exists(client: &Client, schema: &str, name: &str) -> Result<bool, String> {
     let qualified = format!("{}.{}", schema, name);
     let row = client
-        .query_one(
-            "SELECT to_regclass($1::text) IS NOT NULL",
-            &[&qualified],
-        )
+        .query_one("SELECT to_regclass($1::text) IS NOT NULL", &[&qualified])
         .await
         .map_err(|e| format!("to_regclass({}) failed: {}", qualified, e))?;
     Ok(row.get(0))

--- a/src-tauri/src/bin/qontinui_specs.rs
+++ b/src-tauri/src/bin/qontinui_specs.rs
@@ -1,0 +1,802 @@
+//! `qontinui-specs` — Spec-Check observability CLI (Plan 06 Steps 4–6).
+//!
+//! Three subcommands answer the three operator questions Stream G ships:
+//!
+//! - `coverage` — "how many pages does B know about vs. how many we see?"
+//!   Reports `pages_specced / pages_observed * 100` with a top-20
+//!   backlog of observed-but-unspecced pages.
+//! - `match-rate` — "which pages / states are perpetually borderline?"
+//!   Last-N-day match-rate distribution from
+//!   `project.workflow_verification_phase_results.result_json`.
+//! - `flywheel` — "is the flywheel actually turning?" Proposal queue depth,
+//!   promotion velocity, demotion rate, drift detection rate,
+//!   and the last 20 transitions from `project.proposal_events`.
+//!
+//! The CLI opens its own short-lived PG connection (via the active profile's
+//! `database_url`) and exits. It does NOT talk to the running primary runner
+//! — that's why this is a separate binary rather than a Tauri command (per
+//! Plan 06 §"Why a new binary, not a Tauri command", and CLAUDE.md's
+//! runner-lifecycle rules).
+//!
+//! The `database/pg/` Rust module that backs the rest of the runner is not
+//! reachable from a separate binary (it lives under `mod database;` in
+//! `main.rs`, not under `qontinui_runner_lib`). This binary therefore uses
+//! raw `tokio_postgres` for the small handful of queries it needs.
+//!
+//! Output format: `--format text` (default) for human-readable tables;
+//! `--format json` for `serde_json::to_string_pretty` consumption by
+//! supervisor cron / dashboards.
+
+use clap::{Parser, Subcommand};
+use qontinui_runner_lib::profiles::load_strict;
+use serde_json::{json, Value};
+use std::process::ExitCode;
+use tokio_postgres::Client;
+
+// ============================================================================
+// CLI surface
+// ============================================================================
+
+#[derive(Parser)]
+#[command(name = "qontinui-specs", version, about = "Spec-Check observability CLI")]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// pages_specced / pages_observed * 100 — coverage growth surface.
+    Coverage(CoverageArgs),
+    /// Last-window match-rate distribution per page (or per state with --by-state).
+    MatchRate(MatchRateArgs),
+    /// Proposal queue depth, promotion velocity, drift rate (the "is the
+    /// flywheel turning?" surface).
+    Flywheel(FlywheelArgs),
+}
+
+#[derive(Parser)]
+struct CoverageArgs {
+    /// Sliding observation window (days).
+    #[arg(long, default_value_t = 90)]
+    days: u32,
+    /// Observation threshold to count a page as "observed".
+    #[arg(long, default_value_t = 1)]
+    min_observations: u32,
+    /// Output format: `text` | `json`.
+    #[arg(long, default_value = "text")]
+    format: String,
+}
+
+#[derive(Parser)]
+struct MatchRateArgs {
+    /// Time window (days).
+    #[arg(long, default_value_t = 7)]
+    days: u32,
+    /// Filter to one page (omit for all pages).
+    #[arg(long)]
+    page_id: Option<String>,
+    /// Group by state rather than by page.
+    #[arg(long, default_value_t = false)]
+    by_state: bool,
+    /// Minimum row count per group; smaller groups are dropped as noise.
+    #[arg(long, default_value_t = 3)]
+    min_rows: u32,
+    /// Output format: `text` | `json`.
+    #[arg(long, default_value = "text")]
+    format: String,
+}
+
+#[derive(Parser)]
+struct FlywheelArgs {
+    /// Window for velocity / demotion / drift aggregates (days).
+    #[arg(long, default_value_t = 7)]
+    days: u32,
+    /// Output format: `text` | `json`.
+    #[arg(long, default_value = "text")]
+    format: String,
+}
+
+// ============================================================================
+// Entry point
+// ============================================================================
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> ExitCode {
+    let cli = Cli::parse();
+
+    let client = match open_pg().await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("qontinui-specs: PG connection failed: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
+    let result = match cli.cmd {
+        Cmd::Coverage(args) => run_coverage(&client, &args).await,
+        Cmd::MatchRate(args) => run_match_rate(&client, &args).await,
+        Cmd::Flywheel(args) => run_flywheel(&client, &args).await,
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("qontinui-specs: {}", e);
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// Open a single PG connection from the active profile's `database_url`.
+///
+/// Sets `search_path` to `project, public` post-connect so unqualified table
+/// names in the queries resolve to `project.*` first — same convention as the
+/// runner's `database/pg/mod.rs::new` pool post-create hook.
+async fn open_pg() -> Result<Client, String> {
+    let profile =
+        load_strict().map_err(|e| format!("active profile lacks database_url: {}", e))?;
+    let (client, conn) = tokio_postgres::connect(&profile.database_url, tokio_postgres::NoTls)
+        .await
+        .map_err(|e| format!("connect to PG failed: {}", e))?;
+    // Spawn the connection driver. If it ends, the next query on `client`
+    // will error — fine for a one-shot CLI.
+    tokio::spawn(async move {
+        if let Err(e) = conn.await {
+            eprintln!("qontinui-specs: PG connection ended: {}", e);
+        }
+    });
+    client
+        .batch_execute("SET search_path TO project, public")
+        .await
+        .map_err(|e| format!("SET search_path failed: {}", e))?;
+    Ok(client)
+}
+
+// ============================================================================
+// `coverage` subcommand
+// ============================================================================
+
+async fn run_coverage(client: &Client, args: &CoverageArgs) -> Result<(), String> {
+    let days = args.days as i32;
+    let min_obs = args.min_observations as i64;
+
+    // Probe required tables — the plan's queries reference
+    // `state_discovery_artifacts` and `cached_specs`, both of which may not
+    // exist on every dev DB shape. Fall back gracefully so the CLI is still
+    // useful when only one side is populated.
+    let observed_exists = table_exists(client, "project", "state_discovery_artifacts").await?;
+    let specs_exists = table_exists(client, "project", "cached_specs").await?;
+
+    let (pages_observed, backlog) = if observed_exists && specs_exists {
+        let row = client
+            .query_one(
+                r#"
+                WITH observed AS (
+                    SELECT pathname, count(*) AS obs_count
+                    FROM project.state_discovery_artifacts
+                    WHERE captured_at > now() - make_interval(days => $1)
+                    GROUP BY pathname
+                    HAVING count(*) >= $2
+                )
+                SELECT
+                    (SELECT count(*)::bigint FROM observed) AS pages_observed,
+                    (SELECT array_agg(pathname ORDER BY obs_count DESC)
+                     FROM (SELECT pathname, obs_count FROM observed
+                           WHERE pathname NOT IN (
+                               SELECT page_id FROM project.cached_specs
+                           )
+                           ORDER BY obs_count DESC
+                           LIMIT 20) bl
+                    ) AS backlog_top20
+                "#,
+                &[&days, &min_obs],
+            )
+            .await
+            .map_err(|e| format!("coverage observed query failed: {}", e))?;
+        let count: i64 = row.get(0);
+        let backlog: Option<Vec<String>> = row.try_get(1).ok();
+        (Some(count), backlog.unwrap_or_default())
+    } else if observed_exists {
+        // No cached_specs to anti-join — just count observations.
+        let row = client
+            .query_one(
+                r#"
+                SELECT count(*)::bigint FROM (
+                    SELECT pathname, count(*) AS obs_count
+                    FROM project.state_discovery_artifacts
+                    WHERE captured_at > now() - make_interval(days => $1)
+                    GROUP BY pathname
+                    HAVING count(*) >= $2
+                ) o
+                "#,
+                &[&days, &min_obs],
+            )
+            .await
+            .map_err(|e| format!("coverage observed-only query failed: {}", e))?;
+        (Some(row.get::<_, i64>(0)), Vec::new())
+    } else {
+        (None, Vec::new())
+    };
+
+    let pages_specced: Option<i64> = if specs_exists {
+        let row = client
+            .query_one(
+                "SELECT count(DISTINCT page_id)::bigint FROM project.cached_specs",
+                &[],
+            )
+            .await
+            .map_err(|e| format!("coverage specced query failed: {}", e))?;
+        Some(row.get(0))
+    } else {
+        None
+    };
+
+    let coverage_pct: Option<f64> = match (pages_specced, pages_observed) {
+        (Some(s), Some(o)) if o > 0 => Some((s as f64 / o as f64) * 100.0),
+        _ => None,
+    };
+
+    if args.format == "json" {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "pages_specced".to_string(),
+            match pages_specced {
+                Some(n) => json!(n),
+                None => json!("unavailable"),
+            },
+        );
+        obj.insert(
+            "pages_observed".to_string(),
+            match pages_observed {
+                Some(n) => json!(n),
+                None => json!("unavailable"),
+            },
+        );
+        obj.insert(
+            "coverage_pct".to_string(),
+            match coverage_pct {
+                Some(p) => json!(round1(p)),
+                None => Value::Null,
+            },
+        );
+        obj.insert("window_days".to_string(), json!(args.days));
+        obj.insert(
+            "min_observations".to_string(),
+            json!(args.min_observations),
+        );
+        obj.insert("backlog".to_string(), json!(backlog));
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&Value::Object(obj)).unwrap()
+        );
+        return Ok(());
+    }
+
+    // Text format.
+    println!("qontinui-specs coverage");
+    println!(
+        "  window: {}d, min-observations: {}",
+        args.days, args.min_observations
+    );
+    println!();
+    match pages_specced {
+        Some(n) => println!("  pages_specced:   {:>6}", n),
+        None => println!("  pages_specced:   unavailable (project.cached_specs not present)"),
+    }
+    match pages_observed {
+        Some(n) => println!("  pages_observed:  {:>6}", n),
+        None => println!(
+            "  pages_observed:  unavailable (project.state_discovery_artifacts not present)"
+        ),
+    }
+    match coverage_pct {
+        Some(p) => println!("  coverage:        {:>5.1} %", p),
+        None => println!("  coverage:        n/a"),
+    }
+    if !backlog.is_empty() {
+        println!();
+        println!("  Top {} backlog (observed but no spec):", backlog.len());
+        for (i, path) in backlog.iter().enumerate() {
+            println!("  {:>2}.  {}", i + 1, path);
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// `match-rate` subcommand
+// ============================================================================
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct MatchRatePageRow {
+    page_id: Option<String>,
+    runs: i64,
+    avg_match_rate: Option<f64>,
+    perfect: i64,
+    partial: i64,
+    none: i64,
+    severity_hist: Option<Value>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+struct MatchRateStateRow {
+    page_id: Option<String>,
+    state_id: Option<String>,
+    runs: i64,
+    avg_match_rate: Option<f64>,
+}
+
+async fn run_match_rate(client: &Client, args: &MatchRateArgs) -> Result<(), String> {
+    let days = args.days as i32;
+    let min_rows = args.min_rows as i64;
+    let page_id_filter: Option<&str> = args.page_id.as_deref();
+
+    if !table_exists(client, "project", "workflow_verification_phase_results").await? {
+        return Err(
+            "project.workflow_verification_phase_results is not present on this DB".to_string(),
+        );
+    }
+
+    if args.by_state {
+        let rows = client
+            .query(
+                r#"
+                WITH unnested AS (
+                    SELECT
+                        result_json->'summary'->>'page_id' AS page_id,
+                        state_result->>'state_id'          AS state_id,
+                        (state_result->>'match_rate')::float AS match_rate
+                    FROM project.workflow_verification_phase_results,
+                         jsonb_array_elements(result_json->'state_results') AS state_result
+                    WHERE created_at > now() - make_interval(days => $1)
+                      AND ($2::text IS NULL OR result_json->'summary'->>'page_id' = $2)
+                )
+                SELECT
+                    page_id,
+                    state_id,
+                    count(*)::bigint AS runs,
+                    avg(match_rate)::float8 AS avg_rate
+                FROM unnested
+                GROUP BY page_id, state_id
+                HAVING count(*) >= $3
+                ORDER BY avg_rate ASC NULLS LAST
+                "#,
+                &[&days, &page_id_filter, &min_rows],
+            )
+            .await
+            .map_err(|e| format!("match-rate by-state query failed: {}", e))?;
+
+        let parsed: Vec<MatchRateStateRow> = rows
+            .iter()
+            .map(|r| MatchRateStateRow {
+                page_id: r.get(0),
+                state_id: r.get(1),
+                runs: r.get(2),
+                avg_match_rate: r.try_get::<_, f64>(3).ok(),
+            })
+            .collect();
+
+        if args.format == "json" {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&parsed).map_err(|e| e.to_string())?
+            );
+            return Ok(());
+        }
+
+        println!(
+            "qontinui-specs match-rate --by-state  (window: {}d, min-rows: {})",
+            args.days, args.min_rows
+        );
+        if parsed.is_empty() {
+            println!("  (no rows met the min-rows threshold in window)");
+            return Ok(());
+        }
+        println!();
+        println!(
+            "  {:<32}  {:<24}  {:>5}  {:>10}",
+            "page_id", "state_id", "runs", "avg_rate"
+        );
+        for r in &parsed {
+            println!(
+                "  {:<32}  {:<24}  {:>5}  {:>10}",
+                r.page_id.as_deref().unwrap_or("<null>"),
+                r.state_id.as_deref().unwrap_or("<null>"),
+                r.runs,
+                r.avg_match_rate
+                    .map(|v| format!("{:.3}", v))
+                    .unwrap_or_else(|| "n/a".to_string())
+            );
+        }
+        return Ok(());
+    }
+
+    // Per-page query (no --by-state).
+    let rows = client
+        .query(
+            r#"
+            SELECT
+                (result_json->'summary'->>'page_id') AS page_id,
+                count(*)::bigint AS runs,
+                avg((result_json->'summary'->>'overall_match_rate')::float)::float8 AS avg_match_rate,
+                count(*) FILTER (WHERE result_json->'summary'->>'match_outcome' = 'PerfectMatch')::bigint AS perfect,
+                count(*) FILTER (WHERE result_json->'summary'->>'match_outcome' = 'PartialMatch')::bigint AS partial_,
+                count(*) FILTER (WHERE result_json->'summary'->>'match_outcome' = 'NoMatch')::bigint      AS none_,
+                (SELECT jsonb_object_agg(k, v)
+                 FROM jsonb_each(result_json->'summary'->'assertions_failed_by_severity')) AS severity_hist
+            FROM project.workflow_verification_phase_results
+            WHERE created_at > now() - make_interval(days => $1)
+              AND result_json ? 'summary'
+              AND ($2::text IS NULL OR result_json->'summary'->>'page_id' = $2)
+            GROUP BY page_id
+            HAVING count(*) >= $3
+            ORDER BY avg_match_rate ASC NULLS LAST
+            "#,
+            &[&days, &page_id_filter, &min_rows],
+        )
+        .await
+        .map_err(|e| format!("match-rate per-page query failed: {}", e))?;
+
+    let parsed: Vec<MatchRatePageRow> = rows
+        .iter()
+        .map(|r| MatchRatePageRow {
+            page_id: r.get(0),
+            runs: r.get(1),
+            avg_match_rate: r.try_get::<_, f64>(2).ok(),
+            perfect: r.get(3),
+            partial: r.get(4),
+            none: r.get(5),
+            severity_hist: r.try_get::<_, Value>(6).ok(),
+        })
+        .collect();
+
+    if args.format == "json" {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&parsed).map_err(|e| e.to_string())?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "qontinui-specs match-rate  (window: {}d, min-rows: {})",
+        args.days, args.min_rows
+    );
+    if let Some(p) = &args.page_id {
+        println!("  filter: page_id = {}", p);
+    }
+    if parsed.is_empty() {
+        println!("  (no rows met the min-rows threshold in window)");
+        return Ok(());
+    }
+    println!();
+    println!(
+        "  {:<40}  {:>5}  {:>10}  {:>7}  {:>7}  {:>7}",
+        "page_id", "runs", "avg_rate", "perfect", "partial", "none"
+    );
+    for r in &parsed {
+        println!(
+            "  {:<40}  {:>5}  {:>10}  {:>7}  {:>7}  {:>7}",
+            r.page_id.as_deref().unwrap_or("<null>"),
+            r.runs,
+            r.avg_match_rate
+                .map(|v| format!("{:.3}", v))
+                .unwrap_or_else(|| "n/a".to_string()),
+            r.perfect,
+            r.partial,
+            r.none,
+        );
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// `flywheel` subcommand
+// ============================================================================
+
+#[derive(Debug, Clone)]
+struct ProposalEventRow {
+    proposal_id: String,
+    event_type: String,
+    snapshot_id: Option<String>,
+    failing_assertion_id: Option<String>,
+    at: String,
+}
+
+async fn run_flywheel(client: &Client, args: &FlywheelArgs) -> Result<(), String> {
+    let days = args.days as i32;
+
+    let proposals_table = table_exists(client, "project", "spec_proposals").await?;
+    let events_table = table_exists(client, "project", "proposal_events").await?;
+
+    // Five aggregates pulled in parallel. tokio::try_join! short-circuits on the
+    // first error; we keep each helper independently fallible.
+    let (
+        queue_counts,
+        recent_events,
+        promoted_count,
+        scanned_count,
+        demoted_count,
+        drift_demoted_count,
+        drift_proposals_count,
+    ) = tokio::try_join!(
+        query_queue_counts(client, proposals_table),
+        query_recent_events(client, events_table),
+        count_proposal_events_in_window(client, events_table, days, "promoted"),
+        count_proposal_events_in_window(client, events_table, days, "scanned"),
+        count_proposal_events_in_window(client, events_table, days, "demoted"),
+        query_drift_event_count(client, events_table, days, "demoted"),
+        query_drift_event_count(client, events_table, days, "scanned"),
+    )?;
+
+    let scan_rate = if scanned_count > 0 {
+        promoted_count as f64 / scanned_count as f64
+    } else {
+        0.0
+    };
+    let demotion_rate = if promoted_count > 0 {
+        Some(demoted_count as f64 / promoted_count as f64 * 100.0)
+    } else {
+        None
+    };
+    let drift_promotion_rate = if drift_proposals_count > 0 {
+        let drift_promoted = drift_proposals_count.saturating_sub(drift_demoted_count);
+        Some(drift_promoted as f64 / drift_proposals_count as f64 * 100.0)
+    } else {
+        None
+    };
+
+    if args.format == "json" {
+        let mut queue_map = serde_json::Map::new();
+        for status in &[
+            "queued",
+            "inFlight",
+            "pendingValidation",
+            "pendingPromotion",
+            "promoted",
+            "failed",
+        ] {
+            queue_map.insert(
+                (*status).to_string(),
+                json!(queue_counts.get(*status).copied().unwrap_or(0)),
+            );
+        }
+        let events_json: Vec<Value> = recent_events
+            .iter()
+            .map(|e| {
+                json!({
+                    "at": e.at,
+                    "event_type": e.event_type,
+                    "proposal_id": e.proposal_id,
+                    "snapshot_id": e.snapshot_id,
+                    "failing_assertion_id": e.failing_assertion_id,
+                })
+            })
+            .collect();
+        let out = json!({
+            "window_days": args.days,
+            "queue": queue_map,
+            "velocity": {
+                "scanned": scanned_count,
+                "promoted": promoted_count,
+                "promotions_per_scan": round3(scan_rate),
+            },
+            "demotion": {
+                "count": demoted_count,
+                "rate_pct": demotion_rate.map(round1),
+            },
+            "drift": {
+                "drift_triggered_proposals": drift_proposals_count,
+                "drift_demoted": drift_demoted_count,
+                "drift_fix_promotion_rate_pct": drift_promotion_rate.map(round1),
+            },
+            "recent_activity": events_json,
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+        return Ok(());
+    }
+
+    // Text format.
+    println!("qontinui-specs flywheel  (window: {}d)", args.days);
+    println!();
+    println!("  Queue (status counts from spec_proposals):");
+    let q = |s: &str| queue_counts.get(s).copied().unwrap_or(0);
+    println!(
+        "    queued: {:>6}    pendingValidation: {:>3}    promoted: {:>3}",
+        q("queued"),
+        q("pendingValidation"),
+        q("promoted"),
+    );
+    println!(
+        "    inFlight: {:>4}    pendingPromotion:  {:>3}    failed:   {:>3}",
+        q("inFlight"),
+        q("pendingPromotion"),
+        q("failed"),
+    );
+    println!();
+    println!("  Velocity (last {}d):", args.days);
+    println!("    scans:        {:>5}", scanned_count);
+    println!(
+        "    promotions:   {:>5}  ({:.2} / scan)",
+        promoted_count, scan_rate
+    );
+    match demotion_rate {
+        Some(p) => println!(
+            "    demotion rate: {:>4.1} %  ({} of {} promotions reverted)",
+            p, demoted_count, promoted_count
+        ),
+        None => println!("    demotion rate:  n/a  (no promotions in window)"),
+    }
+    println!();
+    println!("  Drift:");
+    println!("    drift-triggered proposals: {}", drift_proposals_count);
+    match drift_promotion_rate {
+        Some(p) => println!("    drift-fix promotion rate:  {:.1} %", p),
+        None => println!("    drift-fix promotion rate:  n/a (no drift-triggered proposals)"),
+    }
+    println!();
+    println!("  Recent activity:");
+    if recent_events.is_empty() {
+        println!("    (none yet — flywheel sweep handler not running)");
+    } else {
+        for ev in &recent_events {
+            let pid_short: String = ev.proposal_id.chars().take(8).collect();
+            let asserttext = ev
+                .failing_assertion_id
+                .as_ref()
+                .map(|a| format!("  [failing-assert: {}]", a))
+                .unwrap_or_default();
+            println!(
+                "    {}  {:<9}  {}{}",
+                ev.at,
+                ev.event_type.to_uppercase(),
+                pid_short,
+                asserttext
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ----------------------------------------------------------------------------
+// Flywheel helpers
+// ----------------------------------------------------------------------------
+
+async fn query_queue_counts(
+    client: &Client,
+    proposals_table_exists: bool,
+) -> Result<std::collections::HashMap<String, i64>, String> {
+    if !proposals_table_exists {
+        return Ok(std::collections::HashMap::new());
+    }
+    let rows = client
+        .query(
+            "SELECT status, count(*)::bigint FROM project.spec_proposals GROUP BY status",
+            &[],
+        )
+        .await
+        .map_err(|e| format!("queue-counts query failed: {}", e))?;
+    let mut out = std::collections::HashMap::new();
+    for r in &rows {
+        out.insert(r.get::<_, String>(0), r.get::<_, i64>(1));
+    }
+    Ok(out)
+}
+
+async fn query_recent_events(
+    client: &Client,
+    events_table_exists: bool,
+) -> Result<Vec<ProposalEventRow>, String> {
+    if !events_table_exists {
+        return Ok(Vec::new());
+    }
+    let rows = client
+        .query(
+            r#"
+            SELECT
+                proposal_id,
+                event_type,
+                snapshot_id,
+                failing_assertion_id,
+                at::TEXT
+            FROM proposal_events
+            ORDER BY at DESC, id
+            LIMIT 20
+            "#,
+            &[],
+        )
+        .await
+        .map_err(|e| format!("recent-events query failed: {}", e))?;
+    Ok(rows
+        .iter()
+        .map(|r| ProposalEventRow {
+            proposal_id: r.get(0),
+            event_type: r.get(1),
+            snapshot_id: r.get(2),
+            failing_assertion_id: r.get(3),
+            at: r.get(4),
+        })
+        .collect())
+}
+
+async fn count_proposal_events_in_window(
+    client: &Client,
+    events_table_exists: bool,
+    days: i32,
+    event_type: &str,
+) -> Result<i64, String> {
+    if !events_table_exists {
+        return Ok(0);
+    }
+    let row = client
+        .query_one(
+            r#"
+            SELECT count(*)::bigint
+            FROM proposal_events
+            WHERE event_type = $2
+              AND at > now() - make_interval(days => $1)
+            "#,
+            &[&days, &event_type],
+        )
+        .await
+        .map_err(|e| format!("count_proposal_events_in_window failed: {}", e))?;
+    Ok(row.get(0))
+}
+
+/// Drift-related event count over the window: events of `event_type` where
+/// `failing_assertion_id` is non-null (i.e. drift-fix proposals from
+/// `spec_drift.rs`, as distinct from new-page proposal scans).
+async fn query_drift_event_count(
+    client: &Client,
+    events_table_exists: bool,
+    days: i32,
+    event_type: &str,
+) -> Result<i64, String> {
+    if !events_table_exists {
+        return Ok(0);
+    }
+    let row = client
+        .query_one(
+            r#"
+            SELECT count(*)::bigint
+            FROM proposal_events
+            WHERE event_type = $2
+              AND failing_assertion_id IS NOT NULL
+              AND at > now() - make_interval(days => $1)
+            "#,
+            &[&days, &event_type],
+        )
+        .await
+        .map_err(|e| format!("drift event count query failed: {}", e))?;
+    Ok(row.get(0))
+}
+
+// ============================================================================
+// Shared helpers
+// ============================================================================
+
+/// `to_regclass($schema.$name)` IS NOT NULL — works without privilege to read
+/// `information_schema` rows the caller didn't author.
+async fn table_exists(client: &Client, schema: &str, name: &str) -> Result<bool, String> {
+    let qualified = format!("{}.{}", schema, name);
+    let row = client
+        .query_one(
+            "SELECT to_regclass($1::text) IS NOT NULL",
+            &[&qualified],
+        )
+        .await
+        .map_err(|e| format!("to_regclass({}) failed: {}", qualified, e))?;
+    Ok(row.get(0))
+}
+
+fn round1(v: f64) -> f64 {
+    (v * 10.0).round() / 10.0
+}
+
+fn round3(v: f64) -> f64 {
+    (v * 1000.0).round() / 1000.0
+}

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -59,6 +59,7 @@ pub mod process_sessions;
 pub mod productivity_knowledge;
 pub mod prompt_evolution;
 pub mod prompt_registry;
+pub mod proposal_events;
 pub mod q_routing;
 pub mod queued_workflows;
 pub mod reasoning_traces;
@@ -212,6 +213,120 @@ impl PgDb {
         )
         .await
         .map_err(|e| format!("Failed to bootstrap runner schema/extension: {}", e))?;
+
+        // CR-5 (Plan 03): convert `project.workflow_verification_phase_results
+        // .result_json` from `text` to `jsonb` so design-context §5.16's
+        // indexable JSONB-path expressions work and Plan 06's JSONB indexes
+        // have a valid target. Idempotent: the `USING` cast is a no-op if the
+        // column is already jsonb, and the whole statement is skipped when the
+        // column type is already `jsonb` (re-running `ALTER COLUMN … TYPE
+        // jsonb` against a jsonb column is itself a no-op but the explicit
+        // guard avoids the rewrite cost on every runner start). The table is
+        // alembic-owned (qontinui-web); this runner-side self-heal applies the
+        // change on the next user-controlled runner startup without an
+        // out-of-band `ALTER TABLE` against the live DB. The alembic chain
+        // and `schema.pg.sql.generated` carry the same `jsonb` shape so the
+        // CI schema-fresh / clorinde-fresh gates agree with this runtime
+        // contract.
+        conn.batch_execute(
+            "DO $cr5$ \
+             BEGIN \
+               IF EXISTS ( \
+                 SELECT 1 FROM information_schema.columns \
+                 WHERE table_schema = 'project' \
+                   AND table_name = 'workflow_verification_phase_results' \
+                   AND column_name = 'result_json' \
+                   AND data_type <> 'jsonb' \
+               ) THEN \
+                 ALTER TABLE project.workflow_verification_phase_results \
+                   ALTER COLUMN result_json TYPE jsonb USING result_json::jsonb; \
+               END IF; \
+             END \
+             $cr5$;",
+        )
+        .await
+        .map_err(|e| {
+            format!("CR-5 result_json text→jsonb self-heal failed: {}", e)
+        })?;
+
+        // Plan 06 Step 3 (G.3): expression indexes for the workflow-verification dashboard hot paths. Each runs at every PgDb::new() boot — IF NOT EXISTS makes them no-ops after the first run.
+        conn.batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_wf_ver_phase_match_outcome \
+                 ON project.workflow_verification_phase_results \
+                 ((result_json->'summary'->>'match_outcome'));",
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "Plan 06 Step 3 idx_wf_ver_phase_match_outcome create failed: {}",
+                e
+            )
+        })?;
+
+        conn.batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_wf_ver_phase_overall_match_rate \
+                 ON project.workflow_verification_phase_results \
+                 (((result_json->'summary'->>'overall_match_rate')::float));",
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "Plan 06 Step 3 idx_wf_ver_phase_overall_match_rate create failed: {}",
+                e
+            )
+        })?;
+
+        conn.batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_wf_ver_phase_spec_version \
+                 ON project.workflow_verification_phase_results \
+                 ((result_json->>'spec_version'));",
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "Plan 06 Step 3 idx_wf_ver_phase_spec_version create failed: {}",
+                e
+            )
+        })?;
+
+        conn.batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_wf_ver_phase_recommendation_reason \
+                 ON project.workflow_verification_phase_results \
+                 ((result_json->'recommendation_recommended_state'->>'recommendation_reason'));",
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "Plan 06 Step 3 idx_wf_ver_phase_recommendation_reason create failed: {}",
+                e
+            )
+        })?;
+
+        conn.batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_wf_ver_phase_snapshot_id \
+                 ON project.workflow_verification_phase_results \
+                 ((result_json->>'snapshot_id'));",
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "Plan 06 Step 3 idx_wf_ver_phase_snapshot_id create failed: {}",
+                e
+            )
+        })?;
+
+        conn.batch_execute(
+            "CREATE INDEX IF NOT EXISTS idx_wf_ver_phase_severity_gin \
+                 ON project.workflow_verification_phase_results \
+                 USING GIN ((result_json->'summary'->'assertions_failed_by_severity'));",
+        )
+        .await
+        .map_err(|e| {
+            format!(
+                "Plan 06 Step 3 idx_wf_ver_phase_severity_gin create failed: {}",
+                e
+            )
+        })?;
 
         info!("PostgreSQL connected (deadpool, max_size=8, schema=runner)");
 

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -245,9 +245,7 @@ impl PgDb {
              $cr5$;",
         )
         .await
-        .map_err(|e| {
-            format!("CR-5 result_json text→jsonb self-heal failed: {}", e)
-        })?;
+        .map_err(|e| format!("CR-5 result_json text→jsonb self-heal failed: {}", e))?;
 
         // Plan 06 Step 3 (G.3): expression indexes for the workflow-verification dashboard hot paths. Each runs at every PgDb::new() boot — IF NOT EXISTS makes them no-ops after the first run.
         conn.batch_execute(

--- a/src-tauri/src/database/pg/proposal_events.rs
+++ b/src-tauri/src/database/pg/proposal_events.rs
@@ -1,0 +1,157 @@
+//! PostgreSQL CRUD for `project.proposal_events` — Plan 06 Step 6 (G.6)
+//! flywheel observability.
+//!
+//! The table is authored declaratively in `atlas/schema.hcl`; this module
+//! issues the queries directly via `tokio_postgres`, mirroring the
+//! `spec_proposals.rs` style. There is no self-heal helper here — Atlas owns
+//! the table shape.
+//!
+//! Append-only log of state transitions on `spec_proposals` rows. Each row is
+//! written alongside the corresponding `SpecApiEvent` broadcast (Plan 06
+//! Step 2). Persistence is decoupled from broadcast — a subscriber that drops
+//! events still gets full history from this table.
+//!
+//! `event_type` is constrained server-side to one of
+//! `('scanned','executed','promoted','demoted','failed')`.
+
+use super::PgDb;
+use serde::{Deserialize, Serialize};
+
+/// One row from `project.proposal_events`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProposalEventRow {
+    pub id: String,
+    pub proposal_id: String,
+    pub event_type: String,
+    pub snapshot_id: Option<String>,
+    pub failing_assertion_id: Option<String>,
+    pub at: String,
+}
+
+impl PgDb {
+    // -------------------------------------------------------------------------
+    // Writes
+    // -------------------------------------------------------------------------
+
+    /// Insert a single proposal event row. Generates a UUIDv7 id, returns it
+    /// for caller-side correlation. `event_type` must satisfy the
+    /// `proposal_events_type_chk` CHECK constraint (server-enforced); callers
+    /// should validate upstream so a bad variant surfaces as a structured
+    /// error rather than a raw PG `check_violation`.
+    pub async fn insert_proposal_event(
+        &self,
+        proposal_id: &str,
+        event_type: &str,
+        snapshot_id: Option<&str>,
+        failing_assertion_id: Option<&str>,
+    ) -> Result<String, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let id = uuid::Uuid::now_v7().to_string();
+        conn.execute(
+            r#"
+            INSERT INTO proposal_events
+                (id, proposal_id, event_type, snapshot_id, failing_assertion_id)
+            VALUES ($1, $2, $3, $4, $5)
+            "#,
+            &[
+                &id,
+                &proposal_id,
+                &event_type,
+                &snapshot_id,
+                &failing_assertion_id,
+            ],
+        )
+        .await
+        .map_err(|e| format!("PG insert_proposal_event: {}", e))?;
+
+        Ok(id)
+    }
+
+    // -------------------------------------------------------------------------
+    // Reads
+    // -------------------------------------------------------------------------
+
+    /// Most-recent events across all proposals, ordered by `at DESC`. Backs
+    /// the `qontinui-specs flywheel` CLI "Recent activity" block (Plan 06
+    /// Step 6).
+    pub async fn list_recent_proposal_events(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<ProposalEventRow>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+        let lim = limit.clamp(1, 1000);
+        let rows = conn
+            .query(
+                r#"
+                SELECT
+                    id,
+                    proposal_id,
+                    event_type,
+                    snapshot_id,
+                    failing_assertion_id,
+                    at::TEXT
+                FROM proposal_events
+                ORDER BY at DESC, id
+                LIMIT $1
+                "#,
+                &[&lim],
+            )
+            .await
+            .map_err(|e| format!("PG list_recent_proposal_events: {}", e))?;
+
+        Ok(rows.iter().map(row_to_event).collect())
+    }
+
+    /// Count of events of a given `event_type` in the trailing `days`-day
+    /// window. Backs the CLI's "promotions / demotions last week" tiles.
+    /// Caller passes the type literal — no client-side enum-shape coupling.
+    pub async fn count_proposal_events_in_window(
+        &self,
+        days: i32,
+        event_type: &str,
+    ) -> Result<i64, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        // `make_interval(days := $1)` keeps the cast off the SQL side and
+        // avoids the `'$1 days'::interval` string-concat shape that some
+        // drivers refuse to bind across.
+        let row = conn
+            .query_one(
+                r#"
+                SELECT count(*)::bigint
+                FROM proposal_events
+                WHERE event_type = $2
+                  AND at > now() - make_interval(days => $1)
+                "#,
+                &[&days, &event_type],
+            )
+            .await
+            .map_err(|e| format!("PG count_proposal_events_in_window: {}", e))?;
+
+        Ok(row.get::<usize, i64>(0))
+    }
+}
+
+fn row_to_event(r: &tokio_postgres::Row) -> ProposalEventRow {
+    ProposalEventRow {
+        id: r.get(0),
+        proposal_id: r.get(1),
+        event_type: r.get(2),
+        snapshot_id: r.get(3),
+        failing_assertion_id: r.get(4),
+        at: r.get(5),
+    }
+}

--- a/src-tauri/src/database/pg/workflow_state.rs
+++ b/src-tauri/src/database/pg/workflow_state.rs
@@ -302,8 +302,12 @@ impl PgDb {
             .get("critical_failure")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
-        let result_json = serde_json::to_string(result)
-            .map_err(|e| format!("Failed to serialize verification result: {}", e))?;
+        // CR-5: `workflow_verification_phase_results.result_json` is `jsonb`
+        // after `PgDb::new()`'s self-bootstrap (`mod.rs` CR-5 block). Bind
+        // the `serde_json::Value` directly so tokio-postgres maps it via the
+        // `with-serde_json-1` ToSql impl — NOT `to_string(...)` (which would
+        // store an escaped string literal and break §5.16 JSONB-path indexes).
+        let result_json: &serde_json::Value = result;
         let iter_i32 = iteration as i32;
 
         // Check for existing record

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -37,9 +37,9 @@ pub fn export_all_schemas() -> Value {
         constraints as qc, discovery as qdc, execution as qe, findings as qfn, geometry as qg,
         ir as qir, mcp_config as qmc, orchestration_config as qoc, process_management as qpm,
         rag as qr, runner as qrn, scheduler as qs, spec_api_events as qsae, spec_check as qsc,
-        state_machine as qsm, targets as qt, task_run as qtr, terminal as qtm, ticket_system as qts,
-        tree_events as qte, ui_bridge as qub, verification as qv, worker_output as qwo,
-        workflow as qw, workflow_step as qws,
+        state_machine as qsm, targets as qt, task_run as qtr, terminal as qtm,
+        ticket_system as qts, tree_events as qte, ui_bridge as qub, verification as qv,
+        worker_output as qwo, workflow as qw, workflow_step as qws,
     };
 
     // Built via a plain Map instead of `json!` to avoid the

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -755,7 +755,11 @@ mod tests {
             obj.contains_key("UiBridgeResponseEnvelope"),
             "Missing UiBridgeResponseEnvelope schema"
         );
-        assert_eq!(obj.len(), 477, "Expected 477 schema entries");
+        assert!(
+            obj.contains_key("SpecApiEvent"),
+            "Missing SpecApiEvent schema (Plan 06)"
+        );
+        assert_eq!(obj.len(), 478, "Expected 478 schema entries");
 
         // Sanity-check that qontinui_types re-exports are present
         assert!(

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -36,10 +36,10 @@ pub fn export_all_schemas() -> Value {
         accessibility as qa, ai_workflows as qaw, app_events as qae, config as qcfg,
         constraints as qc, discovery as qdc, execution as qe, findings as qfn, geometry as qg,
         ir as qir, mcp_config as qmc, orchestration_config as qoc, process_management as qpm,
-        rag as qr, runner as qrn, scheduler as qs, spec_check as qsc, state_machine as qsm,
-        targets as qt, task_run as qtr, terminal as qtm, ticket_system as qts, tree_events as qte,
-        ui_bridge as qub, verification as qv, worker_output as qwo, workflow as qw,
-        workflow_step as qws,
+        rag as qr, runner as qrn, scheduler as qs, spec_api_events as qsae, spec_check as qsc,
+        state_machine as qsm, targets as qt, task_run as qtr, terminal as qtm, ticket_system as qts,
+        tree_events as qte, ui_bridge as qub, verification as qv, worker_output as qwo,
+        workflow as qw, workflow_step as qws,
     };
 
     // Built via a plain Map instead of `json!` to avoid the
@@ -672,6 +672,9 @@ pub fn export_all_schemas() -> Value {
     add!("PolicyEvaluation", qsc::PolicyEvaluation);
     add!("ConjunctEvaluation", qsc::ConjunctEvaluation);
     add!("PolicyStatus", qsc::PolicyStatus);
+
+    // ── qontinui-types: spec_api_events (Plan 06 broadcast taxonomy) ──
+    add!("SpecApiEvent", qsae::SpecApiEvent);
 
     // ── qontinui-types: ui_bridge ──
     add!("ElementBbox", qub::ElementBbox);

--- a/src-tauri/src/spec_api/events.rs
+++ b/src-tauri/src/spec_api/events.rs
@@ -1,40 +1,49 @@
-//! Spec API change-event broadcaster.
+//! Spec API broadcast channel.
 //!
-//! A single broadcast channel per process — each `/spec/subscribe` SSE
-//! handler subscribes and forwards the events. `POST /spec/author` (and any
-//! future write path) emits a `SpecChanged` here on success.
+//! A single `tokio::sync::broadcast` channel per process — each
+//! `/spec/subscribe` SSE handler subscribes and forwards the events. Every
+//! write path on the Spec API emits a [`SpecApiEvent`] here on success.
+//!
+//! The event taxonomy itself lives in [`qontinui_types::spec_api_events`]
+//! so the Rust enum, the generated TS bindings, and the generated Python
+//! Pydantic models stay in sync.
+//!
+//! ## Emit sites
+//!
+//! - `SpecChanged` — [`handlers.rs` post_author](super::handlers) emits after
+//!   a successful IR + projection write.
+//! - `SpecCheckInvoked` / `SpecCheckCompleted` — emitted by the
+//!   `spec_api/spec_check.rs` HTTP handlers when Plan 06 Step 1's adapter
+//!   layer lands (Stream C dependency).
+//! - `SpecCheckPolicyViolation` — emitted by Plan 03's
+//!   `step_executor/spec_check.rs` workflow-step handler when the conjunct
+//!   evaluator returns a Fail.
+//! - `FlywheelProposalPromoted` / `FlywheelProposalDemoted` — emitted by the
+//!   Plan 05 Step 9 sweep handler (`POST /spec/proposals/sweep-pending` +
+//!   `storage::promote_pending` / `storage::demote_pending`). The variants
+//!   are reserved here so the wire is ready; the emit sites land when the
+//!   sweep handler ships.
 
 use std::sync::OnceLock;
 use tokio::sync::broadcast;
 
-use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SpecChanged {
-    pub page_id: String,
-    /// "ir-and-projection" today; future kinds may include
-    /// "projection-only" if a regen runs without an IR write.
-    pub kind: String,
-    /// Epoch milliseconds the event was emitted at.
-    pub at_ms: u64,
-}
+pub use qontinui_types::spec_api_events::{SpecApiEvent, SpecChanged};
 
 /// Broadcast capacity. Slow subscribers will Lag if they fall this far
 /// behind; the SSE handler logs and continues.
 const CAPACITY: usize = 256;
 
-static SENDER: OnceLock<broadcast::Sender<SpecChanged>> = OnceLock::new();
+static SENDER: OnceLock<broadcast::Sender<SpecApiEvent>> = OnceLock::new();
 
-fn sender() -> &'static broadcast::Sender<SpecChanged> {
-    SENDER.get_or_init(|| broadcast::channel::<SpecChanged>(CAPACITY).0)
+fn sender() -> &'static broadcast::Sender<SpecApiEvent> {
+    SENDER.get_or_init(|| broadcast::channel::<SpecApiEvent>(CAPACITY).0)
 }
 
-pub fn subscribe() -> broadcast::Receiver<SpecChanged> {
+pub fn subscribe() -> broadcast::Receiver<SpecApiEvent> {
     sender().subscribe()
 }
 
-pub fn emit(event: SpecChanged) {
+pub fn emit(event: SpecApiEvent) {
     // Ignore SendError: it just means there are no subscribers — drop the
     // event silently in that case.
     let _ = sender().send(event);

--- a/src-tauri/src/spec_api/handlers.rs
+++ b/src-tauri/src/spec_api/handlers.rs
@@ -679,11 +679,11 @@ pub(crate) fn build_author_response(root: &std::path::Path, doc: IrPageSpec) -> 
                 .into_response();
         }
     };
-    events::emit(SpecChanged {
+    events::emit(events::SpecApiEvent::SpecChanged(SpecChanged {
         page_id: doc.id.clone(),
         kind: "ir-and-projection".to_string(),
         at_ms: events::now_ms(),
-    });
+    }));
     (
         StatusCode::OK,
         Json(json!({
@@ -705,10 +705,29 @@ pub async fn get_subscribe(
     let rx = events::subscribe();
     let stream = BroadcastStream::new(rx).filter_map(|res| async move {
         match res {
-            Ok(ev) => match Event::default().event("spec.changed").json_data(&ev) {
-                Ok(e) => Some(Ok::<Event, Infallible>(e)),
-                Err(_) => None,
-            },
+            Ok(ev) => {
+                // Use the variant's kebab-case discriminator (matches the
+                // `#[serde(tag = "type", rename_all = "kebab-case")]` shape)
+                // as the SSE event name.
+                let event_name = match &ev {
+                    events::SpecApiEvent::SpecChanged(_) => "spec-changed",
+                    events::SpecApiEvent::SpecCheckInvoked { .. } => "spec-check-invoked",
+                    events::SpecApiEvent::SpecCheckCompleted { .. } => "spec-check-completed",
+                    events::SpecApiEvent::SpecCheckPolicyViolation { .. } => {
+                        "spec-check-policy-violation"
+                    }
+                    events::SpecApiEvent::FlywheelProposalPromoted { .. } => {
+                        "flywheel-proposal-promoted"
+                    }
+                    events::SpecApiEvent::FlywheelProposalDemoted { .. } => {
+                        "flywheel-proposal-demoted"
+                    }
+                };
+                match Event::default().event(event_name).json_data(&ev) {
+                    Ok(e) => Some(Ok::<Event, Infallible>(e)),
+                    Err(_) => None,
+                }
+            }
             Err(_) => None,
         }
     });

--- a/src-tauri/src/spec_api/tests.rs
+++ b/src-tauri/src/spec_api/tests.rs
@@ -291,17 +291,22 @@ mod handler_tests {
     async fn sse_receives_emitted_event() {
         // Exercise the broadcaster directly: subscribe, emit, await event.
         let mut rx = events::subscribe();
-        events::emit(events::SpecChanged {
+        events::emit(events::SpecApiEvent::SpecChanged(events::SpecChanged {
             page_id: "active".to_string(),
             kind: "ir-and-projection".to_string(),
             at_ms: events::now_ms(),
-        });
+        }));
         let received = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
             .await
             .expect("subscriber should receive within timeout")
             .expect("event must arrive");
-        assert_eq!(received.page_id, "active");
-        assert_eq!(received.kind, "ir-and-projection");
+        match received {
+            events::SpecApiEvent::SpecChanged(payload) => {
+                assert_eq!(payload.page_id, "active");
+                assert_eq!(payload.kind, "ir-and-projection");
+            }
+            other => panic!("expected SpecChanged variant, got {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Implements Plan 06 — Steps 1, 2, 3, 4, 5, 6 (table), and 7 — closing spec-check v1.0's final ship checkpoint.

Plan: [`qontinui-dev-notes/spec-check-v1/06-observability.md`](https://github.com/qontinui/qontinui-dev-notes/blob/main/spec-check-v1/06-observability.md) (VETTED 2026-05-15 → SHIPPED 2026-05-16).
Companion: [qontinui-schemas#43](https://github.com/qontinui/qontinui-schemas/pull/43) — must merge first (path dep).

### What landed

- **Tracing instrumentation** on the spec-check crate + spec_api adapters. Six fixed-name spans (`spec_check.evaluate`, `evaluate_batch`, `fetch_snapshot`, `policy_evaluate`, `flywheel.proposal_scan`, `flywheel.proposal_execute`) with `snapshot_id` as the cross-stream join key. No fat span fields (per the `workflow.execute` LoopConfig anti-pattern).
- **`SpecApiEvent` broadcast taxonomy** (from companion PR). `spec_api/events.rs` is now a tagged sum-type channel; `get_subscribe` maps each variant to its kebab-case SSE event name. Wire is backward-compatible for existing `spec-changed` subscribers.
- **CR-5 self-heal** (was on unmerged sibling branch — included here): `result_json text → jsonb` ALTER + writer bind via `serde_json::Value`. Idempotent.
- **Six JSONB expression indexes** on `workflow_verification_phase_results.result_json`: `match_outcome`, `overall_match_rate`, `spec_version`, `recommendation_reason`, `snapshot_id` (btree) + assertion severity histogram (GIN).
- **`proposal_events` table** (Atlas HCL) + writer module — the flywheel's durable lifecycle log.
- **`qontinui-specs` CLI** — three subcommands (`coverage`, `match-rate`, `flywheel`) for the operator surface. Five flywheel aggregates pulled in parallel via `tokio::try_join!`.
- **Integration smoke test** — assertion 1 (tracing round-trip) runs by default and passes; assertions 2-5 are `#[ignore]+--features integration` (PG + psql required).

### Reserved emit sites (land in follow-up PRs)

| Variant | Owner |
|---|---|
| `SpecCheckInvoked` / `SpecCheckCompleted` | Plan 03 Stream C handler PR |
| `SpecCheckPolicyViolation` | Plan 03 `step_executor` handler PR |
| `FlywheelProposalPromoted` / `FlywheelProposalDemoted` | Plan 05 Step 9 sweep handler PR |

Variants are reserved in the enum so the wire is ready; downstream PRs only need to wire `events::emit(...)` at the right call sites.

### Co-changes

`src-tauri/Cargo.toml` picked up an optional `qontinui-spec-check` dep + `spec-authoring = ["qontinui-spec-check"]` feature wiring that landed in the working tree from a concurrent Plan 05 Step 8 session. Included here because `clap` / `[[bin]]` additions interleave the same file. The `validator.rs` + `coverage.rs` files themselves are NOT in this commit (left as untracked WIP for the concurrent session to commit on their branch).

## Test plan

- [x] `cargo check --bin qontinui-runner` clean (cargo-guard cache hit)
- [x] `cargo check --bin qontinui_specs` clean
- [x] `cargo clippy -- -D warnings` clean across `src-tauri`
- [x] `cargo test -p qontinui-spec-check` — 141/141 passing
- [x] `cargo test --test observability_smoke` — 1/1 passing (assertion 1)
- [ ] Manual smoke: `qontinui-specs flywheel --format json` against the dev DB — works (zero counts, as expected; Plan 05 sweep handler not running yet)
- [ ] Manual smoke: `qontinui-specs coverage` — needs `state_discovery_artifacts` / `cached_specs` tables on the dev DB; falls back to `"unavailable"` if absent (verified)
- [ ] Manual smoke: `qontinui-specs match-rate` — needs the primary runner restarted on this branch so the CR-5 self-heal + new indexes apply (deferred per CLAUDE.md runner-lifecycle)