### PR TITLE
feat(runner): --tenant-id flag + OAuth-claim auto-resolve on device pair (Phase 2 retry)

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -57,7 +57,8 @@
 
 use clap::{Parser, Subcommand};
 use qontinui_runner_lib::pair::{
-    coord_http_base, pair_via_browser, pair_with_auth_token, persist_pairing, PairCompleteResponse,
+    coord_http_base, pair_via_browser, pair_with_auth_token, persist_pairing,
+    tenant_id_from_oauth_claim, PairCompleteResponse,
 };
 use qontinui_runner_lib::profiles::{
     load_strict, profiles_path, AuthConfig, BlobConfig, Profile, ProfilesFile,
@@ -151,6 +152,13 @@ enum DeviceCmd {
         /// Browser mode (default). Mutually exclusive with `--auth-token`.
         #[arg(long)]
         browser: bool,
+        /// Explicit tenant scope for the new device. Overrides any
+        /// `tenant_id` claim auto-extracted from the OAuth token.
+        /// Required for `--browser` mode (no OAuth token to read a claim
+        /// from). Phase 2 of the default-tenant-propagation plan
+        /// (Q3 resolution: OAuth claim with `--tenant-id` override).
+        #[arg(long, value_name = "UUID")]
+        tenant_id: Option<String>,
     },
 }
 
@@ -176,7 +184,8 @@ fn main() -> ExitCode {
             DeviceCmd::Pair {
                 auth_token,
                 browser,
-            } => cmd_device_pair(auth_token.as_deref(), browser),
+                tenant_id,
+            } => cmd_device_pair(auth_token.as_deref(), browser, tenant_id.as_deref()),
         },
     }
 }
@@ -692,7 +701,11 @@ fn select_pair_mode(auth_token: Option<&str>, _browser: bool) -> Result<PairMode
     }
 }
 
-fn cmd_device_pair(auth_token: Option<&str>, browser: bool) -> ExitCode {
+fn cmd_device_pair(
+    auth_token: Option<&str>,
+    browser: bool,
+    tenant_id_flag: Option<&str>,
+) -> ExitCode {
     // clap can't express "exactly one of browser/auth_token"; reject the
     // combination by hand.
     if auth_token.is_some() && browser {
@@ -713,9 +726,46 @@ fn cmd_device_pair(auth_token: Option<&str>, browser: bool) -> ExitCode {
             return ExitCode::from(2);
         }
     };
+
+    // Resolve tenant_id: explicit `--tenant-id` flag wins; otherwise pull
+    // from the OAuth token's `tenant_id` claim (headless mode only — the
+    // browser flow has no OAuth token here). Phase 2 of the
+    // default-tenant-propagation plan.
+    let resolved_tenant_id: Result<uuid::Uuid, String> = match tenant_id_flag {
+        Some(s) => uuid::Uuid::parse_str(s.trim())
+            .map_err(|e| format!("--tenant-id is not a valid UUID: {e}")),
+        None => match &mode {
+            PairMode::AuthToken(token) => match tenant_id_from_oauth_claim(token) {
+                Some(s) => uuid::Uuid::parse_str(s.trim()).map_err(|e| {
+                    format!(
+                        "OAuth token's tenant_id claim is not a valid UUID ({e}); \
+                         pass --tenant-id <uuid> to override"
+                    )
+                }),
+                None => Err(
+                    "no `tenant_id` claim found in OAuth token; \
+                     pass --tenant-id <uuid> explicitly"
+                        .to_string(),
+                ),
+            },
+            PairMode::Browser => Err(
+                "--tenant-id <uuid> is required for the browser pair flow \
+                 (no OAuth token to read a claim from)"
+                    .to_string(),
+            ),
+        },
+    };
+    let tenant_id = match resolved_tenant_id {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error: {}", e);
+            return ExitCode::from(2);
+        }
+    };
+
     let result: Result<PairCompleteResponse, String> = match mode {
-        PairMode::AuthToken(token) => pair_with_auth_token(&base, &token),
-        PairMode::Browser => pair_via_browser(&base),
+        PairMode::AuthToken(token) => pair_with_auth_token(&base, &token, tenant_id),
+        PairMode::Browser => pair_via_browser(&base, tenant_id),
     };
     match result {
         Ok(resp) => {

--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -742,17 +742,13 @@ fn cmd_device_pair(
                          pass --tenant-id <uuid> to override"
                     )
                 }),
-                None => Err(
-                    "no `tenant_id` claim found in OAuth token; \
+                None => Err("no `tenant_id` claim found in OAuth token; \
                      pass --tenant-id <uuid> explicitly"
-                        .to_string(),
-                ),
+                    .to_string()),
             },
