### PR TITLE
feat(runner): claim pre-flight + conflict UX (plan Phase 3)

### DIFF
--- a/src-tauri/src/agent_claims/mod.rs
+++ b/src-tauri/src/agent_claims/mod.rs
@@ -1,0 +1,251 @@
+//! Process-global registry of active claim heartbeats per agent.
+//!
+//! Plan reference:
+//! `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md` Phase 3.
+//!
+//! When the runner's spawn flow pre-acquires a coord claim via
+//! `POST /claims/acquire`, this module:
+//!
+//! 1. Spawns a tokio task that posts `/claims/heartbeat` every TTL/3
+//!    seconds. On `HeartbeatResult::Stolen`, the task emits the Tauri
+//!    `agent-claim-stolen` event to the webview and exits.
+//! 2. Holds the [`ClaimHeartbeatHandle`] in a process-global map keyed
+//!    by `agent_id` (UUID string), so [`release_for_agent`] can be
+//!    called from the agent-completion / abandon path. Dropping the
+//!    handle cancels the heartbeat task on its next tick boundary.
+//!
+//! Best-effort throughout. A missing claim heartbeat degrades
+//! coordination observability — coord will eventually evict the Redis
+//! key on TTL expiry — but never breaks correctness. The runner side
+//! of this protocol mirrors `agent_daemons` (same per-agent registry
+//! shape, same cancel-on-drop pattern, sibling concern).
+//!
+//! Tauri event emission requires an `AppHandle`. We resolve it via
+//! [`crate::tauri_app_handle::current`] (set once at startup from
+//! `main.rs`); if no handle is set (early-startup race or in unit
+//! tests) the emit is silently dropped — by design, since the
+//! webview isn't there to listen yet.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use serde::Serialize;
+use tauri::Emitter;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::agent_worktree::{
+    release_claim_best_effort, spawn_heartbeat_task, ActiveClaim, ClaimHeartbeatHandle,
+};
+
+/// Tauri event subject the webview's ConflictModal subscribes to.
+pub const EVENT_CLAIM_CONFLICT: &str = "agent-claim-conflict";
+/// Tauri event subject the webview's StolenBanner subscribes to.
+pub const EVENT_CLAIM_STOLEN: &str = "agent-claim-stolen";
+
+/// Payload shape emitted on `agent-claim-stolen`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StolenEventPayload {
+    pub kind: String,
+    pub resource_key: String,
+    pub current_holder: Option<String>,
+    pub agent_id: String,
+}
+
+static REGISTRY: OnceLock<Mutex<HashMap<String, ClaimHeartbeatHandle>>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<HashMap<String, ClaimHeartbeatHandle>> {
+    REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Spawn the per-agent heartbeat task and register it in the process
+/// registry. Re-registering the same agent_id drops the prior handle,
+/// stopping the old task on its next tick.
+///
+/// `coord_http_base` is the coord URL (already converted from ws→http).
+/// `claim` carries `kind` / `resource_key` / `ttl_seconds` from the
+/// `AllocateResult`.
+pub fn register_active_claim(
+    agent_id: &str,
+    coord_http_base: String,
+    machine_id: Uuid,
+    claim: &ActiveClaim,
+) {
+    let kind = claim.kind.clone();
+    let resource_key = claim.resource_key.clone();
+    let ttl_seconds = claim.ttl_seconds;
+    let agent_id_owned = agent_id.to_string();
+
+    let on_stolen_agent_id = agent_id_owned.clone();
+    let on_stolen_kind = kind.clone();
+    let on_stolen_key = resource_key.clone();
+    let handle = spawn_heartbeat_task(
+        coord_http_base,
+        machine_id,
+        &kind,
+        resource_key.clone(),
+        ttl_seconds,
+        move |current_holder| {
+            emit_stolen_event(
+                &on_stolen_agent_id,
+                &on_stolen_kind,
+                &on_stolen_key,
+                current_holder,
+            );
+        },
+    );
+
+    let mut reg = match registry().lock() {
+        Ok(g) => g,
+        Err(e) => {
+            warn!("agent_claims registry poisoned: {e}");
+            return;
+        }
+    };
+    reg.insert(agent_id_owned.clone(), handle);
+    info!(
+        "agent_claims: registered agent_id={} kind={} key={} ttl={}s",
+        agent_id_owned, kind, resource_key, ttl_seconds
+    );
+}
+
+/// Stop the heartbeat task for `agent_id` and best-effort release the
+/// claim. Idempotent — no-op if no handle is registered.
+pub async fn release_for_agent(agent_id: &str) {
+    let handle = {
+        let mut reg = match registry().lock() {
+            Ok(g) => g,
+            Err(e) => {
+                warn!("agent_claims registry poisoned in release_for_agent: {e}");
+                return;
+            }
+        };
+        reg.remove(agent_id)
+    };
+    let Some(h) = handle else {
+        debug!("agent_claims: release_for_agent {agent_id} — no handle registered");
+        return;
+    };
+    let coord_http_base = h.coord_http_base.clone();
+    let machine_id = h.machine_id;
+    let kind = h.kind.clone();
+    let resource_key = h.resource_key.clone();
+    // Drop the handle to cancel the heartbeat task.
+    drop(h);
+    // Then call /claims/release. Best-effort.
+    release_claim_best_effort(&coord_http_base, machine_id, &kind, &resource_key).await;
+    info!(
+        "agent_claims: released agent_id={} kind={} key={}",
+        agent_id, kind, resource_key
+    );
+}
+
+/// Number of registered claim heartbeats — exposed for diagnostics + tests.
+pub fn tracked_count() -> usize {
+    registry().lock().map(|g| g.len()).unwrap_or(0)
+}
+
+/// Returns `true` iff `agent_id` has an active claim heartbeat
+/// registered. Test/debug helper.
+pub fn tracked_contains(agent_id: &str) -> bool {
+    registry()
+        .lock()
+        .map(|g| g.contains_key(agent_id))
+        .unwrap_or(false)
+}
+
+fn emit_stolen_event(
+    agent_id: &str,
+    kind: &str,
+    resource_key: &str,
+    current_holder: Option<String>,
+) {
+    // Drop from the registry so a subsequent /claims/acquire for the
+    // same agent doesn't race against the now-stale handle.
+    if let Ok(mut reg) = registry().lock() {
+        reg.remove(agent_id);
+    }
+
+    let payload = StolenEventPayload {
+        kind: kind.to_string(),
+        resource_key: resource_key.to_string(),
+        current_holder,
+        agent_id: agent_id.to_string(),
+    };
+    match crate::tauri_app_handle::current() {
+        Some(app) => {
+            if let Err(e) = app.emit(EVENT_CLAIM_STOLEN, &payload) {
+                warn!("agent_claims: emit {EVENT_CLAIM_STOLEN} failed: {e}");
+            }
+        }
+        None => {
+            debug!(
+                "agent_claims: no AppHandle registered — dropping {EVENT_CLAIM_STOLEN} \
+                 emit for agent_id={agent_id}"
+            );
+        }
+    }
+}
+
+/// Emit the `agent-claim-conflict` Tauri event so the ConflictModal
+/// renders. Called by the Tauri command that drives the spawn flow
+/// from the webview — the HTTP `/agents/allocate-local` path returns
+/// the conflict as a structured 409 body, and the IPC translator
+/// surfaces it as an event here.
+pub fn emit_conflict_event(
+    kind: &str,
+    resource_key: &str,
+    current_holder: &str,
+    intent: Option<&str>,
+) {
+    #[derive(Serialize)]
+    #[serde(rename_all = "camelCase")]
+    struct ConflictPayload<'a> {
+        kind: &'a str,
+        resource_key: &'a str,
+        current_holder: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        intent: Option<&'a str>,
+    }
+    let payload = ConflictPayload {
+        kind,
+        resource_key,
+        current_holder,
+        intent,
+    };
+    match crate::tauri_app_handle::current() {
+        Some(app) => {
+            if let Err(e) = app.emit(EVENT_CLAIM_CONFLICT, &payload) {
+                warn!("agent_claims: emit {EVENT_CLAIM_CONFLICT} failed: {e}");
+            }
+        }
+        None => {
+            debug!(
+                "agent_claims: no AppHandle registered — dropping {EVENT_CLAIM_CONFLICT} \
+                 emit for kind={kind} key={resource_key}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tracked_count_starts_empty_or_consistent() {
+        // The registry is process-global; other tests may register, so
+        // we can only assert non-panicking access here.
+        let _ = tracked_count();
+    }
+
+    #[test]
+    fn release_unknown_agent_is_noop() {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            // No handle registered for this id — should be a silent no-op.
+            release_for_agent("00000000-0000-0000-0000-0000000000ff").await;
+        });
+    }
+}

--- a/src-tauri/src/agent_daemons/mod.rs
+++ b/src-tauri/src/agent_daemons/mod.rs
@@ -143,6 +143,7 @@ mod tests {
             token: token.to_string(),
             token_jti: Uuid::nil(),
             token_exp: chrono::Utc::now().timestamp() + 4 * 3600,
+            active_claim: None,
         }
     }
 

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -41,15 +41,389 @@
 //!   directories is Phase 6+ territory.
 
 use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tracing::{info, warn};
+use tokio::sync::Notify;
+use tracing::{debug, info, warn};
 
 use crate::worktree::run_git_command;
 
 /// Env var that turns the new spawn path on. Default off — `feature
 /// flag agent_worktree_mode` per plan §5 Phase 1.
 const FLAG_ENV: &str = "QONTINUI_AGENT_WORKTREE_MODE";
