### PR TITLE
feat(runner): isolate temp runner config/storage from primary

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -903,7 +903,13 @@ pub fn set_runner_tier(tier: String) -> Result<(), String> {
     let mut s = settings::load_settings();
     s.tier = parsed;
     s.tier_initialized = true;
-    settings::save_settings(&s).map_err(|e| e.to_string())?;
+    if crate::instance::is_secondary() {
+        warn!(
+            "set_runner_tier: secondary runner — applying in-memory only, skipping save_settings"
+        );
+    } else {
+        settings::save_settings(&s).map_err(|e| e.to_string())?;
+    }
     // Kick both the relay (so it picks up the new tier without a runner
     // restart) and the device-JWT refresher (Phase 2 of unified-devices
     // — promotion into Tier 2 should trigger a JWT refresh check, and
@@ -1116,8 +1122,12 @@ async fn pair_with_credentials_impl(
         s.qontinui_user_id = Some(user_id.clone());
         s.tier = settings::RunnerTier::QontinuiAccount;
         s.tier_initialized = true;
-        settings::save_settings(&s)
-            .map_err(|e| AppError::Raw(format!("persist tier promotion: {e}")))?;
+        if crate::instance::is_secondary() {
+            warn!("pair_with_credentials: secondary runner — applying in-memory only, skipping save_settings");
+        } else {
+            settings::save_settings(&s)
+                .map_err(|e| AppError::Raw(format!("persist tier promotion: {e}")))?;
+        }
     }
     tokio::spawn(async {
         crate::mcp::backend_relay::commands::kick_cloud_relay().await;
@@ -1165,11 +1175,17 @@ pub async fn qontinui_sign_out() -> Result<(), String> {
     s.qontinui_user_id = None;
     s.tier = settings::RunnerTier::Local;
     s.tier_initialized = true;
-    settings::save_settings(&s).map_err(|e| {
-        let msg = format!("failed to persist sign-out: {}", e);
-        error!("qontinui_sign_out: {}", msg);
-        msg
-    })?;
+    if crate::instance::is_secondary() {
+        warn!(
+            "qontinui_sign_out: secondary runner — applying in-memory only, skipping save_settings"
+        );
+    } else {
+        settings::save_settings(&s).map_err(|e| {
+            let msg = format!("failed to persist sign-out: {}", e);
+            error!("qontinui_sign_out: {}", msg);
+            msg
+        })?;
+    }
 
     // Kick the relay — now that tier != QontinuiAccount, the cloud relay
     // task enters its idle-await-kick state and drops the WS.

--- a/src-tauri/src/commands/web_integration.rs
+++ b/src-tauri/src/commands/web_integration.rs
@@ -770,7 +770,12 @@ pub async fn redeem_pair_code(
         if s.tier != settings::RunnerTier::QontinuiAccount {
             s.tier = settings::RunnerTier::QontinuiAccount;
             s.tier_initialized = true;
-            if let Err(e) = settings::save_settings(&s) {
+            if crate::instance::is_secondary() {
+                warn!("redeem_pair_code: secondary runner — applying in-memory only, skipping save_settings");
+                crate::mcp::backend_relay::commands::kick_cloud_relay().await;
+                crate::mcp::device_jwt_refresher::commands::kick_device_jwt_refresher().await;
+                info!("redeem_pair_code: promoted runner to Tier QontinuiAccount + kicked relay");
+            } else if let Err(e) = settings::save_settings(&s) {
                 warn!("redeem_pair_code: tier promotion persist failed (continuing): {e}");
             } else {
                 crate::mcp::backend_relay::commands::kick_cloud_relay().await;

--- a/src-tauri/src/mcp/auth_callback.rs
+++ b/src-tauri/src/mcp/auth_callback.rs
@@ -344,7 +344,9 @@ fn promote_to_tier_2(token: &str) {
     }
 
     if mutated {
-        if let Err(e) = crate::settings::save_settings(&s) {
+        if crate::instance::is_secondary() {
+            warn!("promote_to_tier_2: secondary runner — applying in-memory only, skipping save_settings");
+        } else if let Err(e) = crate::settings::save_settings(&s) {
             warn!(
                 "runner_token_callback: failed to persist tier/setup_completed: {}",
                 e

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -152,7 +152,12 @@ fn read_device_id() -> Result<String, String> {
 /// `auth_tokens.enc`) so the CLI bin and the GUI runner read the same
 /// file.
 pub(crate) fn paired_user_path() -> Option<PathBuf> {
-    dirs::data_local_dir().map(|d| d.join("com.qontinui.runner").join("paired_user.json"))
+    let base = std::env::var("QONTINUI_SECURE_STORAGE_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::data_local_dir().map(|d| d.join("com.qontinui.runner")))?;
+    Some(base.join("paired_user.json"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -59,9 +59,12 @@ impl SecureStorage {
     ///
     /// The storage file will be created in the app's data directory.
     pub fn new() -> Result<Self> {
-        let data_dir = dirs::data_local_dir()
-            .context("Failed to get local data directory")?
-            .join(SERVICE_NAME);
+        let data_dir = std::env::var("QONTINUI_SECURE_STORAGE_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::data_local_dir().map(|d| d.join(SERVICE_NAME)))
+            .context("Failed to get data directory")?;
 
         // Ensure directory exists
         fs::create_dir_all(&data_dir).context("Failed to create data directory")?;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1757,9 +1757,12 @@ fn default_app_mode() -> String {
 
 /// Get the settings file path in the app data directory
 fn get_settings_path() -> Result<PathBuf, String> {
-    let app_data_dir = dirs::config_dir()
-        .ok_or("Failed to get config directory")?
-        .join("com.qontinui.runner");
+    let app_data_dir = std::env::var("QONTINUI_CONFIG_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::config_dir().map(|d| d.join("com.qontinui.runner")))
+        .ok_or("Failed to get config directory")?;
 
     // Create directory if it doesn't exist
     if !app_data_dir.exists() {


### PR DESCRIPTION
## Summary
- **Phase 1**: `is_secondary()` guards on 5 tier-mutation `save_settings()` call sites
- **Phase 2**: `get_settings_path()` checks `QONTINUI_CONFIG_DIR` env var
- **Phase 3**: `SecureStorage::new()` and `paired_user_path()` check `QONTINUI_SECURE_STORAGE_DIR`

## Test plan
- [x] `cargo check` passes
- [ ] Spawn temp runner with isolated config → verify primary settings unchanged