### PR TITLE
feat(envelope): canonical error envelope for axum JSON rejections (Phase A1)

### DIFF
--- a/src-tauri/src/mcp/api_surface.rs
+++ b/src-tauri/src/mcp/api_surface.rs
@@ -185,6 +185,8 @@ async fn handle_scan(
                 error: Some(format!("Scan task failed: {}", e)),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         )
     })?;
@@ -195,6 +197,8 @@ async fn handle_scan(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 

--- a/src-tauri/src/mcp/api_surface_diff.rs
+++ b/src-tauri/src/mcp/api_surface_diff.rs
@@ -91,6 +91,8 @@ async fn handle_diff(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 
@@ -109,6 +111,8 @@ async fn handle_save_snapshot(
                 error: Some(format!("PG pool error: {}", e)),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         )
     })?;
@@ -128,6 +132,8 @@ async fn handle_save_snapshot(
                 error: Some(format!("Serialize scan: {}", e)),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         )
     })?;
@@ -157,6 +163,8 @@ async fn handle_save_snapshot(
                     error: Some(format!("PG insert snapshot: {}", e)),
                     error_detail: None,
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 }),
             )
         })?;
@@ -181,6 +189,8 @@ async fn handle_save_snapshot(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 
@@ -200,6 +210,8 @@ async fn handle_list_snapshots(
                 error: Some(format!("PG pool error: {}", e)),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         )
     })?;
@@ -220,6 +232,8 @@ async fn handle_list_snapshots(
                     error: Some(format!("PG query snapshots: {}", e)),
                     error_detail: None,
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 }),
             )
         })?;
@@ -241,6 +255,8 @@ async fn handle_list_snapshots(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 

--- a/src-tauri/src/mcp/auto_continue.rs
+++ b/src-tauri/src/mcp/auto_continue.rs
@@ -57,6 +57,8 @@ pub async fn set_auto_continue_setting(
             error: Some(format!("Failed to save setting: {}", e)),
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         }),
     }
 }
@@ -113,6 +115,8 @@ pub async fn set_workflow_auto_continue(
             error: Some(format!("Failed to update auto-continue setting: {}", e)),
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         }),
     }
 }