+
+// =============================================================================
+// Pre-allocate claim acquire + heartbeat task — Phase 3 of
+// plan 2026-05-18-agent-spawn-coordination.
+// =============================================================================
+
+/// Spawn-time claim conflict — surfaced when coord's
+/// `POST /claims/acquire` returns `Held`. The runner caller bubbles
+/// this up to the webview via the `agent-claim-conflict` Tauri event;
+/// the user decides abort / wait / steal.
+///
+/// `current_holder` is coord's best-effort `machine_id` of the agent
+/// currently holding the claim (per `AcquireResult::Held` at
+/// `coord:claims.rs:162-167`). Empty when the Redis key vanished
+/// between coord's SET-NX and follow-up GET.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimConflict {
+    pub kind: String,
+    pub resource_key: String,
+    pub current_holder: String,
+    pub intent: Option<String>,
+}
+
+/// Pre-allocate claim parameters passed into [`allocate_and_materialize`].
+///
+/// Constructed via [`ClaimSpawnContext::from_intent_and_paths`] and the
+/// callers' optional explicit plan-id / phase / file-glob hints.
+#[derive(Debug, Clone)]
+pub struct ClaimSpawnContext {
+    /// snake_case ClaimKind matching coord's enum (`phase`, `file_glob`).
+    pub kind: &'static str,
+    pub resource_key: String,
+    pub intent: Option<String>,
+    pub plan_id: Option<String>,
+    pub phase: Option<String>,
+}
+
+impl ClaimSpawnContext {
+    /// Derive a claim context from the spawn payload's optional fields.
+    ///
+    /// Precedence (per plan Phase 3 spec):
+    /// 1. Both `plan_id` AND `phase` present → `ClaimKind::Phase` with
+    ///    `resource_key = "plan:<plan_id>:phase:<phase>"`.
+    /// 2. Otherwise, if `declared_overlap_paths` non-empty → first non-empty
+    ///    path joined with `,` becomes a `ClaimKind::FileGlob` claim.
+    /// 3. Otherwise `None` — proceed to allocate without claim pre-flight
+    ///    (preserves existing behavior for legacy callers).
+    pub fn from_intent_and_paths(
+        intent: Option<&str>,
+        plan_id: Option<&str>,
+        phase: Option<&str>,
+        declared_overlap_paths: Option<&[String]>,
+    ) -> Option<Self> {
+        let intent_s = intent.map(|s| s.to_string());
+        if let (Some(p), Some(n)) = (plan_id, phase) {
+            if !p.is_empty() && !n.is_empty() {
+                return Some(Self {
+                    kind: "phase",
+                    resource_key: format!("plan:{p}:phase:{n}"),
+                    intent: intent_s,
+                    plan_id: Some(p.to_string()),
+                    phase: Some(n.to_string()),
+                });
+            }
+        }
+        if let Some(paths) = declared_overlap_paths {
+            let non_empty: Vec<&str> = paths
+                .iter()
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| s.as_str())
+                .collect();
+            if !non_empty.is_empty() {
+                return Some(Self {
+                    kind: "file_glob",
+                    resource_key: non_empty.join(","),
+                    intent: intent_s,
+                    plan_id: None,
+                    phase: None,
+                });
+            }
+        }
+        None
+    }
+}
+
+/// Outcome of the pre-allocate `/claims/acquire` call.
+#[derive(Debug)]
+enum AcquireOutcome {
+    /// `result: claimed` or `renewed` — proceed to `/agents/allocate`.
+    Acquired { ttl_seconds: i64 },
+    /// `result: held` — return [`ClaimConflict`] to the caller.
+    Held(ClaimConflict),
+    /// Topic / unknown / invalid_topic results from
+    /// `AcquireResult::TopicConflict | TopicUnknown | InvalidTopic`.
+    /// Treated as a hard error — the spawn path doesn't pass `topic`
+    /// today so these shouldn't fire, but handle defensively.
+    Other(String),
+}
+
+async fn pre_allocate_claim(
+    coord_http_base: &str,
+    machine_id: &uuid::Uuid,
+    ctx: &ClaimSpawnContext,
+) -> Result<AcquireOutcome, String> {
+    let url = format!("{}/claims/acquire", coord_http_base.trim_end_matches('/'));
+    let mut metadata = serde_json::json!({});
+    if let Some(intent) = &ctx.intent {
+        metadata["intent"] = serde_json::json!(intent);
+    }
+    if let Some(plan_id) = &ctx.plan_id {
+        metadata["plan_id"] = serde_json::json!(plan_id);
+    }
+    if let Some(phase) = &ctx.phase {
+        metadata["phase"] = serde_json::json!(phase);
+    }
+    let body = serde_json::json!({
+        "kind": ctx.kind,
+        "resource_key": ctx.resource_key,
+        "machine_id": machine_id.to_string(),
+        "metadata": metadata,
+    });
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build claim http client: {e}"))?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+    let status = resp.status();
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("read /claims/acquire body: {e}"))?;
+    if !status.is_success() && status != reqwest::StatusCode::CONFLICT {
+        return Err(format!(
+            "POST /claims/acquire returned {} — body: {body_text}",
+            status.as_u16()
+        ));
+    }
+    let v: serde_json::Value = serde_json::from_str(&body_text)
+        .map_err(|e| format!("parse /claims/acquire body: {e} (raw: {body_text})"))?;
+    match v.get("result").and_then(|r| r.as_str()) {
+        Some("claimed") | Some("renewed") => {
+            let ttl = v
+                .get("ttl_seconds")
+                .and_then(|n| n.as_i64())
+                .unwrap_or_else(|| default_ttl_seconds_for(ctx.kind));
+            Ok(AcquireOutcome::Acquired { ttl_seconds: ttl })
+        }
+        Some("held") => {
+            let current_holder = v
+                .get("current_holder")
+                .and_then(|s| s.as_str())
+                .unwrap_or("")
+                .to_string();
+            Ok(AcquireOutcome::Held(ClaimConflict {
+                kind: ctx.kind.to_string(),
+                resource_key: ctx.resource_key.clone(),
+                current_holder,
+                intent: ctx.intent.clone(),
+            }))
+        }
+        Some(other) => Ok(AcquireOutcome::Other(format!(
+            "/claims/acquire unexpected result `{other}` — body: {body_text}"
+        ))),
+        None => Ok(AcquireOutcome::Other(format!(
+            "/claims/acquire body missing `result` discriminator: {body_text}"
+        ))),
+    }
+}
+
+/// Per-kind default TTL — must stay in sync with coord's `default_ttl_for`
+/// at `claims.rs:119-128`. Used only as a fallback when coord's response
+/// omits `ttl_seconds` (shouldn't happen on success but be defensive).
+fn default_ttl_seconds_for(kind: &str) -> i64 {
+    match kind {
+        "phase" => 7200,
+        "file_glob" => 90,
+        "worktree" => 300,
+        "branch_name" => 1800,
+        "alembic_revision" => 600,
+        "ci_wait" => 1800,
+        _ => 300,
+    }
+}
+
+/// Handle to the heartbeat task spawned for a claim. Dropping it
+/// signals the task to exit on its next tick.
+#[derive(Debug)]
+pub struct ClaimHeartbeatHandle {
+    cancel: Arc<Notify>,
+    join: Option<tokio::task::JoinHandle<()>>,
+    /// Snake-case ClaimKind — for the eventual release call.
+    pub kind: String,
+    pub resource_key: String,
+    pub machine_id: uuid::Uuid,
+    pub coord_http_base: String,
+}
+
+impl Drop for ClaimHeartbeatHandle {
+    fn drop(&mut self) {
+        self.cancel.notify_waiters();
+        let _ = self.join.take();
+    }
+}
+
+/// Spawn a tokio task that posts `/claims/heartbeat` every TTL/3 seconds.
+/// On `HeartbeatResult::Stolen`, the task invokes `on_stolen` with the
+/// optional `current_holder` and exits — the displaced agent's runner
+/// is responsible for surfacing the banner from there.
+///
+/// The cancellation token returned via the handle's `Drop` is the
+/// shutdown signal — the task exits on the next tick boundary.
+pub fn spawn_heartbeat_task<F>(
+    coord_http_base: String,
+    machine_id: uuid::Uuid,
+    kind: &str,
+    resource_key: String,
+    ttl_seconds: i64,
+    on_stolen: F,
+) -> ClaimHeartbeatHandle
+where
+    F: Fn(Option<String>) + Send + Sync + 'static,
+{
+    let cancel = Arc::new(Notify::new());
+    let cancel_clone = cancel.clone();
+    let kind_owned = kind.to_string();
+    let resource_clone = resource_key.clone();
+    let base_clone = coord_http_base.clone();
+
+    let interval_secs: u64 = (ttl_seconds / 3).max(15) as u64;
+
+    let join = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Skip the first tick (fires immediately) — we just acquired
+        // the claim, no need to heartbeat in the same second.
+        interval.tick().await;
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = cancel_clone.notified() => {
+                    debug!(
+                        "claim-heartbeat: stopping kind={kind_owned} key={resource_clone}"
+                    );
+                    return;
+                }
+            }
+            match heartbeat_once(&base_clone, machine_id, &kind_owned, &resource_clone).await {
+                Ok(HeartbeatTickOutcome::Ok) => {}
+                Ok(HeartbeatTickOutcome::Stolen { current_holder }) => {
+                    warn!(
+                        "claim-heartbeat: stolen kind={kind_owned} key={resource_clone} \
+                         current_holder={current_holder:?}"
+                    );
+                    on_stolen(current_holder);
+                    return;
+                }
+                Err(e) => {
+                    warn!(
+                        "claim-heartbeat: tick failed kind={kind_owned} key={resource_clone}: {e}"
+                    );
+                }
+            }
+        }
+    });
+
+    ClaimHeartbeatHandle {
+        cancel,
+        join: Some(join),
+        kind: kind.to_string(),
+        resource_key,
+        machine_id,
+        coord_http_base,
+    }
+}
+
+enum HeartbeatTickOutcome {
+    Ok,
+    Stolen { current_holder: Option<String> },
+}
+
+async fn heartbeat_once(
+    coord_http_base: &str,
+    machine_id: uuid::Uuid,
+    kind: &str,
+    resource_key: &str,
+) -> Result<HeartbeatTickOutcome, String> {
+    let url = format!("{}/claims/heartbeat", coord_http_base.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "kind": kind,
+        "resource_key": resource_key,
+        "machine_id": machine_id.to_string(),
+        "metadata": {},
+    });
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("build heartbeat client: {e}"))?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+    let status = resp.status();
+    let body_text = resp.text().await.map_err(|e| format!("read body: {e}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "POST /claims/heartbeat {} — body: {body_text}",
+            status.as_u16()
+        ));
+    }
+    let v: serde_json::Value =
+        serde_json::from_str(&body_text).map_err(|e| format!("parse heartbeat body: {e}"))?;
+    match v.get("result").and_then(|r| r.as_str()) {
+        Some("ok") => Ok(HeartbeatTickOutcome::Ok),
+        Some("stolen") => {
+            let h = v
+                .get("current_holder")
+                .and_then(|s| s.as_str())
+                .map(|s| s.to_string());
+            Ok(HeartbeatTickOutcome::Stolen { current_holder: h })
+        }
+        _ => Err(format!("heartbeat: unexpected body: {body_text}")),
+    }
+}
+
+/// Best-effort release of a claim. Idempotent — returns `Ok(())` on
+/// `Released` AND `NotHeld` outcomes, and on transport-level errors
+/// (the caller is shutting down the spawn flow; observability matters
+/// but correctness does not).
+pub async fn release_claim_best_effort(
+    coord_http_base: &str,
+    machine_id: uuid::Uuid,
+    kind: &str,
+    resource_key: &str,
+) {
+    let url = format!("{}/claims/release", coord_http_base.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "kind": kind,
+        "resource_key": resource_key,
+        "machine_id": machine_id.to_string(),
+        "metadata": {},
+    });
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("release_claim_best_effort: build client failed: {e}");
+            return;
+        }
+    };
+    match client.post(&url).json(&body).send().await {
+        Ok(r) => {
+            debug!(
+                "release_claim_best_effort: kind={kind} key={resource_key} status={}",
+                r.status().as_u16()
+            );
+        }
+        Err(e) => {
+            debug!("release_claim_best_effort: kind={kind} key={resource_key} err={e}");
+        }
+    }
+}
 
 /// Returns true iff the worktree-per-agent spawn mode is enabled.
 /// Accepts the usual truthy values; anything else (including unset) is
