### PR TITLE
feat(runner): runner-mediated memory federation via observable_bridge

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -1,0 +1,357 @@
+//! Spawn-site glue between [`ClaudeSession`] / `run_claude_session_inline`
+//! and [`observable_bridge`](qontinui_runner_lib::observable_bridge).
+//!
+//! Plan: `2026-05-22-memories-on-coord-cross-machine.md` Phase 5.
+//!
+//! Two responsibilities only:
+//!
+//! 1. **[`build_federation_ctx`]** — assemble the [`SessionContext`] every
+//!    spawn site needs (tenant_id + device_id + account_name + memory_dir
+//!    + session_id). Returns `None` when any required identity field is
+//!    missing; spawn sites then skip federation and proceed locally.
+//! 2. **[`emit_federation_report`]** — uniform telemetry surface for
+//!    `reconcile`'s `ReconcileReport`. Logs via `tracing` and broadcasts
+//!    on the Tauri event channel `memory-federation:reconcile` so the
+//!    React frontend can render a banner.
+//!
+//! No business logic lives here — the bridge itself owns pull / push /
+//! reconcile. This module is the spawn-site adapter only.
+//!
+//! [`ClaudeSession`]: crate::claude_session::ClaudeSession
+//! [`SessionContext`]: qontinui_runner_lib::observable_bridge::SessionContext
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use serde::Serialize;
+use tauri::Emitter;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use qontinui_runner_lib::observable_bridge::{ReconcileReport, SessionContext};
+use crate::settings::ClaudeCliSettings;
+
+/// Tauri event channel for reconcile-result broadcasts. The React
+/// frontend listens here to render the "Memory federation: N pushed,
+/// M pulled, K failed" banner described in plan Phase 5.
+pub const RECONCILE_EVENT: &str = "memory-federation:reconcile";
+
+/// Cross-account memory federation kill switch — reads from
+/// `AiSettings::memory_federation_enabled`. Default ON; the field is
+/// `#[serde(default = "default_memory_federation_enabled")]` so the
+/// missing-on-existing-settings case still resolves to true.
+pub fn federation_enabled() -> bool {
+    crate::settings::get_ai_settings().memory_federation_enabled
+}
+
+/// Convert a `&str` session id into a UUID. The runner uses several
+/// session-id schemes (raw UUIDs for workflows, `task_run_id + phase`
+/// strings for interactive sessions). The bridge keys watchers by UUID
+/// only, so non-UUID ids get a deterministic v5-style hash so two
+/// reconciles for the same string still collide on the same watcher
+/// slot.
+pub fn session_uuid(session_id: &str) -> Uuid {
+    if let Ok(u) = Uuid::parse_str(session_id) {
+        return u;
+    }
+    // UUID v5 of the runner's federation namespace + session_id. Stable
+    // across the process lifetime so `stop_watcher(session_id_of(s))`
+    // matches the `start_watcher` call site for the same string.
+    static NS: Uuid = Uuid::from_bytes([
+        0x6f, 0x6e, 0x74, 0x69, 0x6e, 0x75, 0x69, 0x2d, 0x66, 0x65, 0x64, 0x65, 0x72, 0x61, 0x74,
+        0x65,
+    ]);
+    Uuid::new_v5(&NS, session_id.as_bytes())
+}
+
+/// Build a `SessionContext` for the about-to-spawn Claude subprocess.
+/// Returns `None` (with a warn log) when any required identity field is
+/// missing — that signals the spawn site to skip federation.
+///
+/// Resolution sources:
+///
+/// - `tenant_id` → `fleet::resolve_tenant_id`-equivalent: prefer
+///   `paired_user.json::tenant_id`, fall back to the cached
+///   device-token JWT claim.
+/// - `device_id` → `~/.qontinui/machine.json::device_id`.
+/// - `account_name` → derived from `effective_config_dir` (trailing
+///   `.claude-<name>` component). Falls back to `"default"` for a
+///   single-account install where `config_dir` is `~/.claude`.
+/// - `memory_dir` → `<effective_config_dir>/projects/<encoded
+///   working_dir>/memory/` per Claude Code's on-disk convention.
+pub fn build_federation_ctx(
+    session_id: &str,
+    working_dir: &str,
+    cli_settings: &ClaudeCliSettings,
+) -> Option<SessionContext> {
+    let tenant_id = match resolve_tenant_id() {
+        Some(t) => t,
+        None => {
+            warn!(
+                "claude_session::federation: tenant_id unresolvable \
+                 (no paired_user.json::tenant_id, no claim in cached device-token JWT); \
+                 skipping memory federation for session {session_id}"
+            );
+            return None;
+        }
+    };
+
+    let device_id = match resolve_device_id() {
+        Some(d) => d,
+        None => {
+            warn!(
+                "claude_session::federation: ~/.qontinui/machine.json missing or unparseable; \
+                 skipping memory federation for session {session_id}"
+            );
+            return None;
+        }
+    };
+
+    let effective_config_dir = crate::ai_provider::get_effective_config_dir(cli_settings);
+    let config_dir_str = match effective_config_dir {
+        Some(s) => s,
+        None => {
+            warn!(
+                "claude_session::federation: no effective claude config_dir; \
+                 skipping memory federation for session {session_id}"
+            );
+            return None;
+        }
+    };
+
+    let memory_dir = derive_memory_dir(&config_dir_str, working_dir);
+    let account_name = derive_account_name(&config_dir_str);
+
+    Some(SessionContext {
+        tenant_id,
+        device_id,
+        account_name,
+        memory_dir,
+        session_id: session_uuid(session_id),
+        post_pull_snapshot: None,
+    })
+}
+
+/// Tauri event payload mirroring [`ReconcileReport`] plus session
+/// identity. Serialized straight onto `RECONCILE_EVENT`.
+#[derive(Debug, Clone, Serialize)]
+struct ReconcilePayload<'a> {
+    session_id: String,
+    account: &'a str,
+    report: ReconcileReport,
+}
+
+/// Surface a `reconcile` result on stderr (`tracing`) + the Tauri event
+/// channel. Best-effort — emit failures are swallowed because telemetry
+/// must never block the session-end cleanup path.
+pub fn emit_federation_report(
+    app_handle: &tauri::AppHandle,
+    ctx: &SessionContext,
+    report: Result<ReconcileReport>,
+) {
+    match report {
+        Ok(r) => {
+            info!(
+                session_id = %ctx.session_id,
+                account = %ctx.account_name,
+                pushed = r.pushed,
+                pulled = r.pulled,
+                unchanged = r.unchanged,
+                failed = r.failed,
+                "memory federation reconcile complete"
+            );
+            let payload = ReconcilePayload {
+                session_id: ctx.session_id.to_string(),
+                account: &ctx.account_name,
+                report: r,
+            };
+            if let Err(e) = app_handle.emit(RECONCILE_EVENT, &payload) {
+                debug!(
+                    "claude_session::federation: emit {RECONCILE_EVENT} failed: {e} (non-fatal)"
+                );
+            }
+        }
+        Err(e) => {
+            warn!(
+                session_id = %ctx.session_id,
+                account = %ctx.account_name,
+                error = %e,
+                "memory federation reconcile failed"
+            );
+        }
+    }
+}
+
+/// Reachable from contexts that have a `tracing` logger but no Tauri
+/// `AppHandle` (the inline path uses `tracing` only — see plan Phase 5.C
+/// "If the inline path doesn't have an `AppHandle` accessible, emit via
+/// `tracing::info!`"). Same content as [`emit_federation_report`]
+/// minus the Tauri broadcast.
+pub fn log_federation_report(ctx: &SessionContext, report: Result<ReconcileReport>) {
+    match report {
+        Ok(r) => info!(
+            session_id = %ctx.session_id,
+            account = %ctx.account_name,
+            pushed = r.pushed,
+            pulled = r.pulled,
+            unchanged = r.unchanged,
+            failed = r.failed,
+            "memory federation reconcile complete"
+        ),
+        Err(e) => warn!(
+            session_id = %ctx.session_id,
+            account = %ctx.account_name,
+            error = %e,
+            "memory federation reconcile failed"
+        ),
+    }
+}
+
+/// Resolve the tenant UUID. Mirrors `fleet.rs::resolve_tenant_id` but
+/// that's private to `fleet`; the duplication here keeps the federation
+/// module self-contained.
+fn resolve_tenant_id() -> Option<Uuid> {
+    if let Some(s) = qontinui_runner_lib::pair::read_paired_tenant_id_from_disk() {
+        if let Ok(t) = Uuid::parse_str(s.trim()) {
+            return Some(t);
+        }
+    }
+    let token = crate::auth::AuthManager::new()
+        .get_access_token()
+        .ok()
+        .unwrap_or_default();
+    if token.is_empty() {
+        return None;
+    }
+    let claim = qontinui_runner_lib::pair::tenant_id_from_oauth_claim(&token)?;
+    Uuid::parse_str(claim.trim()).ok()
+}
+
+/// Read `~/.qontinui/machine.json::device_id` (with `machine_id` alias
+/// for legacy installs). Returns `None` if the file is missing,
+/// unparseable, or holds a non-UUID id.
+fn resolve_device_id() -> Option<Uuid> {
+    #[derive(serde::Deserialize)]
+    struct DeviceFile {
+        #[serde(alias = "machine_id")]
+        device_id: String,
+    }
+    let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
+    let bytes = std::fs::read(&path).ok()?;
+    let parsed: DeviceFile = serde_json::from_slice(&bytes).ok()?;
+    Uuid::parse_str(parsed.device_id.trim()).ok()
+}
+
+/// Derive the per-project memory dir Claude Code reads/writes for the
+/// session. Layout (per plan D2):
+///
+///   `<config_dir>/projects/<encoded(working_dir)>/memory/`
+///
+/// `encoded` follows the same convention as
+/// `terminal::transcript::encode_project_path` — normalize `\` → `/`,
+/// then `:/` → `--`, then every `:` `/` `\` `_` `.` → `-`.
+fn derive_memory_dir(config_dir: &str, working_dir: &str) -> PathBuf {
+    let encoded = encode_workspace_path(working_dir);
+    PathBuf::from(config_dir)
+        .join("projects")
+        .join(encoded)
+        .join("memory")
+}
+
+/// Workspace-path encoder shared with Claude Code's on-disk projects
+/// layout. Returns e.g. `D--qontinui-root` for `D:\qontinui-root`.
+///
+/// Encoding matches `terminal::transcript::encode_project_path`'s rules
+/// (normalize `\` → `/`, then `:/` → `--`, then `: / \ _` → `-`). The
+/// transcript encoder is the canonical reference for what lands on disk
+/// under `<config_dir>/projects/`.
+fn encode_workspace_path(working_dir: &str) -> String {
+    let normalized = working_dir
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string();
+    normalized
+        .replace(":/", "--")
+        .replace([':', '/', '\\', '_'], "-")
+}
+
+/// Pull a human-readable account label off the `effective_config_dir`.
+/// E.g. `C:\claude\.claude-hotmail` → `"hotmail"`; `~/.claude` →
+/// `"default"`. The label is purely for telemetry — the bridge keys on
+/// `device_id` + `tenant_id`, not account name.
+fn derive_account_name(config_dir: &str) -> String {
+    let basename = std::path::Path::new(config_dir)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(config_dir);
+    let stripped = basename
+        .trim_start_matches('.')
+        .strip_prefix("claude-")
+        .unwrap_or("");
+    if stripped.is_empty() {
+        "default".to_string()
+    } else {
+        stripped.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encodes_drive_letter_path() {
+        assert_eq!(encode_workspace_path("D:\\qontinui-root"), "D--qontinui-root");
+        assert_eq!(encode_workspace_path("D:/qontinui-root"), "D--qontinui-root");
+    }
+
+    #[test]
+    fn encodes_unix_path() {
+        assert_eq!(
+            encode_workspace_path("/home/user/work_dir"),
+            "-home-user-work-dir"
+        );
+    }
+
+    #[test]
+    fn encodes_path_with_period_preserved() {
+        // Dots in path segments are NOT replaced — this matches Claude
+        // Code's transcript.rs encoder. If Claude ever changes behavior
+        // and starts encoding dots, both encoders must update in
+        // lockstep; until then, dots stay.
+        assert_eq!(
+            encode_workspace_path("/repo/app.config"),
+            "-repo-app.config"
+        );
+    }
+
+    #[test]
+    fn derives_account_name_from_hotmail_dir() {
+        assert_eq!(
+            derive_account_name("C:\\claude\\.claude-hotmail"),
+            "hotmail"
+        );
+    }
+
+    #[test]
+    fn derives_default_when_no_account_suffix() {
+        assert_eq!(derive_account_name("/home/user/.claude"), "default");
+        assert_eq!(derive_account_name("/home/user/.claude-"), "default");
+    }
+
+    #[test]
+    fn session_uuid_is_deterministic_for_non_uuid_string() {
+        let a = session_uuid("task-run-42:setup");
+        let b = session_uuid("task-run-42:setup");
+        assert_eq!(a, b, "same input must produce same UUID");
+        let c = session_uuid("task-run-42:verification");
+        assert_ne!(a, c, "different inputs must produce different UUIDs");
+    }
+
+    #[test]
+    fn session_uuid_passes_through_real_uuid() {
+        let raw = "550e8400-e29b-41d4-a716-446655440000";
+        let u = session_uuid(raw);
+        assert_eq!(u.to_string(), raw);
+    }
+}

--- a/src-tauri/src/claude_session/mod.rs
+++ b/src-tauri/src/claude_session/mod.rs
@@ -11,6 +11,7 @@
 //! - Autonomous-to-interactive context switching
 
 pub mod dispatcher;
+pub mod federation;
 pub mod manager;
 pub mod resume;
 pub mod runner;

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -10,6 +10,11 @@ use std::sync::Arc;
 use tauri::Emitter;
 use tracing::{debug, info, warn};
 
+// `RunnerObservableBridge` is in scope so `bridge.pull`/`bridge.reconcile`
+// resolve through the trait — `MemoryBridge`'s impl is the only one
+// today and the receiver `Arc<MemoryBridge>` requires the trait.
+use qontinui_runner_lib::observable_bridge::RunnerObservableBridge;
+
 use crate::doctor::DoctorHandle;
 use crate::findings::{
     Finding, FindingCategoryExt, FindingParser, FindingSeverityExt, ParsedFinding,
@@ -257,6 +262,23 @@ fn extract_text_from_stream_json(json_line: &str) -> Option<String> {
 }
 
 /// Run a Claude CLI session inline (as a child process) and wait for completion.
+/// Bridge sync → async for memory-federation pull / start_watcher /
+/// reconcile calls from the inline session runner.
+///
+/// `run_claude_session_inline` is invoked from a sync worker thread that
+/// is already inside Tauri's tokio runtime (via `tokio::task::spawn_blocking`
+/// or equivalent). The federation bridge methods are `async`, so we
+/// need to bridge them back to a blocking call. Mirrors the
+/// `demo_workflows::seed_demo_workflows_if_needed` idiom — prefer the
+/// caller's runtime via `Handle::try_current` + `block_in_place`, fall
+/// back to Tauri's process-wide runtime when not inside one.
+fn run_async_inline<F: std::future::Future>(fut: F) -> F::Output {
+    match tokio::runtime::Handle::try_current() {
+        Ok(rt) => tokio::task::block_in_place(|| rt.block_on(fut)),
+        Err(_) => tauri::async_runtime::block_on(fut),
+    }
+}
+
 /// Returns the session output when complete.
 ///
 /// This is the new "in-runner" execution model that replaces independent process spawning.
@@ -372,9 +394,83 @@ fn run_claude_session_inline(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("Failed to spawn Claude CLI: {}", e))?;
+    // ── Memory federation: spawn-time pull + start watcher ────────────
+    //
+    // Plan 2026-05-22-memories-on-coord-cross-machine.md Phase 5.C.
+    // Resolve the federation context (`tenant_id` + `device_id` +
+    // `memory_dir` + `account_name` + `session_id`), pull the tenant
+    // pool into `memory_dir`, then start a per-session file watcher
+    // that pushes in-session edits to coord. All steps short-circuit
+    // silently on missing identity / disabled toggle / no global
+    // bridge — federation is best-effort and never blocks the spawn.
+    let federation_ctx_opt = if crate::claude_session::federation::federation_enabled() {
+        let ai_settings = crate::settings::get_ai_settings();
+        crate::claude_session::federation::build_federation_ctx(
+            session_id,
+            working_dir,
+            &ai_settings.claude_cli,
+        )
+    } else {
+        debug!(
+            "memory federation disabled via settings (memory_federation_enabled=false); \
+             skipping pull/watch for session {}",
+            session_id
+        );
+        None
+    };
+    let federation_ctx_opt = if let (Some(mut ctx), Some(bridge)) = (
+        federation_ctx_opt,
+        qontinui_runner_lib::observable_bridge::global().cloned(),
+    ) {
+        // pull + start_watcher must run in async context. Inline runner
+        // is invoked from a sync worker thread that itself runs inside
+        // Tauri's tokio runtime — match the `demo_workflows.rs` idiom.
+        let pull_result = run_async_inline(async {
+            bridge.pull(&mut ctx).await
+        });
+        match pull_result {
+            Ok(()) => {
+                let watcher_result = run_async_inline(async {
+                    bridge.start_watcher(ctx.clone()).await
+                });
+                if let Err(e) = watcher_result {
+                    warn!(
+                        "memory federation: start_watcher failed for session {} ({}); \
+                         continuing without in-session watcher — reconcile will still run",
+                        session_id, e
+                    );
+                }
+                Some(ctx)
+            }
+            Err(e) => {
+                warn!(
+                    "memory federation: pull failed for session {} ({}); \
+                     skipping watcher + reconcile for this session",
+                    session_id, e
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            // Stop the memory-federation watcher we just installed so a
+            // spawn failure does not leak an orphan `notify` hook.
+            if let (Some(ctx), Some(bridge)) = (
+                federation_ctx_opt.as_ref(),
+                qontinui_runner_lib::observable_bridge::global().cloned(),
+            ) {
+                run_async_inline(async {
+                    bridge.stop_watcher(ctx.session_id).await
+                });
+            }
+            return Err(format!("Failed to spawn Claude CLI: {}", e));
+        }
+    };
 
     // Assign to Windows Job Object for crash safety (auto-kill on runner exit)
     #[cfg(target_os = "windows")]
@@ -1867,6 +1963,25 @@ fn run_claude_session_inline(
 
     // Remove PID from tracker now that session is complete
     remove_pid(&pid_tracker);
+
+    // ── Memory federation: session-end reconcile ─────────────────────
+    //
+    // Plan Phase 5.C — final pass after the subprocess exits, before
+    // the function returns. Stops the per-session watcher (idempotent),
+    // diffs the dir against the post-pull snapshot, pushes any deltas
+    // the watcher missed, and emits a report on Tauri's event bus +
+    // tracing. `app_handle` is in scope here, so we use the full
+    // emit_federation_report path.
+    if let (Some(ctx), Some(bridge)) = (
+        federation_ctx_opt.as_ref(),
+        qontinui_runner_lib::observable_bridge::global().cloned(),
+    ) {
+        let report = run_async_inline(async {
+            bridge.stop_watcher(ctx.session_id).await;
+            bridge.reconcile(ctx).await
+        });
+        crate::claude_session::federation::emit_federation_report(app_handle, ctx, report);
+    }
 
     Ok(CliSessionOutput {
         success,

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -15,6 +15,11 @@ use std::time::{Duration, Instant};
 use tauri::Emitter;
 use tracing::{debug, error, info, warn};
 
+// `RunnerObservableBridge` is in scope so `bridge.pull` / `bridge.reconcile`
+// resolve through the trait — `MemoryBridge`'s impl is the only one
+// today and the receiver `Arc<MemoryBridge>` requires the trait.
+use qontinui_runner_lib::observable_bridge::RunnerObservableBridge;
+
 use crate::claude_protocol::request_id::next_request_id;
 use crate::claude_protocol::types::{OutgoingControlRequest, UserInputMessage};
 use crate::findings::{
@@ -118,6 +123,15 @@ pub struct ClaudeSession {
     /// git worktree. `None` means the session is running in the original
     /// working directory (the default for fresh sessions).
     worktree: Option<WorktreeInfo>,
+    /// Memory-federation context for this session, when federation is
+    /// enabled and identity could be resolved at spawn time. The waiter
+    /// thread (see `wait_for_child` callsite) reads it on subprocess
+    /// exit to fire the session-end reconcile + Tauri event broadcast.
+    /// `None` means federation is disabled or unconfigured — the session
+    /// runs purely against the local memory dir.
+    ///
+    /// Plan: `2026-05-22-memories-on-coord-cross-machine.md` Phase 5.D.
+    federation_ctx: Option<qontinui_runner_lib::observable_bridge::SessionContext>,
 }
 
 // SAFETY: ClaudeSession contains a raw Windows handle (RawHandle = *mut c_void) for the stdout
@@ -203,9 +217,78 @@ impl ClaudeSession {
             cmd.env("CLAUDE_CONFIG_DIR", config_dir.as_str());
         }
 
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| format!("Failed to spawn Claude CLI: {}", e))?;
+        // ── Memory federation: spawn-time pull + start watcher ────────
+        //
+        // Plan 2026-05-22-memories-on-coord-cross-machine.md Phase 5.D.
+        // The materialization MUST land before `cmd.spawn()` because
+        // Claude's auto-memory subsystem reads `memory_dir` during init.
+        // The watcher starts immediately after pull so in-session writes
+        // get pushed to coord without waiting for session-end. All
+        // identity / toggle short-circuits return `None` so federation
+        // never blocks the spawn.
+        let federation_ctx = if crate::claude_session::federation::federation_enabled() {
+            super::federation::build_federation_ctx(
+                session_id,
+                working_dir,
+                &ai_settings.claude_cli,
+            )
+        } else {
+            debug!(
+                "memory federation disabled via settings; skipping pull/watch for session {}",
+                session_id
+            );
+            None
+        };
+        let federation_ctx = if let (Some(mut ctx), Some(bridge)) = (
+            federation_ctx,
+            qontinui_runner_lib::observable_bridge::global().cloned(),
+        ) {
+            let pull_result = Self::block_on_async(async {
+                bridge.pull(&mut ctx).await
+            });
+            match pull_result {
+                Ok(()) => {
+                    if let Err(e) = Self::block_on_async(async {
+                        bridge.start_watcher(ctx.clone()).await
+                    }) {
+                        warn!(
+                            "memory federation: start_watcher failed for session {} ({}); \
+                             continuing without watcher — reconcile will still run",
+                            session_id, e
+                        );
+                    }
+                    Some(ctx)
+                }
+                Err(e) => {
+                    warn!(
+                        "memory federation: pull failed for session {} ({}); \
+                         skipping watcher + reconcile",
+                        session_id, e
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+        let mut child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                // Clean up the memory-federation watcher we just started
+                // so a spawn failure doesn't leave an orphaned `notify`
+                // hook running for the lifetime of the runner process.
+                if let (Some(ctx), Some(bridge)) = (
+                    federation_ctx.as_ref(),
+                    qontinui_runner_lib::observable_bridge::global().cloned(),
+                ) {
+                    Self::block_on_async(async {
+                        bridge.stop_watcher(ctx.session_id).await
+                    });
+                }
+                return Err(format!("Failed to spawn Claude CLI: {}", e));
+            }
+        };
 
         // Assign to Windows Job Object for crash safety (auto-kill on runner exit)
         #[cfg(target_os = "windows")]
@@ -838,6 +921,10 @@ impl ClaudeSession {
         let app_handle_for_waiter = app_handle.clone();
         let session_ctx_for_waiter = session_ctx.clone();
         let shared_stderr_for_waiter = shared_stderr;
+        // Memory federation: clone the federation context into the
+        // waiter so reconcile fires when the subprocess actually exits
+        // (NOT when `spawn()` returns, which is just after init).
+        let federation_ctx_for_waiter = federation_ctx.clone();
 
         thread::spawn(move || {
             // Wait for the child process to exit
@@ -856,6 +943,29 @@ impl ClaudeSession {
 
             // Brief pause to let the stderr reader thread finish
             thread::sleep(Duration::from_millis(200));
+
+            // ── Memory federation: session-end reconcile ─────────────
+            //
+            // Fires AFTER the subprocess exits (not after `spawn()`
+            // returns — `spawn` returns once init handshakes, the
+            // session continues until the CLI itself exits). Stops
+            // the watcher (idempotent), re-snapshots the memory dir,
+            // pushes any deltas the watcher missed, broadcasts a
+            // Tauri event for the React frontend banner. Plan Phase 5.D.
+            if let (Some(ctx), Some(bridge)) = (
+                federation_ctx_for_waiter.as_ref(),
+                qontinui_runner_lib::observable_bridge::global().cloned(),
+            ) {
+                let report = Self::block_on_async(async {
+                    bridge.stop_watcher(ctx.session_id).await;
+                    bridge.reconcile(ctx).await
+                });
+                super::federation::emit_federation_report(
+                    &app_handle_for_waiter,
+                    ctx,
+                    report,
+                );
+            }
 
             // Check if the exit was due to rate-limiting
             let stderr_output = shared_stderr_for_waiter
@@ -973,7 +1083,20 @@ impl ClaudeSession {
             persisted_output_len,
             turn_persist_tx: turn_persist_tx_option,
             worktree,
+            federation_ctx,
         })
+    }
+
+    /// Bridge sync → async for the memory-federation calls made from
+    /// the spawn site (pull / start_watcher) and the wait-for-child
+    /// thread (stop_watcher / reconcile). Prefers the caller's tokio
+    /// runtime when one exists (we're typically inside Tauri's), falls
+    /// back to Tauri's process-wide runtime for std-thread callers.
+    pub(super) fn block_on_async<F: std::future::Future>(fut: F) -> F::Output {
+        match tokio::runtime::Handle::try_current() {
+            Ok(rt) => tokio::task::block_in_place(|| rt.block_on(fut)),
+            Err(_) => tauri::async_runtime::block_on(fut),
+        }
     }
 
     /// Get the current session state.

--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -167,6 +167,7 @@ pub fn save_ai_settings(
         interactive_sessions_enabled: interactive_sessions_enabled
             .unwrap_or(existing_settings.interactive_sessions_enabled),
         ai_path_prediction_enabled: existing_settings.ai_path_prediction_enabled,
+        memory_federation_enabled: existing_settings.memory_federation_enabled,
     };
 
     settings::save_ai_settings(ai_settings).map_err(|e| {
@@ -260,6 +261,7 @@ pub fn save_gemini_settings(
         routing: existing_settings.routing,
         interactive_sessions_enabled: existing_settings.interactive_sessions_enabled,
         ai_path_prediction_enabled: existing_settings.ai_path_prediction_enabled,
+        memory_federation_enabled: existing_settings.memory_federation_enabled,
     };
 
     settings::save_ai_settings(ai_settings).map_err(|e| {
@@ -317,6 +319,7 @@ pub fn save_ollama_settings(
         routing: existing_settings.routing,
         interactive_sessions_enabled: existing_settings.interactive_sessions_enabled,
         ai_path_prediction_enabled: existing_settings.ai_path_prediction_enabled,
+        memory_federation_enabled: existing_settings.memory_federation_enabled,
     };
 
     settings::save_ai_settings(ai_settings).map_err(|e| {
@@ -373,6 +376,7 @@ pub fn save_openai_compatible_settings(
         routing: existing_settings.routing,
         interactive_sessions_enabled: existing_settings.interactive_sessions_enabled,
         ai_path_prediction_enabled: existing_settings.ai_path_prediction_enabled,
+        memory_federation_enabled: existing_settings.memory_federation_enabled,
     };
 
     settings::save_ai_settings(ai_settings).map_err(|e| {
@@ -980,6 +984,7 @@ pub fn save_agentic_settings(
         routing: routing_config,
         interactive_sessions_enabled: existing_settings.interactive_sessions_enabled,
         ai_path_prediction_enabled: existing_settings.ai_path_prediction_enabled,
+        memory_federation_enabled: existing_settings.memory_federation_enabled,
     };
 
     settings::save_ai_settings(ai_settings).map_err(|e| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use std::sync::OnceLock;
 use tauri::Manager;
 
 pub mod accessibility;
+pub mod observable_bridge;
 pub mod profiles;
 pub mod relay_envelopes;
 pub mod schema_export;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1687,6 +1687,29 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // to the webview without taking an AppHandle parameter.
             tauri_app_handle::set(app.handle().clone());
 
+            // Plan 2026-05-22-memories-on-coord-cross-machine.md Phase 5.G —
+            // initialize the process-wide memory-federation bridge. The
+            // bridge mediates the per-session pull / watcher / reconcile
+            // lifecycle that materializes the tenant memory pool into the
+            // about-to-spawn Claude CLI's per-account memory dir, watches
+            // for in-session writes, and pushes them back to coord. Init
+            // failure is non-fatal — the spawn sites short-circuit when
+            // `observable_bridge::global()` returns `None`.
+            match qontinui_runner_lib::observable_bridge::memory::MemoryBridge::new() {
+                Ok(bridge) => {
+                    let arc = std::sync::Arc::new(bridge);
+                    qontinui_runner_lib::observable_bridge::init_global(arc.clone());
+                    app.manage(arc);
+                    info!("memory federation bridge initialized");
+                }
+                Err(e) => {
+                    warn!(
+                        "memory federation bridge init failed ({}); feature disabled this session",
+                        e
+                    );
+                }
+            }
+
             // Phase F.1 — register the deep-link `on_open_url` callback so
             // `qontinui://wake?intent=...` URLs delivered by the OS (cold
             // start) or forwarded by the single-instance plugin (warm start)

--- a/src-tauri/src/observable_bridge/memory.rs
+++ b/src-tauri/src/observable_bridge/memory.rs
@@ -1,0 +1,636 @@
+//! `MemoryBridge` — runner-side reference implementation of
+//! [`RunnerObservableBridge`] for the `coord.memories` category.
+//!
+//! Lifecycle (plan `2026-05-22-memories-on-coord-cross-machine.md`):
+//!
+//! 1. **`pull`** (spawn-time): list coord's tenant pool, materialize
+//!    differences into `session_ctx.memory_dir`, push back any local
+//!    files coord doesn't know about (first-contact import), delete
+//!    tombstoned files, snapshot the resulting state into
+//!    `session_ctx.post_pull_snapshot`.
+//! 2. **`start_watcher`** (during-session, helper not in trait): spawn
+//!    a `notify` file watcher on `memory_dir`, debounce per-file events
+//!    250ms, route to `push`.
+//! 3. **`push`** (per-event): upsert or delete to coord. Best-effort —
+//!    failures are logged, never propagated.
+//! 4. **`reconcile`** (session-end): stop watcher, re-snapshot, diff
+//!    against `post_pull_snapshot`, push any deltas the watcher missed,
+//!    return aggregate `ReconcileReport`.
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use qontinui_types::memory::{MemoryUpsertRequest, MemoryWithHistory};
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use super::memory_client;
+use super::{
+    DirSnapshot, FileFingerprint, ObservableChange, ReconcileReport, RunnerObservableBridge,
+    SessionContext,
+};
+
+const DEBOUNCE_MS: u64 = 250;
+const MD_EXT: &str = "md";
+
+/// Reusable bridge for the lifetime of one runner process. `pull`,
+/// `push`, `reconcile`, and `start_watcher` can all be called multiple
+/// times for *concurrent* sessions — watchers are keyed by
+/// `session_id`, so a hotmail session and a gmail session can run
+/// against their own memory dirs simultaneously without trampling each
+/// other's `notify` hooks.
+pub struct MemoryBridge {
+    http: reqwest::Client,
+    /// Async-aware mutex so locks can be held across `.await` points
+    /// (e.g., when `start_watcher` registers a new handle).
+    watchers: tokio::sync::Mutex<HashMap<Uuid, WatcherHandle>>,
+}
+
+struct WatcherHandle {
+    /// Keep alive — dropping the watcher disconnects the OS-level
+    /// notify hook. Underscore-prefixed to document the "hold for side
+    /// effect" intent.
+    _notify: RecommendedWatcher,
+    /// Cancellation token wired into the debounce/dispatch task so a
+    /// session-end shutdown unblocks the loop cleanly.
+    cancel: CancellationToken,
+}
+
+impl MemoryBridge {
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            http: memory_client::build_client()?,
+            watchers: tokio::sync::Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Start the per-session file watcher. Must be called AFTER `pull`
+    /// (so the post-pull snapshot is the watcher's starting baseline).
+    /// Idempotent per `session_id`: re-calling with the same id cleanly
+    /// cancels the prior watcher before installing the new one.
+    pub async fn start_watcher(self: &Arc<Self>, session_ctx: SessionContext) -> Result<()> {
+        let session_id = session_ctx.session_id;
+        let mut guard = self.watchers.lock().await;
+        if let Some(prev) = guard.remove(&session_id) {
+            prev.cancel.cancel();
+        }
+
+        if !session_ctx.memory_dir.exists() {
+            std::fs::create_dir_all(&session_ctx.memory_dir).with_context(|| {
+                format!(
+                    "create memory_dir for watcher: {}",
+                    session_ctx.memory_dir.display()
+                )
+            })?;
+        }
+
+        let (tx, rx) = mpsc::channel::<notify::Result<Event>>(256);
+        let mut watcher = notify::recommended_watcher(move |res: notify::Result<Event>| {
+            // The notify callback is a sync std-thread closure; use the
+            // blocking_send variant to push into the tokio channel
+            // without an executor handle.
+            let _ = tx.blocking_send(res);
+        })
+        .context("observable_bridge::memory: build notify watcher")?;
+        watcher
+            .watch(&session_ctx.memory_dir, RecursiveMode::NonRecursive)
+            .with_context(|| {
+                format!(
+                    "notify::watch on memory_dir: {}",
+                    session_ctx.memory_dir.display()
+                )
+            })?;
+
+        let cancel = CancellationToken::new();
+        let bridge = Arc::clone(self);
+        let task_cancel = cancel.clone();
+        tokio::spawn(async move {
+            run_watch_loop(bridge, session_ctx, rx, task_cancel).await;
+        });
+
+        guard.insert(
+            session_id,
+            WatcherHandle {
+                _notify: watcher,
+                cancel,
+            },
+        );
+        Ok(())
+    }
+
+    /// Stop the watcher for `session_id` if one is running. Called by
+    /// `reconcile` so the final snapshot reflects a quiesced directory.
+    /// No-op when the id isn't registered.
+    pub async fn stop_watcher(&self, session_id: Uuid) {
+        let mut guard = self.watchers.lock().await;
+        if let Some(prev) = guard.remove(&session_id) {
+            prev.cancel.cancel();
+        }
+    }
+
+    /// Cancel every active watcher. Called at runner shutdown to
+    /// guarantee no `notify` hooks linger past process exit.
+    pub async fn shutdown_all(&self) {
+        let mut guard = self.watchers.lock().await;
+        for (_, handle) in guard.drain() {
+            handle.cancel.cancel();
+        }
+    }
+
+    /// Read the device-token JWT used as `Authorization: Bearer`.
+    /// Returns `None` if the runner is not paired — every call site
+    /// short-circuits in that case (best-effort posture).
+    fn device_token(&self) -> Option<String> {
+        crate::auth::AuthManager::new().get_access_token().ok()
+    }
+}
+
+/// Walk `dir` for `*.md` files, returning a deterministic snapshot.
+/// `name` is the basename without `.md`. Sort by name so two snapshots
+/// of the same directory are byte-equal regardless of OS readdir order.
+fn snapshot_dir(dir: &Path) -> Result<DirSnapshot> {
+    if !dir.exists() {
+        return Ok(DirSnapshot::default());
+    }
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(dir).with_context(|| format!("read_dir {}", dir.display()))? {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(e) => {
+                warn!("observable_bridge::memory: read_dir entry error: {e}");
+                continue;
+            }
+        };
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some(MD_EXT) {
+            continue;
+        }
+        let name = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s.to_string(),
+            None => continue,
+        };
+        let content = match std::fs::read(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("observable_bridge::memory: read {} failed: {e}", path.display());
+                continue;
+            }
+        };
+        files.push(FileFingerprint {
+            name,
+            sha256: hex_sha256(&content),
+        });
+    }
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(DirSnapshot { files })
+}
+
+fn hex_sha256(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn memory_file_path(memory_dir: &Path, name: &str) -> PathBuf {
+    memory_dir.join(format!("{name}.{MD_EXT}"))
+}
+
+/// Background task that drains notify events, debounces by file path,
+/// and forwards to `MemoryBridge::push`.
+async fn run_watch_loop(
+    bridge: Arc<MemoryBridge>,
+    session_ctx: SessionContext,
+    mut rx: mpsc::Receiver<notify::Result<Event>>,
+    cancel: CancellationToken,
+) {
+    use std::collections::HashMap;
+    use std::time::Instant;
+    use tokio::time::{sleep_until, Instant as TokioInstant};
+
+    // Per-path debounce: each event extends the "fire after" timestamp.
+    // The task wakes either on the next event OR on the earliest
+    // pending deadline.
+    let mut pending: HashMap<PathBuf, (Instant, bool)> = HashMap::new();
+
+    loop {
+        // Compute the next deadline to wake up at, if any.
+        let next_deadline = pending
+            .values()
+            .map(|(t, _)| *t)
+            .min()
+            .map(|t| TokioInstant::from_std(t));
+
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                debug!("observable_bridge::memory: watch loop cancelled");
+                return;
+            }
+            maybe_event = rx.recv() => {
+                let event = match maybe_event {
+                    Some(Ok(ev)) => ev,
+                    Some(Err(e)) => {
+                        warn!("observable_bridge::memory: notify error: {e}");
+                        continue;
+                    }
+                    None => {
+                        debug!("observable_bridge::memory: notify channel closed");
+                        return;
+                    }
+                };
+                let deleted = matches!(event.kind, EventKind::Remove(_));
+                let interesting = matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                );
+                if !interesting {
+                    continue;
+                }
+                let deadline = Instant::now() + std::time::Duration::from_millis(DEBOUNCE_MS);
+                for path in event.paths.into_iter() {
+                    if path.extension().and_then(|s| s.to_str()) != Some(MD_EXT) {
+                        continue;
+                    }
+                    // Each event overwrites the (deadline, was_deleted)
+                    // tuple. Latest signal wins; if a Modify follows a
+                    // Remove, the Modify takes over.
+                    pending.insert(path, (deadline, deleted));
+                }
+            }
+            _ = async {
+                match next_deadline {
+                    Some(d) => sleep_until(d).await,
+                    None => futures::future::pending::<()>().await,
+                }
+            } => {
+                // Fire any entries whose deadline has passed.
+                let now = Instant::now();
+                let mut ready: Vec<(PathBuf, bool)> = Vec::new();
+                pending.retain(|path, (t, deleted)| {
+                    if *t <= now {
+                        ready.push((path.clone(), *deleted));
+                        false
+                    } else {
+                        true
+                    }
+                });
+                for (path, was_deleted) in ready {
+                    dispatch_change(&bridge, &session_ctx, &path, was_deleted).await;
+                }
+            }
+        }
+    }
+}
+
+async fn dispatch_change(
+    bridge: &MemoryBridge,
+    session_ctx: &SessionContext,
+    path: &Path,
+    was_deleted: bool,
+) {
+    let name = match path.file_stem().and_then(|s| s.to_str()) {
+        Some(s) => s.to_string(),
+        None => return,
+    };
+
+    // Real ground truth at debounce-fire: does the file exist now?
+    // notify can deliver a Remove followed by a Create within the
+    // debounce window; trust the filesystem over the event kind.
+    let change = if path.exists() {
+        match std::fs::read_to_string(path) {
+            Ok(content) => ObservableChange::Upserted { name, content },
+            Err(e) => {
+                warn!(
+                    "observable_bridge::memory: read {} failed in watcher: {e}",
+                    path.display()
+                );
+                return;
+            }
+        }
+    } else if was_deleted {
+        ObservableChange::Deleted { name }
+    } else {
+        // Race: event fired but file already gone and we never saw a
+        // Remove. Best-effort delete.
+        ObservableChange::Deleted { name }
+    };
+
+    if let Err(e) = bridge.push(change, session_ctx).await {
+        warn!("observable_bridge::memory: push from watcher failed: {e}");
+    }
+}
+
+#[async_trait]
+impl RunnerObservableBridge for MemoryBridge {
+    fn category(&self) -> &'static str {
+        "memory"
+    }
+
+    /// Spawn-time materialization. See module docstring for the full
+    /// algorithm. Coord-side failures are logged + best-effort (the
+    /// watcher + reconcile recover later); `memory_dir` IO failures
+    /// propagate as fatal because they indicate misconfiguration.
+    async fn pull(&self, session_ctx: &mut SessionContext) -> Result<()> {
+        if !session_ctx.memory_dir.exists() {
+            std::fs::create_dir_all(&session_ctx.memory_dir).with_context(|| {
+                format!(
+                    "create memory_dir: {}",
+                    session_ctx.memory_dir.display()
+                )
+            })?;
+        }
+
+        let local_pre = snapshot_dir(&session_ctx.memory_dir)?;
+
+        let token = match self.device_token() {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                warn!(
+                    "observable_bridge::memory::pull: no device token; skipping coord sync \
+                     (memory_dir left untouched, snapshot recorded as post-pull baseline)"
+                );
+                session_ctx.post_pull_snapshot = Some(local_pre);
+                return Ok(());
+            }
+        };
+        let base = match memory_client::coord_http_base() {
+            Some(b) => b,
+            None => {
+                warn!(
+                    "observable_bridge::memory::pull: no coord_url in active profile; \
+                     skipping coord sync"
+                );
+                session_ctx.post_pull_snapshot = Some(local_pre);
+                return Ok(());
+            }
+        };
+
+        // Step 1: list coord's tenant pool.
+        let listing = match memory_client::list(&self.http, &base, &token).await {
+            Ok(l) => l,
+            Err(e) => {
+                warn!(
+                    "observable_bridge::memory::pull: list failed ({e}); \
+                     leaving memory_dir untouched, snapshot = local"
+                );
+                session_ctx.post_pull_snapshot = Some(local_pre);
+                return Ok(());
+            }
+        };
+
+        // Step 2: for each coord entry, GET full payload (the list
+        // response omits content + hash to keep the metadata call
+        // cheap; comparing requires the full body). Apply tombstones
+        // and content updates. Tradeoff documented in plan §Phase 2:
+        // GET-per-name is O(N) but typical pools are < 200; if it
+        // becomes a bottleneck, gate on `version` deltas tracked
+        // across sessions.
+        let mut coord_names: HashSet<String> = HashSet::new();
+        for summary in &listing.items {
+            coord_names.insert(summary.name.clone());
+            let full = match memory_client::get(&self.http, &base, &token, &summary.name).await {
+                Ok(p) => p,
+                Err(e) => {
+                    warn!(
+                        "observable_bridge::memory::pull: get {} failed: {e}",
+                        summary.name
+                    );
+                    continue;
+                }
+            };
+            if let Err(e) = apply_coord_row(&session_ctx.memory_dir, &full, &local_pre) {
+                warn!(
+                    "observable_bridge::memory::pull: apply {} failed: {e}",
+                    summary.name
+                );
+            }
+        }
+
+        // Step 3: first-contact import — any local file whose name is
+        // not in coord's list gets POSTed. Per plan D3 §4 this is how
+        // pre-runner content migrates in.
+        for fp in &local_pre.files {
+            if coord_names.contains(&fp.name) {
+                continue;
+            }
+            let path = memory_file_path(&session_ctx.memory_dir, &fp.name);
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(
+                        "observable_bridge::memory::pull: read {} failed: {e}",
+                        path.display()
+                    );
+                    continue;
+                }
+            };
+            let req = MemoryUpsertRequest {
+                name: fp.name.clone(),
+                content,
+                description: None,
+                r#type: None,
+                written_by_agent: Some(session_ctx.session_id.to_string()),
+                written_by_device: Some(session_ctx.device_id.to_string()),
+            };
+            if let Err(e) = memory_client::upsert(&self.http, &base, &token, &req).await {
+                warn!(
+                    "observable_bridge::memory::pull: first-contact upsert {} failed: {e}",
+                    fp.name
+                );
+            } else {
+                info!(
+                    "observable_bridge::memory::pull: first-contact imported {}",
+                    fp.name
+                );
+            }
+        }
+
+        // Step 4: re-snapshot — the post-pull baseline is what
+        // `reconcile` diffs against at session end.
+        session_ctx.post_pull_snapshot = Some(snapshot_dir(&session_ctx.memory_dir)?);
+        Ok(())
+    }
+
+    async fn push(
+        &self,
+        change: ObservableChange,
+        session_ctx: &SessionContext,
+    ) -> Result<()> {
+        let token = match self.device_token() {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                debug!("observable_bridge::memory::push: no device token; dropping change");
+                return Ok(());
+            }
+        };
+        let base = match memory_client::coord_http_base() {
+            Some(b) => b,
+            None => {
+                debug!("observable_bridge::memory::push: no coord_url; dropping change");
+                return Ok(());
+            }
+        };
+
+        match change {
+            ObservableChange::Upserted { name, content } => {
+                let req = MemoryUpsertRequest {
+                    name: name.clone(),
+                    content,
+                    description: None,
+                    r#type: None,
+                    written_by_agent: Some(session_ctx.session_id.to_string()),
+                    written_by_device: Some(session_ctx.device_id.to_string()),
+                };
+                if let Err(e) = memory_client::upsert(&self.http, &base, &token, &req).await {
+                    warn!("observable_bridge::memory::push upsert {name} failed: {e}");
+                }
+            }
+            ObservableChange::Deleted { name } => {
+                if let Err(e) = memory_client::delete(&self.http, &base, &token, &name).await {
+                    warn!("observable_bridge::memory::push delete {name} failed: {e}");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    async fn reconcile(&self, session_ctx: &SessionContext) -> Result<ReconcileReport> {
+        self.stop_watcher(session_ctx.session_id).await;
+
+        let post_pull = match &session_ctx.post_pull_snapshot {
+            Some(s) => s.clone(),
+            None => {
+                return Err(anyhow!(
+                    "observable_bridge::memory::reconcile: no post_pull_snapshot \
+                     in session_ctx — was pull() called?"
+                ));
+            }
+        };
+        let post_session = snapshot_dir(&session_ctx.memory_dir)?;
+
+        let token = match self.device_token() {
+            Some(t) if !t.is_empty() => t,
+            _ => {
+                warn!(
+                    "observable_bridge::memory::reconcile: no device token; \
+                     reporting zero counts"
+                );
+                return Ok(ReconcileReport::default());
+            }
+        };
+        let base = match memory_client::coord_http_base() {
+            Some(b) => b,
+            None => {
+                warn!(
+                    "observable_bridge::memory::reconcile: no coord_url; \
+                     reporting zero counts"
+                );
+                return Ok(ReconcileReport::default());
+            }
+        };
+
+        let mut report = ReconcileReport::default();
+        let pre_names: HashSet<&str> =
+            post_pull.files.iter().map(|f| f.name.as_str()).collect();
+        let post_names: HashSet<&str> =
+            post_session.files.iter().map(|f| f.name.as_str()).collect();
+
+        // Upserts: name present now AND (absent before OR hash changed).
+        for fp in &post_session.files {
+            let prev_hash = post_pull.get(&fp.name).map(|p| p.sha256.as_str());
+            if prev_hash == Some(fp.sha256.as_str()) {
+                report.unchanged = report.unchanged.saturating_add(1);
+                continue;
+            }
+            let path = memory_file_path(&session_ctx.memory_dir, &fp.name);
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!(
+                        "observable_bridge::memory::reconcile: read {} failed: {e}",
+                        path.display()
+                    );
+                    report.failed = report.failed.saturating_add(1);
+                    continue;
+                }
+            };
+            let req = MemoryUpsertRequest {
+                name: fp.name.clone(),
+                content,
+                description: None,
+                r#type: None,
+                written_by_agent: Some(session_ctx.session_id.to_string()),
+                written_by_device: Some(session_ctx.device_id.to_string()),
+            };
+            match memory_client::upsert(&self.http, &base, &token, &req).await {
+                Ok(_) => report.pushed = report.pushed.saturating_add(1),
+                Err(e) => {
+                    warn!(
+                        "observable_bridge::memory::reconcile: upsert {} failed: {e}",
+                        fp.name
+                    );
+                    report.failed = report.failed.saturating_add(1);
+                }
+            }
+        }
+
+        // Deletes: name in pre_pull but gone now.
+        for name in pre_names.difference(&post_names) {
+            match memory_client::delete(&self.http, &base, &token, name).await {
+                Ok(_) => report.pushed = report.pushed.saturating_add(1),
+                Err(e) => {
+                    warn!(
+                        "observable_bridge::memory::reconcile: delete {} failed: {e}",
+                        name
+                    );
+                    report.failed = report.failed.saturating_add(1);
+                }
+            }
+        }
+
+        info!(
+            "observable_bridge::memory::reconcile: pushed={} unchanged={} failed={}",
+            report.pushed, report.unchanged, report.failed
+        );
+        Ok(report)
+    }
+}
+
+/// Materialize one coord row into the local memory dir. Skips no-op
+/// writes (hash matches), deletes locally on tombstone.
+fn apply_coord_row(
+    memory_dir: &Path,
+    payload: &MemoryWithHistory,
+    local: &DirSnapshot,
+) -> Result<()> {
+    let name = &payload.latest.name;
+    let path = memory_file_path(memory_dir, name);
+
+    if payload.latest.is_tombstone {
+        if path.exists() {
+            std::fs::remove_file(&path)
+                .with_context(|| format!("remove tombstoned {}", path.display()))?;
+            info!("observable_bridge::memory: removed tombstoned {name}");
+        }
+        return Ok(());
+    }
+
+    let coord_hash = hex_sha256(payload.latest.content.as_bytes());
+    if let Some(local_fp) = local.get(name) {
+        if local_fp.sha256 == coord_hash {
+            return Ok(());
+        }
+    }
+    std::fs::write(&path, payload.latest.content.as_bytes())
+        .with_context(|| format!("write memory file {}", path.display()))?;
+    debug!("observable_bridge::memory: materialized {name}");
+    Ok(())
+}

--- a/src-tauri/src/observable_bridge/memory_client.rs
+++ b/src-tauri/src/observable_bridge/memory_client.rs
@@ -1,0 +1,161 @@
+//! Thin HTTP wrapper around coord's `/coord/memory/*` routes used by
+//! [`crate::observable_bridge::memory::MemoryBridge`].
+//!
+//! Mirrors the ad-hoc idiom from `fleet.rs::register_with_coord` /
+//! `fleet.rs::heartbeat_to_coord` — there is no central `coord_client`
+//! crate in the runner. Each module passes its own long-lived
+//! `reqwest::Client` so TLS keepalives amortize across the per-session
+//! call chain (pull → many upserts → reconcile).
+//!
+//! Auth: every call carries `Authorization: Bearer <device-token JWT>`.
+//! The token is fetched by the caller via
+//! [`crate::auth::AuthManager::get_access_token`] and threaded through
+//! as an argument so this module stays Tauri-free and testable.
+
+use anyhow::{anyhow, Context, Result};
+use qontinui_types::memory::{
+    MemoryListResponse, MemoryUpsertRequest, MemoryUpsertResponse, MemoryWithHistory,
+};
+use std::time::Duration;
+
+/// Per-call timeout. List/get are cheap metadata reads; upsert writes
+/// one row; delete writes one tombstone — all should land well under
+/// this. Matches the 10s timeout `fleet::publish_budget` uses for
+/// similar single-row POSTs.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Build the long-lived reqwest client the bridge reuses across calls.
+/// Returned to the bridge once at construction; cloned cheaply (it's an
+/// `Arc` internally) into each method call.
+pub fn build_client() -> Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .pool_idle_timeout(Duration::from_secs(300))
+        .tcp_keepalive(Duration::from_secs(60))
+        .build()
+        .context("observable_bridge::memory_client: reqwest client build")
+}
+
+/// Resolve the coord HTTP base from the active profile's `coord_url`.
+///
+/// Duplicated from `fleet.rs::coord_http_base` (private there) rather
+/// than re-exporting to keep the bridge self-contained. Five lines, no
+/// drift risk.
+pub fn coord_http_base() -> Option<String> {
+    let coord_url = crate::profiles::load_strict().ok()?.coord_url?;
+    let trimmed = coord_url.trim_end_matches("/ws");
+    let with_http = trimmed
+        .strip_prefix("wss://")
+        .map(|rest| format!("https://{rest}"))
+        .or_else(|| {
+            trimmed
+                .strip_prefix("ws://")
+                .map(|rest| format!("http://{rest}"))
+        })
+        .unwrap_or_else(|| trimmed.to_string());
+    Some(with_http)
+}
+
+/// `GET /coord/memory/list` — metadata-only catalog of every live
+/// memory in the caller's tenant pool. Tenant is resolved server-side
+/// from the device-token JWT.
+pub async fn list(
+    client: &reqwest::Client,
+    base: &str,
+    device_token: &str,
+) -> Result<MemoryListResponse> {
+    let url = format!("{base}/coord/memory/list");
+    let resp = client
+        .get(&url)
+        .bearer_auth(device_token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(400).collect();
+        return Err(anyhow!("GET {url} -> HTTP {status}: {excerpt}"));
+    }
+    resp.json::<MemoryListResponse>()
+        .await
+        .with_context(|| format!("decode MemoryListResponse from {url}"))
+}
+
+/// `GET /coord/memory/:name` — latest row + up to 10 recent versions.
+/// Returns the full content blob.
+pub async fn get(
+    client: &reqwest::Client,
+    base: &str,
+    device_token: &str,
+    name: &str,
+) -> Result<MemoryWithHistory> {
+    let url = format!("{base}/coord/memory/{}", urlencoding::encode(name));
+    let resp = client
+        .get(&url)
+        .bearer_auth(device_token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(400).collect();
+        return Err(anyhow!("GET {url} -> HTTP {status}: {excerpt}"));
+    }
+    resp.json::<MemoryWithHistory>()
+        .await
+        .with_context(|| format!("decode MemoryWithHistory from {url}"))
+}
+
+/// `POST /coord/memory/upsert` — append a new version of `req.name`.
+/// Coord assigns the version monotonically per-tenant.
+pub async fn upsert(
+    client: &reqwest::Client,
+    base: &str,
+    device_token: &str,
+    req: &MemoryUpsertRequest,
+) -> Result<MemoryUpsertResponse> {
+    let url = format!("{base}/coord/memory/upsert");
+    let resp = client
+        .post(&url)
+        .bearer_auth(device_token)
+        .json(req)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(400).collect();
+        return Err(anyhow!("POST {url} -> HTTP {status}: {excerpt}"));
+    }
+    resp.json::<MemoryUpsertResponse>()
+        .await
+        .with_context(|| format!("decode MemoryUpsertResponse from {url}"))
+}
+
+/// `DELETE /coord/memory/:name` — soft delete (appends a tombstone row).
+/// 200 on success, 404 if the memory never existed. 404 is treated as
+/// success (idempotent intent: "this name should not exist in coord").
+pub async fn delete(
+    client: &reqwest::Client,
+    base: &str,
+    device_token: &str,
+    name: &str,
+) -> Result<()> {
+    let url = format!("{base}/coord/memory/{}", urlencoding::encode(name));
+    let resp = client
+        .delete(&url)
+        .bearer_auth(device_token)
+        .send()
+        .await
+        .with_context(|| format!("DELETE {url}"))?;
+    let status = resp.status();
+    if status.is_success() || status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(());
+    }
+    let body = resp.text().await.unwrap_or_default();
+    let excerpt: String = body.chars().take(400).collect();
+    Err(anyhow!("DELETE {url} -> HTTP {status}: {excerpt}"))
+}

--- a/src-tauri/src/observable_bridge/mod.rs
+++ b/src-tauri/src/observable_bridge/mod.rs
@@ -1,0 +1,190 @@
+//! Federated observable categories — runner-mediated coord bridges.
+//!
+//! Plan: `2026-05-22-memories-on-coord-cross-machine.md`.
+//!
+//! ## Pattern
+//!
+//! Every federated agent observable (memories first, git-ops next, more
+//! later) follows the same shape:
+//!
+//!   Agent (Claude session, ...) writes/reads via local convention
+//!     → Runner bridges on session boundary + during session
+//!     → Coord HTTP API (per-category routes)
+//!     → Single tenant-scoped store, fleet-wide
+//!     → Fan-out: pulls into other runners' next session prep
+//!
+//! The [`RunnerObservableBridge`] trait abstracts this lifecycle.
+//! [`MemoryBridge`] is the reference implementation; subsequent
+//! categories (e.g. `GitOpBridge`) reuse the trait without modification.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use std::sync::Arc;
+use uuid::Uuid;
+
+pub mod memory;
+pub mod memory_client;
+
+/// Process-wide singleton `MemoryBridge` set once at runner init by
+/// `main.rs::setup`. Spawn-site call paths (`claude_session::runner`,
+/// `claude_session::session`) reach it via [`global`] because they run
+/// in the binary tree without access to Tauri `State`.
+///
+/// `None` if init failed (e.g., no profile, no reqwest builder) — every
+/// caller short-circuits on that and the spawn proceeds without
+/// federation.
+static GLOBAL_BRIDGE: OnceCell<Arc<memory::MemoryBridge>> = OnceCell::new();
+
+/// Install the process-wide `MemoryBridge`. Idempotent — subsequent
+/// calls are silently ignored so accidental double-init (e.g., from
+/// two Tauri `.setup` closures during testing) does not panic.
+pub fn init_global(bridge: Arc<memory::MemoryBridge>) {
+    let _ = GLOBAL_BRIDGE.set(bridge);
+}
+
+/// Read the process-wide `MemoryBridge`. Returns `None` until
+/// [`init_global`] runs successfully — federation-aware call sites
+/// must treat this as the "feature disabled this session" signal.
+pub fn global() -> Option<&'static Arc<memory::MemoryBridge>> {
+    GLOBAL_BRIDGE.get()
+}
+
+/// Per-session context every bridge receives.
+///
+/// `tenant_id` is carried for local bookkeeping + UI surfacing only —
+/// the coord-side `TenantId` extractor resolves it from the device-token
+/// JWT, so HTTP request bodies do not include it.
+#[derive(Debug, Clone)]
+pub struct SessionContext {
+    pub tenant_id: Uuid,
+    pub device_id: Uuid,
+    pub account_name: String,
+    pub memory_dir: PathBuf,
+    pub session_id: Uuid,
+    /// Snapshot of `memory_dir` taken immediately after `pull` completed.
+    /// Used by `reconcile` to diff against final state at session end.
+    /// `None` until `pull` runs.
+    pub post_pull_snapshot: Option<DirSnapshot>,
+}
+
+/// A single file's identity in a memory directory snapshot.
+/// `name` is the file basename without `.md`; `sha256` is hex.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileFingerprint {
+    pub name: String,
+    pub sha256: String,
+}
+
+/// All `.md` files in a memory directory at a point in time.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DirSnapshot {
+    pub files: Vec<FileFingerprint>,
+}
+
+impl DirSnapshot {
+    pub fn get(&self, name: &str) -> Option<&FileFingerprint> {
+        self.files.iter().find(|f| f.name == name)
+    }
+}
+
+/// Local-change event surfaced by a bridge's file watcher to `push`.
+#[derive(Debug, Clone)]
+pub enum ObservableChange {
+    Upserted { name: String, content: String },
+    Deleted { name: String },
+}
+
+/// Aggregate counts from a `reconcile` pass — useful for UI banner.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ReconcileReport {
+    pub pushed: u32,
+    pub pulled: u32,
+    pub unchanged: u32,
+    pub failed: u32,
+}
+
+/// The trait every federated observable category implements.
+#[async_trait]
+pub trait RunnerObservableBridge: Send + Sync {
+    /// Stable category name — used as the `coord.<category>` table name
+    /// and the dashboard route segment. Memories: `"memory"`. Git-ops
+    /// (future): `"git_op"`.
+    fn category(&self) -> &'static str;
+
+    /// Spawn-time: pull the tenant pool from coord, materialize locally.
+    /// Populates `session_ctx.post_pull_snapshot`.
+    async fn pull(&self, session_ctx: &mut SessionContext) -> Result<()>;
+
+    /// During-session: invoked on a debounced local change event.
+    async fn push(
+        &self,
+        change: ObservableChange,
+        session_ctx: &SessionContext,
+    ) -> Result<()>;
+
+    /// Session-end: re-snapshot, diff against `post_pull_snapshot`,
+    /// push anything the watcher missed, return aggregate counts.
+    async fn reconcile(&self, session_ctx: &SessionContext) -> Result<ReconcileReport>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_fingerprint_equality() {
+        let a = FileFingerprint {
+            name: "feedback_demo".to_string(),
+            sha256: "abc123".to_string(),
+        };
+        let b = FileFingerprint {
+            name: "feedback_demo".to_string(),
+            sha256: "abc123".to_string(),
+        };
+        let c = FileFingerprint {
+            name: "feedback_demo".to_string(),
+            sha256: "def456".to_string(),
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn dir_snapshot_get_finds_existing() {
+        let snap = DirSnapshot {
+            files: vec![
+                FileFingerprint {
+                    name: "alpha".to_string(),
+                    sha256: "h1".to_string(),
+                },
+                FileFingerprint {
+                    name: "beta".to_string(),
+                    sha256: "h2".to_string(),
+                },
+            ],
+        };
+        let found = snap.get("beta").expect("beta should be present");
+        assert_eq!(found.sha256, "h2");
+    }
+
+    #[test]
+    fn dir_snapshot_get_returns_none_for_missing() {
+        let snap = DirSnapshot {
+            files: vec![FileFingerprint {
+                name: "alpha".to_string(),
+                sha256: "h1".to_string(),
+            }],
+        };
+        assert!(snap.get("missing").is_none());
+    }
+
+    #[test]
+    fn dir_snapshot_default_is_empty() {
+        let snap = DirSnapshot::default();
+        assert!(snap.files.is_empty());
+        assert!(snap.get("anything").is_none());
+    }
+}

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -35,11 +35,12 @@ pub fn export_all_schemas() -> Value {
     use qontinui_types::{
         accessibility as qa, ai_workflows as qaw, app_events as qae, apps as qap, config as qcfg,
         constraints as qc, discovery as qdc, execution as qe, findings as qfn, geometry as qg,
-        ir as qir, mcp_config as qmc, orchestration_config as qoc, process_management as qpm,
-        rag as qr, runner as qrn, scheduler as qs, spec_api_events as qsae, spec_check as qsc,
-        state_machine as qsm, targets as qt, task_run as qtr, terminal as qtm,
-        ticket_system as qts, tree_events as qte, ui_bridge as qub, verification as qv,
-        worker_output as qwo, workflow as qw, workflow_step as qws,
+        ir as qir, mcp_config as qmc, memory as qmem, orchestration_config as qoc,
+        process_management as qpm, rag as qr, runner as qrn, scheduler as qs,
+        spec_api_events as qsae, spec_check as qsc, state_machine as qsm, targets as qt,
+        task_run as qtr, terminal as qtm, ticket_system as qts, tree_events as qte,
+        ui_bridge as qub, verification as qv, worker_output as qwo, workflow as qw,
+        workflow_step as qws,
     };
 
     // Built via a plain Map instead of `json!` to avoid the
@@ -676,6 +677,17 @@ pub fn export_all_schemas() -> Value {
     // ── qontinui-types: spec_api_events (Plan 06 broadcast taxonomy) ──
     add!("SpecApiEvent", qsae::SpecApiEvent);
 
+    // ── qontinui-types: memory (coord-mediated memory federation —
+    // plan 2026-05-22-memories-on-coord-cross-machine.md Phase 6) ──
+    add!("MemoryUpsertRequest", qmem::MemoryUpsertRequest);
+    add!("MemoryUpsertResponse", qmem::MemoryUpsertResponse);
+    add!("MemoryRestoreRequest", qmem::MemoryRestoreRequest);
+    add!("MemoryListQuery", qmem::MemoryListQuery);
+    add!("MemoryRow", qmem::MemoryRow);
+    add!("MemorySummary", qmem::MemorySummary);
+    add!("MemoryWithHistory", qmem::MemoryWithHistory);
+    add!("MemoryListResponse", qmem::MemoryListResponse);
+
     // ── qontinui-types: apps (multi-tenant Spec API registry — Stream A) ──
     add!("App", qap::App);
     add!("RegisterAppRequest", qap::RegisterAppRequest);
@@ -766,7 +778,7 @@ mod tests {
             obj.contains_key("SpecApiEvent"),
             "Missing SpecApiEvent schema (Plan 06)"
         );
-        assert_eq!(obj.len(), 483, "Expected 483 schema entries");
+        assert_eq!(obj.len(), 491, "Expected 491 schema entries");
 
         // Sanity-check that qontinui_types re-exports are present
         assert!(

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -262,6 +262,15 @@ pub struct AiSettings {
     /// regex extractor is always on regardless of this flag.
     #[serde(default = "default_ai_path_prediction_enabled")]
     pub ai_path_prediction_enabled: bool,
+    /// Federate Claude memory writes through coord. When true (default),
+    /// each spawned Claude session pulls the tenant memory pool before
+    /// spawn, runs a file watcher during the session that pushes
+    /// changes to coord, and reconciles on session end. When false,
+    /// each session is local-only (the per-account memory dir is
+    /// untouched by the runner). UI surface for this is deferred —
+    /// flip via direct settings edit.
+    #[serde(default = "default_memory_federation_enabled")]
+    pub memory_federation_enabled: bool,
 }
 
 fn default_interactive_sessions_enabled() -> bool {
@@ -269,6 +278,10 @@ fn default_interactive_sessions_enabled() -> bool {
 }
 
 fn default_ai_path_prediction_enabled() -> bool {
+    true
+}
+
+fn default_memory_federation_enabled() -> bool {
     true
 }
 
@@ -292,6 +305,7 @@ impl Default for AiSettings {
             routing: RoutingConfig::default(),
             interactive_sessions_enabled: default_interactive_sessions_enabled(),
             ai_path_prediction_enabled: default_ai_path_prediction_enabled(),
+            memory_federation_enabled: default_memory_federation_enabled(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- New \`observable_bridge/\` module with \`RunnerObservableBridge\` trait + first reference impl \`MemoryBridge\`.
- Pattern: spawn-time pull from coord.memories → in-session notify watcher (250ms debounced push) → session-end reconcile diffing local vs post-pull snapshot.
- Concurrent sessions safe via \`Mutex<HashMap<Uuid, WatcherHandle>>\` keyed on session_id.
- Wired into both Claude-CLI spawn paths (inline + interactive); spawn-failure cleanup paths included.
- Tauri \`memory-federation:reconcile\` event emits \`ReconcileReport\` for future frontend banner.
- New \`claude_session/federation.rs\` resolves device_id (machine.json), tenant_id (fleet idiom), account_name (CLAUDE_CONFIG_DIR basename), memory_dir (Claude's per-project convention).
- Settings field \`memory_federation_enabled\` defaults true via serde(default); UI toggle deferred.
- 8 new schema types registered in \`schema_export\` (483→491).

## Why
Phases 1-5 of plan 2026-05-22-memories-on-coord-cross-machine.md. Reference implementation of the federation pattern; git-ops + other categories follow the same trait without modification.

## Test plan
- [x] \`cargo check --bin qontinui-runner\` clean
- [x] \`cargo check --tests --bin qontinui-runner\` clean
- [x] \`cargo test observable_bridge\` — 4/4 pass
- [ ] Temp runner via supervisor (port 9875) end-to-end pull/push against staging coord — in progress
- [ ] Concurrent gmail+hotmail spawn → both reach coord without watcher collision

Depends-On: qontinui/qontinui-schemas#58 (must merge first — adds the qontinui-types::memory module this PR consumes via qontinui-coord's exported types).