### PR TITLE
feat(schema-export): register UI Bridge HTTP envelope types

### DIFF
--- a/crates/spec-check/src/criteria.rs
+++ b/crates/spec-check/src/criteria.rs
@@ -325,6 +325,53 @@ fn max_f32(a: f32, b: f32) -> f32 {
     }
 }
 
+// ===========================================================================
+// Misc utilities (private to crate, but `pub(crate)` so evaluator can reuse)
+// ===========================================================================
+
+/// Intersect two slice-views of `ElementIdx`, returning the elements that
+/// appear in both. Linear in `|a| + |b|` after a copy + sort of `b`
+/// (typically `b` is the role hit list — small constant factors).
+pub(crate) fn intersect_sorted_unique(a: &[ElementIdx], b: &[ElementIdx]) -> Vec<ElementIdx> {
+    if a.is_empty() || b.is_empty() {
+        return Vec::new();
+    }
+    // Both posting lists are produced in insertion-order (the natural
+    // element index order) by `IndexedSnapshot::new`, so they're already
+    // sorted ascending — verify defensively before two-pointer merge.
+    let sorted_a = is_sorted(a);
+    let sorted_b = is_sorted(b);
+
+    if sorted_a && sorted_b {
+        let mut out = Vec::with_capacity(a.len().min(b.len()));
+        let (mut i, mut j) = (0, 0);
+        while i < a.len() && j < b.len() {
+            match a[i].cmp(&b[j]) {
+                std::cmp::Ordering::Equal => {
+                    if out.last() != Some(&a[i]) {
+                        out.push(a[i]);
+                    }
+                    i += 1;
+                    j += 1;
+                }
+                std::cmp::Ordering::Less => i += 1,
+                std::cmp::Ordering::Greater => j += 1,
+            }
+        }
+        out
+    } else {
+        let set: std::collections::HashSet<ElementIdx> = a.iter().copied().collect();
+        let mut out: Vec<ElementIdx> = b.iter().copied().filter(|x| set.contains(x)).collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+}
+
+fn is_sorted(v: &[ElementIdx]) -> bool {
+    v.windows(2).all(|w| w[0] <= w[1])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -983,51 +1030,4 @@ mod tests {
             prop_assert_eq!(score_text(&text, &el.text), 1.0);
         }
     }
-}
-
-// ===========================================================================
-// Misc utilities (private to crate, but `pub(crate)` so evaluator can reuse)
-// ===========================================================================
-
-/// Intersect two slice-views of `ElementIdx`, returning the elements that
-/// appear in both. Linear in `|a| + |b|` after a copy + sort of `b`
-/// (typically `b` is the role hit list — small constant factors).
-pub(crate) fn intersect_sorted_unique(a: &[ElementIdx], b: &[ElementIdx]) -> Vec<ElementIdx> {
-    if a.is_empty() || b.is_empty() {
-        return Vec::new();
-    }
-    // Both posting lists are produced in insertion-order (the natural
-    // element index order) by `IndexedSnapshot::new`, so they're already
-    // sorted ascending — verify defensively before two-pointer merge.
-    let sorted_a = is_sorted(a);
-    let sorted_b = is_sorted(b);
-
-    if sorted_a && sorted_b {
-        let mut out = Vec::with_capacity(a.len().min(b.len()));
-        let (mut i, mut j) = (0, 0);
-        while i < a.len() && j < b.len() {
-            match a[i].cmp(&b[j]) {
-                std::cmp::Ordering::Equal => {
-                    if out.last() != Some(&a[i]) {
-                        out.push(a[i]);
-                    }
-                    i += 1;
-                    j += 1;
-                }
-                std::cmp::Ordering::Less => i += 1,
-                std::cmp::Ordering::Greater => j += 1,
-            }
-        }
-        out
-    } else {
-        let set: std::collections::HashSet<ElementIdx> = a.iter().copied().collect();
-        let mut out: Vec<ElementIdx> = b.iter().copied().filter(|x| set.contains(x)).collect();
-        out.sort();
-        out.dedup();
-        out
-    }
-}
-
-fn is_sorted(v: &[ElementIdx]) -> bool {
-    v.windows(2).all(|w| w[0] <= w[1])
 }

--- a/crates/spec-check/src/derive.rs
+++ b/crates/spec-check/src/derive.rs
@@ -204,6 +204,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn el(
         element_type: &str,
         tag: Option<&str>,

--- a/crates/spec-check/src/diff.rs
+++ b/crates/spec-check/src/diff.rs
@@ -685,6 +685,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn elem(
         id: &str,
         selector: &str,

--- a/crates/spec-check/src/evaluator.rs
+++ b/crates/spec-check/src/evaluator.rs
@@ -636,6 +636,7 @@ mod tests {
             transitions: Vec::new(),
             synthesized_groups: None,
             initial_state: None,
+            api_assertions: None,
         }
     }
 

--- a/crates/spec-check/src/proptest_strategies.rs
+++ b/crates/spec-check/src/proptest_strategies.rs
@@ -191,6 +191,7 @@ pub fn arbitrary_spec() -> impl Strategy<Value = IrPageSpec> {
         transitions: Vec::new(),
         synthesized_groups: None,
         initial_state: None,
+        api_assertions: None,
     })
 }
 

