### PR TITLE
feat: Stream E flywheel — validator + promotion + E2E (Steps 8/9/11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,6 +6369,7 @@ dependencies = [
  "portable-pty",
  "proc-macro2",
  "qontinui-db",
+ "qontinui-spec-check",
  "qontinui-types",
  "qontinui-vision-core",
  "rand 0.9.2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -105,6 +105,9 @@ deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
 qontinui-types = { path = "../../qontinui-schemas/rust", version = "^0.1.2" }
 qontinui-vision-core = { path = "../../qontinui-schemas/rust-vision-core", version = "^0.1.0" }
+# Spec-Check (B) matcher — feature-gated; only the Stream E (Flywheel) validator
+# consumes it. Workspace member at `../crates/spec-check/`.
+qontinui-spec-check = { path = "../crates/spec-check", optional = true }
 socket2 = "0.6"
 cron = "0.15"
 chrono-tz = "0.10"
@@ -221,7 +224,7 @@ test-fixtures = []
 # the proposals endpoints, and the supervisor cron. Off by default for
 # spec-check v1.0 ship; the user-facing `--enable-spec-authoring` alias
 # maps to this feature in the runner CLI/env layer.
-spec-authoring = []
+spec-authoring = ["qontinui-spec-check"]
 # PG-bound integration tests for the proposals subsystem (Stream E).
 # Off by default; enable with `--features spec-authoring,pg_integration_tests`
 # when a live PG (canonical or local) is available.

--- a/src-tauri/src/flywheel_e2e_tests.rs
+++ b/src-tauri/src/flywheel_e2e_tests.rs
@@ -1,0 +1,662 @@
+//! End-to-end integration test for the Stream E (Flywheel) coverage-growth
+//! loop — Step 11 of `qontinui-dev-notes/spec-check-v1/05-flywheel.md`.
+//!
+//! These tests exercise the closed-loop INVARIANTS of the flywheel without
+//! standing up a real PG + AppState + HTTP transport. Per the plan's
+//! "pragmatic alternative" framing, we drive the production functions
+//! directly — `storage::write_pending_ir`, `storage::promote_pending`,
+//! `storage::demote_pending`, `coverage::generate_regression_suite`,
+//! `coverage::coverage_of`, `validator::gate_b_execution_green_with_snapshot`,
+//! `spec_authoring::merge_patch_into_ir`.
+//!
+//! Tests that require a live PG (e.g. concurrent-scan UNIQUE-constraint
+//! exercise) are gated behind `--features pg_integration_tests` to match
+//! the sibling proposals::tests::pg pattern.
+//!
+//! Each test maps to one of the six required invariants in Step 11:
+//!
+//!   1. flywheel_full_walk_synthetic_page_through_promotion
+//!      — write_pending_ir → simulate green → promote → assert canonical IR
+//!        exists with provenance.status = Promoted.
+//!   2. flywheel_demotes_on_single_red
+//!      — write_pending_ir → simulate red → demote → assert _pending/ gone
+//!        and no canonical IR was written.
+//!   3. flywheel_skips_existing_specs_in_scan
+//!      — pre-create canonical IR for spec_id → list_pages exposes it →
+//!        scan filter would skip it.
+//!   4. flywheel_dedupes_concurrent_scans
+//!      — insert_proposal twice with same kind+pathname → second returns
+//!        Ok(false) per the UNIQUE constraint.
+//!   5. flywheel_patch_preserves_hand_authored
+//!      — merge_patch_into_ir on hand-authored state → rejects with the
+//!        "pinned state" sentinel.
+//!   6. flywheel_validator_rejects_low_coverage
+//!      — synthetic IR with no transitions → gate_coverage returns
+//!        CoverageBelowFloor.
+//!
+//! Pretty much all of these rely on integration-time visibility of
+//! `spec_api`, `workflow_generation`, and (for the validator inner helper +
+//! merge_patch_into_ir) symbol widening. See the agent report for the
+//! exhaustive list of widenings the orchestrator needs to apply before this
+//! file compiles.
+
+#![cfg(all(test, feature = "spec-authoring"))]
+
+use std::path::Path;
+
+use crate::spec_api::storage;
+use crate::spec_api::types::{
+    IrAssertion, IrAssertionTarget, IrPageSpec, IrProvenance, IrState, IrTransition, ProposalStatus,
+};
+use crate::spec_api::validator::{
+    gate_b_execution_green_with_snapshot, gate_coverage, ValidatorError,
+};
+use crate::workflow_generation::coverage::{coverage_of, generate_regression_suite};
+use crate::workflow_generation::spec_authoring::{merge_patch_into_ir, IrPatch};
+
+use qontinui_types::ui_bridge::{
+    ElementIdentifier, ElementRect, ElementState, UIBridgeElement, UIBridgeSnapshot,
+};
+use serde_json::json;
+use tempfile::TempDir;
+
+// =============================================================================
+// TestEnv — minimal harness shared across tests
+// =============================================================================
+
+/// Holds a temp specs root + makes it the resolved `QONTINUI_SPECS_ROOT` for
+/// the duration of a single test. NOT for parallel use — set via env var,
+/// so each test serializes on `ENV_GUARD` if it relies on the override.
+struct TestEnv {
+    tmp: TempDir,
+}
+
+impl TestEnv {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        Self { tmp }
+    }
+
+    fn root(&self) -> &Path {
+        self.tmp.path()
+    }
+}
+
+// =============================================================================
+// IR / snapshot fixtures
+// =============================================================================
+
+/// Single-element snapshot whose `tag_name == "body"`. Matches the IR
+/// `tagName == "body"` search criteria emitted by `chain_ir`. Mirrors the
+/// shape in `validator.rs::tests::body_snapshot`.
+fn body_snapshot() -> UIBridgeSnapshot {
+    UIBridgeSnapshot {
+        timestamp: 1_700_000_000_000,
+        elements: vec![UIBridgeElement {
+            id: "body-1".into(),
+            element_type: "body".into(),
+            label: None,
+            actions: Vec::new(),
+            custom_actions: None,
+            identifier: ElementIdentifier {
+                ui_id: None,
+                test_id: None,
+                awas_id: None,
+                html_id: None,
+                xpath: String::new(),
+                selector: "body".into(),
+            },
+            state: ElementState {
+                visible: true,
+                enabled: true,
+                focused: false,
+                rect: ElementRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 100.0,
+                    top: 0.0,
+                    right: 100.0,
+                    bottom: 100.0,
+                    left: 0.0,
+                },
+                value: None,
+                checked: None,
+                selected_options: None,
+                text_content: None,
+            },
+            registered_at: 0,
+            mounted: true,
+            bbox: None,
+            visible: Some(true),
+            role: Some("document".into()),
+            tag_name: Some("body".into()),
+            aria_label: None,
+            accessible_name: None,
+            text: None,
+        }],
+        components: Vec::new(),
+        workflows: Vec::new(),
+        modal_stack: None,
+        toasts: None,
+        undo_redo: None,
+        current_route: None,
+        segments: Vec::new(),
+    }
+}
+
+/// Snapshot with no elements — every assertion misses.
+fn empty_snapshot() -> UIBridgeSnapshot {
+    UIBridgeSnapshot {
+        timestamp: 1_700_000_000_000,
+        elements: Vec::new(),
+        components: Vec::new(),
+        workflows: Vec::new(),
+        modal_stack: None,
+        toasts: None,
+        undo_redo: None,
+        current_route: None,
+        segments: Vec::new(),
+    }
+}
+
+/// IR with one state asserting on a `tagName == "body"` element. Status =
+/// `Proposed` so `write_pending_ir` can flip it to Pending on stage and
+/// `promote_pending` can flip it again to Promoted.
+///
+/// The `single state + single assertion` shape passes distinctness (no peers
+/// to be identical-with) and round-trips cleanly; coverage is 0/1 = 0
+/// against the default 0.80 floor, which is why we set
+/// `QONTINUI_SPEC_COVERAGE_FLOOR=0.0` in tests that exercise gate-3 alongside
+/// gate-4.
+fn proposed_ir(id: &str) -> IrPageSpec {
+    IrPageSpec {
+        version: "1.0".into(),
+        id: id.into(),
+        name: id.into(),
+        description: None,
+        metadata: None,
+        provenance: Some(IrProvenance {
+            source: "ai-generated".into(),
+            file: None,
+            line: None,
+            column: None,
+            plugin_version: None,
+            status: Some(ProposalStatus::Proposed),
+        }),
+        states: vec![IrState {
+            id: "s0".into(),
+            name: "s0".into(),
+            description: None,
+            assertions: vec![IrAssertion {
+                id: "a-s0".into(),
+                description: "body exists".into(),
+                category: "structural".into(),
+                severity: "critical".into(),
+                assertion_type: "element-exists".into(),
+                target: IrAssertionTarget {
+                    kind: "search".into(),
+                    criteria: json!({ "tagName": "body" }),
+                    label: "body".into(),
+                },
+                source: "ai-generated".into(),
+                reviewed: false,
+                enabled: true,
+                precondition: None,
+            }],
+            excluded_elements: None,
+            conditions: None,
+            is_initial: Some(true),
+            is_terminal: None,
+            blocking: None,
+            group: None,
+            path_cost: None,
+            precondition: None,
+            element_ids: None,
+            incoming_transitions: None,
+            metadata: None,
+            provenance: None,
+            cross_refs: None,
+        }],
+        transitions: Vec::new(),
+        synthesized_groups: None,
+        initial_state: Some("s0".into()),
+    }
+}
+
+/// IR with one bare state and no transitions. Reachable = {s0}, covered =
+/// {} (no transitions touch any state). Ratio = 0/1 = 0 — below the default
+/// 0.80 floor.
+fn disconnected_ir(id: &str) -> IrPageSpec {
+    IrPageSpec {
+        version: "1.0".into(),
+        id: id.into(),
+        name: id.into(),
+        description: None,
+        metadata: None,
+        provenance: None,
+        states: vec![IrState {
+            id: "s0".into(),
+            name: "s0".into(),
+            description: None,
+            assertions: Vec::new(),
+            excluded_elements: None,
+            conditions: None,
+            is_initial: Some(true),
+            is_terminal: None,
+            blocking: None,
+            group: None,
+            path_cost: None,
+            precondition: None,
+            element_ids: None,
+            incoming_transitions: None,
+            metadata: None,
+            provenance: None,
+            cross_refs: None,
+        }],
+        transitions: Vec::new(),
+        synthesized_groups: None,
+        initial_state: Some("s0".into()),
+    }
+}
+
+/// Existing IR with one state stamped `provenance.source = "hand-authored"`
+/// — used to prove the patch path refuses to mutate it.
+fn hand_authored_ir(id: &str, state_id: &str) -> IrPageSpec {
+    let mut ir = disconnected_ir(id);
+    ir.states[0].id = state_id.into();
+    ir.states[0].name = state_id.into();
+    ir.states[0].provenance = Some(IrProvenance {
+        source: "hand-authored".into(),
+        file: None,
+        line: None,
+        column: None,
+        plugin_version: None,
+        status: None,
+    });
+    ir.initial_state = Some(state_id.into());
+    ir
+}
+
+// =============================================================================
+// Test 1 — full walk through promotion
+// =============================================================================
+//
+// Plan invariant (Step 11):
+//   write_pending_ir → simulate sweep iteration #1 (green) → simulate sweep
+//   iteration #2 (green) → promote → assert canonical files exist + _pending/
+//   gone + provenance.status = Promoted.
+//
+// We drive the production storage helpers directly. The "two greens"
+// requirement is exercised by calling `gate_b_execution_green_with_snapshot`
+// twice with the same canned-matching snapshot; both must return Ok. The
+// page-lock + canonical-write + rm-rf-_pending dance is exercised by
+// `promote_pending`.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flywheel_full_walk_synthetic_page_through_promotion() {
+    let env = TestEnv::new();
+    let root = env.root();
+    let page_id = "test-page-a";
+    let ir = proposed_ir(page_id);
+
+    // Stage the candidate into _pending/. This stamps status = Pending on
+    // the on-disk doc (caller's IR is untouched).
+    let staged_path = storage::write_pending_ir(root, &ir).expect("write_pending_ir");
+    assert!(
+        staged_path.to_string_lossy().contains("_pending"),
+        "staged path should land under _pending/: {}",
+        staged_path.display()
+    );
+    let pending_ir = root.join("pages").join(page_id).join("_pending");
+    assert!(
+        pending_ir.exists(),
+        "_pending/ should exist after stage: {}",
+        pending_ir.display()
+    );
+
+    // Simulate sweep iteration #1 — gate-3 green.
+    let snap1 = body_snapshot();
+    let r1 = gate_b_execution_green_with_snapshot(&snap1, &ir);
+    assert!(
+        r1.is_ok(),
+        "first sweep should be green (matching snapshot): {:?}",
+        r1.err()
+    );
+
+    // Simulate sweep iteration #2 — gate-3 green again.
+    let snap2 = body_snapshot();
+    let r2 = gate_b_execution_green_with_snapshot(&snap2, &ir);
+    assert!(
+        r2.is_ok(),
+        "second sweep should be green (matching snapshot): {:?}",
+        r2.err()
+    );
+
+    // Two greens → promote. promote_pending stamps status = Promoted and
+    // moves the file out of _pending/.
+    storage::promote_pending(root, page_id).expect("promote_pending");
+
+    // Canonical IR + projection exist.
+    let canonical_ir = root
+        .join("pages")
+        .join(page_id)
+        .join("state-machine.derived.json");
+    let canonical_projection = root.join("pages").join(page_id).join("spec.uibridge.json");
+    assert!(
+        canonical_ir.exists(),
+        "canonical IR missing after promotion: {}",
+        canonical_ir.display()
+    );
+    assert!(
+        canonical_projection.exists(),
+        "canonical projection missing after promotion: {}",
+        canonical_projection.display()
+    );
+
+    // _pending/ is gone.
+    assert!(
+        !pending_ir.exists(),
+        "_pending/ should have been removed after promotion: {}",
+        pending_ir.display()
+    );
+
+    // Promoted IR carries provenance.status = Promoted.
+    let read = storage::read_ir(root, page_id)
+        .expect("read canonical")
+        .expect("present");
+    let prov = read.provenance.as_ref().expect("provenance");
+    assert_eq!(prov.source, "ai-generated");
+    assert_eq!(prov.status, Some(ProposalStatus::Promoted));
+}
+
+// =============================================================================
+// Test 2 — demote on single red
+// =============================================================================
+//
+// Plan invariant (Step 11):
+//   write_pending_ir → simulate sweep iteration #1 green → simulate sweep
+//   iteration #2 red (missing element) → demote → _pending/ gone, NO
+//   canonical IR was written, greens counter reset (verified by the demote
+//   sentinel — no canonical file).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flywheel_demotes_on_single_red() {
+    let env = TestEnv::new();
+    let root = env.root();
+    let page_id = "test-page-b";
+    let ir = proposed_ir(page_id);
+
+    storage::write_pending_ir(root, &ir).expect("write_pending_ir");
+    let pending_dir = root.join("pages").join(page_id).join("_pending");
+    assert!(pending_dir.exists(), "_pending/ should exist after stage");
+
+    // First sweep — green.
+    let snap_green = body_snapshot();
+    let r1 = gate_b_execution_green_with_snapshot(&snap_green, &ir);
+    assert!(r1.is_ok(), "first sweep should be green: {:?}", r1.err());
+
+    // Second sweep — RED (empty snapshot misses the `body` assertion).
+    let snap_red = empty_snapshot();
+    let r2 = gate_b_execution_green_with_snapshot(&snap_red, &ir);
+    match r2 {
+        Err(ValidatorError::BExecutionRed { .. }) => { /* expected */ }
+        other => panic!(
+            "expected BExecutionRed on missing-element snapshot, got {:?}",
+            other
+        ),
+    }
+
+    // Demote — _pending/ gets nuked, canonical was never written.
+    storage::demote_pending(root, page_id).expect("demote_pending");
+    assert!(
+        !pending_dir.exists(),
+        "_pending/ should be removed after demote: {}",
+        pending_dir.display()
+    );
+
+    let canonical_ir = root
+        .join("pages")
+        .join(page_id)
+        .join("state-machine.derived.json");
+    assert!(
+        !canonical_ir.exists(),
+        "canonical IR should NOT have been written on demote: {}",
+        canonical_ir.display()
+    );
+
+    // Re-reading after demote returns None (no on-disk file).
+    let read = storage::read_ir(root, page_id).expect("read ok");
+    assert!(
+        read.is_none(),
+        "no canonical IR should be readable after demote"
+    );
+}
+
+// =============================================================================
+// Test 3 — scan skips pathnames already covered by an on-disk spec
+// =============================================================================
+//
+// Plan invariant (Step 11):
+//   hand-create specs/pages/<spec_id>/state-machine.derived.json BEFORE the
+//   scan → scan's on-disk filter (`storage::list_pages`) catches the
+//   pathname → no proposal queued for that pathname.
+//
+// We exercise the filter directly because the full scan path requires a
+// live PG (covered in flywheel_dedupes_concurrent_scans).
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flywheel_skips_existing_specs_in_scan() {
+    let env = TestEnv::new();
+    let root = env.root();
+    let page_id = "test-page-c";
+
+    // Pre-create the canonical IR for `test-page-c` so the scan would skip it.
+    let mut ir = proposed_ir(page_id);
+    if let Some(prov) = ir.provenance.as_mut() {
+        prov.status = Some(ProposalStatus::Promoted);
+    }
+    storage::write_ir_and_regenerate(root, &ir).expect("write canonical");
+
+    // The on-disk filter the scan uses lives in `storage::list_pages`. After
+    // pre-creating the canonical spec, the page id must show up — this is
+    // exactly what `proposals.rs::post_scan` consults to skip pre-spec'd
+    // pathnames (`on_disk_pathnames.contains(&pathname)`).
+    let pages = storage::list_pages(root).expect("list_pages");
+    assert!(
+        pages.iter().any(|p| p == page_id),
+        "list_pages should report {} after canonical write; got {:?}",
+        page_id,
+        pages
+    );
+
+    // A simulated scan-time filter mirroring post_scan's behaviour: for any
+    // candidate pathname whose slugified id matches an on-disk page, skip
+    // it. Here we just assert the membership predicate.
+    let candidate_pathname = "/test/page-c";
+    let candidate_slug = slugify_pathname(candidate_pathname);
+    assert_eq!(candidate_slug, page_id);
+    let skip = pages.iter().any(|p| p == &candidate_slug);
+    assert!(
+        skip,
+        "scan should skip pathname {} (already on disk as {})",
+        candidate_pathname, candidate_slug
+    );
+}
+
+/// Local slug helper mirroring `spec_authoring::pathname_to_spec_id` — used
+/// only in test 3 since the production helper is `pub(crate)` and not
+/// reachable from an integration test. Behaviour is identical: lowercase
+/// ASCII alphanumeric, runs of non-alphanumeric collapse to `-`, leading/
+/// trailing `-` trimmed, empty maps to `"root"`.
+fn slugify_pathname(pathname: &str) -> String {
+    let mut out = String::with_capacity(pathname.len());
+    let mut last_was_hyphen = true;
+    for ch in pathname.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            last_was_hyphen = false;
+        } else if !last_was_hyphen {
+            out.push('-');
+            last_was_hyphen = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    if out.is_empty() {
+        "root".into()
+    } else {
+        out
+    }
+}
+
+// =============================================================================
+// Test 4 — concurrent /scan calls dedupe via UNIQUE constraint
+// =============================================================================
+//
+// Plan invariant (Step 11):
+//   /scan called twice in rapid succession → only one row in spec_proposals
+//   (UNIQUE constraint kicks). PgDb::insert_proposal returns Ok(true) on
+//   first insert and Ok(false) on the duplicate.
+//
+// PG-bound — gated behind `pg_integration_tests`. Mirrors the dedup test
+// pattern in `proposals.rs::tests::pg::insert_dedupes_on_kind_and_target`.
+
+#[cfg(feature = "pg_integration_tests")]
+#[tokio::test(flavor = "multi_thread")]
+async fn flywheel_dedupes_concurrent_scans() {
+    use crate::database::pg::PgDb;
+
+    let db = PgDb::new_blocking_for_test();
+    // Wipe any prior test rows so dedup behaves deterministically. Mirrors
+    // the `fresh_db` fixture used in proposals::tests::pg.
+    {
+        let conn = db.pool().get().await.expect("pg conn");
+        conn.execute("TRUNCATE TABLE spec_proposals", &[])
+            .await
+            .expect("truncate spec_proposals");
+    }
+
+    let pathname = "/test/concurrent-dedupe";
+    let metadata = serde_json::json!({ "minObservations": 50, "lookbackDays": 90 });
+
+    let first = db
+        .insert_proposal(
+            "prop_flywheel_dedupe_one",
+            "fullPage",
+            Some(pathname),
+            None,
+            "queued",
+            &metadata,
+        )
+        .await
+        .expect("first insert");
+    assert!(first, "first insert should succeed");
+
+    let second = db
+        .insert_proposal(
+            "prop_flywheel_dedupe_two",
+            "fullPage",
+            Some(pathname),
+            None,
+            "queued",
+            &metadata,
+        )
+        .await
+        .expect("second insert");
+    assert!(
+        !second,
+        "second insert should be deduped by the UNIQUE constraint"
+    );
+}
+
+// =============================================================================
+// Test 5 — patch preserves hand-authored states
+// =============================================================================
+//
+// Plan invariant (Step 11):
+//   seed a hand-authored IR + a drift report → patch authoring rejects the
+//   merge with the "pinned state" sentinel. The pure logic lives in
+//   `spec_authoring::merge_patch_into_ir`; we exercise it directly to avoid
+//   spinning the meta-workflow executor + AppState.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flywheel_patch_preserves_hand_authored() {
+    use qontinui_types::ir::IrElementCriteria;
+
+    let existing = hand_authored_ir("test-page-d", "s-hand");
+    // Build a patch targeting the hand-authored state. `IrPatch` has
+    // `add_required_elements: BTreeMap<String, Vec<IrElementCriteria>>` and
+    // `add_transitions: Vec<IrTransition>`. We populate just the required-
+    // elements bucket — the merge helper validates BEFORE applying so it
+    // never half-mutates.
+    let mut crit = IrElementCriteria::default();
+    crit.id = Some("new-elem".into());
+
+    let mut patch = IrPatch::default();
+    patch
+        .add_required_elements
+        .insert("s-hand".into(), vec![crit]);
+
+    let err = merge_patch_into_ir(existing, patch)
+        .expect_err("merge must refuse pinned hand-authored state");
+    assert!(
+        err.contains("pinned state 's-hand'") || err.contains("hand-authored"),
+        "expected pinned-state error, got: {}",
+        err
+    );
+}
+
+// =============================================================================
+// Test 6 — validator rejects low-coverage candidates
+// =============================================================================
+//
+// Plan invariant (Step 11):
+//   synthetic IR with a disconnected state subgraph → `gate_coverage`
+//   returns `ValidatorError::CoverageBelowFloor`.
+//
+// The default floor is `QONTINUI_SPEC_COVERAGE_FLOOR` (0.80). A 1-state IR
+// with no transitions has states_covered = 0 (no transition touches any
+// state) and reachable = {s0}; ratio = 0/1 = 0 < 0.80 → must fail.
+//
+// We also assert the underlying coverage report shape directly to confirm
+// the production helper computes the report the gate consumes.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn flywheel_validator_rejects_low_coverage() {
+    // Serialize on the env-var guard — gate_coverage reads
+    // QONTINUI_SPEC_COVERAGE_FLOOR and the validator's unit tests share
+    // the same env-var with their own Mutex; we don't have access to that
+    // Mutex from an integration test, so we make sure the env var is unset
+    // and accept that parallel test execution against the same env var
+    // (other tests in this file don't touch it) is safe here.
+    std::env::remove_var("QONTINUI_SPEC_COVERAGE_FLOOR");
+
+    let ir = disconnected_ir("test-page-e");
+
+    // Sanity-check the underlying coverage report so a future change to
+    // the coverage helper surfaces here too.
+    let suite = generate_regression_suite(&ir);
+    let report = coverage_of(&ir, &suite);
+    assert_eq!(report.states_covered, 0, "expected 0 covered states");
+    assert_eq!(
+        report.reachable_states.len(),
+        1,
+        "expected only s0 reachable"
+    );
+    // Ratio = 0/1 = 0.0 ⇒ below default 0.80 floor.
+
+    let result = gate_coverage(&ir);
+    match result {
+        Err(ValidatorError::CoverageBelowFloor { ratio, floor }) => {
+            assert!(ratio < 0.01, "expected ~0 ratio, got {}", ratio);
+            assert!(
+                (floor - 0.80).abs() < 1e-6,
+                "expected default 0.80 floor, got {}",
+                floor
+            );
+        }
+        other => panic!("expected CoverageBelowFloor, got {:?}", other),
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -185,6 +185,12 @@ mod workflow_event_bus;
 mod workflow_generation;
 mod workflow_queue;
 mod workflow_state;
+
+// Stream E (Flywheel) Step 11 — end-to-end integration test module. The
+// file-level `#![cfg(all(test, feature = "spec-authoring"))]` ensures it
+// only compiles when running tests with the feature enabled.
+#[cfg(test)]
+mod flywheel_e2e_tests;
 mod worktree;
 mod wrappers;
 mod zombie_sweep;

--- a/src-tauri/src/spec_api/mod.rs
+++ b/src-tauri/src/spec_api/mod.rs
@@ -30,6 +30,8 @@ pub mod types;
 
 #[cfg(feature = "spec-authoring")]
 pub mod proposals;
+#[cfg(feature = "spec-authoring")]
+pub mod validator;
 
 #[cfg(test)]
 mod tests;
@@ -68,6 +70,10 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route(
             "/spec/proposals/{id}/execute",
             post(proposals::post_execute),
+        )
+        .route(
+            "/spec/proposals/sweep-pending",
+            post(proposals::post_sweep_pending),
         );
 
     r

--- a/src-tauri/src/spec_api/proposals.rs
+++ b/src-tauri/src/spec_api/proposals.rs
@@ -1,6 +1,6 @@
 //! Spec proposals — Stream E (Flywheel) coverage-growth queue.
 //!
-//! Three endpoints, mounted under `/spec/proposals/...` when the
+//! Four endpoints, mounted under `/spec/proposals/...` when the
 //! `spec-authoring` feature is enabled:
 //!
 //! - `POST /spec/proposals/scan` — discovers eligible `fullPage` candidates
@@ -8,18 +8,25 @@
 //!   `patch` candidates (drift-flagged specs), inserts them into
 //!   `project.spec_proposals` with `status = 'queued'`.
 //! - `POST /spec/proposals/{id}/execute` — drives one queued proposal through
-//!   `spec_authoring::author_candidate` and (in Step 8) the three-gate
-//!   validator. **This PR stubs the validator** — successful authoring lands
-//!   the candidate in `_pending/` via a placeholder writer; failures persist
-//!   the structured `AuthoringError` reason.
+//!   `spec_authoring::author_candidate` then `validator::validate_candidate`
+//!   (Step 8 — distinctness → round-trip → coverage → b-green) and lands
+//!   the candidate in `_pending/` via `storage::write_pending_ir` (Step 9).
+//!   On validator rejection the structured `ValidatorError` reason + detail
+//!   is persisted to `spec_proposals.last_error` and returned as `outcome:
+//!   "validator-rejected"`. Authoring failures stay distinct and surface as
+//!   `outcome: "authoring-failed"`.
+//! - `POST /spec/proposals/sweep-pending` — Step 9's 2-green sweep. Re-runs
+//!   gate-3 (B-green) against every `pendingPromotion` row; on Ok bumps
+//!   `consecutive_greens` and promotes at ≥ 2; on `BExecutionRed` demotes
+//!   immediately back to `queued`; on infra error (snapshot fetch failed
+//!   etc.) only `last_attempt_at` moves.
 //! - `GET /spec/proposals` — paginated list of all proposal rows.
 //!
-//! See `qontinui-dev-notes/spec-check-v1/05-flywheel.md` Steps 6–7 for the
+//! See `qontinui-dev-notes/spec-check-v1/05-flywheel.md` Steps 6–9 for the
 //! design context; the SQL trigger query is verbatim from the plan
 //! (§ Step 7 — "Full-page branch").
 
 use std::collections::HashSet;
-use std::path::Path;
 use std::sync::Arc;
 
 use axum::extract::{Path as AxPath, Query, State};
@@ -405,6 +412,7 @@ pub async fn post_execute(
     // Dispatch to spec_authoring. The sibling agent owns this module — at
     // integration time, an unresolved import here means the sibling's PR
     // hasn't landed yet.
+    let app_state_for_validator = app_state.clone();
     let outcome = match crate::workflow_generation::spec_authoring::author_candidate(
         pg_db.clone(),
         app_state,
@@ -433,11 +441,70 @@ pub async fn post_execute(
         }
     };
 
-    // TODO(Step 8): replace with full validator gate (round-trip + coverage +
-    // b-green) and Step 9: replace with storage::write_pending_ir.
-    let staged_path =
-        match stage_pending_ir_placeholder(&storage::resolve_specs_root(), &outcome.candidate) {
-            Ok(p) => p,
+    // Step 8 — three-gate validator (distinctness → round-trip → coverage →
+    // b-green). On Err, surface as `validator-rejected` + persist the
+    // reason in `spec_proposals.last_error`. Authoring failures stay
+    // distinct (`authoring-failed` codepath above).
+    let root = storage::resolve_specs_root();
+    let pathname_for_gate = match row.kind.as_str() {
+        "fullPage" => row.pathname.clone().unwrap_or_default(),
+        "patch" => row.spec_id.clone().unwrap_or_default(),
+        _ => String::new(),
+    };
+    if let Err(verr) = crate::spec_api::validator::validate_candidate(
+        app_state_for_validator,
+        &outcome.candidate,
+        &pathname_for_gate,
+        &root,
+    )
+    .await
+    {
+        let reason = crate::spec_api::validator::validator_error_reason(&verr);
+        let detail = crate::spec_api::validator::validator_error_detail(&verr);
+        let _ = pg_db
+            .update_proposal_status_with_error(&row.id, "failed", &detail)
+            .await;
+        warn!(
+            "post_execute: validator rejected proposal {}: {} — {}",
+            row.id, reason, detail
+        );
+        return (
+            StatusCode::OK,
+            Json(json!({
+                "ok": false,
+                "proposalId": row.id,
+                "outcome": "validator-rejected",
+                "reason": reason,
+                "detail": detail,
+            })),
+        )
+            .into_response();
+    }
+
+    // Step 9 — stage the candidate into `<root>/pages/<id>/_pending/`. The
+    // helper stamps `provenance.status = Pending` and regenerates the
+    // projection sibling, both atomically via temp-rename. The page-level
+    // lock guards against a concurrent sweep promoting / demoting the same
+    // page while we write.
+    let staged_path = {
+        let _guard = match storage::page_lock(&root, &outcome.candidate.id) {
+            Ok(g) => g,
+            Err(e) => {
+                let _ = pg_db
+                    .update_proposal_status_with_error(&row.id, "failed", &e)
+                    .await;
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(SpecError::with_detail(
+                        "stage-pending-locked",
+                        json!({ "proposalId": row.id, "error": e }),
+                    )),
+                )
+                    .into_response();
+            }
+        };
+        match storage::write_pending_ir(&root, &outcome.candidate) {
+            Ok(p) => p.display().to_string(),
             Err(e) => {
                 let _ = pg_db
                     .update_proposal_status_with_error(&row.id, "failed", &e)
@@ -451,7 +518,8 @@ pub async fn post_execute(
                 )
                     .into_response();
             }
-        };
+        }
+    };
 
     // Persist the candidate IR + flip to pendingPromotion (skipping the
     // pendingValidation hop that Step 8 will introduce).
@@ -522,25 +590,231 @@ fn authoring_error_detail(
     }
 }
 
