### PR TITLE
feat(ws-bridge): dispatch state_machine.ui_bridge.{discover,pathfind}

### DIFF
--- a/python-bridge/handlers/dispatch.py
+++ b/python-bridge/handlers/dispatch.py
@@ -44,6 +44,16 @@ def _load_handler(command: str) -> HandlerFn:
 
         return discover_ui_bridge
 
+    if command == "state_machine.ui_bridge.discover":
+        from handlers.state_machine import ui_bridge_discover
+
+        return ui_bridge_discover
+
+    if command == "state_machine.ui_bridge.pathfind":
+        from handlers.state_machine import ui_bridge_pathfind
+
+        return ui_bridge_pathfind
+
     raise ValueError(f"unknown command: {command!r}")
 
 

--- a/python-bridge/handlers/state_machine.py
+++ b/python-bridge/handlers/state_machine.py
@@ -5,20 +5,19 @@ qontinui-web ``runner_command_ws`` relay. Each public coroutine takes a
 JSON-serialisable payload dict (already-validated wire envelope) and
 returns a JSON-serialisable response dict.
 
-Wire contract:
-- Inbound payload validates against
-  :class:`qontinui_schemas.commands.state_machine.DiscoverUIBridgeRequest`.
-- On success: returns
-  :class:`qontinui_schemas.commands.state_machine.DiscoverUIBridgeResponse`
-  ``.model_dump(mode='json')``.
-- On qontinui-side exception: returns
-  :class:`qontinui_schemas.commands.state_machine.DiscoverUIBridgeError`
-  ``.model_dump(mode='json')`` (the dispatcher logs + re-raises if needed).
+Wire contract: each handler accepts a JSON payload (already-validated
+wire envelope) and returns a JSON-serialisable response dict — either
+a successful ``…Response`` or an error envelope
+(``invalid_payload`` / ``qontinui_exception`` / etc.). The Rust-side
+dispatcher (``mcp/backend_relay.rs``) wraps the response in a
+``command_response`` WS frame; web-side ``dispatch_and_wait`` correlates
+by ``request_id``.
 
