### PR TITLE
feat(spec-api): clean degenerate-spec corpus + enforce distinctness unconditionally

### DIFF
--- a/specs/pages/opik-integration/state-machine.derived.json
+++ b/specs/pages/opik-integration/state-machine.derived.json
@@ -42,7 +42,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "status",
+              "textContains": "Opik"
+            },
             "label": "Required element for Semantic — Purpose & Communication"
           },
           "source": "migrated",
@@ -57,7 +60,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "traces"
+            },
             "label": "Required element for Semantic — Purpose & Communication"
           },
           "source": "migrated",
@@ -72,7 +77,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "$"
+            },
             "label": "Required element for Semantic — Purpose & Communication"
           },
           "source": "migrated",
@@ -98,7 +105,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "heading"
+            },
             "label": "Required element for Element Presence — Required UI Controls"
           },
           "source": "migrated",
@@ -130,7 +139,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "combobox"
+            },
             "label": "Required element for Element Presence — Required UI Controls"
           },
           "source": "migrated",
@@ -145,7 +156,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "table"
+            },
             "label": "Required element for Element Presence — Required UI Controls"
           },
           "source": "migrated",
@@ -160,7 +173,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "columnheader"
+            },
             "label": "Required element for Element Presence — Required UI Controls"
           },
           "source": "migrated",
@@ -175,7 +190,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "complementary"
+            },
             "label": "Required element for Element Presence — Required UI Controls"
           },
           "source": "migrated",
@@ -235,7 +252,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "$"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -250,7 +269,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "ms"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -265,7 +286,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "tokens"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -280,7 +303,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "tree"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -295,7 +320,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "treeitem"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -310,7 +337,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "tagName": "code"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -325,7 +354,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "ago"
+            },
             "label": "Required element for Data Display — Formatting & Presentation"
           },
           "source": "migrated",
@@ -351,7 +382,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "searchbox"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -366,7 +399,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "combobox"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -381,7 +416,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "row"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -396,7 +433,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "treeitem"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -411,7 +450,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Add feedback"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -426,7 +468,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Close"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -441,7 +486,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Refresh"
+            },
             "label": "Required element for Interaction — User Actions & Responses"
           },
           "source": "migrated",
@@ -484,7 +532,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "progressbar"
+            },
             "label": "Required element for Behavior — Loading, Empty, Error, & Auto-refresh States"
           },
           "source": "migrated",
@@ -499,7 +549,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "alert",
+              "textContains": "Opik unavailable"
+            },
             "label": "Required element for Behavior — Loading, Empty, Error, & Auto-refresh States"
           },
           "source": "migrated",
@@ -514,7 +567,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Auto-refresh"
+            },
             "label": "Required element for Behavior — Loading, Empty, Error, & Auto-refresh States"
           },
           "source": "migrated",
@@ -540,7 +595,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "status",
+              "textContains": "Synced"
+            },
             "label": "Required element for State Consistency — Local ↔ Opik Data Agreement"
           },
           "source": "migrated",
@@ -555,7 +613,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "fallback"
+            },
             "label": "Required element for State Consistency — Local ↔ Opik Data Agreement"
           },
           "source": "migrated",
@@ -570,7 +630,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Last synced"
+            },
             "label": "Required element for State Consistency — Local ↔ Opik Data Agreement"
           },
           "source": "migrated",
@@ -614,7 +676,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "navigation"
+            },
             "label": "Required element for Navigation — Page Access & Internal Navigation"
           },
           "source": "migrated",
@@ -629,7 +693,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "complementary",
+              "ariaLabel": "Trace detail panel"
+            },
             "label": "Required element for Navigation — Page Access & Internal Navigation"
           },
           "source": "migrated",
@@ -655,7 +722,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "main"
+            },
             "label": "Required element for Style — Visual Design & Theming"
           },
           "source": "migrated",
@@ -670,7 +739,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "heading",
+              "tag": "h1"
+            },
             "label": "Required element for Style — Visual Design & Theming"
           },
           "source": "migrated",
