### PR TITLE
feat(process-reconcile): process-tile UI Bridge ids + structured ExternallyOwned guard codes

### DIFF
--- a/src-tauri/src/mcp/processes.rs
+++ b/src-tauri/src/mcp/processes.rs
@@ -17,6 +17,45 @@ use crate::mcp::types::{api_error, ApiResponse, ApiState};
 use crate::process_capture::primary_proxy;
 use crate::process_capture::types::{OutputLine, ProcessStatus};
 
+/// Map a process-manager error string into a canonical envelope.
+///
+/// The manager's lifecycle methods return `Result<_, String>`. The Phase-B2
+/// `ExternallyOwned` guards embed a `[CODE]` prefix (e.g.
+/// `"[ACTION_NOT_SUPPORTED] Process ... "`) so this HTTP boundary can surface a
+/// structured `code` field on the canonical envelope instead of burying the
+/// code in free text. Errors without a recognised `[CODE]` prefix fall back to
+/// a plain `api_error` under `default_status`.
+fn manager_error_to_envelope(
+    err: &str,
+    default_status: StatusCode,
+    fallback_prefix: &str,
+) -> (StatusCode, Json<ApiResponse<()>>) {
+    if let Some(rest) = err.strip_prefix('[') {
+        if let Some((code, message)) = rest.split_once(']') {
+            let code = code.trim();
+            let message = message.trim();
+            if !code.is_empty() {
+                let status = match code {
+                    "INVALID_STATE" | "ACTION_NOT_SUPPORTED" => StatusCode::BAD_REQUEST,
+                    "EXTERNAL_PORT_OWNED" => StatusCode::CONFLICT,
+                    _ => default_status,
+                };
+                return (
+                    status,
+                    Json(ApiResponse::error_with_code(
+                        message.to_string(),
+                        code.to_string(),
+                    )),
+                );
+            }
+        }
+    }
+    (
+        default_status,
+        Json(api_error(format!("{}: {}", fallback_prefix, err))),
+    )
+}
+
 /// List all managed processes with their status.
 pub async fn list_processes(
     State(state): State<Arc<ApiState>>,
@@ -98,9 +137,10 @@ pub async fn start_process(
         .await
         .unwrap_or_else(|| id.clone());
     manager.start_process(&resolved).await.map_err(|e| {
-        (
+        manager_error_to_envelope(
+            &e,
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(api_error(format!("Failed to start process: {}", e))),
+            "Failed to start process",
         )
     })?;
 
@@ -135,10 +175,7 @@ pub async fn stop_process(
         .await
         .unwrap_or_else(|| id.clone());
     manager.stop_process(&resolved).await.map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            Json(api_error(format!("Failed to stop process: {}", e))),
-        )
+        manager_error_to_envelope(&e, StatusCode::BAD_REQUEST, "Failed to stop process")
     })?;
 
     Ok(Json(ApiResponse::success("stopped".to_string())))

--- a/src/components/process-manager/ProcessManagerTab.tsx
+++ b/src/components/process-manager/ProcessManagerTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useUIComponent } from "@qontinui/ui-bridge";
+import { useUIComponent, useUIElement } from "@qontinui/ui-bridge";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
@@ -113,6 +113,25 @@ export function ProcessManagerTab() {
    * `reconcile-tick` Tauri event. Used to derive the flap-count badge.
    */
   const [reconcileTicks, setReconcileTicks] = useState<Record<string, ReconcileTickPayload>>({});
+
+  // Stable UI Bridge anchors for spec-check (IrPageSpec authoring). These give
+  // the process-manager page id-addressable structure that survives copy edits
+  // and live-data drift, independent of the per-process tile content.
+  const { ref: panelRef } = useUIElement({
+    id: "process-manager-panel",
+    type: "generic",
+    label: "Process Manager panel",
+  });
+  const { ref: headingRef } = useUIElement({
+    id: "process-manager-heading",
+    type: "generic",
+    label: "Process Manager heading",
+  });
+  const { ref: processListRef } = useUIElement({
+    id: "process-list",
+    type: "generic",
+    label: "Process list",
+  });
 
   // AI Fix session state
   const [aiFixActive, setAiFixActive] = useState(false);
@@ -597,12 +616,14 @@ Be concise and actionable.`;
   const selected = selectedId ? processes.find((p) => p.id === selectedId) : null;
 
   return (
-    <div className="flex flex-col h-full">
+    <div ref={panelRef} className="flex flex-col h-full">
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
         <div className="flex items-center gap-2">
           <Cpu className="w-4 h-4 text-cyan-400" />
-          <h2 className="text-sm font-medium text-zinc-200">Process Manager</h2>
+          <h2 ref={headingRef} className="text-sm font-medium text-zinc-200">
+            Process Manager
+          </h2>
           <span className="text-xs text-zinc-500">
             {processes.filter((p) => isRunning(p.state)).length}/{processes.length} running
           </span>
@@ -654,7 +675,7 @@ Be concise and actionable.`;
       {/* Main content */}
       <div className="flex flex-1 min-h-0">
         {/* Process list */}
-        <div className="w-[400px] border-r border-white/10 overflow-y-auto">
+        <div ref={processListRef} className="w-[400px] border-r border-white/10 overflow-y-auto">
           {loading ? (
             <div className="flex items-center justify-center h-32 text-zinc-500 text-sm">
               Loading...
@@ -671,6 +692,11 @@ Be concise and actionable.`;
             processes.map((proc) => (
               <div
                 key={proc.id}
+                data-testid={`process-tile-${proc.name
+                  .toLowerCase()
+                  .replace(/[^a-z0-9]+/g, "-")
+                  .replace(/(^-|-$)/g, "")}`}
+                data-state={proc.state}
                 onClick={(e) => {
                   // Ignore clicks on child buttons (start, stop, edit, etc.)
                   if ((e.target as HTMLElement).closest("button")) return;

--- a/src/components/process-manager/ProcessStatusBadge.tsx
+++ b/src/components/process-manager/ProcessStatusBadge.tsx
@@ -140,6 +140,8 @@ export function ProcessStatusBadge({
 
   return (
     <span
+      data-testid="process-status-badge"
+      data-state={state}
       className={cn(
         "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium border",
         config.classes,


### PR DESCRIPTION
Two process-reconcile follow-ups (from the shipped error-envelope/process-reconcile plan).

**Frontend (enables IrPageSpec authoring for the processes page):** register process-manager-panel / heading / process-list via useUIElement; add data-testid + data-state to each process tile and the ProcessStatusBadge. Gives the page stable, id-addressable spec-check anchors independent of live process state.

**Backend (follow-up d):** parse the manager s [CODE]-prefixed lifecycle errors at the HTTP boundary into ApiResponse::error_with_code, so ExternallyOwned Start/Stop refusals surface a structured code field (INVALID_STATE / ACTION_NOT_SUPPORTED -> 400, EXTERNAL_PORT_OWNED -> 409) instead of a [CODE] message prefix. Manager keeps its Result<_,String> contract.

fmt + clippy -D warnings clean. Autonomous /update-spec follow-up work.

Session-Id: 183b6990-eb68-47f3-aa69-46979c7ec7be
Session-Name: error-envelope-coverage-and-process-reconcile