--- a/src-tauri/src/mcp/envelope.rs
+++ b/src-tauri/src/mcp/envelope.rs
@@ -1,0 +1,392 @@
+//! Canonical error-envelope layer for axum JSON rejections (Phase A1).
+//!
+//! ## Two surfaces
+//!
+//! * **`envelope_rewrite_middleware`** — global `axum::middleware::from_fn` that
+//!   intercepts any `4xx text/plain` response produced by axum's built-in
+//!   extractors and rewrites it as a `application/json` [`ApiResponse`] with a
+//!   machine-readable `code`. This is the catch-all: all existing handlers get
+//!   correct envelopes without any per-handler migration.
+//!
+//! * **`UiBridgeJson<T>`** — an opt-in `FromRequest` extractor that wraps
+//!   `axum::Json<T>` and maps each [`JsonRejection`] variant to the correct
+//!   envelope at extraction time, giving richer per-handler control. Later
+//!   phases can migrate individual handlers to use this extractor.
+//!
+//! ## Ordering guarantee
+//!
+//! The middleware is layered BELOW the panic catcher in `mcp_api.rs` so that:
+//!
+//! ```text
+//! [CatchPanicLayer]           <- outermost: converts panics → 500 JSON
+//!   [envelope_rewrite_middleware]  <- rewrites 4xx text/plain → JSON envelope
+//!     [TraceLayer, CORS, ...]
+//!       [handlers]
+//! ```
+//!
+//! Async-graphql emits `application/json` for its own errors, so the
+//! `text/plain` guard ensures GraphQL responses are never rewritten.
+
+use axum::extract::rejection::JsonRejection;
+use axum::{
+    body::Body,
+    extract::{FromRequest, Request},
+    http::{header, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::de::DeserializeOwned;
+
+use crate::mcp::types::ApiResponse;
+
+// ─── Code constants ──────────────────────────────────────────────────────────
+
+const CODE_UNSUPPORTED_MEDIA_TYPE: &str = "UNSUPPORTED_MEDIA_TYPE";
+const CODE_INVALID_JSON: &str = "INVALID_JSON";
+const CODE_INVALID_REQUEST: &str = "INVALID_REQUEST";
+const CODE_PAYLOAD_TOO_LARGE: &str = "PAYLOAD_TOO_LARGE";
+const CODE_BAD_REQUEST: &str = "BAD_REQUEST";
+
+// ─── Envelope helpers ─────────────────────────────────────────────────────────
+
+/// Build a 415 envelope for a missing / wrong `Content-Type` header.
+pub fn envelope_415() -> (StatusCode, Json<ApiResponse<()>>) {
+    (
+        StatusCode::UNSUPPORTED_MEDIA_TYPE,
+        Json(ApiResponse::<()>::error_with_code(
+            "Expected request with `Content-Type: application/json`",
+            CODE_UNSUPPORTED_MEDIA_TYPE,
+        )),
+    )
+}
+
+/// Build a 400 envelope for a JSON syntax error.
+pub fn envelope_400(msg: impl Into<String>) -> (StatusCode, Json<ApiResponse<()>>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ApiResponse::<()>::error_with_code(msg, CODE_INVALID_JSON)),
+    )
+}
+
+/// Build a 413 envelope for a body-too-large rejection.
+pub fn envelope_413() -> (StatusCode, Json<ApiResponse<()>>) {
+    (
+        StatusCode::PAYLOAD_TOO_LARGE,
+        Json(ApiResponse::<()>::error_with_code(
+            "Request body exceeds the maximum allowed size",
+            CODE_PAYLOAD_TOO_LARGE,
+        )),
+    )
+}
+
+/// Build a 422 envelope for a JSON deserialize error (wrong type / missing field).
+pub fn envelope_422(msg: impl Into<String>) -> (StatusCode, Json<ApiResponse<()>>) {
+    (
+        StatusCode::UNPROCESSABLE_ENTITY,
+        Json(ApiResponse::<()>::error_with_code(
+            msg,
+            CODE_INVALID_REQUEST,
+        )),
+    )
+}
+
+// ─── UiBridgeJson<T> extractor ───────────────────────────────────────────────
+
+/// Opt-in JSON extractor that maps [`JsonRejection`] variants to the canonical
+/// error envelope at extraction time.
+///
+/// Drop-in replacement for `axum::Json<T>` on handlers that want per-handler
+/// envelope control. A1 stages the type; later phases migrate individual
+/// handlers.
+///
+/// ```rust,ignore
+/// async fn my_handler(UiBridgeJson(body): UiBridgeJson<MyRequest>) -> impl IntoResponse {
+///     // …
+/// }
+/// ```
+pub struct UiBridgeJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for UiBridgeJson<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = (StatusCode, Json<ApiResponse<()>>);
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(UiBridgeJson(value)),
+            Err(rejection) => Err(map_json_rejection(rejection)),
+        }
+    }
+}
+
+/// Map a [`JsonRejection`] to the canonical envelope tuple.
+///
+/// The `JsonRejection` enum (axum 0.8) is `#[non_exhaustive]` with variants:
+/// - `JsonDataError`         — syntactically valid JSON, failed to deserialize into T (→ 422)
+/// - `JsonSyntaxError`       — JSON parse error (→ 400)
+/// - `MissingJsonContentType`— no / wrong Content-Type header (→ 415)
+/// - `BytesRejection`        — body read failure (→ 400)
+fn map_json_rejection(rejection: JsonRejection) -> (StatusCode, Json<ApiResponse<()>>) {
+    match rejection {
+        JsonRejection::MissingJsonContentType(_) => envelope_415(),
+        JsonRejection::JsonSyntaxError(e) => envelope_400(e.to_string()),
+        JsonRejection::JsonDataError(e) => envelope_422(e.to_string()),
+        JsonRejection::BytesRejection(e) => {
+            // BytesRejection fires when the body read itself fails (connection
+            // reset, body-limit exceeded before the limit layer fires, etc.).
+            // Treat as 400 rather than 413 because we can't reliably
+            // distinguish "body too large" at this layer — the
+            // RequestBodyLimitLayer fires first and produces a distinct status.
+            envelope_400(e.to_string())
+        }
+        // Non-exhaustive: cover future variants defensively.
+        _ => (
+            StatusCode::BAD_REQUEST,
+            Json(ApiResponse::<()>::error_with_code(
+                rejection.to_string(),
+                CODE_BAD_REQUEST,
+            )),
+        ),
+    }
+}
+
+// ─── Global rewrite middleware ────────────────────────────────────────────────
+
+/// Axum middleware that rewrites `4xx text/plain` responses into the canonical
+/// JSON error envelope.
+///
+/// ## Safety boundary
+///
+/// Only `text/plain` 4xx responses are rewritten. `application/json` responses
+/// (including async-graphql errors) pass through untouched, as do 2xx/3xx/5xx
+/// responses.
+///
+/// ## Body size cap
+///
+/// The original plain-text body is read up to 64 KiB. Bodies larger than that
+/// (pathological) are discarded and the code-derived fallback message is used
+/// instead.
+pub async fn envelope_rewrite_middleware(req: Request, next: Next) -> Response {
+    let response = next.run(req).await;
+
+    let status = response.status();
+
+    // Pass through non-4xx responses immediately.
+    if !status.is_client_error() {
+        return response;
+    }
+
+    // Check Content-Type; only rewrite text/plain.
+    let content_type = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !content_type.starts_with("text/plain") {
+        return response;
+    }
+
+    // Read the body (capped at 64 KiB to avoid holding large bodies in memory).
+    let (parts, body) = response.into_parts();
+    let bytes = axum::body::to_bytes(body, 64 * 1024)
+        .await
+        .unwrap_or_default();
+    let original_msg = String::from_utf8_lossy(&bytes);
+
+    // Map the status code to a canonical error code and a human message.
+    let (code, message): (&str, String) = match status {
+        StatusCode::UNSUPPORTED_MEDIA_TYPE => (
+            CODE_UNSUPPORTED_MEDIA_TYPE,
+            if original_msg.is_empty() {
+                "Expected request with `Content-Type: application/json`".to_string()
+            } else {
+                original_msg.into_owned()
+            },
+        ),
+        StatusCode::PAYLOAD_TOO_LARGE => (
+            CODE_PAYLOAD_TOO_LARGE,
+            if original_msg.is_empty() {
+                "Request body exceeds the maximum allowed size".to_string()
+            } else {
+                original_msg.into_owned()
+            },
+        ),
+        StatusCode::UNPROCESSABLE_ENTITY => (
+            CODE_INVALID_REQUEST,
+            if original_msg.is_empty() {
+                "Failed to deserialize the JSON body into the target type".to_string()
+            } else {
+                original_msg.into_owned()
+            },
+        ),
+        StatusCode::BAD_REQUEST => (
+            CODE_INVALID_JSON,
+            if original_msg.is_empty() {
+                "Bad request".to_string()
+            } else {
+                original_msg.into_owned()
+            },
+        ),
+        _ => (
+            CODE_BAD_REQUEST,
+            if original_msg.is_empty() {
+                format!("Client error ({})", status.as_u16())
+            } else {
+                original_msg.into_owned()
+            },
+        ),
+    };
+
+    let envelope = ApiResponse::<()>::error_with_code(message, code);
+    let mut response = (parts.status, Json(envelope)).into_response();
+
+    // Preserve any non-Content-Type headers from the original response that
+    // callers might depend on (e.g. Retry-After on 429).
+    for (key, value) in &parts.headers {
+        if key != header::CONTENT_TYPE && key != header::CONTENT_LENGTH {
+            response.headers_mut().insert(key.clone(), value.clone());
+        }
+    }
+
+    response
+}
+
+// ─── Unit tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::Body, http::Request, middleware, routing::post, Router};
+    use serde::Deserialize;
+    use tower::ServiceExt;
+
+    /// Minimal request body used by the test router.
+    #[derive(Debug, Deserialize)]
+    struct Probe {
+        value: String,
+    }
+
+    /// Handler that echoes `value` back in the success envelope.
+    async fn probe_handler(axum::Json(body): axum::Json<Probe>) -> Json<ApiResponse<String>> {
+        Json(ApiResponse::success(body.value))
+    }
+
+    /// Build a minimal test router: `POST /probe` with the envelope middleware.
+    fn test_router() -> Router {
+        Router::new()
+            .route("/probe", post(probe_handler))
+            .layer(middleware::from_fn(envelope_rewrite_middleware))
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    async fn send(
+        app: Router,
+        content_type: Option<&'static str>,
+        body: &'static str,
+    ) -> (StatusCode, serde_json::Value) {
+        let mut builder = Request::builder().method("POST").uri("/probe");
+        if let Some(ct) = content_type {
+            builder = builder.header(header::CONTENT_TYPE, ct);
+        }
+        let req = builder.body(Body::from(body)).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    /// 415 UNSUPPORTED_MEDIA_TYPE — no Content-Type header.
+    #[tokio::test]
+    async fn no_content_type_gives_415_unsupported_media_type() {
+        let (status, body) = send(test_router(), None, r#"{"value":"hi"}"#).await;
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "UNSUPPORTED_MEDIA_TYPE");
+    }
+
+    /// 400 INVALID_JSON — malformed JSON body.
+    #[tokio::test]
+    async fn bad_json_gives_400_invalid_json() {
+        let (status, body) = send(test_router(), Some("application/json"), "not-valid-json{").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_JSON");
+    }
+
+    /// 422 INVALID_REQUEST — syntactically valid JSON but missing required field.
+    #[tokio::test]
+    async fn missing_field_gives_422_invalid_request() {
+        let (status, body) = send(
+            test_router(),
+            Some("application/json"),
+            r#"{"other_field":"oops"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+    }
+
+    /// 2xx text/plain response must pass through untouched (middleware MUST NOT
+    /// rewrite non-error responses).
+    #[tokio::test]
+    async fn success_response_passes_through_unchanged() {
+        let (status, body) = send(
+            test_router(),
+            Some("application/json"),
+            r#"{"value":"hello"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["success"], true);
+        assert_eq!(body["data"], "hello");
+    }
+
+    /// An already-JSON 4xx response (e.g. from a handler returning an explicit
+    /// error) must NOT be rewritten — the text/plain guard is the discriminator.
+    #[tokio::test]
+    async fn already_json_4xx_passes_through_unchanged() {
+        /// Handler that returns an explicit JSON 400.
+        async fn explicit_json_error() -> impl IntoResponse {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ApiResponse::<()>::error("explicit handler error")),
+            )
+        }
+
+        let app = Router::new()
+            .route("/json-err", post(explicit_json_error))
+            .layer(middleware::from_fn(envelope_rewrite_middleware));
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/json-err")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(body["success"], false);
+        // The `code` field should NOT be present — the handler set `error` but not `code`.
+        assert!(
+            body["code"].is_null(),
+            "already-JSON 4xx must not be rewritten"
+        );
+        assert_eq!(body["error"], "explicit handler error");
+    }
+}

--- a/src-tauri/src/mcp/executor.rs
+++ b/src-tauri/src/mcp/executor.rs
@@ -125,6 +125,8 @@ pub async fn restart_executor(
                         error: Some("Bridge manager not initialised".to_string()),
                         error_detail: None,
                         hint: None,
+                        code: None,
+                        suggestions: None,
                     }),
                 ));
             }
