### PR TITLE
runner: manual-test-loop iter 2 — PM logs endpoint + start/restart correctness + type unicode + elapsed_ms backcompat

### DIFF
--- a/src-tauri/src/mcp/processes.rs
+++ b/src-tauri/src/mcp/processes.rs
@@ -99,7 +99,7 @@ pub async fn start_process(
         .unwrap_or_else(|| id.clone());
     manager.start_process(&resolved).await.map_err(|e| {
         (
-            StatusCode::BAD_REQUEST,
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(api_error(format!("Failed to start process: {}", e))),
         )
     })?;
@@ -173,7 +173,7 @@ pub async fn restart_process(
         .unwrap_or_else(|| id.clone());
     manager.restart_process(&resolved).await.map_err(|e| {
         (
-            StatusCode::BAD_REQUEST,
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(api_error(format!("Failed to restart process: {}", e))),
         )
     })?;
@@ -273,6 +273,64 @@ pub async fn get_output(
     Ok(Json(ApiResponse::success(output)))
 }
 
+/// Get recent log lines for a process, split into stdout / stderr ring-buffer
+/// tails. Default `lines=200`, clamped to `[1, 5000]`.
+///
+/// Response shape: `{ stdout: [..], stderr: [..], truncated: bool }`.
+/// `truncated` is `true` when either side's live ring buffer held more
+/// entries than the per-stream cap (i.e. older entries were dropped from the
+/// returned slice).
+pub async fn get_logs(
+    State(state): State<Arc<ApiState>>,
+    Path(id): Path<String>,
+    axum::extract::Query(query): axum::extract::Query<std::collections::HashMap<String, String>>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    let lines_raw = query
+        .get("lines")
+        .and_then(|t| t.parse::<usize>().ok())
+        .unwrap_or(200);
+    let lines = lines_raw.clamp(1, 5000);
+
+    if primary_proxy::is_secondary() {
+        let logs = primary_proxy::get_logs(&id, lines).await.map_err(|e| {
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(api_error(format!("Primary runner proxy error: {}", e))),
+            )
+        })?;
+        return Ok(Json(ApiResponse::success(serde_json::json!({
+            "stdout": logs.stdout,
+            "stderr": logs.stderr,
+            "truncated": logs.truncated,
+        }))));
+    }
+
+    let manager = state.app_state.process_capture_manager.lock().await;
+    let manager = manager.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(api_error("Process capture manager not initialized")),
+        )
+    })?;
+
+    let resolved = manager
+        .resolve_process_id(&id)
+        .await
+        .unwrap_or_else(|| id.clone());
+    let (stdout, stderr, truncated) = manager.get_logs(&resolved, lines).await.map_err(|e| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(api_error(format!("Failed to get logs: {}", e))),
+        )
+    })?;
+
+    Ok(Json(ApiResponse::success(serde_json::json!({
+        "stdout": stdout,
+        "stderr": stderr,
+        "truncated": truncated,
+    }))))
+}
+
 /// Build the axum routes for process management.
 pub fn routes() -> axum::Router<Arc<ApiState>> {
     use axum::routing::{get, post};
@@ -287,4 +345,5 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             post(rebuild_and_restart_process),
         )
         .route("/processes/{id}/output", get(get_output))
+        .route("/processes/{id}/logs", get(get_logs))
 }

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -2261,6 +2261,10 @@ pub async fn ui_bridge_wait_for_element_handler(
             body.data = Some(serde_json::json!({
                 "found": false,
                 "durationMs": elapsed_ms,
+                // TODO(remove 2026-06): deprecated snake_case alias kept for
+                // pre-F1 callers still parsing `elapsed_ms`. New callers
+                // must read `durationMs`.
+                "elapsed_ms": elapsed_ms,
                 "polls": polls,
             }));
             return Err((StatusCode::REQUEST_TIMEOUT, Json(body)));
@@ -2947,10 +2951,24 @@ pub async fn ui_bridge_type_into_handler(
         ));
     };
 
