### PR TITLE
fix(agent_worktree): wire HTTP-proxy + backend-relay terminal_create through facade

### DIFF
--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -182,6 +182,63 @@ pub async fn acquire(
     }))
 }
 
+/// Convenience helper for the three runner terminal-spawn entry points
+/// (`commands/terminal.rs::terminal_create`, `commands/productivity.rs::
+/// spawn_worker_session`, `mcp/tauri_proxy.rs::"terminal_create"`,
+/// `mcp/backend_relay.rs::handle_terminal_create`). Given the caller's
+/// `intent_repo` + `purpose` + original `working_dir`, returns the
+/// effective working dir for the PTY plus an `IsolatedEditContext` to
+/// park on the resulting `TerminalSession`.
+///
+/// Behavior:
+/// - `intent_repo == None` → returns `(working_dir, None)`. Observation
+///   session; legacy shared-checkout path.
+/// - `intent_repo == Some(_)` but `worktree_mode_enabled()` is false →
+///   returns `(working_dir, None)`. Caller's existing behavior preserved.
+/// - `intent_repo == Some(_)` and worktree mode is on, allocate succeeds
+///   → returns `(Some(worktree_path), Some(ctx))`.
+/// - `intent_repo == Some(_)` and worktree mode is on, allocate fails →
+///   returns `(working_dir, None)`. Failure is logged as a warning;
+///   the spawn flow falls back to the primary checkout (this matches
+///   the in-place Phase 2 wireup of `terminal_create` and
+///   `spawn_worker_session`).
+pub async fn acquire_for_terminal(
+    intent_repo: Option<&str>,
+    purpose: &str,
+    working_dir: Option<String>,
+) -> (Option<String>, Option<IsolatedEditContext>) {
+    let Some(repo) = intent_repo else {
+        return (working_dir, None);
+    };
+    let repos = vec![repo.to_string()];
+    match acquire(AcquireRequest {
+        repos: &repos,
+        intent: Some(purpose),
+        declared_overlap_paths: None,
+        plan_id: None,
+        phase: None,
+    })
+    .await
+    {
+        Ok(Some(ctx)) => {
+            let wt_path = ctx
+                .worktrees
+                .first()
+                .map(|w| w.worktree_path.to_string_lossy().to_string());
+            (wt_path.or(working_dir), Some(ctx))
+        }
+        Ok(None) => (working_dir, None),
+        Err(e) => {
+            warn!(
+                intent_repo = %repo,
+                error = %e,
+                "acquire_for_terminal: isolated worktree allocate failed — falling back to shared cwd"
+            );
+            (working_dir, None)
+        }
+    }
+}
+
 /// Read the device UUID from `~/.qontinui/machine.json`. Accepts the
 /// canonical `"device_id"` field (post-unified-devices) and falls back
 /// to legacy `"machine_id"`.

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1019,40 +1019,19 @@ pub async fn spawn_worker_session(
     let primary_repo_path = resolve_runner_repo_path()
         .ok_or_else(|| "Failed to resolve qontinui-runner repo path".to_string())?;
 
-    // Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
-    // Worker sessions always intend to edit qontinui-runner (the
-    // Coordinator's `assign-task` dispatch targets runner code). When
-    // worktree mode is on, allocate an isolated worktree and route the
-    // PTY there instead of the primary checkout; on failure or
-    // flag-off, fall back to the primary path. The context is parked
-    // on the TerminalSession after spawn.
+    // Phase 2 — worker sessions always intend to edit qontinui-runner
+    // (the Coordinator's `assign-task` dispatch targets runner code).
+    // Route through `acquire_for_terminal` so this path stays in
+    // lockstep with the other three terminal-spawn entry points.
     let intent_repo = "qontinui-runner".to_string();
-    let repos = vec![intent_repo.clone()];
-    let isolated_ctx = match crate::agent_worktree::isolated_edit::acquire(
-        crate::agent_worktree::isolated_edit::AcquireRequest {
-            repos: &repos,
-            intent: Some("Worker session"),
-            declared_overlap_paths: None,
-            plan_id: None,
-            phase: None,
-        },
-    )
-    .await
-    {
-        Ok(Some(ctx)) => Some(ctx),
-        Ok(None) => None, // flag off
-        Err(e) => {
-            warn!(
-                error = %e,
-                "spawn_worker_session: isolated worktree allocate failed — using primary checkout"
-            );
-            None
-        }
-    };
-    let repo_path = match isolated_ctx.as_ref().and_then(|c| c.worktrees.first()) {
-        Some(w) => w.worktree_path.to_string_lossy().to_string(),
-        None => primary_repo_path,
-    };
+    let (effective_repo_path, isolated_ctx) =
+        crate::agent_worktree::isolated_edit::acquire_for_terminal(
+            Some(&intent_repo),
+            "Worker session",
+            Some(primary_repo_path.clone()),
+        )
+        .await;
+    let repo_path = effective_repo_path.unwrap_or(primary_repo_path);
 
     let terminal_manager = app_handle
         .try_state::<Arc<TerminalManager>>()

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -36,45 +36,17 @@ pub async fn terminal_create(
     rows: Option<u16>,
     intent_repo: Option<String>,
 ) -> Result<CommandResponse, String> {
-    // Phase 2 — try to allocate an isolated worktree when the caller
-    // declared edit intent on a registered repo AND worktree mode is on.
-    // On failure or flag-off, fall through to legacy shared-cwd behavior.
-    let isolated_ctx = if let Some(ref repo) = intent_repo {
-        let repos = vec![repo.clone()];
-        let purpose = title.as_deref().unwrap_or("Terminal edit session");
-        match crate::agent_worktree::isolated_edit::acquire(
-            crate::agent_worktree::isolated_edit::AcquireRequest {
-                repos: &repos,
-                intent: Some(purpose),
-                declared_overlap_paths: None,
-                plan_id: None,
-                phase: None,
-            },
-        )
-        .await
-        {
-            Ok(Some(ctx)) => Some(ctx),
-            Ok(None) => None, // flag off — legacy path
-            Err(e) => {
-                warn!(
-                    intent_repo = %repo,
-                    error = %e,
-                    "terminal_create: isolated worktree allocate failed — falling back to shared cwd"
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    // If we allocated a worktree, route the PTY there instead of the
-    // operator's primary checkout. The Intent built below uses the same
-    // resolved cwd so `coord.sessions` reflects what actually happened.
-    let working_dir = match isolated_ctx.as_ref().and_then(|c| c.worktrees.first()) {
-        Some(w) => Some(w.worktree_path.to_string_lossy().to_string()),
-        None => working_dir,
-    };
+    // Phase 2 — route through the shared `acquire_for_terminal` helper
+    // so this entry point + the HTTP-proxy / backend-relay siblings stay
+    // in lockstep. When `intent_repo` is `None`, the helper is a no-op;
+    // when it's `Some(_)` but worktree mode is off or allocation fails,
+    // the helper returns the original `working_dir` and logs.
+    let (working_dir, isolated_ctx) = crate::agent_worktree::isolated_edit::acquire_for_terminal(
+        intent_repo.as_deref(),
+        title.as_deref().unwrap_or("Terminal edit session"),
+        working_dir,
+    )
+    .await;
 
     let repo_detect_handle = app_handle.clone();
     let repo_detect_dir = working_dir.clone();

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -1127,7 +1127,7 @@ async fn handle_relay_command(
         // Mobile terminal session relay
         // --------------------------------------------------------------
         "terminal_list" => handle_terminal_list(api_state, data),
-        "terminal_create" => handle_terminal_create(api_state, data),
+        "terminal_create" => handle_terminal_create(api_state, data).await,
         "terminal_input" => handle_terminal_input(api_state, data),
         "terminal_resize" => handle_terminal_resize(api_state, data),
         "terminal_close" => handle_terminal_close(api_state, data).await,
@@ -2029,7 +2029,7 @@ fn handle_terminal_list(api_state: &Arc<ApiState>, data: &Value) -> Option<Value
     }
 }
 
-fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Option<Value> {
+async fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Option<Value> {
     let terminal_manager: Option<Arc<crate::terminal::TerminalManager>> = api_state
         .app_handle
         .try_state::<Arc<crate::terminal::TerminalManager>>()
@@ -2049,6 +2049,23 @@ fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Option<Val
             .get("rows")
             .and_then(|v| v.as_u64())
             .map(|v| v.min(u16::MAX as u64) as u16);
+        // Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
+        // Accept the same `intent_repo` opt-in the Tauri command + HTTP-SDK
+        // proxy accept so backend-relay callers can declare edit intent on
+        // a registered repo. Allocation happens via the shared helper; the
+        // context (if any) is parked on the resulting TerminalSession.
+        let intent_repo = data
+            .get("intent_repo")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let (working_dir, isolated_ctx) =
+            crate::agent_worktree::isolated_edit::acquire_for_terminal(
+                intent_repo.as_deref(),
+                title.as_deref().unwrap_or("Terminal edit session"),
+                working_dir,
+            )
+            .await;
 
         match tm.create(
             title,
@@ -2058,11 +2075,18 @@ fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Option<Val
             rows,
             api_state.app_handle.clone(),
         ) {
-            Ok(info) => Some(serde_json::json!({
-                "type": "terminal_created",
-                "terminal": info,
-                "request_id": data.get("request_id"),
-            })),
+            Ok(info) => {
+                if let Some(ctx) = isolated_ctx {
+                    if let Some(session) = tm.get(&info.id) {
+                        session.set_isolated_edit_ctx(ctx);
+                    }
+                }
+                Some(serde_json::json!({
+                    "type": "terminal_created",
+                    "terminal": info,
+                    "request_id": data.get("request_id"),
+                }))
+            }
             Err(e) => Some(serde_json::json!({
                 "type": "error",
                 "message": format!("Failed to create terminal: {}", e),

--- a/src-tauri/src/mcp/tauri_proxy.rs
+++ b/src-tauri/src/mcp/tauri_proxy.rs
@@ -171,6 +171,12 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 page_id: Option<String>,
                 cols: Option<u16>,
                 rows: Option<u16>,
+                /// Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
+                /// When `Some(repo_slug)` AND `QONTINUI_AGENT_WORKTREE_MODE` is on,
+                /// allocate an isolated worktree for that repo and use it as the
+                /// PTY cwd instead of `working_dir`. Mirrors the `intent_repo`
+                /// argument on the `terminal_create` Tauri command.
+                intent_repo: Option<String>,
             }
             let a = match serde_json::from_value::<Args>(req.args) {
                 Ok(v) => v,
@@ -181,15 +187,29 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 .state::<Arc<TerminalManager>>()
                 .inner()
                 .clone();
+
+            let (working_dir, isolated_ctx) =
+                crate::agent_worktree::isolated_edit::acquire_for_terminal(
+                    a.intent_repo.as_deref(),
+                    a.title.as_deref().unwrap_or("Terminal edit session"),
+                    a.working_dir,
+                )
+                .await;
+
             match tm.create(
                 a.title,
-                a.working_dir,
+                working_dir,
                 a.page_id,
                 a.cols,
                 a.rows,
                 state.app_handle.clone(),
             ) {
                 Ok(info) => {
+                    if let Some(ctx) = isolated_ctx {
+                        if let Some(session) = tm.get(&info.id) {
+                            session.set_isolated_edit_ctx(ctx);
+                        }
+                    }
                     TauriInvokeResponse::ok(serde_json::to_value(&info).unwrap_or(Value::Null))
                 }
                 Err(e) => TauriInvokeResponse::err(e),


### PR DESCRIPTION
## Summary

Phase 2 gap discovered while prepping Phase 4 verification of the worktree-isolation plan. `terminal_create` exists at three entry points; the original Phase 2 (PR #311) only wired the Tauri command. HTTP-SDK and backend-relay callers were skipping the allocation logic entirely — even with `QONTINUI_AGENT_WORKTREE_MODE=1`, they got the operator's primary checkout.

- Extract shared helper `agent_worktree::isolated_edit::acquire_for_terminal(intent_repo, purpose, working_dir) → (Option<String>, Option<IsolatedEditContext>)`.
- Refactor `terminal_create` + `spawn_worker_session` to use it (removes duplication from #311).
- Add intent_repo parsing + allocation wiring to `mcp/tauri_proxy.rs:"terminal_create"` and `mcp/backend_relay.rs::handle_terminal_create`.
- `handle_terminal_create` becomes async (the dispatcher already uses `.await` for sibling handlers).

Net: -80 LOC at call sites, +57 LOC in the helper. All four entry points now identical shape: \`let (working_dir, ctx) = acquire_for_terminal(...).await; tm.create(...)?; ctx.map(...).map(park_on_session);\`.

Default-OFF behind `QONTINUI_AGENT_WORKTREE_MODE` — observation/no-intent callers untouched.

Follow-up to #311. Plan: \`plans/2026-05-28-isolate-session-edit-work-in-worktrees.md\` (archived in qontinui-dev-notes).

## Test plan

- [ ] \`cargo check\` + \`cargo clippy -D warnings\` + \`cargo fmt --check\` — all green locally
- [ ] Phase 4 verification (next session task #8): spawn temp runner with flag on, exercise the HTTP-proxy and backend-relay paths via curl, verify worktree allocation + claim + primary checkout untouched
- [ ] Verify flag-off (default) behavior on all four entry points stays exactly as before