@@ -215,6 +217,8 @@ pub async fn restart_executor(
                 error: Some(format!("Failed to spawn Python executor: {}", e)),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         ));
     }
@@ -300,6 +304,8 @@ pub async fn restart_executor(
                     error: Some(message),
                     error_detail: None,
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 }),
             ))
         }

--- a/src-tauri/src/mcp/memory_consolidation_api.rs
+++ b/src-tauri/src/mcp/memory_consolidation_api.rs
@@ -97,6 +97,8 @@ async fn consolidate_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -122,6 +124,8 @@ async fn consolidation_log_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -162,6 +166,8 @@ async fn mental_models_handler(
                 error: None,
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }))
         }
         Err(e) => Err((
@@ -188,6 +194,8 @@ async fn decay_preview_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -227,6 +235,8 @@ async fn health_handler(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 
@@ -286,6 +296,8 @@ async fn contradiction_scan_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -317,6 +329,8 @@ async fn contradiction_log_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -343,6 +357,8 @@ async fn dreamer_run_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -379,6 +395,8 @@ async fn dreamer_traces_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -410,6 +428,8 @@ async fn dreamer_log_handler(
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         })),
         Err(e) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src-tauri/src/mcp/meta_optimizer_api.rs
+++ b/src-tauri/src/mcp/meta_optimizer_api.rs
@@ -1398,6 +1398,8 @@ async fn get_prompt_optimization_status_handler(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 
@@ -1417,6 +1419,8 @@ async fn get_prompt_group_metrics_handler(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 
@@ -1448,6 +1452,8 @@ async fn get_prompt_optimization_evidence_handler(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 
@@ -1471,6 +1477,8 @@ async fn get_prompt_evolution_handler(
         error: None,
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }))
 }
 

--- a/src-tauri/src/mcp/misc.rs
+++ b/src-tauri/src/mcp/misc.rs
@@ -587,6 +587,8 @@ pub async fn launch_debug_chrome() -> Json<ApiResponse<String>> {
                         error: Some(format!("Failed to launch Chrome: {}", e)),
                         error_detail: None,
                         hint: None,
+                        code: None,
+                        suggestions: None,
                     })
                 }
             }