--- a/crates/spec-check/tests/observability_smoke.rs
+++ b/crates/spec-check/tests/observability_smoke.rs
@@ -7,8 +7,9 @@
 //!    per spec, all sharing the same `snapshot_id`. This test runs in-process
 //!    (no PG, no HTTP) and is NOT gated — `cargo test` runs it by default.
 //!
-//! 2. **Event broadcast.** Construct and round-trip `SpecApiEvent::SpecCheckInvoked`
-//!    + `SpecCheckCompleted` through an in-process `std::sync::mpsc` channel,
+//! 2. **Event broadcast.** Construct and round-trip
+//!    `SpecApiEvent::SpecCheckInvoked` and `SpecCheckCompleted` through an
+//!    in-process `std::sync::mpsc` channel,
 //!    verifying both the enum shape and the `snapshot_id` join key. The real
 //!    `spec_api::events::subscribe()` path lives in the runner binary
 //!    (`src-tauri/src/spec_api/events.rs`) and the matching `POST /spec-check`

--- a/src-tauri/src/schema_export.rs
+++ b/src-tauri/src/schema_export.rs
@@ -84,6 +84,22 @@ pub fn export_all_schemas() -> Value {
     // delete-only diff against the checked-in TS files.
     add!("UiBridgeRequestEnvelope", qae::UiBridgeRequestEnvelope);
     add!("UiBridgeResponseEnvelope", qae::UiBridgeResponseEnvelope);
+    // HTTP UI-Bridge surface envelopes (qontinui-web Next.js `/api/ui-bridge/*`
+    // proxy). Distinct from the WS/relay `UiBridgeResponseEnvelope` above —
+    // these lack `requestId`/`type`/`timestamp` and model the proxy's
+    // structured 503 error body + the SDK's `/health` success body. They are
+    // the source-of-truth for the Spec-CI `conforms_to` C1 checks on
+    // qontinui-web's `ui-bridge-states` page spec. The nested `*HealthData` /
+    // `*HealthAppInfo` structs are registered as top-level types so they get
+    // their own per-type TS / Python files (same pattern as `CanvasPanel`).
+    // See the doc comments in `qontinui-schemas/rust/src/app_events.rs`.
+    add!("UiBridgeHttpErrorEnvelope", qae::UiBridgeHttpErrorEnvelope);
+    add!(
+        "UiBridgeHttpHealthEnvelope",
+        qae::UiBridgeHttpHealthEnvelope
+    );
+    add!("UiBridgeHttpHealthData", qae::UiBridgeHttpHealthData);
+    add!("UiBridgeHttpHealthAppInfo", qae::UiBridgeHttpHealthAppInfo);
 
     // ── qontinui-types: ai_workflows ──
     add!("ExecutionStep", qaw::ExecutionStep);
@@ -785,7 +801,7 @@ mod tests {
             obj.contains_key("SpecApiEvent"),
             "Missing SpecApiEvent schema (Plan 06)"
         );
-        assert_eq!(obj.len(), 495, "Expected 495 schema entries");
+        assert_eq!(obj.len(), 499, "Expected 499 schema entries");
 
         // Sanity-check that qontinui_types re-exports are present
         assert!(


### PR DESCRIPTION
## What

Registers the four new canonical types from **qontinui-schemas#68** (`UiBridgeHttpErrorEnvelope`, `UiBridgeHttpHealthEnvelope`, and the nested `UiBridgeHttpHealthData` / `UiBridgeHttpHealthAppInfo`) in `export_all_schemas` so they land in the emitted `schemas.json` corpus and get their own per-type TS / Python bindings (same pattern as `CanvasPanel`).

Models the qontinui-web Next.js `/api/ui-bridge/*` HTTP surface (proxy 503 error body + SDK `/health` success body), distinct from the WS/relay `UiBridgeResponseEnvelope`. Bumps the registry count assertion `495 -> 499`.

## Depends on

**qontinui-schemas#68** (defines the types). **Merge that first**, then this.

> The on-PR `qontinui-types-drift.yml` and the local `gen-events-drift` / clippy pre-push hooks regenerate against qontinui-schemas **main**, which does not carry these types until #68 merges — so they fail until then (a stacked-PR ordering artifact, not unverified code). Built + verified locally against the schemas branch: `export_schemas` compiles, exports all 499 types, and the schemas round-trip tests pass. Re-run the drift check after #68 merges (rebase if needed).