### PR TITLE
feat(runner): periodic HTTP heartbeat to coord

### DIFF
--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -380,9 +380,7 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
     } else {
         let body = resp.text().await.unwrap_or_default();
         let excerpt: String = body.chars().take(200).collect();
-        Err(format!(
-            "coord returned {status} for POST {url}: {excerpt}"
-        ))
+        Err(format!("coord returned {status} for POST {url}: {excerpt}"))
     }
 }
 

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -20,9 +20,10 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::Deserialize;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::database::pg::PgDb;
 
@@ -238,6 +239,183 @@ pub async fn publish_on_startup(pg: &Arc<PgDb>, role: MachineRole) {
     if let Err(e) = publish_budget(pg, role, resources, 0).await {
         warn!("fleet::publish_on_startup failed (non-fatal — runner still boots): {e}");
     }
+}
+
+// =============================================================================
+// HTTP heartbeat to coord (plan 2026-05-18-push-aware-fleet-liveness.md §5).
+//
+// The direct-PG `publish_budget` path above is a one-shot at boot. To keep
+// `coord.machines.last_seen_at` fresh under coord's new push-aware liveness
+// model, the runner periodically POSTs `{machine_id, hostname}` to coord's
+// `/coord/machine/register` endpoint. The handler's UPSERT refreshes
+// `last_seen_at` and `COALESCE`s a previously-advertised `health_url`, so
+// heartbeating from the runner side is a clean, side-effect-free refresh.
+//
+// The HTTP heartbeat path is intentionally additive: it never touches the
+// direct-PG publisher and tolerates missing identity, missing profile, or
+// network failure with `info!`/`warn!` and a retry on the next tick.
+// =============================================================================
+
+/// `~/.qontinui/profiles.json` — minimum subset we need (the active
+/// profile's `coord_url`). Mirrors the supervisor's shape at
+/// `qontinui-supervisor/src/fleet.rs:96-107` verbatim so the same
+/// active-profile + trim-`/ws` logic applies on both sides.
+#[derive(Debug, Clone, Deserialize)]
+struct Profiles {
+    #[serde(default)]
+    active: Option<String>,
+    #[serde(default)]
+    profiles: std::collections::HashMap<String, Profile>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct Profile {
+    #[serde(default)]
+    coord_url: Option<String>,
+}
+
+fn profiles_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".qontinui").join("profiles.json"))
+}
+
+/// Resolve the coord HTTP base from the active profile's `coord_url`.
+/// Profile stores `ws://host:9870/ws` or `wss://host:9870/ws` (the
+/// WebSocket upgrade URL); convert that to `http://host:9870` /
+/// `https://host:9870` so reqwest can POST to `/coord/machine/register`.
+/// Returns `None` if profiles.json is missing or the active profile has
+/// no coord_url. Mirrors `qontinui-supervisor/src/fleet.rs:122-138`.
+///
+/// Re-read each tick — `profiles.json` is tiny and the active profile
+/// may change between ticks; caching would defeat that.
+fn coord_http_base() -> Option<String> {
+    let bytes = std::fs::read(profiles_path()?).ok()?;
+    let pf: Profiles = serde_json::from_slice(&bytes).ok()?;
+    let active = pf.active.as_deref().unwrap_or("dev");
+    let coord_url = pf.profiles.get(active)?.coord_url.as_deref()?;
+
+    let trimmed = coord_url.trim_end_matches("/ws");
+    let with_http = trimmed
+        .strip_prefix("wss://")
+        .map(|rest| format!("https://{rest}"))
+        .or_else(|| {
+            trimmed
+                .strip_prefix("ws://")
+                .map(|rest| format!("http://{rest}"))
+        })
+        .unwrap_or_else(|| trimmed.to_string());
+    Some(with_http)
+}
+
+#[derive(Debug, serde::Serialize)]
+struct HeartbeatPayload {
+    machine_id: uuid::Uuid,
+    hostname: String,
+}
+
+/// POST `{machine_id, hostname}` to `<base>/coord/machine/register`.
+///
+/// `health_url` is deliberately omitted — coord's `register_machine`
+/// handler `COALESCE`s `EXCLUDED.health_url` with the existing value,
+/// so omitting from the heartbeat preserves any URL the machine
+/// previously advertised. Failures are reported as `Err(String)` so
+/// the caller can log them; the loop never panics.
+pub async fn heartbeat_to_coord() -> Result<(), String> {
+    let machine = match load_machine_file() {
+        Some(m) => m,
+        None => {
+            info!(
+                "fleet::heartbeat: ~/.qontinui/machine.json missing — \
+                 run `qontinui_profile machine init` to enable fleet visibility. Skipping."
+            );
+            return Ok(());
+        }
+    };
+
+    let machine_id = match uuid::Uuid::parse_str(&machine.machine_id) {
+        Ok(id) => id,
+        Err(e) => {
+            warn!("fleet::heartbeat: machine.json machine_id is not a valid UUID ({e}). Skipping.");
+            return Ok(());
+        }
+    };
+
+    let base = match coord_http_base() {
+        Some(b) => b,
+        None => {
+            info!(
+                "fleet::heartbeat: ~/.qontinui/profiles.json missing or active profile \
+                 has no coord_url — no coord to heartbeat to. Skipping."
+            );
+            return Ok(());
+        }
+    };
+
+    let payload = HeartbeatPayload {
+        machine_id,
+        hostname: machine.hostname.clone(),
+    };
+    let url = format!("{base}/coord/machine/register");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("reqwest builder: {e}"))?;
+
+    let resp = client
+        .post(&url)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+
+    let status = resp.status();
+    if status.is_success() {
+        // 30s cadence — `info!` would be noisy, debug! keeps the
+        // happy path quiet while still discoverable.
+        debug!(
+            "fleet::heartbeat: ok machine_id={machine_id} hostname={} status={}",
+            machine.hostname, status
+        );
+        Ok(())
+    } else {
+        let body = resp.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(200).collect();
+        Err(format!(
+            "coord returned {status} for POST {url}: {excerpt}"
+        ))
+    }
+}
+
+/// Spawn the periodic heartbeat task on the ambient tokio runtime.
+///
+/// Interval is read from `COORD_HEARTBEAT_INTERVAL_SECS` (default 30s,
+/// floored at 1s). `MissedTickBehavior::Skip` mirrors the watcher in
+/// `qontinui-coord/src/health_watcher.rs:99-100` — if a tick is missed
+/// (e.g. system suspend), skip catch-up and resume on the next aligned
+/// tick. Heartbeat failures `warn!` and retry on the next interval;
+/// the loop never panics.
+pub fn spawn_heartbeat() {
+    let secs: u64 = std::env::var("COORD_HEARTBEAT_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(30)
+        .max(1);
+
+    info!(
+        "fleet::heartbeat: starting periodic heartbeat task, interval={}s",
+        secs
+    );
+
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = heartbeat_to_coord().await {
+                warn!("fleet::heartbeat: {e}");
+            }
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -417,6 +417,54 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         ));
     }
 
