### PR TITLE
feat(envelope): curated UiBridgeJson migration for skills/ai_generation/findings (Phase A4)

### DIFF
--- a/src-tauri/src/mcp/ai_generation.rs
+++ b/src-tauri/src/mcp/ai_generation.rs
@@ -12,6 +12,7 @@ use tracing::{error, info};
 
 use crate::commands::ai_generation::build_provider_settings;
 use crate::executor::with_default_bridge;
+use crate::mcp::envelope::{RequestHints, UiBridgeJson};
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
 // ============================================================================
@@ -64,6 +65,18 @@ pub struct GeneratePromptRequest {
     pub user_prompt: String,
     /// Mode: "generate" or "improve"
     pub mode: String,
+}
+
+impl RequestHints for GeneratePromptRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required fields: `user_prompt` (string), `mode` (\"generate\" | \"improve\").".to_string(),
+            "Use \"generate\" to create a new prompt from scratch; use \"improve\" to enhance an existing one.".to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "allowedModes": ["generate", "improve"] }))
+    }
 }
 
 /// Request body for POST /ai/generate-macro
@@ -320,7 +333,7 @@ pub async fn generate_context_handler(
 /// Generate or improve an AI task prompt via the Python bridge.
 pub async fn generate_prompt_handler(
     State(state): State<Arc<ApiState>>,
-    Json(request): Json<GeneratePromptRequest>,
+    UiBridgeJson(request): UiBridgeJson<GeneratePromptRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     use crate::settings;
 
@@ -631,4 +644,96 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             "/ai/suggest-exploration-strategy",
             post(suggest_exploration_strategy_handler),
         )
+}
+
+// ============================================================================
+// Unit tests — Phase A4 UiBridgeJson migration
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use super::GeneratePromptRequest;
+    use crate::mcp::envelope::UiBridgeJson;
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    async fn send_uib<T>(body: &'static str) -> (StatusCode, serde_json::Value)
+    where
+        T: serde::de::DeserializeOwned + crate::mcp::envelope::RequestHints + Send + 'static,
+    {
+        async fn handler<
+            T: serde::de::DeserializeOwned + crate::mcp::envelope::RequestHints + Send,
+        >(
+            UiBridgeJson(_): UiBridgeJson<T>,
+        ) -> axum::http::StatusCode {
+            axum::http::StatusCode::OK
+        }
+
+        let app = Router::new().route("/test", post(handler::<T>));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    // ── GeneratePromptRequest ─────────────────────────────────────────────────
+
+    /// Missing `mode` field → 422 with `allowedModes` in hint.
+    #[tokio::test]
+    async fn generate_prompt_request_422_carries_allowed_modes() {
+        let (status, body) =
+            send_uib::<GeneratePromptRequest>(r#"{"user_prompt": "write a button test"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let suggestions = body["suggestions"].as_array().expect("suggestions array");
+        assert!(!suggestions.is_empty(), "suggestions must not be empty");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry allowedModes");
+        let modes = hint["allowedModes"].as_array().expect("allowedModes array");
+        assert_eq!(
+            modes.len(),
+            2,
+            "must expose both generate and improve modes"
+        );
+        assert!(
+            modes.iter().any(|m| m.as_str() == Some("generate")),
+            "generate must be listed"
+        );
+        assert!(
+            modes.iter().any(|m| m.as_str() == Some("improve")),
+            "improve must be listed"
+        );
+    }
+
+    /// Missing `user_prompt` field → 422 with suggestions (both fields are required).
+    #[tokio::test]
+    async fn generate_prompt_request_missing_user_prompt_gives_422() {
+        let (status, body) = send_uib::<GeneratePromptRequest>(r#"{"mode": "generate"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        // suggestions and hint both populated by RequestHints impl
+        assert!(
+            !body["suggestions"].is_null(),
+            "suggestions must be present even when user_prompt is missing"
+        );
+    }
 }

--- a/src-tauri/src/mcp/findings_api.rs
+++ b/src-tauri/src/mcp/findings_api.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use tracing::info;
 
 use crate::findings::{Finding, FindingStatus, FindingStatusExt};
+use crate::mcp::envelope::{RequestHints, UiBridgeJson};
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
 /// Request body for updating finding status
@@ -23,6 +24,27 @@ pub struct UpdateFindingStatusRequest {
     pub status: String,
     /// Optional resolution text
     pub resolution: Option<String>,
+}
+
+impl RequestHints for UpdateFindingStatusRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `status` (one of: \"detected\", \"in_progress\", \"needs_input\", \
+             \"resolved\", \"wont_fix\", \"deferred\"). Optional: `resolution` (string)."
+                .to_string(),
+            "Terminal statuses (resolved, wont_fix, deferred) cannot be undone via this endpoint."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({
+            "allowedStatuses": [
+                "detected", "in_progress", "needs_input",
+                "resolved", "wont_fix", "deferred"
+            ],
+            "terminalStatuses": ["resolved", "wont_fix", "deferred"]
+        }))
+    }
 }
 
 /// Request body for resolving a finding
@@ -197,7 +219,7 @@ pub async fn get_task_findings_handler(
 pub async fn update_finding_status_handler(
     State(state): State<Arc<ApiState>>,
     Path(finding_id): Path<String>,
-    Json(req): Json<UpdateFindingStatusRequest>,
+    UiBridgeJson(req): UiBridgeJson<UpdateFindingStatusRequest>,
 ) -> Result<Json<ApiResponse<FindingMutationResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
     let status = FindingStatus::from_str(&req.status).ok_or_else(|| {
         (
@@ -410,4 +432,134 @@ pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
             "/findings/{finding_id}/user-response",
             post(user_response_handler),
         )
+}
+
+// ============================================================================
+// Unit tests — Phase A4 UiBridgeJson migration
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        routing::put,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use super::UpdateFindingStatusRequest;
+    use crate::mcp::envelope::UiBridgeJson;
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    async fn send_uib<T>(body: &'static str) -> (StatusCode, serde_json::Value)
+    where
+        T: serde::de::DeserializeOwned + crate::mcp::envelope::RequestHints + Send + 'static,
+    {
+        async fn handler<
+            T: serde::de::DeserializeOwned + crate::mcp::envelope::RequestHints + Send,
+        >(
+            UiBridgeJson(_): UiBridgeJson<T>,
+        ) -> axum::http::StatusCode {
+            axum::http::StatusCode::OK
+        }
+
+        let app = Router::new().route("/test", put(handler::<T>));
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    // ── UpdateFindingStatusRequest ────────────────────────────────────────────
+
+    /// Missing `status` field → 422 with `allowedStatuses` + `terminalStatuses` in hint.
+    #[tokio::test]
+    async fn update_finding_status_request_422_carries_allowed_statuses() {
+        let (status, body) =
+            send_uib::<UpdateFindingStatusRequest>(r#"{"resolution": "fixed it"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let suggestions = body["suggestions"].as_array().expect("suggestions array");
+        assert!(!suggestions.is_empty(), "suggestions must not be empty");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry allowedStatuses");
+        let statuses = hint["allowedStatuses"]
+            .as_array()
+            .expect("allowedStatuses array");
+        assert_eq!(
+            statuses.len(),
+            6,
+            "must expose all 6 FindingStatus variants"
+        );
+        // Spot-check a few
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("detected")),
+            "detected must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("in_progress")),
+            "in_progress must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("needs_input")),
+            "needs_input must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("resolved")),
+            "resolved must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("wont_fix")),
+            "wont_fix must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("deferred")),
+            "deferred must be listed"
+        );
+        // Terminal statuses also surfaced for caller guidance
+        let terminal = hint["terminalStatuses"]
+            .as_array()
+            .expect("terminalStatuses array");
+        assert_eq!(terminal.len(), 3, "must expose 3 terminal statuses");
+    }
+
+    /// Valid body (status present) → extractor succeeds (200, no rejection).
+    #[tokio::test]
+    async fn update_finding_status_request_valid_body_succeeds() {
+        // Use the standalone extractor path — a valid body must NOT be rejected.
+        // The inner handler returns 200 with an empty body; we only check the status.
+        async fn handler_ok(
+            UiBridgeJson(_): UiBridgeJson<UpdateFindingStatusRequest>,
+        ) -> axum::http::StatusCode {
+            axum::http::StatusCode::OK
+        }
+
+        let app = Router::new().route("/test", put(handler_ok));
+        let req = Request::builder()
+            .method("PUT")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                r#"{"status": "resolved", "resolution": "fixed"}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "valid body must extract successfully"
+        );
+    }
 }

--- a/src-tauri/src/mcp/skills.rs
+++ b/src-tauri/src/mcp/skills.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::mcp::envelope::{RequestHints, UiBridgeJson};
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 use crate::skills::SkillDefinition;
 
@@ -102,9 +103,32 @@ pub struct ApproveSkillRequest {
     pub status: String, // "approved" | "rejected" | "pending"
 }
 
+impl RequestHints for ApproveSkillRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `status` (one of: \"approved\", \"rejected\", \"pending\")."
+                .to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "allowedStatuses": ["approved", "rejected", "pending"] }))
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct BumpVersionRequest {
     pub bump_type: String, // "patch" | "minor" | "major"
+}
+
+impl RequestHints for BumpVersionRequest {
+    fn shape_error_suggestions() -> Option<Vec<String>> {
+        Some(vec![
+            "Required field: `bump_type` (one of: \"patch\", \"minor\", \"major\").".to_string(),
+        ])
+    }
+    fn shape_error_data() -> Option<serde_json::Value> {
+        Some(serde_json::json!({ "allowedBumpTypes": ["patch", "minor", "major"] }))
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -407,7 +431,7 @@ pub async fn import_skills(
 pub async fn approve_skill(
     State(state): State<Arc<ApiState>>,
     axum::extract::Path(id): axum::extract::Path<String>,
-    Json(req): Json<ApproveSkillRequest>,
+    UiBridgeJson(req): UiBridgeJson<ApproveSkillRequest>,
 ) -> Result<Json<ApiResponse<Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     let valid_statuses = ["approved", "rejected", "pending"];
     if !valid_statuses.contains(&req.status.as_str()) {
@@ -731,7 +755,7 @@ fn bump_semver(version: &str, bump_type: &str) -> String {
 pub async fn bump_version(
     State(state): State<Arc<ApiState>>,
     axum::extract::Path(id): axum::extract::Path<String>,
-    Json(req): Json<BumpVersionRequest>,
+    UiBridgeJson(req): UiBridgeJson<BumpVersionRequest>,
 ) -> Result<Json<ApiResponse<Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     // Don't allow bumping builtin skills
     if id.starts_with("builtin:") {
@@ -818,4 +842,115 @@ pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
         .route("/skills/{id}/fork", post(fork_skill))
         .route("/skills/{id}/bump-version", post(bump_version))
         .route("/skills/{id}/increment-usage", post(increment_usage))
+}
+
+// ============================================================================
+// Unit tests — Phase A4 UiBridgeJson migration
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use tower::ServiceExt;
+
+    use super::{ApproveSkillRequest, BumpVersionRequest};
+    use crate::mcp::envelope::UiBridgeJson;
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    async fn send_uib<T>(body: &'static str) -> (StatusCode, serde_json::Value)
+    where
+        T: serde::de::DeserializeOwned + crate::mcp::envelope::RequestHints + Send + 'static,
+    {
+        async fn handler<
+            T: serde::de::DeserializeOwned + crate::mcp::envelope::RequestHints + Send,
+        >(
+            UiBridgeJson(_): UiBridgeJson<T>,
+        ) -> axum::http::StatusCode {
+            axum::http::StatusCode::OK
+        }
+
+        let app = Router::new().route("/test", post(handler::<T>));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/test")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        (status, json)
+    }
+
+    // ── ApproveSkillRequest ───────────────────────────────────────────────────
+
+    /// Missing `status` field → 422 with `allowedStatuses` in hint.
+    #[tokio::test]
+    async fn approve_skill_request_422_carries_allowed_statuses() {
+        let (status, body) =
+            send_uib::<ApproveSkillRequest>(r#"{"wrong_field": "approved"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let suggestions = body["suggestions"].as_array().expect("suggestions array");
+        assert!(!suggestions.is_empty(), "suggestions must not be empty");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry allowedStatuses");
+        let statuses = hint["allowedStatuses"]
+            .as_array()
+            .expect("allowedStatuses array");
+        assert_eq!(statuses.len(), 3, "must expose all 3 approval statuses");
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("approved")),
+            "approved must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("rejected")),
+            "rejected must be listed"
+        );
+        assert!(
+            statuses.iter().any(|s| s.as_str() == Some("pending")),
+            "pending must be listed"
+        );
+    }
+
+    // ── BumpVersionRequest ────────────────────────────────────────────────────
+
+    /// Missing `bump_type` field → 422 with `allowedBumpTypes` in hint.
+    #[tokio::test]
+    async fn bump_version_request_422_carries_allowed_bump_types() {
+        let (status, body) = send_uib::<BumpVersionRequest>(r#"{"wrong_field": "patch"}"#).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(body["success"], false);
+        assert_eq!(body["code"], "INVALID_REQUEST");
+        let suggestions = body["suggestions"].as_array().expect("suggestions array");
+        assert!(!suggestions.is_empty(), "suggestions must not be empty");
+        let hint = &body["hint"];
+        assert!(!hint.is_null(), "hint must carry allowedBumpTypes");
+        let bump_types = hint["allowedBumpTypes"]
+            .as_array()
+            .expect("allowedBumpTypes array");
+        assert_eq!(bump_types.len(), 3, "must expose all 3 bump types");
+        assert!(
+            bump_types.iter().any(|t| t.as_str() == Some("patch")),
+            "patch must be listed"
+        );
+        assert!(
+            bump_types.iter().any(|t| t.as_str() == Some("minor")),
+            "minor must be listed"
+        );
+        assert!(
+            bump_types.iter().any(|t| t.as_str() == Some("major")),
+            "major must be listed"
+        );
+    }
 }


### PR DESCRIPTION
Phase A4 — stacked on #282. Curated migration of skills.rs (approve status, bump type), ai_generation.rs (mode), findings_api.rs (status enum) to UiBridgeJson + RequestHints; pure pass-throughs left on Json<T>. 4 swaps, values cited from code. fmt+clippy clean. Stacked-on: #282. Autonomous /implement-plan.