### PR TITLE
fix(federation): unbreak derives_account_name_from_hotmail_dir on linux

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -280,9 +280,16 @@ fn encode_workspace_path(working_dir: &str) -> String {
 /// `"default"`. The label is purely for telemetry — the bridge keys on
 /// `device_id` + `tenant_id`, not account name.
 fn derive_account_name(config_dir: &str) -> String {
-    let basename = std::path::Path::new(config_dir)
-        .file_name()
-        .and_then(|s| s.to_str())
+    // Take the last segment regardless of host OS path conventions:
+    // `effective_config_dir` may carry Windows-style backslashes even
+    // when this binary runs on Linux (e.g. cross-platform tests, paths
+    // round-tripped through JSON config), and std::path::Path::file_name
+    // only honors the host's separator. Normalize both `\` and `/`
+    // before splitting so "C:\claude\.claude-hotmail" reduces to
+    // ".claude-hotmail" on Linux just as it does on Windows.
+    let basename = config_dir
+        .rsplit(|c| c == '/' || c == '\\')
+        .find(|s| !s.is_empty())
         .unwrap_or(config_dir);
     let stripped = basename
         .trim_start_matches('.')
@@ -333,10 +340,15 @@ mod tests {
 
     #[test]
     fn derives_account_name_from_hotmail_dir() {
+        // Backslash form must work on every host OS — std::path::Path on
+        // Linux does NOT treat `\` as a separator, so this was previously
+        // returning "default" on ubuntu CI.
         assert_eq!(
             derive_account_name("C:\\claude\\.claude-hotmail"),
             "hotmail"
         );
+        // Forward-slash form (the shape on real Linux deployments).
+        assert_eq!(derive_account_name("/home/user/.claude-hotmail"), "hotmail");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix the cross-platform `derive_account_name` so backslash-separated config dirs (`C:\claude\.claude-hotmail`) yield `"hotmail"` on Linux too, not `"default"`.
- Unblocks ubuntu-22.04 CI, which has been red on this test for 5+ runs across PRs in unrelated parts of the codebase.

## Root cause

`derive_account_name` used `std::path::Path::file_name`, which only honors the **host OS's** path separator. On Linux, the `\` in `"C:\claude\.claude-hotmail"` is not a separator, so `file_name` returned the whole string, `trim_start_matches('.')` no-op'd (string starts with `C`), and `strip_prefix("claude-")` returned `None` — falling through to `"default"`.

Test was added in PR #244 with a Windows-shape literal that incidentally compiled but only passed on Windows.

## Fix

Split the basename ourselves on both `/` and `\`. `effective_config_dir` legitimately carries either separator shape depending on serialization round-trips, so normalizing in this helper is the right layer.

Also locks in the inverse case (Linux-style path) so regressions get caught on either host.

## Test plan

- [x] Reasoned through `str::rsplit` semantics for the four covered shapes (Windows backslash, Linux forward-slash, no suffix, trailing dash). All correct on every target.
- [x] `cargo fmt` clean.
- [ ] ubuntu-22.04 CI green on this branch (gates here).
- [ ] windows-latest CI still green.

Local `cargo test` on Windows in this worktree is blocked by an unrelated pre-existing `FrameSourceKind::Device` compile error in `mcp/ui_bridge/vision_frame_source.rs`; CI is the verification gate.

## Risk

Tiny and well-scoped. The helper is only used to derive a telemetry label (`account_name`) — the federation bridge keys on `device_id + tenant_id`, not account name. Worst case if the new splitter mis-derives, the label is wrong; nothing about pull/push/reconcile semantics depends on it.