### PR TITLE
feat(ui-bridge): per-tab command routing via ?tabId= (runner wire-through)

### DIFF
--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -1018,11 +1018,46 @@ async fn handle_element(
     }
 }
 
-/// Optional query parameters for SDK action execution (task_run_id for persistence).
+/// Optional query parameters for SDK action execution.
+///
+/// - `task_run_id` - persistence correlation for the audit event.
+/// - `tab_id` / `target_tab_id` - per-tab routing (UI Bridge Item #4). When a
+///   single relay (e.g. qontinui-web's dashboard at demo.staging.qontinui.io)
+///   has more than one browser tab connected - two operator machines each
+///   driving a headless tab - the relay's default dispatch routes to
+///   `primaryTabId`, which flips to whichever tab registered most recently.
+///   Supplying a `tabId` pins the forwarded command to that specific tab's
+///   pipe instead. Discover live ids via `GET /ui-bridge/sdk/tabs` (proxied to
+///   the relay's `GET /tabs`). All spellings accepted; `tabId` is the public
+///   query name, `targetTabId` the relay's internal option name.
 #[derive(Debug, serde::Deserialize, Default)]
 pub struct SdkActionQueryParams {
     #[serde(default)]
     pub task_run_id: Option<i64>,
+    #[serde(
+        default,
+        alias = "tabId",
+        alias = "targetTabId",
+        alias = "target_tab_id"
+    )]
+    pub tab_id: Option<String>,
+}
+
+/// Append a `tabId=<id>` query parameter to an SDK-relay HTTP path, preserving
+/// any existing query string. Trims and skips empty ids. The SDK's Next.js /
+/// Express adapters sniff `?tabId=` (and the `X-UI-Bridge-Tab-Id` header) and
+/// thread it into the relay's per-tab command dispatch, so threading it onto
+/// the forwarded path is sufficient for the HTTP-transport arm. The
+/// WS-transport arm instead carries `targetTabId` inside the dispatched payload
+/// (the relay's `extractTabRouting` reads it from the command payload).
+fn append_tab_id_query(path: &str, tab_id: Option<&str>) -> String {
+    match tab_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(id) => {
+            let sep = if path.contains('?') { '&' } else { '?' };
+            format!("{}{}tabId={}", path, sep, urlencoding::encode(id))
+        }
+        None => path.to_string(),
+    }
 }
 
 /// POST /ui-bridge/sdk/element/:id/action — Execute an action on an element
