### PR TITLE
fix(ai-provider): send OAuth tokens via Authorization: Bearer + oauth-2025-04-20 beta

### DIFF
--- a/src-tauri/src/ai_provider/anthropic_auth.rs
+++ b/src-tauri/src/ai_provider/anthropic_auth.rs
@@ -1,0 +1,178 @@
+//! Anthropic API authentication helper.
+//!
+//! Anthropic accepts two auth shapes on `api.anthropic.com/v1/messages`:
+//!
+//! 1. **API key** (`sk-ant-api...`): sent as `x-api-key: <token>`.
+//! 2. **OAuth access token** (`sk-ant-oat...`): sent as
+//!    `Authorization: Bearer <token>` PLUS `anthropic-beta: oauth-2025-04-20`.
+//!
+//! The earlier assumption that *"both can be sent via `x-api-key`"* (see the
+//! old doc-comment in `claude_api_warm.rs`) is false for the account-usage
+//! probe path and similar endpoints — OAuth tokens get a hard 401 unless the
+//! Bearer + beta-header shape is used. This module centralises the dispatch so
+//! every API call site routes correctly based on the token prefix.
+
+/// Prefix that identifies an Anthropic OAuth access token.
+pub(crate) const OAUTH_TOKEN_PREFIX: &str = "sk-ant-oat";
+
+/// Anthropic beta header that must accompany OAuth-Bearer auth on
+/// `api.anthropic.com/v1/messages`. Without it, OAuth tokens get a 401.
+pub(crate) const OAUTH_BETA_HEADER: &str = "oauth-2025-04-20";
+
+/// Whether a raw token string is an OAuth access token (vs an API key).
+pub(crate) fn is_oauth_token(token: &str) -> bool {
+    token.starts_with(OAUTH_TOKEN_PREFIX)
+}
+
+/// Apply Anthropic auth headers to an async `reqwest::RequestBuilder`.
+///
+/// Dispatches by token prefix: `sk-ant-oat*` → `Authorization: Bearer` +
+/// `anthropic-beta: oauth-2025-04-20`; anything else → `x-api-key`.
+///
+/// Callers stack their own `anthropic-version`, `anthropic-beta` (additional
+/// betas, like prompt caching), and `content-type` headers — this helper only
+/// owns the auth-related headers so it composes cleanly with the rest of the
+/// request shape.
+pub(crate) fn apply_async(
+    builder: reqwest::RequestBuilder,
+    token: &str,
+) -> reqwest::RequestBuilder {
+    if is_oauth_token(token) {
+        builder
+            .header("Authorization", format!("Bearer {}", token))
+            .header("anthropic-beta", OAUTH_BETA_HEADER)
+    } else {
+        builder.header("x-api-key", token)
+    }
+}
+
+/// Apply Anthropic auth headers to a blocking `reqwest::blocking::RequestBuilder`.
+///
+/// Mirror of [`apply_async`] for the blocking client used by the warm + cached
+/// Claude API paths.
+pub(crate) fn apply_blocking(
+    builder: reqwest::blocking::RequestBuilder,
+    token: &str,
+) -> reqwest::blocking::RequestBuilder {
+    if is_oauth_token(token) {
+        builder
+            .header("Authorization", format!("Bearer {}", token))
+            .header("anthropic-beta", OAUTH_BETA_HEADER)
+    } else {
+        builder.header("x-api-key", token)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oauth_token_detection_matches_anthropic_prefix() {
+        assert!(is_oauth_token("sk-ant-oat01-abc"));
+        assert!(is_oauth_token("sk-ant-oat"));
+        assert!(!is_oauth_token("sk-ant-api03-xyz"));
+        assert!(!is_oauth_token(""));
+        assert!(!is_oauth_token("Bearer sk-ant-oat01-x"));
+    }
+
+    /// Async builder dispatch: OAuth path emits Bearer + beta header,
+    /// non-OAuth path emits x-api-key. We inspect the constructed `Request`
+    /// directly so the test never touches the network.
+    #[test]
+    fn apply_async_routes_oauth_to_bearer() {
+        let client = reqwest::Client::new();
+        let req = apply_async(
+            client.post("https://api.anthropic.com/v1/messages"),
+            "sk-ant-oat01-deadbeef",
+        )
+        .build()
+        .expect("build oauth request");
+
+        let headers = req.headers();
+        let auth = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(auth, "Bearer sk-ant-oat01-deadbeef");
+
+        let beta = headers
+            .get("anthropic-beta")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(beta, OAUTH_BETA_HEADER);
+
+        assert!(
+            headers.get("x-api-key").is_none(),
+            "OAuth path must NOT also set x-api-key"
+        );
+    }
+
+    #[test]
+    fn apply_async_routes_api_key_to_x_api_key() {
+        let client = reqwest::Client::new();
+        let req = apply_async(
+            client.post("https://api.anthropic.com/v1/messages"),
+            "sk-ant-api03-cafebabe",
+        )
+        .build()
+        .expect("build api request");
+
+        let headers = req.headers();
+        let key = headers
+            .get("x-api-key")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert_eq!(key, "sk-ant-api03-cafebabe");
+
+        assert!(
+            headers.get("authorization").is_none(),
+            "API-key path must NOT also set Authorization"
+        );
+        assert!(
+            headers.get("anthropic-beta").is_none(),
+            "API-key path must NOT add the OAuth beta header"
+        );
+    }
+
+    #[test]
+    fn apply_blocking_routes_oauth_to_bearer() {
+        let client = reqwest::blocking::Client::new();
+        let req = apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            "sk-ant-oat01-token",
+        )
+        .build()
+        .expect("build oauth request");
+
+        let headers = req.headers();
+        assert_eq!(
+            headers.get("authorization").and_then(|v| v.to_str().ok()),
+            Some("Bearer sk-ant-oat01-token")
+        );
+        assert_eq!(
+            headers.get("anthropic-beta").and_then(|v| v.to_str().ok()),
+            Some(OAUTH_BETA_HEADER)
+        );
+        assert!(headers.get("x-api-key").is_none());
+    }
+
+    #[test]
+    fn apply_blocking_routes_api_key_to_x_api_key() {
+        let client = reqwest::blocking::Client::new();
+        let req = apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            "sk-ant-api03-key",
+        )
+        .build()
+        .expect("build api request");
+
+        let headers = req.headers();
+        assert_eq!(
+            headers.get("x-api-key").and_then(|v| v.to_str().ok()),
+            Some("sk-ant-api03-key")
+        );
+        assert!(headers.get("authorization").is_none());
+        assert!(headers.get("anthropic-beta").is_none());
+    }
+}