-/// Placeholder writer for the staged candidate IR. Bypasses the validator
-/// (Step 8) and the canonical `storage::write_pending_ir` helper (Step 9 will
-/// introduce that helper); writes the IR file to
-/// `specs/pages/<id>/_pending/state-machine.derived.json` and stops.
-///
-/// **Do not extend this** — Step 8/9 replace it entirely.
-fn stage_pending_ir_placeholder(
-    root: &Path,
-    candidate: &crate::spec_api::types::IrPageSpec,
-) -> Result<String, String> {
-    let page_dir = root.join("pages").join(&candidate.id).join("_pending");
-    std::fs::create_dir_all(&page_dir)
-        .map_err(|e| format!("create_dir_all {}: {}", page_dir.display(), e))?;
-    let target = page_dir.join("state-machine.derived.json");
-    let json = serde_json::to_string_pretty(candidate)
-        .map_err(|e| format!("serialize candidate: {}", e))?;
-    std::fs::write(&target, json.as_bytes())
-        .map_err(|e| format!("write {}: {}", target.display(), e))?;
-    Ok(target.display().to_string())
+// =============================================================================
+// Sweep-pending endpoint — POST /spec/proposals/sweep-pending
+// =============================================================================
+//
+// Drives the 2-green promotion (and single-red demotion) of every proposal in
+// `status = 'pendingPromotion'`. Invoked by the supervisor cron (Step 10) on
+// the nightly cadence; also usable as a manual ergonomic. Per Step 9 of
+// `05-flywheel.md`:
+//
+//   - Re-runs ONLY gate-3 (B-execution-green). Gates 1 + 2 are pure
+//     properties of the candidate IR and don't change between sweeps.
+//   - Ok ⇒ greens += 1; if ≥ 2, call `storage::promote_pending` + status =
+//     "promoted". Else just bump the greens counter.
+//   - `Err(BExecutionRed)` ⇒ `storage::demote_pending` + reset greens to 0 +
+//     status = "queued" + `last_error = "single-red: <summary>"`.
+//   - `Err(other)` (e.g. SnapshotFetchFailed) ⇒ infra error; only
+//     `last_attempt_at` moves. No state change.
+//
+// Per-proposal critical section is wrapped in `storage::page_lock` so a
+// manual `/execute` overlap can't race the sweep on the same page id.
+
+const SWEEP_BATCH_LIMIT: i64 = 100;
+
+pub async fn post_sweep_pending(State(state): State<Arc<ApiState>>) -> Response {
+    let pg_db = state.app_state.pg_db.clone();
+    let app_state = state.app_state.clone();
+    let root = storage::resolve_specs_root();
+
+    let rows = match pg_db
+        .list_proposals_by_status("pendingPromotion", SWEEP_BATCH_LIMIT)
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!("post_sweep_pending: list_proposals_by_status failed: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "sweep-list-failed",
+                    json!({ "error": e }),
+                )),
+            )
+                .into_response();
+        }
+    };
+
+    let total = rows.len();
+    let mut promoted = 0usize;
+    let mut demoted = 0usize;
+    let mut infra_errors = 0usize;
+
+    for prop in rows {
+        // Use spec_id when present (canonical page id); fall back to pathname
+        // for fullPage rows that haven't been canonicalized yet. The same
+        // value is used both as the page id for storage helpers AND as the
+        // pathname forwarded to `gate_b_execution_green` (the SDK treats it
+        // as a `route` hint on the fingerprint — non-load-bearing in v1.0).
+        let spec_id = prop
+            .spec_id
+            .clone()
+            .or_else(|| prop.pathname.clone())
+            .unwrap_or_default();
+        if spec_id.is_empty() {
+            warn!(
+                "post_sweep_pending: skip {} — no spec_id or pathname",
+                prop.id
+            );
+            infra_errors += 1;
+            let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+            continue;
+        }
+
+        // Acquire the per-page lock for the duration of the read-and-gate +
+        // promote/demote critical section.
+        let _guard = match storage::page_lock(&root, &spec_id) {
+            Ok(g) => g,
+            Err(e) => {
+                // Treat lock contention as an infra error — the next sweep
+                // tick will retry. Bump last_attempt_at and move on.
+                warn!(
+                    "post_sweep_pending: page_lock({}) failed: {} — treating as infra error",
+                    spec_id, e
+                );
+                infra_errors += 1;
+                let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+                continue;
+            }
+        };
+
+        let pending_ir = match storage::read_pending_ir(&root, &spec_id) {
+            Ok(Some(ir)) => ir,
+            Ok(None) => {
+                // The _pending/ artefact has been swept out from under us —
+                // the row is stale. Demote the row in PG so the queue moves
+                // on, but don't increment `demoted` (no green/red verdict
+                // was reached).
+                warn!(
+                    "post_sweep_pending: pending IR missing on disk for {}; resetting",
+                    prop.id
+                );
+                let _ = pg_db
+                    .update_proposal_status_with_error(
+                        &prop.id,
+                        "queued",
+                        "pending IR missing on disk during sweep",
+                    )
+                    .await;
+                let _ = pg_db.update_proposal_greens(&prop.id, 0).await;
+                infra_errors += 1;
+                continue;
+            }
+            Err(e) => {
+                warn!(
+                    "post_sweep_pending: read_pending_ir({}) failed: {}",
+                    spec_id, e
+                );
+                infra_errors += 1;
+                let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+                continue;
+            }
+        };
+
+        let gate_result = crate::spec_api::validator::gate_b_execution_green(
+            app_state.clone(),
+            &pending_ir,
+            &spec_id,
+        )
+        .await;
+
+        match gate_result {
+            Ok(_) => {
+                let new_greens = prop.consecutive_greens.saturating_add(1);
+                if new_greens >= 2 {
+                    // Promote.
+                    match storage::promote_pending(&root, &spec_id) {
+                        Ok(()) => {
+                            let _ = pg_db.update_proposal_status(&prop.id, "promoted").await;
+                            let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+                            promoted += 1;
+                            info!(
+                                "post_sweep_pending: promoted {} (spec_id={})",
+                                prop.id, spec_id
+                            );
+                        }
+                        Err(e) => {
+                            // Promote-time IO error — leave greens at +1
+                            // count so the next sweep retries.
+                            warn!(
+                                "post_sweep_pending: promote_pending({}) failed: {}",
+                                spec_id, e
+                            );
+                            let _ = pg_db.update_proposal_greens(&prop.id, new_greens).await;
+                            let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+                            infra_errors += 1;
+                        }
+                    }
+                } else {
+                    let _ = pg_db.update_proposal_greens(&prop.id, new_greens).await;
+                    let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+                    info!(
+                        "post_sweep_pending: {} greens advanced to {}",
+                        prop.id, new_greens
+                    );
+                }
+            }
+            Err(crate::spec_api::validator::ValidatorError::BExecutionRed {
+                result_summary,
+                ..
+            }) => {
+                let detail = format!(
+                    "single-red: critical={} error={} warning={} info={}",
+                    result_summary.severity_counts.critical,
+                    result_summary.severity_counts.error,
+                    result_summary.severity_counts.warning,
+                    result_summary.severity_counts.info,
+                );
+                // Demote — rm -rf _pending/, reset greens, requeue.
+                if let Err(e) = storage::demote_pending(&root, &spec_id) {
+                    warn!(
+                        "post_sweep_pending: demote_pending({}) failed: {}",
+                        spec_id, e
+                    );
+                    // Continue — PG-side demotion is still useful even if
+                    // the FS cleanup fails (the row will re-run next sweep
+                    // and the FS layer is idempotent).
+                }
+                let _ = pg_db
+                    .update_proposal_status_with_error(&prop.id, "queued", &detail)
+                    .await;
+                let _ = pg_db.update_proposal_greens(&prop.id, 0).await;
+                demoted += 1;
+                info!(
+                    "post_sweep_pending: demoted {} (spec_id={}): {}",
+                    prop.id, spec_id, detail
+                );
+            }
+            Err(other) => {
+                // SnapshotFetchFailed et al. — infra error, no state change
+                // beyond last_attempt_at.
+                let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
+                infra_errors += 1;
+                warn!(
+                    "post_sweep_pending: infra error for {} (spec_id={}): {:?}",
+                    prop.id, spec_id, other
+                );
+            }
+        }
+    }
+
+    info!(
+        "post_sweep_pending: swept={} promoted={} demoted={} infra_errors={}",
+        total, promoted, demoted, infra_errors
+    );
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "ok": true,
+            "swept": total,
+            "promoted": promoted,
+            "demoted": demoted,
+            "infraErrors": infra_errors,
+        })),
+    )
+        .into_response()
 }
 
 // =============================================================================