-            PairMode::Browser => Err(
-                "--tenant-id <uuid> is required for the browser pair flow \
+            PairMode::Browser => Err("--tenant-id <uuid> is required for the browser pair flow \
                  (no OAuth token to read a claim from)"
-                    .to_string(),
-            ),
+                .to_string()),
         },
     };
     let tenant_id = match resolved_tenant_id {

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -176,10 +176,30 @@ pub(crate) async fn try_refresh_once(
     let did = device_id.to_string();
     let uid = user_id.to_string();
 
+    // Resolve tenant_id from the OAuth/runner token's `tenant_id` claim.
+    // Phase 2 of the default-tenant-propagation plan makes tenant_id a
+    // required field on `POST /coord/devices/pair-cli`; the refresher
+    // reuses the same endpoint to re-mint the device JWT, so it must
+    // forward a tenant_id. Absent/malformed → keep the existing JWT.
+    let tenant_id = match qontinui_runner_lib::pair::tenant_id_from_oauth_claim(&token)
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
+    {
+        Some(t) => t,
+        None => {
+            warn!(
+                "device_jwt_refresher: OAuth token has no usable tenant_id claim; \
+                 keeping existing JWT"
+            );
+            return RefreshOutcome::KeptExisting;
+        }
+    };
+
     // pair_with_auth_token_with_ids is reqwest::blocking — must run via
     // spawn_blocking or it stalls the tokio runtime.
     let pair_join = tokio::task::spawn_blocking(move || {
-        qontinui_runner_lib::pair::pair_with_auth_token_with_ids(&base, &token, &did, &uid)
+        qontinui_runner_lib::pair::pair_with_auth_token_with_ids(
+            &base, &token, &did, &uid, tenant_id,
+        )
     })
     .await;
 
@@ -643,7 +663,20 @@ mod try_refresh_once_tests {
 
     const DID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const UID: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
-    const TOK: &str = "test-runner-token";
+
+    /// JWT-shaped runner token whose payload carries a `tenant_id` claim.
+    /// `try_refresh_once` extracts the tenant_id from the OAuth/runner
+    /// token's payload (Phase 2 of the default-tenant-propagation plan),
+    /// so the test fixture must look like a real JWT — not the prior
+    /// opaque string. We use a fixed base64-encoded payload so each test
+    /// gets the same tenant_id resolution path.
+    fn tok() -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD
+            .encode(br#"{"sub":"runner","tenant_id":"cccccccc-cccc-4ccc-8ccc-cccccccccccc"}"#);
+        format!("{}.{}.test-signature", header, payload)
+    }
 
     #[tokio::test]
     async fn refresher_handles_coord_401_without_clearing_jwt() {
@@ -660,7 +693,7 @@ mod try_refresh_once_tests {
             r#"{"error":"token expired"}"#.to_string(),
         );
 
-        let outcome = try_refresh_once(&mgr, &base, TOK, DID, UID).await;
+        let outcome = try_refresh_once(&mgr, &base, &tok(), DID, UID).await;
         assert_eq!(
             outcome,
             RefreshOutcome::KeptExisting,
@@ -689,7 +722,7 @@ mod try_refresh_once_tests {
             r#"{"error":"coord overloaded"}"#.to_string(),
         );
 
-        let outcome = try_refresh_once(&mgr, &base, TOK, DID, UID).await;
+        let outcome = try_refresh_once(&mgr, &base, &tok(), DID, UID).await;
         assert_eq!(outcome, RefreshOutcome::KeptExisting);
 
         let still = mgr.get_access_token().expect("token still present");
@@ -721,7 +754,7 @@ mod try_refresh_once_tests {
 
         let (base, _hits, _shutdown) = spawn_mock(StatusCode::OK, body);
 
-        let outcome = try_refresh_once(&mgr, &base, TOK, DID, UID).await;
+        let outcome = try_refresh_once(&mgr, &base, &tok(), DID, UID).await;
         match outcome {
             RefreshOutcome::Replaced { new_jwt: got } => {
                 assert_eq!(got, new_jwt, "Replaced must carry the new JWT");

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -718,8 +718,8 @@ mod tests {
     fn tenant_id_from_oauth_claim_extracts_uuid() {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
         let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
-        let payload =
-            URL_SAFE_NO_PAD.encode(br#"{"sub":"x","tenant_id":"11111111-2222-3333-4444-555555555555"}"#);
+        let payload = URL_SAFE_NO_PAD
+            .encode(br#"{"sub":"x","tenant_id":"11111111-2222-3333-4444-555555555555"}"#);
         let token = format!("{}.{}.signature", header, payload);
         assert_eq!(
             tenant_id_from_oauth_claim(&token).as_deref(),
@@ -918,8 +918,13 @@ mod pair_e2e_tests {
         let expected_jwt = "header-segment.payload-segment.signature-segment";
         let (base, _capture, _shutdown) =
             spawn_mock_coord(StatusCode::OK, canonical_200_body(expected_jwt));
-        let result =
-            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid());
+        let result = pair_with_auth_token_with_ids(
+            &base,
+            TEST_BEARER,
+            TEST_DEVICE_ID,
+            TEST_USER_ID,
+            test_tenant_uuid(),
+        );
         let resp = result.expect("pair_with_auth_token_with_ids should succeed on 200");
         assert_eq!(resp.token, expected_jwt);
         assert_eq!(resp.user_id, "22222222-2222-4222-8222-222222222222");
@@ -938,8 +943,13 @@ mod pair_e2e_tests {
             StatusCode::UNAUTHORIZED,
             r#"{"error":"invalid bearer token"}"#.to_string(),
         );
-        let result =
-            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid());
+        let result = pair_with_auth_token_with_ids(
+            &base,
+            TEST_BEARER,
+            TEST_DEVICE_ID,
+            TEST_USER_ID,
+            test_tenant_uuid(),
+        );
         let err = result.expect_err("401 must return Err");
         assert!(
             err.contains("401"),
@@ -955,8 +965,13 @@ mod pair_e2e_tests {
             StatusCode::INTERNAL_SERVER_ERROR,
             r#"{"error":"coord-side panic"}"#.to_string(),
         );
-        let result =
-            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid());
+        let result = pair_with_auth_token_with_ids(
+            &base,
+            TEST_BEARER,
+            TEST_DEVICE_ID,
+            TEST_USER_ID,
+            test_tenant_uuid(),
+        );
         let err = result.expect_err("500 must return Err");
         assert!(
             err.contains("500"),
@@ -972,8 +987,14 @@ mod pair_e2e_tests {
         // `device_id` + `hostname`.
         let (base, capture, _shutdown) =
             spawn_mock_coord(StatusCode::OK, canonical_200_body("ignored-jwt"));
-        let _ = pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid())
-            .expect("200 path");
+        let _ = pair_with_auth_token_with_ids(
+            &base,
+            TEST_BEARER,
+            TEST_DEVICE_ID,
+            TEST_USER_ID,
+            test_tenant_uuid(),
+        )
+        .expect("200 path");
 
         let captured = capture.lock().expect("capture mutex").clone();
         assert!(captured.called, "mock coord must have been hit");

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -70,6 +70,11 @@ pub struct PairCompleteResponse {
     /// ignored by the CLI today, surfaced for Phase 2 refresh logic.
     #[serde(default)]
     pub exp: Option<i64>,
+    /// Tenant scope coord stamped on this device. Phase 3 of the
+    /// default-tenant-propagation plan may echo this back on the
+    /// wire. `#[serde(default)]` tolerates pre-tenant coord builds.
+    #[serde(default)]
+    pub tenant_id: Option<String>,
 }
 
 // ============================================================================
@@ -243,14 +248,46 @@ pub fn derive_web_base_from_coord(coord_base: &str) -> String {
 /// parameterized form directly so they can run hermetically against an
 /// in-process mock coord without touching `~/.qontinui` or the
 /// `data_local_dir`.
-pub fn pair_with_auth_token(base: &str, oauth_token: &str) -> Result<PairCompleteResponse, String> {
+/// Decode the unverified payload of a JWT and pull the `tenant_id`
+/// claim, if any. Returns `None` if the token isn't a JWT, the payload
+/// isn't valid base64-decoded JSON, or no `tenant_id` claim is present.
+///
+/// We deliberately do NOT verify the JWT signature — coord is the
+/// authority on tenant_id (Phase 4 of the default-tenant-propagation
+/// plan re-validates on receipt via the per-write resolver). This is
+/// just the runner's best-effort auto-resolve to spare the operator
+/// from re-typing a UUID they already authenticated against.
+///
+/// Phase 2 of the default-tenant-propagation plan (Q3 resolution:
+/// "OAuth claim with `--tenant-id` override for CLI"). Also used by
+/// `mcp::device_jwt_refresher` to resolve tenant_id at refresh time
+/// from the stored OAuth/runner token.
+pub fn tenant_id_from_oauth_claim(token: &str) -> Option<String> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    let mut parts = token.splitn(3, '.');
+    let _header = parts.next()?;
+    let payload_b64 = parts.next()?;
+    let _signature = parts.next()?;
+    let payload_bytes = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let payload_json: serde_json::Value = serde_json::from_slice(&payload_bytes).ok()?;
+    payload_json
+        .get("tenant_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+pub fn pair_with_auth_token(
+    base: &str,
+    oauth_token: &str,
+    tenant_id: uuid::Uuid,
+) -> Result<PairCompleteResponse, String> {
     let device_id = read_device_id()?;
     let user_id = read_paired_user_id().ok_or_else(|| {
         "not yet browser-paired — first pair must use --browser mode \
          (no paired_user.json on disk)"
             .to_string()
     })?;
-    pair_with_auth_token_with_ids(base, oauth_token, &device_id, &user_id)
+    pair_with_auth_token_with_ids(base, oauth_token, &device_id, &user_id, tenant_id)
 }
 
 /// Parameterized variant of [`pair_with_auth_token`] — accepts `device_id`
@@ -264,12 +301,14 @@ pub fn pair_with_auth_token_with_ids(
     oauth_token: &str,
     device_id: &str,
     user_id: &str,
+    tenant_id: uuid::Uuid,
 ) -> Result<PairCompleteResponse, String> {
     let url = format!("{}/coord/devices/pair-cli", base);
     let body = serde_json::json!({
         "device_id": device_id,
         "hostname":  detect_hostname(),
         "name":      detect_hostname(),
+        "tenant_id": tenant_id.to_string(),
     });
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
@@ -316,7 +355,10 @@ pub(crate) struct CallbackCapture {
 /// browser to `/connect-runner?state=…&callback=…`, waits for the user's
 /// click + redirect, then exchanges the captured `(state, token)` with
 /// coord's `POST /coord/devices/pair-complete` for the device-token JWT.
-pub fn pair_via_browser(coord_base: &str) -> Result<PairCompleteResponse, String> {
+pub fn pair_via_browser(
+    coord_base: &str,
+    tenant_id: uuid::Uuid,
+) -> Result<PairCompleteResponse, String> {
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -461,7 +503,12 @@ pub fn pair_via_browser(coord_base: &str) -> Result<PairCompleteResponse, String
     // is still running; it'll time out on its own.
     drop(server_handle);
 
-    // Exchange (state, token) for the device-token JWT.
+    // Exchange (state, token) for the device-token JWT. `tenant_id` is a
+    // defensive forward — coord's authoritative source is `flow.tenant_id`
+    // carried from `pair-start`, but the browser pair flow currently mints
+    // its state nonce locally instead of going through coord's pair-start,
+    // so we forward the runner's best-known value here as a hint. Coord
+    // re-validates per Phase 4 of the default-tenant-propagation plan.
     let url = format!("{}/coord/devices/pair-complete", coord_base);
     let body = serde_json::json!({
         "state":      state_nonce,
@@ -471,6 +518,7 @@ pub fn pair_via_browser(coord_base: &str) -> Result<PairCompleteResponse, String
         "name":       hostname_now,
         "os":         detect_os(),
         "os_version": detect_os_version(),
+        "tenant_id":  tenant_id.to_string(),
     });
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(15))
@@ -636,16 +684,19 @@ mod tests {
         // Re-construct the body the same way `pair_with_auth_token`
         // does. If a future refactor diverges, this test fails loudly.
         let device_id = "00000000-0000-4000-8000-000000000000";
+        let tenant_id = "11111111-1111-4111-8111-111111111111";
         let body = serde_json::json!({
             "device_id": device_id,
             "hostname":  detect_hostname(),
             "name":      detect_hostname(),
+            "tenant_id": tenant_id,
         });
         let obj = body.as_object().expect("object");
         // Required keys (per PairCliRequest):
         assert!(obj.contains_key("device_id"), "device_id missing");
         assert!(obj.contains_key("hostname"), "hostname missing");
         assert!(obj.contains_key("name"), "name missing");
+        assert!(obj.contains_key("tenant_id"), "tenant_id missing");
         // Rejected legacy keys (would 422 on coord's PairCliRequest):
         assert!(
             !obj.contains_key("os"),
@@ -661,6 +712,34 @@ mod tests {
             Some(device_id)
         );
         assert!(obj.get("hostname").and_then(|v| v.as_str()).is_some());
+    }
+
+    #[test]
+    fn tenant_id_from_oauth_claim_extracts_uuid() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload =
+            URL_SAFE_NO_PAD.encode(br#"{"sub":"x","tenant_id":"11111111-2222-3333-4444-555555555555"}"#);
+        let token = format!("{}.{}.signature", header, payload);
+        assert_eq!(
+            tenant_id_from_oauth_claim(&token).as_deref(),
+            Some("11111111-2222-3333-4444-555555555555")
+        );
+    }
+
+    #[test]
+    fn tenant_id_from_oauth_claim_returns_none_when_missing() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(br#"{"sub":"x"}"#);
+        let token = format!("{}.{}.signature", header, payload);
+        assert_eq!(tenant_id_from_oauth_claim(&token), None);
+    }
+
+    #[test]
+    fn tenant_id_from_oauth_claim_returns_none_for_non_jwt() {
+        assert_eq!(tenant_id_from_oauth_claim("not-a-jwt"), None);
+        assert_eq!(tenant_id_from_oauth_claim("a.b"), None);
     }
 
     /// The legacy `device_token` field name MUST NOT decode — coord
@@ -825,6 +904,11 @@ mod pair_e2e_tests {
     const TEST_DEVICE_ID: &str = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
     const TEST_USER_ID: &str = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
     const TEST_BEARER: &str = "bearer-token";
+    const TEST_TENANT_ID: &str = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+    fn test_tenant_uuid() -> uuid::Uuid {
+        uuid::Uuid::parse_str(TEST_TENANT_ID).unwrap()
+    }
 
     #[test]
     fn pair_with_auth_token_e2e_200_persists_jwt() {
@@ -835,7 +919,7 @@ mod pair_e2e_tests {
         let (base, _capture, _shutdown) =
             spawn_mock_coord(StatusCode::OK, canonical_200_body(expected_jwt));
         let result =
-            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID);
+            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid());
         let resp = result.expect("pair_with_auth_token_with_ids should succeed on 200");
         assert_eq!(resp.token, expected_jwt);
         assert_eq!(resp.user_id, "22222222-2222-4222-8222-222222222222");
@@ -855,7 +939,7 @@ mod pair_e2e_tests {
             r#"{"error":"invalid bearer token"}"#.to_string(),
         );
         let result =
-            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID);
+            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid());
         let err = result.expect_err("401 must return Err");
         assert!(
             err.contains("401"),
@@ -872,7 +956,7 @@ mod pair_e2e_tests {
             r#"{"error":"coord-side panic"}"#.to_string(),
         );
         let result =
-            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID);
+            pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid());
         let err = result.expect_err("500 must return Err");
         assert!(
             err.contains("500"),
@@ -888,7 +972,7 @@ mod pair_e2e_tests {
         // `device_id` + `hostname`.
         let (base, capture, _shutdown) =
             spawn_mock_coord(StatusCode::OK, canonical_200_body("ignored-jwt"));
-        let _ = pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID)
+        let _ = pair_with_auth_token_with_ids(&base, TEST_BEARER, TEST_DEVICE_ID, TEST_USER_ID, test_tenant_uuid())
             .expect("200 path");
 
         let captured = capture.lock().expect("capture mutex").clone();
@@ -915,6 +999,11 @@ mod pair_e2e_tests {
         assert!(
             obj.get("hostname").and_then(|v| v.as_str()).is_some(),
             "body.hostname must be present"
+        );
+        assert_eq!(
+            obj.get("tenant_id").and_then(|v| v.as_str()),
+            Some(TEST_TENANT_ID),
+            "body.tenant_id must carry the resolved tenant (Phase 2 of default-tenant-propagation)"
         );
         // Reject legacy keys (would 422 against the canonical coord
         // PairCliRequest schema):


### PR DESCRIPTION
## Summary

Phase 2 of the default-tenant-propagation plan, retargeted against current main after PR #207 (unified-devices migration) refactored pair plumbing into `qontinui_runner_lib::pair`. Closes #198 (stale layout).

Three layers wired:
- **`src-tauri/src/pair.rs`** — `PairCompleteResponse` gets `tenant_id: Option<String>` (`#[serde(default)]`). New public `tenant_id_from_oauth_claim` helper. `pair_with_auth_token{,_with_ids}` + `pair_via_browser` take `tenant_id: uuid::Uuid` and bind it in the request body.
- **`src-tauri/src/bin/qontinui_profile.rs`** — `device pair` subcommand gains `--tenant-id <UUID>`. Resolution order: explicit flag > OAuth claim auto-extraction > clear error.
- **`src-tauri/src/mcp/device_jwt_refresher.rs`** — JWT refresher extracts tenant_id from the runner_token's claim before re-pairing; absent/malformed → `KeptExisting` (existing JWT preserved).

## Test plan

- [x] 3 unit tests on `tenant_id_from_oauth_claim` (present claim → Some, absent claim → None, non-JWT → None)
- [x] e2e mock-coord `pair_with_auth_token_with_ids` updated to thread the fixed test tenant; request-shape assertion adds `body.tenant_id`
- [x] Refresher tests use a `tok()` helper that returns a JWT-shaped fixture carrying a `tenant_id` claim
- [ ] CI cargo test (ubuntu/windows) — verifying remotely

Sibling: web #174 forwards the resolved tenant_id from `pair_confirm`; coord #69 makes `tenant_id` REQUIRED on `PairCliRequest`. Both merged.

Plan: `D:/qontinui-root/plans/2026-05-20-default-tenant-propagation.md`