+    // fleet heartbeat — see plan §5 and fleet.rs::spawn_heartbeat.
+    //
+    // Periodic HTTP POST `{machine_id, hostname}` to coord's
+    // `/coord/machine/register`, refreshing `coord.machines.last_seen_at`
+    // so coord's push-aware liveness ladder (plan 2026-05-18-push-aware-
+    // fleet-liveness §4) recognizes this runner as alive even when the
+    // inbound probe can't reach us (NAT/firewall asymmetry).
+    //
+    // We need a long-lived runtime here, but there is no ambient tokio
+    // runtime at this point in `run_app` (Tauri's runtime is constructed
+    // later in `tauri::Builder::run`). So park a dedicated OS thread
+    // hosting a multi-thread runtime, kept alive forever via a `pending`
+    // future. Same posture as the supervisor's interval-style background
+    // tasks — a one-shot `block_on` is the wrong shape because the
+    // heartbeat task lives for the runner's entire lifetime.
+    std::thread::Builder::new()
+        .name("fleet-heartbeat".to_string())
+        .spawn(|| {
+            let rt = match tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .thread_name("fleet-hb-rt")
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    warn!(
+                        "fleet::heartbeat: failed to build dedicated tokio runtime ({e}). \
+                         Skipping periodic heartbeat — runner still boots."
+                    );
+                    return;
+                }
+            };
+            rt.block_on(async {
+                fleet::spawn_heartbeat();
+                // Park this thread's runtime forever so the spawned
+                // interval task keeps ticking for the runner's lifetime.
+                std::future::pending::<()>().await;
+            });
+        })
+        .map(|_| ())
+        .unwrap_or_else(|e| {
+            warn!(
+                "fleet::heartbeat: failed to spawn dedicated OS thread ({e}). \
+                 Skipping periodic heartbeat — runner still boots."
+            );
+        });
+
     // Migrate plaintext API keys to secure keychain storage
     if let Err(e) = config_facade::migrate_api_keys_to_keychain() {
         warn!("API key migration to keychain failed (non-fatal): {}", e);


### PR DESCRIPTION
## Summary

The runner now POSTs `{machine_id, hostname}` to coord's `/coord/machine/register` every 30s (env `COORD_HEARTBEAT_INTERVAL_SECS`). This keeps `coord.machines.last_seen_at` fresh so push-aware fleet liveness (companion change in `qontinui-coord` PR #46) recognizes the runner as alive even when it sits behind NAT and can't accept inbound probes.

## Why runner-side and not supervisor-side

The supervisor is a dev-only process-management tool (per `qontinui-supervisor/CLAUDE.md`); it doesn't run on production fleet machines. The runner is what actually runs on every fleet host, so it's the architecturally correct heartbeat source. The earlier "Option C2 is infeasible" reasoning applied only to the existing direct-PG publish path — adding HTTP alongside is straightforward.

## Changes

- **`Profile`/`Profiles`** deserialize structs + **`coord_http_base()`** resolver in `fleet.rs`, mirroring `qontinui-supervisor/src/fleet.rs:122-138`. Reads `~/.qontinui/profiles.json`, picks the active profile, trims `/ws` off `coord_url`.
- **`heartbeat_to_coord()`** — loads `~/.qontinui/machine.json` identity, resolves the coord base, POSTs `{machine_id, hostname}` to `<base>/coord/machine/register` with a 5s timeout. `health_url` is intentionally omitted — coord's `register_machine` `COALESCE`s `EXCLUDED.health_url` with the existing value, so omitting preserves any previously-advertised URL.
- **`spawn_heartbeat()`** — `tokio::time::interval` with `MissedTickBehavior::Skip` mirroring the coord watcher pattern at `qontinui-coord/src/health_watcher.rs:99-100`. Default interval `30s`, floored at `1s`.
- **`main.rs`** spawns a dedicated OS thread hosting a 1-worker multi-thread tokio runtime parked on `std::future::pending` — `run_app()` is sync, the existing one-shot `current_thread` runtime would drop the interval task on its own drop, and Tauri's runtime isn't constructed until later.

## Failure modes (plan §5 contract, implemented exactly)

| Condition | Behavior |
|---|---|
| `machine.json` missing | `info!`, return `Ok(())` — same posture as existing direct-PG `publish_budget` |
| `profiles.json` missing or no active `coord_url` | `info!`, return `Ok(())` — no coord to talk to |
| HTTP POST fails (timeout / non-2xx) | `warn!` in the loop, retry on next interval |
| Active profile's `coord_url` changes | re-read `profiles.json` every tick (no caching) |
| Success | `debug!` only — 30s cadence would be noisy at `info` |

Never panics, never crashes the runner.

## Tests

- `cargo check --bin qontinui-runner`: clean.
- No new unit tests — the heartbeat is a thin HTTP wrapper; behavior is exercised end-to-end via the staging deploy verification (plan §6 step 5).

## Companion change

Coord-side filter + state-machine change in `qontinui-coord` PR #46 (`feat/push-aware-fleet-liveness`, commit `43b552e`). The two PRs are independent — runner can ship first; heartbeats just refresh `last_seen_at` whether or not coord exposes them in `/coord/fleet/state` yet.

## Test plan

- [x] `cargo check --bin qontinui-runner` clean
- [ ] Build the updated runner on MSI (operator-gated; do not restart active runners)
- [ ] Temporarily set `coord_url=wss://coord.staging.qontinui.io/ws` in MSI's active `profiles.json` (byte-exact revert discipline per plan §1)
- [ ] Verify MSI appears in `/coord/fleet/state` with `state=healthy`, `last_seen_at` advances each interval, stays healthy across ≥2 watcher ticks (60s) despite the inbound probe failing

## Plan

`qontinui-dev-notes/plans/2026-05-18-push-aware-fleet-liveness.md` (VETTED 2026-05-18).