### PR TITLE
fix(pair-tests): align both pair-cli mock-axum routes to /api/v1/devices/pair-cli

### DIFF
--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -673,7 +673,12 @@ mod try_refresh_once_tests {
                     hits: hits_for_handler,
                 };
                 let app: Router = Router::new()
-                    .route("/coord/devices/pair-cli", post(handler))
+                    // Mirror the live route — pair::pair_with_auth_token_with_ids
+                    // POSTs to `{base}/api/v1/devices/pair-cli` (web-routed).
+                    // Was registered as `/coord/devices/pair-cli` (legacy
+                    // coord-direct) and 404'd the request, panicking both
+                    // try_refresh_once_tests. Sibling of the pair.rs:980 fix.
+                    .route("/api/v1/devices/pair-cli", post(handler))
                     .with_state(state);
                 let listener =
                     tokio::net::TcpListener::from_std(std_listener).expect("tokio listener");

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -977,7 +977,12 @@ mod pair_e2e_tests {
                     response_body,
                 };
                 let app: Router = Router::new()
-                    .route("/coord/devices/pair-cli", post(pair_cli_handler))
+                    // Mirror the live route — pair_with_auth_token POSTs to
+                    // `{base}/api/v1/devices/pair-cli` (web-routed). The mock
+                    // used to register `/coord/devices/pair-cli` (the legacy
+                    // coord-direct path) and 404'd the request, panicking all
+                    // four pair_e2e tests. Tied to the call site at line 369.
+                    .route("/api/v1/devices/pair-cli", post(pair_cli_handler))
                     .with_state(mock_state);
                 let listener =
                     tokio::net::TcpListener::from_std(std_listener).expect("tokio listener");


### PR DESCRIPTION
## Summary

Unblock main CI which has been red on six tests since the pair-cli URL pivoted from coord-direct to web-routed without the in-process mock-axum servers being updated.

## Root cause

Both `pair_with_auth_token_with_ids` (the live function in `pair.rs:369`) and `device_jwt_refresher`'s refresh-once helper (in `mcp/device_jwt_refresher.rs`) POST to:

```
{base}/api/v1/devices/pair-cli
```

(The web-routed path — runners go through web's backend now instead of hitting coord directly.)

But the test scaffolding's mock-axum servers in BOTH files registered:

```rust
.route("/coord/devices/pair-cli", post(handler))
```

(The legacy coord-direct path.)

The mocks returned 404 → 6 tests panicked:
- `pair::pair_e2e_tests::pair_with_auth_token_e2e_200_persists_jwt`
- `pair::pair_e2e_tests::pair_with_auth_token_e2e_401_returns_err`
- `pair::pair_e2e_tests::pair_with_auth_token_e2e_500_returns_err`
- `pair::pair_e2e_tests::pair_with_auth_token_e2e_request_shape`
- `mcp::device_jwt_refresher::try_refresh_once_tests::refresher_handles_coord_200_replaces_jwt`
- `mcp::device_jwt_refresher::try_refresh_once_tests::refresher_handles_coord_401_without_clearing_jwt`

PR #212 had to admin-merge through this failure (`60ab43732`).

## Fix

Two route swaps, both with comments explaining the lock-in:
- `src-tauri/src/pair.rs:980` — pair_e2e tests' mock
- `src-tauri/src/mcp/device_jwt_refresher.rs:676` — try_refresh_once_tests' mock

## Test plan

- [x] `cargo test --lib pair_with_auth_token_e2e` → **4 passed, 0 failed**
- [x] `cargo test --bin qontinui-runner try_refresh_once` → **4 passed, 0 failed**

The fix is tied to my Phase 5 work in `qontinui-runner` #207 (unified-devices migration). The live implementation URL changed at some point between when I authored the tests and the merge, but the mock routes weren't updated alongside.