@@ -599,6 +601,8 @@ pub async fn launch_debug_chrome() -> Json<ApiResponse<String>> {
                 error: Some("Chrome not found. Please close Chrome and launch it manually with: chrome.exe --remote-debugging-port=9222".to_string()),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             })
         }
     }

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -55,6 +55,7 @@ pub mod device_jwt_refresher;
 pub mod discovery;
 pub mod dom_capture;
 pub mod entity_profiles_api;
+pub mod envelope;
 pub mod error_monitor;
 pub mod executor;
 pub mod extraction;

--- a/src-tauri/src/mcp/types.rs
+++ b/src-tauri/src/mcp/types.rs
@@ -311,6 +311,16 @@ pub struct ApiResponse<T: Serialize> {
     /// suggestions or workaround guidance to callers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hint: Option<serde_json::Value>,
+    /// Canonical SCREAMING_SNAKE_CASE error code for transport-layer and
+    /// handler-level rejections (e.g. `INVALID_JSON`, `INVALID_REQUEST`,
+    /// `UNSUPPORTED_MEDIA_TYPE`, `PAYLOAD_TOO_LARGE`). Absent on success
+    /// responses and on legacy error paths that predate the envelope plan.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    /// Optional human-readable recovery suggestions surfaced to callers
+    /// alongside `code`. Absent when no actionable guidance is available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestions: Option<Vec<String>>,
 }
 
 impl<T: Serialize> ApiResponse<T> {
@@ -321,6 +331,8 @@ impl<T: Serialize> ApiResponse<T> {
             error: None,
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         }
     }
 
