### PR TITLE
feat(runner): supply tenant_id to coord on heartbeat + CLI register

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -493,6 +493,12 @@ fn paired_user_path() -> Option<PathBuf> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PairedUserFile {
     user_id: String,
+    /// Mirror of `qontinui_runner_lib::pair::PairedUserFile::tenant_id`.
+    /// `#[serde(default)]` keeps legacy files (user_id-only) parsing.
+    /// The CLI bootstrap (`register_with_coord`) forwards this to coord
+    /// on `POST /coord/devices/register`; absent → JWT-claim fallback.
+    #[serde(default)]
+    tenant_id: Option<String>,
 }
 
 fn load_paired_user_id() -> Option<String> {
@@ -500,6 +506,17 @@ fn load_paired_user_id() -> Option<String> {
     let bytes = std::fs::read(&path).ok()?;
     let parsed: PairedUserFile = serde_json::from_slice(&bytes).ok()?;
     Some(parsed.user_id)
+}
+
+/// Load `(user_id, tenant_id_opt)` from `paired_user.json`. Returns
+/// `None` if the file doesn't exist or isn't parseable. Phase 2 of the
+/// default-tenant-propagation plan — the CLI bootstrap needs both
+/// fields to satisfy coord's `tenant_id_required` gate.
+fn load_paired_user() -> Option<(String, Option<String>)> {
+    let path = paired_user_path()?;
+    let bytes = std::fs::read(&path).ok()?;
+    let parsed: PairedUserFile = serde_json::from_slice(&bytes).ok()?;
+    Some((parsed.user_id, parsed.tenant_id))
 }
 
 fn cmd_device_path() -> ExitCode {
@@ -586,12 +603,41 @@ fn cmd_device_init(name_arg: Option<&str>) -> ExitCode {
     // machine.json is the canonical record; coord.devices is a derived view
     // (qontinui-coord re-syncs from machine.json on next /coord/status POST).
     let display_name = file.name.clone().unwrap_or_else(|| file.hostname.clone());
-    let paired_user_id = load_paired_user_id();
+    let paired = load_paired_user();
+    let (paired_user_id, paired_tenant_id) = match paired {
+        Some((uid, tid)) => (Some(uid), tid),
+        None => (None, None),
+    };
+    // Resolve tenant_id for the register payload (coord rejects with
+    // 400 `tenant_id_required` otherwise). Order: paired_user.json
+    // → cached device-token JWT claim → hard error. Matches the
+    // heartbeat resolution chain in `fleet::resolve_tenant_id`.
+    let tenant_id = match paired_tenant_id {
+        Some(s) => s,
+        None => {
+            let token = qontinui_runner_lib::auth::AuthManager::new()
+                .get_access_token()
+                .unwrap_or_default();
+            match tenant_id_from_oauth_claim(&token) {
+                Some(s) => s,
+                None => {
+                    eprintln!(
+                        "warning: cannot register with coord — tenant_id unresolvable. \
+                         Run `qontinui_profile device pair --tenant-id <uuid> [--auth-token <oauth>]` \
+                         first so coord knows which tenant owns this device.\n\
+                         (machine.json was still written.)"
+                    );
+                    return ExitCode::SUCCESS;
+                }
+            }
+        }
+    };
     match register_with_coord(
         &file.device_id,
         &file.hostname,
         &display_name,
         paired_user_id.as_deref(),
+        &tenant_id,
     ) {
         Ok(()) => {
             println!("registered with coord via HTTP (POST /coord/devices/register)");
@@ -765,7 +811,7 @@ fn cmd_device_pair(
     };
     match result {
         Ok(resp) => {
-            if let Err(e) = persist_pairing(&resp) {
+            if let Err(e) = persist_pairing(&resp, tenant_id) {
                 eprintln!(
                     "error: pairing succeeded but persisting locally failed: {}",
                     e
@@ -811,6 +857,7 @@ fn register_with_coord(
     hostname: &str,
     name: &str,
     user_id: Option<&str>,
+    tenant_id: &str,
 ) -> Result<(), String> {
     // Validate UUID shape up front so a malformed machine.json fails fast
     // with a clear error instead of bouncing off a 400 from coord.
@@ -820,12 +867,18 @@ fn register_with_coord(
         uuid::Uuid::parse_str(uid)
             .map_err(|e| format!("paired user_id is not a valid UUID: {}", e))?;
     }
+    let _ = uuid::Uuid::parse_str(tenant_id)
+        .map_err(|e| format!("tenant_id is not a valid UUID: {}", e))?;
     let base = coord_http_base()?;
     let url = format!("{}/coord/devices/register", base);
     // `device_id` is the canonical name in coord.devices. We also emit
     // `machine_id` as a duplicate alias key for back-compat with a Phase-2
     // coord that still reads the old name — the field is removed once
     // Phase 2 is merged everywhere.
+    //
+    // `tenant_id` is REQUIRED by coord's `post_device_register` handler
+    // (`routes_phase3.rs:257-269` returns `400 tenant_id_required`
+    // otherwise). Phase 2 of the default-tenant-propagation plan.
     let body = serde_json::json!({
         "device_id":    device_id,
         "machine_id":   device_id,
@@ -835,6 +888,7 @@ fn register_with_coord(
         "os_version":   detect_os_version(),
         "capabilities": vec!["runner".to_string()],
         "user_id":      user_id,
+        "tenant_id":    tenant_id,
         "health_url":   serde_json::Value::Null,
     });
     let client = reqwest::blocking::Client::builder()

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -144,6 +144,63 @@ fn load_device_file() -> Option<DeviceFile> {
     serde_json::from_slice(&bytes).ok()
 }
 
+/// Resolve the device's `tenant_id` for coord-side requests
+/// (`POST /coord/devices/register`). Returns the first hit:
+///
+/// 1. `paired_user.json::tenant_id` — present on newly-paired devices
+///    (written by `pair::persist_pairing` since 2026-05-22).
+/// 2. JWT-claim fallback — decode `tenant_id` from the cached
+///    device-token JWT via
+///    [`qontinui_runner_lib::pair::tenant_id_from_oauth_claim`].
+///    On success, opportunistically rewrites `paired_user.json` with
+///    the resolved value so subsequent heartbeats hit branch 1.
+///    Best-effort: rewrite IO errors are swallowed.
+/// 3. `None` — neither source has a usable tenant_id. Callers must
+///    skip the request (coord rejects with `400 tenant_id_required`).
+fn resolve_tenant_id() -> Option<uuid::Uuid> {
+    // Branch 1 — paired_user.json
+    if let Some(s) = qontinui_runner_lib::pair::read_paired_tenant_id_from_disk() {
+        if let Ok(t) = uuid::Uuid::parse_str(s.trim()) {
+            return Some(t);
+        }
+    }
+
+    // Branch 2 — cached device-token JWT
+    let token = crate::auth::AuthManager::new()
+        .get_access_token()
+        .ok()
+        .unwrap_or_default();
+    if token.is_empty() {
+        return None;
+    }
+    let claim = qontinui_runner_lib::pair::tenant_id_from_oauth_claim(&token)?;
+    let parsed = uuid::Uuid::parse_str(claim.trim()).ok()?;
+
+    // Opportunistic backfill — best-effort, ignore IO errors.
+    if let Err(e) = qontinui_runner_lib::pair::backfill_paired_tenant_id(&parsed) {
+        tracing::debug!("fleet::resolve_tenant_id: backfill non-fatal: {e}");
+    }
+
+    Some(parsed)
+}
+
+/// Dedupe the "tenant_id unresolvable" startup warning — the heartbeat
+/// ticks every 30s so logging on every miss would flood the journal.
+/// Fires exactly once per process lifetime; subsequent skips are silent
+/// (the operator already saw the recovery hint).
+static TENANT_ID_UNRESOLVABLE_WARNED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn warn_tenant_id_unresolvable_once() {
+    if !TENANT_ID_UNRESOLVABLE_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        warn!(
+            "fleet::heartbeat: tenant_id unresolvable (no paired_user.json::tenant_id, \
+             no claim in cached device-token JWT); skipping all heartbeats until next runner \
+             restart. Re-run `qontinui_profile device pair --tenant-id <uuid>` to recover."
+        );
+    }
+}
+
 /// Cache file for the last successful budget payload. Inspectable when
 /// coord is unreachable; lets operators verify "what was advertised" from
 /// the runner side without coord access. Path: `~/.qontinui/last_budget.json`.
@@ -417,6 +474,13 @@ struct HeartbeatPayload {
     /// the heartbeat's hot path cheap.
     #[serde(skip_serializing_if = "is_false")]
     claude_code_available: bool,
+    /// REQUIRED by coord's `post_device_register` handler — absence
+    /// produces `400 tenant_id_required` (see qontinui-coord
+    /// `routes_phase3.rs:257-269`). Resolved via [`resolve_tenant_id`]
+    /// before the payload is constructed; if `None` there, the
+    /// heartbeat is skipped rather than 400-spamming coord.
+    /// Phase 2 of the default-tenant-propagation plan.
+    tenant_id: uuid::Uuid,
 }
 
 /// Suppress serializing the field when it's the default. Keeps the
@@ -470,12 +534,21 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
         }
     };
 
+    let tenant_id = match resolve_tenant_id() {
+        Some(t) => t,
+        None => {
+            warn_tenant_id_unresolvable_once();
+            return Ok(());
+        }
+    };
+
     let claude_code_available = claude_code_probe();
 
     let payload = HeartbeatPayload {
         device_id,
         hostname: device.hostname.clone(),
         claude_code_available,
+        tenant_id,
     };
     let url = format!("{base}/coord/devices/register");
 
@@ -1144,6 +1217,7 @@ mod tests {
             device_id: uuid::Uuid::nil(),
             hostname: "test".into(),
             claude_code_available: false,
+            tenant_id: uuid::Uuid::nil(),
         };
         let body = serde_json::to_value(&p).unwrap();
         assert!(
@@ -1158,12 +1232,53 @@ mod tests {
             device_id: uuid::Uuid::nil(),
             hostname: "test".into(),
             claude_code_available: true,
+            tenant_id: uuid::Uuid::nil(),
         };
         let body = serde_json::to_value(&p).unwrap();
         assert_eq!(
             body.get("claude_code_available").and_then(|v| v.as_bool()),
             Some(true),
             "true value must appear on the heartbeat wire"
+        );
+    }
+
+    /// `tenant_id` is REQUIRED by coord — `post_device_register` rejects
+    /// with `400 tenant_id_required` if the field is absent. Pin that the
+    /// serialized wire shape includes the field as a UUID string.
+    /// Phase 2 of the default-tenant-propagation plan.
+    #[test]
+    fn heartbeat_payload_serializes_with_tenant_id() {
+        let tenant = uuid::Uuid::parse_str("11111111-2222-3333-4444-555555555555").unwrap();
+        let p = HeartbeatPayload {
+            device_id: uuid::Uuid::nil(),
+            hostname: "test".into(),
+            claude_code_available: true,
+            tenant_id: tenant,
+        };
+        let body = serde_json::to_value(&p).unwrap();
+        assert_eq!(
+            body.get("tenant_id").and_then(|v| v.as_str()),
+            Some("11111111-2222-3333-4444-555555555555"),
+            "tenant_id must serialize as a UUID string on the heartbeat wire"
+        );
+    }
+
+    /// Regression guard against future refactors that drop
+    /// `claude_code_available` when extending `HeartbeatPayload`. PR #216
+    /// shipped this field; the auditor spawn path depends on it.
+    #[test]
+    fn heartbeat_payload_still_includes_claude_code_available() {
+        let p = HeartbeatPayload {
+            device_id: uuid::Uuid::nil(),
+            hostname: "test".into(),
+            claude_code_available: true,
+            tenant_id: uuid::Uuid::nil(),
+        };
+        let body = serde_json::to_value(&p).unwrap();
+        assert_eq!(
+            body.get("claude_code_available").and_then(|v| v.as_bool()),
+            Some(true),
+            "claude_code_available must remain on the heartbeat wire (PR #216 shape)"
         );
     }
 }

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -139,6 +139,14 @@ pub(crate) fn paired_user_path() -> Option<PathBuf> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct PairedUserFile {
     pub user_id: String,
+    /// Stringified UUID. `#[serde(default)]` keeps legacy files
+    /// (written before the 2026-05-22 schema bump) deserializing
+    /// — they carry only `user_id`. A heartbeat/register caller
+    /// that finds `None` here falls back to decoding the cached
+    /// device-token JWT via [`tenant_id_from_oauth_claim`]
+    /// (see `fleet::resolve_tenant_id`).
+    #[serde(default)]
+    pub tenant_id: Option<String>,
 }
 
 /// Read the cached `user_id` written by a prior browser-pair. Returns
@@ -155,6 +163,52 @@ fn read_paired_user_id() -> Option<String> {
     let bytes = std::fs::read(&path).ok()?;
     let parsed: PairedUserFile = serde_json::from_slice(&bytes).ok()?;
     Some(parsed.user_id)
+}
+
+/// Read the cached `tenant_id` from `paired_user.json`. Returns `None`
+/// if the file is missing OR the field is absent (legacy file written
+/// before the 2026-05-22 schema bump). Used by
+/// `fleet::resolve_tenant_id` as the primary resolution branch.
+pub fn read_paired_tenant_id_from_disk() -> Option<String> {
+    let path = paired_user_path()?;
+    let bytes = std::fs::read(&path).ok()?;
+    let parsed: PairedUserFile = serde_json::from_slice(&bytes).ok()?;
+    parsed.tenant_id
+}
+
+/// Opportunistically rewrite `paired_user.json` with the supplied
+/// `tenant_id`, preserving the existing `user_id`. Used by
+/// `fleet::resolve_tenant_id`'s JWT-claim fallback so a legacy file
+/// gets backfilled on the first heartbeat after a runner upgrade.
+///
+/// No-op if the file doesn't exist (the JWT-claim path only fires
+/// when SOMETHING was paired previously, but we tolerate the race
+/// where pair-state was wiped between read and write). Returns
+/// `Err(String)` on filesystem failures so the caller can log them
+/// at `debug!` — the outer flow proceeds either way.
+pub fn backfill_paired_tenant_id(tenant_id: &uuid::Uuid) -> Result<(), String> {
+    let path = paired_user_path().ok_or_else(|| "could not resolve data_local_dir".to_string())?;
+    let bytes = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // No paired file → nothing to backfill. Quiet success.
+            return Ok(());
+        }
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    let mut parsed: PairedUserFile =
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {e}", path.display()))?;
+    if parsed.tenant_id.as_deref() == Some(tenant_id.to_string().as_str()) {
+        // Already up-to-date; avoid an unnecessary disk write.
+        return Ok(());
+    }
+    parsed.tenant_id = Some(tenant_id.to_string());
+    let pretty = serde_json::to_vec_pretty(&parsed)
+        .map_err(|e| format!("serialize paired_user.json: {e}"))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &pretty).map_err(|e| format!("write tmp: {e}"))?;
+    std::fs::rename(&tmp, &path).map_err(|e| format!("rename: {e}"))?;
+    Ok(())
 }
 
 // ============================================================================
@@ -556,7 +610,7 @@ pub fn pair_via_browser(
 /// unused for the device-token flow (the device JWT has its own
 /// lifecycle managed by coord); we pass an empty string. See the
 /// format-change comment in `secure_storage.rs`.
-pub fn persist_pairing(resp: &PairCompleteResponse) -> Result<(), String> {
+pub fn persist_pairing(resp: &PairCompleteResponse, tenant_id: uuid::Uuid) -> Result<(), String> {
     use crate::auth::AuthManager;
     let mgr = AuthManager::new();
     mgr.store_tokens(&resp.token, "")
@@ -567,6 +621,7 @@ pub fn persist_pairing(resp: &PairCompleteResponse) -> Result<(), String> {
     }
     let pf = PairedUserFile {
         user_id: resp.user_id.clone(),
+        tenant_id: Some(tenant_id.to_string()),
     };
     let pretty =
         serde_json::to_vec_pretty(&pf).map_err(|e| format!("serialize paired_user.json: {e}"))?;
@@ -761,6 +816,38 @@ mod tests {
             parsed.is_err(),
             "legacy device_token-only payload must NOT decode (token field required)"
         );
+    }
+
+    /// Back-compat: a `paired_user.json` written by a pre-2026-05-22
+    /// runner has only the `user_id` field. The new `tenant_id` field
+    /// carries `#[serde(default)]` so such files must still deserialize
+    /// — they just yield `tenant_id == None` and the heartbeat path
+    /// falls through to the JWT-claim fallback.
+    #[test]
+    fn paired_user_file_back_compat_user_id_only_deserializes() {
+        let raw = r#"{"user_id":"22222222-2222-4222-8222-222222222222"}"#;
+        let parsed: PairedUserFile =
+            serde_json::from_str(raw).expect("legacy user_id-only must deserialize");
+        assert_eq!(parsed.user_id, "22222222-2222-4222-8222-222222222222");
+        assert!(
+            parsed.tenant_id.is_none(),
+            "legacy file must yield tenant_id = None"
+        );
+    }
+
+    /// Forward shape — a newly-written `paired_user.json` round-trips
+    /// both fields. Pins the serde representation against accidental
+    /// `#[serde(rename)]` / `#[serde(skip)]` regressions.
+    #[test]
+    fn paired_user_file_with_tenant_id_round_trips() {
+        let original = PairedUserFile {
+            user_id: "22222222-2222-4222-8222-222222222222".to_string(),
+            tenant_id: Some("11111111-2222-3333-4444-555555555555".to_string()),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let parsed: PairedUserFile = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.user_id, original.user_id);
+        assert_eq!(parsed.tenant_id, original.tenant_id);
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the 400 `tenant_id_required` from coord's `DeviceRegisterRequest` gate (Phase 2 of default-tenant-propagation). Both runner-side callers of `POST /coord/devices/register` — the supervisor heartbeat (`fleet::heartbeat_to_coord`) and the CLI bootstrap (`qontinui_profile::register_with_coord`) — now resolve and supply `tenant_id`.

- **`HeartbeatPayload`** gains a required `tenant_id: Uuid` field (keeps PR #216's `claude_code_available: bool` shape intact).
- **`PairedUserFile`** gains `tenant_id: Option<String>` with `#[serde(default)]` (back-compat read of legacy files).
- **Resolution chain** (runner-only, no coord call): `paired_user.json::tenant_id` → JWT-claim decode of the cached device-token JWT → skip + once-only warn. JWT-fallback opportunistically backfills `paired_user.json`.
- **`persist_pairing(resp, tenant_id)`** persists the locally-resolved tenant_id at pair time. `cmd_device_pair` already had the UUID in scope (line 754 — PR #208).
- **`register_with_coord(..., tenant_id)`** adds the field to the CLI bootstrap body; `cmd_device_init` resolves through the same chain.

No coord-side changes — `DeviceRegisterRequest.tenant_id: Option<Uuid>` already exists with header fallback (`routes_phase3.rs:104`, `tenant_scope::TENANT_HEADER`).

## Plan

`plans/2026-05-22-runner-heartbeat-tenant-id.md` — VETTED 2026-05-22 with 7 defects auto-fixed against `origin/main` HEADs `9997e27b9` (runner) and `e8a8d81` (coord). The original draft proposed a new coord resolver endpoint; vet found the device-token JWT already carries the `tenant_id` claim (`routes_phase3.rs:603`), collapsing scope to a single runner PR.

## Test plan

- [x] `cargo test --workspace` — all suites green (pair tests 16/16, heartbeat tests 4/4).
- [x] `cargo clippy --tests -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [ ] Manual smoke on operator's spaceship (`c79a07d5-7e40-49b4-87fa-554c749f9644`): `last_seen_at` refreshes on coord; `GET /pr-merge/onboarding/precondition-status` flips to `ready: true`.

## Open follow-up

Pre-existing flakes in `auth::tests::test_token_storage` + `auth::device_jwt_tests::needs_refresh_when_no_token` under parallel runs (reproduce on `origin/main` too) — unrelated to this PR.