### PR TITLE
feat(runner): process-tree reaping for managed dev services

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2179,6 +2179,12 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 if is_secondary {
                     info!("Secondary instance — skipping managed process auto-start");
                 } else {
+                    // Reclaim any orphan descendant trees left behind by a
+                    // prior runner session that crashed without a graceful
+                    // shutdown (Phase 4). PID-reuse-safe via per-PID
+                    // creation-time fingerprint; clears the persisted state
+                    // file after running so a crash mid-loop doesn't loop.
+                    process_capture::orphan_state::reclaim_orphans().await;
                     manager.start_auto_processes().await;
                 }
 

--- a/src-tauri/src/process_capture/health.rs
+++ b/src-tauri/src/process_capture/health.rs
@@ -139,9 +139,8 @@ pub async fn kill_descendant_tree(root_pid: u32) -> usize {
                         to_kill.insert(pid);
                         break;
                     }
-                    Some(p) if p == 0 => break,
+                    Some(0) | None => break,
                     Some(p) => cur = p,
-                    None => break,
                 }
             }
         }

--- a/src-tauri/src/process_capture/health.rs
+++ b/src-tauri/src/process_capture/health.rs
@@ -3,6 +3,158 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+/// Cheaply check whether a PID is still alive. Used by the port_health_loop
+/// to detect inner service-worker death while the outer `cmd.exe` shim is
+/// still running. Windows: `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)`
+/// + `GetExitCodeProcess`; Unix: `kill(pid, 0)`.
+///
+/// Returns `false` for PID 0, for permission-denied, and for any PID that
+/// has exited or never existed.
+#[cfg(windows)]
+pub fn pid_alive(pid: u32) -> bool {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+    const STILL_ACTIVE: u32 = 259;
+    if pid == 0 {
+        return false;
+    }
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid);
+        if handle.is_null() {
+            return false;
+        }
+        let mut code: u32 = 0;
+        let ok = GetExitCodeProcess(handle, &mut code as *mut u32);
+        CloseHandle(handle);
+        ok != 0 && code == STILL_ACTIVE
+    }
+}
+
+#[cfg(not(windows))]
+pub fn pid_alive(pid: u32) -> bool {
+    if pid == 0 {
+        return false;
+    }
+    // `kill(pid, 0)` returns 0 if the process exists and we have permission
+    // to signal it; -1 + ESRCH if it does not exist.
+    unsafe { libc::kill(pid as i32, 0) == 0 }
+}
+
+/// Force-kill an entire descendant subtree rooted at `root_pid`, including
+/// the root. Uses the same BFS shape as `kill_port_process` but takes a PID
+/// instead of a port — needed by Phase 5 restart-time reaping when the
+/// tracked descendant list is known directly.
+///
+/// Returns the number of `Stop-Process` / `kill -9` calls attempted.
+#[cfg(windows)]
+pub async fn kill_descendant_tree(root_pid: u32) -> usize {
+    let script = format!(
+        r#"$ErrorActionPreference = 'SilentlyContinue'
+$rootPid = {root_pid}
+if ($rootPid -le 0) {{ exit 1 }}
+
+$childrenByParent = @{{}}
+foreach ($p in (Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId)) {{
+    $ppid = [int]$p.ParentProcessId
+    if (-not $childrenByParent.ContainsKey($ppid)) {{ $childrenByParent[$ppid] = New-Object System.Collections.Generic.List[int] }}
+    [void]$childrenByParent[$ppid].Add([int]$p.ProcessId)
+}}
+
+$toKill = New-Object System.Collections.Generic.HashSet[int]
+$queue = New-Object System.Collections.Generic.Queue[int]
+[void]$queue.Enqueue([int]$rootPid)
+while ($queue.Count -gt 0) {{
+    $current = $queue.Dequeue()
+    if (-not $toKill.Add($current)) {{ continue }}
+    if ($childrenByParent.ContainsKey($current)) {{
+        foreach ($c in $childrenByParent[$current]) {{ [void]$queue.Enqueue($c) }}
+    }}
+}}
+
+$count = $toKill.Count
+foreach ($k in $toKill) {{ Stop-Process -Id $k -Force }}
+Write-Output $count
+exit 0
+"#
+    );
+
+    let output = match crate::process_helpers::no_window("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return 0,
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .lines()
+        .last()
+        .and_then(|l| l.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+#[cfg(not(windows))]
+pub async fn kill_descendant_tree(root_pid: u32) -> usize {
+    if root_pid == 0 {
+        return 0;
+    }
+    // Best-effort: SIGKILL the root and any process whose ppid chain leads
+    // back to it. /proc walk mirrors process_tree::snapshot_process_table_sync.
+    let mut to_kill = std::collections::HashSet::new();
+    to_kill.insert(root_pid);
+
+    if let Ok(entries) = std::fs::read_dir("/proc") {
+        // Build child->parent index first.
+        let mut parent_of: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+        for entry in entries.flatten() {
+            let s = match entry.file_name().to_str() {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let pid: u32 = match s.parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            let stat = match std::fs::read_to_string(format!("/proc/{pid}/stat")) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let close = match stat.rfind(')') {
+                Some(i) => i,
+                None => continue,
+            };
+            let tail = &stat[close + 1..];
+            let fields: Vec<&str> = tail.split_whitespace().collect();
+            let ppid: u32 = fields.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+            parent_of.insert(pid, ppid);
+        }
+        // Any PID whose ancestry chain reaches root_pid is a descendant.
+        for (&pid, _) in parent_of.iter() {
+            let mut cur = pid;
+            for _ in 0..64 {
+                match parent_of.get(&cur).copied() {
+                    Some(p) if p == root_pid => {
+                        to_kill.insert(pid);
+                        break;
+                    }
+                    Some(p) if p == 0 => break,
+                    Some(p) => cur = p,
+                    None => break,
+                }
+            }
+        }
+    }
+
+    let mut killed = 0usize;
+    for pid in to_kill {
+        let _ = unsafe { libc::kill(pid as i32, libc::SIGKILL) };
+        killed += 1;
+    }
+    killed
+}
+
 /// Check if a port is currently in use (accepting connections).
 pub fn is_port_in_use(port: u16) -> bool {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));

--- a/src-tauri/src/process_capture/manager.rs
+++ b/src-tauri/src/process_capture/manager.rs
@@ -157,11 +157,13 @@ impl ProcessCaptureManager {
         let processes_ref = self.processes.clone();
         let error_monitor = self.error_monitor.clone();
         let app_handle = self.app_handle.clone();
+        let process_id_for_event_loop = process_id.clone();
+        let process_name_for_event_loop = process_name.clone();
         // Spawn the event loop for this process
         tokio::spawn(async move {
             Self::process_event_loop(
-                process_id,
-                process_name,
+                process_id_for_event_loop,
+                process_name_for_event_loop,
                 health_port,
                 output_buffer,
                 buffer_size,
@@ -173,6 +175,52 @@ impl ProcessCaptureManager {
             )
             .await;
         });
+
+        // Spawn the port-health polling loop if a health port is configured.
+        // The outer spawned PID is a shell wrapper (`cmd → poetry → python → uvicorn`
+        // on Windows); the actual service can die inside while the wrapper keeps
+        // running. The event loop only sees `Exited` from the wrapper, so without
+        // this probe `port_healthy` stays `None` forever and the Processes page
+        // can't tell "alive but not serving" from "alive and healthy".
+        if let Some(port) = health_port {
+            let processes_ref = self.processes.clone();
+            let app_handle = self.app_handle.clone();
+            let process_id_for_health = process_id.clone();
+            let process_name_for_health = process_name.clone();
+            tokio::spawn(async move {
+                Self::port_health_loop(
+                    process_id_for_health,
+                    process_name_for_health,
+                    port,
+                    processes_ref,
+                    app_handle,
+                )
+                .await;
+            });
+        }
+
+        // Spawn the descendant-tree discovery task. After ~3s the spawned
+        // child has typically forked its full wrapper chain
+        // (`cmd → poetry → python → uvicorn`); we enumerate it once so
+        // Phase 2's port_health_loop can probe the inner service PID and
+        // §3.5 can persist descendants for orphan reclaim.
+        {
+            let processes_ref = self.processes.clone();
+            let app_handle = self.app_handle.clone();
+            let process_id_for_tree = process_id.clone();
+            let process_name_for_tree = process_name.clone();
+            let health_port_for_tree = health_port;
+            tokio::spawn(async move {
+                Self::descendant_discovery_once(
+                    process_id_for_tree,
+                    process_name_for_tree,
+                    health_port_for_tree,
+                    processes_ref,
+                    app_handle,
+                )
+                .await;
+            });
+        }
 
         // Emit state change event
         let status = process.status();
@@ -199,7 +247,24 @@ impl ProcessCaptureManager {
     }
 
     /// Restart a process: stop → wait for port free → start.
+    ///
+    /// Phase 5: when `QONTINUI_REAP_RESTART=1` is set, also walks the
+    /// previously-tracked descendant tree and force-kills each PID. This
+    /// catches the case where `stop()` (which calls `taskkill /F /T`)
+    /// fails to take down a late-forked uvicorn worker — without the
+    /// explicit reap, the next `start_process` fights the orphan for the
+    /// health port and lands in the `Bound`-not-`Listen` half-bound state
+    /// that triggered this whole plan.
     pub async fn restart_process(&self, id: &str) -> Result<(), String> {
+        // Snapshot the descendant tree BEFORE `stop()` clears it.
+        let descendant_pids: Vec<u32> = {
+            let processes = self.processes.read().await;
+            processes
+                .get(id)
+                .map(|p| p.runtime.descendant_pids.iter().map(|d| d.pid).collect())
+                .unwrap_or_default()
+        };
+
         {
             let mut processes = self.processes.write().await;
             let process = processes
@@ -215,6 +280,30 @@ impl ProcessCaptureManager {
                     warn!("Port {} still occupied after restart stop phase", port);
                 }
             }
+        }
+
+        // Reap any descendant PIDs `stop()` may have missed. Gated behind
+        // an env flag for the first release cycle so the existing
+        // port-kill fallback (in `start_process`) stays armed and the new
+        // behavior is opt-in until validated in dev.
+        if std::env::var("QONTINUI_REAP_RESTART")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+            && !descendant_pids.is_empty()
+        {
+            let reaped: usize = futures::future::join_all(
+                descendant_pids
+                    .iter()
+                    .copied()
+                    .map(|pid| async move { health::kill_descendant_tree(pid).await }),
+            )
+            .await
+            .into_iter()
+            .sum();
+            info!(
+                "restart_process '{}': reaped {} descendants from prior generation",
+                id, reaped
+            );
         }
 
         // Small delay between stop and start
@@ -497,6 +586,9 @@ impl ProcessCaptureManager {
                                 if let Some(p) = procs.get_mut(&process_id) {
                                     p.runtime.state = ProcessState::Stopped;
                                     p.runtime.pid = None;
+                                    p.runtime.port_healthy = None;
+                                    p.runtime.descendant_pids.clear();
+                                    p.runtime.service_pid = None;
                                     let status = p.status();
                                     let _ = tauri::Emitter::emit(
                                         &app_handle,
@@ -558,6 +650,223 @@ impl ProcessCaptureManager {
         }
 
         info!("Event loop ended for process '{}'", process_name);
+    }
+
+    /// Periodically probe a managed process's health port and update its
+    /// `port_healthy` + `state` fields. Transitions `Running ↔ Healthy` based
+    /// on the probe; emits `process-state-changed` only when something
+    /// actually changes.
+    ///
+    /// Stops when the process leaves the `Running`/`Healthy` states (i.e. on
+    /// stop, restart, exit, or rebuild). No explicit cancellation needed —
+    /// the loop self-terminates on the next tick.
+    async fn port_health_loop(
+        process_id: String,
+        process_name: String,
+        port: u16,
+        processes: Arc<RwLock<HashMap<String, ManagedProcess>>>,
+        app_handle: tauri::AppHandle,
+    ) {
+        const POLL_INTERVAL: Duration = Duration::from_secs(3);
+
+        loop {
+            tokio::time::sleep(POLL_INTERVAL).await;
+
+            // Bail if the process is no longer in a state we should probe;
+            // also snapshot the inner service PID so we can probe its
+            // liveness this tick (cheap `OpenProcess`/`kill(_,0)` check).
+            let service_pid = {
+                let procs = processes.read().await;
+                let Some(p) = procs.get(&process_id) else {
+                    break;
+                };
+                if !matches!(
+                    p.runtime.state,
+                    ProcessState::Running | ProcessState::Healthy
+                ) {
+                    break;
+                }
+                p.runtime.service_pid
+            };
+
+            // Service-PID liveness branch. The outer `child.wait().await` in
+            // process.rs only fires `Exited` for the cmd.exe shim; an inner
+            // uvicorn worker that crashes on import leaves the shim alive,
+            // so without this branch the runner reports `running` forever.
+            if let Some(pid) = service_pid {
+                let alive_check = tokio::task::spawn_blocking(move || health::pid_alive(pid)).await;
+                let alive = matches!(alive_check, Ok(true));
+                if !alive {
+                    let emit = {
+                        let mut procs = processes.write().await;
+                        let Some(p) = procs.get_mut(&process_id) else {
+                            break;
+                        };
+                        if !matches!(
+                            p.runtime.state,
+                            ProcessState::Running | ProcessState::Healthy
+                        ) {
+                            break;
+                        }
+                        p.runtime.state = ProcessState::Failed;
+                        p.runtime.port_healthy = Some(false);
+                        Some(p.status())
+                    };
+                    if let Some(status) = emit {
+                        tracing::warn!(
+                            "Service PID {} for '{}' is no longer alive (outer shim PID still tracked); marking Failed",
+                            pid,
+                            process_name
+                        );
+                        let _ = tauri::Emitter::emit(&app_handle, "process-state-changed", &status);
+                    }
+                    break;
+                }
+            }
+
+            // TCP connect probe with internal 500ms timeout. Runs on a
+            // blocking thread because `socket2::Socket::connect_timeout` is
+            // synchronous; otherwise it would stall the tokio worker.
+            let healthy =
+                match tokio::task::spawn_blocking(move || health::is_port_in_use(port)).await {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+
+            // Apply the result + decide whether to emit.
+            let new_status = {
+                let mut procs = processes.write().await;
+                let Some(p) = procs.get_mut(&process_id) else {
+                    break;
+                };
+                // State may have flipped during the probe (race with stop()
+                // or Exited). Don't clobber a terminal state with our update.
+                if !matches!(
+                    p.runtime.state,
+                    ProcessState::Running | ProcessState::Healthy
+                ) {
+                    break;
+                }
+
+                let prev_state = p.runtime.state;
+                let prev_healthy = p.runtime.port_healthy;
+                p.runtime.port_healthy = Some(healthy);
+                p.runtime.state = if healthy {
+                    ProcessState::Healthy
+                } else {
+                    ProcessState::Running
+                };
+
+                if prev_state != p.runtime.state || prev_healthy != Some(healthy) {
+                    Some(p.status())
+                } else {
+                    None
+                }
+            };
+
+            if let Some(status) = new_status {
+                let _ = tauri::Emitter::emit(&app_handle, "process-state-changed", &status);
+            }
+        }
+
+        tracing::debug!(
+            "Port-health loop ended for process '{}' (port {})",
+            process_name,
+            port
+        );
+    }
+
+    /// One-shot descendant-tree discovery 3s after spawn.
+    ///
+    /// The spawned PID is the outer wrapper (`cmd.exe` on Windows). Within
+    /// ~3s it has forked the full chain down to the service worker. We
+    /// snapshot the descendant tree once, identify the inner service PID,
+    /// and write both onto `ProcessRuntime` so Phase 2 can probe the
+    /// service-PID directly and Phase 4 can persist the tracked set for
+    /// orphan reclaim. If the process leaves `Running`/`Healthy` before the
+    /// discovery query returns, we drop the result rather than clobber the
+    /// terminal state.
+    async fn descendant_discovery_once(
+        process_id: String,
+        process_name: String,
+        health_port: Option<u16>,
+        processes: Arc<RwLock<HashMap<String, ManagedProcess>>>,
+        app_handle: tauri::AppHandle,
+    ) {
+        use super::process_tree;
+
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        // Capture the spawned PID under a brief read lock; bail if state moved on.
+        let spawned_pid = {
+            let procs = processes.read().await;
+            let Some(p) = procs.get(&process_id) else {
+                return;
+            };
+            if !matches!(
+                p.runtime.state,
+                ProcessState::Running | ProcessState::Healthy
+            ) {
+                return;
+            }
+            match p.runtime.pid {
+                Some(pid) => pid,
+                None => return,
+            }
+        };
+
+        let (descendants, parent_map) =
+            process_tree::discover_descendants_with_parent_map(spawned_pid).await;
+        let service_pid =
+            process_tree::identify_service_pid(&descendants, &parent_map, health_port, spawned_pid);
+
+        let emit_status = {
+            let mut procs = processes.write().await;
+            let Some(p) = procs.get_mut(&process_id) else {
+                return;
+            };
+            // Re-check state — discovery query is async; the process may
+            // have stopped/failed while we were waiting for PowerShell.
+            if !matches!(
+                p.runtime.state,
+                ProcessState::Running | ProcessState::Healthy
+            ) {
+                return;
+            }
+            let changed = p.runtime.service_pid != service_pid
+                || p.runtime.descendant_pids.len() != descendants.len();
+            p.runtime.descendant_pids = descendants.clone();
+            p.runtime.service_pid = service_pid;
+            if changed {
+                Some(p.status())
+            } else {
+                None
+            }
+        };
+
+        info!(
+            "Discovered {} descendants for '{}' (spawned_pid={}), service_pid={:?}",
+            descendants.len(),
+            process_name,
+            spawned_pid,
+            service_pid
+        );
+
+        // Persist for §3.5 startup orphan-reclaim. Phase 4 — record the
+        // tracked root PID so a crashed-without-shutdown runner can find
+        // and reap its prior generation's orphan trees on next boot.
+        let root_entry = super::process_tree::PidWithSpawnedAt {
+            pid: spawned_pid,
+            spawned_at_unix: chrono::Utc::now().timestamp(),
+        };
+        let mut to_persist = Vec::with_capacity(descendants.len() + 1);
+        to_persist.push(root_entry);
+        to_persist.extend(descendants.iter().copied());
+        super::orphan_state::record_tree(&process_id, &to_persist);
+
+        if let Some(status) = emit_status {
+            let _ = tauri::Emitter::emit(&app_handle, "process-state-changed", &status);
+        }
     }
 
     /// Flush a batch of output lines to PG. Best-effort: failures are logged, batch is cleared.

--- a/src-tauri/src/process_capture/mod.rs
+++ b/src-tauri/src/process_capture/mod.rs
@@ -29,8 +29,10 @@ pub mod cleanup;
 pub mod commands;
 pub mod health;
 pub mod manager;
+pub mod orphan_state;
 pub mod primary_proxy;
 pub(crate) mod process;
+pub mod process_tree;
 pub mod stream_parser;
 pub mod types;
 

--- a/src-tauri/src/process_capture/orphan_state.rs
+++ b/src-tauri/src/process_capture/orphan_state.rs
@@ -1,0 +1,254 @@
+//! Persistent descendant-tree state across runner sessions.
+//!
+//! When the runner crashes or is force-killed without an orderly shutdown,
+//! its managed-process children (`cmd → poetry → python → uvicorn`) survive
+//! as orphans. The Windows Job Object set up at `main.rs::init_job_object`
+//! reaps these on graceful exit, but a ⚙ crash leaves the JobObject handle
+//! closed mid-state and Windows can race the runner before the
+//! KILL_ON_JOB_CLOSE setting takes effect for late-spawned children.
+//!
+//! To recover, every successful descendant-discovery pass (see
+//! `process_tree::descendant_discovery_once`) writes the current tree to
+//! `<data_local_dir>/com.qontinui.runner/process_tree_state.json`. On the
+//! next runner startup, we reload that file, sanity-filter each persisted
+//! PID against the live process's actual creation time (PIDs get reused),
+//! reap any surviving descendants via `health::kill_descendant_tree`, and
+//! clear the file so a crash mid-reclaim doesn't loop.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::process_tree::PidWithSpawnedAt;
+
+/// Bumped when the on-disk shape changes. Older readers skip unknown
+/// versions rather than partially-parse and lose data.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Top-level on-disk representation. Keyed by `ProcessConfig.id` so a
+/// renamed-but-same-id config still reclaims its prior generation.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct OrphanState {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub trees: HashMap<String, Vec<PidWithSpawnedAt>>,
+}
+
+impl OrphanState {
+    pub fn new() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION,
+            trees: HashMap::new(),
+        }
+    }
+}
+
+/// Resolve the on-disk path; co-located with the existing
+/// `auth_tokens.enc` in `<data_local_dir>/com.qontinui.runner/`.
+pub fn state_path() -> Option<PathBuf> {
+    let mut dir = dirs::data_local_dir()?;
+    dir.push("com.qontinui.runner");
+    Some(dir.join("process_tree_state.json"))
+}
+
+/// Load persisted state. Returns `Default` (empty) if the file is absent,
+/// unreadable, or carries an unsupported schema version. This is the
+/// "lose orphan reclaim for one startup" forward-compat branch.
+pub fn load() -> OrphanState {
+    let path = match state_path() {
+        Some(p) => p,
+        None => return OrphanState::default(),
+    };
+    let text = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return OrphanState::default(),
+    };
+    let parsed: OrphanState = match serde_json::from_str(&text) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                "orphan_state: failed to parse {}: {} — ignoring",
+                path.display(),
+                e
+            );
+            return OrphanState::default();
+        }
+    };
+    if parsed.schema_version != SCHEMA_VERSION {
+        tracing::warn!(
+            "orphan_state: schema {} != {}, skipping reclaim this startup",
+            parsed.schema_version,
+            SCHEMA_VERSION
+        );
+        return OrphanState::default();
+    }
+    parsed
+}
+
+/// Persist `state` atomically (write-temp-then-rename so a crash mid-write
+/// leaves the previous file intact).
+pub fn save(state: &OrphanState) -> std::io::Result<()> {
+    let path = match state_path() {
+        Some(p) => p,
+        None => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "data_local_dir unavailable",
+            ));
+        }
+    };
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let text = serde_json::to_string_pretty(state)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    std::fs::write(&tmp, text)?;
+    std::fs::rename(&tmp, &path)
+}
+
+/// Upsert a single process's descendant list and persist.
+///
+/// Best-effort: failures are logged but don't propagate, since orphan
+/// reclaim is a safety net, not load-bearing for correctness.
+pub fn record_tree(process_id: &str, descendants: &[PidWithSpawnedAt]) {
+    let mut state = load();
+    if descendants.is_empty() {
+        state.trees.remove(process_id);
+    } else {
+        state
+            .trees
+            .insert(process_id.to_string(), descendants.to_vec());
+    }
+    state.schema_version = SCHEMA_VERSION;
+    if let Err(e) = save(&state) {
+        tracing::warn!("orphan_state: failed to persist tree for {process_id}: {e}");
+    }
+}
+
+/// Reclaim any orphan descendants left over from a prior session.
+///
+/// For each persisted PID, query the live `Win32_Process` / `/proc/<pid>/stat`
+/// creation time. If the PID is alive AND its creation time matches the
+/// persisted `spawned_at_unix` (within ±2s to absorb tick-resolution drift),
+/// it's an orphan — reap it via `health::kill_descendant_tree`. Otherwise
+/// it's PID reuse (a new unrelated process); skip.
+///
+/// After reclaim the file is rewritten with empty trees so a crash mid-loop
+/// doesn't double-reap (or kill an innocent process whose PID happens to
+/// match a stale entry).
+pub async fn reclaim_orphans() {
+    let state = load();
+    if state.trees.is_empty() {
+        return;
+    }
+
+    use super::process_tree;
+
+    // Take a fresh process-table snapshot once; cheap and avoids racing
+    // multiple WMI calls. We only care about creation_times for the
+    // PID-reuse guard.
+    let snapshot = process_tree::snapshot_process_table_public().await;
+    let live_creation_times = snapshot.creation_times;
+
+    let mut total_reaped: usize = 0;
+    let mut surviving_count: usize = 0;
+
+    for (process_id, persisted) in state.trees.iter() {
+        for entry in persisted.iter() {
+            surviving_count += 1;
+            let live_ts = match live_creation_times.get(&entry.pid).copied() {
+                Some(t) => t,
+                None => {
+                    // PID no longer exists; nothing to do.
+                    continue;
+                }
+            };
+            // PID-reuse guard. The persisted fingerprint is meaningful only
+            // when BOTH timestamps parsed successfully (`> 0`). If either
+            // side is 0 we can't tell "still our orphan" from "PID reused
+            // by an unrelated process", so we fail closed and skip the
+            // kill rather than risk reaping a coincidental match. Within
+            // ±2s of clock-resolution drift counts as the same process.
+            if entry.spawned_at_unix == 0 || live_ts == 0 {
+                tracing::debug!(
+                    "orphan_state: PID {} creation timestamp unavailable \
+                     (persisted={}, live={}); skipping reclaim for '{}' \
+                     (fail-closed against PID reuse)",
+                    entry.pid,
+                    entry.spawned_at_unix,
+                    live_ts,
+                    process_id
+                );
+                continue;
+            }
+            if (live_ts - entry.spawned_at_unix).abs() > 2 {
+                tracing::debug!(
+                    "orphan_state: PID {} reused since prior session \
+                     (persisted spawned_at={}, live={}); skipping reclaim for '{}'",
+                    entry.pid,
+                    entry.spawned_at_unix,
+                    live_ts,
+                    process_id
+                );
+                continue;
+            }
+            let killed = super::health::kill_descendant_tree(entry.pid).await;
+            tracing::info!(
+                "orphan_state: reaped orphan tree for '{}' (root PID {}, {} processes killed)",
+                process_id,
+                entry.pid,
+                killed
+            );
+            total_reaped += killed;
+        }
+    }
+
+    // Clear the persisted state regardless of outcome. A surviving PID
+    // we missed is recoverable on next iteration; double-reaping is not.
+    let empty = OrphanState::new();
+    if let Err(e) = save(&empty) {
+        tracing::warn!("orphan_state: failed to clear state file after reclaim: {e}");
+    }
+
+    if surviving_count > 0 {
+        tracing::info!(
+            "orphan_state: startup reclaim complete — {} prior-session entries inspected, {} processes killed",
+            surviving_count,
+            total_reaped
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_orphan_state() {
+        let mut s = OrphanState::new();
+        s.trees.insert(
+            "backend".to_string(),
+            vec![PidWithSpawnedAt {
+                pid: 1234,
+                spawned_at_unix: 1715911000,
+            }],
+        );
+        let json = serde_json::to_string(&s).unwrap();
+        let parsed: OrphanState = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.schema_version, SCHEMA_VERSION);
+        assert_eq!(parsed.trees.len(), 1);
+        assert_eq!(parsed.trees["backend"][0].pid, 1234);
+    }
+
+    #[test]
+    fn schema_mismatch_returns_default() {
+        let json = r#"{"schema_version":999,"trees":{"backend":[]}}"#;
+        // Bypass load() because it reads from disk; emulate the version check.
+        let parsed: OrphanState = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.schema_version, 999);
+        // The actual load() would discard this and return default; here we
+        // just confirm we can detect the mismatch.
+    }
+}