@@ -685,7 +757,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "row"
+            },
             "label": "Required element for Style — Visual Design & Theming"
           },
           "source": "migrated",

--- a/specs/pages/run-feedback-costs/state-machine.derived.json
+++ b/specs/pages/run-feedback-costs/state-machine.derived.json
@@ -633,7 +633,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "tab"
+            },
             "label": "Required element for Tab Navigation"
           },
           "source": "migrated",
@@ -648,7 +650,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "tablist"
+            },
             "label": "Required element for Tab Navigation"
           },
           "source": "migrated",
@@ -690,7 +694,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "generic"
+            },
             "label": "Required element for Element Presence"
           },
           "source": "migrated",
@@ -705,7 +711,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "progressbar"
+            },
             "label": "Required element for Element Presence"
           },
           "source": "migrated",
@@ -720,7 +728,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "status"
+            },
             "label": "Required element for Element Presence"
           },
           "source": "migrated",
@@ -753,7 +763,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "cell"
+            },
             "label": "Required element for Element Presence"
           },
           "source": "migrated",
@@ -778,7 +790,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "progressbar"
+            },
             "label": "Required element for Data Display Formatting"
           },
           "source": "migrated",
@@ -844,7 +858,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "row"
+            },
             "label": "Required element for Data Display Formatting"
           },
           "source": "migrated",
@@ -932,7 +948,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "text": "Avg Score"
+            },
             "label": "Required element for State Consistency"
           },
           "source": "migrated",
@@ -947,7 +965,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "text": "Total Cost"
+            },
             "label": "Required element for State Consistency"
           },
           "source": "migrated",
@@ -962,7 +982,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Automated"
+            },
             "label": "Required element for State Consistency"
           },
           "source": "migrated",
@@ -977,7 +999,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "row"
+            },
             "label": "Required element for State Consistency"
           },
           "source": "migrated",

--- a/specs/pages/settings-log-sources/state-machine.derived.json
+++ b/specs/pages/settings-log-sources/state-machine.derived.json
@@ -50,7 +50,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "region"
+            },
             "label": "Required element for Page Structure"
           },
           "source": "migrated",
@@ -175,7 +177,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "heading",
+              "text": "AI Source Selection"
+            },
             "label": "Required element for AI Source Selection Section"
           },
           "source": "migrated",
@@ -190,7 +195,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "radiogroup"
+            },
             "label": "Required element for AI Source Selection Section"
           },
           "source": "migrated",
@@ -222,7 +229,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "text": "Dynamic"
+            },
             "label": "Required element for AI Source Selection Section"
           },
           "source": "migrated",
@@ -248,7 +257,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "heading",
+              "textPattern": "Log Sources \\(\\d+\\)"
+            },
             "label": "Required element for Log Sources Section"
           },
           "source": "migrated",
@@ -298,7 +310,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "checkbox"
+            },
             "label": "Required element for Log Sources Section"
           },
           "source": "migrated",
@@ -313,7 +327,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "ariaLabel": "Edit source"
+            },
             "label": "Required element for Log Sources Section"
           },
           "source": "migrated",
@@ -339,7 +355,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "heading",
+              "textPattern": "Profiles \\(\\d+\\)"
+            },
             "label": "Required element for Profiles Section"
           },
           "source": "migrated",
@@ -371,7 +390,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Add Profile"
+            },
             "label": "Required element for Profiles Section"
           },
           "source": "migrated",
@@ -710,7 +732,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "radio",
+              "text": "Dynamic"
+            },
             "label": "Required element for AI Source Selection — Runtime Semantics"
           },
           "source": "migrated",
@@ -725,7 +750,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "radio",
+              "text": "Static"
+            },
             "label": "Required element for AI Source Selection — Runtime Semantics"
           },
           "source": "migrated",
@@ -740,7 +768,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "radio",
+              "text": "Disabled"
+            },
             "label": "Required element for AI Source Selection — Runtime Semantics"
           },
           "source": "migrated",
