### PR TITLE
ci(session-trailers): require Session-Name in addition to Session-Id

### DIFF
--- a/.github/workflows/require-session-id-trailer.yml
+++ b/.github/workflows/require-session-id-trailer.yml
@@ -1,19 +1,23 @@
-# Session-Id trailer gate.
+# Session-Id + Session-Name trailer gate.
 #
 # Walks every commit in a pull request and fails if any commit message
-# lacks a canonical `Session-Id: <uuid>` trailer. The auto-injecting
-# `prepare-commit-msg` hook (qontinui-dev-notes/scripts/git-hooks/)
-# handles this transparently for Claude Code agents; this workflow is
-# the belt-and-suspenders that catches commits made:
-#   - on machines where the hook isn't installed yet,
-#   - by sibling agents that opted out of the env var,
-#   - by direct push to a feature branch (no Claude Code session in
-#     the loop).
+# lacks BOTH:
+#   - `Session-Id: <uuid>` (8-4-4-4-12 hex, the Claude Code session UUID)
+#   - `Session-Name: <name>` (non-empty, human-readable session name)
 #
-# Per `qontinui-dev-notes/memory/current_session_id.md` the trailer
-# value is the Claude Code session UUID (8-4-4-4-12 hex), NOT the
-# `/rename` slug. The regex below enforces UUID shape, not freeform.
-name: Session-Id trailer
+# The auto-injecting `prepare-commit-msg` hook in
+# qontinui-dev-notes/scripts/git-hooks/ handles BOTH trailers
+# transparently when the session has registered a name via either:
+#   1. `$CLAUDE_SESSION_NAME` env var, or
+#   2. A `$HOME/.qontinui/session-names/$CLAUDE_CODE_SESSION_ID` file.
+#
+# Sessions can register a name in one line:
+#     echo "my-session-name" > ~/.qontinui/session-names/$CLAUDE_CODE_SESSION_ID
+#
+# The Session-Name requirement was added because operators identify
+# sessions by name, not by UUID; a UUID-only audit trail makes it
+# nearly impossible to ask "who broke the test suite?".
+name: Session-Id + Session-Name trailers
 
 on:
   pull_request:
@@ -21,7 +25,7 @@ on:
 
 jobs:
   check:
-    name: Verify Session-Id trailer on every PR commit
+    name: Verify Session-Id + Session-Name trailers on every PR commit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -37,28 +41,51 @@ jobs:
         run: |
           set -euo pipefail
           base="origin/${{ github.base_ref }}"
-          missing=0
+          missing_id=0
+          missing_name=0
           total=0
           for sha in $(git log --format=%H "$base..HEAD"); do
             total=$((total+1))
-            if ! git log -1 --format=%B "$sha" \
-                 | grep -qE "^Session-Id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"; then
-              subj=$(git log -1 --format=%s "$sha")
+            body=$(git log -1 --format=%B "$sha")
+            subj=$(git log -1 --format=%s "$sha")
+            id_ok=0
+            name_ok=0
+            if printf '%s\n' "$body" | grep -qE "^Session-Id: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b"; then
+              id_ok=1
+            fi
+            if printf '%s\n' "$body" | grep -qE "^Session-Name: [[:graph:]].*"; then
+              name_ok=1
+            fi
+            if [[ $id_ok -eq 0 ]]; then
               echo "::error::commit $sha lacks 'Session-Id: <uuid>' trailer"
               echo "         subject: $subj"
-              missing=$((missing+1))
+              missing_id=$((missing_id+1))
+            fi
+            if [[ $name_ok -eq 0 ]]; then
+              echo "::error::commit $sha lacks 'Session-Name: <name>' trailer"
+              echo "         subject: $subj"
+              missing_name=$((missing_name+1))
             fi
           done
-          if [[ $missing -gt 0 ]]; then
+          if [[ $missing_id -gt 0 || $missing_name -gt 0 ]]; then
             echo ""
-            echo "::error::$missing of $total commit(s) missing the Session-Id trailer."
+            if [[ $missing_id -gt 0 ]]; then
+              echo "::error::$missing_id of $total commit(s) missing the Session-Id trailer."
+            fi
+            if [[ $missing_name -gt 0 ]]; then
+              echo "::error::$missing_name of $total commit(s) missing the Session-Name trailer."
+            fi
             echo ""
             echo "Fix options:"
+            echo "  - Register a name for this session ONCE (then re-amend / rebase):"
+            echo "      echo 'my-session-name' > ~/.qontinui/session-names/\$CLAUDE_CODE_SESSION_ID"
+            echo "    OR export CLAUDE_SESSION_NAME=my-session-name in the shell rc."
             echo "  - Run scripts/install-session-id-hook.sh once per machine"
-            echo "    (lives in qontinui-dev-notes). Future commits auto-inject."
+            echo "    (lives in qontinui-dev-notes). Future commits auto-inject"
+            echo "    both Session-Id AND Session-Name (when the name source above"
+            echo "    is configured)."
             echo "  - Retroactively: 'git rebase -i $base' and amend each commit"
-            echo "    with a 'Session-Id: <uuid>' trailer (uuid from your"
-            echo "    \$CLAUDE_CODE_SESSION_ID env var)."
+            echo "    with a 'Session-Id: <uuid>' AND 'Session-Name: <name>' trailer."
             exit 1
           fi
-          echo "✓ All $total commit(s) carry a valid Session-Id trailer."
+          echo "✓ All $total commit(s) carry valid Session-Id + Session-Name trailers."


### PR DESCRIPTION
## Summary

Tighten `require-session-id-trailer.yml` to require BOTH `Session-Id:` AND `Session-Name:` trailers on every PR commit (previously only Session-Id).

## Why

Operators identify sessions by name, not by UUID — a UUID-only audit trail makes it impossible to ask "who broke the test suite?". The local `prepare-commit-msg` hook already supports `Session-Name` (via `\$CLAUDE_SESSION_NAME` env var or `\$HOME/.qontinui/session-names/<uuid>` file); this PR brings CI enforcement in line with that capability.

## Changes

- Workflow `name` and job `name` updated to reflect both trailers.
- Top-of-file comment expanded with how-to-register-a-name + rationale.
- Walks each commit once into a `body` variable (reused for both checks).
- Independent `id_ok` / `name_ok` flags — both must be true for the commit to pass.
- Session-Name regex: `^Session-Name: [[:graph:]].*` — requires at least one visible character, freeform after that (not UUID-shaped).
- Error message updated with the one-liner to register a name.

## Test plan

- [ ] CI green on this PR — own commit carries both trailers (Session-Name registered for the authoring session before commit).