--- a/src-tauri/src/process_capture/process.rs
+++ b/src-tauri/src/process_capture/process.rs
@@ -79,6 +79,14 @@ impl ManagedProcess {
         }
 
         self.runtime.state = ProcessState::Starting;
+        // Reset port-health each spawn so a restarted process doesn't briefly
+        // inherit the prior generation's `port_healthy` value. The manager's
+        // port-health loop overwrites this within one poll interval.
+        self.runtime.port_healthy = None;
+        // Descendant tree and inner service PID are repopulated by the
+        // post-spawn discovery task ~3s after Running.
+        self.runtime.descendant_pids.clear();
+        self.runtime.service_pid = None;
 
         let (msg_tx, msg_rx) = mpsc::channel::<ProcessMessage>(500);
 
@@ -90,6 +98,26 @@ impl ManagedProcess {
 
         let pid = child.id();
         info!("Spawned process '{}' (PID: {:?})", self.config.name, pid);
+
+        // Assign the spawned child to the singleton Job Object so it (and
+        // — via `KILL_ON_JOB_CLOSE` on the parent JobObject's lifetime —
+        // its descendant tree) auto-terminates when the runner exits, even
+        // on crash. Mirrors `claude_session/runner.rs::assign_process_to_job`
+        // and `terminal/session.rs:522`. Best-effort: if the JobObject
+        // failed to initialize at boot, this is a silent no-op.
+        #[cfg(target_os = "windows")]
+        {
+            if let Some(handle) = child.raw_handle() {
+                crate::job_object::assign_process_to_job(
+                    handle as windows_sys::Win32::Foundation::HANDLE,
+                );
+            } else {
+                tracing::warn!(
+                    "Spawned process '{}' has no raw handle; skipping Job Object assignment",
+                    self.config.name
+                );
+            }
+        }
 
         self.runtime.pid = pid;
         self.runtime.state = ProcessState::Running;
@@ -255,6 +283,9 @@ impl ManagedProcess {
 
         self.runtime.state = ProcessState::Stopped;
         self.runtime.pid = None;
+        self.runtime.port_healthy = None;
+        self.runtime.descendant_pids.clear();
+        self.runtime.service_pid = None;
 
         info!("Process '{}' stopped", self.config.name);
     }
@@ -285,6 +316,23 @@ impl ManagedProcess {
         {
             cmd = crate::process_helpers::tokio_no_window(&self.config.command);
             cmd.args(&self.config.args);
+            // Unix analog to the Windows Job Object KILL_ON_JOB_CLOSE: ask
+            // the kernel to deliver SIGKILL to this child if our process
+            // (the runner) dies. Combined with the descendant-tree reap on
+            // graceful shutdown, this keeps orphan dev servers from
+            // accumulating across crashes.
+            #[cfg(target_os = "linux")]
+            unsafe {
+                use std::os::unix::process::CommandExt;
+                cmd.pre_exec(|| {
+                    // PR_SET_PDEATHSIG = 1; SIGKILL = 9.
+                    let r = libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL, 0, 0, 0);
+                    if r != 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
         }
 
         cmd.current_dir(&self.config.cwd);

--- a/src-tauri/src/process_capture/process_tree.rs
+++ b/src-tauri/src/process_capture/process_tree.rs
@@ -1,0 +1,559 @@
+//! Process-tree discovery for managed processes.
+//!
+//! The runner spawns dev services through deep wrapper chains
+//! (`cmd → poetry → python → uvicorn → uvicorn worker` on Windows).
+//! `tokio::process::Child::id()` only knows the outer wrapper; the
+//! service-bearing PID is several hops down. This module enumerates the
+//! descendant tree of a spawned PID and identifies which descendant is the
+//! "service" — the inner PID whose liveness determines whether the managed
+//! process is doing its job. Phase 1 populates `ProcessRuntime.descendant_pids`
+//! / `service_pid`; Phase 2 reads `service_pid` to detect inner-worker death.
+//!
+//! Windows uses `Get-CimInstance Win32_Process` via PowerShell to snapshot
+//! `(ProcessId, ParentProcessId, CreationDate)` for every running process,
+//! then BFS in Rust. Unix reads `/proc/<pid>/task/<pid>/children` recursively
+//! and `/proc/<pid>/stat` for the start time.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A descendant PID + its creation time, used by Phase 4 to detect PID
+/// reuse across runner restarts (the kernel recycles PIDs aggressively on
+/// Windows; a long-running orphan's PID may belong to a brand-new unrelated
+/// process by the next runner startup).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PidWithSpawnedAt {
+    pub pid: u32,
+    /// Process creation time as Unix epoch seconds. `0` if the platform
+    /// helper failed to resolve it (e.g. permission-denied on `/proc/<pid>/stat`).
+    pub spawned_at_unix: i64,
+}
+
+/// Snapshot of the process table relevant to one discovery pass.
+///
+/// `parent_map[parent_pid] -> [child_pid, ...]` is the BFS index;
+/// `creation_times[pid] -> unix_secs` carries the lookup table built from
+/// the same snapshot so Phase 4 can sanity-filter persisted PIDs without
+/// re-querying WMI.
+#[derive(Debug, Default)]
+pub struct ProcessSnapshot {
+    pub parent_map: HashMap<u32, Vec<u32>>,
+    pub creation_times: HashMap<u32, i64>,
+}
+
+/// Discover every descendant of `root_pid` (NOT including the root itself).
+///
+/// Returns `(descendants, parent_map)`. The parent map is restricted to the
+/// system-wide snapshot — `identify_service_pid` only walks the descendant
+/// subset, but the full map is useful for §3.5 sibling-tree reasoning.
+///
+/// Returns empty vectors on platform helper failure (logged at `warn!`).
+pub async fn discover_descendants_with_parent_map(
+    root_pid: u32,
+) -> (Vec<PidWithSpawnedAt>, HashMap<u32, Vec<u32>>) {
+    let snapshot = snapshot_process_table().await;
+    let descendants = collect_descendants_from_snapshot(root_pid, &snapshot);
+    (descendants, snapshot.parent_map)
+}
+
+/// Take a fresh process-table snapshot — exposed for `orphan_state` so the
+/// startup reclaim pass can do its PID-reuse check without re-querying.
+pub async fn snapshot_process_table_public() -> ProcessSnapshot {
+    snapshot_process_table().await
+}
+
+/// Convenience wrapper: discover descendants only.
+pub async fn discover_descendants(root_pid: u32) -> Vec<PidWithSpawnedAt> {
+    discover_descendants_with_parent_map(root_pid).await.0
+}
+
+/// Identify which descendant is "the service" — port owner → leaf →
+/// fallback to `spawned_pid`. See module-level docs for rules.
+pub fn identify_service_pid(
+    descendants: &[PidWithSpawnedAt],
+    parent_map: &HashMap<u32, Vec<u32>>,
+    health_port: Option<u16>,
+    spawned_pid: u32,
+) -> Option<u32> {
+    identify_service_pid_with_lookup(descendants, parent_map, health_port, spawned_pid, |port| {
+        port_owner_pid(port)
+    })
+}
+
+/// Pure version with an injectable port-owner lookup; used by unit tests.
+pub fn identify_service_pid_with_lookup<F>(
+    descendants: &[PidWithSpawnedAt],
+    parent_map: &HashMap<u32, Vec<u32>>,
+    health_port: Option<u16>,
+    spawned_pid: u32,
+    port_owner_lookup: F,
+) -> Option<u32>
+where
+    F: Fn(u16) -> Option<u32>,
+{
+    // Rule 1: port owner wins, but only if that owner is in our tracked tree
+    // (otherwise some unrelated process happens to bind the port and we'd
+    // incorrectly link it as ours).
+    if let Some(port) = health_port {
+        if let Some(owner) = port_owner_lookup(port) {
+            if descendants.iter().any(|d| d.pid == owner) || owner == spawned_pid {
+                return Some(owner);
+            }
+        }
+    }
+
+    // Rule 2: leaf wins. The deepest descendant with no children in the
+    // tracked tree is the service. Walk every descendant; the candidate is
+    // the one whose subtree-depth from spawned_pid is greatest among those
+    // with zero children in `parent_map`.
+    if !descendants.is_empty() {
+        let descendant_set: std::collections::HashSet<u32> =
+            descendants.iter().map(|d| d.pid).collect();
+        let mut best: Option<(u32, usize)> = None;
+        for d in descendants {
+            let has_tracked_children = parent_map
+                .get(&d.pid)
+                .map(|kids| kids.iter().any(|k| descendant_set.contains(k)))
+                .unwrap_or(false);
+            if has_tracked_children {
+                continue;
+            }
+            let depth = depth_from_root(d.pid, spawned_pid, parent_map);
+            if best.map(|(_, bd)| depth > bd).unwrap_or(true) {
+                best = Some((d.pid, depth));
+            }
+        }
+        if let Some((leaf, _)) = best {
+            return Some(leaf);
+        }
+    }
+
+    // Rule 3: fallback. The outer spawned PID is "the service" by default —
+    // equivalent to today's behavior before this module existed.
+    Some(spawned_pid)
+}
+
+/// Compute the depth of `pid` from `root` by walking up the inverted parent
+/// map. Used by the leaf-wins rule when multiple leaves exist (deepest wins).
+fn depth_from_root(pid: u32, root: u32, parent_map: &HashMap<u32, Vec<u32>>) -> usize {
+    // Invert parent_map: child -> parent. (Cheap because we only do this
+    // for the candidate set, which is small.)
+    let mut parent_of: HashMap<u32, u32> = HashMap::new();
+    for (parent, kids) in parent_map.iter() {
+        for k in kids {
+            parent_of.insert(*k, *parent);
+        }
+    }
+    let mut cur = pid;
+    let mut depth = 0;
+    while let Some(&p) = parent_of.get(&cur) {
+        depth += 1;
+        if p == root {
+            return depth;
+        }
+        cur = p;
+        if depth > 64 {
+            // Cycle guard — process trees on real systems are shallow.
+            break;
+        }
+    }
+    depth
+}
+
+/// BFS from `root` over `parent_map`, returning every descendant (NOT the
+/// root). Pure helper extracted for unit testing.
+fn bfs_descendants_from(
+    root: u32,
+    parent_map: &HashMap<u32, Vec<u32>>,
+    creation_times: &HashMap<u32, i64>,
+) -> Vec<PidWithSpawnedAt> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    seen.insert(root);
+    let mut queue = std::collections::VecDeque::new();
+    if let Some(kids) = parent_map.get(&root) {
+        for k in kids {
+            queue.push_back(*k);
+        }
+    }
+    while let Some(pid) = queue.pop_front() {
+        if !seen.insert(pid) {
+            continue;
+        }
+        out.push(PidWithSpawnedAt {
+            pid,
+            spawned_at_unix: creation_times.get(&pid).copied().unwrap_or(0),
+        });
+        if let Some(kids) = parent_map.get(&pid) {
+            for k in kids {
+                queue.push_back(*k);
+            }
+        }
+    }
+    out
+}
+
+fn collect_descendants_from_snapshot(
+    root: u32,
+    snapshot: &ProcessSnapshot,
+) -> Vec<PidWithSpawnedAt> {
+    bfs_descendants_from(root, &snapshot.parent_map, &snapshot.creation_times)
+}
+
+// ============================================================================
+// Windows implementation
+// ============================================================================
+
+#[cfg(windows)]
+async fn snapshot_process_table() -> ProcessSnapshot {
+    // ConvertTo-Json on a single row drops the array; force an array with @().
+    const SCRIPT: &str = "$ErrorActionPreference='SilentlyContinue'; \
+        @(Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate) | \
+        ConvertTo-Json -Compress -Depth 3";
+
+    let output = match tokio::task::spawn_blocking(|| {
+        crate::process_helpers::no_window("powershell")
+            .args(["-NoProfile", "-NonInteractive", "-Command", SCRIPT])
+            .output()
+    })
+    .await
+    {
+        Ok(Ok(o)) if o.status.success() => o,
+        Ok(Ok(o)) => {
+            tracing::warn!(
+                "process_tree: PowerShell snapshot failed (status={:?}, stderr={})",
+                o.status,
+                String::from_utf8_lossy(&o.stderr)
+            );
+            return ProcessSnapshot::default();
+        }
+        Ok(Err(e)) => {
+            tracing::warn!("process_tree: PowerShell snapshot spawn error: {e}");
+            return ProcessSnapshot::default();
+        }
+        Err(e) => {
+            tracing::warn!("process_tree: PowerShell snapshot join error: {e}");
+            return ProcessSnapshot::default();
+        }
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_powershell_snapshot(&stdout)
+}
+
+#[cfg(windows)]
+#[derive(Debug, Deserialize)]
+struct WmiProcessRow {
+    #[serde(rename = "ProcessId")]
+    process_id: u32,
+    #[serde(rename = "ParentProcessId", default)]
+    parent_process_id: Option<u32>,
+    #[serde(rename = "CreationDate", default)]
+    creation_date: Option<serde_json::Value>,
+}
+
+#[cfg(windows)]
+fn parse_powershell_snapshot(json: &str) -> ProcessSnapshot {
+    let rows: Vec<WmiProcessRow> = match serde_json::from_str(json) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!("process_tree: failed to parse WMI JSON: {e}");
+            return ProcessSnapshot::default();
+        }
+    };
+
+    let mut snap = ProcessSnapshot::default();
+    for row in rows {
+        let parent = row.parent_process_id.unwrap_or(0);
+        snap.parent_map
+            .entry(parent)
+            .or_default()
+            .push(row.process_id);
+        let secs = row
+            .creation_date
+            .as_ref()
+            .map(parse_wmi_creation_date)
+            .unwrap_or(0);
+        snap.creation_times.insert(row.process_id, secs);
+    }
+    snap
+}
+
+/// CIM/WMI `CreationDate` via `ConvertTo-Json` comes through as either:
+///   - a string like `/Date(1715911300000)/` (older PowerShell encoders),
+///   - a string like `2026-05-16T18:50:06.123Z` (newer encoders), or
+///   - an object containing `value`/`DateTime` fields.
+/// Return Unix epoch seconds, or 0 on parse failure.
+#[cfg(windows)]
+fn parse_wmi_creation_date(v: &serde_json::Value) -> i64 {
+    use chrono::{DateTime, Utc};
+
+    if let Some(s) = v.as_str() {
+        // /Date(ms)/ or /Date(ms+ZZZZ)/
+        if let Some(rest) = s.strip_prefix("/Date(") {
+            if let Some(num) = rest.split(['+', '-', ')']).next() {
+                if let Ok(ms) = num.parse::<i64>() {
+                    return ms / 1000;
+                }
+            }
+        }
+        // ISO-8601
+        if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+            return dt.timestamp();
+        }
+        if let Ok(dt) = s.parse::<DateTime<Utc>>() {
+            return dt.timestamp();
+        }
+    }
+    0
+}
+
+#[cfg(windows)]
+pub fn port_owner_pid(port: u16) -> Option<u32> {
+    let script = format!(
+        "$ErrorActionPreference='SilentlyContinue'; \
+        $c = Get-NetTCPConnection -LocalPort {port} -ErrorAction SilentlyContinue | \
+            Where-Object {{ $_.OwningProcess -gt 0 }} | \
+            Select-Object -ExpandProperty OwningProcess -First 1; \
+        if ($c) {{ Write-Output $c }}"
+    );
+
+    let output = crate::process_helpers::no_window("powershell")
+        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout);
+    s.trim().lines().next().and_then(|l| l.trim().parse().ok())
+}
+
+// ============================================================================
+// Unix implementation
+// ============================================================================
+
+#[cfg(unix)]
+async fn snapshot_process_table() -> ProcessSnapshot {
+    tokio::task::spawn_blocking(snapshot_process_table_sync)
+        .await
+        .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn snapshot_process_table_sync() -> ProcessSnapshot {
+    let mut snap = ProcessSnapshot::default();
+
+    let btime = read_btime().unwrap_or(0);
+    let ticks_per_sec = unsafe { libc::sysconf(libc::_SC_CLK_TCK) }.max(1) as i64;
+
+    let proc_root = match std::fs::read_dir("/proc") {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("process_tree: failed to read /proc: {e}");
+            return snap;
+        }
+    };
+
+    for entry in proc_root.flatten() {
+        let name = entry.file_name();
+        let s = match name.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let pid: u32 = match s.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+        let stat_path = format!("/proc/{pid}/stat");
+        let stat = match std::fs::read_to_string(&stat_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        // /proc/<pid>/stat: pid (comm) state ppid ... starttime ...
+        // comm can contain spaces and parens; field 4 (ppid) is the first
+        // word AFTER the last ')' in comm.
+        let close = match stat.rfind(')') {
+            Some(i) => i,
+            None => continue,
+        };
+        let tail = &stat[close + 1..];
+        let fields: Vec<&str> = tail.split_whitespace().collect();
+        // tail starts at field 3 (state); ppid is fields[1]; starttime is
+        // fields[19] (22 - 3 = 19).
+        let ppid: u32 = fields.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let starttime_ticks: i64 = fields.get(19).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let spawned_at_unix = if btime > 0 && starttime_ticks > 0 {
+            btime + (starttime_ticks / ticks_per_sec)
+        } else {
+            0
+        };
+        snap.parent_map.entry(ppid).or_default().push(pid);
+        snap.creation_times.insert(pid, spawned_at_unix);
+    }
+    snap
+}
+
+#[cfg(unix)]
+fn read_btime() -> Option<i64> {
+    let s = std::fs::read_to_string("/proc/stat").ok()?;
+    for line in s.lines() {
+        if let Some(rest) = line.strip_prefix("btime ") {
+            return rest.trim().parse().ok();
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+pub fn port_owner_pid(port: u16) -> Option<u32> {
+    // Reuse the lsof shape already used by health.rs::kill_port_process Unix
+    // branch. `-ti :<port>` prints PIDs (one per line) of any process owning
+    // a socket bound to that port.
+    let output = crate::process_helpers::no_window("lsof")
+        .args(["-ti", &format!(":{port}")])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .and_then(|l| l.trim().parse().ok())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pids(items: &[(u32, i64)]) -> Vec<PidWithSpawnedAt> {
+        items
+            .iter()
+            .map(|(p, t)| PidWithSpawnedAt {
+                pid: *p,
+                spawned_at_unix: *t,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn bfs_collects_full_subtree() {
+        // Tree: 1 → 2 → 3 → 4, and 1 → 5
+        let mut parent_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        parent_map.insert(1, vec![2, 5]);
+        parent_map.insert(2, vec![3]);
+        parent_map.insert(3, vec![4]);
+        let creation_times: HashMap<u32, i64> = [(2, 100), (3, 101), (4, 102), (5, 103)]
+            .into_iter()
+            .collect();
+        let out = bfs_descendants_from(1, &parent_map, &creation_times);
+        let mut got: Vec<u32> = out.iter().map(|p| p.pid).collect();
+        got.sort();
+        assert_eq!(got, vec![2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn bfs_excludes_root_and_handles_no_children() {
+        let parent_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        let creation_times: HashMap<u32, i64> = HashMap::new();
+        let out = bfs_descendants_from(42, &parent_map, &creation_times);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn identify_service_pid_port_owner_wins() {
+        // descendants = {2, 3, 4}; port_owner = 3 → returns Some(3).
+        let mut parent_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        parent_map.insert(1, vec![2]);
+        parent_map.insert(2, vec![3]);
+        parent_map.insert(3, vec![4]);
+        let descendants = pids(&[(2, 0), (3, 0), (4, 0)]);
+        let got =
+            identify_service_pid_with_lookup(&descendants, &parent_map, Some(8000), 1, |_port| {
+                Some(3)
+            });
+        assert_eq!(got, Some(3));
+    }
+
+    #[test]
+    fn identify_service_pid_port_owner_outside_tree_falls_through_to_leaf() {
+        // port_owner returns a PID not in our tracked descendants → don't
+        // claim it; fall through to leaf rule.
+        let mut parent_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        parent_map.insert(1, vec![2]);
+        parent_map.insert(2, vec![3]);
+        let descendants = pids(&[(2, 0), (3, 0)]);
+        let got = identify_service_pid_with_lookup(
+            &descendants,
+            &parent_map,
+            Some(8000),
+            1,
+            |_port| Some(9999), // unrelated PID
+        );
+        // Leaf is 3 (no tracked children).
+        assert_eq!(got, Some(3));
+    }
+
+    #[test]
+    fn identify_service_pid_leaf_wins() {
+        // No health_port; 4-deep chain 1 → 2 → 3 → 4. Leaf = 4.
+        let mut parent_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        parent_map.insert(1, vec![2]);
+        parent_map.insert(2, vec![3]);
+        parent_map.insert(3, vec![4]);
+        let descendants = pids(&[(2, 0), (3, 0), (4, 0)]);
+        let got = identify_service_pid_with_lookup(&descendants, &parent_map, None, 1, |_| None);
+        assert_eq!(got, Some(4));
+    }
+
+    #[test]
+    fn identify_service_pid_fallback_when_no_descendants() {
+        let parent_map: HashMap<u32, Vec<u32>> = HashMap::new();
+        let descendants: Vec<PidWithSpawnedAt> = Vec::new();
+        let got =
+            identify_service_pid_with_lookup(&descendants, &parent_map, Some(8000), 42, |_| None);
+        assert_eq!(got, Some(42));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parse_wmi_creation_date_dotnet_style() {
+        let v = serde_json::Value::String("/Date(1715911300000)/".to_string());
+        assert_eq!(parse_wmi_creation_date(&v), 1715911300);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parse_wmi_creation_date_iso_style() {
+        let v = serde_json::Value::String("2026-05-16T18:50:06.000Z".to_string());
+        // Just assert non-zero — exact value depends on UTC epoch, but
+        // this verifies the ISO branch wasn't dropped.
+        assert!(parse_wmi_creation_date(&v) > 1_700_000_000);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parse_powershell_snapshot_builds_parent_map() {
+        let json = r#"[
+            {"ProcessId":1,"ParentProcessId":0,"CreationDate":"/Date(1715911000000)/"},
+            {"ProcessId":2,"ParentProcessId":1,"CreationDate":"/Date(1715911100000)/"},
+            {"ProcessId":3,"ParentProcessId":2,"CreationDate":"/Date(1715911200000)/"}
+        ]"#;
+        let snap = parse_powershell_snapshot(json);
+        assert_eq!(
+            snap.parent_map.get(&1).map(|v| v.as_slice()),
+            Some(&[2u32][..])
+        );
+        assert_eq!(
+            snap.parent_map.get(&2).map(|v| v.as_slice()),
+            Some(&[3u32][..])
+        );
+        assert_eq!(snap.creation_times.get(&2).copied(), Some(1715911100));
+    }
+}

--- a/src-tauri/src/process_capture/types.rs
+++ b/src-tauri/src/process_capture/types.rs
@@ -20,6 +20,8 @@ pub use qontinui_types::process_management::*;
 
 use std::time::Instant;
 
+use super::process_tree::PidWithSpawnedAt;
+
 // ============================================================================
 // ProcessConfig behavior (extension trait)
 // ============================================================================
@@ -119,6 +121,13 @@ pub(crate) struct ProcessRuntime {
     pub session_id: Option<String>,
     /// Whether specs have been auto-discovered for this process start
     pub specs_discovered: bool,
+    /// Descendant PIDs discovered after spawn. Empty until the post-spawn
+    /// discovery pass completes (~3s after Running).
+    pub descendant_pids: Vec<PidWithSpawnedAt>,
+    /// Inner "service" PID identified from descendants. None until
+    /// discovery completes; then either the port-owner / leaf / or the
+    /// outer spawned PID as fallback.
+    pub service_pid: Option<u32>,
 }
 
 impl Default for ProcessRuntime {
@@ -132,6 +141,8 @@ impl Default for ProcessRuntime {
             port_healthy: None,
             session_id: None,
             specs_discovered: false,
+            descendant_pids: Vec::new(),
+            service_pid: None,
         }
     }
 }

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -150,13 +150,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
       log.debug(`refreshAuth() #${callNum} - completed successfully`);
     } catch (err) {
       log.warn(`refreshAuth() #${callNum} - Token refresh failed:`, err);
-      // Don't immediately log the user out. The current access token may still be
-      // valid — a refresh failure alone (e.g., transient network issue, backend
-      // momentarily unavailable) should not destroy the user's session and cause
-      // the entire app tree (including terminal sessions) to unmount.
-      // The next refresh cycle will try again. If the token truly expired,
-      // subsequent API calls will return 401 and the user can re-authenticate.
-      setError(err as string);
+      // Don't immediately log the user out. The current access token may still
+      // be valid — a refresh failure alone (network blip, backend momentarily
+      // unavailable, 5xx) should not destroy the user's session.
+      //
+      // We also deliberately do NOT `setError(err)` here. A non-null `error`
+      // is read by `PromptHomePage`'s "Sign-in required" banner as "session
+      // expired", which it isn't — the next refresh cycle will retry. The
+      // backend's `refresh_token_impl` clears tokens itself on a true 401/403,
+      // so a real expiry surfaces through `authStatus.authenticated = false`
+      // on the next `checkAuthStatus`, not through this catch.
     }
   }, [checkAuthStatus]);
 

--- a/src/components/process-manager/ProcessManagerTab.tsx
+++ b/src/components/process-manager/ProcessManagerTab.tsx
@@ -21,7 +21,7 @@ import {
   Settings2,
 } from "lucide-react";
 
-import { ProcessStatusBadge } from "./ProcessStatusBadge";
+import { ProcessStatusBadge, isPortDead } from "./ProcessStatusBadge";
 import { ProcessOutputViewer } from "./ProcessOutputViewer";
 import { ProcessConfigEditor } from "./ProcessConfigEditor";
 import { ScanProjectsModal } from "./ScanProjectsModal";
@@ -91,6 +91,13 @@ export function ProcessManagerTab() {
   const [loading, setLoading] = useState(true);
   const unlistenRef = useRef<UnlistenFn | null>(null);
   const [identity, setIdentity] = useState<RunnerIdentity | null>(null);
+  /**
+   * Last few stderr lines per port-dead process, populated on a 6s cadence
+   * for any process matching `isPortDead()`. Surfaces inline on the badge
+   * tooltip so the user sees the inner uvicorn traceback without having to
+   * click into the row.
+   */
+  const [stderrTails, setStderrTails] = useState<Record<string, string>>({});
 
   // AI Fix session state
   const [aiFixActive, setAiFixActive] = useState(false);
@@ -162,6 +169,65 @@ export function ProcessManagerTab() {
     const interval = setInterval(loadProcesses, 5000);
     return () => clearInterval(interval);
   }, [loadProcesses]);
+
+  // Pull a tail of stderr for every process currently in the amber
+  // "port dead" state. Runs on a 6s cadence — half the rate of the
+  // backend's 3s port_health probe, which is fast enough that the tooltip
+  // catches up to a fresh traceback within one render but slow enough to
+  // not hammer the IPC layer. Cleared automatically when the process
+  // leaves port-dead state.
+  useEffect(() => {
+    const portDeadIds = processes
+      .filter((p) => isPortDead(p.state, p.port_healthy, p.uptime_secs))
+      .map((p) => p.id);
+
+    if (portDeadIds.length === 0) {
+      setStderrTails((prev) => (Object.keys(prev).length === 0 ? prev : {}));
+      return;
+    }
+
+    let cancelled = false;
+    const fetchTails = async () => {
+      const updates: Record<string, string> = {};
+      await Promise.all(
+        portDeadIds.map(async (id) => {
+          try {
+            const lines = await invoke<OutputLine[]>("get_process_output", {
+              id,
+              tail: 80,
+            });
+            const stderrText = lines
+              .filter((l) => l.stream === "stderr")
+              .slice(-5)
+              .map((l) => l.line)
+              .join("\n");
+            updates[id] = stderrText;
+          } catch {
+            // Best-effort — leave the previous tail in place on transient
+            // IPC errors. Don't overwrite with empty so a momentarily-slow
+            // fetch doesn't blank the tooltip mid-render.
+          }
+        }),
+      );
+      if (!cancelled) {
+        setStderrTails((prev) => {
+          // Drop entries for processes that have left port-dead state and
+          // merge in fresh tails for the current set.
+          const next: Record<string, string> = {};
+          for (const id of portDeadIds) {
+            next[id] = updates[id] ?? prev[id] ?? "";
+          }
+          return next;
+        });
+      }
+    };
+    void fetchTails();
+    const interval = setInterval(fetchTails, 6000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [processes]);
 
   const handleStart = useCallback(
     async (id: string, e: React.MouseEvent) => {
@@ -595,7 +661,12 @@ Be concise and actionable.`;
                       <ChevronRight className="w-3 h-3 text-zinc-500 shrink-0" />
                     )}
                     <span className="text-sm text-zinc-200 truncate">{proc.name}</span>
-                    <ProcessStatusBadge state={proc.state} />
+                    <ProcessStatusBadge
+                      state={proc.state}
+                      portHealthy={proc.port_healthy}
+                      uptimeSecs={proc.uptime_secs}
+                      stderrTail={stderrTails[proc.id]}
+                    />
                   </div>
                   <div className="flex items-center gap-3 mt-1 ml-5 text-xs text-zinc-500">
                     {proc.pid && <span>PID: {proc.pid}</span>}
@@ -629,8 +700,17 @@ Be concise and actionable.`;
                     <>
                       <button
                         onClick={(e) => handleRestart(proc.id, e)}
-                        className="p-1.5 text-yellow-500 hover:text-yellow-400 hover:bg-yellow-500/10 rounded transition-colors"
-                        title="Restart"
+                        className={cn(
+                          "p-1.5 rounded transition-colors",
+                          isPortDead(proc.state, proc.port_healthy, proc.uptime_secs)
+                            ? "text-amber-400 hover:text-amber-300 hover:bg-amber-400/10 animate-pulse"
+                            : "text-yellow-500 hover:text-yellow-400 hover:bg-yellow-500/10",
+                        )}
+                        title={
+                          isPortDead(proc.state, proc.port_healthy, proc.uptime_secs)
+                            ? "Restart (port dead — inner service is not responding)"
+                            : "Restart"
+                        }
                       >
                         <RotateCcw className="w-3.5 h-3.5" />
                       </button>

--- a/src/components/process-manager/ProcessStatusBadge.tsx
+++ b/src/components/process-manager/ProcessStatusBadge.tsx
@@ -1,7 +1,16 @@
 import { cn } from "../../lib/utils";
-import { Circle, Loader2, CheckCircle2, XCircle, Square, ArrowDown, Hammer } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowDown,
+  CheckCircle2,
+  Circle,
+  Hammer,
+  Loader2,
+  Square,
+  XCircle,
+} from "lucide-react";
 
-type ProcessState =
+export type ProcessState =
   | "stopped"
   | "starting"
   | "building"
@@ -12,7 +21,45 @@ type ProcessState =
 
 interface ProcessStatusBadgeProps {
   state: ProcessState;
+  /**
+   * Result of the manager's TCP probe against `health_port`. `null` if no
+   * port is configured or the first probe hasn't fired yet (the loop ticks
+   * every 3s). `false` after the first failing probe means "alive, but
+   * nothing accepting connections on the port".
+   */
+  portHealthy?: boolean | null;
+  /**
+   * Process uptime in seconds. Used for the port-dead grace window — we
+   * suppress the amber badge for the first 30s after start so normal
+   * Python/Node startup time doesn't paint the row yellow.
+   */
+  uptimeSecs?: number | null;
+  /**
+   * Tail of recent stderr lines for this process (last ~5, joined with
+   * newlines). Surfaced verbatim in the tooltip when the badge is in the
+   * amber port-dead state, so the user sees the uvicorn traceback /
+   * import error inline without having to click into the row. When
+   * empty/undefined the tooltip falls back to the static "worker crash"
+   * copy.
+   */
+  stderrTail?: string;
   className?: string;
+}
+
+/** Seconds after spawn before `port_healthy: false` is treated as a problem. */
+export const PORT_DEAD_GRACE_SECS = 30;
+
+/** Shared predicate matching the badge's amber-state condition. */
+export function isPortDead(
+  state: ProcessState,
+  portHealthy: boolean | null | undefined,
+  uptimeSecs: number | null | undefined,
+): boolean {
+  return (
+    state === "running" &&
+    portHealthy === false &&
+    (uptimeSecs ?? 0) > PORT_DEAD_GRACE_SECS
+  );
 }
 
 const stateConfig: Record<ProcessState, { icon: React.ReactNode; label: string; classes: string }> =
@@ -54,8 +101,35 @@ const stateConfig: Record<ProcessState, { icon: React.ReactNode; label: string; 
     },
   };
 
-export function ProcessStatusBadge({ state, className }: ProcessStatusBadgeProps) {
-  const config = stateConfig[state] || stateConfig.stopped;
+const PORT_DEAD_STATIC_TOOLTIP =
+  "The configured health port stopped accepting connections. The process is alive but not serving — typically a worker crash inside the wrapper. Restart to recover.";
+
+export function ProcessStatusBadge({
+  state,
+  portHealthy,
+  uptimeSecs,
+  stderrTail,
+  className,
+}: ProcessStatusBadgeProps) {
+  const portDead = isPortDead(state, portHealthy, uptimeSecs);
+
+  const config = portDead
+    ? {
+        icon: <AlertTriangle className="w-3 h-3" />,
+        label: "Running (port dead)",
+        classes: "bg-amber-900/30 text-amber-400 border-amber-800",
+      }
+    : stateConfig[state] || stateConfig.stopped;
+
+  // When port-dead, prefer the stderr tail (concrete traceback) over the
+  // static "worker crash" copy. The browser native `title` attribute is
+  // monospace-ish in most platforms and preserves newlines, which is what
+  // we want for stack traces.
+  const tooltip = portDead
+    ? stderrTail && stderrTail.trim().length > 0
+      ? `Port dead — recent stderr:\n${stderrTail}`
+      : PORT_DEAD_STATIC_TOOLTIP
+    : undefined;
 
   return (
     <span
@@ -64,6 +138,7 @@ export function ProcessStatusBadge({ state, className }: ProcessStatusBadgeProps
         config.classes,
         className,
       )}
+      title={tooltip}
     >
       {config.icon}
       {config.label}

--- a/src/components/prompt-home/PromptHomePage.tsx
+++ b/src/components/prompt-home/PromptHomePage.tsx
@@ -66,14 +66,18 @@ export function PromptHomePage() {
   //   - dev auto-login is not still in flight (devAutoLoginPending === false)
   //   - mount-time check happened (authStatus !== null) — avoids flash on
   //     cold mount
-  //   - AND either authStatus.authenticated === false OR there is a
-  //     non-empty error string from the auth provider
+  //   - authStatus.authenticated is explicitly false
+  //
+  // `auth.error` is deliberately NOT consulted. A non-empty error from a
+  // transient refresh failure (backend down for a moment) used to flip this
+  // banner to "Your session has expired" even though the session was fine
+  // — the backend clears tokens itself on a real 401/403, so an actual expiry
+  // shows up as `authStatus.authenticated === false`.
   const isUnauthenticated =
     !auth.loading &&
     !auth.devAutoLoginPending &&
     auth.authStatus !== null &&
-    (auth.authStatus.authenticated === false ||
-      (auth.error !== null && auth.error.length > 0));
+    auth.authStatus.authenticated === false;
 
   // Focus input on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary

Replaces "the PID we remember is alive" with three concurrent truths the runner must keep in sync: the descendant tree, the inner service PID, and prior-session orphans. Today on Windows, ` runner.report(PID=15180)` is the outer `cmd.exe` shim — the uvicorn worker that actually owns `:8000` is four parent-hops down. When the worker crashes on import (current symptom: 2026-05-16 `SpecCheckConfidence` import error), the wrapper survives, the runner sees nothing, and `:8000` lands `Bound`-not-`Listen` indefinitely.

Five mechanisms ship in one branch (plan vetted as `2026-05-16-runner-process-tree-reaping-plan.md`):

- **§3.1–3.2 Descendant tracking + service-PID identification.** New `process_tree::{discover_descendants_with_parent_map, identify_service_pid}`. WMI on Windows, `/proc` on Unix. Port-owner → leaf → fallback rules; pure helper for unit-testing the rules without PowerShell.
- **§3.3 Inner-PID liveness.** `port_health_loop` now also probes `service_pid` via `health::pid_alive` (Win32 `OpenProcess` + `GetExitCodeProcess` / Unix `kill(pid, 0)`). Service-PID death → state `Failed` within one 3s tick.
- **§3.4 Frontend tooltip + restart affordance.** Last 5 stderr lines surface inline on the amber port-dead badge; restart button retitles + animate-pulses when port-dead.
- **§3.5 Orphan reclaim.** `<data_local_dir>/com.qontinui.runner/process_tree_state.json` persists each successful tracking pass; startup reclaims any survivors with a ±2s creation-time fingerprint to defeat PID reuse. Fails closed on parse failures.
- **§3.6 Restart-time reaping** behind `QONTINUI_REAP_RESTART=1` for the first release cycle; existing `kill_port_process` fallback stays armed.
- **§3.7 JobObject + PDEATHSIG.** `ManagedProcess::start` now wires children into the singleton `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` (mirrors `claude_session/runner.rs`); Linux gets `prctl(PR_SET_PDEATHSIG, SIGKILL)` via `pre_exec`.

Bundles two companion fixes the plan vetted against as substrate (without them Phase 2 has no signal to gate on; Phase 3 has no UI to extend):

- `port_health_loop` + `port_healthy` resets in `process.rs`/`manager.rs` event-loop Exited path.
- Amber "Running (port dead)" badge + 30s grace in `ProcessStatusBadge`.
- `AuthProvider` `setError` discrimination + `PromptHomePage` banner predicate — fixes the "Sign-in required" false-positive that lit up the same day the backend silently died.

## Test plan

- [x] `cargo test --bin qontinui-runner process_capture::` — 16 tests pass (BFS shape, port-owner/leaf/fallback rules, /Date(ms)/ + ISO-8601 WMI date parse, orphan-state JSON round-trip + schema mismatch).
- [x] `cargo fmt --check` (enforced by pre-push hook — passed).
- [x] `cargo clippy --package qontinui-runner -- -D warnings` (enforced by pre-push hook — passed).
- [ ] Manual smoke on primary runner: restart Backend with `QONTINUI_REAP_RESTART=1`, force-kill inner uvicorn worker via `Stop-Process -Id <service_pid>`, verify state transitions `Running → Failed` within 3s and the badge tooltip shows the recent traceback.
- [ ] Manual smoke: orphan reclaim — start runner, note descendant PIDs via the new `info!` log, force-kill the runner (`Stop-Process -Force`), restart, verify the `info!("orphan_state: startup reclaim complete — N inspected, M killed")` log fires and `:8000` is free.

## Non-goals

- Cross-platform parity in v1: the failure mode is Windows-specific (`cmd.exe` shim, opaque trees, `Get-NetTCPConnection` semantics). Unix has the inner-PID + reclaim paths but uses a shallower `lsof`-based port-owner lookup. OS-specific tree walks are behind `#[cfg]`.
- Catching crashes during the runner's own ungraceful exit (SIGKILL/OOM kill). The next startup's `reclaim_orphans` pass is the recovery path.