### PR TITLE
fix(runner): set snapshot_sha256: None at SpecCheckResult initializer sites

### DIFF
--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -161,6 +161,7 @@ fn evaluate_with_indexed(
     SpecCheckResult {
         result_schema_version: RESULT_SCHEMA_VERSION,
         snapshot_id: SENTINEL_SNAPSHOT_ID.to_string(),
+        snapshot_sha256: None,
         spec_content_hash,
         spec_version: spec.version.clone(),
         page_id: spec.id.clone(),

--- a/crates/spec-check/src/policy.rs
+++ b/crates/spec-check/src/policy.rs
@@ -477,6 +477,7 @@ mod tests {
         SpecCheckResult {
             result_schema_version: 1,
             snapshot_id: "scs_test".to_string(),
+            snapshot_sha256: None,
             spec_content_hash: "sha256-test".to_string(),
             spec_version: "1.0".to_string(),
             page_id: "page".to_string(),

--- a/crates/spec-check/src/result_migration.rs
+++ b/crates/spec-check/src/result_migration.rs
@@ -81,6 +81,7 @@ mod tests {
         SpecCheckResult {
             result_schema_version: version,
             snapshot_id: "scs_test".to_string(),
+            snapshot_sha256: None,
             spec_content_hash: "sha256-deadbeef".to_string(),
             spec_version: "1.0".to_string(),
             page_id: "settings-general".to_string(),

--- a/src-tauri/src/spec_api/spec_check.rs
+++ b/src-tauri/src/spec_api/spec_check.rs
@@ -1766,6 +1766,7 @@ mod tests {
         let mk = |outcome: MatchOutcome, rate: f32| SpecCheckResult {
             result_schema_version: 1,
             snapshot_id: String::new(),
+            snapshot_sha256: None,
             spec_content_hash: String::new(),
             spec_version: "1.0".into(),
             page_id: "p".into(),


### PR DESCRIPTION
## Summary
Stopgap unblock for the cross-crate field-addition that schemas#60 merged at 14:03:55Z today (\`feat(spec-check): add snapshot_sha256 field to SpecCheckResult\`).

Runner main last got green CI at 13:21Z on \`3fe7fe2c\` — before #60 landed — so the "main is green" stamp is stale-green. Any PR rebased onto current main fails compilation:

\`\`\`
error[E0063]: missing field \`snapshot_sha256\` in initializer of
  \`qontinui_types::spec_check::SpecCheckResult\`
\`\`\`

Verified directly: \`git show origin/main:<file> | grep -c snapshot_sha256\` returns **0** for all four initializer sites on the current origin/main HEAD.

## What this PR does
Adds \`snapshot_sha256: None\` at the four sites:

| File | Line | Context |
|---|---|---|
| \`crates/spec-check/src/evaluator.rs\` | 161 | real evaluator output |
| \`crates/spec-check/src/policy.rs\` | 477 | test helper \`make_result\` |
| \`crates/spec-check/src/result_migration.rs\` | 81 | test helper \`sample_result\` |
| \`src-tauri/src/spec_api/spec_check.rs\` | 1766 | test closure \`mk\` |

Field is \`Option<String>\` with \`serde(default, skip_serializing_if = "Option::is_none")\` per \`qontinui-schemas/rust/src/spec_check.rs:80\` — so \`None\` is the cleanest stopgap (wire shape unchanged).

## Relationship to PR #252
A follow-up PR ([#252](https://github.com/qontinui/qontinui-runner/pull/252) — DRAFT on \`feat/spec-check-fingerprint-fidelity\`, "feat(spec-check): wire real fingerprint + snapshot_sha256 into responses") will replace the \`None\` placeholders with real snapshot hashes once ready. This stopgap is naturally superseded by that work.

## Why a separate PR rather than folding into #242 / #252
- **#242** (coord-sync drain + heartbeat) is unrelated to spec-check — the stopgap would conflate concerns and need removal later.
- **#252** is draft + larger scope; landing the stopgap separately unblocks #240/#242/#245/#247 immediately without waiting on the real-fix scope.

## Cross-repo CI cycle pattern
Schemas added the field via path-dep; runner main went stale-green because schemas was bumped *after* runner's last CI run; all in-flight PRs inherit the broken state on rebase. Per \`feedback_cross_repo_ci_cycle_pattern\` + \`feedback_verify_function_exists_before_trusting_stamp\`.

## Test plan
- [ ] CI green on Ubuntu + Windows (clippy + tests)
- [ ] After merge, rebase the affected PRs (#242 + any others stalled on the same E0063) and re-run CI