### PR TITLE
fix(spec-api): thread display_name through build_list_response (regression from 5f50090aa)

### DIFF
--- a/src-tauri/src/spec_api/handlers.rs
+++ b/src-tauri/src/spec_api/handlers.rs
@@ -29,6 +29,8 @@ use serde_json::{json, Value};
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::warn;
 
+use qontinui_types::apps::AppError;
+
 use crate::mcp::types::ApiState;
 
 use super::apps::AppErrorExt;
@@ -254,17 +256,37 @@ pub async fn get_list(
     AxPath(app_id): AxPath<String>,
     State(state): State<Arc<ApiState>>,
 ) -> Response {
-    let root = match storage::resolve_specs_root(&state.app_state.pg_db, &app_id).await {
+    let pg = &state.app_state.pg_db;
+    let root = match storage::resolve_specs_root(pg, &app_id).await {
         Ok(p) => p,
         Err(e) => return e.into_app_response(),
     };
-    build_list_response(&root, &app_id)
+    let display_name = match pg.get_app(&app_id).await {
+        Ok(Some(app)) => app.display_name,
+        Ok(None) => return AppError::NotRegistered { app_id }.into_app_response(),
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(SpecError::with_detail(
+                    "get-app-failed",
+                    json!({ "error": e }),
+                )),
+            )
+                .into_response();
+        }
+    };
+    build_list_response(&root, &app_id, &display_name)
 }
 
