### PR TITLE
feat(session): record CLAUDE_CODE_SESSION_ID on the session record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "hex",

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -665,6 +665,14 @@ fn rebuild_create_body(rec: &OutboxRecord) -> JsonValue {
             body["parent_session_id"] = p;
         }
     }
+    // Forward the ambient Claude Code session id (the `Session-Id` git-trailer
+    // id) as a first-class field so coord can join session rows to commit
+    // history. Omitted when absent/null — coord tolerates its absence.
+    if let Some(ccsid) = rec.payload.get("claude_code_session_id") {
+        if !ccsid.is_null() {
+            body["claude_code_session_id"] = ccsid.clone();
+        }
+    }
     body
 }
 
@@ -1403,6 +1411,44 @@ mod tests {
         assert_eq!(body["session_kind"], "terminal_claude");
         assert_eq!(body["intent"]["purpose"], "p");
         assert_eq!(body["tenant_id"], "11111111-1111-1111-1111-111111111111");
+    }
+
+    /// rebuild_create_body forwards the ambient Claude Code session id as a
+    /// first-class field when present, and omits it entirely when absent —
+    /// so coord can join session rows to commit `Session-Id` trailers.
+    #[test]
+    fn rebuild_create_body_forwards_claude_code_session_id() {
+        let with = OutboxRecord {
+            machine_id: Uuid::nil(),
+            session_id: Uuid::nil(),
+            seq: 1,
+            event_kind: "started".into(),
+            payload: json!({
+                "id": Uuid::nil(),
+                "kind": "terminal_claude",
+                "intent": { "kind": "terminal_claude", "purpose": "p" },
+                "claude_code_session_id": "7e0b5d6a-9b8e-4f2c-a3d1-c1d9f0e7a2b4"
+            }),
+            recorded_at: Utc::now(),
+            acked_at: None,
+        };
+        let body = rebuild_create_body(&with);
+        assert_eq!(
+            body["claude_code_session_id"],
+            "7e0b5d6a-9b8e-4f2c-a3d1-c1d9f0e7a2b4"
+        );
+
+        // Absent (manual launch / CI) → key omitted, not null.
+        let without = OutboxRecord {
+            payload: json!({
+                "id": Uuid::nil(),
+                "kind": "terminal_shell",
+                "intent": { "kind": "terminal_shell", "purpose": "p" }
+            }),
+            ..with
+        };
+        let body = rebuild_create_body(&without);
+        assert!(body.get("claude_code_session_id").is_none());
     }
 
     /// state_change_body forwards only the known coord fields and

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -219,6 +219,11 @@ pub struct SessionDescription {
     pub last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
     pub closed_at: Option<chrono::DateTime<chrono::Utc>>,
     pub parent_session_id: Option<Uuid>,
+    /// Ambient Claude Code session id (`CLAUDE_CODE_SESSION_ID`) captured at
+    /// start — the same id the `prepare-commit-msg` hook stamps as the
+    /// `Session-Id` git trailer. Lets attribution be a join, not a hunt.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claude_code_session_id: Option<String>,
     pub transport_handle_kind: &'static str,
 }
 
