### PR TITLE
refactor(adb): drop adb subprocess fallback, use adb_client per-rule remove

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,16 +20,16 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "adb_client"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a085375a2161850f6cc289a9bcc51633e0e484077c4dc12a41d5c95b873dc9fe"
+checksum = "33b180a67fc87ae26980016c7804bfb3e701dfe8a411106e9a4e5e8e9af00fcb"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "chrono",
  "image 0.25.10",
  "log",
- "mdns-sd 0.18.2",
+ "mdns-sd 0.19.2",
  "num-bigint-dig",
  "num-traits",
  "num_enum",
@@ -219,7 +219,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -230,7 +230,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -273,7 +273,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -2121,7 +2121,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2443,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3483,7 +3483,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3518,7 +3518,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3891,7 +3891,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4474,9 +4474,9 @@ dependencies = [
 
 [[package]]
 name = "mdns-sd"
-version = "0.18.2"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d797ab3274a16f4940f9650a29838e940223aeff31773df5c2827ad82150182f"
+checksum = "18148fee27e99e76dbf6e137f27727113d31f766e578d1b93a93c3615fca7081"
 dependencies = [
  "fastrand",
  "flume",
@@ -4811,7 +4811,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4954,7 +4954,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6318,7 +6318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6331,7 +6331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6632,7 +6632,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6670,9 +6670,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7388,14 +7388,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -7421,9 +7421,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7447,7 +7447,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9033,7 +9033,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10569,7 +10569,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/src/mcp/adb_helper.rs
+++ b/src-tauri/src/mcp/adb_helper.rs
@@ -4,12 +4,12 @@
 //! library. Every operation runs on `tokio::task::spawn_blocking` because the
 //! underlying `adb_client` API is synchronous.
 //!
-//! Port forwarding: `establish_forward` now uses `adb_client`'s `forward()` API
+//! Port forwarding: `establish_forward` uses `adb_client`'s `forward()` API
 //! (sends `host:forward:<local>;<remote>`). Because the library's `forward()`
 //! discards the response body, callers must pre-allocate the local port via
-//! `pick_free_local_port` rather than passing `tcp:0`. Per-forward removal
-//! (`host:killforward:tcp:<port>`) is not exposed, so teardown callers still
-//! shell out; only `forward_remove_all` (kills every forward) is available here.
+//! `pick_free_local_port` rather than passing `tcp:0`. Per-forward and
+//! per-reverse teardown use `forward_remove` / `reverse_remove` (added
+//! upstream in adb_client 3.2.1 — cocool97/adb_client#192 and #195).
 
 use std::io::Cursor;
 use std::net::SocketAddrV4;
@@ -259,6 +259,21 @@ pub async fn forward_tcp(serial: String, local_port: u16, remote_port: u16) -> R
     .map_err(|e| format!("task join failed: {e}"))?
 }
 
+/// Remove a single adb reverse by its device-side ("remote") endpoint
+/// (`reverse:killforward:tcp:<device_port>`).
+///
+/// Available since `adb_client` 3.2.1 (cocool97/adb_client#195).
+pub async fn reverse_remove(serial: String, device_port: u16) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut device = ADBServerDevice::new(serial, Some(default_server_addr()));
+        device
+            .reverse_remove(format!("tcp:{device_port}"))
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join failed: {e}"))?
+}
+
 /// Establish an `adb reverse tcp:<device_port> tcp:<host_port>` on the device.
 ///
 /// This is the mirror of [`forward_tcp`]: it makes the *device* listen on
@@ -305,12 +320,25 @@ pub async fn pick_free_local_port() -> Result<u16, String> {
     .map_err(|e| format!("task join failed: {e}"))?
 }
 
+/// Remove a single adb forward by its local endpoint
+/// (`host-serial:<serial>:killforward:tcp:<local_port>`).
+///
+/// Available since `adb_client` 3.2.1 (cocool97/adb_client#192).
+pub async fn forward_remove(serial: String, local_port: u16) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
+        let mut device = ADBServerDevice::new(serial, Some(default_server_addr()));
+        device
+            .forward_remove(format!("tcp:{local_port}"))
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("task join failed: {e}"))?
+}
+
 /// Remove **all** adb forwards (`host:killforward-all`).
 ///
