### PR TITLE
feat(ws-bridge): dispatch discovery.background_removal (Phase 6)

### DIFF
--- a/python-bridge/handlers/discovery.py
+++ b/python-bridge/handlers/discovery.py
@@ -1,0 +1,130 @@
+"""Discovery-pipeline WS bridge handlers.
+
+Implements the runner-side response to commands routed through the
+qontinui-web ``runner_command_ws`` relay for discovery-pipeline work
+that historically lived directly on the web backend but now runs
+runner-side via the existing WS dispatcher.
+
+Wire contract: each handler accepts a JSON payload (already-validated
+wire envelope) and returns a JSON-serialisable response dict — either
+a successful ``…Response`` or an error envelope
+(``invalid_payload`` / ``qontinui_exception`` / etc.). The Rust-side
+dispatcher (``mcp/ws_bridge_dispatch.rs``) wraps the response in a
+``command_response`` WS frame; web-side ``dispatch_and_wait`` correlates
+by ``request_id``.
+
+Phase 6 of plan ``plans/2026-05-17-web-runner-ws-bridge-plan-b.md``
+introduces this module with one command:
+
+- ``discovery.background_removal`` — invokes
+  :func:`qontinui.discovery.background_removal.remove_backgrounds_from_base64`
+  and returns the masked screenshots + analyser statistics.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from typing import Any
+
+from qontinui_schemas.commands.discovery import (
+    BackgroundRemovalError,
+    BackgroundRemovalRequest,
+    BackgroundRemovalResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+_ZERO_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _safe_request_id(payload: dict[str, Any]) -> str:
+    """Best-effort recovery of a UUID-shaped ``request_id`` from a payload.
+
+    Returns the all-zero UUID when the payload's ``request_id`` is
+    missing or not UUID-shaped. Used by error envelopes so that an
+    invalid-payload response still validates against the response
+    schema.
+    """
+    from uuid import UUID
+
+    raw = payload.get("request_id")
+    if not isinstance(raw, str):
+        return _ZERO_UUID
+    try:
+        return str(UUID(raw))
+    except (ValueError, AttributeError):
+        return _ZERO_UUID
+
+
+async def background_removal(payload: dict[str, Any]) -> dict[str, Any]:
+    """Handle ``discovery.background_removal`` WS bridge command.
+
+    Decodes the request, invokes
+    :func:`qontinui.discovery.background_removal.remove_backgrounds_from_base64`,
+    and returns the masked screenshots plus the analyser statistics
+    dict (pixel counts, percentages, image size, optional debug mask).
+
+    Args:
+        payload: Inbound JSON dict (wire envelope; validates against
+            :class:`BackgroundRemovalRequest`).
+
+    Returns:
+        JSON dict; either :class:`BackgroundRemovalResponse`
+        ``.model_dump(mode='json')`` on success or
+        :class:`BackgroundRemovalError` ``.model_dump(mode='json')`` on
+        runner-side failure.
+    """
+    try:
+        req = BackgroundRemovalRequest.model_validate(payload)
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("background_removal: payload validation failed")
+        return BackgroundRemovalError(
+            request_id=_safe_request_id(payload),  # type: ignore[arg-type]
+            error="invalid_payload",
+            message=f"payload validation failed: {exc!s}",
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")
+
+    try:
+        # Lazy-import qontinui so importing this module is cheap when
+        # the command is never invoked.
+        from qontinui.discovery.background_removal import (
+            BackgroundRemovalConfig,
+            remove_backgrounds_from_base64,
+        )
+
+        cfg = (
+            BackgroundRemovalConfig(**req.config)
+            if req.config is not None
+            else BackgroundRemovalConfig()
+        )
+
+        masked_b64, stats = remove_backgrounds_from_base64(
+            req.screenshots_b64,
+            config=cfg,
+            debug=req.debug,
+        )
+
+        # ``stats`` may include a numpy ``image_size`` tuple; pydantic's
+        # JSON mode handles tuples natively but downstream consumers
+        # expect a list. Coerce to a list for wire-friendliness.
+        if isinstance(stats.get("image_size"), tuple):
+            stats = {**stats, "image_size": list(stats["image_size"])}
+
+        response = BackgroundRemovalResponse(
+            request_id=req.request_id,
+            masked_screenshots_b64=masked_b64,
+            statistics=stats,
+        )
+        return response.model_dump(mode="json")
+
+    except Exception as exc:  # noqa: BLE001 - intentionally broad
+        logger.exception("background_removal: runner-side execution failed")
+        return BackgroundRemovalError(
+            request_id=req.request_id,
+            error="qontinui_exception",
+            message=str(exc),
+            traceback=traceback.format_exc(),
+        ).model_dump(mode="json")

--- a/python-bridge/handlers/dispatch.py
+++ b/python-bridge/handlers/dispatch.py
@@ -79,6 +79,11 @@ def _load_handler(command: str) -> HandlerFn:
 
         return compare_screenshots
 
+    if command == "discovery.background_removal":
+        from handlers.discovery import background_removal
+
+        return background_removal
+
     raise ValueError(f"unknown command: {command!r}")
 
 

--- a/src-tauri/src/mcp/ws_bridge_dispatch.rs
+++ b/src-tauri/src/mcp/ws_bridge_dispatch.rs
@@ -76,6 +76,7 @@ pub fn is_supported_command(command_name: &str) -> bool {
             | "recording_pipeline.merge"
             | "vision.compute_perceptual_hash"
             | "vision.compare_screenshots"
+            | "discovery.background_removal"
     )
 }
 
@@ -342,9 +343,15 @@ mod tests {
     }
 
     #[test]
+    fn is_supported_command_recognises_phase_6_discovery() {
+        assert!(is_supported_command("discovery.background_removal"));
+    }
+
+    #[test]
     fn is_supported_command_rejects_unknown() {
         assert!(!is_supported_command("state_machine.unknown"));
         assert!(!is_supported_command("recording_pipeline.unknown"));
+        assert!(!is_supported_command("discovery.unknown"));
         assert!(!is_supported_command(""));
     }
 
@@ -387,6 +394,12 @@ mod tests {
         );
         assert_eq!(
             dispatch_timeout_for("state_machine.ui_bridge.pathfind"),
+            COMMAND_DISPATCH_TIMEOUT_S
+        );
+        // Phase 6 discovery.background_removal is sub-5-second per the
+        // plan; default timeout suffices.
+        assert_eq!(
+            dispatch_timeout_for("discovery.background_removal"),
             COMMAND_DISPATCH_TIMEOUT_S
         );
         // Unknown commands also fall through to the default; the


### PR DESCRIPTION
## Summary

Phase 6 of [plan 2026-05-17-web-runner-ws-bridge-plan-b](../../qontinui/blob/main/plans/2026-05-17-web-runner-ws-bridge-plan-b.md) adds the runner-side handler that responds to the \`discovery.background_removal\` WS bridge command.

- New module \`python-bridge/handlers/discovery.py\` with \`async def background_removal(payload)\` that invokes \`qontinui.discovery.background_removal.remove_backgrounds_from_base64\` and returns the masked screenshots + analyser statistics.
- \`handlers/dispatch.py\` routes \`discovery.background_removal\` to the new handler.
- \`mcp/ws_bridge_dispatch.rs\` accepts the new command in \`is_supported_command\` (default 35s subprocess timeout suffices — background removal is sub-5-second per the plan).
- Tests: \`is_supported_command_recognises_phase_6_discovery\` + default-timeout assertion for the new command.

Depends on qontinui-schemas#50 (additive 0.7.0 with \`qontinui_schemas.commands.discovery\` module).

## Test plan

- [x] \`cargo check -p qontinui-runner --lib --tests\` — clean
- [x] \`cargo clippy -p qontinui-runner --lib --tests\` — clean
- [x] \`cargo test -p qontinui-runner --bin qontinui-runner\` — 3759 passed (incl new ws_bridge_dispatch tests)
- [x] \`python -m py_compile handlers/discovery.py handlers/dispatch.py\` — clean
- [x] Smoke: \`from handlers.dispatch import _load_handler; _load_handler('discovery.background_removal')\` resolves to handler module