@@ -331,6 +343,8 @@ impl<T: Serialize> ApiResponse<T> {
             error: Some(message.into()),
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         }
     }
 
@@ -344,6 +358,42 @@ impl<T: Serialize> ApiResponse<T> {
             error: Some(message.into()),
             error_detail: Some(detail),
             hint: None,
+            code: None,
+            suggestions: None,
+        }
+    }
+
+    /// Build an error response with a canonical SCREAMING_SNAKE_CASE `code`.
+    /// Use for transport-layer rejections (JSON parse errors, missing
+    /// Content-Type, body-too-large) where callers need a machine-readable
+    /// discriminator in addition to the human-readable `error` message.
+    pub fn error_with_code(message: impl Into<String>, code: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            data: None,
+            error: Some(message.into()),
+            error_detail: None,
+            hint: None,
+            code: Some(code.into()),
+            suggestions: None,
+        }
+    }
+
+    /// Like `error_with_code` but also attaches a list of human-readable
+    /// recovery suggestions surfaced to callers alongside the `code`.
+    pub fn error_with_code_and_suggestions(
+        message: impl Into<String>,
+        code: impl Into<String>,
+        suggestions: Vec<String>,
+    ) -> Self {
+        Self {
+            success: false,
+            data: None,
+            error: Some(message.into()),
+            error_detail: None,
+            hint: None,
+            code: Some(code.into()),
+            suggestions: Some(suggestions),
         }
     }
 }
