### PR TITLE
fix(envelope): canonical JSON 404 fallback for unmatched routes

### DIFF
--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1805,6 +1805,14 @@ pub fn create_router(
     #[cfg(any(debug_assertions, feature = "test-fixtures"))]
     let base_router = base_router.merge(crate::mcp::test_fixtures::routes());
 
+    // Canonical JSON 404 for unmatched routes. axum's default fallback returns
+    // an empty body with no Content-Type, which both breaks the canonical
+    // envelope contract and trips the debug envelope_audit layer (it sees a
+    // non-application/json 4xx and panics). Returning the envelope here keeps
+    // the error shape universal — route-not-found included — and is the JSON
+    // the audit expects.
+    let base_router = base_router.fallback(not_found_handler);
+
     // Layer ordering (`.layer()` is bottom-up — last call = outermost):
     //
     //   [CatchPanicLayer]              ← outermost: panics → 500 JSON
@@ -1862,6 +1870,22 @@ pub fn create_router(
 /// The panic payload is `Box<dyn Any + Send>`; downcast to the two common
 /// concrete types (`&'static str` from `panic!("literal")` and `String` from
 /// `panic!("{}", x)`) and fall back to a generic message otherwise.
+/// Canonical JSON 404 handler for unmatched routes. See the `.fallback(...)`
+/// call in `build_router` for why this exists (envelope universality + the
+/// debug envelope_audit layer).
+async fn not_found_handler(
+    method: axum::http::Method,
+    uri: axum::http::Uri,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+
+    let body = crate::mcp::types::ApiResponse::<()>::error_with_code(
+        format!("No route for {} {}", method, uri.path()),
+        "NOT_FOUND",
+    );
+    (axum::http::StatusCode::NOT_FOUND, axum::Json(body)).into_response()
+}
+
 fn runner_panic_handler(err: Box<dyn std::any::Any + Send + 'static>) -> axum::response::Response {
     use axum::response::IntoResponse;
 


### PR DESCRIPTION
Found via the live runner: the A2 debug envelope_audit layer panics on unmatched routes (e.g. GET / probes) because axum default 404 = empty body, no Content-Type — neither text/plain (so A1 rewrite skips it) nor application/json (so the audit panics -> caught 500 in dev). Release unaffected (audit compiles out).

Fix: add a .fallback handler returning ApiResponse::error_with_code(.., "NOT_FOUND") so route-not-found is the canonical envelope too (the plan intent: envelope universal across every error), which also satisfies the audit. fmt+clippy clean.

Session-Id: 183b6990-eb68-47f3-aa69-46979c7ec7be
Session-Name: error-envelope-coverage-and-process-reconcile