@@ -766,7 +797,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "text": "Default"
+            },
             "label": "Required element for Profile Default and Count Semantics"
           },
           "source": "migrated",
@@ -781,7 +814,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "sources enabled"
+            },
             "label": "Required element for Profile Default and Count Semantics"
           },
           "source": "migrated",
@@ -796,7 +831,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Set Default"
+            },
             "label": "Required element for Profile Default and Count Semantics"
           },
           "source": "migrated",
@@ -822,7 +860,12 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "tag": "span",
+              "attributes": {
+                "data-badge": "format"
+              }
+            },
             "label": "Required element for Log Source Data Model"
           },
           "source": "migrated",
@@ -837,7 +880,12 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "tag": "span",
+              "attributes": {
+                "data-badge": "parser"
+              }
+            },
             "label": "Required element for Log Source Data Model"
           },
           "source": "migrated",
@@ -852,7 +900,12 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "tag": "span",
+              "attributes": {
+                "data-badge": "category"
+              }
+            },
             "label": "Required element for Log Source Data Model"
           },
           "source": "migrated",

--- a/specs/pages/settings-mcp/state-machine.derived.json
+++ b/specs/pages/settings-mcp/state-machine.derived.json
@@ -202,7 +202,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Expand server card"
+            },
             "label": "Required element for Server Card Structure"
           },
           "source": "migrated",
@@ -217,7 +220,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Edit server"
+            },
             "label": "Required element for Server Card Structure"
           },
           "source": "migrated",
@@ -232,7 +238,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Delete server"
+            },
             "label": "Required element for Server Card Structure"
           },
           "source": "migrated",
@@ -258,7 +267,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "Connected"
+            },
             "label": "Required element for Connection Status Indicators"
           },
           "source": "migrated",
@@ -273,7 +284,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "Disconnected"
+            },
             "label": "Required element for Connection Status Indicators"
           },
           "source": "migrated",
@@ -288,7 +301,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "Error"
+            },
             "label": "Required element for Connection Status Indicators"
           },
           "source": "migrated",
@@ -303,7 +318,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "Connection status indicator"
+            },
             "label": "Required element for Connection Status Indicators"
           },
           "source": "migrated",
@@ -391,7 +408,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Connect server"
+            },
             "label": "Required element for Connect / Disconnect Actions"
           },
           "source": "migrated",
@@ -406,7 +426,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Disconnect server"
+            },
             "label": "Required element for Connect / Disconnect Actions"
           },
           "source": "migrated",
@@ -421,7 +444,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "Connecting"
+            },
             "label": "Required element for Connect / Disconnect Actions"
           },
           "source": "migrated",
@@ -447,7 +472,11 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "attributes": {
+                "data-content-label": "tool name"
+              }
+            },
             "label": "Required element for Expanded Server Tools List"
           },
           "source": "migrated",
@@ -462,7 +491,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "No tools available"
+            },
             "label": "Required element for Expanded Server Tools List"
           },
           "source": "migrated",
@@ -494,7 +525,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "Expanded Server Tools List"
+            },
             "label": "Required element for Expanded Server Tools List"
           },
           "source": "migrated",
@@ -806,7 +839,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "ariaLabel": "Edit server"
+            },
             "label": "Required element for Edit Server Flow"
           },
           "source": "migrated",
@@ -972,7 +1008,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "accessibleName": "MCP server configuration"
+            },
             "label": "Required element for MCP Server Data Model"
           },
           "source": "migrated",

--- a/specs/pages/specs/state-machine.derived.json
+++ b/specs/pages/specs/state-machine.derived.json
@@ -132,7 +132,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Bundled"
+            },
             "label": "Required element for Connection Bar — Spec Loading Controls"
           },
           "source": "migrated",
@@ -147,7 +150,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "File"
+            },
             "label": "Required element for Connection Bar — Spec Loading Controls"
           },
           "source": "migrated",
@@ -162,7 +168,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "textbox",
+              "textContains": "localhost:3001"
+            },
             "label": "Required element for Connection Bar — Spec Loading Controls"
           },
           "source": "migrated",
