### PR TITLE
fix(findings): drop the divergent insert_finding_pg writer

### DIFF
--- a/src-tauri/src/database/pg/spec_experimentation.rs
+++ b/src-tauri/src/database/pg/spec_experimentation.rs
@@ -1431,58 +1431,6 @@ impl PgDb {
     }
 
     // ========================================================================
-    // Finding insertion (for claude_session, phase_helpers, test_executor)
-    // ========================================================================
-
-    /// Insert a finding into task_run_findings (PG equivalent of finding_storage::insert_finding).
-    pub async fn insert_finding_pg(
-        &self,
-        id: &str,
-        task_run_id: &str,
-        session_num: i32,
-        title: &str,
-        description: &str,
-        category: &str,
-        severity: &str,
-        signature_hash: &str,
-        status: &str,
-        is_resolved: bool,
-        evidence: Option<&str>,
-        ai_model: Option<&str>,
-    ) -> Result<(), String> {
-        let conn = self.pool.get().await.map_err(|e| format!("PG pool: {e}"))?;
-        let now = chrono::Utc::now().to_rfc3339();
-
-        conn.execute(
-            r#"INSERT INTO task_run_findings (
-                id, task_run_id, session_num, title, description,
-                category, severity, signature_hash, status,
-                is_resolved, evidence, ai_model, created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-            ON CONFLICT (id) DO NOTHING"#,
-            &[
-                &id,
-                &task_run_id,
-                &session_num,
-                &title,
-                &description,
-                &category,
-                &severity,
-                &signature_hash,
-                &status,
-                &is_resolved,
-                &evidence as &(dyn tokio_postgres::types::ToSql + Sync),
-                &ai_model as &(dyn tokio_postgres::types::ToSql + Sync),
-                &now,
-            ],
-        )
-        .await
-        .map_err(|e| format!("Failed to insert finding: {e}"))?;
-
-        Ok(())
-    }
-
-    // ========================================================================
     // Causal events (PG equivalents for reflection/causal.rs)
     // ========================================================================
 

--- a/src-tauri/src/unified_workflow_executor/phase_helpers.rs
+++ b/src-tauri/src/unified_workflow_executor/phase_helpers.rs
@@ -1228,46 +1228,29 @@ pub(super) fn parse_findings_from_response(text: &str) -> Vec<ParsedFinding> {
 }
 
 /// Store parsed findings in the database for a given task run (PG).
+///
+/// Routes through the canonical writer `PgDb::insert_parsed_finding`, which
+/// handles signature-hash dedup and INSERTs the canonical column shape that
+/// `GET /findings/task/{id}` reads back. The canonical `task_run_findings`
+/// schema uses `detected_in_session` / `detected_at` (NOT `session_num` /
+/// `created_at`) and has no `is_resolved` / `evidence` / `ai_model` columns
+/// — the resolved state is encoded via the `status` column ('resolved' vs
+/// 'detected'), which `insert_parsed_finding` derives from
+/// `ParsedFinding::is_resolved` internally. See
+/// `database/pg/findings.rs::insert_parsed_finding` for the column mapping;
+/// do NOT add a second divergent writer.
 pub(super) async fn store_parsed_findings(
     pg_db: &std::sync::Arc<PgDb>,
     task_run_id: &str,
     findings: &[ParsedFinding],
 ) {
     for (idx, parsed) in findings.iter().enumerate() {
-        let session_num = (idx + 1) as i32;
-        let id = uuid::Uuid::new_v4().to_string();
-        let signature = format!(
-            "{}:{}:{}:{}",
-            task_run_id,
-            session_num,
-            parsed.category.as_str(),
-            parsed.title
-        );
-        use sha2::{Digest, Sha256};
-        let signature_hash = format!("{:x}", Sha256::digest(signature.as_bytes()));
-
+        let session_num = (idx + 1) as u32;
         match pg_db
-            .insert_finding_pg(
-                &id,
-                task_run_id,
-                session_num,
-                &parsed.title,
-                &parsed.description,
-                parsed.category.as_str(),
-                parsed.severity.as_str(),
-                &signature_hash,
-                if parsed.is_resolved {
-                    "resolved"
-                } else {
-                    "detected"
-                },
-                parsed.is_resolved,
-                None, // evidence not available in ParsedFinding
-                None,
-            )
+            .insert_parsed_finding(task_run_id, session_num, parsed)
             .await
         {
-            Ok(()) => {
+            Ok(_) => {
                 info!(
                     "Response mode: stored finding [{}:{}] '{}'",
                     parsed.category.as_str(),


### PR DESCRIPTION
## Summary

Cleans up the response-mode counterpart to PR #229. PR #229 (`1fd12335`) fixed the agentic-findings persistence path by routing through `PgDb::insert_parsed_finding` (the canonical writer). It deliberately left the response-mode emission path alone — that path was still routing through `insert_finding_pg` in `spec_experimentation.rs`, which INSERTs columns (`session_num`, `is_resolved`, `evidence`, `ai_model`, `created_at`) that do not exist in the canonical `task_run_findings` schema. Whenever the response-mode path fired, the INSERT panicked at runtime.

Canonical schema (per `qontinui-schemas/db/canonical/schema.pg.sql.generated`) uses `detected_in_session` / `detected_at`, encodes resolved state via the `status` column (`'resolved'` vs `'detected'`), and has no `evidence` / `ai_model` columns at all. `insert_parsed_finding` already handles signature-hash dedup and the full canonical column mapping that `GET /findings/task/{id}` reads back.

## Changes

- `src-tauri/src/unified_workflow_executor/phase_helpers.rs` — `store_parsed_findings` now calls `pg_db.insert_parsed_finding(task_run_id, session_num, parsed)`. The caller already holds a `&ParsedFinding`, so no `FindingOutput → ParsedFinding` adapter is needed (unlike #229's `persist_agentic_findings_to_table`). Added a doc-comment naming the canonical column shape and pointing the next maintainer at `insert_parsed_finding`.
- `src-tauri/src/database/pg/spec_experimentation.rs` — deleted `insert_finding_pg` entirely. Zero remaining callers verified via grep.

## Test plan

- [x] `cargo check --bin qontinui-runner --message-format=short` — clean.
- [x] `cargo clippy --bin qontinui-runner --no-deps -- -D warnings` — clean.
- [x] grep confirms zero remaining references to `insert_finding_pg`.
- [ ] Integration verification deferred to the next deliberate runner restart (per task rules).

Verified by applying the worktree changes to the live runner checkout (which has the correct sibling path-deps wired for `qontinui-types`) and running cargo check + clippy there; the worktree itself can't compile due to a sibling-only path-dep for `qontinui-types::memory`, which is independent of this change.