### PR TITLE
feat(agent_worktree): isolate session-spawned edit work in worktrees

### DIFF
--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -1,0 +1,260 @@
+//! Phase 1 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
+//!
+//! Ergonomic facade over [`super::allocate_and_materialize_with_claim`]
+//! for callers that say "I intend to edit these repos" and want a
+//! materialized worktree + held claim + automatic release on drop —
+//! WITHOUT having to resolve coord URL, `device_id`, canonical paths,
+//! and `parent_sha` themselves.
+//!
+//! Phase 2 wires this into `terminal_create` and `spawn_worker_session`;
+//! Phase 3 wires the same shape into the skill orchestrators
+//! (`/manual-test-loop`, `/manual-test`, `/implement-plan`) via the
+//! existing HTTP face at
+//! [`crate::mcp::agent_worktrees::post_allocate_local`].
+//!
+//! Gated behind [`super::worktree_mode_enabled`] — when the flag is off,
+//! [`acquire`] returns `Ok(None)` so callers fall back to the legacy
+//! shared-checkout flow without forking their code path.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use tracing::{info, warn};
+
+use super::{
+    allocate_and_materialize_with_claim, release_claim_best_effort, spawn_heartbeat_task,
+    worktree_mode_enabled, ActiveClaim, AllocateError, ClaimHeartbeatHandle, MaterializedWorktree,
+    RepoRequest,
+};
+
+/// A held isolated edit context. While this value is live, the agent's
+/// claim is being heartbeated. Dropping it stops the heartbeat task and
+/// fires a best-effort claim release.
+///
+/// `worktrees` carries every materialized per-repo worktree; the typical
+/// caller uses `worktrees[0].worktree_path` as its session cwd.
+pub struct IsolatedEditContext {
+    pub agent_id: String,
+    pub worktrees: Vec<MaterializedWorktree>,
+    /// Set when the spawn flow pre-acquired a coord claim. `None` means
+    /// no claim was acquired (the caller passed neither `plan_id`/`phase`
+    /// nor `declared_overlap_paths`).
+    pub active_claim: Option<ActiveClaim>,
+
+    // Held so the heartbeat task lives as long as the context — its
+    // own Drop notifies the cancel token. Underscore-prefixed because
+    // we never inspect it; the handle is keep-alive only.
+    _heartbeat: Option<ClaimHeartbeatHandle>,
+
+    // Captured for the Drop-time release POST. `coord_http_base` and
+    // `device_id` aren't otherwise exposed on the context — Drop is the
+    // only consumer.
+    coord_http_base: String,
+    device_id: uuid::Uuid,
+}
+
+impl Drop for IsolatedEditContext {
+    fn drop(&mut self) {
+        // Stop the heartbeat first so its tick can't race with the
+        // release POST. `ClaimHeartbeatHandle`'s own Drop notifies its
+        // cancel token; the task exits on the next tick boundary.
+        let _ = self._heartbeat.take();
+
+        // Best-effort release on the current Tokio runtime. If there
+        // was no active claim, there's nothing to release. A failed
+        // release is observability-only — the session that drops the
+        // context is shutting down anyway.
+        if let Some(claim) = self.active_claim.take() {
+            let base = self.coord_http_base.clone();
+            let mid = self.device_id;
+            tokio::spawn(async move {
+                release_claim_best_effort(&base, mid, &claim.kind, &claim.resource_key).await;
+            });
+        }
+    }
+}
+
+/// Inputs for [`acquire`]. `repos` are bare slugs (e.g.
+/// `"qontinui-runner"`); the facade resolves canonical checkout paths
+/// from per-platform defaults and reads `parent_sha` from `HEAD` of each
+/// canonical checkout.
+pub struct AcquireRequest<'a> {
+    pub repos: &'a [String],
+    /// Optional opaque human-readable intent. Stored on
+    /// `coord.agent_worktrees.intent`.
+    pub intent: Option<&'a str>,
+    /// Optional pre-derived overlap path set (Phase 1B). When absent,
+    /// coord may LLM-derive from `intent`.
+    pub declared_overlap_paths: Option<&'a [String]>,
+    /// Optional `(plan_id, phase)` pair for a `ClaimKind::Phase`
+    /// pre-flight — see [`super::ClaimSpawnContext::from_intent_and_paths`]
+    /// precedence rules.
+    pub plan_id: Option<&'a str>,
+    pub phase: Option<&'a str>,
+}
+
+/// Allocate isolated worktrees for the given repos.
+///
+/// Returns:
+/// - `Ok(Some(ctx))` — worktree mode is on; allocation succeeded.
+/// - `Ok(None)` — worktree mode is off; the caller should fall back to
+///   the legacy shared-checkout flow.
+/// - `Err(AllocateError::ClaimConflict)` — pre-flight claim was held by
+///   another agent; the caller decides abort/wait/steal.
+/// - `Err(AllocateError::Other(_))` — anything else (resolution failure,
+///   coord transport error, `git worktree add` failure, etc.).
+pub async fn acquire(
+    req: AcquireRequest<'_>,
+) -> Result<Option<IsolatedEditContext>, AllocateError> {
+    if !worktree_mode_enabled() {
+        return Ok(None);
+    }
+    if req.repos.is_empty() {
+        return Err(AllocateError::Other("repos must not be empty".into()));
+    }
+
+    let coord_http_base = crate::mcp::agent_worktrees::coord_http_base()
+        .map_err(|e| AllocateError::Other(format!("coord URL not configured: {e}")))?;
+    let device_id = read_device_id()
+        .map_err(|e| AllocateError::Other(format!("device_id not available: {e}")))?;
+
+    let canonical_paths: HashMap<String, PathBuf> = req
+        .repos
+        .iter()
+        .map(|repo| (repo.clone(), default_canonical_path(repo)))
+        .collect();
+
+    let mut repo_reqs: Vec<RepoRequest> = Vec::with_capacity(req.repos.len());
+    for repo in req.repos {
+        let canonical = canonical_paths.get(repo).ok_or_else(|| {
+            AllocateError::Other(format!("no canonical path for repo '{repo}'"))
+        })?;
+        let parent_sha = resolve_head_sha(canonical)
+            .map_err(|e| AllocateError::Other(format!("git rev-parse HEAD on {repo}: {e}")))?;
+        repo_reqs.push(RepoRequest {
+            repo: repo.clone(),
+            parent_sha,
+        });
+    }
+
+    let result = allocate_and_materialize_with_claim(
+        &coord_http_base,
+        &device_id,
+        &repo_reqs,
+        req.intent,
+        req.declared_overlap_paths,
+        &canonical_paths,
+        req.plan_id,
+        req.phase,
+    )
+    .await?;
+
+    let heartbeat = result.active_claim.as_ref().map(|claim| {
+        info!(
+            agent_id = %result.agent_id,
+            kind = %claim.kind,
+            resource_key = %claim.resource_key,
+            ttl_seconds = claim.ttl_seconds,
+            "isolated_edit: spawning heartbeat"
+        );
+        spawn_heartbeat_task(
+            coord_http_base.clone(),
+            device_id,
+            &claim.kind,
+            claim.resource_key.clone(),
+            claim.ttl_seconds,
+            |displaced_by| {
+                warn!(
+                    displaced_by = ?displaced_by,
+                    "isolated_edit: claim stolen — edits in this worktree may now race"
+                );
+            },
+        )
+    });
+
+    Ok(Some(IsolatedEditContext {
+        agent_id: result.agent_id,
+        worktrees: result.worktrees,
+        active_claim: result.active_claim,
+        _heartbeat: heartbeat,
+        coord_http_base,
+        device_id,
+    }))
+}
+
+/// Read the device UUID from `~/.qontinui/machine.json`. Accepts the
+/// canonical `"device_id"` field (post-unified-devices) and falls back
+/// to legacy `"machine_id"`.
+fn read_device_id() -> Result<uuid::Uuid, String> {
+    let path = dirs::home_dir()
+        .map(|h| h.join(".qontinui").join("machine.json"))
+        .ok_or_else(|| "no HOME dir".to_string())?;
+    let bytes = std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let v: serde_json::Value =
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let id_str = v
+        .get("device_id")
+        .or_else(|| v.get("machine_id"))
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| format!("{}: missing device_id (or machine_id)", path.display()))?;
+    uuid::Uuid::parse_str(id_str).map_err(|e| format!("invalid UUID: {e}"))
+}
+
+#[cfg(target_os = "windows")]
+fn default_canonical_path(repo: &str) -> PathBuf {
+    PathBuf::from(format!("D:/qontinui-root/{}", repo))
+}
+
+#[cfg(not(target_os = "windows"))]
+fn default_canonical_path(repo: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(format!("{}/qontinui-root/{}", home, repo))
+}
+
+fn resolve_head_sha(canonical: &Path) -> Result<String, String> {
+    use std::process::Command;
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(canonical)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .map_err(|e| format!("spawn git: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "git rev-parse HEAD failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        return Err("git rev-parse HEAD: empty SHA".into());
+    }
+    Ok(sha)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_none_when_flag_off() {
+        // Mirrors the `flag_off_by_default` test in `mod.rs` — if any
+        // other test has flipped `QONTINUI_AGENT_WORKTREE_MODE`, this
+        // assertion is moot (the env mutation is global). Skip in that
+        // case to keep the suite parallel-safe.
+        if !worktree_mode_enabled() {
+            let repos = vec!["qontinui-runner".to_string()];
+            let ctx = acquire(AcquireRequest {
+                repos: &repos,
+                intent: None,
+                declared_overlap_paths: None,
+                plan_id: None,
+                phase: None,
+            })
+            .await
+            .expect("flag-off should return Ok(None), not Err");
+            assert!(ctx.is_none(), "flag-off must return None");
+        }
+    }
+}

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -126,9 +126,9 @@ pub async fn acquire(
 
     let mut repo_reqs: Vec<RepoRequest> = Vec::with_capacity(req.repos.len());
     for repo in req.repos {
-        let canonical = canonical_paths.get(repo).ok_or_else(|| {
-            AllocateError::Other(format!("no canonical path for repo '{repo}'"))
-        })?;
+        let canonical = canonical_paths
+            .get(repo)
+            .ok_or_else(|| AllocateError::Other(format!("no canonical path for repo '{repo}'")))?;
         let parent_sha = resolve_head_sha(canonical)
             .map_err(|e| AllocateError::Other(format!("git rev-parse HEAD on {repo}: {e}")))?;
         repo_reqs.push(RepoRequest {

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -16,8 +16,15 @@
 //!
 //! ## Scope (Phase 1)
 //!
-//! - Call coord `/agents/allocate` with `{ machine_id, repos: [{repo,
-//!   parent_sha}], intent? }`.
+//! - Call coord `/agents/allocate` with `{ device_id, repos: [{repo,
+//!   parent_sha}], intent? }`. The body's `device_id` key matches
+//!   coord's `AllocateRequest.device_id` field
+//!   (`qontinui-coord/src/agent_worktrees.rs:77`) after the
+//!   `coord.machines → coord.devices` rename. The runner's local
+//!   variable is still `machine_id` because the rest of the runner
+//!   (claims acquire/heartbeat/release, JWT issuance) hasn't been
+//!   renamed; only the on-the-wire JSON body to `/agents/allocate`
+//!   needs the new key.
 //! - `git worktree add <suggested-path> -b <branch> <parent_sha>` for
 //!   each returned worktree row.
 //! - Return materialized rows.
@@ -49,6 +56,8 @@ use tokio::sync::Notify;
 use tracing::{debug, info, warn};
 
 use crate::worktree::run_git_command;
+
+pub mod isolated_edit;
 
 /// Env var that turns the new spawn path on. Default off — `feature
 /// flag agent_worktree_mode` per plan §5 Phase 1.
@@ -718,8 +727,14 @@ pub async fn allocate_and_materialize_with_claim(
     // Phase 1B: declared_overlap_paths is optional; when present, coord
     // skips its LLM-based derivation step and uses our paths directly.
     // When absent, coord derives from `intent` (or falls back to empty).
+    //
+    // Body key is `device_id` to match coord's `AllocateRequest.device_id`
+    // (`qontinui-coord/src/agent_worktrees.rs:77`) after the
+    // `coord.machines → coord.devices` rename. The runner-side variable
+    // stays `machine_id` for symmetry with claims acquire/heartbeat/release,
+    // which coord's `claims.rs` still expects as `machine_id`.
     let body = serde_json::json!({
-        "machine_id": machine_id.to_string(),
+        "device_id": machine_id.to_string(),
         "repos": repos.iter().map(|r| serde_json::json!({
             "repo": r.repo,
             "parent_sha": r.parent_sha,

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1016,8 +1016,43 @@ pub async fn spawn_worker_session(
 ) -> Result<LaunchResult, String> {
     let app_state = require_app_state(&app_handle)?;
 
-    let repo_path = resolve_runner_repo_path()
+    let primary_repo_path = resolve_runner_repo_path()
         .ok_or_else(|| "Failed to resolve qontinui-runner repo path".to_string())?;
+
+    // Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
+    // Worker sessions always intend to edit qontinui-runner (the
+    // Coordinator's `assign-task` dispatch targets runner code). When
+    // worktree mode is on, allocate an isolated worktree and route the
+    // PTY there instead of the primary checkout; on failure or
+    // flag-off, fall back to the primary path. The context is parked
+    // on the TerminalSession after spawn.
+    let intent_repo = "qontinui-runner".to_string();
+    let repos = vec![intent_repo.clone()];
+    let isolated_ctx = match crate::agent_worktree::isolated_edit::acquire(
+        crate::agent_worktree::isolated_edit::AcquireRequest {
+            repos: &repos,
+            intent: Some("Worker session"),
+            declared_overlap_paths: None,
+            plan_id: None,
+            phase: None,
+        },
+    )
+    .await
+    {
+        Ok(Some(ctx)) => Some(ctx),
+        Ok(None) => None, // flag off
+        Err(e) => {
+            warn!(
+                error = %e,
+                "spawn_worker_session: isolated worktree allocate failed — using primary checkout"
+            );
+            None
+        }
+    };
+    let repo_path = match isolated_ctx.as_ref().and_then(|c| c.worktrees.first()) {
+        Some(w) => w.worktree_path.to_string_lossy().to_string(),
+        None => primary_repo_path,
+    };
 
     let terminal_manager = app_handle
         .try_state::<Arc<TerminalManager>>()
@@ -1074,6 +1109,15 @@ pub async fn spawn_worker_session(
         app_handle.clone(),
     )?;
 
+    // Phase 2 — park the isolated edit context on the TerminalSession
+    // so the heartbeat + claim live as long as the worker PTY. Cleared
+    // in `TerminalSession::close()`.
+    if let Some(ctx) = isolated_ctx {
+        if let Some(session) = terminal_manager.get(&info.id) {
+            session.set_isolated_edit_ctx(ctx);
+        }
+    }
+
     // Save the title for coord registration before it is moved into
     // WorkerSession::new.
     let coord_purpose = title.clone();
@@ -1124,7 +1168,11 @@ pub async fn spawn_worker_session(
             let intent = crate::session::Intent {
                 kind: crate::session::SessionKind::TerminalClaude,
                 purpose: coord_purpose.clone(),
-                repo: None,
+                // Phase 2 — worker sessions edit qontinui-runner.
+                // Declaring the repo on the Intent makes coord.sessions
+                // reflect the edit-intent that drove the worktree
+                // allocation above.
+                repo: Some(intent_repo.clone()),
                 branch: None,
                 declared_paths: vec![],
                 share_output: true,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -14,6 +14,16 @@ use crate::session::{Intent, SessionKind, SessionRegistry};
 use crate::terminal::{strip_ansi, TerminalManager};
 
 /// Create a new terminal session.
+///
+/// Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`:
+/// callers that intend to *edit* a coord-registered repo can pass
+/// `intent_repo: Some("<repo-slug>")`. When
+/// `QONTINUI_AGENT_WORKTREE_MODE` is enabled, the runner allocates an
+/// isolated git worktree for that repo via
+/// `agent_worktree::isolated_edit::acquire` and uses the materialized
+/// worktree path as the session's cwd, instead of the operator's primary
+/// checkout. Observation/read-only callers leave `intent_repo: None` and
+/// keep the legacy shared-cwd behavior — that path is unchanged.
 #[tauri::command]
 pub async fn terminal_create(
     terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
@@ -24,7 +34,48 @@ pub async fn terminal_create(
     page_id: Option<String>,
     cols: Option<u16>,
     rows: Option<u16>,
+    intent_repo: Option<String>,
 ) -> Result<CommandResponse, String> {
+    // Phase 2 — try to allocate an isolated worktree when the caller
+    // declared edit intent on a registered repo AND worktree mode is on.
+    // On failure or flag-off, fall through to legacy shared-cwd behavior.
+    let isolated_ctx = if let Some(ref repo) = intent_repo {
+        let repos = vec![repo.clone()];
+        let purpose = title.as_deref().unwrap_or("Terminal edit session");
+        match crate::agent_worktree::isolated_edit::acquire(
+            crate::agent_worktree::isolated_edit::AcquireRequest {
+                repos: &repos,
+                intent: Some(purpose),
+                declared_overlap_paths: None,
+                plan_id: None,
+                phase: None,
+            },
+        )
+        .await
+        {
+            Ok(Some(ctx)) => Some(ctx),
+            Ok(None) => None, // flag off — legacy path
+            Err(e) => {
+                warn!(
+                    intent_repo = %repo,
+                    error = %e,
+                    "terminal_create: isolated worktree allocate failed — falling back to shared cwd"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    // If we allocated a worktree, route the PTY there instead of the
+    // operator's primary checkout. The Intent built below uses the same
+    // resolved cwd so `coord.sessions` reflects what actually happened.
+    let working_dir = match isolated_ctx.as_ref().and_then(|c| c.worktrees.first()) {
+        Some(w) => Some(w.worktree_path.to_string_lossy().to_string()),
+        None => working_dir,
+    };
+
     let repo_detect_handle = app_handle.clone();
     let repo_detect_dir = working_dir.clone();
     let cred_helper_dir = working_dir.clone();
@@ -37,6 +88,14 @@ pub async fn terminal_create(
         app_handle,
     )?;
 
+    // Park the isolated edit context on the terminal session so its
+    // heartbeat + claim live as long as the PTY. Cleared in `close()`.
+    if let Some(ctx) = isolated_ctx {
+        if let Some(session) = terminal_manager.get(&info.id) {
+            session.set_isolated_edit_ctx(ctx);
+        }
+    }
+
     // Unconditional coord registration — every terminal session is
     // mirrored into the coordinator's session plane so the dashboard
     // renders it from `coord.sessions`. This is NOT gated by dual-write;
@@ -48,7 +107,7 @@ pub async fn terminal_create(
     let intent = Intent {
         kind: SessionKind::TerminalShell,
         purpose,
-        repo: None,
+        repo: intent_repo,
         branch: None,
         declared_paths: working_dir
             .map(std::path::PathBuf::from)

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -147,9 +147,8 @@ pub struct TerminalSession {
     /// stops the heartbeat task and fires a best-effort claim release;
     /// `close()` clears the slot first so release fires before PTY
     /// teardown.
-    isolated_edit_ctx: Arc<
-        Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>,
-    >,
+    isolated_edit_ctx:
+        Arc<Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>>,
 }
 
 impl TerminalSession {

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -140,6 +140,16 @@ pub struct TerminalSession {
     /// terminal into the coordinator's session plane. `None` until wired;
     /// read by `terminal_close` so it can close the coord mirror.
     coord_session_id: Arc<Mutex<Option<uuid::Uuid>>>,
+    /// Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
+    /// When the session declared edit intent on a registered repo and
+    /// `worktree_mode_enabled()` was true at spawn time, this carries
+    /// the allocated `IsolatedEditContext`. The context's `Drop` impl
+    /// stops the heartbeat task and fires a best-effort claim release;
+    /// `close()` clears the slot first so release fires before PTY
+    /// teardown.
+    isolated_edit_ctx: Arc<
+        Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>,
+    >,
 }
 
 impl TerminalSession {
@@ -475,6 +485,7 @@ impl TerminalSession {
             first_osc_title_tx,
             first_osc_title_rx,
             coord_session_id: Arc::new(Mutex::new(None)),
+            isolated_edit_ctx: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -730,6 +741,21 @@ impl TerminalSession {
         self.coord_session_id.lock().ok().and_then(|g| *g)
     }
 
+    /// Phase 2 of the worktree-isolation plan — park the
+    /// `IsolatedEditContext` returned by
+    /// `agent_worktree::isolated_edit::acquire` so its heartbeat task
+    /// + claim live as long as the terminal session. The slot is
+    /// cleared in `close()`, which drops the context and fires
+    /// best-effort claim release.
+    pub fn set_isolated_edit_ctx(
+        &self,
+        ctx: crate::agent_worktree::isolated_edit::IsolatedEditContext,
+    ) {
+        if let Ok(mut slot) = self.isolated_edit_ctx.lock() {
+            *slot = Some(ctx);
+        }
+    }
+
     /// Clone the per-session grid handle so callers can snapshot or read text.
     pub fn grid(&self) -> Arc<Mutex<Grid>> {
         self.grid.clone()
@@ -744,6 +770,14 @@ impl TerminalSession {
     pub fn close(&self) {
         info!(terminal_id = %self.id, "Closing terminal session");
         self.is_alive.store(false, Ordering::Relaxed);
+
+        // Phase 2 — drop the isolated edit context first so the
+        // claim-release fire-and-forget posts ahead of the PTY teardown
+        // (release uses tokio::spawn; running it before we drain threads
+        // makes ordering observable in coord audit logs).
+        if let Ok(mut slot) = self.isolated_edit_ctx.lock() {
+            slot.take();
+        }
 
         // Kill the child process via PID if still alive
         if let Some(pid) = self.child_pid {
@@ -912,6 +946,7 @@ mod tests {
             first_osc_title_tx: Arc::new(Mutex::new(Some(osc_title_tx))),
             first_osc_title_rx: Arc::new(Mutex::new(Some(osc_title_rx))),
             coord_session_id: Arc::new(Mutex::new(None)),
+            isolated_edit_ctx: Arc::new(Mutex::new(None)),
         }
     }
 


### PR DESCRIPTION
## Summary

- **Phase 0** — Fix dormant JSON field-name mismatch on `POST /agents/allocate`. The runner now sends `device_id` (not `machine_id`) to match coord's `AllocateRequest.device_id` after the `coord.machines → coord.devices` rename. Claims acquire/heartbeat/release still use `machine_id` on the wire — intentional, coord's `claims.rs` hasn't been renamed.
- **Phase 1** — New `agent_worktree::isolated_edit` facade: `acquire(AcquireRequest) → Option<IsolatedEditContext>`. Thin wrapper over the existing `allocate_and_materialize_with_claim` primitive that resolves coord URL, `device_id`, canonical checkout paths, and `parent_sha` from `HEAD`; auto-spawns the claim heartbeat; fires best-effort release on `Drop`.
- **Phase 2** — Wire `terminal_create` (new opt-in `intent_repo: Option<String>` Tauri arg) and `spawn_worker_session` (hardcoded `qontinui-runner`) through the facade. When `QONTINUI_AGENT_WORKTREE_MODE` is on, the PTY's cwd becomes the allocated worktree path instead of the operator's primary checkout. `TerminalSession.isolated_edit_ctx` parks the context for the PTY's lifetime; `close()` drops it first so claim release fires before PTY teardown.

Default-OFF behind `QONTINUI_AGENT_WORKTREE_MODE` — observation/read-only callers keep the legacy shared-cwd path untouched.

Companion PR: qontinui-claude-config encodes the binding rule in `/manual-test-loop`, `/manual-test`, `/implement-plan` so skill subagents allocate worktrees via `POST /agents/allocate-local` before any Edit/Write.

Plan: `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md` (archived in qontinui-dev-notes @ 249992d).

## Test plan

- [ ] `cargo check` + `cargo clippy -D warnings` (passing locally)
- [ ] Spawn a temp runner with `QONTINUI_AGENT_WORKTREE_MODE=1` and call `terminal_create` with `intent_repo: "qontinui-runner"` — verify the PTY cwd is a worktree under `D:/qontinui-root.wt/<agent_id>/qontinui-runner/`, not the canonical checkout
- [ ] With the flag on, spawn two worker sessions back-to-back — confirm they land in **distinct** worktrees (`git worktree list`) and the primary checkout's `git status` stays clean
- [ ] Close a worker session — verify the claim is released in coord and the worktree row transitions appropriately
- [ ] With the flag OFF (default), confirm `terminal_create` and `spawn_worker_session` behave exactly as before