### PR TITLE
feat(spec-check): wire real fingerprint + snapshot_id + snapshot_sha256 into /spec-check responses

### DIFF
--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -110,6 +110,64 @@ pub fn evaluate_with_validation(
     result
 }
 
+/// Evaluate a spec against a snapshot using a caller-supplied fingerprint
+/// and snapshot identity. Use this from HTTP/MCP adapters that already minted
+/// the real values via `wrap_snapshot` or an equivalent fetch path — the
+/// resulting `SpecCheckResult` will carry those values through to
+/// serialization instead of the in-process sentinels.
+///
+/// The supplied `content_sha256` populates `SpecCheckResult.snapshot_sha256`.
+/// Pass `String::new()` to omit it (serialized as null via skip_serializing_if).
+///
+/// In-process callers that want sentinel values (validator, distinctness
+/// checks, internal scoring) should keep using `evaluate()`.
+pub fn evaluate_with_identity(
+    snapshot: &UIBridgeSnapshot,
+    spec: &IrPageSpec,
+    fingerprint: BridgeFingerprint,
+    snapshot_id: String,
+    content_sha256: String,
+) -> SpecCheckResult {
+    evaluate_with_identity_and_validation(snapshot, spec, fingerprint, snapshot_id, content_sha256, None)
+}
+
+pub fn evaluate_with_identity_and_validation(
+    snapshot: &UIBridgeSnapshot,
+    spec: &IrPageSpec,
+    fingerprint: BridgeFingerprint,
+    snapshot_id: String,
+    content_sha256: String,
+    validation: Option<&SpecValidation>,
+) -> SpecCheckResult {
+    let mut result = evaluate_with_validation(snapshot, spec, validation);
+
+    // element_count cross-check: both the caller's fp and the in-process
+    // index computed it from the same snapshot; they must agree. Warn (don't
+    // panic) on mismatch in debug builds; release trusts the caller.
+    #[cfg(debug_assertions)]
+    if fingerprint.element_count != snapshot.elements.len() as u32
+        && fingerprint.element_count != 0
+    {
+        tracing::warn!(
+            "evaluate_with_identity: caller fp.element_count={} disagrees with snapshot.elements.len={}; using caller's value",
+            fingerprint.element_count,
+            snapshot.elements.len(),
+        );
+    }
+
+    // Keep the in-process element_count (correct + equal); take the rest from
+    // the caller-supplied fingerprint.
+    result.bridge_fingerprint = BridgeFingerprint {
+        element_count: result.bridge_fingerprint.element_count,
+        ..fingerprint
+    };
+    result.snapshot_id = snapshot_id;
+    if !content_sha256.is_empty() {
+        result.snapshot_sha256 = Some(content_sha256);
+    }
+    result
+}
+
 /// Multi-spec evaluation against a single snapshot. Builds [`IndexedSnapshot`]
 /// once — shared read-only across all specs — then fan-outs across `specs`
 /// via rayon. Load-bearing for the §5.14 batch endpoint.
