### PR TITLE
feat(ws-bridge): dispatch state_machine.discover_ui_bridge WS commands

### DIFF
--- a/python-bridge/handlers/__init__.py
+++ b/python-bridge/handlers/__init__.py
@@ -1,0 +1,11 @@
+"""Runner-side handlers for the qontinui-web ``runner_command_ws`` bridge.
+
+Each submodule exposes one or more ``async def handle_<command>(payload: dict) -> dict``
+coroutines that dispatch a WS bridge command to the local qontinui
+runtime. The Rust side (``mcp/backend_relay.rs``) invokes them by name
+via :mod:`handlers.dispatch` (one Python subprocess per command), JSON
+in / JSON out.
+
+See ``plans/2026-05-17-web-runner-ws-bridge-plan-b.md`` for the
+disposition rationale + the per-phase command mapping.
+"""

--- a/python-bridge/handlers/dispatch.py
+++ b/python-bridge/handlers/dispatch.py
@@ -1,0 +1,117 @@
+"""One-shot WS bridge command dispatcher.
+
+Invoked by the Rust side (``mcp/backend_relay.rs``) as a Python
+subprocess for each inbound WS bridge command. Protocol:
+
+- Argv: ``python -m handlers.dispatch <command_name>``
+- Stdin: JSON-encoded payload dict (one line, terminated by ``\n``).
+- Stdout: JSON-encoded response dict (one line, terminated by ``\n``).
+- Stderr: logs (free-form).
+- Exit code: 0 on success (response is on stdout), non-zero on
+  dispatcher failure (e.g. unknown command, IO error). qontinui-side
+  exceptions are caught by the handler and surfaced as a structured
+  error response on stdout — exit code stays 0 for those.
+
+The dispatcher imports its handler module lazily so adding a new
+command in a follow-up phase is a one-line addition to ``_COMMANDS``
+plus a new submodule.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import traceback
+from typing import Awaitable, Callable
+
+logger = logging.getLogger(__name__)
+
+
+HandlerFn = Callable[[dict], Awaitable[dict]]
+
+
+def _load_handler(command: str) -> HandlerFn:
+    """Resolve a command name to its handler coroutine.
+
+    Lazy-loads the handler module to keep startup cheap.
+    """
+    # The mapping is hand-maintained; each entry corresponds to one
+    # qontinui_schemas.commands.* schema + one runner-side handler.
+    if command == "state_machine.discover_ui_bridge":
+        from handlers.state_machine import discover_ui_bridge
+
+        return discover_ui_bridge
+
+    raise ValueError(f"unknown command: {command!r}")
+
+
+async def _main() -> int:
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] handlers.dispatch: %(message)s",
+    )
+
+    if len(sys.argv) < 2:
+        print(
+            json.dumps(
+                {
+                    "error": "internal_error",
+                    "message": "missing command argument",
+                }
+            )
+        )
+        return 2
+
+    command = sys.argv[1]
+
+    try:
+        payload_raw = sys.stdin.read()
+        payload: dict = json.loads(payload_raw) if payload_raw.strip() else {}
+    except json.JSONDecodeError as exc:
+        print(
+            json.dumps(
+                {
+                    "error": "invalid_payload",
+                    "message": f"stdin JSON parse failed: {exc!s}",
+                }
+            )
+        )
+        return 3
+
+    try:
+        handler = _load_handler(command)
+    except ValueError as exc:
+        print(
+            json.dumps(
+                {
+                    "error": "unknown_command",
+                    "message": str(exc),
+                }
+            )
+        )
+        return 4
+
+    try:
+        response = await handler(payload)
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("dispatcher: handler raised uncaught exception")
+        print(
+            json.dumps(
+                {
+                    "error": "internal_error",
+                    "message": str(exc),
+                    "traceback": traceback.format_exc(),
+                }
+            )
+        )
+        return 5
+
+    print(json.dumps(response))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(_main()))

--- a/python-bridge/handlers/state_machine.py
+++ b/python-bridge/handlers/state_machine.py
@@ -1,0 +1,175 @@
+"""State-machine WS bridge handlers.
+
+Implements the runner-side response to commands routed through the
+qontinui-web ``runner_command_ws`` relay. Each public coroutine takes a
+JSON-serialisable payload dict (already-validated wire envelope) and
+returns a JSON-serialisable response dict.
+
+Wire contract:
+- Inbound payload validates against
+  :class:`qontinui_schemas.commands.state_machine.DiscoverUIBridgeRequest`.
+- On success: returns
+  :class:`qontinui_schemas.commands.state_machine.DiscoverUIBridgeResponse`
+  ``.model_dump(mode='json')``.
+- On qontinui-side exception: returns
+  :class:`qontinui_schemas.commands.state_machine.DiscoverUIBridgeError`
+  ``.model_dump(mode='json')`` (the dispatcher logs + re-raises if needed).
+
+Phase 2 of plan
+``plans/2026-05-17-web-runner-ws-bridge-plan-b.md`` introduces this
+module + the ``state_machine.discover_ui_bridge`` command. Phases 3-7
+extend it with additional commands.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from typing import Any
+
+from qontinui_schemas.commands.state_machine import (
+    DiscoverUIBridgeError,
+    DiscoverUIBridgeRequest,
+    DiscoverUIBridgeResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _state_to_dict(state: Any) -> dict[str, Any]:
+    """Serialize a ``DiscoveredState`` dataclass to a dict.
+
+    The result uses the dataclass attribute names (``element_ids``,
+    ``render_ids``, etc.) so the qontinui-web pydantic models — which
+    declare those names as aliases via ``populate_by_name=True`` — can
+    consume the payload directly.
+    """
+    return {
+        "id": state.id,
+        "name": state.name,
+        "element_ids": list(state.element_ids),
+        "render_ids": list(state.render_ids),
+        "confidence": state.confidence,
+        "position_zone": state.position_zone,
+        "landmark_context": state.landmark_context,
+        "is_global": state.is_global,
+        "is_modal": state.is_modal,
+    }
+
+
+def _element_to_dict(element: Any) -> dict[str, Any]:
+    """Serialize a ``DiscoveredElement`` dataclass to a dict."""
+    return {
+        "id": element.id,
+        "name": element.name,
+        "element_type": element.element_type,
+        "render_ids": list(element.render_ids),
+        "fingerprint_hash": element.fingerprint_hash,
+        "position_zone": element.position_zone,
+    }
+
+
+async def discover_ui_bridge(payload: dict[str, Any]) -> dict[str, Any]:
+    """Handle ``state_machine.discover_ui_bridge`` WS bridge command.
+
+    Runs :class:`qontinui.discovery.state_discovery.StateDiscoveryService`
+    against the supplied render-log entries (or a co-occurrence export
+    if provided) and returns the discovered states + elements.
+
+    Args:
+        payload: Inbound JSON dict (wire envelope; validates against
+            :class:`DiscoverUIBridgeRequest`).
+
+    Returns:
+        JSON dict; either :class:`DiscoverUIBridgeResponse`
+        ``.model_dump(mode='json')`` on success or
+        :class:`DiscoverUIBridgeError` ``.model_dump(mode='json')`` on
+        runner-side failure.
+    """
+    try:
+        req = DiscoverUIBridgeRequest.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("discover_ui_bridge: payload validation failed")
+        return DiscoverUIBridgeError(
+            request_id=_safe_request_id(payload),
+            error="invalid_payload",
+            message=f"payload validation failed: {exc!s}",
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+    try:
+        # Lazy-import qontinui so importing this module is cheap when
+        # the command is never invoked.
+        from qontinui.discovery.state_discovery import (
+            DiscoveryStrategyType,
+            StateDiscoveryService,
+        )
+
+        strategy_map = {
+            "auto": DiscoveryStrategyType.AUTO,
+            "fingerprint": DiscoveryStrategyType.FINGERPRINT,
+        }
+        strategy = strategy_map.get(req.strategy, DiscoveryStrategyType.AUTO)
+
+        service = StateDiscoveryService()
+        if req.cooccurrence_export is not None:
+            result = service.discover_from_export(
+                req.cooccurrence_export,
+                strategy=strategy,
+            )
+        else:
+            result = service.discover_from_renders(
+                req.renders,
+                include_html_ids=req.include_html_ids,
+                strategy=strategy,
+            )
+
+        response = DiscoverUIBridgeResponse(
+            request_id=req.request_id,
+            states=[_state_to_dict(s) for s in result.states],
+            elements=[_element_to_dict(e) for e in result.elements],
+            element_to_renders={
+                k: list(v) for k, v in result.element_to_renders.items()
+            },
+            render_count=result.render_count,
+            unique_element_count=result.unique_element_count,
+            strategy_used=result.strategy_used.value,
+            strategy_metadata=result.strategy_metadata or {},
+        )
+        return response.model_dump(mode="json")
+
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("discover_ui_bridge: runner-side execution failed")
+        return DiscoverUIBridgeError(
+            request_id=req.request_id,
+            error="qontinui_exception",
+            message=str(exc),
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+
+_ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _safe_request_id(payload: dict[str, Any]) -> str:
+    """Best-effort recovery of a UUID-shaped request_id from a payload.
+
+    Returns the all-zero UUID when the payload's ``request_id`` is
+    missing or not UUID-shaped. Used by error envelopes so that an
+    invalid-payload response still validates against the response
+    schema.
+    """
+    from uuid import UUID
+
+    raw = payload.get("request_id")
+    if not isinstance(raw, str):
+        return _ZERO_UUID
+    try:
+        return str(UUID(raw))
+    except (ValueError, AttributeError):
+        return _ZERO_UUID
+
+
+__all__ = [
+    "discover_ui_bridge",
+]

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -758,6 +758,23 @@ async fn handle_relay_command(
         }
 
         // --------------------------------------------------------------
+        // Web -> runner WS bridge commands. The web side's
+        // `dispatch_and_wait` helper publishes JSON payloads with a
+        // top-level `type` matching the command name; we forward to
+        // the Python dispatcher and return a `command_response` frame
+        // carrying the same `request_id` so the web HTTP handler can
+        // correlate the reply. Per
+        // `plans/2026-05-17-web-runner-ws-bridge-plan-b.md` Phase 2,
+        // this is the foundational arm — Phases 3-7 extend the match
+        // (one new arm per new command type) and
+        // `ws_bridge_dispatch::is_supported_command`.
+        // --------------------------------------------------------------
+        cmd if crate::mcp::ws_bridge_dispatch::is_supported_command(cmd) => {
+            let response = crate::mcp::ws_bridge_dispatch::dispatch_command(cmd, data).await;
+            Some(response)
+        }
+
+        // --------------------------------------------------------------
         // Mobile chat session relay (carry-over from legacy relay)
         // --------------------------------------------------------------
         "chat_message" => handle_chat_message(api_state, data).await,

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -156,4 +156,5 @@ pub mod web_backend_workflows;
 pub mod websocket;
 pub mod window_manager;
 pub mod worktrees;
+pub mod ws_bridge_dispatch;
 pub mod ws_relay;

--- a/src-tauri/src/mcp/ws_bridge_dispatch.rs
+++ b/src-tauri/src/mcp/ws_bridge_dispatch.rs
@@ -1,0 +1,292 @@
+//! Web -> runner WebSocket bridge: command dispatch to Python handlers.
+//!
+//! When `qontinui-web` HTTP endpoints need work that lives in the
+//! `qontinui` Python library, they publish a typed command onto
+//! `runner:commands:{runner_id}`. The
+//! [`backend_relay`](crate::mcp::backend_relay) forwards the message
+//! over the runner's WS connection; the runner-side route handlers in
+//! that module dispatch into this module via
+//! [`dispatch_command`].
+//!
+//! The dispatcher spawns a one-shot Python subprocess running
+//! `handlers.dispatch <command_name>` from the
+//! `qontinui-runner/python-bridge/` tree, pipes the JSON payload to its
+//! stdin, and parses the JSON response from its stdout. The response
+//! is then sent back over the WS as a `command_response` message; the
+//! `runners_ws.py` handler on the web side broadcasts it on
+//! `runner:responses:{runner_id}`, where the originating HTTP handler
+//! (`dispatch_and_wait`) is subscribed and filtering for matching
+//! `request_id`.
+//!
+//! Phase 2 of plan
+//! `plans/2026-05-17-web-runner-ws-bridge-plan-b.md` introduces this
+//! module + the single `state_machine.discover_ui_bridge` command.
+//! Phases 3-7 extend it by adding entries to
+//! [`COMMAND_DISPATCH_TIMEOUT_S`] / `handlers/dispatch.py`.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tracing::{debug, error, info, warn};
+
+/// Per-command synchronous timeout (seconds). The web-side
+/// `dispatch_and_wait` default is 30s; we cap subprocess wall-clock at
+/// the next-higher value so the runner side returns an error
+/// envelope rather than letting the subprocess linger past the web's
+/// timeout window.
+const COMMAND_DISPATCH_TIMEOUT_S: u64 = 35;
+
+/// Commands recognised by this dispatcher. Each entry MUST have a
+/// corresponding handler in
+/// `qontinui-runner/python-bridge/handlers/dispatch.py`.
+pub fn is_supported_command(command_name: &str) -> bool {
+    matches!(command_name, "state_machine.discover_ui_bridge")
+}
+
+/// Dispatch a WS bridge command to its Python handler.
+///
+/// Returns `Some(response_value)` on success or a structured error
+/// envelope (also a `Value`) on failure. The caller wraps the result
+/// in a `command_response` WS frame.
+pub async fn dispatch_command(command_name: &str, payload: &Value) -> Value {
+    info!(
+        "ws_bridge_dispatch: starting command={} request_id={:?}",
+        command_name,
+        payload.get("request_id"),
+    );
+
+    if !is_supported_command(command_name) {
+        warn!(
+            "ws_bridge_dispatch: unknown command {} — returning error envelope",
+            command_name
+        );
+        return error_envelope(
+            command_name,
+            payload,
+            "unknown_command",
+            &format!(
+                "command {:?} is not registered on this runner",
+                command_name
+            ),
+        );
+    }
+
+    let bridge_dir = match find_python_bridge_dir() {
+        Some(p) => p,
+        None => {
+            error!("ws_bridge_dispatch: python-bridge dir not found");
+            return error_envelope(
+                command_name,
+                payload,
+                "internal_error",
+                "could not locate qontinui-runner/python-bridge/ on disk",
+            );
+        }
+    };
+
+    let pyproject = bridge_dir.join("pyproject.toml");
+    let mut cmd = if pyproject.exists() {
+        debug!("ws_bridge_dispatch: using poetry from {:?}", bridge_dir);
+        let mut c = Command::new("poetry");
+        c.current_dir(&bridge_dir);
+        c.arg("run").arg("python").arg("-u");
+        c.arg("-m").arg("handlers.dispatch").arg(command_name);
+        c
+    } else {
+        debug!("ws_bridge_dispatch: falling back to system python");
+        let mut c = Command::new("python");
+        c.current_dir(&bridge_dir);
+        c.arg("-u")
+            .arg("-m")
+            .arg("handlers.dispatch")
+            .arg(command_name);
+        c
+    };
+
+    cmd.env("PYTHONUNBUFFERED", "1");
+    cmd.stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            error!("ws_bridge_dispatch: spawn failed: {}", e);
+            return error_envelope(
+                command_name,
+                payload,
+                "internal_error",
+                &format!("failed to spawn python dispatcher: {e}"),
+            );
+        }
+    };
+
+    // Write the payload to stdin and close.
+    let payload_bytes = match serde_json::to_vec(payload) {
+        Ok(b) => b,
+        Err(e) => {
+            return error_envelope(
+                command_name,
+                payload,
+                "internal_error",
+                &format!("payload serialize failed: {e}"),
+            );
+        }
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        if let Err(e) = stdin.write_all(&payload_bytes).await {
+            warn!("ws_bridge_dispatch: stdin write failed: {}", e);
+            // Continue — child may still produce output / non-zero exit.
+        }
+        let _ = stdin.shutdown().await;
+    }
+
+    let output_fut = child.wait_with_output();
+    let output =
+        match tokio::time::timeout(Duration::from_secs(COMMAND_DISPATCH_TIMEOUT_S), output_fut)
+            .await
+        {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => {
+                error!("ws_bridge_dispatch: wait_with_output failed: {}", e);
+                return error_envelope(
+                    command_name,
+                    payload,
+                    "internal_error",
+                    &format!("python process wait failed: {e}"),
+                );
+            }
+            Err(_) => {
+                error!(
+                    "ws_bridge_dispatch: timed out after {}s — command={}",
+                    COMMAND_DISPATCH_TIMEOUT_S, command_name
+                );
+                return error_envelope(
+                    command_name,
+                    payload,
+                    "internal_error",
+                    &format!("python dispatcher exceeded {COMMAND_DISPATCH_TIMEOUT_S}s wall-clock"),
+                );
+            }
+        };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!(
+            "ws_bridge_dispatch: dispatcher exit code={:?} stderr={}",
+            output.status.code(),
+            stderr,
+        );
+        // Try to parse stdout as the dispatcher's structured-error
+        // envelope first (dispatcher.py emits one even on non-zero exit
+        // for unknown_command / invalid_payload).
+        if let Ok(parsed) = serde_json::from_slice::<Value>(&output.stdout) {
+            return merge_with_correlation(command_name, payload, parsed);
+        }
+        return error_envelope(
+            command_name,
+            payload,
+            "internal_error",
+            &format!(
+                "python dispatcher exited with code {:?}; stderr={}",
+                output.status.code(),
+                stderr,
+            ),
+        );
+    }
+
+    match serde_json::from_slice::<Value>(&output.stdout) {
+        Ok(response) => {
+            debug!(
+                "ws_bridge_dispatch: command={} succeeded request_id={:?}",
+                command_name,
+                response.get("request_id"),
+            );
+            merge_with_correlation(command_name, payload, response)
+        }
+        Err(e) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            error!(
+                "ws_bridge_dispatch: stdout JSON parse failed: {} stdout={}",
+                e, stdout,
+            );
+            error_envelope(
+                command_name,
+                payload,
+                "internal_error",
+                &format!("python dispatcher stdout JSON parse failed: {e}"),
+            )
+        }
+    }
+}
+
+/// Build a structured error envelope shaped like the
+/// `qontinui_schemas.commands.state_machine.DiscoverUIBridgeError`
+/// payload. Generic across all WS bridge commands.
+fn error_envelope(command_name: &str, payload: &Value, error: &str, message: &str) -> Value {
+    json!({
+        "type": "command_response",
+        "command": command_name,
+        "request_id": payload.get("request_id"),
+        "error": error,
+        "message": message,
+    })
+}
+
+/// Ensure the dispatcher response carries the wire-framing fields the
+/// web-side `dispatch_and_wait` filter expects: `type`, `command`, and
+/// the originating `request_id`. The Python handler already sets these,
+/// but defending here keeps the contract local to this module.
+fn merge_with_correlation(command_name: &str, payload: &Value, mut response: Value) -> Value {
+    if let Some(obj) = response.as_object_mut() {
+        obj.entry("type")
+            .or_insert_with(|| Value::String("command_response".to_string()));
+        obj.entry("command")
+            .or_insert_with(|| Value::String(command_name.to_string()));
+        if !obj.contains_key("request_id") {
+            if let Some(rid) = payload.get("request_id") {
+                obj.insert("request_id".to_string(), rid.clone());
+            }
+        }
+    }
+    response
+}
+
+/// Best-effort search for the `python-bridge/` directory containing the
+/// handler module. Tries the executable-relative path used by
+/// `executor::process::ProcessManager::find_bridge_script` first, then
+/// `current_dir`-relative fallbacks.
+fn find_python_bridge_dir() -> Option<PathBuf> {
+    let candidates = vec![
+        std::env::current_exe().ok().and_then(|p| {
+            // Walk up from `<runner>/src-tauri/target/{debug,release}/qontinui-runner.exe`
+            // to `<runner>/python-bridge/`.
+            p.parent()
+                .and_then(|p| p.parent())
+                .and_then(|p| p.parent())
+                .and_then(|p| p.parent())
+                .map(|p| p.join("python-bridge"))
+        }),
+        std::env::current_dir().ok().and_then(|p| {
+            if p.ends_with("debug") || p.ends_with("release") {
+                p.parent()
+                    .and_then(|p| p.parent())
+                    .and_then(|p| p.parent())
+                    .map(|p| p.join("python-bridge"))
+            } else if p.ends_with("src-tauri") {
+                p.parent().map(|p| p.join("python-bridge"))
+            } else {
+                Some(p.join("python-bridge"))
+            }
+        }),
+    ];
+
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|p| p.join("handlers").join("dispatch.py").exists())
+}