@@ -356,6 +406,8 @@ pub fn api_error(message: impl Into<String>) -> ApiResponse<()> {
         error: Some(message.into()),
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }
 }
 
@@ -370,6 +422,8 @@ pub fn api_error_detailed(
         error: Some(message.into()),
         error_detail: Some(detail),
         hint: None,
+        code: None,
+        suggestions: None,
     }
 }
 
@@ -390,6 +444,8 @@ pub fn api_error_with_hint(
         error: Some(message.into()),
         error_detail: Some(detail),
         hint: Some(hint),
+        code: None,
+        suggestions: None,
     }
 }
 

--- a/src-tauri/src/mcp/ui_bridge/capabilities.rs
+++ b/src-tauri/src/mcp/ui_bridge/capabilities.rs
@@ -994,6 +994,8 @@ pub async fn ui_bridge_batch_handler(
                 )),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         ));
     }
@@ -1114,6 +1116,8 @@ pub async fn ui_bridge_control_batch_handler(
                 ),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }),
         ));
     }
@@ -1214,6 +1218,8 @@ pub async fn ui_bridge_control_batch_handler(
             error: Some("One or more batch steps failed".to_string()),
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         }))
     }
 }

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -1075,6 +1075,8 @@ pub async fn ui_bridge_execute_action_handler(
                     error: Some("element is disabled".to_string()),
                     error_detail: None,
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 }));
             }
 
@@ -1450,6 +1452,8 @@ pub async fn ui_bridge_execute_action_handler(
                     )),
                     error_detail: None,
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 };
                 result = Ok(Json(envelope));
             } else if recovery.recovered {
@@ -2745,6 +2749,8 @@ fn api_error_to_value(message: impl Into<String>) -> ApiResponse<serde_json::Val
         error: Some(message.into()),
         error_detail: None,
         hint: None,
+        code: None,
+        suggestions: None,
     }
 }
 
@@ -2982,6 +2988,8 @@ fn apply_strict_timeout_reshape(
                 error: err.error,
                 error_detail: err.error_detail,
                 hint: err.hint,
+                code: err.code,
+                suggestions: err.suggestions,
             };
             Err((status, Json(widened)))
         }
@@ -3748,6 +3756,8 @@ pub async fn ui_bridge_expect_element_handler(
                 )),
                 error_detail: None,
                 hint: Some(envelope.data.unwrap_or(serde_json::Value::Null)),
+                code: None,
+                suggestions: None,
             }),
         ))
     }
@@ -4940,6 +4950,8 @@ mod action_not_supported_tests {
             )),
             error_detail: None,
             hint: None,
+            code: None,
+            suggestions: None,
         };
         let envelope_json = serde_json::to_value(&envelope).unwrap();
 
@@ -5013,6 +5025,8 @@ mod action_not_supported_tests {
             error: Some(detail.message.clone()),
             error_detail: Some(detail),
             hint: None,
+            code: None,
+            suggestions: None,
         };
         let env_json = serde_json::to_value(&envelope).unwrap();
         assert_eq!(

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -1231,6 +1231,8 @@ pub async fn ui_bridge_tab_activate_handler(
                     error: Some(message),
                     error_detail: Some(detail),
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 }),
             ));
         }
@@ -1251,6 +1253,8 @@ pub async fn ui_bridge_tab_activate_handler(
                     error: Some(e),
                     error_detail: None,
                     hint: None,
+                    code: None,
+                    suggestions: None,
                 }),
             ))
         }