@@ -1041,8 +1076,22 @@ async fn handle_element_action(
     let start = std::time::Instant::now();
 
     // Phase 1 wrapper framework: WS-transport apps dispatch over their socket.
-    let ws_payload = serde_json::json!({ "id": id, "request": body.clone() });
-    let path = format!("/control/element/{}/action", id);
+    // Per-tab routing (Item #4): when a `tabId` is supplied, carry it as
+    // `targetTabId` in the WS payload (the relay's `extractTabRouting` reads it
+    // from the command payload) AND as a `?tabId=` query on the HTTP path (the
+    // SDK adapter sniffs the query). The relay rejects an unknown/stale tab with
+    // a structured `TAB_NOT_FOUND` / `TAB_STALE` envelope which we forward
+    // verbatim - no silent fall-through to the primary tab.
+    let tab_id = query
+        .tab_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let ws_payload = match tab_id {
+        Some(t) => serde_json::json!({ "id": id, "request": body.clone(), "targetTabId": t }),
+        None => serde_json::json!({ "id": id, "request": body.clone() }),
+    };
+    let path = append_tab_id_query(&format!("/control/element/{}/action", id), tab_id);
     let result = match dispatch_app_request(
         &state,
         "executeElementAction",
@@ -1168,12 +1217,24 @@ async fn handle_snapshot(
     };
     let want_disabled_only = query.get("withDisabledOnly").is_some_and(truthy)
         || query.get("with_disabled_only").is_some_and(truthy);
+    // Per-tab routing (Item #4): pin the snapshot to a specific connected tab
+    // when `?tabId=` (or `?targetTabId=`) is supplied. Lets a caller snapshot
+    // tab A while tab B is the relay's primary, instead of always getting the
+    // primary tab's view.
+    let tab_id = query
+        .get("tabId")
+        .or_else(|| query.get("targetTabId"))
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty());
     let mut ws_payload = serde_json::json!({});
     if let Some(r) = query.get("recency") {
         ws_payload["recency"] = serde_json::Value::String(r.clone());
     }
     if want_disabled_only {
         ws_payload["withDisabledOnly"] = serde_json::Value::Bool(true);
+    }
+    if let Some(t) = tab_id {
+        ws_payload["targetTabId"] = serde_json::Value::String(t.to_string());
     }
     // Forward recency + withDisabledOnly query params to the SDK app
     let mut query_parts: Vec<String> = Vec::new();
@@ -1182,6 +1243,9 @@ async fn handle_snapshot(
     }
     if want_disabled_only {
         query_parts.push("withDisabledOnly=true".to_string());
+    }
+    if let Some(t) = tab_id {
+        query_parts.push(format!("tabId={}", urlencoding::encode(t)));
     }
     let path = if query_parts.is_empty() {
         "/control/snapshot".to_string()
@@ -2145,9 +2209,35 @@ async fn handle_windows(
     super::ui_bridge::ui_bridge_list_windows_handler(axum::extract::State(state)).await
 }
 
-/// GET /ui-bridge/sdk/tabs — List connected browser tabs
-async fn handle_tabs(State(state): State<Arc<ApiState>>) -> Json<serde_json::Value> {
-    match sdk_request(&state, Method::GET, "/tabs", None).await {
+/// GET /ui-bridge/sdk/tabs — List connected browser tabs.
+///
+/// Per-tab routing (Item #4/#15) discovery surface. Forwards the SDK relay's
+/// `?activeOnly=true` (drop tabs whose heartbeat went stale) and `?detailed=true`
+/// (enrich each entry with a live URL/pathname/title round-trip) query params so
+/// a caller can discover the exact `tabId` to pin a subsequent `?tabId=` command
+/// to. Each returned entry carries `tabId`, `isPrimary`, `isActive`, and
+/// `lastHeartbeat`.
+async fn handle_tabs(
+    State(state): State<Arc<ApiState>>,
+    Query(query): Query<HashMap<String, String>>,
+) -> Json<serde_json::Value> {
+    let truthy = |v: &String| {
+        let s = v.trim();
+        s == "1" || s.eq_ignore_ascii_case("true")
+    };
+    let mut parts: Vec<String> = Vec::new();
+    if query.get("activeOnly").is_some_and(truthy) {
+        parts.push("activeOnly=true".to_string());
+    }
+    if query.get("detailed").is_some_and(truthy) {
+        parts.push("detailed=true".to_string());
+    }
+    let path = if parts.is_empty() {
+        "/tabs".to_string()
+    } else {
+        format!("/tabs?{}", parts.join("&"))
+    };
+    match sdk_request(&state, Method::GET, &path, None).await {
         Ok(data) => Json(data),
         Err(e) => Json(serde_json::json!({ "success": false, "error": e })),
     }
@@ -6508,5 +6598,78 @@ mod tests {
         )
         .await;
         assert_eq!(chosen, serde_json::Value::Null);
+    }
+
+    // ------------------------------------------------------------------
+    // Per-tab routing (Item #4) — `?tabId=` thread-through
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn append_tab_id_query_adds_first_param() {
+        assert_eq!(
+            append_tab_id_query("/control/element/btn/action", Some("tab-a")),
+            "/control/element/btn/action?tabId=tab-a"
+        );
+    }
+
+    #[test]
+    fn append_tab_id_query_appends_to_existing_query() {
+        assert_eq!(
+            append_tab_id_query("/control/snapshot?recency=current", Some("tab-b")),
+            "/control/snapshot?recency=current&tabId=tab-b"
+        );
+    }
+
+    #[test]
+    fn append_tab_id_query_url_encodes_special_chars() {
+        assert_eq!(
+            append_tab_id_query("/control/snapshot", Some("a b&c")),
+            "/control/snapshot?tabId=a%20b%26c"
+        );
+    }
+
+    #[test]
+    fn append_tab_id_query_noop_when_absent_or_blank() {
+        assert_eq!(
+            append_tab_id_query("/control/snapshot", None),
+            "/control/snapshot"
+        );
+        assert_eq!(
+            append_tab_id_query("/control/snapshot", Some("   ")),
+            "/control/snapshot",
+            "whitespace-only tab id must be treated as absent"
+        );
+    }
+
+    #[test]
+    fn sdk_action_query_params_accepts_tab_id_aliases() {
+        // serde aliases resolve identically for JSON and urlencoded inputs;
+        // axum's `Query` extractor feeds the same Deserialize impl. Drive it
+        // via serde_json (a direct dependency) to validate the alias wiring
+        // without pulling serde_urlencoded as a direct dev-dep.
+        let parse = |s: &str| -> SdkActionQueryParams {
+            serde_json::from_str(s).expect("parse SdkActionQueryParams")
+        };
+
+        assert_eq!(
+            parse(r#"{"tabId":"tab-a"}"#).tab_id.as_deref(),
+            Some("tab-a")
+        );
+        assert_eq!(
+            parse(r#"{"tab_id":"tab-a2"}"#).tab_id.as_deref(),
+            Some("tab-a2")
+        );
+        assert_eq!(
+            parse(r#"{"targetTabId":"tab-b"}"#).tab_id.as_deref(),
+            Some("tab-b")
+        );
+        assert_eq!(
+            parse(r#"{"target_tab_id":"tab-c"}"#).tab_id.as_deref(),
+            Some("tab-c")
+        );
+
+        let q = parse(r#"{"task_run_id":42}"#);
+        assert_eq!(q.task_run_id, Some(42));
+        assert_eq!(q.tab_id, None);
     }
 }

--- a/src-tauri/src/mcp/ui_bridge/CONTRACT.md
+++ b/src-tauri/src/mcp/ui_bridge/CONTRACT.md
@@ -131,6 +131,36 @@ params are silently ignored unless explicitly added. Example: the
 A new `?fooFilter=bar` will not work until a parallel `query.get("fooFilter")`
 line lands in the same handler.
 
+### Per-tab routing (`?tabId=`) is a thread-through, not a route
+The SDK relay (qontinui-web's `/api/ui-bridge/*`) supports pinning a `/control/*`
+command to a specific connected browser tab via `?tabId=<id>` (UI Bridge Item
+#4). When two relays/tabs are connected (e.g. two operator machines driving the
+same dashboard), the default dispatch targets the relay's `primaryTabId`, which
+flips to whichever tab registered last - so a command can route to the wrong
+session. `tabId` is **a query param on existing routes, not a new route**, so it
+does NOT touch `route_entries()` / the manifest tests; but per the discrete
+query-parsing rule above, each `/ui-bridge/sdk/*` wrapper must forward it
+explicitly or it silently drops.
+
+Wired today in `sdk_client.rs`:
+- `handle_element_action` (`/ui-bridge/sdk/element/:id/action`) - reads
+  `tabId`/`targetTabId`/`tab_id`/`target_tab_id` from `SdkActionQueryParams`,
+  carries it as `targetTabId` in the WS payload AND as `?tabId=` on the HTTP
+  path (`append_tab_id_query`).
+- `handle_snapshot` (`/ui-bridge/sdk/snapshot`) - same, for pinning a snapshot
+  to a non-primary tab.
+- `handle_tabs` (`/ui-bridge/sdk/tabs`) - forwards `?activeOnly=true` /
+  `?detailed=true` so callers can discover the live `tabId` (each entry carries
+  `tabId`, `isPrimary`, `isActive`, `lastHeartbeat`) before pinning.
+- Body-POST wrappers that forward the request body verbatim (`handle_discover`
+  for `find`, `handle_page_navigate`, the `clickByText`/`typeInto` convenience
+  handlers) need no Rust change: a caller supplying `{"tabId":"..."}` in the
+  body is threaded by the SDK's universal `relayCommand` -> `extractTabRouting`.
+
+An unknown/stale `tabId` is rejected by the relay with a structured
+`{success:false, code:"TAB_NOT_FOUND"|"TAB_STALE", ...}` envelope (NOT a silent
+fall-through to the primary tab); the runner forwards it verbatim.
+
 ### Status-code mapping is explicit
 Default `Json` responses are 200. The SDK's `expect`-style endpoints return
 422 on predicate timeout — `ui_bridge_expect_element_handler` at


### PR DESCRIPTION
## What

Wire UI Bridge per-tab routing (Item #4) through the runner's `/ui-bridge/sdk/*` WS wrappers so a runner-driven command can pin to a specific connected browser tab on the relay it forwards to, instead of always hitting the relay's `primaryTabId`.

## Why

Two operator machines running `/manual-test-coord` simultaneously each register a headless browser tab against the SAME dashboard UI Bridge relay (qontinui-web). The relay's `primaryTabId` flips to whichever tab registered most recently, so `/control/*` commands route to the wrong session (stale-element-ID errors + cross-session command bleed). Pinning a command to `?tabId=<id>` fixes this.

## The SDK side already shipped

`TabRoutingError` (`TAB_NOT_FOUND` / `TAB_STALE`), query/header/body `tabId` sniffing in the Next.js adapter, `getActiveTabs`/`isTabActive`, and `GET /tabs?activeOnly=true` all landed in `@qontinui/ui-bridge` **0.8.1** (ui-bridge PR #37) with tests (`relay-per-tab-routing.test.ts`, 16 tests). qontinui-web already pins `^0.8.1` — no SDK bump needed. **This PR is the runner wire-through required by `mcp/ui_bridge/CONTRACT.md`.**

## Changes (`sdk_client.rs`)

- `SdkActionQueryParams` gains `tab_id` (serde aliases `tabId` / `targetTabId` / `target_tab_id`).
- `handle_element_action` carries the tab id as `targetTabId` in the WS payload and as `?tabId=` on the HTTP path (new `append_tab_id_query` helper).
- `handle_snapshot` pins the snapshot to a non-primary tab the same way.
- `handle_tabs` forwards `?activeOnly` / `?detailed` so callers can discover the live `tabId` before pinning.
- Body-POST wrappers (`find`, `pageNavigate`, `clickByText`, `typeInto`) need no change — they forward the body verbatim and the SDK's universal `relayCommand` → `extractTabRouting` reads `{"tabId":...}` from it.
- Unknown/stale tabs are rejected by the relay with a structured `TAB_NOT_FOUND` / `TAB_STALE` envelope, forwarded verbatim (no silent fall-through to primary).
- `CONTRACT.md`: documents the `?tabId=` thread-through (it's a query param on existing routes, not a new route — manifest tests unaffected).

## Tests

- `append_tab_id_query_*` (4) ✓
- `sdk_action_query_params_accepts_tab_id_aliases` ✓
- `manifest_matches_route_calls` ✓
- `sdk_manifest_routes_are_exposed_by_runner` ✓
- `cargo clippy --all-targets -- -D warnings` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)