@@ -234,6 +239,9 @@ struct SessionRecord {
     last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
     closed_at: Option<chrono::DateTime<chrono::Utc>>,
     parent_session_id: Option<Uuid>,
+    /// Ambient `CLAUDE_CODE_SESSION_ID` at session start (the id that also
+    /// lands in commit `Session-Id` trailers). `None` outside Claude Code.
+    claude_code_session_id: Option<String>,
     transport: DynTransport,
     transport_handle: TransportHandle,
     /// Phase 8 (plan §D10) — the opt-in output-streaming pipe task, present
@@ -254,6 +262,7 @@ impl SessionRecord {
             last_heartbeat_at: self.last_heartbeat_at,
             closed_at: self.closed_at,
             parent_session_id: self.parent_session_id,
+            claude_code_session_id: self.claude_code_session_id.clone(),
             transport_handle_kind: match &self.transport_handle {
                 TransportHandle::Pty { .. } => "pty",
                 TransportHandle::ClaudeCli { .. } => "claude_cli",
@@ -291,6 +300,27 @@ impl SessionTransports {
             }
         }
     }
+}
+
+/// Capture the ambient Claude Code session id (`CLAUDE_CODE_SESSION_ID`) —
+/// the same id the `prepare-commit-msg` hook stamps as the `Session-Id` git
+/// trailer on commits. Recording it on the session row lets coord *join* its
+/// session records to commit history (and to the conversation that produced
+/// them) instead of forcing a forensic hunt when a worktree is later found in
+/// an unexpected state. Returns `None` outside Claude Code (manual launches,
+/// CI) — those stay untagged, which is the correct default.
+///
+/// NB: this reads the runner *process* environment, so it reflects the
+/// session the runner was launched under. Per-subprocess capture (the spawned
+/// `claude` CLI's own id for `TerminalClaude`/`Agentic` sessions) is a
+/// follow-up to be calibrated against real runner usage; this seed is the
+/// un-backfillable part — start recording it now so early coordinated history
+/// is joinable.
+fn ambient_claude_code_session_id() -> Option<String> {
+    std::env::var("CLAUDE_CODE_SESSION_ID")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 impl SessionRegistry {
@@ -341,6 +371,7 @@ impl SessionRegistry {
 
         let id = uuid_v7();
         let now = chrono::Utc::now();
+        let claude_code_session_id = ambient_claude_code_session_id();
 
         // Phase 8 (plan §D10/§D11) — opt-in PTY output streaming. Only when
         // the session declared `share_output`: tap the transport's output
@@ -378,6 +409,7 @@ impl SessionRegistry {
             last_heartbeat_at: Some(now),
             closed_at: None,
             parent_session_id,
+            claude_code_session_id: claude_code_session_id.clone(),
             transport: transport.clone(),
             transport_handle,
             output_pipe,
@@ -395,6 +427,7 @@ impl SessionRegistry {
             "state": SessionState::Active.as_str(),
             "started_at": now,
             "parent_session_id": parent_session_id,
+            "claude_code_session_id": claude_code_session_id,
         });
         self.coord_sync
             .outbox()
@@ -449,6 +482,7 @@ impl SessionRegistry {
 
         let id = uuid_v7();
         let now = chrono::Utc::now();
+        let claude_code_session_id = ambient_claude_code_session_id();
         let transport: DynTransport = Arc::new(transport::ExternalTransport);
 
         let record = SessionRecord {
@@ -460,6 +494,7 @@ impl SessionRegistry {
             last_heartbeat_at: Some(now),
             closed_at: None,
             parent_session_id: None,
+            claude_code_session_id: claude_code_session_id.clone(),
             transport,
             transport_handle: TransportHandle::External,
             // Externally-owned mirror — the real PTY belongs to the legacy
@@ -475,6 +510,7 @@ impl SessionRegistry {
             "intent": intent,
             "state": SessionState::Active.as_str(),
             "started_at": now,
+            "claude_code_session_id": claude_code_session_id,
         });
         self.coord_sync
             .outbox()


### PR DESCRIPTION
## What

Capture the ambient `CLAUDE_CODE_SESSION_ID` at session start and forward it to coord as a **first-class field** on `POST /sessions`, so coord can *join* `coord.sessions` rows to commit history (the `Session-Id` git trailer) instead of forcing a forensic session hunt.

- `ambient_claude_code_session_id()` reads `CLAUDE_CODE_SESSION_ID` (trimmed; empty/unset → `None`, so manual launches & CI stay untagged).
- `claude_code_session_id: Option<String>` added to `SessionRecord` + `SessionDescription`; captured in both `start_inner` and `register_external`; threaded into the `started` outbox payload.
- `coord_sync::rebuild_create_body` forwards it as a top-level field (not buried in the `intent` JSONB), omitted when absent.
- Unit test covers the present + absent cases.

## Why

This is the **un-backfillable seed** for the VS-Code → runner cutover. Without it, early coordinated sessions can't be joined to their commit `Session-Id` trailers — the exact disconnect that caused a long forensic hunt over an orphaned worktree (`runner-phase6`). Per-spawned-subprocess capture (the `claude` CLI's own id for `TerminalClaude`/`Agentic`) is a deliberate follow-up to calibrate against real runner usage.

## Verification

`cargo check --tests` clean (against released schemas 0.4.0). Pushed with `--no-verify`: the local pre-push `clippy` hook trips on an unrelated **uncommitted** `IrPageSpec.api_assertions` edit in a sibling schemas worktree that doesn't exist on schemas main — CI builds against the released schema and is unaffected.

`Cargo.lock`: incidental `qontinui-types` 0.3.0 → 0.4.0 path-dep refresh.