### PR TITLE
runner: auto-establish adb reverse tcp:9876 for USB-attached devices

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2982,9 +2982,10 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             });
 
-                            // Release ADB forwards installed by the USB scanner
-                            // so they don't linger in `adb forward --list`
-                            // across runner restarts. Graceful path only — the
+                            // Release ADB forwards and reverses installed by the
+                            // USB scanner so they don't linger in
+                            // `adb forward --list` / `adb reverse --list` across
+                            // runner restarts. Graceful path only — the
                             // supervisor force-kills via taskkill /F and this
                             // code never runs for temp runners. See plan
                             // adb-forwarder-port.md §1.6a.
@@ -2992,7 +2993,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                 if let Some(usb) =
                                     app_state_clone.usb_transport.get()
                                 {
-                                    info!("Releasing ADB forwards on shutdown");
+                                    info!("Releasing ADB forwards and reverses on shutdown");
                                     usb.release_all().await;
                                 }
                             });

--- a/src-tauri/src/mcp/adb_helper.rs
+++ b/src-tauri/src/mcp/adb_helper.rs
@@ -259,6 +259,32 @@ pub async fn forward_tcp(serial: String, local_port: u16, remote_port: u16) -> R
     .map_err(|e| format!("task join failed: {e}"))?
 }
 
+/// Establish an `adb reverse tcp:<device_port> tcp:<host_port>` on the device.
+///
+/// This is the mirror of [`forward_tcp`]: it makes the *device* listen on
+/// `device_port` and tunnel those connections back to `host_port` on the
+/// machine running the runner. The qontinui-mobile app's data path dials the
+/// runner HTTP API (default 9876) at `localhost:<device_port>` on the phone;
+/// without this reverse the request fails with "Network request failed"
+/// because nothing on the USB-attached phone serves that port.
+///
+/// Argument order matches `adb_client`'s `reverse(remote, local)` and the ADB
+/// wire format `reverse:forward:<remote>;<local>`, where `remote` is the
+/// device-side listen port and `local` is the host-side target port.
+///
+/// Idempotent: re-running an identical reverse simply overwrites the existing
+/// rule in adb (it does not error), so this is safe to call on every scan tick.
+pub async fn reverse_tcp(serial: String, device_port: u16, host_port: u16) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut device = ADBServerDevice::new(serial, Some(default_server_addr()));
+        device
+            .reverse(format!("tcp:{device_port}"), format!("tcp:{host_port}"))
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join failed: {e}"))?
+}
+
 /// Pick a free loopback TCP port by briefly binding to `127.0.0.1:0`.
 ///
 /// The OS returns a port that's free at the moment of binding; there is a

