### PR TITLE
chore(runner): widen qontinui-types constraint to bridge 0.2.0 cutover

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -105,7 +105,7 @@ tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_j
 deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
 qontinui-spec-check = { path = "../crates/spec-check" }
-qontinui-types = { path = "../../qontinui-schemas/rust", version = "^0.1.2" }
+qontinui-types = { path = "../../qontinui-schemas/rust", version = ">=0.1.2, <0.3.0" }
 qontinui-vision-core = { path = "../../qontinui-schemas/rust-vision-core", version = "^0.1.0" }
 socket2 = "0.6"
 cron = "0.15"


### PR DESCRIPTION
## Summary

Single-line widening of the `qontinui-types` constraint in `src-tauri/Cargo.toml:108` from `^0.1.2` (i.e. `>=0.1.2, <0.2.0`) to `>=0.1.2, <0.3.0`. Bridges the cutover window for the upcoming qontinui-schemas 0.2.0 release (PR qontinui-schemas#54).

## Why

qontinui-schemas PR #54 renames the canonical `Runner` DTO to `Device` and bumps the Rust crate from 0.1.3 to 0.2.0. The schemas-side `schema-drift` workflow's pre-merge check builds qontinui-runner against the in-PR schemas crate to verify codegen consistency — but the existing `^0.1.2` constraint can't resolve 0.2.0, so the drift check fails and PR #54 blocks.

Widening the constraint to `>=0.1.2, <0.3.0` satisfies both:
- current schemas main 0.1.3 (no regression here)
- post-#54 schemas main 0.2.0 (unblocks the drift check)

Per [[feedback_self_triggering_ci_gates]]: the schemas drift workflow fires before merge, so consumers must widen first.

## Scope discipline

- **Constraint-only.** No code migration to the new `Device` types — that's unified-devices Phase 3 scope.
- One file, one line.
- Future tightening to `^0.2.0` happens later via consumer-side migration plans.

## Test plan

- [x] Local `cargo metadata` resolves `qontinui-types` to `0.1.3` (current schemas main) — widened range still matches.
- [ ] Runner CI passes