### PR TITLE
feat(envelope): migrate ui_bridge handlers to UiBridgeJson with per-type hints (Phase A3)

### DIFF
--- a/src-tauri/src/mcp/envelope.rs
+++ b/src-tauri/src/mcp/envelope.rs
@@ -40,6 +40,32 @@ use serde::de::DeserializeOwned;
 
 use crate::mcp::types::ApiResponse;
 
+// ─── RequestHints trait ───────────────────────────────────────────────────────
+
+/// Per-request-type recovery hints surfaced on a 422 (body shape) rejection.
+///
+/// Implement this trait on request structs that benefit from type-specific
+/// guidance so callers can recover from a shape error without reading the
+/// source. The defaults return `None` (no hints); override only the arms
+/// relevant to your type.
+///
+/// **Do NOT add a blanket impl** — Rust's orphan + no-specialization rules
+/// would prevent any specific impl from ever winning. Add an explicit
+/// `impl RequestHints for T {}` (empty body = all defaults) for request
+/// types that genuinely have no useful hint.
+pub trait RequestHints {
+    /// Human-readable recovery suggestions surfaced in `suggestions` on a
+    /// shape error (e.g. missing field, wrong type).
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        None
+    }
+    /// Structured allowed-values payload surfaced in `data` on a shape error
+    /// (e.g. `{"allowedModes": ["hard", "soft"]}`).
+    fn shape_error_data() -> Option<serde_json::Value> {
+        None
+    }
+}
+
 // ─── Code constants ──────────────────────────────────────────────────────────
 
 const CODE_UNSUPPORTED_MEDIA_TYPE: &str = "UNSUPPORTED_MEDIA_TYPE";
@@ -97,8 +123,9 @@ pub fn envelope_422(msg: impl Into<String>) -> (StatusCode, Json<ApiResponse<()>
 /// error envelope at extraction time.
 ///
 /// Drop-in replacement for `axum::Json<T>` on handlers that want per-handler
-/// envelope control. A1 stages the type; later phases migrate individual
-/// handlers.
+/// envelope control. The bound `T: RequestHints` allows per-request-type
+/// recovery suggestions and allowed-values data to be surfaced on a 422
+/// (body shape) rejection.
 ///
 /// ```rust,ignore
 /// async fn my_handler(UiBridgeJson(body): UiBridgeJson<MyRequest>) -> impl IntoResponse {
@@ -110,30 +137,43 @@ pub struct UiBridgeJson<T>(pub T);
 impl<S, T> FromRequest<S> for UiBridgeJson<T>
 where
     S: Send + Sync,
-    T: DeserializeOwned,
+    T: DeserializeOwned + RequestHints,
 {
     type Rejection = (StatusCode, Json<ApiResponse<()>>);
 
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         match axum::Json::<T>::from_request(req, state).await {
             Ok(axum::Json(value)) => Ok(UiBridgeJson(value)),
-            Err(rejection) => Err(map_json_rejection(rejection)),
+            Err(rejection) => Err(map_json_rejection_with_hints::<T>(rejection)),
         }
     }
 }
 
-/// Map a [`JsonRejection`] to the canonical envelope tuple.
+/// Map a [`JsonRejection`] to the canonical envelope tuple, folding in
+/// type-specific [`RequestHints`] on the 422 arm.
 ///
 /// The `JsonRejection` enum (axum 0.8) is `#[non_exhaustive]` with variants:
 /// - `JsonDataError`         — syntactically valid JSON, failed to deserialize into T (→ 422)
 /// - `JsonSyntaxError`       — JSON parse error (→ 400)
 /// - `MissingJsonContentType`— no / wrong Content-Type header (→ 415)
 /// - `BytesRejection`        — body read failure (→ 400)
