### PR TITLE
fix(ci): unblock the test job — frontend ban-ts-comment lint + coord_sync test flakiness

### DIFF
--- a/src-tauri/src/commands/federation.rs
+++ b/src-tauri/src/commands/federation.rs
@@ -72,10 +72,8 @@ async fn get_federation_reports_impl(
         url.push_str(&params.join("&"));
     }
 
-    let tenant_id =
-        qontinui_runner_lib::pair::read_paired_tenant_id_from_disk().and_then(|s| {
-            uuid::Uuid::parse_str(s.trim()).ok()
-        });
+    let tenant_id = qontinui_runner_lib::pair::read_paired_tenant_id_from_disk()
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok());
 
     let mut req = client.get(&url);
     if let Some(tid) = tenant_id {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -186,8 +186,8 @@ pub mod execution;
 pub mod execution_reporting;
 pub mod execution_variables; // Execution variables (auth source, custom variables)
 pub mod extraction;
-pub mod file_browser; // Safe read-only filesystem browsing for mobile
 pub mod federation; // Memory federation reports from coord
+pub mod file_browser; // Safe read-only filesystem browsing for mobile
 pub mod findings;
 pub mod flow; // Flow designer commands
 pub mod global_log_sources; // Global log source management

--- a/src-tauri/src/observable_bridge/memory.rs
+++ b/src-tauri/src/observable_bridge/memory.rs
@@ -374,17 +374,18 @@ impl RunnerObservableBridge for MemoryBridge {
         };
 
         // Step 1: list coord's tenant pool.
-        let listing = match memory_client::list(&self.http, &base, &token, session_ctx.tenant_id).await {
-            Ok(l) => l,
-            Err(e) => {
-                warn!(
-                    "observable_bridge::memory::pull: list failed ({e}); \
+        let listing =
+            match memory_client::list(&self.http, &base, &token, session_ctx.tenant_id).await {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!(
+                        "observable_bridge::memory::pull: list failed ({e}); \
                      leaving memory_dir untouched, snapshot = local"
-                );
-                session_ctx.post_pull_snapshot = Some(local_pre);
-                return Ok(());
-            }
-        };
+                    );
+                    session_ctx.post_pull_snapshot = Some(local_pre);
+                    return Ok(());
+                }
+            };
 
         // Step 2: for each coord entry, GET full payload (the list
         // response omits content + hash to keep the metadata call
