### PR TITLE
fix(runner): strip /ws path suffix in coord_ws_to_http

### DIFF
--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -867,14 +867,19 @@ pub async fn allocate_and_materialize_with_claim(
 /// Convert a `ws://` or `wss://` coord URL into the matching HTTP base.
 /// Profiles store `coord_url` as a WebSocket URL because the `/ws`
 /// endpoint is the dominant runner-side use case; HTTP callers (this
-/// module, build_events POSTs) flip the scheme.
+/// module, build_events POSTs, fleet-health panel) flip the scheme AND
+/// strip the trailing `/ws` so paths like `/coord/fleet/health` don't
+/// get appended onto the WS upgrade path (which JWT-rejects with 401).
+/// Mirrors the supervisor's resolver at
+/// `qontinui-supervisor/src/fleet.rs::coord_http_base`.
 pub fn coord_ws_to_http(coord_url: &str) -> String {
-    if let Some(rest) = coord_url.strip_prefix("ws://") {
+    let trimmed = coord_url.trim_end_matches('/').trim_end_matches("/ws");
+    if let Some(rest) = trimmed.strip_prefix("ws://") {
         format!("http://{}", rest)
-    } else if let Some(rest) = coord_url.strip_prefix("wss://") {
+    } else if let Some(rest) = trimmed.strip_prefix("wss://") {
         format!("https://{}", rest)
     } else {
-        coord_url.to_string()
+        trimmed.to_string()
     }
 }
 
@@ -901,6 +906,22 @@ mod tests {
         assert_eq!(coord_ws_to_http("wss://h:9870"), "https://h:9870");
         assert_eq!(coord_ws_to_http("http://h:9870"), "http://h:9870");
         assert_eq!(coord_ws_to_http("https://h:9870"), "https://h:9870");
+    }
+
+    #[test]
+    fn coord_ws_to_http_strips_ws_suffix() {
+        // The dominant profile shape is `ws://host:port/ws` — the
+        // resolver MUST strip `/ws` so callers building
+        // `format!("{base}/coord/fleet/health")` don't end up at
+        // `/ws/coord/fleet/health` (the WS upgrade path, which 401s).
+        assert_eq!(coord_ws_to_http("ws://h:9870/ws"), "http://h:9870");
+        assert_eq!(coord_ws_to_http("wss://h:9870/ws"), "https://h:9870");
+        assert_eq!(coord_ws_to_http("http://h:9870/ws"), "http://h:9870");
+        // Trailing-slash tolerance: `ws://h:9870/ws/` collapses too.
+        assert_eq!(coord_ws_to_http("ws://h:9870/ws/"), "http://h:9870");
+        // Bare trailing slash (no `/ws`) is also stripped so callers
+        // don't double-slash when appending a path.
+        assert_eq!(coord_ws_to_http("ws://h:9870/"), "http://h:9870");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`coord_ws_to_http()` in `src-tauri/src/agent_worktree/mod.rs:871` swapped `ws://` → `http://` but **forgot to strip the trailing `/ws` path segment** that profiles always carry. Every runner-side HTTP call to coord then hit `/ws/coord/<path>`, which routes to the WebSocket upgrade endpoint and 401s with `HTTP status client error (401 Unauthorized)`.

Surfaced today via `/manual-test the health-url advertisement` — the Phase 3/4 fleet-health pipeline I shipped 5 days ago is healthy end-to-end at the backend (spaceship probed every 30s, `last_probe_ok=true`), but the `FleetHealthPanel` in `CoordinatorDashboard` renders "0 machines — coord unreachable" because `commands::productivity::get_fleet_health` 401s.

## Root cause

```rust
// before — swap only
if let Some(rest) = coord_url.strip_prefix("ws://") {
    format!("http://{}", rest)
}
// `ws://h:9870/ws` → `http://h:9870/ws`
// Then format!("{base}/coord/fleet/health") → `http://h:9870/ws/coord/fleet/health` → 401
```

The sibling resolver at `qontinui-supervisor/src/fleet.rs::coord_http_base` correctly strips `/ws` before the scheme swap. Same intent, divergent implementation — the runner's version had no `/ws`-suffix test coverage (lines 899-903 only cover bare-host inputs) so it stayed latent.

## Fix

One-line addition: `trim_end_matches('/').trim_end_matches("/ws")` before the prefix-strip branch. 4 new tests lock in the `/ws`, `/ws/`, and trailing-slash cases.

## Blast radius

`coord_ws_to_http` is used by at least:
- `commands::productivity::get_fleet_health` — the panel surfacing this bug
- `commands::claims.rs:95` — also routing coord HTTP via this helper, also broken against `/ws`-suffixed profiles

After merge: both unblock automatically with no further code changes.

## Test plan

- [x] `cargo test --bin qontinui-runner coord_ws_to_http` — both `coord_ws_to_http_swaps_scheme` (existing) and `coord_ws_to_http_strips_ws_suffix` (new, 5 assertions) pass locally
- [ ] CI: 3-OS test matrix + security + 2 freshness gates
- [ ] Post-merge UI re-verification: spawn temp runner (rebuild), navigate Productivity → Coordinator, confirm panel renders "1 machine · spaceship · healthy"

## Plan

`/manual-test` session 2026-05-22 — Phase 6 remediation plan implemented in full.