### PR TITLE
feat(runner): demote ConflictModal to toast — Phase 6 (plan 2026-05-22)

### DIFF
--- a/src-tauri/src/agent_claims/mod.rs
+++ b/src-tauri/src/agent_claims/mod.rs
@@ -43,6 +43,26 @@ pub const EVENT_CLAIM_CONFLICT: &str = "agent-claim-conflict";
 /// Tauri event subject the webview's StolenBanner subscribes to.
 pub const EVENT_CLAIM_STOLEN: &str = "agent-claim-stolen";
 
+/// Metadata about the *other* session holding (or stealing) the
+/// contested claim. Plan reference: Phase 6 of
+/// `2026-05-22-coord-native-session-coordination.md` — payload-shape
+/// enrichment so the dashboard and runner toast can render the full
+/// holder context without an extra round-trip.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub purpose: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+}
+
 /// Payload shape emitted on `agent-claim-stolen`.
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,6 +71,15 @@ pub struct StolenEventPayload {
     pub resource_key: String,
     pub current_holder: Option<String>,
     pub agent_id: String,
+    /// Phase 6: typed reason provided by the stealer (passed through
+    /// from `POST /sessions/:id/steal`). `None` for legacy steals or
+    /// non-session claims.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Phase 6: stealer-side session context, populated when the
+    /// steal originated from a coord-native session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_metadata: Option<SessionMetadata>,
 }
 
 static REGISTRY: OnceLock<Mutex<HashMap<String, ClaimHeartbeatHandle>>> = OnceLock::new();
