### PR TITLE
chore(runner): widen qontinui-types constraint to <2.0.0 for schemas 1.0.0

### DIFF
--- a/crates/spec-check/Cargo.toml
+++ b/crates/spec-check/Cargo.toml
@@ -6,7 +6,7 @@ license = "AGPL-3.0-or-later"
 description = "Pure-Rust matcher: IR page spec × UI Bridge snapshot → SpecCheckResult"
 
 [dependencies]
-qontinui-types = { path = "../../../qontinui-schemas/rust", version = ">=0.1.3, <0.3.0" }
+qontinui-types = { path = "../../../qontinui-schemas/rust", version = ">=0.1.3, <2.0.0" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -105,7 +105,7 @@ tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_j
 deadpool-postgres = "0.14"
 qontinui-db = { path = "./clorinde" }
 qontinui-spec-check = { path = "../crates/spec-check" }
-qontinui-types = { path = "../../qontinui-schemas/rust", version = ">=0.1.2, <0.3.0" }
+qontinui-types = { path = "../../qontinui-schemas/rust", version = ">=0.1.2, <2.0.0" }
 qontinui-vision-core = { path = "../../qontinui-schemas/rust-vision-core", version = "^0.1.0" }
 socket2 = "0.6"
 cron = "0.15"


### PR DESCRIPTION
## Summary
Unblocks qontinui-schemas#39 (release-please PR) which has been stuck since 2026-05-13. The schemas release wants to bump `qontinui-types` to 1.0.0 (legitimate breaking changes: UIBridgeElement accessibility fields, IrState assertion restructure), but the runner's `<0.3.0` upper bound rejects it — schemas' check-drift gate catches the mismatch.

Mirrors the shape of #176 / #178 (which widened from `<0.2.0` to `<0.3.0` for the 0.2.0 cutover window).

## Changes
- `src-tauri/Cargo.toml`         : `>=0.1.2, <0.3.0` → `>=0.1.2, <2.0.0`
- `crates/spec-check/Cargo.toml` : `>=0.1.3, <0.3.0` → `>=0.1.3, <2.0.0`

## Safety
Safe to land BEFORE schemas releases. New range accepts both:
- Current path-dep on disk (0.2.0) — no break
- Future 1.0.0 once schemas#39 lands

No code change needed — the API surface already absorbed the IR/UIBridgeElement breaking changes when they shipped at 0.2.0; 1.0.0 is the SemVer-correct labeling.

## Test plan
- [ ] CI green (build + tests) — should be unaffected since path-dep resolves to current 0.2.0.

## Related
- qontinui-schemas#39 (blocked release-please PR)
- Sibling PR in qontinui-supervisor (same widen)