### PR TITLE
build(runner): pin rust-toolchain to 1.95.0 for cross-machine sccache parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,15 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
+      # Pin matches rust-toolchain.toml (channel = "1.95.0"). The toolchain
+      # file overrides any other channel for every cargo invocation, so the
+      # rustfmt/clippy components must be installed for 1.95.0 specifically —
+      # otherwise `cargo fmt`/`cargo clippy` auto-switch to a component-less
+      # 1.95.0 and fail with "'cargo-fmt' is not installed".
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - name: Install dependencies (Ubuntu)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.95.0"


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` pinning rustc to exactly `1.95.0` at the runner repo root.

## Why
The cross-machine sccache cache (bucket `qontinui-sccache-shared`, shipped Phase 2.2) delivers ~0% benefit between machines on different default rustc versions because sccache cache keys include the rustc version. Pinning an exact toolchain makes cache keys deterministic across machines and scales to N machines / deterministic CI, instead of relying on every machine manually staying in sync.

Adding `rust-toolchain.toml` means CI runners auto-install 1.95.0 via rustup on next run — the intended effect.

## Verification
- `rustup toolchain install 1.95.0` (already present on spaceship — `rustc 1.95.0 (59807616e 2026-04-14)`)
- Local `cargo +1.95.0 check` against the workspace under the pinned toolchain
- CI (ubuntu/windows/macOS) is the authoritative gate

Part of the Stream-2.4 cross-machine sccache parity follow-up.