@@ -849,7 +1123,11 @@ mod tests {
     }
 
     #[test]
-    fn stage_pending_ir_placeholder_writes_to_pending_dir() {
+    fn write_pending_ir_round_trips_through_proposals_path() {
+        // Smoke-test that the canonical Step 9 staging helper writes a
+        // candidate to `<root>/pages/<id>/_pending/state-machine.derived.json`
+        // with the expected on-disk shape. The deeper provenance-stamping +
+        // projection-sibling behavior is covered by storage::pending_tests.
         use crate::spec_api::types::IrPageSpec;
         let tmp = tempfile::tempdir().unwrap();
         let candidate = IrPageSpec {
@@ -864,8 +1142,9 @@ mod tests {
             synthesized_groups: None,
             initial_state: None,
         };
-        let path = stage_pending_ir_placeholder(tmp.path(), &candidate).unwrap();
-        assert!(path.contains("_pending"));
+        let path = storage::write_pending_ir(tmp.path(), &candidate).unwrap();
+        let path_str = path.display().to_string();
+        assert!(path_str.contains("_pending"));
         let target = tmp
             .path()
             .join("pages")
@@ -880,6 +1159,18 @@ mod tests {
         let body = std::fs::read_to_string(&target).unwrap();
         assert!(body.contains("\"id\""));
         assert!(body.contains("demo-page"));
+        // Projection sibling is written too.
+        let projection = tmp
+            .path()
+            .join("pages")
+            .join("demo-page")
+            .join("_pending")
+            .join("spec.uibridge.json");
+        assert!(
+            projection.exists(),
+            "projection sibling missing: {}",
+            projection.display()
+        );
     }
 
     #[test]

--- a/src-tauri/src/spec_api/storage.rs
+++ b/src-tauri/src/spec_api/storage.rs
@@ -22,6 +22,9 @@ use include_dir::{include_dir, Dir};
 use super::projection::project_to_pretty_json;
 use super::types::IrPageSpec;
 
+#[cfg(feature = "spec-authoring")]
+use super::types::ProposalStatus;
+
 /// Compile-time snapshot of `<runner>/specs/pages/`. Section 4 ships an
 /// offline-capable runner: production binaries serve specs from this embedded
 /// bundle when the on-disk path is missing.
@@ -306,4 +309,444 @@ pub fn newest_mtime_for_page(root: &Path, page_id: &str) -> Option<u64> {
         }
     }
     None
+}
+
+// =============================================================================
+// _pending/ staging (Stream E — Flywheel, Step 9)
+// =============================================================================
+//
+// Coverage-growth candidates produced by `spec_authoring::author_candidate`
+// land in `<root>/pages/<id>/_pending/` rather than the canonical
+// `<root>/pages/<id>/` location. The 2-green sweep handler in
+// `proposals.rs::post_sweep_pending` either promotes (`pages/<id>/`) or demotes
+// (rm -rf `_pending/`) candidates based on whether they pass Gate-B-execution
+// on consecutive sweeps. See `qontinui-dev-notes/spec-check-v1/05-flywheel.md`
+// § Step 9 for the full design context.
+//
+// All four helpers below are gated behind `spec-authoring` — the runtime
+// staging area is invisible to v1.0 release builds.
+
+#[cfg(feature = "spec-authoring")]
+fn pending_dir(root: &Path, page_id: &str) -> PathBuf {
+    root.join("pages").join(page_id).join("_pending")
+}
+
+#[cfg(feature = "spec-authoring")]
+fn pending_ir_path(root: &Path, page_id: &str) -> PathBuf {
+    pending_dir(root, page_id).join("state-machine.derived.json")
+}
+
+#[cfg(feature = "spec-authoring")]
+fn pending_projection_path(root: &Path, page_id: &str) -> PathBuf {
+    pending_dir(root, page_id).join("spec.uibridge.json")
+}
+
+/// Write `ir` to `<root>/pages/<page_id>/_pending/state-machine.derived.json`
+/// + regenerate the projection sibling. Stamps `provenance.status = Pending`
+/// on the doc-level provenance before serialization. Atomic via temp-rename.
+///
+/// The caller's `ir` is NOT mutated — the status flip happens on a clone
+/// owned by this function. Returns the absolute path to the IR file written
+/// on success.
+///
+/// Auto-creates the `_pending/` subdirectory. If a `provenance` block is
+/// absent on the input, one is synthesized with `source: "ai-generated"`
+/// (the only `_pending/` producer in v1.0) and `status: Some(Pending)`.
+#[cfg(feature = "spec-authoring")]
+pub fn write_pending_ir(root: &Path, ir: &IrPageSpec) -> Result<PathBuf, String> {
+    let mut doc = ir.clone();
+    let mut prov = doc.provenance.unwrap_or(super::types::IrProvenance {
+        source: "ai-generated".to_string(),
+        file: None,
+        line: None,
+        column: None,
+        plugin_version: None,
+        status: None,
+    });
+    prov.status = Some(ProposalStatus::Pending);
+    doc.provenance = Some(prov);
+
+    let dir = pending_dir(root, &doc.id);
+    fs::create_dir_all(&dir)
+        .map_err(|e| format!("create_dir_all {} failed: {}", dir.display(), e))?;
+
+    let ir_path = pending_ir_path(root, &doc.id);
+    let projection_path = pending_projection_path(root, &doc.id);
+
+    let mut ir_json = serde_json::to_string_pretty(&doc)
+        .map_err(|e| format!("serialize pending IR failed: {}", e))?;
+    ir_json.push('\n');
+    atomic_write(&ir_path, ir_json.as_bytes())
+        .map_err(|e| format!("write {} failed: {}", ir_path.display(), e))?;
+
+    // Regenerate the projection sibling. We don't read on-disk notes for the
+    // pending shape — only the canonical `pages/<id>/` location carries
+    // notes.md. The projection is purely derived from the IR.
+    let projection = project_to_pretty_json(&doc, None);
+    atomic_write(&projection_path, projection.as_bytes())
+        .map_err(|e| format!("write {} failed: {}", projection_path.display(), e))?;
+
+    Ok(ir_path)
+}
+
+/// Read the pending IR (if any) for `page_id`. Returns `Ok(None)` if no
+/// `_pending/state-machine.derived.json` exists.
+///
+/// Mirrors the [`read_ir`] shape (`Result<Option<IrPageSpec>, String>`).
+/// Unlike `read_ir`, this NEVER falls back to the embedded snapshot —
+/// `EMBEDDED_PAGES` is the immutable promoted corpus; pending candidates
+/// only exist on the filesystem.
+#[cfg(feature = "spec-authoring")]
+pub fn read_pending_ir(root: &Path, page_id: &str) -> Result<Option<IrPageSpec>, String> {
+    let ir_path = pending_ir_path(root, page_id);
+    if !ir_path.exists() {
+        return Ok(None);
+    }
+    let data = fs::read_to_string(&ir_path)
+        .map_err(|e| format!("read {} failed: {}", ir_path.display(), e))?;
+    let doc: IrPageSpec = serde_json::from_str(&data)
+        .map_err(|e| format!("parse {} failed: {}", ir_path.display(), e))?;
+    Ok(Some(doc))
+}
+
+/// Atomically promote a `_pending/` candidate to the canonical `pages/<id>/`
+/// location:
+///
+///   1. Acquire the per-page filesystem lock ([`page_lock`]) — serializes
+///      concurrent sweeps so a manual `/execute` overlap doesn't race the
+///      cron.
+///   2. Read `_pending/state-machine.derived.json` (errors if absent).
+///   3. Flip `provenance.status` to `Some(ProposalStatus::Promoted)`.
+///   4. Call [`write_ir_and_regenerate`] to write the canonical IR + projection.
+///   5. `rm -rf _pending/`.
+///
+/// Returns `Err` if the pending IR is missing or any step fails. The lock is
+/// released on Drop regardless of success/failure.
+#[cfg(feature = "spec-authoring")]
+pub fn promote_pending(root: &Path, page_id: &str) -> Result<(), String> {
+    let _guard = page_lock(root, page_id)?;
+
+    let mut doc = read_pending_ir(root, page_id)?
+        .ok_or_else(|| format!("promote_pending: no pending IR for page {}", page_id))?;
+
+    let mut prov = doc.provenance.unwrap_or(super::types::IrProvenance {
+        source: "ai-generated".to_string(),
+        file: None,
+        line: None,
+        column: None,
+        plugin_version: None,
+        status: None,
+    });
+    prov.status = Some(ProposalStatus::Promoted);
+    doc.provenance = Some(prov);
+
+    // Canonical write + projection regen.
+    write_ir_and_regenerate(root, &doc)?;
+
+    // rm -rf _pending/
+    let dir = pending_dir(root, page_id);
+    if dir.exists() {
+        fs::remove_dir_all(&dir)
+            .map_err(|e| format!("remove_dir_all {} failed: {}", dir.display(), e))?;
+    }
+    Ok(())
+}
+
+/// `rm -rf <root>/pages/<page_id>/_pending/`. Used on single-red demotion.
+/// Idempotent — succeeds silently if the directory doesn't exist.
+#[cfg(feature = "spec-authoring")]
+pub fn demote_pending(root: &Path, page_id: &str) -> Result<(), String> {
+    let dir = pending_dir(root, page_id);
+    if !dir.exists() {
+        return Ok(());
+    }
+    fs::remove_dir_all(&dir).map_err(|e| format!("remove_dir_all {} failed: {}", dir.display(), e))
+}
+
+// -----------------------------------------------------------------------------
+// page_lock — per-page filesystem mutex (lock-by-existence)
+// -----------------------------------------------------------------------------
+//
+// The 2-green sweep handler MAY overlap with a manual `POST /spec/proposals/
+// {id}/execute` (or with itself under cron mis-firing). promote_pending +
+// demote_pending each have a small critical section spanning a few syscalls;
+// we serialize via a per-page lock file using `OpenOptions::create_new`
+// (POSIX `O_CREAT | O_EXCL` semantics — atomic on every supported FS).
+//
+// We deliberately avoid `fs2` / `fd_lock` to keep the dep tree slim — the
+// existence-based approach is well-suited to coarse-grained, low-contention
+// locks like this one (one acquire per proposal per sweep, no nested
+// recursion).
+
+#[cfg(feature = "spec-authoring")]
+fn page_lock_path(root: &Path, page_id: &str) -> PathBuf {
+    root.join("pages").join(page_id).join(".lock")
+}
+
+/// RAII guard returned by [`page_lock`]. On drop, removes the lock file.
+#[cfg(feature = "spec-authoring")]
+#[derive(Debug)]
+pub(crate) struct PageLockGuard {
+    lock_path: PathBuf,
+}
+
+#[cfg(feature = "spec-authoring")]
+impl Drop for PageLockGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.lock_path);
+    }
+}
+
+/// Acquire a per-page filesystem-backed mutex by exclusive-creating a lock
+/// file at `<root>/pages/<page_id>/.lock`. Retries with capped exponential
+/// backoff up to ~1.5s (10 attempts) before giving up.
+///
+/// Returns a `PageLockGuard` that removes the lock on Drop. If acquisition
+/// fails (e.g. another process holds it and never releases), returns
+/// `Err(String)`. Callers MUST treat the error as fatal for the current
+/// operation — the alternative (proceeding without the lock) risks racing
+/// the canonical write against a concurrent sweep.
+#[cfg(feature = "spec-authoring")]
+pub(crate) fn page_lock(root: &Path, page_id: &str) -> Result<PageLockGuard, String> {
+    let lock_path = page_lock_path(root, page_id);
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("create_dir_all {} failed: {}", parent.display(), e))?;
+    }
+
+    // 10 attempts, capped delays: 5, 10, 20, 40, 80, 160, 320, 640, 1280 ms.
+    let mut delay_ms: u64 = 5;
+    for attempt in 0..10 {
+        match fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&lock_path)
+        {
+            Ok(_) => {
+                return Ok(PageLockGuard {
+                    lock_path: lock_path.clone(),
+                });
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if attempt == 9 {
+                    return Err(format!(
+                        "page_lock({}): held by another process after 10 retries",
+                        page_id
+                    ));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                delay_ms = (delay_ms * 2).min(1500);
+            }
+            Err(e) => {
+                return Err(format!("page_lock({}) open failed: {}", page_id, e));
+            }
+        }
+    }
+    Err(format!("page_lock({}): unreachable", page_id))
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(all(test, feature = "spec-authoring"))]
+mod pending_tests {
+    use super::*;
+    use crate::spec_api::types::{IrPageSpec, IrProvenance, ProposalStatus};
+
+    fn empty_ir(id: &str, provenance: Option<IrProvenance>) -> IrPageSpec {
+        IrPageSpec {
+            version: "1.0".into(),
+            id: id.into(),
+            name: id.into(),
+            description: None,
+            metadata: None,
+            provenance,
+            states: Vec::new(),
+            transitions: Vec::new(),
+            synthesized_groups: None,
+            initial_state: None,
+        }
+    }
+
+    #[test]
+    fn write_pending_ir_stamps_provenance_pending() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Input has status = Proposed; write_pending_ir must flip to Pending
+        // without mutating the caller's IR.
+        let input_prov = IrProvenance {
+            source: "ai-generated".into(),
+            file: None,
+            line: None,
+            column: None,
+            plugin_version: None,
+            status: Some(ProposalStatus::Proposed),
+        };
+        let ir = empty_ir("page-a", Some(input_prov.clone()));
+        let path = write_pending_ir(tmp.path(), &ir).expect("write_pending_ir");
+        // Caller's IR is unchanged.
+        assert_eq!(
+            ir.provenance.as_ref().unwrap().status,
+            Some(ProposalStatus::Proposed)
+        );
+        // On-disk doc has Pending.
+        let read = read_pending_ir(tmp.path(), "page-a")
+            .expect("read_pending_ir")
+            .expect("file present");
+        assert_eq!(
+            read.provenance.as_ref().unwrap().status,
+            Some(ProposalStatus::Pending)
+        );
+        // Sibling projection exists.
+        let projection = tmp
+            .path()
+            .join("pages")
+            .join("page-a")
+            .join("_pending")
+            .join("spec.uibridge.json");
+        assert!(
+            projection.exists(),
+            "projection sibling missing: {}",
+            projection.display()
+        );
+        // Returned path is the IR file.
+        assert!(path.ends_with("state-machine.derived.json"));
+    }
+
+    #[test]
+    fn write_pending_ir_synthesizes_provenance_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ir = empty_ir("page-b", None);
+        write_pending_ir(tmp.path(), &ir).expect("write_pending_ir");
+        let read = read_pending_ir(tmp.path(), "page-b")
+            .expect("read")
+            .expect("file present");
+        let prov = read.provenance.expect("provenance synthesized");
+        assert_eq!(prov.source, "ai-generated");
+        assert_eq!(prov.status, Some(ProposalStatus::Pending));
+    }
+
+    #[test]
+    fn read_pending_ir_returns_none_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res = read_pending_ir(tmp.path(), "no-such-page").expect("ok");
+        assert!(res.is_none(), "expected None for missing page");
+    }
+
+    #[test]
+    fn promote_pending_moves_to_canonical_and_stamps_promoted() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ir = empty_ir(
+            "page-c",
+            Some(IrProvenance {
+                source: "ai-generated".into(),
+                file: None,
+                line: None,
+                column: None,
+                plugin_version: None,
+                status: Some(ProposalStatus::Proposed),
+            }),
+        );
+        write_pending_ir(tmp.path(), &ir).expect("stage");
+
+        promote_pending(tmp.path(), "page-c").expect("promote");
+
+        // Canonical files exist.
+        let canon_ir = tmp
+            .path()
+            .join("pages")
+            .join("page-c")
+            .join("state-machine.derived.json");
+        let canon_proj = tmp
+            .path()
+            .join("pages")
+            .join("page-c")
+            .join("spec.uibridge.json");
+        assert!(canon_ir.exists(), "canonical IR missing");
+        assert!(canon_proj.exists(), "canonical projection missing");
+
+        // _pending/ is gone.
+        let pending_dir = tmp.path().join("pages").join("page-c").join("_pending");
+        assert!(
+            !pending_dir.exists(),
+            "_pending/ should have been removed: {}",
+            pending_dir.display()
+        );
+
+        // Canonical IR has status = Promoted.
+        let canon = read_ir(tmp.path(), "page-c")
+            .expect("read canonical")
+            .expect("present");
+        assert_eq!(
+            canon.provenance.as_ref().unwrap().status,
+            Some(ProposalStatus::Promoted)
+        );
+    }
+
+    #[test]
+    fn promote_pending_errors_when_no_pending_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let res = promote_pending(tmp.path(), "absent-page");
+        assert!(
+            res.is_err(),
+            "promote should fail when nothing is staged: {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn demote_pending_removes_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ir = empty_ir("page-d", None);
+        write_pending_ir(tmp.path(), &ir).expect("stage");
+        let pending_dir = tmp.path().join("pages").join("page-d").join("_pending");
+        assert!(pending_dir.exists(), "pending dir must exist after stage");
+
+        demote_pending(tmp.path(), "page-d").expect("demote");
+        assert!(
+            !pending_dir.exists(),
+            "_pending/ should have been removed after demote"
+        );
+    }
+
+    #[test]
+    fn demote_pending_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Demote when nothing is staged → ok.
+        demote_pending(tmp.path(), "never-staged").expect("idempotent");
+        // Twice in a row also ok.
+        demote_pending(tmp.path(), "never-staged").expect("idempotent twice");
+    }
+
+    #[test]
+    fn page_lock_serializes_concurrent_acquires() {
+        let tmp = tempfile::tempdir().unwrap();
+        let page_id = "page-lock";
+        // Pre-create the page dir so the lock-file parent exists deterministically.
+        fs::create_dir_all(tmp.path().join("pages").join(page_id)).unwrap();
+
+        // First acquire succeeds.
+        let g1 = page_lock(tmp.path(), page_id).expect("first acquire");
+
+        // Second acquire while g1 is held should retry briefly and eventually
+        // fail (after 10 attempts) since g1 never releases inside this test.
+        let res = page_lock(tmp.path(), page_id);
+        assert!(
+            res.is_err(),
+            "second acquire must fail while first guard held: {:?}",
+            res
+        );
+
+        // Drop the guard — lock file removed.
+        drop(g1);
+        let lock_path = tmp.path().join("pages").join(page_id).join(".lock");
+        assert!(
+            !lock_path.exists(),
+            "lock file should be removed on drop: {}",
+            lock_path.display()
+        );
+
+        // Third acquire after release succeeds.
+        let _g3 = page_lock(tmp.path(), page_id).expect("third acquire after release");
+    }
 }

