### PR TITLE
fix(frontend): unstick boot — hoist langium peers + unwrap traceviewer envelope

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -10,5 +10,9 @@ legacy-peer-deps=true
 # Hoisting the whole vscode-languageserver-* family + vscode-jsonrpc to the
 # top-level node_modules dedups them and makes the bare-specifier imports
 # resolve under pnpm strict mode without needing to publish a langium patch.
-public-hoist-pattern[]=vscode-languageserver*
+public-hoist-pattern[]=vscode-languageserver
+public-hoist-pattern[]=vscode-languageserver-types
+public-hoist-pattern[]=vscode-languageserver-protocol
+public-hoist-pattern[]=vscode-languageserver-textdocument
 public-hoist-pattern[]=vscode-jsonrpc
+public-hoist-pattern[]=vscode-uri

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,14 @@
 legacy-peer-deps=true
+
+# langium 4.2.3 imports vscode-jsonrpc, vscode-languageserver-types, and
+# vscode-languageserver-protocol but does not declare them as direct deps —
+# they're transitive via vscode-languageserver. Under pnpm's default strict
+# node_modules layout these bare imports unresolve, breaking the vite +
+# rolldown bundle: langium ends up as `vscode_languageserver_types is not
+# defined` at runtime and the React app fails on boot.
+#
+# Hoisting the whole vscode-languageserver-* family + vscode-jsonrpc to the
+# top-level node_modules dedups them and makes the bare-specifier imports
+# resolve under pnpm strict mode without needing to publish a langium patch.
+public-hoist-pattern[]=vscode-languageserver*
+public-hoist-pattern[]=vscode-jsonrpc

--- a/src/components/widgets/trace-viewer/useTraceViewerData.ts
+++ b/src/components/widgets/trace-viewer/useTraceViewerData.ts
@@ -11,7 +11,16 @@ async function fetchExecutionSpans(executionId: string): Promise<TraceSpan[]> {
   if (!response.ok) {
     throw new Error(`Failed to fetch spans: ${response.statusText}`);
   }
-  return response.json();
+  // The runner endpoint returns an envelope `{ count, filters, spans }`,
+  // not a bare array. Earlier consumers passed the envelope straight through,
+  // which slipped past TS (no runtime check) and surfaced as
+  // `spans is not iterable` inside computeInsights() when TraceViewerWidget
+  // was rendered for an empty/non-array shape. Unwrap defensively: accept
+  // either the envelope or a bare array, default to [].
+  const body = await response.json();
+  if (Array.isArray(body)) return body;
+  if (body && Array.isArray(body.spans)) return body.spans;
+  return [];
 }
 
 /** Hook to fetch execution spans for a task run. */


### PR DESCRIPTION
## Summary

Two independent fixes that together let a freshly-built runner boot cleanly and survive an audit that activates every tab in sequence.

## .npmrc: hoist \`vscode-languageserver*\` + \`vscode-jsonrpc\`

\`langium\` 4.2.3 imports \`vscode-jsonrpc\`, \`vscode-languageserver-types\`, and \`vscode-languageserver-protocol\` but does not declare them as direct dependencies — they're transitive via \`vscode-languageserver\`. Under pnpm's default strict node_modules layout those bare-specifier imports unresolve and rolldown bundles them as references to undefined locals (\`vscode_languageserver_types is not defined\`), which crashes the React app the moment any consumer of langium renders. Hoisting the family dedups them and lets the imports resolve.

## \`useTraceViewerData\`: unwrap envelope from \`/execution-spans\`

\`GET /execution-spans\` returns \`{ count, filters, spans }\` — \`fetchExecutionSpans\` was doing \`return response.json()\` straight through, slipping past TS. \`computeInsights\` then threw \`spans is not iterable\` (the envelope has no \`.length\`, so the early-return didn't fire). The unhandled exception broke React's render tree and **killed the UI Bridge SDK** — every subsequent \`/spec-check\` against that runner returned HTTP 504 until restart.

This was the root cause of the "SDK disconnect under rapid tab switches" pattern from yesterday's corpus audit attempts (33 specs erroring out from \`run-traces\` onwards alphabetically). With this fix the SDK survives the audit.

## Test plan

- [x] \`npm run build\` succeeds (no rolldown unresolved imports)
- [x] Fresh temp runner spawn shows \`frontend_stale: false\` (was \`build_failed\` before .npmrc fix)
- [x] Auto-login wires through and brings up prompt-home (65 elements)
- [x] Activating \`run-traces\` tab no longer breaks the React tree
- [ ] Full corpus audit completes 96/96 without any HTTP 504 ERRORs (requires this PR to land + rerun \`scripts/spec_audit.py\`)