-    let escaped_text = text.replace('\\', "\\\\").replace('\'', "\\'");
+    // Item C: UTF-8 safe passthrough. The prior single-quote-literal
+    // interpolation broke on non-ASCII codepoints once the body crossed any
+    // pipeline that downgraded UTF-8 (e.g. lossy decode → '?') and also
+    // choked on newlines / U+2028 / U+2029 / control chars that aren't legal
+    // inside a single-quoted JS literal. `serde_json::to_string` produces a
+    // valid double-quoted JSON string — which is also a valid JS string
+    // literal — with every non-ASCII char preserved (either as a raw UTF-8
+    // sequence or a `\uXXXX` escape, both of which JS parses identically).
+    let text_js_literal = serde_json::to_string(text).map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(api_error(format!("Failed to encode text: {}", e))),
+        )
+    })?;
 
     let js = format!(
         r#"(() => {{
+            const __qt_text = {text_literal};
             const matches = Array.from({find_expr}).filter(el => el);
             if (matches.length === 0) return JSON.stringify({{ typed: false, error: 'No elements found' }});
             const idx = {index};
@@ -2965,9 +2983,9 @@ pub async fn ui_bridge_type_into_handler(
             const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set
                 || Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
             if (nativeInputValueSetter) {{
-                nativeInputValueSetter.call(el, {clear} ? '{text}' : el.value + '{text}');
+                nativeInputValueSetter.call(el, {clear} ? __qt_text : el.value + __qt_text);
             }} else {{
-                el.value = {clear} ? '{text}' : el.value + '{text}';
+                el.value = {clear} ? __qt_text : el.value + __qt_text;
             }}
             el.dispatchEvent(new Event('input', {{ bubbles: true }}));
             el.dispatchEvent(new Event('change', {{ bubbles: true }}));
@@ -2981,7 +2999,7 @@ pub async fn ui_bridge_type_into_handler(
         find_expr = find_expr,
         index = index,
         clear = clear,
-        text = escaped_text
+        text_literal = text_js_literal
     );
 
     match evaluate_js_expression(&state, &js).await {
@@ -3245,6 +3263,10 @@ pub async fn ui_bridge_expect_element_handler(
         "passed": found,
         "observedState": observed_state,
         "durationMs": duration_ms,
+        // TODO(remove 2026-06): deprecated snake_case alias kept for pre-F1
+        // callers still parsing `elapsed_ms` from wait-for-element-shaped
+        // responses. New callers must read `durationMs`.
+        "elapsed_ms": duration_ms,
     });
 
     if found {
@@ -3736,13 +3758,16 @@ mod wait_for_element_dual_emit_tests {
         );
     }
 
-    /// F1 — the NL/id timeout path attaches `data: {durationMs, polls}` to
-    /// the HTTP 408 envelope. Mirrors the literal in the timeout branch of
-    /// `ui_bridge_wait_for_element_handler` (`elements.rs:~2102`).
+    /// F1 — the NL/id timeout path attaches `data: {durationMs, elapsed_ms,
+    /// polls}` to the HTTP 408 envelope. Mirrors the literal in the timeout
+    /// branch of `ui_bridge_wait_for_element_handler` (`elements.rs:~2102`).
+    /// The `elapsed_ms` mirror is the Item D back-compat field; new callers
+    /// must read `durationMs`.
     fn nl_timeout_data(elapsed_ms: u64, polls: u32) -> serde_json::Value {
         json!({
             "found": false,
             "durationMs": elapsed_ms,
+            "elapsed_ms": elapsed_ms,
             "polls": polls,
         })
     }
@@ -3753,6 +3778,71 @@ mod wait_for_element_dual_emit_tests {
         assert_eq!(data.get("found").and_then(|v| v.as_bool()), Some(false));
         assert_eq!(data.get("durationMs").and_then(|v| v.as_u64()), Some(5000));
         assert_eq!(data.get("polls").and_then(|v| v.as_u64()), Some(25));
+    }
+
+    /// Item D — the timeout-data payload exposes both `durationMs` (canonical)
+    /// and `elapsed_ms` (deprecated mirror) so pre-F1 callers parsing the
+    /// snake_case form keep working through the 2026-06 sunset window.
+    #[test]
+    fn nl_timeout_data_payload_dual_emits_elapsed_ms_for_backcompat() {
+        let data = nl_timeout_data(1234, 5);
+        assert_eq!(data.get("durationMs").and_then(|v| v.as_u64()), Some(1234));
+        assert_eq!(data.get("elapsed_ms").and_then(|v| v.as_u64()), Some(1234));
+    }
+}
+
+/// Item C — verify the `type-into` JS template encodes the text value via a
+/// double-quoted JSON literal so non-ASCII codepoints (Cyrillic, emoji
+/// surrogate pairs, U+2028/U+2029 line separators) round-trip through the
+/// webview without lossy `?` substitution or string-literal-termination
+/// failures.
+#[cfg(test)]
+mod type_into_unicode_tests {
+    /// Mirror the literal in `ui_bridge_type_into_handler` for unit-testable
+    /// inspection. Keep in sync with the real handler's `text_js_literal`
+    /// construction — the assertions below catch drift if the encoding
+    /// changes back to single-quote interpolation.
+    fn encode_text_for_js(text: &str) -> String {
+        serde_json::to_string(text).expect("text must encode to JSON")
+    }
+
+    #[test]
+    fn cyrillic_round_trips_through_json_string_literal() {
+        let encoded = encode_text_for_js("\u{0442}\u{0435}\u{0441}\u{0442}");
+        // Either form ("тест" raw or "тест") is fine —
+        // JS parses both identically. serde_json defaults to raw UTF-8.
+        assert!(
+            encoded == "\"\u{0442}\u{0435}\u{0441}\u{0442}\""
+                || encoded == "\"\\u0442\\u0435\\u0441\\u0442\"",
+            "unexpected encoding: {encoded}"
+        );
+        // Crucially: no '?' substitution.
+        assert!(!encoded.contains('?'));
+    }
+
+    #[test]
+    fn newlines_are_escaped_not_dropped() {
+        let encoded = encode_text_for_js("line1\nline2");
+        assert_eq!(encoded, "\"line1\\nline2\"");
+    }
+
+    #[test]
+    fn emoji_with_zwj_round_trips() {
+        // Family emoji = woman + ZWJ + woman + ZWJ + girl
+        let encoded = encode_text_for_js("\u{1F469}\u{200D}\u{1F469}\u{200D}\u{1F467}");
+        assert!(encoded.starts_with('"') && encoded.ends_with('"'));
+        // ZWJ (U+200D) is in the BMP; serde_json may emit it raw or escaped.
+        // Either way the codepoint must be present, not stripped.
+        assert!(
+            encoded.contains('\u{200D}') || encoded.contains("\\u200d"),
+            "ZWJ lost: {encoded}"
+        );
+    }
+
+    #[test]
+    fn embedded_double_quote_escapes_correctly() {
+        let encoded = encode_text_for_js("she said \"hi\"");
+        assert_eq!(encoded, "\"she said \\\"hi\\\"\"");
     }
 }
 

--- a/src-tauri/src/process_capture/manager.rs
+++ b/src-tauri/src/process_capture/manager.rs
@@ -227,7 +227,130 @@ impl ProcessCaptureManager {
         drop(processes);
         self.emit_state_change(&status);
 
-        Ok(())
+        // Poll for readiness: the child must stay alive and either reach
+        // Running/Healthy (when no health port is configured the event-loop
+        // sets Running immediately; with a port, port_health_loop flips to
+        // Healthy on first successful probe). If the child exits before
+        // readiness, surface the captured stderr so the operator gets a real
+        // diagnostic instead of a silently-stopped tile.
+        self.await_ready(id, Duration::from_secs(30)).await
+    }
+
+    /// Wait up to `timeout` for a process to reach a stable ready state.
+    ///
+    /// Readiness rules:
+    /// - If the process configures a `health_port`, ready = state `Healthy`
+    ///   (port_health_loop has flipped it). Polling `Running` alone is
+    ///   insufficient because the shell wrapper / pre-fork child can be
+    ///   "running" while the inner service is still importing or crashing.
+    /// - If no health_port is configured, ready = state `Running` that
+    ///   persists past a 1-second post-spawn settle window. A child that
+    ///   crashes during import (e.g. `'next' is not recognized`) flips
+    ///   through Running → Stopped within a few hundred ms; the settle
+    ///   guards against returning Ok before the Exited event lands.
+    ///
+    /// Returns `Err` with the captured stderr tail if the child exits before
+    /// readiness, or a "did not reach ready state in {timeout}s" message if
+    /// the timeout fires.
+    ///
+    /// Polls every 200ms — long enough to amortise lock acquisition, short
+    /// enough that a sub-second post-spawn crash is observed within a few
+    /// ticks.
+    async fn await_ready(&self, id: &str, timeout: Duration) -> Result<(), String> {
+        let deadline = std::time::Instant::now() + timeout;
+        let poll = Duration::from_millis(200);
+        let settle_window = Duration::from_secs(1);
+
+        // Snapshot the health_port + spawn baseline up front so we know which
+        // ready predicate to use for this iteration.
+        let (has_health_port, spawn_started_at) = {
+            let processes = self.processes.read().await;
+            match processes.get(id) {
+                Some(p) => (
+                    p.config.health_port.is_some(),
+                    p.runtime.started_at.unwrap_or_else(std::time::Instant::now),
+                ),
+                None => return Err(format!("Process '{}' not found", id)),
+            }
+        };
+
+        loop {
+            let (state, name) = {
+                let processes = self.processes.read().await;
+                match processes.get(id) {
+                    Some(p) => (p.runtime.state, p.config.name.clone()),
+                    None => return Err(format!("Process '{}' not found", id)),
+                }
+            };
+
+            match state {
+                ProcessState::Healthy => return Ok(()),
+                ProcessState::Running => {
+                    // No health_port → Running past the settle window is ready.
+                    // With a health_port → keep polling until Healthy flips on.
+                    if !has_health_port && spawn_started_at.elapsed() >= settle_window {
+                        return Ok(());
+                    }
+                }
+                ProcessState::Stopped | ProcessState::Failed => {
+                    // Child died before readiness. Capture the stderr tail
+                    // (last 50 lines) so the caller's HTTP error carries the
+                    // actual crash reason instead of a generic "Stopped".
+                    let stderr_tail = self.collect_stderr_tail(id, 50).await;
+                    let snippet = if stderr_tail.is_empty() {
+                        String::from("(no stderr captured)")
+                    } else {
+                        stderr_tail.join("\n")
+                    };
+                    return Err(format!(
+                        "Process '{}' exited before reaching ready state: {}",
+                        name, snippet
+                    ));
+                }
+                _ => {}
+            }
+
+            if std::time::Instant::now() >= deadline {
+                let stderr_tail = self.collect_stderr_tail(id, 50).await;
+                let snippet = if stderr_tail.is_empty() {
+                    format!(
+                        "did not reach ready state in {}s (last state: {})",
+                        timeout.as_secs(),
+                        state.as_str()
+                    )
+                } else {
+                    format!(
+                        "did not reach ready state in {}s (last state: {}); stderr tail:\n{}",
+                        timeout.as_secs(),
+                        state.as_str(),
+                        stderr_tail.join("\n")
+                    )
+                };
+                return Err(snippet);
+            }
+
+            tokio::time::sleep(poll).await;
+        }
+    }
+
+    /// Walk the process's output ring buffer and pull the last `n` stderr
+    /// entries. Returns an empty vec if the process is gone.
+    async fn collect_stderr_tail(&self, id: &str, n: usize) -> Vec<String> {
+        let processes = self.processes.read().await;
+        let Some(process) = processes.get(id) else {
+            return Vec::new();
+        };
+        let buf = process.output_buffer.read().await;
+        let mut stderr_lines: Vec<String> = buf
+            .iter()
+            .filter(|entry| matches!(entry.stream, OutputStream::Stderr))
+            .map(|entry| entry.line.clone())
+            .collect();
+        if stderr_lines.len() > n {
+            let drop = stderr_lines.len() - n;
+            stderr_lines.drain(..drop);
+        }
+        stderr_lines
     }
 
     /// Stop a managed process by ID.
@@ -325,6 +448,47 @@ impl ProcessCaptureManager {
             .get(id)
             .ok_or_else(|| format!("Process '{}' not found", id))?;
         Ok(process.get_output(tail).await)
+    }
+
+    /// Get the last `lines` log lines for a process, split into stdout/stderr
+    /// arrays. Returns `(stdout, stderr, truncated)` where `truncated` is true
+    /// if the live ring buffer holds more lines than fit in `lines` for either
+    /// stream (i.e. the caller may have missed older entries).
+    ///
+    /// Implementation note: the underlying `output_buffer` is a single
+    /// chronological ring buffer mixing both streams (each entry tags itself
+    /// via `OutputStream`). We walk the buffer in order, partition by stream,
+    /// then per-stream tail to `lines` so the caller gets the *most recent*
+    /// `lines` entries from each side rather than the most recent `lines`
+    /// total entries projected onto each stream.
+    pub async fn get_logs(
+        &self,
+        id: &str,
+        lines: usize,
+    ) -> Result<(Vec<String>, Vec<String>, bool), String> {
+        let processes = self.processes.read().await;
+        let process = processes
+            .get(id)
+            .ok_or_else(|| format!("Process '{}' not found", id))?;
+        let buf = process.output_buffer.read().await;
+        let mut stdout: Vec<String> = Vec::new();
+        let mut stderr: Vec<String> = Vec::new();
+        for entry in buf.iter() {
+            match entry.stream {
+                OutputStream::Stdout => stdout.push(entry.line.clone()),
+                OutputStream::Stderr => stderr.push(entry.line.clone()),
+            }
+        }
+        let truncated = stdout.len() > lines || stderr.len() > lines;
+        if stdout.len() > lines {
+            let drop = stdout.len() - lines;
+            stdout.drain(..drop);
+        }
+        if stderr.len() > lines {
+            let drop = stderr.len() - lines;
+            stderr.drain(..drop);
+        }
+        Ok((stdout, stderr, truncated))
     }
 
     /// Start all processes marked as auto_start, respecting start_group ordering.

--- a/src-tauri/src/process_capture/primary_proxy.rs
+++ b/src-tauri/src/process_capture/primary_proxy.rs
@@ -95,6 +95,35 @@ pub async fn get_output(id: &str, tail: usize) -> Result<Vec<OutputLine>, String
     }
 }
 