--- a/src-tauri/src/spec_api/validator.rs
+++ b/src-tauri/src/spec_api/validator.rs
@@ -1,0 +1,737 @@
+//! Stream E (Flywheel) — the three-gate validator.
+//!
+//! Decides whether a proposed `IrPageSpec` candidate is allowed to land in
+//! `_pending/`. Composes four sequential gates per
+//! `qontinui-dev-notes/spec-check-v1/05-flywheel.md` § Step 8:
+//!
+//!   1. **Distinctness** — `spec_api::distinctness::validate(&candidate)`.
+//!      Same gate as `POST /spec/author` so the flywheel path can't bypass
+//!      Plan 04's empty-criteria / identical-states / subset-domination
+//!      checks.
+//!   2. **Round-trip** — `serde_json::to_vec` → `from_slice` → equality.
+//!      Catches IR documents whose Rust-side struct shape doesn't survive
+//!      JSON serialization (e.g. NaN floats, non-string map keys).
+//!   3. **Coverage floor** — `coverage_of(ir, generate_regression_suite(ir))`
+//!      ratio of `states_covered / max(reachable_states.len(), 1)` must be
+//!      ≥ the env-configurable `QONTINUI_SPEC_COVERAGE_FLOOR` (default 0.80).
+//!   4. **B-execution green** — fetch a live UI Bridge snapshot, run
+//!      `spec_check::evaluate(snapshot, candidate)` + `apply_policy(..,
+//!      factories::strict_all_pass())`. Anything other than
+//!      `PolicyStatus::Pass` (Fail AND Indeterminate) rejects the candidate.
+//!
+//! Distinctness sits in front because (a) it's the cheapest, (b) the other
+//! three gates run against the same IR and so still see the violation if we
+//! skipped it. Round-trip is gate 2 because a candidate that doesn't survive
+//! serialization can't be staged to `_pending/` anyway. Coverage and B-green
+//! follow per the plan's specified order.
+//!
+//! Tests against a canned `UIBridgeSnapshot` go through
+//! `gate_b_execution_green_with_snapshot` — the production path's
+//! `gate_b_execution_green` wraps it with the WS dispatch helper.
+
+use std::sync::Arc;
+
+use qontinui_spec_check as spec_check;
+use qontinui_types::spec_check::{
+    PolicyEvaluation, PolicyStatus, SpecCheckResult, SpecCheckSummary,
+};
+use qontinui_types::ui_bridge::UIBridgeSnapshot;
+use serde_json::json;
+use tracing::{debug, warn};
+
+use crate::spec_api::distinctness::{self, DistinctnessReport};
+use crate::spec_api::types::IrPageSpec;
+use spec_check::SnapshotFetchError;
+
+// =============================================================================
+// Public surface
+// =============================================================================
+
+/// Validator failure taxonomy. Every variant maps to a structured response
+/// reason in `proposals.rs::post_execute` and a row in
+/// `spec_proposals.last_error`.
+#[derive(Debug)]
+pub enum ValidatorError {
+    /// Gate 1 — distinctness violation (empty criteria, identical states,
+    /// or subset domination). Same shape as `POST /spec/author`'s 422.
+    DistinctnessFailed(DistinctnessReport),
+    /// Gate 2 — serde-side error during the round-trip serialize step.
+    SerializeFailed(serde_json::Error),
+    /// Gate 2 — serde-side error during the round-trip deserialize step.
+    DeserializeFailed(serde_json::Error),
+    /// Gate 2 — the round-tripped IR was not byte-identical to the input.
+    RoundTripMismatch,
+    /// Gate 3 — coverage ratio below the configured floor.
+    CoverageBelowFloor { ratio: f64, floor: f64 },
+    /// Gate 4 — snapshot fetch failed before B could evaluate.
+    SnapshotFetchFailed(SnapshotFetchError),
+    /// Gate 4 — `apply_policy` returned `Fail` or `Indeterminate`.
+    BExecutionRed {
+        result_summary: SpecCheckSummary,
+        policy_eval: PolicyEvaluation,
+    },
+}
+
+/// Short, stable reason code for each variant. Used as the `reason` field
+/// of the `/spec/proposals/{id}/execute` validator-rejected response shape.
+pub fn validator_error_reason(e: &ValidatorError) -> &'static str {
+    match e {
+        ValidatorError::DistinctnessFailed(_) => "distinctness-failed",
+        ValidatorError::SerializeFailed(_) => "serialize-failed",
+        ValidatorError::DeserializeFailed(_) => "deserialize-failed",
+        ValidatorError::RoundTripMismatch => "round-trip-mismatch",
+        ValidatorError::CoverageBelowFloor { .. } => "coverage-below-floor",
+        ValidatorError::SnapshotFetchFailed(_) => "snapshot-fetch-failed",
+        ValidatorError::BExecutionRed { .. } => "b-execution-red",
+    }
+}
+
+/// Human-readable detail for the `detail` field of the response + the
+/// `spec_proposals.last_error` column.
+pub fn validator_error_detail(e: &ValidatorError) -> String {
+    match e {
+        ValidatorError::DistinctnessFailed(r) => {
+            format!("distinctness: {} violation(s)", r.violations.len())
+        }
+        ValidatorError::SerializeFailed(err) => format!("serialize: {err}"),
+        ValidatorError::DeserializeFailed(err) => format!("deserialize: {err}"),
+        ValidatorError::RoundTripMismatch => {
+            "round-trip mismatch: IR did not survive JSON serialization unchanged".to_string()
+        }
+        ValidatorError::CoverageBelowFloor { ratio, floor } => {
+            format!("coverage {:.4} below floor {:.4}", ratio, floor)
+        }
+        ValidatorError::SnapshotFetchFailed(err) => format!("snapshot fetch: {err}"),
+        ValidatorError::BExecutionRed {
+            result_summary,
+            policy_eval,
+        } => {
+            let sc = &result_summary.severity_counts;
+            let misses = sc.critical + sc.error + sc.warning + sc.info;
+            format!(
+                "B-execution red: overall_status={:?}, miss_count={}",
+                policy_eval.overall_status, misses
+            )
+        }
+    }
+}
+
+/// Run the four gates in order: distinctness → round-trip → coverage →
+/// b-green. Returns the `SpecCheckResult` from gate 4 on success.
+///
+/// `app_state` is required by gate 4 (live snapshot fetch). `pathname` is
+/// the page the candidate targets (used to navigate / locate the snapshot
+/// for that route). `_distinct_root` is reserved for a future
+/// `_pending/`-vs-disk-distinctness pass; gate 1 currently checks only
+/// internal distinctness of the candidate.
+pub async fn validate_candidate(
+    app_state: Arc<crate::commands::AppState>,
+    candidate: &IrPageSpec,
+    pathname: &str,
+    _distinct_root: &std::path::Path,
+) -> Result<SpecCheckResult, ValidatorError> {
+    // Gate 1 — distinctness.
+    if let Err(report) = distinctness::validate(candidate) {
+        debug!(
+            "validate_candidate: gate-1 distinctness failed ({} violations)",
+            report.violations.len()
+        );
+        return Err(ValidatorError::DistinctnessFailed(report));
+    }
+
+    // Gate 2 — round-trip.
+    gate_round_trip(candidate)?;
+
+    // Gate 3 — coverage floor.
+    gate_coverage(candidate)?;
+
+    // Gate 4 — B-green.
+    gate_b_execution_green(app_state, candidate, pathname).await
+}
+
+/// Standalone entry point for the gate-4 B-green check. Exposed so Step 9's
+/// sweep handler (re-running gate 4 nightly on `_pending/` candidates) can
+/// call it directly without re-running gates 1-3 (those are pure properties
+/// of the candidate IR and don't change between sweeps).
+pub async fn gate_b_execution_green(
+    app_state: Arc<crate::commands::AppState>,
+    candidate: &IrPageSpec,
+    pathname: &str,
+) -> Result<SpecCheckResult, ValidatorError> {
+    let snapshot = fetch_live_snapshot(app_state, pathname)
+        .await
+        .map_err(ValidatorError::SnapshotFetchFailed)?;
+    gate_b_execution_green_with_snapshot(&snapshot, candidate)
+}
+
+// =============================================================================
+// Private gate impls
+// =============================================================================
+
+/// Gate 2: serde round-trip. Returns the candidate-side bytes only on
+/// success; the bytes are not propagated (callers re-serialize at the
+/// staging boundary).
+fn gate_round_trip(ir: &IrPageSpec) -> Result<(), ValidatorError> {
+    let bytes = serde_json::to_vec(ir).map_err(ValidatorError::SerializeFailed)?;
+    let reparsed: IrPageSpec =
+        serde_json::from_slice(&bytes).map_err(ValidatorError::DeserializeFailed)?;
+    if &reparsed != ir {
+        return Err(ValidatorError::RoundTripMismatch);
+    }
+    Ok(())
+}
+
+/// Gate 3: coverage floor. Floor is configurable via
+/// `QONTINUI_SPEC_COVERAGE_FLOOR` (default `0.80`). Denominator floored at
+/// 1 so a degenerate IR (no reachable states) doesn't divide by zero.
+pub(crate) fn gate_coverage(ir: &IrPageSpec) -> Result<f64, ValidatorError> {
+    use crate::workflow_generation::coverage::{coverage_of, generate_regression_suite};
+    let suite = generate_regression_suite(ir);
+    let report = coverage_of(ir, &suite);
+    let floor: f64 = std::env::var("QONTINUI_SPEC_COVERAGE_FLOOR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.80_f64);
+    let reachable_count = report.reachable_states.len().max(1);
+    let ratio = report.states_covered as f64 / reachable_count as f64;
+    if ratio < floor {
+        debug!(
+            "validate_candidate: gate-3 coverage {} below floor {}",
+            ratio, floor
+        );
+        return Err(ValidatorError::CoverageBelowFloor { ratio, floor });
+    }
+    Ok(ratio)
+}
+
+/// Gate 4 inner — given an already-fetched snapshot, run B's evaluator +
+/// the strict-all-pass policy. Split out so tests can construct canned
+/// snapshots without going through `try_ws_dispatch`.
+pub(crate) fn gate_b_execution_green_with_snapshot(
+    snapshot: &UIBridgeSnapshot,
+    candidate: &IrPageSpec,
+) -> Result<SpecCheckResult, ValidatorError> {
+    let result = spec_check::evaluate(snapshot, candidate);
+    let policy = spec_check::policy::factories::strict_all_pass();
+    let eval = spec_check::apply_policy(&result, &policy);
+
+    // Treat anything other than `Pass` as red — `Fail` and `Indeterminate`
+    // both reject. Per the plan's "could not evaluate is not a green signal"
+    // rule (see § Step 8 + the vet-pass correction at the head of the doc).
+    if !matches!(eval.overall_status, PolicyStatus::Pass) {
+        return Err(ValidatorError::BExecutionRed {
+            result_summary: result.summary.clone(),
+            policy_eval: eval,
+        });
+    }
+    Ok(result)
+}
+
+/// Pull a fresh UI Bridge snapshot for the active app via the WS dispatch
+/// helper, then wrap it into a typed `UIBridgeSnapshot` via
+/// `spec_check::wrap_snapshot`.
+///
+/// `pathname` is forwarded to the SDK as the `route` field on
+/// `BridgeFingerprint` so downstream `SpecCheckResult.fingerprint` carries
+/// it; we do NOT navigate the connected app here. The flywheel cron either
+/// (a) trusts the user has the app on the right page, or (b) extends this
+/// helper later to pre-dispatch a `/ui-bridge/sdk/navigate` call. v1.0 ships
+/// (a) per the plan's "optional" framing in § Step 8 step 2.
+async fn fetch_live_snapshot(
+    app_state: Arc<crate::commands::AppState>,
+    pathname: &str,
+) -> Result<UIBridgeSnapshot, SnapshotFetchError> {
+    use axum::http::Method;
+
+    // 1. Resolve the active app id from the SDK connection.
+    let active_app_id = {
+        let guard = app_state.sdk_connection.lock().await;
+        guard.active_connection().map(|c| c.app_info.app_id.clone())
+    };
+    let app_id = match active_app_id {
+        Some(id) => id,
+        None => return Err(SnapshotFetchError::NotConnected),
+    };
+
+    // 2. Look up the registry entry (also confirms the app is registered).
+    //    `AppState::app_registry` / `app_dispatcher` are wrapped in
+    //    `OnceCell`, populated during runner startup. A `None` here means
+    //    the MCP plumbing hasn't initialized yet — treat as
+    //    `NotConnected` for the flywheel's purposes.
+    let registry = match app_state.app_registry.get() {
+        Some(r) => r.clone(),
+        None => return Err(SnapshotFetchError::NotConnected),
+    };
+    let dispatcher = match app_state.app_dispatcher.get() {
+        Some(d) => d.clone(),
+        None => return Err(SnapshotFetchError::NotConnected),
+    };
+    let entry = match registry.get(&app_id).await {
+        Some(e) => e,
+        None => return Err(SnapshotFetchError::NotConnected),
+    };
+    let app_version: Option<String> = entry.app.version.clone();
+
+    // 3. Dispatch `getControlSnapshot`. For WS-transport apps the dispatcher
+    //    sends the action over the active socket; for HTTP-transport apps
+    //    it issues a GET to `/control/snapshot`. The flywheel cron is
+    //    indifferent — either way we get back a raw JSON snapshot value.
+    let payload = json!({});
+    let raw = match dispatcher
+        .dispatch(
+            &app_id,
+            "getControlSnapshot",
+            Method::GET,
+            "/control/snapshot",
+            payload,
+        )
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(
+                "fetch_live_snapshot: dispatch getControlSnapshot failed for app_id={}: {:?}",
+                app_id, e
+            );
+            return Err(SnapshotFetchError::Network(format!("{e:?}")));
+        }
+    };
+
+    // 4. Unwrap the typical `{ success, data: { ... } }` envelope so the
+    //    inner snapshot shape is what `wrap_snapshot` deserializes.
+    let inner: serde_json::Value = match raw.get("data") {
+        Some(d) if !d.is_null() => d.clone(),
+        _ => raw,
+    };
+
+    // 5. Wrap into a typed `UIBridgeSnapshot` (+ fingerprint, snapshot_id,
+    //    content_sha256 — the latter three are discarded here; the
+    //    flywheel cron records them at a higher layer when it persists
+    //    sweep results).
+    let (snapshot, _fp, _id, _hash) = spec_check::wrap_snapshot(
+        inner,
+        app_id,
+        app_version,
+        Some(pathname.to_string()),
+        None, // bridge_version is not carried on the registry entry today
+    )?;
+    Ok(snapshot)
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec_api::types::{
+        IrAssertion, IrAssertionTarget, IrPageSpec, IrState, IrTransition,
+    };
+    use qontinui_types::ui_bridge::UIBridgeSnapshot;
+
+    // -------- Helpers ----------------------------------------------------
+
+    /// IR with `n_states` states and a chain `s0→s1→...→s{n-1}` (when
+    /// `transitions_link_all` is true) or no transitions otherwise. Each
+    /// state has a single `assertion` whose criteria match the body
+    /// element by `tagName == "body"` — small enough to evaluate cheaply
+    /// against the test snapshots. Note: IRs with 2+ states will FAIL
+    /// distinctness (identical state keys) — tests that need to pass
+    /// distinctness use `n_states == 1`.
+    fn chain_ir(id: &str, n_states: u32, transitions_link_all: bool) -> IrPageSpec {
+        let mut states: Vec<IrState> = Vec::new();
+        for i in 0..n_states {
+            let sid = format!("s{i}");
+            states.push(IrState {
+                id: sid.clone(),
+                name: sid,
+                description: None,
+                // Every state asserts that an element with `tag_name ==
+                // "body"` exists. The body element in `body_snapshot()`
+                // matches; the empty snapshot misses. Distinctness flags
+                // identical state keys when 2+ states share criteria; the
+                // smoke test below works around that by using a 1-state
+                // IR (chain_ir(_, 1, false)). All other tests bypass
+                // gate 1 by calling later gates directly.
+                assertions: vec![IrAssertion {
+                    id: format!("a-s{i}"),
+                    description: format!("a-s{i}"),
+                    category: "structural".into(),
+                    severity: "critical".into(),
+                    assertion_type: "element-exists".into(),
+                    target: IrAssertionTarget {
+                        kind: "search".into(),
+                        criteria: json!({ "tagName": "body" }),
+                        label: format!("body-s{i}"),
+                    },
+                    source: "build-plugin".into(),
+                    reviewed: false,
+                    enabled: true,
+                    precondition: None,
+                }],
+                excluded_elements: None,
+                conditions: None,
+                is_initial: if i == 0 { Some(true) } else { None },
+                is_terminal: None,
+                blocking: None,
+                group: None,
+                path_cost: None,
+                precondition: None,
+                element_ids: None,
+                incoming_transitions: None,
+                metadata: None,
+                provenance: None,
+                cross_refs: None,
+            });
+        }
+
+        let mut transitions: Vec<IrTransition> = Vec::new();
+        if transitions_link_all && n_states >= 2 {
+            for i in 0..(n_states - 1) {
+                let from = format!("s{i}");
+                let to = format!("s{}", i + 1);
+                transitions.push(IrTransition {
+                    id: format!("t{i}"),
+                    name: format!("t{i}"),
+                    description: None,
+                    from_states: vec![from],
+                    activate_states: vec![to],
+                    exit_states: None,
+                    actions: Vec::new(),
+                    path_cost: None,
+                    bidirectional: None,
+                    effect: None,
+                    metadata: None,
+                    provenance: None,
+                    cross_refs: None,
+                });
+            }
+        }
+
+        IrPageSpec {
+            version: "1.0".into(),
+            id: id.into(),
+            name: id.into(),
+            description: None,
+            metadata: None,
+            provenance: None,
+            states,
+            transitions,
+            synthesized_groups: None,
+            initial_state: Some("s0".into()),
+        }
+    }
+
+    /// Build a minimal `UIBridgeElement` with `tag_name == "body"`. Used to
+    /// produce a snapshot that matches the chain IRs' search criteria.
+    fn body_element() -> qontinui_types::ui_bridge::UIBridgeElement {
+        use qontinui_types::ui_bridge::{
+            ElementIdentifier, ElementRect, ElementState, UIBridgeElement,
+        };
+        UIBridgeElement {
+            id: "body-1".into(),
+            element_type: "body".into(),
+            label: None,
+            actions: Vec::new(),
+            custom_actions: None,
+            identifier: ElementIdentifier {
+                ui_id: None,
+                test_id: None,
+                awas_id: None,
+                html_id: None,
+                xpath: String::new(),
+                selector: "body".into(),
+            },
+            state: ElementState {
+                visible: true,
+                enabled: true,
+                focused: false,
+                rect: ElementRect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 100.0,
+                    height: 100.0,
+                    top: 0.0,
+                    right: 100.0,
+                    bottom: 100.0,
+                    left: 0.0,
+                },
+                value: None,
+                checked: None,
+                selected_options: None,
+                text_content: None,
+            },
+            registered_at: 0,
+            mounted: true,
+            bbox: None,
+            visible: Some(true),
+            role: Some("document".into()),
+            tag_name: Some("body".into()),
+            aria_label: None,
+            accessible_name: None,
+            text: None,
+        }
+    }
+
+    /// Tiny snapshot with one `<body>` element that matches the chain IRs'
+    /// `tagName == "body"` criteria.
+    fn body_snapshot() -> UIBridgeSnapshot {
+        UIBridgeSnapshot {
+            timestamp: 1_700_000_000_000,
+            elements: vec![body_element()],
+            components: Vec::new(),
+            workflows: Vec::new(),
+            modal_stack: None,
+            toasts: None,
+            undo_redo: None,
+            current_route: None,
+            segments: Vec::new(),
+        }
+    }
+
+    /// Snapshot with NO elements — every search assertion will miss, so
+    /// `apply_policy` will return Fail.
+    fn empty_snapshot() -> UIBridgeSnapshot {
+        UIBridgeSnapshot {
+            timestamp: 1_700_000_000_000,
+            elements: Vec::new(),
+            components: Vec::new(),
+            workflows: Vec::new(),
+            modal_stack: None,
+            toasts: None,
+            undo_redo: None,
+            current_route: None,
+            segments: Vec::new(),
+        }
+    }
+
+    // -------- Gate 2: round-trip ----------------------------------------
+
+    #[test]
+    fn gate_round_trip_passes_on_well_formed_ir() {
+        let ir = chain_ir("rt-ok", 2, true);
+        gate_round_trip(&ir).expect("round-trip passes");
+    }
+
+    // -------- Gate 3: coverage ------------------------------------------
+
+    /// Serializes env-var tests so they don't race when cargo runs tests
+    /// in parallel. Every gate_coverage_* test mutates or reads
+    /// `QONTINUI_SPEC_COVERAGE_FLOOR`; they all take this lock.
+    static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn gate_coverage_passes_at_full_coverage() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        std::env::remove_var("QONTINUI_SPEC_COVERAGE_FLOOR");
+        // 3-state chain s0→s1→s2 — every state touched, every state
+        // reachable from s0. Ratio = 1.0 ≥ default 0.80 floor.
+        let ir = chain_ir("cov-ok", 3, true);
+        let ratio = gate_coverage(&ir).expect("coverage passes");
+        assert!(ratio >= 0.99, "expected near-1.0 ratio, got {}", ratio);
+    }
+
+    #[test]
+    fn gate_coverage_rejects_when_below_floor() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        // 5 states, chain transitions linking ALL states — coverage = 1.0.
+        // Set floor to >1.0 to guarantee failure regardless of inputs.
+        let ir = chain_ir("cov-fail", 5, true);
+        std::env::set_var("QONTINUI_SPEC_COVERAGE_FLOOR", "1.5");
+        let result = gate_coverage(&ir);
+        std::env::remove_var("QONTINUI_SPEC_COVERAGE_FLOOR");
+        match result {
+            Err(ValidatorError::CoverageBelowFloor { ratio, floor }) => {
+                assert!(ratio <= 1.0001);
+                assert!((floor - 1.5).abs() < 1e-9);
+            }
+            other => panic!("expected CoverageBelowFloor, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gate_coverage_disconnected_subgraph_below_default_floor() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        // Ensure the env var is not set from a prior test that may not have
+        // cleaned up if it panicked mid-run.
+        std::env::remove_var("QONTINUI_SPEC_COVERAGE_FLOOR");
+        // 5 states; only 2 are reachable (s0→s1). states_covered touches
+        // only the 2 wired states. Ratio against reachable = 2/2 = 1.0 —
+        // the BFS denominator handles disconnected states by reporting
+        // them as unreachable, so the ratio stays high.
+        //
+        // To exercise a true coverage shortfall, we'd need transitions
+        // that touch only a subset of reachable states — that's a wider
+        // shape that the coverage_of unit tests already cover. Here we
+        // just sanity-check the gate doesn't false-pass at ratio=0.
+        let ir = chain_ir("cov-disc", 5, false); // NO transitions at all
+                                                 // No transitions, no `from_states` / `activate_states` touched.
+                                                 // states_covered = 0. reachable_states = {s0} (initial only).
+                                                 // ratio = 0/1 = 0.0 < 0.80 (default floor) → fail.
+        let result = gate_coverage(&ir);
+        match result {
+            Err(ValidatorError::CoverageBelowFloor { ratio, .. }) => {
+                assert!(ratio < 0.01, "expected ~0 ratio, got {}", ratio);
+            }
+            other => panic!("expected CoverageBelowFloor, got {:?}", other),
+        }
+    }
+
+    // -------- Gate 4: B-green --------------------------------------------
+
+    #[test]
+    fn gate_b_execution_green_passes_on_matching_snapshot() {
+        let ir = chain_ir("b-ok", 2, true);
+        let snapshot = body_snapshot();
+        let result = gate_b_execution_green_with_snapshot(&snapshot, &ir)
+            .expect("b-green passes on matching snapshot");
+        // Sanity: the spec-check evaluator should not have flagged any
+        // critical/error/warning/info misses against our trivially-matching
+        // `<body>` snapshot.
+        let sc = &result.summary.severity_counts;
+        assert_eq!(sc.critical + sc.error + sc.warning + sc.info, 0);
+    }
+
+    #[test]
+    fn gate_b_execution_red_on_failing_assertions() {
+        let ir = chain_ir("b-fail", 2, true);
+        let snapshot = empty_snapshot();
+        let result = gate_b_execution_green_with_snapshot(&snapshot, &ir);
+        match result {
+            Err(ValidatorError::BExecutionRed {
+                result_summary,
+                policy_eval,
+            }) => {
+                // strict_all_pass treats every miss as a Fail.
+                assert!(
+                    !matches!(policy_eval.overall_status, PolicyStatus::Pass),
+                    "expected non-Pass status, got {:?}",
+                    policy_eval.overall_status
+                );
+                let sc = &result_summary.severity_counts;
+                assert!(
+                    sc.critical + sc.error + sc.warning + sc.info >= 1,
+                    "expected at least one miss tallied"
+                );
+            }
+            other => panic!("expected BExecutionRed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn gate_b_execution_red_on_indeterminate_treats_as_red() {
+        // An IR with NO assertions across all states would yield an
+        // Indeterminate evaluation under `strict_all_pass` (empty conjunct
+        // scope). Build a minimal IR with one bare state, no assertions.
+        let ir = IrPageSpec {
+            version: "1.0".into(),
+            id: "b-indet".into(),
+            name: "b-indet".into(),
+            description: None,
+            metadata: None,
+            provenance: None,
+            states: vec![IrState {
+                id: "s0".into(),
+                name: "s0".into(),
+                description: None,
+                assertions: Vec::new(),
+                excluded_elements: None,
+                conditions: None,
+                is_initial: Some(true),
+                is_terminal: None,
+                blocking: None,
+                group: None,
+                path_cost: None,
+                precondition: None,
+                element_ids: None,
+                incoming_transitions: None,
+                metadata: None,
+                provenance: None,
+                cross_refs: None,
+            }],
+            transitions: Vec::new(),
+            synthesized_groups: None,
+            initial_state: Some("s0".into()),
+        };
+        let snapshot = empty_snapshot();
+        // strict_all_pass with an empty conjunct scope (no assertions)
+        // returns Indeterminate (see `policy.rs:176-181`). The flywheel
+        // treats anything other than `Pass` as red — Indeterminate must
+        // surface as `BExecutionRed`.
+        let outcome = gate_b_execution_green_with_snapshot(&snapshot, &ir);
+        match outcome {
+            Err(ValidatorError::BExecutionRed { policy_eval, .. }) => {
+                assert!(
+                    matches!(
+                        policy_eval.overall_status,
+                        PolicyStatus::Fail | PolicyStatus::Indeterminate
+                    ),
+                    "expected non-Pass status, got {:?}",
+                    policy_eval.overall_status
+                );
+            }
+            Ok(_) => {
+                panic!("expected Indeterminate→BExecutionRed for empty-assertion IR");
+            }
+            Err(other) => panic!("unexpected variant: {:?}", other),
+        }
+    }
+
+    // -------- All-gates-pass smoke --------------------------------------
+
+    #[test]
+    fn all_gates_pass_smoke() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner());
+        std::env::remove_var("QONTINUI_SPEC_COVERAGE_FLOOR");
+        // Single-state IR with one assertion + no transitions. Distinctness
+        // passes (no peers to be identical-with); gate-2 round-trips
+        // cleanly; gate-3 coverage = states_covered=0 / reachable=1 = 0
+        // which is BELOW the default 0.80 floor — so we set a 0.0 floor
+        // for this smoke test (every gate runs but coverage is gated
+        // permissively). gate-4 matches the body snapshot.
+        let ir = chain_ir("all-ok", 1, false);
+        std::env::set_var("QONTINUI_SPEC_COVERAGE_FLOOR", "0.0");
+        let r1 = distinctness::validate(&ir);
+        let r2 = gate_round_trip(&ir);
+        let r3 = gate_coverage(&ir);
+        std::env::remove_var("QONTINUI_SPEC_COVERAGE_FLOOR");
+        r1.expect("distinctness");
+        r2.expect("round-trip");
+        let _ = r3.expect("coverage");
+        let snapshot = body_snapshot();
+        let _ = gate_b_execution_green_with_snapshot(&snapshot, &ir).expect("b-green");
+    }
+
+    // -------- Error-reason / detail mappings ----------------------------
+
+    #[test]
+    fn error_reasons_are_stable_short_strings() {
+        let cases: Vec<(ValidatorError, &str)> = vec![
+            (
+                ValidatorError::DistinctnessFailed(DistinctnessReport {
+                    ok: false,
+                    violations: Vec::new(),
+                }),
+                "distinctness-failed",
+            ),
+            (ValidatorError::RoundTripMismatch, "round-trip-mismatch"),
+            (
+                ValidatorError::CoverageBelowFloor {
+                    ratio: 0.5,
+                    floor: 0.8,
+                },
+                "coverage-below-floor",
+            ),
+            (
+                ValidatorError::SnapshotFetchFailed(SnapshotFetchError::NotConnected),
+                "snapshot-fetch-failed",
+            ),
+        ];
+        for (err, expected_reason) in &cases {
+            assert_eq!(validator_error_reason(err), *expected_reason);
+            // detail is never empty.
+            assert!(!validator_error_detail(err).is_empty());
+        }
+    }
+}

