### PR TITLE
feat(pair): pair-with-pair-code (6-char single-use code) — Settings UI + CLI

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -57,8 +57,8 @@
 
 use clap::{Parser, Subcommand};
 use qontinui_runner_lib::pair::{
-    coord_http_base, pair_via_browser, pair_with_auth_token, persist_pairing,
-    tenant_id_from_oauth_claim, PairCompleteResponse,
+    coord_http_base, derive_web_base_from_coord, pair_via_browser, pair_with_auth_token,
+    pair_with_pair_code, persist_pairing, tenant_id_from_oauth_claim, PairCompleteResponse,
 };
 use qontinui_runner_lib::profiles::{
     load_strict, profiles_path, AuthConfig, BlobConfig, Profile, ProfilesFile,
@@ -146,16 +146,25 @@ enum DeviceCmd {
     /// JWT + paired user_id locally.
     Pair {
         /// Headless mode: use a pre-issued OAuth token. Mutually exclusive
-        /// with `--browser`.
+        /// with `--browser` and `--pair-code`.
         #[arg(long, value_name = "OAUTH_TOKEN")]
         auth_token: Option<String>,
-        /// Browser mode (default). Mutually exclusive with `--auth-token`.
+        /// Headless mode: redeem a 6-char single-use pair code minted from
+        /// the dashboard's Auth Tokens tab. Mutually exclusive with
+        /// `--browser` and `--auth-token`. The pair code itself is the
+        /// credential — no OAuth token required.
+        #[arg(long, value_name = "CODE")]
+        pair_code: Option<String>,
+        /// Browser mode (default). Mutually exclusive with `--auth-token`
+        /// and `--pair-code`.
         #[arg(long)]
         browser: bool,
         /// Explicit tenant scope for the new device. Overrides any
         /// `tenant_id` claim auto-extracted from the OAuth token.
         /// Required for `--browser` mode (no OAuth token to read a claim
-        /// from). Phase 2 of the default-tenant-propagation plan
+        /// from). Ignored for `--pair-code` — the tenant is burned into
+        /// the code at mint time and propagates through the redeem
+        /// response. Phase 2 of the default-tenant-propagation plan
         /// (Q3 resolution: OAuth claim with `--tenant-id` override).
         #[arg(long, value_name = "UUID")]
         tenant_id: Option<String>,
@@ -183,9 +192,15 @@ fn main() -> ExitCode {
             DeviceCmd::Path => cmd_device_path(),
             DeviceCmd::Pair {
                 auth_token,
+                pair_code,
                 browser,
                 tenant_id,
-            } => cmd_device_pair(auth_token.as_deref(), browser, tenant_id.as_deref()),
+            } => cmd_device_pair(
+                auth_token.as_deref(),
+                pair_code.as_deref(),
+                browser,
+                tenant_id.as_deref(),
+            ),
         },
     }
 }
