### PR TITLE
feat(spec-check): wire real fingerprint + snapshot_sha256 into responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "hex",

--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -110,6 +110,79 @@ pub fn evaluate_with_validation(
     result
 }
 
+/// Evaluate using a caller-supplied fingerprint + snapshot identity.
+///
+/// HTTP / MCP adapters that go through [`crate::wrap_snapshot`] already mint
+/// the real `app_id`, `snapshot_id`, and `content_sha256`. Use this entrypoint
+/// to thread those values into the result struct instead of the in-process
+/// sentinels written by [`evaluate`].
+///
+/// `content_sha256` populates [`SpecCheckResult::snapshot_sha256`]. Pass
+/// `String::new()` to omit it; the field skips serialization when None.
+///
+/// In-process callers that legitimately want sentinels (the distinctness
+/// validator, internal scoring) should keep using [`evaluate`].
+pub fn evaluate_with_identity(
+    snapshot: &UIBridgeSnapshot,
+    spec: &IrPageSpec,
+    fingerprint: BridgeFingerprint,
+    snapshot_id: String,
+    content_sha256: String,
+) -> SpecCheckResult {
+    evaluate_with_identity_and_validation(
+        snapshot,
+        spec,
+        fingerprint,
+        snapshot_id,
+        content_sha256,
+        None,
+    )
+}
+
+/// Identity-bearing twin of [`evaluate_with_validation`].
+///
+/// Preserves the in-process compute's `element_count` on the returned
+/// fingerprint — both values are derived from the same snapshot and must
+/// agree. In debug builds, a mismatch between the caller's non-zero
+/// `element_count` and the indexed snapshot's emits a `tracing::warn!`
+/// rather than panicking — a telemetry disagreement should never crash a
+/// production evaluator.
+pub fn evaluate_with_identity_and_validation(
+    snapshot: &UIBridgeSnapshot,
+    spec: &IrPageSpec,
+    fingerprint: BridgeFingerprint,
+    snapshot_id: String,
+    content_sha256: String,
+    validation: Option<&SpecValidation>,
+) -> SpecCheckResult {
+    #[cfg(debug_assertions)]
+    {
+        let snap_count = snapshot.elements.len() as u32;
+        if fingerprint.element_count != 0 && fingerprint.element_count != snap_count {
+            tracing::warn!(
+                fingerprint_element_count = fingerprint.element_count,
+                snapshot_element_count = snap_count,
+                "evaluate_with_identity: caller fingerprint.element_count disagrees with snapshot.elements.len; keeping snapshot value"
+            );
+        }
+    }
+
+    let mut result = evaluate_with_validation(snapshot, spec, validation);
+    // Stitch the caller's identity into the result. Preserve the in-process
+    // `element_count` (it was computed from the same snapshot bytes, so both
+    // values are correct; the in-process compute is the cross-check).
+    let preserved_element_count = result.bridge_fingerprint.element_count;
+    result.bridge_fingerprint = BridgeFingerprint {
+        element_count: preserved_element_count,
+        ..fingerprint
+    };
+    result.snapshot_id = snapshot_id;
+    if !content_sha256.is_empty() {
+        result.snapshot_sha256 = Some(content_sha256);
+    }
+    result
+}
+
 /// Multi-spec evaluation against a single snapshot. Builds [`IndexedSnapshot`]
 /// once — shared read-only across all specs — then fan-outs across `specs`
 /// via rayon. Load-bearing for the §5.14 batch endpoint.
