### PR TITLE
fix(pair): route pair-cli through web backend + use user JWT bearer

### DIFF
--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -154,10 +154,15 @@ pub fn start_refresher(api_state: Arc<ApiState>) -> Arc<RefresherState> {
     })
 }
 
-/// Attempt one refresh against `coord_base` using `runner_token` as the
+/// Attempt one refresh against `pair_base` using `runner_token` as the
 /// bearer + `device_id` / `user_id` as the wire body / header fields.
 /// Factored out of the inline Pair-arm body so the Phase 5.2 tests can
-/// drive it directly against an in-process mock coord.
+/// drive it directly against an in-process mock backend.
+///
+/// `pair_base` is the web-backend URL (e.g. `http://127.0.0.1:8000`);
+/// the underlying [`pair_with_auth_token_with_ids`] hits
+/// `{pair_base}/api/v1/devices/pair-cli`, which the backend proxies to
+/// coord with `tenant_id` resolved from the authenticated user.
 ///
 /// Invariant: a non-2xx HTTP response, a network error, or a
 /// spawn_blocking join failure all collapse to
@@ -166,12 +171,12 @@ pub fn start_refresher(api_state: Arc<ApiState>) -> Arc<RefresherState> {
 /// [`RefreshOutcome`].
 pub(crate) async fn try_refresh_once(
     auth_manager: &crate::auth::AuthManager,
-    coord_base: &str,
+    pair_base: &str,
     runner_token: &str,
     device_id: &str,
     user_id: &str,
 ) -> RefreshOutcome {
-    let base = coord_base.to_string();
+    let base = pair_base.to_string();
     let token = runner_token.to_string();
     let did = device_id.to_string();
     let uid = user_id.to_string();
@@ -314,18 +319,26 @@ async fn refresher_loop(
                     .runner_token
                     .trim()
                     .to_string();
-                let coord_base = match qontinui_runner_lib::pair::coord_http_base() {
-                    Ok(b) => b,
-                    Err(e) => {
-                        warn!("device_jwt_refresher: coord_url unresolved: {e}");
-                        if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx)
-                            .await
-                        {
-                            return;
-                        }
-                        continue;
+                // Post-2026-05-22: pair-cli now goes through the web
+                // backend (`/api/v1/devices/pair-cli`), not coord directly,
+                // so the backend can resolve `tenant_id` from the
+                // authenticated user. Use the web_integration's
+                // `backend_url` setting — same one the relay reads.
+                let pair_base = settings_snapshot
+                    .web_integration
+                    .backend_url
+                    .trim()
+                    .trim_end_matches('/')
+                    .to_string();
+                if pair_base.is_empty() {
+                    warn!("device_jwt_refresher: backend_url empty — cannot pair");
+                    if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx)
+                        .await
+                    {
+                        return;
                     }
-                };
+                    continue;
+                }
 
                 // Resolve device_id + user_id from disk. Phase 5 split:
                 // these reads live here (operator-facing files) so the
@@ -369,7 +382,7 @@ async fn refresher_loop(
                 // the existing JWT on any non-2xx outcome.
                 let outcome = try_refresh_once(
                     &auth_manager,
-                    &coord_base,
+                    &pair_base,
                     &runner_token,
                     &device_id,
                     &user_id,

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -314,16 +314,30 @@ async fn refresher_loop(
                 continue;
             }
             Decision::Pair => {
-                let runner_token = settings_snapshot
-                    .web_integration
-                    .runner_token
-                    .trim()
-                    .to_string();
                 // Post-2026-05-22: pair-cli now goes through the web
                 // backend (`/api/v1/devices/pair-cli`), not coord directly,
                 // so the backend can resolve `tenant_id` from the
-                // authenticated user. Use the web_integration's
-                // `backend_url` setting — same one the relay reads.
+                // authenticated user. The backend gates on the FastAPI
+                // user-JWT (`Authorization: Bearer <access_token>`) — not
+                // the legacy `runner_token`, which only coord ever
+                // accepted. Pull the user JWT that the runner stashed at
+                // sign-in time (`commands::auth::login` →
+                // `AuthManager::store_tokens`).
+                let bearer_token = match auth_manager.get_access_token() {
+                    Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+                    _ => {
+                        warn!(
+                            "device_jwt_refresher: access_token slot empty — user must \
+                             sign in to Qontinui before the refresher can pair"
+                        );
+                        if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx)
+                            .await
+                        {
+                            return;
+                        }
+                        continue;
+                    }
+                };
                 let pair_base = settings_snapshot
                     .web_integration
                     .backend_url
@@ -383,7 +397,7 @@ async fn refresher_loop(
                 let outcome = try_refresh_once(
                     &auth_manager,
                     &pair_base,
-                    &runner_token,
+                    &bearer_token,
                     &device_id,
                     &user_id,
                 )

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -350,6 +350,15 @@ pub fn pair_with_auth_token(
 /// Phase 5 of the unified-devices migration introduced this split so the
 /// E2E pair tests can target an in-process mock coord without mutating
 /// (or relying on) per-user files.
+///
+/// Routes through the web backend at `{base}/api/v1/devices/pair-cli`,
+/// not coord directly. The web backend is the only component allowed to
+/// resolve `tenant_id` from the authenticated user — coord's pair-cli
+/// requires `tenant_id` as of the 2026-05-20
+/// default-tenant-propagation plan, and threading that through the
+/// runner would leak tenancy concerns into a layer that doesn't need
+/// them. Callers pass the web-backend base URL (e.g.
+/// `http://127.0.0.1:8000`), NOT the coord URL.
 pub fn pair_with_auth_token_with_ids(
     base: &str,
     oauth_token: &str,
@@ -357,7 +366,7 @@ pub fn pair_with_auth_token_with_ids(
     user_id: &str,
     tenant_id: uuid::Uuid,
 ) -> Result<PairCompleteResponse, String> {
-    let url = format!("{}/coord/devices/pair-cli", base);
+    let url = format!("{}/api/v1/devices/pair-cli", base);
     let body = serde_json::json!({
         "device_id": device_id,
         "hostname":  detect_hostname(),


### PR DESCRIPTION
## Summary
- `pair.rs::pair_with_auth_token_with_ids` now POSTs to `{backend}/api/v1/devices/pair-cli` instead of `{coord}/coord/devices/pair-cli`
- `device_jwt_refresher.rs` reads bearer from `AuthManager::get_access_token()` (the user JWT from sign-in) instead of the legacy `runner_token`
- `device_jwt_refresher.rs` reads pair base URL from `settings.web_integration.backend_url` instead of `coord_http_base()`

## Why
Coord required `tenant_id` since the 2026-05-20 default-tenant-propagation rollout, but the runner had no business resolving tenancy. Route through web-backend (which holds the user→operators chain) so it injects `tenant_id` server-side, same architecture pair-confirm has used since Wave 3c.

The new web-backend endpoint gates on the FastAPI user-JWT (not the legacy `runner_token`), so the refresher pulls the user JWT from the access_token slot that `commands::auth::login` populates at sign-in time.

## Dependency
⚠️ **Must merge AFTER** [qontinui-web #203 feat-pair-cli-proxy-clean](https://github.com/qontinui/qontinui-web/pull/203) — that PR adds the `/api/v1/devices/pair-cli` endpoint this PR depends on.

## Trade-off
The `access_token` slot now holds the user JWT until first successful pair-cli, then the device-JWT replaces it. When the device-JWT expires (~4h), the refresher needs a fresh user JWT — operator re-signs-in via the runner UI. Long-term the slot should be split (user_jwt vs device_jwt); tracked for a follow-up.

## Diff scope
- `src-tauri/src/pair.rs` (+11/-3)
- `src-tauri/src/mcp/device_jwt_refresher.rs` (+~40/-15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)