-Phase 2 of plan
-``plans/2026-05-17-web-runner-ws-bridge-plan-b.md`` introduces this
-module + the ``state_machine.discover_ui_bridge`` command. Phases 3-7
-extend it with additional commands.
+Phase 2 introduces this module + ``state_machine.discover_ui_bridge``.
+Phase 3 adds ``state_machine.ui_bridge.discover`` (discover + the
+web-side persistence handshake) and ``state_machine.ui_bridge.pathfind``
+(multistate pathfinding over a runner-reconstructed
+``UIBridgeRuntime``). Phases 4-7 extend further.
 """
 
 from __future__ import annotations
@@ -31,6 +30,13 @@ from qontinui_schemas.commands.state_machine import (
     DiscoverUIBridgeError,
     DiscoverUIBridgeRequest,
     DiscoverUIBridgeResponse,
+    UIBridgeDiscoverError,
+    UIBridgeDiscoverRequest,
+    UIBridgeDiscoverResponse,
+    UIBridgePathfindError,
+    UIBridgePathfindRequest,
+    UIBridgePathfindResponse,
+    UIBridgePathfindStep,
 )
 
 logger = logging.getLogger(__name__)
@@ -170,6 +176,268 @@ def _safe_request_id(payload: dict[str, Any]) -> str:
         return _ZERO_UUID
 
 
+# =============================================================================
+# Phase 3 — state_machine.ui_bridge.discover
+# =============================================================================
+
+
+async def ui_bridge_discover(payload: dict[str, Any]) -> dict[str, Any]:
+    """Handle ``state_machine.ui_bridge.discover`` WS bridge command.
+
+    Runs :class:`qontinui.discovery.state_discovery.StateDiscoveryService`
+    against the supplied render-log entries (or a co-occurrence export
+    if provided) and returns the discovered states + elements. The web
+    side persists the result to ``ui_bridge_state_configs`` +
+    ``ui_bridge_states`` rows after the response returns; the runner
+    is stateless w.r.t. persistence.
+
+    Args:
+        payload: Inbound JSON dict (wire envelope; validates against
+            :class:`UIBridgeDiscoverRequest`).
+
+    Returns:
+        JSON dict; either :class:`UIBridgeDiscoverResponse`
+        ``.model_dump(mode='json')`` on success or
+        :class:`UIBridgeDiscoverError` ``.model_dump(mode='json')`` on
+        runner-side failure.
+    """
+    try:
+        req = UIBridgeDiscoverRequest.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("ui_bridge_discover: payload validation failed")
+        return UIBridgeDiscoverError(
+            request_id=_safe_request_id(payload),
+            error="invalid_payload",
+            message=f"payload validation failed: {exc!s}",
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+    try:
+        from qontinui.discovery.state_discovery import (
+            DiscoveryStrategyType,
+            StateDiscoveryService,
+        )
+
+        strategy_map = {
+            "auto": DiscoveryStrategyType.AUTO,
+            "fingerprint": DiscoveryStrategyType.FINGERPRINT,
+        }
+        strategy = strategy_map.get(req.strategy, DiscoveryStrategyType.AUTO)
+
+        service = StateDiscoveryService()
+        if req.cooccurrence_export is not None:
+            result = service.discover_from_export(
+                req.cooccurrence_export,
+                strategy=strategy,
+            )
+        else:
+            result = service.discover_from_renders(
+                req.renders,
+                include_html_ids=req.include_html_ids,
+                strategy=strategy,
+            )
+
+        response = UIBridgeDiscoverResponse(
+            request_id=req.request_id,
+            states=[_state_to_dict(s) for s in result.states],
+            elements=[_element_to_dict(e) for e in result.elements],
+            element_to_renders={
+                k: list(v) for k, v in result.element_to_renders.items()
+            },
+            render_count=result.render_count,
+            unique_element_count=result.unique_element_count,
+            strategy_used=result.strategy_used.value,
+            strategy_metadata=result.strategy_metadata or {},
+        )
+        return response.model_dump(mode="json")
+
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("ui_bridge_discover: runner-side execution failed")
+        return UIBridgeDiscoverError(
+            request_id=req.request_id,
+            error="qontinui_exception",
+            message=str(exc),
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+
+# =============================================================================
+# Phase 3 — state_machine.ui_bridge.pathfind
+# =============================================================================
+
+
+class _PathfindStubClient:
+    """Stub UI Bridge client for runtime construction during pathfinding.
+
+    Pathfinding is read-only; it never executes transitions. This stub
+    matches the shape used by the pre-#136 web-side endpoint
+    (``qontinui-web/backend/app/api/v1/endpoints/ui_bridge_states.py``
+    pathfind handler) so the multistate pathfinding code path runs as
+    if a real client were attached.
+    """
+
+    def __init__(self, from_states: list[str]) -> None:
+        self._from_states = from_states
+
+    def find(self, **_kwargs: Any) -> Any:
+        return type("R", (), {"elements": []})()
+
+    def get_active_states(self) -> list[str]:
+        return list(self._from_states)
+
+    def execute_transition(self, _transition_id: str) -> Any:
+        return type("R", (), {"success": True})()
+
+    def navigate_to(self, _targets: list[str]) -> Any:
+        raise NotImplementedError
+
+    def click(self, _element_id: str, **_kwargs: Any) -> Any:
+        return type("R", (), {"success": True})()
+
+    def type(self, _element_id: str, _text: str, **_kwargs: Any) -> Any:
+        return type("R", (), {"success": True})()
+
+
+async def ui_bridge_pathfind(payload: dict[str, Any]) -> dict[str, Any]:
+    """Handle ``state_machine.ui_bridge.pathfind`` WS bridge command.
+
+    Reconstructs a :class:`qontinui.state_machine.ui_bridge_runtime.UIBridgeRuntime`
+    from the serialised config (states + transitions) carried in the
+    request, then invokes ``find_path`` with the supplied
+    ``from_states`` / ``target_states``. The runner is stateless: the
+    web side ships the persisted ``UIBridgeRuntimeConfig`` payload in
+    each request to avoid a runner -> web -> runner config-fetch
+    round-trip.
+
+    Args:
+        payload: Inbound JSON dict (wire envelope; validates against
+            :class:`UIBridgePathfindRequest`).
+
+    Returns:
+        JSON dict; either :class:`UIBridgePathfindResponse`
+        ``.model_dump(mode='json')`` on success (``found=True/False``
+        for the no-path case) or
+        :class:`UIBridgePathfindError` ``.model_dump(mode='json')`` on
+        runner-side failure.
+    """
+    try:
+        req = UIBridgePathfindRequest.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("ui_bridge_pathfind: payload validation failed")
+        return UIBridgePathfindError(
+            request_id=_safe_request_id(payload),
+            error="invalid_payload",
+            message=f"payload validation failed: {exc!s}",
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+    try:
+        from qontinui.state_machine.ui_bridge_runtime import (
+            MULTISTATE_AVAILABLE,
+            UIBridgeRuntime,
+            UIBridgeRuntimeConfig,
+        )
+        from qontinui.state_machine.ui_bridge_runtime import (
+            UIBridgeState as UIBridgeStateData,
+        )
+        from qontinui.state_machine.ui_bridge_runtime import (
+            UIBridgeTransition as UIBridgeTransitionData,
+        )
+
+        if not MULTISTATE_AVAILABLE:
+            return UIBridgePathfindError(
+                request_id=req.request_id,
+                error="multistate_unavailable",
+                message=(
+                    "multistate package is not installed on this runner; "
+                    "pathfinding is unavailable. Install the runner's "
+                    "[pathfinding] extra to enable."
+                ),
+                traceback=None,
+            ).model_dump(mode="json")
+
+        stub = _PathfindStubClient(req.from_states)
+        runtime_config = UIBridgeRuntimeConfig(enable_reliability_tracking=False)
+        runtime = UIBridgeRuntime(stub, runtime_config)
+
+        # Register states from the serialised config
+        for state_dict in req.config.get("states", []):
+            runtime.register_state(
+                UIBridgeStateData(
+                    id=state_dict["state_id"],
+                    name=state_dict["name"],
+                    element_ids=list(state_dict.get("element_ids") or []),
+                )
+            )
+
+        # Register transitions from the serialised config
+        for trans_dict in req.config.get("transitions", []):
+            runtime.register_transition(
+                UIBridgeTransitionData(
+                    id=trans_dict["transition_id"],
+                    name=trans_dict["name"],
+                    from_states=list(trans_dict.get("from_states") or []),
+                    activate_states=list(trans_dict.get("activate_states") or []),
+                    exit_states=list(trans_dict.get("exit_states") or []),
+                    actions=list(trans_dict.get("actions") or []),
+                    path_cost=float(trans_dict.get("path_cost", 1.0)),
+                    stays_visible=bool(trans_dict.get("stays_visible", False)),
+                )
+            )
+
+        path = runtime.find_path(
+            target_states=req.target_states,
+            from_states=set(req.from_states),
+        )
+
+        if not path:
+            return UIBridgePathfindResponse(
+                request_id=req.request_id,
+                found=False,
+                steps=[],
+                total_cost=0.0,
+                error="No path found between specified states",
+            ).model_dump(mode="json")
+
+        # Build response steps from the path
+        steps: list[UIBridgePathfindStep] = []
+        total_cost = 0.0
+        for trans in path.transitions_sequence:
+            ui_trans = runtime._ui_transitions.get(trans.id)  # noqa: SLF001
+            if ui_trans is None:
+                continue
+            steps.append(
+                UIBridgePathfindStep(
+                    transition_id=ui_trans.id,
+                    transition_name=ui_trans.name,
+                    from_states=list(ui_trans.from_states),
+                    activate_states=list(ui_trans.activate_states),
+                    exit_states=list(ui_trans.exit_states),
+                    path_cost=float(ui_trans.path_cost),
+                )
+            )
+            total_cost += float(ui_trans.path_cost)
+
+        return UIBridgePathfindResponse(
+            request_id=req.request_id,
+            found=True,
+            steps=steps,
+            total_cost=total_cost,
+            error=None,
+        ).model_dump(mode="json")
+
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("ui_bridge_pathfind: runner-side execution failed")
+        return UIBridgePathfindError(
+            request_id=req.request_id,
+            error="qontinui_exception",
+            message=str(exc),
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+
 __all__ = [
     "discover_ui_bridge",
+    "ui_bridge_discover",
+    "ui_bridge_pathfind",
 ]

--- a/src-tauri/src/mcp/ws_bridge_dispatch.rs
+++ b/src-tauri/src/mcp/ws_bridge_dispatch.rs
@@ -21,8 +21,9 @@
 //! Phase 2 of plan
 //! `plans/2026-05-17-web-runner-ws-bridge-plan-b.md` introduces this
 //! module + the single `state_machine.discover_ui_bridge` command.
-//! Phases 3-7 extend it by adding entries to
-//! [`COMMAND_DISPATCH_TIMEOUT_S`] / `handlers/dispatch.py`.
+//! Phase 3 adds `state_machine.ui_bridge.discover` and
+//! `state_machine.ui_bridge.pathfind`. Phases 4-7 extend it further by
+//! adding entries to [`is_supported_command`] / `handlers/dispatch.py`.
 
 use std::path::PathBuf;
 use std::process::Stdio;
@@ -44,7 +45,12 @@ const COMMAND_DISPATCH_TIMEOUT_S: u64 = 35;
 /// corresponding handler in
 /// `qontinui-runner/python-bridge/handlers/dispatch.py`.
 pub fn is_supported_command(command_name: &str) -> bool {
-    matches!(command_name, "state_machine.discover_ui_bridge")
+    matches!(
+        command_name,
+        "state_machine.discover_ui_bridge"
+            | "state_machine.ui_bridge.discover"
+            | "state_machine.ui_bridge.pathfind"
+    )
 }
 
 /// Dispatch a WS bridge command to its Python handler.


### PR DESCRIPTION
## Summary

Phase 3 of plan `2026-05-17-web-runner-ws-bridge-plan-b.md` extends the runner-side WS bridge dispatcher with two new command types:

- **`state_machine.ui_bridge.discover`** → `handlers.state_machine.ui_bridge_discover`. Calls `qontinui.discovery.state_discovery.StateDiscoveryService` and returns the discovered states + elements. Web persists the result. Subtly different from Phase 2's `state_machine.discover_ui_bridge`: this carries a `project_id` for the web-side persistence step and a chosen `config_name`.
- **`state_machine.ui_bridge.pathfind`** → `handlers.state_machine.ui_bridge_pathfind`. Reconstructs a `qontinui.state_machine.ui_bridge_runtime.UIBridgeRuntime` from the serialised `config` (states + transitions) carried in the request and invokes `find_path` against the supplied `from_states` / `target_states`. Returns a runner-stateless pathfinding result (no runner → web → runner → web round-trip for config fetch). Returns `multistate_unavailable` when `MULTISTATE_AVAILABLE=False` on the runner.

Surface:
- `python-bridge/handlers/state_machine.py`: two new async handlers + a shared `_PathfindStubClient` (matches the pre-#136 web-side stub shape).
- `python-bridge/handlers/dispatch.py`: two new arms in `_load_handler`.
- `src-tauri/src/mcp/ws_bridge_dispatch.rs`: extend `is_supported_command` match.

Schema source: qontinui-schemas PR #48 (`50c9fb99`) adds the `UIBridgeDiscover{Request,Response,Error}` and `UIBridgePathfind{Request,Step,Response,Error}` models.

## Test plan

- [x] `cargo check` — clean (pre-existing build-ir/dist warnings unrelated)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `python -m py_compile` on both handler modules — clean
- [ ] Live smoke: companion qontinui-web PR exercises both endpoints