@@ -177,7 +186,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Discover"
+            },
             "label": "Required element for Connection Bar — Spec Loading Controls"
           },
           "source": "migrated",
@@ -192,7 +204,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "ariaLabel": "BookOpen"
+            },
             "label": "Required element for Connection Bar — Spec Loading Controls"
           },
           "source": "migrated",
@@ -207,7 +221,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "ariaLabel": "FolderOpen"
+            },
             "label": "Required element for Connection Bar — Spec Loading Controls"
           },
           "source": "migrated",
@@ -232,7 +248,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Edit"
+            },
             "label": "Required element for Connection Bar — Spec Action Controls"
           },
           "source": "migrated",
@@ -247,7 +266,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Save"
+            },
             "label": "Required element for Connection Bar — Spec Action Controls"
           },
           "source": "migrated",
@@ -262,7 +284,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "AI Eval"
+            },
             "label": "Required element for Connection Bar — Spec Action Controls"
           },
           "source": "migrated",
@@ -277,7 +302,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "textContains": "Regression"
+            },
             "label": "Required element for Connection Bar — Spec Action Controls"
           },
           "source": "migrated",
@@ -292,7 +320,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "switch",
+              "id": "specs-ai-toggle"
+            },
             "label": "Required element for Connection Bar — Spec Action Controls"
           },
           "source": "migrated",
@@ -414,7 +445,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Compiling state machine"
+            },
             "label": "Required element for Sync Progress Banner"
           },
           "source": "migrated",
@@ -1035,7 +1068,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Build Workflow"
+            },
             "label": "Required element for Build Workflow Pipeline"
           },
           "source": "migrated",
@@ -1050,7 +1086,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "switch",
+              "id": "specs-ai-toggle"
+            },
             "label": "Required element for Build Workflow Pipeline"
           },
           "source": "migrated",
@@ -1065,7 +1104,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Generating"
+            },
             "label": "Required element for Build Workflow Pipeline"
           },
           "source": "migrated",
@@ -1135,7 +1176,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "id": "specs-btn-compile-sm"
+            },
             "label": "Required element for Compile State Machine"
           },
           "source": "migrated",
@@ -1150,7 +1194,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "text": "Compile State Machine"
+            },
             "label": "Required element for Compile State Machine"
           },
           "source": "migrated",
@@ -1176,7 +1222,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "File"
+            },
             "label": "Required element for File Loading and Saving"
           },
           "source": "migrated",
@@ -1191,7 +1240,10 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "button",
+              "text": "Save"
+            },
             "label": "Required element for File Loading and Saving"
           },
           "source": "migrated",
@@ -1206,7 +1258,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "File"
+            },
             "label": "Required element for File Loading and Saving"
           },
           "source": "migrated",
@@ -1249,7 +1303,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "id": "specs-ai-toggle"
+            },
             "label": "Required element for AI Spec-Brief Toggle"
           },
           "source": "migrated",

--- a/specs/pages/visual-dashboard/state-machine.derived.json
+++ b/specs/pages/visual-dashboard/state-machine.derived.json
@@ -15,7 +15,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "banner"
+            },
             "label": "Required element for Page Structure — Fixed Bars and Content Area"
           },
           "source": "migrated",
@@ -30,7 +32,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "main"
+            },
             "label": "Required element for Page Structure — Fixed Bars and Content Area"
           },
           "source": "migrated",
@@ -45,7 +49,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "contentinfo"
+            },
             "label": "Required element for Page Structure — Fixed Bars and Content Area"
           },
           "source": "migrated",
@@ -188,7 +194,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "banner"
+            },
             "label": "Required element for Control Bar — Task Name and Phase"
           },
           "source": "migrated",
@@ -203,7 +211,11 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "attributes": {
+                "data-content-label": "task name"
+              }
+            },
             "label": "Required element for Control Bar — Task Name and Phase"
           },
           "source": "migrated",
@@ -218,7 +230,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "RUNNING"
+            },
             "label": "Required element for Control Bar — Task Name and Phase"
           },
           "source": "migrated",