@@ -161,6 +219,7 @@ fn evaluate_with_indexed(
     SpecCheckResult {
         result_schema_version: RESULT_SCHEMA_VERSION,
         snapshot_id: SENTINEL_SNAPSHOT_ID.to_string(),
+        snapshot_sha256: None,
         spec_content_hash,
         spec_version: spec.version.clone(),
         page_id: spec.id.clone(),
@@ -849,6 +908,133 @@ mod tests {
         assert_eq!(result.summary.match_outcome, MatchOutcome::NoMatch);
         assert_eq!(result.summary.overall_match_rate, 0.0);
         assert!(result.state_results.is_empty());
+    }
+
+    // ----- evaluate_with_identity -----
+
+    /// Build a caller-supplied fingerprint with a real `app_id` (not the
+    /// sentinel) for the identity tests.
+    fn caller_fingerprint(app_id: &str, element_count: u32) -> BridgeFingerprint {
+        BridgeFingerprint {
+            app_id: app_id.to_string(),
+            app_version: Some("2.1.0".to_string()),
+            route: Some("/operations".to_string()),
+            bridge_version: Some("react".to_string()),
+            snapshot_timestamp: "2026-05-23T11:03:11.087Z".to_string(),
+            element_count,
+        }
+    }
+
+    fn identity_fixture() -> (UIBridgeSnapshot, IrPageSpec) {
+        let s = snap(vec![elem(
+            "btn-save",
+            "#btn-save",
+            Some("button"),
+            Some("Save"),
+            true,
+        )]);
+        let a = assertion(
+            "a1",
+            "critical",
+            json!({ "role": "button", "text": "Save" }),
+            true,
+        );
+        let st = state("s1", "Loaded", Some(true), vec![a]);
+        let spec = page_spec("page-1", vec![st]);
+        (s, spec)
+    }
+
+    #[test]
+    fn evaluate_with_identity_writes_caller_fingerprint() {
+        let (s, spec) = identity_fixture();
+        let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
+        let result = evaluate_with_identity(
+            &s,
+            &spec,
+            fp,
+            "scs_018f-abc".to_string(),
+            String::new(),
+        );
+        // Caller's app_id flows through; NOT the sentinel.
+        assert_eq!(result.bridge_fingerprint.app_id, "qontinui-web");
+        assert_ne!(result.bridge_fingerprint.app_id, "internal-evaluator");
+        assert_eq!(
+            result.bridge_fingerprint.app_version.as_deref(),
+            Some("2.1.0")
+        );
+        assert_eq!(
+            result.bridge_fingerprint.route.as_deref(),
+            Some("/operations")
+        );
+        // element_count is preserved from the in-process index (== caller's).
+        assert_eq!(result.bridge_fingerprint.element_count, 1);
+    }
+
+    #[test]
+    fn evaluate_with_identity_writes_caller_snapshot_id() {
+        let (s, spec) = identity_fixture();
+        let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
+        let result = evaluate_with_identity(
+            &s,
+            &spec,
+            fp,
+            "scs_018f-abc".to_string(),
+            String::new(),
+        );
+        assert_eq!(result.snapshot_id, "scs_018f-abc");
+        assert_ne!(result.snapshot_id, "scs_internal_eval");
+    }
+
+    #[test]
+    fn evaluate_with_identity_populates_snapshot_sha256() {
+        let (s, spec) = identity_fixture();
+
+        // Non-empty hash => Some(hash).
+        let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
+        let result = evaluate_with_identity(
+            &s,
+            &spec,
+            fp,
+            "scs_x".to_string(),
+            "sha256-cafebabe".to_string(),
+        );
+        assert_eq!(result.snapshot_sha256.as_deref(), Some("sha256-cafebabe"));
+
+        // Empty hash => None (serialized as null via skip_serializing_if).
+        let fp2 = caller_fingerprint("qontinui-web", s.elements.len() as u32);
+        let result2 = evaluate_with_identity(
+            &s,
+            &spec,
+            fp2,
+            "scs_x".to_string(),
+            String::new(),
+        );
+        assert!(result2.snapshot_sha256.is_none());
+    }
+
+    #[test]
+    fn evaluate_with_identity_preserves_match_outcome() {
+        let (s, spec) = identity_fixture();
+        let plain = evaluate(&s, &spec);
+        let fp = caller_fingerprint("qontinui-web", s.elements.len() as u32);
+        let identity = evaluate_with_identity(
+            &s,
+            &spec,
+            fp,
+            "scs_x".to_string(),
+            "sha256-abc".to_string(),
+        );
+        // The matching outcome must be identical regardless of entrypoint —
+        // only the identity fields differ.
+        assert_eq!(
+            identity.summary.match_outcome,
+            plain.summary.match_outcome
+        );
+        assert_eq!(
+            identity.summary.overall_match_rate,
+            plain.summary.overall_match_rate
+        );
+        assert_eq!(identity.state_results.len(), plain.state_results.len());
     }
 
     // ----- Severity routing -----

--- a/crates/spec-check/src/lib.rs
+++ b/crates/spec-check/src/lib.rs
@@ -19,7 +19,9 @@ pub mod snapshot;
 #[cfg(test)]
 pub mod proptest_strategies;
 
-pub use evaluator::{evaluate, evaluate_batch};
+pub use evaluator::{
+    evaluate, evaluate_batch, evaluate_with_identity, evaluate_with_identity_and_validation,
+};
 pub use fetch::{wrap_snapshot, SnapshotFetchError};
 pub use policy::apply_policy;
 pub use result_migration::deserialize_result_with_migration;

--- a/crates/spec-check/src/policy.rs
+++ b/crates/spec-check/src/policy.rs
@@ -477,6 +477,7 @@ mod tests {
         SpecCheckResult {
             result_schema_version: 1,
             snapshot_id: "scs_test".to_string(),
+            snapshot_sha256: None,
             spec_content_hash: "sha256-test".to_string(),
             spec_version: "1.0".to_string(),
             page_id: "page".to_string(),

--- a/crates/spec-check/src/result_migration.rs
+++ b/crates/spec-check/src/result_migration.rs
@@ -81,6 +81,7 @@ mod tests {
         SpecCheckResult {
             result_schema_version: version,
             snapshot_id: "scs_test".to_string(),
+            snapshot_sha256: None,
             spec_content_hash: "sha256-deadbeef".to_string(),
             spec_version: "1.0".to_string(),
             page_id: "settings-general".to_string(),

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -598,7 +598,7 @@ pub async fn post_spec_check(
     };
 
     // Fetch snapshot (fresh or supplied).
-    let (snapshot, _fingerprint, snapshot_id, _content_hash) = match req.snapshot {
+    let (snapshot, fingerprint, snapshot_id, content_hash) = match req.snapshot {
         Some(raw) => {
             // Caller-supplied path: try-strict-then-adapt to accept both the
             // canonical UIBridgeSnapshot shape and the SDK control-mode shape
@@ -649,8 +649,16 @@ pub async fn post_spec_check(
     invoke_emit(&req.app_id, &snapshot_id, vec![req.page_id.clone()], "http");
     let started_ms = events::now_ms();
 
-    // Evaluate — pure crate call, no logic here.
-    let result = spec_check::evaluate(&snapshot, &ir);
+    // Evaluate — pure crate call, no logic here. Thread the real fingerprint
+    // + snapshot identity (minted by fetch_fresh_snapshot or synthesized on
+    // the supplied path) into the result instead of the in-process sentinels.
+    let result = spec_check::evaluate_with_identity(
+        &snapshot,
+        &ir,
+        fingerprint,
+        snapshot_id.clone(),
+        content_hash,
+    );
 
     info!(
         "spec_check page_id={} snapshot_id={} match_outcome={:?} match_rate={:.3}",
@@ -740,17 +748,32 @@ pub async fn post_spec_check_batch(
 
     // Resolve snapshot once. The batch handler Arc-shares the snapshot
     // itself and forwards `snapshot_id` as the response field/header.
-    let (snapshot, snapshot_id) = match req.snapshot.source.as_str() {
+    let (snapshot, fingerprint, content_hash, snapshot_id) = match req.snapshot.source.as_str() {
         "fresh" => match fetch_fresh_snapshot(&state).await {
-            Ok((s, _fp, id, _hash)) => (Arc::new(s), id),
+            Ok((s, fp, id, hash)) => (Arc::new(s), fp, hash, id),
             Err(err) => return snapshot_error_to_response(err),
         },
         "supplied" => match req.snapshot.blob {
             Some(raw) => match adapt_supplied_snapshot(raw) {
-                Ok(s) => (
-                    Arc::new(s),
-                    format!("scs_supplied_{}", uuid::Uuid::now_v7()),
-                ),
+                Ok(s) => {
+                    // Mirror the single supplied path: bind the synthesized
+                    // fingerprint to the requested app; no raw bytes hashed
+                    // on the supplied path (content hash stays empty).
+                    let fp = qontinui_types::spec_check::BridgeFingerprint {
+                        app_id: req.app_id.clone(),
+                        app_version: None,
+                        route: None,
+                        bridge_version: None,
+                        snapshot_timestamp: String::new(),
+                        element_count: s.elements.len() as u32,
+                    };
+                    (
+                        Arc::new(s),
+                        fp,
+                        String::new(),
+                        format!("scs_supplied_{}", uuid::Uuid::now_v7()),
+                    )
+                }
                 Err(detail) => {
                     return (
                         StatusCode::UNPROCESSABLE_ENTITY,
@@ -834,6 +857,8 @@ pub async fn post_spec_check_batch(
             req.app_id.clone(),
             snapshot,
             snapshot_id,
+            fingerprint,
+            content_hash,
             root,
             req.pages,
             req.shared_policy,
@@ -849,6 +874,8 @@ pub async fn post_spec_check_batch(
         let shared_policy = req.shared_policy.clone();
         let snapshot_id_owned = snapshot_id.clone();
         let app_id_owned = req.app_id.clone();
+        let fingerprint_owned = fingerprint.clone();
+        let content_hash_owned = content_hash.clone();
         set.spawn(async move {
             evaluate_one(
                 &app_id_owned,
@@ -856,6 +883,8 @@ pub async fn post_spec_check_batch(
                 &entry,
                 &snapshot,
                 &snapshot_id_owned,
+                &fingerprint_owned,
+                &content_hash_owned,
                 shared_policy.as_ref(),
             )
             .await
@@ -976,12 +1005,15 @@ impl BatchElementResult {
 
 /// Evaluate one batch entry. Identical to the single-shot handler except
 /// errors become per-element statuses, not HTTP responses (§5.14).
+#[allow(clippy::too_many_arguments)]
 async fn evaluate_one(
     app_id: &str,
     root: &std::path::Path,
     entry: &BatchPageEntry,
     snapshot: &Arc<UIBridgeSnapshot>,
     snapshot_id: &str,
+    fingerprint: &qontinui_types::spec_check::BridgeFingerprint,
+    content_sha256: &str,
     shared_policy: Option<&SpecCheckPolicy>,
 ) -> BatchElementResult {
     if invalid_page_id(&entry.page_id) {
@@ -996,7 +1028,15 @@ async fn evaluate_one(
 
     // Pure crate call. `evaluate` is sync + rayon-internal; for v1 N ≤ 256
     // we run it inline on the spawned task (see Risks §"contention").
-    let result = spec_check::evaluate(snapshot, &ir);
+    // Thread the batch's shared fingerprint + snapshot identity through so
+    // the per-element result carries real telemetry, not the sentinel.
+    let result = spec_check::evaluate_with_identity(
+        snapshot,
+        &ir,
+        fingerprint.clone(),
+        snapshot_id.to_string(),
+        content_sha256.to_string(),
+    );
 
     // Per-entry override wins over the shared policy.
     let policy = entry.policy_override.as_ref().or(shared_policy);
@@ -1022,10 +1062,13 @@ async fn evaluate_one(
 ///
 /// Stream D: `app_id` is threaded through so per-page evaluation routes to
 /// the right specs root and `SpecCheckCompleted` emits on the right channel.
+#[allow(clippy::too_many_arguments)]
 async fn stream_batch_results(
     app_id: String,
     snapshot: Arc<UIBridgeSnapshot>,
     snapshot_id: String,
+    fingerprint: qontinui_types::spec_check::BridgeFingerprint,
+    content_hash: String,
     root: Arc<std::path::PathBuf>,
     pages: Vec<BatchPageEntry>,
     shared_policy: Option<SpecCheckPolicy>,
@@ -1063,6 +1106,8 @@ async fn stream_batch_results(
         let shared_policy = shared_policy.clone();
         let snap_id = snapshot_id_for_completion.clone();
         let app_id = app_id.clone();
+        let fingerprint = fingerprint.clone();
+        let content_hash = content_hash.clone();
         async move {
             let entry = match st.iter.next() {
                 Some(e) => e,
@@ -1098,6 +1143,8 @@ async fn stream_batch_results(
                 &entry,
                 &snapshot,
                 &snap_id,
+                &fingerprint,
+                &content_hash,
                 shared_policy.as_ref(),
             )
             .await;
@@ -1157,6 +1204,22 @@ mod tests {
             "elements": [],
             "components": []
         })
+    }
+
+    /// A real-ish fingerprint for `evaluate_one` test callsites, bound to a
+    /// fixed `app_id` so the adapted assertions can verify the caller value
+    /// flows through instead of the sentinel.
+    fn test_fingerprint(
+        snapshot: &UIBridgeSnapshot,
+    ) -> qontinui_types::spec_check::BridgeFingerprint {
+        qontinui_types::spec_check::BridgeFingerprint {
+            app_id: "test-app".to_string(),
+            app_version: None,
+            route: None,
+            bridge_version: None,
+            snapshot_timestamp: String::new(),
+            element_count: snapshot.elements.len() as u32,
+        }
     }
 
     #[test]
@@ -1250,7 +1313,18 @@ mod tests {
             page_id: "no-such-page".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(RUNNER_APP_ID, &root, &entry, &snapshot, "scs_test", None).await;
+        let fp = test_fingerprint(&snapshot);
+        let r = evaluate_one(
+            RUNNER_APP_ID,
+            &root,
+            &entry,
+            &snapshot,
+            "scs_test",
+            &fp,
+            "",
+            None,
+        )
+        .await;
         assert_eq!(r.status, "spec-not-found");
         assert!(r.result.is_none());
         assert_eq!(r.page_id, "no-such-page");
@@ -1266,7 +1340,18 @@ mod tests {
             page_id: "../escape".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(RUNNER_APP_ID, &root, &entry, &snapshot, "scs_test", None).await;
+        let fp = test_fingerprint(&snapshot);
+        let r = evaluate_one(
+            RUNNER_APP_ID,
+            &root,
+            &entry,
+            &snapshot,
+            "scs_test",
+            &fp,
+            "",
+            None,
+        )
+        .await;
         assert_eq!(r.status, "eval-error");
         assert_eq!(r.error.as_deref(), Some("invalid-page-id"));
     }
@@ -1323,11 +1408,28 @@ mod tests {
             page_id: "batch-page".to_string(),
             policy_override: None,
         };
-        let r = evaluate_one(RUNNER_APP_ID, root, &entry, &snapshot, "scs_test", None).await;
+        let fp = test_fingerprint(&snapshot);
+        let r = evaluate_one(
+            RUNNER_APP_ID,
+            root,
+            &entry,
+            &snapshot,
+            "scs_test",
+            &fp,
+            "",
+            None,
+        )
+        .await;
         assert_eq!(r.status, "ok");
         let result = r.result.expect("ok status carries a result");
         assert_eq!(result.page_id, "batch-page");
         assert_eq!(result.result_schema_version, 1);
+        // The caller-supplied fingerprint + snapshot identity flow through
+        // instead of the in-process sentinel.
+        assert_eq!(result.bridge_fingerprint.app_id, "test-app");
+        assert_eq!(result.snapshot_id, "scs_test");
+        // Empty content_sha256 ("") leaves snapshot_sha256 as None.
+        assert_eq!(result.snapshot_sha256, None);
     }
 
     #[tokio::test]
@@ -1390,12 +1492,15 @@ mod tests {
 
         let mut rx = events::subscribe(RUNNER_APP_ID);
         let marker = "scs_batch_emit_test_marker_xyz";
+        let fp = test_fingerprint(&snapshot);
         let r = evaluate_one(
             RUNNER_APP_ID,
             root,
             &entry,
             &snapshot,
             marker,
+            &fp,
+            "",
             Some(&policy),
         )
         .await;
@@ -1766,6 +1871,7 @@ mod tests {
         let mk = |outcome: MatchOutcome, rate: f32| SpecCheckResult {
             result_schema_version: 1,
             snapshot_id: String::new(),
+            snapshot_sha256: None,
             spec_content_hash: String::new(),
             spec_version: "1.0".into(),
             page_id: "p".into(),


### PR DESCRIPTION
## Problem
`POST /spec-check` and `/spec-check/batch` match against real snapshots (after #237's envelope-unwrap fetch fix), but the response still serialized the evaluator's in-process **sentinels** — `snapshotId: "scs_internal_eval"`, `bridgeFingerprint.appId: "internal-evaluator"`. The real `BridgeFingerprint` + `scs_<uuidv7>` snapshot_id + `content_sha256` minted in `fetch_fresh_snapshot` were dropped before serialization, breaking observability joins, replay correlation, and content-addressing.

## Change
- **crate (`qontinui-spec-check`):** new `evaluate_with_identity` + `evaluate_with_identity_and_validation` — wrap `evaluate_with_validation` and override the sentinel-bearing fields (`bridge_fingerprint`, `snapshot_id`, `snapshot_sha256`) with caller-supplied real values, keeping the in-process `element_count` (debug-only cross-check warn on mismatch). `evaluate()` stays unchanged for in-process callers (validator / distinctness — sentinel is correct there).
- **schema:** consumes `SpecCheckResult.snapshot_sha256: Option<String>` (additive; landed separately as schemas #60). `#[schemars(deny_unknown_fields)]` kept — the field ships in the regenerated schema as a declared property.
- **adapter (`spec_api/spec_check.rs`):** threads the real fingerprint + snapshot_id + content hash through the single and batch paths into `evaluate_with_identity`. The **batch supplied-snapshot** path now synthesizes an app-id-bound fingerprint (it minted none before). `validator.rs` keeps the sentinel `evaluate()`.

## Tests
- Crate: `evaluate_with_identity` unit tests (caller fingerprint / snapshot_id / snapshot_sha256 Some+None / preserves match_outcome).
- Adapter: `evaluate_one` tests assert the real `app_id` / `snapshot_id` flow through, not the sentinel.
- Full binary build + `cargo test spec_api::spec_check` green locally (27 passed) against current schemas main.

## Notes
- Implements plan `2026-05-23-spec-check-fingerprint-fidelity`.
- Supersedes draft #252 (parallel implementation of the same plan); #252 to be closed.