### PR TITLE
fix(device-bridge): re-establish USB transport after health-monitor eviction

### DIFF
--- a/src-tauri/src/mcp/physical_device.rs
+++ b/src-tauri/src/mcp/physical_device.rs
@@ -149,6 +149,24 @@ impl PhysicalDeviceRegistry {
         map.get(id).cloned()
     }
 
+    /// Whether the device has a live transport of `kind`.
+    ///
+    /// Returns `false` for unknown devices and for known devices whose
+    /// `transports` list contains no entry of the requested kind. The USB
+    /// scanner uses this to decide whether to re-establish an `adb forward`
+    /// after the health monitor evicted a stale transport (3 consecutive
+    /// failures → `remove_transport` leaves the device entry behind with
+    /// `transports: []` and `health_state: Unreachable`). A naive
+    /// `get_device(...).is_some()` dedup matches that stuck state too, which
+    /// stranded the device permanently unreachable in the registry while it
+    /// was still a live adb target. See `mcp_api.rs` USB scanner loop.
+    pub async fn has_transport_kind(&self, id: &str, kind: TransportKind) -> bool {
+        let map = self.devices.read().await;
+        map.get(id)
+            .map(|d| d.transports.iter().any(|t| t.kind == kind))
+            .unwrap_or(false)
+    }
+
     /// Clone and return all registered devices.
     pub async fn list_all(&self) -> Vec<PhysicalDevice> {
         let map = self.devices.read().await;
@@ -307,4 +325,148 @@ impl Default for PhysicalDeviceRegistry {
 /// Sort transports by priority (lowest number = highest priority).
 fn sort_transports(transports: &mut Vec<ActiveTransport>) {
     transports.sort_by_key(|t| t.kind.priority());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_info(id: &str) -> PhysicalDeviceInfo {
+        PhysicalDeviceInfo {
+            id: id.to_string(),
+            os: DeviceOs::Android,
+            device_kind: "physical".to_string(),
+            model: Some("SM-S911B".to_string()),
+            app_id: None,
+            ui_bridge_version: None,
+            first_seen_at: 1_000,
+            pairing_token: None,
+        }
+    }
+
+    fn usb_transport(port: u16) -> ActiveTransport {
+        ActiveTransport {
+            kind: TransportKind::Usb,
+            proxy_url: format!("http://127.0.0.1:{}", port),
+            established_at: 1_000,
+            last_healthy_at: 1_000,
+            fail_count: 0,
+        }
+    }
+
+    /// has_transport_kind returns false for unknown devices.
+    #[tokio::test]
+    async fn has_transport_kind_false_for_unknown_device() {
+        let registry = PhysicalDeviceRegistry::new();
+        assert!(
+            !registry
+                .has_transport_kind("ghost", TransportKind::Usb)
+                .await
+        );
+    }
+
+    /// has_transport_kind returns true immediately after register.
+    #[tokio::test]
+    async fn has_transport_kind_true_after_register() {
+        let registry = PhysicalDeviceRegistry::new();
+        registry
+            .register(sample_info("RFCW6041HHN"), usb_transport(51583))
+            .await;
+
+        assert!(
+            registry
+                .has_transport_kind("RFCW6041HHN", TransportKind::Usb)
+                .await,
+            "freshly-registered device must report a USB transport"
+        );
+        // Sanity: not registered for LAN.
+        assert!(
+            !registry
+                .has_transport_kind("RFCW6041HHN", TransportKind::Lan)
+                .await
+        );
+    }
+
+    /// The bug reproducer: register a device, then have the health monitor
+    /// evict its USB transport via `remove_transport`. The entry remains in
+    /// the registry (so the old `get_device().is_some()` dedup matched it
+    /// and skipped re-establishment forever — leaving the API responding
+    /// with `transports: []` and `healthState: unreachable` even though the
+    /// adb device was reachable). The new `has_transport_kind` predicate
+    /// must return `false` in this state so the scanner re-establishes
+    /// the forward.
+    #[tokio::test]
+    async fn has_transport_kind_false_after_health_monitor_eviction() {
+        let registry = PhysicalDeviceRegistry::new();
+        registry
+            .register(sample_info("RFCW6041HHN"), usb_transport(51583))
+            .await;
+        assert!(
+            registry
+                .has_transport_kind("RFCW6041HHN", TransportKind::Usb)
+                .await
+        );
+
+        // Simulate the health monitor's 3-consecutive-failure path: it
+        // calls `remove_transport`, which leaves the device entry behind
+        // with `transports: []` and `health_state: Unreachable`.
+        registry
+            .remove_transport("RFCW6041HHN", TransportKind::Usb)
+            .await;
+
+        // Device entry still exists (the bug: legacy dedup
+        // `get_device().is_some()` would have matched this and the scanner
+        // would never have retried `establish_forward`).
+        let device = registry.get_device("RFCW6041HHN").await.expect(
+            "entry must persist after remove_transport so the registry can record \
+             the unreachable state",
+        );
+        assert!(device.transports.is_empty());
+        assert!(matches!(device.health_state, HealthState::Unreachable));
+
+        // The new predicate must distinguish this "stuck" state from a
+        // genuinely-live USB transport so the scanner re-establishes.
+        assert!(
+            !registry
+                .has_transport_kind("RFCW6041HHN", TransportKind::Usb)
+                .await,
+            "device with empty transports must not be treated as USB-live"
+        );
+    }
+
+    /// Re-establishment via `register` on a stuck entry must populate the
+    /// new transport and flip health back to Healthy. This is what the USB
+    /// scanner does on the next 30s tick after the predicate fix lets it
+    /// through.
+    #[tokio::test]
+    async fn reregister_restores_usb_transport_and_health() {
+        let registry = PhysicalDeviceRegistry::new();
+        registry
+            .register(sample_info("RFCW6041HHN"), usb_transport(51583))
+            .await;
+        registry
+            .remove_transport("RFCW6041HHN", TransportKind::Usb)
+            .await;
+        assert!(
+            !registry
+                .has_transport_kind("RFCW6041HHN", TransportKind::Usb)
+                .await
+        );
+
+        // Scanner re-registers with a freshly-allocated local port.
+        registry
+            .register(sample_info("RFCW6041HHN"), usb_transport(62001))
+            .await;
+
+        assert!(
+            registry
+                .has_transport_kind("RFCW6041HHN", TransportKind::Usb)
+                .await
+        );
+        let device = registry.get_device("RFCW6041HHN").await.unwrap();
+        assert!(matches!(device.health_state, HealthState::Healthy));
+        assert_eq!(device.transports.len(), 1);
+        assert_eq!(device.transports[0].proxy_url, "http://127.0.0.1:62001");
+        assert_eq!(device.transports[0].fail_count, 0);
+    }
 }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1223,7 +1223,21 @@ pub fn create_router(
                 let devices = usb_transport.scan_devices().await;
                 let registry = &state.physical_device_registry;
 
-                // Register newly connected physical devices
+                // Register newly connected physical devices.
+                //
+                // Re-establishment after transport eviction: the dedup below
+                // skips a device only when it already has a live USB transport
+                // entry in the registry. If the health monitor removed the
+                // USB transport (3 consecutive failures → `remove_transport`
+                // leaves the device entry with `transports: []` and
+                // `health_state: Unreachable`), the next scanner pass must
+                // retry `establish_forward` — otherwise the device is
+                // permanently dead in the registry while still being a live
+                // adb target. Previously the dedup checked `get_device(...).is_some()`,
+                // which also matched the empty-transport "stuck" state and
+                // produced `transports: []` + `healthState: unreachable`
+                // responses on /ui-bridge/devices even though raw probes to
+                // localhost:<ui_bridge_port> succeeded.
                 for (device_id, status, model) in &devices {
                     if status != "device" {
                         continue;
@@ -1232,8 +1246,13 @@ pub fn create_router(
                         continue; // Skip emulators — handled by app_discovery
                     }
 
-                    // Skip already-registered devices
-                    if registry.get_device(device_id).await.is_some() {
+                    // Skip devices that already have a live USB transport.
+                    // A device entry with empty `transports` (or only
+                    // non-USB transports) falls through to re-establishment.
+                    if registry
+                        .has_transport_kind(device_id, crate::mcp::transport::TransportKind::Usb)
+                        .await
+                    {
                         continue;
                     }
 


### PR DESCRIPTION
## Symptom

From `/manual-test-loop` iter 2:

```
curl http://localhost:9876/ui-bridge/devices       -> {transports: [], healthState: "unreachable"} for RFCW6041HHN
adb forward --list                                 -> device:RFCW6041HHN tcp:8087 tcp:8087 (forward live)
curl http://localhost:8087/ui-bridge/control/snapshot -> 200 with 78 elements (device fully reachable)
```

The runner reported an adb-forwarded mobile device as `healthState: unreachable` even when raw probes to the local forward succeeded.

## Root cause

The USB scanner in `src-tauri/src/mcp_api.rs` deduped via `registry.get_device(device_id).await.is_some()`. When the health monitor evicted a transport after 3 consecutive failures (`PhysicalDeviceRegistry::remove_transport`), the device entry persisted with `transports: []` and `health_state: Unreachable`. The next 30s scan pass matched the entry via the old `is_some()` predicate and skipped re-establishment forever, leaving the device permanently dead in the registry while still being a live adb target.

Once in this state, no scanner pass would ever retry `establish_forward`, even though adb continued to report the device as connected and the device-side UI Bridge was fully reachable on its original local port.

## Fix

Added `PhysicalDeviceRegistry::has_transport_kind(id, kind)` — a precise predicate that returns true only when the device has a live transport of the requested kind. The USB scanner uses it in place of the boolean "already registered" check, so:

- Devices with a live USB transport: skipped (unchanged behavior).
- Devices with `transports: []` or only non-USB transports: fall through to `establish_forward`, recovering the entry on the next 30s scanner tick.

The cleanup pass below (line 1297-1320) was already correct — it only acts on devices that still have a USB transport, so an empty-transports entry plus a re-established forward via `register()` (which sorts and resets `health_state: Healthy`) cleanly restores the device.

## Tests

`src-tauri/src/mcp/physical_device.rs` gains a `tests` module with 4 cases:

1. `has_transport_kind_false_for_unknown_device`
2. `has_transport_kind_true_after_register`
3. `has_transport_kind_false_after_health_monitor_eviction` — the bug reproducer; asserts the entry persists with `transports: []` + `Unreachable`, but the predicate correctly returns `false`.
4. `reregister_restores_usb_transport_and_health` — asserts the registry recovery path after re-establishment.

```
running 4 tests
test mcp::physical_device::tests::has_transport_kind_false_for_unknown_device ... ok
test mcp::physical_device::tests::has_transport_kind_true_after_register ... ok
test mcp::physical_device::tests::has_transport_kind_false_after_health_monitor_eviction ... ok
test mcp::physical_device::tests::reregister_restores_usb_transport_and_health ... ok

test result: ok. 4 passed; 0 failed
```

`cargo check`, `cargo clippy --tests -- -D warnings`, and `cargo fmt --check` all clean.

## Test plan

- [x] cargo check
- [x] cargo clippy --tests -- -D warnings
- [x] cargo fmt --check
- [x] cargo test mcp::physical_device::tests
- [ ] Manual repro on staging: with a paired device, kill the device-side UI Bridge until the health monitor evicts the transport (~45s of failed probes), then bring the device-side UI Bridge back up. Within 30s `/ui-bridge/devices` should report `healthy` with a non-empty `transports[]` again. (Cannot reproduce locally without restarting the primary runner; deferred to a follow-up smoke run.)

## Do NOT auto-merge

Per the parent task: investigate + fix, open PR, no auto-merge.