### PR TITLE
feat: CI Runner settings UI

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -903,7 +903,13 @@ pub fn set_runner_tier(tier: String) -> Result<(), String> {
     let mut s = settings::load_settings();
     s.tier = parsed;
     s.tier_initialized = true;
-    settings::save_settings(&s).map_err(|e| e.to_string())?;
+    if crate::instance::is_secondary() {
+        warn!(
+            "set_runner_tier: secondary runner — applying in-memory only, skipping save_settings"
+        );
+    } else {
+        settings::save_settings(&s).map_err(|e| e.to_string())?;
+    }
     // Kick both the relay (so it picks up the new tier without a runner
     // restart) and the device-JWT refresher (Phase 2 of unified-devices
     // — promotion into Tier 2 should trigger a JWT refresh check, and
@@ -1116,8 +1122,12 @@ async fn pair_with_credentials_impl(
         s.qontinui_user_id = Some(user_id.clone());
         s.tier = settings::RunnerTier::QontinuiAccount;
         s.tier_initialized = true;
-        settings::save_settings(&s)
-            .map_err(|e| AppError::Raw(format!("persist tier promotion: {e}")))?;
+        if crate::instance::is_secondary() {
+            warn!("pair_with_credentials: secondary runner — applying in-memory only, skipping save_settings");
+        } else {
+            settings::save_settings(&s)
+                .map_err(|e| AppError::Raw(format!("persist tier promotion: {e}")))?;
+        }
     }
     tokio::spawn(async {
         crate::mcp::backend_relay::commands::kick_cloud_relay().await;
@@ -1165,11 +1175,17 @@ pub async fn qontinui_sign_out() -> Result<(), String> {
     s.qontinui_user_id = None;
     s.tier = settings::RunnerTier::Local;
     s.tier_initialized = true;
-    settings::save_settings(&s).map_err(|e| {
-        let msg = format!("failed to persist sign-out: {}", e);
-        error!("qontinui_sign_out: {}", msg);
-        msg
-    })?;
+    if crate::instance::is_secondary() {
+        warn!(
+            "qontinui_sign_out: secondary runner — applying in-memory only, skipping save_settings"
+        );
+    } else {
+        settings::save_settings(&s).map_err(|e| {
+            let msg = format!("failed to persist sign-out: {}", e);
+            error!("qontinui_sign_out: {}", msg);
+            msg
+        })?;
+    }
 
     // Kick the relay — now that tier != QontinuiAccount, the cloud relay
     // task enters its idle-await-kick state and drops the WS.

--- a/src-tauri/src/commands/web_integration.rs
+++ b/src-tauri/src/commands/web_integration.rs
@@ -770,7 +770,12 @@ pub async fn redeem_pair_code(
         if s.tier != settings::RunnerTier::QontinuiAccount {
             s.tier = settings::RunnerTier::QontinuiAccount;
             s.tier_initialized = true;
-            if let Err(e) = settings::save_settings(&s) {
+            if crate::instance::is_secondary() {
+                warn!("redeem_pair_code: secondary runner — applying in-memory only, skipping save_settings");
+                crate::mcp::backend_relay::commands::kick_cloud_relay().await;
+                crate::mcp::device_jwt_refresher::commands::kick_device_jwt_refresher().await;
+                info!("redeem_pair_code: promoted runner to Tier QontinuiAccount + kicked relay");
+            } else if let Err(e) = settings::save_settings(&s) {
                 warn!("redeem_pair_code: tier promotion persist failed (continuing): {e}");
             } else {
                 crate::mcp::backend_relay::commands::kick_cloud_relay().await;

--- a/src-tauri/src/mcp/auth_callback.rs
+++ b/src-tauri/src/mcp/auth_callback.rs
@@ -344,7 +344,9 @@ fn promote_to_tier_2(token: &str) {
     }
 
     if mutated {
-        if let Err(e) = crate::settings::save_settings(&s) {
+        if crate::instance::is_secondary() {
+            warn!("promote_to_tier_2: secondary runner — applying in-memory only, skipping save_settings");
+        } else if let Err(e) = crate::settings::save_settings(&s) {
             warn!(
                 "runner_token_callback: failed to persist tier/setup_completed: {}",
                 e

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -152,7 +152,12 @@ fn read_device_id() -> Result<String, String> {
 /// `auth_tokens.enc`) so the CLI bin and the GUI runner read the same
 /// file.
 pub(crate) fn paired_user_path() -> Option<PathBuf> {
-    dirs::data_local_dir().map(|d| d.join("com.qontinui.runner").join("paired_user.json"))
+    let base = std::env::var("QONTINUI_SECURE_STORAGE_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::data_local_dir().map(|d| d.join("com.qontinui.runner")))?;
+    Some(base.join("paired_user.json"))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -59,9 +59,12 @@ impl SecureStorage {
     ///
     /// The storage file will be created in the app's data directory.
     pub fn new() -> Result<Self> {
-        let data_dir = dirs::data_local_dir()
-            .context("Failed to get local data directory")?
-            .join(SERVICE_NAME);
+        let data_dir = std::env::var("QONTINUI_SECURE_STORAGE_DIR")
+            .ok()
+            .filter(|s| !s.is_empty())
+            .map(std::path::PathBuf::from)
+            .or_else(|| dirs::data_local_dir().map(|d| d.join(SERVICE_NAME)))
+            .context("Failed to get data directory")?;
 
         // Ensure directory exists
         fs::create_dir_all(&data_dir).context("Failed to create data directory")?;

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1757,9 +1757,12 @@ fn default_app_mode() -> String {
 
 /// Get the settings file path in the app data directory
 fn get_settings_path() -> Result<PathBuf, String> {
-    let app_data_dir = dirs::config_dir()
-        .ok_or("Failed to get config directory")?
-        .join("com.qontinui.runner");
+    let app_data_dir = std::env::var("QONTINUI_CONFIG_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::config_dir().map(|d| d.join("com.qontinui.runner")))
+        .ok_or("Failed to get config directory")?;
 
     // Create directory if it doesn't exist
     if !app_data_dir.exists() {

--- a/src/components/app/tab-types.ts
+++ b/src/components/app/tab-types.ts
@@ -74,6 +74,7 @@ export type MainTabId =
   | "settings-notifications"
   | "settings-otel"
   | "settings-containers"
+  | "settings-ci-runner"
   | "settings-lock-yield"
   | "accessibility-explorer"
   | "settings-updates"
@@ -179,6 +180,7 @@ const VALID_TAB_IDS: MainTabId[] = [
   "settings-notifications",
   "settings-otel",
   "settings-containers",
+  "settings-ci-runner",
   "settings-lock-yield",
   "accessibility-explorer",
   "settings-updates",
@@ -295,6 +297,7 @@ export const TAB_LABELS: Record<MainTabId, string> = {
   "settings-notifications": "Notification Settings",
   "settings-otel": "OpenTelemetry Settings",
   "settings-containers": "Container Isolation Settings",
+  "settings-ci-runner": "CI Runner Settings",
   "settings-lock-yield": "Lock-yield Policy Settings",
   "accessibility-explorer": "Accessibility Explorer",
   "settings-updates": "Updates Settings",

--- a/src/components/settings/CiRunnerSettings.tsx
+++ b/src/components/settings/CiRunnerSettings.tsx
@@ -1,0 +1,358 @@
+/**
+ * CiRunnerSettings.tsx
+ *
+ * Settings panel for enabling/disabling a GitHub Actions self-hosted CI runner
+ * on this machine. Communicates with the supervisor process at localhost:9875
+ * which manages the runner lifecycle (install, start, stop, uninstall).
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Play, Square, Info, X, Check, CircleDot } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
+import { getAccentColors } from "@/design-system";
+import type { LogFunction } from "./types";
+
+// --- Types ---
+
+interface CiRunnerStatus {
+  installed: boolean;
+  status: {
+    status: "idle" | "busy" | "offline";
+    labels: string[];
+    service_names: string[];
+  };
+}
+
+interface CiRunnerSettingsProps {
+  onLog: LogFunction;
+}
+
+const SUPERVISOR_BASE = "http://localhost:9875";
+const POLL_INTERVAL_MS = 10_000;
+
+// Toggle Switch (matches ContainerSettings / SelfHealingSettings pattern)
+function ToggleSwitch({
+  checked,
+  onChange,
+  disabled,
+}: {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <button
+      onClick={() => {
+        if (!disabled) onChange(!checked);
+      }}
+      disabled={disabled}
+      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+        checked ? "bg-primary" : "bg-muted"
+      } ${disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+          checked ? "translate-x-4" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
+}
+
+function StatusBadge({ status }: { status: "idle" | "busy" | "offline" }) {
+  const colors: Record<string, string> = {
+    idle: "text-green-400",
+    busy: "text-yellow-400",
+    offline: "text-zinc-400",
+  };
+  const labels: Record<string, string> = {
+    idle: "Idle",
+    busy: "Busy",
+    offline: "Offline",
+  };
+  return (
+    <span className={`inline-flex items-center gap-1.5 text-xs font-medium ${colors[status]}`}>
+      <CircleDot className="w-3 h-3" />
+      {labels[status]}
+    </span>
+  );
+}
+
+export function CiRunnerSettings({ onLog }: CiRunnerSettingsProps) {
+  const [status, setStatus] = useState<CiRunnerStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/status`);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const data: CiRunnerStatus = await resp.json();
+      setStatus(data);
+      setError(null);
+    } catch (err) {
+      setError(`Failed to reach supervisor: ${err instanceof Error ? err.message : String(err)}`);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Poll status on mount and every POLL_INTERVAL_MS
+  useEffect(() => {
+    void fetchStatus();
+    timerRef.current = setInterval(() => {
+      void fetchStatus();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [fetchStatus]);
+
+  const handleEnable = useCallback(async () => {
+    setActionLoading(true);
+    setError(null);
+    setActionSuccess(null);
+    try {
+      const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/enable`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          labels: ["self-hosted", "qontinui"],
+        }),
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(body || `HTTP ${resp.status}`);
+      }
+      setActionSuccess("CI runner enabled successfully");
+      onLog("success", "CI runner enabled");
+      // Refresh status immediately
+      await fetchStatus();
+      setTimeout(() => setActionSuccess(null), 3000);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(`Failed to enable CI runner: ${msg}`);
+      onLog("error", `Failed to enable CI runner: ${msg}`);
+    } finally {
+      setActionLoading(false);
+    }
+  }, [fetchStatus, onLog]);
+
+  const handleDisable = useCallback(async () => {
+    setActionLoading(true);
+    setError(null);
+    setActionSuccess(null);
+    try {
+      const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/disable`, {
+        method: "POST",
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(body || `HTTP ${resp.status}`);
+      }
+      setActionSuccess("CI runner disabled successfully");
+      onLog("success", "CI runner disabled");
+      await fetchStatus();
+      setTimeout(() => setActionSuccess(null), 3000);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(`Failed to disable CI runner: ${msg}`);
+      onLog("error", `Failed to disable CI runner: ${msg}`);
+    } finally {
+      setActionLoading(false);
+    }
+  }, [fetchStatus, onLog]);
+
+  const handleStart = useCallback(async () => {
+    setActionLoading(true);
+    setError(null);
+    setActionSuccess(null);
+    try {
+      const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/start`, {
+        method: "POST",
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(body || `HTTP ${resp.status}`);
+      }
+      setActionSuccess("CI runner started");
+      onLog("success", "CI runner started");
+      await fetchStatus();
+      setTimeout(() => setActionSuccess(null), 3000);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(`Failed to start CI runner: ${msg}`);
+      onLog("error", `Failed to start CI runner: ${msg}`);
+    } finally {
+      setActionLoading(false);
+    }
+  }, [fetchStatus, onLog]);
+
+  const handleStop = useCallback(async () => {
+    setActionLoading(true);
+    setError(null);
+    setActionSuccess(null);
+    try {
+      const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/stop`, {
+        method: "POST",
+      });
+      if (!resp.ok) {
+        const body = await resp.text();
+        throw new Error(body || `HTTP ${resp.status}`);
+      }
+      setActionSuccess("CI runner stopped");
+      onLog("success", "CI runner stopped");
+      await fetchStatus();
+      setTimeout(() => setActionSuccess(null), 3000);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(`Failed to stop CI runner: ${msg}`);
+      onLog("error", `Failed to stop CI runner: ${msg}`);
+    } finally {
+      setActionLoading(false);
+    }
+  }, [fetchStatus, onLog]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="text-muted-foreground">Loading CI runner status...</div>
+      </div>
+    );
+  }
+
+  const installed = status?.installed ?? false;
+  const runnerStatus = status?.status.status ?? "offline";
+  const labels = status?.status.labels ?? [];
+
+  return (
+    <div className="space-y-6">
+      <SectionHeader
+        title="CI Runner"
+        description="Enable a GitHub Actions self-hosted runner on this machine. The supervisor manages the runner lifecycle — registration, service install, start/stop, and removal."
+        icon={<CircleDot className="w-6 h-6" />}
+      />
+
+      {error && (
+        <div className={`p-3 ${getAccentColors("red").bg} rounded-lg flex items-start gap-2`}>
+          <X className={`w-4 h-4 ${getAccentColors("red").text} shrink-0 mt-0.5`} />
+          <span className={`${getAccentColors("red").text} text-xs`}>{error}</span>
+        </div>
+      )}
+
+      {actionSuccess && (
+        <div className={`p-3 ${getAccentColors("green").bg} rounded-lg flex items-start gap-2`}>
+          <Check className={`w-4 h-4 ${getAccentColors("green").text} shrink-0 mt-0.5`} />
+          <span className={`${getAccentColors("green").text} text-xs`}>{actionSuccess}</span>
+        </div>
+      )}
+
+      {/* Enable/Disable Toggle */}
+      <div className="rounded-lg bg-card/50 overflow-hidden">
+        <div className="p-4 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <CircleDot className="w-5 h-5 text-primary" />
+            <div>
+              <h4 className="font-medium text-sm">Enable CI Runner</h4>
+              <p className="text-xs text-muted-foreground">
+                Register and install a GitHub Actions self-hosted runner
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            {installed && <StatusBadge status={runnerStatus} />}
+            <ToggleSwitch
+              checked={installed}
+              onChange={(checked) => {
+                if (checked) {
+                  void handleEnable();
+                } else {
+                  void handleDisable();
+                }
+              }}
+              disabled={actionLoading}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Runner details — only when installed */}
+      {installed && (
+        <div className="rounded-lg bg-card/50 overflow-hidden">
+          <div className="p-4 space-y-4">
+            {/* Labels */}
+            {labels.length > 0 && (
+              <div className="space-y-1.5">
+                <label className="text-xs font-medium">Labels</label>
+                <div className="flex flex-wrap gap-1.5">
+                  {labels.map((label) => (
+                    <span
+                      key={label}
+                      className="inline-flex items-center px-2 py-0.5 rounded text-[0.7rem] font-medium bg-muted text-muted-foreground"
+                    >
+                      {label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Start/Stop Controls */}
+            <div className="space-y-3 pt-2 border-t border-border/50">
+              <div className="flex items-center justify-between">
+                <div>
+                  <h4 className="text-xs font-medium">Service Control</h4>
+                  <p className="text-[10px] text-muted-foreground">
+                    Start or stop the runner service without removing it
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleStart}
+                    disabled={actionLoading || runnerStatus !== "offline"}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-green-600 hover:bg-green-700 text-white rounded-md text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {actionLoading ? (
+                      <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    ) : (
+                      <Play className="w-3.5 h-3.5" />
+                    )}
+                    Start
+                  </button>
+                  <button
+                    onClick={handleStop}
+                    disabled={actionLoading || runnerStatus === "offline"}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded-md text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {actionLoading ? (
+                      <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                    ) : (
+                      <Square className="w-3.5 h-3.5" />
+                    )}
+                    Stop
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Info banner */}
+      <div className={`p-3 ${getAccentColors("blue").bg} rounded-lg flex gap-2`}>
+        <Info className={`w-4 h-4 ${getAccentColors("blue").text} shrink-0 mt-0.5`} />
+        <p className={`text-xs ${getAccentColors("blue").text}`}>
+          The CI runner registers this machine as a GitHub Actions self-hosted runner. Once enabled,
+          workflows targeting the <code className="font-mono">self-hosted</code> and{" "}
+          <code className="font-mono">qontinui</code> labels will be picked up by this machine. The
+          supervisor polls the coordinator for a registration token during setup.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -31,6 +31,7 @@ import { ContainerSettings } from "./ContainerSettings";
 import { LockYieldPolicySettings } from "./LockYieldPolicySettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { AccountSettings } from "./AccountSettings";
+import { CiRunnerSettings } from "./CiRunnerSettings";
 
 interface SettingsProps {
   /** Default tab to open. If provided, overrides instanceStorage persistence. */
@@ -60,6 +61,7 @@ type SettingsTab =
   | "otel"
   | "containers"
   | "security"
+  | "ci-runner"
   | "lock-yield"
   | "advanced"
   | "updates";
@@ -94,6 +96,7 @@ const SETTINGS_TABS = [
   { id: "instances", label: "Runner Instances" },
   { id: "otel", label: "OpenTelemetry" },
   { id: "containers", label: "Container Isolation" },
+  { id: "ci-runner", label: "CI Runner" },
   { id: "security", label: "Security" },
   { id: "lock-yield", label: "Lock-yield Policy" },
   { id: "advanced", label: "Debug" },
@@ -132,6 +135,7 @@ const SUB_TAB_TO_MAIN_TAB: Record<SettingsTab, string> = {
   instances: "settings-instances",
   otel: "settings-otel",
   containers: "settings-containers",
+  "ci-runner": "settings-ci-runner",
   security: "settings-security",
   "lock-yield": "settings-lock-yield",
   // SETTINGS_TABS id is "advanced" (label "Debug"); MainTabId is "settings-debug"
@@ -291,6 +295,8 @@ export function Settings({ defaultTab, onLog, onDebugModeChange }: SettingsProps
         return <OtelSettings onLog={onLog} />;
       case "containers":
         return <ContainerSettings onLog={onLog} />;
+      case "ci-runner":
+        return <CiRunnerSettings onLog={onLog} />;
       case "security":
         return <SecuritySettings onLog={onLog} />;
       case "lock-yield":

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -8,6 +8,7 @@ export { AgenticSettings } from "./AgenticSettings";
 export { SelfHealingSettings } from "./SelfHealingSettings";
 export { OtelSettings } from "./OtelSettings";
 export { ContainerSettings } from "./ContainerSettings";
+export { CiRunnerSettings } from "./CiRunnerSettings";
 export { SecuritySettings } from "./SecuritySettings";
 export { ExecutionVariablesSettings } from "./ExecutionVariablesSettings";
 export { SectionHeader } from "./SectionHeader";


### PR DESCRIPTION
## Summary
- New `CiRunnerSettings` component in Settings panel as a CI Runner sub-tab
- Polls supervisor `GET /ci-runner/status` every 10s for install state + status badge
- Enable/disable toggle calls supervisor `POST /ci-runner/enable` and `/disable`
- Start/stop controls when installed
- Follows existing patterns: `ToggleSwitch`, `SectionHeader`, `getAccentColors`

## Dependencies
- Requires qontinui-supervisor PR #55 (merged) — provides the `/ci-runner/*` API endpoints

## Test plan
- [ ] Settings panel shows CI Runner sub-tab
- [ ] Toggle shows disabled state when no runner is installed
- [ ] Toggle enables runner (calls supervisor, coord, GitHub for token)
- [ ] Status badge shows idle/busy/offline with correct colors
- [ ] Start/stop buttons work when runner is installed