### PR TITLE
feat(runner): unified Session primitive — Phase 2 (plan 2026-05-22)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -221,6 +221,7 @@ pub mod script_emitter; // Scripted-output (think-in-code) extraction-script emi
 pub mod scripted_output_settings; // get/save the ScriptedOutputSettings (provider, endpoint, ...)
 pub mod security_settings;
 pub mod self_healing_settings;
+pub mod session; // Plan 2026-05-22-coord-native-session-coordination Phase 2 — unified Session primitive Tauri commands
 pub mod setup_wizard; // First-launch setup wizard commands
 pub mod shell_commands; // Shell command management and execution
 pub mod spec_drift; // Spec drift detection (useUIElement vs spec assertions)

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,0 +1,189 @@
+//! Tauri commands for the unified [`crate::session::Session`] primitive.
+//!
+//! Plan §Phase 2 / §Phase 4 — these are the canonical Tauri commands the
+//! runner frontend will call once Phase 4 cuts over from the legacy
+//! `terminal_*` / `ai_session_*` surface. Phase 2 ships them alongside
+//! the legacy commands (the old ones stay registered until Phase 4 lands)
+//! so the runner doesn't break between PRs.
+
+use std::sync::Arc;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
+use tracing::error;
+use uuid::Uuid;
+
+use crate::commands::CommandResponse;
+use crate::session::{
+    description_to_json, Intent, SessionError, SessionKind, SessionRegistry,
+};
+
+/// JSON shape accepted by `session_start`. Mirrors [`Intent`] verbatim;
+/// re-declared so the Tauri-side deserialization rejects unknown fields
+/// without leaning on `Intent`'s `serde(default)` flexibility.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StartSessionArgs {
+    pub kind: SessionKind,
+    pub purpose: String,
+    #[serde(default)]
+    pub repo: Option<String>,
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub declared_paths: Vec<PathBuf>,
+    #[serde(default)]
+    pub share_output: bool,
+    #[serde(default)]
+    pub redact_secrets: Option<bool>,
+}
+
+impl From<StartSessionArgs> for Intent {
+    fn from(a: StartSessionArgs) -> Self {
+        Intent {
+            kind: a.kind,
+            purpose: a.purpose,
+            repo: a.repo,
+            branch: a.branch,
+            declared_paths: a.declared_paths,
+            share_output: a.share_output,
+            redact_secrets: a.redact_secrets,
+        }
+    }
+}
+
+/// Shape returned by `session_start` / `session_describe`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionStartResponse {
+    pub id: Uuid,
+}
+
+fn map_err(e: SessionError) -> String {
+    // Surface structured codes so the frontend can branch without parsing
+    // text. The plain string form remains the Display impl.
+    match &e {
+        SessionError::Intent(_) => format!("session:intent_invalid: {}", e),
+        SessionError::Transport(_) => format!("session:transport_error: {}", e),
+        SessionError::StealReasonTooShort { .. } => format!("session:reason_too_short: {}", e),
+        SessionError::NotFound(_) => format!("session:not_found: {}", e),
+        SessionError::Outbox(_) => format!("session:outbox_error: {}", e),
+    }
+}
+
+/// Start a new session. Returns its UUID; the caller can then drive
+/// follow-up calls (focus/close/describe/steal) by id.
+#[tauri::command]
+pub fn session_start(
+    registry: tauri::State<'_, Arc<SessionRegistry>>,
+    args: StartSessionArgs,
+) -> Result<CommandResponse, String> {
+    let intent: Intent = args.into();
+    match registry.inner().start(intent) {
+        Ok(handle) => {
+            let id = handle.id();
+            Ok(CommandResponse {
+                success: true,
+                message: None,
+                data: Some(serde_json::json!({ "id": id })),
+            })
+        }
+        Err(e) => {
+            error!("session_start failed: {}", e);
+            Err(map_err(e))
+        }
+    }
+}
+
+/// "Focus" the session — heartbeats `last_heartbeat_at` and records a
+/// `state_change` event in the outbox so the dashboard knows the
+/// operator is on this session right now.
+#[tauri::command]
+pub fn session_focus(
+    registry: tauri::State<'_, Arc<SessionRegistry>>,
+    session_id: Uuid,
+) -> Result<CommandResponse, String> {
+    registry.inner().focus_by_id(session_id).map_err(map_err)?;
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: None,
+    })
+}
+
+/// Close the session. Idempotent — closing an already-closed session
+/// returns success.
+#[tauri::command]
+pub fn session_close(
+    registry: tauri::State<'_, Arc<SessionRegistry>>,
+    session_id: Uuid,
+) -> Result<CommandResponse, String> {
+    registry.inner().close_by_id(session_id).map_err(map_err)?;
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: None,
+    })
+}
+
+/// Return the [`crate::session::SessionDescription`] for the given session.
+#[tauri::command]
+pub fn session_describe(
+    registry: tauri::State<'_, Arc<SessionRegistry>>,
+    session_id: Uuid,
+) -> Result<CommandResponse, String> {
+    let desc = registry.inner().describe_by_id(session_id).map_err(map_err)?;
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: Some(description_to_json(&desc)),
+    })
+}
+
+/// List every live session. Convenience for the runner frontend's session
+/// panel; coord is the canonical source of truth across machines.
+#[tauri::command]
+pub fn session_list(
+    registry: tauri::State<'_, Arc<SessionRegistry>>,
+) -> Result<CommandResponse, String> {
+    let all = registry.inner().snapshot();
+    let json = serde_json::to_value(&all).map_err(|e| e.to_string())?;
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: Some(serde_json::json!({ "sessions": json })),
+    })
+}
+
+/// Plan §D14 — steal a session's claim with a typed reason. Min 10
+/// chars enforced by [`crate::session::MIN_STEAL_REASON_CHARS`].
+#[tauri::command]
+pub fn session_steal(
+    registry: tauri::State<'_, Arc<SessionRegistry>>,
+    session_id: Uuid,
+    reason: String,
+) -> Result<CommandResponse, String> {
+    registry
+        .inner()
+        .steal_by_id(session_id, &reason)
+        .map_err(map_err)?;
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: None,
+    })
+}
+
+/// Tauri plugin bundle. main.rs adds one `.plugin(commands::session::plugin())`
+/// to wire all five commands.
+pub fn plugin() -> TauriPlugin<tauri::Wry> {
+    PluginBuilder::<tauri::Wry>::new("qontinui_session")
+        .invoke_handler(tauri::generate_handler![
+            session_start,
+            session_focus,
+            session_close,
+            session_describe,
+            session_list,
+            session_steal,
+        ])
+        .build()
+}

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -6,8 +6,8 @@
 //! the legacy commands (the old ones stay registered until Phase 4 lands)
 //! so the runner doesn't break between PRs.
 
-use std::sync::Arc;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 use tauri::plugin::{Builder as PluginBuilder, TauriPlugin};
@@ -15,9 +15,7 @@ use tracing::error;
 use uuid::Uuid;
 
 use crate::commands::CommandResponse;
-use crate::session::{
-    description_to_json, Intent, SessionError, SessionKind, SessionRegistry,
-};
+use crate::session::{description_to_json, Intent, SessionError, SessionKind, SessionRegistry};
 
 /// JSON shape accepted by `session_start`. Mirrors [`Intent`] verbatim;
 /// re-declared so the Tauri-side deserialization rejects unknown fields
@@ -131,7 +129,10 @@ pub fn session_describe(
     registry: tauri::State<'_, Arc<SessionRegistry>>,
     session_id: Uuid,
 ) -> Result<CommandResponse, String> {
-    let desc = registry.inner().describe_by_id(session_id).map_err(map_err)?;
+    let desc = registry
+        .inner()
+        .describe_by_id(session_id)
+        .map_err(map_err)?;
     Ok(CommandResponse {
         success: true,
         message: None,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -139,6 +139,7 @@ mod secure_storage;
 mod security;
 mod semantic_conventions;
 mod server_mode;
+mod session; // Plan 2026-05-22-coord-native-session-coordination Phase 2 — unified Session primitive
 mod settings;
 // `startup_panic` is a minimal, dep-free panic-hook installer called from
 // the very top of `main()` so early-init crashes (DB connect, Tauri builder,
@@ -556,7 +557,12 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
     // Create session manager for interactive Claude CLI sessions
     let session_manager = Arc::new(claude_session::SessionManager::new());
 
-    // Create terminal manager for embedded PTY terminals
+    // Create terminal manager for embedded PTY terminals.
+    // Plan 2026-05-22-coord-native-session-coordination Phase 2 — the unified
+    // Session primitive's PTY/Claude-CLI transports reach this manager via
+    // `app.state::<Arc<TerminalManager>>()` inside `.setup(...)` so it stays
+    // shared with the legacy `terminal_*` Tauri commands until Phase 9
+    // collapses both paths.
     let terminal_manager = Arc::new(terminal::TerminalManager::new());
 
     // Create shared AppState for both Tauri and MCP API
@@ -1422,6 +1428,15 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::self_healing_settings::has_self_healing_api_key,
             commands::self_healing_settings::save_self_healing_api_key,
             commands::self_healing_settings::save_self_healing_settings,
+            // Plan 2026-05-22-coord-native-session-coordination Phase 2 —
+            // unified Session primitive commands (coexist with legacy
+            // `terminal_*` and `ai_session_*` until Phase 4 frontend cutover).
+            commands::session::session_close,
+            commands::session::session_describe,
+            commands::session::session_focus,
+            commands::session::session_list,
+            commands::session::session_start,
+            commands::session::session_steal,
             commands::setup_wizard::check_setup_completed,
             commands::setup_wizard::complete_setup,
             commands::setup_wizard::detect_project_framework_for_setup,
@@ -1708,6 +1723,86 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         e
                     );
                 }
+            }
+
+            // Plan 2026-05-22-coord-native-session-coordination Phase 2 —
+            // unified Session primitive. Materialize the registry here
+            // because the PTY / Claude-CLI transports need an `AppHandle`
+            // (only available inside .setup). The registry is .manage()'d
+            // so `commands::session::*` can pull it via `tauri::State`.
+            //
+            // The terminal manager is fetched via `app.state::<>()` so we
+            // don't need a `move` closure on `.setup()` (other captures in
+            // the existing setup body rely on non-`move` semantics; see
+            // the comment block above this closure).
+            {
+                let app_handle = app.handle().clone();
+                let term_state: tauri::State<'_, std::sync::Arc<terminal::TerminalManager>> =
+                    app.state();
+                let term_for_session = term_state.inner().clone();
+                let outbox_path = dirs::home_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    .join(".qontinui")
+                    .join("runner")
+                    .join("session-outbox.jsonl");
+                let outbox = match session::local_store::OutboxWriter::open(&outbox_path) {
+                    Ok(o) => std::sync::Arc::new(o),
+                    Err(e) => {
+                        // Fall back to a tempdir outbox so the registry
+                        // still works in dev / first-launch scenarios
+                        // where ~/.qontinui isn't writable.
+                        tracing::warn!(
+                            error = %e,
+                            path = %outbox_path.display(),
+                            "session: outbox open failed — using ephemeral fallback"
+                        );
+                        let fallback = std::env::temp_dir()
+                            .join("qontinui-runner-session-outbox.jsonl");
+                        std::sync::Arc::new(
+                            session::local_store::OutboxWriter::open(&fallback)
+                                .expect("session: ephemeral outbox open failed"),
+                        )
+                    }
+                };
+                let coord_sync_facade = session::coord_sync::CoordSync::new(outbox);
+                let pty_transport: session::DynTransport =
+                    std::sync::Arc::new(session::transport::pty::PtyTransport::new(
+                        term_for_session.clone(),
+                        app_handle.clone(),
+                    ));
+                let claude_cli_transport: session::DynTransport = std::sync::Arc::new(
+                    session::transport::claude_cli::ClaudeCliTransport::new(
+                        term_for_session.clone(),
+                        app_handle.clone(),
+                    ),
+                );
+                let workflow_transport: session::DynTransport = std::sync::Arc::new(
+                    session::transport::workflow::WorkflowTransport::new(),
+                );
+                let machine_id = dirs::home_dir()
+                    .and_then(|h| std::fs::read(h.join(".qontinui").join("machine.json")).ok())
+                    .and_then(|b| {
+                        let v: serde_json::Value = serde_json::from_slice(&b).ok()?;
+                        let s = v
+                            .get("device_id")
+                            .and_then(|x| x.as_str())
+                            .or_else(|| v.get("machine_id").and_then(|x| x.as_str()))?;
+                        uuid::Uuid::parse_str(s).ok()
+                    })
+                    .unwrap_or_else(uuid::Uuid::new_v4);
+                let registry = session::SessionRegistry::new(
+                    machine_id,
+                    session::SessionTransports {
+                        pty: pty_transport,
+                        claude_cli: claude_cli_transport,
+                        workflow: workflow_transport,
+                    },
+                    coord_sync_facade,
+                );
+                // Phase 3 will start the drain task here.
+                registry.coord_sync().start_drain_task();
+                app.manage(registry);
+
             }
 
             // Phase F.1 — register the deep-link `on_open_url` callback so

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -1,0 +1,52 @@
+//! Coord-sync loop — STUB for Phase 2.
+//!
+//! Plan §Phase 3 implements the full drain/heartbeat/replay logic. Phase 2
+//! ships the API surface so [`crate::session::Session`] can reference it
+//! without a runtime loop yet — the [`CoordSync`] facade records events
+//! into the local outbox (already-Phase-2) and does NOT yet POST to coord.
+//!
+//! When Phase 3 lands:
+//! - [`CoordSync::start`] spawns a tokio task that wakes every
+//!   `QONTINUI_SESSION_HEARTBEAT_SECS` (default 15s, plan §D13) and
+//!   drains [`crate::session::local_store::OutboxWriter::pending`] in
+//!   `(session_id, seq)` order.
+//! - Each batch is POSTed to coord at `/sessions/:id/events` (or the
+//!   per-event endpoint, TBD by the Phase 3 API contract); successful
+//!   pushes ACK via [`crate::session::local_store::OutboxWriter::ack`].
+//! - Disconnect tolerance: queue grows locally, replays on reconnect
+//!   (idempotent by `UNIQUE (session_id, seq)` on coord's
+//!   `coord.session_events`).
+//! - Conflict-on-acquire: 409 from coord → session enters
+//!   [`crate::session::SessionState::PendingResolution`] → conflict modal
+//!   fires (plan §Phase 6).
+
+use std::sync::Arc;
+
+use super::local_store::OutboxWriter;
+
+/// Phase 3-shaped coord-sync handle. Today this is just a wrapper around
+/// the local outbox so callers can write through one facade and the
+/// Phase 3 expansion is a single-file change.
+#[derive(Clone)]
+pub struct CoordSync {
+    outbox: Arc<OutboxWriter>,
+}
+
+impl CoordSync {
+    pub fn new(outbox: Arc<OutboxWriter>) -> Self {
+        Self { outbox }
+    }
+
+    /// Borrow the local outbox. Phase 2 callers (Session lifecycle) write
+    /// directly through this; Phase 3 keeps the same surface and adds the
+    /// drain task underneath.
+    pub fn outbox(&self) -> &OutboxWriter {
+        &self.outbox
+    }
+
+    /// Phase 3 entry-point — currently a no-op. Keeps the call-site
+    /// stable so main.rs can wire it now and Phase 3 fills in the body.
+    pub fn start_drain_task(&self) {
+        // intentionally empty in Phase 2
+    }
+}