@@ -244,7 +258,11 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "attributes": {
+                "data-content-label": "setup stage"
+              }
+            },
             "label": "Required element for Control Bar — Orchestrated Workflow Stage Pills"
           },
           "source": "migrated",
@@ -259,7 +277,11 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "attributes": {
+                "data-content-label": "agentic stage"
+              }
+            },
             "label": "Required element for Control Bar — Orchestrated Workflow Stage Pills"
           },
           "source": "migrated",
@@ -274,7 +296,11 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "attributes": {
+                "data-content-label": "verification stage"
+              }
+            },
             "label": "Required element for Control Bar — Orchestrated Workflow Stage Pills"
           },
           "source": "migrated",
@@ -417,7 +443,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "contentinfo"
+            },
             "label": "Required element for Bottom Bar — Real-Time Status Metrics"
           },
           "source": "migrated",
@@ -432,7 +460,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Elapsed"
+            },
             "label": "Required element for Bottom Bar — Real-Time Status Metrics"
           },
           "source": "migrated",
@@ -447,7 +477,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Orchestrator"
+            },
             "label": "Required element for Bottom Bar — Real-Time Status Metrics"
           },
           "source": "migrated",
@@ -462,7 +494,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "textContains": "Updated"
+            },
             "label": "Required element for Bottom Bar — Real-Time Status Metrics"
           },
           "source": "migrated",
@@ -477,7 +511,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "status"
+            },
             "label": "Required element for Bottom Bar — Real-Time Status Metrics"
           },
           "source": "migrated",
@@ -699,7 +735,11 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "attributes": {
+                "data-content-label": "breakpoint step"
+              }
+            },
             "label": "Required element for Control Bar — Breakpoint Pause Indicator"
           },
           "source": "migrated",
@@ -1002,7 +1042,9 @@
           "assertionType": "exists",
           "target": {
             "type": "search",
-            "criteria": {},
+            "criteria": {
+              "role": "tooltip"
+            },
             "label": "Required element for Keyboard Shortcuts"
           },
           "source": "migrated",

--- a/src-tauri/src/spec_api/handlers.rs
+++ b/src-tauri/src/spec_api/handlers.rs
@@ -37,15 +37,6 @@ use super::storage::{self, ReadWithinRootError};
 use super::types::IrPageSpec;
 use qontinui_types::spec_check::SpecValidation;
 
-/// Feature flag for `POST /spec/derive`: when set, the endpoint hard-stops
-/// on distinctness violations. Default off for the first 30 days post-ship
-/// per Plan 04 Step 5 — gives the corpus cleanup pass (Path A) runway.
-fn enforce_distinctness_on_derive() -> bool {
-    std::env::var("QONTINUI_SPEC_DISTINCTNESS_ENFORCE_ON_DERIVE")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-}
-
 // ---------------------------------------------------------------------------
 // GET /spec/get?path=<rel>
 // ---------------------------------------------------------------------------
@@ -454,21 +445,12 @@ pub async fn post_derive(
     State(_state): State<Arc<ApiState>>,
     Json(body): Json<DeriveBody>,
 ) -> Response {
-    build_derive_response(
-        &storage::resolve_specs_root(),
-        body,
-        enforce_distinctness_on_derive(),
-    )
+    build_derive_response(&storage::resolve_specs_root(), body)
 }
 
 /// Inner implementation of `post_derive` parameterized by the storage root
