### PR TITLE
fix(runner): real port-health probe + stop misfiring auth banner

### DIFF
--- a/src-tauri/src/process_capture/manager.rs
+++ b/src-tauri/src/process_capture/manager.rs
@@ -157,11 +157,13 @@ impl ProcessCaptureManager {
         let processes_ref = self.processes.clone();
         let error_monitor = self.error_monitor.clone();
         let app_handle = self.app_handle.clone();
+        let process_id_for_event_loop = process_id.clone();
+        let process_name_for_event_loop = process_name.clone();
         // Spawn the event loop for this process
         tokio::spawn(async move {
             Self::process_event_loop(
-                process_id,
-                process_name,
+                process_id_for_event_loop,
+                process_name_for_event_loop,
                 health_port,
                 output_buffer,
                 buffer_size,
@@ -173,6 +175,29 @@ impl ProcessCaptureManager {
             )
             .await;
         });
+
+        // Spawn the port-health polling loop if a health port is configured.
+        // The outer spawned PID is a shell wrapper (`cmd → poetry → python → uvicorn`
+        // on Windows); the actual service can die inside while the wrapper keeps
+        // running. The event loop only sees `Exited` from the wrapper, so without
+        // this probe `port_healthy` stays `None` forever and the Processes page
+        // can't tell "alive but not serving" from "alive and healthy".
+        if let Some(port) = health_port {
+            let processes_ref = self.processes.clone();
+            let app_handle = self.app_handle.clone();
+            let process_id_for_health = process_id.clone();
+            let process_name_for_health = process_name.clone();
+            tokio::spawn(async move {
+                Self::port_health_loop(
+                    process_id_for_health,
+                    process_name_for_health,
+                    port,
+                    processes_ref,
+                    app_handle,
+                )
+                .await;
+            });
+        }
 
         // Emit state change event
         let status = process.status();
@@ -497,6 +522,7 @@ impl ProcessCaptureManager {
                                 if let Some(p) = procs.get_mut(&process_id) {
                                     p.runtime.state = ProcessState::Stopped;
                                     p.runtime.pid = None;
+                                    p.runtime.port_healthy = None;
                                     let status = p.status();
                                     let _ = tauri::Emitter::emit(
                                         &app_handle,
@@ -558,6 +584,93 @@ impl ProcessCaptureManager {
         }
 
         info!("Event loop ended for process '{}'", process_name);
+    }
+
+    /// Periodically probe a managed process's health port and update its
+    /// `port_healthy` + `state` fields. Transitions `Running ↔ Healthy` based
+    /// on the probe; emits `process-state-changed` only when something
+    /// actually changes.
+    ///
+    /// Stops when the process leaves the `Running`/`Healthy` states (i.e. on
+    /// stop, restart, exit, or rebuild). No explicit cancellation needed —
+    /// the loop self-terminates on the next tick.
+    async fn port_health_loop(
+        process_id: String,
+        process_name: String,
+        port: u16,
+        processes: Arc<RwLock<HashMap<String, ManagedProcess>>>,
+        app_handle: tauri::AppHandle,
+    ) {
+        const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+
+            // Bail if the process is no longer in a state we should probe.
+            // Read lock kept brief so we don't contend with the event loop.
+            {
+                let procs = processes.read().await;
+                let still_polling = procs.get(&process_id).is_some_and(|p| {
+                    matches!(
+                        p.runtime.state,
+                        ProcessState::Running | ProcessState::Healthy
+                    )
+                });
+                if !still_polling {
+                    break;
+                }
+            }
+
+            // TCP connect probe with internal 500ms timeout. Runs on a
+            // blocking thread because `socket2::Socket::connect_timeout` is
+            // synchronous; otherwise it would stall the tokio worker.
+            let healthy =
+                match tokio::task::spawn_blocking(move || health::is_port_in_use(port)).await {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+            // Apply the result + decide whether to emit.
+            let new_status = {
+                let mut procs = processes.write().await;
+                let Some(p) = procs.get_mut(&process_id) else {
+                    break;
+                };
+                // State may have flipped during the probe (race with stop()
+                // or Exited). Don't clobber a terminal state with our update.
+                if !matches!(
+                    p.runtime.state,
+                    ProcessState::Running | ProcessState::Healthy
+                ) {
+                    break;
+                }
+
+                let prev_state = p.runtime.state;
+                let prev_healthy = p.runtime.port_healthy;
+                p.runtime.port_healthy = Some(healthy);
+                p.runtime.state = if healthy {
+                    ProcessState::Healthy
+                } else {
+                    ProcessState::Running
+                };
+
+                if prev_state != p.runtime.state || prev_healthy != Some(healthy) {
+                    Some(p.status())
+                } else {
+                    None
+                }
+            };
+
+            if let Some(status) = new_status {
+                let _ = tauri::Emitter::emit(&app_handle, "process-state-changed", &status);
+            }
+        }
+
+        tracing::debug!(
+            "Port-health loop ended for process '{}' (port {})",
+            process_name,
+            port
+        );
     }
 
     /// Flush a batch of output lines to PG. Best-effort: failures are logged, batch is cleared.

--- a/src-tauri/src/process_capture/process.rs
+++ b/src-tauri/src/process_capture/process.rs
@@ -79,6 +79,10 @@ impl ManagedProcess {
         }
 
         self.runtime.state = ProcessState::Starting;
+        // Reset port-health each spawn so a restarted process doesn't briefly
+        // inherit the prior generation's `port_healthy` value. The manager's
+        // port-health loop overwrites this within one poll interval.
+        self.runtime.port_healthy = None;
 
         let (msg_tx, msg_rx) = mpsc::channel::<ProcessMessage>(500);
 
@@ -255,6 +259,7 @@ impl ManagedProcess {
 
         self.runtime.state = ProcessState::Stopped;
         self.runtime.pid = None;
+        self.runtime.port_healthy = None;
 
         info!("Process '{}' stopped", self.config.name);
     }

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -150,13 +150,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
       log.debug(`refreshAuth() #${callNum} - completed successfully`);
     } catch (err) {
       log.warn(`refreshAuth() #${callNum} - Token refresh failed:`, err);
-      // Don't immediately log the user out. The current access token may still be
-      // valid — a refresh failure alone (e.g., transient network issue, backend
-      // momentarily unavailable) should not destroy the user's session and cause
-      // the entire app tree (including terminal sessions) to unmount.
-      // The next refresh cycle will try again. If the token truly expired,
-      // subsequent API calls will return 401 and the user can re-authenticate.
-      setError(err as string);
+      // Don't immediately log the user out. The current access token may still
+      // be valid — a refresh failure alone (network blip, backend momentarily
+      // unavailable, 5xx) should not destroy the user's session.
+      //
+      // We also deliberately do NOT `setError(err)` here. A non-null `error`
+      // is read by `PromptHomePage`'s "Sign-in required" banner as "session
+      // expired", which it isn't — the next refresh cycle will retry. The
+      // backend's `refresh_token_impl` clears tokens itself on a true 401/403,
+      // so a real expiry surfaces through `authStatus.authenticated = false`
+      // on the next `checkAuthStatus`, not through this catch.
     }
   }, [checkAuthStatus]);
 

--- a/src/components/process-manager/ProcessManagerTab.tsx
+++ b/src/components/process-manager/ProcessManagerTab.tsx
@@ -595,7 +595,11 @@ Be concise and actionable.`;
                       <ChevronRight className="w-3 h-3 text-zinc-500 shrink-0" />
                     )}
                     <span className="text-sm text-zinc-200 truncate">{proc.name}</span>
-                    <ProcessStatusBadge state={proc.state} />
+                    <ProcessStatusBadge
+                      state={proc.state}
+                      portHealthy={proc.port_healthy}
+                      uptimeSecs={proc.uptime_secs}
+                    />
                   </div>
                   <div className="flex items-center gap-3 mt-1 ml-5 text-xs text-zinc-500">
                     {proc.pid && <span>PID: {proc.pid}</span>}

--- a/src/components/process-manager/ProcessStatusBadge.tsx
+++ b/src/components/process-manager/ProcessStatusBadge.tsx
@@ -1,5 +1,14 @@
 import { cn } from "../../lib/utils";
-import { Circle, Loader2, CheckCircle2, XCircle, Square, ArrowDown, Hammer } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowDown,
+  CheckCircle2,
+  Circle,
+  Hammer,
+  Loader2,
+  Square,
+  XCircle,
+} from "lucide-react";
 
 type ProcessState =
   | "stopped"
@@ -12,8 +21,24 @@ type ProcessState =
 
 interface ProcessStatusBadgeProps {
   state: ProcessState;
+  /**
+   * Result of the manager's TCP probe against `health_port`. `null` if no
+   * port is configured or the first probe hasn't fired yet (the loop ticks
+   * every 3s). `false` after the first failing probe means "alive, but
+   * nothing accepting connections on the port".
+   */
+  portHealthy?: boolean | null;
+  /**
+   * Process uptime in seconds. Used for the port-dead grace window — we
+   * suppress the amber badge for the first 30s after start so normal
+   * Python/Node startup time doesn't paint the row yellow.
+   */
+  uptimeSecs?: number | null;
   className?: string;
 }
+
+/** Seconds after spawn before `port_healthy: false` is treated as a problem. */
+const PORT_DEAD_GRACE_SECS = 30;
 
 const stateConfig: Record<ProcessState, { icon: React.ReactNode; label: string; classes: string }> =
   {
@@ -54,8 +79,24 @@ const stateConfig: Record<ProcessState, { icon: React.ReactNode; label: string; 
     },
   };
 
-export function ProcessStatusBadge({ state, className }: ProcessStatusBadgeProps) {
-  const config = stateConfig[state] || stateConfig.stopped;
+export function ProcessStatusBadge({
+  state,
+  portHealthy,
+  uptimeSecs,
+  className,
+}: ProcessStatusBadgeProps) {
+  const portDead =
+    state === "running" &&
+    portHealthy === false &&
+    (uptimeSecs ?? 0) > PORT_DEAD_GRACE_SECS;
+
+  const config = portDead
+    ? {
+        icon: <AlertTriangle className="w-3 h-3" />,
+        label: "Running (port dead)",
+        classes: "bg-amber-900/30 text-amber-400 border-amber-800",
+      }
+    : stateConfig[state] || stateConfig.stopped;
 
   return (
     <span
@@ -64,6 +105,11 @@ export function ProcessStatusBadge({ state, className }: ProcessStatusBadgeProps
         config.classes,
         className,
       )}
+      title={
+        portDead
+          ? "The configured health port stopped accepting connections. The process is alive but not serving — typically a worker crash inside the wrapper. Restart to recover."
+          : undefined
+      }
     >
       {config.icon}
       {config.label}

--- a/src/components/prompt-home/PromptHomePage.tsx
+++ b/src/components/prompt-home/PromptHomePage.tsx
@@ -66,14 +66,18 @@ export function PromptHomePage() {
   //   - dev auto-login is not still in flight (devAutoLoginPending === false)
   //   - mount-time check happened (authStatus !== null) — avoids flash on
   //     cold mount
-  //   - AND either authStatus.authenticated === false OR there is a
-  //     non-empty error string from the auth provider
+  //   - authStatus.authenticated is explicitly false
+  //
+  // `auth.error` is deliberately NOT consulted. A non-empty error from a
+  // transient refresh failure (backend down for a moment) used to flip this
+  // banner to "Your session has expired" even though the session was fine
+  // — the backend clears tokens itself on a real 401/403, so an actual expiry
+  // shows up as `authStatus.authenticated === false`.
   const isUnauthenticated =
     !auth.loading &&
     !auth.devAutoLoginPending &&
     auth.authStatus !== null &&
-    (auth.authStatus.authenticated === false ||
-      (auth.error !== null && auth.error.length > 0));
+    auth.authStatus.authenticated === false;
 
   // Focus input on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Two related fixes for the symptom **"Sign-in required to run prompts / Your session has expired"** shown on the Home page while the user is actually authenticated.

**Root cause chain** (full investigation in session transcript):
- The dev backend (FastAPI on :8000) crashed at start on an `ImportError: cannot import name 'SpecCheckConfidence'` from `qontinui_schemas`, but only the uvicorn worker died. The surrounding `cmd.exe → poetry → python` wrappers stayed alive, so the runner reported `state: "running"` indefinitely.
- The frontend's auto-login refresh hit `:8000/api/v1/auth/jwt/refresh` every 14 min, got connection-refused, and `setError(err)` on the AuthProvider.
- The `PromptHomePage`'s "Sign-in required" banner gate keyed off `auth.error` non-empty, treating a transient network failure as session expiry — even though `authStatus.authenticated` was still `true`.

This PR fixes:
- **#2 (real port-health check):** spawn a per-process `port_health_loop` that TCP-probes the configured `health_port` every 3s and writes `runtime.port_healthy`. The Processes page now renders an amber "Running (port dead)" badge (with a 30s grace) when the wrapper is alive but the port isn't accepting connections.
- **#4 (banner gate):** `refreshAuth` no longer pollutes `auth.error` with transient refresh failures; the banner gate drops the `auth.error` branch and keys off `authStatus.authenticated === false` only.

Two adjacent issues are out of scope for this PR and tracked separately: `#1` (today's stuck backend — fixed by restarting it from the Processes page once #2 lands and surfaces the dead state) and `#3` (process-tree reaping — captured in [`plans/2026-05-16-runner-process-tree-reaping-plan.md`](https://github.com/qontinui/qontinui-runner/) and being implemented in a sibling worktree).

## Changes

**Backend (Rust)**
- `process_capture/manager.rs` — new `port_health_loop` spawned from `start_process` per managed process when `health_port` is set; clears `port_healthy` on the Exited path.
- `process_capture/process.rs` — resets `port_healthy = None` on Starting and Stopped so a restart doesn't briefly inherit the prior generation's value.

**Frontend (TypeScript / React)**
- `process-manager/ProcessStatusBadge.tsx` — new amber "Running (port dead)" variant with 30s grace + explanatory tooltip.
- `process-manager/ProcessManagerTab.tsx` — wires `portHealthy` + `uptimeSecs` into the badge.
- `AuthProvider.tsx` — drops `setError(err)` from the `refreshAuth` catch (the comment already said we shouldn't log the user out on a network blip; the `setError` was defeating that intent).
- `prompt-home/PromptHomePage.tsx` — banner predicate drops the `auth.error` branch.

## Test plan

- [x] `cargo check -p qontinui-runner` clean locally
- [x] `tsc --noEmit` shows no errors in any touched file (pre-existing TS drift in `workflow-builder/`/`regression/` is unrelated)
- [ ] CI: Ubuntu + macOS + Windows green
- [ ] Manual: after this lands and a runner rebuild, kill the FastAPI worker inside its wrapper; Processes page should show amber "Running (port dead)" within ~30s. Home page should NOT show the "Sign-in required" banner while `check_auth_status` still reports `authenticated: true`.

Session-Id: 61bdc915-6f1d-422c-88f8-0ba78c2fd26f