### PR TITLE
fix(tests): run server-backed coord_sync tests on multi-thread runtime

### DIFF
--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -1164,7 +1164,7 @@ mod tests {
         assert_eq!(pending[0].event_kind, SessionEventKind::Started.as_str());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_pushes_started_event_as_post_sessions() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1203,7 +1203,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_treats_409_as_acked_for_started() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1240,7 +1240,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_retries_after_5xx() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1267,7 +1267,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn heartbeat_emits_outbox_rows_for_active_sessions() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1301,7 +1301,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn heartbeat_records_patch_to_coord() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1328,7 +1328,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn autoclose_fires_delete_after_threshold() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());


### PR DESCRIPTION
## Why CI is red on main
The `coord_sync` test suite has been intermittently red on `main` for several merges, **blocking every other PR's CI**. The two failures (`drain_pushes_started_event_as_post_sessions`, `autoclose_fires_delete_after_threshold`) both time out at `coord_sync.rs:1106` (`wait_until` 5s budget) on both Windows and Ubuntu.

## Root cause
All 6 async `coord_sync` tests each spawn a **fake axum coord server** plus the **drain** and/or **heartbeat** background loops, then poll from the test body. They use the default `#[tokio::test]` = **current_thread** runtime, so the server, the background loops, *and* the polling loop are all serialized onto **one** thread. It completes fine on an idle machine, but under CI load — where the test's OS thread gets few time slices — the work doesn't finish inside the 5s budget. Hence "inconsistent on both OSes." The two flagged tests just lost the race most often; all 6 were latently flaky.

## Fix
Switch the 6 server-backed tests to `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` so the fake server, drain loop, heartbeat loop, and polling run on **real parallel threads**. This is the root-cause fix — raising the timeout (the other option) would only make the failures slower, not eliminate them. tokio already has `features=["full"]` so `rt-multi-thread` is available. 6 one-line annotation changes; no production code touched.

## Verification
Ran the module repeatedly against the built test binary:
- **20/20 green** unloaded
- **15/15 green under 32-burner CPU saturation** (simulating a loaded CI host) — wall time held at ~3.5s, essentially unchanged from unloaded (~3.1s), confirming the budget is no longer marginal.

35/35 runs green total.