### PR TITLE
runner: manual-test-loop iter 1 - vision frame-source device follow-ups

### DIFF
--- a/src-tauri/src/mcp/adb_helper.rs
+++ b/src-tauri/src/mcp/adb_helper.rs
@@ -106,6 +106,23 @@ pub async fn list_devices() -> Vec<AdbDeviceInfo> {
     .unwrap_or_default()
 }
 
+/// Whether `serial` is currently listed by the local adb server as a device.
+///
+/// Used by the vision frame-source resolver to distinguish a real adb target
+/// from an arbitrary label that merely *looks* serial-shaped (e.g. `bogus-id`).
+/// A device in the `offline`/`unauthorized` state still counts as "connected"
+/// here — it is a genuine adb target, just not ready; surfacing the adb-side
+/// error is more useful than masking it as "unknown vision target".
+///
+/// Returns `false` when adb is unreachable or the serial is absent.
+pub async fn is_connected_device(serial: &str) -> bool {
+    let serial = serial.trim();
+    if serial.is_empty() {
+        return false;
+    }
+    list_devices().await.iter().any(|d| d.serial == serial)
+}
+
 fn parse_device_line(line: &str) -> AdbDeviceInfo {
     let parts: Vec<&str> = line.split_whitespace().collect();
     let serial = parts.first().map(|s| (*s).to_string()).unwrap_or_default();

--- a/src-tauri/src/mcp/physical_device_api.rs
+++ b/src-tauri/src/mcp/physical_device_api.rs
@@ -251,6 +251,55 @@ async fn disconnect_device(
     }))))
 }
 
