### PR TITLE
fix(dev): setup-firewall.ps1 resolves subst-mapped paths + purges stale rules

### DIFF
--- a/scripts/setup-firewall.ps1
+++ b/scripts/setup-firewall.ps1
@@ -41,6 +41,40 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# Resolve any `subst`-mapped drive prefix in a path to the underlying
+# physical path. The Windows Firewall service runs as SYSTEM and does NOT
+# see per-logon subst drives, so a `Program=` rule registered against
+# `D:\qontinui-root\...` will not match a process whose kernel image path
+# is `C:\Users\jspin\Documents\qontinui-root\...` (the substed source).
+# Result: rules silently fail to match and every spawn pops the "Allow
+# access" dialog. Resolve substs at rule-creation time so the recorded
+# Program path is what the firewall service actually sees at match time.
+function Resolve-SubstPath {
+    param([Parameter(Mandatory)][string]$Path)
+    # Parse `subst` output once into a drive-letter -> real-root map.
+    # Lines look like: `D:\: => C:\Users\jspin\Documents`
+    $script:_SubstMap = $script:_SubstMap
+    if ($null -eq $script:_SubstMap) {
+        $script:_SubstMap = @{}
+        try {
+            $substOutput = & subst.exe 2>$null
+            foreach ($line in $substOutput) {
+                if ($line -match '^([A-Z]):\\?:\s*=>\s*(.+)$') {
+                    $script:_SubstMap[$matches[1].ToUpper()] = $matches[2].TrimEnd('\')
+                }
+            }
+        } catch { }
+    }
+    if ($Path.Length -ge 2 -and $Path[1] -eq ':') {
+        $letter = $Path.Substring(0,1).ToUpper()
+        if ($script:_SubstMap.ContainsKey($letter)) {
+            $rest = $Path.Substring(2).TrimStart('\')
+            return Join-Path $script:_SubstMap[$letter] $rest
+        }
+    }
+    return $Path
+}
+
 # Verify admin. New-NetFirewallRule silently no-ops without it.
 $current = [System.Security.Principal.WindowsPrincipal]::new(
     [System.Security.Principal.WindowsIdentity]::GetCurrent())
@@ -48,6 +82,18 @@ if (-not $current.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Admin
     Write-Host "ERROR: this script must run elevated. Re-launch from an admin PowerShell or:" -ForegroundColor Red
     Write-Host "  Start-Process pwsh -Verb RunAs -ArgumentList '-File','D:\qontinui-root\qontinui-runner\scripts\setup-firewall.ps1'"
     exit 1
+}
+
+# Purge ANY pre-existing qontinui-multi-app-* rules before recreating. The
+# rule-name format embeds the path basename, so a rename or subst-drive
+# change produces a NEW name on next run and the stale entries would
+# otherwise accumulate forever. The script is the sole owner of this
+# DisplayName prefix; nuking the whole set on each run is safe.
+$stale = Get-NetFirewallRule -DisplayName 'qontinui-multi-app-*' -ErrorAction SilentlyContinue
+$staleCount = @($stale).Count
+if ($staleCount -gt 0) {
+    Write-Host "Removing $staleCount pre-existing qontinui-multi-app-* rules (recreating with current paths)..." -ForegroundColor Yellow
+    $stale | Remove-NetFirewallRule -ErrorAction SilentlyContinue
 }
 
 # Collect every path the supervisor + dev-start might launch.
@@ -81,28 +127,30 @@ $paths.Add((Join-Path $SupervisorRoot "target\debug\copies\qontinui-supervisor.e
 # every qontinui HTTP server binds loopback -- the rule grants no real
 # network exposure, just lets the bind happen without a popup.
 $added = 0
-$skipped = 0
 $failed = 0
 
 foreach ($path in $paths) {
-    $name = "qontinui-multi-app-{0}" -f ([System.IO.Path]::GetFileNameWithoutExtension($path) + "-" + ([System.IO.Path]::GetDirectoryName($path) -split '\\' | Select-Object -Last 1))
-    if (Get-NetFirewallRule -DisplayName $name -ErrorAction SilentlyContinue) {
-        $skipped++
-        continue
-    }
+    # Resolve `subst`-mapped drive prefix so the Program path matches what
+    # the Windows Firewall service (running as SYSTEM, no subst visibility)
+    # sees on the running process's image path.
+    $resolved = Resolve-SubstPath -Path $path
+    $name = "qontinui-multi-app-{0}" -f ([System.IO.Path]::GetFileNameWithoutExtension($resolved) + "-" + ([System.IO.Path]::GetDirectoryName($resolved) -split '\\' | Select-Object -Last 1))
+    # No per-rule skip: the bulk purge above cleared the namespace, so we
+    # always create fresh. This catches the case where the same DisplayName
+    # would be reused but the Program path has changed (subst, rename, etc.).
     try {
-        New-NetFirewallRule -DisplayName $name -Description "Auto-added by setup-firewall.ps1: allows qontinui binaries to bind on 127.0.0.1 without triggering Windows Security Alert popups during testing." -Program $path -Direction Inbound -Action Allow -Protocol TCP -LocalAddress 127.0.0.1 -Profile Any -EdgeTraversalPolicy Block | Out-Null
+        New-NetFirewallRule -DisplayName $name -Description "Auto-added by setup-firewall.ps1: allows qontinui binaries to bind on 127.0.0.1 without triggering Windows Security Alert popups during testing." -Program $resolved -Direction Inbound -Action Allow -Protocol TCP -LocalAddress 127.0.0.1 -Profile Any -EdgeTraversalPolicy Block | Out-Null
         $added++
     } catch {
-        Write-Host ("WARN: failed to add rule for {0}: {1}" -f $path, $_) -ForegroundColor Yellow
+        Write-Host ("WARN: failed to add rule for {0}: {1}" -f $resolved, $_) -ForegroundColor Yellow
         $failed++
     }
 }
 
 Write-Host ""
 Write-Host "Firewall setup complete:" -ForegroundColor Green
+Write-Host "  purged=$staleCount (stale rules cleared at start)"
 Write-Host "  added=$added (new rules created)"
-Write-Host "  skipped=$skipped (already had a rule)"
 Write-Host "  failed=$failed"
 Write-Host ""
 Write-Host "Total rules cover $($paths.Count) binary paths:"


### PR DESCRIPTION
## Summary
Dev-only script fix. Two issues on `setup-firewall.ps1` when re-run across renames / subst-drive changes:

1. **Subst-drive paths don't match the firewall service's view of the process.** Windows Firewall runs as SYSTEM and doesn't see per-logon `subst` drives. Rules registered with `Program=D:\qontinui-root\...` silently fail to match a process whose actual kernel image path is `C:\Users\jspin\Documents\qontinui-root\...`. Result: every binary spawn pops the "Allow access" dialog despite the rules being there. Added `Resolve-SubstPath` to walk `subst.exe` output and rewrite the `Program` path to the physical root before `New-NetFirewallRule`.

2. **Stale rules accumulated forever.** The DisplayName format `qontinui-multi-app-<exe>-<dir-basename>` embeds the path basename, so a rename (e.g. `qontinui_parent` → `qontinui-root`, 2026-05-17) or subst-drive change produces a brand-new DisplayName on next run. The old per-rule "skip if exists" path missed the stale entry and accumulated rules forever. Switched to bulk-purging every `qontinui-multi-app-*` rule at the top of each run and always recreating — script is the sole owner of that DisplayName prefix, namespace-nuke is safe.

## Test plan
- [x] No source-code touch; only `scripts/setup-firewall.ps1` modified.
- [ ] Run elevated `pwsh -File scripts/setup-firewall.ps1` once — verify `purged=N (stale rules cleared)` line appears, then `added=M (new rules created)`.
- [ ] Spawn a runner via supervisor / dev-start — no "Allow access" popup.
- [ ] Re-run the script — `added` count matches `purged` count (idempotent under the new bulk-purge model).