### PR TITLE
runner: iter 6 — heartbeat URL rename /dev-dashboard → /operations

### DIFF
--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -77,7 +77,13 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
     let backend_url = std::env::var("QONTINUI_WEB_BACKEND_URL")
         .unwrap_or_else(|_| crate::api_config::get_api_base_url());
 
-    let heartbeat_url = format!("{}/api/v1/dev-dashboard/heartbeat", backend_url);
+    // Backend renamed the route from `/api/v1/dev-dashboard/heartbeat` to
+    // `/api/v1/operations/heartbeat` as part of the operations-rename refactor
+    // (see `qontinui-web/backend/app/api/v1/endpoints/operations.py` — the
+    // file was renamed from `dev_dashboard.py` and re-mounted at the new
+    // prefix in `api.py`). The `/heartbeat` endpoint itself stays unauth +
+    // LAN-only as the cross-machine beacon path.
+    let heartbeat_url = format!("{}/api/v1/operations/heartbeat", backend_url);
 
     // If this is a secondary, also heartbeat to the primary runner
     let primary_port = crate::instance::primary_port();

--- a/src-tauri/src/ui_error.rs
+++ b/src-tauri/src/ui_error.rs
@@ -10,7 +10,7 @@
 //!    view poll this to flag runners whose Rust backend is up but whose UI
 //!    is broken (errored) or whose embedding subsystem is unreachable
 //!    (degraded).
-//! 2. The runner's heartbeats (both the dev-dashboard heartbeat in
+//! 2. The runner's heartbeats (both the operations heartbeat in
 //!    [`crate::heartbeat`] and the runner-fleet heartbeat in
 //!    [`crate::server_mode`]). Each heartbeat payload includes the
 //!    `derived_status` and `ui_error` fields so receivers can react
@@ -170,7 +170,7 @@ fn matches_existing(existing: &UiError, message: &str, digest: Option<&str>) -> 
 ///   unknown, not degraded — avoids false positives during boot). `Some(true)`
 ///   = healthy. `Some(false)` = degraded.
 ///
-/// All three heartbeat sinks (`/health`, dev-dashboard heartbeat, web-backend
+/// All three heartbeat sinks (`/health`, operations heartbeat, web-backend
 /// heartbeat) call this so their `derived_status` stays in lockstep.
 pub fn compute_derived_status(
     has_ui_error: bool,


### PR DESCRIPTION
## Summary

- Fixes every runner heartbeat 404ing against the web backend since the operations-rename refactor.
- `src-tauri/src/heartbeat.rs:80` — change `format!("{}/api/v1/dev-dashboard/heartbeat", backend_url)` → `/api/v1/operations/heartbeat`.
- `src-tauri/src/ui_error.rs` — comment-only rename (descriptive label "dev-dashboard heartbeat" → "operations heartbeat") in module + function docstrings.

## Why

Backend renamed `app/api/v1/endpoints/dev_dashboard.py` → `operations.py` and re-mounted at `prefix="/operations"` (see `qontinui-web/backend/app/api/v1/api.py:184` and the `operations.py` module docstring). The runner's `start_heartbeat` was still hard-coding the old `/dev-dashboard/heartbeat` path, so every 30s tick 404'd, polluting backend stderr and breaking the cross-machine fleet beacon.

The `/heartbeat` and `/claude-sessions` endpoints stay unauthenticated + LAN-only (operations.py:10-13) — payload shape unchanged, just the prefix moved.

## Verification

- `cargo check --bin qontinui-runner` — clean
- `cargo clippy --bin qontinui-runner -- -D warnings` — clean
- `cargo test --bin qontinui-runner heartbeat` — clean (no tests in module; binary compiles + links + runs)
- Live backend check: `curl -X POST -H 'Content-Type: application/json' -d '{}' http://localhost:8000/api/v1/operations/heartbeat` → **HTTP 422** with field-required validation errors. Route exists, payload-shape contract unchanged from `RunnerHeartbeat` schema.
- `grep -rn 'dev-dashboard\|dev_dashboard' src-tauri/src/` — only the new explanatory comment in `heartbeat.rs` (the comment intentionally cites both names for the operator reading future blames).

## Test plan

- [ ] Merge, restart runner, watch backend stderr — no more `404 POST /api/v1/dev-dashboard/heartbeat` lines.
- [ ] `/api/v1/operations/runners` shows this runner with fresh `last_heartbeat`.