### PR TITLE
fix(ai-provider): complete OAuth dispatch migration to inference call sites

### DIFF
--- a/src-tauri/src/ai_provider/claude_api.rs
+++ b/src-tauri/src/ai_provider/claude_api.rs
@@ -96,13 +96,14 @@ pub(super) fn run_claude_api(
     });
 
     retry_with_backoff("Claude API", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let response = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            &api_key,
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request_body)
+        .send();
 
         match response {
             Ok(resp) => {
@@ -202,13 +203,14 @@ pub(super) fn run_claude_api_with_overrides(
     }
 
     retry_with_backoff("Claude API (overrides)", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let response = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            &api_key,
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request_body)
+        .send();
 
         match response {
             Ok(resp) => {
@@ -317,13 +319,14 @@ pub(super) fn run_claude_api_multimodal(
     }
 
     retry_with_backoff("Claude API (multimodal)", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let response = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            &api_key,
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request_body)
+        .send();
 
         match response {
             Ok(resp) => {
@@ -569,13 +572,14 @@ pub(super) fn run_claude_api_with_structured_output(
     }
 
     retry_with_backoff("Claude API (structured output)", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let response = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            &api_key,
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("content-type", "application/json")
+        .json(&request_body)
+        .send();
 
         match response {
             Ok(resp) => {

--- a/src-tauri/src/ai_provider/claude_api_warm.rs
+++ b/src-tauri/src/ai_provider/claude_api_warm.rs
@@ -469,14 +469,15 @@ pub(crate) fn run_claude_api_warm_with_structured_output(
     let client = warm_client();
 
     retry_with_backoff("Claude API (warm, structured)", || {
-        let response = client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", credential.token())
-            .header("anthropic-version", "2023-06-01")
-            .header("anthropic-beta", PROMPT_CACHING_BETA_HEADER)
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send();
+        let response = super::anthropic_auth::apply_blocking(
+            client.post("https://api.anthropic.com/v1/messages"),
+            credential.token(),
+        )
+        .header("anthropic-version", "2023-06-01")
+        .header("anthropic-beta", PROMPT_CACHING_BETA_HEADER)
+        .header("content-type", "application/json")
+        .json(&request_body)
+        .send();
 
         match response {
             Ok(resp) => {


### PR DESCRIPTION
## Summary
- Companion to PR #260 (`85ad86e4`). Completes the OAuth-token dispatch migration via `anthropic_auth::apply_async` to the 5 remaining inference call sites in `claude_api.rs` + `claude_api_warm.rs`.
- Before this PR, any user whose primary chat provider is an OAuth account (`sk-ant-oat*`) would 401 on every actual chat request, not just the analytics probe.

## Test plan
- [x] cargo check + clippy clean (agent-verified)
- [ ] CI green
- [ ] Post-merge: temp runner spawned from `origin/main`, real chat request via OAuth account returns 200 (defer-verifies on the next `/manual-test-loop`).

Surfaced as an out-of-scope finding from /manual-test-loop on the AccountUsageCard.