@@ -108,6 +482,14 @@ pub fn remote_agent_ref(branch: &str) -> String {
 /// pushes to the coord-hosted git origin. Empty `token` (JWT keys
 /// not configured on coord) means "skip pusher spawn for this
 /// allocation."
+///
+/// Plan 2026-05-18-agent-spawn-coordination Phase 3 added
+/// `active_claim`: when the spawn flow pre-acquired a coord claim via
+/// `POST /claims/acquire`, this carries the claim's `(kind,
+/// resource_key, ttl_seconds)` so callers can spawn the heartbeat
+/// task and release on agent completion. `None` when no claim was
+/// pre-acquired (legacy callers that don't pass plan_id/phase or
+/// `declared_overlap_paths`).
 #[derive(Debug, Clone, Serialize)]
 pub struct AllocateResult {
     pub agent_id: String,
@@ -115,6 +497,18 @@ pub struct AllocateResult {
     pub token: String,
     pub token_jti: uuid::Uuid,
     pub token_exp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_claim: Option<ActiveClaim>,
+}
+
+/// Per-spawn active claim — the resource_key / kind / TTL acquired
+/// before `/agents/allocate`. Surfaced via [`AllocateResult`] so the
+/// caller can spawn a heartbeat task and release on agent completion.
+#[derive(Debug, Clone, Serialize)]
+pub struct ActiveClaim {
+    pub kind: String,
+    pub resource_key: String,
+    pub ttl_seconds: i64,
 }
 
 /// Coord's JSON response shape for `POST /agents/allocate`. Mirrored
@@ -163,6 +557,40 @@ struct CoordAllocatedWorktree {
     push_ref: String,
 }
 
+/// Error variants returned by [`allocate_and_materialize`]. Distinct
+/// from a plain `String` so the runner-side caller can pattern-match
+/// the spawn-time claim conflict and surface a structured Tauri event
+/// to the webview (per plan 2026-05-18-agent-spawn-coordination Phase 3).
+#[derive(Debug, Clone)]
+pub enum AllocateError {
+    /// `POST /claims/acquire` returned `result: held`. The webview's
+    /// ConflictModal listens for `agent-claim-conflict` events with
+    /// this payload.
+    ClaimConflict(ClaimConflict),
+    /// Anything else — config errors, transport failures, coord 5xx,
+    /// `git worktree add` failures, etc.
+    Other(String),
+}
+
+impl std::fmt::Display for AllocateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AllocateError::ClaimConflict(c) => write!(
+                f,
+                "claim already held: kind={} resource_key={} current_holder={}",
+                c.kind, c.resource_key, c.current_holder
+            ),
+            AllocateError::Other(s) => f.write_str(s),
+        }
+    }
+}
+
+impl From<String> for AllocateError {
+    fn from(s: String) -> Self {
+        AllocateError::Other(s)
+    }
+}
+
 /// Call coord's `/agents/allocate` and then `git worktree add` for each
 /// returned row.
 ///
