### PR TITLE
fix(findings-api): PG type-cast bug + camelCase wire + status transition + GET endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "hex",

--- a/src-tauri/src/database/pg/findings.rs
+++ b/src-tauri/src/database/pg/findings.rs
@@ -30,16 +30,27 @@ impl PgDb {
         };
         let now = chrono::Utc::now().to_rfc3339();
         let session: Option<i32> = session_num.map(|s| s as i32);
+        // tokio_postgres requires concrete Option<String> (not Option<&str>) so
+        // the parameter type is inferred as `text` rather than failing with
+        // "serializing parameter 2" when NULL is passed.
+        let resolution_owned: Option<String> = resolution.map(|s| s.to_owned());
+        let status_owned: String = status.to_owned();
+        let id_owned: String = id.to_owned();
 
+        // Explicit `$N::text` / `$N::int4` casts force PG to infer parameter
+        // types up front so tokio_postgres can pre-encode `None` as a typed
+        // NULL. Without these casts COALESCE($2, resolution) gives $2 no
+        // inherent type and tokio_postgres errors with "error serializing
+        // parameter N" the moment we pass `None`.
         conn.execute(
-            "UPDATE task_run_findings SET status = $1, resolution = COALESCE($2, resolution), resolved_at = COALESCE($3, resolved_at), resolved_in_session = COALESCE($4, resolved_in_session), updated_at = $5 WHERE id = $6",
+            "UPDATE task_run_findings SET status = $1::text, resolution = COALESCE($2::text, resolution), resolved_at = COALESCE($3::text::timestamptz, resolved_at), resolved_in_session = COALESCE($4::int4, resolved_in_session), updated_at = $5::text::timestamptz WHERE id = $6::text",
             &[
-                &status as &(dyn tokio_postgres::types::ToSql + Sync),
-                &resolution as &(dyn tokio_postgres::types::ToSql + Sync),
+                &status_owned as &(dyn tokio_postgres::types::ToSql + Sync),
+                &resolution_owned as &(dyn tokio_postgres::types::ToSql + Sync),
                 &resolved_at as &(dyn tokio_postgres::types::ToSql + Sync),
                 &session as &(dyn tokio_postgres::types::ToSql + Sync),
                 &now as &(dyn tokio_postgres::types::ToSql + Sync),
-                &id as &(dyn tokio_postgres::types::ToSql + Sync),
+                &id_owned as &(dyn tokio_postgres::types::ToSql + Sync),
             ],
         ).await.map_err(|e| format!("PG update_finding_status: {}", e))?;
 
@@ -69,6 +80,46 @@ impl PgDb {
             .map_err(|e| format!("PG get_finding: {}", e))?;
 
         Ok(row.map(|r| pg_row_to_finding(&r)))
+    }
+
+    /// List findings across all task runs, optionally filtered by status and/or
+    /// category. `limit` is clamped to [1, 500]; `offset` is non-negative.
+    /// Returns rows ordered by `detected_at DESC` (most recent first).
+    pub async fn list_findings(
+        &self,
+        status: Option<&str>,
+        category: Option<&str>,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<Finding>, String> {
+        let conn = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let status_owned: Option<String> = status.map(|s| s.to_owned());
+        let category_owned: Option<String> = category.map(|s| s.to_owned());
+
+        // Use COALESCE-style NULL guards so a single prepared statement covers
+        // every filter combination without dynamic SQL.
+        let sql = r#"SELECT id, task_run_id, detected_in_session, category, severity, status,
+                       action_type, title, description, resolution, file_path, line_number,
+                       column_number, code_snippet, signature_hash, needs_input, question,
+                       input_options, user_response, detected_at, resolved_at,
+                       resolved_in_session, updated_at
+                FROM task_run_findings
+                WHERE ($1::text IS NULL OR status = $1)
+                  AND ($2::text IS NULL OR category = $2)
+                ORDER BY detected_at DESC
+                LIMIT $3 OFFSET $4"#;
+
+        let rows = conn
+            .query(sql, &[&status_owned, &category_owned, &limit, &offset])
+            .await
+            .map_err(|e| format!("PG list_findings: {}", e))?;
+
+        Ok(rows.iter().map(pg_row_to_finding).collect())
     }
 
     /// Get all findings for a task run.

--- a/src-tauri/src/mcp/findings_api.rs
+++ b/src-tauri/src/mcp/findings_api.rs
@@ -5,7 +5,7 @@
 //! underlying logic as the Tauri commands in `commands/findings.rs`.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
 };
