### PR TITLE
feat(banner): MemoryFederationBanner for memory-federation:reconcile event

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -28,8 +28,8 @@ use tauri::Emitter;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use qontinui_runner_lib::observable_bridge::{ReconcileReport, SessionContext};
 use crate::settings::ClaudeCliSettings;
+use qontinui_runner_lib::observable_bridge::{ReconcileReport, SessionContext};
 
 /// Tauri event channel for reconcile-result broadcasts. The React
 /// frontend listens here to render the "Memory federation: N pushed,
@@ -301,8 +301,14 @@ mod tests {
 
     #[test]
     fn encodes_drive_letter_path() {
-        assert_eq!(encode_workspace_path("D:\\qontinui-root"), "D--qontinui-root");
-        assert_eq!(encode_workspace_path("D:/qontinui-root"), "D--qontinui-root");
+        assert_eq!(
+            encode_workspace_path("D:\\qontinui-root"),
+            "D--qontinui-root"
+        );
+        assert_eq!(
+            encode_workspace_path("D:/qontinui-root"),
+            "D--qontinui-root"
+        );
     }
 
     #[test]

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -425,14 +425,11 @@ fn run_claude_session_inline(
         // pull + start_watcher must run in async context. Inline runner
         // is invoked from a sync worker thread that itself runs inside
         // Tauri's tokio runtime — match the `demo_workflows.rs` idiom.
-        let pull_result = run_async_inline(async {
-            bridge.pull(&mut ctx).await
-        });
+        let pull_result = run_async_inline(async { bridge.pull(&mut ctx).await });
         match pull_result {
             Ok(()) => {
-                let watcher_result = run_async_inline(async {
-                    bridge.start_watcher(ctx.clone()).await
-                });
+                let watcher_result =
+                    run_async_inline(async { bridge.start_watcher(ctx.clone()).await });
                 if let Err(e) = watcher_result {
                     warn!(
                         "memory federation: start_watcher failed for session {} ({}); \
@@ -464,9 +461,7 @@ fn run_claude_session_inline(
                 federation_ctx_opt.as_ref(),
                 qontinui_runner_lib::observable_bridge::global().cloned(),
             ) {
-                run_async_inline(async {
-                    bridge.stop_watcher(ctx.session_id).await
-                });
+                run_async_inline(async { bridge.stop_watcher(ctx.session_id).await });
             }
             return Err(format!("Failed to spawn Claude CLI: {}", e));
         }

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -243,14 +243,12 @@ impl ClaudeSession {
             federation_ctx,
             qontinui_runner_lib::observable_bridge::global().cloned(),
         ) {
-            let pull_result = Self::block_on_async(async {
-                bridge.pull(&mut ctx).await
-            });
+            let pull_result = Self::block_on_async(async { bridge.pull(&mut ctx).await });
             match pull_result {
                 Ok(()) => {
-                    if let Err(e) = Self::block_on_async(async {
-                        bridge.start_watcher(ctx.clone()).await
-                    }) {
+                    if let Err(e) =
+                        Self::block_on_async(async { bridge.start_watcher(ctx.clone()).await })
+                    {
                         warn!(
                             "memory federation: start_watcher failed for session {} ({}); \
                              continuing without watcher — reconcile will still run",
@@ -282,9 +280,7 @@ impl ClaudeSession {
                     federation_ctx.as_ref(),
                     qontinui_runner_lib::observable_bridge::global().cloned(),
                 ) {
-                    Self::block_on_async(async {
-                        bridge.stop_watcher(ctx.session_id).await
-                    });
+                    Self::block_on_async(async { bridge.stop_watcher(ctx.session_id).await });
                 }
                 return Err(format!("Failed to spawn Claude CLI: {}", e));
             }
@@ -960,11 +956,7 @@ impl ClaudeSession {
                     bridge.stop_watcher(ctx.session_id).await;
                     bridge.reconcile(ctx).await
                 });
-                super::federation::emit_federation_report(
-                    &app_handle_for_waiter,
-                    ctx,
-                    report,
-                );
+                super::federation::emit_federation_report(&app_handle_for_waiter, ctx, report);
             }
 
             // Check if the exit was due to rate-limiting

--- a/src-tauri/src/observable_bridge/memory.rs
+++ b/src-tauri/src/observable_bridge/memory.rs
@@ -181,7 +181,10 @@ fn snapshot_dir(dir: &Path) -> Result<DirSnapshot> {
         let content = match std::fs::read(&path) {
             Ok(c) => c,
             Err(e) => {
-                warn!("observable_bridge::memory: read {} failed: {e}", path.display());
+                warn!(
+                    "observable_bridge::memory: read {} failed: {e}",
+                    path.display()
+                );
                 continue;
             }
         };
@@ -341,10 +344,7 @@ impl RunnerObservableBridge for MemoryBridge {
     async fn pull(&self, session_ctx: &mut SessionContext) -> Result<()> {
         if !session_ctx.memory_dir.exists() {
             std::fs::create_dir_all(&session_ctx.memory_dir).with_context(|| {
-                format!(
-                    "create memory_dir: {}",
-                    session_ctx.memory_dir.display()
-                )
+                format!("create memory_dir: {}", session_ctx.memory_dir.display())
             })?;
         }
 
@@ -459,11 +459,7 @@ impl RunnerObservableBridge for MemoryBridge {
         Ok(())
     }
 
-    async fn push(
-        &self,
-        change: ObservableChange,
-        session_ctx: &SessionContext,
-    ) -> Result<()> {
+    async fn push(&self, change: ObservableChange, session_ctx: &SessionContext) -> Result<()> {
         let token = match self.device_token() {
             Some(t) if !t.is_empty() => t,
             _ => {
@@ -538,8 +534,7 @@ impl RunnerObservableBridge for MemoryBridge {
         };
 
         let mut report = ReconcileReport::default();
-        let pre_names: HashSet<&str> =
-            post_pull.files.iter().map(|f| f.name.as_str()).collect();
+        let pre_names: HashSet<&str> = post_pull.files.iter().map(|f| f.name.as_str()).collect();
         let post_names: HashSet<&str> =
             post_session.files.iter().map(|f| f.name.as_str()).collect();
 

--- a/src-tauri/src/observable_bridge/mod.rs
+++ b/src-tauri/src/observable_bridge/mod.rs
@@ -119,11 +119,7 @@ pub trait RunnerObservableBridge: Send + Sync {
     async fn pull(&self, session_ctx: &mut SessionContext) -> Result<()>;
 
     /// During-session: invoked on a debounced local change event.
-    async fn push(
-        &self,
-        change: ObservableChange,
-        session_ctx: &SessionContext,
-    ) -> Result<()>;
+    async fn push(&self, change: ObservableChange, session_ctx: &SessionContext) -> Result<()>;
 
     /// Session-end: re-snapshot, diff against `post_pull_snapshot`,
     /// push anything the watcher missed, return aggregate counts.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,6 +51,7 @@ import { ToastContainer } from "./components/ToastContainer";
 import { BuildRefreshBanner } from "./components/BuildRefreshBanner";
 import { ConflictModal } from "./components/ConflictModal";
 import { StolenBanner } from "./components/StolenBanner";
+import { MemoryFederationBanner } from "./components/MemoryFederationBanner";
 import { WebIntegrationAuthBanner } from "./components/WebIntegrationAuthBanner";
 import { ApprovalDialog } from "./components/dag-workflow-editor";
 import StatusIndicator from "./components/StatusIndicator";
@@ -676,6 +677,7 @@ function AppContent() {
           */}
           <ConflictModal />
           <StolenBanner />
+          <MemoryFederationBanner />
         </div>
       </RenderLogWrapper>
     </ProfilerWrapper>

--- a/src/components/MemoryFederationBanner.tsx
+++ b/src/components/MemoryFederationBanner.tsx
@@ -1,0 +1,244 @@
+/**
+ * Non-modal banner that surfaces a `ReconcileReport` after each
+ * runner-spawned Claude session reaches session-end.
+ *
+ * Plan reference:
+ * `qontinui-dev-notes/plans/2026-05-22-memories-on-coord-cross-machine.md`
+ * Phase 5 — "Surface failures in the runner UI: a single-line banner
+ * 'Memory federation: N pushed, M pulled, K failed' with click-through
+ * to the failure log."
+ *
+ * Listens for the runner's `memory-federation:reconcile` Tauri event
+ * (emitted from `claude_session::federation::emit_federation_report`).
+ * Successes auto-dismiss after 6s so the banner doesn't accumulate
+ * across many short sessions. Reports with `report.failed > 0` are
+ * persistent and styled with a destructive border so the operator
+ * notices.
+ */
+
+import { useEffect, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+interface ReconcileReport {
+  pushed: number;
+  pulled: number;
+  unchanged: number;
+  failed: number;
+}
+
+interface ReconcileEvent {
+  session_id: string;
+  account: string;
+  report: ReconcileReport;
+}
+
+interface ActiveNotice extends ReconcileEvent {
+  id: number;
+  receivedAt: number;
+}
+
+const SUCCESS_TTL_MS = 6000;
+
+export function MemoryFederationBanner() {
+  const [notices, setNotices] = useState<ActiveNotice[]>([]);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let counter = 0;
+    (async () => {
+      try {
+        unlisten = await listen<ReconcileEvent>(
+          "memory-federation:reconcile",
+          (event) => {
+            counter += 1;
+            const notice: ActiveNotice = {
+              ...event.payload,
+              id: counter,
+              receivedAt: Date.now(),
+            };
+            setNotices((prev) => [...prev, notice]);
+          },
+        );
+      } catch (e) {
+        console.error("MemoryFederationBanner: listen failed", e);
+      }
+    })();
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (notices.length === 0) return;
+    const earliestSuccess = notices.find((n) => n.report.failed === 0);
+    if (!earliestSuccess) return;
+    const elapsed = Date.now() - earliestSuccess.receivedAt;
+    const remaining = Math.max(0, SUCCESS_TTL_MS - elapsed);
+    const timeout = window.setTimeout(() => {
+      setNotices((prev) => prev.filter((n) => n.id !== earliestSuccess.id));
+    }, remaining);
+    return () => window.clearTimeout(timeout);
+  }, [notices]);
+
+  const dismiss = (id: number) => {
+    setNotices((prev) => prev.filter((n) => n.id !== id));
+  };
+
+  if (notices.length === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label="Memory federation reconcile notifications"
+      style={containerStyle}
+    >
+      {notices.map((n) => {
+        const hasFailures = n.report.failed > 0;
+        return (
+          <div
+            key={n.id}
+            role="status"
+            aria-live="polite"
+            style={hasFailures ? bannerStyleFailure : bannerStyleSuccess}
+          >
+            <div style={{ flex: 1 }}>
+              <p
+                style={hasFailures ? titleStyleFailure : titleStyleSuccess}
+              >
+                Memory federation
+              </p>
+              <p style={messageStyle}>
+                <code style={codeStyle}>{n.account}</code>:{" "}
+                <strong>{n.report.pushed}</strong> pushed,{" "}
+                <strong>{n.report.pulled}</strong> pulled,{" "}
+                <strong>{n.report.unchanged}</strong> unchanged
+                {hasFailures ? (
+                  <>
+                    ,{" "}
+                    <strong style={failedNumberStyle}>
+                      {n.report.failed}
+                    </strong>{" "}
+                    failed
+                  </>
+                ) : null}
+                {" — session "}
+                <code style={codeStyle}>{n.session_id.slice(0, 8)}</code>
+              </p>
+            </div>
+            <div style={actionsColumnStyle}>
+              {hasFailures ? (
+                <a
+                  href="#/admin/memory-federation"
+                  style={linkStyle}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    window.location.hash = "#/admin/memory-federation";
+                  }}
+                >
+                  Open log
+                </a>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => dismiss(n.id)}
+                style={dismissBtn}
+                aria-label="Dismiss"
+              >
+                Dismiss
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  position: "fixed",
+  top: 16,
+  right: 16,
+  zIndex: 9997,
+  display: "flex",
+  flexDirection: "column",
+  gap: 8,
+  maxWidth: 480,
+};
+
+const bannerBase: React.CSSProperties = {
+  display: "flex",
+  alignItems: "flex-start",
+  gap: 12,
+  padding: "12px 14px",
+  background: "var(--bg-tertiary, #242837)",
+  color: "var(--text-primary, #e4e4e7)",
+  borderRadius: 8,
+  boxShadow: "0 4px 16px rgba(0, 0, 0, 0.35)",
+  fontSize: "0.875rem",
+};
+
+const bannerStyleSuccess: React.CSSProperties = {
+  ...bannerBase,
+  border: "1px solid var(--border, #3f3f46)",
+};
+
+const bannerStyleFailure: React.CSSProperties = {
+  ...bannerBase,
+  border: "1px solid var(--destructive, #ef4444)",
+};
+
+const titleStyleSuccess: React.CSSProperties = {
+  margin: 0,
+  marginBottom: 4,
+  fontWeight: 600,
+  color: "var(--text-primary, #e4e4e7)",
+};
+
+const titleStyleFailure: React.CSSProperties = {
+  margin: 0,
+  marginBottom: 4,
+  fontWeight: 600,
+  color: "var(--destructive, #ef4444)",
+};
+
+const messageStyle: React.CSSProperties = {
+  margin: 0,
+  color: "var(--text-secondary, #a1a1aa)",
+  fontSize: "0.8125rem",
+  lineHeight: 1.4,
+};
+
+const codeStyle: React.CSSProperties = {
+  background: "rgba(255, 255, 255, 0.08)",
+  padding: "1px 4px",
+  borderRadius: 3,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: "0.75rem",
+};
+
+const failedNumberStyle: React.CSSProperties = {
+  color: "var(--destructive, #ef4444)",
+};
+
+const actionsColumnStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 4,
+};
+
+const linkStyle: React.CSSProperties = {
+  color: "var(--accent, #6366f1)",
+  fontSize: "0.75rem",
+  textDecoration: "underline",
+  cursor: "pointer",
+};
+
+const dismissBtn: React.CSSProperties = {
+  background: "transparent",
+  color: "var(--text-secondary, #a1a1aa)",
+  border: "1px solid var(--border, #3f3f46)",
+  borderRadius: 4,
+  padding: "2px 8px",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+};


### PR DESCRIPTION
## Summary
- New React component \`src/components/MemoryFederationBanner.tsx\` subscribes to the runner's \`memory-federation:reconcile\` Tauri event (emitted by \`claude_session::federation::emit_federation_report\`).
- Renders a non-modal corner banner after every session-end reconcile: \`<account>: N pushed, M pulled, K unchanged\` plus a destructive-styled \`K failed\` tail when \`failed > 0\`.
- Success notices auto-dismiss after 6s; failure notices are persistent + dismissible + carry an "Open log" link to \`#/admin/memory-federation\` (placeholder route until the dashboard surface lands).
- Mounted in \`App.tsx\` adjacent to \`StolenBanner\` — the import + mount actually landed in \`352c7744\` (cargo-fmt-drift commit also touched App.tsx); this PR provides the missing component file that the import was pointing at.

## Why
Completes the Phase 5 follow-up surface from plan \`2026-05-22-memories-on-coord-cross-machine.md\`. The Phase 5 agent emitted the Tauri event but deferred the React subscriber; this lands it.

## Test plan
- [x] \`npx tsc --noEmit\` clean on qontinui-runner frontend
- [ ] End-to-end: spawn a Claude session in a temp runner with memory federation enabled, observe the banner on session-end. (Deferred — same supervisor build-pool wait that bit the parent plan.)

Depends-On: none — the wireup point already exists in \`352c7744\`.