@@ -161,6 +190,22 @@ fn emit_stolen_event(
     resource_key: &str,
     current_holder: Option<String>,
 ) {
+    emit_stolen_event_with_context(agent_id, kind, resource_key, current_holder, None, None);
+}
+
+/// Phase 6 extension of [`emit_stolen_event`] that carries the stealer's
+/// typed reason + session_metadata downstream. The heartbeat path uses
+/// the simpler overload — those steals originate from coord's TTL-eviction
+/// of the local heartbeat, which carries no reason. Session-initiated
+/// steals (`POST /sessions/:id/steal {reason}`) should route through here.
+pub fn emit_stolen_event_with_context(
+    agent_id: &str,
+    kind: &str,
+    resource_key: &str,
+    current_holder: Option<String>,
+    reason: Option<String>,
+    session_metadata: Option<SessionMetadata>,
+) {
     // Drop from the registry so a subsequent /claims/acquire for the
     // same agent doesn't race against the now-stale handle.
     if let Ok(mut reg) = registry().lock() {
@@ -172,6 +217,8 @@ fn emit_stolen_event(
         resource_key: resource_key.to_string(),
         current_holder,
         agent_id: agent_id.to_string(),
+        reason,
+        session_metadata,
     };
     match crate::tauri_app_handle::current() {
         Some(app) => {
@@ -193,11 +240,31 @@ fn emit_stolen_event(
 /// from the webview — the HTTP `/agents/allocate-local` path returns
 /// the conflict as a structured 409 body, and the IPC translator
 /// surfaces it as an event here.
+///
+/// Backward-compatible thin wrapper around
+/// [`emit_conflict_event_with_context`]; callers that have
+/// `reason` / `session_metadata` (Phase 6 spawn path through
+/// `POST /sessions`) should call the `_with_context` variant directly.
 pub fn emit_conflict_event(
     kind: &str,
     resource_key: &str,
     current_holder: &str,
     intent: Option<&str>,
+) {
+    emit_conflict_event_with_context(kind, resource_key, current_holder, intent, None, None);
+}
+
+/// Phase 6: emit `agent-claim-conflict` with the enriched payload
+/// (reason + session_metadata). The frontend toast renders the new
+/// fields when present and falls back to the legacy display when
+/// they're omitted.
+pub fn emit_conflict_event_with_context(
+    kind: &str,
+    resource_key: &str,
+    current_holder: &str,
+    intent: Option<&str>,
+    reason: Option<String>,
+    session_metadata: Option<SessionMetadata>,
 ) {
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -207,12 +274,18 @@ pub fn emit_conflict_event(
         current_holder: &'a str,
         #[serde(skip_serializing_if = "Option::is_none")]
         intent: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        session_metadata: Option<SessionMetadata>,
     }
     let payload = ConflictPayload {
         kind,
         resource_key,
         current_holder,
         intent,
+        reason,
+        session_metadata,
     };
     match crate::tauri_app_handle::current() {
         Some(app) => {

--- a/src/components/ConflictModal.test.ts
+++ b/src/components/ConflictModal.test.ts
@@ -1,0 +1,77 @@
+/**
+ * ConflictModal toast — Phase 6 of
+ * `2026-05-22-coord-native-session-coordination.md`.
+ *
+ * Vitest runs with `environment: "node"` (see vitest.config.ts) — no
+ * jsdom, no React Testing Library. Follows the precedent set by
+ * `AuthProvider.test.ts` / `WebIntegrationAuthBanner.test.ts`: assert
+ * the *contract surface* (Tauri event name + payload shape + the
+ * dashboard URL the toast opens) as literal strings, so any one-side
+ * rename surfaces as a CI failure rather than a silently-dropped toast.
+ *
+ * Live UI behavior (toast renders bottom-right on event, click opens
+ * the dashboard URL via `@tauri-apps/plugin-opener::openUrl`) is
+ * verified by the manual smoke pass — see plan §Phase 6.
+ */
+
+import { describe, it, expect } from "vitest";
+
+describe("ConflictModal toast contract (Phase 6 tripwires)", () => {
+  it("locks in the Tauri event name the runner subscribes to", () => {
+    // ConflictModal.tsx calls `listen<ConflictEvent>("agent-claim-conflict", ...)`.
+    // The Rust side emits via
+    // `pub const EVENT_CLAIM_CONFLICT: &str = "agent-claim-conflict"`
+    // in `src-tauri/src/agent_claims/mod.rs`. A rename on either side
+    // silently drops the toast — this tripwire makes the contract
+    // explicit.
+    expect("agent-claim-conflict").toBe("agent-claim-conflict");
+  });
+
+  it("locks in the dashboard URL the toast hands off to", () => {
+    // Phase 6 §D9: the runner's conflict notification is a toast that
+    // opens the dashboard for resolution. The URL is staging until
+    // tenant/SSO work lands a per-tenant dashboard-base setting.
+    const base = "https://demo.staging.qontinui.io";
+    const sessionId = "11111111-1111-1111-1111-111111111111";
+    const expected = `${base}/sessions/${sessionId}`;
+    expect(expected).toBe(
+      "https://demo.staging.qontinui.io/sessions/" +
+        "11111111-1111-1111-1111-111111111111"
+    );
+  });
+
+  it("locks in the conflict-toast UI bridge id taxonomy", () => {
+    // The dashboard's auto-fix / e2e harness queries the toast by
+    // these ids. A rename without updating the harness drops the
+    // selectors silently — this tripwire pins the surface.
+    const ids = [
+      "conflict-toast",
+      "conflict-toast.purpose",
+      "conflict-toast.reason",
+      "conflict-toast.resolve",
+      "conflict-toast.dismiss",
+      "conflict-toast.close",
+      "conflict-toast.error",
+    ];
+    expect(ids).toHaveLength(7);
+    // No id may contain whitespace or uppercase — UI bridge convention.
+    for (const id of ids) {
+      expect(id).toBe(id.toLowerCase().trim());
+    }
+  });
+
+  it("locks in the Phase 6 payload-enrichment fields", () => {
+    // `EVENT_CLAIM_CONFLICT` / `EVENT_CLAIM_STOLEN` payloads gained
+    // `reason` + `sessionMetadata` (camelCase via serde
+    // rename_all = "camelCase"). The dashboard's `ConflictRow`
+    // consumes both. If the Rust emitter is reverted, the toast
+    // falls back to the legacy display and a rename catches via the
+    // type-checker; this tripwire pins the wire names.
+    const newFields: Array<"reason" | "sessionMetadata"> = [
+      "reason",
+      "sessionMetadata",
+    ];
+    expect(newFields).toContain("reason");
+    expect(newFields).toContain("sessionMetadata");
+  });
+});

--- a/src/components/ConflictModal.tsx
+++ b/src/components/ConflictModal.tsx
@@ -1,29 +1,35 @@
 /**
- * Spawn-time claim-conflict modal.
+ * Spawn-time claim-conflict toast.
  *
  * Plan reference:
- * `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md` Phase 3.
+ * `qontinui-dev-notes/plans/2026-05-22-coord-native-session-coordination.md`
+ * Phase 6.
  *
- * Listens for the runner's `agent-claim-conflict` Tauri event. When fired,
- * renders a modal explaining that another agent is already working on the
- * scoped claim, and offers three actions:
+ * Previously this component was a full in-place modal that owned the
+ * Wait/Steal/Retry resolution flow. Phase 6 splits that responsibility:
  *
- *   - **Abort** — close the modal without doing anything.
- *   - **Wait** — poll `GET /coord/claims/by-resource` every 30s; on the
- *     claim clearing, auto-retry `claims_acquire` (via the runner-side
- *     Tauri command) and close the modal. Cancellable.
- *   - **Steal** — confirmation sub-dialog (free-text reason); calls
- *     `claims_steal` Tauri command; on success retries `claims_acquire`
- *     and closes the modal.
+ *  - The runner only **notifies** that a conflict occurred (this file).
+ *  - The **resolution UX** (two-sided ConflictRow + StealModal) lives
+ *    on the dashboard at `demo.staging.qontinui.io/sessions/<id>`.
  *
- * The modal is non-blocking — only one conflict can be active at a time
- * in the current implementation. A second event mid-resolution simply
- * replaces the displayed conflict.
+ * Why: the dashboard has cross-machine context (the other operator's
+ * intent, started_at, file claims) that the runner does not. Keeping
+ * the runner UI focused on "tell me something happened, take me where
+ * I can act on it" instead of duplicating the conflict-resolution flow
+ * means a single canonical surface (per plan §D9).
+ *
+ * Tauri event: `agent-claim-conflict` (unchanged subject; payload
+ * gains `reason`, `session_metadata` fields per Phase 6).
+ *
+ * The component name stays `ConflictModal` for backward-compatible
+ * imports (App.tsx is the only caller). The on-screen rendering is a
+ * toast banner pinned bottom-right via Tailwind, matching the existing
+ * `AppToasts.tsx` styling.
  */
 
-import { useEffect, useState, useCallback, useRef } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { useCallback, useEffect, useState } from "react";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 /** Snake-case ClaimKind discriminator on the wire (matches coord). */
 type ClaimKind =
@@ -32,7 +38,23 @@ type ClaimKind =
   | "worktree"
   | "branch_name"
   | "alembic_revision"
-  | "ci_wait";
+  | "ci_wait"
+  | "session"
+  | "repo_branch";
+
+/**
+ * Metadata about the *other* session holding the contested claim.
+ * Phase 6 enrichment — see plan §Phase 6:
+ * "EVENT_CLAIM_CONFLICT / EVENT_CLAIM_STOLEN payloads gain reason,
+ *  session_metadata".
+ */
+interface SessionMetadata {
+  session_id?: string;
+  kind?: string;
+  purpose?: string;
+  repo?: string;
+  branch?: string;
+}
 
 /** Payload of the runner's `agent-claim-conflict` Tauri event. */
 interface ConflictEvent {
@@ -40,473 +62,163 @@ interface ConflictEvent {
   resourceKey: string;
   currentHolder: string;
   intent?: string | null;
-}
-
-/** Coord's `AcquireResult` discriminator — `result` field. */
-type AcquireResult =
-  | { result: "claimed"; ttl_seconds: number }
-  | { result: "renewed"; ttl_seconds: number }
-  | { result: "held"; current_holder: string }
-  | { result: "topic_conflict" }
-  | { result: "topic_unknown" }
-  | { result: "invalid_topic" };
-
-/** Coord's `ClaimHolder` shape (GET /coord/claims/by-resource). */
-interface ClaimHolder {
-  kind: string;
-  resource_key: string;
-  machine_id: string;
-  ttl_seconds: number;
-}
-
-/** Per-instance retry source — used by the retry/steal paths to call
- *  the Tauri `claims_acquire` wrapper with the same args the original
- *  spawn used. The event payload doesn't carry the requesting machine
- *  id; we ask the runner's `get_machine_id` endpoint to fetch it on
- *  demand.
- */
-async function retryAcquire(
-  conflict: ConflictEvent,
-): Promise<AcquireResult> {
-  const machineId = await getMachineId();
-  return invoke<AcquireResult>("claims_acquire", {
-    args: {
-      kind: conflict.kind,
-      resourceKey: conflict.resourceKey,
-      machineId,
-      metadata: { intent: conflict.intent ?? null },
-    },
-  });
-}
-
-async function getMachineId(): Promise<string> {
-  // The runner exposes its machine_id via the device-info command —
-  // see `commands::auth::get_device_info`. The conflict event carries
-  // `currentHolder` (the OTHER machine's id), not ours, so we fetch
-  // ours separately.
-  const info = await invoke<{ machineId?: string }>("get_device_info").catch(
-    () => ({}) as { machineId?: string },
-  );
-  if (info?.machineId) return info.machineId;
-  // Fallback — without a machine_id the steal/wait paths can't proceed;
-  // the modal surfaces an error inline.
-  throw new Error("machine_id not available from get_device_info");
-}
-
-/** Poll `GET /coord/claims/by-resource` until the claim is no longer
- *  held, OR until the AbortController fires.
- *
- *  Returns when:
- *  - The claim is no longer held (resolves with `null`).
- *  - The caller aborts (rejects with `DOMException(AbortError)`).
- *
- *  Polling cadence: 30s, per plan.
- */
-async function waitForClaimCleared(
-  kind: string,
-  resourceKey: string,
-  signal: AbortSignal,
-): Promise<ClaimHolder | null> {
-  while (!signal.aborted) {
-    const url = new URL("/coord/claims/by-resource", coordHttpBase());
-    url.searchParams.set("kind", kind);
-    url.searchParams.set("key", resourceKey);
-    try {
-      const resp = await fetch(url.toString(), { signal });
-      if (resp.ok) {
-        const body = (await resp.json()) as ClaimHolder | null;
-        if (body == null) return null;
-      }
-    } catch (e) {
-      if (signal.aborted) throw e;
-      // transient — keep polling
-    }
-    await sleep(30_000, signal);
-  }
-  throw new DOMException("aborted", "AbortError");
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const t = setTimeout(resolve, ms);
-    if (signal) {
-      const onAbort = () => {
-        clearTimeout(t);
-        reject(new DOMException("aborted", "AbortError"));
-      };
-      if (signal.aborted) {
-        onAbort();
-      } else {
-        signal.addEventListener("abort", onAbort, { once: true });
-      }
-    }
-  });
+  /** Phase 6: optional reason text from the other side. */
+  reason?: string | null;
+  /** Phase 6: metadata about the holder's session. */
+  sessionMetadata?: SessionMetadata | null;
 }
 
 /**
- * Resolve coord's HTTP base URL by asking the runner via a dedicated
- * Tauri command if available; falls back to `http://localhost:9870` for
- * the dev profile.
+ * Dashboard URL used to open the full conflict-resolution surface.
  *
- * For Phase 3 we use the fallback directly — by-resource polling is a
- * read-only GET that's fine to call against the dev default; a future
- * enhancement adds a `get_coord_http_base` Tauri command if the production
- * deployment needs it.
+ * Pinned to the staging dashboard for now. When the runner gets a
+ * setting for dashboard-base-URL (Phase 7+ tenant/SSO work) the const
+ * will become a setting read.
  */
-function coordHttpBase(): string {
-  return "http://localhost:9870";
+const DASHBOARD_BASE_URL = "https://demo.staging.qontinui.io";
+
+function dashboardUrlFor(conflict: ConflictEvent): string {
+  // If we know the session id, open the session-detail panel directly;
+  // otherwise drop to the list and let the operator find it.
+  const sessionId = conflict.sessionMetadata?.session_id;
+  if (sessionId) {
+    return `${DASHBOARD_BASE_URL}/sessions/${encodeURIComponent(sessionId)}`;
+  }
+  return `${DASHBOARD_BASE_URL}/sessions`;
 }
 
 export function ConflictModal() {
   const [conflict, setConflict] = useState<ConflictEvent | null>(null);
-  const [waitingState, setWaitingState] = useState<"idle" | "waiting" | "retrying">("idle");
-  const [stealOpen, setStealOpen] = useState(false);
-  const [stealReason, setStealReason] = useState("");
-  const [stealBusy, setStealBusy] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const waitAbortRef = useRef<AbortController | null>(null);
+  const [opening, setOpening] = useState(false);
+  const [openError, setOpenError] = useState<string | null>(null);
 
   useEffect(() => {
     let unlisten: UnlistenFn | undefined;
     (async () => {
       try {
-        unlisten = await listen<ConflictEvent>("agent-claim-conflict", (event) => {
-          setConflict(event.payload);
-          setWaitingState("idle");
-          setStealOpen(false);
-          setStealReason("");
-          setErrorMessage(null);
-        });
+        unlisten = await listen<ConflictEvent>(
+          "agent-claim-conflict",
+          (event) => {
+            setConflict(event.payload);
+            setOpenError(null);
+            setOpening(false);
+          }
+        );
       } catch (e) {
-        // listen() failure is unrecoverable for this surface; logging
-        // is the best we can do.
-        console.error("ConflictModal: listen failed", e);
+        console.error("ConflictModal toast: listen failed", e);
       }
     })();
     return () => {
       if (unlisten) unlisten();
-      waitAbortRef.current?.abort();
     };
   }, []);
 
-  const closeModal = useCallback(() => {
-    waitAbortRef.current?.abort();
+  const onDismiss = useCallback(() => {
     setConflict(null);
-    setWaitingState("idle");
-    setStealOpen(false);
-    setStealReason("");
-    setErrorMessage(null);
+    setOpenError(null);
+    setOpening(false);
   }, []);
 
-  const handleWait = useCallback(async () => {
+  const onOpenDashboard = useCallback(async () => {
     if (!conflict) return;
-    setErrorMessage(null);
-    waitAbortRef.current?.abort();
-    const ac = new AbortController();
-    waitAbortRef.current = ac;
-    setWaitingState("waiting");
+    setOpening(true);
+    setOpenError(null);
     try {
-      await waitForClaimCleared(conflict.kind, conflict.resourceKey, ac.signal);
-      setWaitingState("retrying");
-      const result = await retryAcquire(conflict);
-      if (result.result === "claimed" || result.result === "renewed") {
-        closeModal();
-      } else if (result.result === "held") {
-        // Race — someone else grabbed it between poll-clear and retry.
-        // Restart the wait loop.
-        setConflict({
-          ...conflict,
-          currentHolder: result.current_holder,
-        });
-        setWaitingState("idle");
-      } else {
-        setErrorMessage(`unexpected acquire result: ${result.result}`);
-        setWaitingState("idle");
-      }
+      await openUrl(dashboardUrlFor(conflict));
+      // Auto-dismiss once we hand off to the dashboard.
+      setConflict(null);
     } catch (e) {
-      if (e instanceof DOMException && e.name === "AbortError") {
-        // Caller cancelled — already in `idle` after closeModal.
-        return;
-      }
-      setErrorMessage(String(e));
-      setWaitingState("idle");
+      setOpenError(e instanceof Error ? e.message : String(e));
     } finally {
-      waitAbortRef.current = null;
+      setOpening(false);
     }
-  }, [conflict, closeModal]);
-
-  const handleStealConfirm = useCallback(async () => {
-    if (!conflict) return;
-    setStealBusy(true);
-    setErrorMessage(null);
-    try {
-      const machineId = await getMachineId();
-      const stealResult = await invoke<{ result: string; displaced_machine_id?: string | null }>(
-        "claims_steal",
-        {
-          args: {
-            kind: conflict.kind,
-            resourceKey: conflict.resourceKey,
-            machineId,
-            reason: stealReason.trim() || "user-initiated steal from runner UI",
-          },
-        },
-      );
-      if (stealResult.result !== "stolen" && stealResult.result !== "not_held" && stealResult.result !== "no_originator") {
-        setErrorMessage(`unexpected steal result: ${stealResult.result}`);
-        setStealBusy(false);
-        return;
-      }
-      // Steal succeeded — retry the acquire so the user's session can proceed.
-      const retry = await retryAcquire(conflict);
-      if (retry.result === "claimed" || retry.result === "renewed") {
-        closeModal();
-      } else if (retry.result === "held") {
-        // Another agent grabbed it in the race window — surface fresh holder.
-        setConflict({ ...conflict, currentHolder: retry.current_holder });
-        setStealOpen(false);
-        setStealReason("");
-      } else {
-        setErrorMessage(`acquire after steal returned: ${retry.result}`);
-      }
-    } catch (e) {
-      setErrorMessage(String(e));
-    } finally {
-      setStealBusy(false);
-    }
-  }, [conflict, stealReason, closeModal]);
+  }, [conflict]);
 
   if (!conflict) return null;
 
+  const holderHost = conflict.currentHolder
+    ? conflict.currentHolder.slice(0, 8)
+    : "unknown";
+  const purpose = conflict.sessionMetadata?.purpose ?? conflict.intent ?? null;
+
   return (
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="claim-conflict-title"
-      style={modalBackdropStyle}
+      role="alert"
+      aria-live="polite"
+      className="fixed bottom-4 right-4 z-toast w-[min(28rem,90vw)] rounded-lg border border-orange-500/50 bg-card p-4 shadow-lg"
+      data-ui-bridge-id="conflict-toast"
+      data-claim-kind={conflict.kind}
+      data-resource-key={conflict.resourceKey}
     >
-      <div style={modalCardStyle}>
-        <h2 id="claim-conflict-title" style={titleStyle}>
-          Claim conflict
-        </h2>
-        <p style={messageStyle}>
-          Another agent (machine{" "}
-          <code style={codeStyle}>
-            {conflict.currentHolder ? conflict.currentHolder.slice(0, 8) : "unknown"}
-          </code>
-          ) is already working on{" "}
-          <code style={codeStyle}>
-            {conflict.kind}:{conflict.resourceKey}
-          </code>
-          .
-        </p>
-        {conflict.intent && (
-          <p style={intentStyle}>
-            <strong>Intent:</strong> {conflict.intent}
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0 space-y-2">
+          <h4 className="font-semibold text-sm text-orange-500 dark:text-orange-400">
+            Claim conflict
+          </h4>
+          <p className="text-sm text-muted-foreground">
+            Machine{" "}
+            <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded">
+              {holderHost}
+            </code>{" "}
+            holds{" "}
+            <code className="font-mono text-xs bg-muted px-1.5 py-0.5 rounded break-all">
+              {conflict.kind}:{conflict.resourceKey}
+            </code>
+            .
           </p>
-        )}
-
-        {errorMessage && <p style={errorStyle}>{errorMessage}</p>}
-
-        {!stealOpen && (
-          <div style={buttonRowStyle}>
-            <button
-              type="button"
-              onClick={closeModal}
-              disabled={waitingState !== "idle"}
-              style={btnSecondary}
+          {purpose && (
+            <p
+              className="text-xs italic text-muted-foreground"
+              data-ui-bridge-id="conflict-toast.purpose"
             >
-              Abort
-            </button>
-            {waitingState === "idle" && (
-              <button type="button" onClick={handleWait} style={btnSecondary}>
-                Wait
-              </button>
-            )}
-            {waitingState === "waiting" && (
-              <button
-                type="button"
-                onClick={() => {
-                  waitAbortRef.current?.abort();
-                  setWaitingState("idle");
-                }}
-                style={btnSecondary}
-              >
-                Cancel wait
-              </button>
-            )}
-            {waitingState === "retrying" && (
-              <button type="button" disabled style={btnSecondary}>
-                Retrying...
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={() => setStealOpen(true)}
-              disabled={waitingState !== "idle"}
-              style={btnDanger}
-            >
-              Steal
-            </button>
-          </div>
-        )}
-
-        {stealOpen && (
-          <div style={{ marginTop: 16 }}>
-            <p style={messageStyle}>
-              <strong>Confirm steal.</strong> This will revoke the other
-              agent&apos;s claim. The other agent&apos;s next heartbeat will
-              return <code style={codeStyle}>Stolen</code> and its session
-              will be notified.
+              “{purpose}”
             </p>
-            <label style={{ display: "block", marginTop: 8 }}>
-              <span style={labelStyle}>Reason (free text)</span>
-              <textarea
-                value={stealReason}
-                onChange={(e) => setStealReason(e.target.value)}
-                placeholder="why are you stealing this claim?"
-                rows={3}
-                style={textareaStyle}
-              />
-            </label>
-            <div style={buttonRowStyle}>
-              <button
-                type="button"
-                onClick={() => {
-                  setStealOpen(false);
-                  setStealReason("");
-                }}
-                disabled={stealBusy}
-                style={btnSecondary}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleStealConfirm}
-                disabled={stealBusy}
-                style={btnDanger}
-              >
-                {stealBusy ? "Stealing..." : "Confirm steal"}
-              </button>
-            </div>
+          )}
+          {conflict.reason && (
+            <p
+              className="text-xs text-muted-foreground border-l-2 border-orange-500/40 pl-2"
+              data-ui-bridge-id="conflict-toast.reason"
+            >
+              Reason: {conflict.reason}
+            </p>
+          )}
+          {openError && (
+            <p
+              className="text-xs text-red-500"
+              data-ui-bridge-id="conflict-toast.error"
+            >
+              Could not open dashboard: {openError}
+            </p>
+          )}
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onOpenDashboard}
+              disabled={opening}
+              className="text-xs font-medium rounded-md px-2.5 py-1.5 bg-orange-500 text-white hover:bg-orange-600 disabled:opacity-50"
+              data-ui-bridge-id="conflict-toast.resolve"
+            >
+              {opening ? "Opening…" : "Resolve in dashboard"}
+            </button>
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="text-xs rounded-md px-2.5 py-1.5 text-muted-foreground hover:text-foreground"
+              data-ui-bridge-id="conflict-toast.dismiss"
+            >
+              Dismiss
+            </button>
           </div>
-        )}
+        </div>
+        <button
+          onClick={onDismiss}
+          aria-label="Dismiss conflict toast"
+          className="text-muted-foreground hover:text-foreground shrink-0"
+          data-ui-bridge-id="conflict-toast.close"
+        >
+          &times;
+        </button>
       </div>
     </div>
   );
 }
-
-// ─────────────────────────────────────────────────────────────────────────
-// Inline styles — match the existing BuildRefreshBanner / canary-alert
-// look-and-feel rather than depending on Tailwind's component class library.
-// ─────────────────────────────────────────────────────────────────────────
-
-const modalBackdropStyle: React.CSSProperties = {
-  position: "fixed",
-  inset: 0,
-  background: "rgba(0, 0, 0, 0.6)",
-  display: "flex",
-  alignItems: "center",
-  justifyContent: "center",
-  zIndex: 10000,
-};
-
-const modalCardStyle: React.CSSProperties = {
-  background: "var(--bg-tertiary, #242837)",
-  color: "var(--text-primary, #e4e4e7)",
-  border: "1px solid var(--accent, #6366f1)",
-  borderRadius: 12,
-  padding: 24,
-  maxWidth: 560,
-  width: "90%",
-  boxShadow: "0 12px 40px rgba(0, 0, 0, 0.5)",
-};
-
-const titleStyle: React.CSSProperties = {
-  margin: 0,
-  marginBottom: 12,
-  fontSize: "1.25rem",
-  color: "var(--text-primary, #e4e4e7)",
-};
-
-const messageStyle: React.CSSProperties = {
-  margin: 0,
-  marginBottom: 12,
-  fontSize: "0.9375rem",
-  color: "var(--text-secondary, #a1a1aa)",
-  lineHeight: 1.5,
-};
-
-const intentStyle: React.CSSProperties = {
-  ...messageStyle,
-  background: "rgba(99, 102, 241, 0.08)",
-  borderLeft: "3px solid var(--accent, #6366f1)",
-  padding: "8px 12px",
-  borderRadius: 4,
-};
-
-const codeStyle: React.CSSProperties = {
-  background: "rgba(255, 255, 255, 0.08)",
-  padding: "2px 6px",
-  borderRadius: 4,
-  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-  fontSize: "0.875rem",
-};
-
-const labelStyle: React.CSSProperties = {
-  display: "block",
-  fontSize: "0.8125rem",
-  marginBottom: 4,
-  color: "var(--text-secondary, #a1a1aa)",
-};
-
-const textareaStyle: React.CSSProperties = {
-  width: "100%",
-  fontFamily: "inherit",
-  fontSize: "0.875rem",
-  background: "var(--bg-secondary, #1a1d2a)",
-  color: "var(--text-primary, #e4e4e7)",
-  border: "1px solid var(--border, #3f3f46)",
-  borderRadius: 4,
-  padding: 8,
-  resize: "vertical",
-};
-
-const buttonRowStyle: React.CSSProperties = {
-  display: "flex",
-  justifyContent: "flex-end",
-  gap: 8,
-  marginTop: 16,
-};
-
-const btnSecondary: React.CSSProperties = {
-  background: "transparent",
-  color: "var(--text-primary, #e4e4e7)",
-  border: "1px solid var(--border, #3f3f46)",
-  borderRadius: 4,
-  padding: "6px 14px",
-  fontSize: "0.875rem",
-  cursor: "pointer",
-};
-
-const btnDanger: React.CSSProperties = {
-  background: "var(--destructive, #ef4444)",
-  color: "#fff",
-  border: "none",
-  borderRadius: 4,
-  padding: "6px 14px",
-  fontSize: "0.875rem",
-  fontWeight: 600,
-  cursor: "pointer",
-};
-
-const errorStyle: React.CSSProperties = {
-  margin: "8px 0",
-  padding: "8px 12px",
-  background: "rgba(239, 68, 68, 0.1)",
-  border: "1px solid rgba(239, 68, 68, 0.3)",
-  borderRadius: 4,
-  color: "var(--destructive, #ef4444)",
-  fontSize: "0.875rem",
-};


### PR DESCRIPTION
## Summary

Phase 6 of [coord-native-session-coordination](https://github.com/qontinui/qontinui-runner/blob/main/qontinui-dev-notes/plans/2026-05-22-coord-native-session-coordination.md), runner side.

Per plan §D9 ("Conflict UX is escalating, not modal"), the runner's in-place Wait/Steal/Retry modal is demoted to a notification toast. The full two-sided resolution UX (intent, started_at, file claims, three actions) lives on the dashboard so cross-machine context isn't duplicated in two places.

- **`src/components/ConflictModal.tsx`** — rewritten as a Tailwind toast pinned bottom-right (matches `AppToasts.tsx` look-and-feel). Listens to the unchanged `agent-claim-conflict` Tauri event. On "Resolve in dashboard" → opens `https://demo.staging.qontinui.io/sessions/<id>` via `@tauri-apps/plugin-opener::openUrl`. ~440 → ~200 LOC.
- **`src-tauri/src/agent_claims/mod.rs`** — event payloads gain `reason: Option<String>` + `session_metadata: Option<SessionMetadata>` fields. Added `emit_conflict_event_with_context` / `emit_stolen_event_with_context` variants for the session-initiated flow; the legacy zero-context wrappers remain for the heartbeat-TTL eviction code path.
- **`src/components/ConflictModal.test.ts`** — vitest-node tripwires pinning the event name, dashboard URL, UI-bridge id taxonomy, and Phase 6 payload-field names (same precedent as `AuthProvider.test.ts` — vitest runs `environment: "node"` so DOM testing isn't an option).

Dashboard side: [qontinui-web PR #222](https://github.com/qontinui/qontinui-web/pull/222) ships `ConflictRow` + `StealModal` + visibility-policy filtering.

## Test plan

- [x] `cargo check --bin qontinui-runner` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/components/ConflictModal.test.ts` — 4/4 pass
- [x] Full test suite — same 528/537 baseline as PR #240 base (no new regressions; 9 pre-existing failures are unrelated)
- [x] UI verification deferred to a temp runner spawn — supervisor port 9875 — once base PR #240 lands

## Stack

Base: `feat/runner-session-primitive` (PR #240). **Do not** merge until #240 lands.