### PR TITLE
chore: untrack stale tmpclaude-*-cwd files

### DIFF
--- a/src-tauri/tmpclaude-27b0-cwd
+++ b/src-tauri/tmpclaude-27b0-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-280f-cwd
+++ b/src-tauri/tmpclaude-280f-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-2a2f-cwd
+++ b/src-tauri/tmpclaude-2a2f-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-2a69-cwd
+++ b/src-tauri/tmpclaude-2a69-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-2ab8-cwd
+++ b/src-tauri/tmpclaude-2ab8-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-2bc8-cwd
+++ b/src-tauri/tmpclaude-2bc8-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-384a-cwd
+++ b/src-tauri/tmpclaude-384a-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-457a-cwd
+++ b/src-tauri/tmpclaude-457a-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-560f-cwd
+++ b/src-tauri/tmpclaude-560f-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-785e-cwd
+++ b/src-tauri/tmpclaude-785e-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-7a0c-cwd
+++ b/src-tauri/tmpclaude-7a0c-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-902e-cwd
+++ b/src-tauri/tmpclaude-902e-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-a3b9-cwd
+++ b/src-tauri/tmpclaude-a3b9-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-a5b5-cwd
+++ b/src-tauri/tmpclaude-a5b5-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-b14f-cwd
+++ b/src-tauri/tmpclaude-b14f-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-c01f-cwd
+++ b/src-tauri/tmpclaude-c01f-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-c8db-cwd
+++ b/src-tauri/tmpclaude-c8db-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-cb68-cwd
+++ b/src-tauri/tmpclaude-cb68-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-d30f-cwd
+++ b/src-tauri/tmpclaude-d30f-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-dc59-cwd
+++ b/src-tauri/tmpclaude-dc59-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-e0b3-cwd
+++ b/src-tauri/tmpclaude-e0b3-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-e2b8-cwd
+++ b/src-tauri/tmpclaude-e2b8-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-ebed-cwd
+++ b/src-tauri/tmpclaude-ebed-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-f9f7-cwd
+++ b/src-tauri/tmpclaude-f9f7-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-fb54-cwd
+++ b/src-tauri/tmpclaude-fb54-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-fd2b-cwd
+++ b/src-tauri/tmpclaude-fd2b-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src-tauri/tmpclaude-ff71-cwd
+++ b/src-tauri/tmpclaude-ff71-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src-tauri

--- a/src/components/tmpclaude-98e7-cwd
+++ b/src/components/tmpclaude-98e7-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src/components

--- a/src/tmpclaude-51b0-cwd
+++ b/src/tmpclaude-51b0-cwd
@@ -1,1 +1,0 @@
-/c/Users/Joshua/Documents/qontinui-root/qontinui-runner/src


### PR DESCRIPTION
## Summary
- `git rm --cached` 29 `tmpclaude-*-cwd` files that were accidentally tracked despite matching the existing `tmpclaude-*` `.gitignore` pattern
- Restores the gitignore guarantee so future temp-cwd writes from Claude Code sessions don't get re-committed
- No on-disk file changes — only removes them from the git index

## Files affected
- 27 files under `src-tauri/`
- 1 file under `src/components/`
- 1 file under `src/`

Follow-up to PR #166 where these were noted but deliberately left for a separate PR.

## Test plan
- [ ] CI passes (no source code changed, only index entries removed)
- [ ] After merge, `git ls-files | grep tmpclaude` is empty on main