@@ -177,11 +605,24 @@ struct CoordAllocatedWorktree {
 /// is the dependency injection point so tests can substitute scratch
 /// repos.
 ///
-/// On success returns `AllocateResult`. On any error, returns a
-/// caller-readable string. Partial failure is handled at the boundary:
-/// if any `git worktree add` fails after coord has minted rows, the
-/// partial materialization stops; coord's sweeper will eventually
-/// reclaim the unused rows once they age into `abandoned`.
+/// Per plan 2026-05-18-agent-spawn-coordination Phase 3, when a
+/// `ClaimSpawnContext` can be derived from the inputs (either
+/// plan_id + phase, or non-empty `declared_overlap_paths`), this
+/// function first calls coord's `POST /claims/acquire` with the
+/// derived `(kind, resource_key)`. On `Held`, returns
+/// `Err(AllocateError::ClaimConflict)` WITHOUT touching
+/// `/agents/allocate`. On `Claimed`/`Renewed`, proceeds to allocate;
+/// the caller is responsible for spawning a heartbeat task and
+/// releasing the claim on agent completion (see [`spawn_heartbeat_task`]
+/// and [`release_claim_best_effort`]). The returned [`AllocateResult`]
+/// carries the active claim context for that purpose.
+///
+/// On success returns `AllocateResult`. On any non-claim error,
+/// returns `Err(AllocateError::Other(String))`. Partial failure is
+/// handled at the boundary: if any `git worktree add` fails after coord
+/// has minted rows, the partial materialization stops; coord's sweeper
+/// will eventually reclaim the unused rows once they age into
+/// `abandoned`.
 pub async fn allocate_and_materialize(
     coord_http_base: &str,
     machine_id: &uuid::Uuid,
@@ -189,27 +630,88 @@ pub async fn allocate_and_materialize(
     intent: Option<&str>,
     declared_overlap_paths: Option<&[String]>,
     repo_canonical_paths: &std::collections::HashMap<String, PathBuf>,
-) -> Result<AllocateResult, String> {
+) -> Result<AllocateResult, AllocateError> {
+    allocate_and_materialize_with_claim(
+        coord_http_base,
+        machine_id,
+        repos,
+        intent,
+        declared_overlap_paths,
+        repo_canonical_paths,
+        None,
+        None,
+    )
+    .await
+}
+
+/// Like [`allocate_and_materialize`] but accepts explicit `plan_id` /
+/// `phase` strings for `ClaimKind::Phase` pre-flight. When both are
+/// supplied, the claim shape is `phase / plan:<plan>:phase:<phase>`
+/// per plan 2026-05-18-agent-spawn-coordination Phase 3.
+pub async fn allocate_and_materialize_with_claim(
+    coord_http_base: &str,
+    machine_id: &uuid::Uuid,
+    repos: &[RepoRequest],
+    intent: Option<&str>,
+    declared_overlap_paths: Option<&[String]>,
+    repo_canonical_paths: &std::collections::HashMap<String, PathBuf>,
+    plan_id: Option<&str>,
+    phase: Option<&str>,
+) -> Result<AllocateResult, AllocateError> {
     if !worktree_mode_enabled() {
-        return Err(format!(
+        return Err(AllocateError::Other(format!(
             "{} is not enabled; spawn path is disabled",
             FLAG_ENV
-        ));
+        )));
     }
     if repos.is_empty() {
-        return Err("repos must not be empty".to_string());
+        return Err(AllocateError::Other("repos must not be empty".to_string()));
     }
+
+    // Phase 3: pre-allocate `/claims/acquire`. When a claim context can
+    // be derived from the inputs, call coord's atomic acquire-or-fail
+    // BEFORE `/agents/allocate`. On `Held`, return ClaimConflict.
+    let claim_ctx =
+        ClaimSpawnContext::from_intent_and_paths(intent, plan_id, phase, declared_overlap_paths);
+    let active_claim = if let Some(ref ctx) = claim_ctx {
+        match pre_allocate_claim(coord_http_base, machine_id, ctx).await {
+            Ok(AcquireOutcome::Acquired { ttl_seconds }) => {
+                info!(
+                    "claims/acquire ok kind={} key={} ttl={}s",
+                    ctx.kind, ctx.resource_key, ttl_seconds
+                );
+                Some(ActiveClaim {
+                    kind: ctx.kind.to_string(),
+                    resource_key: ctx.resource_key.clone(),
+                    ttl_seconds,
+                })
+            }
+            Ok(AcquireOutcome::Held(conflict)) => {
+                warn!(
+                    "claims/acquire held kind={} key={} current_holder={}",
+                    conflict.kind, conflict.resource_key, conflict.current_holder
+                );
+                return Err(AllocateError::ClaimConflict(conflict));
+            }
+            Ok(AcquireOutcome::Other(msg)) => {
+                return Err(AllocateError::Other(msg));
+            }
+            Err(e) => return Err(AllocateError::Other(e)),
+        }
+    } else {
+        None
+    };
 
     // Pre-flight: every requested repo must have a canonical path the
     // runner can `git worktree add` from. Surface this before bothering
     // coord with the request.
     for r in repos {
         if !repo_canonical_paths.contains_key(&r.repo) {
-            return Err(format!(
+            return Err(AllocateError::Other(format!(
                 "no canonical checkout known for repo '{}' — pass it in \
                  repo_canonical_paths",
                 r.repo
-            ));
+            )));
         }
     }
 
@@ -232,20 +734,20 @@ pub async fn allocate_and_materialize(
         .json(&body)
         .send()
         .await
-        .map_err(|e| format!("POST {url}: {e}"))?;
+        .map_err(|e| AllocateError::Other(format!("POST {url}: {e}")))?;
     let status = resp.status();
     if !status.is_success() {
         let body_text = resp.text().await.unwrap_or_default();
-        return Err(format!(
+        return Err(AllocateError::Other(format!(
             "POST {url} returned {} — body: {}",
             status.as_u16(),
             body_text
-        ));
+        )));
     }
     let coord_resp: CoordAllocateResponse = resp
         .json()
         .await
-        .map_err(|e| format!("decode coord response: {e}"))?;
+        .map_err(|e| AllocateError::Other(format!("decode coord response: {e}")))?;
 
     info!(
         "coord allocated agent_id={} repos={}",
@@ -255,9 +757,9 @@ pub async fn allocate_and_materialize(
 
     let mut materialized: Vec<MaterializedWorktree> = Vec::with_capacity(repos.len());
     for w in coord_resp.worktrees {
-        let canonical = repo_canonical_paths
-            .get(&w.repo)
-            .ok_or_else(|| format!("missing canonical path for repo '{}'", w.repo))?;
+        let canonical = repo_canonical_paths.get(&w.repo).ok_or_else(|| {
+            AllocateError::Other(format!("missing canonical path for repo '{}'", w.repo))
+        })?;
         let target = PathBuf::from(&w.worktree_path);
 
         // Ensure the parent dir exists. `git worktree add` will create
@@ -265,12 +767,12 @@ pub async fn allocate_and_materialize(
         // doesn't exist on first allocation.
         if let Some(parent) = target.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
-                format!(
+                AllocateError::Other(format!(
                     "create parent dir {} for worktree {}: {}",
                     parent.display(),
                     w.repo,
                     e
-                )
+                ))
             })?;
         }
 
@@ -303,10 +805,10 @@ pub async fn allocate_and_materialize(
                     target.display(),
                     e
                 );
-                return Err(format!(
+                return Err(AllocateError::Other(format!(
                     "git worktree add for repo '{}' (branch {}) failed: {}",
                     w.repo, w.branch, e
-                ));
+                )));
             }
         }
 
@@ -358,6 +860,7 @@ pub async fn allocate_and_materialize(
         token: coord_resp.token,
         token_jti: coord_resp.token_jti.unwrap_or(uuid::Uuid::nil()),
         token_exp: coord_resp.token_exp.unwrap_or(0),
+        active_claim,
     })
 }
 

--- a/src-tauri/src/commands/claims.rs
+++ b/src-tauri/src/commands/claims.rs
@@ -1,0 +1,309 @@
+//! Tauri commands bridging the webview to coord's claims API.
+//!
+//! Plan reference:
+//! `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md` Phase 3.
+//!
+//! Three thin wrappers around `POST /claims/acquire`, `POST /claims/release`,
+//! and `POST /coord/claims/steal`. The webview's `ConflictModal` calls
+//! `claims_acquire` (retry after wait/steal), `claims_steal` (on the user
+//! pressing Steal), and the agent-spawn flow itself can release on
+//! completion via `claims_release`. Heartbeats are NOT user-driven —
+//! the runner-side spawn flow spawns a tokio task at acquire time and
+//! the webview never sees them.
+//!
+//! All three commands use the same coord-HTTP-base resolution chain
+//! as `mcp::agent_worktrees::coord_http_base`: env `COORD_HTTP_URL` →
+//! profile `coord_url` (ws→http) → `http://localhost:9870`. JWT is
+//! NOT applied here — `/claims/acquire` is gated behind no auth on
+//! coord today (Phase 2 spec §1.1); `/coord/claims/steal` accepts
+//! either an admin-secret header or a Bearer JWT, with the JWT path
+//! reserved for runner-internal use (commands invoked from the webview
+//! always go through the originator-machine-id pathway, not the
+//! operator pathway, which is correct for in-product UX).
+
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// Snake-case ClaimKind discriminator on the wire — must match coord's
+/// `serde(rename_all = "snake_case")` enum at `claims.rs:31-47`.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClaimKindDto {
+    AlembicRevision,
+    BranchName,
+    FileGlob,
+    Phase,
+    Worktree,
+    CiWait,
+}
+
+/// Request body for `claims_acquire` (Tauri command) — wraps the
+/// coord `ClaimRequest` shape but uses camelCase on the IPC boundary
+/// (the existing Tauri-command convention in this codebase).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcquireArgs {
+    pub kind: ClaimKindDto,
+    pub resource_key: String,
+    pub machine_id: String,
+    #[serde(default)]
+    pub ttl_seconds: Option<i64>,
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+}
+
+/// Response payload for `claims_acquire` — passes coord's
+/// `AcquireResult` through as opaque JSON so the frontend can pattern
+/// match on the `result` discriminator. We keep this opaque because
+/// the underlying enum has six variants and we'd rather not chase a
+/// drift between Rust enum copies.
+pub type AcquireResultDto = serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReleaseArgs {
+    pub kind: ClaimKindDto,
+    pub resource_key: String,
+    pub machine_id: String,
+}
+
+pub type ReleaseResultDto = serde_json::Value;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StealArgs {
+    pub kind: ClaimKindDto,
+    pub resource_key: String,
+    pub machine_id: String,
+    pub reason: String,
+}
+
+pub type StealResultDto = serde_json::Value;
+
+/// Coord-HTTP-base resolver — mirrors the proven chain from
+/// `mcp::agent_worktrees::coord_http_base`. Held here as a private
+/// helper so this module is callable without taking the `ApiState`
+/// dependency that lives behind axum (Tauri commands don't have
+/// access to it without significantly more plumbing).
+fn coord_http_base() -> String {
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
+        return crate::agent_worktree::coord_ws_to_http(ws);
+    }
+    "http://localhost:9870".to_string()
+}
+
+fn http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))
+}
+
+/// `claims_acquire` — wrapper around `POST /claims/acquire`. Returns
+/// coord's `AcquireResult` as opaque JSON; the frontend matches on the
+/// `result` discriminator (`claimed`/`held`/`renewed`/`topic_conflict`/
+/// `topic_unknown`/`invalid_topic`). HTTP-level errors are returned as
+/// `Err(String)` for the React layer's `.catch`.
+#[tauri::command]
+pub async fn claims_acquire(args: AcquireArgs) -> Result<AcquireResultDto, String> {
+    let base = coord_http_base();
+    let base = base.trim_end_matches('/');
+    let url = format!("{base}/claims/acquire");
+
+    let body = serde_json::json!({
+        "kind": args.kind,
+        "resource_key": args.resource_key,
+        "machine_id": args.machine_id,
+        "ttl_seconds": args.ttl_seconds,
+        "metadata": args.metadata,
+    });
+
+    let client = http_client()?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+    // 200, 409 (topic conflict/unknown), 400 (invalid topic) all carry
+    // a valid `AcquireResult` body — surface them. Anything else is an
+    // unexpected error.
+    let status = resp.status();
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("read /claims/acquire body: {e}"))?;
+    if status == reqwest::StatusCode::OK
+        || status == reqwest::StatusCode::CONFLICT
+        || status == reqwest::StatusCode::BAD_REQUEST
+    {
+        serde_json::from_str::<serde_json::Value>(&body_text)
+            .map_err(|e| format!("parse /claims/acquire body: {e} (raw: {body_text})"))
+    } else {
+        Err(format!(
+            "POST /claims/acquire returned {} — body: {body_text}",
+            status.as_u16()
+        ))
+    }
+}
+
+/// `claims_release` — wrapper around `POST /claims/release`. Idempotent:
+/// returns `Released` on success, `NotHeld` if the claim was already
+/// gone. Both are surfaced as 200; only transport-level errors yield
+/// `Err`.
+#[tauri::command]
+pub async fn claims_release(args: ReleaseArgs) -> Result<ReleaseResultDto, String> {
+    let base = coord_http_base();
+    let base = base.trim_end_matches('/');
+    let url = format!("{base}/claims/release");
+
+    let body = serde_json::json!({
+        "kind": args.kind,
+        "resource_key": args.resource_key,
+        "machine_id": args.machine_id,
+        // /claims/release requires the full ClaimRequest shape but only
+        // consults `kind`/`resource_key`/`machine_id`. The rest are
+        // ignored.
+        "metadata": serde_json::Value::Object(Default::default()),
+    });
+
+    let client = http_client()?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+    let status = resp.status();
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("read /claims/release body: {e}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "POST /claims/release returned {} — body: {body_text}",
+            status.as_u16()
+        ));
+    }
+    serde_json::from_str::<serde_json::Value>(&body_text)
+        .map_err(|e| format!("parse /claims/release body: {e} (raw: {body_text})"))
+}
+
+/// `claims_steal` — wrapper around `POST /coord/claims/steal`. The
+/// webview-initiated path uses the originator-machine-id JWT
+/// authorization branch (per coord routes.rs:462-651 spec §1). Today
+/// the runner doesn't mint a Bearer JWT for ad-hoc webview calls
+/// (Phase 5 wires this in if needed); without a JWT, the operator
+/// path is the only available branch and requires the admin secret
+/// to be supplied via env at runner startup OR be presented in the
+/// originator-from-this-machine case where coord's auth still passes
+/// based on the body's `machine_id` matching the originator's row.
+///
+/// In practice for Phase 3: a runner stealing its own claim works
+/// without a JWT because coord's StealAuthOutcome::Forbidden path
+/// (routes.rs:636-650) maps to 401 only when no credential was
+/// presented; the 403 path only fires when a JWT IS presented but
+/// disagrees with the originator. Since we present no auth, callers
+/// who aren't the originator will get 401 here — the modal renders
+/// that as "you can't steal this claim."
+///
+/// Phase 5 will mint a self-signed token at runner startup for
+/// originator-path steals so cross-machine UX works. For now the
+/// 401 fallback is acceptable — the modal's "Wait" / "Abort" paths
+/// remain functional.
+#[tauri::command]
+pub async fn claims_steal(args: StealArgs) -> Result<StealResultDto, String> {
+    let base = coord_http_base();
+    let base = base.trim_end_matches('/');
+    let url = format!("{base}/coord/claims/steal");
+
+    let body = serde_json::json!({
+        "kind": args.kind,
+        "resource_key": args.resource_key,
+        "machine_id": args.machine_id,
+        "reason": args.reason,
+    });
+
+    let client = http_client()?;
+    let mut req = client.post(&url).json(&body);
+    // If the admin secret is exposed via env on the runner host
+    // (operator-managed runner deploys), forward it. Most production
+    // runners won't have this set, in which case coord falls back to
+    // the JWT-originator path and we hit 401 unless a JWT is presented.
+    if let Ok(secret) = std::env::var("COORD_ADMIN_SECRET") {
+        if !secret.is_empty() {
+            req = req.header("X-Coord-Admin-Secret", secret);
+        }
+    }
+
+    let resp = req.send().await.map_err(|e| format!("POST {url}: {e}"))?;
+    let status = resp.status();
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("read /coord/claims/steal body: {e}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "POST /coord/claims/steal returned {} — body: {body_text}",
+            status.as_u16()
+        ));
+    }
+    serde_json::from_str::<serde_json::Value>(&body_text)
+        .map_err(|e| format!("parse /coord/claims/steal body: {e} (raw: {body_text})"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claim_kind_dto_serializes_snake_case() {
+        // Must match coord's `serde(rename_all = "snake_case")`.
+        assert_eq!(
+            serde_json::to_string(&ClaimKindDto::AlembicRevision).unwrap(),
+            "\"alembic_revision\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ClaimKindDto::FileGlob).unwrap(),
+            "\"file_glob\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ClaimKindDto::Phase).unwrap(),
+            "\"phase\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ClaimKindDto::CiWait).unwrap(),
+            "\"ci_wait\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ClaimKindDto::Worktree).unwrap(),
+            "\"worktree\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ClaimKindDto::BranchName).unwrap(),
+            "\"branch_name\""
+        );
+    }
+
+    #[test]
+    fn acquire_args_camelcase_resource_key() {
+        // Validate that the IPC payload from the webview uses the
+        // expected camelCase shape (`resourceKey`) and we hand it off
+        // to coord as the snake_case shape (`resource_key`).
+        let s = r#"{
+            "kind": "phase",
+            "resourceKey": "plan:p:phase:1",
+            "machineId": "00000000-0000-0000-0000-000000000000",
+            "metadata": {}
+        }"#;
+        let parsed: AcquireArgs = serde_json::from_str(s).unwrap();
+        assert_eq!(parsed.resource_key, "plan:p:phase:1");
+        assert_eq!(parsed.machine_id, "00000000-0000-0000-0000-000000000000");
+        assert!(matches!(parsed.kind, ClaimKindDto::Phase));
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -166,6 +166,7 @@ pub mod checkpoint_browser; // Orchestrator checkpoint browser (time-travel debu
 pub mod checkpoints;
 pub mod checks; // Code quality checks (linting, formatting, type checking)
 pub mod chunk_labels; // Per-config user-chosen chunk label overrides for chunked state-machine graph view
+pub mod claims; // Plan 2026-05-18-agent-spawn-coordination Phase 3 — Tauri wrappers around coord's /claims/* API
 pub mod clipboard; // Clipboard sync: share text to mobile via backend relay
 pub mod comparison; // Side-by-side architecture comparison runs
 pub mod compartments; // Workstream C: scoped wrappers around Arc<AppState> for gradual migration

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::too_many_arguments)]
 
 mod action_service;