-/// Currently unused by callers but exposed for future teardown paths. Because
-/// there is no per-forward `killforward` API in `adb_client` 3.x, this is the
-/// only library-level removal available; individual forward cleanup still
-/// shells out to `adb forward --remove tcp:<port>`.
+/// Nuclear option — wipes every forward on the local adb server, not just this
+/// process's. Unused by current callers; prefer [`forward_remove`] for cleanup.
 #[allow(dead_code)]
 pub async fn forward_remove_all() -> Result<(), String> {
     tokio::task::spawn_blocking(|| -> Result<(), String> {

--- a/src-tauri/src/mcp/transport/usb.rs
+++ b/src-tauri/src/mcp/transport/usb.rs
@@ -1,13 +1,11 @@
 //! USB/ADB transport for physical Android device connections.
 //!
-//! Plan 1A refactor: device listing, shell commands, and `establish_forward`
-//! now use the pure-Rust `adb_client` crate via `mcp::adb_helper`. The one
-//! remaining subprocess call is `release_forward`, which still shells out to
-//! `adb forward --remove tcp:<port>` because `adb_client` 3.x exposes only
-//! `forward_remove_all` (nuclear) and not per-forward `killforward`.
+//! Plan 1A refactor: every ADB operation this transport performs (device
+//! listing, shell, screenshot, logcat, forward/reverse establish, forward/
+//! reverse per-rule removal) goes through the pure-Rust `adb_client` crate
+//! via `mcp::adb_helper`. No subprocess fallback remains.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
@@ -21,33 +19,27 @@ use crate::mcp::adb_helper;
 
 /// Manages ADB port forwards for connected Android devices.
 ///
-/// `adb_path` is still used by `release_forward` because `adb_client` 3.x has
-/// no per-forward `killforward` API (only `forward_remove_all`, which would
-/// stomp every forward on the machine). Everything else (device listing,
-/// shell, screenshot, logcat, `establish_forward`) goes through `adb_helper`.
+/// All ADB I/O goes through `adb_helper` (the pure-Rust `adb_client` crate);
+/// no subprocess fallback is needed.
 ///
-/// `Clone` is cheap: `active_forwards` is an `Arc<Mutex<_>>` shared across
-/// clones, and `adb_path` is a small `PathBuf`. We rely on cloning so the
-/// shutdown handler in `main.rs` can call `release_all` on the same forward
-/// registry the USB scanner task owns.
+/// `Clone` is cheap — both registries are `Arc<Mutex<_>>` shared across clones.
+/// We rely on cloning so the shutdown handler in `main.rs` can call
+/// `release_all` on the same forward/reverse registries the USB scanner task
+/// owns.
 #[derive(Clone)]
 pub struct UsbTransport {
-    /// Path to the `adb` (or `adb.exe`) binary. Still needed for
-    /// `release_forward` — see struct-level doc above.
-    pub adb_path: PathBuf,
     /// Maps ADB serial number → locally forwarded TCP port.
     pub active_forwards: Arc<Mutex<HashMap<String, u16>>>,
     /// Maps ADB serial number → device-side port currently reversed back to the
     /// runner HTTP API (`adb reverse tcp:<port> tcp:<port>`). Tracked so the
-    /// shutdown / disconnect paths can `adb reverse --remove` exactly the rules
-    /// this process installed, rather than nuking every reverse on the machine.
+    /// shutdown / disconnect paths can remove exactly the rules this process
+    /// installed, rather than nuking every reverse on the machine.
     pub active_reverses: Arc<Mutex<HashMap<String, u16>>>,
 }
 
 impl UsbTransport {
-    pub fn new(adb_path: PathBuf) -> Self {
+    pub fn new() -> Self {
         Self {
-            adb_path,
             active_forwards: Arc::new(Mutex::new(HashMap::new())),
             active_reverses: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -104,23 +96,11 @@ impl UsbTransport {
             }
         };
 
-        let output = crate::process_helpers::tokio_no_window(&self.adb_path)
-            .args([
-                "-s",
-                adb_serial,
-                "forward",
-                "--remove",
-                &format!("tcp:{}", port),
-            ])
-            .output()
-            .await
-            .map_err(|e| TransportError::AdbCommandFailed(e.to_string()))?;
-
-        if !output.status.success() {
+        if let Err(e) = adb_helper::forward_remove(adb_serial.to_string(), port).await {
             warn!(
                 serial = %adb_serial,
                 port,
-                stderr = %String::from_utf8_lossy(&output.stderr),
+                error = %e,
                 "Failed to remove ADB forward (device may be disconnected)"
             );
         }
@@ -173,13 +153,6 @@ impl UsbTransport {
     }
 
     /// Remove the ADB reverse for the given device and clean up the map entry.
-    ///
-    /// `adb_client` 3.x exposes only `reverse_remove_all` (which would stomp
-    /// every reverse on the machine), so per-rule removal shells out to
-    /// `adb -s <serial> reverse --remove tcp:<port>`, mirroring
-    /// [`release_forward`].
-    ///
-    /// [`release_forward`]: UsbTransport::release_forward
     pub async fn release_reverse(&self, adb_serial: &str) -> Result<(), TransportError> {
         let port = {
             let reverses = self.active_reverses.lock().await;
@@ -192,23 +165,11 @@ impl UsbTransport {
             }
         };
 
-        let output = crate::process_helpers::tokio_no_window(&self.adb_path)
-            .args([
-                "-s",
-                adb_serial,
-                "reverse",
-                "--remove",
-                &format!("tcp:{}", port),
-            ])
-            .output()
-            .await
-            .map_err(|e| TransportError::AdbCommandFailed(e.to_string()))?;
-
-        if !output.status.success() {
+        if let Err(e) = adb_helper::reverse_remove(adb_serial.to_string(), port).await {
             warn!(
                 serial = %adb_serial,
                 port,
-                stderr = %String::from_utf8_lossy(&output.stderr),
+                error = %e,
                 "Failed to remove ADB reverse (device may be disconnected)"
             );
         }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1163,44 +1163,7 @@ pub fn create_router(
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
             let mobile_settings = crate::settings::get_mobile_settings();
-
-            // Resolve ADB path: prefer custom setting, then fall back to auto-detection
-            let adb_path = if let Some(custom) = &mobile_settings.adb_path {
-                std::path::PathBuf::from(custom)
-            } else {
-                // Mirror the find_adb() logic from app_discovery.rs
-                let adb_name = if cfg!(windows) { "adb.exe" } else { "adb" };
-                let mut resolved = std::path::PathBuf::from(adb_name);
-                if let Ok(android_home) = std::env::var("ANDROID_HOME") {
-                    let p = std::path::PathBuf::from(android_home)
-                        .join("platform-tools")
-                        .join(adb_name);
-                    if p.exists() {
-                        resolved = p;
-                    }
-                } else if let Ok(sdk_root) = std::env::var("ANDROID_SDK_ROOT") {
-                    let p = std::path::PathBuf::from(sdk_root)
-                        .join("platform-tools")
-                        .join(adb_name);
-                    if p.exists() {
-                        resolved = p;
-                    }
-                } else if cfg!(windows) {
-                    if let Ok(local_app_data) = std::env::var("LOCALAPPDATA") {
-                        let p = std::path::PathBuf::from(local_app_data)
-                            .join("Android")
-                            .join("Sdk")
-                            .join("platform-tools")
-                            .join(adb_name);
-                        if p.exists() {
-                            resolved = p;
-                        }
-                    }
-                }
-                resolved
-            };
-
-            let usb_transport = crate::mcp::transport::usb::UsbTransport::new(adb_path);
+            let usb_transport = crate::mcp::transport::usb::UsbTransport::new();
 
             // Publish for the CloseRequested shutdown handler in main.rs, which
             // calls release_all so this process's `adb forward` entries don't


### PR DESCRIPTION
## Summary

- Bump `adb_client` 3.2.0 → 3.2.1 (released 2026-05-03) to pull in upstream PRs [cocool97/adb_client#192](https://github.com/cocool97/adb_client/pull/192) (`forward_remove`) and [#195](https://github.com/cocool97/adb_client/pull/195) (`reverse_remove`) — per-rule killforward/killreverse APIs we previously lacked.
- Replace the two remaining `adb -s <serial> forward/reverse --remove` subprocess calls in `UsbTransport` (`release_forward`, `release_reverse`) with native helpers in `adb_helper`.
- Delete the now-unused `adb_path: PathBuf` field from `UsbTransport` (constructor is parameterless) and the 36-line ADB-path resolution block in `mcp_api.rs` that existed only to feed it.

After this PR, `UsbTransport` has **zero** subprocess fallback — every ADB operation it performs goes through the pure-Rust `adb_client` crate. `mobile_settings.adb_path` (user setting) still serves `commands/mobile.rs::find_adb_path()` for unrelated mobile flows (APK install, etc.) and the React settings UI; only the `UsbTransport` consumer was removed.

Lockfile pulled compatible transitive bumps for `mdns-sd 0.18 → 0.19` (adb_client's mDNS dep) and `rustls 0.23.37 → 0.23.40` / `rustls-pki-types 1.14.0 → 1.14.1`. No `Cargo.toml` changes.

## Test plan

- [x] `cargo-guard.sh check --bin qontinui-runner` — exit 0
- [ ] CI green (schema-fresh, clorinde-fresh, full build)
- [ ] Smoke: USB Android device → connect → disconnect → confirm forward+reverse maps cleared cleanly in logs (no `Failed to remove ADB forward/reverse` warnings unless device was unplugged mid-teardown)