### PR TITLE
fix(session): use tauri::async_runtime::spawn for coord-sync + handoff loops

### DIFF
--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -72,7 +72,7 @@ use chrono::Utc;
 use reqwest::StatusCode;
 use serde::Serialize;
 use serde_json::{json, Value as JsonValue};
-use tokio::task::JoinHandle;
+use tauri::async_runtime::JoinHandle;
 use uuid::Uuid;
 
 use super::dual_write::DualWriteGate;
@@ -323,14 +323,14 @@ impl CoordSync {
     /// keep it alive for the lifetime of the process.
     pub fn start_drain_task(&self) -> JoinHandle<()> {
         let inner = Arc::clone(&self.inner);
-        tokio::spawn(run_drain_loop(inner))
+        tauri::async_runtime::spawn(run_drain_loop(inner))
     }
 
     /// Start the heartbeat task. Returns the [`JoinHandle`] so `main.rs`
     /// can keep it alive.
     pub fn start_heartbeat_task(&self) -> JoinHandle<()> {
         let inner = Arc::clone(&self.inner);
-        tokio::spawn(run_heartbeat_loop(inner))
+        tauri::async_runtime::spawn(run_heartbeat_loop(inner))
     }
 
     // -----------------------------------------------------------------
@@ -369,7 +369,9 @@ impl CoordSync {
     pub fn start_flag_poll_task(&self) -> Option<JoinHandle<()>> {
         let tenant_id = self.inner.dual_write.tenant_id()?;
         let inner = Arc::clone(&self.inner);
-        Some(tokio::spawn(run_flag_poll_loop(inner, tenant_id)))
+        Some(tauri::async_runtime::spawn(run_flag_poll_loop(
+            inner, tenant_id,
+        )))
     }
 
     /// Phase 10 dual-write entry point — called by the **legacy** session

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -213,8 +213,8 @@ pub async fn trigger_handoff(
 /// addressed to this device the instant coord fans it out. On every
 /// (re)connect it also runs a single catch-up GET so anything published
 /// while the runner was offline is replayed. Plan §Phase 7.
-pub fn start_receiver_task(registry: Arc<SessionRegistry>) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(run_receiver_loop(registry))
+pub fn start_receiver_task(registry: Arc<SessionRegistry>) -> tauri::async_runtime::JoinHandle<()> {
+    tauri::async_runtime::spawn(run_receiver_loop(registry))
 }
 
 /// Derive coord's `/ws` URL (with the session pattern) from the resolved


### PR DESCRIPTION
## Summary

Fixes a startup panic on `origin/main` that crash-loops every fresh-main runner spawn.

`tokio::spawn` is called from inside Tauri's synchronous `.setup()` hook (`main.rs:1819-1835`). Tauri's setup callback has no Tokio runtime context, so the spawn panics on startup:

```
[LIFECYCLE] [PANIC] Thread: main
[LIFECYCLE] [PANIC] Location: src-tauri\src\session\coord_sync.rs:326:9
[LIFECYCLE] [PANIC] Message: there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

PRs implicated: #242 (coord-sync drain + heartbeat — Phase 3), #257 (Phase 10 dual-write flag-poll), #258 (handoff receiver — Phase 7). The runner has been crash-looping on every fresh-main spawn since #258 landed (existing primary runners are unaffected because they're built from older branches that predate these PRs).

## Fix

Swap to `tauri::async_runtime::spawn` at 4 startup-task call sites:
- `coord_sync.rs` `start_drain_task`
- `coord_sync.rs` `start_heartbeat_task`
- `coord_sync.rs` `start_flag_poll_task`
- `handoff.rs` `start_receiver_task`

Plus matching `JoinHandle` type swap (`tokio::task::JoinHandle` → `tauri::async_runtime::JoinHandle`) in the function signatures + the `coord_sync.rs` `use` statement. The async test helper at `coord_sync.rs:1075` stays on `tokio::spawn` (`#[tokio::test]` provides the runtime).

## Empirical verification

- **WITHOUT the fix**: temp runner spawned via supervisor with `use_lkg: true` crashes on startup with the panic above.
- **WITH the fix (handoff only)**: same panic moves to `handoff.rs:217` (same class of bug).
- **WITH both fixes**: temp runner boots cleanly. `git_sha: 0156c6775b18` (origin/main). `GET /analytics/account-usage` returns `count: 4` with `error: null` on every account row — confirms both this fix AND PR #260's OAuth fix work end-to-end.

## Out of scope (follow-up)

`main.rs:2499` + `main.rs:2512` — gated by `#[cfg(feature = "restate")]`, same class of bug, same one-line fix. We don't build with the `restate` feature so they don't fire today.

## Test plan

- [ ] CI cargo gate (fmt + clippy + check)
- [ ] CI test suite
- [ ] Local: empirical verification already done by the coordinator — temp runner on this branch boots cleanly and `/analytics/account-usage` returns clean data