### PR TITLE
fix(fleet): honor COORD_HTTP_URL in heartbeat coord_http_base

### DIFF
--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -225,9 +225,21 @@ struct DeviceBudgetRequest {
     max_concurrent_builds: i32,
 }
 
-/// Resolve the coord HTTP base from `~/.qontinui/profiles.json` active
-/// profile's `coord_url`. Mirrors the CLI helper of the same name.
+/// Resolve the coord HTTP base. Source-of-truth chain: env `COORD_HTTP_URL`
+/// → `~/.qontinui/profiles.json` active profile's `coord_url` (ws→http).
+///
+/// Honors `COORD_HTTP_URL` to match `mcp::agent_worktrees::coord_http_base`,
+/// `commands::claims`, and `commands::productivity`, so per-machine
+/// staging-pointing of the heartbeat no longer requires a profiles.json edit.
+/// Unlike those resolvers this deliberately returns `None` (rather than
+/// defaulting to `http://localhost:9870`) when nothing is configured, so the
+/// heartbeat cleanly skips instead of spamming connection errors every tick.
 fn coord_http_base() -> Option<String> {
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
     let coord_url = qontinui_runner_lib::profiles::load_strict()
         .ok()?
         .coord_url?;


### PR DESCRIPTION
## What
`fleet.rs::coord_http_base()` (the resolver behind the periodic device heartbeat → `POST /coord/devices/register`) now honors the `COORD_HTTP_URL` env var as the first source-of-truth, ahead of `profiles.json` `coord_url`.

## Why
The other coord-base resolvers already honor `COORD_HTTP_URL` (`mcp::agent_worktrees::coord_http_base`, `commands::claims`, `commands::productivity`), but the **fleet heartbeat** did not — it read only the active profile's `coord_url`. So pointing a machine's heartbeat at staging required editing `profiles.json`; with no `coord_url` it logged "no coord to heartbeat to. Skipping." every tick. This was the last residual of the coord.devices-refactor runner drift.

## Note on semantics
Unlike the other resolvers, this one **deliberately keeps returning `None`** (rather than defaulting to `http://localhost:9870`) when neither `COORD_HTTP_URL` nor a profile `coord_url` is set — so the heartbeat cleanly *skips* on unconfigured machines instead of spamming connection errors every tick. Only the env-var precedence is added; the skip behavior is preserved.