### PR TITLE
fix(runner): manual-test-loop iter 1 — drop /ui-bridge/ai/idle-status from runner_only_baseline

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -727,7 +727,13 @@ mod manifest_drift_tests {
             ("GET", "/ui-bridge/ai/element-screenshot"),
             ("GET", "/ui-bridge/ai/elements/last-discovered"),
             ("GET", "/ui-bridge/ai/forms"),
-            ("GET", "/ui-bridge/ai/idle-status"),
+            // NOTE: `/ai/idle-status` was previously in this allow-list
+            // because the SDK only declared `/control/idle-status`. The web
+            // SDK now declares the `/ai/` alias too (alongside `/control/`),
+            // so the route is part of the contract and intentionally omitted
+            // here. Both paths point at the same handler via `add_dual!` at
+            // `errors.rs::routes` — bodies are byte-identical modulo
+            // per-request timestamp/ms-precision drift.
             ("POST", "/ui-bridge/ai/analyze/data"),
             ("POST", "/ui-bridge/ai/analyze/regions"),
             ("POST", "/ui-bridge/ai/analyze/structured-data"),

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -803,7 +803,11 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/control/navigate-tab"),
             ("POST", "/ui-bridge/control/network/stubs"),
             ("POST", "/ui-bridge/control/network/verify-stub"),
-            ("POST", "/ui-bridge/control/page-health"),
+            // NOTE: `/control/page-health` was previously runner-only; SDK
+            // iter-1 (ui-bridge PR #30) ported `page-health.ts` and added the
+            // route to `UI_BRIDGE_ROUTES`. Runner side still exposes it at
+            // `screenshots.rs::routes` — the entry is now part of the
+            // contract and intentionally omitted here.
             ("POST", "/ui-bridge/control/page/close-request"),
             ("POST", "/ui-bridge/control/page/evaluate-batch"),
             ("POST", "/ui-bridge/control/page/evaluate-raw"),


### PR DESCRIPTION
## Summary

- `runner_only_baseline` previously declared `('GET', '/ui-bridge/ai/idle-status')` as runner-only because the SDK didn't expose it.
- The SDK iter-1 PR ships the alias (qontinui/ui-bridge#30); runner baseline now drops the declaration so the manifest tests stay consistent.

## Pairing

Paired with qontinui/ui-bridge#30 (the SDK adds the `/ai/idle-status` alias). **The SDK PR must merge first** to keep `manifest_matches_route_calls` and `sdk_manifest_routes_are_exposed_by_runner` passing.

## Test plan

- [ ] CI green on `fix/iter1-runner-uibridge-baseline`
- [ ] Verify post-SDK-merge that manifest tests still pass once both land