### PR TITLE
fix(restate): use tauri::async_runtime::spawn under restate feature

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2499,7 +2499,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                 ))
                             }
                         };
-                        tokio::spawn(async move {
+                        tauri::async_runtime::spawn(async move {
                             if let Err(e) = restate::http_endpoint::start_restate_endpoint(
                                 endpoint_port,
                                 restate_app_state,
@@ -2512,7 +2512,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
 
                     // Register our endpoint with the Restate server once both are ready
                     let rs = restate_settings.clone();
-                    tokio::spawn(async move {
+                    tauri::async_runtime::spawn(async move {
                         // When using an external Restate server we cannot probe a
                         // local port for it — trust that it's up and skip the wait.
                         let admin_ready = if rs.is_external() {


### PR DESCRIPTION
## Summary

Companion to PR #265 (`5aa815c4`). The same `tokio::spawn`-outside-runtime bug exists at two more sites in `src-tauri/src/main.rs`, both gated by `#[cfg(feature = "restate")]`:

- `main.rs:2502` -- startup of the Restate HTTP endpoint
- `main.rs:2515` -- register-endpoint task

Default builds don't enable `restate`, so these don't crash today, but any build with `--features restate` would hit the same `there is no reactor running` panic that PR #265 fixed for the other 4 sites.

Same trivial fix: `tokio::spawn` -> `tauri::async_runtime::spawn`. Both spawns are fire-and-forget (no captured `JoinHandle`), so no type-signature change is needed.

## Test plan

- [x] Grep confirms only the comment reference to `tokio::spawn` remains in `main.rs` after the change
- [x] `cargo check --bin qontinui-runner` (default features) reaches the qontinui-runner crate; only failure is a pre-existing `lib.rs:98` proc-macro panic from a missing `ui-bridge-build-ir` binary in PATH -- unrelated to this change
- [x] `cargo check --bin qontinui-runner --features "custom-protocol restate"` exhibits the same pre-existing `lib.rs:98` error and no new errors from the edited sites
- [ ] CI gates full clippy + fmt