### PR TITLE
feat(runner): Phase 2.2 — switch sccache to shared S3 backend

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,6 +1,16 @@
-# Row 2 Phase 2 — sccache defaults for the LAN-shared compile-unit
-# cache backed by canonical MinIO. See
-# plans/2026-05-14-fleet-topology-and-build-pool-design.md §3.3.
+# sccache defaults for the shared compile-unit cache (Phase 2.2 cutover
+# from in-stack MinIO to real AWS S3). See
+# plans/2026-05-14-fleet-topology-and-build-pool-design.md §3.3 and
+# plans/2026-05-21-coordination-improvements.md Phase 2.
+#
+# sccache wired to shared AWS S3 (qontinui-sccache-shared, us-east-1).
+# Developer setup (env exports + daemon restart): see
+# qontinui-stack/docs/sccache-cross-machine.md.
+#
+# The in-stack docker-compose MinIO lane (`qontinui-sccache` bucket via
+# `minio:9000`) is unchanged — it serves the compose-internal CI path,
+# while this file points developer machines at real AWS S3 so spaceship
+# and MSI share artifacts directly without going through canonical.
 #
 # RUSTC_WRAPPER is intentionally NOT pinned here. Opt in by exporting
 # `RUSTC_WRAPPER=sccache` in the invoking shell — dev-start.ps1,
@@ -10,14 +20,16 @@
 # RUSTC_WRAPPER is set, sccache picks up the SCCACHE_* defaults below
 # — same bucket, same region, same prefix, fleet-wide.
 #
-# SCCACHE_ENDPOINT + AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY are
-# also per-machine env (LAN IP varies, creds sensitive). dev-start.ps1
-# and cargo-guard.sh export them from ~/.qontinui/profile.
+# AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY are per-machine env (creds
+# sensitive). dev-start.ps1 and cargo-guard.sh export them from
+# ~/.qontinui/profile.
 [env]
-SCCACHE_BUCKET = { value = "qontinui-sccache", force = false }
+SCCACHE_BUCKET = { value = "qontinui-sccache-shared", force = false }
 SCCACHE_REGION = { value = "us-east-1", force = false }
-SCCACHE_S3_USE_SSL = { value = "off", force = false }
 SCCACHE_S3_KEY_PREFIX = { value = "sccache", force = false }
+# SCCACHE_S3_USE_SSL omitted — defaults on for real AWS S3.
+# SCCACHE_ENDPOINT / SCCACHE_MINIO_HOST omitted — real S3 uses the
+# default regional endpoint; in-stack MinIO env stays in docker-compose.
 
 # Increase linker stack size to prevent STATUS_STACK_BUFFER_OVERRUN
 # when linking the large test binary on Windows. Default MSVC stack is


### PR DESCRIPTION
## Summary

Phase 2.2 of `plans/2026-05-21-coordination-improvements.md` — cuts the `src-tauri/.cargo/config.toml` SCCACHE_* defaults from the in-stack MinIO bucket (`qontinui-sccache`) to the shared real-AWS S3 bucket provisioned in Phase 2.1 (`qontinui-sccache-shared`, `us-east-1`), so spaceship + MSI build hosts share rustc compile-unit cache artifacts directly.

The in-stack docker-compose MinIO lane is **unchanged** — it still serves compose-internal CI builds via the local MinIO bucket. This change only affects developer-machine builds.

## Diff summary

- `SCCACHE_BUCKET`: `"qontinui-sccache"` → `"qontinui-sccache-shared"`
- `SCCACHE_REGION`: unchanged (`"us-east-1"`)
- `SCCACHE_S3_KEY_PREFIX`: unchanged (`"sccache"`)
- `SCCACHE_S3_USE_SSL = "off"` removed — sccache defaults to TLS for real AWS S3
- Header comment rewritten to point at `qontinui-stack/docs/sccache-cross-machine.md`

**Preserved unchanged:** all `[target.*]` blocks — Windows `/STACK:8388608 /Brepro` link args (linker stack-size fix + repro flag), Linux `--build-id=none`, and all `--remap-path-prefix` entries for cross-worktree cache-key parity.

## Developer migration (operator action required on MSI + spaceship)

Per `feedback_sccache_daemon_env_inheritance` — sccache picks up env at fork, so the daemon must be bounced after pulling:

```bash
sccache --stop-server
sccache --start-server
sccache --show-stats   # must report "Bucket(name=qontinui-sccache-shared)"
```

Per-shell setup (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` exports, `unset SCCACHE_ENDPOINT` etc.): see `qontinui-stack/docs/sccache-cross-machine.md` for the operator-side step-by-step.

If `--show-stats` still reports `Bucket(name=qontinui-sccache)` after a daemon restart, your shell still has stale `SCCACHE_*` env from the old in-stack setup overriding the new `.cargo/config.toml` defaults — re-export per the doc, then bounce again.

## Test plan

- [x] TOML parse-check via `tomllib` — clean
- [x] Confirmed `qontinui-stack/docker-compose.yml` sccache service env-vars untouched (in-stack lane still uses MinIO bucket)
- [x] Cross-checked against coord twin (`qontinui-coord` Phase 2.2 PR) which compiled green via `cargo check`
- [ ] CI ubuntu + windows green
- [ ] CI macOS green OR hang >90min (admin-merge per `feedback_macos_ci_env_hang_admin_merge`)
- [ ] Operator: bounce sccache daemon on MSI + spaceship after merge, confirm `--show-stats` reports the new bucket
- [ ] Phase 2.3 (separate agent) measures the cross-machine cycle-time hit-rate gain

## Verification notes

Full `cargo check` not runnable in the implementation worktree because the `qontinui-schemas` path-dep sibling isn't laid out under `tmp_coord_improvements/`. Worked around with a junction during fmt verification; clippy gate skipped via `QONTINUI_PREPUSH_SKIP=1` (per `feedback_fresh_worktree_prepush_skip`) because the failure was the fresh-worktree env (`frontendDist` missing, `ui-bridge-build-ir` not on PATH), not lint drift in our change. CI re-gates on real infrastructure.

Session-Id: b5e52c01-6fbc-496a-93b4-f9063449c210