-fn map_json_rejection(rejection: JsonRejection) -> (StatusCode, Json<ApiResponse<()>>) {
+fn map_json_rejection_with_hints<T: RequestHints>(
+    rejection: JsonRejection,
+) -> (StatusCode, Json<ApiResponse<()>>) {
     match rejection {
         JsonRejection::MissingJsonContentType(_) => envelope_415(),
-        JsonRejection::JsonSyntaxError(e) => envelope_400(e.to_string()),
-        JsonRejection::JsonDataError(e) => envelope_422(e.to_string()),
+        JsonRejection::JsonSyntaxError(e) => {
+            // Syntax errors (e.g. truncated JSON, bad escape) benefit from
+            // shape hints too — a caller who sends `{action:"click"}` with
+            // bad JSON likely still wants the allowed-values list.
+            envelope_400_with_hints::<T>(e.to_string())
+        }
+        JsonRejection::JsonDataError(e) => {
+            // Primary target for hints: the body was valid JSON but didn't
+            // match the expected shape (wrong field type, missing required
+            // field, unknown tag value).
+            envelope_422_with_hints::<T>(e.to_string())
+        }
         JsonRejection::BytesRejection(e) => {
             // BytesRejection fires when the body read itself fails (connection
             // reset, body-limit exceeded before the limit layer fires, etc.).
@@ -150,6 +190,60 @@ fn map_json_rejection(rejection: JsonRejection) -> (StatusCode, Json<ApiResponse
                 CODE_BAD_REQUEST,
             )),
         ),
+    }
+}
+
+/// Build a 400 envelope optionally enriched with type-level hints.
+fn envelope_400_with_hints<T: RequestHints>(
+    msg: impl Into<String>,
+) -> (StatusCode, Json<ApiResponse<()>>) {
+    let msg = msg.into();
+    match T::shape_error_suggestions() {
+        Some(suggestions) if !suggestions.is_empty() => {
+            let mut resp = ApiResponse::<()>::error_with_code_and_suggestions(
+                &msg,
+                CODE_INVALID_JSON,
+                suggestions,
+            );
+            resp.data = T::shape_error_data().map(|_| ());
+            // Can't attach arbitrary data to `ApiResponse<()>` — surface the
+            // allowed-values payload in the `hint` field instead so no info
+            // is lost (hint is a `serde_json::Value`, not typed by T).
+            let mut base_resp = ApiResponse::<()>::error_with_code_and_suggestions(
+                msg,
+                CODE_INVALID_JSON,
+                T::shape_error_suggestions().unwrap_or_default(),
+            );
+            base_resp.hint = T::shape_error_data();
+            (StatusCode::BAD_REQUEST, Json(base_resp))
+        }
+        _ => envelope_400(msg),
+    }
+}
+
+/// Build a 422 envelope enriched with type-level hints (suggestions + data).
+fn envelope_422_with_hints<T: RequestHints>(
+    msg: impl Into<String>,
+) -> (StatusCode, Json<ApiResponse<()>>) {
+    let msg = msg.into();
+    let suggestions = T::shape_error_suggestions();
+    let data = T::shape_error_data();
+
+    match (suggestions, data) {
+        (None, None) => envelope_422(msg),
+        (suggestions, data) => {
+            let mut resp = match suggestions {
+                Some(s) if !s.is_empty() => {
+                    ApiResponse::<()>::error_with_code_and_suggestions(msg, CODE_INVALID_REQUEST, s)
+                }
+                _ => ApiResponse::<()>::error_with_code(msg, CODE_INVALID_REQUEST),
+            };
+            // Surface the allowed-values payload in `hint` (a
+            // `serde_json::Value` free field) so structured data like
+            // `{"allowedModes":["hard","soft"]}` reaches the caller.
+            resp.hint = data;
+            (StatusCode::UNPROCESSABLE_ENTITY, Json(resp))
+        }
     }
 }
 
@@ -270,6 +364,8 @@ mod tests {
         value: String,
     }
 