--- a/src-tauri/src/mcp/ui_bridge/terminals.rs
+++ b/src-tauri/src/mcp/ui_bridge/terminals.rs
@@ -89,6 +89,8 @@ pub(crate) fn classify_terminal_session_get_response(
                 error: Some(format!("unknown terminal session: \"{}\"", id)),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             };
             Err((StatusCode::NOT_FOUND, Json(body)))
         }
@@ -105,6 +107,8 @@ pub(crate) fn classify_terminal_session_get_response(
                 ),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             };
             Err((StatusCode::INTERNAL_SERVER_ERROR, Json(body)))
         }
@@ -135,6 +139,8 @@ pub async fn ui_bridge_terminal_session_get_handler(
                 error: Some(e),
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             };
             Err((StatusCode::INTERNAL_SERVER_ERROR, Json(body)))
         }

--- a/src-tauri/src/mcp/unified_workflows.rs
+++ b/src-tauri/src/mcp/unified_workflows.rs
@@ -2795,6 +2795,8 @@ async fn sync_slash_commands_handler(
                 error: None,
                 error_detail: None,
                 hint: None,
+                code: None,
+                suggestions: None,
             }))
         }
         Err(e) => {

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1761,13 +1761,22 @@ pub fn create_router(
         .layer(cors)
         .layer(RequestBodyLimitLayer::new(100 * 1024 * 1024))
         .layer(axum::Extension(graphql_schema))
-        // Outermost layer: catch panics from any handler/middleware below and
-        // convert them into a JSON 500 matching the runner's `ApiResponse<()>`
-        // shape. Without this, a handler panic surfaces to the client as
-        // "empty reply from server" — diagnostically indistinguishable from a
-        // legitimate empty success response. `.layer()` is bottom-up, so the
-        // LAST `.layer()` call wraps the rest. `with_state` must remain
-        // terminal.
+        // Layer ordering (`.layer()` is bottom-up — last call = outermost):
+        //
+        //   [CatchPanicLayer]              ← outermost: panics → 500 JSON
+        //     [envelope_rewrite_middleware] ← rewrites 4xx text/plain → JSON envelope
+        //       [TraceLayer, CORS, BodyLimit, ...]
+        //         [handlers]
+        //
+        // The panic layer must remain outermost so it can catch panics that
+        // originate in any layer below, including the envelope middleware itself.
+        // The envelope layer sits immediately inside so it rewrites axum's own
+        // rejection bodies (missing Content-Type, bad JSON, etc.) before they
+        // reach the client. `application/json` responses — including
+        // async-graphql errors — are never rewritten (text/plain guard).
+        .layer(axum::middleware::from_fn(
+            crate::mcp::envelope::envelope_rewrite_middleware,
+        ))
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(
             runner_panic_handler,
         ))


### PR DESCRIPTION
Phase A1 of plan `2026-05-24-error-envelope-coverage-and-process-reconcile`. First of a 4-PR Part-A stack (A1←A2←A3←A4).

## What
Every axum `Json<T>` extractor rejection (415 missing content-type, 400 syntax, 422 deserialize, 413 too-large) currently returns a `text/plain` body, violating the runner's canonical JSON error envelope. This adds:
- `ApiResponse<T>`: new `code` + `suggestions` fields (`skip_serializing_if=None`, success wire shape unchanged) + `error_with_code` builders.
- `mcp::envelope`: `UiBridgeJson<T>` opt-in extractor + `envelope_rewrite_middleware` (global `from_fn` rewriting 4xx `text/plain` → JSON envelope with SCREAMING_SNAKE_CASE `code`). The `text/plain` guard leaves async-graphql (application/json) untouched.
- Middleware wired immediately inside `CatchPanicLayer`. 5 unit tests pass; `cargo fmt` + `clippy -D warnings` clean.

Codes: `UNSUPPORTED_MEDIA_TYPE` (415), `INVALID_JSON` (400), `INVALID_REQUEST` (422), `PAYLOAD_TOO_LARGE` (413).

Follow-up: doc codes table lives on the unmerged ui-bridge `fix/sdk-interaction-relay-parity` branch — add these 4 codes there when it merges.

Implemented autonomously via /implement-plan. No AI attribution per repo convention.