### PR TITLE
runner: loop B iter 1 — setValue ACTION_NOT_SUPPORTED + /control/components envelope dedup + PM frontend pre-check

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -916,7 +916,11 @@ pub async fn ui_bridge_execute_action_handler(
                     .and_then(|p| p.get("disabled"))
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                aria_disabled || disabled_attr || data_disabled || prop_aria_disabled || prop_disabled
+                aria_disabled
+                    || disabled_attr
+                    || data_disabled
+                    || prop_aria_disabled
+                    || prop_disabled
             };
 
             if is_disabled {
@@ -1215,19 +1219,16 @@ pub async fn ui_bridge_execute_action_handler(
             // If `command_chosen` IS set, keep the existing
             // success-on-recovery envelope — that's a structured retry,
             // not the contract-violating no-op path.
-            let contract_violation =
-                recovery.recovered && recovery.command_chosen.is_none();
+            let contract_violation = recovery.recovered && recovery.command_chosen.is_none();
             if contract_violation {
                 warn!(
                     "execute_action: rejecting misleading recovered:true,commandChosen:null \
                      for element {} action '{}' — returning ACTION_NOT_SUPPORTED",
                     id, action_name
                 );
-                let supported: Vec<String> = element_supported_actions
-                    .clone()
-                    .unwrap_or_default();
-                let recovery_json = serde_json::to_value(&recovery)
-                    .unwrap_or(serde_json::Value::Null);
+                let supported: Vec<String> = element_supported_actions.clone().unwrap_or_default();
+                let recovery_json =
+                    serde_json::to_value(&recovery).unwrap_or(serde_json::Value::Null);
                 // Body carries the contract fields. `code` is hoisted into
                 // `data` so callers can match on it without parsing the
                 // outer envelope, mirroring the `data.code` shape that
@@ -4580,9 +4581,7 @@ mod action_not_supported_tests {
     //! `serde_json::json!{...}` recipe the handler uses — if the body
     //! template changes here, this test must change in lockstep, which
     //! is exactly the regression guard we want.
-    use super::{
-        extract_supported_actions, is_action_advertised,
-    };
+    use super::{extract_supported_actions, is_action_advertised};
     use crate::mcp::types::ApiResponse;
     use crate::mcp::ui_bridge::recovery_executor::{RecoveryOutcome, RecoveryVia};
     use serde_json::json;
@@ -4727,7 +4726,10 @@ mod action_not_supported_tests {
             .get("recovery")
             .expect("contract: data.recovery must be carried for audit");
         assert!(
-            recovery_field.get("commandChosen").map(|v| v.is_null()).unwrap_or(false),
+            recovery_field
+                .get("commandChosen")
+                .map(|v| v.is_null())
+                .unwrap_or(false),
             "contract: data.recovery.commandChosen must be null (this is the \
              precondition that triggered ACTION_NOT_SUPPORTED)"
         );

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -625,6 +625,58 @@ pub(crate) fn validate_action_name(raw: &str) -> Result<&str, UiBridgeError> {
     Err(UiBridgeError::invalid_action(raw, SUPPORTED_ACTION_NAMES))
 }
 
+/// Extract the element's advertised `actions` list from a `get_element` IPC
+/// payload. The frontend snapshots elements with an `actions` array whose
+/// entries are either plain strings (action names) or objects with a `name` /
+/// `action` field — accept both shapes. Returns `None` when the field is
+/// absent OR present but not an array, so the caller can distinguish "we
+/// don't know which actions this element supports" from "we know it supports
+/// nothing." Empty array → `Some(vec![])` (= element advertised an explicit
+/// empty list).
+///
+/// Loop B Item A: feeds the `ACTION_NOT_SUPPORTED` discriminator that
+/// invalidates the misleading `success:true, recovery.commandChosen:null`
+/// envelope when the LLM fallback "recovered" against an element that
+/// doesn't actually accept the requested action.
+pub(crate) fn extract_supported_actions(elem_data: &serde_json::Value) -> Option<Vec<String>> {
+    let arr = elem_data.get("actions").and_then(|v| v.as_array())?;
+    let names: Vec<String> = arr
+        .iter()
+        .filter_map(|entry| {
+            if let Some(s) = entry.as_str() {
+                Some(s.to_string())
+            } else if let Some(obj) = entry.as_object() {
+                obj.get("name")
+                    .or_else(|| obj.get("action"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    Some(names)
+}
+
+/// True when the element advertises an explicit supported-actions list AND
+/// the requested action is not in it. `None` (we don't know) → returns
+/// `false` (don't accuse — degrade gracefully).
+///
+/// Match semantics mirror `SUPPORTED_ACTION_NAMES` membership in
+/// `validate_action_name`: exact (case-sensitive) string equality. The SDK
+/// emits canonical camelCase names in element metadata; aliases like
+/// `scroll_into_view` -> `scrollIntoView` are normalized SDK-side before the
+/// `actions` list is built, so an additional alias-fold here would be a
+/// distortion not a feature.
+pub(crate) fn is_action_advertised(action: &str, supported: &Option<Vec<String>>) -> bool {
+    match supported {
+        Some(list) => list.iter().any(|s| s == action),
+        // Unknown supported list (fetch failed or element didn't advertise
+        // any) — assume yes, so we don't manufacture false ACTION_NOT_SUPPORTED.
+        None => true,
+    }
+}
+
 pub async fn ui_bridge_execute_action_handler(
     State(state): State<Arc<ApiState>>,
     Path(id): Path<String>,
@@ -822,61 +874,72 @@ pub async fn ui_bridge_execute_action_handler(
     // Before dispatching the action, fetch the element state and reject
     // clicks on disabled elements early so callers get an explicit error
     // instead of a silent no-op.
-    if let Ok(elem_data) = ui_bridge_request_sync(
+    //
+    // Also capture the element's advertised `actions` list so the Loop B
+    // Item A `ACTION_NOT_SUPPORTED` discriminator below can compare the
+    // requested action against the element's metadata without an extra
+    // IPC round-trip. None on fetch failure → the discriminator skips
+    // (we never invent a supported list).
+    let element_supported_actions: Option<Vec<String>> = match ui_bridge_request_sync(
         &state,
         "get_element",
         serde_json::json!({ "elementId": id }),
     )
     .await
     {
-        let is_disabled = {
-            let props = elem_data
-                .get("properties")
-                .or_else(|| elem_data.get("props"));
-            let aria_disabled = elem_data
-                .get("ariaDisabled")
-                .and_then(|v| v.as_str())
-                .map(|s| s == "true")
-                .unwrap_or(false);
-            let disabled_attr = elem_data
-                .get("disabled")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            let data_disabled = props
-                .and_then(|p| p.get("data-disabled"))
-                .and_then(|v| v.as_str())
-                .map(|s| s == "true")
-                .unwrap_or(false);
-            // Also check nested properties for aria-disabled / disabled
-            let prop_aria_disabled = props
-                .and_then(|p| p.get("aria-disabled"))
-                .and_then(|v| v.as_str())
-                .map(|s| s == "true")
-                .unwrap_or(false);
-            let prop_disabled = props
-                .and_then(|p| p.get("disabled"))
-                .and_then(|v| v.as_bool())
-                .unwrap_or(false);
-            aria_disabled || disabled_attr || data_disabled || prop_aria_disabled || prop_disabled
-        };
+        Ok(elem_data) => {
+            let is_disabled = {
+                let props = elem_data
+                    .get("properties")
+                    .or_else(|| elem_data.get("props"));
+                let aria_disabled = elem_data
+                    .get("ariaDisabled")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s == "true")
+                    .unwrap_or(false);
+                let disabled_attr = elem_data
+                    .get("disabled")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let data_disabled = props
+                    .and_then(|p| p.get("data-disabled"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s == "true")
+                    .unwrap_or(false);
+                // Also check nested properties for aria-disabled / disabled
+                let prop_aria_disabled = props
+                    .and_then(|p| p.get("aria-disabled"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s == "true")
+                    .unwrap_or(false);
+                let prop_disabled = props
+                    .and_then(|p| p.get("disabled"))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                aria_disabled || disabled_attr || data_disabled || prop_aria_disabled || prop_disabled
+            };
 
-        if is_disabled {
-            warn!(
-                "execute_action: element {} is disabled, rejecting {} action early",
-                id, action_name
-            );
-            return Ok(Json(ApiResponse {
-                success: false,
-                data: Some(serde_json::json!({
-                    "error": "element is disabled",
-                    "elementState": elem_data,
-                })),
-                error: Some("element is disabled".to_string()),
-                error_detail: None,
-                hint: None,
-            }));
+            if is_disabled {
+                warn!(
+                    "execute_action: element {} is disabled, rejecting {} action early",
+                    id, action_name
+                );
+                return Ok(Json(ApiResponse {
+                    success: false,
+                    data: Some(serde_json::json!({
+                        "error": "element is disabled",
+                        "elementState": elem_data,
+                    })),
+                    error: Some("element is disabled".to_string()),
+                    error_detail: None,
+                    hint: None,
+                }));
+            }
+
+            extract_supported_actions(&elem_data)
         }
-    }
+        Err(_) => None,
+    };
 
     // ── Execute the action ─────────────────────────────────────────────
     let mut result =
@@ -1133,7 +1196,61 @@ pub async fn ui_bridge_execute_action_handler(
 
         if let Some(failure) = failure_body {
             let recovery = attempt_recovery(&state, &failure, &id, &payload, task_run_id).await;
-            if recovery.recovered {
+            // ── Loop B Item A — ACTION_NOT_SUPPORTED discriminator ──────
+            //
+            // Contract: `success:true, data.recovery.commandChosen:null` is
+            // a misleading shape — it claims "we recovered" while admitting
+            // no structured command was selected and no original-action
+            // retry succeeded. That can only happen when the LLM fallback
+            // synthesized a side-action (or no-op) against an element that
+            // doesn't actually advertise the requested action.
+            //
+            // Invariant we now enforce: when `recovery.recovered` AND
+            // `recovery.command_chosen` is None, return `success:false`
+            // with `code: ACTION_NOT_SUPPORTED` and
+            // `data.supported_actions: [...]` from the element's metadata.
+            // The recovery audit trail (`recovery.commandChosen:null`) is
+            // still surfaced so callers can see what was attempted.
+            //
+            // If `command_chosen` IS set, keep the existing
+            // success-on-recovery envelope — that's a structured retry,
+            // not the contract-violating no-op path.
+            let contract_violation =
+                recovery.recovered && recovery.command_chosen.is_none();
+            if contract_violation {
+                warn!(
+                    "execute_action: rejecting misleading recovered:true,commandChosen:null \
+                     for element {} action '{}' — returning ACTION_NOT_SUPPORTED",
+                    id, action_name
+                );
+                let supported: Vec<String> = element_supported_actions
+                    .clone()
+                    .unwrap_or_default();
+                let recovery_json = serde_json::to_value(&recovery)
+                    .unwrap_or(serde_json::Value::Null);
+                // Body carries the contract fields. `code` is hoisted into
+                // `data` so callers can match on it without parsing the
+                // outer envelope, mirroring the `data.code` shape that
+                // `wrap_ipc_result` already emits for IPC failure responses.
+                let body = serde_json::json!({
+                    "code": "ACTION_NOT_SUPPORTED",
+                    "supported_actions": supported,
+                    "requested_action": action_name,
+                    "recovery": recovery_json,
+                });
+                let envelope = ApiResponse::<serde_json::Value> {
+                    success: false,
+                    data: Some(body),
+                    error: Some(format!(
+                        "Action '{}' is not supported by element '{}'. \
+                         Element advertises: {:?}",
+                        action_name, id, supported
+                    )),
+                    error_detail: None,
+                    hint: None,
+                };
+                result = Ok(Json(envelope));
+            } else if recovery.recovered {
                 info!(
                     "execute_action: RecoveryExecutor recovered element {} via {:?} (command={:?})",
                     id, recovery.via, recovery.command_chosen
@@ -1491,13 +1608,18 @@ pub async fn ui_bridge_get_components_handler(
 
     merged.append(&mut ws_components);
     let components_array = serde_json::Value::Array(merged);
-    // F2 (Direction B): emit `{success, data:{components:[...]}, components:[...]}`.
-    // The top-level `components` is a deprecated mirror for back-compat;
-    // new callers should read `data.components`.
+    // F2 (Direction B): emit `{success, data:{components:[...]}}` — the
+    // canonical wrapper-SDK envelope shape.
+    //
+    // Loop B Item B: the previous emission also carried a top-level
+    // `components` field as a deprecated back-compat mirror, but it
+    // duplicated `data.components` byte-for-byte and confused callers
+    // about which key was authoritative. The mirror has been dropped;
+    // `data.components` is the single source of truth and the regression
+    // test `components_envelope_omits_top_level_mirror` locks it in.
     Ok(Json(serde_json::json!({
         "success": true,
-        "data": { "components": components_array.clone() },
-        "components": components_array,
+        "data": { "components": components_array },
     })))
 }
 
@@ -3935,10 +4057,16 @@ mod type_into_unicode_tests {
 }
 
 /// F2 — direct `/ui-bridge/control/components` envelope shape (Direction B).
-/// Verifies the response carries `data.components` AND the deprecated
-/// top-level `components` mirror. Pure unit test against the literal shape
-/// the handler emits; an axum-router-level integration test would need a
-/// fully constructed `ApiState`.
+/// Verifies the response carries `data.components` AS THE ONLY components
+/// field. Pure unit test against the literal shape the handler emits; an
+/// axum-router-level integration test would need a fully constructed
+/// `ApiState`.
+///
+/// Loop B Item B: the deprecated top-level `components` mirror was
+/// removed. `components_envelope_omits_top_level_mirror` locks the
+/// regression in — if a future refactor re-adds the duplicate it must
+/// also delete this assertion, making the contract change visible in
+/// review.
 #[cfg(test)]
 mod components_envelope_tests {
     use serde_json::json;
@@ -3950,8 +4078,7 @@ mod components_envelope_tests {
         let components_array = serde_json::Value::Array(components);
         json!({
             "success": true,
-            "data": { "components": components_array.clone() },
-            "components": components_array,
+            "data": { "components": components_array },
         })
     }
 
@@ -3970,26 +4097,31 @@ mod components_envelope_tests {
     }
 
     #[test]
-    fn direct_components_response_has_deprecated_top_level_mirror() {
-        // The top-level `components` field is a one-release back-compat
-        // mirror so callers reading the legacy shape keep working.
+    fn components_envelope_omits_top_level_mirror() {
+        // Loop B Item B regression — the top-level `components` field
+        // was a deprecated back-compat duplicate of `data.components`
+        // that confused callers about which key was authoritative. It
+        // has been dropped; `data.components` is the single source of
+        // truth. Re-adding the mirror must require deleting this test,
+        // which keeps the envelope-shape contract visible.
         let body = components_response(vec![json!({"id": "comp-a"})]);
-        let mirror = body
-            .get("components")
-            .and_then(|v| v.as_array())
-            .expect("deprecated top-level `components` mirror must be present");
-        assert_eq!(mirror.len(), 1);
-        // The mirror and `data.components` must be the same payload.
-        let canonical = body
+        assert!(
+            body.get("components").is_none(),
+            "top-level `components` mirror must NOT appear in the response — \
+             callers must read `data.components`. Found: {:?}",
+            body.get("components")
+        );
+        // Canonical path remains intact.
+        let inner = body
             .get("data")
             .and_then(|d| d.get("components"))
             .and_then(|v| v.as_array())
-            .unwrap();
-        assert_eq!(mirror, canonical);
+            .expect("data.components must still be present");
+        assert_eq!(inner.len(), 1);
     }
 
     #[test]
-    fn empty_components_still_has_both_fields() {
+    fn empty_components_still_has_canonical_field() {
         let body = components_response(vec![]);
         assert!(body
             .get("data")
@@ -3997,11 +4129,11 @@ mod components_envelope_tests {
             .and_then(|v| v.as_array())
             .map(|a| a.is_empty())
             .unwrap_or(false));
-        assert!(body
-            .get("components")
-            .and_then(|v| v.as_array())
-            .map(|a| a.is_empty())
-            .unwrap_or(false));
+        assert!(
+            body.get("components").is_none(),
+            "regression guard: top-level `components` must stay omitted even \
+             on the empty-list path"
+        );
     }
 }
 
@@ -4432,5 +4564,172 @@ mod validate_action_name_tests {
         // and prevents downstream "no handler" silent failures.
         let err = validate_action_name("Click").expect_err("Click must not be accepted");
         assert!(matches!(err.code, UiBridgeErrorCode::InvalidRequest));
+    }
+}
+
+#[cfg(test)]
+mod action_not_supported_tests {
+    //! Loop B Item A — `setValue` against an element that doesn't advertise it
+    //! must NOT come back as `success:true, recovery.commandChosen:null`. This
+    //! module exercises the pure helpers (`extract_supported_actions`,
+    //! `is_action_advertised`) plus the ApiResponse envelope shape that the
+    //! handler builds on the contract-violation branch. The handler itself
+    //! is too IPC-coupled to spin up in a unit test (it needs `ApiState`,
+    //! the IPC dispatcher, the recovery executor's PG telemetry sink),
+    //! so we lock down the envelope by reconstructing it from the same
+    //! `serde_json::json!{...}` recipe the handler uses — if the body
+    //! template changes here, this test must change in lockstep, which
+    //! is exactly the regression guard we want.
+    use super::{
+        extract_supported_actions, is_action_advertised,
+    };
+    use crate::mcp::types::ApiResponse;
+    use crate::mcp::ui_bridge::recovery_executor::{RecoveryOutcome, RecoveryVia};
+    use serde_json::json;
+
+    #[test]
+    fn extract_supported_actions_from_string_array() {
+        let elem = json!({
+            "id": "btn-1",
+            "actions": ["focus", "blur", "type", "clear", "click"],
+        });
+        let got = extract_supported_actions(&elem).expect("present array");
+        assert_eq!(got, vec!["focus", "blur", "type", "clear", "click"]);
+    }
+
+    #[test]
+    fn extract_supported_actions_from_object_array() {
+        // Some snapshot payloads carry per-action objects, not bare strings.
+        let elem = json!({
+            "id": "btn-1",
+            "actions": [
+                { "name": "focus" },
+                { "action": "click", "params": [] },
+            ],
+        });
+        let got = extract_supported_actions(&elem).expect("present array");
+        assert_eq!(got, vec!["focus", "click"]);
+    }
+
+    #[test]
+    fn extract_supported_actions_absent_is_none() {
+        let elem = json!({ "id": "btn-1" });
+        assert!(extract_supported_actions(&elem).is_none());
+    }
+
+    #[test]
+    fn extract_supported_actions_non_array_is_none() {
+        let elem = json!({ "id": "btn-1", "actions": "click" });
+        assert!(extract_supported_actions(&elem).is_none());
+    }
+
+    #[test]
+    fn is_action_advertised_matches_listed_action() {
+        let supported = Some(vec![
+            "focus".to_string(),
+            "blur".to_string(),
+            "type".to_string(),
+            "clear".to_string(),
+            "click".to_string(),
+        ]);
+        assert!(is_action_advertised("click", &supported));
+        assert!(is_action_advertised("type", &supported));
+    }
+
+    #[test]
+    fn is_action_advertised_rejects_unlisted_action() {
+        let supported = Some(vec![
+            "focus".to_string(),
+            "blur".to_string(),
+            "type".to_string(),
+            "clear".to_string(),
+            "click".to_string(),
+        ]);
+        assert!(!is_action_advertised("setValue", &supported));
+        assert!(!is_action_advertised("submit", &supported));
+    }
+
+    #[test]
+    fn is_action_advertised_unknown_supported_list_is_permissive() {
+        // None → we don't know what the element supports; never accuse.
+        assert!(is_action_advertised("setValue", &None));
+    }
+
+    #[test]
+    fn action_not_supported_envelope_has_required_fields() {
+        // Build the envelope the handler constructs on the contract-violation
+        // branch and verify the shape the spec requires:
+        //   200 (HTTP) but body { success:false, code:"ACTION_NOT_SUPPORTED",
+        //   data:{ supported_actions:[...] }, recovery:{ commandChosen:null,...} }
+        let action_name = "setValue";
+        let supported = vec![
+            "focus".to_string(),
+            "blur".to_string(),
+            "type".to_string(),
+            "clear".to_string(),
+            "click".to_string(),
+        ];
+        let recovery = RecoveryOutcome {
+            recovered: true,
+            via: RecoveryVia::LlmFallback,
+            command_chosen: None,
+            error_code: None,
+            result: None,
+        };
+        let recovery_json = serde_json::to_value(&recovery).unwrap();
+        let body = json!({
+            "code": "ACTION_NOT_SUPPORTED",
+            "supported_actions": supported,
+            "requested_action": action_name,
+            "recovery": recovery_json,
+        });
+        let envelope = ApiResponse::<serde_json::Value> {
+            success: false,
+            data: Some(body),
+            error: Some(format!(
+                "Action '{}' is not supported by element 'btn-1'. \
+                 Element advertises: {:?}",
+                action_name, supported
+            )),
+            error_detail: None,
+            hint: None,
+        };
+        let envelope_json = serde_json::to_value(&envelope).unwrap();
+
+        assert_eq!(
+            envelope_json.get("success").and_then(|v| v.as_bool()),
+            Some(false),
+            "contract: envelope.success must be false (not the misleading true)"
+        );
+        let data = envelope_json
+            .get("data")
+            .expect("contract: data field must be present");
+        assert_eq!(
+            data.get("code").and_then(|v| v.as_str()),
+            Some("ACTION_NOT_SUPPORTED"),
+            "contract: data.code must be ACTION_NOT_SUPPORTED"
+        );
+        let supp = data
+            .get("supported_actions")
+            .and_then(|v| v.as_array())
+            .expect("contract: data.supported_actions must be an array");
+        let names: Vec<&str> = supp.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"click"));
+        assert!(names.contains(&"type"));
+        assert!(
+            !names.contains(&"setValue"),
+            "contract: requested action must NOT appear in the advertised list \
+             (else the discriminator wouldn't fire)"
+        );
+        // Recovery audit trail still surfaced — commandChosen is null
+        // exactly because that's the contract violation we're flagging.
+        let recovery_field = data
+            .get("recovery")
+            .expect("contract: data.recovery must be carried for audit");
+        assert!(
+            recovery_field.get("commandChosen").map(|v| v.is_null()).unwrap_or(false),
+            "contract: data.recovery.commandChosen must be null (this is the \
+             precondition that triggered ACTION_NOT_SUPPORTED)"
+        );
     }
 }

--- a/src-tauri/src/process_capture/manager.rs
+++ b/src-tauri/src/process_capture/manager.rs
@@ -1666,11 +1666,7 @@ mod preflight_node_bin_tests {
         // `npx --quiet next dev` should still resolve to `next`.
         let tmp = tempdir().unwrap();
         let mut cfg = npx_next_config(tmp.path());
-        cfg.args = vec![
-            "--quiet".to_string(),
-            "next".to_string(),
-            "dev".to_string(),
-        ];
+        cfg.args = vec!["--quiet".to_string(), "next".to_string(), "dev".to_string()];
         assert_eq!(expected_node_bin(&cfg), Some("next".to_string()));
     }
 

--- a/src-tauri/src/process_capture/manager.rs
+++ b/src-tauri/src/process_capture/manager.rs
@@ -129,6 +129,28 @@ impl ProcessCaptureManager {
             .get_mut(id)
             .ok_or_else(|| format!("Process '{}' not found", id))?;
 
+        // Loop B Item C — node-dependent process pre-flight.
+        //
+        // When a managed process invokes `npx next` (the Frontend Next.js
+        // dev service) or any `next`-based wrapper, the actual binary
+        // resolved is `<cwd>/node_modules/.bin/next`. With a broken
+        // pnpm-style install the `.pnpm/` tree can exist while the
+        // `.bin/` symlinks were never created — `npx` then falls through
+        // to PATH and emits the cryptic
+        // `'next' is not recognized as an internal or external command`,
+        // making it indistinguishable from "next was never installed"
+        // for the operator reading the Processes page.
+        //
+        // Fail-fast with an explicit, actionable message before spawning
+        // so the operator knows exactly what to fix.
+        if let Err(precheck_err) = preflight_node_bin_check(&process.config) {
+            warn!(
+                "start_process: pre-flight check rejected '{}': {}",
+                process.config.name, precheck_err
+            );
+            return Err(precheck_err);
+        }
+
         let msg_rx = process.start()?;
         let process_id = id.to_string();
         let process_name = process.config.name.clone();
@@ -1376,6 +1398,115 @@ impl ProcessCaptureManager {
     }
 }
 
+/// Loop B Item C — fail-fast pre-flight for node-dependent managed processes.
+///
+/// When the configured command is `npx`/`npm`/`pnpm`/`yarn` (or any direct
+/// `node_modules/.bin/<name>` invocation), the binary actually resolved at
+/// spawn time lives under `<cwd>/node_modules/.bin/`. A broken pnpm install
+/// can leave `<cwd>/node_modules/.pnpm/` populated while the `.bin/`
+/// symlinks were never created — `npx` then falls through to PATH and the
+/// child crashes with `'next' is not recognized` on Windows or
+/// `next: command not found` on Unix, which the operator cannot easily
+/// disambiguate from "next was never installed."
+///
+/// This pre-flight inspects the `command`+`args` to figure out which
+/// node-resolved binary the spawn expects, then verifies it exists under
+/// the configured `cwd/node_modules/.bin/`. When missing, returns
+/// `Err(...)` with the explicit fix-up command so the operator knows
+/// exactly what to run. Returns `Ok(())` when:
+///   - the process isn't a node-dependent invocation (no .bin lookup needed),
+///   - the expected `.bin/<name>` file exists,
+///   - the process's `cwd` doesn't have a `node_modules` directory yet
+///     (first-time install case — let the normal build path handle it).
+///
+/// Auto-heal was deliberately not chosen — silently masking a broken
+/// install accumulates state-drift; fail-fast surfaces it once.
+fn preflight_node_bin_check(config: &ProcessConfig) -> Result<(), String> {
+    let Some(bin_name) = expected_node_bin(config) else {
+        // Not a node-dependent invocation — nothing to pre-flight.
+        return Ok(());
+    };
+
+    let cwd = std::path::Path::new(&config.cwd);
+    let node_modules = cwd.join("node_modules");
+    if !node_modules.exists() {
+        // First-time install — `node_modules` itself missing is a clearer
+        // signal than ".bin/<x> missing" and the rebuild_enabled build
+        // command (e.g. `npx next build`) will surface it directly.
+        return Ok(());
+    }
+
+    let bin_dir = node_modules.join(".bin");
+    // Probe BOTH the bare name and the Windows shim variants
+    // (npm/pnpm/yarn emit either `.cmd` or `.ps1` wrappers on Windows).
+    #[cfg(windows)]
+    let candidates: [std::path::PathBuf; 3] = [
+        bin_dir.join(format!("{}.cmd", bin_name)),
+        bin_dir.join(format!("{}.ps1", bin_name)),
+        bin_dir.join(&bin_name),
+    ];
+    #[cfg(not(windows))]
+    let candidates: [std::path::PathBuf; 1] = [bin_dir.join(&bin_name)];
+
+    if candidates.iter().any(|p| p.exists()) {
+        return Ok(());
+    }
+
+    Err(format!(
+        "frontend dependencies incomplete — node_modules/.bin/{name} not found at \
+         {bin_dir_disp}, run `npm install` in {cwd_disp}",
+        name = bin_name,
+        bin_dir_disp = bin_dir.display(),
+        cwd_disp = cwd.display(),
+    ))
+}
+
+/// Determine which `node_modules/.bin/<name>` a [`ProcessConfig`] expects
+/// to resolve at spawn time. Returns `None` when the command isn't a
+/// node-binary invocation we can pre-check.
+///
+/// Recognized shapes:
+///   - `command = "npx"`, args = `[<name>, ...]` → `Some(<name>)`
+///   - `command = "node_modules/.bin/<name>"` (relative) → `Some(<name>)`
+///   - `command = "<absolute>/node_modules/.bin/<name>"` → `Some(<name>)`
+///
+/// `npm run <script>` / `pnpm <script>` / `yarn <script>` are deliberately
+/// NOT pre-checked: the script body is in `package.json` and may invoke
+/// any number of binaries — pre-flighting would require parsing package.json
+/// and tracking which scripts our managed-process registry runs, which
+/// duplicates state the dev_services.rs config already encodes. We instead
+/// pin those configs to `npx <name>` in dev_services.rs (see the Frontend
+/// service block) so the pre-flight has a single shape to recognize.
+fn expected_node_bin(config: &ProcessConfig) -> Option<String> {
+    let cmd = config.command.trim();
+    if cmd.eq_ignore_ascii_case("npx") {
+        // First non-flag positional after the leading subcommand
+        // (npx supports `npx --quiet next dev`, etc.) is the binary name.
+        return config
+            .args
+            .iter()
+            .find(|a| !a.starts_with('-'))
+            .map(|s| s.to_string());
+    }
+    // Direct `.bin/<name>` invocations (relative or absolute). Match the
+    // bare segment so both `node_modules/.bin/<name>` (relative) and
+    // `<abs>/node_modules/.bin/<name>` shapes resolve.
+    let normalized = cmd.replace('\\', "/");
+    if let Some(idx) = normalized.rfind("node_modules/.bin/") {
+        let after = &normalized[idx + "node_modules/.bin/".len()..];
+        // Strip any platform shim suffix so the probe re-adds them all.
+        let stripped = after
+            .strip_suffix(".cmd")
+            .or_else(|| after.strip_suffix(".ps1"))
+            .or_else(|| after.strip_suffix(".exe"))
+            .unwrap_or(after);
+        if !stripped.is_empty() && !stripped.contains('/') {
+            return Some(stripped.to_string());
+        }
+    }
+    None
+}
+
 /// Pure resolution helper backing [`ProcessCaptureManager::resolve_process_id`].
 ///
 /// Each entry is `(id, name, category)`. Match precedence:
@@ -1474,5 +1605,190 @@ mod tests {
         // But the category itself is also ambiguous (both are "backend"),
         // so the category lookup also returns None.
         assert_eq!(resolve_process_id_from_entries(&e, "backend"), None);
+    }
+}
+
+#[cfg(test)]
+mod preflight_node_bin_tests {
+    //! Loop B Item C — fail-fast pre-flight for node-dependent processes.
+    //!
+    //! The pre-flight needs a real on-disk `cwd` because the broken-install
+    //! signal we're guarding against is the *absence* of a file inside
+    //! `<cwd>/node_modules/.bin/`. `tempfile::tempdir` (a dev-dep already
+    //! pulled in) gives us a per-test scratch directory with automatic
+    //! cleanup, so the tests are hermetic without mocking std::fs.
+    use super::{expected_node_bin, preflight_node_bin_check};
+    use crate::process_capture::types::*;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn npx_next_config(cwd: &Path) -> ProcessConfig {
+        ProcessConfig {
+            id: "test-frontend".to_string(),
+            name: "Frontend (Next.js)".to_string(),
+            command: "npx".to_string(),
+            args: vec![
+                "next".to_string(),
+                "dev".to_string(),
+                "--port".to_string(),
+                "3001".to_string(),
+            ],
+            cwd: cwd.to_string_lossy().to_string(),
+            env: HashMap::new(),
+            health_port: Some(3001),
+            parser: ParserType::JavaScript,
+            auto_start: true,
+            category: "frontend".to_string(),
+            buffer_size: 2000,
+            enabled: true,
+            ignore_patterns: vec![],
+            start_group: 1,
+            dev_only: true,
+            rebuild_enabled: true,
+            build_command: Some("npx".to_string()),
+            build_args: vec!["next".to_string(), "build".to_string()],
+        }
+    }
+
+    #[test]
+    fn expected_node_bin_npx_returns_first_positional() {
+        let tmp = tempdir().unwrap();
+        assert_eq!(
+            expected_node_bin(&npx_next_config(tmp.path())),
+            Some("next".to_string())
+        );
+    }
+
+    #[test]
+    fn expected_node_bin_npx_skips_flags_before_bin_name() {
+        // `npx --quiet next dev` should still resolve to `next`.
+        let tmp = tempdir().unwrap();
+        let mut cfg = npx_next_config(tmp.path());
+        cfg.args = vec![
+            "--quiet".to_string(),
+            "next".to_string(),
+            "dev".to_string(),
+        ];
+        assert_eq!(expected_node_bin(&cfg), Some("next".to_string()));
+    }
+
+    #[test]
+    fn expected_node_bin_direct_bin_path() {
+        let tmp = tempdir().unwrap();
+        let mut cfg = npx_next_config(tmp.path());
+        cfg.command = "node_modules/.bin/vite".to_string();
+        cfg.args = vec![];
+        assert_eq!(expected_node_bin(&cfg), Some("vite".to_string()));
+
+        // Absolute, with Windows shim suffix stripped.
+        cfg.command = "C:/proj/node_modules/.bin/next.cmd".to_string();
+        assert_eq!(expected_node_bin(&cfg), Some("next".to_string()));
+    }
+
+    #[test]
+    fn expected_node_bin_non_node_command_returns_none() {
+        let tmp = tempdir().unwrap();
+        let mut cfg = npx_next_config(tmp.path());
+        cfg.command = "poetry".to_string();
+        cfg.args = vec!["run".to_string(), "python".to_string()];
+        assert_eq!(expected_node_bin(&cfg), None);
+
+        cfg.command = "cargo".to_string();
+        cfg.args = vec!["run".to_string()];
+        assert_eq!(expected_node_bin(&cfg), None);
+    }
+
+    #[test]
+    fn preflight_passes_when_bin_present() {
+        // Healthy install: node_modules/.bin/next exists on disk.
+        let tmp = tempdir().unwrap();
+        let bin_dir = tmp.path().join("node_modules").join(".bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        // On Windows, the real shim is `next.cmd`; on Unix, the bare name.
+        #[cfg(windows)]
+        fs::write(bin_dir.join("next.cmd"), "@echo off\nnext").unwrap();
+        #[cfg(not(windows))]
+        fs::write(bin_dir.join("next"), "#!/usr/bin/env node\n").unwrap();
+
+        let cfg = npx_next_config(tmp.path());
+        let res = preflight_node_bin_check(&cfg);
+        assert!(
+            res.is_ok(),
+            "pre-flight must pass when .bin/next exists; got {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn preflight_fails_fast_when_bin_missing() {
+        // Broken pnpm-style install: `node_modules/.pnpm/` exists but
+        // `node_modules/.bin/` does not (or doesn't contain the binary).
+        let tmp = tempdir().unwrap();
+        let pnpm_dir = tmp.path().join("node_modules").join(".pnpm");
+        fs::create_dir_all(&pnpm_dir).unwrap();
+        // Deliberately omit `.bin/next`.
+
+        let cfg = npx_next_config(tmp.path());
+        let res = preflight_node_bin_check(&cfg);
+        let err = res.expect_err(
+            "pre-flight must fail-fast when node_modules exists but .bin/next is missing",
+        );
+        assert!(
+            err.contains("frontend dependencies incomplete"),
+            "error must surface the canonical fail-fast prefix; got: {}",
+            err
+        );
+        assert!(
+            err.contains("npm install"),
+            "error must tell the operator how to fix it; got: {}",
+            err
+        );
+        assert!(
+            err.contains("next"),
+            "error must name the missing binary; got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn preflight_skips_when_node_modules_absent() {
+        // First-time install case — `node_modules` itself doesn't exist
+        // yet. The rebuild_enabled build_command path will surface the
+        // need to install; the pre-flight has nothing more to add.
+        let tmp = tempdir().unwrap();
+        let cfg = npx_next_config(tmp.path());
+        let res = preflight_node_bin_check(&cfg);
+        assert!(
+            res.is_ok(),
+            "pre-flight must skip when node_modules itself is absent; got {:?}",
+            res
+        );
+    }
+
+    #[test]
+    fn preflight_passes_for_non_node_processes() {
+        // Backend / Python / cargo etc. must not be touched by this check.
+        let tmp = tempdir().unwrap();
+        // Even with a broken node_modules tree present, a non-node command
+        // is still let through.
+        let bin_dir = tmp.path().join("node_modules").join(".pnpm");
+        fs::create_dir_all(&bin_dir).unwrap();
+
+        let mut cfg = npx_next_config(tmp.path());
+        cfg.command = "poetry".to_string();
+        cfg.args = vec![
+            "run".to_string(),
+            "python".to_string(),
+            "run.py".to_string(),
+        ];
+        let res = preflight_node_bin_check(&cfg);
+        assert!(
+            res.is_ok(),
+            "pre-flight must be a no-op for non-node commands; got {:?}",
+            res
+        );
     }
 }


### PR DESCRIPTION
## Summary

Loop B iter 1 remediation for 3 manual-test findings on the runner.

### Item A (P1) — `setValue` misleading success
`POST /control/element/:id/action {action:"setValue"}` against an element that doesn't advertise setValue returned `success:true, data.recovered:true, data.recovery.commandChosen:null` — a contract violation where the Phase 5 RecoveryExecutor's LLM fallback "recovered" without selecting any structured command, synthesizing a no-op while advertising success.

Fix: capture the element's advertised `actions` list pre-flight (reusing the existing disabled-check `get_element` IPC — no extra round-trip). After `attempt_recovery`, when `recovery.recovered && recovery.command_chosen.is_none()`, invert the envelope to:
```json
{
  "success": false,
  "data": {
    "code": "ACTION_NOT_SUPPORTED",
    "supported_actions": [...],
    "requested_action": "setValue",
    "recovery": {"commandChosen": null, ...}
  }
}
```
When `command_chosen` IS set, the existing success-on-recovery envelope is preserved.

### Item B (P2) — `/control/components` duplicate envelope
`GET /control/components` previously returned `components` both at the top level AND nested under `data.components` (byte-identical mirror). Drop the top-level field; `data.components` is the single source of truth.

### Item C (P2) — PM frontend start fails opaquely on broken `node_modules/.bin`
When `<frontend>/node_modules/.pnpm/` exists but `.bin/next` was never created, the spawn crashed with the cryptic `'next' is not recognized`. Added a fail-fast pre-flight in `ProcessCaptureManager::start_process` that probes `<cwd>/node_modules/.bin/<name>` (with Windows shim variants) before spawning. Missing → explicit `frontend dependencies incomplete — node_modules/.bin/<name> not found at <dir>, run \`npm install\` in <cwd>`.

Fail-fast picked over auto-heal per spec — silently masking a broken install accumulates state-drift.

## Files
- `src-tauri/src/mcp/ui_bridge/elements.rs` — Items A + B (handler, helpers, tests)
- `src-tauri/src/process_capture/manager.rs` — Item C (pre-flight, helpers, tests)

## Test plan
- [x] `cargo check --bin qontinui-runner` (clean)
- [x] `cargo clippy --bin qontinui-runner -- -D warnings` (clean)
- [x] `cargo test --bin qontinui-runner sdk_manifest_routes_are_exposed_by_runner manifest_matches_route_calls action_not_supported_tests components_envelope_tests preflight_node_bin_tests` — **21/21 passing**
  - 7 tests `action_not_supported_tests::*` (Item A pure helpers + envelope shape)
  - 3 tests `components_envelope_tests::*` (Item B regression + canonical shape)
  - 8 tests `preflight_node_bin_tests::*` (Item C mocked-filesystem fail-fast + healthy + skip + non-node)
  - 2 cargo-gate tests `manifest_drift_tests::*` (unchanged, still passing)
- [ ] Manual probe: `POST /control/element/<button>/action {"action":"setValue"}` → body now `success:false, code:"ACTION_NOT_SUPPORTED"` instead of misleading `success:true`
- [ ] Manual probe: `GET /control/components` → response has only `data.components`, no top-level `components`
- [ ] Manual probe: blow away `qontinui-web/frontend/node_modules/.bin/next` and try to start Frontend service → explicit fail-fast message in Processes page