+    impl super::RequestHints for Probe {}
+
     /// Handler that echoes `value` back in the success envelope.
     async fn probe_handler(axum::Json(body): axum::Json<Probe>) -> Json<ApiResponse<String>> {
         Json(ApiResponse::success(body.value))
@@ -388,5 +484,244 @@ mod tests {
             "already-JSON 4xx must not be rewritten"
         );
         assert_eq!(body["error"], "explicit handler error");
+    }
+
+    // ── Phase A3 tests: per-type hints on 422 ────────────────────────────────
+
+    /// Helper: build a UiBridgeJson<T> router + send a malformed body.
+    async fn send_uib<T>(body: &'static str) -> (StatusCode, serde_json::Value)
+    where
+        T: serde::de::DeserializeOwned + RequestHints + Send + 'static,
+    {
+        async fn handler<T: serde::de::DeserializeOwned + RequestHints + Send>(
+            UiBridgeJson(_): UiBridgeJson<T>,
+        ) -> impl IntoResponse {
+            StatusCode::OK
+        }
+
+        let app = Router::new().route("/test", axum::routing::post(handler::<T>));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    // ── PageNavigateRequest: allowedModes in hint + INVALID_REQUEST code ──────
+
+    #[derive(Debug, serde::Deserialize)]
+    struct PageNavigateRequestStub {
+        #[allow(dead_code)]
+        url: String,
+        #[serde(default)]
+        #[allow(dead_code)]
+        mode: Option<String>,
+    }
+
+    impl RequestHints for PageNavigateRequestStub {
+        fn shape_error_suggestions() -> Option<Vec<String>> {
+            Some(vec![
+                "Required field: `url` (string). Optional: `mode` (\"hard\" | \"soft\")."
+                    .to_string(),
+            ])
+        }
+        fn shape_error_data() -> Option<serde_json::Value> {
+            Some(serde_json::json!({ "allowedModes": ["hard", "soft"] }))
+        }
+    }
+
+    /// 422 with `allowedModes` in `hint` and `INVALID_REQUEST` code.
+    #[tokio::test]
+    async fn page_navigate_request_422_carries_allowed_modes_hint() {
+        // Missing required `url` field → JsonDataError → 422
+        let (status, body) = send_uib::<PageNavigateRequestStub>(r#"{"mode": "hard"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(
+            body["code"], "INVALID_REQUEST",
+            "code must be INVALID_REQUEST on shape error"
+        );
+        let suggestions = body["suggestions"].as_array().expect("suggestions array");
+        assert!(!suggestions.is_empty(), "suggestions must not be empty");
+        let hint = &body["hint"];
+        assert!(
+            !hint.is_null(),
+            "hint must be populated with allowedModes for navigate"
+        );
+        let modes = hint["allowedModes"].as_array().expect("allowedModes array");
+        assert!(
+            modes.iter().any(|m| m.as_str() == Some("hard")),
+            "allowedModes must contain 'hard'"
+        );
+        assert!(
+            modes.iter().any(|m| m.as_str() == Some("soft")),
+            "allowedModes must contain 'soft'"
+        );
+    }
+
+    // ── AssertRequestStub: allowedAssertionTypes in hint ─────────────────────
+
+    #[derive(Debug, serde::Deserialize)]
+    struct AssertRequestStub {
+        #[allow(dead_code)]
+        assertions: Vec<serde_json::Value>,
+    }
+
+    impl RequestHints for AssertRequestStub {
+        fn shape_error_suggestions() -> Option<Vec<String>> {
+            Some(vec![
+                "Required field: `assertions` (array of Assertion objects).".to_string(),
+                "Assertion `type` values: no_overlap, contains_text, text_fits_container, \
+                 aligned_horizontally, aligned_vertically, color_within, \
+                 typography_consistent, no_layout_shift_since, no_clipping, \
+                 animation_settled, contrast_meets_wcag."
+                    .to_string(),
+            ])
+        }
+        fn shape_error_data() -> Option<serde_json::Value> {
+            Some(serde_json::json!({
+                "allowedAssertionTypes": [
+                    "no_overlap", "contains_text", "text_fits_container",
+                    "aligned_horizontally", "aligned_vertically", "color_within",
+                    "typography_consistent", "no_layout_shift_since", "no_clipping",
+                    "animation_settled", "contrast_meets_wcag"
+                ]
+            }))
+        }
+    }
+
+    /// 422 with `allowedAssertionTypes` in `hint`.
+    #[tokio::test]
+    async fn assert_request_422_carries_assertion_types_hint() {
+        // Missing required `assertions` field → 422
+        let (status, body) = send_uib::<AssertRequestStub>(r#"{"target": "foo"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry assertion DSL info");
+        let types = hint["allowedAssertionTypes"]
+            .as_array()
+            .expect("allowedAssertionTypes array");
+        assert!(
+            types.iter().any(|t| t.as_str() == Some("no_overlap")),
+            "no_overlap must be in allowed types"
+        );
+        assert!(
+            types
+                .iter()
+                .any(|t| t.as_str() == Some("contrast_meets_wcag")),
+            "contrast_meets_wcag must be in allowed types"
+        );
+    }
+
+    // ── AnalyzeRequestStub: allowedAnalyzers in hint ──────────────────────────
+
+    #[derive(Debug, serde::Deserialize)]
+    struct AnalyzeRequestStub {
+        #[allow(dead_code)]
+        analyzer: String,
+    }
+
+    impl RequestHints for AnalyzeRequestStub {
+        fn shape_error_suggestions() -> Option<Vec<String>> {
+            Some(vec![
+                "Required field: `analyzer` (one of: \"layout\", \"typography\", \
+                 \"color\", \"dynamic\", \"elements\")."
+                    .to_string(),
+            ])
+        }
+        fn shape_error_data() -> Option<serde_json::Value> {
+            Some(serde_json::json!({
+                "allowedAnalyzers": ["layout", "typography", "color", "dynamic", "elements"]
+            }))
+        }
+    }
+
+    /// 422 with `allowedAnalyzers` in `hint`.
+    #[tokio::test]
+    async fn analyze_request_422_carries_allowed_analyzers_hint() {
+        // Missing required `analyzer` field → 422
+        let (status, body) = send_uib::<AnalyzeRequestStub>(r#"{"target": "foo"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry analyzer info");
+        let analyzers = hint["allowedAnalyzers"]
+            .as_array()
+            .expect("allowedAnalyzers");
+        assert_eq!(analyzers.len(), 5, "should expose all 5 analyzers");
+        assert!(
+            analyzers.iter().any(|a| a.as_str() == Some("layout")),
+            "layout must be listed"
+        );
+    }
+
+    // ── NavigateAndWaitRequestStub: allowedActions in hint ────────────────────
+
+    #[derive(Debug, serde::Deserialize)]
+    struct NavigateAndWaitRequestStub {
+        #[allow(dead_code)]
+        element_id: String,
+    }
+
+    impl RequestHints for NavigateAndWaitRequestStub {
+        fn shape_error_suggestions() -> Option<Vec<String>> {
+            Some(vec!["Required field: `elementId` (string).".to_string()])
+        }
+        fn shape_error_data() -> Option<serde_json::Value> {
+            Some(serde_json::json!({
+                "allowedActions": ["click", "doubleClick", "hover", "type"]
+            }))
+        }
+    }
+
+    /// 422 with `allowedActions` in `hint`.
+    #[tokio::test]
+    async fn navigate_and_wait_request_422_carries_allowed_actions_hint() {
+        // Missing required `elementId` field → 422
+        let (status, body) = send_uib::<NavigateAndWaitRequestStub>(r#"{"action": "click"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry allowedActions");
+        let actions = hint["allowedActions"].as_array().expect("allowedActions");
+        assert!(
+            actions.iter().any(|a| a.as_str() == Some("click")),
+            "click must be in allowedActions"
+        );
+    }
+
+    // ── Hint-less request: no suggestions or hint fields ─────────────────────
+
+    #[derive(Debug, serde::Deserialize)]
+    struct NakedRequest {
+        #[allow(dead_code)]
+        value: String,
+    }
+
+    impl RequestHints for NakedRequest {}
+
+    /// A type with no hints produces the baseline 422 envelope without
+    /// `suggestions` or `hint` fields.
+    #[tokio::test]
+    async fn naked_request_422_has_no_hint_or_suggestions() {
+        let (status, body) = send_uib::<NakedRequest>(r#"{"other": "oops"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        // No hints provided — these fields must be absent (null in serde_json::Value terms).
+        assert!(body["suggestions"].is_null(), "suggestions must be absent");
+        assert!(body["hint"].is_null(), "hint must be absent");
     }
 }

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -32,6 +32,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::mcp::app_dispatch::AppDispatcher;
 use crate::mcp::app_registry::{AppRegistry, AppTransport};
+use crate::mcp::envelope::UiBridgeJson;
 use crate::mcp::types::{api_error, api_error_detailed, ApiResponse, ApiState};
 
 use super::diagnostics::{extract_error_code, CanonicalCode};
@@ -1921,7 +1922,7 @@ pub async fn ui_bridge_get_component_handler(
 pub async fn ui_bridge_execute_component_action_handler(
     State(state): State<Arc<ApiState>>,
     Path((id, action_id)): Path<(String, String)>,
-    Json(request): Json<UIBridgeComponentActionRequest>,
+    UiBridgeJson(request): UiBridgeJson<UIBridgeComponentActionRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     info!(
         "UI Bridge API: Executing action {} on component {}",

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -20,6 +20,7 @@ use tauri::Emitter;
 use tracing::{debug, error, info};
 
 use super::types::UiBridgeError;
+use crate::mcp::envelope::{RequestHints, UiBridgeJson};
 use crate::mcp::types::{api_error, api_error_detailed, ApiResponse, ApiState};
 
 use super::helpers::{direct_webview_evaluate_with_result, evaluate_js_expression, safe_evaluate};
@@ -63,6 +64,28 @@ pub struct NavigateAndWaitRequest {
     pub timeout_ms: u64,
 }
 
+impl RequestHints for NavigateAndWaitRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required fields: `elementId` (string). Optional: `action` (default \"click\"), \
+             `params`, `waitForStableMs` (default 800), `timeoutMs` (default 8000)."
+                .to_string(),
+            "The `action` field must be a supported element action (click, type, hover, etc.)."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "allowedActions": [
+                "click", "doubleClick", "double_click", "double", "right", "middle",
+                "type", "sendKeys", "clear", "select", "focus", "blur", "hover",
+                "scroll", "scrollIntoView", "scroll_into_view", "check", "uncheck",
+                "toggle", "drag", "setValue", "submit", "reset", "autocomplete"
+            ]
+        }))
+    }
+}
+
 fn default_nav_action() -> String {
     "click".into()
 }
@@ -86,6 +109,22 @@ pub struct PageNavigateRequest {
     pub(crate) mode: Option<String>,
 }
 
+impl RequestHints for PageNavigateRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `url` (string). Optional: `mode` (\"hard\" | \"soft\", \
+             default \"hard\")."
+                .to_string(),
+            "\"hard\" performs a full webview reload; \"soft\" does SPA-style \
+             history.pushState and preserves injected window state."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "allowedModes": ["hard", "soft"] }))
+    }
+}
+
 /// Request for CSS selector query
 #[derive(Debug, Deserialize)]
 pub struct QuerySelectorRequest {
@@ -94,6 +133,16 @@ pub struct QuerySelectorRequest {
     pub action: Option<String>,
     /// Index of the matched element to perform the action on (default: 0)
     pub index: Option<u32>,
+}
+
+impl RequestHints for QuerySelectorRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `selector` (CSS selector string). \
+             Optional: `action` (\"click\"), `index` (number, default 0)."
+                .to_string(),
+        ])
+    }
 }
 
 /// Request for page evaluation
