### PR TITLE
fix(runner): align heartbeat + machine init with coord.devices endpoint

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -103,7 +103,7 @@ enum Cmd {
 #[derive(Subcommand, Debug)]
 enum MachineCmd {
     /// Mint UUID v4 + hostname to machine.json (atomic), then UPSERT into the
-    /// active profile's coord.machines via POST /coord/machine/register.
+    /// active profile's coord.devices via POST /coord/devices/register.
     /// Idempotent: re-runs re-use the existing UUID and refresh hostname.
     Init,
     /// Print machine_id + coord.machines registration timestamps as JSON.
@@ -485,13 +485,13 @@ fn cmd_machine_init() -> ExitCode {
         );
     }
 
-    // Register with coord via HTTP `POST /coord/machine/register`. File
+    // Register with coord via HTTP `POST /coord/devices/register`. File
     // creation succeeds even if coord registration fails — the local
-    // machine.json is the canonical record; coord.machines is a derived view
+    // machine.json is the canonical record; coord.devices is a derived view
     // (qontinui-coord re-syncs from machine.json on next /coord/status POST).
     match register_with_coord(&file.machine_id, &file.hostname) {
         Ok(()) => {
-            println!("registered with coord via HTTP (POST /coord/machine/register)");
+            println!("registered with coord via HTTP (POST /coord/devices/register)");
             ExitCode::SUCCESS
         }
         Err(e) => {
@@ -547,10 +547,11 @@ fn cmd_machine_show() -> ExitCode {
     ExitCode::SUCCESS
 }
 
-/// Register this machine with coord via `POST /coord/machine/register`.
-/// The endpoint (added in qontinui-coord PR #37) UPSERTs `coord.machines`
-/// and returns the resulting row. Replaces the prior direct-PG INSERT path
-/// so the runner no longer needs PG credentials to coord's database.
+/// Register this machine with coord via `POST /coord/devices/register`.
+/// The endpoint (renamed from `/coord/machine/register` by qontinui-coord
+/// PR #49 Phase 2 — unified-devices) UPSERTs `coord.devices` and returns
+/// the resulting row. Replaces the prior direct-PG INSERT path so the
+/// runner no longer needs PG credentials to coord's database.
 ///
 /// The CLI bootstrap doesn't know its health URL — that's the supervisor's
 /// job (Phase 3 of the fleet-health-url advertisement plan). We pass
@@ -562,9 +563,9 @@ fn register_with_coord(machine_id: &str, hostname: &str) -> Result<(), String> {
     let _ = uuid::Uuid::parse_str(machine_id)
         .map_err(|e| format!("machine_id is not a valid UUID: {}", e))?;
     let base = coord_http_base()?;
-    let url = format!("{}/coord/machine/register", base);
+    let url = format!("{}/coord/devices/register", base);
     let body = serde_json::json!({
-        "machine_id": machine_id,
+        "device_id": machine_id,
         "hostname": hostname,
         "health_url": serde_json::Value::Null,
     });
@@ -593,7 +594,7 @@ fn register_with_coord(machine_id: &str, hostname: &str) -> Result<(), String> {
 /// Resolve the coord HTTP base from the active profile's `coord_url`.
 /// Profiles store `ws://host:9870/ws` (the WebSocket upgrade URL); we
 /// convert that to `http://host:9870` so reqwest can POST to
-/// `/coord/machine/register`. Mirrors `qontinui-supervisor/src/fleet.rs`
+/// `/coord/devices/register`. Mirrors `qontinui-supervisor/src/fleet.rs`
 /// `coord_http_base` so both registration paths follow the same recipe.
 fn coord_http_base() -> Result<String, String> {
     let coord_url = load_strict()

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -245,9 +245,9 @@ pub async fn publish_on_startup(pg: &Arc<PgDb>, role: MachineRole) {
 // HTTP heartbeat to coord (plan 2026-05-18-push-aware-fleet-liveness.md §5).
 //
 // The direct-PG `publish_budget` path above is a one-shot at boot. To keep
-// `coord.machines.last_seen_at` fresh under coord's new push-aware liveness
-// model, the runner periodically POSTs `{machine_id, hostname}` to coord's
-// `/coord/machine/register` endpoint. The handler's UPSERT refreshes
+// `coord.devices.last_seen_at` fresh under coord's new push-aware liveness
+// model, the runner periodically POSTs `{device_id, hostname}` to coord's
+// `/coord/devices/register` endpoint. The handler's UPSERT refreshes
 // `last_seen_at` and `COALESCE`s a previously-advertised `health_url`, so
 // heartbeating from the runner side is a clean, side-effect-free refresh.
 //
@@ -281,7 +281,7 @@ fn profiles_path() -> Option<PathBuf> {
 /// Resolve the coord HTTP base from the active profile's `coord_url`.
 /// Profile stores `ws://host:9870/ws` or `wss://host:9870/ws` (the
 /// WebSocket upgrade URL); convert that to `http://host:9870` /
-/// `https://host:9870` so reqwest can POST to `/coord/machine/register`.
+/// `https://host:9870` so reqwest can POST to `/coord/devices/register`.
 /// Returns `None` if profiles.json is missing or the active profile has
 /// no coord_url. Mirrors `qontinui-supervisor/src/fleet.rs:122-138`.
 ///
@@ -308,15 +308,15 @@ fn coord_http_base() -> Option<String> {
 
 #[derive(Debug, serde::Serialize)]
 struct HeartbeatPayload {
-    machine_id: uuid::Uuid,
+    device_id: uuid::Uuid,
     hostname: String,
 }
 
-/// POST `{machine_id, hostname}` to `<base>/coord/machine/register`.
+/// POST `{device_id, hostname}` to `<base>/coord/devices/register`.
 ///
-/// `health_url` is deliberately omitted — coord's `register_machine`
+/// `health_url` is deliberately omitted — coord's `register_device`
 /// handler `COALESCE`s `EXCLUDED.health_url` with the existing value,
-/// so omitting from the heartbeat preserves any URL the machine
+/// so omitting from the heartbeat preserves any URL the device
 /// previously advertised. Failures are reported as `Err(String)` so
 /// the caller can log them; the loop never panics.
 pub async fn heartbeat_to_coord() -> Result<(), String> {
@@ -351,10 +351,10 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
     };
 
     let payload = HeartbeatPayload {
-        machine_id,
+        device_id: machine_id,
         hostname: machine.hostname.clone(),
     };
-    let url = format!("{base}/coord/machine/register");
+    let url = format!("{base}/coord/devices/register");
 
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(5))

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -419,8 +419,8 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
 
     // fleet heartbeat — see plan §5 and fleet.rs::spawn_heartbeat.
     //
-    // Periodic HTTP POST `{machine_id, hostname}` to coord's
-    // `/coord/machine/register`, refreshing `coord.machines.last_seen_at`
+    // Periodic HTTP POST `{device_id, hostname}` to coord's
+    // `/coord/devices/register`, refreshing `coord.devices.last_seen_at`
     // so coord's push-aware liveness ladder (plan 2026-05-18-push-aware-
     // fleet-liveness §4) recognizes this runner as alive even when the
     // inbound probe can't reach us (NAT/firewall asymmetry).


### PR DESCRIPTION
## Summary

qontinui-coord PR #49 (Phase 2 unified-devices) renamed \`POST /coord/machine/register\` to \`POST /coord/devices/register\` and renamed the request body field \`machine_id\` to \`device_id\`. Runner side was not updated when PR #179 (push-aware heartbeat) merged hours before #49 deployed.

## Empirical observation (2026-05-19 AWS staging)

- \`POST /coord/machine/register\` → HTTP 500 "Wrong number of path arguments for Path" (route signature gone).
- \`POST /coord/devices/register\` with old body → HTTP 422 missing field \`device_id\`.

## Changes

- \`fleet::heartbeat_to_coord\` POSTs \`{device_id, hostname}\` to \`/coord/devices/register\`
- \`qontinui_profile machine init\` (via \`register_with_coord\`) sends the same shape
- Doc comments updated across \`fleet.rs\`, \`qontinui_profile.rs\`, \`main.rs\`

Local variable names (\`machine_id\` from \`machine.json\`) are preserved — rename only at the wire boundary. machine.json file format unchanged.

## Companion coord fix

PR qontinui-coord#51 \`fix(coord): set last_seen_at on register_device INSERT path\` shipped 2026-05-19T14:30Z; AWS staging coord redeployed and verified returning 200 for fresh device registrations.

## Test plan

- [x] Manual probes against AWS staging coord confirm \`/coord/devices/register\` accepts the new body shape
- [ ] CI green (local cargo clippy blocked on environmental Tauri \`frontendDist\` issue in fresh worktrees; pushed with \`QONTINUI_PREPUSH_SKIP=1\` per the pre-push hook's own sanctioned skip for fresh-worktree builds; CI environment builds frontend first)
- [ ] MSI runner build picks up this PR + heartbeats to staging coord, MSI appears in \`/coord/fleet/state\`

## Discipline note

Cross-stack drift instance per \`feedback_cross_crate_type_move_checklist\`. PR #179 merged 3h before PR #49 deployed; runner-side was never updated. Cleaner forward pattern: type-rename PRs land coord + runner atomically as paired PRs.