@@ -44,6 +44,128 @@ pub struct UserResponseRequest {
 pub struct FindingMutationResponse {
     pub finding_id: String,
     pub status: String,
+}
+
+/// Query string for `GET /findings`.
+#[derive(Debug, Deserialize, Default)]
+pub struct ListFindingsQuery {
+    /// Optional status filter (e.g. "needs_input", "detected").
+    pub status: Option<String>,
+    /// Optional category filter (e.g. "code_bug", "test_failure").
+    pub category: Option<String>,
+    /// Page size (clamped to 1..=200; defaults to 50).
+    pub limit: Option<i64>,
+    /// 1-based page index (defaults to 1).
+    pub page: Option<i64>,
+}
+
+/// Envelope for paginated finding listings.
+#[derive(Debug, Serialize)]
+pub struct ListFindingsResponse {
+    pub items: Vec<Finding>,
+    pub page: i64,
+    pub limit: i64,
+    pub count: usize,
+}
+
+/// GET /findings/:finding_id
+///
+/// Returns a single finding by id, or 404 if not found.
+pub async fn get_finding_handler(
+    State(state): State<Arc<ApiState>>,
+    Path(finding_id): Path<String>,
+) -> Result<Json<ApiResponse<Finding>>, (StatusCode, Json<ApiResponse<()>>)> {
+    match state.app_state.pg_db.get_finding(&finding_id).await {
+        Ok(Some(finding)) => Ok(Json(ApiResponse::success(finding))),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            Json(api_error(format!("Finding not found: {}", finding_id))),
+        )),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(api_error(format!("Failed to get finding: {}", e))),
+        )),
+    }
+}
+
+/// GET /findings
+///
+/// Paginated cross-task-run listing. Supports `status`, `category`, `limit`,
+/// `page` query parameters. Results are ordered by `detected_at` DESC.
+pub async fn list_findings_handler(
+    State(state): State<Arc<ApiState>>,
+    Query(q): Query<ListFindingsQuery>,
+) -> Result<Json<ApiResponse<ListFindingsResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
+    let limit = q.limit.unwrap_or(50).clamp(1, 200);
+    let page = q.page.unwrap_or(1).max(1);
+    let offset = (page - 1) * limit;
+
+    match state
+        .app_state
+        .pg_db
+        .list_findings(q.status.as_deref(), q.category.as_deref(), limit, offset)
+        .await
+    {
+        Ok(items) => {
+            let count = items.len();
+            Ok(Json(ApiResponse::success(ListFindingsResponse {
+                items,
+                page,
+                limit,
+                count,
+            })))
+        }
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(api_error(format!("Failed to list findings: {}", e))),
+        )),
+    }
+}
+
+/// GET /findings/by-status/:status
+///
+/// Shortcut for `GET /findings?status=<status>` with default pagination.
+pub async fn findings_by_status_handler(
+    State(state): State<Arc<ApiState>>,
+    Path(status): Path<String>,
+    Query(q): Query<ListFindingsQuery>,
+) -> Result<Json<ApiResponse<ListFindingsResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
+    // Validate the status value up front so callers get a 400 rather than an
+    // empty list when they typo the variant.
+    if FindingStatus::from_str(&status).is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(api_error(format!("Invalid status: {}", status))),
+        ));
+    }
+
+    let limit = q.limit.unwrap_or(50).clamp(1, 200);
+    let page = q.page.unwrap_or(1).max(1);
+    let offset = (page - 1) * limit;
+
+    match state
+        .app_state
+        .pg_db
+        .list_findings(Some(&status), q.category.as_deref(), limit, offset)
+        .await
+    {
+        Ok(items) => {
+            let count = items.len();
+            Ok(Json(ApiResponse::success(ListFindingsResponse {
+                items,
+                page,
+                limit,
+                count,
+            })))
+        }
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(api_error(format!(
+                "Failed to list findings by status: {}",
+                e
+            ))),
+        )),
+    }
 }
 
 /// GET /findings/task/:task_run_id
@@ -169,6 +291,23 @@ pub async fn user_response_handler(
             )
         })?;
 