+mod agent_claims;
 mod agent_daemons;
 mod agent_pusher;
 mod agent_token;
@@ -158,6 +159,7 @@ mod steps;
 mod storage;
 pub(crate) mod str_utils;
 mod summary_generator;
+mod tauri_app_handle;
 mod terminal;
 mod test_executor;
 mod test_orchestrator;
@@ -834,6 +836,9 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::chunk_labels::delete_chunk_label,
             commands::chunk_labels::list_chunk_labels,
             commands::chunk_labels::upsert_chunk_label,
+            commands::claims::claims_acquire,
+            commands::claims::claims_release,
+            commands::claims::claims_steal,
             commands::clipboard::share_file_to_mobile,
             commands::clipboard::share_to_mobile,
             commands::comparison::get_comparison_status,
@@ -1549,6 +1554,12 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         // for any future migration that updates the frontend invoke sites.
         .setup(|app| {
             info!("Tauri application setup starting");
+
+            // Plan 2026-05-18-agent-spawn-coordination Phase 3 — stash a
+            // global AppHandle so background tokio tasks (e.g. claim
+            // heartbeats from `agent_claims`) can emit Tauri events
+            // to the webview without taking an AppHandle parameter.
+            tauri_app_handle::set(app.handle().clone());
 
             // Phase F.1 — register the deep-link `on_open_url` callback so
             // `qontinui://wake?intent=...` URLs delivered by the OS (cold

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -29,7 +29,8 @@ use serde_json::json;
 use tracing::{info, warn};
 
 use crate::agent_worktree::{
-    allocate_and_materialize, coord_ws_to_http, worktree_mode_enabled, RepoRequest,
+    allocate_and_materialize_with_claim, coord_ws_to_http, worktree_mode_enabled, AllocateError,
+    RepoRequest,
 };
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
@@ -54,6 +55,21 @@ pub struct AllocateLocalRequest {
     /// or `$HOME/qontinui-root/<repo>/` (POSIX).
     #[serde(default)]
     pub repo_canonical_paths: HashMap<String, String>,
+    /// Plan 2026-05-18-agent-spawn-coordination Phase 3 — optional plan
+    /// id used to derive a `ClaimKind::Phase` pre-flight claim. When
+    /// supplied together with `phase`, the runner calls
+    /// `POST /claims/acquire` with
+    /// `kind=phase, resource_key=plan:<plan_id>:phase:<phase>` BEFORE
+    /// `/agents/allocate`. On `Held` the response is `409 Conflict` with
+    /// a structured body so the caller can surface the
+    /// abort/wait/steal modal.
+    #[serde(default)]
+    pub plan_id: Option<String>,
+    /// Phase 3 — sibling of `plan_id`. When both are present the claim
+    /// kind is `Phase`; when only `declared_overlap_paths` is present,
+    /// falls back to `FileGlob`; otherwise no pre-flight claim.
+    #[serde(default)]
+    pub phase: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -111,13 +127,15 @@ pub async fn post_allocate_local(
         })
         .collect();
 
-    match allocate_and_materialize(
+    match allocate_and_materialize_with_claim(
         &coord_http_base,
         &machine_id,
         &repo_reqs,
         req.intent.as_deref(),
         req.declared_overlap_paths.as_deref(),
         &canonical_paths,
+        req.plan_id.as_deref(),
+        req.phase.as_deref(),
     )
     .await
     {
@@ -127,6 +145,19 @@ pub async fn post_allocate_local(
                 result.agent_id,
                 result.worktrees.len()
             );
+            // Plan 2026-05-18-agent-spawn-coordination Phase 3 — spawn
+            // a heartbeat task for the pre-acquired claim, if any. The
+            // handle is registered in a process-global map keyed by
+            // agent_id so the agent-completion path can release the
+            // claim by lookup.
+            if let Some(claim) = &result.active_claim {
+                crate::agent_claims::register_active_claim(
+                    &result.agent_id,
+                    coord_http_base.clone(),
+                    machine_id,
+                    claim,
+                );
+            }
             // Spawn this agent's long-lived daemons (Row 9 Phase 3
             // pusher + Coordination Phase 6 dirty-poller) through the
             // single unified site. One shared, self-refreshing token
@@ -144,9 +175,33 @@ pub async fn post_allocate_local(
                     "parent_sha": w.parent_sha,
                     "worktree_path": w.worktree_path.to_string_lossy(),
                 })).collect::<Vec<_>>(),
+                "active_claim": result.active_claim,
             }))))
         }