-/// and the distinctness-enforce toggle (tests pass the flag explicitly to
-/// avoid env-var races under cargo's parallel test runner).
-pub(crate) fn build_derive_response(
-    root: &std::path::Path,
-    body: DeriveBody,
-    enforce_distinctness: bool,
-) -> Response {
+/// so tests can inject a temp directory.
+pub(crate) fn build_derive_response(root: &std::path::Path, body: DeriveBody) -> Response {
     let doc = match storage::read_ir(root, &body.page_id) {
         Ok(Some(d)) => d,
         Ok(None) => {
@@ -493,22 +475,18 @@ pub(crate) fn build_derive_response(
         }
     };
 
-    // Plan 04 Step 5 — feature-flagged distinctness enforcement on derive.
-    // Default off; flipped to on after the corpus cleanup pass (Step 9) lands.
-    if enforce_distinctness {
-        if let Err(report) = distinctness::validate(&doc) {
-            return (
-                StatusCode::UNPROCESSABLE_ENTITY,
-                Json(SpecError::with_detail(
-                    "spec-validation-failed",
-                    json!({
-                        "pageId": body.page_id,
-                        "violations": report.violations,
-                    }),
-                )),
-            )
-                .into_response();
-        }
+    if let Err(report) = distinctness::validate(&doc) {
+        return (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(SpecError::with_detail(
+                "spec-validation-failed",
+                json!({
+                    "pageId": body.page_id,
+                    "violations": report.violations,
+                }),
+            )),
+        )
+            .into_response();
     }
 
     match body.derivation.as_str() {

--- a/src-tauri/src/spec_api/tests.rs
+++ b/src-tauri/src/spec_api/tests.rs
@@ -681,11 +681,11 @@ mod handler_tests {
     }
 
     // ------------------------------------------------------------------------
-    // 7. post_derive_respects_feature_flag
+    // 7. post_derive_rejects_degenerate_ir
     // ------------------------------------------------------------------------
 
     #[tokio::test]
-    async fn post_derive_respects_feature_flag() {
+    async fn post_derive_rejects_degenerate_ir() {
         let tmp = tempfile::tempdir().unwrap();
         // Seed a degenerate IR on disk.
         let doc = degenerate_doc("derive-degen");
@@ -697,27 +697,11 @@ mod handler_tests {
         )
         .unwrap();
 
-        // Flag OFF — derivation succeeds despite degenerate IR.
-        let body_off = DeriveBody {
+        let body = DeriveBody {
             page_id: "derive-degen".to_string(),
             derivation: "incomingTransitions".to_string(),
         };
-        let resp = build_derive_response(tmp.path(), body_off, false);
-        let (status, v) = response_to_json(resp).await;
-        assert_eq!(
-            status,
-            axum::http::StatusCode::OK,
-            "with flag off, derive should succeed; body={}",
-            v
-        );
-        assert_eq!(v["ok"], true);
-
-        // Flag ON — derivation rejects with 422.
-        let body_on = DeriveBody {
-            page_id: "derive-degen".to_string(),
-            derivation: "incomingTransitions".to_string(),
-        };
-        let resp = build_derive_response(tmp.path(), body_on, true);
+        let resp = build_derive_response(tmp.path(), body);
         let (status, v) = response_to_json(resp).await;
         assert_eq!(status, axum::http::StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(v["ok"], false);


### PR DESCRIPTION
## Summary

- Cleans the last 6 dirty specs (115 empty-criteria violations across `opik-integration`, `run-feedback-costs`, `settings-log-sources`, `settings-mcp`, `specs`, `visual-dashboard`) by adding `role` / `text` / `ariaLabel` discriminators to previously-empty `IrElementCriteria` objects. Scanner now reports **96/96 clean** (was 90/96).
- Removes the 30-day-default-off feature flag (`QONTINUI_SPEC_DISTINCTNESS_ENFORCE_ON_DERIVE`). With the corpus distinctness-clean, `POST /spec/derive` now enforces unconditionally. `enforce_distinctness_on_derive()` helper deleted; the `enforce_distinctness` param dropped from `build_derive_response`; conditional unwrapped.
- Per Plan 04 §5.12 and the "delete over deprecate" principle in `CLAUDE.md`.

## Test plan

- [x] Scanner: `cargo run --bin scan_spec_distinctness -- --json` reports `any_violation: 0`, `clean: 96`
- [x] Unit test: `cargo test --bin qontinui-runner post_derive_rejects_degenerate_ir` passes (renamed from `post_derive_respects_feature_flag` since the two-case fork is gone)
- [x] `cargo check --bin qontinui-runner` clean
- [ ] CI green