+    // Transition status `needs_input` -> `in_progress` so downstream consumers
+    // (and the mutation response below) reflect what the docstring promises.
+    state
+        .app_state
+        .pg_db
+        .update_finding_status(&finding_id, "in_progress", None, None)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(api_error(format!(
+                    "Failed to transition finding to in_progress: {}",
+                    e
+                ))),
+            )
+        })?;
+
     info!("HTTP: Set user response for finding {}", finding_id);
 
     Ok(Json(ApiResponse::success(FindingMutationResponse {
@@ -242,10 +381,23 @@ pub async fn clear_all_findings_handler(
 pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
     use axum::routing::{get, post, put};
     axum::Router::new()
+        .route("/findings", get(list_findings_handler))
+        .route(
+            "/findings/by-status/{status}",
+            get(findings_by_status_handler),
+        )
         .route(
             "/findings/task/{task_run_id}",
             get(get_task_findings_handler),
         )
+        .route(
+            "/findings/task/{task_run_id}/clear-all",
+            post(clear_all_findings_handler),
+        )
+        // Capture routes go last so the literal `/findings/task/...` and
+        // `/findings/by-status/...` patterns above take priority in axum 0.8's
+        // matchit router.
+        .route("/findings/{finding_id}", get(get_finding_handler))
         .route(
             "/findings/{finding_id}/status",
             put(update_finding_status_handler),
@@ -257,9 +409,5 @@ pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
         .route(
             "/findings/{finding_id}/user-response",
             post(user_response_handler),
-        )
-        .route(
-            "/findings/task/{task_run_id}/clear-all",
-            post(clear_all_findings_handler),
         )
 }

--- a/src-tauri/src/tauri_event_payloads.rs
+++ b/src-tauri/src/tauri_event_payloads.rs
@@ -104,7 +104,8 @@ pub struct FindingCodeContext {
 /// Renamed in the schema registry to `RunnerFindingUserInput` to
 /// disambiguate from `qontinui_types::findings::FindingUserInput`.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[schemars(title = "RunnerFindingUserInput")]
+#[serde(rename_all = "camelCase")]
+#[schemars(rename_all = "camelCase", title = "RunnerFindingUserInput")]
 pub struct FindingUserInput {
     pub question: String,
     #[serde(default = "default_input_type")]


### PR DESCRIPTION
## Summary

Iter 1 of `/manual-test-loop --target=findings` surfaced 5 runner-side deficiencies. All 5 land here.

- **PUT `/findings/{id}/status` returned 500 "error serializing parameter 2" for every status value.** Root cause: tokio-postgres can't infer the SQL type for `Option<&str>` when the param is `None` and the SQL uses `COALESCE($N, existing_column)`. Fixed by adding explicit `::text` / `::int4` / `::timestamptz` casts in the SQL AND switching bindings to owned `Option<String>` for clarity.

- **`FindingUserInput` on the wire was snake_case** (`input_type`, etc.) inside an otherwise camelCase `Finding` payload. Mobile read `userInput.inputType` as `undefined`, silently fell back to `'text'` for choice/confirmation inputs. Fixed by adding `#[serde(rename_all = "camelCase")]` + `#[schemars(rename_all = "camelCase")]` on `FindingUserInput`. Paired schemas regen landed first in qontinui-schemas#64 to keep the drift check green.

- **POST `/findings/{id}/user-response` wrote the response but never transitioned status** from `needs_input` to `in_progress`, contradicting the handler docstring. Fixed: `user_response_handler` now calls `update_finding_status(id, "in_progress", None, None)` after `set_finding_user_response` succeeds.

- **Added GET `/findings/{finding_id}`** — single-finding fetch with 404 envelope on miss.

- **Added GET `/findings?status=&category=&limit=&page=`** for cross-run listing (paginated, `detected_at DESC`), with `limit` clamped to [1,200] and `page>=1`; and the shortcut **GET `/findings/by-status/{status}`** validating against the `FindingStatus` enum.

Routes registered in order so axum 0.8's matchit doesn't collide on the `/findings/{finding_id}` capture vs the literal `/findings/task/` and `/findings/by-status/` paths.

## Test plan

- [x] `cargo check` + `cargo clippy -D warnings` clean
- [x] Live verified against a temp runner spawned via supervisor port 9875: PUT status PASS; user-response transitions status PASS; GET `/findings/{id}` PASS; GET `/findings?...` PASS
- [x] Paired schemas regen merged (qontinui-schemas#64 at 646417d)
- [ ] `qontinui-types-drift` CI green after schemas main carries the camelCase bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)