### PR TITLE
feat(vision): decouple /ui-bridge/vision/* frame source from the runner desktop

### DIFF
--- a/src-tauri/src/mcp/adb_helper.rs
+++ b/src-tauri/src/mcp/adb_helper.rs
@@ -35,6 +35,44 @@ fn default_server_addr() -> SocketAddrV4 {
     "127.0.0.1:5037".parse().expect("static addr parses")
 }
 
+/// Best-effort classifier for an adb serial / transport id.
+///
+/// Used by the vision frame-source resolver to decide whether an opaque
+/// `target` string should be routed to `adb` (device framebuffer) when it
+/// isn't a registered physical device or app. Conservative on purpose — a
+/// false positive routes a non-adb id to adb and surfaces a clean "device
+/// not found" error, never a panic.
+///
+/// Matches the three shapes `adb devices` actually emits:
+///   - emulator transport ids: `emulator-5554` (`emulator-<digits>`)
+///   - networked devices: `host:port`, e.g. `192.168.1.20:5555` (contains `:`)
+///   - USB hardware serials: non-empty run of `[A-Za-z0-9._-]` (e.g.
+///     `R3CN30XXXXX`, `0123456789ABCDEF`). Rejects strings with spaces,
+///     slashes, or other punctuation that an app-id / arbitrary label might
+///     carry.
+pub fn is_adb_serial(s: &str) -> bool {
+    let s = s.trim();
+    if s.is_empty() {
+        return false;
+    }
+    // emulator-<digits>
+    if let Some(rest) = s.strip_prefix("emulator-") {
+        return !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit());
+    }
+    // host:port (networked adb). Require a port-ish suffix after the last ':'.
+    if let Some((host, port)) = s.rsplit_once(':') {
+        let host_ok = !host.is_empty()
+            && host
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_'));
+        let port_ok = !port.is_empty() && port.chars().all(|c| c.is_ascii_digit());
+        return host_ok && port_ok;
+    }
+    // USB hardware serial: alphanumeric with the limited punctuation adb allows.
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
 // ----------------------------------------------------------------------------
 // Operations
 // ----------------------------------------------------------------------------
@@ -249,4 +287,34 @@ pub async fn forward_remove_all() -> Result<(), String> {
 #[allow(dead_code)]
 fn _keep_cursor_in_scope() -> Cursor<Vec<u8>> {
     Cursor::new(Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_adb_serial;
+
+    #[test]
+    fn classifies_adb_serials() {
+        // emulator transport ids
+        assert!(is_adb_serial("emulator-5554"));
+        assert!(is_adb_serial("emulator-0"));
+        // networked devices (host:port)
+        assert!(is_adb_serial("192.168.1.20:5555"));
+        assert!(is_adb_serial("phone.local:5555"));
+        // USB hardware serials
+        assert!(is_adb_serial("R3CN30ABCDEF"));
+        assert!(is_adb_serial("0123456789ABCDEF"));
+        assert!(is_adb_serial("HT4-A1B2"));
+
+        // Non-serials
+        assert!(!is_adb_serial(""));
+        assert!(!is_adb_serial("   "));
+        assert!(!is_adb_serial("emulator-"));
+        assert!(!is_adb_serial("emulator-abc"));
+        assert!(!is_adb_serial("192.168.1.20:")); // empty port
+        assert!(!is_adb_serial(":5555")); // empty host
+        assert!(!is_adb_serial("host:notaport"));
+        assert!(!is_adb_serial("my app id")); // space
+        assert!(!is_adb_serial("https://example.com/app")); // slash + scheme
+    }
 }

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -45,6 +45,7 @@ pub mod terminals;
 pub mod toasts;
 pub mod types;
 pub mod vision_ai;
+pub mod vision_frame_source;
 pub mod vision_routes;
 
 // Re-export all public symbols so every currently-used path like

--- a/src-tauri/src/mcp/ui_bridge/vision_frame_source.rs
+++ b/src-tauri/src/mcp/ui_bridge/vision_frame_source.rs
@@ -1,0 +1,281 @@
+//! Frame-source decoupling for the `/ui-bridge/vision/*` pipeline.
+//!
+//! Historically every vision handler captured the runner's *own* desktop
+//! window via [`capture_runner_window_frame`]. That made the vision skills
+//! unusable against a remote target (a paired phone, an HTTP-registered app):
+//! pointing them at a device id silently analyzed the runner desktop instead.
+//!
+//! This module introduces a [`FrameProvider`] abstraction so a handler can
+//! source its [`Frame`] from a *target* device/app instead. The resolution is
+//! driven by an optional `target` field on each request:
+//!
+//!   - `None`            → [`RunnerWindowSource`] — byte-identical to the
+//!     pre-existing behavior (delegates straight to
+//!     [`capture_runner_window_frame`]).
+//!   - registered phone  → [`DeviceScreenshotSource`] hitting the device's
+//!     proxy `…/ui-bridge/control/screenshot` endpoint.
+//!   - registered app    → [`DeviceScreenshotSource`] hitting the app's own
+//!     base url.
+//!   - adb serial         → [`AdbScreencapSource`] pulling the framebuffer.
+//!
+//! The runner ships no vision models; these sources only *acquire pixels*. The
+//! downstream pipeline (crop / encode / OCR / VLM) is untouched.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use chrono::Utc;
+use qontinui_vision_core::{Frame, FrameSource, FrameSourceKind};
+
+use crate::mcp::adb_helper;
+use crate::mcp::types::ApiState;
+
+use super::vision_routes::capture_runner_window_frame;
+
+/// Timeout for the remote `control/screenshot` fetch.
+const SCREENSHOT_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A source of a single [`Frame`] for the vision pipeline.
+///
+/// Implementors acquire pixels from somewhere (the runner desktop, a remote
+/// device's HTTP endpoint, an adb framebuffer) and wrap them in a `Frame` with
+/// an appropriate [`FrameSource`]. Errors are returned as `String` to match
+/// the existing capture-fn error contract in `vision_routes`.
+#[async_trait]
+pub trait FrameProvider: Send + Sync {
+    async fn frame(&self, state: &Arc<ApiState>) -> Result<Frame, String>;
+}
+
+/// Captures the runner's own desktop window. This is the legacy behavior and
+/// the resolution target for `target == None`; it delegates directly to the
+/// untouched [`capture_runner_window_frame`] so the no-target path is
+/// byte-identical to pre-decoupling.
+pub struct RunnerWindowSource;
+
+#[async_trait]
+impl FrameProvider for RunnerWindowSource {
+    async fn frame(&self, state: &Arc<ApiState>) -> Result<Frame, String> {
+        capture_runner_window_frame(state).await
+    }
+}
+
+/// Fetches a screenshot over HTTP from a target that speaks the UI Bridge
+/// `control/screenshot` contract (a paired phone via its proxy url, or an
+/// HTTP-registered app via its base url).
+///
+/// Response shape (tolerated both enveloped and flat):
+/// ```json
+/// { "success": true,
+///   "data": { "screenshot": "<base64 png>", "width": <logical>, "height": <logical> },
+///   "timestamp": ... }
+/// ```
+/// `width` is in *logical points*; the decoded PNG is *physical px*, so the
+/// HiDPI scale factor is `decoded.width() / reported_width`.
+pub struct DeviceScreenshotSource {
+    /// Base url, e.g. `http://127.0.0.1:8087`. Trailing slash tolerated.
+    pub base_url: String,
+}
+
+#[async_trait]
+impl FrameProvider for DeviceScreenshotSource {
+    async fn frame(&self, _state: &Arc<ApiState>) -> Result<Frame, String> {
+        let base = self.base_url.trim_end_matches('/');
+        let url = format!("{base}/ui-bridge/control/screenshot");
+
+        let client = reqwest::Client::builder()
+            .timeout(SCREENSHOT_HTTP_TIMEOUT)
+            .build()
+            .map_err(|e| format!("build screenshot client: {e}"))?;
+
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("device screenshot request to {url}: {e}"))?;
+        if !resp.status().is_success() {
+            return Err(format!(
+                "device screenshot {url} returned HTTP {}",
+                resp.status()
+            ));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("device screenshot {url} bad JSON: {e}"))?;
+
+        frame_from_screenshot_json(&body).map_err(|e| format!("device at {base}: {e}"))
+    }
+}
+
+/// Decode a `control/screenshot` JSON body into a [`Frame`]. Pure (no I/O) so
+/// the parsing + HiDPI-scale logic is unit-testable without a live device.
+///
+/// Tolerates both the enveloped shape (`{ data: { screenshot, width } }`) and a
+/// flat top-level object. `width` is *logical points*; the decoded PNG is
+/// *physical px*, so `scale_factor = decoded.width() / reported_width` (default
+/// 1.0 when width is absent/zero).
+fn frame_from_screenshot_json(body: &serde_json::Value) -> Result<Frame, String> {
+    // Prefer the `data` envelope; fall back to a flat top-level object.
+    let payload = body.get("data").unwrap_or(body);
+
+    let b64 = payload
+        .get("screenshot")
+        .and_then(|v| v.as_str())
+        .ok_or("returned no `screenshot` field — target has no screenshotProvider configured")?;
+
+    let png_bytes = BASE64
+        .decode(b64)
+        .map_err(|e| format!("screenshot base64 decode: {e}"))?;
+    let rgba = image::load_from_memory(&png_bytes)
+        .map_err(|e| format!("screenshot image decode: {e}"))?
+        .to_rgba8();
+
+    let reported_width = payload.get("width").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let scale_factor = if reported_width > 0.0 {
+        f64::from(rgba.width()) / reported_width
+    } else {
+        1.0
+    };
+
+    Ok(Frame::from_rgba(
+        rgba,
+        FrameSource {
+            kind: FrameSourceKind::Device,
+            scale_factor,
+            captured_at: Utc::now(),
+        },
+    ))
+}
+
+/// Pulls a device framebuffer directly over adb (`screenshot_png`). The
+/// framebuffer is already physical pixels, so `scale_factor` is `1.0`.
+pub struct AdbScreencapSource {
+    pub serial: String,
+}
+
+#[async_trait]
+impl FrameProvider for AdbScreencapSource {
+    async fn frame(&self, _state: &Arc<ApiState>) -> Result<Frame, String> {
+        let png_bytes = adb_helper::screenshot_png(self.serial.clone()).await?;
+        let rgba = image::load_from_memory(&png_bytes)
+            .map_err(|e| format!("adb framebuffer image decode: {e}"))?
+            .to_rgba8();
+        Ok(Frame::from_rgba(
+            rgba,
+            FrameSource {
+                kind: FrameSourceKind::Device,
+                scale_factor: 1.0,
+                captured_at: Utc::now(),
+            },
+        ))
+    }
+}
+
+/// Resolve a [`FrameProvider`] for an optional vision `target`.
+///
+/// `None` reproduces today's behavior exactly ([`RunnerWindowSource`]). When a
+/// target id is supplied it is matched, in priority order, against:
+///   1. a registered physical device (its active proxy url),
+///   2. a registered app (its base url),
+///   3. an adb serial / emulator transport id,
+/// and otherwise rejected with a clear error.
+pub async fn resolve_frame_provider(
+    state: &Arc<ApiState>,
+    target: &Option<String>,
+) -> Result<Box<dyn FrameProvider>, String> {
+    let id = match target {
+        None => return Ok(Box::new(RunnerWindowSource)),
+        Some(id) => id,
+    };
+
+    // 1. Registered physical device → proxy screenshot.
+    if let Some(base_url) = state
+        .physical_device_registry
+        .get_active_proxy_url(id)
+        .await
+    {
+        return Ok(Box::new(DeviceScreenshotSource { base_url }));
+    }
+
+    // 2. Registered app → its base url.
+    if let Some(entry) = state.app_registry.get(id).await {
+        return Ok(Box::new(DeviceScreenshotSource {
+            base_url: entry.app.url.clone(),
+        }));
+    }
+
+    // 3. adb serial / emulator transport id → framebuffer.
+    if id.starts_with("emulator-") || adb_helper::is_adb_serial(id) {
+        return Ok(Box::new(AdbScreencapSource { serial: id.clone() }));
+    }
+
+    Err(format!("unknown vision target '{id}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine as _;
+    use image::{ImageFormat, RgbaImage};
+    use std::io::Cursor;
+
+    /// Encode a solid `w×h` physical-px RGBA PNG as a base64 string.
+    fn png_b64(w: u32, h: u32) -> String {
+        let img = RgbaImage::from_pixel(w, h, image::Rgba([10, 20, 30, 255]));
+        let mut buf = Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(img)
+            .write_to(&mut buf, ImageFormat::Png)
+            .expect("encode png");
+        BASE64.encode(buf.into_inner())
+    }
+
+    #[test]
+    fn enveloped_response_computes_hidpi_scale() {
+        // 200×100 physical px, reported logical width 100 ⇒ scale 2.0 (Retina).
+        let body = serde_json::json!({
+            "success": true,
+            "data": { "screenshot": png_b64(200, 100), "width": 100, "height": 50 },
+            "timestamp": 0
+        });
+        let frame = frame_from_screenshot_json(&body).expect("decode");
+        assert_eq!((frame.width, frame.height), (200, 100));
+        assert_eq!(frame.source.kind, FrameSourceKind::Device);
+        assert!((frame.source.scale_factor - 2.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn flat_response_without_envelope_is_tolerated() {
+        // No `data` wrapper; width matches physical ⇒ scale 1.0.
+        let body = serde_json::json!({ "screenshot": png_b64(120, 80), "width": 120 });
+        let frame = frame_from_screenshot_json(&body).expect("decode");
+        assert_eq!((frame.width, frame.height), (120, 80));
+        assert!((frame.source.scale_factor - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn missing_width_defaults_scale_to_one() {
+        let body = serde_json::json!({ "data": { "screenshot": png_b64(64, 64) } });
+        let frame = frame_from_screenshot_json(&body).expect("decode");
+        assert!((frame.source.scale_factor - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn missing_screenshot_field_fails_loudly() {
+        // The whole point of the decoupling: a target with no screenshotProvider
+        // must error, never silently fall back to a runner-window capture.
+        let body = serde_json::json!({ "success": true, "data": { "width": 100 } });
+        let err = frame_from_screenshot_json(&body).expect_err("must error");
+        assert!(
+            err.contains("screenshotProvider"),
+            "error should name the missing provider, got: {err}"
+        );
+    }
+
+    #[test]
+    fn malformed_base64_is_an_error_not_a_panic() {
+        let body = serde_json::json!({ "data": { "screenshot": "not-base64!!!", "width": 10 } });
+        assert!(frame_from_screenshot_json(&body).is_err());
+    }
+}

--- a/src-tauri/src/mcp/ui_bridge/vision_routes.rs
+++ b/src-tauri/src/mcp/ui_bridge/vision_routes.rs
@@ -38,6 +38,7 @@ use tracing::{debug, info, warn};
 
 use super::screenshots::lookup_element_normalized_rect;
 use super::vision_ai::{self, OcrClient, VlmClient};
+use super::vision_frame_source::resolve_frame_provider;
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
 // ============================================================================
@@ -171,6 +172,12 @@ pub struct CaptureRequest {
     /// `{ captures: { name: CaptureResponse } }`.
     #[serde(default)]
     pub captures: Option<Vec<NamedCapture>>,
+    /// Optional frame source. `None` (default) captures the runner's own
+    /// desktop window (legacy behavior). A device/app id sources the frame
+    /// from that target instead — see [`super::vision_frame_source`].
+    /// Participates in the cache key via the request's `Debug` formatting.
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -200,6 +207,9 @@ impl From<&NamedCapture> for CaptureRequest {
             redact: n.redact.clone(),
             force: None,
             captures: None,
+            // Parent `target` is threaded through `do_multi_capture` separately,
+            // not via NamedCapture (which carries no per-capture target).
+            target: None,
         }
     }
 }
@@ -258,6 +268,9 @@ impl From<CaptureSpec> for CaptureRequest {
             redact: s.redact,
             force: None,
             captures: None,
+            // `CaptureSpec` carries no target; callers (diff, baseline) set it
+            // explicitly on the produced `CaptureRequest` when needed.
+            target: None,
         }
     }
 }
@@ -272,6 +285,10 @@ pub struct DiffRequest {
     /// the other modes — clustering / side-by-side composition is Phase 3.
     #[serde(default)]
     pub mode: Option<String>,
+    /// Optional frame source for *both* baseline and comparison captures.
+    /// `None` (default) = runner desktop. See [`super::vision_frame_source`].
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -305,6 +322,10 @@ pub struct ExtractRequest {
     /// Bypass the read-side cache.
     #[serde(default)]
     pub force: Option<bool>,
+    /// Optional frame source. `None` (default) = runner desktop. See
+    /// [`super::vision_frame_source`]. Participates in the cache key.
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -339,6 +360,10 @@ pub struct DescribeRequest {
     pub max_tokens: Option<u32>,
     #[serde(default)]
     pub force: Option<bool>,
+    /// Optional frame source. `None` (default) = runner desktop. See
+    /// [`super::vision_frame_source`]. Participates in the cache key.
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -367,6 +392,10 @@ pub struct RawRequest {
     pub element: Option<String>,
     /// Audit reason — required when the gate env is on.
     pub reason: Option<String>,
+    /// Optional frame source. `None` (default) = runner desktop. See
+    /// [`super::vision_frame_source`]. Participates in the cache key.
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -468,7 +497,7 @@ fn capture_runner_window_rgba(
 /// then-thrashes" pattern documented in `proj_supervisor_build_pool.md` —
 /// the bounded permit pool (size 2) prevents thrash under multi-agent load.
 /// Permit is held for the entire `spawn_blocking` span and released on drop.
-async fn capture_runner_window_frame(state: &Arc<ApiState>) -> Result<Frame, String> {
+pub(super) async fn capture_runner_window_frame(state: &Arc<ApiState>) -> Result<Frame, String> {
     use tauri::Manager;
 
     let window = state
@@ -710,7 +739,7 @@ async fn vision_capture_handler(
     let mut req = body.map(|b| b.0).unwrap_or_default();
     if let Some(captures) = req.captures.take() {
         let force = req.force.unwrap_or(false);
-        let captures_map = do_multi_capture(&state, captures, force).await?;
+        let captures_map = do_multi_capture(&state, captures, force, &req.target).await?;
         return Ok(Json(ApiResponse::success(VisionCaptureResp::Multi {
             captures: captures_map,
         })));
@@ -811,7 +840,11 @@ async fn do_capture(
         }
     }
 
-    let frame = capture_runner_window_frame(state)
+    let provider = resolve_frame_provider(state, &req.target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
 
@@ -892,6 +925,7 @@ async fn do_multi_capture(
     state: &Arc<ApiState>,
     captures: Vec<NamedCapture>,
     force: bool,
+    target: &Option<String>,
 ) -> Result<std::collections::HashMap<String, CaptureResponse>, (StatusCode, Json<ApiResponse<()>>)>
 {
     use std::collections::HashMap;
@@ -926,7 +960,11 @@ async fn do_multi_capture(
     let mut results: HashMap<String, CaptureResponse> = HashMap::new();
     let mut misses: Vec<Pending> = Vec::new();
     for cap in &captures {
-        let req = CaptureRequest::from(cap);
+        let mut req = CaptureRequest::from(cap);
+        // Propagate the parent request's frame source onto each derived
+        // capture so its cache key namespaces by target (NamedCapture has no
+        // per-capture target of its own).
+        req.target = target.clone();
         let contract = resolve_contract(req.contract.as_deref())
             .map_err(|e| (StatusCode::BAD_REQUEST, Json(api_error(e))))?;
         let format = pick_format(&contract).expect("contract has at least one format");
@@ -982,7 +1020,11 @@ async fn do_multi_capture(
 
     // Capture frame once (one xcap, one permit) and run each missed pipeline
     // against a clone of the same Frame.
-    let frame = capture_runner_window_frame(state)
+    let provider = resolve_frame_provider(state, target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
     let frame_w = frame.width;
@@ -1086,8 +1128,13 @@ async fn vision_diff_handler(
         ));
     }
 
-    let baseline_req: CaptureRequest = req.baseline.into();
-    let comparison_req: CaptureRequest = req.comparison.into();
+    let mut baseline_req: CaptureRequest = req.baseline.into();
+    let mut comparison_req: CaptureRequest = req.comparison.into();
+    // A single top-level `target` drives both captures. Threading it onto each
+    // derived request makes `produce_intermediate_frame` source from the target
+    // and namespaces the diff cache key (which Debug-formats both reqs).
+    baseline_req.target = req.target.clone();
+    comparison_req.target = req.target.clone();
 
     // We need both raw RGBA buffers to compute a meaningful diff before encoding.
     // Run each spec's crop + alpha-flatten + resize but skip the encoder, then
@@ -1206,7 +1253,11 @@ async fn produce_intermediate_frame(
     let contract = resolve_contract(req.contract.as_deref())
         .map_err(|e| (StatusCode::BAD_REQUEST, Json(api_error(e))))?;
 
-    let frame = capture_runner_window_frame(state)
+    let provider = resolve_frame_provider(state, &req.target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
 
@@ -1370,6 +1421,7 @@ async fn vision_raw_handler(
         region: None,
         element: None,
         reason: None,
+        target: None,
     });
     let reason = req.reason.clone().unwrap_or_default();
     if !matches!(reason.as_str(), "vga_grounding" | "regression_baseline") {
@@ -1388,7 +1440,11 @@ async fn vision_raw_handler(
         "vision/raw invoked (Phase 2: tracing audit; PG audit table is Phase 3)"
     );
 
-    let frame = capture_runner_window_frame(&state)
+    let provider = resolve_frame_provider(&state, &req.target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(&state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
 
@@ -1490,7 +1546,7 @@ async fn vision_extract_handler(
     }
 
     // Miss → capture + encode + call OCR.
-    let png_bytes = capture_and_encode_png(&state, &req.region, &req.element)
+    let png_bytes = capture_and_encode_png(&state, &req.region, &req.element, &req.target)
         .await
         .map_err(|(code, msg)| (code, Json(api_error(msg))))?;
     let (blocks, aggregate_text) = client
@@ -1575,7 +1631,7 @@ async fn vision_describe_handler(
         }
     }
 
-    let png_bytes = capture_and_encode_png(&state, &req.region, &req.element)
+    let png_bytes = capture_and_encode_png(&state, &req.region, &req.element, &req.target)
         .await
         .map_err(|(code, msg)| (code, Json(api_error(msg))))?;
     let vlm = client
@@ -1618,8 +1674,13 @@ async fn capture_and_encode_png(
     state: &Arc<ApiState>,
     region_req: &Option<RegionRequest>,
     element_id: &Option<String>,
+    target: &Option<String>,
 ) -> Result<Vec<u8>, (StatusCode, String)> {
-    let frame = capture_runner_window_frame(state)
+    let provider = resolve_frame_provider(state, target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    let frame = provider
+        .frame(state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
     let crop =
@@ -1790,6 +1851,11 @@ pub struct AnalyzeRequest {
     pub region: Option<RegionRequest>,
     #[serde(default)]
     pub element: Option<String>,
+    /// Optional vision target. `None` analyzes the runner's own desktop
+    /// window; a device/app id sources the frame from that target instead —
+    /// see [`super::vision_frame_source`].
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1819,6 +1885,11 @@ pub struct AssertRequest {
     /// snapshot text fall back to these.
     #[serde(default)]
     pub ocr_blocks: Option<Vec<vision_ai::OcrBlock>>,
+    /// Optional vision target. `None` asserts against the runner's own
+    /// desktop window; a device/app id sources the frame from that target
+    /// instead — see [`super::vision_frame_source`].
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1839,6 +1910,11 @@ pub struct BaselineRequest {
     /// the full window with the PNG-strict contract.
     #[serde(default)]
     pub capture: Option<CaptureSpec>,
+    /// Optional vision target. `None` baselines the runner's own desktop
+    /// window; a device/app id sources the frame from that target instead —
+    /// see [`super::vision_frame_source`].
+    #[serde(default)]
+    pub target: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1864,7 +1940,14 @@ async fn vision_analyze_handler(
     State(state): State<Arc<ApiState>>,
     Json(req): Json<AnalyzeRequest>,
 ) -> Result<Json<ApiResponse<AnalyzeResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
-    let frame = capture_runner_window_frame(&state)
+    // `target` selects the frame source: None = runner desktop (today's
+    // behavior); a device/app id sources from that target. visual-audit relies
+    // on this to analyze a paired device rather than the runner window.
+    let provider = resolve_frame_provider(&state, &req.target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(&state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
     let width = frame.width;
@@ -1899,7 +1982,14 @@ async fn vision_assert_handler(
     State(state): State<Arc<ApiState>>,
     Json(req): Json<AssertRequest>,
 ) -> Result<Json<ApiResponse<AssertResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
-    let frame = capture_runner_window_frame(&state)
+    // `target` selects the frame source: None = runner desktop (today's
+    // behavior); a device/app id sources from that target. visual-audit relies
+    // on this to assert against a paired device rather than the runner window.
+    let provider = resolve_frame_provider(&state, &req.target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(&state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
 
@@ -1970,7 +2060,14 @@ async fn vision_baseline_handler(
     State(state): State<Arc<ApiState>>,
     Json(req): Json<BaselineRequest>,
 ) -> Result<Json<ApiResponse<BaselineCreateResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
-    let frame = capture_runner_window_frame(&state)
+    // `target` selects the frame source: None = runner desktop (today's
+    // behavior); a device/app id sources from that target so a baseline can be
+    // captured from a paired device rather than the runner window.
+    let provider = resolve_frame_provider(&state, &req.target)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
+    let frame = provider
+        .frame(&state)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
 


### PR DESCRIPTION
## Problem
Every `/ui-bridge/vision/*` handler captured the runner's **own desktop window** via `capture_runner_window_frame()`. Aiming the vision skills at a phone or registered app silently analyzed the runner desktop — a decoy bug.

## Change
New `FrameProvider` abstraction (`mcp/ui_bridge/vision_frame_source.rs`):
- `RunnerWindowSource` — delegates to the existing capture; `target=None` is byte-identical to today.
- `DeviceScreenshotSource` — `GET <base>/ui-bridge/control/screenshot`, base64-decode PNG, derive HiDPI `scale_factor` from logical width.
- `AdbScreencapSource` — adb framebuffer for a bare serial / `emulator-NNNN`.
- `resolve_frame_provider()` routes an optional `target`: physical-device proxy → registered-app url → adb serial → error.

Wires an optional `target` field through every vision request struct (Capture/Extract/Describe/Diff/Raw **and** Analyze/Assert/Baseline — the latter three drive `/visual-audit`) and all 8 capture call sites incl. `capture_and_encode_png`. Request-Debug-hashed cache keys auto-namespace by target. Adds `adb_helper::is_adb_serial` + unit tests for the screenshot-JSON decode/scale logic and the serial classifier.

A target that resolves but serves no `screenshot` field **fails loudly** instead of silently falling back to the runner window.

## Verification
`cargo check` + `clippy -D warnings` clean; 6 new unit tests pass. `target=None` path unchanged (regression-safe).

**Depends-On:** qontinui-schemas `FrameSourceKind::Device` — merged to schemas `main` (#59). Runner CI clones schemas `main`, so this can now compile.

Part of plan `2026-05-23-vision-frame-source-decoupling`.