@@ -121,11 +170,30 @@ pub struct PageEvaluateRequest {
     pub allow_network_requests: Option<bool>,
 }
 
+impl RequestHints for PageEvaluateRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec!["Required field: `expression` (JavaScript string). \
+             Optional: `timeoutMs` (number, 1000–600000), `awaitPromise` (bool), \
+             `unwrap` (bool), `allowNetworkRequests` (bool)."
+            .to_string()])
+    }
+}
+
 /// Request to evaluate multiple JS expressions in one round-trip.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BatchEvaluateRequest {
     pub expressions: Vec<BatchExpression>,
+}
+
+impl RequestHints for BatchEvaluateRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `expressions` (array of `{id, expression}` objects). \
+             Maximum 50 expressions per batch."
+                .to_string(),
+        ])
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -152,6 +220,17 @@ pub struct SetTabRequest {
     pub tab: String,
 }
 
+impl RequestHints for SetTabRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `tab` (string). Must be a known tab id from VALID_TAB_IDS \
+             (e.g. \"specs\", \"tasks\", \"terminal\", \"settings\"). \
+             Use GET /ui-bridge/control/tabs for the full list."
+                .to_string(),
+        ])
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SetTabResponse {
@@ -167,6 +246,17 @@ pub struct SetTabResponse {
 #[serde(rename_all = "camelCase")]
 pub struct TabActivateRequest {
     pub tab_id: String,
+}
+
+impl RequestHints for TabActivateRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `tabId` (string). Must be a known tab id \
+             (e.g. \"specs\", \"tasks\", \"terminal\", \"settings\"). \
+             Use GET /ui-bridge/control/tabs for the full list."
+                .to_string(),
+        ])
+    }
 }
 
 // ============================================================================
