### PR TITLE
fix(runner): add tenant_id to device-pair test destructures (unbreak main)

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -1158,10 +1158,12 @@ mod tests {
                     DeviceCmd::Pair {
                         auth_token,
                         browser,
+                        tenant_id,
                     },
             }) => {
                 assert_eq!(auth_token.as_deref(), Some("oauth"));
                 assert!(!browser);
+                assert!(tenant_id.is_none());
             }
             other => panic!("expected Device::Pair, got {:?}", other),
         }
@@ -1177,10 +1179,12 @@ mod tests {
                     DeviceCmd::Pair {
                         auth_token,
                         browser,
+                        tenant_id,
                     },
             }) => {
                 assert!(auth_token.is_none());
                 assert!(browser);
+                assert!(tenant_id.is_none());
             }
             other => panic!("expected Device::Pair {{browser}}, got {:?}", other),
         }


### PR DESCRIPTION
## Summary

PR #208 (`76f868a4` — `feat(runner): --tenant-id flag + OAuth-claim auto-resolve on device pair`) added `tenant_id: Option<String>` to the `DeviceCmd::Pair` variant in `src-tauri/src/bin/qontinui_profile.rs` but missed two existing tests that destructure the variant:

- `qontinui_profile.rs:1158` in `device_pair_parses_with_auth_token`
- `qontinui_profile.rs:1177` in `device_pair_parses_with_browser_flag`

Both produce `error[E0027]: pattern does not mention field 'tenant_id'`, breaking the `test` job on both `ubuntu-22.04` and `windows-latest` since #208 merged at 17:58Z. Main has been red since.

## Fix

Add `tenant_id` to both destructure patterns and assert `tenant_id.is_none()` (the default — neither test passes `--tenant-id`). 4 lines added, no logic change to non-test code.

## Test plan

- [x] `cargo check --tests --bin qontinui_profile` exits 0 locally
- [ ] CI `test (ubuntu-22.04)` passes
- [ ] CI `test (windows-latest)` passes