@@ -396,7 +397,15 @@ impl RunnerObservableBridge for MemoryBridge {
         let mut coord_names: HashSet<String> = HashSet::new();
         for summary in &listing.items {
             coord_names.insert(summary.name.clone());
-            let full = match memory_client::get(&self.http, &base, &token, session_ctx.tenant_id, &summary.name).await {
+            let full = match memory_client::get(
+                &self.http,
+                &base,
+                &token,
+                session_ctx.tenant_id,
+                &summary.name,
+            )
+            .await
+            {
                 Ok(p) => p,
                 Err(e) => {
                     warn!(
@@ -440,7 +449,9 @@ impl RunnerObservableBridge for MemoryBridge {
                 written_by_agent: Some(session_ctx.session_id.to_string()),
                 written_by_device: Some(session_ctx.device_id.to_string()),
             };
-            if let Err(e) = memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req).await {
+            if let Err(e) =
+                memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req).await
+            {
                 warn!(
                     "observable_bridge::memory::pull: first-contact upsert {} failed: {e}",
                     fp.name
@@ -506,12 +517,18 @@ impl RunnerObservableBridge for MemoryBridge {
                     written_by_agent: Some(session_ctx.session_id.to_string()),
                     written_by_device: Some(session_ctx.device_id.to_string()),
                 };
-                if let Err(e) = memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req).await {
+                if let Err(e) =
+                    memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req)
+                        .await
+                {
                     warn!("observable_bridge::memory::push upsert {name} failed: {e}");
                 }
             }
             ObservableChange::Deleted { name } => {
-                if let Err(e) = memory_client::delete(&self.http, &base, &token, session_ctx.tenant_id, &name).await {
+                if let Err(e) =
+                    memory_client::delete(&self.http, &base, &token, session_ctx.tenant_id, &name)
+                        .await
+                {
                     warn!("observable_bridge::memory::push delete {name} failed: {e}");
                 }
             }
@@ -588,7 +605,9 @@ impl RunnerObservableBridge for MemoryBridge {
                 written_by_agent: Some(session_ctx.session_id.to_string()),
                 written_by_device: Some(session_ctx.device_id.to_string()),
             };
-            match memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req).await {
+            match memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req)
+                .await
+            {
                 Ok(_) => report.pushed = report.pushed.saturating_add(1),
                 Err(e) => {
                     warn!(
@@ -603,7 +622,9 @@ impl RunnerObservableBridge for MemoryBridge {
 
         // Deletes: name in pre_pull but gone now.
         for name in pre_names.difference(&post_names) {
-            match memory_client::delete(&self.http, &base, &token, session_ctx.tenant_id, name).await {
+            match memory_client::delete(&self.http, &base, &token, session_ctx.tenant_id, name)
+                .await
+            {
                 Ok(_) => report.pushed = report.pushed.saturating_add(1),
                 Err(e) => {
                     warn!(

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -1164,7 +1164,7 @@ mod tests {
         assert_eq!(pending[0].event_kind, SessionEventKind::Started.as_str());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_pushes_started_event_as_post_sessions() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1203,7 +1203,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_treats_409_as_acked_for_started() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1240,7 +1240,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn drain_retries_after_5xx() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1267,7 +1267,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn heartbeat_emits_outbox_rows_for_active_sessions() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1301,7 +1301,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn heartbeat_records_patch_to_coord() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
@@ -1328,7 +1328,7 @@ mod tests {
         .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn autoclose_fires_delete_after_threshold() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());

--- a/src/components/widgets/trace-viewer/trace-utils.test.ts
+++ b/src/components/widgets/trace-viewer/trace-utils.test.ts
@@ -690,62 +690,62 @@ describe("defensive guards for non-array input", () => {
   });
 
   it("computeInsights returns empty result for null", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against null
     const result = computeInsights(null);
     expect(result.spanCount).toBe(0);
   });
 
   it("buildTraceTree returns empty array for null", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against null
     expect(buildTraceTree(null)).toEqual([]);
   });
 
   it("buildTraceTree returns empty array for undefined", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against undefined
     expect(buildTraceTree(undefined)).toEqual([]);
   });
 
   it("buildTraceTree returns empty array for object", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against envelope object
     expect(buildTraceTree({ spans: [] })).toEqual([]);
   });
 
   it("flattenTree returns empty array for undefined", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against undefined
     expect(flattenTree(undefined)).toEqual([]);
   });
 
   it("flattenTree returns empty array for null", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against null
     expect(flattenTree(null)).toEqual([]);
   });
 
   it("filterSpans returns empty array for non-array", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     expect(filterSpans(undefined, { nameSearch: "", minDurationMs: null, phase: "all", status: "all" })).toEqual([]);
   });
 
   it("buildFlameData returns empty array for non-array", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     expect(buildFlameData(null)).toEqual([]);
   });
 
   it("flattenFlameNodes returns empty array for non-array", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     expect(flattenFlameNodes(undefined)).toEqual([]);
   });
 
   it("alignSpans returns empty array for non-array inputs", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     expect(alignSpans(null, [])).toEqual([]);
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     expect(alignSpans([], undefined)).toEqual([]);
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     expect(alignSpans(null, null)).toEqual([]);
   });
 
   it("computeTokenInsights returns empty result for non-array", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against non-array
     const result = computeTokenInsights(undefined);
     expect(result.totalInputTokens).toBe(0);
     expect(result.totalOutputTokens).toBe(0);
@@ -754,7 +754,7 @@ describe("defensive guards for non-array input", () => {
   });
 
   it("computeTokenInsights returns empty result for object input", () => {
-    // @ts-expect-error
+    // @ts-expect-error - testing runtime defense against envelope object
     const result = computeTokenInsights({ spans: [] });
     expect(result.totalInputTokens).toBe(0);
     expect(result.maxInputTokens).toBe(0);


### PR DESCRIPTION
## Why the runner `test` job is red on main (blocking every PR)
Two **independent** failures, both in the single `test (ubuntu-22.04)` / `test (windows-latest)` job:

### 1. Frontend lint (the hard, all-PR blocker)
The job's **"Lint frontend code"** step runs *before* the Rust build. It fails with **14 `@typescript-eslint/ban-ts-comment` errors** — bare `@ts-expect-error` directives (no description) in `src/components/widgets/trace-viewer/trace-utils.test.ts`. Because lint runs first, the job dies in ~1.5 min and the Rust tests never run. The directives pre-date this branch; an `@typescript-eslint` bump (in the memory-federation commit `3414fd1a`, pushed direct to main) appears to have newly promoted them to errors. **Fix:** add a 3+ char description to each, matching the convention already on the file's first directive. The 20 react-compiler *warnings* in other files do not block (the lint script has no `--max-warnings`).

### 2. coord_sync test flakiness
`drain_pushes_started_event_as_post_sessions` and `autoclose_fires_delete_after_threshold` timed out at `coord_sync.rs:1106` (`wait_until` 5s) intermittently on both OSes. **Root cause:** all 6 async `coord_sync` tests run on tokio's default **current_thread** runtime while each spawns a fake axum coord server + drain/heartbeat loops + a polling loop — all serialized onto one thread, which starves under CI load. **Fix:** `#[tokio::test(flavor = "multi_thread", worker_threads = 2)]` on all 6. Root-cause fix, not a timeout bump.

## Why both in one PR
A green `test` job needs the lint step to pass **and** the Rust tests to pass. Either fix alone still leaves the job red (lint-only would hit the flaky tests; coord_sync-only dies at lint). So the minimal green PR carries both.

## Verification
- **coord_sync:** ran the module against the built test binary **35/35 green** — 20/20 unloaded + 15/15 under 32-burner CPU saturation, wall time flat at ~3.5s.
- **lint:** all 14 bare directives now carry descriptions; 0 bare `@ts-expect-error` remain (`ban-ts-comment` is satisfied by any 3+ char description).

Branched off current `origin/main` (3414fd1a). Supersedes #275 (which was coord_sync-only on a stale base).