-        Err(e) => {
+        Err(AllocateError::ClaimConflict(conflict)) => {
+            warn!(
+                "/agents/allocate-local claim held: kind={} key={} current_holder={}",
+                conflict.kind, conflict.resource_key, conflict.current_holder
+            );
+            // 409 Conflict with structured body so the caller (orchestrator
+            // or runner-side IPC translator) can surface the abort/wait/
+            // steal modal. Per plan 2026-05-18-agent-spawn-coordination
+            // Phase 3.
+            Err((
+                StatusCode::CONFLICT,
+                Json(api_error(
+                    serde_json::to_string(&serde_json::json!({
+                        "error": "claim_conflict",
+                        "kind": conflict.kind,
+                        "resource_key": conflict.resource_key,
+                        "current_holder": conflict.current_holder,
+                        "intent": conflict.intent,
+                    }))
+                    .unwrap_or_else(|_| "claim_conflict".into()),
+                )),
+            ))
+        }
+        Err(AllocateError::Other(e)) => {
             warn!("/agents/allocate-local failed: {e}");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src-tauri/src/tauri_app_handle.rs
+++ b/src-tauri/src/tauri_app_handle.rs
@@ -1,0 +1,30 @@
+//! Process-global `tauri::AppHandle` slot.
+//!
+//! Tauri commands receive `AppHandle` as a parameter, but background
+//! tokio tasks (e.g. claim heartbeats from `agent_claims`) don't have
+//! direct access. Set once during `tauri::Builder::setup()` and read
+//! by any background task that needs to emit events to the webview.
+//!
+//! Plan reference: `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md`
+//! Phase 3 — required for `agent_claims` heartbeat-task → webview
+//! event emission.
+
+use std::sync::OnceLock;
+
+use tauri::AppHandle;
+
+static APP_HANDLE: OnceLock<AppHandle> = OnceLock::new();
+
+/// Store the global `AppHandle`. Idempotent — first set wins.
+/// Called from `main.rs::setup()`.
+pub fn set(handle: AppHandle) {
+    let _ = APP_HANDLE.set(handle);
+}
+
+/// Get the global `AppHandle` if it's been set. Returns `None` if
+/// the runner is still starting up or running in a context with no
+/// Tauri runtime (e.g., unit tests). Callers should silently drop
+/// events when this returns `None`.
+pub fn current() -> Option<AppHandle> {
+    APP_HANDLE.get().cloned()
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,8 @@ import { useStateMachineRegistration } from "./hooks/useStateMachineRegistration
 
 import { ToastContainer } from "./components/ToastContainer";
 import { BuildRefreshBanner } from "./components/BuildRefreshBanner";
+import { ConflictModal } from "./components/ConflictModal";
+import { StolenBanner } from "./components/StolenBanner";
 import { WebIntegrationAuthBanner } from "./components/WebIntegrationAuthBanner";
 import { ApprovalDialog } from "./components/dag-workflow-editor";
 import StatusIndicator from "./components/StatusIndicator";
@@ -614,6 +616,14 @@ function AppContent() {
           <GiantSCCFixture />
           <CommandPalette />
           <GlobalKnowledgeBrowser />
+          {/*
+            Plan 2026-05-18-agent-spawn-coordination Phase 3 — spawn-time
+            claim-conflict modal + post-acquire stolen-claim banner.
+            Both listen for runner-side Tauri events; they render nothing
+            until those events fire.
+          */}
+          <ConflictModal />
+          <StolenBanner />
         </div>
       </RenderLogWrapper>
     </ProfilerWrapper>

--- a/src/components/ConflictModal.tsx
+++ b/src/components/ConflictModal.tsx
@@ -1,0 +1,512 @@
+/**
+ * Spawn-time claim-conflict modal.
+ *
+ * Plan reference:
+ * `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md` Phase 3.
+ *
+ * Listens for the runner's `agent-claim-conflict` Tauri event. When fired,
+ * renders a modal explaining that another agent is already working on the
+ * scoped claim, and offers three actions:
+ *
+ *   - **Abort** — close the modal without doing anything.
+ *   - **Wait** — poll `GET /coord/claims/by-resource` every 30s; on the
+ *     claim clearing, auto-retry `claims_acquire` (via the runner-side
+ *     Tauri command) and close the modal. Cancellable.
+ *   - **Steal** — confirmation sub-dialog (free-text reason); calls
+ *     `claims_steal` Tauri command; on success retries `claims_acquire`
+ *     and closes the modal.
+ *
+ * The modal is non-blocking — only one conflict can be active at a time
+ * in the current implementation. A second event mid-resolution simply
+ * replaces the displayed conflict.
+ */
+
+import { useEffect, useState, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+/** Snake-case ClaimKind discriminator on the wire (matches coord). */
+type ClaimKind =
+  | "phase"
+  | "file_glob"
+  | "worktree"
+  | "branch_name"
+  | "alembic_revision"
+  | "ci_wait";
+
+/** Payload of the runner's `agent-claim-conflict` Tauri event. */
+interface ConflictEvent {
+  kind: ClaimKind | string;
+  resourceKey: string;
+  currentHolder: string;
+  intent?: string | null;
+}
+
+/** Coord's `AcquireResult` discriminator — `result` field. */
+type AcquireResult =
+  | { result: "claimed"; ttl_seconds: number }
+  | { result: "renewed"; ttl_seconds: number }
+  | { result: "held"; current_holder: string }
+  | { result: "topic_conflict" }
+  | { result: "topic_unknown" }
+  | { result: "invalid_topic" };
+
+/** Coord's `ClaimHolder` shape (GET /coord/claims/by-resource). */
+interface ClaimHolder {
+  kind: string;
+  resource_key: string;
+  machine_id: string;
+  ttl_seconds: number;
+}
+
+/** Per-instance retry source — used by the retry/steal paths to call
+ *  the Tauri `claims_acquire` wrapper with the same args the original
+ *  spawn used. The event payload doesn't carry the requesting machine
+ *  id; we ask the runner's `get_machine_id` endpoint to fetch it on
+ *  demand.
+ */
+async function retryAcquire(
+  conflict: ConflictEvent,
+): Promise<AcquireResult> {
+  const machineId = await getMachineId();
+  return invoke<AcquireResult>("claims_acquire", {
+    args: {
+      kind: conflict.kind,
+      resourceKey: conflict.resourceKey,
+      machineId,
+      metadata: { intent: conflict.intent ?? null },
+    },
+  });
+}
+
+async function getMachineId(): Promise<string> {
+  // The runner exposes its machine_id via the device-info command —
+  // see `commands::auth::get_device_info`. The conflict event carries
+  // `currentHolder` (the OTHER machine's id), not ours, so we fetch
+  // ours separately.
+  const info = await invoke<{ machineId?: string }>("get_device_info").catch(
+    () => ({}) as { machineId?: string },
+  );
+  if (info?.machineId) return info.machineId;
+  // Fallback — without a machine_id the steal/wait paths can't proceed;
+  // the modal surfaces an error inline.
+  throw new Error("machine_id not available from get_device_info");
+}
+
+/** Poll `GET /coord/claims/by-resource` until the claim is no longer
+ *  held, OR until the AbortController fires.
+ *
+ *  Returns when:
+ *  - The claim is no longer held (resolves with `null`).
+ *  - The caller aborts (rejects with `DOMException(AbortError)`).
+ *
+ *  Polling cadence: 30s, per plan.
+ */
+async function waitForClaimCleared(
+  kind: string,
+  resourceKey: string,
+  signal: AbortSignal,
+): Promise<ClaimHolder | null> {
+  while (!signal.aborted) {
+    const url = new URL("/coord/claims/by-resource", coordHttpBase());
+    url.searchParams.set("kind", kind);
+    url.searchParams.set("key", resourceKey);
+    try {
+      const resp = await fetch(url.toString(), { signal });
+      if (resp.ok) {
+        const body = (await resp.json()) as ClaimHolder | null;
+        if (body == null) return null;
+      }
+    } catch (e) {
+      if (signal.aborted) throw e;
+      // transient — keep polling
+    }
+    await sleep(30_000, signal);
+  }
+  throw new DOMException("aborted", "AbortError");
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t = setTimeout(resolve, ms);
+    if (signal) {
+      const onAbort = () => {
+        clearTimeout(t);
+        reject(new DOMException("aborted", "AbortError"));
+      };
+      if (signal.aborted) {
+        onAbort();
+      } else {
+        signal.addEventListener("abort", onAbort, { once: true });
+      }
+    }
+  });
+}
+
+/**
+ * Resolve coord's HTTP base URL by asking the runner via a dedicated
+ * Tauri command if available; falls back to `http://localhost:9870` for
+ * the dev profile.
+ *
+ * For Phase 3 we use the fallback directly — by-resource polling is a
+ * read-only GET that's fine to call against the dev default; a future
+ * enhancement adds a `get_coord_http_base` Tauri command if the production
+ * deployment needs it.
+ */
+function coordHttpBase(): string {
+  return "http://localhost:9870";
+}
+
+export function ConflictModal() {
+  const [conflict, setConflict] = useState<ConflictEvent | null>(null);
+  const [waitingState, setWaitingState] = useState<"idle" | "waiting" | "retrying">("idle");
+  const [stealOpen, setStealOpen] = useState(false);
+  const [stealReason, setStealReason] = useState("");
+  const [stealBusy, setStealBusy] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const waitAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    (async () => {
+      try {
+        unlisten = await listen<ConflictEvent>("agent-claim-conflict", (event) => {
+          setConflict(event.payload);
+          setWaitingState("idle");
+          setStealOpen(false);
+          setStealReason("");
+          setErrorMessage(null);
+        });
+      } catch (e) {
+        // listen() failure is unrecoverable for this surface; logging
+        // is the best we can do.
+        console.error("ConflictModal: listen failed", e);
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+      waitAbortRef.current?.abort();
+    };
+  }, []);
+
+  const closeModal = useCallback(() => {
+    waitAbortRef.current?.abort();
+    setConflict(null);
+    setWaitingState("idle");
+    setStealOpen(false);
+    setStealReason("");
+    setErrorMessage(null);
+  }, []);
+
+  const handleWait = useCallback(async () => {
+    if (!conflict) return;
+    setErrorMessage(null);
+    waitAbortRef.current?.abort();
+    const ac = new AbortController();
+    waitAbortRef.current = ac;
+    setWaitingState("waiting");
+    try {
+      await waitForClaimCleared(conflict.kind, conflict.resourceKey, ac.signal);
+      setWaitingState("retrying");
+      const result = await retryAcquire(conflict);
+      if (result.result === "claimed" || result.result === "renewed") {
+        closeModal();
+      } else if (result.result === "held") {
+        // Race — someone else grabbed it between poll-clear and retry.
+        // Restart the wait loop.
+        setConflict({
+          ...conflict,
+          currentHolder: result.current_holder,
+        });
+        setWaitingState("idle");
+      } else {
+        setErrorMessage(`unexpected acquire result: ${result.result}`);
+        setWaitingState("idle");
+      }
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") {
+        // Caller cancelled — already in `idle` after closeModal.
+        return;
+      }
+      setErrorMessage(String(e));
+      setWaitingState("idle");
+    } finally {
+      waitAbortRef.current = null;
+    }
+  }, [conflict, closeModal]);
+
+  const handleStealConfirm = useCallback(async () => {
+    if (!conflict) return;
+    setStealBusy(true);
+    setErrorMessage(null);
+    try {
+      const machineId = await getMachineId();
+      const stealResult = await invoke<{ result: string; displaced_machine_id?: string | null }>(
+        "claims_steal",
+        {
+          args: {
+            kind: conflict.kind,
+            resourceKey: conflict.resourceKey,
+            machineId,
+            reason: stealReason.trim() || "user-initiated steal from runner UI",
+          },
+        },
+      );
+      if (stealResult.result !== "stolen" && stealResult.result !== "not_held" && stealResult.result !== "no_originator") {
+        setErrorMessage(`unexpected steal result: ${stealResult.result}`);
+        setStealBusy(false);
+        return;
+      }
+      // Steal succeeded — retry the acquire so the user's session can proceed.
+      const retry = await retryAcquire(conflict);
+      if (retry.result === "claimed" || retry.result === "renewed") {
+        closeModal();
+      } else if (retry.result === "held") {
+        // Another agent grabbed it in the race window — surface fresh holder.
+        setConflict({ ...conflict, currentHolder: retry.current_holder });
+        setStealOpen(false);
+        setStealReason("");
+      } else {
+        setErrorMessage(`acquire after steal returned: ${retry.result}`);
+      }
+    } catch (e) {
+      setErrorMessage(String(e));
+    } finally {
+      setStealBusy(false);
+    }
+  }, [conflict, stealReason, closeModal]);
+
+  if (!conflict) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="claim-conflict-title"
+      style={modalBackdropStyle}
+    >
+      <div style={modalCardStyle}>
+        <h2 id="claim-conflict-title" style={titleStyle}>
+          Claim conflict
+        </h2>
+        <p style={messageStyle}>
+          Another agent (machine{" "}
+          <code style={codeStyle}>
+            {conflict.currentHolder ? conflict.currentHolder.slice(0, 8) : "unknown"}
+          </code>
+          ) is already working on{" "}
+          <code style={codeStyle}>
+            {conflict.kind}:{conflict.resourceKey}
+          </code>
+          .
+        </p>
+        {conflict.intent && (
+          <p style={intentStyle}>
+            <strong>Intent:</strong> {conflict.intent}
+          </p>
+        )}
+
+        {errorMessage && <p style={errorStyle}>{errorMessage}</p>}
+
+        {!stealOpen && (
+          <div style={buttonRowStyle}>
+            <button
+              type="button"
+              onClick={closeModal}
+              disabled={waitingState !== "idle"}
+              style={btnSecondary}
+            >
+              Abort
+            </button>
+            {waitingState === "idle" && (
+              <button type="button" onClick={handleWait} style={btnSecondary}>
+                Wait
+              </button>
+            )}
+            {waitingState === "waiting" && (
+              <button
+                type="button"
+                onClick={() => {
+                  waitAbortRef.current?.abort();
+                  setWaitingState("idle");
+                }}
+                style={btnSecondary}
+              >
+                Cancel wait
+              </button>
+            )}
+            {waitingState === "retrying" && (
+              <button type="button" disabled style={btnSecondary}>
+                Retrying...
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setStealOpen(true)}
+              disabled={waitingState !== "idle"}
+              style={btnDanger}
+            >
+              Steal
+            </button>
+          </div>
+        )}
+
+        {stealOpen && (
+          <div style={{ marginTop: 16 }}>
+            <p style={messageStyle}>
+              <strong>Confirm steal.</strong> This will revoke the other
+              agent&apos;s claim. The other agent&apos;s next heartbeat will
+              return <code style={codeStyle}>Stolen</code> and its session
+              will be notified.
+            </p>
+            <label style={{ display: "block", marginTop: 8 }}>
+              <span style={labelStyle}>Reason (free text)</span>
+              <textarea
+                value={stealReason}
+                onChange={(e) => setStealReason(e.target.value)}
+                placeholder="why are you stealing this claim?"
+                rows={3}
+                style={textareaStyle}
+              />
+            </label>
+            <div style={buttonRowStyle}>
+              <button
+                type="button"
+                onClick={() => {
+                  setStealOpen(false);
+                  setStealReason("");
+                }}
+                disabled={stealBusy}
+                style={btnSecondary}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleStealConfirm}
+                disabled={stealBusy}
+                style={btnDanger}
+              >
+                {stealBusy ? "Stealing..." : "Confirm steal"}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Inline styles — match the existing BuildRefreshBanner / canary-alert
+// look-and-feel rather than depending on Tailwind's component class library.
+// ─────────────────────────────────────────────────────────────────────────
+
+const modalBackdropStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  background: "rgba(0, 0, 0, 0.6)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 10000,
+};
+
+const modalCardStyle: React.CSSProperties = {
+  background: "var(--bg-tertiary, #242837)",
+  color: "var(--text-primary, #e4e4e7)",
+  border: "1px solid var(--accent, #6366f1)",
+  borderRadius: 12,
+  padding: 24,
+  maxWidth: 560,
+  width: "90%",
+  boxShadow: "0 12px 40px rgba(0, 0, 0, 0.5)",
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  marginBottom: 12,
+  fontSize: "1.25rem",
+  color: "var(--text-primary, #e4e4e7)",
+};
+
+const messageStyle: React.CSSProperties = {
+  margin: 0,
+  marginBottom: 12,
+  fontSize: "0.9375rem",
+  color: "var(--text-secondary, #a1a1aa)",
+  lineHeight: 1.5,
+};
+
+const intentStyle: React.CSSProperties = {
+  ...messageStyle,
+  background: "rgba(99, 102, 241, 0.08)",
+  borderLeft: "3px solid var(--accent, #6366f1)",
+  padding: "8px 12px",
+  borderRadius: 4,
+};
+
+const codeStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.08)",
+  padding: "2px 6px",
+  borderRadius: 4,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: "0.875rem",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: "0.8125rem",
+  marginBottom: 4,
+  color: "var(--text-secondary, #a1a1aa)",
+};
+
+const textareaStyle: React.CSSProperties = {
+  width: "100%",
+  fontFamily: "inherit",
+  fontSize: "0.875rem",
+  background: "var(--bg-secondary, #1a1d2a)",
+  color: "var(--text-primary, #e4e4e7)",
+  border: "1px solid var(--border, #3f3f46)",
+  borderRadius: 4,
+  padding: 8,
+  resize: "vertical",
+};
+
+const buttonRowStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: 8,
+  marginTop: 16,
+};
+
+const btnSecondary: React.CSSProperties = {
+  background: "transparent",
+  color: "var(--text-primary, #e4e4e7)",
+  border: "1px solid var(--border, #3f3f46)",
+  borderRadius: 4,
+  padding: "6px 14px",
+  fontSize: "0.875rem",
+  cursor: "pointer",
+};
+
+const btnDanger: React.CSSProperties = {
+  background: "var(--destructive, #ef4444)",
+  color: "#fff",
+  border: "none",
+  borderRadius: 4,
+  padding: "6px 14px",
+  fontSize: "0.875rem",
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const errorStyle: React.CSSProperties = {
+  margin: "8px 0",
+  padding: "8px 12px",
+  background: "rgba(239, 68, 68, 0.1)",
+  border: "1px solid rgba(239, 68, 68, 0.3)",
+  borderRadius: 4,
+  color: "var(--destructive, #ef4444)",
+  fontSize: "0.875rem",
+};

--- a/src/components/StolenBanner.tsx
+++ b/src/components/StolenBanner.tsx
@@ -1,0 +1,183 @@
+/**
+ * Non-modal banner that surfaces when this runner's claim was stolen
+ * by another machine.
+ *
+ * Plan reference:
+ * `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md` Phase 3.
+ *
+ * Listens for the runner's `agent-claim-stolen` Tauri event (emitted by
+ * the `agent_claims` heartbeat task when `HeartbeatResult::Stolen` fires).
+ * Displays a dismissible banner with the resource_key + stolen-by holder
+ * and a link to the audit-log page (placeholder route; Phase 5 builds
+ * the actual dashboard).
+ */
+
+import { useEffect, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+interface StolenEvent {
+  kind: string;
+  resourceKey: string;
+  currentHolder?: string | null;
+  agentId: string;
+}
+
+interface ActiveStolenNotice extends StolenEvent {
+  id: number;
+}
+
+export function StolenBanner() {
+  const [notices, setNotices] = useState<ActiveStolenNotice[]>([]);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let counter = 0;
+    (async () => {
+      try {
+        unlisten = await listen<StolenEvent>("agent-claim-stolen", (event) => {
+          counter += 1;
+          const notice: ActiveStolenNotice = {
+            ...event.payload,
+            id: counter,
+          };
+          setNotices((prev) => [...prev, notice]);
+        });
+      } catch (e) {
+        console.error("StolenBanner: listen failed", e);
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  const dismiss = (id: number) => {
+    setNotices((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  if (notices.length === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Stolen claim notifications"
+      style={containerStyle}
+    >
+      {notices.map((n) => (
+        <div key={n.id} role="status" aria-live="polite" style={bannerStyle}>
+          <div style={{ flex: 1 }}>
+            <p style={titleStyle}>Claim stolen</p>
+            <p style={messageStyle}>
+              Your claim{" "}
+              <code style={codeStyle}>
+                {n.kind}:{n.resourceKey}
+              </code>{" "}
+              was revoked
+              {n.currentHolder ? (
+                <>
+                  {" "}by machine{" "}
+                  <code style={codeStyle}>{n.currentHolder.slice(0, 8)}</code>
+                </>
+              ) : null}
+              . Agent{" "}
+              <code style={codeStyle}>{n.agentId.slice(0, 8)}</code>
+              {" "}has been notified.
+            </p>
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <a
+              href="#/admin/agent-claims"
+              style={linkStyle}
+              onClick={(e) => {
+                // Phase 5 wires this to the actual dashboard route. For
+                // now: navigate via window.location.hash so the link
+                // doesn't 404 in a standard router setup. If the user's
+                // router doesn't have the route yet, this is harmless.
+                e.preventDefault();
+                window.location.hash = "#/admin/agent-claims";
+              }}
+            >
+              Open audit log
+            </a>
+            <button
+              type="button"
+              onClick={() => dismiss(n.id)}
+              style={dismissBtn}
+              aria-label="Dismiss"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Inline styles — same vocabulary as the canary-rollback banner already in
+// App.tsx so the visual rhythm stays consistent.
+// ─────────────────────────────────────────────────────────────────────────
+
+const containerStyle: React.CSSProperties = {
+  position: "fixed",
+  top: 16,
+  right: 16,
+  zIndex: 9998,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  maxWidth: 480,
+};
+
+const bannerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 12,
+  padding: "12px 14px",
+  background: "var(--bg-tertiary, #242837)",
+  color: "var(--text-primary, #e4e4e7)",
+  border: "1px solid var(--destructive, #ef4444)",
+  borderRadius: 8,
+  boxShadow: "0 4px 16px rgba(0, 0, 0, 0.35)",
+  fontSize: "0.875rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  margin: 0,
+  marginBottom: 4,
+  fontWeight: 600,
+  color: "var(--destructive, #ef4444)",
+};
+
+const messageStyle: React.CSSProperties = {
+  margin: 0,
+  color: "var(--text-secondary, #a1a1aa)",
+  fontSize: "0.8125rem",
+  lineHeight: 1.4,
+};
+
+const codeStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.08)",
+  padding: "1px 4px",
+  borderRadius: 3,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: "0.75rem",
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "var(--accent, #6366f1)",
+  fontSize: "0.75rem",
+  textDecoration: "underline",
+  cursor: "pointer",
+};
+
+const dismissBtn: React.CSSProperties = {
+  background: "transparent",
+  color: "var(--text-secondary, #a1a1aa)",
+  border: "1px solid var(--border, #3f3f46)",
+  borderRadius: 4,
+  padding: "2px 8px",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+};


### PR DESCRIPTION
## Summary

Plan `2026-05-18-agent-spawn-coordination.md` Phase 3 — runner-side wiring of coord's claims API + webview conflict/stolen UX. Built on Phase 2 coord PR #44 (merged at `c920c34`).

- **Runner Rust side:** pre-allocate `/claims/acquire` from `allocate_and_materialize`; new `ClaimSpawnContext` derives `ClaimKind::Phase` (plan_id+phase) or `ClaimKind::FileGlob` (declared_overlap_paths); new `AllocateError::ClaimConflict` variant; new `spawn_heartbeat_task` posts TTL/3s heartbeats and fires `agent-claim-stolen` event on `HeartbeatResult::Stolen`; new `release_claim_best_effort`. New `agent_claims` module is the process-global heartbeat registry. New `tauri_app_handle` shim lets background tasks emit Tauri events. New `commands::claims` exposes `claims_acquire` / `claims_release` / `claims_steal` Tauri commands.
- **Runner React side:** `ConflictModal` listens for `agent-claim-conflict`, offers Abort/Wait/Steal (with confirmation sub-dialog + free-text reason). `StolenBanner` listens for `agent-claim-stolen`, stacks dismissible notices, links to placeholder `/admin/agent-claims` route (Phase 5 builds that page). Both mounted in `AppContent`.
- **HTTP `/agents/allocate-local`:** accepts new optional `plan_id` + `phase` body fields; on `Held` returns 409 with structured body; on success registers a heartbeat task keyed by `agent_id`.

## Test plan

- [x] `cargo test --bin qontinui-runner` — 3792 pass, 0 fail, 36 ignored (including 3 new tests in `commands::claims` + `agent_claims`)
- [x] UI Bridge manifest-drift sanity tests (`manifest_matches_route_calls`, `sdk_manifest_routes_are_exposed_by_runner`) — both pass (new Tauri commands are invoke-only, no HTTP routes)
- [x] `cargo check -p qontinui-runner --bins --tests --benches` — clean
- [x] `tsc --noEmit` — clean
- [x] `eslint` on new component files — clean
- [ ] End-to-end two-runner smoke (deferred — requires live coord + Phase 4 orchestrator paths)

## Files

- `src-tauri/src/agent_worktree/mod.rs` — pre-allocate claim + heartbeat task + `ActiveClaim` field on `AllocateResult`
- `src-tauri/src/agent_claims/mod.rs` (new) — process-global heartbeat registry + Tauri event emission
- `src-tauri/src/commands/claims.rs` (new) — `claims_acquire` / `claims_release` / `claims_steal` Tauri commands
- `src-tauri/src/tauri_app_handle.rs` (new) — `OnceLock<AppHandle>` for background-task event emission
- `src-tauri/src/mcp/agent_worktrees.rs` — `plan_id`/`phase` body fields + 409 ClaimConflict response + heartbeat registration
- `src-tauri/src/main.rs` — register new modules; stash AppHandle in `setup()`; register new commands in invoke_handler
- `src-tauri/src/agent_daemons/mod.rs` — test fixture updated for new `AllocateResult::active_claim` field
- `src-tauri/src/commands/mod.rs` — register `claims` module
- `src/App.tsx` — mount `ConflictModal` + `StolenBanner`
- `src/components/ConflictModal.tsx` (new) — Abort/Wait/Steal modal
- `src/components/StolenBanner.tsx` (new) — non-modal stolen-claim notice stack