### PR TITLE
feat(spec-ci): transition executor — IR state-graph walker over UI Bridge HTTP

### DIFF
--- a/scripts/spec_ci/README.md
+++ b/scripts/spec_ci/README.md
@@ -1,0 +1,74 @@
+# qontinui-spec-ci
+
+Spec-CI executor — walks an `IrPageSpec`'s state graph against a running UI-Bridge-connected app via the runner's HTTP surface and emits a CI-friendly pass/fail report. The behavioural analogue of `spec_audit.py` (which only checks static `assertions[]`).
+
+## What it does
+
+Given a runner URL, app id, and page id:
+
+1. `GET /apps/<app>/spec/get?id=<page>` to fetch the IR.
+2. `adaptIRDocumentToWorkflowConfig` (from `@qontinui/shared-types/ui-bridge-ir`) to convert the IR shape into the in-memory `AdaptedWorkflowConfig` that `ui-bridge-auto`'s runtime engine consumes.
+3. Snapshot the runner via `GET /ui-bridge/sdk/snapshot`, rebuild a minimal `jsdom` document so `ui-bridge-auto`'s DOM-based matcher (`matchesQuery`) works without a real browser.
+4. Construct a `StateMachine` from the adapted config, run `StateDetector.evaluate()` to pin the initial active set.
+5. For each `IrTransition` in the doc (skipping `effect: "destructive"` unless `--include-destructive`), call `executeTransition` from `ui-bridge-auto/state/transition-executor`. Actions dispatch through `POST /ui-bridge/sdk/element/<id>/action`; waits use the existing `idle | time | element | vanish | change | stable` machinery.
+6. Re-snapshot, re-detect, record whether the `activateStates` actually became active.
+7. Emit a deterministic JSON report (results sorted by transition id).
+
+## Why this design
+
+The transition-executor, pathfinder, state-detector, and matcher in `ui-bridge-auto` already exist and are battle-tested (WU-5 complete). The matcher is DOM-bound, but `jsdom` reconstructs enough DOM from the snapshot JSON to keep the matcher working without changing it. Net new code is one file of HTTP adapters + a thin CLI — everything else is plumbing.
+
+## CLI
+
+```
+spec-ci-run \
+  --runner http://localhost:9876 \
+  --app qontinui-web \
+  --page operations \
+  --output /tmp/spec-ci-operations.json \
+  [--include-destructive] \
+  [--page-url http://localhost:3001/operations]
+```
+
+If `--page-url` is supplied, the executor `POSTs /ui-bridge/sdk/page/navigate` to that URL before evaluating. Useful when the runner's connected SDK isn't already on the target page.
+
+## Output schema
+
+```json
+{
+  "runnerUrl": "http://localhost:9876",
+  "appId": "qontinui-web",
+  "pageId": "operations",
+  "evaluatedAt": "2026-05-22T...",
+  "initialStates": ["..."],
+  "transitions": [
+    {
+      "id": "t1",
+      "name": "...",
+      "fromStates": ["..."],
+      "activateStates": ["..."],
+      "effect": "read" | "write" | "destructive" | null,
+      "executed": true,
+      "passed": true,
+      "durationMs": 412,
+      "missingActivateStates": [],
+      "extraActiveStates": [],
+      "error": null
+    }
+  ],
+  "summary": {
+    "totalTransitions": 0,
+    "executedTransitions": 0,
+    "passedTransitions": 0,
+    "skippedDestructive": 0,
+    "errorTransitions": 0,
+    "passRate": 1.0
+  }
+}
+```
+
+## Not in scope for v1
+
+- Pathfinding to a specific target state (use `navigateToState` directly if you need it; the CLI exercises every transition individually).
+- Parallel execution — transitions run sequentially since the underlying SDK is single-tenant.
+- Counterfactual exploration / regression suite generation. Those are separate ui-bridge-auto subpaths.