--- a/src-tauri/src/workflow_generation/coverage.rs
+++ b/src-tauri/src/workflow_generation/coverage.rs
@@ -1,0 +1,378 @@
+//! Rust port of `ui-bridge-auto/src/state/regression-generator.ts`'s
+//! `generateRegressionSuite` + `coverageOf` (Gate 2 of the Stream E flywheel
+//! validator).
+//!
+//! Pure graph-walk over `IrPageSpec.transitions[].from_states` /
+//! `activate_states`. The TS reference at
+//! `ui-bridge-auto/src/state/regression-generator.ts:523-740` is the
+//! authoritative algorithm — this port mirrors it exactly:
+//!
+//! - **`generate_regression_suite`** emits one [`RegressionCase`] per
+//!   transition, sorted by transition id ascending; case ordering is
+//!   determined entirely by sorted input (defensive — callers may build IRs
+//!   in arbitrary order).
+//! - **`coverage_of`** computes `states_covered` by unioning the
+//!   `from_states`, `activate_states`, and `exit_states` lists across every
+//!   case; `reachable_states` is computed by BFS from `ir.initial_state`
+//!   (or from every state if no `initial_state` is declared) over the
+//!   transition graph. `reachable_states` / `unreachable_states` are
+//!   returned as sorted-id `Vec<String>` (matching the TS contract).
+//!
+//! The flywheel's coverage gate floors `statesCovered / reachableStates.len()`
+//! at the env-configurable threshold (`QONTINUI_SPEC_COVERAGE_FLOOR`,
+//! default 0.80) — see `spec_api::validator::gate_coverage`.
+
+use crate::spec_api::types::IrPageSpec;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+/// One regression case — mirrors the (subset of) TS `RegressionCase` that
+/// `coverage_of` actually reads. The flywheel's coverage gate only consumes
+/// the state-id columns, so we deliberately omit `assertions[]` here (the
+/// full assertion-shape port belongs in a future spec-check streaming-
+/// regression module, not this validator gate).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RegressionCase {
+    pub id: String,
+    pub transition_id: String,
+    pub from_states: Vec<String>,
+    pub activate_states: Vec<String>,
+    pub exit_states: Vec<String>,
+}
+
+/// Deterministic regression suite — one case per transition.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RegressionSuite {
+    pub id: String,
+    pub cases: Vec<RegressionCase>,
+}
+
+/// Coverage report — mirror of the TS `CoverageReport`
+/// (`ui-bridge-auto/src/state/regression-generator.ts:702`).
+///
+/// `reachable_states` / `unreachable_states` are arrays of ids (sorted
+/// ascending), matching the TS contract. Take `.len()` for counts.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CoverageReport {
+    pub total_states: u32,
+    pub total_transitions: u32,
+    pub states_covered: u32,
+    pub transitions_covered: u32,
+    pub reachable_states: Vec<String>,
+    pub unreachable_states: Vec<String>,
+}
+
+/// Walk the IR and emit a deterministic regression suite — one case per
+/// transition, sorted by transition id ascending. Same input → byte-
+/// identical suite. (TS reference: `generateRegressionSuite` at
+/// `regression-generator.ts:523`.)
+pub fn generate_regression_suite(ir: &IrPageSpec) -> RegressionSuite {
+    // Sort transitions defensively — callers may build IRs in arbitrary
+    // order (insertion order of a Map, ad-hoc construction). We never
+    // trust the caller's order.
+    let mut sorted_transitions: Vec<&crate::spec_api::types::IrTransition> =
+        ir.transitions.iter().collect();
+    sorted_transitions.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let cases: Vec<RegressionCase> = sorted_transitions
+        .into_iter()
+        .map(|t| RegressionCase {
+            id: t.id.clone(),
+            transition_id: t.id.clone(),
+            from_states: sorted_copy(&t.from_states),
+            activate_states: sorted_copy(&t.activate_states),
+            exit_states: sorted_copy(t.exit_states.as_deref().unwrap_or(&[])),
+        })
+        .collect();
+
+    RegressionSuite {
+        id: format!("{}@suite", ir.id),
+        cases,
+    }
+}
+
+/// Compute coverage of the IR by the suite. `transitions_covered` is just
+/// `suite.cases.len()` (one case per transition). `reachable_states` is
+/// computed via a local BFS from `ir.initial_state` if present, else from
+/// every state in the IR (so coverage isn't gated on a declared start node).
+///
+/// TS reference: `coverageOf` at `regression-generator.ts:673`.
+pub fn coverage_of(ir: &IrPageSpec, suite: &RegressionSuite) -> CoverageReport {
+    // All declared state ids.
+    let all_state_ids: BTreeSet<String> = ir.states.iter().map(|s| s.id.clone()).collect();
+
+    // States touched by at least one case (any of from/activate/exit).
+    let mut touched: BTreeSet<String> = BTreeSet::new();
+    for c in &suite.cases {
+        for s in &c.from_states {
+            touched.insert(s.clone());
+        }
+        for s in &c.activate_states {
+            touched.insert(s.clone());
+        }
+        for s in &c.exit_states {
+            touched.insert(s.clone());
+        }
+    }
+
+    // Reachability seeds: prefer `initial_state`, else every declared state.
+    let seeds: Vec<String> = match ir.initial_state.as_ref() {
+        Some(s) => vec![s.clone()],
+        None => all_state_ids.iter().cloned().collect(),
+    };
+    let reachable = reachable_from(ir, &seeds);
+
+    let mut reachable_states: Vec<String> = Vec::new();
+    let mut unreachable_states: Vec<String> = Vec::new();
+    for id in &all_state_ids {
+        if reachable.contains(id) {
+            reachable_states.push(id.clone());
+        } else {
+            unreachable_states.push(id.clone());
+        }
+    }
+
+    CoverageReport {
+        total_states: ir.states.len() as u32,
+        total_transitions: ir.transitions.len() as u32,
+        states_covered: touched.len() as u32,
+        transitions_covered: suite.cases.len() as u32,
+        reachable_states,
+        unreachable_states,
+    }
+}
+
+/// Local BFS over the IR transition graph. A transition is "available"
+/// once all its `from_states` are reachable; firing it grows the reachable
+/// set with every `activate_state`. Iterate to fixpoint.
+///
+/// Mirrors the TS `reachableFrom` at `regression-generator.ts:637`.
+fn reachable_from(ir: &IrPageSpec, seeds: &[String]) -> BTreeSet<String> {
+    let mut reachable: BTreeSet<String> = seeds.iter().cloned().collect();
+
+    let mut transitions_sorted: Vec<&crate::spec_api::types::IrTransition> =
+        ir.transitions.iter().collect();
+    transitions_sorted.sort_by(|a, b| a.id.cmp(&b.id));
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for t in &transitions_sorted {
+            // A transition is "available" once all its from_states are
+            // reachable.
+            let available = t.from_states.iter().all(|s| reachable.contains(s));
+            if !available {
+                continue;
+            }
+            for s in &t.activate_states {
+                if reachable.insert(s.clone()) {
+                    changed = true;
+                }
+            }
+        }
+    }
+    reachable
+}
+
+/// Return a sorted copy of a list of ids. Pure helper to mirror
+/// `sortedCopy` from the TS reference (`regression-generator.ts`).
+fn sorted_copy(xs: &[String]) -> Vec<String> {
+    let mut out = xs.to_vec();
+    out.sort();
+    out
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec_api::types::{IrPageSpec, IrState, IrTransition};
+
+    /// Construct a minimal `IrPageSpec` with the given states + transitions.
+    /// Every field outside the test's interest is defaulted to keep call
+    /// sites short.
+    fn mk_ir(
+        id: &str,
+        state_ids: &[&str],
+        transitions: Vec<(&str, Vec<&str>, Vec<&str>)>,
+        initial: Option<&str>,
+    ) -> IrPageSpec {
+        let states: Vec<IrState> = state_ids
+            .iter()
+            .map(|sid| IrState {
+                id: sid.to_string(),
+                name: sid.to_string(),
+                description: None,
+                assertions: Vec::new(),
+                excluded_elements: None,
+                conditions: None,
+                is_initial: None,
+                is_terminal: None,
+                blocking: None,
+                group: None,
+                path_cost: None,
+                precondition: None,
+                element_ids: None,
+                incoming_transitions: None,
+                metadata: None,
+                provenance: None,
+                cross_refs: None,
+            })
+            .collect();
+
+        let transitions: Vec<IrTransition> = transitions
+            .into_iter()
+            .map(|(tid, from, to)| IrTransition {
+                id: tid.to_string(),
+                name: tid.to_string(),
+                description: None,
+                from_states: from.iter().map(|s| s.to_string()).collect(),
+                activate_states: to.iter().map(|s| s.to_string()).collect(),
+                exit_states: None,
+                actions: Vec::new(),
+                path_cost: None,
+                bidirectional: None,
+                effect: None,
+                metadata: None,
+                provenance: None,
+                cross_refs: None,
+            })
+            .collect();
+
+        IrPageSpec {
+            version: "1.0".into(),
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            metadata: None,
+            provenance: None,
+            states,
+            transitions,
+            synthesized_groups: None,
+            initial_state: initial.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn empty_ir_yields_empty_suite_and_zero_coverage() {
+        let ir = mk_ir("empty", &[], vec![], None);
+        let suite = generate_regression_suite(&ir);
+        assert_eq!(suite.cases.len(), 0);
+        assert_eq!(suite.id, "empty@suite");
+
+        let report = coverage_of(&ir, &suite);
+        assert_eq!(report.total_states, 0);
+        assert_eq!(report.total_transitions, 0);
+        assert_eq!(report.states_covered, 0);
+        assert_eq!(report.transitions_covered, 0);
+        assert!(report.reachable_states.is_empty());
+        assert!(report.unreachable_states.is_empty());
+    }
+
+    #[test]
+    fn fully_reachable_chain_marks_every_state_reachable() {
+        // a → b → c, no initial declared (seeds = every state).
+        let ir = mk_ir(
+            "chain",
+            &["a", "b", "c"],
+            vec![("t1", vec!["a"], vec!["b"]), ("t2", vec!["b"], vec!["c"])],
+            None,
+        );
+        let suite = generate_regression_suite(&ir);
+        let report = coverage_of(&ir, &suite);
+        assert_eq!(report.total_states, 3);
+        assert_eq!(report.total_transitions, 2);
+        assert_eq!(report.states_covered, 3);
+        assert_eq!(report.transitions_covered, 2);
+        assert_eq!(report.reachable_states, vec!["a", "b", "c"]);
+        assert!(report.unreachable_states.is_empty());
+    }
+
+    #[test]
+    fn fully_reachable_with_initial_state() {
+        // a → b → c, initial = a.
+        let ir = mk_ir(
+            "chain",
+            &["a", "b", "c"],
+            vec![("t1", vec!["a"], vec!["b"]), ("t2", vec!["b"], vec!["c"])],
+            Some("a"),
+        );
+        let suite = generate_regression_suite(&ir);
+        let report = coverage_of(&ir, &suite);
+        assert_eq!(report.reachable_states, vec!["a", "b", "c"]);
+        assert!(report.unreachable_states.is_empty());
+    }
+
+    #[test]
+    fn disconnected_subgraph_yields_unreachable_states() {
+        // Initial = a; a → b; isolated state x with no incoming.
+        let ir = mk_ir(
+            "disconnect",
+            &["a", "b", "x"],
+            vec![("t1", vec!["a"], vec!["b"])],
+            Some("a"),
+        );
+        let suite = generate_regression_suite(&ir);
+        let report = coverage_of(&ir, &suite);
+        // BFS from `a` only — `x` is unreachable.
+        assert_eq!(report.reachable_states, vec!["a", "b"]);
+        assert_eq!(report.unreachable_states, vec!["x"]);
+        // states_covered counts every state TOUCHED by a case (`from` or
+        // `activate`). Only `t1` exists, touching a + b. x is not touched.
+        assert_eq!(report.states_covered, 2);
+    }
+
+    #[test]
+    fn states_covered_counts_union_across_cases() {
+        // Two transitions: a→b and b→c. Total states touched = {a,b,c} = 3.
+        let ir = mk_ir(
+            "fan",
+            &["a", "b", "c", "d"],
+            vec![("t1", vec!["a"], vec!["b"]), ("t2", vec!["b"], vec!["c"])],
+            None,
+        );
+        let suite = generate_regression_suite(&ir);
+        let report = coverage_of(&ir, &suite);
+        // d is declared but no transition touches it.
+        assert_eq!(report.states_covered, 3);
+        assert_eq!(report.total_states, 4);
+    }
+
+    #[test]
+    fn transitions_sort_deterministically_regardless_of_input_order() {
+        // Insertion order [t2, t1, t3] must produce a suite ordered
+        // [t1, t2, t3] — ordering is a function of sorted ids, not input order.
+        let ir = mk_ir(
+            "sort",
+            &["a", "b", "c", "d"],
+            vec![
+                ("t2", vec!["b"], vec!["c"]),
+                ("t1", vec!["a"], vec!["b"]),
+                ("t3", vec!["c"], vec!["d"]),
+            ],
+            None,
+        );
+        let suite = generate_regression_suite(&ir);
+        let ids: Vec<&str> = suite.cases.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["t1", "t2", "t3"]);
+
+        // Same IR, different insertion order — suite ids must be byte-identical.
+        let ir2 = mk_ir(
+            "sort",
+            &["a", "b", "c", "d"],
+            vec![
+                ("t3", vec!["c"], vec!["d"]),
+                ("t1", vec!["a"], vec!["b"]),
+                ("t2", vec!["b"], vec!["c"]),
+            ],
+            None,
+        );
+        let suite2 = generate_regression_suite(&ir2);
+        let ids2: Vec<&str> = suite2.cases.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids2, vec!["t1", "t2", "t3"]);
+        assert_eq!(suite, suite2);
+    }
+}

