### PR TITLE
fix(runner-ci): env-gate keychain access to unblock macOS test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,20 @@ jobs:
         # PR #84, so the cap is just bounding normal variance now.
         timeout-minutes: 90
         env:
+          # `auth::tests::test_device_id_*` and `test_token_storage` exercise
+          # `AuthManager::get_device_id` / `store_tokens`, which fall through
+          # to `keyring::Entry::{get,set}_password()` when file storage is
+          # empty (the test helper wipes the storage file). On macOS GitHub
+          # runners the Keychain blocks indefinitely waiting for a permission
+          # dialog (no TTY/desktop session), hanging the three tests past
+          # cargo's per-test heartbeat — the entire test step then eats the
+          # 90-min budget. Bumping the step timeout only delays the hang.
+          # The fix is to skip the keychain-backup path in CI entirely: see
+          # `keychain_enabled()` in `src-tauri/src/auth.rs`, which
+          # short-circuits all keychain ops when this var is set. File
+          # storage remains the source of truth, so auth tests stay real
+          # integration tests against the encrypted file backend.
+          QONTINUI_DISABLE_KEYCHAIN: "1"
           # `CARGO_BUILD_JOBS` reduces the parallel-rustc memory peak.
           # Empirically:
           #   - Windows: was passing at JOBS=2 with a 16 GB pagefile (run

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -16,6 +16,17 @@ use uuid::Uuid;
 /// Service name used for keychain entries (legacy)
 const SERVICE_NAME: &str = "com.qontinui.runner";
 
+/// When `QONTINUI_DISABLE_KEYCHAIN` is set, keychain reads return an error
+/// (callers fall back to file storage) and keychain writes are no-ops. The
+/// keychain path is best-effort migration backup; file storage is the source
+/// of truth. On macOS CI, `keyring::Entry::get_password()` blocks indefinitely
+/// waiting for a Keychain user-permission dialog that never resolves — three
+/// auth tests would hang past the 90-min step timeout. Setting this env var
+/// in CI bypasses the dialog cleanly.
+fn keychain_enabled() -> bool {
+    std::env::var_os("QONTINUI_DISABLE_KEYCHAIN").is_none()
+}
+
 /// Manages authentication tokens and device ID storage.
 ///
 /// The AuthManager provides secure storage for:
