### PR TITLE
fix(backend-relay): gate terminal-output/exit forwarding on subscriber presence

### DIFF
--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -592,14 +592,37 @@ async fn handle_outbound<S>(
     write: Arc<
         Mutex<futures_util::stream::SplitSink<tokio_tungstenite::WebSocketStream<S>, Message>>,
     >,
-    _api_state: Arc<ApiState>,
+    api_state: Arc<ApiState>,
 ) where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
 {
+    // The WS relay is per-connection and the ServerModeState clone is a
+    // cheap Arc-backed handle that lives for the connection's lifetime, so
+    // fetch it once up front. If it's absent at connection start (state not
+    // yet installed) we re-fetch lazily below.
+    let mut server_mode = api_state.app_state.current_server_mode().await;
+
     loop {
         match event_rx.recv().await {
             Ok(event) => {
                 let channel = event.get("channel").and_then(|v| v.as_str()).unwrap_or("");
+
+                // Flood control: only forward terminal-output / terminal-exit
+                // frames when the backend has an active terminal subscriber.
+                // Never gate phase-result / ui-error / recent-crash /
+                // ai-output / session-state.
+                if channel == "terminal-output" || channel == "terminal-exit" {
+                    if server_mode.is_none() {
+                        server_mode = api_state.app_state.current_server_mode().await;
+                    }
+                    let subscribed = server_mode
+                        .as_ref()
+                        .map(|sm| sm.terminal_subscriber_count() > 0)
+                        .unwrap_or(false);
+                    if !subscribed {
+                        continue;
+                    }
+                }
 
                 // Wire shapes are defined in `qontinui_runner_lib::relay_envelopes`
                 // (lib-side so the schema_export aggregator can register them) —
@@ -758,6 +781,49 @@ async fn handle_relay_command(
         "terminal_buffer" => handle_terminal_buffer(api_state, data),
 
         "heartbeat" => Some(serde_json::json!({"type": "heartbeat_ack"})),
+
+        // --------------------------------------------------------------
+        // Terminal-output flow control. The backend opens/closes interest
+        // in terminal frames so the runner can suppress the
+        // `terminal-output` / `terminal-exit` WS flood when nobody is
+        // attached. Wire contract (other repos depend on it):
+        //   {"type":"terminal_subscribe","runner_id":"<uuid>"}
+        //   {"type":"terminal_unsubscribe","runner_id":"<uuid>"}
+        // runner_id is informational — the WS is already runner-scoped.
+        // Fire-and-forget: no response is sent.
+        // --------------------------------------------------------------
+        "terminal_subscribe" => {
+            if let Some(sm) = api_state.app_state.current_server_mode().await {
+                sm.incr_terminal_subscribers();
+                info!(
+                    "terminal_subscribe: terminal-output relay enabled \
+                     (subscribers={})",
+                    sm.terminal_subscriber_count()
+                );
+            } else {
+                warn!(
+                    "terminal_subscribe received but no ServerModeState is \
+                     installed; terminal-output relay stays suppressed"
+                );
+            }
+            None
+        }
+
+        "terminal_unsubscribe" => {
+            if let Some(sm) = api_state.app_state.current_server_mode().await {
+                sm.decr_terminal_subscribers();
+                info!(
+                    "terminal_unsubscribe: subscribers now {}",
+                    sm.terminal_subscriber_count()
+                );
+            } else {
+                warn!(
+                    "terminal_unsubscribe received but no ServerModeState is \
+                     installed"
+                );
+            }
+            None
+        }
 
         _ => {
             warn!("Unknown relay command type: {}", msg_type);

--- a/src-tauri/src/server_mode/mod.rs
+++ b/src-tauri/src/server_mode/mod.rs
@@ -18,7 +18,7 @@
 //! The "Connect with web login" OAuth-style flow is independent of the WS
 //! relay and lives in [`token_flow`].
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -104,6 +104,13 @@ pub struct ServerModeState {
     /// command calls [`ServerModeState::shutdown`] to flip this to `true`;
     /// the relay loop checks between iterations and returns cleanly.
     shutdown: Arc<AtomicBool>,
+    /// Number of backend-side subscribers currently interested in terminal
+    /// output frames. The backend sends `terminal_subscribe` /
+    /// `terminal_unsubscribe` messages over the relay; the outbound forwarder
+    /// reads this and *skips* sending `terminal-output` / `terminal-exit`
+    /// frames entirely when this is `0`, preventing a WS flood when no
+    /// consumer is attached.
+    terminal_subscriber_count: Arc<AtomicUsize>,
 }
 
 impl ServerModeState {
@@ -115,6 +122,7 @@ impl ServerModeState {
             connection_error: Arc::new(RwLock::new(None)),
             ws_connected: Arc::new(AtomicBool::new(false)),
             shutdown: Arc::new(AtomicBool::new(false)),
+            terminal_subscriber_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -179,5 +187,88 @@ impl ServerModeState {
     /// Whether shutdown has been requested.
     pub fn is_shutting_down(&self) -> bool {
         self.shutdown.load(Ordering::Relaxed)
+    }
+
+    /// Current number of backend-side terminal-output subscribers.
+    ///
+    /// The outbound relay forwarder consults this before forwarding a
+    /// `terminal-output` / `terminal-exit` frame; when it is `0` the frame
+    /// is dropped (never serialized or sent) so an unattended terminal
+    /// session cannot flood the relay WebSocket.
+    pub fn terminal_subscriber_count(&self) -> usize {
+        self.terminal_subscriber_count.load(Ordering::SeqCst)
+    }
+
+    /// Register one additional backend-side terminal subscriber. Called by
+    /// the relay command handler on an inbound `terminal_subscribe`.
+    pub fn incr_terminal_subscribers(&self) {
+        self.terminal_subscriber_count
+            .fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Remove one backend-side terminal subscriber, saturating at `0` so a
+    /// stray / duplicate `terminal_unsubscribe` can never make the count
+    /// underflow (which would re-enable the flood forever).
+    pub fn decr_terminal_subscribers(&self) {
+        let _ = self.terminal_subscriber_count.fetch_update(
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+            |cur| {
+                if cur == 0 {
+                    None
+                } else {
+                    Some(cur - 1)
+                }
+            },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_state() -> ServerModeState {
+        ServerModeState::new(ServerModeConfig {
+            web_backend_url: "https://example.test".to_string(),
+            runner_token: "qontinui_runner_test".to_string(),
+        })
+    }
+
+    #[test]
+    fn terminal_subscriber_count_starts_at_zero() {
+        let s = test_state();
+        assert_eq!(s.terminal_subscriber_count(), 0);
+    }
+
+    #[test]
+    fn incr_decr_terminal_subscribers_roundtrip() {
+        let s = test_state();
+        s.incr_terminal_subscribers();
+        s.incr_terminal_subscribers();
+        assert_eq!(s.terminal_subscriber_count(), 2);
+        s.decr_terminal_subscribers();
+        assert_eq!(s.terminal_subscriber_count(), 1);
+        s.decr_terminal_subscribers();
+        assert_eq!(s.terminal_subscriber_count(), 0);
+    }
+
+    #[test]
+    fn decr_terminal_subscribers_saturates_at_zero() {
+        let s = test_state();
+        s.decr_terminal_subscribers();
+        s.decr_terminal_subscribers();
+        assert_eq!(s.terminal_subscriber_count(), 0);
+        // and a subsequent incr still works correctly (no underflow wrap).
+        s.incr_terminal_subscribers();
+        assert_eq!(s.terminal_subscriber_count(), 1);
+    }
+
+    #[test]
+    fn terminal_subscriber_count_shared_across_clones() {
+        let s = test_state();
+        let c = s.clone();
+        s.incr_terminal_subscribers();
+        assert_eq!(c.terminal_subscriber_count(), 1);
     }
 }


### PR DESCRIPTION
Runner half of the runner→backend WS terminal-flood fix (plan: runner-ws-terminal-flood-fix). Siblings: qontinui-web #135, qontinui-mobile #5.

**Side A (runner):** `ServerModeState` gains an `Arc<AtomicUsize> terminal_subscriber_count` (incr/decr/read helpers, 4 unit tests). `handle_relay_command` handles backend-sent `terminal_subscribe`/`terminal_unsubscribe` to bump/decrement it. `handle_outbound` skips `terminal-output`/`terminal-exit` frames entirely when the count is 0 — a Claude terminal session no longer floods the runner→backend WS (and triggers the Windows Proactor RST/reconnect flap) when no mobile is watching. No other relay channel is gated.

Pairs with web #135's `connect_mobile_terminal` emit so the count is driven by real mobile subscribers. `cargo check` clean against origin/main; `cargo test ... server_mode` 10/10 (incl. 4 new).