@@ -728,14 +743,25 @@ fn cmd_device_show() -> ExitCode {
 enum PairMode {
     Browser,
     AuthToken(String),
+    PairCode(String),
 }
 
-fn select_pair_mode(auth_token: Option<&str>, _browser: bool) -> Result<PairMode, String> {
-    // clap's `Pair` variant carries both `--browser` and `--auth-token`. The
-    // mutually-exclusive constraint is enforced here (we can't use clap's
-    // `conflicts_with` because `browser` is a bool flag with a default of
-    // false). If `--auth-token` is set, that wins; otherwise browser is the
-    // default mode (whether or not `--browser` was explicitly passed).
+fn select_pair_mode(
+    auth_token: Option<&str>,
+    pair_code: Option<&str>,
+    _browser: bool,
+) -> Result<PairMode, String> {
+    // clap's `Pair` variant carries `--browser`, `--auth-token`, and
+    // `--pair-code`. The mutually-exclusive constraint is enforced here
+    // (we can't use clap's `conflicts_with` because `browser` is a bool
+    // flag with a default of false). Priority: pair_code > auth_token >
+    // browser-default.
+    if let Some(code) = pair_code {
+        if code.is_empty() {
+            return Err("--pair-code requires a value: --pair-code <CODE>".to_string());
+        }
+        return Ok(PairMode::PairCode(code.to_string()));
+    }
     match auth_token {
         Some(token) => {
             if token.is_empty() {
@@ -749,16 +775,18 @@ fn select_pair_mode(auth_token: Option<&str>, _browser: bool) -> Result<PairMode
 
 fn cmd_device_pair(
     auth_token: Option<&str>,
+    pair_code: Option<&str>,
     browser: bool,
     tenant_id_flag: Option<&str>,
 ) -> ExitCode {
-    // clap can't express "exactly one of browser/auth_token"; reject the
-    // combination by hand.
-    if auth_token.is_some() && browser {
-        eprintln!("error: --browser and --auth-token are mutually exclusive");
+    // clap can't express "exactly one of browser/auth_token/pair_code";
+    // reject the combinations by hand.
+    let exclusive_set = [auth_token.is_some(), pair_code.is_some(), browser];
+    if exclusive_set.iter().filter(|b| **b).count() > 1 {
+        eprintln!("error: --browser, --auth-token, and --pair-code are mutually exclusive");
         return ExitCode::from(2);
     }
-    let mode = match select_pair_mode(auth_token, browser) {
+    let mode = match select_pair_mode(auth_token, pair_code, browser) {
         Ok(m) => m,
         Err(e) => {
             eprintln!("error: {}", e);
@@ -773,45 +801,101 @@ fn cmd_device_pair(
         }
     };
 
-    // Resolve tenant_id: explicit `--tenant-id` flag wins; otherwise pull
-    // from the OAuth token's `tenant_id` claim (headless mode only — the
-    // browser flow has no OAuth token here). Phase 2 of the
-    // default-tenant-propagation plan.
-    let resolved_tenant_id: Result<uuid::Uuid, String> = match tenant_id_flag {
-        Some(s) => uuid::Uuid::parse_str(s.trim())
-            .map_err(|e| format!("--tenant-id is not a valid UUID: {e}")),
-        None => match &mode {
-            PairMode::AuthToken(token) => match tenant_id_from_oauth_claim(token) {
-                Some(s) => uuid::Uuid::parse_str(s.trim()).map_err(|e| {
-                    format!(
-                        "OAuth token's tenant_id claim is not a valid UUID ({e}); \
-                         pass --tenant-id <uuid> to override"
-                    )
-                }),
-                None => Err("no `tenant_id` claim found in OAuth token; \
-                     pass --tenant-id <uuid> explicitly"
-                    .to_string()),
-            },
-            PairMode::Browser => Err("--tenant-id <uuid> is required for the browser pair flow \
-                 (no OAuth token to read a claim from)"
-                .to_string()),
-        },
-    };
-    let tenant_id = match resolved_tenant_id {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("error: {}", e);
-            return ExitCode::from(2);
+    // Resolve tenant_id when needed. For PairCode mode the tenant is
+    // carried back in the redeem response (we resolve it from there
+    // post-pair); for AuthToken + Browser we need an explicit value
+    // up-front. Phase 2 of the default-tenant-propagation plan.
+    let preflight_tenant_id: Option<uuid::Uuid> = match &mode {
+        PairMode::PairCode(_) => None,
+        _ => {
+            let resolved: Result<uuid::Uuid, String> = match tenant_id_flag {
+                Some(s) => uuid::Uuid::parse_str(s.trim())
+                    .map_err(|e| format!("--tenant-id is not a valid UUID: {e}")),
+                None => match &mode {
+                    PairMode::AuthToken(token) => match tenant_id_from_oauth_claim(token) {
+                        Some(s) => uuid::Uuid::parse_str(s.trim()).map_err(|e| {
+                            format!(
+                                "OAuth token's tenant_id claim is not a valid UUID ({e}); \
+                                 pass --tenant-id <uuid> to override"
+                            )
+                        }),
+                        None => Err("no `tenant_id` claim found in OAuth token; \
+                             pass --tenant-id <uuid> explicitly"
+                            .to_string()),
+                    },
+                    PairMode::Browser => {
+                        Err("--tenant-id <uuid> is required for the browser pair flow \
+                             (no OAuth token to read a claim from)"
+                            .to_string())
+                    }
+                    PairMode::PairCode(_) => unreachable!("handled above"),
+                },
+            };
+            match resolved {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    eprintln!("error: {}", e);
+                    return ExitCode::from(2);
+                }
+            }
         }
     };
 
-    let result: Result<PairCompleteResponse, String> = match mode {
-        PairMode::AuthToken(token) => pair_with_auth_token(&base, &token, tenant_id),
-        PairMode::Browser => pair_via_browser(&base, tenant_id),
+    let result: Result<PairCompleteResponse, String> = match &mode {
+        PairMode::PairCode(code) => {
+            let device_id = match qontinui_runner_lib::pair::read_device_id_from_disk() {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("error: {}", e);
+                    return ExitCode::from(2);
+                }
+            };
+            // Pair codes redeem against the web backend. Derive the web
+            // base from the active profile's coord_url just like
+            // pair_via_browser does — operator can override via
+            // QONTINUI_WEB_BASE.
+            let web_base = std::env::var("QONTINUI_WEB_BASE")
+                .ok()
+                .unwrap_or_else(|| derive_web_base_from_coord(&base));
+            pair_with_pair_code(&web_base, code, &device_id)
+        }
+        PairMode::AuthToken(token) => {
+            pair_with_auth_token(&base, token, preflight_tenant_id.expect("set above"))
+        }
+        PairMode::Browser => pair_via_browser(&base, preflight_tenant_id.expect("set above")),
     };
+
     match result {
         Ok(resp) => {
-            if let Err(e) = persist_pairing(&resp, tenant_id) {
+            // For PairCode mode the tenant came back in the response;
+            // for the other modes we resolved it pre-flight.
+            let effective_tenant_id: uuid::Uuid = match preflight_tenant_id {
+                Some(t) => t,
+                None => {
+                    // PairCode path: the redeem response sets
+                    // PairCompleteResponse.tenant_id (Option<String>).
+                    // Parse it; bail if missing / malformed (would indicate
+                    // a backend protocol break, not a runner-side bug).
+                    match resp.tenant_id.as_deref() {
+                        Some(s) => match uuid::Uuid::parse_str(s.trim()) {
+                            Ok(t) => t,
+                            Err(e) => {
+                                eprintln!(
+                                    "error: pairing succeeded but server returned malformed tenant_id ({e}); not persisting"
+                                );
+                                return ExitCode::from(2);
+                            }
+                        },
+                        None => {
+                            eprintln!(
+                                "error: pairing succeeded but server omitted tenant_id; not persisting"
+                            );
+                            return ExitCode::from(2);
+                        }
+                    }
+                }
+            };
+            if let Err(e) = persist_pairing(&resp, effective_tenant_id) {
                 eprintln!(
                     "error: pairing succeeded but persisting locally failed: {}",
                     e
@@ -1211,11 +1295,13 @@ mod tests {
                 sub:
                     DeviceCmd::Pair {
                         auth_token,
+                        pair_code,
                         browser,
                         tenant_id,
                     },
             }) => {
                 assert_eq!(auth_token.as_deref(), Some("oauth"));
+                assert!(pair_code.is_none());
                 assert!(!browser);
                 assert!(tenant_id.is_none());
             }
@@ -1232,15 +1318,46 @@ mod tests {
                 sub:
                     DeviceCmd::Pair {
                         auth_token,
+                        pair_code,
                         browser,
                         tenant_id,
                     },
             }) => {
                 assert!(auth_token.is_none());
+                assert!(pair_code.is_none());
                 assert!(browser);
                 assert!(tenant_id.is_none());
             }
             other => panic!("expected Device::Pair {{browser}}, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn device_pair_parses_with_pair_code_flag() {
+        let cli = Cli::try_parse_from([
+            "qontinui_profile",
+            "device",
+            "pair",
+            "--pair-code",
+            "A7K2P3",
+        ])
+        .expect("parses");
+        match cli.cmd {
+            Some(Cmd::Device {
+                sub:
+                    DeviceCmd::Pair {
+                        auth_token,
+                        pair_code,
+                        browser,
+                        tenant_id,
+                    },
+            }) => {
+                assert!(auth_token.is_none());
+                assert_eq!(pair_code.as_deref(), Some("A7K2P3"));
+                assert!(!browser);
+                assert!(tenant_id.is_none());
+            }
+            other => panic!("expected Device::Pair {{pair_code}}, got {:?}", other),
         }
     }
 

--- a/src-tauri/src/commands/web_integration.rs
+++ b/src-tauri/src/commands/web_integration.rs
@@ -630,6 +630,114 @@ pub async fn start_web_token_flow<R: Runtime>(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// redeem_pair_code — paste-pair via single-use 5-min code (Phase 2a.3)
+// ---------------------------------------------------------------------------
+
+/// Wire response for [`redeem_pair_code`].
+///
+/// Mirrors the runner-side ``PairCompleteResponse`` shape so the frontend
+/// can show the operator a uniform "paired!" confirmation regardless of
+/// which pair flow was used. The device-token JWT is NOT returned to JS
+/// — it's persisted to the auth store on the Rust side via
+/// ``pair::persist_pairing``.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RedeemPairCodeResponse {
+    pub user_id: String,
+    pub tenant_id: String,
+    pub device_id: String,
+}
+
+/// Redeem a 6-char single-use pair code against the active profile's web
+/// backend. Single round-trip; on success persists the device JWT +
+/// updates `paired_user.json` so the WS relay picks it up.
+///
+/// Phase 2a.3 of plan
+/// ``D:/qontinui-root/plans/2026-05-22-mtc-iter3-remediation-web-dashboard.md``.
+///
+/// # Errors
+///
+/// Returns `Err(String)` if:
+/// - `code` is blank.
+/// - The active profile has no `coord_url` (we can't derive the web base).
+/// - The device has not been initialised (`~/.qontinui/machine.json`
+///   missing).
+/// - The web backend returns 4xx/5xx (`Err` carries the structured error
+///   from the response so the UI can surface "expired" / "already
+///   redeemed" / "unknown code").
+/// - Network failure.
+/// - Persisting the resulting JWT to local storage failed (in which case
+///   the device IS paired server-side but the runner cannot use the
+///   credential — operator should retry).
+#[tauri::command]
+pub async fn redeem_pair_code(code: String) -> Result<RedeemPairCodeResponse, String> {
+    use qontinui_runner_lib::pair::{
+        coord_http_base, derive_web_base_from_coord, pair_with_pair_code, persist_pairing,
+        read_device_id_from_disk,
+    };
+
+    let code_trimmed = code.trim().to_string();
+    if code_trimmed.is_empty() {
+        return Err("pair code is empty".to_string());
+    }
+
+    // Resolve the device_id from disk. The runner must have been
+    // initialised at least once (machine.json present) — typically true
+    // for any installed runner; surfacing a clear error if not.
+    let device_id =
+        read_device_id_from_disk().map_err(|e| format!("could not read device identity: {}", e))?;
+
+    // Resolve the web base. Pair-code endpoints live on qontinui-web,
+    // not coord. Derive via the same recipe used by the browser flow;
+    // operator can override via QONTINUI_WEB_BASE if web + coord are
+    // split across hosts.
+    let coord_base = coord_http_base().map_err(|e| format!("active profile: {}", e))?;
+    let web_base = std::env::var("QONTINUI_WEB_BASE")
+        .ok()
+        .unwrap_or_else(|| derive_web_base_from_coord(&coord_base));
+
+    // Run the blocking HTTP call on a tokio blocking thread so we don't
+    // tie up the async runtime. `pair_with_pair_code` uses a 30-second
+    // timeout internally, so this never hangs indefinitely.
+    let code_for_blocking = code_trimmed.clone();
+    let device_id_for_blocking = device_id.clone();
+    let web_base_for_blocking = web_base.clone();
+    let resp = tokio::task::spawn_blocking(move || {
+        pair_with_pair_code(
+            &web_base_for_blocking,
+            &code_for_blocking,
+            &device_id_for_blocking,
+        )
+    })
+    .await
+    .map_err(|e| format!("pair-code redeem task panicked: {e}"))??;
+
+    // Parse the tenant_id off the response so we can pass it through to
+    // persist_pairing.
+    let tenant_id_str = resp
+        .tenant_id
+        .as_deref()
+        .ok_or_else(|| "server omitted tenant_id in pair-code redeem response".to_string())?;
+    let tenant_id = uuid::Uuid::parse_str(tenant_id_str.trim())
+        .map_err(|e| format!("server returned malformed tenant_id: {e}"))?;
+
+    persist_pairing(&resp, tenant_id).map_err(|e| format!("persist pairing: {}", e))?;
+
+    let response_device_id = resp.device_id.clone().unwrap_or_else(|| device_id.clone());
+
+    info!(
+        "redeem_pair_code: device paired (user_id={}, tenant_id={}, device_id={})",
+        resp.user_id, tenant_id_str, response_device_id
+    );
+
+    Ok(RedeemPairCodeResponse {
+        user_id: resp.user_id,
+        tenant_id: tenant_id_str.to_string(),
+        device_id: response_device_id,
+    })
+}
+
 /// Tauri plugin exposing all web-integration commands.
 pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
     PluginBuilder::new("qontinui_web_integration")
@@ -638,6 +746,7 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             save_web_integration_settings,
             test_web_integration_connection,
             start_web_token_flow,
+            redeem_pair_code,
         ])
         .build()
 }

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -399,6 +399,116 @@ pub fn pair_with_auth_token_with_ids(
 }
 
 // ============================================================================
+// Pair: pair-code (--pair-code <CODE>)
+// ============================================================================
+
+/// On-wire response shape for ``POST /api/v1/devices/pair-codes/{code}/redeem``.
+///
+/// The web backend mirrors the canonical ``PairCompleteResponse`` shape
+/// returned by ``pair-cli`` so the runner can use a single decoder for
+/// both paths. This struct is named for the field set declared in the
+/// web schema (``app/schemas/pair_code.py::PairCodeRedeemOut``):
+/// ``{user_id, tenant_id, device_id, expires_at?, device_token_jwt}``.
+///
+/// The redeem path returns ``device_token_jwt`` (not ``token``) for
+/// disambiguation in the web schema, so we accept both spellings via
+/// `serde(alias)` to remain compatible if the API ever renames back.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PairCodeRedeemResponse {
+    pub user_id: String,
+    pub tenant_id: String,
+    pub device_id: String,
+    #[serde(default)]
+    pub expires_at: Option<String>,
+    /// Coord-issued device-token JWT. The web schema names this field
+    /// ``device_token_jwt`` to make its intent unambiguous; we accept
+    /// the legacy ``token`` alias too in case the API ever renames.
+    #[serde(alias = "token")]
+    pub device_token_jwt: String,
+}
+
+impl PairCodeRedeemResponse {
+    /// Convert to the canonical ``PairCompleteResponse`` shape so the
+    /// caller can use the same decoder + ``persist_pairing`` path for
+    /// pair-code-mediated pairing as for ``pair-cli``.
+    pub fn into_pair_complete(self) -> PairCompleteResponse {
+        // Best-effort tenant UUID parsing; the field is on the wire as
+        // a string, but ``PairCompleteResponse::tenant_id`` is
+        // ``Option<String>`` (the canonical decoder is lenient — see
+        // its doc-comment), so we just pass the raw string through.
+        PairCompleteResponse {
+            token: self.device_token_jwt,
+            user_id: self.user_id,
+            device_id: Some(self.device_id),
+            jti: None,
+            exp: None,
+            tenant_id: Some(self.tenant_id),
+        }
+    }
+}
+
+/// Headless pair flow that consumes a 6-char single-use pair code (no
+/// browser, no OAuth round-trip). The operator mints the code on the
+/// dashboard's ``Auth Tokens`` tab and types it into the runner's
+/// Settings UI; this function POSTs the code to the web backend's
+/// ``POST /api/v1/devices/pair-codes/{code}/redeem`` endpoint and gets
+/// back the same ``PairCompleteResponse`` shape that ``pair-cli``
+/// returns.
+///
+/// **Unauthenticated by design** — the pair code IS the credential.
+/// The resulting device JWT is tenant-scoped to the **code's**
+/// mint-time tenant (the web backend burns the issuing operator's
+/// tenant into the code row and refuses to let the runner override
+/// it).
+///
+/// `base` is the web-backend base URL (e.g. ``http://127.0.0.1:8000``),
+/// NOT the coord URL — the pair-code endpoints live exclusively on
+/// qontinui-web. `code` is the 6-char code the operator typed in;
+/// it is upper-cased server-side so casing doesn't matter, but we
+/// upper-case here too for symmetric display.
+pub fn pair_with_pair_code(
+    base: &str,
+    code: &str,
+    device_id: &str,
+) -> Result<PairCompleteResponse, String> {
+    if code.trim().is_empty() {
+        return Err("pair code is empty".to_string());
+    }
+    let url = format!(
+        "{}/api/v1/devices/pair-codes/{}/redeem",
+        base.trim_end_matches('/'),
+        code.trim().to_uppercase()
+    );
+    let body = serde_json::json!({
+        "device_id": device_id,
+        "hostname":  detect_hostname(),
+    });
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("reqwest client build failed: {}", e))?;
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .map_err(|e| format!("POST {} failed: {}", url, e))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body_text = resp
+            .text()
+            .unwrap_or_else(|_| "<unable to read response body>".to_string());
+        // Translate the web's structured-detail shape into a friendlier
+        // single-line operator message. We don't need to JSON-decode it
+        // — the calling UI surfaces the raw string verbatim.
+        return Err(format!("POST {} -> HTTP {}: {}", url, status, body_text));
+    }
+    let redeem: PairCodeRedeemResponse = resp
+        .json()
+        .map_err(|e| format!("decode redeem response failed: {}", e))?;
+    Ok(redeem.into_pair_complete())
+}
+
+// ============================================================================
 // Pair: browser (--browser, default)
 // ============================================================================
 
@@ -845,6 +955,82 @@ mod tests {
             parsed.tenant_id.is_none(),
             "legacy file must yield tenant_id = None"
         );
+    }
+
+    /// Pair-code redeem response decodes the web schema's
+    /// ``PairCodeRedeemOut`` shape: ``{user_id, tenant_id, device_id,
+    /// device_token_jwt, expires_at?}``. The runner must accept the
+    /// ``device_token_jwt`` spelling AND fall back gracefully if the
+    /// API ever renames back to ``token`` (via the serde alias).
+    #[test]
+    fn pair_code_redeem_response_decodes_web_schema_shape() {
+        let wire = serde_json::json!({
+            "user_id":          "22222222-2222-4222-8222-222222222222",
+            "tenant_id":        "11111111-2222-3333-4444-555555555555",
+            "device_id":        "00000000-0000-4000-8000-000000000000",
+            "device_token_jwt": "abc.def.ghi",
+            "expires_at":       "2026-05-23T00:00:00Z",
+        });
+        let parsed: PairCodeRedeemResponse =
+            serde_json::from_value(wire).expect("decode web schema shape");
+        assert_eq!(parsed.device_token_jwt, "abc.def.ghi");
+        assert_eq!(parsed.tenant_id, "11111111-2222-3333-4444-555555555555");
+        assert_eq!(parsed.device_id, "00000000-0000-4000-8000-000000000000");
+    }
+
+    /// Backward-compat: if the web schema ever renames
+    /// ``device_token_jwt`` back to ``token``, the runner still
+    /// decodes it (via serde alias).
+    #[test]
+    fn pair_code_redeem_response_decodes_legacy_token_alias() {
+        let wire = serde_json::json!({
+            "user_id":   "22222222-2222-4222-8222-222222222222",
+            "tenant_id": "11111111-2222-3333-4444-555555555555",
+            "device_id": "00000000-0000-4000-8000-000000000000",
+            "token":     "legacy.jwt.xyz",
+        });
+        let parsed: PairCodeRedeemResponse =
+            serde_json::from_value(wire).expect("decode legacy token alias");
+        assert_eq!(parsed.device_token_jwt, "legacy.jwt.xyz");
+    }
+
+    /// ``PairCodeRedeemResponse::into_pair_complete`` produces a
+    /// ``PairCompleteResponse`` with the same fields callers expect
+    /// from ``pair-cli``, so ``persist_pairing`` can consume it
+    /// unmodified.
+    #[test]
+    fn pair_code_redeem_response_converts_to_pair_complete() {
+        let redeem = PairCodeRedeemResponse {
+            user_id: "22222222-2222-4222-8222-222222222222".to_string(),
+            tenant_id: "11111111-2222-3333-4444-555555555555".to_string(),
+            device_id: "00000000-0000-4000-8000-000000000000".to_string(),
+            expires_at: None,
+            device_token_jwt: "abc.def.ghi".to_string(),
+        };
+        let pc = redeem.into_pair_complete();
+        assert_eq!(pc.token, "abc.def.ghi");
+        assert_eq!(pc.user_id, "22222222-2222-4222-8222-222222222222");
+        assert_eq!(
+            pc.device_id.as_deref(),
+            Some("00000000-0000-4000-8000-000000000000")
+        );
+        assert_eq!(
+            pc.tenant_id.as_deref(),
+            Some("11111111-2222-3333-4444-555555555555")
+        );
+    }
+
+    /// ``pair_with_pair_code`` upper-cases the code before posting so
+    /// operator typing casing doesn't reach the server (web upper-cases
+    /// too — defense in depth).
+    #[test]
+    fn pair_with_pair_code_rejects_blank_code() {
+        // We can't easily invoke the real HTTP call from a unit test,
+        // but the empty-code guard is pure and worth pinning here.
+        let result = pair_with_pair_code("http://unused", "   ", "device-x");
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("empty"), "got: {err}");
     }
 
     /// Forward shape — a newly-written `paired_user.json` round-trips

--- a/src/components/settings/WebIntegrationSettings.tsx
+++ b/src/components/settings/WebIntegrationSettings.tsx
@@ -129,6 +129,15 @@ export function WebIntegrationSettings({ onLog }: WebIntegrationSettingsProps) {
   const [helpTokenOpen, setHelpTokenOpen] = useState(false);
   const [helpWhatOpen, setHelpWhatOpen] = useState(false);
 
+  // --- Pair-code paste flow (Phase 2a.3) -------------------------------------
+  // Single-use 5-char-from-32-alphabet code minted by the operator on
+  // qontinui-web's /runners Auth Tokens tab and typed in here.
+  const [pairCodeInput, setPairCodeInput] = useState("");
+  const [pairCodeState, setPairCodeState] = useState<{
+    state: "idle" | "redeeming" | "success" | "error";
+    message?: string;
+  }>({ state: "idle" });
+
   // --- Tick to keep "last heartbeat <relative> ago" alive --------------------
   const [, setTick] = useState(0);
   useEffect(() => {
@@ -352,6 +361,43 @@ export function WebIntegrationSettings({ onLog }: WebIntegrationSettingsProps) {
     }
   }, [formBackendUrl, formEnabled, formToken, tokenEdited, onLog, refreshStatus]);
 
+  /**
+   * Redeem a 6-char one-time pair code minted from the dashboard.
+   *
+   * Phase 2a.3 of plan
+   * `D:/qontinui-root/plans/2026-05-22-mtc-iter3-remediation-web-dashboard.md`.
+   * Calls the Rust-side `redeem_pair_code` command which POSTs to
+   * `/api/v1/devices/pair-codes/{code}/redeem` and persists the
+   * resulting device JWT.
+   */
+  const handleRedeemPairCode = useCallback(async () => {
+    const trimmed = pairCodeInput.trim().toUpperCase();
+    if (!trimmed) {
+      setPairCodeState({ state: "error", message: "Enter a pair code first." });
+      return;
+    }
+    setPairCodeState({ state: "redeeming" });
+    try {
+      const result = await invoke<{
+        userId: string;
+        tenantId: string;
+        deviceId: string;
+      }>("redeem_pair_code", { code: trimmed });
+      setPairCodeInput("");
+      setPairCodeState({
+        state: "success",
+        message: `Paired (device ${result.deviceId.slice(0, 8)}…).`,
+      });
+      onLog("info", `Paired via one-time code (user=${result.userId})`);
+      // Refresh status so the UI picks up the new auth + ws state.
+      void refreshStatus();
+    } catch (err) {
+      const msg = String(err);
+      setPairCodeState({ state: "error", message: msg });
+      onLog("error", `Pair-code redeem failed: ${msg}`);
+    }
+  }, [pairCodeInput, onLog, refreshStatus]);
+
   const handleStartWebTokenFlow = useCallback(async () => {
     try {
       await invoke<void>("start_web_token_flow", {
@@ -554,6 +600,61 @@ export function WebIntegrationSettings({ onLog }: WebIntegrationSettingsProps) {
           ) : (
             <p className="text-[10px] text-muted-foreground">
               Base URL of the qontinui-web backend this runner will register with.
+            </p>
+          )}
+        </div>
+
+        {/* Pair code paste flow (Phase 2a.3) — recommended for new pairs.
+            Sits above the long-lived runner-token input because pair
+            codes are the simpler/safer path for new operators. */}
+        <div className="space-y-1.5">
+          <label htmlFor="web-integration-pair-code" className="text-xs font-medium">
+            Pair code (6 chars)
+          </label>
+          <div className="flex items-stretch gap-2">
+            <input
+              id="web-integration-pair-code"
+              type="text"
+              inputMode="text"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              maxLength={6}
+              value={pairCodeInput}
+              onChange={(e) => {
+                setPairCodeInput(e.target.value.toUpperCase());
+                if (pairCodeState.state !== "idle") {
+                  setPairCodeState({ state: "idle" });
+                }
+              }}
+              placeholder="A7K2P3"
+              className="flex-1 min-w-0 px-2.5 py-1.5 text-sm bg-muted/50 rounded-md placeholder:text-muted-foreground outline-hidden focus:ring-1 focus:ring-primary/50 font-mono tracking-[0.3em] uppercase"
+            />
+            <button
+              type="button"
+              onClick={handleRedeemPairCode}
+              disabled={
+                pairCodeState.state === "redeeming" || pairCodeInput.trim().length === 0
+              }
+              className="px-3 py-1.5 text-xs font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+            >
+              {pairCodeState.state === "redeeming" ? "Pairing…" : "Pair"}
+            </button>
+          </div>
+          {pairCodeState.state === "success" && pairCodeState.message && (
+            <p className="text-[10px] text-green-500 flex items-center gap-1">
+              <CheckCircle2 className="w-3 h-3" /> {pairCodeState.message}
+            </p>
+          )}
+          {pairCodeState.state === "error" && pairCodeState.message && (
+            <p className="text-[10px] text-destructive flex items-center gap-1">
+              <AlertTriangle className="w-3 h-3" /> {truncate(pairCodeState.message, 120)}
+            </p>
+          )}
+          {pairCodeState.state === "idle" && (
+            <p className="text-[10px] text-muted-foreground">
+              Generate a one-time pair code on qontinui-web (Runners &rarr; Auth
+              Tokens) and paste it here. The code expires after 5 minutes.
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary

Phase 2a.3 of plan `D:/qontinui-root/plans/2026-05-22-mtc-iter3-remediation-web-dashboard.md`.

Runner-side consumer of qontinui-web's `POST /api/v1/devices/pair-codes/{code}/redeem` (web PR https://github.com/qontinui/qontinui-web/pull/219). Three pieces:

1. **`pair.rs::pair_with_pair_code(base, code, device_id)`** — blocking reqwest call against the web backend's redeem endpoint; decodes the `PairCodeRedeemResponse` shape (`{user_id, tenant_id, device_id, device_token_jwt, expires_at?}`) and converts to the canonical `PairCompleteResponse` so `persist_pairing` consumes both the new and the existing pair-cli paths identically.
2. **`qontinui_profile device pair --pair-code <CODE>`** — third headless pair mode alongside `--browser` and `--auth-token`. The tenant is carried back in the redeem response, so no `--tenant-id` flag is needed.
3. **`redeem_pair_code` Tauri IPC command + Settings UI input** — new `Pair code (6 chars)` field on Web Integration settings, sitting ABOVE the existing Runner Token paste field. Pair codes are the recommended path for new operators; long-lived tokens remain for CI / advanced use.

Decoder is forward-compat: `PairCodeRedeemResponse.device_token_jwt` also accepts the legacy `token` alias via `serde(alias)`, so if the web schema ever renames the field the runner still pairs.

## Cross-repo

`coord:downstream-of/qontinui-web#219`. The backend PR must land first — until the web `/devices/pair-codes/{code}/redeem` endpoint is live, this runner change builds but cannot redeem a real code.

## Test plan

- [x] `cargo test --lib pair_code` — 4 new tests (web schema decode, legacy `token` alias, `into_pair_complete` conversion, blank-code rejection) + all 16 existing pair tests still pass.
- [x] `cargo test --bin qontinui_profile` — 27 tests pass including the new `device_pair_parses_with_pair_code_flag`.
- [x] `cargo check --bin qontinui_profile && cargo clippy --bin qontinui_profile --lib -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `npx tsc --noEmit` + `npx eslint` clean on the frontend changes.
- [ ] Manual end-to-end (deferred until web PR #219 deploys to staging): mint a code on the dashboard, paste into runner Settings, verify pairing completes and the WS relay connects.