### PR TITLE
feat(spec-api): wire 5 SpecApiEvent emit callsites (Plan 06 closure)

### DIFF
--- a/src-tauri/src/spec_api/proposals.rs
+++ b/src-tauri/src/spec_api/proposals.rs
@@ -40,8 +40,10 @@ use tracing::{debug, info, warn};
 use crate::commands::spec_drift::RegisteredElement;
 use crate::database::pg::spec_proposals::SpecProposalRow;
 use crate::mcp::types::ApiState;
+use crate::spec_api::events;
 use crate::spec_api::responses::SpecError;
 use crate::spec_api::storage;
+use qontinui_types::spec_api_events::SpecApiEvent;
 
 // =============================================================================
 // Scan endpoint — POST /spec/proposals/scan
@@ -720,7 +722,7 @@ pub async fn post_sweep_pending(State(state): State<Arc<ApiState>>) -> Response 
         .await;
 
         match gate_result {
-            Ok(_) => {
+            Ok(green_result) => {
                 let new_greens = prop.consecutive_greens.saturating_add(1);
                 if new_greens >= 2 {
                     // Promote.
@@ -729,6 +731,15 @@ pub async fn post_sweep_pending(State(state): State<Arc<ApiState>>) -> Response 
                             let _ = pg_db.update_proposal_status(&prop.id, "promoted").await;
                             let _ = pg_db.update_proposal_attempt_only(&prop.id).await;
                             promoted += 1;
+                            // Plan 06: Promoted emit — joins via snapshot_id
+                            // against the green run that triggered it.
+                            events::emit(SpecApiEvent::FlywheelProposalPromoted {
+                                proposal_id: prop.id.clone(),
+                                page_id: spec_id.clone(),
+                                consecutive_greens: new_greens.max(0) as u32,
+                                snapshot_id: green_result.snapshot_id.clone(),
+                                at_ms: events::now_ms(),
+                            });
                             info!(
                                 "post_sweep_pending: promoted {} (spec_id={})",
                                 prop.id, spec_id
@@ -757,6 +768,8 @@ pub async fn post_sweep_pending(State(state): State<Arc<ApiState>>) -> Response 
             }
             Err(crate::spec_api::validator::ValidatorError::BExecutionRed {
                 result_summary,
+                snapshot_id: red_snapshot_id,
+                failing_assertion,
                 ..
             }) => {
                 let detail = format!(
@@ -781,6 +794,20 @@ pub async fn post_sweep_pending(State(state): State<Arc<ApiState>>) -> Response 
                     .await;
                 let _ = pg_db.update_proposal_greens(&prop.id, 0).await;
                 demoted += 1;
+                // Plan 06: Demoted emit. `failing_assertion` is `None` only
+                // when the red came from policy `Indeterminate` over an
+                // empty-in-scope assertion set — emit empty-string locator
+                // in that case so the wire shape stays uniform.
+                let (failing_state_id, failing_assertion_id) =
+                    failing_assertion.unwrap_or_default();
+                events::emit(SpecApiEvent::FlywheelProposalDemoted {
+                    proposal_id: prop.id.clone(),
+                    page_id: spec_id.clone(),
+                    failing_assertion_id,
+                    failing_state_id,
+                    snapshot_id: red_snapshot_id,
+                    at_ms: events::now_ms(),
+                });
                 info!(
                     "post_sweep_pending: demoted {} (spec_id={}): {}",
                     prop.id, spec_id, detail

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -20,11 +20,55 @@ use tokio::task::JoinSet;
 use tracing::{info, warn};
 
 use crate::mcp::types::ApiState;
+use crate::spec_api::events;
 use crate::spec_api::responses::SpecError;
 use crate::spec_api::storage;
 use qontinui_spec_check as spec_check; // crate name = "qontinui-spec-check"
-use qontinui_types::spec_check::{PolicyEvaluation, SpecCheckPolicy, SpecCheckResult};
+use qontinui_types::spec_api_events::SpecApiEvent;
+use qontinui_types::spec_check::{
+    MatchOutcome, PolicyEvaluation, SpecCheckPolicy, SpecCheckResult,
+};
 use qontinui_types::ui_bridge::UIBridgeSnapshot; // capital UI; lives in ui_bridge
+
+/// Wall-clock at evaluator entry → end. Carried into `SpecCheckCompleted`'s
+/// `total_duration_ms` field. Sync-only — the evaluator itself is sync.
+fn invoke_emit(snapshot_id: &str, page_ids: Vec<String>, invoked_via: &str) {
+    events::emit(SpecApiEvent::SpecCheckInvoked {
+        snapshot_id: snapshot_id.to_string(),
+        page_ids,
+        invoked_via: invoked_via.to_string(),
+        at_ms: events::now_ms(),
+    });
+}
+
+/// Roll up a single `SpecCheckResult` (or many) into the `SpecCheckCompleted`
+/// counts. `page_count` is the input count — `eval_error_count` is the
+/// difference between input and successfully-evaluated results (only meaningful
+/// for the batch path).
+fn completion_counts(
+    results: &[&SpecCheckResult],
+    input_page_count: usize,
+) -> (usize, usize, usize, usize, f32) {
+    let mut perfect = 0;
+    let mut partial = 0;
+    let mut no_match = 0;
+    let mut rate_sum = 0f32;
+    for r in results {
+        match r.summary.match_outcome {
+            MatchOutcome::FullMatch => perfect += 1,
+            MatchOutcome::PartialMatch => partial += 1,
+            MatchOutcome::NoMatch => no_match += 1,
+        }
+        rate_sum += r.summary.overall_match_rate;
+    }
+    let eval_error = input_page_count.saturating_sub(results.len());
+    let overall = if results.is_empty() {
+        0.0
+    } else {
+        rate_sum / results.len() as f32
+    };
+    (perfect, partial, no_match, eval_error, overall)
+}
 
 // ===========================================================================
 // Shared snapshot fetch + error mapping
@@ -229,6 +273,11 @@ pub async fn post_spec_check(
         },
     };
 
+    // Plan 06: emit Invoked before the (potentially slow) evaluator runs so
+    // subscribers can correlate `snapshot_id` against tracing spans.
+    invoke_emit(&snapshot_id, vec![req.page_id.clone()], "http");
+    let started_ms = events::now_ms();
+
     // Evaluate — pure crate call, no logic here.
     let result = spec_check::evaluate(&snapshot, &ir);
 
@@ -236,6 +285,22 @@ pub async fn post_spec_check(
         "spec_check page_id={} snapshot_id={} match_outcome={:?} match_rate={:.3}",
         req.page_id, snapshot_id, result.summary.match_outcome, result.summary.overall_match_rate
     );
+
+    // Plan 06: emit Completed after the evaluator returns. The full result
+    // body stays out of the broadcast (subscribers join by snapshot_id).
+    let (perfect, partial, no_match, eval_error, overall_rate) = completion_counts(&[&result], 1);
+    let completed_ms = events::now_ms();
+    events::emit(SpecApiEvent::SpecCheckCompleted {
+        snapshot_id: snapshot_id.clone(),
+        page_count: 1,
+        overall_match_rate: overall_rate,
+        perfect_match_count: perfect,
+        partial_match_count: partial,
+        no_match_count: no_match,
+        eval_error_count: eval_error,
+        total_duration_ms: completed_ms.saturating_sub(started_ms),
+        at_ms: completed_ms,
+    });
 
     (StatusCode::OK, Json(result)).into_response()
 }
@@ -336,6 +401,13 @@ pub async fn post_spec_check_batch(
         snapshot_id
     );
 
+    // Plan 06: emit Invoked once for the batch. Both the streaming and
+    // collected paths reach the evaluator below.
+    let input_page_count = req.pages.len();
+    let page_ids: Vec<String> = req.pages.iter().map(|p| p.page_id.clone()).collect();
+    invoke_emit(&snapshot_id, page_ids, "http");
+    let batch_started_ms = events::now_ms();
+
     if req.stream {
         return stream_batch_results(snapshot, snapshot_id, root, req.pages, req.shared_policy)
             .await;
@@ -363,6 +435,28 @@ pub async fn post_spec_check_batch(
     }
     // Stable order by input pageId for determinism.
     results.sort_by(|a, b| a.page_id.cmp(&b.page_id));
+
+    // Plan 06: emit Completed once after all per-element evaluations have
+    // landed. The `eval_error_count` derives from input vs successfully-evaluated.
+    let ok_results: Vec<&SpecCheckResult> = results
+        .iter()
+        .filter(|r| r.status == "ok")
+        .filter_map(|r| r.result.as_ref())
+        .collect();
+    let (perfect, partial, no_match, eval_error, overall_rate) =
+        completion_counts(&ok_results, input_page_count);
+    let completed_ms = events::now_ms();
+    events::emit(SpecApiEvent::SpecCheckCompleted {
+        snapshot_id: snapshot_id.clone(),
+        page_count: input_page_count,
+        overall_match_rate: overall_rate,
+        perfect_match_count: perfect,
+        partial_match_count: partial,
+        no_match_count: no_match,
+        eval_error_count: eval_error,
+        total_duration_ms: completed_ms.saturating_sub(batch_started_ms),
+        at_ms: completed_ms,
+    });
 
     (
         StatusCode::OK,
@@ -480,13 +574,78 @@ async fn stream_batch_results(
     pages: Vec<BatchPageEntry>,
     shared_policy: Option<SpecCheckPolicy>,
 ) -> Response {
-    let body_stream = stream::unfold(pages.into_iter(), move |mut it| {
+    // Plan 06: stream-path Completed emission. Accumulate counts as we
+    // walk each item, then emit on stream end (when the inner iterator is
+    // exhausted). The `started_ms` is captured outside the unfold so it's
+    // consistent with the Invoked emit in the caller.
+    let input_page_count = pages.len();
+    let started_ms = events::now_ms();
+    let snapshot_id_for_completion = snapshot_id.clone();
+    struct StreamState {
+        iter: std::vec::IntoIter<BatchPageEntry>,
+        perfect: usize,
+        partial: usize,
+        no_match: usize,
+        eval_error: usize,
+        rate_sum: f32,
+        ok_count: usize,
+        emitted: bool,
+    }
+    let initial = StreamState {
+        iter: pages.into_iter(),
+        perfect: 0,
+        partial: 0,
+        no_match: 0,
+        eval_error: 0,
+        rate_sum: 0.0,
+        ok_count: 0,
+        emitted: false,
+    };
+    let body_stream = stream::unfold(initial, move |mut st| {
         let snapshot = snapshot.clone();
         let root = root.clone();
         let shared_policy = shared_policy.clone();
+        let snap_id = snapshot_id_for_completion.clone();
         async move {
-            let entry = it.next()?;
+            let entry = match st.iter.next() {
+                Some(e) => e,
+                None => {
+                    if !st.emitted {
+                        let overall = if st.ok_count == 0 {
+                            0.0
+                        } else {
+                            st.rate_sum / st.ok_count as f32
+                        };
+                        let completed_ms = events::now_ms();
+                        events::emit(SpecApiEvent::SpecCheckCompleted {
+                            snapshot_id: snap_id,
+                            page_count: input_page_count,
+                            overall_match_rate: overall,
+                            perfect_match_count: st.perfect,
+                            partial_match_count: st.partial,
+                            no_match_count: st.no_match,
+                            eval_error_count: st.eval_error,
+                            total_duration_ms: completed_ms.saturating_sub(started_ms),
+                            at_ms: completed_ms,
+                        });
+                        st.emitted = true;
+                    }
+                    return None;
+                }
+            };
             let r = evaluate_one(&root, &entry, &snapshot, shared_policy.as_ref()).await;
+            match (r.status, r.result.as_ref()) {
+                ("ok", Some(res)) => {
+                    st.ok_count += 1;
+                    st.rate_sum += res.summary.overall_match_rate;
+                    match res.summary.match_outcome {
+                        MatchOutcome::FullMatch => st.perfect += 1,
+                        MatchOutcome::PartialMatch => st.partial += 1,
+                        MatchOutcome::NoMatch => st.no_match += 1,
+                    }
+                }
+                _ => st.eval_error += 1,
+            }
             let mut line = match serde_json::to_vec(&r) {
                 Ok(v) => v,
                 Err(e) => {
@@ -495,7 +654,7 @@ async fn stream_batch_results(
                 }
             };
             line.push(b'\n');
-            Some((Ok::<_, std::io::Error>(line), it))
+            Some((Ok::<_, std::io::Error>(line), st))
         }
     });
     match Response::builder()
@@ -708,5 +867,101 @@ mod tests {
             serde_json::from_value(json!({ "page_id": "settings-general" })).unwrap();
         assert_eq!(req.page_id, "settings-general");
         assert!(req.snapshot.is_none());
+    }
+
+    // ------------------------------------------------------------------------
+    // Plan 06 — emit-callsite helpers
+    // ------------------------------------------------------------------------
+
+    /// Drain any pre-existing events on the broadcast (cross-test
+    /// contamination) and recv up to `max_attempts` items, returning the
+    /// first one whose `snapshot_id` matches the supplied marker.
+    /// Defensive against parallel-test interference on the singleton.
+    fn recv_matching_invoked(
+        rx: &mut tokio::sync::broadcast::Receiver<SpecApiEvent>,
+        marker: &str,
+        max_attempts: usize,
+    ) -> Option<SpecApiEvent> {
+        for _ in 0..max_attempts {
+            match rx.try_recv() {
+                Ok(ev) => match &ev {
+                    SpecApiEvent::SpecCheckInvoked { snapshot_id, .. }
+                    | SpecApiEvent::SpecCheckCompleted { snapshot_id, .. }
+                        if snapshot_id == marker =>
+                    {
+                        return Some(ev)
+                    }
+                    _ => continue,
+                },
+                Err(_) => return None,
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn invoke_emit_publishes_spec_check_invoked() {
+        let mut rx = events::subscribe();
+        let marker = "scs_test_invoke_emit_1";
+        invoke_emit(marker, vec!["settings-general".into()], "http");
+        let event = recv_matching_invoked(&mut rx, marker, 32)
+            .expect("SpecCheckInvoked with marker must arrive");
+        match event {
+            SpecApiEvent::SpecCheckInvoked {
+                page_ids,
+                invoked_via,
+                ..
+            } => {
+                assert_eq!(page_ids, vec!["settings-general".to_string()]);
+                assert_eq!(invoked_via, "http");
+            }
+            other => panic!("expected SpecCheckInvoked, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn completion_counts_rolls_up_match_outcomes() {
+        // Hand-construct three SpecCheckResults with deterministic outcomes
+        // to exercise the rate-mean + outcome-bucket math.
+        let mk = |outcome: MatchOutcome, rate: f32| SpecCheckResult {
+            result_schema_version: 1,
+            snapshot_id: String::new(),
+            spec_content_hash: String::new(),
+            spec_version: "1.0".into(),
+            page_id: "p".into(),
+            state_results: vec![],
+            summary: qontinui_types::spec_check::SpecCheckSummary {
+                match_outcome: outcome,
+                overall_match_rate: rate,
+                severity_counts: Default::default(),
+                recommended_state: None,
+                recommendation_reason: None,
+            },
+            bridge_fingerprint: qontinui_types::spec_check::BridgeFingerprint {
+                app_id: "test".into(),
+                app_version: None,
+                route: None,
+                bridge_version: None,
+                snapshot_timestamp: String::new(),
+                element_count: 0,
+            },
+            evaluated_at: String::new(),
+            warnings: vec![],
+        };
+        let a = mk(MatchOutcome::FullMatch, 1.0);
+        let b = mk(MatchOutcome::PartialMatch, 0.5);
+        let c = mk(MatchOutcome::NoMatch, 0.0);
+        let results = vec![&a, &b, &c];
+        let (perfect, partial, no_match, eval_error, overall) = completion_counts(&results, 4); // 4 inputs, 3 evaluated → 1 eval_error
+        assert_eq!(perfect, 1);
+        assert_eq!(partial, 1);
+        assert_eq!(no_match, 1);
+        assert_eq!(eval_error, 1);
+        assert!((overall - 0.5).abs() < f32::EPSILON);
+
+        // Empty results bucket: zero across the board, overall = 0.0.
+        let (p, q, n, e, o) = completion_counts(&[], 0);
+        assert_eq!((p, q, n, e), (0, 0, 0, 0));
+        assert_eq!(o, 0.0);
     }
 }

--- a/src-tauri/src/spec_api/validator.rs
+++ b/src-tauri/src/spec_api/validator.rs
@@ -69,6 +69,15 @@ pub enum ValidatorError {
     BExecutionRed {
         result_summary: SpecCheckSummary,
         policy_eval: PolicyEvaluation,
+        /// The snapshot id of the result that produced the red. Populated
+        /// so downstream emit sites (Plan 06 `FlywheelProposalDemoted`) can
+        /// join against tracing spans / `workflow_verification_phase_results`.
+        snapshot_id: String,
+        /// First failing assertion's `(state_id, assertion_id)`. None when
+        /// the red came from policy `Indeterminate` over a fully-passing
+        /// result set (e.g. empty in-scope assertions); the demote emit
+        /// substitutes an empty string in that case.
+        failing_assertion: Option<(String, String)>,
     },
 }
 
@@ -105,6 +114,7 @@ pub fn validator_error_detail(e: &ValidatorError) -> String {
         ValidatorError::BExecutionRed {
             result_summary,
             policy_eval,
+            ..
         } => {
             let sc = &result_summary.severity_counts;
             let misses = sc.critical + sc.error + sc.warning + sc.info;
@@ -219,12 +229,31 @@ pub(crate) fn gate_b_execution_green_with_snapshot(
     // both reject. Per the plan's "could not evaluate is not a green signal"
     // rule (see § Step 8 + the vet-pass correction at the head of the doc).
     if !matches!(eval.overall_status, PolicyStatus::Pass) {
+        let failing_assertion = first_failing_assertion(&result);
         return Err(ValidatorError::BExecutionRed {
             result_summary: result.summary.clone(),
             policy_eval: eval,
+            snapshot_id: result.snapshot_id.clone(),
+            failing_assertion,
         });
     }
     Ok(result)
+}
+
+/// Locate the first assertion with a `Fail` outcome in result-iteration
+/// order. Returns `Some((state_id, assertion_id))` or `None` if every
+/// assertion passed (the red came from policy `Indeterminate` rather than
+/// a structural failure).
+fn first_failing_assertion(result: &SpecCheckResult) -> Option<(String, String)> {
+    use qontinui_types::spec_check::AssertionOutcome;
+    for state in &result.state_results {
+        for assertion in &state.assertions {
+            if matches!(assertion.outcome, AssertionOutcome::Fail { .. }) {
+                return Some((state.state_id.clone(), assertion.assertion_id.clone()));
+            }
+        }
+    }
+    None
 }
 
 /// Pull a fresh UI Bridge snapshot for the active app via the WS dispatch
@@ -602,6 +631,7 @@ mod tests {
             Err(ValidatorError::BExecutionRed {
                 result_summary,
                 policy_eval,
+                ..
             }) => {
                 // strict_all_pass treats every miss as a Fail.
                 assert!(

--- a/src-tauri/src/step_executor/handlers/spec_check.rs
+++ b/src-tauri/src/step_executor/handlers/spec_check.rs
@@ -24,8 +24,56 @@ use serde_json::json;
 use tracing::{info, warn};
 
 use super::{ExecutionStepConfig, HandlerContext, StepHandler, StepHandlerResult};
+use crate::spec_api::events;
 use qontinui_spec_check as spec_check; // crate name = "qontinui-spec-check"
-use qontinui_types::spec_check::{MatchOutcome, PolicyStatus, SpecCheckPolicy};
+use qontinui_types::spec_api_events::SpecApiEvent;
+use qontinui_types::spec_check::{
+    ConjunctRule, MatchOutcome, PolicyConjunct, PolicyEvaluation, PolicyStatus, SpecCheckPolicy,
+};
+
+/// Wire name for the `ConjunctRule` variant — mirrors the
+/// `#[serde(tag = "kind", rename_all = "snake_case")]` discriminator.
+fn rule_kind_str(rule: &ConjunctRule) -> &'static str {
+    match rule {
+        ConjunctRule::AllPass => "all_pass",
+        ConjunctRule::MaxFailures { .. } => "max_failures",
+        ConjunctRule::FailureRateBelow { .. } => "failure_rate_below",
+        ConjunctRule::StateMatchRateAtLeast { .. } => "state_match_rate_at_least",
+        ConjunctRule::AnyStateMatchRateAtLeast { .. } => "any_state_match_rate_at_least",
+        ConjunctRule::MatchOutcomeAtLeast { .. } => "match_outcome_at_least",
+    }
+}
+
+/// Emit one `SpecCheckPolicyViolation` per failing `ConjunctEvaluation`.
+/// Looks up each evaluation by `name` in the originating policy so the
+/// emit carries the structural `rule_kind` discriminator alongside the
+/// evidence string. Indeterminate conjuncts are NOT emitted — only `Fail`.
+fn emit_policy_violations(
+    snapshot_id: &str,
+    page_id: &str,
+    policy: &SpecCheckPolicy,
+    eval: &PolicyEvaluation,
+) {
+    for conjunct_eval in &eval.conjunct_results {
+        if conjunct_eval.status != PolicyStatus::Fail {
+            continue;
+        }
+        let rule_kind = policy
+            .conjuncts
+            .iter()
+            .find(|c: &&PolicyConjunct| c.name == conjunct_eval.name)
+            .map(|c| rule_kind_str(&c.rule))
+            .unwrap_or("unknown");
+        events::emit(SpecApiEvent::SpecCheckPolicyViolation {
+            snapshot_id: snapshot_id.to_string(),
+            page_id: page_id.to_string(),
+            conjunct_name: conjunct_eval.name.clone(),
+            rule_kind: rule_kind.to_string(),
+            observed: serde_json::Value::String(conjunct_eval.evidence.clone()),
+            at_ms: events::now_ms(),
+        });
+    }
+}
 
 pub struct SpecCheckHandler;
 
@@ -143,6 +191,13 @@ impl StepHandler for SpecCheckHandler {
         let policy_eval = policy
             .as_ref()
             .map(|p| spec_check::apply_policy(&result, p));
+
+        // 5b. Plan 06: per-conjunct emission of `SpecCheckPolicyViolation`.
+        //     One event per `Fail` conjunct; `Indeterminate` is not emitted
+        //     (only deliberate violations count as observability signal).
+        if let (Some(pol), Some(eval)) = (policy.as_ref(), policy_eval.as_ref()) {
+            emit_policy_violations(&result.snapshot_id, &page_id, pol, eval);
+        }
 
         // 6. Status: prefer policy, fall back to summary.match_outcome.
         //    MatchOutcome: FullMatch | PartialMatch | NoMatch (no `Match`).
@@ -405,5 +460,112 @@ mod tests {
         assert!(d.spec_check_fail_when_no_app.is_none());
         assert!(d.spec_check_fail_when_no_spec.is_none());
         assert!(d.spec_check_fail_on.is_none());
+    }
+
+    // ------------------------------------------------------------------------
+    // Plan 06 — emit-callsite helpers
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn rule_kind_str_covers_every_variant() {
+        // Locks the snake_case discriminator strings against accidental
+        // drift from `#[serde(tag = "kind", rename_all = "snake_case")]`.
+        assert_eq!(rule_kind_str(&ConjunctRule::AllPass), "all_pass");
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::MaxFailures { count: 0 }),
+            "max_failures"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::FailureRateBelow { rate: 0.0 }),
+            "failure_rate_below"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::StateMatchRateAtLeast { rate: 0.0 }),
+            "state_match_rate_at_least"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::AnyStateMatchRateAtLeast { rate: 0.0 }),
+            "any_state_match_rate_at_least"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::MatchOutcomeAtLeast {
+                outcome: MatchOutcome::FullMatch
+            }),
+            "match_outcome_at_least"
+        );
+    }
+
+    #[test]
+    fn emit_policy_violations_publishes_one_per_failing_conjunct() {
+        use qontinui_types::spec_api_events::SpecApiEvent;
+        use qontinui_types::spec_check::{AssertionScope, ConjunctEvaluation, PolicyConjunct};
+        let mut rx = events::subscribe();
+        let marker = "scs_test_policy_violation_emit_1";
+        let page_id = "settings-test-violation";
+        let policy = SpecCheckPolicy {
+            conjuncts: vec![
+                PolicyConjunct {
+                    name: "critical-all-pass".into(),
+                    scope: AssertionScope::default(),
+                    rule: ConjunctRule::AllPass,
+                },
+                PolicyConjunct {
+                    name: "max-three-failures".into(),
+                    scope: AssertionScope::default(),
+                    rule: ConjunctRule::MaxFailures { count: 3 },
+                },
+                PolicyConjunct {
+                    name: "passing-conjunct".into(),
+                    scope: AssertionScope::default(),
+                    rule: ConjunctRule::AllPass,
+                },
+            ],
+        };
+        let eval = qontinui_types::spec_check::PolicyEvaluation {
+            overall_status: PolicyStatus::Fail,
+            conjunct_results: vec![
+                ConjunctEvaluation {
+                    name: "critical-all-pass".into(),
+                    status: PolicyStatus::Fail,
+                    evidence: "2 of 17 assertions failed".into(),
+                },
+                ConjunctEvaluation {
+                    name: "max-three-failures".into(),
+                    status: PolicyStatus::Fail,
+                    evidence: "5 failures > 3 budget".into(),
+                },
+                ConjunctEvaluation {
+                    name: "passing-conjunct".into(),
+                    status: PolicyStatus::Pass,
+                    evidence: "all green".into(),
+                },
+            ],
+        };
+        emit_policy_violations(marker, page_id, &policy, &eval);
+        // Two failing conjuncts → expect two emits with our marker.
+        // Drain up to 64 events from the broadcast, filter by marker.
+        let mut violations = Vec::new();
+        for _ in 0..64 {
+            match rx.try_recv() {
+                Ok(SpecApiEvent::SpecCheckPolicyViolation {
+                    snapshot_id,
+                    page_id: pid,
+                    conjunct_name,
+                    rule_kind,
+                    ..
+                }) if snapshot_id == marker => {
+                    violations.push((conjunct_name, rule_kind, pid));
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+        assert_eq!(violations.len(), 2, "expected exactly 2 violation emits");
+        // Order is policy declaration order; first failing conjunct first.
+        assert_eq!(violations[0].0, "critical-all-pass");
+        assert_eq!(violations[0].1, "all_pass");
+        assert_eq!(violations[0].2, page_id);
+        assert_eq!(violations[1].0, "max-three-failures");
+        assert_eq!(violations[1].1, "max_failures");
     }
 }


### PR DESCRIPTION
## Summary

Plan 06 reserved the 5 `SpecApiEvent` variants with the SSE wire ready but the emit-callsites were deferred to "follow-up PRs" pending Plan 03 + Plan 05's actual ship. With those plans on main, this PR closes that loop — every spec-check codepath that should fire an event now does.

| Variant | Emitted from | When |
|---|---|---|
| `SpecCheckInvoked` | `spec_api/spec_check.rs` (single + batch + streaming) | After snapshot fetch, before evaluator runs |
| `SpecCheckCompleted` | `spec_api/spec_check.rs` (single + batch + streaming) | After all results landed; carries roll-up counts |
| `SpecCheckPolicyViolation` | `step_executor/handlers/spec_check.rs` | After `apply_policy`, one emit per failing `ConjunctEvaluation` |
| `FlywheelProposalPromoted` | `spec_api/proposals.rs` sweep handler | After `storage::promote_pending` succeeds |
| `FlywheelProposalDemoted` | `spec_api/proposals.rs` sweep handler | After `storage::demote_pending` (whether or not the FS cleanup itself succeeded — PG-side demotion is independent) |

## Validator changes (internal, no schema impact)

`ValidatorError::BExecutionRed` now carries `snapshot_id` + `failing_assertion: Option<(state_id, assertion_id)>` so the demote emit has the locators its payload requires. `first_failing_assertion` helper walks `state_results` for the first `AssertionOutcome::Fail`; returns `None` when the red came from `Indeterminate` over an all-passing assertion set (emit substitutes empty strings in that case to keep the wire shape uniform).

## Notes on Indeterminate

`SpecCheckPolicyViolation` is emitted only for `Fail` conjuncts — `Indeterminate` is skipped per the rule "only deliberate violations count as observability signal." Open to revisiting if downstream consumers care about the indeterminate state.

## Tests

- \`invoke_emit_publishes_spec_check_invoked\`
- \`completion_counts_rolls_up_match_outcomes\` (pure-helper math)
- \`rule_kind_str_covers_every_variant\` (locks the snake_case discriminator)
- \`emit_policy_violations_publishes_one_per_failing_conjunct\`

Defensive against parallel-test contamination on the singleton broadcast: each test subscribes first, uses a unique marker in `snapshot_id`, filters via `try_recv` + drain.

## What this does NOT do

- Does **not** flip the flywheel default — `--features spec-authoring` stays opt-in. The supervisor cron stays default-off; production activation is the user's separate strategic checkpoint.
- Does not write to `public.spec_check_runs` directly — emission lands on the broadcast channel; the AC gate's consumer subscribes from there (or via the SSE wire when remote).

## Test plan

- [x] \`cargo check --bin qontinui-runner\` (default features)
- [x] \`cargo check --bin qontinui-runner --features spec-authoring\`
- [x] \`cargo test -- spec_check\` — 21 tests pass (17 existing + 4 new)
- [ ] CI green
- [ ] End-to-end emission verification (post-merge: fire synthetic, confirm SSE + spec_check_runs row)