### PR TITLE
chore(spec-check): widen qontinui-types constraint (follow-up to #176)

### DIFF
--- a/crates/spec-check/Cargo.toml
+++ b/crates/spec-check/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-or-later"
 description = "Pure-Rust matcher: IR page spec × UI Bridge snapshot → SpecCheckResult"
 
 [dependencies]
-qontinui-types = { path = "../../../qontinui-schemas/rust", version = "^0.1.3" }
+qontinui-types = { path = "../../../qontinui-schemas/rust", version = ">=0.1.3, <0.3.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

Follow-up to #176. PR #176 widened `src-tauri/Cargo.toml:108` but missed the inner workspace crate `crates/spec-check/Cargo.toml:9` which carries its own `qontinui-types = "^0.1.3"` constraint. This PR widens that to `>=0.1.3, <0.3.0` so the qontinui-schemas#54 check-drift workflow can resolve `qontinui-types 0.2.0`.

## Why

Post-#176 the schemas drift check progressed past `src-tauri/Cargo.toml` and now fails on:

```
required by package `qontinui-spec-check v0.1.0`
  (/home/runner/work/qontinui-schemas/qontinui-schemas/qontinui-runner/crates/spec-check)
error: failed to select a version for the requirement `qontinui-types = "^0.1.3"`
candidate versions found which didn't match: 0.2.0
```

`^0.1.3` means `>=0.1.3, <0.2.0` — incompatible with 0.2.0. Widening to `>=0.1.3, <0.3.0` (preserving the existing 0.1.3 floor) accepts both the current schemas main (0.1.3) and post-#54 schemas main (0.2.0).

## Audit context

Comprehensive audit across all 33 `qontinui-*` repos at origin/main today identified this as the **only** remaining `qontinui-types` constraint that still needed widening (everywhere else already on `>=0.1.x, <0.3.0` post-#176/#38 or already at `^0.2.0` inside qontinui-schemas#54). After this lands, the schemas drift workflow should resolve cleanly.

## Scope discipline

- **Constraint-only.** No spec-check code migration.
- One file, one line.

## Test plan

- [x] Local `cargo metadata` resolves `qontinui-types` to `0.1.3` — widened range matches.
- [ ] Runner CI passes