-/// Inner implementation of `get_list` parameterized by the storage root and
-/// `app_id` so tests can exercise the response-building logic without
-/// constructing an `ApiState`.
-pub(crate) fn build_list_response(root: &std::path::Path, app_id: &str) -> Response {
+/// Inner implementation of `get_list` parameterized by the storage root,
+/// `app_id`, and `display_name` so tests can exercise the response-building
+/// logic without constructing an `ApiState`. The `display_name` is sourced
+/// from the `project.apps` registry (it is NOT derivable from `app_id`).
+pub(crate) fn build_list_response(
+    root: &std::path::Path,
+    app_id: &str,
+    display_name: &str,
+) -> Response {
     let ids = match storage::list_pages(root, app_id) {
         Ok(ids) => ids,
         Err(e) => {
@@ -324,7 +346,7 @@ pub(crate) fn build_list_response(root: &std::path::Path, app_id: &str) -> Respo
         };
         let mut entry = json!({
             "specId": id,
-            "appName": app_id,
+            "appName": display_name,
             "config": {
                 "version": projection.get("version").cloned().unwrap_or(Value::Null),
                 "description": projection.get("description").cloned().unwrap_or(Value::Null),

--- a/src-tauri/src/spec_api/tests.rs
+++ b/src-tauri/src/spec_api/tests.rs
@@ -327,12 +327,9 @@ mod handler_tests {
         super::super::storage::write_ir_and_regenerate(root, RUNNER_APP_ID, &doc_a).unwrap();
         super::super::storage::write_ir_and_regenerate(root, RUNNER_APP_ID, &doc_b).unwrap();
 
-        let resp = super::super::handlers::build_list_response(
-            root,
-            RUNNER_APP_ID,
-            "Qontinui Runner",
-        )
-        .into_response();
+        let resp =
+            super::super::handlers::build_list_response(root, RUNNER_APP_ID, "Qontinui Runner")
+                .into_response();
         assert_eq!(resp.status(), axum::http::StatusCode::OK);
         let bytes = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
         let v: Value = serde_json::from_slice(&bytes).unwrap();
@@ -648,8 +645,11 @@ mod handler_tests {
         )
         .unwrap();
 
-        let resp =
-            super::super::handlers::build_list_response(tmp.path(), RUNNER_APP_ID, "Qontinui Runner");
+        let resp = super::super::handlers::build_list_response(
+            tmp.path(),
+            RUNNER_APP_ID,
+            "Qontinui Runner",
+        );
         let (status, v) = response_to_json(resp).await;
         assert_eq!(status, axum::http::StatusCode::OK);
         let specs = v["specs"].as_array().expect("specs must be an array");

--- a/src-tauri/src/spec_api/tests.rs
+++ b/src-tauri/src/spec_api/tests.rs
@@ -327,7 +327,12 @@ mod handler_tests {
         super::super::storage::write_ir_and_regenerate(root, RUNNER_APP_ID, &doc_a).unwrap();
         super::super::storage::write_ir_and_regenerate(root, RUNNER_APP_ID, &doc_b).unwrap();
 
-        let resp = super::super::handlers::build_list_response(root, RUNNER_APP_ID).into_response();
+        let resp = super::super::handlers::build_list_response(
+            root,
+            RUNNER_APP_ID,
+            "Qontinui Runner",
+        )
+        .into_response();
         assert_eq!(resp.status(), axum::http::StatusCode::OK);
         let bytes = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
         let v: Value = serde_json::from_slice(&bytes).unwrap();
@@ -643,7 +648,8 @@ mod handler_tests {
         )
         .unwrap();
 
-        let resp = super::super::handlers::build_list_response(tmp.path(), RUNNER_APP_ID);
+        let resp =
+            super::super::handlers::build_list_response(tmp.path(), RUNNER_APP_ID, "Qontinui Runner");
         let (status, v) = response_to_json(resp).await;
         assert_eq!(status, axum::http::StatusCode::OK);
         let specs = v["specs"].as_array().expect("specs must be an array");
@@ -908,7 +914,8 @@ mod handler_tests {
         super::super::storage::write_ir_and_regenerate(&specs_root, &app_id, &doc_a).unwrap();
         super::super::storage::write_ir_and_regenerate(&specs_root, &app_id, &doc_b).unwrap();
 
-        let resp = super::super::handlers::build_list_response(&specs_root, &app_id);
+        let resp =
+            super::super::handlers::build_list_response(&specs_root, &app_id, &req.display_name);
         let (status, v) = response_to_json(resp).await;
         assert_eq!(status, axum::http::StatusCode::OK);
         let specs = v["specs"].as_array().expect("specs must be array");
@@ -918,11 +925,12 @@ mod handler_tests {
             .collect();
         assert!(ids.contains(&"c8-page-alpha"), "alpha missing: {:?}", ids);
         assert!(ids.contains(&"c8-page-beta"), "beta missing: {:?}", ids);
-        // appName should now be the registered app_id (Stream C — no more
-        // hard-coded "Qontinui Runner" literal).
+        // appName surfaces the registered `display_name`, not the slug
+        // `app_id` (the prior behavior dropped the registry's display_name
+        // on the floor — see `build_list_response` doc comment).
         for entry in specs {
             if entry["specId"] == "c8-page-alpha" || entry["specId"] == "c8-page-beta" {
-                assert_eq!(entry["appName"], app_id);
+                assert_eq!(entry["appName"], req.display_name);
             }
         }
 


### PR DESCRIPTION
## Summary
- `/apps/<id>/spec/list` was emitting `appName: "qontinui-runner"` (the slug) instead of `"Qontinui Runner"` (the `project.apps.display_name`). Regression from #N5f50090aa (multi-tenant app registry rewrite) and #N6b2008c8e (app_id threading).
- `build_list_response` now takes `display_name` explicitly; `get_list` looks the App row up via `PgDb::get_app` and surfaces `AppError::NotRegistered` through the existing `AppErrorExt::into_app_response` mapping.
- Single-file production fix (`spec_api/handlers.rs`); tests updated.

## Why now
Blocking unrelated PR #206 (UI Bridge headline change). That PR has already folded three other red-main fix-forwards in; this regression is the last one and warrants its own commit because the contract change (slug → display_name) is a real semantic shift, not formatting drift.

## Test plan
- [x] `cargo check --bin qontinui-runner` — clean
- [x] `cargo test --bin qontinui-runner spec_api::tests::handler_tests::list_returns_per_page_discovered_specs` — passes (was the failing test on main)
- [x] `cargo test --bin qontinui-runner spec_api::` — 72 passed / 3 ignored / 0 failed
- [ ] CI green on this PR
- [ ] #206 auto-unblocks once this lands