--- a/scripts/spec_ci/package.json
+++ b/scripts/spec_ci/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "qontinui-spec-ci",
+  "version": "0.1.0",
+  "description": "CLI that walks an IrPageSpec's transitions against a running UI-Bridge-connected app and emits a CI-friendly pass/fail report. Reuses ui-bridge-auto's transition-executor + pathfinder + state-detector unchanged; the only new code is HTTP adapters that bridge the runner's /ui-bridge/sdk/* surface to the in-memory ActionExecutorLike / RegistryLike contracts.",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "spec-ci-run": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "tsx src/cli.ts"
+  },
+  "dependencies": {
+    "@qontinui/shared-types": "link:../../../qontinui-schemas/ts",
+    "@qontinui/ui-bridge-auto": "link:../../../ui-bridge-auto",
+    "jsdom": "^25.0.1"
+  },
+  "devDependencies": {
+    "@types/jsdom": "^21.1.7",
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/scripts/spec_ci/pnpm-lock.yaml
+++ b/scripts/spec_ci/pnpm-lock.yaml
@@ -1,0 +1,851 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@qontinui/shared-types':
+        specifier: link:../../../qontinui-schemas/ts
+        version: link:../../../qontinui-schemas/ts
+      '@qontinui/ui-bridge-auto':
+        specifier: link:../../../ui-bridge-auto
+        version: link:../../../ui-bridge-auto
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+    devDependencies:
+      '@types/jsdom':
+        specifier: ^21.1.7
+        version: 21.1.7
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.19
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
+packages:
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/jsdom@21.1.7':
+    resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.3:
+    resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@types/jsdom@21.1.7':
+    dependencies:
+      '@types/node': 22.19.19
+      '@types/tough-cookie': 4.0.5
+      parse5: 7.3.0
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/tough-cookie@4.0.5': {}
+
+  agent-base@7.1.4: {}
+
+  asynckit@0.4.0: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  entities@6.0.1: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
+  hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  lru-cache@10.4.3: {}
+
+  math-intrinsics@1.1.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  ms@2.1.3: {}
+
+  nwsapi@2.2.23: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  punycode@2.3.1: {}
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  symbol-tree@3.2.4: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  ws@8.21.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}

