### PR TITLE
feat(runner): GET /control/tauri-command-history audit-trail endpoint

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -167,6 +167,7 @@ mod storage;
 pub(crate) mod str_utils;
 mod summary_generator;
 mod tauri_app_handle;
+mod tauri_command_audit;
 mod terminal;
 mod test_executor;
 mod test_orchestrator;
@@ -749,7 +750,32 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         //
         // The per-module `plugin()` fns are left in place for future reuse
         // even though nothing invokes them now.
-        .invoke_handler(tauri::generate_handler![
+        //
+        // 2026-05-21 audit-trail shim — every IPC dispatch is observed once
+        // before being forwarded to the macro-generated handler. We record
+        // *only* the command name and a unix-millis timestamp into the bounded
+        // ring buffer at `crate::tauri_command_audit`. No args, no return
+        // values; the security argument for keeping credential-returning
+        // commands (e.g. `get_test_auto_login`) off the UI Bridge invoke
+        // allowlist is preserved — operators only learn that a command with
+        // that name fired at some moment, surfaced via the runner-only
+        // `GET /ui-bridge/control/tauri-command-history` endpoint
+        // (see `mcp/ui_bridge/tauri_audit.rs`).
+        //
+        // The `generate_handler!` macro expands to `move |invoke| { … }` of
+        // exact type `Fn(tauri::Invoke<tauri::Wry>) -> bool` (see
+        // `tauri-macros-2.6.0/src/command/handler.rs::From<Handler>`), which
+        // matches `Builder::invoke_handler`'s `F: Fn(Invoke<R>) -> bool + Send
+        // + Sync + 'static` bound. Binding it to a local lets us wrap with a
+        // pre-hook without forking the macro or losing per-command ACL
+        // matching.
+        .invoke_handler({
+            // Type-annotate the binding so Rust can resolve the macro's
+            // untyped closure parameter (`move |invoke| { ... }`) — without
+            // the explicit `impl Fn(...) -> bool` ascription the call to
+            // `invoke.message.command()` is ambiguous.
+            let inner: Box<dyn Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Send + Sync> =
+                Box::new(tauri::generate_handler![
             commands::accessibility::a11y_ai_context,
             commands::accessibility::a11y_capture,
             commands::accessibility::a11y_click,
@@ -1618,7 +1644,12 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::workflow_events::emit_workflow_event,
             commands::worktrees::merge_worktree,
             commands::worktrees::merge_worktree_force
-        ])
+            ]);
+            move |invoke: tauri::ipc::Invoke<tauri::Wry>| -> bool {
+                tauri_command_audit::record(invoke.message.command());
+                inner(invoke)
+            }
+        })
         .manage(shared_app_state)
         .manage(launch_env.clone()) // Item 3: typed startup env snapshot, read once in run_app()
         .manage(bridge_compartment)

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -40,6 +40,7 @@ pub mod screenshots;
 pub mod sdk_spec_sync;
 pub mod state_machine;
 pub mod stubs;
+pub mod tauri_audit;
 pub mod terminals;
 pub mod toasts;
 pub mod types;
@@ -357,6 +358,7 @@ pub(super) fn route_manifest() -> &'static [(&'static str, &'static str)] {
         all.extend_from_slice(sdk_spec_sync::route_entries());
         all.extend_from_slice(state_machine::route_entries());
         all.extend_from_slice(stubs::route_entries());
+        all.extend_from_slice(tauri_audit::route_entries());
         all.extend_from_slice(terminals::route_entries());
         all.extend_from_slice(toasts::route_entries());
         all.extend_from_slice(vision_routes::route_entries());
@@ -405,6 +407,7 @@ pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
         .merge(sdk_spec_sync::routes())
         .merge(state_machine::routes())
         .merge(stubs::routes())
+        .merge(tauri_audit::routes())
         .merge(terminals::routes())
         .merge(toasts::routes())
         .merge(vision_routes::routes())