--- a/src-tauri/src/mcp/transport/usb.rs
+++ b/src-tauri/src/mcp/transport/usb.rs
@@ -37,6 +37,11 @@ pub struct UsbTransport {
     pub adb_path: PathBuf,
     /// Maps ADB serial number → locally forwarded TCP port.
     pub active_forwards: Arc<Mutex<HashMap<String, u16>>>,
+    /// Maps ADB serial number → device-side port currently reversed back to the
+    /// runner HTTP API (`adb reverse tcp:<port> tcp:<port>`). Tracked so the
+    /// shutdown / disconnect paths can `adb reverse --remove` exactly the rules
+    /// this process installed, rather than nuking every reverse on the machine.
+    pub active_reverses: Arc<Mutex<HashMap<String, u16>>>,
 }
 
 impl UsbTransport {
@@ -44,6 +49,7 @@ impl UsbTransport {
         Self {
             adb_path,
             active_forwards: Arc::new(Mutex::new(HashMap::new())),
+            active_reverses: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -126,7 +132,96 @@ impl UsbTransport {
         Ok(())
     }
 
-    /// Release all active forwards.  Errors are logged but do not stop teardown.
+    /// Establish an `adb reverse tcp:<runner_port> tcp:<runner_port>` so the
+    /// USB-attached device can reach the runner's HTTP API (default 9876) at
+    /// `localhost:<runner_port>` on the phone.
+    ///
+    /// This is the data-path counterpart to [`establish_forward`] (which is the
+    /// control-path: host → device UI Bridge). Without it, qontinui-mobile's
+    /// requests to the runner API fail with "Network request failed" because
+    /// nothing on the phone serves that port. Same port on both ends — the
+    /// device dials the identical port number it would use on the host.
+    ///
+    /// Idempotent: adb overwrites an identical reverse rule without erroring, so
+    /// this is safe to re-run on every scan tick. Records the rule for teardown.
+    ///
+    /// [`establish_forward`]: UsbTransport::establish_forward
+    pub async fn establish_reverse(
+        &self,
+        adb_serial: &str,
+        runner_port: u16,
+    ) -> Result<(), TransportError> {
+        adb_helper::reverse_tcp(adb_serial.to_string(), runner_port, runner_port)
+            .await
+            .map_err(|e| TransportError::ForwardFailed {
+                device_id: adb_serial.to_string(),
+                reason: e,
+            })?;
+
+        info!(
+            serial = %adb_serial,
+            runner_port,
+            "ADB reverse established (device -> runner API)"
+        );
+
+        self.active_reverses
+            .lock()
+            .await
+            .insert(adb_serial.to_string(), runner_port);
+
+        Ok(())
+    }
+
+    /// Remove the ADB reverse for the given device and clean up the map entry.
+    ///
+    /// `adb_client` 3.x exposes only `reverse_remove_all` (which would stomp
+    /// every reverse on the machine), so per-rule removal shells out to
+    /// `adb -s <serial> reverse --remove tcp:<port>`, mirroring
+    /// [`release_forward`].
+    ///
+    /// [`release_forward`]: UsbTransport::release_forward
+    pub async fn release_reverse(&self, adb_serial: &str) -> Result<(), TransportError> {
+        let port = {
+            let reverses = self.active_reverses.lock().await;
+            match reverses.get(adb_serial).copied() {
+                Some(p) => p,
+                None => {
+                    debug!(serial = %adb_serial, "release_reverse: no active reverse found");
+                    return Ok(());
+                }
+            }
+        };
+
+        let output = crate::process_helpers::tokio_no_window(&self.adb_path)
+            .args([
+                "-s",
+                adb_serial,
+                "reverse",
+                "--remove",
+                &format!("tcp:{}", port),
+            ])
+            .output()
+            .await
+            .map_err(|e| TransportError::AdbCommandFailed(e.to_string()))?;
+
+        if !output.status.success() {
+            warn!(
+                serial = %adb_serial,
+                port,
+                stderr = %String::from_utf8_lossy(&output.stderr),
+                "Failed to remove ADB reverse (device may be disconnected)"
+            );
+        }
+
+        let mut reverses = self.active_reverses.lock().await;
+        reverses.remove(adb_serial);
+
+        debug!(serial = %adb_serial, port, "ADB reverse released");
+        Ok(())
+    }
+
+    /// Release all active forwards and reverses. Errors are logged but do not
+    /// stop teardown.
     pub async fn release_all(&self) {
         let serials: Vec<String> = {
             let forwards = self.active_forwards.lock().await;
@@ -135,6 +230,16 @@ impl UsbTransport {
         for serial in serials {
             if let Err(e) = self.release_forward(&serial).await {
                 warn!(serial = %serial, error = %e, "Error releasing ADB forward");
+            }
+        }
+
+        let reverse_serials: Vec<String> = {
+            let reverses = self.active_reverses.lock().await;
+            reverses.keys().cloned().collect()
+        };
+        for serial in reverse_serials {
+            if let Err(e) = self.release_reverse(&serial).await {
+                warn!(serial = %serial, error = %e, "Error releasing ADB reverse");
             }
         }
     }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1246,6 +1246,36 @@ pub fn create_router(
                         continue; // Skip emulators — handled by app_discovery
                     }
 
+                    // Reverse the runner HTTP API port back to the device so the
+                    // qontinui-mobile app's data path can reach the runner at
+                    // `localhost:<port>` on the phone. Without this, USB-attached
+                    // phones see "Network request failed". This is independent of
+                    // UI Bridge discovery below — the data path is needed whenever
+                    // a physical device is attached, registered or not — so it runs
+                    // before the already-registered skip. Idempotent + only logged
+                    // on first install per serial (re-runs are skipped via the
+                    // active_reverses map).
+                    if usb_transport
+                        .active_reverses
+                        .lock()
+                        .await
+                        .get(device_id)
+                        .is_none()
+                    {
+                        let runner_port = state.app_state.api_port.load(Ordering::Relaxed);
+                        if let Err(e) = usb_transport
+                            .establish_reverse(device_id, runner_port)
+                            .await
+                        {
+                            tracing::debug!(
+                                "Failed to establish ADB reverse for {} (port {}): {}",
+                                device_id,
+                                runner_port,
+                                e
+                            );
+                        }
+                    }
+
                     // Skip devices that already have a live USB transport.
                     // A device entry with empty `transports` (or only
                     // non-USB transports) falls through to re-establishment.
@@ -1335,6 +1365,24 @@ pub fn create_router(
                             .await;
                         let _ = usb_transport.release_forward(&device.info.id).await;
                         tracing::info!("USB device disconnected: {}", device.info.id);
+                    }
+                }
+
+                // Tear down ADB reverses for devices no longer attached. Reverses
+                // are installed for every physical device (even those without a UI
+                // Bridge, which never register in the registry above), so they need
+                // their own disconnect sweep keyed off the live `adb devices` list.
+                let reversed_serials: Vec<String> = {
+                    let reverses = usb_transport.active_reverses.lock().await;
+                    reverses.keys().cloned().collect()
+                };
+                for serial in reversed_serials {
+                    let still_connected = devices
+                        .iter()
+                        .any(|(id, status, _)| id == &serial && status == "device");
+                    if !still_connected {
+                        let _ = usb_transport.release_reverse(&serial).await;
+                        tracing::info!("USB device reverse released (disconnected): {}", serial);
                     }
                 }
             }


### PR DESCRIPTION
## What

Auto-establishes `adb reverse tcp:9876 tcp:9876` on every USB-attached physical Android device so the **qontinui-mobile app's data path can reach the runner's HTTP API** at `localhost:<port>` on the phone. This is the host-side counterpart to qontinui-mobile PR #17.

## Why

USB-connected phones hit the headline **"Network request failed"** because nothing on the phone served the runner API port. The runner already installs an `adb forward` for the control path (host → device UI Bridge); this adds the missing **reverse** for the data path (device → runner API). The reverse runs for every physical device whether or not it registers a UI Bridge, since the data path is needed regardless.

## How (4 files)

- **`src-tauri/src/mcp/adb_helper.rs`** — new `reverse_tcp(serial, device_port, host_port)` wrapper, the mirror of `forward_tcp`. Idempotent (adb overwrites an identical rule without erroring).
- **`src-tauri/src/mcp/transport/usb.rs`** — `active_reverses: HashMap<serial, port>` map + `establish_reverse` / `release_reverse` (per-rule `adb reverse --remove`, mirroring `release_forward`) + `release_all` now tears down reverses too.
- **`src-tauri/src/mcp_api.rs`** — establishes the reverse on physical-device attach (guarded by the `active_reverses` map so it only installs once per serial / logs once), runs before the already-registered skip; plus a disconnect sweep keyed off the live `adb devices` list to release reverses for departed devices.
- **`src-tauri/src/main.rs`** — graceful-shutdown comment updated; `release_all()` (already wired) now also releases reverses.

**Idempotency:** re-running an identical reverse is a no-op in adb; the `active_reverses` guard skips re-install per serial per scan tick.
**Teardown:** released on USB disconnect sweep and on graceful shutdown via `release_all`.

## Recovery note

This recovers commit `7ebf9482` whose original push to `feat/mobile-remote-runner-relay` was lost (that branch was reset to a merged commit). Cherry-picked cleanly onto current `main`; only `mcp_api.rs` conflicted — resolved by keeping main's eviction-aware `has_transport_kind` re-establishment skip (#271) AND running the new reverse-establishment block before it. The other 3 files applied without conflict.

## Verification

All run with sccache disabled (`RUSTC_WRAPPER=""`) to dodge the transient sccache "Failed to read response header" error:

- `cargo fmt --check` — clean
- `cargo check` — clean (exit 0)
- `cargo clippy -- -D warnings` — clean (exit 0)
- `cargo clippy --all-targets -- -D warnings` (matches the pre-push hook) — clean (exit 0)
- Pre-push hook passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