+/// Proxy: GET /processes/{id}/logs?lines=N
+pub async fn get_logs(id: &str, lines: usize) -> Result<LogsResponse, String> {
+    let url = format!("{}/processes/{}/logs?lines={}", base_url(), id, lines);
+    let resp = client()
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("Failed to reach primary runner: {}", e))?;
+
+    let api: ApiResponse<LogsResponse> = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse primary response: {}", e))?;
+
+    if api.success {
+        Ok(api.data.unwrap_or_default())
+    } else {
+        Err(api.error.unwrap_or_else(|| "Unknown error".to_string()))
+    }
+}
+
+/// Body returned by GET /processes/{id}/logs.
+#[derive(Debug, Default, Deserialize, serde::Serialize, Clone)]
+pub struct LogsResponse {
+    pub stdout: Vec<String>,
+    pub stderr: Vec<String>,
+    pub truncated: bool,
+}
+
 /// Proxy: GET /processes (list with configs)
 pub async fn get_configs() -> Result<Vec<ProcessConfig>, String> {
     // The primary doesn't have a separate /processes/configs endpoint,


### PR DESCRIPTION
## Summary
Manual-test-loop iter 2 remediation for qontinui-runner — Process Manager + UI Bridge correctness fixes.

- New `GET /processes/{id}/logs?lines=N` returns `{stdout, stderr, truncated}` ringbuffer per process (cap 1000, clamp 1..=5000)
- `start_process` / `restart_process` now poll readiness for 30s and return HTTP 500 with stderr-tail when child fails to spawn (no more silent success)
- `type` action JS template switched to `serde_json::to_string()` for UTF-8 safety — Cyrillic / emoji / control chars round-trip cleanly
- `wait-for-element` + `expect` responses now dual-emit `durationMs` + `elapsed_ms` (deprecated marker for 2026-06 removal)

## Test plan
- [ ] `GET /processes/{id}/logs?lines=50` returns ringbuffer body
- [ ] Failed-spawn case returns HTTP 500 with stderr tail (not silent success)
- [ ] type action handles Cyrillic / emoji / control chars without JS template breakage
- [ ] wait-for-element response carries both `durationMs` and `elapsed_ms`
- [ ] 5 new unit tests pass (in elements.rs)