### PR TITLE
fix(claude_session): derive_account_name handles both path separators

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -286,7 +286,7 @@ fn derive_account_name(config_dir: &str) -> String {
     // Linux CI runners. Split on both separators ourselves to get the
     // last segment regardless of host OS.
     let basename = config_dir
-        .rsplit(|c| c == '/' || c == '\\')
+        .rsplit(['/', '\\'])
         .next()
         .unwrap_or(config_dir);
     let stripped = basename

--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -280,9 +280,14 @@ fn encode_workspace_path(working_dir: &str) -> String {
 /// `"default"`. The label is purely for telemetry — the bridge keys on
 /// `device_id` + `tenant_id`, not account name.
 fn derive_account_name(config_dir: &str) -> String {
-    let basename = std::path::Path::new(config_dir)
-        .file_name()
-        .and_then(|s| s.to_str())
+    // Cross-platform path parsing: `std::path::Path::new` on Linux treats
+    // `\` as part of the filename, so a Windows-style path like
+    // `"C:\\claude\\.claude-hotmail"` resolves to one big basename on
+    // Linux CI runners. Split on both separators ourselves to get the
+    // last segment regardless of host OS.
+    let basename = config_dir
+        .rsplit(|c| c == '/' || c == '\\')
+        .next()
         .unwrap_or(config_dir);
     let stripped = basename
         .trim_start_matches('.')

--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -285,10 +285,7 @@ fn derive_account_name(config_dir: &str) -> String {
     // `"C:\\claude\\.claude-hotmail"` resolves to one big basename on
     // Linux CI runners. Split on both separators ourselves to get the
     // last segment regardless of host OS.
-    let basename = config_dir
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(config_dir);
+    let basename = config_dir.rsplit(['/', '\\']).next().unwrap_or(config_dir);
     let stripped = basename
         .trim_start_matches('.')
         .strip_prefix("claude-")


### PR DESCRIPTION
Unblocks main test matrix on `test (ubuntu-22.04)` + `test (windows-latest)`. Cross-platform bug introduced by [PR #244](https://github.com/qontinui/qontinui-runner/pull/244): `std::path::Path::new(\"C:\\claude\\.claude-hotmail\").file_name()` on Linux treats backslashes as part of the filename, so `derive_account_name` returns `\"default\"` instead of `\"hotmail\"`.

Switched to manual rsplit on `'/'` OR `'\\'` — works on either host.

## Verification
- `cargo test claude_session::federation::tests::derives` passes locally on Windows.
- Unblocks PR #240/#242/#243/#245 (coord-native sessions stack) which inherit the failure.