### PR TITLE
fix(pg): guard task_runs NULL panic in verification-phase results

### DIFF
--- a/src-tauri/src/database/pg/task_runs.rs
+++ b/src-tauri/src/database/pg/task_runs.rs
@@ -1761,14 +1761,22 @@ impl PgDb {
             .get()
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
+        // NULL-guard: bind Option<String> to avoid uncatchable panic if a row
+        // has result_json = NULL (schema declares NOT NULL, but local-PG drift
+        // has been observed in the wild — see commit log). The defensive WHERE
+        // is belt-and-braces; the Option bind is the primary fix.
         let rows = conn.query(
-            "SELECT result_json FROM workflow_verification_phase_results WHERE task_run_id = $1 ORDER BY iteration ASC",
+            "SELECT result_json FROM workflow_verification_phase_results WHERE task_run_id = $1 AND result_json IS NOT NULL ORDER BY iteration ASC",
             &[&task_run_id],
         ).await.map_err(|e| format!("PG get_all_verification_phase_results: {}", e))?;
 
         let mut results = Vec::new();
         for row in &rows {
-            let json_str: String = row.get(0);
+            let json_opt: Option<String> = row.get(0);
+            let Some(json_str) = json_opt else {
+                // Defensive: WHERE filter should have excluded these.
+                continue;
+            };
             if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json_str) {
                 results.push(parsed);
             }
@@ -1786,14 +1794,18 @@ impl PgDb {
             .get()
             .await
             .map_err(|e| format!("PG pool error: {}", e))?;
+        // NULL-guard: bind Option<String>. See get_all_verification_phase_results.
         let row = conn.query_opt(
-            "SELECT result_json FROM workflow_verification_phase_results WHERE task_run_id = $1 ORDER BY iteration DESC LIMIT 1",
+            "SELECT result_json FROM workflow_verification_phase_results WHERE task_run_id = $1 AND result_json IS NOT NULL ORDER BY iteration DESC LIMIT 1",
             &[&task_run_id],
         ).await.map_err(|e| format!("PG get_latest_verification_results: {}", e))?;
 
         match row {
             Some(r) => {
-                let json_str: String = r.get(0);
+                let json_opt: Option<String> = r.get(0);
+                let Some(json_str) = json_opt else {
+                    return Ok(None);
+                };
                 Ok(serde_json::from_str(&json_str).ok())
             }
             None => Ok(None),

--- a/src-tauri/src/database/pg/workflow_state.rs
+++ b/src-tauri/src/database/pg/workflow_state.rs
@@ -385,9 +385,13 @@ impl PgDb {
             .map_err(|e| format!("PG pool error: {}", e))?;
         let iter_i32 = iteration as i32;
 
+        // NULL-guard: bind Option<String> to avoid an uncatchable panic in
+        // tokio-postgres if result_json is NULL (schema declares NOT NULL, but
+        // local-PG drift has been seen). The defensive `IS NOT NULL` in the
+        // WHERE is belt-and-braces; the Option bind is the primary fix.
         let row = conn
             .query_opt(
-                "SELECT result_json FROM workflow_verification_phase_results WHERE task_run_id = $1 AND iteration = $2 LIMIT 1",
+                "SELECT result_json FROM workflow_verification_phase_results WHERE task_run_id = $1 AND iteration = $2 AND result_json IS NOT NULL LIMIT 1",
                 &[&task_run_id, &iter_i32],
             )
             .await
@@ -395,7 +399,10 @@ impl PgDb {
 
         match row {
             Some(r) => {
-                let json_str: String = r.get(0);
+                let json_opt: Option<String> = r.get(0);
+                let Some(json_str) = json_opt else {
+                    return Ok(None);
+                };
                 let parsed: serde_json::Value = serde_json::from_str(&json_str)
                     .map_err(|e| format!("Failed to parse verification result JSON: {}", e))?;
                 Ok(Some(parsed))


### PR DESCRIPTION
## Summary

- Runner was hard-crashing whenever `workflow_verification_phase_results.result_json` returned NULL — `tokio-postgres` `Row::get::<_, String>` PANICS on NULL, uncatchable in the `Ok(rows)` arm, killing the entire process. The supervisor restarted the runner, which surfaced as a "can't reconnect to the WS" symptom (manual-test-loop iter-4).
- Crash file `runner-last-panic.txt` pointed at `task_runs.rs:1771` (`get_all_verification_phase_results`). Two siblings share the shape and risk: `get_latest_verification_results` (same file, line ~1796) and `get_verification_phase_result` in `workflow_state.rs` (called by `health_monitor` + `phases`).
- Per the canonical tokio-postgres NULL-panic pattern: bind `Option<String>` and skip `None` rows. Added defensive `WHERE result_json IS NOT NULL` to each query as belt-and-braces — the bind change is the primary fix.

## Sites fixed

- `src-tauri/src/database/pg/task_runs.rs:1771` — `get_all_verification_phase_results` (the crash site)
- `src-tauri/src/database/pg/task_runs.rs:~1796` — `get_latest_verification_results`
- `src-tauri/src/database/pg/workflow_state.rs:~398` — `get_verification_phase_result`

## Schema note

`schema.pg.sql.generated` line 10616 declares `result_json text NOT NULL` for `project.workflow_verification_phase_results`. The crash demonstrates local-PG drift in the field, so the defensive guards hold even when the canonical schema says they shouldn't be necessary.

## Test plan

- [x] `cargo check --bin qontinui-runner` clean (after worktree dist/ stub for the Tauri proc-macro)
- [x] `cargo clippy --bin qontinui-runner --no-deps -- -D warnings` clean
- [ ] Follow-up integration session: run a verification-phase workflow against a row where `result_json` has been hand-nulled and confirm no panic (deferred — do not restart the primary runner from this PR session).

## Rules followed

- Do not auto-merge; awaiting operator review.
- No Claude attribution trailer.
- No `--no-verify`. Used config-sanctioned `QONTINUI_PREPUSH_SKIP=1` only because the worktree lacks the frontend `dist/` build artifact, which makes pre-push clippy fail on env, not code (CI re-gates).