### PR TITLE
fix(settings): wire 'settings-account' MainTabId so Settings → Account renders

### DIFF
--- a/src/components/app/TabContent.tsx
+++ b/src/components/app/TabContent.tsx
@@ -947,6 +947,7 @@ export function TabContent({
       );
 
     case "settings":
+    case "settings-account":
     case "settings-ai":
     case "settings-agentic":
     case "settings-self-healing":
@@ -967,6 +968,7 @@ export function TabContent({
     case "settings-updates": {
       const settingsTabMap: Record<string, string> = {
         settings: "backend-connection",
+        "settings-account": "account",
         "settings-ai": "ai",
         "settings-agentic": "agentic",
         "settings-self-healing": "self-healing",

--- a/src/components/app/tab-types.ts
+++ b/src/components/app/tab-types.ts
@@ -53,6 +53,7 @@ export type MainTabId =
   | "triggers"
   | "tasks"
   | "settings"
+  | "settings-account"
   | "settings-ai"
   | "settings-agentic"
   | "settings-self-healing"
@@ -152,6 +153,7 @@ const VALID_TAB_IDS: MainTabId[] = [
   "triggers",
   "tasks",
   "settings",
+  "settings-account",
   "settings-ai",
   "settings-agentic",
   "settings-self-healing",
@@ -262,6 +264,7 @@ export const TAB_LABELS: Record<MainTabId, string> = {
   triggers: "Triggers",
   tasks: "Scheduler",
   settings: "Settings",
+  "settings-account": "Account Settings",
   "settings-ai": "AI Settings",
   "settings-agentic": "Agentic Settings",
   "settings-self-healing": "Self-Healing Settings",

--- a/src/lib/ui-bridge/UIBridgeHooks.tsx
+++ b/src/lib/ui-bridge/UIBridgeHooks.tsx
@@ -72,6 +72,7 @@ const TAB_GROUPS = {
   tools: ["terminal", "specs", "state-machine", "generator-eval", "config-ui-bridge"],
   system: [
     "settings",
+    "settings-account",
     "settings-ai",
     "settings-agentic",
     "settings-self-healing",


### PR DESCRIPTION
## Summary

Surfaced 2026-05-22 as "Settings → Account shows an empty page" on the primary runner. The Account sub-tab in Settings was added by the tier-decoupling work (commit \`91a4a4621\`) along with \`AccountSettings.tsx\` and a \`{ id: "account" }\` entry in \`SETTINGS_TABS\`, but the corresponding \`"settings-account"\` MainTabId was never wired through the TabContent / tab-types / UIBridge layer the runner uses to route top-level navigation events.

## Click flow with the bug

1. User clicks **Account** in the Settings sub-nav.
2. \`@qontinui/navigation\`'s \`SETTINGS_ITEMS\` table emits a navigation event with id \`settings-account\` (this string IS in the nav package — was the only thing that knew about the tab).
3. Tab system sets \`activeTab = "settings-account"\`.
4. \`TabContent.tsx\` switch (which already lists 17 \`settings-*\` MainTabIds from \`settings-ai\` through \`settings-updates\`) has no \`case "settings-account":\` — falls through to \`default: return null;\`.
5. Content panel renders nothing. Empty page.

## Fix

Add \`"settings-account"\` to all **6** wiring sites, mirroring the pattern the other 17 \`settings-*\` tabs already use. **+6 lines, no removals.**

| File | Site | Line |
|---|---|---|
| \`src/components/app/tab-types.ts\` | \`MainTabId\` union | ~56 |
| \`src/components/app/tab-types.ts\` | \`VALID_TAB_IDS\` array | ~155 |
| \`src/components/app/tab-types.ts\` | \`TAB_LABELS\` record | ~265 |
| \`src/components/app/TabContent.tsx\` | switch \`case\` in settings-* block | ~950 |
| \`src/components/app/TabContent.tsx\` | \`settingsTabMap\` entry (\`settings-account\` → \`account\`) | ~970 |
| \`src/lib/ui-bridge/UIBridgeHooks.tsx\` | \`TAB_GROUPS.system\` array | ~74 |

## Test plan

- [x] \`npm run typecheck\` clean (canonical clone with node_modules installed).
- [x] \`npm run build\` emits a 15.5MB \`index-NTZ3Puds.js\`. Verified both wirings made it into the minified output:
  - \`case"settings-account"\` (the TabContent switch case)
  - \`"settings-account":"account"\` (the settingsTabMap entry)
- [ ] **Live UI verification deferred** — temp runner verification was blocked by an unrelated auth-creds issue (the \`VITE_DEV_PASSWORD\` in \`qontinui-runner/.env\` is no longer accepted by the local web backend — \`"Invalid email or password"\`). The primary runner is signed in but cannot be restarted per \`/ufix\` rules. The fix is confirmed by pattern parity with the 17 working \`settings-*\` tabs.

The user will see the fix on the next regular runner rebuild — either by the supervisor's build pool refreshing the LKG, or by an operator-triggered rebuild.