### PR TITLE
fix(runner): spawn frontend via npx so node_modules/.bin resolves

### DIFF
--- a/src-tauri/src/dev_services.rs
+++ b/src-tauri/src/dev_services.rs
@@ -158,11 +158,18 @@ pub fn get_default_dev_services(workspace: &Path) -> Vec<ProcessConfig> {
         env.insert("TEMP".to_string(), temp_dir.to_string_lossy().to_string());
         env.insert("TMP".to_string(), temp_dir.to_string_lossy().to_string());
 
+        // Use `npx next dev` rather than `npm run dev`: npx resolves the
+        // project-local Next.js binary from `node_modules/.bin` directly,
+        // independent of whether the spawning shell has populated PATH with
+        // the project's `node_modules/.bin`. Tauri's process_capture spawn
+        // path doesn't run the `npm run` PATH-injection lifecycle reliably
+        // on all hosts, so `npm run dev` was failing with `next: ENOENT`
+        // when the user POST'd `/processes/frontend/restart`.
         services.push(ProcessConfig {
             id: dev_service_id(workspace, FRONTEND_SERVICE_ID_SUFFIX),
             name: "Frontend (Next.js)".to_string(),
-            command: "npm".to_string(),
-            args: vec!["run".to_string(), "dev".to_string()],
+            command: "npx".to_string(),
+            args: vec!["next".to_string(), "dev".to_string()],
             cwd: frontend_dir.to_string_lossy().to_string(),
             env,
             health_port: Some(3001),
@@ -175,8 +182,8 @@ pub fn get_default_dev_services(workspace: &Path) -> Vec<ProcessConfig> {
             start_group: 1,
             dev_only: true,
             rebuild_enabled: true,
-            build_command: Some("npm".to_string()),
-            build_args: vec!["run".to_string(), "build".to_string()],
+            build_command: Some("npx".to_string()),
+            build_args: vec!["next".to_string(), "build".to_string()],
         });
     }
 


### PR DESCRIPTION
## Summary

Tauri Process Manager spawned `npm run dev` for the frontend without `node_modules/.bin` in PATH — `next` was ENOENT after `POST /processes/frontend/restart`. npm's lifecycle PATH-injection doesn't run reliably under Tauri spawn.

## Fix

`src-tauri/src/dev_services.rs:161-188` changes `command: "npm" / args: ["run", "dev"]` → `command: "npx" / args: ["next", "dev"]`. Same swap for `build_command`/`build_args`. 6-line comment explains the rationale.

`upgrade_and_dedupe_configs` in the same file already auto-syncs stale user configs to the new defaults, so existing canonical-PG-stored process configs will auto-correct on next runner boot — no separate data migration needed.

## Test plan

- [x] `cargo check --features custom-protocol` passes
- [x] No tests assert `command == "npm"` for dev-frontend
- [ ] Live: `POST /processes/frontend/restart` against a fresh temp runner — frontend starts within 30s

Pre-push hook bypassed with `--no-verify` per sanctioned `feedback_fresh_worktree_prepush_skip` (missing `ui-bridge-build-ir` + stub `dist/` in fresh worktree env). CI re-gates downstream.

Session-Id: ad7f07af-e9c9-40cf-97ec-fccf78e97abb