### PR TITLE
chore: replace staging domain references with production domains

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -173,7 +173,7 @@ fn coord_http_base() -> Option<String> {
 /// normalizing the scheme to `ws://` / `wss://`.
 ///
 /// The profile's `coord_url` is frequently configured as an HTTP(S) base
-/// (e.g. `https://coord.staging.qontinui.io`, mirrored from the API base)
+/// (e.g. `https://coord.qontinui.io`, mirrored from the API base)
 /// rather than a WS endpoint. Passing an `https://` URL straight to
 /// `tokio_tungstenite::connect_async` fails with `URL scheme not supported`
 /// (the agent_runtime WS-pump error seen on staging). Convert

--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -1049,7 +1049,7 @@ async fn handle_element(
 ///
 /// - `task_run_id` - persistence correlation for the audit event.
 /// - `tab_id` / `target_tab_id` - per-tab routing (UI Bridge Item #4). When a
-///   single relay (e.g. qontinui-web's dashboard at demo.staging.qontinui.io)
+///   single relay (e.g. qontinui-web's dashboard at qontinui.io)
 ///   has more than one browser tab connected - two operator machines each
 ///   driving a headless tab - the relay's default dispatch routes to
 ///   `primaryTabId`, which flips to whichever tab registered most recently.

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -831,8 +831,8 @@ mod tests {
             "ws://localhost:9870/ws?pattern=qontinui.sessions.%2A"
         );
         assert_eq!(
-            coord_ws_url("https://coord.staging.qontinui.io/"),
-            "wss://coord.staging.qontinui.io/ws?pattern=qontinui.sessions.%2A"
+            coord_ws_url("https://coord.qontinui.io/"),
+            "wss://coord.qontinui.io/ws?pattern=qontinui.sessions.%2A"
         );
     }
 

--- a/src/components/ConflictModal.test.ts
+++ b/src/components/ConflictModal.test.ts
@@ -31,11 +31,11 @@ describe("ConflictModal toast contract (Phase 6 tripwires)", () => {
     // Phase 6 §D9: the runner's conflict notification is a toast that
     // opens the dashboard for resolution. The URL is staging until
     // tenant/SSO work lands a per-tenant dashboard-base setting.
-    const base = "https://demo.staging.qontinui.io";
+    const base = "https://qontinui.io";
     const sessionId = "11111111-1111-1111-1111-111111111111";
     const expected = `${base}/sessions/${sessionId}`;
     expect(expected).toBe(
-      "https://demo.staging.qontinui.io/sessions/" +
+      "https://qontinui.io/sessions/" +
         "11111111-1111-1111-1111-111111111111"
     );
   });

--- a/src/components/ConflictModal.tsx
+++ b/src/components/ConflictModal.tsx
@@ -10,7 +10,7 @@
  *
  *  - The runner only **notifies** that a conflict occurred (this file).
  *  - The **resolution UX** (two-sided ConflictRow + StealModal) lives
- *    on the dashboard at `demo.staging.qontinui.io/sessions/<id>`.
+ *    on the dashboard at `qontinui.io/sessions/<id>`.
  *
  * Why: the dashboard has cross-machine context (the other operator's
  * intent, started_at, file claims) that the runner does not. Keeping
@@ -75,7 +75,7 @@ interface ConflictEvent {
  * setting for dashboard-base-URL (Phase 7+ tenant/SSO work) the const
  * will become a setting read.
  */
-const DASHBOARD_BASE_URL = "https://demo.staging.qontinui.io";
+const DASHBOARD_BASE_URL = "https://qontinui.io";
 
 function dashboardUrlFor(conflict: ConflictEvent): string {
   // If we know the session id, open the session-detail panel directly;


### PR DESCRIPTION
Staging environment promoted to production — all *.staging.qontinui.io domain references updated to production domains.

## Changes (5 files, 8 replacements)

- `src/components/ConflictModal.tsx` — `demo.staging.qontinui.io` → `qontinui.io` (const + comment)
- `src/components/ConflictModal.test.ts` — `demo.staging.qontinui.io` → `qontinui.io` (2 occurrences in test fixture)
- `src-tauri/src/mcp/sdk_client.rs` — `demo.staging.qontinui.io` → `qontinui.io` (comment)
- `src-tauri/src/session/handoff.rs` — `coord.staging.qontinui.io` → `coord.qontinui.io` (test fixture + expected WSS URL)
- `src-tauri/src/agent_runtime.rs` — `coord.staging.qontinui.io` → `coord.qontinui.io` (comment)