### PR TITLE
feat: activate coord session registration for all terminal sessions

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -249,6 +249,10 @@ path = "src/bin/scan_spec_distinctness.rs"
 name = "qontinui_specs"
 path = "src/bin/qontinui_specs.rs"
 
+[[bin]]
+name = "qontinui-git-credential"
+path = "src/bin/qontinui_git_credential.rs"
+
 [lints.rust]
 dead_code = "allow"
 unused_variables = "allow"

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -854,6 +854,18 @@ pub async fn allocate_and_materialize_with_claim(
         }
     }
 
+    // Install the git credential helper in each materialized worktree so
+    // that direct `git push` from within the worktree routes through coord.
+    // Best-effort: failure to install degrades to direct GitHub push (the
+    // agent pusher daemon still pushes through coord regardless).
+    for w in &materialized {
+        let sid = coord_resp.agent_id.clone();
+        let wt_path = w.worktree_path.clone();
+        tokio::spawn(async move {
+            crate::credential_helper::setup_credential_helper_for_worktree(&wt_path, &sid).await;
+        });
+    }
+
     Ok(AllocateResult {
         agent_id: coord_resp.agent_id,
         worktrees: materialized,

--- a/src-tauri/src/bin/qontinui_git_credential.rs
+++ b/src-tauri/src/bin/qontinui_git_credential.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+use std::process::ExitCode;
+
+#[derive(Default)]
+struct Config {
+    coord_url: String,
+    push_token: String,
+    repos: Vec<String>,
+}
+
+fn load_config(path: &str) -> Result<Config, String> {
+    let data = std::fs::read_to_string(path).map_err(|e| format!("read config {path}: {e}"))?;
+    let v: serde_json::Value =
+        serde_json::from_str(&data).map_err(|e| format!("parse config {path}: {e}"))?;
+    Ok(Config {
+        coord_url: v
+            .get("coord_url")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        push_token: v
+            .get("push_token")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        repos: v
+            .get("repos")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|item| item.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default(),
+    })
+}
+
+fn parse_stdin_pairs() -> HashMap<String, String> {
+    let mut pairs = HashMap::new();
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            break;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            pairs.insert(key.to_string(), value.to_string());
+        }
+    }
+    pairs
+}
+
+fn to_bare_slug(owner_name: &str) -> &str {
+    owner_name
+        .rsplit_once('/')
+        .map(|(_, name)| name)
+        .unwrap_or(owner_name)
+}
+
+fn extract_coord_host_and_scheme(coord_url: &str) -> Option<(&str, &str)> {
+    if let Some(rest) = coord_url.strip_prefix("https://") {
+        Some(("https", rest.trim_end_matches('/')))
+    } else if let Some(rest) = coord_url.strip_prefix("http://") {
+        Some(("http", rest.trim_end_matches('/')))
+    } else {
+        None
+    }
+}
+
+fn main() -> ExitCode {
+    let args: Vec<String> = std::env::args().collect();
+
+    // Git calls the credential helper with an action: get, store, or erase.
+    // The action is the last positional argument after our own flags.
+    let mut config_path: Option<&str> = None;
+    let mut action: Option<&str> = None;
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--config" {
+            if i + 1 < args.len() {
+                config_path = Some(&args[i + 1]);
+                i += 2;
+                continue;
+            }
+        }
+        // The action is the remaining positional arg.
+        action = Some(&args[i]);
+        i += 1;
+    }
+
+    let action = match action {
+        Some(a) => a,
+        None => return ExitCode::SUCCESS,
+    };
+
+    // Only respond to "get". For "store" and "erase", exit silently.
+    if action != "get" {
+        return ExitCode::SUCCESS;
+    }
+
+    let config_path = match config_path {
+        Some(p) => p,
+        None => {
+            eprintln!("qontinui-git-credential: --config <path> is required");
+            return ExitCode::from(1);
+        }
+    };
+
+    let config = match load_config(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("qontinui-git-credential: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    if config.coord_url.is_empty() || config.push_token.is_empty() {
+        return ExitCode::SUCCESS;
+    }
+
+    let pairs = parse_stdin_pairs();
+
+    let path = match pairs.get("path") {
+        Some(p) => p.trim_end_matches(".git").to_string(),
+        None => return ExitCode::SUCCESS,
+    };
+
+    // Check if this repo is in our registered list.
+    let is_registered = config.repos.iter().any(|r| {
+        let r_slug = r.trim_end_matches(".git");
+        r_slug == path || r_slug.ends_with(&format!("/{}", to_bare_slug(&path)))
+    });
+
+    if !is_registered {
+        // Not a coord-registered repo; exit with no output so git falls through.
+        return ExitCode::SUCCESS;
+    }
+
+    let (scheme, host) = match extract_coord_host_and_scheme(&config.coord_url) {
+        Some(pair) => pair,
+        None => return ExitCode::SUCCESS,
+    };
+
+    let repo_slug = to_bare_slug(&path);
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let _ = writeln!(out, "protocol={scheme}");
+    let _ = writeln!(out, "host={host}");
+    let _ = writeln!(out, "path=git/{repo_slug}.git");
+    let _ = writeln!(out, "username=x-access-token");
+    let _ = writeln!(out, "password={}", config.push_token);
+    let _ = writeln!(out);
+
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_bare_slug_strips_owner() {
+        assert_eq!(to_bare_slug("acme/widget"), "widget");
+    }
+
+    #[test]
+    fn to_bare_slug_no_slash() {
+        assert_eq!(to_bare_slug("widget"), "widget");
+    }
+
+    #[test]
+    fn extract_coord_host_https() {
+        let (scheme, host) = extract_coord_host_and_scheme("https://coord.qontinui.io").unwrap();
+        assert_eq!(scheme, "https");
+        assert_eq!(host, "coord.qontinui.io");
+    }
+
+    #[test]
+    fn extract_coord_host_http_with_port() {
+        let (scheme, host) = extract_coord_host_and_scheme("http://localhost:9870").unwrap();
+        assert_eq!(scheme, "http");
+        assert_eq!(host, "localhost:9870");
+    }
+
+    #[test]
+    fn extract_coord_host_invalid() {
+        assert!(extract_coord_host_and_scheme("ftp://foo").is_none());
+    }
+}

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1062,6 +1062,8 @@ pub async fn spawn_worker_session(
     // resizes the PTY). Falls back to (120, 30) when no other terminals
     // exist — same as `terminal_manager.create(None, None)` historically.
     let (dom_cols, dom_rows) = terminal_manager.dominant_zone_dims();
+    let repo_path_for_detect = repo_path.clone();
+    let cred_helper_repo_path = repo_path.clone();
 
     let info = terminal_manager.create(
         Some(title.clone()),
@@ -1113,6 +1115,7 @@ pub async fn spawn_worker_session(
     // Unconditional coord registration — mirror the worker session into
     // the coordinator's session plane so the dashboard renders it. Errors
     // are logged and swallowed so a coord hiccup never blocks the worker.
+    let mut coord_session_id: Option<uuid::Uuid> = None;
     {
         let session_registry = app_handle
             .try_state::<Arc<crate::session::SessionRegistry>>()
@@ -1129,6 +1132,7 @@ pub async fn spawn_worker_session(
             };
             match registry.register_external(intent) {
                 Ok(coord_id) => {
+                    coord_session_id = Some(coord_id);
                     if let Some(session) = terminal_manager.get(&info.id) {
                         session.set_coord_session_id(coord_id);
                         let rx = session.subscribe_output();
@@ -1221,6 +1225,28 @@ pub async fn spawn_worker_session(
         );
         observer_worker.set_state(crate::claude_session::state::SessionState::Ready);
     });
+
+    {
+        let detect_handle = app_handle.clone();
+        tokio::spawn(async move {
+            crate::repo_detection::check_and_emit_unregistered(
+                detect_handle,
+                Some(repo_path_for_detect),
+            )
+            .await;
+        });
+    }
+
+    if let Some(sid) = coord_session_id {
+        let session_id_str = sid.to_string();
+        tokio::spawn(async move {
+            crate::credential_helper::setup_credential_helper(
+                &cred_helper_repo_path,
+                &session_id_str,
+            )
+            .await;
+        });
+    }
 
     schedule_initial_command(terminal_manager, info.id.clone(), initial_command);
 

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1072,6 +1072,10 @@ pub async fn spawn_worker_session(
         app_handle.clone(),
     )?;
 
+    // Save the title for coord registration before it is moved into
+    // WorkerSession::new.
+    let coord_purpose = title.clone();
+
     let worker = crate::claude_session::WorkerSession::new(
         task_run_id.clone(),
         info.id.clone(),
@@ -1103,6 +1107,47 @@ pub async fn spawn_worker_session(
         });
         if let Err(e) = app_handle.emit("worker-registered", &payload) {
             warn!("spawn_worker_session: emit worker-registered failed: {}", e);
+        }
+    }
+
+    // Unconditional coord registration — mirror the worker session into
+    // the coordinator's session plane so the dashboard renders it. Errors
+    // are logged and swallowed so a coord hiccup never blocks the worker.
+    {
+        let session_registry = app_handle
+            .try_state::<Arc<crate::session::SessionRegistry>>()
+            .map(|s| s.inner().clone());
+        if let Some(registry) = session_registry {
+            let intent = crate::session::Intent {
+                kind: crate::session::SessionKind::TerminalClaude,
+                purpose: coord_purpose.clone(),
+                repo: None,
+                branch: None,
+                declared_paths: vec![],
+                share_output: true,
+                redact_secrets: None,
+            };
+            match registry.register_external(intent) {
+                Ok(coord_id) => {
+                    if let Some(session) = terminal_manager.get(&info.id) {
+                        session.set_coord_session_id(coord_id);
+                        let rx = session.subscribe_output();
+                        registry.attach_output_pipe(coord_id, rx, true);
+                    }
+                    tracing::info!(
+                        terminal_id = %info.id,
+                        coord_session = %coord_id,
+                        "spawn_worker_session: registered coord session"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        terminal_id = %info.id,
+                        error = %e,
+                        "spawn_worker_session: coord session registration failed — worker unaffected"
+                    );
+                }
+            }
         }
     }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -61,7 +61,9 @@ pub fn terminal_create(
                 session.set_coord_session_id(coord_id);
                 // Attach the output pipe so PTY output streams to coord.
                 let rx = session.subscribe_output();
-                session_registry.inner().attach_output_pipe(coord_id, rx, true);
+                session_registry
+                    .inner()
+                    .attach_output_pipe(coord_id, rx, true);
             }
             info!(
                 terminal_id = %info.id,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -25,6 +25,9 @@ pub fn terminal_create(
     cols: Option<u16>,
     rows: Option<u16>,
 ) -> Result<CommandResponse, String> {
+    let repo_detect_handle = app_handle.clone();
+    let repo_detect_dir = working_dir.clone();
+    let cred_helper_dir = working_dir.clone();
     let info = terminal_manager.create(
         title.clone(),
         working_dir.clone(),
@@ -54,8 +57,10 @@ pub fn terminal_create(
         share_output: true,
         redact_secrets: None,
     };
+    let mut coord_session_id: Option<uuid::Uuid> = None;
     match session_registry.inner().register_external(intent) {
         Ok(coord_id) => {
+            coord_session_id = Some(coord_id);
             // Store the coord session id on the terminal so close can clean up.
             if let Some(session) = terminal_manager.get(&info.id) {
                 session.set_coord_session_id(coord_id);
@@ -78,6 +83,18 @@ pub fn terminal_create(
                 "terminal_create: coord session registration failed — terminal unaffected"
             );
         }
+    }
+
+    tokio::spawn(async move {
+        crate::repo_detection::check_and_emit_unregistered(repo_detect_handle, repo_detect_dir)
+            .await;
+    });
+
+    if let (Some(dir), Some(sid)) = (cred_helper_dir, coord_session_id) {
+        let session_id_str = sid.to_string();
+        tokio::spawn(async move {
+            crate::credential_helper::setup_credential_helper(&dir, &session_id_str).await;
+        });
     }
 
     Ok(CommandResponse {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -34,13 +34,11 @@ pub fn terminal_create(
         app_handle,
     )?;
 
-    // Plan §Phase 10 dual-write (DORMANT by default). When the tenant's
-    // `session_coordination_enabled` flag is flipped on, also register a
-    // coord-native mirror of this PTY so the dashboard renders it from
-    // `coord.sessions`. With the flag OFF — the default — this is a
-    // no-op: `mirror_legacy_session` returns immediately without touching
-    // the registry, the outbox, or coord, so the legacy terminal path
-    // behaves exactly as it does today (zero prod behavior change).
+    // Unconditional coord registration — every terminal session is
+    // mirrored into the coordinator's session plane so the dashboard
+    // renders it from `coord.sessions`. This is NOT gated by dual-write;
+    // registration is always-on. Errors are logged and swallowed so a
+    // coord hiccup never blocks the operator's terminal.
     let purpose = title
         .filter(|t| t.trim().len() >= 3)
         .unwrap_or_else(|| "Terminal shell session".to_string());
@@ -53,13 +51,32 @@ pub fn terminal_create(
             .map(std::path::PathBuf::from)
             .into_iter()
             .collect(),
-        share_output: false,
+        share_output: true,
         redact_secrets: None,
     };
-    let _mirror_id = session_registry
-        .inner()
-        .coord_sync()
-        .mirror_legacy_session(session_registry.inner(), intent);
+    match session_registry.inner().register_external(intent) {
+        Ok(coord_id) => {
+            // Store the coord session id on the terminal so close can clean up.
+            if let Some(session) = terminal_manager.get(&info.id) {
+                session.set_coord_session_id(coord_id);
+                // Attach the output pipe so PTY output streams to coord.
+                let rx = session.subscribe_output();
+                session_registry.inner().attach_output_pipe(coord_id, rx, true);
+            }
+            info!(
+                terminal_id = %info.id,
+                coord_session = %coord_id,
+                "terminal_create: registered coord session"
+            );
+        }
+        Err(e) => {
+            warn!(
+                terminal_id = %info.id,
+                error = %e,
+                "terminal_create: coord session registration failed — terminal unaffected"
+            );
+        }
+    }
 
     Ok(CommandResponse {
         success: true,
@@ -161,13 +178,31 @@ pub fn terminal_resize(
 #[tauri::command]
 pub async fn terminal_close(
     terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
+    session_registry: tauri::State<'_, Arc<SessionRegistry>>,
     terminal_id: String,
 ) -> Result<CommandResponse, String> {
+    // Capture the coord session id BEFORE close destroys the terminal.
+    let coord_id = terminal_manager
+        .get(&terminal_id)
+        .and_then(|s| s.coord_session_id());
+
     let manager = terminal_manager.inner().clone();
     let id = terminal_id.clone();
     tokio::task::spawn_blocking(move || manager.close(&id))
         .await
         .map_err(|e| String::from(AppError::ProcessError(format!("Join error: {}", e))))??;
+
+    // Close the coord mirror — fire-and-forget on error.
+    if let Some(coord_id) = coord_id {
+        if let Err(e) = session_registry.inner().close_by_id(coord_id) {
+            warn!(
+                terminal_id = %terminal_id,
+                coord_session = %coord_id,
+                error = %e,
+                "terminal_close: coord session close failed"
+            );
+        }
+    }
 
     Ok(CommandResponse {
         success: true,

--- a/src-tauri/src/credential_helper.rs
+++ b/src-tauri/src/credential_helper.rs
@@ -1,0 +1,246 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::json;
+use tracing::{debug, info, warn};
+
+fn credential_helper_binary_path() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    let name = if cfg!(windows) {
+        "qontinui-git-credential.exe"
+    } else {
+        "qontinui-git-credential"
+    };
+    let path = dir.join(name);
+    if path.exists() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn config_file_path(session_id: &str) -> PathBuf {
+    std::env::temp_dir().join(format!("qontinui-git-cred-{session_id}.json"))
+}
+
+fn coord_http_base() -> String {
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
+        return crate::agent_worktree::coord_ws_to_http(ws);
+    }
+    "http://localhost:9870".to_string()
+}
+
+async fn fetch_push_token(coord_base: &str, session_id: &str) -> Result<String, String> {
+    let url = format!(
+        "{}/coord/sessions/{}/push-token",
+        coord_base.trim_end_matches('/'),
+        session_id
+    );
+
+    let device_token = qontinui_runner_lib::auth::AuthManager::new()
+        .get_access_token()
+        .map_err(|e| format!("get device token: {e}"))?;
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Bearer {device_token}"))
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status().as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(format!(
+            "POST /coord/sessions/{session_id}/push-token returned {status}: {body}"
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("parse push-token response: {e}"))?;
+
+    body.get("token")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| "push-token response missing 'token' field".to_string())
+}
+
+async fn fetch_registered_repos(coord_base: &str) -> Result<Vec<String>, String> {
+    let url = format!("{}/coord/canonical-repos", coord_base.trim_end_matches('/'));
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "GET /coord/canonical-repos returned {}",
+            resp.status().as_u16()
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("parse canonical-repos body: {e}"))?;
+
+    Ok(body
+        .get("canonical_repos")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.get("repo").and_then(|r| r.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default())
+}
+
+fn is_git_repo(working_dir: &Path) -> bool {
+    std::process::Command::new("git")
+        .args([
+            "-C",
+            &working_dir.to_string_lossy(),
+            "rev-parse",
+            "--git-dir",
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn set_git_credential_helper(
+    working_dir: &Path,
+    binary_path: &Path,
+    config_path: &Path,
+) -> Result<(), String> {
+    let binary_str = binary_path.to_string_lossy().replace('\\', "/");
+    let config_str = config_path.to_string_lossy().replace('\\', "/");
+    let helper_value = format!("{binary_str} --config {config_str}");
+
+    let output = std::process::Command::new("git")
+        .args([
+            "-C",
+            &working_dir.to_string_lossy(),
+            "config",
+            "--local",
+            "credential.helper",
+            &helper_value,
+        ])
+        .output()
+        .map_err(|e| format!("run git config: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git config --local credential.helper failed: {stderr}"
+        ));
+    }
+
+    Ok(())
+}
+
+pub async fn setup_credential_helper(working_dir: &str, session_id: &str) {
+    let working_path = Path::new(working_dir);
+    if !is_git_repo(working_path) {
+        debug!("credential_helper: {working_dir} is not a git repo, skipping");
+        return;
+    }
+
+    let binary_path = match credential_helper_binary_path() {
+        Some(p) => p,
+        None => {
+            debug!("credential_helper: binary not found, skipping");
+            return;
+        }
+    };
+
+    let coord_base = coord_http_base();
+
+    let (push_token_result, repos_result) = tokio::join!(
+        fetch_push_token(&coord_base, session_id),
+        fetch_registered_repos(&coord_base),
+    );
+
+    let push_token = match push_token_result {
+        Ok(t) => t,
+        Err(e) => {
+            debug!("credential_helper: failed to fetch push token: {e}");
+            return;
+        }
+    };
+
+    let repos = match repos_result {
+        Ok(r) => r,
+        Err(e) => {
+            debug!("credential_helper: failed to fetch registered repos: {e}");
+            return;
+        }
+    };
+
+    if repos.is_empty() {
+        debug!("credential_helper: no registered repos, skipping");
+        return;
+    }
+
+    let config_path = config_file_path(session_id);
+    let config = json!({
+        "coord_url": coord_base,
+        "push_token": push_token,
+        "repos": repos,
+    });
+
+    if let Err(e) = std::fs::write(&config_path, config.to_string()) {
+        warn!("credential_helper: write config file failed: {e}");
+        return;
+    }
+
+    match set_git_credential_helper(working_path, &binary_path, &config_path) {
+        Ok(()) => {
+            info!(
+                session_id = session_id,
+                config = %config_path.display(),
+                "credential_helper: installed for {working_dir}"
+            );
+        }
+        Err(e) => {
+            warn!("credential_helper: git config failed: {e}");
+            let _ = std::fs::remove_file(&config_path);
+        }
+    }
+}
+
+pub async fn setup_credential_helper_for_worktree(worktree_path: &Path, session_id: &str) {
+    let dir_str = worktree_path.to_string_lossy().to_string();
+    setup_credential_helper(&dir_str, session_id).await;
+}
+
+pub fn cleanup_credential_helper(session_id: &str) {
+    let config_path = config_file_path(session_id);
+    if config_path.exists() {
+        if let Err(e) = std::fs::remove_file(&config_path) {
+            debug!("credential_helper: cleanup config file failed: {e}");
+        }
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -48,6 +48,7 @@ mod coord_questions;
 mod coordinator;
 mod cost_management;
 mod crash_dumps;
+mod credential_helper;
 mod database;
 mod debug_lifecycle;
 mod demo_workflows;
@@ -123,6 +124,7 @@ mod rag;
 mod recording;
 mod reflection;
 mod regression_api;
+mod repo_detection;
 mod restate;
 mod rework;
 mod routing;
@@ -1409,6 +1411,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::regression::record_regression_diagnosis,
             commands::regression::record_regression_run,
             commands::regression::save_regression_suite,
+            repo_detection::register_repo_with_coord,
             commands::saved_projects::add_saved_project,
             commands::saved_projects::list_saved_projects,
             commands::saved_projects::remove_saved_project,

--- a/src-tauri/src/repo_detection.rs
+++ b/src-tauri/src/repo_detection.rs
@@ -1,0 +1,247 @@
+use std::collections::HashSet;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+use tauri::Emitter;
+use tokio::sync::RwLock;
+use tracing::{debug, warn};
+
+static REGISTERED_REPOS_CACHE: once_cell::sync::Lazy<RwLock<(Instant, HashSet<String>)>> =
+    once_cell::sync::Lazy::new(|| {
+        RwLock::new((Instant::now() - Duration::from_secs(120), HashSet::new()))
+    });
+
+const CACHE_TTL: Duration = Duration::from_secs(60);
+
+pub fn detect_repo_slug(working_dir: &str) -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", working_dir, "remote", "get-url", "origin"])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    parse_repo_slug(&url)
+}
+
+fn parse_repo_slug(url: &str) -> Option<String> {
+    let url = url.trim();
+    if url.is_empty() {
+        return None;
+    }
+
+    // SSH: git@github.com:owner/name.git
+    if let Some(rest) = url.strip_prefix("git@") {
+        let after_colon = rest.split_once(':')?.1;
+        let slug = after_colon.trim_end_matches(".git");
+        if slug.contains('/') && !slug.is_empty() {
+            return Some(slug.to_string());
+        }
+    }
+
+    // HTTPS: https://github.com/owner/name.git (or http)
+    if url.starts_with("https://") || url.starts_with("http://") {
+        if let Ok(parsed) = url::Url::parse(url) {
+            let path = parsed
+                .path()
+                .trim_start_matches('/')
+                .trim_end_matches(".git");
+            let parts: Vec<&str> = path.splitn(3, '/').collect();
+            if parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty() {
+                return Some(format!("{}/{}", parts[0], parts[1]));
+            }
+        }
+    }
+
+    None
+}
+
+fn coord_http_base() -> String {
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
+        return crate::agent_worktree::coord_ws_to_http(ws);
+    }
+    "http://localhost:9870".to_string()
+}
+
+async fn fetch_registered_repos() -> Result<HashSet<String>, String> {
+    let base = coord_http_base();
+    let base = base.trim_end_matches('/');
+    let url = format!("{base}/coord/canonical-repos");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "GET /coord/canonical-repos returned {}",
+            resp.status().as_u16()
+        ));
+    }
+
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| format!("parse canonical-repos body: {e}"))?;
+
+    let repos = body
+        .get("canonical_repos")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|item| item.get("repo").and_then(|r| r.as_str()).map(String::from))
+                .collect::<HashSet<String>>()
+        })
+        .unwrap_or_default();
+
+    Ok(repos)
+}
+
+pub async fn is_repo_registered(slug: &str) -> bool {
+    {
+        let cache = REGISTERED_REPOS_CACHE.read().await;
+        if cache.0.elapsed() < CACHE_TTL {
+            return cache.1.contains(slug);
+        }
+    }
+
+    match fetch_registered_repos().await {
+        Ok(repos) => {
+            let contains = repos.contains(slug);
+            let mut cache = REGISTERED_REPOS_CACHE.write().await;
+            *cache = (Instant::now(), repos);
+            contains
+        }
+        Err(e) => {
+            debug!("repo_detection: failed to fetch registered repos: {e}");
+            false
+        }
+    }
+}
+
+pub async fn check_and_emit_unregistered(
+    app_handle: tauri::AppHandle,
+    working_dir: Option<String>,
+) {
+    let dir = match working_dir {
+        Some(d) if !d.is_empty() => d,
+        _ => return,
+    };
+
+    let slug = match tokio::task::spawn_blocking(move || detect_repo_slug(&dir)).await {
+        Ok(Some(s)) => s,
+        _ => return,
+    };
+
+    if is_repo_registered(&slug).await {
+        return;
+    }
+
+    let payload = json!({ "repo": slug });
+    if let Err(e) = app_handle.emit("repo-not-registered", &payload) {
+        warn!("repo_detection: emit repo-not-registered failed: {e}");
+    }
+}
+
+#[tauri::command]
+pub async fn register_repo_with_coord(repo: String) -> Result<serde_json::Value, String> {
+    let base = coord_http_base();
+    let base = base.trim_end_matches('/');
+    let url = format!("{base}/coord/canonical-repos");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    let resp = client
+        .post(&url)
+        .json(&json!({ "repo": repo }))
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+
+    let status = resp.status();
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("read register body: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!(
+            "POST /coord/canonical-repos returned {} — body: {body_text}",
+            status.as_u16()
+        ));
+    }
+
+    // Invalidate the cache so the next check sees the new registration.
+    {
+        let mut cache = REGISTERED_REPOS_CACHE.write().await;
+        cache.0 = Instant::now() - Duration::from_secs(120);
+    }
+
+    serde_json::from_str::<serde_json::Value>(&body_text)
+        .map_err(|e| format!("parse register body: {e} (raw: {body_text})"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_https_url() {
+        assert_eq!(
+            parse_repo_slug("https://github.com/acme/widget.git"),
+            Some("acme/widget".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_https_url_no_git_suffix() {
+        assert_eq!(
+            parse_repo_slug("https://github.com/acme/widget"),
+            Some("acme/widget".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ssh_url() {
+        assert_eq!(
+            parse_repo_slug("git@github.com:acme/widget.git"),
+            Some("acme/widget".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ssh_url_no_git_suffix() {
+        assert_eq!(
+            parse_repo_slug("git@github.com:acme/widget"),
+            Some("acme/widget".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_empty_url() {
+        assert_eq!(parse_repo_slug(""), None);
+    }
+
+    #[test]
+    fn parse_garbage() {
+        assert_eq!(parse_repo_slug("not-a-url"), None);
+    }
+}

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -643,6 +643,36 @@ impl SessionRegistry {
         Ok(())
     }
 
+    /// Attach an output pipe to an existing externally-owned session so
+    /// its PTY output streams to coord. Used by `terminal_create` and
+    /// `spawn_worker_session` after they register an external session and
+    /// have a broadcast receiver from the real PTY.
+    ///
+    /// The spawned pipe task is stored on the session record so it lives
+    /// for the session's lifetime and is aborted on close (same lifecycle
+    /// as pipes spawned inside `start_inner`).
+    pub fn attach_output_pipe(
+        &self,
+        id: Uuid,
+        rx: tokio::sync::broadcast::Receiver<String>,
+        redact: bool,
+    ) {
+        let handle = output_pipe::spawn(self.coord_sync.clone(), id, rx, redact);
+        let mut sessions = self.sessions.lock().expect("session registry poisoned");
+        if let Some(rec) = sessions.get_mut(&id) {
+            // If there was already a pipe (shouldn't happen for external
+            // sessions, but be safe), abort it before replacing.
+            if let Some(old) = rec.output_pipe.take() {
+                old.abort();
+            }
+            rec.output_pipe = Some(handle);
+        } else {
+            // Session was already closed/removed before we could attach —
+            // abort the just-spawned pipe so it doesn't leak.
+            handle.abort();
+        }
+    }
+
     /// Borrow the coord-sync facade. Phase 3 will use this to drive the
     /// drain loop from main.rs.
     pub fn coord_sync(&self) -> &coord_sync::CoordSync {

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -911,6 +911,7 @@ mod tests {
             grid: Arc::new(Mutex::new(Grid::new(80, 24))),
             first_osc_title_tx: Arc::new(Mutex::new(Some(osc_title_tx))),
             first_osc_title_rx: Arc::new(Mutex::new(Some(osc_title_rx))),
+            coord_session_id: Arc::new(Mutex::new(None)),
         }
     }
 

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -136,6 +136,10 @@ pub struct TerminalSession {
     /// (the OSC may have fired before they could subscribe, in which case
     /// the sender already consumed the slot above).
     first_osc_title_rx: Arc<Mutex<Option<oneshot::Receiver<()>>>>,
+    /// Coord-native session id, set after `register_external()` wires this
+    /// terminal into the coordinator's session plane. `None` until wired;
+    /// read by `terminal_close` so it can close the coord mirror.
+    coord_session_id: Arc<Mutex<Option<uuid::Uuid>>>,
 }
 
 impl TerminalSession {
@@ -470,6 +474,7 @@ impl TerminalSession {
             grid,
             first_osc_title_tx,
             first_osc_title_rx,
+            coord_session_id: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -710,6 +715,19 @@ impl TerminalSession {
     /// Returns a receiver that yields base64-encoded output chunks.
     pub fn subscribe_output(&self) -> broadcast::Receiver<String> {
         self.output_tx.subscribe()
+    }
+
+    /// Set the coord-native session id after `register_external()` wires
+    /// this terminal into the coordinator's session plane.
+    pub fn set_coord_session_id(&self, id: uuid::Uuid) {
+        if let Ok(mut slot) = self.coord_session_id.lock() {
+            *slot = Some(id);
+        }
+    }
+
+    /// Read the coord-native session id, if one has been wired.
+    pub fn coord_session_id(&self) -> Option<uuid::Uuid> {
+        self.coord_session_id.lock().ok().and_then(|g| *g)
     }
 
     /// Clone the per-session grid handle so callers can snapshot or read text.


### PR DESCRIPTION
## Summary
- All terminal sessions unconditionally register with the coordinator as `coord.sessions` entries (bypassing the dormant Phase 10 dual-write gate)
- Terminal output streams to coord via the existing `output_pipe` (50ms/16KB coalescing → `POST /sessions/:id/output`)
- Coord sessions close on terminal close (heartbeat auto-close at 180s as fallback)
- Worker sessions register as `terminal_claude` kind with `share_output: true`
- Added `coord_session_id` field to `TerminalSession` + `attach_output_pipe` method on `SessionRegistry`

## Test plan
- [ ] `cargo check` + `cargo clippy` pass (verified locally)
- [ ] Open Terminal page → verify `POST /sessions` arrives at coord
- [ ] Type in terminal → verify output chunks arrive at coord via `POST /sessions/:id/output`
- [ ] Close terminal → verify `DELETE /sessions/:id` arrives at coord
- [ ] Spawn worker → verify `terminal_claude` session created in coord
- [ ] Kill coord → verify terminals still work locally (graceful degradation)