### PR DESCRIPTION
## Summary

Adds runner-side dispatch for the web -> runner WebSocket bridge under disposition (A) of plan `2026-05-17-web-runner-ws-bridge-plan-b.md` (Phase 2).

When `qontinui-web` HTTP endpoints publish a typed command on `runner:commands:{runner_id}`, the backend relay routes recognised command types into a new dispatcher (`src-tauri/src/mcp/ws_bridge_dispatch.rs`) which spawns a one-shot Python subprocess running the matching handler module from `python-bridge/handlers/`.

Phase 2 lands the foundation + the single `state_machine.discover_ui_bridge` command, which forwards to `qontinui.discovery.state_discovery.StateDiscoveryService`. Phases 3-7 extend the dispatcher (one new arm + one new handler module per phase).

## Wire shape

- Inbound: JSON envelope with `type: "state_machine.discover_ui_bridge"` + `request_id: <uuid>` + payload fields.
- Outbound: JSON envelope with `type: "command_response"` + the same `request_id` (and either the success fields or an `error` literal + `message`).
- The web side's `runners_ws.py` `_route_runner_message` already broadcasts `command_response` frames on `runner:responses:{runner_id}`; the originating HTTP handler's `dispatch_and_wait` is subscribed there and filters by `request_id`.

## Test plan

- [x] `cargo check` — clean (3m36s)
- [x] `cargo clippy -- -D warnings` — clean (4m11s)
- [x] `python -m py_compile handlers/{__init__,state_machine,dispatch}.py` — clean
- [ ] Live smoke deferred to web-phase2 PR (depends on this PR landing)

## Sibling PRs (Phase 2 wave)

- qontinui-schemas: https://github.com/qontinui/qontinui-schemas/pull/47 (MERGED `868332c3`)
- qontinui-web: (sibling PR to land in parallel after schemas merge)

## Related

- Plan: `plans/2026-05-17-web-runner-ws-bridge-plan-b.md` Phase 2
- Phase 1 (shipped): qontinui-schemas#46, qontinui#12, qontinui-web#140