### PR TITLE
feat(runner): self-heal agent_session_id columns + agent_sessions table

### DIFF
--- a/src-tauri/src/coordinator/scheduler.rs
+++ b/src-tauri/src/coordinator/scheduler.rs
@@ -189,6 +189,22 @@ pub fn start_coordinator_scheduler(
             );
         }
 
+        // Plan `coord-agent-session-id-tracking.md` Phase 2 (Side B):
+        // self-heal coord.agent_sessions (the Claude Code session
+        // lookup table). Idempotent. Logs but doesn't fail — coord's
+        // upsert_agent_session helper degrades gracefully when the
+        // table is missing, so a self-heal failure is non-blocking.
+        // Same posture as the merge-proposals helper above: runner
+        // doesn't write this table directly today; the self-heal
+        // exists so local-coord harnesses + fresh dev DBs have a
+        // path to bootstrap without waiting for alembic.
+        if let Err(e) = state.app_state.pg_db.ensure_agent_sessions_table().await {
+            warn!(
+                "Coordinator scheduler: ensure_agent_sessions_table failed: {} — agent-session lineage may be sparse until alembic upgrade",
+                e
+            );
+        }
+
         info!(
             "Coordinator (Rust) scheduler started: instance_id={} interval={}s rule_version={} max_llm_calls_per_hour={} auto_review_enabled={} shadow_mode_enabled={} initial_enabled={}",
             instance_id,

--- a/src-tauri/src/database/pg/agent_sessions.rs
+++ b/src-tauri/src/database/pg/agent_sessions.rs
@@ -1,0 +1,70 @@
+//! Self-heal helper for `coord.agent_sessions` — the Claude Code
+//! session lookup table introduced by Plan
+//! `D:/qontinui-root/plans/coord-agent-session-id-tracking.md` Phase 2
+//! (Side B).
+//!
+//! Plan reference: see Side B "lookup table" section. The runner does
+//! NOT write this table directly today — `POST /coord/...` mutating
+//! endpoints in qontinui-coord own the writes via the
+//! `agent_sessions::upsert_agent_session` helper. The ensure_* helper
+//! is provided so a runner-driven local-coord harness (or a fresh dev
+//! database whose alembic chain hasn't reached the agent_sessions
+//! revision yet) can still allocate the table before coord first
+//! writes to it.
+//!
+//! Schema must stay byte-equivalent to the alembic migration. Plan
+//! Phase 6 will tighten `id` columns to NOT NULL on the audit tables
+//! after Side C2 (Claude Code env-var surface) lands; this lookup
+//! table itself has `id PRIMARY KEY` from day one.
+
+use super::PgDb;
+
+impl PgDb {
+    /// Self-heal `coord.agent_sessions`. Idempotent — `CREATE TABLE
+    /// IF NOT EXISTS` plus `CREATE INDEX IF NOT EXISTS`. Logs but does
+    /// not own auth.users / coord.machines provisioning (those land via
+    /// other self-heal helpers / alembic).
+    ///
+    /// The FK to `coord.machines(machine_id)` is omitted from the
+    /// self-heal — different alembic chains seed `coord.machines` at
+    /// different revisions, and an out-of-order self-heal would fail
+    /// trying to reference a not-yet-present table. The alembic
+    /// migration in qontinui-web/backend/alembic/versions/ adds the
+    /// FK constraint when both tables are guaranteed to exist.
+    pub async fn ensure_agent_sessions_table(&self) -> Result<(), String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        conn.batch_execute(
+            r#"
+            CREATE SCHEMA IF NOT EXISTS coord;
+
+            CREATE TABLE IF NOT EXISTS coord.agent_sessions (
+                id           UUID PRIMARY KEY,
+                user_id      UUID,
+                machine_id   UUID,
+                first_seen   TIMESTAMPTZ NOT NULL DEFAULT now(),
+                last_seen    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                label        TEXT,
+                closed_at    TIMESTAMPTZ
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_agent_sessions_user
+                ON coord.agent_sessions (user_id)
+                WHERE user_id IS NOT NULL;
+
+            CREATE INDEX IF NOT EXISTS idx_agent_sessions_machine
+                ON coord.agent_sessions (machine_id)
+                WHERE machine_id IS NOT NULL;
+
+            CREATE INDEX IF NOT EXISTS idx_agent_sessions_last_seen
+                ON coord.agent_sessions (last_seen DESC);
+            "#,
+        )
+        .await
+        .map_err(|e| format!("Failed to ensure coord.agent_sessions: {}", e))
+    }
+}

--- a/src-tauri/src/database/pg/agent_worktrees.rs
+++ b/src-tauri/src/database/pg/agent_worktrees.rs
@@ -149,6 +149,17 @@ impl PgDb {
 
             CREATE INDEX IF NOT EXISTS idx_agent_worktrees_overlap_paths_gin
                 ON coord.agent_worktrees USING gin (declared_overlap_paths);
+
+            -- Plan `coord-agent-session-id-tracking.md` Phase 2 (Side B):
+            -- agent_session_id lineage column. Mirrors the alembic
+            -- migration shape. NULL until Phase 6 tightens to required
+            -- after Side C2 (Claude Code env-var surface) lands.
+            ALTER TABLE coord.agent_worktrees
+                ADD COLUMN IF NOT EXISTS agent_session_id UUID;
+
+            CREATE INDEX IF NOT EXISTS idx_agent_worktrees_agent_session
+                ON coord.agent_worktrees (agent_session_id)
+                WHERE agent_session_id IS NOT NULL;
             "#,
         )
         .await

--- a/src-tauri/src/database/pg/merge_proposals.rs
+++ b/src-tauri/src/database/pg/merge_proposals.rs
@@ -88,6 +88,17 @@ impl PgDb {
 
             CREATE INDEX IF NOT EXISTS idx_merge_proposal_repos_head_sha
                 ON coord.merge_proposal_repos (repo, head_sha);
+
+            -- Plan `coord-agent-session-id-tracking.md` Phase 2 (Side B):
+            -- agent_session_id lineage column on the parent proposal row.
+            -- Mirrors the alembic migration shape. NULL until Phase 6
+            -- tightens to required after Side C2 lands.
+            ALTER TABLE coord.merge_proposals
+                ADD COLUMN IF NOT EXISTS agent_session_id UUID;
+
+            CREATE INDEX IF NOT EXISTS idx_merge_proposals_agent_session
+                ON coord.merge_proposals (agent_session_id)
+                WHERE agent_session_id IS NOT NULL;
             "#,
         )
         .await

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod activity_timeline;
 pub mod adaptive_learning;
+pub mod agent_sessions;
 pub mod agent_worktrees;
 pub mod agentic_metrics;
 pub mod ai_sessions;


### PR DESCRIPTION
## Summary

Runner-side mirror of qontinui-coord PR #47 + the upcoming Phase 1 alembic migration. Plan reference: `D:/qontinui-root/plans/coord-agent-session-id-tracking.md` Phase 2 (Side B).

Changes to runner self-heal helpers (`src-tauri/src/database/pg/`):

- `agent_worktrees.rs::ensure_agent_worktrees_table` — `ALTER TABLE ADD COLUMN IF NOT EXISTS agent_session_id UUID` + partial index `WHERE agent_session_id IS NOT NULL`. Idempotent.
- `merge_proposals.rs::ensure_merge_proposals_tables` — same shape on `coord.merge_proposals`.
- `agent_sessions.rs` (NEW) — `ensure_agent_sessions_table()` creates the Claude Code session lookup table (`id PK`, `user_id`, `machine_id`, `first_seen`, `last_seen`, `label`, `closed_at`) + three indexes. FK constraints omitted from self-heal (alembic adds them when sibling tables guaranteed present).
- `coordinator/scheduler.rs` — wires `ensure_agent_sessions_table()` into boot, same warn-and-continue posture as existing helpers.

Schema matches Plan Side B verbatim. CI's alembic chain is authoritative; this is the runtime fallback for fresh dev DBs and local-coord harnesses per [[proj_pg_dual_schema_runner_public]].

## Test plan

- [x] `cargo check --lib` clean
- [x] `cargo test --lib --no-run` compiles
- [x] `cargo fmt --check` clean (via direct rustfmt after junctioning sibling `qontinui-schemas`)
- [ ] CI: relies on Ubuntu/Windows green; macOS hang admin-merge per [[feedback_macos_ci_env_hang_admin_merge]] if applicable

Note: A pre-existing bin-side compile error in `mcp/backend_relay.rs` (`terminal_subscriber_count` not found on `ServerModeState`) is present on origin/main and unrelated to this PR — main CI is green so this only affects local-windows-machine builds.

Pushed with `QONTINUI_PREPUSH_SKIP=1` per [[feedback_fresh_worktree_prepush_skip]] — fresh worktree pre-push fails on missing `../dist` frontend artifacts (env, not code).