### PR TITLE
refactor(pair-tests): rename spawn_mock_coord + align doc comments post-PR #226

### DIFF
--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -183,9 +183,10 @@ pub(crate) async fn try_refresh_once(
 
     // Resolve tenant_id from the OAuth/runner token's `tenant_id` claim.
     // Phase 2 of the default-tenant-propagation plan makes tenant_id a
-    // required field on `POST /coord/devices/pair-cli`; the refresher
-    // reuses the same endpoint to re-mint the device JWT, so it must
-    // forward a tenant_id. Absent/malformed → keep the existing JWT.
+    // required field on `POST /api/v1/devices/pair-cli` (the web-backend
+    // proxy that fronts coord since PR #224); the refresher reuses the
+    // same endpoint to re-mint the device JWT, so it must forward a
+    // tenant_id. Absent/malformed → keep the existing JWT.
     let tenant_id = match qontinui_runner_lib::pair::tenant_id_from_oauth_claim(&token)
         .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
     {
@@ -594,11 +595,11 @@ mod tests {
 #[cfg(test)]
 mod try_refresh_once_tests {
     //! Phase 5.2 integration tests — `try_refresh_once` against an
-    //! in-process mock coord. These exercise the JWT-preservation
+    //! in-process mock web backend. These exercise the JWT-preservation
     //! invariant: a non-2xx coord response MUST NOT clear the existing
     //! access_token slot.
     //!
-    //! Mock coord: inline axum server on `127.0.0.1:0`, same pattern as
+    //! Mock web backend: inline axum server on `127.0.0.1:0`, same pattern as
     //! `pair::pair_e2e_tests`. AuthManager: `with_storage(...)` +
     //! `SecureStorage::with_path(<temp_file>)` so each test has its own
     //! isolated tokens file.
@@ -713,7 +714,7 @@ mod try_refresh_once_tests {
     #[tokio::test]
     async fn refresher_handles_coord_401_without_clearing_jwt() {
         // Setup: AuthManager holds a valid-shape (not-yet-expired) JWT.
-        // Run: mock coord returns 401 on pair-cli.
+        // Run: mock web backend returns 401 on pair-cli.
         // Assert: access_token slot STILL holds the original JWT (not
         // cleared) AND the outcome is KeptExisting.
         let mgr = test_auth_manager("handles_coord_401_without_clearing");
@@ -731,7 +732,11 @@ mod try_refresh_once_tests {
             RefreshOutcome::KeptExisting,
             "401 must yield KeptExisting (not Replaced, not PersistFailed)"
         );
-        assert_eq!(*hits.lock().unwrap(), 1, "coord should be hit exactly once");
+        assert_eq!(
+            *hits.lock().unwrap(),
+            1,
+            "web backend pair-cli endpoint should be hit exactly once"
+        );
 
         let still = mgr.get_access_token().expect("token still present");
         assert_eq!(
@@ -767,7 +772,7 @@ mod try_refresh_once_tests {
     #[tokio::test]
     async fn refresher_handles_coord_200_replaces_jwt() {
         // Setup: AuthManager holds the OLD JWT.
-        // Run: mock coord returns canonical 200 with a NEW JWT.
+        // Run: mock web backend returns canonical 200 with a NEW JWT.
         // Assert: outcome is Replaced with the NEW JWT, and the
         // access_token slot now holds the NEW JWT.
         let mgr = test_auth_manager("handles_coord_200_replaces");

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -7,7 +7,8 @@
 //! ## Public surface
 //!
 //! - [`pair_with_auth_token`] — headless flow: POST `Authorization: Bearer
-//!   <oauth-or-runner-token>` to coord's `POST /coord/devices/pair-cli`.
+//!   <user-jwt>` to the web backend's `POST /api/v1/devices/pair-cli`,
+//!   which proxies to coord with server-side-injected `tenant_id`.
 //!   Requires the device to already be browser-paired at least once
 //!   (uses the cached `user_id` from `paired_user.json`).
 //! - [`pair_via_browser`] — interactive flow: opens
@@ -46,8 +47,9 @@ use std::path::PathBuf;
 // Wire types — must match qontinui-coord/src/routes_phase3.rs exactly.
 // ============================================================================
 
-/// Canonical response shape for `POST /coord/devices/pair-cli` and
-/// `POST /coord/devices/pair-complete`. Coord serializes this as
+/// Canonical response shape for `POST /api/v1/devices/pair-cli` (proxied
+/// through the web backend) and `POST /coord/devices/pair-complete`
+/// (browser flow, called by coord directly). Coord serializes this as
 /// `{token, device_id, user_id, jti, exp}`. We accept the wire shape
 /// directly: no `serde(rename)` indirection — the struct field name *is*
 /// the wire name.
@@ -285,10 +287,11 @@ pub fn derive_web_base_from_coord(coord_base: &str) -> String {
 // Pair: headless (--auth-token)
 // ============================================================================
 
-/// POST `Authorization: Bearer <oauth-or-runner-token>` +
-/// `X-Qontinui-User-Id: <uuid>` to `POST /coord/devices/pair-cli`. Coord
-/// verifies the bearer token, looks up the device, and returns a fresh
-/// device-token JWT.
+/// POST `Authorization: Bearer <user-jwt>` +
+/// `X-Qontinui-User-Id: <uuid>` to `POST /api/v1/devices/pair-cli` (the
+/// web backend's pair-cli proxy, which injects `tenant_id` server-side
+/// and forwards to coord). Coord verifies the bearer token, looks up the
+/// device, and returns a fresh device-token JWT.
 ///
 /// Requirements (Defect 5):
 /// - `~/.qontinui/machine.json` must exist with a UUID `device_id`
@@ -300,7 +303,7 @@ pub fn derive_web_base_from_coord(coord_base: &str) -> String {
 /// Thin wrapper around [`pair_with_auth_token_with_ids`] — reads
 /// `device_id` and `user_id` from disk then delegates. Tests use the
 /// parameterized form directly so they can run hermetically against an
-/// in-process mock coord without touching `~/.qontinui` or the
+/// in-process mock web backend without touching `~/.qontinui` or the
 /// `data_local_dir`.
 /// Decode the unverified payload of a JWT and pull the `tenant_id`
 /// claim, if any. Returns `None` if the token isn't a JWT, the payload
@@ -348,7 +351,7 @@ pub fn pair_with_auth_token(
 /// and `user_id` as explicit arguments instead of reading them from
 /// `~/.qontinui/machine.json` + `{data_local_dir}/.../paired_user.json`.
 /// Phase 5 of the unified-devices migration introduced this split so the
-/// E2E pair tests can target an in-process mock coord without mutating
+/// E2E pair tests can target an in-process mock web backend without mutating
 /// (or relying on) per-user files.
 ///
 /// Routes through the web backend at `{base}/api/v1/devices/pair-cli`,
@@ -861,7 +864,7 @@ mod tests {
 }
 
 // ============================================================================
-// E2E pair tests against an in-process mock coord (Phase 5.1)
+// E2E pair tests against an in-process mock web backend (Phase 5.1)
 // ============================================================================
 //
 // These tests exercise `pair_with_auth_token_with_ids` against a real
@@ -910,8 +913,9 @@ mod pair_e2e_tests {
         response_body: String,
     }
 
-    /// Canonical-shape 200 body returned by coord's
-    /// `POST /coord/devices/pair-cli` on success.
+    /// Canonical-shape 200 body returned by the web-backend's
+    /// `POST /api/v1/devices/pair-cli` on success (passthrough of the
+    /// coord response).
     fn canonical_200_body(token: &str) -> String {
         serde_json::json!({
             "token": token,
@@ -923,7 +927,7 @@ mod pair_e2e_tests {
         .to_string()
     }
 
-    /// Handler for `POST /coord/devices/pair-cli`. Captures the inbound
+    /// Handler for `POST /api/v1/devices/pair-cli`. Captures the inbound
     /// request shape onto shared state then returns the canned response.
     async fn pair_cli_handler(
         State(state): State<MockState>,
@@ -944,10 +948,11 @@ mod pair_e2e_tests {
         (state.status, state.response_body.clone())
     }
 
-    /// Boot the mock coord on `127.0.0.1:0`. Returns
-    /// `(base_url, capture_handle, shutdown_signal)`. The caller drops
-    /// `shutdown_signal` (or sends on it) to terminate the server.
-    fn spawn_mock_coord(
+    /// Boot a mock web backend on `127.0.0.1:0` serving the pair-cli
+    /// proxy endpoint. Returns `(base_url, capture_handle, shutdown_signal)`.
+    /// The caller drops `shutdown_signal` (or sends on it) to terminate the
+    /// server.
+    fn spawn_mock_web_backend(
         status: StatusCode,
         response_body: String,
     ) -> (
@@ -1013,12 +1018,12 @@ mod pair_e2e_tests {
 
     #[test]
     fn pair_with_auth_token_e2e_200_persists_jwt() {
-        // Mock coord at 127.0.0.1:<port> returns the canonical 200 JSON;
+        // Mock web backend at 127.0.0.1:<port> returns the canonical 200 JSON;
         // assert the returned PairCompleteResponse.token matches the
         // synthetic JWT we configured the mock to emit.
         let expected_jwt = "header-segment.payload-segment.signature-segment";
         let (base, _capture, _shutdown) =
-            spawn_mock_coord(StatusCode::OK, canonical_200_body(expected_jwt));
+            spawn_mock_web_backend(StatusCode::OK, canonical_200_body(expected_jwt));
         let result = pair_with_auth_token_with_ids(
             &base,
             TEST_BEARER,
@@ -1040,7 +1045,7 @@ mod pair_e2e_tests {
         // Mock returns 401 with a coord-shaped error body; assert the
         // error string surfaces the status code + body so an operator
         // can diagnose by reading the log.
-        let (base, _capture, _shutdown) = spawn_mock_coord(
+        let (base, _capture, _shutdown) = spawn_mock_web_backend(
             StatusCode::UNAUTHORIZED,
             r#"{"error":"invalid bearer token"}"#.to_string(),
         );
@@ -1062,7 +1067,7 @@ mod pair_e2e_tests {
     fn pair_with_auth_token_e2e_500_returns_err() {
         // Coord-side bug → 500. Caller must surface the error rather
         // than silently treating it as a refresh-needed signal.
-        let (base, _capture, _shutdown) = spawn_mock_coord(
+        let (base, _capture, _shutdown) = spawn_mock_web_backend(
             StatusCode::INTERNAL_SERVER_ERROR,
             r#"{"error":"coord-side panic"}"#.to_string(),
         );
@@ -1087,7 +1092,7 @@ mod pair_e2e_tests {
         // `X-Qontinui-User-Id: <uuid>` header, and a JSON body containing
         // `device_id` + `hostname`.
         let (base, capture, _shutdown) =
-            spawn_mock_coord(StatusCode::OK, canonical_200_body("ignored-jwt"));
+            spawn_mock_web_backend(StatusCode::OK, canonical_200_body("ignored-jwt"));
         let _ = pair_with_auth_token_with_ids(
             &base,
             TEST_BEARER,
@@ -1098,7 +1103,7 @@ mod pair_e2e_tests {
         .expect("200 path");
 
         let captured = capture.lock().expect("capture mutex").clone();
-        assert!(captured.called, "mock coord must have been hit");
+        assert!(captured.called, "mock web backend must have been hit");
         assert_eq!(
             captured.authorization.as_deref(),
             Some(&*format!("Bearer {TEST_BEARER}")),


### PR DESCRIPTION
## Summary

Follow-up cleanup after PR #226 landed the same route-line fix while this branch was being built.

PR #226's fix is correct and shipped — but it left the codebase with documentation-vs-reality drift:

- Helper named `spawn_mock_coord` actually mocks the web-backend pair-cli proxy
- Test bodies still say `// Mock coord at 127.0.0.1:<port>`
- Module-doc + helper-doc + handler-doc + `PairCompleteResponse` doc all refer to coord
- Assert message: `"coord should be hit exactly once"`

After this PR:

- `spawn_mock_coord` → `spawn_mock_web_backend` (helper now correctly named for what it mocks)
- `pair_with_auth_token` doc: `<oauth-or-runner-token>` → `<user-jwt>` (matches PR #224's bearer change)
- `PairCompleteResponse` doc: mentions both `POST /api/v1/devices/pair-cli` (web-routed) and `POST /coord/devices/pair-complete` (browser flow)
- Test comments + assert messages: "coord" → "web backend pair-cli endpoint" where the test is talking about the proxy
- `device_jwt_refresher.rs` doc-comments + assert message: same naming/doc fixes

**The route lines themselves are unchanged** (PR #226 already shipped them on main).

## Verification

```
cargo test --lib pair_e2e_tests                                          → 4 passed
cargo test --bin qontinui-runner mcp::device_jwt_refresher::try_refresh  → 4 passed
```

Both modules pass; functional behavior unchanged from current main; the rename touches 4 call sites in `pair.rs` test bodies.

## Test plan

- [x] `cargo test --lib pair_e2e_tests` — 4/4 pass locally
- [x] `cargo test --bin qontinui-runner mcp::device_jwt_refresher::try_refresh_once_tests` — 4/4 pass locally
- [ ] CI green (Session-Id trailer gate now in effect on PRs against main — both commits amended with trailer)