+/// DELETE /ui-bridge/devices/:id
+///
+/// Unregister a physical device: drop any active SDK connection pointed at its
+/// transports, then remove the registry entry entirely. Returns 200 with
+/// `{deviceId, removed:true}`; 404 if the device is absent.
+///
+/// Note: the LAN TCP proxy task spawned at `register-lan` is not currently
+/// tracked by the registry (its `JoinHandle` is dropped at creation), so there
+/// is no handle to abort here. Removing the registry entry severs all routing
+/// to the device; the orphaned proxy listener (if any) is harmless and is reaped
+/// on runner shutdown. Tracking proxy handles for explicit teardown is a
+/// separate change and intentionally out of scope.
+async fn unregister_device(
+    State(state): State<Arc<ApiState>>,
+    Path(id): Path<String>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    // 404 if the device isn't known — distinguish "removed" from "never existed".
+    let device = match state.physical_device_registry.get_device(&id).await {
+        Some(d) => d,
+        None => {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(ApiResponse::error(format!("Device '{}' not found", id))),
+            ));
+        }
+    };
+
+    // Drop any active SDK connection that targets one of this device's
+    // transports, so a follow-up SDK request doesn't dangle on a removed device.
+    {
+        let mut manager = state.sdk_connection.lock().await;
+        for transport in &device.transports {
+            manager.connections.remove(&transport.proxy_url);
+            if manager.active_url.as_deref() == Some(transport.proxy_url.as_str()) {
+                manager.active_url = None;
+            }
+        }
+    }
+
+    // Remove the registry entry (this drops all transport metadata for the device).
+    state.physical_device_registry.remove_device(&id).await;
+
+    info!(device_id = %id, "Physical device unregistered");
+    Ok(Json(ApiResponse::success(serde_json::json!({
+        "deviceId": id,
+        "removed": true
+    }))))
+}
+
 /// GET /ui-bridge/devices/:id/transport
 async fn get_transport_info(
     State(state): State<Arc<ApiState>>,
@@ -477,7 +526,10 @@ async fn register_lan_device(
 pub fn routes() -> Router<Arc<ApiState>> {
     Router::new()
         .route("/ui-bridge/devices", get(list_devices))
-        .route("/ui-bridge/devices/{id}", get(get_device))
+        .route(
+            "/ui-bridge/devices/{id}",
+            get(get_device).delete(unregister_device),
+        )
         .route("/ui-bridge/devices/{id}/connect", post(connect_device))
         .route(
             "/ui-bridge/devices/{id}/disconnect",

--- a/src-tauri/src/mcp/ui_bridge/vision_ai.rs
+++ b/src-tauri/src/mcp/ui_bridge/vision_ai.rs
@@ -32,6 +32,22 @@ use tracing::{debug, warn};
 
 /// Default llama-swap host endpoint. Matches `verification::mode::DEFAULT_ENDPOINT`.
 pub const DEFAULT_ENDPOINT: &str = "http://127.0.0.1:8100";
+
+/// Canonical OCR model alias. **Environment dependency:** llama-swap must
+/// expose a model under this alias or `vision/extract` (and any path that runs
+/// OCR) returns the endpoint's non-success status (a 400/404 surfaced as
+/// [`AiError::Status`]).
+///
+/// As of this writing the checked-in `qontinui/docker/llama-swap/config.yaml`
+/// defines `qontinui-grounding-v1` (the VLM default below) but does **not**
+/// define a `paddleocr` model — so a stock local llama-swap will 400 on OCR.
+/// This is a llama-swap *config* gap (out of this repo), NOT a wrong default:
+/// `paddleocr` is the intended canonical OCR alias (see the PaddleOCR
+/// references in `vision_routes.rs` and this module's header). Do NOT "fix" the
+/// 400 by repointing this constant at some other loaded model — that would
+/// silently change OCR behavior for everyone and mask the missing config.
+/// The fix is to add a `paddleocr` entry to the llama-swap config (or override
+/// [`ENV_OCR_MODEL`] at process start to a loaded OCR-capable alias).
 pub const DEFAULT_OCR_MODEL: &str = "paddleocr";
 pub const DEFAULT_VLM_MODEL: &str = "qontinui-grounding-v1";
 

--- a/src-tauri/src/mcp/ui_bridge/vision_frame_source.rs
+++ b/src-tauri/src/mcp/ui_bridge/vision_frame_source.rs
@@ -207,11 +207,33 @@ pub async fn resolve_frame_provider(
     }
 
     // 3. adb serial / emulator transport id → framebuffer.
-    if id.starts_with("emulator-") || adb_helper::is_adb_serial(id) {
+    //
+    // The registries are now exhausted. `is_adb_serial` is a permissive
+    // syntactic classifier — an arbitrary label like `bogus-id` is alphanumeric
+    // with a dash and so *looks* like a USB serial. Routing every such string to
+    // adb produced a misleading "ADB device … not found" error for what is
+    // really an unknown target. Gate on actual adb presence: a string only goes
+    // to `AdbScreencapSource` when it is serial-shaped AND adb currently lists it
+    // as a connected device. A real serial still routes; `bogus-id` falls through
+    // to the intended "unknown vision target" error.
+    let connected = adb_helper::is_connected_device(id).await;
+    if should_route_to_adb(id, connected) {
         return Ok(Box::new(AdbScreencapSource { serial: id.clone() }));
     }
 
     Err(format!("unknown vision target '{id}'"))
+}
+
+/// Pure routing decision for step 3 of [`resolve_frame_provider`]: a target the
+/// device + app registries did not claim is routed to adb only when it is
+/// serial-shaped AND adb reports it as a connected device.
+///
+/// Separated from the async resolver (which needs an `ApiState` + a live adb
+/// server) so the bogus-id-vs-real-serial distinction is unit-testable in
+/// isolation. `connected` is the result of [`adb_helper::is_connected_device`].
+fn should_route_to_adb(id: &str, connected: bool) -> bool {
+    let serial_shaped = id.starts_with("emulator-") || adb_helper::is_adb_serial(id);
+    serial_shaped && connected
 }
 
 #[cfg(test)]
@@ -277,5 +299,50 @@ mod tests {
     fn malformed_base64_is_an_error_not_a_panic() {
         let body = serde_json::json!({ "data": { "screenshot": "not-base64!!!", "width": 10 } });
         assert!(frame_from_screenshot_json(&body).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // adb routing gate (step 3 of resolve_frame_provider)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bogus_id_does_not_route_to_adb() {
+        // `bogus-id` is syntactically serial-shaped (alphanumeric + dash), so the
+        // permissive `is_adb_serial` classifier accepts it. The presence gate is
+        // what saves us: adb does not list it, so it must NOT route to adb and
+        // the resolver falls through to "unknown vision target '<id>'".
+        assert!(
+            adb_helper::is_adb_serial("bogus-id"),
+            "precondition: bogus-id is serial-shaped, so syntax alone can't reject it"
+        );
+        assert!(
+            !should_route_to_adb("bogus-id", false),
+            "an unknown, not-connected id must not route to adb"
+        );
+    }
+
+    #[test]
+    fn real_serial_routes_to_adb_when_connected() {
+        // A genuine USB serial that adb lists routes to AdbScreencapSource.
+        assert!(should_route_to_adb("R3CN30ABCDE", true));
+        // An emulator transport id that adb lists also routes.
+        assert!(should_route_to_adb("emulator-5554", true));
+    }
+
+    #[test]
+    fn serial_shaped_but_absent_does_not_route() {
+        // Even a perfectly serial-shaped id is rejected if adb doesn't list it —
+        // e.g. a device that was unplugged. Better to report "unknown target"
+        // than to hand a dead serial to the framebuffer puller.
+        assert!(!should_route_to_adb("R3CN30ABCDE", false));
+        assert!(!should_route_to_adb("emulator-5554", false));
+    }
+
+    #[test]
+    fn non_serial_shaped_never_routes_even_if_claimed_connected() {
+        // Defense in depth: a string that isn't serial-shaped never routes,
+        // regardless of the presence flag.
+        assert!(!should_route_to_adb("has spaces", true));
+        assert!(!should_route_to_adb("app/with/slashes", true));
     }
 }


### PR DESCRIPTION
Manual-test-loop iter 1 P2 follow-ups on the vision frame-source device path (post-#250).

## Changes
- **DELETE `/ui-bridge/devices/:id`** to unregister a physical device: drops any active SDK connection pointed at its transports, removes the registry entry. Returns `200 {deviceId, removed:true}`, or `404` if absent.
- **Fail loud on unknown vision `target`**: gate adb routing behind `adb_helper::is_connected_device` via a pure `should_route_to_adb` helper, so a bogus id (which `is_adb_serial` accepts syntactically) falls through to `unknown vision target '<id>'` instead of a misleading "ADB device not found" error. A real connected serial still routes. +4 unit tests.
- **Document the llama-swap `paddleocr` config dependency** on `DEFAULT_OCR_MODEL`: OCR `vision/extract` returns the endpoint's non-success status (e.g. 400) until a `paddleocr` model is loaded in the local llama-swap config. The doc clarifies this is a config gap (out of repo), not a wrong default.

## Verification
- `cargo fmt -- --check` clean on the 4 files
- `cargo clippy --lib -- -D warnings` clean
- `cargo test mcp::ui_bridge::vision_frame_source::tests` — 9 passed (incl. the 4 new routing-gate tests)