@@ -161,6 +234,10 @@ fn evaluate_with_indexed(
     SpecCheckResult {
         result_schema_version: RESULT_SCHEMA_VERSION,
         snapshot_id: SENTINEL_SNAPSHOT_ID.to_string(),
+        // In-process evaluator path: no raw snapshot bytes to hash. HTTP/MCP
+        // adapters that mint a real `snapshot_sha256` via wrap_snapshot
+        // override this via `evaluate_with_identity`.
+        snapshot_sha256: None,
         spec_content_hash,
         spec_version: spec.version.clone(),
         page_id: spec.id.clone(),

--- a/crates/spec-check/src/lib.rs
+++ b/crates/spec-check/src/lib.rs
@@ -19,7 +19,9 @@ pub mod snapshot;
 #[cfg(test)]
 pub mod proptest_strategies;
 
-pub use evaluator::{evaluate, evaluate_batch};
+pub use evaluator::{
+    evaluate, evaluate_batch, evaluate_with_identity, evaluate_with_identity_and_validation,
+};
 pub use fetch::{wrap_snapshot, SnapshotFetchError};
 pub use policy::apply_policy;
 pub use result_migration::deserialize_result_with_migration;

--- a/crates/spec-check/src/policy.rs
+++ b/crates/spec-check/src/policy.rs
@@ -477,6 +477,7 @@ mod tests {
         SpecCheckResult {
             result_schema_version: 1,
             snapshot_id: "scs_test".to_string(),
+            snapshot_sha256: None,
             spec_content_hash: "sha256-test".to_string(),
             spec_version: "1.0".to_string(),
             page_id: "page".to_string(),

--- a/crates/spec-check/src/result_migration.rs
+++ b/crates/spec-check/src/result_migration.rs
@@ -81,6 +81,7 @@ mod tests {
         SpecCheckResult {
             result_schema_version: version,
             snapshot_id: "scs_test".to_string(),
+            snapshot_sha256: None,
             spec_content_hash: "sha256-deadbeef".to_string(),
             spec_version: "1.0".to_string(),
             page_id: "settings-general".to_string(),

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -597,8 +597,11 @@ pub async fn post_spec_check(
         }
     };
 
-    // Fetch snapshot (fresh or supplied).
-    let (snapshot, _fingerprint, snapshot_id, _content_hash) = match req.snapshot {
+    // Fetch snapshot (fresh or supplied). All four fields are now load-bearing:
+    // the fingerprint + snapshot_id + content_sha256 are threaded into
+    // `spec_check::evaluate_with_identity` below so the response telemetry
+    // carries the real values instead of the evaluator's in-process sentinels.
+    let (snapshot, fingerprint, snapshot_id, content_sha256) = match req.snapshot {
         Some(raw) => {
             // Caller-supplied path: try-strict-then-adapt to accept both the
             // canonical UIBridgeSnapshot shape and the SDK control-mode shape
@@ -649,8 +652,20 @@ pub async fn post_spec_check(
     invoke_emit(&req.app_id, &snapshot_id, vec![req.page_id.clone()], "http");
     let started_ms = events::now_ms();
 
-    // Evaluate — pure crate call, no logic here.
-    let result = spec_check::evaluate(&snapshot, &ir);
+    // Evaluate — pure crate call, no logic here. `evaluate_with_identity`
+    // threads the caller's real fingerprint + snapshot_id + content_sha256 into
+    // the result struct, replacing the in-process sentinels. Both the
+    // fresh-fetch and supplied-snapshot branches above produce real identity
+    // values; the only path that legitimately wants sentinels is the
+    // in-process distinctness validator at `validator.rs`, which keeps using
+    // `spec_check::evaluate`.
+    let result = spec_check::evaluate_with_identity(
+        &snapshot,
+        &ir,
+        fingerprint,
+        snapshot_id.clone(),
+        content_sha256,
+    );
 
     info!(
         "spec_check page_id={} snapshot_id={} match_outcome={:?} match_rate={:.3}",
@@ -740,17 +755,38 @@ pub async fn post_spec_check_batch(
 
     // Resolve snapshot once. The batch handler Arc-shares the snapshot
     // itself and forwards `snapshot_id` as the response field/header.
-    let (snapshot, snapshot_id) = match req.snapshot.source.as_str() {
+    // Per-element results now also carry the shared fingerprint + content
+    // hash via `evaluate_with_identity` so each one's `bridgeFingerprint`
+    // / `snapshotSha256` / `snapshotId` reflect the real upstream values
+    // instead of evaluator sentinels.
+    let (snapshot, snapshot_id, fingerprint, content_sha256): (
+        Arc<UIBridgeSnapshot>,
+        String,
+        qontinui_types::spec_check::BridgeFingerprint,
+        String,
+    ) = match req.snapshot.source.as_str() {
         "fresh" => match fetch_fresh_snapshot(&state).await {
-            Ok((s, _fp, id, _hash)) => (Arc::new(s), id),
+            Ok((s, fp, id, hash)) => (Arc::new(s), id, fp, hash),
             Err(err) => return snapshot_error_to_response(err),
         },
         "supplied" => match req.snapshot.blob {
             Some(raw) => match adapt_supplied_snapshot(raw) {
-                Ok(s) => (
-                    Arc::new(s),
-                    format!("scs_supplied_{}", uuid::Uuid::now_v7()),
-                ),
+                Ok(s) => {
+                    let fp = qontinui_types::spec_check::BridgeFingerprint {
+                        app_id: req.app_id.clone(),
+                        app_version: None,
+                        route: None,
+                        bridge_version: None,
+                        snapshot_timestamp: String::new(),
+                        element_count: s.elements.len() as u32,
+                    };
+                    (
+                        Arc::new(s),
+                        format!("scs_supplied_{}", uuid::Uuid::now_v7()),
+                        fp,
+                        String::new(),
+                    )
+                }
                 Err(detail) => {
                     return (
                         StatusCode::UNPROCESSABLE_ENTITY,
@@ -834,6 +870,8 @@ pub async fn post_spec_check_batch(
             req.app_id.clone(),
             snapshot,
             snapshot_id,
+            fingerprint,
+            content_sha256,
             root,
             req.pages,
             req.shared_policy,
@@ -849,6 +887,10 @@ pub async fn post_spec_check_batch(
         let shared_policy = req.shared_policy.clone();
         let snapshot_id_owned = snapshot_id.clone();
         let app_id_owned = req.app_id.clone();
+        // Clone identity values for each spawned task. fingerprint is small
+        // (handful of strings); content_sha256 is a 71-byte string. Cheap.
+        let fingerprint_owned = fingerprint.clone();
+        let content_sha256_owned = content_sha256.clone();
         set.spawn(async move {
             evaluate_one(
                 &app_id_owned,
@@ -856,6 +898,8 @@ pub async fn post_spec_check_batch(
                 &entry,
                 &snapshot,
                 &snapshot_id_owned,
+                &fingerprint_owned,
+                &content_sha256_owned,
                 shared_policy.as_ref(),
             )
             .await
@@ -976,12 +1020,18 @@ impl BatchElementResult {
 
 /// Evaluate one batch entry. Identical to the single-shot handler except
 /// errors become per-element statuses, not HTTP responses (§5.14).
+///
+/// `fingerprint` + `content_sha256` are the batch's shared identity values
+/// — every entry's result carries them so per-element telemetry can be
+/// joined back to the upstream snapshot.
 async fn evaluate_one(
     app_id: &str,
     root: &std::path::Path,
     entry: &BatchPageEntry,
     snapshot: &Arc<UIBridgeSnapshot>,
     snapshot_id: &str,
+    fingerprint: &qontinui_types::spec_check::BridgeFingerprint,
+    content_sha256: &str,
     shared_policy: Option<&SpecCheckPolicy>,
 ) -> BatchElementResult {
     if invalid_page_id(&entry.page_id) {
@@ -994,9 +1044,16 @@ async fn evaluate_one(
         Err(e) => return BatchElementResult::spec_malformed(entry.page_id.clone(), e),
     };
 
-    // Pure crate call. `evaluate` is sync + rayon-internal; for v1 N ≤ 256
-    // we run it inline on the spawned task (see Risks §"contention").
-    let result = spec_check::evaluate(snapshot, &ir);
+    // Pure crate call. `evaluate_with_identity` carries the shared
+    // fingerprint + snapshot_id + content_sha256 onto each per-element
+    // result so the response telemetry doesn't fall back to sentinels.
+    let result = spec_check::evaluate_with_identity(
+        snapshot,
+        &ir,
+        fingerprint.clone(),
+        snapshot_id.to_string(),
+        content_sha256.to_string(),
+    );
 
     // Per-entry override wins over the shared policy.
     let policy = entry.policy_override.as_ref().or(shared_policy);
@@ -1026,6 +1083,8 @@ async fn stream_batch_results(
     app_id: String,
     snapshot: Arc<UIBridgeSnapshot>,
     snapshot_id: String,
+    fingerprint: qontinui_types::spec_check::BridgeFingerprint,
+    content_sha256: String,
     root: Arc<std::path::PathBuf>,
     pages: Vec<BatchPageEntry>,
     shared_policy: Option<SpecCheckPolicy>,
@@ -1063,6 +1122,8 @@ async fn stream_batch_results(
         let shared_policy = shared_policy.clone();
         let snap_id = snapshot_id_for_completion.clone();
         let app_id = app_id.clone();
+        let fingerprint = fingerprint.clone();
+        let content_sha256 = content_sha256.clone();
         async move {
             let entry = match st.iter.next() {
                 Some(e) => e,
@@ -1098,6 +1159,8 @@ async fn stream_batch_results(
                 &entry,
                 &snapshot,
                 &snap_id,
+                &fingerprint,
+                &content_sha256,
                 shared_policy.as_ref(),
             )
             .await;
@@ -1157,6 +1220,22 @@ mod tests {
             "elements": [],
             "components": []
         })
+    }
+
+    /// Test-only stand-in for the real upstream fingerprint that
+    /// `fetch_fresh_snapshot` / supplied-snapshot path would build. Per
+    /// `evaluate_with_identity`, the `element_count` in the supplied
+    /// fingerprint is replaced by the in-process compute, so leaving it
+    /// at 0 here is safe.
+    fn test_fingerprint() -> qontinui_types::spec_check::BridgeFingerprint {
+        qontinui_types::spec_check::BridgeFingerprint {
+            app_id: RUNNER_APP_ID.to_string(),
+            app_version: None,
+            route: None,
+            bridge_version: None,
+            snapshot_timestamp: String::new(),
+            element_count: 0,
+        }
     }
 
     #[test]
@@ -1250,7 +1329,17 @@ mod tests {
             page_id: "no-such-page".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(RUNNER_APP_ID, &root, &entry, &snapshot, "scs_test", None).await;
+        let r = evaluate_one(
+            RUNNER_APP_ID,
+            &root,
+            &entry,
+            &snapshot,
+            "scs_test",
+            &test_fingerprint(),
+            "",
+            None,
+        )
+        .await;
         assert_eq!(r.status, "spec-not-found");
         assert!(r.result.is_none());
         assert_eq!(r.page_id, "no-such-page");
@@ -1266,7 +1355,17 @@ mod tests {
             page_id: "../escape".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(RUNNER_APP_ID, &root, &entry, &snapshot, "scs_test", None).await;
+        let r = evaluate_one(
+            RUNNER_APP_ID,
+            &root,
+            &entry,
+            &snapshot,
+            "scs_test",
+            &test_fingerprint(),
+            "",
+            None,
+        )
+        .await;
         assert_eq!(r.status, "eval-error");
         assert_eq!(r.error.as_deref(), Some("invalid-page-id"));
     }
@@ -1323,7 +1422,17 @@ mod tests {
             page_id: "batch-page".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(RUNNER_APP_ID, root, &entry, &snapshot, "scs_test", None).await;
+        let r = evaluate_one(
+            RUNNER_APP_ID,
+            root,
+            &entry,
+            &snapshot,
+            "scs_test",
+            &test_fingerprint(),
+            "",
+            None,
+        )
+        .await;
         assert_eq!(r.status, "ok");
         let result = r.result.expect("ok status carries a result");
         assert_eq!(result.page_id, "batch-page");
@@ -1396,6 +1505,8 @@ mod tests {
             &entry,
             &snapshot,
             marker,
+            &test_fingerprint(),
+            "",
             Some(&policy),
         )
         .await;
@@ -1766,6 +1877,7 @@ mod tests {
         let mk = |outcome: MatchOutcome, rate: f32| SpecCheckResult {
             result_schema_version: 1,
             snapshot_id: String::new(),
+            snapshot_sha256: None,
             spec_content_hash: String::new(),
             spec_version: "1.0".into(),
             page_id: "p".into(),


### PR DESCRIPTION
**Status: DRAFT — depends on [qontinui-schemas#60](https://github.com/qontinui/qontinui-schemas/pull/60).** Cannot merge until schemas#60 lands.

## Summary

\`POST /spec-check\` responses (single + batch) now carry the real upstream identity instead of the evaluator's in-process sentinels:

| Field | Before | After |
|---|---|---|
| \`bridgeFingerprint.appId\` | \`"internal-evaluator"\` | real SDK \`app_id\` (e.g. \`"qontinui-web"\`) |
| \`snapshotId\` | \`"scs_internal_eval"\` | \`scs_<UUIDv7>\` minted by \`wrap_snapshot\` |
| \`snapshotSha256\` | (missing) | JCS canonical hash, \`"sha256-<hex>"\`, or null on supplied-snapshot path |

**Commits B + C** of the fingerprint-fidelity rollout (full plan: \`plans/2026-05-23-spec-check-fingerprint-fidelity.md\` in qontinui-root). Commit A landed via qontinui-schemas#60.

## What changed

**Crate (\`crates/spec-check/\`):**
- New pub fns \`evaluate_with_identity\` + \`evaluate_with_identity_and_validation\`. They wrap \`evaluate_with_validation\` and override the result's \`snapshot_id\`, \`bridge_fingerprint\`, and \`snapshot_sha256\` with caller-supplied values.
- \`element_count\` on the returned fingerprint is **preserved from the in-process compute** as a cross-check; debug builds emit \`tracing::warn!\` on caller-vs-compute mismatch (never panic — telemetry disagreement must not crash a production evaluator).
- \`snapshot_sha256: None\` added to the in-process struct literal. \`evaluate()\`, \`evaluate_with_validation()\`, \`evaluate_batch()\` retain sentinel-bearing semantics for in-process callers (distinctness validator, internal scoring).
- Re-exported the new entrypoints from \`lib.rs\`.

**Adapter (\`src-tauri/src/spec_api/spec_check.rs\`):**
- \`post_spec_check\` (single): un-mute the destructured \`fingerprint\` / \`content_hash\`, thread both into \`evaluate_with_identity\`. Fresh-fetch and supplied-snapshot branches both produce real identity values; supplied path's fingerprint binds to \`req.app_id\` (mirrors Stream D's per-app channel routing).
- \`evaluate_one\` (batch entry): new \`fingerprint: &BridgeFingerprint\` + \`content_sha256: &str\` parameters; per-element responses now carry the batch's shared identity. The \`stream_batch_results\` NDJSON variant threads the same values through the \`stream::unfold\` seed.
- \`validator.rs\` (distinctness validator): **unchanged.** Still uses \`spec_check::evaluate()\` — sentinel values are correct there per plan §3.3.

**Tests:** \`test_fingerprint()\` helper for the batch tests; existing \`evaluate_one\` test calls updated to pass it. The \`completion_counts_rolls_up\` test's hand-built \`SpecCheckResult\` literal gets \`snapshot_sha256: None\`. \`policy.rs\` and \`result_migration.rs\` test fixtures get the field too.

## Cross-repo coordination

- **Local clippy / cargo-prepush fails** because canonical \`qontinui-schemas\` doesn't yet have the \`snapshot_sha256\` field. Used \`QONTINUI_PREPUSH_SKIP=1\` to push (sanctioned by \`feedback_fresh_worktree_prepush_skip\` memory — CI re-gates properly).
- **CI on this PR will be red** for the same reason. Sequence: merge [schemas#60](https://github.com/qontinui/qontinui-schemas/pull/60) → mark this ready → CI goes green → merge.
- **Mirror workflow \`qontinui-types-drift.yml\`** will also turn red on runner main the moment schemas#60 lands. This PR is the only fix.

## Verification recipe (after both PRs land)

\`\`\`bash
# With a runner built off this branch + SDK connected to qontinui-web on /operations:
curl -X POST http://localhost:9876/spec-check \
  -H 'Content-Type: application/json' \
  -d '{"appId":"qontinui-web","pageId":"operations"}' \
  | jq '.bridgeFingerprint, .snapshotId, .snapshotSha256'
\`\`\`

Expected:
\`\`\`
bridgeFingerprint.appId    "qontinui-web"
snapshotId                  matches /^scs_[0-9a-f-]{36}$/i (UUIDv7)
snapshotSha256              matches /^sha256-[0-9a-f]{64}$/
\`\`\`

## Test plan

- [x] \`cargo check --tests\` clean against schemas-wt-main (where the snapshot_sha256 field lives in this branch's test environment)
- [x] All existing \`evaluate_one\` tests updated for new signature; pass locally
- [x] Validator at \`validator.rs:224\` left on the sentinel-bearing \`evaluate()\` path
- [ ] Mark ready for review after qontinui-schemas#60 merges
- [ ] CI green
- [ ] Manual verification per recipe above