@@ -286,7 +376,7 @@ const VALID_TAB_IDS: &[&str] = &[
 
 pub async fn ui_bridge_navigate_and_wait_handler(
     State(state): State<Arc<ApiState>>,
-    Json(req): Json<NavigateAndWaitRequest>,
+    UiBridgeJson(req): UiBridgeJson<NavigateAndWaitRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     use tokio::time::{sleep, Instant};
 
@@ -483,7 +573,7 @@ pub async fn ui_bridge_page_close_request_handler(
 /// work.
 pub async fn ui_bridge_page_navigate_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<PageNavigateRequest>,
+    UiBridgeJson(request): UiBridgeJson<PageNavigateRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     info!(
         "UI Bridge API: Page navigate to {} (mode={:?})",
@@ -592,7 +682,7 @@ pub async fn ui_bridge_page_go_forward_handler(
 /// Query elements by CSS selector, optionally performing an action.
 pub async fn ui_bridge_query_selector_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<QuerySelectorRequest>,
+    UiBridgeJson(request): UiBridgeJson<QuerySelectorRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     info!("UI Bridge API: Query selector '{}'", request.selector);
 
@@ -897,7 +987,7 @@ mod static_guard_hint_tests {
 /// Evaluate a JavaScript expression in the webview.
 pub async fn ui_bridge_page_evaluate_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<PageEvaluateRequest>,
+    UiBridgeJson(request): UiBridgeJson<PageEvaluateRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     let timeout = request.timeout_ms.map(|ms| ms.clamp(1000, 600_000));
     let unwrap = request.unwrap.unwrap_or(false);
@@ -930,7 +1020,7 @@ pub async fn ui_bridge_page_evaluate_raw_handler(
 /// POST /ui-bridge/control/page/evaluate-safe
 pub async fn ui_bridge_page_evaluate_safe_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<PageEvaluateRequest>,
+    UiBridgeJson(request): UiBridgeJson<PageEvaluateRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     let preview: String = request.expression.chars().take(80).collect();
     info!("UI Bridge API: Safe evaluate ({}...)", preview);
@@ -947,7 +1037,7 @@ pub async fn ui_bridge_page_evaluate_safe_handler(
 /// POST /ui-bridge/control/page/evaluate-batch
 pub async fn ui_bridge_page_evaluate_batch_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<BatchEvaluateRequest>,
+    UiBridgeJson(request): UiBridgeJson<BatchEvaluateRequest>,
 ) -> Result<Json<ApiResponse<Vec<BatchExpressionResult>>>, (StatusCode, Json<ApiResponse<()>>)> {
     info!(
         "UI Bridge API: Batch evaluate ({} expressions)",
@@ -1018,7 +1108,7 @@ pub async fn ui_bridge_page_evaluate_batch_handler(
 /// POST /ui-bridge/control/page/set-tab
 pub async fn ui_bridge_page_set_tab_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<SetTabRequest>,
+    UiBridgeJson(request): UiBridgeJson<SetTabRequest>,
 ) -> Result<Json<ApiResponse<SetTabResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     let tab = request.tab.trim().to_string();
     if tab.is_empty() {
@@ -1202,7 +1292,7 @@ pub async fn ui_bridge_tabs_list_handler(
 /// guard in case the two lists ever diverge.
 pub async fn ui_bridge_tab_activate_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<TabActivateRequest>,
+    UiBridgeJson(request): UiBridgeJson<TabActivateRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<serde_json::Value>>)>
 {
     let tab_id = match validate_tab_id(&request.tab_id) {

--- a/src-tauri/src/mcp/ui_bridge/types.rs
+++ b/src-tauri/src/mcp/ui_bridge/types.rs
@@ -7,6 +7,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::mcp::envelope::RequestHints;
+
 /// Request to execute an action on an element
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -32,6 +34,29 @@ pub struct UIBridgeActionRequest {
     pub(crate) extra: serde_json::Map<String, serde_json::Value>,
 }
 
+impl RequestHints for UIBridgeActionRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `action` (string). \
+             Optional: `params` (object), `waitOptions` (object), `expectChange` (bool or object)."
+                .to_string(),
+            "Use the element's advertised actions. Common values: click, type, hover, \
+             scroll, focus, blur, clear, select, setValue."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "allowedActions": [
+                "click", "doubleClick", "double_click", "double", "right", "middle",
+                "type", "sendKeys", "clear", "select", "focus", "blur", "hover",
+                "scroll", "scrollIntoView", "scroll_into_view", "check", "uncheck",
+                "toggle", "drag", "setValue", "submit", "reset", "autocomplete"
+            ]
+        }))
+    }
+}
+
 /// Request to execute an action on a component
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -39,6 +64,8 @@ pub struct UIBridgeComponentActionRequest {
     #[serde(default)]
     pub(crate) params: Option<serde_json::Value>,
 }
+
+impl RequestHints for UIBridgeComponentActionRequest {}
 
 /// Discovery options request
 #[derive(Debug, Default, Deserialize)]

--- a/src-tauri/src/mcp/ui_bridge/vision_routes.rs
+++ b/src-tauri/src/mcp/ui_bridge/vision_routes.rs
@@ -39,6 +39,7 @@ use tracing::{debug, info, warn};
 use super::screenshots::lookup_element_normalized_rect;
 use super::vision_ai::{self, OcrClient, VlmClient};
 use super::vision_frame_source::resolve_frame_provider;
+use crate::mcp::envelope::{RequestHints, UiBridgeJson};
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
 // ============================================================================
@@ -289,6 +290,20 @@ pub struct DiffRequest {
     /// `None` (default) = runner desktop. See [`super::vision_frame_source`].
     #[serde(default)]
     pub target: Option<String>,
+}
+
+impl RequestHints for DiffRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required fields: `baseline` and `comparison` (CaptureSpec objects with optional \
+             `region`, `element`, `contract`, `annotations`, `redact`). \
+             Optional: `mode` (default \"delta\"), `target` (device/app id)."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "allowedModes": ["delta", "overlay", "side_by_side"] }))
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -1118,7 +1133,7 @@ async fn do_multi_capture(
 /// `POST /ui-bridge/vision/diff` — capture twice + naive pixel diff.
 async fn vision_diff_handler(
     State(state): State<Arc<ApiState>>,
-    Json(req): Json<DiffRequest>,
+    UiBridgeJson(req): UiBridgeJson<DiffRequest>,
 ) -> Result<Json<ApiResponse<DiffResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     let mode = req.mode.as_deref().unwrap_or("delta").to_lowercase();
     if !["delta", "overlay", "side_by_side"].contains(&mode.as_str()) {
@@ -1858,6 +1873,25 @@ pub struct AnalyzeRequest {
     pub target: Option<String>,
 }
 
+impl RequestHints for AnalyzeRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `analyzer` (one of: \"layout\", \"typography\", \"color\", \
+             \"dynamic\", \"elements\"). \
+             Optional: `snapshot` (ElementSnapshot), `region`, `element`, `target`."
+                .to_string(),
+            "Use `vision/assert` for targeted pass/fail checks; \
+             use `vision/analyze` for broad findings across a frame."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "allowedAnalyzers": ["layout", "typography", "color", "dynamic", "elements"]
+        }))
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AnalyzeResponse {
@@ -1892,6 +1926,44 @@ pub struct AssertRequest {
     pub target: Option<String>,
 }
 
+impl RequestHints for AssertRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `assertions` (array of Assertion objects). \
+             Each assertion has a `type` discriminator plus type-specific fields."
+                .to_string(),
+            "Assertion `type` values: no_overlap, contains_text, text_fits_container, \
+             aligned_horizontally, aligned_vertically, color_within, typography_consistent, \
+             no_layout_shift_since, no_clipping, animation_settled, contrast_meets_wcag."
+                .to_string(),
+            "Optional top-level fields: `snapshot` (ElementSnapshot from /discover), \
+             `ocr_blocks` (from /vision/extract), `target` (device/app id)."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "allowedAssertionTypes": [
+                "no_overlap",
+                "contains_text",
+                "text_fits_container",
+                "aligned_horizontally",
+                "aligned_vertically",
+                "color_within",
+                "typography_consistent",
+                "no_layout_shift_since",
+                "no_clipping",
+                "animation_settled",
+                "contrast_meets_wcag"
+            ],
+            "exampleAssertion": {
+                "type": "no_overlap",
+                "elements": ["element-id-a", "element-id-b"]
+            }
+        }))
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AssertResponse {
@@ -1917,6 +1989,20 @@ pub struct BaselineRequest {
     pub target: Option<String>,
 }
 
+impl RequestHints for BaselineRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required fields: `name` (string identifier for the baseline), \
+             `snapshot` (ElementSnapshot with an `elements` array from /discover). \
+             Optional: `capture` (CaptureSpec), `target` (device/app id)."
+                .to_string(),
+            "Capture the snapshot first via POST /ui-bridge/sdk/discover or \
+             /ui-bridge/control/discover, then pass the result here."
+                .to_string(),
+        ])
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BaselineCreateResponse {
@@ -1938,7 +2024,7 @@ pub struct BaselineListResponse {
 /// structured findings; never pixels.
 async fn vision_analyze_handler(
     State(state): State<Arc<ApiState>>,
-    Json(req): Json<AnalyzeRequest>,
+    UiBridgeJson(req): UiBridgeJson<AnalyzeRequest>,
 ) -> Result<Json<ApiResponse<AnalyzeResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     // `target` selects the frame source: None = runner desktop (today's
     // behavior); a device/app id sources from that target. visual-audit relies
@@ -1980,7 +2066,7 @@ async fn vision_analyze_handler(
 /// Returns per-assertion pass/fail + reason.
 async fn vision_assert_handler(
     State(state): State<Arc<ApiState>>,
-    Json(req): Json<AssertRequest>,
+    UiBridgeJson(req): UiBridgeJson<AssertRequest>,
 ) -> Result<Json<ApiResponse<AssertResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     // `target` selects the frame source: None = runner desktop (today's
     // behavior); a device/app id sources from that target. visual-audit relies
@@ -2058,7 +2144,7 @@ async fn vision_assert_handler(
 /// against the recorded bboxes.
 async fn vision_baseline_handler(
     State(state): State<Arc<ApiState>>,
-    Json(req): Json<BaselineRequest>,
+    UiBridgeJson(req): UiBridgeJson<BaselineRequest>,
 ) -> Result<Json<ApiResponse<BaselineCreateResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     // `target` selects the frame source: None = runner desktop (today's
     // behavior); a device/app id sources from that target so a baseline can be


### PR DESCRIPTION
Phase A3 — stacked on #281. Migrates page.rs/elements.rs/vision_routes.rs (+types) to the UiBridgeJson extractor with a new RequestHints trait that surfaces per-type recovery hints (allowedModes/allowedActions/allowedAssertionTypes/allowedAnalyzers — values sourced from the actual handler code) on 422/400 rejections. 13 swaps. fmt+clippy clean. Stacked-on: #281. Autonomous /implement-plan.