@@ -783,6 +786,10 @@ mod manifest_drift_tests {
             ("GET", "/ui-bridge/control/page/playbook"),
             ("GET", "/ui-bridge/control/spec/{}"),
             ("GET", "/ui-bridge/control/tabs"),
+            // Tauri-command audit trail — runner-only, no SDK consumer
+            // (mobile / web don't have Tauri commands to record). See
+            // `mcp/ui_bridge/tauri_audit.rs` and `crate::tauri_command_audit`.
+            ("GET", "/ui-bridge/control/tauri-command-history"),
             ("GET", "/ui-bridge/control/toasts"),
             ("GET", "/ui-bridge/control/windows"),
             ("POST", "/ui-bridge/control/action-plan"),

--- a/src-tauri/src/mcp/ui_bridge/tauri_audit.rs
+++ b/src-tauri/src/mcp/ui_bridge/tauri_audit.rs
@@ -1,0 +1,81 @@
+//! Tauri command-fire attestation endpoint.
+//!
+//! Surfaces the bounded ring buffer maintained by
+//! `crate::tauri_command_audit` over HTTP so manual-test operators can
+//! verify that a non-allowlisted Tauri command fired without exposing its
+//! args or return values. See the module-level doc on
+//! `crate::tauri_command_audit` for the motivation (2026-05-21
+//! `/manual-test` Phase 8 `get_test_auto_login` verification gap).
+//!
+//! Runner-only by design: there is no UI Bridge SDK consumer for this
+//! endpoint (mobile / web don't have Tauri commands to record). The route
+//! is therefore intentionally absent from the SDK's `UI_BRIDGE_ROUTES`
+//! table and listed in `mod.rs::sdk_manifest_routes_are_exposed_by_runner`'s
+//! `runner_only_baseline` allow-list.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    response::Json,
+};
+use serde::Deserialize;
+use tracing::debug;
+
+use crate::mcp::types::{ApiResponse, ApiState};
+use crate::tauri_command_audit::{self, CommandFireEvent};
+
+/// Query parameters for the audit-trail endpoint.
+///
+/// Both fields are optional:
+///   - `since` filters by strict `fired_at_unix_ms > since` (so the operator
+///     can record a startup timestamp `T0` and ask "did this fire after
+///     React mount?")
+///   - `command` filters by exact-equals on the command name
+#[derive(Debug, Deserialize)]
+pub struct TauriCommandHistoryQuery {
+    /// Unix epoch millis; only events strictly greater than this are returned.
+    #[serde(default)]
+    pub since: Option<u64>,
+    /// Tauri command name; only events matching this exact string are
+    /// returned.
+    #[serde(default)]
+    pub command: Option<String>,
+}
+
+/// Response payload — a flat events array wrapped in the standard envelope.
+#[derive(Debug, serde::Serialize)]
+pub struct TauriCommandHistoryResponse {
+    pub events: Vec<CommandFireEvent>,
+}
+
+/// `GET /ui-bridge/control/tauri-command-history`
+///
+/// Returns the (filtered) snapshot of the global Tauri command-fire ring
+/// buffer. Never fails — an empty or lock-poisoned buffer just yields
+/// `events: []`.
+pub async fn ui_bridge_tauri_command_history_handler(
+    State(_state): State<Arc<ApiState>>,
+    Query(query): Query<TauriCommandHistoryQuery>,
+) -> Json<ApiResponse<TauriCommandHistoryResponse>> {
+    let events = tauri_command_audit::query(query.since, query.command.as_deref());
+    debug!(
+        since = ?query.since,
+        command = ?query.command,
+        count = events.len(),
+        "ui_bridge tauri-command-history query",
+    );
+    Json(ApiResponse::success(TauriCommandHistoryResponse { events }))
+}
+
+pub fn routes() -> axum::Router<Arc<ApiState>> {
+    use axum::routing::get;
+    axum::Router::new().route(
+        "/ui-bridge/control/tauri-command-history",
+        get(ui_bridge_tauri_command_history_handler),
+    )
+}
+
+pub fn route_entries() -> &'static [(&'static str, &'static str)] {
+    &[("GET", "/ui-bridge/control/tauri-command-history")]
+}

