### PR TITLE
fix(spec-check): derive role/text/accessibleName from snapshot fallbacks

### DIFF
--- a/crates/spec-check/src/criteria.rs
+++ b/crates/spec-check/src/criteria.rs
@@ -20,6 +20,7 @@ use qontinui_types::ir::IrElementCriteria;
 use qontinui_types::text_norm::normalize_text;
 use qontinui_types::ui_bridge::UIBridgeElement;
 
+use crate::derive;
 use crate::role_categories::same_category;
 use crate::snapshot::{ElementIdx, IndexedSnapshot};
 
@@ -39,7 +40,7 @@ pub fn matches_all(
     let el = snapshot.element(idx);
 
     if let Some(role) = crit.role.as_deref() {
-        if score_role(role, &el.role) < 1.0 {
+        if score_role(role, &derive::role(el)) < 1.0 {
             return false;
         }
     }
@@ -49,22 +50,22 @@ pub fn matches_all(
         }
     }
     if let Some(text) = crit.text.as_deref() {
-        if score_text(text, &el.text) < 1.0 {
+        if score_text(text, &derive::text(el)) < 1.0 {
             return false;
         }
     }
     if let Some(needle) = crit.text_contains.as_deref() {
-        if !text_contains(needle, &el.text) {
+        if !text_contains(needle, &derive::text(el)) {
             return false;
         }
     }
     if let Some(label) = crit.aria_label.as_deref() {
-        if score_aria_label(label, &el.aria_label) < 1.0 {
+        if score_aria_label(label, &derive::aria_label(el)) < 1.0 {
             return false;
         }
     }
     if let Some(name) = crit.accessible_name.as_deref() {
-        if score_text(name, &el.accessible_name) < 1.0 {
+        if score_text(name, &derive::accessible_name(el)) < 1.0 {
             return false;
         }
     }
@@ -768,6 +769,171 @@ mod tests {
         }
     }
 
+    // -- live-snapshot derivation regression -----------------------------
+    //
+    // These tests exercise the matcher against snapshots shaped the way the
+    // real UI Bridge SDK actually emits them: top-level `role`/`text`/
+    // `accessibleName`/`ariaLabel` are all `None`; the SDK puts visible
+    // text in `state.text_content` and the human-readable name in `label`,
+    // and conveys the ARIA role only through `tag_name` (and the SDK-
+    // semantic `element_type`). Before the `derive` module was wired in,
+    // every `{role: "heading"}` criterion narrowed to zero candidates;
+    // these tests pin that fix.
+
+    /// Build an element whose shape mirrors the live snapshot — top-level
+    /// `role`/`text`/`accessibleName`/`ariaLabel` are `None`, with the
+    /// observed values living in `tag_name` / `state.text_content` /
+    /// `label` instead. Mirrors what `GET /ui-bridge/control/snapshot`
+    /// actually returns on a real runner.
+    fn live_elem(
+        id: &str,
+        tag_name: &str,
+        element_type: &str,
+        label: Option<&str>,
+        text_content: Option<&str>,
+    ) -> UIBridgeElement {
+        let mut state = empty_state();
+        state.text_content = text_content.map(String::from);
+        UIBridgeElement {
+            id: id.to_string(),
+            element_type: element_type.to_string(),
+            label: label.map(String::from),
+            actions: Vec::new(),
+            custom_actions: None,
+            identifier: empty_identifier(),
+            state,
+            registered_at: 0,
+            mounted: true,
+            bbox: None,
+            visible: Some(true),
+            role: None,
+            tag_name: Some(tag_name.to_string()),
+            aria_label: None,
+            accessible_name: None,
+            text: None,
+        }
+    }
+
+    #[test]
+    fn live_h1_matches_role_heading_and_text_via_derivation() {
+        // The acceptance bullet from the task: synthetic snapshot with
+        // role=null, tagName="h1", state.textContent="Hello" + criteria
+        // {role: "heading", text: "Hello"} must produce exactly one
+        // candidate.
+        let s = snap(vec![live_elem("h", "h1", "heading", None, Some("Hello"))]);
+        let idx = IndexedSnapshot::new(&s);
+
+        let crit = IrElementCriteria {
+            role: Some("heading".to_string()),
+            text: Some("Hello".to_string()),
+            ..Default::default()
+        };
+
+        let cands = narrow_candidates(&idx, &crit);
+        assert_eq!(cands.len(), 1, "expected exactly one h1 candidate");
+        assert!(matches_all(&idx, &crit, cands[0]));
+    }
+
+    #[test]
+    fn live_button_matches_via_label_fallback_for_accessible_name() {
+        // accessibleName fallback chain: el.accessible_name → el.label →
+        // state.text_content. Here label is populated (the SDK's typical
+        // emit for buttons) but accessible_name is None.
+        let s = snap(vec![live_elem(
+            "btn",
+            "button",
+            "button",
+            Some("Sign In"),
+            Some("Sign In"),
+        )]);
+        let idx = IndexedSnapshot::new(&s);
+
+        let crit = IrElementCriteria {
+            role: Some("button".to_string()),
+            accessible_name: Some("Sign In".to_string()),
+            ..Default::default()
+        };
+
+        let cands = narrow_candidates(&idx, &crit);
+        assert!(cands.iter().any(|i| matches_all(&idx, &crit, *i)));
+    }
+
+    #[test]
+    fn live_paragraph_matches_text_via_state_text_content() {
+        // text fallback: el.text is None, state.text_content carries the
+        // visible text. A `{text: "..."}` criterion must still narrow
+        // and pass matches_all.
+        let s = snap(vec![
+            live_elem(
+                "p0",
+                "p",
+                "paragraph",
+                Some("App preferences"),
+                Some("Application-level preferences"),
+            ),
+            live_elem(
+                "p1",
+                "p",
+                "paragraph",
+                Some("Other prose"),
+                Some("Something else"),
+            ),
+        ]);
+        let idx = IndexedSnapshot::new(&s);
+
+        let crit = IrElementCriteria {
+            text: Some("Application-level preferences".to_string()),
+            ..Default::default()
+        };
+
+        let cands = narrow_candidates(&idx, &crit);
+        assert!(
+            cands.iter().any(|i| matches_all(&idx, &crit, *i)),
+            "expected the paragraph with the matching text_content to match"
+        );
+    }
+
+    #[test]
+    fn live_input_role_textbox_derived_from_element_type() {
+        // ARIA role for <input type=email> is "textbox". The snapshot
+        // doesn't carry the `type=` attribute but the SDK has already
+        // resolved it into `element_type: "email"` — derivation routes
+        // that to ARIA "textbox".
+        let mut email = live_elem("email", "input", "email", Some("Email"), None);
+        email.state.value = Some(String::new());
+        let s = snap(vec![email]);
+        let idx = IndexedSnapshot::new(&s);
+
+        let crit = IrElementCriteria {
+            role: Some("textbox".to_string()),
+            ..Default::default()
+        };
+
+        let cands = narrow_candidates(&idx, &crit);
+        assert_eq!(cands.len(), 1, "expected the email input to derive role=textbox");
+        assert!(matches_all(&idx, &crit, cands[0]));
+    }
+
+    #[test]
+    fn live_snapshot_role_index_is_populated_via_derivation() {
+        // IndexedSnapshot::lookup_by_role must find candidates even when
+        // every element on the wire has `role: null` — derivation must
+        // run inside the indexer too, otherwise narrow_candidates can
+        // never reach matches_all.
+        let s = snap(vec![
+            live_elem("h", "h1", "heading", None, Some("Title")),
+            live_elem("b", "button", "button", Some("Go"), Some("Go")),
+            live_elem("a", "a", "link", Some("More"), Some("More")),
+        ]);
+        let idx = IndexedSnapshot::new(&s);
+
+        assert_eq!(idx.lookup_by_role("heading").len(), 1);
+        assert_eq!(idx.lookup_by_role("button").len(), 1);
+        assert_eq!(idx.lookup_by_role("link").len(), 1);
+        // Sanity: tag_name still indexes raw.
+        assert_eq!(idx.lookup_by_tag("h1").len(), 1);
+    }
+
     // -- property test (proptest) — randomized variant of the above -----
 
     use proptest::prelude::*;
@@ -777,8 +943,13 @@ mod tests {
         fn proptest_matches_all_implies_score_one(
             role in "[a-z]{3,10}",
             tag in "[a-z]{2,8}",
-            aria in "[A-Za-z ]{2,15}",
-            text in "[A-Za-z ]{3,30}",
+            // Anchor with a non-space character so the strategy never
+            // produces whitespace-only inputs. The derive layer treats
+            // whitespace-only values as "absent" (so the matcher can fall
+            // through to the next source); a real SDK never emits them
+            // deliberately, so excluding them is fine.
+            aria in "[A-Za-z][A-Za-z ]{1,14}",
+            text in "[A-Za-z][A-Za-z ]{2,29}",
         ) {
             // Build a snapshot containing exactly the element we'll point at.
             let s = snap(vec![elem(

--- a/crates/spec-check/src/derive.rs
+++ b/crates/spec-check/src/derive.rs
@@ -1,0 +1,465 @@
+//! Bridge `IrElementCriteria` field names to the values the UI Bridge
+//! snapshot actually carries.
+//!
+//! ## Why this module exists
+//!
+//! The IR uses W3C-ARIA-style criteria (`role: "heading"`, `text: "General"`,
+//! `accessibleName: "Sign In"`) but the live snapshot's top-level
+//! `role` / `text` / `accessibleName` fields on [`UIBridgeElement`] are
+//! almost always `None`. The SDK emits the same information in different
+//! places: `tagName` carries the implicit ARIA role, `state.textContent`
+//! carries the visible text, `label` carries the accessible name.
+//!
+//! Hand-fixing the SDK to populate the top-level fields would alter the
+//! wire contract for every consumer. The right place to bridge the gap is
+//! the matcher — `qontinui-spec-check` is the only consumer that needs
+//! the IR↔snapshot translation, so we resolve it here.
+//!
+//! ## Precedence
+//!
+//! Each derivation prefers the direct field (so a future SDK that *does*
+//! populate top-level `role` keeps working) and falls back to alternative
+//! locations only when the direct field is `None` or empty.
+//!
+//! | Derived         | 1st choice          | 2nd                       | 3rd                            |
+//! |-----------------|---------------------|---------------------------|--------------------------------|
+//! | role            | `el.role`           | implicit role from `tag_name` | `element_type` keyword     |
+//! | accessible_name | `el.accessible_name`| `el.label`                | `el.state.text_content`        |
+//! | text            | `el.text`           | `el.state.text_content`   | `el.label`                     |
+//! | aria_label      | `el.aria_label`     | `el.label`                | —                              |
+
+use qontinui_types::ui_bridge::UIBridgeElement;
+
+/// Effective ARIA role for matching purposes.
+///
+/// 1. `el.role` if non-empty (a future SDK that populates this wins).
+/// 2. Implicit ARIA role from `el.tag_name` per the table below.
+/// 3. `el.element_type` when it looks like an ARIA role keyword
+///    (covers SDK-emitted semantic types like `"heading"`, `"button"`,
+///    `"link"`, `"paragraph"` even when the tag name is generic).
+pub fn role(el: &UIBridgeElement) -> Option<String> {
+    if let Some(r) = non_empty(el.role.as_deref()) {
+        return Some(r.to_string());
+    }
+    if let Some(tag) = el.tag_name.as_deref() {
+        if let Some(role) = role_from_tag(tag, el.element_type.as_str()) {
+            return Some(role.to_string());
+        }
+    }
+    let et = el.element_type.trim().to_ascii_lowercase();
+    if !et.is_empty() && et != "div" && et != "span" && et != "input" {
+        // Allow-list the SDK's semantic type names that already read as
+        // ARIA roles. We exclude "input" because the W3C role for `<input>`
+        // depends on `type=` (textbox / searchbox / button / checkbox /
+        // radio / spinbutton …) — `role_from_tag` handles the common
+        // cases above and we'd rather return None than mis-tag.
+        return Some(et);
+    }
+    None
+}
+
+/// Effective accessible name for matching purposes.
+///
+/// 1. `el.accessible_name` if non-empty.
+/// 2. `el.label` — the SDK's human-readable label, populated whenever the
+///    accessible-name algorithm produces a result.
+/// 3. `el.state.text_content` — visible text as a last resort, since for
+///    most non-form-control elements `accessibleName === textContent`.
+pub fn accessible_name(el: &UIBridgeElement) -> Option<String> {
+    non_empty(el.accessible_name.as_deref())
+        .map(str::to_string)
+        .or_else(|| non_empty(el.label.as_deref()).map(str::to_string))
+        .or_else(|| non_empty(el.state.text_content.as_deref()).map(str::to_string))
+}
+
+/// Effective visible text for matching purposes.
+///
+/// 1. `el.text` if non-empty (SDK-canonical innerText slot).
+/// 2. `el.state.text_content` — same slot under the legacy nested name.
+/// 3. `el.label` — covers content elements where the SDK chose to expose
+///    the visible text only via the label.
+pub fn text(el: &UIBridgeElement) -> Option<String> {
+    non_empty(el.text.as_deref())
+        .map(str::to_string)
+        .or_else(|| non_empty(el.state.text_content.as_deref()).map(str::to_string))
+        .or_else(|| non_empty(el.label.as_deref()).map(str::to_string))
+}
+
+/// Effective aria-label for matching purposes.
+///
+/// 1. `el.aria_label` if non-empty.
+/// 2. `el.label` — when the SDK didn't surface an explicit `aria-label`
+///    attribute but did expose a human-readable label, that label is the
+///    closest equivalent.
+pub fn aria_label(el: &UIBridgeElement) -> Option<String> {
+    non_empty(el.aria_label.as_deref())
+        .map(str::to_string)
+        .or_else(|| non_empty(el.label.as_deref()).map(str::to_string))
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+fn non_empty(s: Option<&str>) -> Option<&str> {
+    s.map(str::trim).filter(|s| !s.is_empty())
+}
+
+/// Implicit ARIA role for a given HTML tag.
+///
+/// Curated from the WAI-ARIA-in-HTML mapping
+/// (<https://www.w3.org/TR/html-aria/>) — only the elements that carry an
+/// unambiguous implicit role with no attribute disambiguation are listed.
+/// `<input>` is delegated to `element_type` because its role depends on
+/// the `type=` attribute, which the snapshot doesn't expose directly but
+/// the SDK has already resolved into the semantic `element_type` string
+/// (`"input"` / `"button"` / `"checkbox"` / `"radio"` / `"search"` / …).
+fn role_from_tag(tag: &str, element_type: &str) -> Option<&'static str> {
+    let t = tag.trim().to_ascii_lowercase();
+    match t.as_str() {
+        "h1" | "h2" | "h3" | "h4" | "h5" | "h6" => Some("heading"),
+        "button" => Some("button"),
+        "a" => Some("link"),
+        "select" => Some("combobox"),
+        "textarea" => Some("textbox"),
+        "input" => role_from_input_type(element_type),
+        "nav" => Some("navigation"),
+        "main" => Some("main"),
+        "header" => Some("banner"),
+        "footer" => Some("contentinfo"),
+        "aside" => Some("complementary"),
+        "article" => Some("article"),
+        "section" => Some("region"),
+        "form" => Some("form"),
+        "table" => Some("table"),
+        "thead" | "tbody" | "tfoot" => Some("rowgroup"),
+        "tr" => Some("row"),
+        "td" => Some("cell"),
+        "th" => Some("columnheader"),
+        "p" => Some("paragraph"),
+        "ul" | "ol" | "menu" => Some("list"),
+        "li" => Some("listitem"),
+        "dialog" => Some("dialog"),
+        "img" => Some("img"),
+        "hr" => Some("separator"),
+        "fieldset" => Some("group"),
+        "figure" => Some("figure"),
+        _ => None,
+    }
+}
+
+/// Map the SDK's semantic `element_type` for `<input>` elements onto an
+/// ARIA role. The SDK normalizes `<input type="X">` into one of a small
+/// set of strings (`"input"`, `"button"`, `"checkbox"`, `"radio"`,
+/// `"search"`, …) — we route each to the W3C ARIA-in-HTML mapping.
+fn role_from_input_type(element_type: &str) -> Option<&'static str> {
+    match element_type.trim().to_ascii_lowercase().as_str() {
+        // Generic / text-flavored inputs all map to "textbox" in ARIA.
+        "input" | "text" | "email" | "password" | "tel" | "url" | "number" | "date"
+        | "datetime-local" | "month" | "time" | "week" | "color" | "file" => Some("textbox"),
+        "search" => Some("searchbox"),
+        "button" | "submit" | "reset" => Some("button"),
+        "checkbox" => Some("checkbox"),
+        "radio" => Some("radio"),
+        "range" => Some("slider"),
+        _ => Some("textbox"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qontinui_types::ui_bridge::{ElementIdentifier, ElementRect, ElementState};
+
+    fn empty_state() -> ElementState {
+        ElementState {
+            visible: true,
+            enabled: true,
+            focused: false,
+            rect: ElementRect {
+                x: 0.0,
+                y: 0.0,
+                width: 0.0,
+                height: 0.0,
+                top: 0.0,
+                right: 0.0,
+                bottom: 0.0,
+                left: 0.0,
+            },
+            value: None,
+            checked: None,
+            selected_options: None,
+            text_content: None,
+        }
+    }
+
+    fn empty_identifier() -> ElementIdentifier {
+        ElementIdentifier {
+            ui_id: None,
+            test_id: None,
+            awas_id: None,
+            html_id: None,
+            xpath: String::new(),
+            selector: String::new(),
+        }
+    }
+
+    fn el(
+        element_type: &str,
+        tag: Option<&str>,
+        role: Option<&str>,
+        aria_label: Option<&str>,
+        accessible_name: Option<&str>,
+        label: Option<&str>,
+        text: Option<&str>,
+        text_content: Option<&str>,
+    ) -> UIBridgeElement {
+        let mut state = empty_state();
+        state.text_content = text_content.map(String::from);
+        UIBridgeElement {
+            id: "e0".to_string(),
+            element_type: element_type.to_string(),
+            label: label.map(String::from),
+            actions: Vec::new(),
+            custom_actions: None,
+            identifier: empty_identifier(),
+            state,
+            registered_at: 0,
+            mounted: true,
+            bbox: None,
+            visible: Some(true),
+            role: role.map(String::from),
+            tag_name: tag.map(String::from),
+            aria_label: aria_label.map(String::from),
+            accessible_name: accessible_name.map(String::from),
+            text: text.map(String::from),
+        }
+    }
+
+    // -- role -------------------------------------------------------------
+
+    #[test]
+    fn role_prefers_explicit_top_level() {
+        let e = el(
+            "heading",
+            Some("h1"),
+            Some("button"), // explicit role wins even when wrong-looking
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(role(&e).as_deref(), Some("button"));
+    }
+
+    #[test]
+    fn role_falls_back_to_tag_for_headings() {
+        for tag in ["h1", "h2", "h3", "h4", "h5", "h6"] {
+            let e = el("heading", Some(tag), None, None, None, None, None, None);
+            assert_eq!(role(&e).as_deref(), Some("heading"), "tag={tag}");
+        }
+    }
+
+    #[test]
+    fn role_falls_back_to_tag_for_common_widgets() {
+        let cases = [
+            ("button", "button"),
+            ("a", "link"),
+            ("select", "combobox"),
+            ("textarea", "textbox"),
+            ("p", "paragraph"),
+            ("ul", "list"),
+            ("li", "listitem"),
+            ("nav", "navigation"),
+            ("main", "main"),
+            ("dialog", "dialog"),
+        ];
+        for (tag, expected) in cases {
+            let e = el("misc", Some(tag), None, None, None, None, None, None);
+            assert_eq!(role(&e).as_deref(), Some(expected), "tag={tag}");
+        }
+    }
+
+    #[test]
+    fn role_for_input_uses_element_type() {
+        let cases = [
+            ("input", "textbox"),     // plain text input
+            ("email", "textbox"),
+            ("password", "textbox"),
+            ("search", "searchbox"),
+            ("button", "button"),
+            ("checkbox", "checkbox"),
+            ("radio", "radio"),
+            ("range", "slider"),
+        ];
+        for (et, expected) in cases {
+            let e = el(et, Some("input"), None, None, None, None, None, None);
+            assert_eq!(role(&e).as_deref(), Some(expected), "element_type={et}");
+        }
+    }
+
+    #[test]
+    fn role_falls_back_to_element_type_when_tag_is_generic() {
+        // `<div role="...">` style — generic tag, but element_type is semantic.
+        let e = el(
+            "heading",
+            Some("div"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(role(&e).as_deref(), Some("heading"));
+    }
+
+    #[test]
+    fn role_returns_none_for_pure_generic_div() {
+        let e = el("div", Some("div"), None, None, None, None, None, None);
+        assert_eq!(role(&e), None);
+    }
+
+    // -- accessible_name --------------------------------------------------
+
+    #[test]
+    fn accessible_name_prefers_top_level() {
+        let e = el(
+            "button",
+            Some("button"),
+            None,
+            None,
+            Some("Submit form"),
+            Some("Submit"),       // label loses to accessible_name
+            None,
+            Some("Submit form"),
+        );
+        assert_eq!(accessible_name(&e).as_deref(), Some("Submit form"));
+    }
+
+    #[test]
+    fn accessible_name_falls_back_to_label() {
+        let e = el(
+            "button",
+            Some("button"),
+            None,
+            None,
+            None,
+            Some("Sign In"),
+            None,
+            None,
+        );
+        assert_eq!(accessible_name(&e).as_deref(), Some("Sign In"));
+    }
+
+    #[test]
+    fn accessible_name_falls_back_to_text_content() {
+        let e = el(
+            "heading",
+            Some("h1"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("Qontinui"),
+        );
+        assert_eq!(accessible_name(&e).as_deref(), Some("Qontinui"));
+    }
+
+    #[test]
+    fn accessible_name_none_when_all_sources_absent() {
+        let e = el("div", Some("div"), None, None, None, None, None, None);
+        assert_eq!(accessible_name(&e), None);
+    }
+
+    // -- text -------------------------------------------------------------
+
+    #[test]
+    fn text_prefers_top_level() {
+        let e = el(
+            "heading",
+            Some("h1"),
+            None,
+            None,
+            None,
+            None,
+            Some("Top-level"),
+            Some("Nested"),
+        );
+        assert_eq!(text(&e).as_deref(), Some("Top-level"));
+    }
+
+    #[test]
+    fn text_falls_back_to_text_content() {
+        let e = el(
+            "heading",
+            Some("h1"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some("General"),
+        );
+        assert_eq!(text(&e).as_deref(), Some("General"));
+    }
+
+    #[test]
+    fn text_falls_back_to_label() {
+        let e = el(
+            "paragraph",
+            Some("p"),
+            None,
+            None,
+            None,
+            Some("Some prose"),
+            None,
+            None,
+        );
+        assert_eq!(text(&e).as_deref(), Some("Some prose"));
+    }
+
+    // -- aria_label -------------------------------------------------------
+
+    #[test]
+    fn aria_label_prefers_top_level() {
+        let e = el(
+            "button",
+            Some("button"),
+            None,
+            Some("Save"),
+            None,
+            Some("Save changes"), // ignored
+            None,
+            None,
+        );
+        assert_eq!(aria_label(&e).as_deref(), Some("Save"));
+    }
+
+    #[test]
+    fn aria_label_falls_back_to_label() {
+        let e = el(
+            "button",
+            Some("button"),
+            None,
+            None,
+            None,
+            Some("Save"),
+            None,
+            None,
+        );
+        assert_eq!(aria_label(&e).as_deref(), Some("Save"));
+    }
+
+    // -- non_empty edge cases --------------------------------------------
+
+    #[test]
+    fn whitespace_only_strings_are_treated_as_absent() {
+        // role: "   " should NOT short-circuit; we should fall through to
+        // the tag-derived role.
+        let e = el("heading", Some("h1"), Some("   "), None, None, None, None, None);
+        assert_eq!(role(&e).as_deref(), Some("heading"));
+    }
+}

--- a/crates/spec-check/src/diff.rs
+++ b/crates/spec-check/src/diff.rs
@@ -33,6 +33,7 @@ use qontinui_types::ui_bridge::UIBridgeElement;
 use crate::criteria::{
     score_aria_label, score_attributes, score_role, score_tag, score_text, score_visibility,
 };
+use crate::derive;
 use crate::snapshot::{ElementIdx, IndexedSnapshot};
 use crate::{AssertionMiss, CandidateMiss, FieldDiff, MissReason};
 
@@ -107,9 +108,13 @@ impl SelectivityIndex {
         let mut aria_label_counts: HashMap<String, u32> = HashMap::new();
         let mut text_word_counts: HashMap<String, u32> = HashMap::new();
 
+        // Selectivity weights must reflect the same value-space the matcher
+        // operates on — use the derive layer so a `{role: heading}` criterion
+        // sees the IDF weight of the *derived* role population, not the
+        // top-level (almost-always-None) `el.role` distribution.
         for (_idx, el) in indexed.iter_elements() {
-            if let Some(role) = el.role.as_deref() {
-                let key = normalize_text(role);
+            if let Some(role) = derive::role(el) {
+                let key = normalize_text(&role);
                 if !key.is_empty() {
                     *role_counts.entry(key).or_insert(0) += 1;
                 }
@@ -120,14 +125,14 @@ impl SelectivityIndex {
                     *tag_counts.entry(key).or_insert(0) += 1;
                 }
             }
-            if let Some(label) = el.aria_label.as_deref() {
-                let key = normalize_text(label);
+            if let Some(label) = derive::aria_label(el) {
+                let key = normalize_text(&label);
                 if !key.is_empty() {
                     *aria_label_counts.entry(key).or_insert(0) += 1;
                 }
             }
-            if let Some(text) = el.text.as_deref() {
-                let normalized = normalize_text(text);
+            if let Some(text) = derive::text(el) {
+                let normalized = normalize_text(&text);
                 // Per-element dedup so an element with repeated tokens
                 // doesn't inflate the count for its own posting.
                 let mut seen_in_el: std::collections::HashSet<&str> =
@@ -318,17 +323,16 @@ pub(crate) fn score_element_against(
     let mut diffs: Vec<FieldDiff> = Vec::new();
 
     if let Some(role) = crit.role.as_deref() {
-        let sim = score_role(role, &el.role);
+        let observed = derive::role(el);
+        let sim = score_role(role, &observed);
         let w = sel.weight_for_role(role);
         score += sim * w;
         if sim < 1.0 {
             diffs.push(FieldDiff {
                 field: "role".to_string(),
                 expected: serde_json::Value::String(role.to_string()),
-                actual: el
-                    .role
-                    .as_ref()
-                    .map(|s| serde_json::Value::String(s.clone()))
+                actual: observed
+                    .map(serde_json::Value::String)
                     .unwrap_or(serde_json::Value::Null),
                 similarity: sim,
             });
@@ -354,17 +358,16 @@ pub(crate) fn score_element_against(
     }
 
     if let Some(text) = crit.text.as_deref() {
-        let sim = score_text(text, &el.text);
+        let observed = derive::text(el);
+        let sim = score_text(text, &observed);
         let w = sel.weight_for_text_phrase(text);
         score += sim * w;
         if sim < 1.0 {
             diffs.push(FieldDiff {
                 field: "text".to_string(),
                 expected: serde_json::Value::String(text.to_string()),
-                actual: el
-                    .text
-                    .as_ref()
-                    .map(|s| serde_json::Value::String(s.clone()))
+                actual: observed
+                    .map(serde_json::Value::String)
                     .unwrap_or(serde_json::Value::Null),
                 similarity: sim,
             });
@@ -374,24 +377,22 @@ pub(crate) fn score_element_against(
     if let Some(needle) = crit.text_contains.as_deref() {
         // text_contains is asymmetric — emit 1.0 if the observed text
         // contains the needle, else use score_text similarity for the diff.
-        let observed_lower = el
-            .text
-            .as_ref()
-            .map(|s| normalize_text(s))
+        let observed = derive::text(el);
+        let observed_lower = observed
+            .as_deref()
+            .map(normalize_text)
             .unwrap_or_default();
         let needle_lower = normalize_text(needle);
         let contains = !needle_lower.is_empty() && observed_lower.contains(&needle_lower);
-        let sim = if contains { 1.0 } else { score_text(needle, &el.text) };
+        let sim = if contains { 1.0 } else { score_text(needle, &observed) };
         let w = sel.weight_for_text_phrase(needle);
         score += sim * w;
         if sim < 1.0 {
             diffs.push(FieldDiff {
                 field: "textContains".to_string(),
                 expected: serde_json::Value::String(needle.to_string()),
-                actual: el
-                    .text
-                    .as_ref()
-                    .map(|s| serde_json::Value::String(s.clone()))
+                actual: observed
+                    .map(serde_json::Value::String)
                     .unwrap_or(serde_json::Value::Null),
                 similarity: sim,
             });
@@ -399,17 +400,16 @@ pub(crate) fn score_element_against(
     }
 
     if let Some(label) = crit.aria_label.as_deref() {
-        let sim = score_aria_label(label, &el.aria_label);
+        let observed = derive::aria_label(el);
+        let sim = score_aria_label(label, &observed);
         let w = sel.weight_for_aria_label(label);
         score += sim * w;
         if sim < 1.0 {
             diffs.push(FieldDiff {
                 field: "ariaLabel".to_string(),
                 expected: serde_json::Value::String(label.to_string()),
-                actual: el
-                    .aria_label
-                    .as_ref()
-                    .map(|s| serde_json::Value::String(s.clone()))
+                actual: observed
+                    .map(serde_json::Value::String)
                     .unwrap_or(serde_json::Value::Null),
                 similarity: sim,
             });
@@ -417,17 +417,16 @@ pub(crate) fn score_element_against(
     }
 
     if let Some(name) = crit.accessible_name.as_deref() {
-        let sim = score_text(name, &el.accessible_name);
+        let observed = derive::accessible_name(el);
+        let sim = score_text(name, &observed);
         let w = sel.weight_for_text_phrase(name);
         score += sim * w;
         if sim < 1.0 {
             diffs.push(FieldDiff {
                 field: "accessibleName".to_string(),
                 expected: serde_json::Value::String(name.to_string()),
-                actual: el
-                    .accessible_name
-                    .as_ref()
-                    .map(|s| serde_json::Value::String(s.clone()))
+                actual: observed
+                    .map(serde_json::Value::String)
                     .unwrap_or(serde_json::Value::Null),
                 similarity: sim,
             });
@@ -603,8 +602,12 @@ fn into_candidate_miss(
     let el = indexed.element(idx);
     CandidateMiss {
         element_id: Some(el.id.clone()).filter(|s| !s.is_empty()),
-        role: el.role.clone().filter(|s| !s.is_empty()),
-        text: el.text.clone().filter(|s| !s.is_empty()),
+        // Surface derived values for parity with the matcher's effective view
+        // — top-level `el.role` / `el.text` are almost always None on the
+        // live wire (the SDK populates `tag_name` / `state.text_content`
+        // instead). See `evaluator::matched_from` for the same reasoning.
+        role: derive::role(el).filter(|s| !s.is_empty()),
+        text: derive::text(el).filter(|s| !s.is_empty()),
         path: el.identifier.selector.clone(),
         field_diffs,
         score,

--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -22,6 +22,7 @@ use qontinui_types::ir::{IrAssertion, IrElementCriteria, IrPageSpec, IrState};
 
 use crate::confidence::recommend_state;
 use crate::criteria::{matches_all, narrow_candidates};
+use crate::derive;
 use crate::diff::compute_miss;
 use crate::fetch::{compute_content_sha256, millis_to_iso8601};
 use crate::snapshot::{ElementIdx, IndexedSnapshot};
@@ -261,8 +262,12 @@ fn matched_from(indexed: &IndexedSnapshot, idx: ElementIdx) -> MatchedElement {
     let el = indexed.element(idx);
     MatchedElement {
         element_id: Some(el.id.clone()).filter(|s| !s.is_empty()),
-        role: el.role.clone().filter(|s| !s.is_empty()),
-        text: el.text.clone().filter(|s| !s.is_empty()),
+        // Report the *derived* role/text — top-level `el.role` / `el.text`
+        // are almost always None on the live wire, so callers that surface
+        // these to AI/users need the resolved values to make sense of
+        // matches that came through the tagName / textContent fallbacks.
+        role: derive::role(el).filter(|s| !s.is_empty()),
+        text: derive::text(el).filter(|s| !s.is_empty()),
         path: el.identifier.selector.clone(),
     }
 }

--- a/crates/spec-check/src/lib.rs
+++ b/crates/spec-check/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod confidence;
 pub mod criteria;
+pub mod derive;
 pub mod diff;
 pub mod evaluator;
 pub mod fetch;

--- a/crates/spec-check/src/snapshot.rs
+++ b/crates/spec-check/src/snapshot.rs
@@ -14,6 +14,8 @@ use std::collections::HashMap;
 use qontinui_types::text_norm::normalize_text;
 use qontinui_types::ui_bridge::{UIBridgeElement, UIBridgeSnapshot};
 
+use crate::derive;
+
 /// Stable index into [`UIBridgeSnapshot::elements`]. Minted by
 /// [`IndexedSnapshot::new`] — never construct manually unless you know what
 /// you are doing.
@@ -72,15 +74,18 @@ impl<'a> IndexedSnapshot<'a> {
         for (i, el) in raw.elements.iter().enumerate() {
             let idx = ElementIdx(i as u32);
 
-            // -- role (Addendum A.5)
-            if let Some(role) = el.role.as_deref() {
-                let key = normalize_text(role);
+            // -- role: derived (top-level `el.role` → tag-implicit role →
+            //    `element_type` keyword) so a `{role: "heading"}` criterion
+            //    finds `<h1>` even when the SDK didn't populate top-level
+            //    role. See `crate::derive::role`.
+            if let Some(role) = derive::role(el) {
+                let key = normalize_text(&role);
                 if !key.is_empty() {
                     by_role.entry(key).or_default().push(idx);
                 }
             }
 
-            // -- tag_name (Addendum A.5)
+            // -- tag_name (Addendum A.5) — no derivation, raw field.
             if let Some(tag) = el.tag_name.as_deref() {
                 let key = normalize_text(tag);
                 if !key.is_empty() {
@@ -88,17 +93,18 @@ impl<'a> IndexedSnapshot<'a> {
                 }
             }
 
-            // -- aria_label (Addendum A.5)
-            if let Some(label) = el.aria_label.as_deref() {
-                let key = normalize_text(label);
+            // -- aria_label: derived (top-level `el.aria_label` → `el.label`).
+            if let Some(label) = derive::aria_label(el) {
+                let key = normalize_text(&label);
                 if !key.is_empty() {
                     by_aria_label.entry(key).or_default().push(idx);
                 }
             }
 
-            // -- accessible_name (Addendum A.5)
-            if let Some(name) = el.accessible_name.as_deref() {
-                let key = normalize_text(name);
+            // -- accessible_name: derived (top-level → `el.label` →
+            //    `state.text_content`).
+            if let Some(name) = derive::accessible_name(el) {
+                let key = normalize_text(&name);
                 if !key.is_empty() {
                     by_accessible_name.entry(key).or_default().push(idx);
                 }
@@ -119,9 +125,11 @@ impl<'a> IndexedSnapshot<'a> {
                 insert_id_key(&mut by_id, v, idx);
             }
 
-            // -- text inverted index (tokenize on ASCII whitespace post-normalization)
-            if let Some(text) = el.text.as_deref() {
-                let normalized = normalize_text(text);
+            // -- text inverted index: derived (top-level `el.text` →
+            //    `state.text_content` → `el.label`). Tokenize on ASCII
+            //    whitespace post-normalization.
+            if let Some(text) = derive::text(el) {
+                let normalized = normalize_text(&text);
                 for word in normalized.split_ascii_whitespace() {
                     if word.is_empty() {
                         continue;


### PR DESCRIPTION
## Summary

Fixes the spec-check matcher: every spec returned `matchOutcome: "no_match"` with `matchRate: 0.0` across every page, every app, because the matcher narrowed on top-level `UIBridgeElement.role` / `.text` / `.accessibleName` / `.ariaLabel` — all of which the live SDK leaves `null`. The information is on the wire, just in different slots.

- New \`crates/spec-check/src/derive.rs\` with \`role\` / \`text\` / \`accessible_name\` / \`aria_label\` getters that prefer the direct field and fall back through tagName-implicit-role, \`element_type\` keyword, \`label\`, and \`state.text_content\`.
- Derivation wired into the matcher (\`criteria.rs\`), the indexer (\`snapshot.rs\`), the Phase-2 diagnostic (\`diff.rs\`), and the \`MatchedElement\` / \`CandidateMiss\` reporters so callers see the effective values.

## Live verification (temp runner port 9877, settings-general spec, against \`/\`)

| | matchOutcome | overallMatchRate | best state matchRate |
|---|---|---|---|
| before | \`no_match\` | 0.0 | 0.0 (every state) |
| after  | \`partial_match\` | 0.167 | 0.667 |

Failing assertions now correctly classified as \`text_mismatch\` vs \`no_candidates\` depending on whether candidates exist on the current page. Passing assertions confirm derivation paths: \`button-sign-in\` matched as \`role: "button"\` (from tagName) with \`text: "Sign In"\` (from \`state.text_content\`); \`content-paragraph-runner-0\` matched as \`role: "paragraph"\` from tagName \`<p>\`.

## Test plan

- [x] \`cargo test --package qontinui-spec-check\` — 165 unit + 2 integration tests pass
- [x] \`cargo check --workspace --tests\` — clean across runner + crates + clorinde
- [x] End-to-end via temp runner with rebuild — matchRate went from 0.0 to 0.167 with \`partial_match\` outcome and correctly-classified miss reasons
- [x] 5 new live-snapshot regression tests in \`criteria.rs\` covering \`{role: "heading", text: "Hello"}\` against synthetic \`<h1>\` with \`role: null\` + \`state.textContent: "Hello"\`, \`accessibleName\` fallback through \`label\`, text fallback through \`state.text_content\`, input \`role\` derived from \`element_type\`, and indexer population via derivation
- [x] 14 new \`derive.rs\` tests covering per-tag role mapping, input-type-to-role, fallback chains, and whitespace-only edge cases

The 0.5-threshold acceptance criterion from the brief is for a logged-in runner on the actual settings-general page — that side requires manual navigation; the matcher correctness side is fully proven by the regression tests and the live partial_match signal.