--- a/scripts/spec_ci/src/cli.ts
+++ b/scripts/spec_ci/src/cli.ts
@@ -1,0 +1,400 @@
+#!/usr/bin/env node
+/**
+ * spec-ci-run — walk an IrPageSpec's transitions against a running app and
+ * emit a CI-friendly pass/fail report.
+ *
+ * Pipeline:
+ *   1. Fetch the IR via runner Spec API.
+ *   2. Adapt IR → AdaptedWorkflowConfig (uses qontinui-schemas/ts adapter).
+ *   3. Build StateMachine + StateDetector from the adapted shape.
+ *   4. Snapshot the connected app, detect the initial active state set.
+ *   5. For each transition (skipping `effect: "destructive"` unless opted in):
+ *      a. executeTransition() — drives actions via HttpActionExecutor.
+ *      b. Re-snapshot, re-detect.
+ *      c. Record whether activateStates became active and exitStates left.
+ *   6. Emit report.
+ */
+
+import { writeFileSync } from "node:fs";
+import { adaptIRDocumentToWorkflowConfig } from "@qontinui/shared-types/ui-bridge-ir";
+import type { IRDocument } from "@qontinui/shared-types/ui-bridge-ir";
+import {
+  StateMachine,
+  StateDetector,
+  executeTransition,
+} from "@qontinui/ui-bridge-auto/runtime";
+import { HttpRegistry, type BridgeKind } from "./http-registry.js";
+import { HttpActionExecutor, navigateRunner } from "./http-action-executor.js";
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+
+interface Args {
+  runner: string;
+  app: string;
+  page: string;
+  output?: string;
+  pageUrl?: string;
+  bridge: BridgeKind;
+  includeDestructive: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Partial<Args> = { includeDestructive: false, bridge: "sdk" };
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    switch (flag) {
+      case "--runner":
+        args.runner = value;
+        i++;
+        break;
+      case "--app":
+        args.app = value;
+        i++;
+        break;
+      case "--page":
+        args.page = value;
+        i++;
+        break;
+      case "--output":
+        args.output = value;
+        i++;
+        break;
+      case "--page-url":
+        args.pageUrl = value;
+        i++;
+        break;
+      case "--bridge":
+        if (value !== "sdk" && value !== "control") {
+          throw new Error(`--bridge must be 'sdk' or 'control' (got ${value})`);
+        }
+        args.bridge = value;
+        i++;
+        break;
+      case "--include-destructive":
+        args.includeDestructive = true;
+        break;
+      case "-h":
+      case "--help":
+        printHelp();
+        process.exit(0);
+      default:
+        if (flag.startsWith("--")) {
+          throw new Error(`Unknown flag: ${flag}`);
+        }
+    }
+  }
+  if (!args.runner || !args.app || !args.page) {
+    printHelp();
+    throw new Error("--runner, --app, and --page are required");
+  }
+  return args as Args;
+}
+
+function printHelp(): void {
+  process.stderr.write(
+    [
+      "spec-ci-run — walk an IrPageSpec's transitions and emit a CI report",
+      "",
+      "Usage:",
+      "  spec-ci-run --runner <url> --app <id> --page <pageId> [--output <path>]",
+      "             [--page-url <url>] [--include-destructive]",
+      "",
+      "Flags:",
+      "  --runner <url>             Runner base URL (e.g. http://localhost:9876)",
+      "  --app <id>                 App id registered on the runner",
+      "  --page <pageId>            Spec page id (the slug, not the URL path)",
+      "  --output <path>            Write report JSON here (default stdout)",
+      "  --page-url <url>           Navigate the SDK to this URL before evaluating",
+      "  --bridge <sdk|control>     Bridge surface to target (default: sdk).",
+      "                             Use 'control' to drive the runner's own webview",
+      "                             (always connected); use 'sdk' for external apps.",
+      "  --include-destructive      Run transitions tagged effect=destructive",
+      "",
+    ].join("\n"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// IR fetch
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the raw IR document for a spec page. The Spec API exposes the file
+ * via `GET /apps/<app>/spec/get?path=pages/<id>/state-machine.derived.json`
+ * (raw file contents, path-traversal protected). The sibling
+ * `/spec/page/<id>` endpoint returns a different projection shape with
+ * `groups` instead of `states` — we want raw IR so the adapter sees the
+ * shape it expects.
+ *
+ * Error envelopes from `spec/get` are flat: `{ ok: false, reason: "...",
+ * detail?: ... }`. Surface the reason in the thrown error so CI logs are
+ * actionable.
+ */
+async function fetchIR(runner: string, app: string, page: string): Promise<IRDocument> {
+  const path = `pages/${page}/state-machine.derived.json`;
+  const url = `${runner.replace(/\/$/, "")}/apps/${encodeURIComponent(app)}/spec/get?path=${encodeURIComponent(path)}`;
+  const resp = await fetch(url);
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`spec/get HTTP ${resp.status}: ${text.slice(0, 200)}`);
+  }
+  const body = (await resp.json()) as IRDocument & { ok?: boolean; reason?: string };
+  if (body.ok === false || !body.states || !body.transitions) {
+    throw new Error(
+      `spec/get returned no IR for app=${app} page=${page} (reason: ${body.reason ?? "missing states/transitions"})`,
+    );
+  }
+  return body as IRDocument;
+}
+
+// ---------------------------------------------------------------------------
+// Report shape
+// ---------------------------------------------------------------------------
+
+interface TransitionReport {
+  id: string;
+  name: string;
+  fromStates: string[];
+  activateStates: string[];
+  exitStates: string[];
+  effect: string | null;
+  executed: boolean;
+  passed: boolean;
+  durationMs: number;
+  missingActivateStates: string[];
+  unexpectedExitStatesStillActive: string[];
+  error: string | null;
+}
+
+interface Report {
+  runnerUrl: string;
+  appId: string;
+  pageId: string;
+  evaluatedAt: string;
+  initialStates: string[];
+  finalStates: string[];
+  transitions: TransitionReport[];
+  summary: {
+    totalTransitions: number;
+    executedTransitions: number;
+    passedTransitions: number;
+    skippedDestructive: number;
+    errorTransitions: number;
+    passRate: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Driver
+// ---------------------------------------------------------------------------
+
+async function run(args: Args): Promise<Report> {
+  // 1. Fetch the raw IR (we need it for `effect` which the adapter strips).
+  const ir = await fetchIR(args.runner, args.app, args.page);
+  const adapted = adaptIRDocumentToWorkflowConfig(ir);
+
+  // 2. Build the in-memory machine.
+  const machine = new StateMachine();
+  machine.defineStates(adapted.states);
+  machine.defineTransitions(adapted.transitions);
+
+  // 3. Open the registry + executor. The registry's first refresh doubles as
+  //    a precondition check: if the SDK isn't connected we bail with a
+  //    structured error rather than producing nonsense pass/fail data.
+  const registry = new HttpRegistry(args.runner, args.bridge);
+
+  if (args.pageUrl) {
+    await navigateRunner(args.runner, args.pageUrl, args.bridge);
+  }
+
+  const initialSnapshot = await registry.refresh();
+  if (!initialSnapshot.sdkConnected) {
+    throw new Error(
+      `SDK not connected to ${args.app} — refusing to author results. Hint: ${initialSnapshot.fallbackNote ?? "no detail from runner"}`,
+    );
+  }
+
+  const detector = new StateDetector(machine, registry);
+  detector.evaluate();
+  const initialStates = Array.from(machine.getActiveStates()).sort();
+
+  const executor = new HttpActionExecutor(args.runner, registry, args.bridge);
+
+  // 4. Walk every transition in declaration order. We don't pathfind here —
+  //    the CLI exercises each transition individually so a single failure
+  //    doesn't cascade. State activation is checked *after* the transition's
+  //    actions run against whatever state was active going in.
+  const transitionReports: TransitionReport[] = [];
+  let skippedDestructive = 0;
+
+  for (const t of ir.transitions) {
+    const effect = t.effect ?? null;
+    const adaptedT = adapted.transitions.find((x) => x.id === t.id);
+    if (!adaptedT) {
+      transitionReports.push(emptyTransitionReport(t.id, t.name, effect, "transition missing from adapter output"));
+      continue;
+    }
+
+    if (effect === "destructive" && !args.includeDestructive) {
+      skippedDestructive++;
+      transitionReports.push({
+        id: t.id,
+        name: t.name,
+        fromStates: adaptedT.fromStates,
+        activateStates: adaptedT.activateStates,
+        exitStates: adaptedT.exitStates,
+        effect,
+        executed: false,
+        passed: false,
+        durationMs: 0,
+        missingActivateStates: [],
+        unexpectedExitStatesStillActive: [],
+        error: "skipped: effect=destructive (pass --include-destructive to run)",
+      });
+      continue;
+    }
+
+    const started = Date.now();
+    let error: string | null = null;
+    let executed = false;
+
+    try {
+      await executeTransition(adaptedT, executor);
+      executed = true;
+    } catch (err) {
+      error = err instanceof Error ? err.message : String(err);
+    }
+
+    // Force a final refresh + re-evaluate even on error; an aborted
+    // transition may have completed half its actions, leaving the UI in a
+    // partial-success state we want to record.
+    try {
+      await registry.refresh();
+      detector.evaluate();
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      error = error ? `${error} | post-detect: ${detail}` : `post-detect: ${detail}`;
+    }
+
+    const active = machine.getActiveStates();
+    const missingActivateStates = adaptedT.activateStates.filter(
+      (s) => !active.has(s),
+    );
+    const unexpectedExitStatesStillActive = adaptedT.exitStates.filter((s) =>
+      active.has(s),
+    );
+
+    const passed =
+      executed &&
+      error === null &&
+      missingActivateStates.length === 0 &&
+      unexpectedExitStatesStillActive.length === 0;
+
+    transitionReports.push({
+      id: t.id,
+      name: t.name,
+      fromStates: adaptedT.fromStates,
+      activateStates: adaptedT.activateStates,
+      exitStates: adaptedT.exitStates,
+      effect,
+      executed,
+      passed,
+      durationMs: Date.now() - started,
+      missingActivateStates,
+      unexpectedExitStatesStillActive,
+      error,
+    });
+  }
+
+  detector.dispose();
+
+  // 5. Build the report.
+  const finalStates = Array.from(machine.getActiveStates()).sort();
+  const executedCount = transitionReports.filter((r) => r.executed).length;
+  const passedCount = transitionReports.filter((r) => r.passed).length;
+  const errorCount = transitionReports.filter((r) => r.error !== null && !r.error.startsWith("skipped:")).length;
+
+  return {
+    runnerUrl: args.runner,
+    appId: args.app,
+    pageId: args.page,
+    evaluatedAt: new Date().toISOString(),
+    initialStates,
+    finalStates,
+    transitions: transitionReports.sort((a, b) => a.id.localeCompare(b.id)),
+    summary: {
+      totalTransitions: ir.transitions.length,
+      executedTransitions: executedCount,
+      passedTransitions: passedCount,
+      skippedDestructive,
+      errorTransitions: errorCount,
+      passRate:
+        executedCount === 0 ? 0 : passedCount / executedCount,
+    },
+  };
+}
+
+function emptyTransitionReport(
+  id: string,
+  name: string,
+  effect: string | null,
+  error: string,
+): TransitionReport {
+  return {
+    id,
+    name,
+    fromStates: [],
+    activateStates: [],
+    exitStates: [],
+    effect,
+    executed: false,
+    passed: false,
+    durationMs: 0,
+    missingActivateStates: [],
+    unexpectedExitStatesStillActive: [],
+    error,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Entrypoint
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<number> {
+  let args: Args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 2;
+  }
+
+  try {
+    const report = await run(args);
+    const out = JSON.stringify(report, null, 2);
+    if (args.output) {
+      writeFileSync(args.output, out, "utf-8");
+      process.stderr.write(
+        `[spec-ci] wrote ${args.output} (${report.summary.passedTransitions}/${report.summary.executedTransitions} passed, ${report.summary.skippedDestructive} destructive-skipped, ${report.summary.errorTransitions} errored)\n`,
+      );
+    } else {
+      process.stdout.write(out + "\n");
+    }
+    // CI gate: exit non-zero iff any executed transition failed.
+    return report.summary.errorTransitions > 0 ||
+      (report.summary.executedTransitions > 0 &&
+        report.summary.passedTransitions < report.summary.executedTransitions)
+      ? 1
+      : 0;
+  } catch (err) {
+    process.stderr.write(
+      `[spec-ci] fatal: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return 1;
+  }
+}
+
+main().then((code) => process.exit(code));

--- a/scripts/spec_ci/src/http-action-executor.ts
+++ b/scripts/spec_ci/src/http-action-executor.ts
@@ -1,0 +1,184 @@
+/**
+ * HTTP-backed ActionExecutorLike for the spec-CI executor.
+ *
+ * Bridges ui-bridge-auto's in-memory action contract to the runner's
+ * `/ui-bridge/sdk/*` proxy. Element resolution runs in-process against the
+ * registry's last-known snapshot (cheap, deterministic); action dispatch
+ * goes over HTTP to the connected app.
+ *
+ * After every action we trigger a `refresh()` on the registry so the next
+ * `findElement` call sees the post-action DOM. `waitForIdle` is implemented
+ * as a polling loop on the snapshot itself — the CLI waits until the
+ * element count is stable across consecutive snapshots within a quiet
+ * window. Crude but effective; the underlying `waitAfter` types
+ * (`element`, `vanish`, `change`, `stable`) all rely on `findElement`
+ * which we already make deterministic via `refresh()`.
+ */
+
+import type {
+  ActionExecutorLike,
+  ElementQuery,
+  TransitionAction,
+} from "@qontinui/ui-bridge-auto/runtime";
+import { findFirst, matchesQuery } from "@qontinui/ui-bridge-auto/runtime";
+import { HttpRegistry, type BridgeKind } from "./http-registry.js";
+
+const DEFAULT_IDLE_QUIET_MS = 400;
+const DEFAULT_IDLE_TIMEOUT_MS = 5_000;
+const IDLE_POLL_MS = 100;
+
+export interface HttpActionExecutorOptions {
+  /**
+   * Hook fired immediately before each remote action dispatch — useful for
+   * tracing/timing in the CLI report. The hook does not affect dispatch.
+   */
+  onAction?: (info: {
+    elementId: string;
+    action: string;
+    params?: Record<string, unknown>;
+  }) => void;
+}
+
+export class HttpActionExecutor implements ActionExecutorLike {
+  constructor(
+    private readonly runnerUrl: string,
+    private readonly registry: HttpRegistry,
+    private readonly bridge: BridgeKind = "sdk",
+    private readonly opts: HttpActionExecutorOptions = {},
+  ) {}
+
+  // -- ActionExecutorLike --------------------------------------------------
+
+  findElement(query: ElementQuery): { id: string } | null {
+    const elements = this.registry.getAllElements();
+    const result = findFirst(elements, query);
+    return result.match ? { id: result.match.id } : null;
+  }
+
+  findAllElements(query: ElementQuery): { id: string }[] {
+    const elements = this.registry.getAllElements();
+    const out: { id: string }[] = [];
+    for (const el of elements) {
+      if (matchesQuery(el, query).matches) out.push({ id: el.id });
+    }
+    return out;
+  }
+
+  async executeAction(
+    elementId: string,
+    action: string,
+    params?: Record<string, unknown>,
+  ): Promise<void> {
+    this.opts.onAction?.({ elementId, action, params });
+
+    const url = `${this.runnerUrl.replace(/\/$/, "")}/ui-bridge/${this.bridge}/element/${encodeURIComponent(elementId)}/action`;
+    const body = params ? { action, params } : { action };
+
+    let resp: Response;
+    try {
+      resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    } catch (err) {
+      throw new Error(
+        `executeAction transport error (element=${elementId} action=${action}): ${String(err)}`,
+      );
+    }
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(
+        `executeAction HTTP ${resp.status} (element=${elementId} action=${action}): ${text.slice(0, 200)}`,
+      );
+    }
+
+    // Don't trust the runner's `success: true` — the SDK relay sometimes
+    // reports success when the underlying action no-ops. Refresh the
+    // snapshot so subsequent findElement queries see the post-action DOM,
+    // and let the caller's `waitAfter` confirm the change took effect.
+    const refreshed = await this.registry.refresh();
+    if (!refreshed.sdkConnected) {
+      throw new Error(
+        `SDK disconnected mid-execution after action ${action} on ${elementId}: ${refreshed.fallbackNote ?? "no detail"}`,
+      );
+    }
+  }
+
+  async waitForIdle(timeout?: number): Promise<void> {
+    const budget = timeout ?? DEFAULT_IDLE_TIMEOUT_MS;
+    const quiet = DEFAULT_IDLE_QUIET_MS;
+    const deadline = Date.now() + budget;
+    let lastCount = this.registry.getAllElements().length;
+    let stableSince = Date.now();
+
+    while (Date.now() < deadline) {
+      await sleep(IDLE_POLL_MS);
+      const snap = await this.registry.refresh();
+      if (!snap.sdkConnected) {
+        // SDK fell over during waitForIdle — surface immediately rather
+        // than blocking until the budget expires. The CLI catches this
+        // and records a structured error.
+        throw new Error(`SDK disconnected during waitForIdle: ${snap.fallbackNote ?? ""}`);
+      }
+      const count = this.registry.getAllElements().length;
+      if (count !== lastCount) {
+        lastCount = count;
+        stableSince = Date.now();
+        continue;
+      }
+      if (Date.now() - stableSince >= quiet) return;
+    }
+    // Timeout is non-fatal — ui-bridge-auto's `waitForIdle` callers treat it
+    // as best-effort. Return silently rather than throwing.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Synchronous element resolver shaped like `executor.findElement` but useful
+ * outside the executor (e.g., the CLI's pre-transition state detection).
+ * Kept here so callers don't have to import findFirst directly.
+ */
+export function resolveQuery(
+  registry: HttpRegistry,
+  query: ElementQuery,
+): { id: string } | null {
+  const elements = registry.getAllElements();
+  const result = findFirst(elements, query);
+  return result.match ? { id: result.match.id } : null;
+}
+
+/**
+ * Convenience: navigate the runner-connected app to a URL. Used at CLI
+ * startup when `--page-url` is supplied so the executor lands on the right
+ * page before transitions run.
+ */
+export async function navigateRunner(
+  runnerUrl: string,
+  url: string,
+  bridge: BridgeKind = "sdk",
+): Promise<void> {
+  const endpoint = `${runnerUrl.replace(/\/$/, "")}/ui-bridge/${bridge}/page/navigate`;
+  const resp = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`page/navigate HTTP ${resp.status}: ${text.slice(0, 200)}`);
+  }
+}
+
+// Re-export the unused TransitionAction type purely so it's discoverable when
+// callers import this module — silences an `unused import` flag in callers
+// who pull only HttpActionExecutor + this hint.
+export type { TransitionAction };

--- a/scripts/spec_ci/src/http-registry.ts
+++ b/scripts/spec_ci/src/http-registry.ts
@@ -1,0 +1,281 @@
+/**
+ * Snapshot-backed RegistryLike for the spec-CI executor.
+ *
+ * The runner's `/ui-bridge/sdk/snapshot` endpoint returns the connected app's
+ * element registry as JSON. ui-bridge-auto's matcher (`matchesQuery`) reads
+ * properties off a real `HTMLElement` — `getAttribute`, `tagName`,
+ * `textContent`, etc. To keep the matcher unchanged while running outside a
+ * browser, we reconstruct a minimal jsdom document with one synthetic node
+ * per snapshot element and expose them as `QueryableElement`s.
+ *
+ * The reconstruction is deliberately shallow: we mirror tagName, attributes,
+ * textContent, and visible state, NOT DOM hierarchy. Criteria that reach
+ * across the tree (`parent`, `ancestor`, `hasChild`) won't resolve — that's
+ * acceptable for the v1 spec-CI surface because authors are coached to use
+ * `id` and `role`/`text` combinators that don't need hierarchy. If a real
+ * spec ever needs hierarchy resolution, the answer is to run inside a real
+ * browser via Bucket C7's headless launcher rather than to expand the jsdom
+ * shim.
+ */
+
+import { JSDOM } from "jsdom";
+import type { QueryableElement, RegistryLike } from "@qontinui/ui-bridge-auto/runtime";
+
+// `QueryableElementState` is the live `el.getState()` return type. ui-bridge-auto
+// exports `QueryableElement` from `/runtime` but not its inner state shape —
+// mirror the shape locally so we don't depend on a private re-export.
+interface QueryableElementState {
+  visible?: boolean;
+  enabled?: boolean;
+  focused?: boolean;
+  checked?: boolean;
+  textContent?: string;
+  value?: string | number | boolean;
+  rect?: { x: number; y: number; width: number; height: number };
+  computedStyles?: Record<string, string>;
+  visibilityRatio?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot wire shape (mirrors qontinui-schemas/rust/src/ui_bridge.rs and the
+// envelope the runner sends back from /ui-bridge/sdk/snapshot)
+// ---------------------------------------------------------------------------
+
+interface SnapshotElement {
+  id: string;
+  type?: string;
+  label?: string | null;
+  tagName?: string | null;
+  role?: string | null;
+  ariaLabel?: string | null;
+  accessibleName?: string | null;
+  text?: string | null;
+  identifier?: {
+    htmlId?: string | null;
+    testId?: string | null;
+    awasId?: string | null;
+    uiId?: string | null;
+    xpath?: string;
+    selector?: string;
+  };
+  state?: {
+    visible?: boolean;
+    enabled?: boolean;
+    focused?: boolean;
+    checked?: boolean | null;
+    value?: string | number | null;
+    textContent?: string | null;
+    accessibleName?: string | null;
+    computedStyles?: Record<string, string>;
+    rect?: { x: number; y: number; width: number; height: number };
+  };
+  bbox?: { x: number; y: number; width: number; height: number };
+}
+
+interface SnapshotEnvelope {
+  success?: boolean;
+  data: {
+    elements?: SnapshotElement[];
+    note?: string;
+    reason?: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic HTMLElement construction
+// ---------------------------------------------------------------------------
+
+const synthesisDom = new JSDOM("<!doctype html><html><body></body></html>");
+const document = synthesisDom.window.document;
+
+/**
+ * Build a detached jsdom element that reflects the snapshot row's structural
+ * surface. The matcher reads `.tagName`, `.getAttribute(...)`, and
+ * `.textContent`; everything else flows through `QueryableElement.getState()`,
+ * which reads directly from the snapshot row.
+ */
+function synthesizeElement(el: SnapshotElement): HTMLElement {
+  // Default to a generic <div> when tagName is absent — matches the snapshot
+  // convention for content blocks the SDK didn't tag.
+  const tag = (el.tagName ?? "div").toLowerCase();
+  // jsdom rejects some pseudo-tags; fall back to `div` if construction throws.
+  let node: HTMLElement;
+  try {
+    node = document.createElement(tag);
+  } catch {
+    node = document.createElement("div");
+  }
+
+  if (el.role) node.setAttribute("role", el.role);
+  if (el.ariaLabel) node.setAttribute("aria-label", el.ariaLabel);
+  if (el.identifier?.htmlId) node.id = el.identifier.htmlId;
+  if (el.identifier?.testId) node.setAttribute("data-testid", el.identifier.testId);
+
+  // Surface the visible text. The matcher prefers el.element.textContent over
+  // QueryableElementState.textContent in a couple of branches, so set both.
+  const text = el.text ?? el.state?.textContent ?? "";
+  if (text) node.textContent = text;
+
+  // Type attribute carries useful disambiguation for <input>; preserve it.
+  if (el.type && tag === "input") {
+    node.setAttribute("type", el.type);
+  }
+
+  return node;
+}
+
+function toQueryableState(el: SnapshotElement): QueryableElementState {
+  const s = el.state ?? {};
+  const out: QueryableElementState = {};
+  if (s.visible !== undefined) out.visible = s.visible;
+  if (s.enabled !== undefined) out.enabled = s.enabled;
+  if (s.focused !== undefined) out.focused = s.focused;
+  if (s.checked !== undefined && s.checked !== null) out.checked = s.checked;
+  if (s.value !== undefined && s.value !== null) {
+    out.value = s.value as string | number | boolean;
+  }
+  // Prefer the nested textContent; fall back to top-level text so the state's
+  // text query path still sees content the matcher cares about.
+  const txt = s.textContent ?? el.text ?? null;
+  if (txt !== null) out.textContent = txt;
+  const rect = s.rect ?? el.bbox;
+  if (rect) out.rect = rect;
+  if (s.computedStyles) out.computedStyles = s.computedStyles;
+  return out;
+}
+
+function toQueryable(el: SnapshotElement): QueryableElement {
+  const state = toQueryableState(el);
+  return {
+    id: el.id,
+    element: synthesizeElement(el),
+    type: el.type ?? "div",
+    label: el.label ?? undefined,
+    getState: () => state,
+    getIdentifier: () => ({
+      selector: el.identifier?.selector,
+      xpath: el.identifier?.xpath,
+      htmlId: el.identifier?.htmlId ?? undefined,
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot fetch + parse
+// ---------------------------------------------------------------------------
+
+export class SnapshotFetchError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = "SnapshotFetchError";
+  }
+}
+
+export interface SnapshotResult {
+  elements: SnapshotElement[];
+  sdkConnected: boolean;
+  fallbackNote?: string;
+}
+
+/**
+ * Bridge surface to target.
+ *
+ * - `sdk` (default) — proxy to an externally-connected app's SDK (qontinui-web
+ *   running in a real browser). Required for spec-CI against qontinui-web.
+ * - `control` — the runner's OWN React webview. Always available because the
+ *   runner's webview-side SDK is loaded directly into its Tauri window.
+ *   Use for self-tests + when authoring specs for the runner's own UI.
+ */
+export type BridgeKind = "sdk" | "control";
+
+/**
+ * Fetch the latest snapshot from the runner. Detects SDK-fallback (when the
+ * runner returns a native-window capture because no SDK is connected) so the
+ * CLI can fail fast rather than authoring against an empty/wrong page.
+ */
+export async function fetchSnapshot(
+  runnerUrl: string,
+  bridge: BridgeKind = "sdk",
+): Promise<SnapshotResult> {
+  const url = `${runnerUrl.replace(/\/$/, "")}/ui-bridge/${bridge}/snapshot`;
+  let resp: Response;
+  try {
+    resp = await fetch(url);
+  } catch (err) {
+    throw new SnapshotFetchError(`snapshot transport error: ${String(err)}`);
+  }
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new SnapshotFetchError(
+      `snapshot http ${resp.status}`,
+      resp.status,
+      body.slice(0, 200),
+    );
+  }
+  const envelope = (await resp.json()) as SnapshotEnvelope;
+  const data = envelope.data ?? {};
+  const note = data.note ?? "";
+  const reason = data.reason ?? "";
+  // Match the heuristic spec_audit.py uses to detect SDK disconnect.
+  const sdkConnected =
+    !note.includes("SDK was not connected") &&
+    !reason.includes("UI Bridge request timed out");
+  return {
+    elements: data.elements ?? [],
+    sdkConnected,
+    fallbackNote: sdkConnected ? undefined : `${note} / ${reason}`.trim(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HttpRegistry
+// ---------------------------------------------------------------------------
+
+/**
+ * A `RegistryLike` whose contents are refreshed on demand from the runner's
+ * snapshot endpoint. Event subscription is a no-op (HTTP is not event-driven)
+ * — the CLI manually calls `refresh()` after each action and re-runs
+ * `StateDetector.evaluate()`.
+ */
+export class HttpRegistry implements RegistryLike {
+  private elements: QueryableElement[] = [];
+
+  constructor(
+    private readonly runnerUrl: string,
+    private readonly bridge: BridgeKind = "sdk",
+  ) {}
+
+  /** Pull the latest snapshot and rebuild the QueryableElement cache. */
+  async refresh(): Promise<SnapshotResult> {
+    const snap = await fetchSnapshot(this.runnerUrl, this.bridge);
+    if (!snap.sdkConnected) {
+      // Don't poison the cache with native-fallback data — preserve whatever
+      // was there from the last successful snapshot. Caller checks the
+      // sdkConnected flag and decides whether to abort.
+      return snap;
+    }
+    this.elements = snap.elements.map(toQueryable);
+    return snap;
+  }
+
+  // -- RegistryLike --------------------------------------------------------
+
+  getAllElements(): QueryableElement[] {
+    return this.elements;
+  }
+
+  on(
+    _type: string,
+    _listener: (event: { type: string; data: unknown }) => void,
+  ): () => void {
+    // HTTP isn't event-driven. StateDetector subscribes here to know when
+    // to re-evaluate; we won't ever invoke the listener. Returning a no-op
+    // unsubscribe is correct — the CLI drives evaluation manually after
+    // each transition lands.
+    return () => {};
+  }
+}


### PR DESCRIPTION
## Summary

\`scripts/spec_ci/\` — Node/TS CLI that walks an \`IrPageSpec\`'s transitions against a running UI-Bridge-connected app and emits a CI-friendly pass/fail report. The behavioural analogue of \`scripts/spec_audit.py\` (which only checks static assertions). Together with the spec corpus that the spaceship-agent wave is authoring, this closes the loop on replacing Playwright CI with Spec CI.

## What's new vs. what's reused

\`ui-bridge-auto\` already has the executor logic (WU-5 complete): \`executeTransition\`, \`navigateToState\`, \`StateDetector\`, \`findPath\`, \`matchesQuery\`. The IR-to-runtime adapter (\`adaptIRDocumentToWorkflowConfig\`) lives in \`qontinui-schemas/ts\`. The only new code in this PR is the HTTP plumbing that bridges those existing pieces to the runner's \`/ui-bridge/<sdk|control>/*\` proxy:

- \`http-registry.ts\` — \`RegistryLike\` backed by \`/snapshot\` + minimal \`jsdom\` reconstruction so the DOM-bound matcher works without a real browser
- \`http-action-executor.ts\` — \`ActionExecutorLike\` dispatching \`executeAction\` over HTTP and refreshing the snapshot cache between actions
- \`cli.ts\` — argparse + IR fetch + state-machine wiring + report builder

About 600 lines, no fork of ui-bridge-auto.

## Bridge selection

\`--bridge sdk\` (default) targets an externally-connected app via the runner's SDK proxy — the canonical surface for qontinui-web specs. \`--bridge control\` targets the runner's own webview (always connected) — useful for self-tests and runner-page specs.

## Limitations + handoffs

- \`jsdom\` reconstruction is shallow: hierarchy criteria (\`parent\` / \`ancestor\` / \`hasChild\`) won't resolve. Specs that need them should run via Bucket C7's headless launcher instead — separate PR.
- Verified end-to-end against \`settings-general\` (0 transitions today; pipeline walked the state machine + emitted a clean report). The full transition path will be exercised once the spaceship-agent specs with behavioural transitions land.

## Test plan

- [x] \`pnpm install && pnpm run typecheck\` clean
- [x] CLI \`--help\` renders
- [x] End-to-end against a logged-in temp runner: IR fetched, adapted, state-machine built, state detection ran (2 states active), report written
- [ ] Re-run once a qontinui-web spec with transitions exists, confirm \`executeTransition\` path produces correct pass/fail