@@ -83,6 +94,10 @@ impl AuthManager {
 
     /// Stores tokens in the OS keychain (legacy/backup).
     fn store_tokens_in_keychain(&self, access_token: &str, refresh_token: &str) -> Result<()> {
+        if !keychain_enabled() {
+            debug!("keychain disabled via QONTINUI_DISABLE_KEYCHAIN, skipping store");
+            return Ok(());
+        }
         let entry_access = Entry::new(&self.service_name, "access_token")
             .context("Failed to create keychain entry for access token")?;
         let entry_refresh = Entry::new(&self.service_name, "refresh_token")
@@ -141,6 +156,11 @@ impl AuthManager {
 
     /// Retrieves access token from keychain (legacy).
     fn get_access_token_from_keychain(&self) -> Result<String> {
+        if !keychain_enabled() {
+            return Err(anyhow::anyhow!(
+                "keychain disabled via QONTINUI_DISABLE_KEYCHAIN"
+            ));
+        }
         let entry = Entry::new(&self.service_name, "access_token")
             .context("Failed to create keychain entry for access token")?;
         entry
@@ -182,6 +202,11 @@ impl AuthManager {
 
     /// Retrieves refresh token from keychain (legacy).
     fn get_refresh_token_from_keychain(&self) -> Result<String> {
+        if !keychain_enabled() {
+            return Err(anyhow::anyhow!(
+                "keychain disabled via QONTINUI_DISABLE_KEYCHAIN"
+            ));
+        }
         let entry = Entry::new(&self.service_name, "refresh_token")
             .context("Failed to create keychain entry for refresh token")?;
         entry
@@ -213,6 +238,9 @@ impl AuthManager {
 
     /// Clears tokens from keychain (legacy).
     fn clear_tokens_from_keychain(&self) -> Result<()> {
+        if !keychain_enabled() {
+            return Ok(());
+        }
         let entry_access = Entry::new(&self.service_name, "access_token")
             .context("Failed to create keychain entry for access token")?;
         let entry_refresh = Entry::new(&self.service_name, "refresh_token")
@@ -241,8 +269,10 @@ impl AuthManager {
             .context("Failed to store device_id in secure storage")?;
 
         // Also store in keychain (backup, best effort)
-        if let Ok(entry) = Entry::new(&self.service_name, "device_id") {
-            let _ = entry.set_password(device_id);
+        if keychain_enabled() {
+            if let Ok(entry) = Entry::new(&self.service_name, "device_id") {
+                let _ = entry.set_password(device_id);
+            }
         }
 
         info!("Device ID stored: {}", device_id);
@@ -265,17 +295,19 @@ impl AuthManager {
         }
 
         // Try keychain (for migration)
-        if let Ok(entry) = Entry::new(&self.service_name, "device_id") {
-            if let Ok(id) = entry.get_password() {
-                info!(
-                    "Retrieved existing device ID from keychain (migrating): {}",
-                    id
-                );
-                // Migrate to file storage
-                if let Err(e) = self.secure_storage.store_device_id(&id) {
-                    warn!("Failed to migrate device ID to secure storage: {}", e);
+        if keychain_enabled() {
+            if let Ok(entry) = Entry::new(&self.service_name, "device_id") {
+                if let Ok(id) = entry.get_password() {
+                    info!(
+                        "Retrieved existing device ID from keychain (migrating): {}",
+                        id
+                    );
+                    // Migrate to file storage
+                    if let Err(e) = self.secure_storage.store_device_id(&id) {
+                        warn!("Failed to migrate device ID to secure storage: {}", e);
+                    }
+                    return Ok(id);
                 }
-                return Ok(id);
             }
         }
 


### PR DESCRIPTION
## Summary

Supersedes #189. The macOS CI test step has been timing out at the 90-min cap, but the root cause is NOT slow tests — three auth tests **hang** on a Keychain user-permission dialog that never resolves on headless macOS runners. Bumping the timeout (the #189 approach) only delays the same failure; hung tests stay hung.

## Symptom

```
test auth::tests::test_device_id_generation has been running for over 60 seconds
test auth::tests::test_device_id_persistence has been running for over 60 seconds
test auth::tests::test_token_storage has been running for over 60 seconds
...
##[error]The action 'Run Rust tests' has timed out after 90 minutes.
```

## Root cause

`AuthManager::get_device_id()` / `store_tokens()` fall through to the keychain-backup path (`keyring::Entry::get_password()` / `set_password()`) when file storage is empty. The test helper (`create_test_auth_manager`) deliberately wipes the encrypted-storage file to isolate tests, so every keychain-touching test starts on the fall-through branch. On GitHub macOS runners, `keyring::Entry` calls into the Keychain Services API which blocks indefinitely waiting for an authorization dialog that never gets a user.

## Fix

1. **`src-tauri/src/auth.rs`** — new `keychain_enabled()` helper. When `QONTINUI_DISABLE_KEYCHAIN` is set, all six keychain access sites short-circuit: read paths return an error (callers fall back to file storage, which IS the source of truth), write/clear paths no-op. The keychain path is documented as best-effort migration backup, so disabling it changes nothing functionally.

2. **`.github/workflows/ci.yml`** — set `QONTINUI_DISABLE_KEYCHAIN=1` in the `Run Rust tests` step env across all three platforms. Linux libsecret and Windows Credential Manager don't block the way macOS Keychain does, but uniformity is simpler than per-platform branching, and CI never needs the migration backup.

Auth tests remain real integration tests against the encrypted file backend — they exercise the same `SecureStorage` paths used in production.

## Test plan
- [ ] Ubuntu test job green (no regression from the keychain-skip).
- [ ] Windows test job green.
- [ ] macOS test job completes in normal duration (~58 min p50 per the existing workflow-comment baseline) — no hang.
- [ ] Auth tests still run (not skipped) — visible in test output.

## Closes
Supersedes #189 (will be closed).