### PR TITLE
fix(runner): ui-bridge /tabs envelope + redeem_pair_code allowlist + relay/kick route

### DIFF
--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -185,13 +185,38 @@ async fn web_integration_status_handler(
     axum::response::Json(web_integration_status(&state).await)
 }
 
-/// Router exposing the relay's web-integration diagnostic endpoint. Merged
-/// into the base router in `mcp_api::start_server`.
+/// `POST /web-integration/relay/kick` — force the WS relay to interrupt any
+/// in-progress backoff sleep and immediately retry a connect with
+/// freshly-read settings + tokens.
+///
+/// The relay reconnects on its own exponential backoff (2s → 120s), so after
+/// a fresh pair (which DOES kick internally via `redeem_pair_code`) or any
+/// out-of-band credential change there's otherwise no way to force an
+/// immediate reconnect without a UI action or a runner restart. This endpoint
+/// pokes the same kick channel the in-process callers use
+/// ([`commands::kick_cloud_relay`]). It's a no-op (still returns ack) when no
+/// relay task is running. Local-only + unauthenticated, consistent with the
+/// rest of the runner's localhost-bound API surface.
+async fn relay_kick_handler() -> axum::response::Json<Value> {
+    commands::kick_cloud_relay().await;
+    axum::response::Json(serde_json::json!({
+        "ok": true,
+        "kicked": true,
+    }))
+}
+
+/// Router exposing the relay's web-integration diagnostic + control
+/// endpoints. Merged into the base router in `mcp_api::start_server`.
 pub fn routes() -> axum::Router<Arc<ApiState>> {
-    axum::Router::new().route(
-        "/web-integration/status",
-        axum::routing::get(web_integration_status_handler),
-    )
+    axum::Router::new()
+        .route(
+            "/web-integration/status",
+            axum::routing::get(web_integration_status_handler),
+        )
+        .route(
+            "/web-integration/relay/kick",
+            axum::routing::post(relay_kick_handler),
+        )
 }
 
 /// Return true iff `e` is a tungstenite handshake error with HTTP 401

--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -2247,7 +2247,7 @@ async fn handle_windows(
 async fn handle_tabs(
     State(state): State<Arc<ApiState>>,
     Query(query): Query<HashMap<String, String>>,
-) -> Json<serde_json::Value> {
+) -> Json<ApiResponse<serde_json::Value>> {
     let truthy = |v: &String| {
         let s = v.trim();
         s == "1" || s.eq_ignore_ascii_case("true")
@@ -2264,9 +2264,13 @@ async fn handle_tabs(
     } else {
         format!("/tabs?{}", parts.join("&"))
     };
+    // Wrap in the canonical `ApiResponse` envelope like every sibling
+    // `/ui-bridge/sdk/*` handler (e.g. `handle_windows`) so the
+    // `envelope_audit` layer doesn't trip on a bare value, and callers see a
+    // uniform `{ success, data | error }` shape.
     match sdk_request(&state, Method::GET, &path, None).await {
-        Ok(data) => Json(data),
-        Err(e) => Json(serde_json::json!({ "success": false, "error": e })),
+        Ok(data) => Json(ApiResponse::success(data)),
+        Err(e) => Json(ApiResponse::error(e)),
     }
 }
 

--- a/src-tauri/src/ui_bridge_invoke.rs
+++ b/src-tauri/src/ui_bridge_invoke.rs
@@ -196,6 +196,15 @@ pub const UI_BRIDGE_COMMANDS: &[ProxyableCommand] = &[
         probe_with_empty_args: false,
     },
     ProxyableCommand {
+        name: "redeem_pair_code",
+        description: "Redeem a 6-char single-use pair code against the active profile's web backend (already registered in Tauri — this entry only allowlists it over HTTP, so an agent can complete pairing without DOM-driving the Settings form). On success the device JWT is persisted Rust-side (never returned to JS) and the runner is promoted to the Qontinui-account tier with the relay kicked to dial in. `backendUrl` is optional — when omitted, derives the web base from the active profile's coord_url.",
+        args_schema: "{ \"code\": string, \"backendUrl\"?: string | null }",
+        response_schema: "{ \"userId\": string, \"tenantId\": string, \"deviceId\": string }",
+        // Redeeming requires a real code; an empty-args boot probe would do a
+        // pointless failed round-trip. Skip the startup probe.
+        probe_with_empty_args: false,
+    },
+    ProxyableCommand {
         name: "emit_extraction_script",
         description: "Synthesise a one-line JS extraction expression for the scripted-output indirection (already registered in Tauri — this entry only allowlists it over HTTP). Maps to a 500 with `{ kind, message }` error body on failure; `kind` is one of `cost_cap` (per-task_run call cap exceeded), `token_budget` (input/output token budget exhausted), `timeout` (LLM exceeded 5s), `breaker_open` (shared Claude circuit breaker is Open), `disabled` (global kill switch off), `llm_error`, or `invalid_response`.",
         args_schema: "{ \"goal\": string, \"schemaHint\": object, \"outputPreview\": string, \"taskRunId\"?: string | null }",
@@ -455,6 +464,7 @@ mod tests {
         assert!(is_allowlisted("save_web_integration_settings"));
         assert!(is_allowlisted("test_web_integration_connection"));
         assert!(is_allowlisted("start_web_token_flow"));
+        assert!(is_allowlisted("redeem_pair_code"));
     }
 
     #[test]


### PR DESCRIPTION
Three P3 follow-ups from the device-bridge pairing work (builds on c3b45cef):

- `/ui-bridge/sdk/tabs` now returns the canonical `Json<ApiResponse<..>>` envelope (was a bare value → envelope_audit 500).
- `redeem_pair_code` added to the UI-Bridge HTTP command allowlist (enables headless pairing without DOM-driving Settings).
- New `POST /web-integration/relay/kick` route to force an immediate relay reconnect after a fresh pair (instead of waiting on the 2s→120s backoff).

fmt + clippy --all-targets clean. Verified via compile/lint gate + allowlist unit test.