--- a/src-tauri/src/ai_provider/claude_api.rs
+++ b/src-tauri/src/ai_provider/claude_api.rs
@@ -422,14 +422,15 @@ pub(super) fn run_claude_api_cached(
     let request_body = builder.build(&prompt.user_message);
 
     retry_with_backoff("Claude API (cached)", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("anthropic-beta", PROMPT_CACHING_BETA_HEADER)
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let request = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            &api_key,
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("anthropic-beta", PROMPT_CACHING_BETA_HEADER)
+        .header("content-type", "application/json")
+        .json(&request_body);
+        let response = request.send();
 
         match response {
             Ok(resp) => {

--- a/src-tauri/src/ai_provider/claude_api_warm.rs
+++ b/src-tauri/src/ai_provider/claude_api_warm.rs
@@ -9,8 +9,9 @@
 //!   across calls (first call ~150ms handshake, subsequent <10ms pool reuse).
 //! - Credential resolution that prefers an explicit API key, then falls
 //!   through to the Claude CLI's OAuth `accessToken` read from
-//!   `.credentials.json`. Both credentials are sent as `x-api-key` — Anthropic
-//!   accepts either through that header.
+//!   `.credentials.json`. Auth header shape is dispatched by token prefix via
+//!   [`super::anthropic_auth`]: `sk-ant-oat*` → `Authorization: Bearer` +
+//!   `anthropic-beta: oauth-2025-04-20`; anything else → `x-api-key`.
 //! - The `anthropic-beta: prompt-caching-2024-07-31` header so `cache_control`
 //!   markers on the system prompt actually fire once Phase B fattens the
 //!   prompt past the ~1024-token Haiku minimum.
@@ -326,14 +327,15 @@ pub(crate) fn run_claude_api_warm(
     let client = warm_client();
 
     retry_with_backoff("Claude API (warm)", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", credential.token())
-            .header("anthropic-version", "2023-06-01")
-            .header("anthropic-beta", PROMPT_CACHING_BETA_HEADER)
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let request = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            credential.token(),
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("anthropic-beta", PROMPT_CACHING_BETA_HEADER)
+        .header("content-type", "application/json")
+        .json(&request_body);
+        let response = request.send();
 
         match response {
             Ok(resp) => {

--- a/src-tauri/src/ai_provider/mod.rs
+++ b/src-tauri/src/ai_provider/mod.rs
@@ -10,6 +10,7 @@
 //! Other modules should use this module to interact with AI providers.
 
 pub mod account_usage;
+pub(crate) mod anthropic_auth;
 pub mod cache_aware_builder;
 pub mod circuit_breaker;
 mod claude_api;

--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -1083,6 +1083,27 @@ pub(crate) fn read_oauth_token(config_dir: &str) -> Result<String, String> {
         .ok_or_else(|| "No accessToken in credentials".to_string())
 }
 
+/// Whether the OAuth credentials at `creds_path` carry an `expiresAt` that is
+/// already in the past. Returns `false` on any read/parse failure or when the
+/// field is absent — callers fall back to the existing error-surfacing path.
+pub(crate) fn is_oauth_token_expired(creds_path: &std::path::Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(creds_path) else {
+        return false;
+    };
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+    let expires_at_ms = json["claudeAiOauth"]["expiresAt"].as_i64().unwrap_or(0);
+    if expires_at_ms <= 0 {
+        return false;
+    }
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64;
+    now_ms >= expires_at_ms
+}
+
 /// Probe a single account for its weekly rate limit utilization.
 ///
 /// Makes a minimal API call (1 token, cheapest model) and reads the
@@ -1093,6 +1114,16 @@ pub async fn probe_account_usage(config_dir: String) -> AccountUsageInfo {
         .file_name()
         .map(|n| n.to_string_lossy().to_string())
         .unwrap_or_else(|| config_dir.clone());
+
+    // Pre-flight: if the stored OAuth token is already expired, attempt a
+    // silent refresh BEFORE issuing the probe. Mirrors the warm-path discipline
+    // at `claude_api_warm.rs:174-188`. Refresh failure is non-fatal — we still
+    // try the probe with whatever token we have so the caller sees a real auth
+    // error rather than a swallowed "couldn't refresh."
+    let creds_path = std::path::PathBuf::from(&config_dir).join(".credentials.json");
+    if is_oauth_token_expired(&creds_path) {
+        let _ = crate::ai_provider::oauth_refresh::try_refresh_credentials(&creds_path);
+    }
 
     let token = match read_oauth_token(&config_dir) {
         Ok(t) => t,
@@ -1113,20 +1144,23 @@ pub async fn probe_account_usage(config_dir: String) -> AccountUsageInfo {
         }
     };
 
-    // Make a minimal API call — Haiku with max_tokens=1 is the cheapest possible
+    // Make a minimal API call — Haiku with max_tokens=1 is the cheapest possible.
+    // OAuth tokens (`sk-ant-oat*`) must go via `Authorization: Bearer` +
+    // `anthropic-beta: oauth-2025-04-20`; API keys (`sk-ant-api*`) go via
+    // `x-api-key`. `anthropic_auth::apply_async` dispatches on token prefix.
     let client = reqwest::Client::new();
-    let response = client
-        .post("https://api.anthropic.com/v1/messages")
-        .header("x-api-key", &token)
-        .header("anthropic-version", "2023-06-01")
-        .header("content-type", "application/json")
-        .json(&serde_json::json!({
-            "model": "claude-haiku-4-5-20251001",
-            "max_tokens": 1,
-            "messages": [{"role": "user", "content": "hi"}]
-        }))
-        .send()
-        .await;
+    let request = crate::ai_provider::anthropic_auth::apply_async(
+        client.post("https://api.anthropic.com/v1/messages"),
+        &token,
+    )
+    .header("anthropic-version", "2023-06-01")
+    .header("content-type", "application/json")
+    .json(&serde_json::json!({
+        "model": "claude-haiku-4-5-20251001",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}]
+    }));
+    let response = request.send().await;
 
     match response {
         Ok(resp) => {


### PR DESCRIPTION
## Summary
- New `ai_provider::anthropic_auth` helper detects `sk-ant-oat` prefix and dispatches to `Authorization: Bearer` + `anthropic-beta: oauth-2025-04-20`; `sk-ant-api` keys still route through `x-api-key`. Applied at `probe_account_usage`, `claude_api.rs:429`, `claude_api_warm.rs:331`.
- `probe_account_usage` now pre-flight-refreshes expired OAuth tokens via `oauth_refresh::try_refresh_credentials` (mirroring warm path). 5 unit tests cover header dispatch on sync + async builders.

## Test plan
- [ ] Mobile AccountUsageCard renders the 4 configured OAuth accounts with usage data (not empty / not error-state) after runner restart with this build.

Surfaced by /manual-test-loop iter 1 on the mobile AccountUsageCard surface.