--- a/src-tauri/src/tauri_command_audit/mod.rs
+++ b/src-tauri/src/tauri_command_audit/mod.rs
@@ -1,0 +1,176 @@
+//! Bounded ring buffer of recently-fired Tauri command names + timestamps.
+//!
+//! **Purpose.** Provides an attestation surface for manual-test operators
+//! verifying that React-frontend code paths invoked a non-allowlisted Tauri
+//! command. The `2026-05-21` `/manual-test` session hit a verification gap on
+//! `commands::auth::get_test_auto_login`: the command returns credentials so
+//! it is intentionally **not** in the UI Bridge `invoke` allowlist, but
+//! operators still needed a way to confirm that the React `AuthProvider`
+//! mount-time invocation fired (so a tracing log gating Phase 8's
+//! `test_auto_login_skipped` path could be reasoned about).
+//!
+//! This ring buffer records ONLY:
+//!   - the command name (a `&'static str`-equivalent owned `String`)
+//!   - the unix-millis timestamp at which the global Tauri
+//!     `invoke_handler` shim saw the command dispatch
+//!
+//! **No args, no return values, no payload data.** Pure attestation. The
+//! security argument that justified keeping `get_test_auto_login` off the
+//! invoke allowlist (don't expose credentials) is preserved: we leak only
+//! that a function with that name fired at some moment.
+//!
+//! The buffer is process-global, capped at [`MAX_ENTRIES`] (oldest dropped
+//! on overflow), and exposed via the runner-only HTTP endpoint
+//! `GET /ui-bridge/control/tauri-command-history` (see
+//! `crate::mcp::ui_bridge::tauri_audit`).
+//!
+//! Lock-poisoning is treated as a best-effort drop: this is a debug /
+//! attestation surface, not a correctness substrate, and we'd rather lose a
+//! few entries than crash the IPC dispatch closure.
+
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Maximum number of command-fire events retained in the global ring buffer.
+///
+/// 100 chosen as a small constant: large enough to capture the bursty
+/// mount-time IPC traffic of a fresh React shell load (~30-50 commands), but
+/// small enough that an operator can `GET` the entire buffer without
+/// pagination. Oldest entries are dropped on overflow.
+const MAX_ENTRIES: usize = 100;
+
+/// A single command-fire observation. Serialised verbatim into the
+/// `/ui-bridge/control/tauri-command-history` response array.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CommandFireEvent {
+    /// The Tauri command name as seen by `Invoke.message.command()`.
+    pub command: String,
+    /// Wall-clock unix epoch millis at the time `record` was called.
+    pub fired_at_unix_ms: u64,
+}
+
+/// Process-global ring buffer. `Mutex::new(VecDeque::new())` is `const`-stable
+/// in modern Rust toolchains, so no `OnceLock`/lazy init is needed.
+static BUFFER: Mutex<VecDeque<CommandFireEvent>> = Mutex::new(VecDeque::new());
+
+/// Record a command-fire observation. Called from the `invoke_handler` shim
+/// in `main.rs` for every IPC dispatch. Best-effort: lock-poisoning silently
+/// drops the entry so a panicked test in another module never wedges the
+/// production IPC dispatch closure.
+pub fn record(command: &str) {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    let event = CommandFireEvent {
+        command: command.to_string(),
+        fired_at_unix_ms: now,
+    };
+    if let Ok(mut buf) = BUFFER.lock() {
+        if buf.len() >= MAX_ENTRIES {
+            buf.pop_front();
+        }
+        buf.push_back(event);
+    }
+    // Lock-poisoned: silently drop. Audit trail is best-effort.
+}
+
+/// Snapshot-query the buffer, applying optional `since` (strict `>` on
+/// `fired_at_unix_ms`) and `command` (exact-equals on name) filters. Returns
+/// owned clones so the caller can release the mutex immediately.
+///
+/// Both filters are `Option<>`: omit either to skip that filter axis.
+pub fn query(since: Option<u64>, command: Option<&str>) -> Vec<CommandFireEvent> {
+    let buf = match BUFFER.lock() {
+        Ok(b) => b,
+        Err(_) => return Vec::new(),
+    };
+    buf.iter()
+        .filter(|e| since.map(|s| e.fired_at_unix_ms > s).unwrap_or(true))
+        .filter(|e| command.map(|c| e.command == c).unwrap_or(true))
+        .cloned()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // BUFFER is process-global; the in-process unit tests below all use
+    // unique command-name prefixes derived from the test fn name so concurrent
+    // execution (cargo's default per-binary test harness) doesn't cross-
+    // pollute results. Filtering by `command` in `query()` then isolates each
+    // test's view.
+
+    #[test]
+    fn record_and_query_basic() {
+        record("test_record_and_query_basic_cmd_a");
+        record("test_record_and_query_basic_cmd_b");
+        let results = query(None, Some("test_record_and_query_basic_cmd_a"));
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].command, "test_record_and_query_basic_cmd_a");
+    }
+
+    #[test]
+    fn ring_buffer_bound() {
+        // Spray MAX_ENTRIES * 1.5 events with a unique command name; the
+        // buffer caps total entries at MAX_ENTRIES across all commands, so our
+        // filtered view is bounded by MAX_ENTRIES.
+        let cmd = "test_ring_buffer_bound_cmd";
+        for _ in 0..(MAX_ENTRIES + 50) {
+            record(cmd);
+        }
+        let results = query(None, Some(cmd));
+        assert!(
+            results.len() <= MAX_ENTRIES,
+            "buffer over-cap: {} > {}",
+            results.len(),
+            MAX_ENTRIES
+        );
+    }
+
+    #[test]
+    fn since_filter() {
+        let cmd = "test_since_filter_cmd";
+        let t_before = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        // 2ms sleeps put the record cleanly between the timestamp pair on
+        // realistic clock resolutions (Windows ~15ms, Linux ~1ms).
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        record(cmd);
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let t_after = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64;
+        let results_before = query(Some(t_before), Some(cmd));
+        let results_after = query(Some(t_after), Some(cmd));
+        assert_eq!(
+            results_before.len(),
+            1,
+            "expected since=t_before to include our record"
+        );
+        assert_eq!(
+            results_after.len(),
+            0,
+            "expected since=t_after to exclude our record (strict >)"
+        );
+    }
+
+    #[test]
+    fn no_filters_returns_at_least_recent() {
+        // Sanity: with both filters None, at least our just-recorded entry is
+        // present (other tests may have added entries too — we just need our
+        // one back).
+        let cmd = "test_no_filters_returns_at_least_recent_cmd";
+        record(cmd);
+        let results = query(None, None);
+        assert!(
+            results.iter().any(|e| e.command == cmd),
+            "no_filters query missed our just-recorded event"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GET /ui-bridge/control/tauri-command-history?since=<unix_ms>&command=<name>` so UI Bridge operators can verify a non-allowlisted Tauri command fired without exposing its args/return values. Closes the verification gap surfaced by `/manual-test 2026-05-21` on Phase 8's `test_auto_login_skipped` log path (the command is correctly NOT in the UI Bridge allowlist — returns credentials).
- Wraps `tauri::Builder::invoke_handler` once so every command is recorded automatically — no per-command opt-in, no touch to the existing `tauri::generate_handler![…]` block.
- Process-global bounded ring buffer (100 events, oldest dropped on overflow). NO args, NO return values — pure attestation.

## Files
- `src-tauri/src/tauri_command_audit/mod.rs` (NEW): record + query API + 4 unit tests
- `src-tauri/src/mcp/ui_bridge/tauri_audit.rs` (NEW): UI Bridge handler family file
- `src-tauri/src/main.rs`: wraps `invoke_handler` with the recording shim
- `src-tauri/src/mcp/ui_bridge/mod.rs`: registers the new family + adds the route to `runner_only_baseline` (mobile/web have no Tauri commands to record)

## Commits
1. `feat(runner): …audit-trail endpoint` — the feature itself
2. `style: cargo fmt pre-existing drift…` — pre-push fmt-check runs whole-crate; 15 unrelated files needed cargo fmt (pre-existing drift on origin/main, not from this PR)
3. `style(clippy): drop explicit lifetimes…` — pre-push clippy `-D warnings` failed on a pre-existing `needless_lifetimes` lint in `scenarios::handlers::validate_request` (also unrelated)

## Test plan
- [x] `cargo check --bin qontinui-runner` clean
- [x] `cargo clippy --bin qontinui-runner -- -D warnings` clean
- [x] `cargo test --bin qontinui-runner tauri_command_audit` — 4/4 pass
- [x] `cargo test --bin qontinui-runner manifest_matches_route_calls` — pass
- [x] `cargo test --bin qontinui-runner sdk_manifest_routes_are_exposed_by_runner` — pass (with new route added to `runner_only_baseline`)
- [ ] CI green (this PR)