### PR TITLE
feat(spec-api): emit SpecCheckPolicyViolation from /spec-check/batch (Issue 3)

### DIFF
--- a/src-tauri/src/spec_api/events.rs
+++ b/src-tauri/src/spec_api/events.rs
@@ -55,3 +55,215 @@ pub fn now_ms() -> u64 {
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
+
+// ===========================================================================
+// SpecCheckPolicyViolation helpers
+// ===========================================================================
+//
+// The `emit_policy_violations` helper lives here (rather than in either
+// adapter) so HTTP (`/spec-check/batch`) and the workflow-step handler
+// share one canonical implementation. One emit per `PolicyStatus::Fail`
+// conjunct; `Indeterminate` is not emitted (per Plan 06 §5.6 — only
+// deliberate violations count as observability signal).
+
+use qontinui_types::spec_check::{
+    ConjunctRule, PolicyConjunct, PolicyEvaluation, PolicyStatus, SpecCheckPolicy,
+};
+
+/// Wire name for the [`ConjunctRule`] variant — mirrors the
+/// `#[serde(tag = "kind", rename_all = "snake_case")]` discriminator.
+/// Carried on `SpecCheckPolicyViolation.rule_kind` so subscribers can
+/// group violations by rule type without round-tripping the policy.
+pub fn rule_kind_str(rule: &ConjunctRule) -> &'static str {
+    match rule {
+        ConjunctRule::AllPass => "all_pass",
+        ConjunctRule::MaxFailures { .. } => "max_failures",
+        ConjunctRule::FailureRateBelow { .. } => "failure_rate_below",
+        ConjunctRule::StateMatchRateAtLeast { .. } => "state_match_rate_at_least",
+        ConjunctRule::AnyStateMatchRateAtLeast { .. } => "any_state_match_rate_at_least",
+        ConjunctRule::MatchOutcomeAtLeast { .. } => "match_outcome_at_least",
+    }
+}
+
+/// Emit one [`SpecApiEvent::SpecCheckPolicyViolation`] per failing
+/// [`qontinui_types::spec_check::ConjunctEvaluation`]. Looks up each
+/// evaluation by `name` in the originating policy so the emit carries
+/// the structural `rule_kind` discriminator alongside the evidence
+/// string. `Indeterminate` conjuncts are NOT emitted — only `Fail`.
+///
+/// Called from both `/spec-check/batch` (when `sharedPolicy` /
+/// `policyOverride` apply) and the workflow-step handler (which applies
+/// policy locally after self-calling `/spec-check`). No double-emit risk
+/// since the workflow handler self-calls the **single** endpoint, which
+/// doesn't run policy.
+pub fn emit_policy_violations(
+    snapshot_id: &str,
+    page_id: &str,
+    policy: &SpecCheckPolicy,
+    eval: &PolicyEvaluation,
+) {
+    for conjunct_eval in &eval.conjunct_results {
+        if conjunct_eval.status != PolicyStatus::Fail {
+            continue;
+        }
+        let rule_kind = policy
+            .conjuncts
+            .iter()
+            .find(|c: &&PolicyConjunct| c.name == conjunct_eval.name)
+            .map(|c| rule_kind_str(&c.rule))
+            .unwrap_or("unknown");
+        emit(SpecApiEvent::SpecCheckPolicyViolation {
+            snapshot_id: snapshot_id.to_string(),
+            page_id: page_id.to_string(),
+            conjunct_name: conjunct_eval.name.clone(),
+            rule_kind: rule_kind.to_string(),
+            observed: serde_json::Value::String(conjunct_eval.evidence.clone()),
+            at_ms: now_ms(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qontinui_types::spec_check::{
+        AssertionScope, ConjunctEvaluation, MatchOutcome, PolicyConjunct, SpecCheckPolicy,
+    };
+
+    #[test]
+    fn rule_kind_str_covers_every_variant() {
+        // Locks the snake_case discriminator strings against accidental
+        // drift from `#[serde(tag = "kind", rename_all = "snake_case")]`.
+        assert_eq!(rule_kind_str(&ConjunctRule::AllPass), "all_pass");
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::MaxFailures { count: 0 }),
+            "max_failures"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::FailureRateBelow { rate: 0.0 }),
+            "failure_rate_below"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::StateMatchRateAtLeast { rate: 0.0 }),
+            "state_match_rate_at_least"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::AnyStateMatchRateAtLeast { rate: 0.0 }),
+            "any_state_match_rate_at_least"
+        );
+        assert_eq!(
+            rule_kind_str(&ConjunctRule::MatchOutcomeAtLeast {
+                outcome: MatchOutcome::FullMatch
+            }),
+            "match_outcome_at_least"
+        );
+    }
+
+    #[test]
+    fn emit_policy_violations_publishes_one_per_failing_conjunct() {
+        let mut rx = subscribe();
+        let marker = "scs_test_policy_violation_emit_shared_1";
+        let page_id = "settings-test-violation-shared";
+        let policy = SpecCheckPolicy {
+            conjuncts: vec![
+                PolicyConjunct {
+                    name: "critical-all-pass".into(),
+                    scope: AssertionScope::default(),
+                    rule: ConjunctRule::AllPass,
+                },
+                PolicyConjunct {
+                    name: "max-three-failures".into(),
+                    scope: AssertionScope::default(),
+                    rule: ConjunctRule::MaxFailures { count: 3 },
+                },
+                PolicyConjunct {
+                    name: "passing-conjunct".into(),
+                    scope: AssertionScope::default(),
+                    rule: ConjunctRule::AllPass,
+                },
+            ],
+        };
+        let eval = PolicyEvaluation {
+            overall_status: PolicyStatus::Fail,
+            conjunct_results: vec![
+                ConjunctEvaluation {
+                    name: "critical-all-pass".into(),
+                    status: PolicyStatus::Fail,
+                    evidence: "2 of 17 assertions failed".into(),
+                },
+                ConjunctEvaluation {
+                    name: "max-three-failures".into(),
+                    status: PolicyStatus::Fail,
+                    evidence: "5 failures > 3 budget".into(),
+                },
+                ConjunctEvaluation {
+                    name: "passing-conjunct".into(),
+                    status: PolicyStatus::Pass,
+                    evidence: "all green".into(),
+                },
+            ],
+        };
+        emit_policy_violations(marker, page_id, &policy, &eval);
+        let mut violations = Vec::new();
+        for _ in 0..128 {
+            match rx.try_recv() {
+                Ok(SpecApiEvent::SpecCheckPolicyViolation {
+                    snapshot_id,
+                    page_id: pid,
+                    conjunct_name,
+                    rule_kind,
+                    ..
+                }) if snapshot_id == marker => {
+                    violations.push((conjunct_name, rule_kind, pid));
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+        assert_eq!(violations.len(), 2, "expected exactly 2 violation emits");
+        // Order = policy declaration order; first failing conjunct first.
+        assert_eq!(violations[0].0, "critical-all-pass");
+        assert_eq!(violations[0].1, "all_pass");
+        assert_eq!(violations[0].2, page_id);
+        assert_eq!(violations[1].0, "max-three-failures");
+        assert_eq!(violations[1].1, "max_failures");
+    }
+
+    #[test]
+    fn emit_policy_violations_skips_pass_and_indeterminate_conjuncts() {
+        let mut rx = subscribe();
+        let marker = "scs_test_policy_violation_emit_skip_1";
+        let policy = SpecCheckPolicy {
+            conjuncts: vec![PolicyConjunct {
+                name: "single".into(),
+                scope: AssertionScope::default(),
+                rule: ConjunctRule::AllPass,
+            }],
+        };
+        // Indeterminate must NOT emit (per the §5.6 contract — only
+        // deliberate Fail violations count as observability signal).
+        let eval = PolicyEvaluation {
+            overall_status: PolicyStatus::Indeterminate,
+            conjunct_results: vec![ConjunctEvaluation {
+                name: "single".into(),
+                status: PolicyStatus::Indeterminate,
+                evidence: "no in-scope assertions".into(),
+            }],
+        };
+        emit_policy_violations(marker, "page-x", &policy, &eval);
+        // Drain; expect zero matching events.
+        let mut hits = 0;
+        for _ in 0..32 {
+            match rx.try_recv() {
+                Ok(SpecApiEvent::SpecCheckPolicyViolation { snapshot_id, .. })
+                    if snapshot_id == marker =>
+                {
+                    hits += 1;
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+        assert_eq!(hits, 0, "Indeterminate must not emit");
+    }
+}

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -639,9 +639,17 @@ pub async fn post_spec_check_batch(
         let snapshot = snapshot.clone();
         let root = root.clone();
         let shared_policy = req.shared_policy.clone();
-        set.spawn(
-            async move { evaluate_one(&root, &entry, &snapshot, shared_policy.as_ref()).await },
-        );
+        let snapshot_id_owned = snapshot_id.clone();
+        set.spawn(async move {
+            evaluate_one(
+                &root,
+                &entry,
+                &snapshot,
+                &snapshot_id_owned,
+                shared_policy.as_ref(),
+            )
+            .await
+        });
     }
     let mut results = Vec::with_capacity(set.len());
     while let Some(joined) = set.join_next().await {
@@ -761,6 +769,7 @@ async fn evaluate_one(
     root: &std::path::Path,
     entry: &BatchPageEntry,
     snapshot: &Arc<UIBridgeSnapshot>,
+    snapshot_id: &str,
     shared_policy: Option<&SpecCheckPolicy>,
 ) -> BatchElementResult {
     if invalid_page_id(&entry.page_id) {
@@ -780,6 +789,16 @@ async fn evaluate_one(
     // Per-entry override wins over the shared policy.
     let policy = entry.policy_override.as_ref().or(shared_policy);
     let policy_eval = policy.map(|p| spec_check::apply_policy(&result, p));
+
+    // Plan 06 / Issue 3 (2026-05-17): emit SpecCheckPolicyViolation per
+    // failing conjunct. Carries the batch's *shared* snapshot_id (not the
+    // crate's internal sentinel from `result.snapshot_id`) so subscribers
+    // can join all per-element violations under one batch run. The
+    // workflow-step handler does the same emit, but it self-calls
+    // /spec-check (single), not /spec-check/batch, so no double-counting.
+    if let (Some(pol), Some(eval)) = (policy, policy_eval.as_ref()) {
+        events::emit_policy_violations(snapshot_id, &entry.page_id, pol, eval);
+    }
 
     BatchElementResult::ok(entry.page_id.clone(), result, policy_eval)
 }
@@ -853,7 +872,7 @@ async fn stream_batch_results(
                     return None;
                 }
             };
-            let r = evaluate_one(&root, &entry, &snapshot, shared_policy.as_ref()).await;
+            let r = evaluate_one(&root, &entry, &snapshot, &snap_id, shared_policy.as_ref()).await;
             match (r.status, r.result.as_ref()) {
                 ("ok", Some(res)) => {
                     st.ok_count += 1;
@@ -982,7 +1001,7 @@ mod tests {
             page_id: "no-such-page".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(&root, &entry, &snapshot, None).await;
+        let r = evaluate_one(&root, &entry, &snapshot, "scs_test", None).await;
         assert_eq!(r.status, "spec-not-found");
         assert!(r.result.is_none());
         assert_eq!(r.page_id, "no-such-page");
@@ -998,7 +1017,7 @@ mod tests {
             page_id: "../escape".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(&root, &entry, &snapshot, None).await;
+        let r = evaluate_one(&root, &entry, &snapshot, "scs_test", None).await;
         assert_eq!(r.status, "eval-error");
         assert_eq!(r.error.as_deref(), Some("invalid-page-id"));
     }
@@ -1055,11 +1074,104 @@ mod tests {
             page_id: "batch-page".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(root, &entry, &snapshot, None).await;
+        let r = evaluate_one(root, &entry, &snapshot, "scs_test", None).await;
         assert_eq!(r.status, "ok");
         let result = r.result.expect("ok status carries a result");
         assert_eq!(result.page_id, "batch-page");
         assert_eq!(result.result_schema_version, 1);
+    }
+
+    #[tokio::test]
+    async fn evaluate_one_emits_policy_violation_with_batch_snapshot_id() {
+        // Issue 3 (2026-05-17): when /spec-check/batch's evaluate_one applies
+        // a failing policy, it must emit SpecCheckPolicyViolation tagged with
+        // the BATCH's shared snapshot_id (not the crate's internal sentinel).
+        use qontinui_types::spec_api_events::SpecApiEvent;
+        use qontinui_types::spec_check::{AssertionScope, ConjunctRule, PolicyConjunct};
+        // Seed an IR with one critical assertion that will not match an
+        // empty snapshot — guarantees the policy's all_pass fails.
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        let page_dir = root.join("pages").join("batch-violation-page");
+        std::fs::create_dir_all(&page_dir).unwrap();
+        let ir = serde_json::json!({
+            "version": "1.0",
+            "id": "batch-violation-page",
+            "name": "Batch Violation Test",
+            "states": [{
+                "id": "s1",
+                "name": "Sole State",
+                "assertions": [{
+                    "id": "must-have-button",
+                    "description": "must have a Submit button",
+                    "category": "element-presence",
+                    "severity": "critical",
+                    "assertionType": "exists",
+                    "target": {
+                        "type": "search",
+                        "criteria": { "role": "button", "text": "Submit" },
+                        "label": "Submit button"
+                    },
+                    "source": "ai-generated",
+                    "reviewed": false,
+                    "enabled": true
+                }]
+            }],
+            "transitions": []
+        });
+        std::fs::write(
+            page_dir.join("state-machine.derived.json"),
+            serde_json::to_string_pretty(&ir).unwrap(),
+        )
+        .unwrap();
+
+        let snapshot: UIBridgeSnapshot = serde_json::from_value(minimal_snapshot_json()).unwrap();
+        let snapshot = Arc::new(snapshot);
+        let entry = BatchPageEntry {
+            page_id: "batch-violation-page".into(),
+            policy_override: None,
+        };
+        let policy = SpecCheckPolicy {
+            conjuncts: vec![PolicyConjunct {
+                name: "critical-all-pass".into(),
+                scope: AssertionScope::default(),
+                rule: ConjunctRule::AllPass,
+            }],
+        };
+
+        let mut rx = events::subscribe();
+        let marker = "scs_batch_emit_test_marker_xyz";
+        let r = evaluate_one(root, &entry, &snapshot, marker, Some(&policy)).await;
+        assert_eq!(r.status, "ok");
+        let pe = r.policy_evaluation.as_ref().expect("policy_evaluation set");
+        assert_eq!(
+            pe.overall_status,
+            qontinui_types::spec_check::PolicyStatus::Fail
+        );
+
+        // Drain; find the violation event tagged with our marker.
+        let mut found = None;
+        for _ in 0..64 {
+            match rx.try_recv() {
+                Ok(SpecApiEvent::SpecCheckPolicyViolation {
+                    snapshot_id,
+                    page_id,
+                    conjunct_name,
+                    rule_kind,
+                    ..
+                }) if snapshot_id == marker => {
+                    found = Some((page_id, conjunct_name, rule_kind));
+                    break;
+                }
+                Ok(_) => continue,
+                Err(_) => break,
+            }
+        }
+        let (page_id, conjunct_name, rule_kind) =
+            found.expect("violation emit must arrive with batch snapshot_id");
+        assert_eq!(page_id, "batch-violation-page");
+        assert_eq!(conjunct_name, "critical-all-pass");
+        assert_eq!(rule_kind, "all_pass");
     }
 
     #[test]

--- a/src-tauri/src/step_executor/handlers/spec_check.rs
+++ b/src-tauri/src/step_executor/handlers/spec_check.rs
@@ -24,56 +24,9 @@ use serde_json::json;
 use tracing::{info, warn};
 
 use super::{ExecutionStepConfig, HandlerContext, StepHandler, StepHandlerResult};
-use crate::spec_api::events;
+use crate::spec_api::events::emit_policy_violations;
 use qontinui_spec_check as spec_check; // crate name = "qontinui-spec-check"
-use qontinui_types::spec_api_events::SpecApiEvent;
-use qontinui_types::spec_check::{
-    ConjunctRule, MatchOutcome, PolicyConjunct, PolicyEvaluation, PolicyStatus, SpecCheckPolicy,
-};
-
-/// Wire name for the `ConjunctRule` variant — mirrors the
-/// `#[serde(tag = "kind", rename_all = "snake_case")]` discriminator.
-fn rule_kind_str(rule: &ConjunctRule) -> &'static str {
-    match rule {
-        ConjunctRule::AllPass => "all_pass",
-        ConjunctRule::MaxFailures { .. } => "max_failures",
-        ConjunctRule::FailureRateBelow { .. } => "failure_rate_below",
-        ConjunctRule::StateMatchRateAtLeast { .. } => "state_match_rate_at_least",
-        ConjunctRule::AnyStateMatchRateAtLeast { .. } => "any_state_match_rate_at_least",
-        ConjunctRule::MatchOutcomeAtLeast { .. } => "match_outcome_at_least",
-    }
-}
-
-/// Emit one `SpecCheckPolicyViolation` per failing `ConjunctEvaluation`.
-/// Looks up each evaluation by `name` in the originating policy so the
-/// emit carries the structural `rule_kind` discriminator alongside the
-/// evidence string. Indeterminate conjuncts are NOT emitted — only `Fail`.
-fn emit_policy_violations(
-    snapshot_id: &str,
-    page_id: &str,
-    policy: &SpecCheckPolicy,
-    eval: &PolicyEvaluation,
-) {
-    for conjunct_eval in &eval.conjunct_results {
-        if conjunct_eval.status != PolicyStatus::Fail {
-            continue;
-        }
-        let rule_kind = policy
-            .conjuncts
-            .iter()
-            .find(|c: &&PolicyConjunct| c.name == conjunct_eval.name)
-            .map(|c| rule_kind_str(&c.rule))
-            .unwrap_or("unknown");
-        events::emit(SpecApiEvent::SpecCheckPolicyViolation {
-            snapshot_id: snapshot_id.to_string(),
-            page_id: page_id.to_string(),
-            conjunct_name: conjunct_eval.name.clone(),
-            rule_kind: rule_kind.to_string(),
-            observed: serde_json::Value::String(conjunct_eval.evidence.clone()),
-            at_ms: events::now_ms(),
-        });
-    }
-}
+use qontinui_types::spec_check::{MatchOutcome, PolicyStatus, SpecCheckPolicy};
 
 pub struct SpecCheckHandler;
 
@@ -462,110 +415,7 @@ mod tests {
         assert!(d.spec_check_fail_on.is_none());
     }
 
-    // ------------------------------------------------------------------------
-    // Plan 06 — emit-callsite helpers
-    // ------------------------------------------------------------------------
-
-    #[test]
-    fn rule_kind_str_covers_every_variant() {
-        // Locks the snake_case discriminator strings against accidental
-        // drift from `#[serde(tag = "kind", rename_all = "snake_case")]`.
-        assert_eq!(rule_kind_str(&ConjunctRule::AllPass), "all_pass");
-        assert_eq!(
-            rule_kind_str(&ConjunctRule::MaxFailures { count: 0 }),
-            "max_failures"
-        );
-        assert_eq!(
-            rule_kind_str(&ConjunctRule::FailureRateBelow { rate: 0.0 }),
-            "failure_rate_below"
-        );
-        assert_eq!(
-            rule_kind_str(&ConjunctRule::StateMatchRateAtLeast { rate: 0.0 }),
-            "state_match_rate_at_least"
-        );
-        assert_eq!(
-            rule_kind_str(&ConjunctRule::AnyStateMatchRateAtLeast { rate: 0.0 }),
-            "any_state_match_rate_at_least"
-        );
-        assert_eq!(
-            rule_kind_str(&ConjunctRule::MatchOutcomeAtLeast {
-                outcome: MatchOutcome::FullMatch
-            }),
-            "match_outcome_at_least"
-        );
-    }
-
-    #[test]
-    fn emit_policy_violations_publishes_one_per_failing_conjunct() {
-        use qontinui_types::spec_api_events::SpecApiEvent;
-        use qontinui_types::spec_check::{AssertionScope, ConjunctEvaluation, PolicyConjunct};
-        let mut rx = events::subscribe();
-        let marker = "scs_test_policy_violation_emit_1";
-        let page_id = "settings-test-violation";
-        let policy = SpecCheckPolicy {
-            conjuncts: vec![
-                PolicyConjunct {
-                    name: "critical-all-pass".into(),
-                    scope: AssertionScope::default(),
-                    rule: ConjunctRule::AllPass,
-                },
-                PolicyConjunct {
-                    name: "max-three-failures".into(),
-                    scope: AssertionScope::default(),
-                    rule: ConjunctRule::MaxFailures { count: 3 },
-                },
-                PolicyConjunct {
-                    name: "passing-conjunct".into(),
-                    scope: AssertionScope::default(),
-                    rule: ConjunctRule::AllPass,
-                },
-            ],
-        };
-        let eval = qontinui_types::spec_check::PolicyEvaluation {
-            overall_status: PolicyStatus::Fail,
-            conjunct_results: vec![
-                ConjunctEvaluation {
-                    name: "critical-all-pass".into(),
-                    status: PolicyStatus::Fail,
-                    evidence: "2 of 17 assertions failed".into(),
-                },
-                ConjunctEvaluation {
-                    name: "max-three-failures".into(),
-                    status: PolicyStatus::Fail,
-                    evidence: "5 failures > 3 budget".into(),
-                },
-                ConjunctEvaluation {
-                    name: "passing-conjunct".into(),
-                    status: PolicyStatus::Pass,
-                    evidence: "all green".into(),
-                },
-            ],
-        };
-        emit_policy_violations(marker, page_id, &policy, &eval);
-        // Two failing conjuncts → expect two emits with our marker.
-        // Drain up to 64 events from the broadcast, filter by marker.
-        let mut violations = Vec::new();
-        for _ in 0..64 {
-            match rx.try_recv() {
-                Ok(SpecApiEvent::SpecCheckPolicyViolation {
-                    snapshot_id,
-                    page_id: pid,
-                    conjunct_name,
-                    rule_kind,
-                    ..
-                }) if snapshot_id == marker => {
-                    violations.push((conjunct_name, rule_kind, pid));
-                }
-                Ok(_) => continue,
-                Err(_) => break,
-            }
-        }
-        assert_eq!(violations.len(), 2, "expected exactly 2 violation emits");
-        // Order is policy declaration order; first failing conjunct first.
-        assert_eq!(violations[0].0, "critical-all-pass");
-        assert_eq!(violations[0].1, "all_pass");
-        assert_eq!(violations[0].2, page_id);
-        assert_eq!(violations[1].0, "max-three-failures");
-        assert_eq!(violations[1].1, "max_failures");
-    }
+    // Plan 06 emit-callsite helper tests (rule_kind_str + emit_policy_violations)
+    // moved to qontinui-runner/src-tauri/src/spec_api/events.rs alongside the
+    // helpers themselves (which now back both this handler and /spec-check/batch).
 }


### PR DESCRIPTION
## Summary

Closes the asymmetry surfaced by /manual-test: the workflow-step handler emitted \`SpecCheckPolicyViolation\` per failing conjunct, but \`/spec-check/batch\` with \`sharedPolicy\` / \`policyOverride\` was silent. The Wave 7.2 AC gate consumer (\`spec_check_runs\`) needs source-agnostic events, so batch-driven CI sweeps must reach it the same way workflow-step ones do.

## What moves where

- \`emit_policy_violations\` + \`rule_kind_str\` moved from \`step_executor/handlers/spec_check.rs\` into \`spec_api/events.rs\` (canonical home — \`events.rs\` already owns \`subscribe\` / \`emit\` / \`now_ms\`).
- \`evaluate_one\` in \`/spec-check/batch\` now calls the shared helper after \`apply_policy\`. Threads the **batch's shared snapshot_id** (not the crate's internal \`SENTINEL_SNAPSHOT_ID\`) so subscribers can join all per-element violations under one batch run.
- Workflow-step handler keeps its emit, now via the shared location. **No double-emission risk** — it self-calls \`/spec-check\` (single), not \`/spec-check/batch\`; the single endpoint doesn't run policy.

## Tests

- \`rule_kind_str_covers_every_variant\` — moved from workflow-handler tests; locks the snake_case discriminator strings.
- \`emit_policy_violations_publishes_one_per_failing_conjunct\` — moved.
- \`emit_policy_violations_skips_pass_and_indeterminate_conjuncts\` — **new** edge-case (Indeterminate must not emit per Plan 06 §5.6).
- \`evaluate_one_emits_policy_violation_with_batch_snapshot_id\` — **new** integration-style test; seeds an IR with an unmatchable critical assertion, runs \`evaluate_one\` with an all_pass policy + a custom marker snapshot_id, asserts the emission carries that marker (not the internal sentinel).

## Plan reference

\`qontinui-dev-notes/plans/2026-05-17-spec-check-remediation.md\` — Followups → Issue 3 (was deferred as a design call; now decided: widen the contract).

## Test plan

- [x] \`cargo clippy --bin qontinui-runner -- -D warnings\` clean
- [x] \`cargo test --bin qontinui-runner -- emit_policy_violations rule_kind_str evaluate_one_emits\` — 4 pass
- [ ] CI green