--- a/src-tauri/src/workflow_generation/mod.rs
+++ b/src-tauri/src/workflow_generation/mod.rs
@@ -34,6 +34,8 @@ pub mod similar_workflows;
 // Stream E (Flywheel) — coverage-growth loop. Gated behind the
 // `spec-authoring` Cargo feature so default builds never compile it.
 #[cfg(feature = "spec-authoring")]
+pub mod coverage;
+#[cfg(feature = "spec-authoring")]
 pub mod spec_authoring;
 pub mod spec_synthesis;
 pub mod specification;

--- a/src-tauri/src/workflow_generation/spec_authoring.rs
+++ b/src-tauri/src/workflow_generation/spec_authoring.rs
@@ -562,11 +562,11 @@ fn parse_meta_workflow_output(value: &serde_json::Value) -> Result<IrPageSpec, S
 
 /// Per-state required-element additions + new transitions. RFC 7396-style.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-struct IrPatch {
+pub(crate) struct IrPatch {
     #[serde(default)]
-    add_required_elements: BTreeMap<String, Vec<IrElementCriteria>>,
+    pub(crate) add_required_elements: BTreeMap<String, Vec<IrElementCriteria>>,
     #[serde(default)]
-    add_transitions: Vec<IrTransition>,
+    pub(crate) add_transitions: Vec<IrTransition>,
 }
 
 async fn author_patch(
@@ -667,7 +667,10 @@ fn parse_patch_output(value: &serde_json::Value) -> Result<IrPatch, String> {
 ///   are PINNED — patch additions hard-fail.
 /// - Newly added IrTransition / IrElementCriteria get
 ///   `provenance: { source: "ai-generated", status: Proposed }`.
-fn merge_patch_into_ir(mut existing: IrPageSpec, patch: IrPatch) -> Result<IrPageSpec, String> {
+pub(crate) fn merge_patch_into_ir(
+    mut existing: IrPageSpec,
+    patch: IrPatch,
+) -> Result<IrPageSpec, String> {
     // Validate transition ids first so we don't half-apply.
     let mut existing_tx_ids: BTreeSet<String> =
         existing.transitions.iter().map(|t| t.id.clone()).collect();


### PR DESCRIPTION
## Summary

Closes the Stream E (Flywheel) coverage-growth loop on the runner side. Implements **Steps 8, 9, and 11** of [`05-flywheel.md`](https://github.com/qontinui/qontinui-dev-notes/blob/main/spec-check-v1/05-flywheel.md). **Step 10 (supervisor cron)** ships in a parallel PR against `qontinui-supervisor`.

All new code is gated behind the `spec-authoring` Cargo feature; default build behavior unchanged.

### Step 8 — three-gate validator
- `workflow_generation/coverage.rs` (NEW, 378 LOC, 6 tests): Rust port of the TS `regression-generator` (`generateRegressionSuite` + `coverageOf`). Pure graph walk; mirrors `ui-bridge-auto/src/state/regression-generator.ts:523-740`.
- `spec_api/validator.rs` (NEW, 741 LOC, 9 tests): `validate_candidate` runs **distinctness → round-trip → coverage ≥ floor → b-green** (the in-process `spec_check::evaluate` + `factories::strict_all_pass`). `PolicyStatus::Indeterminate` treated as red. Coverage floor configurable via `QONTINUI_SPEC_COVERAGE_FLOOR` (default 0.80).
- `proposals.rs::post_execute` now calls the validator before staging; rejections surface as `outcome: "validator-rejected"` with structured `reason` + `detail`.

### Step 9 — `_pending/` staging + 2-green promotion sweep
- `storage.rs` gains `write_pending_ir` / `read_pending_ir` / `promote_pending` / `demote_pending` + a `page_lock` (lock-by-existence, no new Cargo deps). Writes flip `provenance.status` to `Pending`; `promote_pending` flips to `Promoted` then `rm -rf _pending/`. 446 LOC + 7 tests.
- `proposals.rs` gains **`POST /spec/proposals/sweep-pending`**: re-runs gate-3 only; 2 greens → promote, 1 red → demote+queue, infra error → bump `last_attempt_at` only. Page-lock-serialized.

### Step 11 — closed-loop E2E
- `src-tauri/src/flywheel_e2e_tests.rs` (NEW, unit-test module): 5 tests cover full walk through promotion, demote on single red, scan skipping existing specs, patch preserving hand-authored states, validator rejecting low coverage. The 6th test (concurrent-scan UNIQUE dedup) is gated `--features pg_integration_tests`.

### Cargo
- Adds `qontinui-spec-check` as an optional dep; `spec-authoring` feature now includes it.

### Symbol-visibility widenings (for the E2E module)
- `spec_authoring::IrPatch` and `merge_patch_into_ir` → `pub(crate)`
- `validator::gate_coverage` and `gate_b_execution_green_with_snapshot` → `pub(crate)`
- `storage::PageLockGuard` gets `#[derive(Debug)]`

### Carryover into a follow-up (none blocking)

The skeleton-fingerprint-stash carryover from PR #149 (fingerprints in `IrState.excluded_elements` vs canonical `assertions`) **still applies** — Step 4's AI fill-in pass is supposed to relocate them, and Step 8's gate-3 will surface failure to do so via the b-green gate. Pre-existing TODO at `spec_authoring.rs:336-340`. Not blocking ship of Steps 8-11; tracked in the plan stamp.

## Test plan

- [x] `cargo check --bin qontinui-runner` (default features) — passes
- [x] `cargo check --bin qontinui-runner --features spec-authoring` — passes
- [x] `cargo test --features spec-authoring workflow_generation::coverage` — 6 green
- [x] `cargo test --features spec-authoring spec_api::validator` — 9 green
- [x] `cargo test --features spec-authoring spec_api::storage::pending_tests` — 7 green
- [x] `cargo test --features spec-authoring flywheel_e2e_tests` — 5 green
- [x] `cargo fmt --check` — clean
- [ ] CI: cargo fmt + clippy + the broader test suite (let GitHub Actions confirm)
