### PR TITLE
feat(ui-bridge): remediation hint when /ui-bridge/devices is empty

### DIFF
--- a/src-tauri/src/mcp/physical_device_api.rs
+++ b/src-tauri/src/mcp/physical_device_api.rs
@@ -31,6 +31,12 @@ use crate::mcp::types::{ApiResponse, ApiState};
 struct DeviceListResponse {
     devices: Vec<PhysicalDevice>,
     count: usize,
+    /// Operator remediation hint, present only when no devices are paired.
+    /// A release AAB is not auto-reachable until a transport is set up, so
+    /// `count: 0` is the common "nothing to test" state — surface the fix
+    /// inline instead of leaving callers to guess.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    hint: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -121,9 +127,24 @@ async fn list_devices(
 ) -> Result<Json<ApiResponse<DeviceListResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     let devices = state.physical_device_registry.list_all().await;
     let count = devices.len();
+    let hint = if count == 0 {
+        Some(
+            "No devices paired. Set up a transport, then re-query: \
+             (USB) `adb forward tcp:8087 tcp:8087` and hit \
+             http://localhost:8087/ui-bridge/health; or \
+             (LAN/cloud) in qontinui-mobile enable Settings -> Developer -> \
+             \"Local UI Bridge server\" and pair via the Connection Wizard \
+             (deep link: qontinui:///connect). Release AABs are not \
+             auto-reachable until paired."
+                .to_string(),
+        )
+    } else {
+        None
+    };
     Ok(Json(ApiResponse::success(DeviceListResponse {
         devices,
         count,
+        hint,
     })))
 }
 


### PR DESCRIPTION
When no physical devices are paired, `GET /ui-bridge/devices` returns `count: 0` with no guidance. A release AAB is not auto-reachable until the operator sets up a transport, so this is the common "nothing to test" state during mobile manual-test.

Adds an optional `hint` field to `DeviceListResponse`, serialized only when `count == 0` (`#[serde(skip_serializing_if)]` — no shape change when devices exist), pointing at the two fixes: `adb forward tcp:8087 tcp:8087` or the in-app Connection Wizard (`qontinui:///connect`).

Part of the release-AAB transport remediation surfaced during the 2026-05-18 keep-awake manual-test. Verified: clean `cargo check` on a fresh worktree off origin/main (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)