### PR TITLE
fix(auth): defensive timeout on initial-mount Tauri-invoke probes

### DIFF
--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -17,6 +17,15 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import type { AuthStatus, AuthContextValue, LoginResponse } from "../types";
 import { createLogger } from "@/lib/logger";
+import { withTimeout } from "@/lib/withTimeout";
+
+// Defensive timeout for the initial-mount Tauri-invoke calls in AuthProvider.
+// If the IPC channel is mid-setup on the first webview render and the
+// invoke Promise never settles, the effect chain stays stuck and auto-login
+// never fires. A 5s cap unsticks the chain so the existing catch handlers
+// run their normal cleanup. See
+// qontinui-dev-notes/plans/2026-05-17-runner-auto-login-initial-mount.md.
+const AUTH_PROBE_TIMEOUT_MS = 5000;
 
 const log = createLogger("Auth");
 
@@ -105,7 +114,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
     log.debug("checkAuthStatus() called");
     try {
       setError(null);
-      const status = await invoke<AuthStatus>("check_auth_status");
+      const status = await withTimeout(
+        invoke<AuthStatus>("check_auth_status"),
+        AUTH_PROBE_TIMEOUT_MS,
+        "check_auth_status",
+      );
       log.debug("checkAuthStatus() result:", status);
       setAuthStatus(status);
       return status;
@@ -242,7 +255,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
    */
   useEffect(() => {
     let cancelled = false;
-    invoke<{ email: string; password: string } | null>("get_test_auto_login")
+    withTimeout(
+      invoke<{ email: string; password: string } | null>("get_test_auto_login"),
+      AUTH_PROBE_TIMEOUT_MS,
+      "get_test_auto_login",
+    )
       .then((creds) => {
         if (cancelled) return;
         if (creds && creds.email && creds.password) {

--- a/src/lib/withTimeout.test.ts
+++ b/src/lib/withTimeout.test.ts
@@ -26,9 +26,15 @@ describe("withTimeout", () => {
     // Inner promise that never resolves — simulates the Tauri IPC hang.
     const hanging = new Promise<string>(() => {});
     const racing = withTimeout(hanging, 5000, "check_auth_status");
-    // Advance past the timeout window.
+    // Pre-attach a catch handler so the race rejection is observed
+    // synchronously when the fake timer fires; otherwise vitest+Node-22
+    // logs a spurious PromiseRejectionHandledWarning even though the
+    // rejection IS handled below.
+    const captured = racing.catch((e: unknown) => e as Error);
     await vi.advanceTimersByTimeAsync(5001);
-    await expect(racing).rejects.toThrow("check_auth_status timed out after 5000ms");
+    const err = await captured;
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("check_auth_status timed out after 5000ms");
   });
 
   it("propagates the inner promise's rejection unchanged when it rejects before the timeout", async () => {

--- a/src/lib/withTimeout.test.ts
+++ b/src/lib/withTimeout.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for `withTimeout` — the defensive timeout wrapper used by
+ * AuthProvider against the initial-mount Tauri IPC hang. The runner's
+ * vitest config is `environment: "node"`, so we exercise the helper
+ * purely (no React, no Tauri mock).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { withTimeout } from "./withTimeout";
+
+describe("withTimeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves with the inner value when the promise settles before the timeout", async () => {
+    const inner = Promise.resolve("ok");
+    await expect(withTimeout(inner, 5000, "probe")).resolves.toBe("ok");
+  });
+
+  it("rejects with a labelled error when the inner promise never settles before the timeout", async () => {
+    // Inner promise that never resolves — simulates the Tauri IPC hang.
+    const hanging = new Promise<string>(() => {});
+    const racing = withTimeout(hanging, 5000, "check_auth_status");
+    // Advance past the timeout window.
+    await vi.advanceTimersByTimeAsync(5001);
+    await expect(racing).rejects.toThrow("check_auth_status timed out after 5000ms");
+  });
+
+  it("propagates the inner promise's rejection unchanged when it rejects before the timeout", async () => {
+    const failing = Promise.reject(new Error("backend went away"));
+    await expect(withTimeout(failing, 5000, "probe")).rejects.toThrow("backend went away");
+  });
+
+  it("does not leak a pending setTimeout after the inner promise resolves", async () => {
+    // Tripwire: if `.finally(clearTimeout)` ever regresses, the fake-timer
+    // queue would still have a pending callback. Track active timer count.
+    expect(vi.getTimerCount()).toBe(0);
+    const inner = Promise.resolve(42);
+    const result = await withTimeout(inner, 5000, "probe");
+    expect(result).toBe(42);
+    // Flush any microtasks in flight (the .finally on the Promise chain).
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/lib/withTimeout.ts
+++ b/src/lib/withTimeout.ts
@@ -1,0 +1,21 @@
+/**
+ * Race a promise against a timeout. If the wrapped promise doesn't settle
+ * within `ms`, the returned promise rejects with an `Error` tagged with
+ * `label` so the caller's existing catch path runs the same cleanup it
+ * would on any other failure.
+ *
+ * Used by `AuthProvider` to defend against the initial-mount Tauri IPC
+ * hang that left the runner stuck on LoginScreen — see plan
+ * `qontinui-dev-notes/plans/2026-05-17-runner-auto-login-initial-mount.md`.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${ms}ms`));
+    }, ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}


### PR DESCRIPTION
## Summary
- Wraps the two on-mount `invoke()` calls in `AuthProvider` (`check_auth_status`, `get_test_auto_login`) in a 5s `withTimeout` race.
- Fixes the symptom where the runner lands on LoginScreen and only logs in after a Ctrl+R webview reload.

## Why
If the Tauri IPC channel is mid-setup on the first webview render and the inbound call is dropped silently, the `await invoke(...)` in either effect blocks forever. `loading` stays `true` and `testAutoLoginProbed` stays `false`, so the auto-login effect (`AuthProvider.tsx:338-399`) bails on every render. Ctrl+R re-establishes the IPC channel and unsticks the chain.

This patch doesn't identify the root cause (needs Tauri webview devtools — see plan link below). What it DOES do is unstick the effect chain regardless of which hypothesis is correct: on timeout the existing `.catch` paths run, doing the same cleanup they'd do on any other failure (`setAuthStatus({authenticated:false,...})` + `setLoading(false)`; `setTestAutoLoginProbed(true)`). The auto-login then fires on the same render the timeout hits.

If the inner `invoke` eventually does resolve, its result is simply ignored (race already settled). On the next refresh cycle, auth state reconciles.

## Plan
[`2026-05-17-runner-auto-login-initial-mount.md`](https://github.com/qontinui/qontinui-dev-notes/blob/main/plans/2026-05-17-runner-auto-login-initial-mount.md) — captures observations, ranked hypotheses, and the targeted-fix-vs-root-cause tradeoff this PR resolves.

## Test plan
- [x] `npx vitest run src/lib/withTimeout.test.ts` — 4/4 passing (resolve, timeout-reject, inner-reject-passthrough, no-timer-leak).
- [x] `npx tsc --noEmit` clean.
- [ ] After merge: restart primary runner, confirm it lands past LoginScreen on initial mount without Ctrl+R.