### PR TITLE
fix(runner): graduate /ai/idle-status + /control/page-health from drift baseline

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -723,11 +723,16 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/control/ai/structured-changes"),
             ("POST", "/ui-bridge/control/ai/summarize-diff"),
             ("POST", "/ui-bridge/control/ai/wait-for-change"),
-            // /ai/* runner extensions not in SDK contract
+            // /ai/* runner extensions not in SDK contract.
+            // Note: /ai/idle-status graduated to the SDK contract in
+            // ui-bridge#30 (6f427bc, "alias /ai/idle-status to
+            // /control/idle-status"). Removed from this allow-list so the
+            // drift test asserts end-to-end wiring. Handler is registered
+            // via add_dual! in errors.rs:453-458; route_entries() includes
+            // it at errors.rs:476.
             ("GET", "/ui-bridge/ai/element-screenshot"),
             ("GET", "/ui-bridge/ai/elements/last-discovered"),
             ("GET", "/ui-bridge/ai/forms"),
-            ("GET", "/ui-bridge/ai/idle-status"),
             ("POST", "/ui-bridge/ai/analyze/data"),
             ("POST", "/ui-bridge/ai/analyze/regions"),
             ("POST", "/ui-bridge/ai/analyze/structured-data"),
@@ -797,7 +802,11 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/control/navigate-tab"),
             ("POST", "/ui-bridge/control/network/stubs"),
             ("POST", "/ui-bridge/control/network/verify-stub"),
-            ("POST", "/ui-bridge/control/page-health"),
+            // /control/page-health graduated to the SDK contract in
+            // ui-bridge#30 (6f427bc, "port page-health to web SDK").
+            // Removed from this allow-list so the drift test asserts
+            // end-to-end wiring. Handler is in screenshots.rs:798;
+            // route_entries() includes it at screenshots.rs:849.
             ("POST", "/ui-bridge/control/page/close-request"),
             ("POST", "/ui-bridge/control/page/evaluate-batch"),
             ("POST", "/ui-bridge/control/page/evaluate-raw"),


### PR DESCRIPTION
## Summary
Unblocks origin/main + every open runner PR's CI. The \`sdk_manifest_routes_are_exposed_by_runner\` test has been failing since 44f70633 with:

\`\`\`
SDK declares but runner does not expose (2):
  GET /ui-bridge/ai/idle-status
  POST /ui-bridge/control/page-health
\`\`\`

## Root cause
Both routes ARE actually exposed by runner — handlers + \`route_entries()\` exist. They were left in the \`runner_only_baseline\` allow-list (mod.rs lines 728 + 798) from back when they were considered "runner extensions not in SDK contract."

ui-bridge#30 (6f427bc, "alias /ai/idle-status to /control/idle-status" + "port page-health to web SDK") and predecessors graduated them into the SDK contract. The drift test's logic filters \`runner_routes\` by \`runner_only_baseline\` — so listed entries get excluded from comparison. Once SDK declares them too, the set-difference flags them.

## Fix
Remove the two entries from \`runner_only_baseline\`, with comments documenting which commit graduated each.

## Already-verified
- \`GET /ui-bridge/ai/idle-status\` — handler in \`errors.rs:335\` (\`ui_bridge_get_idle_status_handler\`), wired via \`add_dual!\` macro at \`errors.rs:453-458\`, \`route_entries()\` includes it at \`errors.rs:476\`
- \`POST /ui-bridge/control/page-health\` — handler in \`screenshots.rs\`, registered at \`screenshots.rs:798\`, \`route_entries()\` includes it at \`screenshots.rs:849\`

## Test plan
- [ ] CI: \`sdk_manifest_routes_are_exposed_by_runner\` now passes
- [ ] Full test suite green on Ubuntu + Windows

## Related
- ui-bridge#30 (the SDK addition that graduated these routes)
- Will unblock runner#197 (currently blocked by this drift)