### PR TITLE
fix: agent_runtime WS 401 and hostname inconsistency

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -170,30 +170,29 @@ fn coord_http_base() -> Option<String> {
 }
 
 /// Resolve the coord WS URL from the active profile's `coord_url`,
-/// normalizing the scheme to `ws://` / `wss://`.
+/// normalizing the scheme to `ws://` / `wss://` and appending the
+/// `/ws` path with an `events.agent.*` pattern filter.
 ///
-/// The profile's `coord_url` is frequently configured as an HTTP(S) base
-/// (e.g. `https://coord.qontinui.io`, mirrored from the API base)
-/// rather than a WS endpoint. Passing an `https://` URL straight to
-/// `tokio_tungstenite::connect_async` fails with `URL scheme not supported`
-/// (the agent_runtime WS-pump error seen on staging). Convert
-/// `https://`→`wss://` and `http://`→`ws://`; leave an already-WS scheme as-is.
-/// Mirrors the converter in `session::handoff::coord_ws_url`.
-fn coord_ws_url() -> Option<String> {
+/// Mirrors `session::handoff::coord_ws_url` which appends
+/// `/ws?pattern=qontinui.sessions.*`. The coord `/ws` endpoint is a
+/// Redis pub/sub bridge at the `/ws` path (not the root); connecting to
+/// the root returns 401 from the ALB.
+fn coord_ws_url(device_id: uuid::Uuid) -> Option<String> {
     let coord_url = qontinui_runner_lib::profiles::load_strict()
         .ok()?
         .coord_url?;
-    let trimmed = coord_url.trim();
-    let ws = trimmed
+    let base = coord_url.trim().trim_end_matches('/');
+    let ws_base = base
         .strip_prefix("https://")
         .map(|rest| format!("wss://{rest}"))
         .or_else(|| {
-            trimmed
-                .strip_prefix("http://")
+            base.strip_prefix("http://")
                 .map(|rest| format!("ws://{rest}"))
         })
-        .unwrap_or_else(|| trimmed.to_string());
-    Some(ws)
+        .unwrap_or_else(|| base.to_string());
+    Some(format!(
+        "{ws_base}/ws?pattern=events.agent.spawn_requested.{device_id}"
+    ))
 }
 
 /// Read `~/.qontinui/machine.json` → device_id. Falls back to None.
@@ -258,7 +257,7 @@ pub fn spawn_runtime() {
 /// `run_agent_subprocess` in its own task. Reconnects with capped
 /// exponential backoff.
 async fn subscribe_to_spawn_requests(device_id: uuid::Uuid) -> anyhow::Result<()> {
-    let ws_url = match coord_ws_url() {
+    let ws_url = match coord_ws_url(device_id) {
         Some(u) => u,
         None => {
             warn!("agent_runtime: no coord_url; subscriber loop exiting");
@@ -287,28 +286,15 @@ async fn subscribe_to_spawn_requests(device_id: uuid::Uuid) -> anyhow::Result<()
 /// Single connect-and-pump iteration: opens the WS, listens for events,
 /// dispatches spawn-requests. Returns on disconnect.
 ///
-/// The coord WS surface broadcasts every Redis channel that matches a
-/// subscriber's filter; we use the simple "send subject filter on
-/// connect" protocol that coord's `ws::upgrade` accepts.
+/// Coord's `/ws` endpoint is a Redis pub/sub bridge; the pattern filter
+/// is set via the `?pattern=` query param at upgrade time (client-sent
+/// Text frames are silently ignored). The URL already carries the
+/// device-scoped pattern from [`coord_ws_url`].
 async fn connect_and_pump(ws_url: &str, device_id: uuid::Uuid) -> anyhow::Result<()> {
-    use futures_util::{SinkExt, StreamExt};
+    use futures_util::StreamExt;
 
     let (mut ws, _resp) = tokio_tungstenite::connect_async(ws_url).await?;
-
-    // Subscribe to this device's spawn-request channel + lifecycle
-    // channel. Coord's WS upgrade accepts a JSON subscribe frame; the
-    // implementation may also support automatic-fanout-by-prefix.
-    let sub = serde_json::json!({
-        "type": "subscribe",
-        "channels": [
-            format!("events.agent.spawn_requested.{device_id}"),
-        ],
-    });
-    ws.send(tokio_tungstenite::tungstenite::Message::Text(
-        sub.to_string().into(),
-    ))
-    .await?;
-    info!("agent_runtime: WS subscribed for device_id={device_id}");
+    info!("agent_runtime: WS connected for device_id={device_id}");
 
     while let Some(msg) = ws.next().await {
         let msg = match msg {

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -144,6 +144,21 @@ fn load_device_file() -> Option<DeviceFile> {
     serde_json::from_slice(&bytes).ok()
 }
 
+/// Canonical hostname: read from `~/.qontinui/machine.json`, falling
+/// back to the OS hostname. All device-registration and heartbeat
+/// surfaces should use this single source so the dashboard never shows
+/// a stale or mismatched hostname for temp runners that share the
+/// primary's `settings.json`.
+pub fn canonical_hostname() -> Option<String> {
+    load_device_file()
+        .map(|d| d.hostname)
+        .or_else(|| {
+            hostname::get()
+                .ok()
+                .map(|h| h.to_string_lossy().to_string())
+        })
+}
+
 /// Resolve the device's `tenant_id` for coord-side requests
 /// (`POST /coord/devices/register`). Returns the first hit:
 ///

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -150,13 +150,11 @@ fn load_device_file() -> Option<DeviceFile> {
 /// a stale or mismatched hostname for temp runners that share the
 /// primary's `settings.json`.
 pub fn canonical_hostname() -> Option<String> {
-    load_device_file()
-        .map(|d| d.hostname)
-        .or_else(|| {
-            hostname::get()
-                .ok()
-                .map(|h| h.to_string_lossy().to_string())
-        })
+    load_device_file().map(|d| d.hostname).or_else(|| {
+        hostname::get()
+            .ok()
+            .map(|h| h.to_string_lossy().to_string())
+    })
 }
 
 /// Resolve the device's `tenant_id` for coord-side requests

--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -116,8 +116,7 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
             }
         };
 
-        let hostname = crate::fleet::canonical_hostname()
-            .unwrap_or_else(|| "unknown".to_string());
+        let hostname = crate::fleet::canonical_hostname().unwrap_or_else(|| "unknown".to_string());
 
         let instance_name = crate::instance::instance_name();
 

--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -116,9 +116,8 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
             }
         };
 
-        let hostname = hostname::get()
-            .map(|h| h.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "unknown".to_string());
+        let hostname = crate::fleet::canonical_hostname()
+            .unwrap_or_else(|| "unknown".to_string());
 
         let instance_name = crate::instance::instance_name();
 

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -642,9 +642,7 @@ where
 {
     let port = api_state.app_state.api_port.load(Ordering::Relaxed);
     let instance_name = crate::instance::instance_name();
-    let hostname = hostname::get()
-        .ok()
-        .map(|h| h.to_string_lossy().to_string());
+    let hostname = crate::fleet::canonical_hostname();
 
     // Capabilities are static for now; the runner does GUI automation +
     // accessibility + Restate-style durable execution. Future work can


### PR DESCRIPTION
## Summary
- **Agent runtime WS 401**: `coord_ws_url()` converted `https://` → `wss://` but didn't append the `/ws` path. Coord's WS endpoint lives at `/ws` (not root); connecting to root returned 401 from the ALB. Now mirrors `session::handoff::coord_ws_url` by appending `/ws?pattern=events.agent.spawn_requested.<device_id>`. Also removed the dead "subscribe" JSON frame that coord silently ignores (it takes the pattern from the query param at upgrade time).
- **Hostname inconsistency**: `backend_relay.rs` and `heartbeat.rs` used OS `hostname::get()` while `fleet.rs` used `~/.qontinui/machine.json`. Added `pub fn canonical_hostname()` to `fleet.rs` (reads machine.json, falls back to OS hostname) and wired both consumers through it. Fixes temp runners showing the wrong hostname on the dashboard when sharing the primary's settings.

## Test plan
- [x] `cargo check` passes
- [ ] Spawn temp runner against staging with `extra_env` overrides → agent_runtime WS connects without 401
- [ ] Temp runner on MSI shows hostname "MSI" (not "spaceship") on the dashboard

Found during `/manual-test-coord` dual-machine run (MSI + spaceship, 2026-05-26T23:50).