### PR TITLE
fix(session): revert spawn primitives to tokio::spawn (test compat)

### DIFF
--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -72,7 +72,7 @@ use chrono::Utc;
 use reqwest::StatusCode;
 use serde::Serialize;
 use serde_json::{json, Value as JsonValue};
-use tauri::async_runtime::JoinHandle;
+use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use super::dual_write::DualWriteGate;
@@ -323,14 +323,14 @@ impl CoordSync {
     /// keep it alive for the lifetime of the process.
     pub fn start_drain_task(&self) -> JoinHandle<()> {
         let inner = Arc::clone(&self.inner);
-        tauri::async_runtime::spawn(run_drain_loop(inner))
+        tokio::spawn(run_drain_loop(inner))
     }
 
     /// Start the heartbeat task. Returns the [`JoinHandle`] so `main.rs`
     /// can keep it alive.
     pub fn start_heartbeat_task(&self) -> JoinHandle<()> {
         let inner = Arc::clone(&self.inner);
-        tauri::async_runtime::spawn(run_heartbeat_loop(inner))
+        tokio::spawn(run_heartbeat_loop(inner))
     }
 
     // -----------------------------------------------------------------
@@ -369,9 +369,7 @@ impl CoordSync {
     pub fn start_flag_poll_task(&self) -> Option<JoinHandle<()>> {
         let tenant_id = self.inner.dual_write.tenant_id()?;
         let inner = Arc::clone(&self.inner);
-        Some(tauri::async_runtime::spawn(run_flag_poll_loop(
-            inner, tenant_id,
-        )))
+        Some(tokio::spawn(run_flag_poll_loop(inner, tenant_id)))
     }
 
     /// Phase 10 dual-write entry point — called by the **legacy** session

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -213,8 +213,8 @@ pub async fn trigger_handoff(
 /// addressed to this device the instant coord fans it out. On every
 /// (re)connect it also runs a single catch-up GET so anything published
 /// while the runner was offline is replayed. Plan §Phase 7.
-pub fn start_receiver_task(registry: Arc<SessionRegistry>) -> tauri::async_runtime::JoinHandle<()> {
-    tauri::async_runtime::spawn(run_receiver_loop(registry))
+pub fn start_receiver_task(registry: Arc<SessionRegistry>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(run_receiver_loop(registry))
 }
 
 /// Derive coord's `/ws` URL (with the session pattern) from the resolved


### PR DESCRIPTION
## Summary
- PR #265 (`5aa815c4`) swapped `tokio::spawn` → `tauri::async_runtime::spawn` in `coord_sync.rs` + `handoff.rs`. Fixed runner startup empirically — but broke `coord_sync::tests::drain_treats_409_as_acked_for_started` (tasks spawned via Tauri's runtime don't run inside `#[tokio::test]` context).
- Revert the spawn primitives back to `tokio::spawn`. The caller at `main.rs:1832` already wraps the startup-task launch in `tauri::async_runtime::spawn(async move { ... })`, which establishes a Tauri-runtime context that the inner `tokio::spawn`s correctly join.

## Test plan
- [x] `cargo test session::coord_sync::tests::drain_treats_409_as_acked_for_started` — **passes locally**
- [ ] CI green on full test suite
- [ ] Unblocks #271 + #272 once merged

Surfaced as a regression from PR #265 caught by ubuntu CI on #271 + #272.