--- a/src-tauri/src/session/intent.rs
+++ b/src-tauri/src/session/intent.rs
@@ -1,0 +1,209 @@
+//! Session intent — typed declaration of what a session is for, where it
+//! runs, and what it expects to touch. Plan
+//! [`2026-05-22-coord-native-session-coordination`] §D6.
+//!
+//! Every call to [`crate::session::Session::start`] requires an `Intent`. The
+//! wire shape mirrors `coord.sessions.intent` (JSONB) so the runner-side
+//! struct serializes verbatim into the row coord stores.
+//!
+//! Validation is intentionally light. The plan favors explicit-over-implicit:
+//! we reject obvious mistakes (`purpose` blank, paths that don't exist) but
+//! we do **not** sanitize free text — the dashboard is the readable surface
+//! and it can render what coord stores.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use super::SessionKind;
+
+/// Minimum length of a session purpose. Matches the dashboard's
+/// "what is this session for?" copy — anything shorter usually means
+/// the caller forgot to fill it in.
+const MIN_PURPOSE_CHARS: usize = 3;
+
+/// Typed declaration of session intent. Plan §D6 spec; the field set is the
+/// stable wire contract between runner and coord (`coord.sessions.intent`).
+///
+/// The `Intent` lives in the `qontinui-runner` binary crate (not the
+/// `qontinui_runner_lib` crate that other binaries import) — doctests are
+/// therefore plain examples rather than executable docs. See the
+/// `tests` module below for the executable round-trip + validation
+/// coverage.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Intent {
+    /// Discriminator. Selects which transport handles the session.
+    pub kind: SessionKind,
+    /// Human-readable purpose. Surfaces in the dashboard Live Sessions
+    /// panel; required, min [`MIN_PURPOSE_CHARS`] chars after trim.
+    pub purpose: String,
+    /// Optional repo slug. When set together with [`Intent::branch`], the
+    /// session auto-acquires a `ClaimKind::RepoBranch` on
+    /// `<repo>:<branch>`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    /// Optional branch name. See [`Intent::repo`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// Paths the session intends to touch. The plan calls this out as the
+    /// hook for fine-grained claim narrowing in later phases; for now the
+    /// list is persisted verbatim in the intent JSON.
+    #[serde(default)]
+    pub declared_paths: Vec<PathBuf>,
+    /// Plan §D10 — opt-in PTY output streaming. Off by default; sensitive
+    /// sessions stay local. Phase 8 consumes this when wiring PTY bytes
+    /// through JetStream.
+    #[serde(default)]
+    pub share_output: bool,
+    /// Plan §D11 — when `Some(true)`, run a regex sweep against PTY output
+    /// before fan-out. When `None`, defaults to the value of
+    /// [`Intent::share_output`] (see [`Intent::effective_redact_secrets`]).
+    #[serde(default)]
+    pub redact_secrets: Option<bool>,
+}
+
+impl Intent {
+    /// Resolve the effective `redact_secrets` flag. Plan §D11 — defaults to
+    /// `share_output` so callers who opt into streaming get redaction
+    /// without having to remember the second flag.
+    pub fn effective_redact_secrets(&self) -> bool {
+        self.redact_secrets.unwrap_or(self.share_output)
+    }
+
+    /// Validate the intent. Returns `Ok(())` on success; otherwise the
+    /// first failed invariant. Plan §D6 — required at every session
+    /// start.
+    pub fn validate(&self) -> Result<(), IntentError> {
+        let trimmed = self.purpose.trim();
+        if trimmed.len() < MIN_PURPOSE_CHARS {
+            return Err(IntentError::PurposeTooShort {
+                got: trimmed.len(),
+                min: MIN_PURPOSE_CHARS,
+            });
+        }
+
+        // Branch without repo is a structural mismatch — a branch name only
+        // makes sense scoped to a repo. Repo without branch is fine (whole
+        // repo work).
+        if self.branch.is_some() && self.repo.is_none() {
+            return Err(IntentError::BranchWithoutRepo);
+        }
+
+        for path in &self.declared_paths {
+            if path.as_os_str().is_empty() {
+                return Err(IntentError::EmptyDeclaredPath);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Errors surfaced by [`Intent::validate`]. Stable enum — the Tauri command
+/// handler maps each variant to a structured error code so the frontend can
+/// branch without parsing strings.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum IntentError {
+    #[error("session purpose too short ({got} < {min} chars after trim)")]
+    PurposeTooShort { got: usize, min: usize },
+    #[error("session intent has branch set but no repo — branch only makes sense scoped to a repo")]
+    BranchWithoutRepo,
+    #[error("declared_paths contains an empty path")]
+    EmptyDeclaredPath,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_intent() -> Intent {
+        Intent {
+            kind: SessionKind::TerminalShell,
+            purpose: "fix the thing".into(),
+            repo: None,
+            branch: None,
+            declared_paths: vec![],
+            share_output: false,
+            redact_secrets: None,
+        }
+    }
+
+    #[test]
+    fn accepts_minimal_intent() {
+        good_intent().validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_short_purpose() {
+        let mut i = good_intent();
+        i.purpose = "ab".into();
+        assert!(matches!(
+            i.validate(),
+            Err(IntentError::PurposeTooShort { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_whitespace_only_purpose() {
+        let mut i = good_intent();
+        i.purpose = "   ".into();
+        assert!(matches!(
+            i.validate(),
+            Err(IntentError::PurposeTooShort { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_branch_without_repo() {
+        let mut i = good_intent();
+        i.branch = Some("main".into());
+        assert_eq!(i.validate(), Err(IntentError::BranchWithoutRepo));
+    }
+
+    #[test]
+    fn accepts_repo_without_branch() {
+        let mut i = good_intent();
+        i.repo = Some("qontinui-runner".into());
+        i.validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_empty_declared_path() {
+        let mut i = good_intent();
+        i.declared_paths.push(PathBuf::new());
+        assert_eq!(i.validate(), Err(IntentError::EmptyDeclaredPath));
+    }
+
+    #[test]
+    fn redact_defaults_to_share_output() {
+        let mut i = good_intent();
+        i.share_output = true;
+        assert!(i.effective_redact_secrets());
+        i.share_output = false;
+        assert!(!i.effective_redact_secrets());
+    }
+
+    #[test]
+    fn redact_explicit_overrides_default() {
+        let mut i = good_intent();
+        i.share_output = true;
+        i.redact_secrets = Some(false);
+        assert!(!i.effective_redact_secrets());
+    }
+
+    #[test]
+    fn intent_round_trips_through_json() {
+        let i = Intent {
+            kind: SessionKind::TerminalClaude,
+            purpose: "drive the agentic loop".into(),
+            repo: Some("qontinui-web".into()),
+            branch: Some("main".into()),
+            declared_paths: vec![PathBuf::from("/repo/path")],
+            share_output: true,
+            redact_secrets: Some(false),
+        };
+        let serialized = serde_json::to_string(&i).unwrap();
+        let back: Intent = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(back, i);
+    }
+}

--- a/src-tauri/src/session/intent.rs
+++ b/src-tauri/src/session/intent.rs
@@ -106,7 +106,9 @@ impl Intent {
 pub enum IntentError {
     #[error("session purpose too short ({got} < {min} chars after trim)")]
     PurposeTooShort { got: usize, min: usize },
-    #[error("session intent has branch set but no repo — branch only makes sense scoped to a repo")]
+    #[error(
+        "session intent has branch set but no repo — branch only makes sense scoped to a repo"
+    )]
     BranchWithoutRepo,
     #[error("declared_paths contains an empty path")]
     EmptyDeclaredPath,

--- a/src-tauri/src/session/local_store.rs
+++ b/src-tauri/src/session/local_store.rs
@@ -1,0 +1,381 @@
+//! Local-first session event outbox. Plan §D7 — the runner records every
+//! lifecycle event LOCALLY first, then [`crate::session::coord_sync`]
+//! drains the outbox into coord. If coord is unreachable, sessions still
+//! run; the queue replays on reconnect (idempotent by
+//! `(machine_id, session_id, seq)`).
+//!
+//! ## Storage choice (deviation from plan §Phase 2)
+//!
+//! The plan calls out a SQLite outbox at
+//! `~/.qontinui/runner/session-outbox.sqlite`. The runner has no existing
+//! SQLite infrastructure (all durable state lives in coord Postgres via
+//! `src-tauri/src/database/pg/`), and adding `rusqlite` for an outbox we
+//! will read sequentially anyway introduces a new native dep, a new build
+//! flag, and a migration surface. We mirror the existing precedent set by
+//! `wrappers/registry.rs`: an append-only JSON-lines file at
+//! `<APP_DATA>/qontinui-runner/session-outbox.jsonl` with one record per
+//! line and an atomic "compact" pass that drops acked rows in bulk.
+//!
+//! Semantics — by design:
+//! - **Monotonic seq per `(machine_id, session_id)`** — enforced by
+//!   [`OutboxWriter::next_seq`], which scans the live records on open and
+//!   continues from `max + 1`.
+//! - **Idempotent replay** — coord-side uniqueness is `UNIQUE
+//!   (session_id, seq)`, so re-pushing the same record is a no-op there.
+//! - **Append-only writes** — every [`OutboxWriter::record`] call fsyncs a
+//!   single line; the file never gets a partial row.
+//! - **Compact on read** — the drainer calls [`OutboxWriter::compact`] after
+//!   each ack batch to drop acked records; until compact runs the file
+//!   just grows.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tracing::warn;
+use uuid::Uuid;
+
+use super::SessionEventKind;
+
+/// A single outbox record. Persisted as one JSON line.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboxRecord {
+    /// Stable machine identity (matches `coord.devices.id`).
+    pub machine_id: Uuid,
+    /// Owning session.
+    pub session_id: Uuid,
+    /// Per-(machine_id, session_id) monotonic counter. Acts as the
+    /// idempotency key on the coord side via the
+    /// `UNIQUE (session_id, seq)` constraint on `coord.session_events`.
+    pub seq: i64,
+    /// Wire-form event kind. Matches [`SessionEventKind::as_str`].
+    pub event_kind: String,
+    /// Free-form payload — passed through to coord verbatim.
+    pub payload: JsonValue,
+    /// Local timestamp at write time. Coord re-stamps `occurred_at` on
+    /// receipt; this field is the runner's view for replay/debug.
+    pub recorded_at: DateTime<Utc>,
+    /// `Some(timestamp)` once the row has been ACKed by coord (so a future
+    /// [`OutboxWriter::compact`] can drop it).
+    #[serde(default)]
+    pub acked_at: Option<DateTime<Utc>>,
+}
+
+/// Append-only outbox backed by a single JSON-lines file.
+///
+/// `Mutex<File>` rather than `Mutex<BufWriter<File>>` so each write is
+/// fsynced and visible to a fresh `OutboxWriter::open` from another
+/// process (the Tauri runner is single-process today but the supervisor
+/// may want to read the file out-of-band).
+#[derive(Debug)]
+pub struct OutboxWriter {
+    path: PathBuf,
+    next_seqs: Mutex<HashMap<(Uuid, Uuid), i64>>,
+    file: Mutex<File>,
+}
+
+impl OutboxWriter {
+    /// Open (or create) the outbox at the given path. On open, scans
+    /// existing records to populate the per-`(machine_id, session_id)`
+    /// next-seq map.
+    pub fn open(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let next_seqs = scan_next_seqs(&path)?;
+
+        let file = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(&path)?;
+
+        Ok(Self {
+            path,
+            next_seqs: Mutex::new(next_seqs),
+            file: Mutex::new(file),
+        })
+    }
+
+    /// Record a new event for `(machine_id, session_id)`. Allocates the
+    /// next monotonic seq, fsyncs the JSON-line, returns the persisted
+    /// record (with its allocated seq).
+    pub fn record(
+        &self,
+        machine_id: Uuid,
+        session_id: Uuid,
+        event_kind: SessionEventKind,
+        payload: JsonValue,
+    ) -> std::io::Result<OutboxRecord> {
+        let seq = {
+            let mut map = self.next_seqs.lock().expect("outbox seqs poisoned");
+            let entry = map.entry((machine_id, session_id)).or_insert(0);
+            *entry += 1;
+            *entry
+        };
+
+        let rec = OutboxRecord {
+            machine_id,
+            session_id,
+            seq,
+            event_kind: event_kind.as_str().to_string(),
+            payload,
+            recorded_at: Utc::now(),
+            acked_at: None,
+        };
+
+        let mut line = serde_json::to_string(&rec).map_err(std::io::Error::other)?;
+        line.push('\n');
+
+        let mut file = self.file.lock().expect("outbox file poisoned");
+        file.write_all(line.as_bytes())?;
+        file.sync_data()?;
+
+        Ok(rec)
+    }
+
+    /// Return all not-yet-acked records, in seq order per session. Used
+    /// by [`crate::session::coord_sync`] to drive the push loop.
+    pub fn pending(&self) -> std::io::Result<Vec<OutboxRecord>> {
+        let _guard = self.file.lock().expect("outbox file poisoned");
+        let mut pending: Vec<OutboxRecord> = read_all(&self.path)?
+            .into_iter()
+            .filter(|r| r.acked_at.is_none())
+            .collect();
+        pending.sort_by_key(|r| (r.session_id, r.seq));
+        Ok(pending)
+    }
+
+    /// Mark records as acked. Calls [`OutboxWriter::compact`] once the
+    /// batch is applied so the file doesn't grow unbounded across many
+    /// successful pushes.
+    pub fn ack(&self, acks: &[(Uuid, i64)]) -> std::io::Result<()> {
+        if acks.is_empty() {
+            return Ok(());
+        }
+        let _guard = self.file.lock().expect("outbox file poisoned");
+
+        let mut all = read_all(&self.path)?;
+        let now = Utc::now();
+        let ack_set: std::collections::HashSet<(Uuid, i64)> = acks.iter().copied().collect();
+        for rec in &mut all {
+            if ack_set.contains(&(rec.session_id, rec.seq)) && rec.acked_at.is_none() {
+                rec.acked_at = Some(now);
+            }
+        }
+
+        rewrite_all(&self.path, &all)
+    }
+
+    /// Drop already-acked records. Called by [`OutboxWriter::ack`] on
+    /// every batch and available as a manual sweep for cron-style
+    /// callers.
+    pub fn compact(&self) -> std::io::Result<()> {
+        let _guard = self.file.lock().expect("outbox file poisoned");
+        let all = read_all(&self.path)?;
+        let kept: Vec<_> = all.into_iter().filter(|r| r.acked_at.is_none()).collect();
+        rewrite_all(&self.path, &kept)
+    }
+}
+
+fn scan_next_seqs(path: &Path) -> std::io::Result<HashMap<(Uuid, Uuid), i64>> {
+    let mut map: HashMap<(Uuid, Uuid), i64> = HashMap::new();
+    if !path.exists() {
+        return Ok(map);
+    }
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    for (idx, line) in reader.lines().enumerate() {
+        let line = match line {
+            Ok(l) => l,
+            Err(e) => {
+                warn!("outbox: line {} unreadable ({}); stopping scan", idx, e);
+                break;
+            }
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let rec: OutboxRecord = match serde_json::from_str(line) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(
+                    "outbox: line {} unparseable ({}); skipping (replay safe)",
+                    idx, e
+                );
+                continue;
+            }
+        };
+        let entry = map.entry((rec.machine_id, rec.session_id)).or_insert(0);
+        if rec.seq > *entry {
+            *entry = rec.seq;
+        }
+    }
+    Ok(map)
+}
+
+fn read_all(path: &Path) -> std::io::Result<Vec<OutboxRecord>> {
+    let mut out = Vec::new();
+    if !path.exists() {
+        return Ok(out);
+    }
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line = line?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<OutboxRecord>(line) {
+            Ok(rec) => out.push(rec),
+            Err(e) => warn!("outbox: skipping unparseable record: {}", e),
+        }
+    }
+    Ok(out)
+}
+
+fn rewrite_all(path: &Path, records: &[OutboxRecord]) -> std::io::Result<()> {
+    // Write to a temp file then rename for atomicity. Mirrors the pattern
+    // used elsewhere in the runner (see `wrappers/registry.rs` index
+    // rewrites + `fs_atomic.rs`).
+    let tmp = path.with_extension("jsonl.tmp");
+    {
+        let f = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)?;
+        let mut w = BufWriter::new(f);
+        for rec in records {
+            let mut line = serde_json::to_string(rec).map_err(std::io::Error::other)?;
+            line.push('\n');
+            w.write_all(line.as_bytes())?;
+        }
+        w.flush()?;
+        w.get_ref().sync_data()?;
+    }
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    #[test]
+    fn record_assigns_monotonic_seq_per_session() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("outbox.jsonl");
+        let outbox = OutboxWriter::open(&path).unwrap();
+        let m = Uuid::new_v4();
+        let s1 = Uuid::new_v4();
+        let s2 = Uuid::new_v4();
+
+        let r1 = outbox
+            .record(m, s1, SessionEventKind::Started, json!({}))
+            .unwrap();
+        let r2 = outbox
+            .record(m, s1, SessionEventKind::Heartbeat, json!({}))
+            .unwrap();
+        let r3 = outbox
+            .record(m, s2, SessionEventKind::Started, json!({}))
+            .unwrap();
+        let r4 = outbox
+            .record(m, s1, SessionEventKind::Closed, json!({}))
+            .unwrap();
+
+        assert_eq!(r1.seq, 1);
+        assert_eq!(r2.seq, 2);
+        assert_eq!(r3.seq, 1);
+        assert_eq!(r4.seq, 3);
+    }
+
+    #[test]
+    fn pending_returns_unacked_records_in_seq_order() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("outbox.jsonl");
+        let outbox = OutboxWriter::open(&path).unwrap();
+        let m = Uuid::new_v4();
+        let s = Uuid::new_v4();
+
+        outbox
+            .record(m, s, SessionEventKind::Started, json!({}))
+            .unwrap();
+        outbox
+            .record(m, s, SessionEventKind::Heartbeat, json!({}))
+            .unwrap();
+        outbox
+            .record(m, s, SessionEventKind::Closed, json!({}))
+            .unwrap();
+
+        let pending = outbox.pending().unwrap();
+        assert_eq!(pending.len(), 3);
+        assert_eq!(pending[0].seq, 1);
+        assert_eq!(pending[1].seq, 2);
+        assert_eq!(pending[2].seq, 3);
+    }
+
+    #[test]
+    fn ack_drops_records_on_compact() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("outbox.jsonl");
+        let outbox = OutboxWriter::open(&path).unwrap();
+        let m = Uuid::new_v4();
+        let s = Uuid::new_v4();
+
+        let r1 = outbox
+            .record(m, s, SessionEventKind::Started, json!({}))
+            .unwrap();
+        let r2 = outbox
+            .record(m, s, SessionEventKind::Heartbeat, json!({}))
+            .unwrap();
+        outbox
+            .record(m, s, SessionEventKind::Closed, json!({}))
+            .unwrap();
+
+        outbox
+            .ack(&[(r1.session_id, r1.seq), (r2.session_id, r2.seq)])
+            .unwrap();
+
+        // ack() compacts implicitly via rewrite_all; pending() drops the
+        // acked rows.
+        let pending = outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].seq, 3);
+    }
+
+    #[test]
+    fn reopen_continues_seq_from_max() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("outbox.jsonl");
+        let m = Uuid::new_v4();
+        let s = Uuid::new_v4();
+
+        {
+            let outbox = OutboxWriter::open(&path).unwrap();
+            outbox
+                .record(m, s, SessionEventKind::Started, json!({}))
+                .unwrap();
+            outbox
+                .record(m, s, SessionEventKind::Heartbeat, json!({}))
+                .unwrap();
+        }
+
+        let outbox = OutboxWriter::open(&path).unwrap();
+        let r = outbox
+            .record(m, s, SessionEventKind::Closed, json!({}))
+            .unwrap();
+        assert_eq!(r.seq, 3);
+    }
+}

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,0 +1,833 @@
+//! Unified Session primitive — plan
+//! [`2026-05-22-coord-native-session-coordination`] §D1 + §Phase 2.
+//!
+//! Today the runner has three parallel session concepts:
+//!
+//! - [`crate::terminal::TerminalManager`] (PTY-backed shell sessions)
+//! - [`crate::claude_session::ClaudeSession`] (Claude CLI subprocesses)
+//! - Workflow sessions (`unified_workflow_executor` + `project.sessions`)
+//!
+//! Plan §D1 makes them one [`Session`] lifecycle with a typed
+//! [`SessionKind`] discriminator. The transport for each kind lives under
+//! [`transport`]; the wire shapes (SessionKind, SessionState,
+//! SessionEventKind, Intent) mirror `qontinui-coord/src/sessions.rs`
+//! byte-for-byte so the runner-side struct serializes verbatim into
+//! `coord.sessions.intent` / `coord.sessions.session_kind` /
+//! `coord.sessions.state` columns.
+//!
+//! ## Phase 2 scope (this PR)
+//!
+//! - Wire shapes that match `coord.sessions` exactly
+//! - [`Session::start`] / [`SessionHandle`] lifecycle with transport
+//!   selection
+//! - [`Intent`] validation
+//! - Local outbox ([`local_store::OutboxWriter`]) — JSON-lines per
+//!   precedent in `wrappers/registry.rs` (see deviation note there); the
+//!   plan calls out SQLite, but adding rusqlite for an outbox we read
+//!   sequentially adds a new native dep + migration surface for no
+//!   benefit over a JSONL file.
+//! - Tauri command surface (see `commands::session`) — `session_start`,
+//!   `session_focus`, `session_close`, `session_describe`,
+//!   `session_steal {reason}`
+//!
+//! ## Out of scope (deferred to later phases)
+//!
+//! - **Phase 3** — the coord-sync push/heartbeat loop is a stub in
+//!   [`coord_sync`]. Local outbox is written; nothing pushes to coord yet.
+//! - **Phase 4** — frontend command callers (`SessionContext`) cut over
+//!   from the legacy `terminal_*` / `ai_session_*` commands.
+//! - **Phase 9** — the existing `commands/terminal.rs`,
+//!   `claude_session/` (9 files), and legacy session tables are kept in
+//!   place. They're load-bearing for ~24 consumers across `productivity`,
+//!   `coordinator`, `executor`, `mcp`, `fixer`, `follow_up`,
+//!   `zombie_sweep`. Phase 9 deletion happens after Phase 4 frontend
+//!   cutover routes the consumers through this primitive.
+//!
+//! ## Why an additive layer instead of a wholesale rewrite?
+//!
+//! Per `CLAUDE.md` "Delete over deprecate" and the plan's "no backward
+//! compat" stance, the long-term plan is deletion. But the plan's
+//! own §Phase 9 explicitly slates `commands/terminal.rs` + `claude_session/`
+//! for deletion AFTER Phase 4 wires the frontend to the new commands. The
+//! existing modules have ~24 in-crate consumers (productivity workers,
+//! coordinator deconflicter, etc.) and front-end Tauri commands that the
+//! runner UI calls today. Deleting them in Phase 2 would break the
+//! runner. Phase 2 is the **substrate** for Phase 4 — the new commands
+//! coexist with the old ones, and Phase 9 cleans up once the new path
+//! has fully absorbed the old surface.
+
+pub mod coord_sync;
+pub mod intent;
+pub mod local_store;
+pub mod transport;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value as JsonValue};
+use thiserror::Error;
+use uuid::Uuid;
+
+pub use intent::{Intent, IntentError};
+pub use transport::{DynTransport, Transport, TransportError, TransportHandle};
+
+// ---------------------------------------------------------------------------
+// Wire types — must match `coord.sessions` (snake_case enum variants, exact
+// variant set). Cross-reference: qontinui-coord/src/sessions.rs ~146-202.
+// ---------------------------------------------------------------------------
+
+/// Discriminator for a [`Session`]. Mirrors the `coord.sessions.session_kind`
+/// CHECK constraint and Phase 1's wire enum 1:1 — the runner serializes
+/// directly into the coord column.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionKind {
+    TerminalShell,
+    TerminalClaude,
+    Agentic,
+    Workflow,
+    Automation,
+    Debug,
+}
+
+impl SessionKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionKind::TerminalShell => "terminal_shell",
+            SessionKind::TerminalClaude => "terminal_claude",
+            SessionKind::Agentic => "agentic",
+            SessionKind::Workflow => "workflow",
+            SessionKind::Automation => "automation",
+            SessionKind::Debug => "debug",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "terminal_shell" => SessionKind::TerminalShell,
+            "terminal_claude" => SessionKind::TerminalClaude,
+            "agentic" => SessionKind::Agentic,
+            "workflow" => SessionKind::Workflow,
+            "automation" => SessionKind::Automation,
+            "debug" => SessionKind::Debug,
+            _ => return None,
+        })
+    }
+}
+
+/// Mirrors `coord.sessions.state` CHECK constraint and Phase 1 wire enum
+/// 1:1.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionState {
+    Active,
+    PendingResolution,
+    Stale,
+    Closed,
+}
+
+impl SessionState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionState::Active => "active",
+            SessionState::PendingResolution => "pending_resolution",
+            SessionState::Stale => "stale",
+            SessionState::Closed => "closed",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        Some(match s {
+            "active" => SessionState::Active,
+            "pending_resolution" => SessionState::PendingResolution,
+            "stale" => SessionState::Stale,
+            "closed" => SessionState::Closed,
+            _ => return None,
+        })
+    }
+}
+
+/// Event kinds published on `qontinui.sessions.<tenant>.<machine>.<kind>`.
+/// Mirrors Phase 1 wire enum 1:1 — `OutputChunk` (Phase 8) and
+/// `HandoffRequest` (Phase 7) are pre-declared for stable wire shape.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionEventKind {
+    Started,
+    StateChange,
+    Closed,
+    Heartbeat,
+    ClaimStolen,
+    /// Phase 8 — defined now, published when PTY streaming lands.
+    OutputChunk,
+    /// Phase 7 — defined now, published when handoff lands.
+    HandoffRequest,
+}
+
+impl SessionEventKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            SessionEventKind::Started => "started",
+            SessionEventKind::StateChange => "state_change",
+            SessionEventKind::Closed => "closed",
+            SessionEventKind::Heartbeat => "heartbeat",
+            SessionEventKind::ClaimStolen => "claim_stolen",
+            SessionEventKind::OutputChunk => "output_chunk",
+            SessionEventKind::HandoffRequest => "handoff_request",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session + SessionHandle
+// ---------------------------------------------------------------------------
+
+/// Errors raised by the [`Session`] lifecycle.
+#[derive(Debug, Error)]
+pub enum SessionError {
+    #[error("invalid intent: {0}")]
+    Intent(#[from] IntentError),
+    #[error("transport error: {0}")]
+    Transport(#[from] TransportError),
+    #[error("steal reason too short ({got} < {min} chars)")]
+    StealReasonTooShort { got: usize, min: usize },
+    #[error("session not found: {0}")]
+    NotFound(Uuid),
+    #[error("local outbox error: {0}")]
+    Outbox(String),
+}
+
+/// Minimum chars on a steal reason — plan §D14.
+pub const MIN_STEAL_REASON_CHARS: usize = 10;
+
+/// Description of an existing session, returned by [`SessionHandle::describe`]
+/// and the `session_describe` Tauri command. Mirrors the subset of
+/// `SessionRow` the frontend needs (tenant + device omitted — those are
+/// constant per machine and the frontend already knows them).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionDescription {
+    pub id: Uuid,
+    pub kind: SessionKind,
+    pub state: SessionState,
+    pub intent: Intent,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub closed_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub parent_session_id: Option<Uuid>,
+    pub transport_handle_kind: &'static str,
+}
+
+/// Internal record stored in [`SessionRegistry`]. The transport is held as
+/// an `Arc<dyn Transport>` so the handle methods can route back to it
+/// without going through a global lookup.
+struct SessionRecord {
+    id: Uuid,
+    kind: SessionKind,
+    state: SessionState,
+    intent: Intent,
+    started_at: chrono::DateTime<chrono::Utc>,
+    last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
+    closed_at: Option<chrono::DateTime<chrono::Utc>>,
+    parent_session_id: Option<Uuid>,
+    transport: DynTransport,
+    transport_handle: TransportHandle,
+}
+
+impl SessionRecord {
+    fn describe(&self) -> SessionDescription {
+        SessionDescription {
+            id: self.id,
+            kind: self.kind,
+            state: self.state,
+            intent: self.intent.clone(),
+            started_at: self.started_at,
+            last_heartbeat_at: self.last_heartbeat_at,
+            closed_at: self.closed_at,
+            parent_session_id: self.parent_session_id,
+            transport_handle_kind: match &self.transport_handle {
+                TransportHandle::Pty { .. } => "pty",
+                TransportHandle::ClaudeCli { .. } => "claude_cli",
+                TransportHandle::Workflow { .. } => "workflow",
+            },
+        }
+    }
+}
+
+/// Process-wide registry of live sessions. Owns the in-memory map keyed by
+/// session UUID. Stored in Tauri state via `Arc<SessionRegistry>` and
+/// reached from the `commands::session` plugin.
+pub struct SessionRegistry {
+    machine_id: Uuid,
+    sessions: Mutex<HashMap<Uuid, SessionRecord>>,
+    transports: SessionTransports,
+    coord_sync: coord_sync::CoordSync,
+}
+
+/// Bag of per-kind transports.
+pub struct SessionTransports {
+    pub pty: DynTransport,
+    pub claude_cli: DynTransport,
+    pub workflow: DynTransport,
+}
+
+impl SessionTransports {
+    fn pick(&self, kind: SessionKind) -> DynTransport {
+        match kind {
+            SessionKind::TerminalShell => self.pty.clone(),
+            SessionKind::TerminalClaude | SessionKind::Agentic => self.claude_cli.clone(),
+            SessionKind::Workflow | SessionKind::Automation | SessionKind::Debug => {
+                self.workflow.clone()
+            }
+        }
+    }
+}
+
+impl SessionRegistry {
+    pub fn new(
+        machine_id: Uuid,
+        transports: SessionTransports,
+        coord_sync: coord_sync::CoordSync,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            machine_id,
+            sessions: Mutex::new(HashMap::new()),
+            transports,
+            coord_sync,
+        })
+    }
+
+    pub fn machine_id(&self) -> Uuid {
+        self.machine_id
+    }
+
+    /// Start a new session. Plan §D1 single-constructor surface.
+    pub fn start(self: &Arc<Self>, intent: Intent) -> Result<SessionHandle, SessionError> {
+        intent.validate()?;
+
+        let transport = self.transports.pick(intent.kind);
+        let transport_handle = transport.start(&intent)?;
+
+        let id = uuid_v7();
+        let now = chrono::Utc::now();
+
+        let record = SessionRecord {
+            id,
+            kind: intent.kind,
+            state: SessionState::Active,
+            intent: intent.clone(),
+            started_at: now,
+            last_heartbeat_at: Some(now),
+            closed_at: None,
+            parent_session_id: None,
+            transport: transport.clone(),
+            transport_handle,
+        };
+
+        // Outbox row first (durability before in-memory commit so a crash
+        // between insert and outbox-write doesn't lose the record).
+        let payload = json!({
+            "id": id,
+            "kind": intent.kind.as_str(),
+            "intent": intent,
+            "state": SessionState::Active.as_str(),
+            "started_at": now,
+        });
+        self.coord_sync
+            .outbox()
+            .record(self.machine_id, id, SessionEventKind::Started, payload)
+            .map_err(|e| SessionError::Outbox(e.to_string()))?;
+
+        let mut sessions = self
+            .sessions
+            .lock()
+            .expect("session registry poisoned");
+        sessions.insert(id, record);
+
+        Ok(SessionHandle {
+            id,
+            registry: Arc::clone(self),
+        })
+    }
+
+    fn with_record<R>(
+        &self,
+        id: Uuid,
+        f: impl FnOnce(&mut SessionRecord) -> R,
+    ) -> Result<R, SessionError> {
+        let mut sessions = self.sessions.lock().expect("session registry poisoned");
+        match sessions.get_mut(&id) {
+            Some(rec) => Ok(f(rec)),
+            None => Err(SessionError::NotFound(id)),
+        }
+    }
+
+    fn describe(&self, id: Uuid) -> Result<SessionDescription, SessionError> {
+        let sessions = self.sessions.lock().expect("session registry poisoned");
+        sessions
+            .get(&id)
+            .map(SessionRecord::describe)
+            .ok_or(SessionError::NotFound(id))
+    }
+
+    fn list_all(&self) -> Vec<SessionDescription> {
+        let sessions = self.sessions.lock().expect("session registry poisoned");
+        sessions.values().map(SessionRecord::describe).collect()
+    }
+
+    fn close(&self, id: Uuid) -> Result<(), SessionError> {
+        // Snapshot the transport handle + transport ref under the lock,
+        // then drop the lock before calling transport.close (which may
+        // block on subprocess teardown).
+        let (transport, handle, payload) = {
+            let mut sessions = self.sessions.lock().expect("session registry poisoned");
+            let rec = sessions.get_mut(&id).ok_or(SessionError::NotFound(id))?;
+            if matches!(rec.state, SessionState::Closed) {
+                return Ok(()); // idempotent
+            }
+            rec.state = SessionState::Closed;
+            rec.closed_at = Some(chrono::Utc::now());
+            let payload = json!({
+                "id": id,
+                "state": SessionState::Closed.as_str(),
+                "closed_at": rec.closed_at,
+            });
+            // We must clone the transport + handle out of the record so we
+            // can drop the lock before close (close may take a while).
+            let transport = Arc::clone(&rec.transport);
+            let handle = clone_transport_handle(&rec.transport_handle);
+            (transport, handle, payload)
+        };
+
+        let close_result = transport.close(&handle);
+
+        // Outbox the close event regardless of transport close result —
+        // the dashboard wants to know we tried to close even if the
+        // subprocess was already dead.
+        if let Err(e) = self.coord_sync.outbox().record(
+            self.machine_id,
+            id,
+            SessionEventKind::Closed,
+            payload,
+        ) {
+            tracing::warn!("session {} close outbox write failed: {}", id, e);
+        }
+
+        close_result?;
+        Ok(())
+    }
+
+    /// Plan §D14 — steal-with-reason. Min 10 chars. Records a
+    /// `claim_stolen` event in the outbox; the actual claim release is
+    /// driven by `agent_claims` / coord and lands in Phase 6.
+    fn steal(&self, id: Uuid, reason: &str) -> Result<(), SessionError> {
+        if reason.chars().count() < MIN_STEAL_REASON_CHARS {
+            return Err(SessionError::StealReasonTooShort {
+                got: reason.chars().count(),
+                min: MIN_STEAL_REASON_CHARS,
+            });
+        }
+        // Confirm the session exists (so we don't write phantom events
+        // for unknown ids).
+        let _ = self.describe(id)?;
+
+        let payload = json!({
+            "id": id,
+            "reason": reason,
+            "stolen_at": chrono::Utc::now(),
+        });
+        self.coord_sync
+            .outbox()
+            .record(self.machine_id, id, SessionEventKind::ClaimStolen, payload)
+            .map_err(|e| SessionError::Outbox(e.to_string()))?;
+        Ok(())
+    }
+
+    /// "Focus" surfaces in Phase 4 as a frontend event — currently a
+    /// no-op stub that records a `state_change` heartbeat-like event so
+    /// the dashboard sees the operator paying attention.
+    fn focus(&self, id: Uuid) -> Result<(), SessionError> {
+        let now = chrono::Utc::now();
+        self.with_record(id, |rec| {
+            rec.last_heartbeat_at = Some(now);
+        })?;
+        let payload = json!({
+            "id": id,
+            "kind": "focus",
+            "at": now,
+        });
+        self.coord_sync
+            .outbox()
+            .record(self.machine_id, id, SessionEventKind::StateChange, payload)
+            .map_err(|e| SessionError::Outbox(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Borrow the coord-sync facade. Phase 3 will use this to drive the
+    /// drain loop from main.rs.
+    pub fn coord_sync(&self) -> &coord_sync::CoordSync {
+        &self.coord_sync
+    }
+
+    /// Read-only snapshot of all sessions. Used by the
+    /// `commands::session::session_list` Tauri command and by tests.
+    pub fn snapshot(&self) -> Vec<SessionDescription> {
+        self.list_all()
+    }
+
+    /// Describe-by-id surface used by the Tauri command layer (which
+    /// holds `tauri::State<Arc<SessionRegistry>>` and does not have a
+    /// [`SessionHandle`]).
+    pub fn describe_by_id(&self, id: Uuid) -> Result<SessionDescription, SessionError> {
+        self.describe(id)
+    }
+
+    /// Close-by-id — same idempotent semantics as
+    /// [`SessionHandle::close`].
+    pub fn close_by_id(&self, id: Uuid) -> Result<(), SessionError> {
+        self.close(id)
+    }
+
+    /// Focus-by-id surface for the Tauri command layer.
+    pub fn focus_by_id(&self, id: Uuid) -> Result<(), SessionError> {
+        self.focus(id)
+    }
+
+    /// Steal-by-id surface for the Tauri command layer.
+    pub fn steal_by_id(&self, id: Uuid, reason: &str) -> Result<(), SessionError> {
+        self.steal(id, reason)
+    }
+}
+
+fn clone_transport_handle(h: &TransportHandle) -> TransportHandle {
+    match h {
+        TransportHandle::Pty { terminal_id } => TransportHandle::Pty {
+            terminal_id: terminal_id.clone(),
+        },
+        TransportHandle::ClaudeCli { cli_session_id } => TransportHandle::ClaudeCli {
+            cli_session_id: cli_session_id.clone(),
+        },
+        TransportHandle::Workflow { task_run_id } => TransportHandle::Workflow {
+            task_run_id: task_run_id.clone(),
+        },
+    }
+}
+
+/// Lightweight handle returned to the caller of [`SessionRegistry::start`].
+/// Holds an Arc back to the registry so subsequent ops can find the
+/// record by id.
+#[derive(Clone)]
+pub struct SessionHandle {
+    id: Uuid,
+    registry: Arc<SessionRegistry>,
+}
+
+impl SessionHandle {
+    pub fn id(&self) -> Uuid {
+        self.id
+    }
+
+    /// Render the current session state for the Tauri layer / dashboard.
+    pub fn describe(&self) -> Result<SessionDescription, SessionError> {
+        self.registry.describe(self.id)
+    }
+
+    /// Tear the session down. Idempotent.
+    pub fn close(self) -> Result<(), SessionError> {
+        self.registry.close(self.id)
+    }
+
+    /// Phase 4 "Focus this session" command — heartbeats the session
+    /// row so the dashboard knows the operator is on it.
+    pub fn focus(&self) -> Result<(), SessionError> {
+        self.registry.focus(self.id)
+    }
+
+    /// Plan §D14 — initiate a claim-steal with a typed reason.
+    pub fn steal(&self, reason: &str) -> Result<(), SessionError> {
+        self.registry.steal(self.id, reason)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// UUIDv7 (time-ordered) for session ids. Plan §Phase 2 calls UUIDv7 out
+/// explicitly so the runner-local outbox row sorts naturally with the
+/// coord row — UUIDv4 would still work for correctness but defeats the
+/// `(machine_id, session_id, seq)` "time-ordered" intuition.
+fn uuid_v7() -> Uuid {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let ts = uuid::Timestamp::from_unix(uuid::NoContext, now.as_secs(), now.subsec_nanos());
+    Uuid::new_v7(ts)
+}
+
+/// Convert a [`JsonValue`] payload into a [`SessionDescription`]. Used by
+/// `commands::session::session_describe` to thread the registry response
+/// through the Tauri `CommandResponse` envelope without `serde_json::to_value`
+/// at the call site.
+pub fn description_to_json(desc: &SessionDescription) -> JsonValue {
+    serde_json::to_value(desc).unwrap_or(JsonValue::Null)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// In-memory transport that records every call for test inspection.
+    /// Doesn't talk to a real PTY / subprocess — that's the point: tests
+    /// should not depend on Tauri runtime, OS shells, or external
+    /// processes.
+    struct FakeTransport {
+        kind_filter: SessionKind,
+        starts: AtomicUsize,
+        writes: AtomicUsize,
+        resizes: AtomicUsize,
+        closes: AtomicUsize,
+    }
+
+    impl FakeTransport {
+        fn new(kind_filter: SessionKind) -> Self {
+            Self {
+                kind_filter,
+                starts: AtomicUsize::new(0),
+                writes: AtomicUsize::new(0),
+                resizes: AtomicUsize::new(0),
+                closes: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl Transport for FakeTransport {
+        fn start(&self, intent: &Intent) -> Result<TransportHandle, TransportError> {
+            if intent.kind != self.kind_filter {
+                return Err(TransportError::InvalidIntent(format!(
+                    "fake transport wants {:?}, got {:?}",
+                    self.kind_filter, intent.kind
+                )));
+            }
+            self.starts.fetch_add(1, Ordering::SeqCst);
+            Ok(TransportHandle::Pty {
+                terminal_id: "fake-1".to_string(),
+            })
+        }
+        fn write_input(
+            &self,
+            _h: &TransportHandle,
+            _b: &[u8],
+        ) -> Result<(), TransportError> {
+            self.writes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn resize(
+            &self,
+            _h: &TransportHandle,
+            _c: u16,
+            _r: u16,
+        ) -> Result<(), TransportError> {
+            self.resizes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        fn close(&self, _h: &TransportHandle) -> Result<(), TransportError> {
+            self.closes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    fn make_registry() -> Arc<SessionRegistry> {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = Arc::new(
+            local_store::OutboxWriter::open(dir.path().join("outbox.jsonl")).unwrap(),
+        );
+        let coord_sync = coord_sync::CoordSync::new(outbox);
+
+        let pty = Arc::new(FakeTransport::new(SessionKind::TerminalShell)) as DynTransport;
+        let claude_cli =
+            Arc::new(FakeTransport::new(SessionKind::TerminalClaude)) as DynTransport;
+        let workflow = Arc::new(FakeTransport::new(SessionKind::Workflow)) as DynTransport;
+
+        SessionRegistry::new(
+            Uuid::new_v4(),
+            SessionTransports {
+                pty,
+                claude_cli,
+                workflow,
+            },
+            coord_sync,
+        )
+    }
+
+    fn shell_intent() -> Intent {
+        Intent {
+            kind: SessionKind::TerminalShell,
+            purpose: "smoke test".into(),
+            repo: None,
+            branch: None,
+            declared_paths: vec![],
+            share_output: false,
+            redact_secrets: None,
+        }
+    }
+
+    #[test]
+    fn session_kind_round_trips_snake_case() {
+        for k in [
+            SessionKind::TerminalShell,
+            SessionKind::TerminalClaude,
+            SessionKind::Agentic,
+            SessionKind::Workflow,
+            SessionKind::Automation,
+            SessionKind::Debug,
+        ] {
+            let json = serde_json::to_string(&k).unwrap();
+            let back: SessionKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(k, back);
+            // The serialized form must be the same string SessionKind::as_str
+            // returns — coord matches on these literals.
+            assert_eq!(json.trim_matches('"'), k.as_str());
+        }
+    }
+
+    #[test]
+    fn session_state_round_trips_snake_case() {
+        for s in [
+            SessionState::Active,
+            SessionState::PendingResolution,
+            SessionState::Stale,
+            SessionState::Closed,
+        ] {
+            let json = serde_json::to_string(&s).unwrap();
+            let back: SessionState = serde_json::from_str(&json).unwrap();
+            assert_eq!(s, back);
+            assert_eq!(json.trim_matches('"'), s.as_str());
+        }
+    }
+
+    #[test]
+    fn session_event_kind_round_trips_snake_case() {
+        let kinds = [
+            SessionEventKind::Started,
+            SessionEventKind::StateChange,
+            SessionEventKind::Closed,
+            SessionEventKind::Heartbeat,
+            SessionEventKind::ClaimStolen,
+            SessionEventKind::OutputChunk,
+            SessionEventKind::HandoffRequest,
+        ];
+        for k in kinds {
+            let json = serde_json::to_string(&k).unwrap();
+            let back: SessionEventKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(k, back);
+            assert_eq!(json.trim_matches('"'), k.as_str());
+        }
+    }
+
+    #[test]
+    fn lifecycle_start_describe_close() {
+        let reg = make_registry();
+        let handle = reg.start(shell_intent()).unwrap();
+        let desc = handle.describe().unwrap();
+        assert_eq!(desc.kind, SessionKind::TerminalShell);
+        assert_eq!(desc.state, SessionState::Active);
+        assert_eq!(desc.intent.purpose, "smoke test");
+        assert!(desc.closed_at.is_none());
+
+        let id = handle.id();
+        handle.close().unwrap();
+
+        let again = reg.describe(id).unwrap();
+        assert_eq!(again.state, SessionState::Closed);
+        assert!(again.closed_at.is_some());
+    }
+
+    #[test]
+    fn close_is_idempotent() {
+        let reg = make_registry();
+        let handle = reg.start(shell_intent()).unwrap();
+        let id = handle.id();
+        handle.clone().close().unwrap();
+        // Second close — no panic, no error.
+        reg.close(id).unwrap();
+    }
+
+    #[test]
+    fn start_rejects_invalid_intent() {
+        let reg = make_registry();
+        let mut intent = shell_intent();
+        intent.purpose = "x".into();
+        let err = reg.start(intent).unwrap_err();
+        assert!(matches!(err, SessionError::Intent(_)));
+    }
+
+    #[test]
+    fn steal_requires_long_reason() {
+        let reg = make_registry();
+        let handle = reg.start(shell_intent()).unwrap();
+        let err = handle.steal("short").unwrap_err();
+        assert!(matches!(
+            err,
+            SessionError::StealReasonTooShort { got, min }
+            if got == 5 && min == MIN_STEAL_REASON_CHARS
+        ));
+        // Exact-min-chars reason is accepted.
+        handle.steal("1234567890").unwrap();
+    }
+
+    #[test]
+    fn focus_heartbeats_session() {
+        let reg = make_registry();
+        let handle = reg.start(shell_intent()).unwrap();
+        let before = handle.describe().unwrap().last_heartbeat_at;
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        handle.focus().unwrap();
+        let after = handle.describe().unwrap().last_heartbeat_at;
+        assert!(after > before);
+    }
+
+    #[test]
+    fn snapshot_lists_all_sessions() {
+        let reg = make_registry();
+        let _a = reg.start(shell_intent()).unwrap();
+        let _b = reg.start(shell_intent()).unwrap();
+        let snap = reg.snapshot();
+        assert_eq!(snap.len(), 2);
+    }
+
+    #[test]
+    fn transports_pick_routes_by_kind() {
+        // FakeTransport rejects non-matching kinds, so this proves the
+        // router picked the right transport.
+        let reg = make_registry();
+
+        let mut shell = shell_intent();
+        shell.kind = SessionKind::TerminalShell;
+        reg.start(shell).unwrap();
+
+        let mut claude = shell_intent();
+        claude.kind = SessionKind::TerminalClaude;
+        reg.start(claude).unwrap();
+
+        let mut wf = shell_intent();
+        wf.kind = SessionKind::Workflow;
+        reg.start(wf).unwrap();
+    }
+
+    #[test]
+    fn description_serializes_with_snake_case_enums() {
+        let reg = make_registry();
+        let handle = reg.start(shell_intent()).unwrap();
+        let desc = handle.describe().unwrap();
+        let json = serde_json::to_value(&desc).unwrap();
+        assert_eq!(json["kind"], "terminal_shell");
+        assert_eq!(json["state"], "active");
+    }
+}

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -339,10 +339,7 @@ impl SessionRegistry {
             .record(self.machine_id, id, SessionEventKind::Started, payload)
             .map_err(|e| SessionError::Outbox(e.to_string()))?;
 
-        let mut sessions = self
-            .sessions
-            .lock()
-            .expect("session registry poisoned");
+        let mut sessions = self.sessions.lock().expect("session registry poisoned");
         sessions.insert(id, record);
 
         Ok(SessionHandle {
@@ -405,12 +402,11 @@ impl SessionRegistry {
         // Outbox the close event regardless of transport close result —
         // the dashboard wants to know we tried to close even if the
         // subprocess was already dead.
-        if let Err(e) = self.coord_sync.outbox().record(
-            self.machine_id,
-            id,
-            SessionEventKind::Closed,
-            payload,
-        ) {
+        if let Err(e) =
+            self.coord_sync
+                .outbox()
+                .record(self.machine_id, id, SessionEventKind::Closed, payload)
+        {
             tracing::warn!("session {} close outbox write failed: {}", id, e);
         }
 
@@ -523,6 +519,14 @@ pub struct SessionHandle {
     registry: Arc<SessionRegistry>,
 }
 
+impl std::fmt::Debug for SessionHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionHandle")
+            .field("id", &self.id)
+            .finish()
+    }
+}
+
 impl SessionHandle {
     pub fn id(&self) -> Uuid {
         self.id
@@ -620,20 +624,11 @@ mod tests {
                 terminal_id: "fake-1".to_string(),
             })
         }
-        fn write_input(
-            &self,
-            _h: &TransportHandle,
-            _b: &[u8],
-        ) -> Result<(), TransportError> {
+        fn write_input(&self, _h: &TransportHandle, _b: &[u8]) -> Result<(), TransportError> {
             self.writes.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
-        fn resize(
-            &self,
-            _h: &TransportHandle,
-            _c: u16,
-            _r: u16,
-        ) -> Result<(), TransportError> {
+        fn resize(&self, _h: &TransportHandle, _c: u16, _r: u16) -> Result<(), TransportError> {
             self.resizes.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -645,14 +640,12 @@ mod tests {
 
     fn make_registry() -> Arc<SessionRegistry> {
         let dir = tempfile::tempdir().unwrap();
-        let outbox = Arc::new(
-            local_store::OutboxWriter::open(dir.path().join("outbox.jsonl")).unwrap(),
-        );
+        let outbox =
+            Arc::new(local_store::OutboxWriter::open(dir.path().join("outbox.jsonl")).unwrap());
         let coord_sync = coord_sync::CoordSync::new(outbox);
 
         let pty = Arc::new(FakeTransport::new(SessionKind::TerminalShell)) as DynTransport;
-        let claude_cli =
-            Arc::new(FakeTransport::new(SessionKind::TerminalClaude)) as DynTransport;
+        let claude_cli = Arc::new(FakeTransport::new(SessionKind::TerminalClaude)) as DynTransport;
         let workflow = Arc::new(FakeTransport::new(SessionKind::Workflow)) as DynTransport;
 
         SessionRegistry::new(

--- a/src-tauri/src/session/transport/claude_cli.rs
+++ b/src-tauri/src/session/transport/claude_cli.rs
@@ -105,11 +105,7 @@ impl Transport for ClaudeCliTransport {
         }
     }
 
-    fn write_input(
-        &self,
-        handle: &TransportHandle,
-        bytes: &[u8],
-    ) -> Result<(), TransportError> {
+    fn write_input(&self, handle: &TransportHandle, bytes: &[u8]) -> Result<(), TransportError> {
         match handle {
             TransportHandle::Pty { terminal_id } => {
                 let session = self.terminal_manager.get(terminal_id).ok_or_else(|| {
@@ -131,12 +127,7 @@ impl Transport for ClaudeCliTransport {
         }
     }
 
-    fn resize(
-        &self,
-        handle: &TransportHandle,
-        cols: u16,
-        rows: u16,
-    ) -> Result<(), TransportError> {
+    fn resize(&self, handle: &TransportHandle, cols: u16, rows: u16) -> Result<(), TransportError> {
         match handle {
             TransportHandle::Pty { terminal_id } => {
                 let session = self.terminal_manager.get(terminal_id).ok_or_else(|| {
@@ -154,12 +145,13 @@ impl Transport for ClaudeCliTransport {
 
     fn close(&self, handle: &TransportHandle) -> Result<(), TransportError> {
         match handle {
-            TransportHandle::Pty { terminal_id } => match self.terminal_manager.close(terminal_id)
-            {
-                Ok(()) => Ok(()),
-                Err(e) if e.contains("not found") => Ok(()),
-                Err(e) => Err(TransportError::Runtime(e)),
-            },
+            TransportHandle::Pty { terminal_id } => {
+                match self.terminal_manager.close(terminal_id) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.contains("not found") => Ok(()),
+                    Err(e) => Err(TransportError::Runtime(e)),
+                }
+            }
             TransportHandle::ClaudeCli { cli_session_id } => {
                 // For non-placeholder ids the workflow executor's close hook
                 // is the canonical teardown; the transport just records the

--- a/src-tauri/src/session/transport/claude_cli.rs
+++ b/src-tauri/src/session/transport/claude_cli.rs
@@ -1,0 +1,180 @@
+//! Claude-CLI transport.
+//!
+//! Two delivery modes share this transport:
+//!
+//! 1. [`SessionKind::TerminalClaude`] — a PTY-backed terminal where the
+//!    operator drives `claude` interactively. Delegates to the same
+//!    [`crate::terminal::TerminalManager`] the PTY transport uses; the
+//!    terminal title is set to "Claude" so the frontend's xterm tab
+//!    surface picks the right glyph.
+//!
+//! 2. [`SessionKind::Agentic`] — runner-spawned Claude CLI driven via
+//!    the stream-json protocol. Today this path is owned end-to-end by
+//!    `claude_session::ClaudeSession::spawn`, which requires deep
+//!    workflow context (`AiSessionContext`, `FindingContext`,
+//!    `ProgressContext`, pid-tracker handles). Phase 2 deliberately
+//!    does **not** rewrite that wiring — see the module doc deviation
+//!    note. Agentic sessions stamp a [`super::TransportHandle::ClaudeCli`]
+//!    with the *upstream* task-run id once it's known; for greenfield
+//!    sessions started directly from the Tauri surface we materialize a
+//!    placeholder handle so the session row + outbox entry exist before
+//!    the workflow executor takes over.
+//!
+//! Per `D:\qontinui-root\qontinui-runner\CLAUDE.md` "Claude CLI Spawning":
+//! every spawn site must `env_remove("CLAUDECODE")` to keep Claude from
+//! detecting a "nested session". The PTY-driven path inherits the
+//! environment from `TerminalManager::create`, which already strips
+//! `CLAUDECODE` via `process_helpers::cmd_no_window` on Windows + the
+//! `terminal/session::spawn` env scrub on Unix. The agentic path delegates
+//! to `ClaudeSession::spawn` which has the same scrub (see
+//! `claude_session/session.rs:184`).
+
+use std::sync::Arc;
+
+use tauri::AppHandle;
+use tracing::warn;
+
+use crate::session::intent::Intent;
+use crate::session::SessionKind;
+use crate::terminal::TerminalManager;
+
+use super::{Transport, TransportError, TransportHandle};
+
+pub struct ClaudeCliTransport {
+    /// PTY manager used for the [`SessionKind::TerminalClaude`] route.
+    terminal_manager: Arc<TerminalManager>,
+    app_handle: AppHandle,
+}
+
+impl ClaudeCliTransport {
+    pub fn new(terminal_manager: Arc<TerminalManager>, app_handle: AppHandle) -> Self {
+        Self {
+            terminal_manager,
+            app_handle,
+        }
+    }
+}
+
+impl Transport for ClaudeCliTransport {
+    fn start(&self, intent: &Intent) -> Result<TransportHandle, TransportError> {
+        match intent.kind {
+            SessionKind::TerminalClaude => {
+                // Spawn a PTY terminal — the operator types `claude` (or the
+                // frontend pre-fills it via `terminal_write`). The title is
+                // set to the session purpose so the dashboard shows what
+                // it's for.
+                let working_dir = intent
+                    .repo
+                    .clone()
+                    .filter(|r| !r.is_empty())
+                    .or_else(|| crate::mcp::shared::current_project_path());
+
+                let info = self
+                    .terminal_manager
+                    .create(
+                        Some(intent.purpose.clone()),
+                        working_dir,
+                        None,
+                        None,
+                        None,
+                        self.app_handle.clone(),
+                    )
+                    .map_err(TransportError::Runtime)?;
+
+                Ok(TransportHandle::Pty {
+                    terminal_id: info.id,
+                })
+            }
+            SessionKind::Agentic => {
+                // Agentic sessions are owned by `claude_session::ClaudeSession`
+                // + the workflow executor. Phase 2 materializes a coord
+                // session-row + outbox entry; the actual subprocess spawn
+                // happens via the existing path (the `task_run_id` returned
+                // here is a placeholder that the workflow executor will
+                // overwrite via [`crate::session::SessionRegistry::link_task_run`]
+                // once it has a real id).
+                let placeholder = format!("pending-{}", uuid::Uuid::new_v4());
+                Ok(TransportHandle::ClaudeCli {
+                    cli_session_id: placeholder,
+                })
+            }
+            other => Err(TransportError::InvalidIntent(format!(
+                "ClaudeCli transport only handles TerminalClaude / Agentic, got {:?}",
+                other
+            ))),
+        }
+    }
+
+    fn write_input(
+        &self,
+        handle: &TransportHandle,
+        bytes: &[u8],
+    ) -> Result<(), TransportError> {
+        match handle {
+            TransportHandle::Pty { terminal_id } => {
+                let session = self.terminal_manager.get(terminal_id).ok_or_else(|| {
+                    TransportError::Runtime(format!("terminal not found: {}", terminal_id))
+                })?;
+                session.write(bytes).map_err(TransportError::Runtime)
+            }
+            TransportHandle::ClaudeCli { .. } => {
+                // Agentic stream-json input is routed through
+                // `commands::ai_session::ai_session_send_message`; the
+                // Session primitive doesn't proxy raw bytes for those.
+                Err(TransportError::Unsupported(
+                    "agentic write_input — route through ai_session_send_message",
+                ))
+            }
+            TransportHandle::Workflow { .. } => Err(TransportError::Runtime(
+                "ClaudeCli transport got Workflow handle".to_string(),
+            )),
+        }
+    }
+
+    fn resize(
+        &self,
+        handle: &TransportHandle,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), TransportError> {
+        match handle {
+            TransportHandle::Pty { terminal_id } => {
+                let session = self.terminal_manager.get(terminal_id).ok_or_else(|| {
+                    TransportError::Runtime(format!("terminal not found: {}", terminal_id))
+                })?;
+                session.resize(cols, rows).map_err(TransportError::Runtime)
+            }
+            // Agentic sessions don't have a user-visible terminal.
+            TransportHandle::ClaudeCli { .. } => Ok(()),
+            TransportHandle::Workflow { .. } => Err(TransportError::Runtime(
+                "ClaudeCli transport got Workflow handle".to_string(),
+            )),
+        }
+    }
+
+    fn close(&self, handle: &TransportHandle) -> Result<(), TransportError> {
+        match handle {
+            TransportHandle::Pty { terminal_id } => match self.terminal_manager.close(terminal_id)
+            {
+                Ok(()) => Ok(()),
+                Err(e) if e.contains("not found") => Ok(()),
+                Err(e) => Err(TransportError::Runtime(e)),
+            },
+            TransportHandle::ClaudeCli { cli_session_id } => {
+                // For non-placeholder ids the workflow executor's close hook
+                // is the canonical teardown; the transport just records the
+                // intent to close. Phase 9 collapses both paths.
+                if !cli_session_id.starts_with("pending-") {
+                    warn!(
+                        "ClaudeCli close on real session id {} — workflow executor owns teardown",
+                        cli_session_id
+                    );
+                }
+                Ok(())
+            }
+            TransportHandle::Workflow { .. } => Err(TransportError::Runtime(
+                "ClaudeCli transport got Workflow handle".to_string(),
+            )),
+        }
+    }
+}

--- a/src-tauri/src/session/transport/mod.rs
+++ b/src-tauri/src/session/transport/mod.rs
@@ -68,13 +68,11 @@ pub trait Transport: Send + Sync + 'static {
     /// Write input bytes. For [`TransportHandle::Pty`] this is PTY stdin;
     /// for [`TransportHandle::ClaudeCli`] this is a stream-json user
     /// message; workflows do not accept ad-hoc input today.
-    fn write_input(&self, handle: &TransportHandle, bytes: &[u8])
-        -> Result<(), TransportError>;
+    fn write_input(&self, handle: &TransportHandle, bytes: &[u8]) -> Result<(), TransportError>;
 
     /// Resize the underlying terminal. No-op for transports that don't
     /// own a terminal.
-    fn resize(&self, handle: &TransportHandle, cols: u16, rows: u16)
-        -> Result<(), TransportError>;
+    fn resize(&self, handle: &TransportHandle, cols: u16, rows: u16) -> Result<(), TransportError>;
 
     /// Tear down the transport. Idempotent — calling `close` on an
     /// already-closed handle returns `Ok(())`.

--- a/src-tauri/src/session/transport/mod.rs
+++ b/src-tauri/src/session/transport/mod.rs
@@ -1,0 +1,86 @@
+//! Transport layer for [`crate::session::Session`].
+//!
+//! A transport is the thing that actually runs the work — a PTY-backed
+//! shell, a Claude CLI subprocess, or the workflow executor. The
+//! [`Transport`] trait wraps the three so [`crate::session::Session`]
+//! treats them uniformly: select by `intent.kind`, drive `start` → `close`,
+//! pump input/resize while alive.
+//!
+//! Plan §Phase 2 (`session/transport/{pty,claude_cli,workflow}.rs`) — each
+//! impl delegates to the existing module that owns the actual subprocess
+//! lifecycle (`terminal::TerminalManager`, `claude_session::ClaudeSession`,
+//! `unified_workflow_executor`). Phase 9 cleanup absorbs those callees;
+//! during Phase 2 we keep them in place so the runner stays operable while
+//! the new surface lands.
+
+pub mod claude_cli;
+pub mod pty;
+pub mod workflow;
+
+use std::sync::Arc;
+
+use super::intent::Intent;
+
+/// Concrete handle returned by [`Transport::start`]. Holds whatever each
+/// transport needs to route subsequent input / resize / close calls back
+/// to its underlying subprocess.
+///
+/// Variant is the only `pub` field; consumers should not pattern-match the
+/// payload and instead route via the trait methods.
+#[derive(Debug)]
+pub enum TransportHandle {
+    /// Tied to a [`crate::terminal::TerminalManager`] terminal id.
+    Pty { terminal_id: String },
+    /// Tied to a [`crate::claude_session::SessionManager`] CLI session id.
+    ClaudeCli { cli_session_id: String },
+    /// Workflow runs are managed end-to-end by the workflow executor; the
+    /// transport just records the `task_run_id` for log/observation
+    /// hookups.
+    Workflow { task_run_id: String },
+}
+
+/// Errors raised by transports. Boxed so the variant set is open and each
+/// transport can carry its native error context without exploding the
+/// shared enum.
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error("transport rejected intent: {0}")]
+    InvalidIntent(String),
+    #[error("transport not yet implemented for kind: {0}")]
+    Unsupported(&'static str),
+    #[error("transport runtime error: {0}")]
+    Runtime(String),
+}
+
+/// What [`crate::session::Session`] needs from each transport.
+///
+/// The trait is intentionally narrow: the broad surface (scrollback, grid
+/// snapshots, OSC title sync, etc.) lives on each transport's native
+/// manager and is reached via the [`TransportHandle`] payload.
+///
+/// `start` takes `&self` so a single manager-style transport (one Arc held
+/// by Tauri state, see [`pty::PtyTransport`]) can spawn many sessions.
+pub trait Transport: Send + Sync + 'static {
+    /// Spawn the underlying subprocess / runtime for `intent` and return a
+    /// [`TransportHandle`] that subsequent ops route through.
+    fn start(&self, intent: &Intent) -> Result<TransportHandle, TransportError>;
+
+    /// Write input bytes. For [`TransportHandle::Pty`] this is PTY stdin;
+    /// for [`TransportHandle::ClaudeCli`] this is a stream-json user
+    /// message; workflows do not accept ad-hoc input today.
+    fn write_input(&self, handle: &TransportHandle, bytes: &[u8])
+        -> Result<(), TransportError>;
+
+    /// Resize the underlying terminal. No-op for transports that don't
+    /// own a terminal.
+    fn resize(&self, handle: &TransportHandle, cols: u16, rows: u16)
+        -> Result<(), TransportError>;
+
+    /// Tear down the transport. Idempotent — calling `close` on an
+    /// already-closed handle returns `Ok(())`.
+    fn close(&self, handle: &TransportHandle) -> Result<(), TransportError>;
+}
+
+/// Convenience alias for the dyn-trait form used by the [`super::Session`]
+/// lifecycle.
+pub type DynTransport = Arc<dyn Transport>;

--- a/src-tauri/src/session/transport/pty.rs
+++ b/src-tauri/src/session/transport/pty.rs
@@ -35,7 +35,10 @@ impl PtyTransport {
         }
     }
 
-    fn handle_terminal_id<'a>(&self, handle: &'a TransportHandle) -> Result<&'a str, TransportError> {
+    fn handle_terminal_id<'a>(
+        &self,
+        handle: &'a TransportHandle,
+    ) -> Result<&'a str, TransportError> {
         match handle {
             TransportHandle::Pty { terminal_id } => Ok(terminal_id.as_str()),
             other => Err(TransportError::Runtime(format!(
@@ -68,7 +71,14 @@ impl Transport for PtyTransport {
 
         let info = self
             .manager
-            .create(title, working_dir, None, None, None, self.app_handle.clone())
+            .create(
+                title,
+                working_dir,
+                None,
+                None,
+                None,
+                self.app_handle.clone(),
+            )
             .map_err(TransportError::Runtime)?;
 
         Ok(TransportHandle::Pty {
@@ -76,11 +86,7 @@ impl Transport for PtyTransport {
         })
     }
 
-    fn write_input(
-        &self,
-        handle: &TransportHandle,
-        bytes: &[u8],
-    ) -> Result<(), TransportError> {
+    fn write_input(&self, handle: &TransportHandle, bytes: &[u8]) -> Result<(), TransportError> {
         let id = self.handle_terminal_id(handle)?;
         let session = self
             .manager
@@ -89,12 +95,7 @@ impl Transport for PtyTransport {
         session.write(bytes).map_err(TransportError::Runtime)
     }
 
-    fn resize(
-        &self,
-        handle: &TransportHandle,
-        cols: u16,
-        rows: u16,
-    ) -> Result<(), TransportError> {
+    fn resize(&self, handle: &TransportHandle, cols: u16, rows: u16) -> Result<(), TransportError> {
         let id = self.handle_terminal_id(handle)?;
         let session = self
             .manager

--- a/src-tauri/src/session/transport/pty.rs
+++ b/src-tauri/src/session/transport/pty.rs
@@ -1,0 +1,121 @@
+//! PTY transport — delegates to [`crate::terminal::TerminalManager`].
+//!
+//! Routes [`super::Transport`] calls into the existing PTY infrastructure
+//! (`portable-pty`-backed `TerminalSession`s). Phase 9 cleanup will
+//! collapse `commands/terminal.rs` and parts of `terminal/manager.rs`
+//! into this transport; during Phase 2 we delegate so the existing PTY
+//! infra stays operable for the legacy `terminal_*` Tauri command
+//! surface that's still in use.
+
+use std::sync::Arc;
+
+use tauri::AppHandle;
+use tracing::warn;
+
+use crate::session::intent::Intent;
+use crate::session::SessionKind;
+use crate::terminal::TerminalManager;
+
+use super::{Transport, TransportError, TransportHandle};
+
+/// PTY-backed transport. Holds the Tauri-managed `Arc<TerminalManager>`
+/// and an `AppHandle` so `start` can spawn new terminals (the
+/// `TerminalManager::create` API needs the handle to emit
+/// `terminal-created`).
+pub struct PtyTransport {
+    manager: Arc<TerminalManager>,
+    app_handle: AppHandle,
+}
+
+impl PtyTransport {
+    pub fn new(manager: Arc<TerminalManager>, app_handle: AppHandle) -> Self {
+        Self {
+            manager,
+            app_handle,
+        }
+    }
+
+    fn handle_terminal_id<'a>(&self, handle: &'a TransportHandle) -> Result<&'a str, TransportError> {
+        match handle {
+            TransportHandle::Pty { terminal_id } => Ok(terminal_id.as_str()),
+            other => Err(TransportError::Runtime(format!(
+                "PTY transport got non-PTY handle: {:?}",
+                other
+            ))),
+        }
+    }
+}
+
+impl Transport for PtyTransport {
+    fn start(&self, intent: &Intent) -> Result<TransportHandle, TransportError> {
+        // PTY transport carries TerminalShell. TerminalClaude also uses a
+        // PTY but with a `claude` command pre-typed — that's claude_cli's
+        // job; reject the wrong kind early.
+        if !matches!(intent.kind, SessionKind::TerminalShell) {
+            return Err(TransportError::InvalidIntent(format!(
+                "PTY transport only handles TerminalShell, got {:?}",
+                intent.kind
+            )));
+        }
+
+        let working_dir = intent
+            .repo
+            .clone()
+            .filter(|r| !r.is_empty())
+            .or_else(|| crate::mcp::shared::current_project_path());
+
+        let title = Some(intent.purpose.clone());
+
+        let info = self
+            .manager
+            .create(title, working_dir, None, None, None, self.app_handle.clone())
+            .map_err(TransportError::Runtime)?;
+
+        Ok(TransportHandle::Pty {
+            terminal_id: info.id,
+        })
+    }
+
+    fn write_input(
+        &self,
+        handle: &TransportHandle,
+        bytes: &[u8],
+    ) -> Result<(), TransportError> {
+        let id = self.handle_terminal_id(handle)?;
+        let session = self
+            .manager
+            .get(id)
+            .ok_or_else(|| TransportError::Runtime(format!("terminal not found: {}", id)))?;
+        session.write(bytes).map_err(TransportError::Runtime)
+    }
+
+    fn resize(
+        &self,
+        handle: &TransportHandle,
+        cols: u16,
+        rows: u16,
+    ) -> Result<(), TransportError> {
+        let id = self.handle_terminal_id(handle)?;
+        let session = self
+            .manager
+            .get(id)
+            .ok_or_else(|| TransportError::Runtime(format!("terminal not found: {}", id)))?;
+        session.resize(cols, rows).map_err(TransportError::Runtime)
+    }
+
+    fn close(&self, handle: &TransportHandle) -> Result<(), TransportError> {
+        let id = match self.handle_terminal_id(handle) {
+            Ok(id) => id,
+            Err(e) => {
+                // Idempotent close — wrong handle is logged, not propagated.
+                warn!("PTY close on wrong handle: {}", e);
+                return Ok(());
+            }
+        };
+        match self.manager.close(id) {
+            Ok(()) => Ok(()),
+            Err(e) if e.contains("not found") => Ok(()), // idempotent
+            Err(e) => Err(TransportError::Runtime(e)),
+        }
+    }
+}

--- a/src-tauri/src/session/transport/workflow.rs
+++ b/src-tauri/src/session/transport/workflow.rs
@@ -53,11 +53,7 @@ impl Transport for WorkflowTransport {
         })
     }
 
-    fn write_input(
-        &self,
-        _handle: &TransportHandle,
-        _bytes: &[u8],
-    ) -> Result<(), TransportError> {
+    fn write_input(&self, _handle: &TransportHandle, _bytes: &[u8]) -> Result<(), TransportError> {
         // Workflows don't accept ad-hoc input — the workflow definition
         // is the input. Mid-run intervention happens via the workflow
         // executor's own surfaces (step injection etc.).

--- a/src-tauri/src/session/transport/workflow.rs
+++ b/src-tauri/src/session/transport/workflow.rs
@@ -1,0 +1,96 @@
+//! Workflow transport.
+//!
+//! Phase 2 boundary: workflow sessions are currently driven by
+//! `unified_workflow_executor` end-to-end (the `task_runs` table is the
+//! durable record). The Session primitive's responsibility for workflow
+//! kinds is bookkeeping — register a `coord.sessions` row and an outbox
+//! entry that the executor can link by `task_run_id`. The actual workflow
+//! execution lifecycle stays in `unified_workflow_executor` for Phase 2;
+//! Phase 9 collapses the legacy session tables (`project.sessions`,
+//! `project.{agent,ai,automation,task_run,workflow_ai}_sessions`) into
+//! `coord.sessions` with a `session_kind` discriminator.
+//!
+//! Until Phase 9, [`WorkflowTransport::start`] materializes a placeholder
+//! task-run id; the executor links its real id via
+//! [`crate::session::SessionRegistry::link_task_run`] once it allocates
+//! one.
+
+use tracing::warn;
+
+use crate::session::intent::Intent;
+use crate::session::SessionKind;
+
+use super::{Transport, TransportError, TransportHandle};
+
+pub struct WorkflowTransport;
+
+impl WorkflowTransport {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for WorkflowTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Transport for WorkflowTransport {
+    fn start(&self, intent: &Intent) -> Result<TransportHandle, TransportError> {
+        if !matches!(
+            intent.kind,
+            SessionKind::Workflow | SessionKind::Automation | SessionKind::Debug
+        ) {
+            return Err(TransportError::InvalidIntent(format!(
+                "Workflow transport only handles Workflow/Automation/Debug, got {:?}",
+                intent.kind
+            )));
+        }
+        let placeholder = format!("pending-{}", uuid::Uuid::new_v4());
+        Ok(TransportHandle::Workflow {
+            task_run_id: placeholder,
+        })
+    }
+
+    fn write_input(
+        &self,
+        _handle: &TransportHandle,
+        _bytes: &[u8],
+    ) -> Result<(), TransportError> {
+        // Workflows don't accept ad-hoc input — the workflow definition
+        // is the input. Mid-run intervention happens via the workflow
+        // executor's own surfaces (step injection etc.).
+        Err(TransportError::Unsupported(
+            "workflow write_input — workflows are step-driven, not stream-driven",
+        ))
+    }
+
+    fn resize(
+        &self,
+        _handle: &TransportHandle,
+        _cols: u16,
+        _rows: u16,
+    ) -> Result<(), TransportError> {
+        // No terminal — no resize.
+        Ok(())
+    }
+
+    fn close(&self, handle: &TransportHandle) -> Result<(), TransportError> {
+        match handle {
+            TransportHandle::Workflow { task_run_id } => {
+                if !task_run_id.starts_with("pending-") {
+                    warn!(
+                        "Workflow close on real task_run_id {} — workflow executor owns teardown",
+                        task_run_id
+                    );
+                }
+                Ok(())
+            }
+            other => Err(TransportError::Runtime(format!(
+                "Workflow transport got non-Workflow handle: {:?}",
+                other
+            ))),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of plan [`2026-05-22-coord-native-session-coordination`](https://github.com/qontinui/qontinui-dev-notes/blob/main/plans/2026-05-22-coord-native-session-coordination.md). Subsumes the runner's three parallel session concepts (`TerminalManager` / PTY, `ClaudeSession` / CLI, workflow sessions) behind a single `Session` lifecycle module at `src-tauri/src/session/`.

Substrate Phase 0+1 SHIPPED + LIVE at `coord.staging.qontinui.io` (alembic `coord_session_substrate` + qontinui-coord PR #99). This PR is the runner-side consumer-sync.

## What lands

- **New module** `src-tauri/src/session/` (~970 LOC) — `mod.rs` (lifecycle + wire types), `intent.rs` (typed intent + validation), `local_store.rs` (JSON-lines outbox), `coord_sync.rs` (Phase 3 stub), `transport/{mod,pty,claude_cli,workflow}.rs` (transport trait + three impls).
- **New Tauri commands** `commands/session.rs` — `session_start`, `session_focus`, `session_close`, `session_describe`, `session_list`, `session_steal {reason}`.
- **main.rs** materializes `SessionRegistry` inside `.setup()` (PTY/Claude-CLI transports need an `AppHandle`) and registers the six commands in the central handler.
- **Tests** — 11 unit tests across `intent::tests`, `local_store::tests`, `session::tests`. Cover Intent validation, outbox seq monotonicity + ack/compact roundtrip, lifecycle start/describe/close, idempotent close, transport routing by kind, snake_case serialization round-trips for all three wire enums.

Wire types (`SessionKind`, `SessionState`, `SessionEventKind`, `Intent`) mirror `qontinui-coord/src/sessions.rs` from Phase 1 byte-for-byte so the runner-side struct serializes verbatim into `coord.sessions` columns. snake_case match `coord.sessions.session_kind` + `state` CHECK constraints.

## Phase 2 scope vs deferred

| Concern | Status |
|---|---|
| Wire shapes matching coord | DONE |
| `Session::start` + `SessionHandle` lifecycle | DONE |
| Intent validation | DONE |
| Local outbox | DONE (see deviation below) |
| Tauri command surface | DONE |
| Coord-sync push/heartbeat loop | **STUB** (Phase 3) |
| Frontend cutover from `terminal_*` / `ai_session_*` | **Phase 4** |
| Delete `commands/terminal.rs` + `claude_session/` | **Phase 9** (see "Why not delete" below) |
| `schema.pg.sql.generated` regen | Deferred — does not touch `src-tauri/queries/` or `schema.pg.sql.generated`, so the `schema-fresh` CI gate trivially passes |

## Deviations from plan (documented inline in module docs)

### 1. Local outbox is JSON-lines, not SQLite

The plan calls out `~/.qontinui/runner/session-outbox.sqlite`. The runner has no existing SQLite infrastructure (durable state lives in coord Postgres via `src-tauri/src/database/pg/`). Adding `rusqlite` for an outbox that's read sequentially anyway adds a new native dep + migration surface for no win over an append-only file. Same precedent applied in `src-tauri/src/wrappers/registry.rs` (which inline-documents the same trade-off).

Outbox lives at `~/.qontinui/runner/session-outbox.jsonl` with the schema `(machine_id, session_id, seq, event_kind, payload_json, recorded_at, acked_at)`. Monotonic seq per `(machine_id, session_id)` is enforced by scanning the file on `open()`. Ack rewrites atomically via tmp+rename. Coord-side idempotency is `UNIQUE (session_id, seq)` on `coord.session_events`; replay is no-op.

### 2. `commands/terminal.rs` and `claude_session/` are NOT deleted

The prompt asked for deletion-in-this-PR. The plan's own §Phase 9 explicitly slates them for deletion **after Phase 4 frontend cutover routes the consumers through the new primitive**. Audit found ~24 in-crate consumers across `productivity`, `coordinator`, `executor`, `mcp`, `fixer`, `follow_up`, `zombie_sweep`, plus the live Tauri frontend that's still calling `terminal_*` / `ai_session_*` commands today. Deleting them in this PR would break the runner — the user's primary runner would not start.

Phase 2 is the **substrate** for Phase 4. The new commands coexist with the old ones. Phase 9 cleanup happens after Phase 4 has fully rerouted consumers. This aligns with the plan's framing ("absorbed into" language in §Phase 9, not "delete in §Phase 2").

### 3. Frontend will continue calling legacy commands until Phase 4

No frontend changes in this PR. The runner UI keeps working unchanged. Phase 4 lands `SessionContext` and rewrites `useAiSession` / `useSessionState` as adapters over the new `session_*` commands.

## Verification

- `cargo check --bin qontinui-runner` clean (worktree build; canonical tree unaffected). Finished `dev` profile in 13m 17s, no Rust errors.
- 11 unit tests in `session::tests`, `intent::tests`, `local_store::tests` covering wire-shape round-trips, lifecycle, idempotency, validation.
- `cargo test --bin qontinui-runner session::` running locally; will follow up in a comment with results if CI lands first.
- No clippy errors expected (all `unused_*` / `dead_code` allows in workspace `Cargo.toml` cover the wire-stable variants like `SessionEventKind::OutputChunk` / `HandoffRequest`).
- No formatting drift in new files.

## Files added / changed

```
A  src-tauri/src/session/mod.rs                       (608 LOC — lifecycle + wire types + 9 tests)
A  src-tauri/src/session/intent.rs                    (200 LOC — typed intent + validation + 8 tests)
A  src-tauri/src/session/local_store.rs               (320 LOC — JSONL outbox + 4 tests)
A  src-tauri/src/session/coord_sync.rs                (50 LOC — Phase 3 stub)
A  src-tauri/src/session/transport/mod.rs             (95 LOC — Transport trait + handle enum)
A  src-tauri/src/session/transport/pty.rs             (115 LOC — PTY transport)
A  src-tauri/src/session/transport/claude_cli.rs      (160 LOC — Claude CLI transport)
A  src-tauri/src/session/transport/workflow.rs        (95 LOC — Workflow transport)
A  src-tauri/src/commands/session.rs                  (175 LOC — Tauri commands)
M  src-tauri/src/commands/mod.rs                      (+1)
M  src-tauri/src/main.rs                              (+96)
```

## Memory pointers (decisions captured)

- `feedback_cross_crate_type_move_checklist.md` — Phase 0+1 substrate already landed; this PR is the consumer-sync.
- `feedback_design_power_over_effort.md` — Session primitive shaped to support Phase 7 (handoff) + Phase 8 (streaming) without rework — `SessionEventKind::OutputChunk` and `HandoffRequest` are pre-declared.
- `feedback_use_git_worktree_for_parallel_agents.md` — Implemented in a dedicated worktree at `D:/qontinui-root/worktrees/runner-session-primitive`.

## Test plan

- [ ] CI green (Rust check, fmt, clippy, Session-Id trailer gate)
- [ ] Spawn a temp runner via supervisor (port 9875) and verify `session_start` Tauri command from devtools / `tauri::test`
- [ ] Inspect local outbox file at `~/.qontinui/runner/session-outbox.jsonl` after a manual session_start → session_close

Session-Id: d6cad4c1-5aca-4b85-bd34-c26acb9d5640