### PR TITLE
feat(terminal): chrome redesign — registry + 3-tier CommandBar + suggestions + hover + status strip + AI subprocess + hoisted launch-menu + wizard bypass

### DIFF
--- a/src-tauri/src/commands/command_interpreter.rs
+++ b/src-tauri/src/commands/command_interpreter.rs
@@ -161,8 +161,8 @@ pub async fn command_interpret(
         ));
     }
 
-    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout)
-        .map_err(|e| format!("envelope JSON parse: {e}"))?;
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stdout).map_err(|e| format!("envelope JSON parse: {e}"))?;
 
     if envelope
         .get("is_error")

--- a/src-tauri/src/commands/command_interpreter.rs
+++ b/src-tauri/src/commands/command_interpreter.rs
@@ -1,0 +1,191 @@
+//! Phase 8 — Tier-3 free-text → registry action resolver.
+//!
+//! The CommandBar's two synchronous tiers (slash autocomplete, declarative
+//! regex patterns) cover the long tail of expected phrasings; this module
+//! catches the rest by spawning the local `claude` CLI as a one-shot
+//! subprocess and asking it to route a user's free-text prompt to a
+//! registered action with structured-output enforcement.
+//!
+//! ## Architecture choice — local subprocess, not HTTP
+//!
+//! The plan's vet pass made this an explicit decision per
+//! `feedback_no_anthropic_api`: the operator pays per Claude Code
+//! subscription, not per-token. Calling `api.anthropic.com` from coord
+//! or runner would be a double-bill failure mode. The mandated pattern
+//! is the same one used by `agent_runtime.rs:638-670` — spawn `claude`
+//! via tokio and pipe the prompt through. Each invocation re-uses the
+//! operator's existing OAuth/keychain auth.
+//!
+//! ## CLI flags validated against `claude --help`
+//!
+//! - `-p / --print` — non-interactive mode
+//! - `--output-format json` — wraps the response in a metadata envelope
+//! - `--json-schema <schema>` — enforces structured output; the model
+//!   can't return free text once this is set, eliminating the brittle
+//!   "scrape JSON out of prose" parser the original plan relied on
+//! - `--system-prompt <text>` — overrides the default system prompt
+//! - `--disallowed-tools` — comma- or space-separated tool denylist; we
+//!   block edit/exec tools entirely since this is a router, not an agent
+//! - `--model haiku` — alias for the cheapest fast model; routing is
+//!   pure classification + arg extraction, doesn't need Sonnet
+//!
+//! ## Envelope shape
+//!
+//! Verified empirically (`claude -p --output-format json --json-schema
+//! ... "say hi"`):
+//!
+//! ```json
+//! {
+//!     "type": "result",
+//!     "subtype": "success",
+//!     "is_error": false,
+//!     "duration_ms": 4111,
+//!     "session_id": "...",
+//!     "total_cost_usd": 0.0384,
+//!     "structured_output": {...},  // ← our payload lives here
+//!     "result": "",                // ← empty when --json-schema is set
+//!     ...
+//! }
+//! ```
+//!
+//! On error (`is_error: true`), `.result` carries an error message and
+//! `.structured_output` is absent.
+//!
+//! ## What's deferred from the plan's Phase 8 spec
+//!
+//! - **Long-lived subprocess + session resume** — claude `--print` is
+//!   one-shot by design; reusing prompt-cache across calls requires
+//!   threading the returned `session_id` back via `--resume`. The L1
+//!   cache covers most repeated phrasings without it; revisit if the
+//!   ~3-5s cold-start ever becomes a complaint.
+//! - **Coord PG `command_interpretations` table + `coord_command_interpret`
+//!   MCP tool (L2 cache)** — second repo, separate migration. Single-
+//!   machine L1 cache lives in `instanceStorage` on the TS side.
+//! - **Optimistic execution + Undo** — the CommandBar always shows the
+//!   match as the selected suggestion; operator confirms with Enter.
+//!   Undo affordance lands when destructive registry actions are added.
+//! - **Telemetry to coord** — same gating as the coord cache.
+//! - **Idle-shutdown + restart-on-crash** — irrelevant for the one-shot
+//!   path. Revisit if we ever go long-lived.
+
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+/// Strict shape the model is constrained to emit by `--json-schema`.
+///
+/// `tool` is a registered action id (e.g. `"terminal.spawn-ai"`) or the
+/// empty string when nothing fits. `args` is the parameter map matching
+/// the action's `paramSchema`. `confidence` is the model's own [0..1]
+/// estimate — the frontend gates display + execution on it.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct InterpretResult {
+    pub tool: String,
+    pub args: serde_json::Value,
+    pub confidence: f64,
+}
+
+/// Schema enforced on the model's response. Kept narrow so the model
+/// can't hallucinate extra fields and so any deserialization failure
+/// surfaces as a clear runtime error.
+const OUTPUT_SCHEMA: &str = r#"{
+    "type": "object",
+    "properties": {
+        "tool": {"type": "string"},
+        "args": {"type": "object"},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1}
+    },
+    "required": ["tool", "args", "confidence"],
+    "additionalProperties": false
+}"#;
+
+const SYSTEM_PROMPT: &str = "You are a slash-command router for the Qontinui Terminal page. \
+The user will give you a free-text request. You will also receive a JSON catalog of available actions, \
+each with: id (the stable wire id), slash (the slash-command form), label, description, and paramSchema \
+(parameter shape). \
+Choose the single action that best matches the user's intent and return ONLY a JSON object with: \
+- tool: the action id from the catalog (or empty string \"\" when nothing fits) \
+- args: an object whose keys match the chosen action's paramSchema; coerce numeric tokens to numbers; \
+  omit optional fields the user did not mention \
+- confidence: a real number in [0.0, 1.0]; use >= 0.95 only when the mapping is unambiguous \
+Do not invent action ids that are not in the catalog. Do not include prose, code fences, or markdown. \
+Return only the JSON object.";
+
+/// Phase 8 Tier-3 entry point — invoked from the TS frontend's
+/// `interpretCommand` after Tier-1/2 miss.
+///
+/// `text` is the operator's raw input (already stripped of any leading
+/// `/` slash). `tools_json` is a JSON-serialized array of `{id, slash,
+/// label, description, paramSchema}` objects projected from the live
+/// registry by the caller — we don't reach into the registry from Rust
+/// because the registry is a frontend-only React module.
+///
+/// Returns the model's structured choice or an error string. Errors:
+/// spawn failure, non-zero exit, missing envelope, missing
+/// `structured_output`, JSON parse failure. The frontend surfaces these
+/// to the operator as "Tier-3 unavailable" and falls back to fuzzy.
+#[tauri::command]
+pub async fn command_interpret(
+    text: String,
+    tools_json: String,
+) -> Result<InterpretResult, String> {
+    let prompt = format!(
+        "Available actions (JSON array):\n{}\n\nUser input: {}",
+        tools_json, text
+    );
+
+    let output = Command::new("claude")
+        .arg("-p")
+        .arg("--output-format")
+        .arg("json")
+        .arg("--json-schema")
+        .arg(OUTPUT_SCHEMA)
+        .arg("--system-prompt")
+        .arg(SYSTEM_PROMPT)
+        // Block every edit/exec tool — this is a router, not an agent.
+        // The model still has read tools available (Read, Grep, etc.)
+        // but those have no useful effect on a one-shot routing call.
+        .arg("--disallowed-tools")
+        .arg("Edit,Write,Bash,WebFetch,WebSearch,NotebookEdit,Task,Agent")
+        .arg("--model")
+        .arg("haiku")
+        .arg(&prompt)
+        .output()
+        .await
+        .map_err(|e| format!("claude spawn failed: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "claude exited {} — stderr: {}",
+            output.status, stderr
+        ));
+    }
+
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .map_err(|e| format!("envelope JSON parse: {e}"))?;
+
+    if envelope
+        .get("is_error")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        let result_str = envelope
+            .get("result")
+            .and_then(|v| v.as_str())
+            .unwrap_or("(no error message)");
+        return Err(format!("claude returned is_error=true: {result_str}"));
+    }
+
+    // `--json-schema` mode routes the structured payload to
+    // `.structured_output` and leaves `.result` empty. If a future CLI
+    // version changes this convention, the parser below will surface a
+    // clear error rather than silently returning garbage.
+    let structured = envelope
+        .get("structured_output")
+        .ok_or_else(|| "envelope missing .structured_output".to_string())?;
+
+    let parsed: InterpretResult = serde_json::from_value(structured.clone())
+        .map_err(|e| format!("structured_output parse: {e} — raw: {structured}"))?;
+
+    Ok(parsed)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -168,6 +168,7 @@ pub mod checks; // Code quality checks (linting, formatting, type checking)
 pub mod chunk_labels; // Per-config user-chosen chunk label overrides for chunked state-machine graph view
 pub mod claims; // Plan 2026-05-18-agent-spawn-coordination Phase 3 — Tauri wrappers around coord's /claims/* API
 pub mod clipboard; // Clipboard sync: share text to mobile via backend relay
+pub mod command_interpreter; // Phase 8 — Tier-3 free-text → registry action via local `claude` CLI
 pub mod comparison; // Side-by-side architecture comparison runs
 pub mod compartments; // Workstream C: scoped wrappers around Arc<AppState> for gradual migration
 pub mod config;

--- a/src-tauri/src/commands/setup_wizard.rs
+++ b/src-tauri/src/commands/setup_wizard.rs
@@ -17,9 +17,31 @@ use uuid::Uuid;
 // Setup Status
 // ============================================================================
 
-/// Check if the first-launch setup wizard has been completed
+/// Check if the first-launch setup wizard has been completed.
+///
+/// Auto-bypass for test runners: when the supervisor forwards
+/// `QONTINUI_TEST_AUTO_LOGIN_EMAIL` (the same env var that drives the
+/// existing test auto-login), report setup as complete regardless of
+/// the persisted settings value. Temp runners always start with a
+/// fresh profile (setup_completed=false) which previously blocked any
+/// route-scoped UI Bridge testing behind the 7-step wizard. Reusing
+/// the supervisor's existing auto-login env var means zero new
+/// configuration on the spawn side — the same plumbing that auto-logs
+/// also auto-skips.
+///
+/// Operators running the runner directly never set this env var, so
+/// their wizard behaviour is unchanged. Manual dismissal is also
+/// available via the `setup-wizard` UI Bridge component's `complete`
+/// action (registered in `SetupWizard.tsx`).
 #[tauri::command]
 pub fn check_setup_completed() -> Result<bool, String> {
+    if std::env::var("QONTINUI_TEST_AUTO_LOGIN_EMAIL")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .is_some()
+    {
+        return Ok(true);
+    }
     Ok(settings::get_setup_completed())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -971,6 +971,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::claims::claims_steal,
             commands::clipboard::share_file_to_mobile,
             commands::clipboard::share_to_mobile,
+            commands::command_interpreter::command_interpret,
             commands::comparison::get_comparison_status,
             commands::comparison::list_comparisons,
             commands::comparison::start_comparison,

--- a/src/components/setup-wizard/SetupWizard.tsx
+++ b/src/components/setup-wizard/SetupWizard.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useUIComponent } from "@qontinui/ui-bridge";
 import { StepIndicator } from "./StepIndicator";
 import { TierStep } from "./TierStep";
 import { WelcomeStep } from "./WelcomeStep";
@@ -90,6 +91,68 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
       onComplete();
     }
   }, [selectedProcessConfigs, onComplete]);
+
+  // UI Bridge: expose programmatic wizard control so test runs and
+  // automation can dismiss the wizard without driving 7 steps of OS
+  // dialogs. `scope: 'global'` so the component is discoverable even
+  // when the wizard isn't the active route (matters less in practice
+  // since the wizard owns the whole viewport when shown, but keeps the
+  // discovery contract explicit for `/control/components` callers who
+  // are spawning a fresh temp runner and haven't navigated anywhere
+  // yet). The `complete` action calls the same `finishSetup` flow that
+  // the Claude-Sessions "Finish" button does, so persisted state ends
+  // up identical to a real user completion (`complete_setup` Tauri
+  // command writes `settings.setup_completed=true`, plus any process
+  // configs the user picked).
+  //
+  // Operators who set the supervisor-forwarded
+  // `QONTINUI_TEST_AUTO_LOGIN_EMAIL` env var don't need this action at
+  // all — `check_setup_completed` returns true on the Rust side and
+  // the wizard never mounts. This component-action is the second
+  // discovery vector: useful for non-supervisor automation (e.g. a
+  // CI smoke from outside the supervisor's spawn lane) and for
+  // operators who want to dismiss the wizard from a UI Bridge driver
+  // without restarting the runner.
+  useUIComponent({
+    id: "setup-wizard",
+    name: "Setup Wizard",
+    description:
+      "First-launch onboarding wizard. Use 'complete' to dismiss programmatically " +
+      "without driving 7 step interactions; equivalent to clicking through every step's " +
+      "default + 'Finish'. Use 'go-to-step' to jump directly to a specific step (0-6).",
+    scope: "global",
+    actions: [
+      {
+        id: "complete",
+        label: "Complete Setup",
+        description:
+          "Mark setup complete and dismiss the wizard. Persists via the same " +
+          "`complete_setup` Tauri command the user-driven 'Finish' button uses.",
+        handler: async () => {
+          await finishSetup();
+          return { success: true };
+        },
+      },
+      {
+        id: "go-to-step",
+        label: "Jump to Step",
+        description:
+          "Set the wizard's current step. Values 0-6 correspond to: " +
+          "Tier, Welcome, Projects, Processes, Dev Services, AI Provider, Claude Sessions.",
+        paramSchema: { step: "number (0-6)" },
+        handler: (params?: unknown) => {
+          const { step } = (params ?? {}) as { step?: number };
+          if (typeof step !== "number" || step < 0 || step >= STEPS.length) {
+            throw new Error(
+              `go-to-step requires { step: number } where 0 <= step < ${STEPS.length}`,
+            );
+          }
+          setCurrentStep(step);
+          return { success: true, step };
+        },
+      },
+    ],
+  });
 
   return (
     <div className="min-h-screen bg-background grid-dots flex flex-col items-center justify-center p-4">

--- a/src/components/terminal/CommandBar.tsx
+++ b/src/components/terminal/CommandBar.tsx
@@ -1,0 +1,559 @@
+/**
+ * Phase 2 — CommandBar v1.
+ *
+ * Bottom-pinned slash-command input. Tier-1 resolver only (slash +
+ * fuzzy); no AI tier. The 10 actions registered by `useTerminalCommands`
+ * drive every match shown here, so adding a future action is a single
+ * `useCommandAction` call — no edits in this component.
+ *
+ * Behavior contracted by the audit (`commands/audit.md` §"Per-action
+ * success criterion checks"):
+ *
+ *   - **Empty input + focus** drops a fuzzy palette under the input,
+ *     sorted by recency. Common case = zero keystrokes past focus +
+ *     arrow + Enter.
+ *   - **`Ctrl+/`** focuses the bar from anywhere on the page. Listener
+ *     is attached with `capture: true` so xterm's textarea (which
+ *     captures most Ctrl-chords for the PTY) doesn't swallow it.
+ *   - **Tab** completes the selected suggestion's slash form into the
+ *     input (`/sp` → `/spawn-ai `), leaving the cursor at the arg
+ *     position.
+ *   - **Enter** parses args from the input and executes the selected
+ *     action. Result feedback goes into a 3s status line just above
+ *     the bar; recents are updated on success.
+ *   - **Escape** clears + blurs.
+ *   - **Rotating placeholder** cycles example slash commands every 8s
+ *     when the input is empty (passive learning surface per redesign
+ *     plan §3 item 3).
+ *
+ * Mounts via `TerminalPage.tsx` next to the existing overlays
+ * (`MidSessionToast`, `HoldingLockBanner`) — same `absolute`
+ * positioning convention.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+
+import { instanceStorage } from "@/lib/instance-storage";
+
+import {
+  type CommandAction,
+  type CommandResult,
+  type InterpretMatch,
+  getAll,
+  interpretCommand,
+  matchPattern,
+  parseArgs,
+  resolve,
+  subscribe,
+} from "./commands";
+
+const RECENTS_STORAGE_KEY = "terminal-command-bar-recents";
+const MAX_RECENTS = 6;
+const STATUS_AUTO_CLEAR_MS = 3000;
+const PLACEHOLDER_ROTATE_MS = 8000;
+
+// Tier-3 (claude subprocess) debounce + gating. The subprocess takes
+// ~1.5-3s; we don't want to fire it on every keystroke. 600ms is long
+// enough to let the operator finish typing a phrase, short enough that
+// they don't feel a lag after they stop.
+const TIER3_DEBOUNCE_MS = 600;
+// Minimum normalized-query length that's "meaningful enough" to spend a
+// subprocess call on. Below this, Tier-1 fuzzy carries the response.
+const TIER3_MIN_CHARS = 3;
+
+const PLACEHOLDER_EXAMPLES = [
+  "/spawn-ai 3 best",
+  "/spawn 2",
+  "/layout six-pack",
+  "/focus needs-input",
+  "/swap 1 3",
+];
+
+interface StatusLine {
+  kind: "ok" | "error";
+  text: string;
+}
+
+/** Subscribe to the registry via useSyncExternalStore so the suggestion
+ *  list rebuilds when `useTerminalCommands` registers / unregisters. */
+function useRegistrySnapshot(): readonly CommandAction[] {
+  return useSyncExternalStore(subscribe, getAll);
+}
+
+function useRotatingPlaceholder(): string {
+  const [idx, setIdx] = useState(0);
+  useEffect(() => {
+    const id = setInterval(
+      () => setIdx((i) => (i + 1) % PLACEHOLDER_EXAMPLES.length),
+      PLACEHOLDER_ROTATE_MS,
+    );
+    return () => clearInterval(id);
+  }, []);
+  return `Press / or try: ${PLACEHOLDER_EXAMPLES[idx]}`;
+}
+
+export function CommandBar() {
+  const [query, setQuery] = useState("");
+  const [focused, setFocused] = useState(false);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [status, setStatus] = useState<StatusLine | null>(null);
+  const [recents, setRecents] = useState<string[]>(() =>
+    instanceStorage.getJSON<string[]>(RECENTS_STORAGE_KEY, []),
+  );
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const blurTimerRef = useRef<number | null>(null);
+  const statusTimerRef = useRef<number | null>(null);
+
+  // Tier-3 state — async AI resolution result + in-flight indicator.
+  // Lives outside the synchronous `matches` useMemo because the
+  // subprocess call is debounced + async, not a pure function of query.
+  const [tier3Match, setTier3Match] = useState<InterpretMatch | null>(null);
+  const [interpreting, setInterpreting] = useState(false);
+
+  // Re-render when actions register / unregister.
+  useRegistrySnapshot();
+  const placeholder = useRotatingPlaceholder();
+
+  // ── Ctrl+/ → focus the input. Capture-phase so xterm's textarea (which
+  //    intercepts most Ctrl-letter chords for PTY input) doesn't swallow
+  //    it; preventDefault + stopPropagation block the default
+  //    "control-_" character from reaching the focused terminal.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && !e.shiftKey && !e.altKey && e.key === "/") {
+        e.preventDefault();
+        e.stopPropagation();
+        inputRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handler, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", handler, { capture: true });
+    };
+  }, []);
+
+  // ── Auto-clear the status line.
+  useEffect(() => {
+    if (!status) return;
+    if (statusTimerRef.current !== null) {
+      window.clearTimeout(statusTimerRef.current);
+    }
+    statusTimerRef.current = window.setTimeout(() => {
+      setStatus(null);
+      statusTimerRef.current = null;
+    }, STATUS_AUTO_CLEAR_MS);
+    return () => {
+      if (statusTimerRef.current !== null) {
+        window.clearTimeout(statusTimerRef.current);
+        statusTimerRef.current = null;
+      }
+    };
+  }, [status]);
+
+  // Match list — Tier 3 (AI), then Tier 2 (regex patterns), then Tier 1
+  // (exact slash / fuzzy). Higher tiers WIN because shape-aware routing
+  // beats verb-only routing: Tier-1's exact `/spawn` hit would let
+  // parseArgs mis-bind `count` to "3 best" via the free-form catch-all,
+  // and Tier-3's free-text understanding routes phrasings neither
+  // tier-1 nor tier-2 can catch. When a higher tier hits, its action is
+  // filtered out of the lower tiers so the dropdown doesn't show the
+  // same row twice. Pre-parsed args from the higher tier (regex named
+  // groups for Tier-2, model output for Tier-3) ride on the match as
+  // `presetArgs` so `execute` can skip `parseArgs` and use them
+  // directly.
+  const matches = useMemo(() => {
+    type LocalMatch = {
+      action: CommandAction;
+      exact: boolean;
+      recent: boolean;
+      indices: number[];
+      /** Pre-extracted args from Tier-2 / Tier-3. Bypasses parseArgs. */
+      presetArgs?: Record<string, unknown>;
+      /** Source tier — surfaces in the dropdown so operators can
+       *  sanity-check the AI hit before pressing Enter. */
+      tier?: "ai";
+      /** Model self-confidence for Tier-3 entries. */
+      confidence?: number;
+    };
+    const tier2 = matchPattern(query);
+    const tier1 = resolve(query, recents);
+    const tier3 = tier3Match;
+
+    const headMatch: LocalMatch | null = tier3
+      ? {
+          action: tier3.action,
+          exact: true,
+          recent: recents.includes(tier3.action.id),
+          indices: [],
+          presetArgs: tier3.args,
+          tier: "ai",
+          confidence: tier3.confidence,
+        }
+      : tier2
+        ? {
+            action: tier2.action,
+            exact: true,
+            recent: recents.includes(tier2.action.id),
+            indices: [],
+            presetArgs: tier2.args,
+          }
+        : null;
+
+    if (!headMatch) return tier1 as LocalMatch[];
+
+    // Filter the lower tier(s) so the dropdown shows the head match
+    // once, not twice. Cast the spread to `LocalMatch[]` so the
+    // optional `tier` / `confidence` fields are reachable downstream.
+    return [
+      headMatch,
+      ...(tier1.filter((m) => m.action.id !== headMatch.action.id) as LocalMatch[]),
+    ];
+  }, [query, recents, tier3Match]);
+
+  // ── Tier-3 debounced fire ──────────────────────────────────────────
+  // After the operator stops typing for TIER3_DEBOUNCE_MS, if Tier-1/2
+  // didn't produce an exact match AND the input is long enough to be
+  // meaningful, fire the claude subprocess. Result lands in
+  // `tier3Match` and prepends to the dropdown above.
+  useEffect(() => {
+    const trimmed = query.trim();
+    // Clear any previous result whenever the query changes — operator
+    // is mid-typing or starting over, the prior Tier-3 hit no longer
+    // applies.
+    setTier3Match(null);
+
+    if (trimmed.length < TIER3_MIN_CHARS) {
+      setInterpreting(false);
+      return;
+    }
+    // Skip if Tier-1 / Tier-2 already nailed it — Tier-3 would burn a
+    // subprocess on a query that's already resolved.
+    const tier1Exact = resolve(query, recents).find((m) => m.exact);
+    if (tier1Exact || matchPattern(query)) {
+      setInterpreting(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(async () => {
+      setInterpreting(true);
+      try {
+        const result = await interpretCommand(query, { signal: controller.signal });
+        if (!controller.signal.aborted) {
+          setTier3Match(result);
+        }
+      } finally {
+        if (!controller.signal.aborted) setInterpreting(false);
+      }
+    }, TIER3_DEBOUNCE_MS);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timer);
+      setInterpreting(false);
+    };
+  }, [query, recents]);
+
+  // Keep the selection in range when the match list shrinks.
+  useEffect(() => {
+    if (selectedIdx >= matches.length) {
+      setSelectedIdx(0);
+    }
+  }, [matches.length, selectedIdx]);
+
+  const selectedMatch = matches[selectedIdx];
+
+  const persistRecent = useCallback(
+    (id: string) => {
+      setRecents((prev) => {
+        const next = [id, ...prev.filter((x) => x !== id)].slice(0, MAX_RECENTS);
+        instanceStorage.setJSON(RECENTS_STORAGE_KEY, next);
+        return next;
+      });
+    },
+    [setRecents],
+  );
+
+  const execute = useCallback(
+    async (
+      action: CommandAction,
+      rawInput: string,
+      presetArgs?: Record<string, unknown>,
+      tier?: "ai",
+    ) => {
+      // Tier-2 / Tier-3 hits arrive with args already extracted (regex
+      // named groups for Tier-2, model output for Tier-3); use them
+      // verbatim rather than re-parsing positionally (positional parse
+      // on "spawn 3 best" against /spawn's 1-field schema would silently
+      // mis-bind).
+      const args = presetArgs ?? parseArgs(rawInput, action);
+      let result: CommandResult;
+      try {
+        result = await action.handler(args, {
+          source: tier === "ai" ? "ai" : "slash",
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setStatus({ kind: "error", text: `${action.slash}: ${message}` });
+        return;
+      }
+      if (result.ok) {
+        persistRecent(action.id);
+        // Result.value may be `undefined` (action just ran) — render the
+        // slash itself so the operator gets the "yes, that happened"
+        // confirmation regardless of return shape.
+        setStatus({
+          kind: "ok",
+          text: `${action.slash} ✓`,
+        });
+        setQuery("");
+        setSelectedIdx(0);
+        inputRef.current?.blur();
+      } else {
+        setStatus({
+          kind: "error",
+          text: `${action.slash}: ${result.message ?? result.code}`,
+        });
+      }
+    },
+    [persistRecent],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.min(i + 1, Math.max(0, matches.length - 1)));
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIdx((i) => Math.max(0, i - 1));
+        return;
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        if (selectedMatch) {
+          // If the input already starts with the slash, keep what's
+          // past it (user is mid-arg-edit). Otherwise replace the
+          // input with the slash + trailing space so the cursor is at
+          // the arg position.
+          const slash = selectedMatch.action.slash;
+          if (query.trim().startsWith(slash)) {
+            const argsTail = query.replace(slash, "").trimStart();
+            setQuery(`${slash} ${argsTail}`);
+          } else {
+            setQuery(`${slash} `);
+          }
+        }
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (selectedMatch) {
+          void execute(
+            selectedMatch.action,
+            query,
+            selectedMatch.presetArgs,
+            selectedMatch.tier,
+          );
+        }
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setQuery("");
+        setSelectedIdx(0);
+        inputRef.current?.blur();
+        return;
+      }
+    },
+    [matches.length, query, selectedMatch, execute],
+  );
+
+  const handleSuggestionClick = useCallback(
+    (
+      action: CommandAction,
+      idx: number,
+      presetArgs?: Record<string, unknown>,
+      tier?: "ai",
+    ) => {
+      // If the user clicks an action that takes args and they haven't typed
+      // any AND we didn't pattern-match preset args, populate the input
+      // rather than executing — they probably wanted to fill in the args.
+      const hasArgs = action.paramSchema && Object.keys(action.paramSchema).length > 0;
+      const argsTyped = query.trim().length > action.slash.length;
+      if (hasArgs && !argsTyped && !presetArgs) {
+        setQuery(`${action.slash} `);
+        setSelectedIdx(idx);
+        inputRef.current?.focus();
+        return;
+      }
+      void execute(action, query.trim().length > 0 ? query : action.slash, presetArgs, tier);
+    },
+    [execute, query],
+  );
+
+  // Delay the blur-driven dropdown hide so click events on suggestions
+  // fire before the dropdown unmounts. Standard fuzzy-finder pattern.
+  const handleBlur = useCallback(() => {
+    if (blurTimerRef.current !== null) {
+      window.clearTimeout(blurTimerRef.current);
+    }
+    blurTimerRef.current = window.setTimeout(() => {
+      setFocused(false);
+      blurTimerRef.current = null;
+    }, 120);
+  }, []);
+
+  const handleFocus = useCallback(() => {
+    if (blurTimerRef.current !== null) {
+      window.clearTimeout(blurTimerRef.current);
+      blurTimerRef.current = null;
+    }
+    setFocused(true);
+  }, []);
+
+  const dropdownVisible = focused && matches.length >= 0;
+
+  return (
+    <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-40 w-[420px] pointer-events-none">
+      {/* Status line — sits above the input, visible briefly after execute. */}
+      {status && !focused && (
+        <div className="mb-1 px-2 py-1 text-[10px] rounded bg-[#1a1b26]/90 border border-[#2a2d3d]/60 backdrop-blur-sm pointer-events-auto">
+          <span
+            className={
+              status.kind === "ok"
+                ? "text-[#9ece6a] font-mono"
+                : "text-[#f7768e] font-mono"
+            }
+          >
+            {status.text}
+          </span>
+        </div>
+      )}
+
+      {/* Suggestion dropdown — drops UPWARD above the input since the
+          input is bottom-pinned. Only renders when focused. */}
+      {dropdownVisible && (
+        <div className="mb-1 bg-[#1a1b26]/95 border border-[#2a2d3d] rounded-md shadow-xl backdrop-blur-sm overflow-hidden pointer-events-auto">
+          {/* Preview row — only shown when there's an exact match (operator
+              has past the disambiguation point). For Tier-3 matches the
+              row also surfaces the confidence so operators can sanity-
+              check the AI's choice before pressing Enter. */}
+          {selectedMatch?.exact && (
+            <div className="px-3 py-1.5 border-b border-[#2a2d3d]/50 flex items-baseline gap-2 text-[11px]">
+              <span className="text-[#9ece6a]">⏎</span>
+              <span className="text-[#c0caf5] font-mono truncate">
+                {query.trim().length > 0 ? query.trim() : selectedMatch.action.slash}
+              </span>
+              {selectedMatch.tier === "ai" && selectedMatch.confidence !== undefined && (
+                <span
+                  className="text-[9px] font-mono px-1 rounded bg-[#bb9af7]/15 text-[#bb9af7] shrink-0"
+                  title={`AI Tier-3 match — model confidence ${Math.round(
+                    selectedMatch.confidence * 100,
+                  )}%`}
+                >
+                  AI {Math.round(selectedMatch.confidence * 100)}%
+                </span>
+              )}
+              <span className="text-[#565f89] ml-auto shrink-0">
+                {selectedMatch.action.label}
+              </span>
+            </div>
+          )}
+
+          {/* Tier-3 in-flight indicator. Sits above the match list so
+              the dropdown shifts predictably as state changes. */}
+          {interpreting && (
+            <div
+              className="px-3 py-1 border-b border-[#2a2d3d]/50 flex items-center gap-2 text-[10px] text-[#bb9af7]"
+              data-page-element="status-indicator"
+              data-indicator="tier3-interpreting"
+            >
+              <span className="w-2 h-2 border-2 border-[#bb9af7] border-t-transparent rounded-full animate-spin" />
+              Interpreting…
+              <span className="ml-auto text-[#565f89]">Esc to cancel</span>
+            </div>
+          )}
+
+          {/* Match list */}
+          {matches.length === 0 ? (
+            <div className="px-3 py-2 text-[11px] text-[#565f89]">
+              No match — press{" "}
+              <span className="font-mono text-[#a9b1d6]">Ctrl+Shift+K</span> to browse.
+            </div>
+          ) : (
+            matches.map((m, idx) => (
+              <button
+                key={m.action.id}
+                type="button"
+                onMouseDown={(e) => e.preventDefault() /* keep input focus */}
+                onClick={() => handleSuggestionClick(m.action, idx, m.presetArgs, m.tier)}
+                onMouseEnter={() => setSelectedIdx(idx)}
+                className={`w-full flex items-center gap-2 px-3 py-1 text-[11px] text-left transition-colors ${
+                  idx === selectedIdx
+                    ? "bg-[#7aa2f7]/10 text-[#c0caf5]"
+                    : "text-[#a9b1d6] hover:bg-[#2a2d3d]/50"
+                }`}
+              >
+                <span className="font-mono text-[#7aa2f7] shrink-0 w-24 truncate">
+                  {m.action.slash}
+                </span>
+                <span className="text-[#565f89] truncate flex-1">{m.action.label}</span>
+                {m.tier === "ai" && (
+                  <span
+                    className="ml-auto text-[8px] font-mono uppercase tracking-wider shrink-0 text-[#bb9af7]"
+                    title={
+                      m.confidence !== undefined
+                        ? `Tier-3 AI match — confidence ${Math.round(m.confidence * 100)}%`
+                        : "Tier-3 AI match"
+                    }
+                  >
+                    AI{m.confidence !== undefined ? ` ${Math.round(m.confidence * 100)}%` : ""}
+                  </span>
+                )}
+                {m.recent && m.tier !== "ai" && (
+                  <span className="ml-auto text-[8px] text-[#bb9af7] uppercase tracking-wider shrink-0">
+                    recent
+                  </span>
+                )}
+              </button>
+            ))
+          )}
+        </div>
+      )}
+
+      {/* The bar itself — bottom strip, 28px tall. */}
+      <div
+        className={`h-7 flex items-center gap-2 px-3 border rounded-md backdrop-blur-sm transition-colors pointer-events-auto ${
+          focused
+            ? "bg-[#13141f]/95 border-[#7aa2f7]/60"
+            : "bg-[#13141f]/70 border-[#2a2d3d]"
+        }`}
+      >
+        <span className="text-[10px] text-[#565f89] font-mono select-none">›</span>
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          className="flex-1 bg-transparent outline-hidden text-[11px] text-[#c0caf5] placeholder-[#565f89]/70"
+        />
+        <span
+          className="text-[9px] text-[#565f89] font-mono select-none"
+          title="Press Ctrl+/ to focus this bar from anywhere on the page"
+        >
+          Ctrl+/
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/CommandPalette.tsx
+++ b/src/components/terminal/CommandPalette.tsx
@@ -1,61 +1,15 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, useSyncExternalStore } from "react";
 import type { ReactNode } from "react";
 import { instanceStorage } from "@/lib/instance-storage";
 import { Search } from "lucide-react";
 import type { SessionState, ZoneAssignments } from "./useZoneLayout";
 import type { TerminalTab } from "./useTerminalManager";
-
-/* ── Fuzzy match scoring ─────────────────────────────────────────────── */
-
-function fuzzyScore(text: string, query: string): { score: number; indices: number[] } | null {
-  const lower = text.toLowerCase();
-  const q = query.toLowerCase();
-
-  // Exact prefix match — highest score
-  if (lower.startsWith(q)) {
-    return {
-      score: 100 + q.length,
-      indices: Array.from({ length: q.length }, (_, i) => i),
-    };
-  }
-
-  // Word boundary match
-  const words = lower.split(/[\s\-_:]/);
-  let wordStart = 0;
-  const wordBoundaryIndices: number[] = [];
-  let qi = 0;
-  for (const word of words) {
-    if (qi < q.length && word.startsWith(q[qi])) {
-      for (let wi = 0; wi < word.length && qi < q.length; wi++) {
-        if (word[wi] === q[qi]) {
-          wordBoundaryIndices.push(wordStart + wi);
-          qi++;
-        }
-      }
-    }
-    wordStart += word.length + 1;
-  }
-  if (qi === q.length) {
-    return { score: 70 + q.length, indices: wordBoundaryIndices };
-  }
-
-  // Sequential character match (fuzzy)
-  const indices: number[] = [];
-  let si = 0;
-  for (let i = 0; i < lower.length && si < q.length; i++) {
-    if (lower[i] === q[si]) {
-      indices.push(i);
-      si++;
-    }
-  }
-  if (si === q.length) {
-    const spread = indices[indices.length - 1] - indices[0];
-    const compactness = Math.max(0, 50 - spread);
-    return { score: 30 + compactness, indices };
-  }
-
-  return null;
-}
+import { fuzzyScore } from "./commands/fuzzy";
+import {
+  getAll as getRegistrySnapshot,
+  getRegistryPaletteActions,
+  subscribe as subscribeToRegistry,
+} from "./commands";
 
 function renderHighlightedLabel(label: string, indices: number[]): ReactNode {
   if (indices.length === 0) return label;
@@ -150,9 +104,30 @@ export function CommandPalette({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
+  // Phase 7 — subscribe to the command registry so a new
+  // `useCommandAction` registration appears in the palette without a
+  // re-mount. Snapshot identity is stable between mutations, so this is
+  // cheap re-key for the useMemo below.
+  const registrySnapshot = useSyncExternalStore(
+    subscribeToRegistry,
+    getRegistrySnapshot,
+  );
+
   // Build action list
   const actions = useMemo(() => {
     const list: PaletteAction[] = [];
+
+    // Phase 7 — prepend every registry action as a discoverability row.
+    // Categorised under "Commands" so the palette's existing
+    // category-tinted grouping treats them as a distinct block at the
+    // top of the list. Their `priority: 0` lands them just below the
+    // (deduped) `approve-all` and above the per-zone enumerations.
+    for (const row of getRegistryPaletteActions()) {
+      list.push(row as PaletteAction);
+    }
+    // Capture which registry slashes we've already projected so the
+    // hard-coded equivalents (`approve-all`, etc.) below can dedupe.
+    const projectedSlashes = new Set(registrySnapshot.map((a) => a.slash));
 
     // Per-zone actions
     for (let z = 0; z < zoneCount; z++) {
@@ -247,7 +222,13 @@ export function CommandPalette({
 
     // Global actions
     const needsInputCount = Object.values(sessionStates).filter((s) => s === "needs-input").length;
-    if (needsInputCount > 0) {
+    // Phase 7 dedupe — only render the hard-coded `approve-all` row
+    // when the registry hasn't already projected its equivalent. This
+    // is the one "delete the duplicated construction" beat from the
+    // plan that actually applies; the per-zone focus / restart loops
+    // below stay because they carry per-tab titles the registry's
+    // abstract `/focus N` row can't reproduce.
+    if (needsInputCount > 0 && !projectedSlashes.has("/approve-all")) {
       list.push({
         id: "approve-all",
         label: `Approve all (${needsInputCount} waiting)`,
@@ -367,6 +348,7 @@ export function CommandPalette({
 
     return list.sort((a, b) => a.priority - b.priority);
   }, [
+    registrySnapshot, // Phase 7 — re-run projection when actions register/unregister
     tabs,
     assignments,
     sessionStates,

--- a/src/components/terminal/StatusStrip.tsx
+++ b/src/components/terminal/StatusStrip.tsx
@@ -1,0 +1,335 @@
+/**
+ * Phase 6 — Top status strip.
+ *
+ * Thin 24px top-pinned strip that surfaces *only* the conditions
+ * requiring attention. Auto-hides entirely when every pill is at zero
+ * (`return null`) so the top of the viewport is clean by default —
+ * matches the plan's invisible-chrome principle.
+ *
+ * Pills shipped in this phase (all read from existing contexts; no new
+ * state machines):
+ *
+ *   - **N need input · Tab to cycle** — clickable, focuses the next
+ *     needs-input zone via `zoneLayout.focusNextNeedsInput`.
+ *   - **N stuck on lock Xm** — count + max age of `kind:"waiting"`
+ *     entries in `fileLockStates`. Clicking focuses the longest-stuck
+ *     waiter's zone.
+ *   - **N errors** — clickable, cycles to the next errored zone (an
+ *     inline mirror of `focusNextNeedsInput`'s walk for `state ==="error"`,
+ *     since `useZoneLayout` doesn't expose a dedicated cycler).
+ *   - **N wrapper tools** — read from `useWrapperTools`; informational
+ *     count (no click target until the registry grows a wrappers-page
+ *     action). Hides at zero — same self-hide rule the existing
+ *     `WrapperToolsBadge` uses.
+ *
+ * Deferred from the plan's pill list:
+ *
+ *   - **Profile pill** — active-profile name lives as private React
+ *     state inside `ZoneProfilePicker` (line 109) and is only
+ *     reachable via an `invoke("setting_get")` round-trip. Surfacing
+ *     it here would mean either lifting the state into a context
+ *     (cross-cutting, out of Phase-6 scope) or duplicating the fetch
+ *     (drift risk). Skip until the profile state is lifted.
+ *
+ * The existing `WrapperToolsBadge` inside `TerminalTabBar` stays in
+ * place during this phase — the plan's "replaces `WrapperToolsBadge`"
+ * note belongs to Phase 9 demolition. Operators see both during the
+ * transition.
+ *
+ * 1Hz heartbeat drives the "Xm" duration text so the value advances
+ * without external state changes (mirrors `useNow1Hz` from
+ * `TerminalTabBar`'s lock-tooltip plumbing; kept local here to avoid
+ * an import cycle through the tab bar's deep dependency chain).
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AlertOctagon, Lock, Package, RefreshCw, Sparkles } from "lucide-react";
+
+import { useTerminalSession } from "./contexts";
+import { useWrapperTools } from "@/hooks/useWrapperTools";
+
+const HEARTBEAT_MS = 1_000;
+
+function formatAge(ms: number): string {
+  const sec = Math.max(0, Math.floor(ms / 1000));
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3_600) return `${Math.floor(sec / 60)}m`;
+  return `${Math.floor(sec / 3_600)}h`;
+}
+
+interface PillProps {
+  icon: React.ReactNode;
+  text: string;
+  color: string;
+  /** When defined, the pill renders as a `<button>` (clickable) and
+   *  fires the callback. Otherwise informational — renders as a span. */
+  onClick?: () => void;
+  title?: string;
+}
+
+function Pill({ icon, text, color, onClick, title }: PillProps) {
+  const baseClass =
+    "flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium leading-none whitespace-nowrap";
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`${baseClass} hover:bg-white/5 transition-colors`}
+        style={{ color }}
+        title={title}
+      >
+        {icon}
+        <span>{text}</span>
+      </button>
+    );
+  }
+  return (
+    <span className={baseClass} style={{ color }} title={title}>
+      {icon}
+      <span>{text}</span>
+    </span>
+  );
+}
+
+export function StatusStrip() {
+  const session = useTerminalSession();
+  const { tabs, sessionStates, fileLockStates, zoneLayout } = session;
+  const {
+    tools: wrapperTools,
+    routes: wrapperRoutes,
+    loading: wrapperLoading,
+    error: wrapperError,
+    refresh: refreshWrapperTools,
+  } = useWrapperTools();
+
+  // Phase 9a — the WrapperToolsBadge popover folded into this pill so
+  // operators see one wrapper-tools surface, not two. State + outside-
+  // click dismiss mirror the original badge in
+  // `components/wrappers/WrapperToolsBadge.tsx`.
+  const [showWrapperPopover, setShowWrapperPopover] = useState(false);
+  const wrapperPopoverRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!showWrapperPopover) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        wrapperPopoverRef.current &&
+        !wrapperPopoverRef.current.contains(e.target as Node)
+      ) {
+        setShowWrapperPopover(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showWrapperPopover]);
+
+  // 1Hz heartbeat so the "Xm" duration text advances. Stops nothing —
+  // the strip auto-hides when there's nothing to show, so the interval
+  // only burns cycles while something requires attention.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), HEARTBEAT_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // Counts + derived signals. Reused across the pill list AND the
+  // outer auto-hide gate.
+  const { needsInputCount, errorCount, stuckLocks, maxStuckMs, longestStuckTabId } = useMemo(() => {
+    let needsInput = 0;
+    let errors = 0;
+    for (const tab of tabs) {
+      const state = sessionStates[tab.id];
+      if (state === "needs-input") needsInput++;
+      else if (state === "error") errors++;
+    }
+    let stuck = 0;
+    let maxMs = 0;
+    let longestTabId: string | null = null;
+    const now = Date.now();
+    for (const [tabId, lockState] of Object.entries(fileLockStates ?? {})) {
+      if (lockState.kind !== "waiting") continue;
+      stuck++;
+      const since = lockState.sinceMs;
+      if (typeof since === "number") {
+        const elapsed = now - since;
+        if (elapsed > maxMs) {
+          maxMs = elapsed;
+          longestTabId = tabId;
+        }
+      }
+    }
+    return {
+      needsInputCount: needsInput,
+      errorCount: errors,
+      stuckLocks: stuck,
+      maxStuckMs: maxMs,
+      longestStuckTabId: longestTabId,
+    };
+    // The tick covers cadence-driven re-eval for the maxStuckMs reading;
+    // tabs / sessionStates / fileLockStates cover state-driven re-eval.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabs, sessionStates, fileLockStates]);
+
+  const wrapperCount = wrapperTools.length;
+
+  // Auto-hide gate — when nothing requires attention, the strip
+  // disappears entirely so the top of viewport is fully clean.
+  const hasContent =
+    needsInputCount > 0 || errorCount > 0 || stuckLocks > 0 || wrapperCount > 0;
+
+  const focusNextError = useCallback(() => {
+    // Inline mirror of `useZoneLayout.focusNextNeedsInput`'s walk,
+    // looking for `error` instead. Cycles starting at `focusedZone + 1`
+    // and wraps around. Un-maximizes on hit so the operator can see
+    // the zone (same posture as the needs-input cycler).
+    const zones = zoneLayout.layout.zones.length;
+    const start = zoneLayout.focusedZone;
+    for (let i = 1; i <= zones; i++) {
+      const candidate = (start + i) % zones;
+      const tabId = zoneLayout.assignments[candidate];
+      if (tabId && sessionStates[tabId] === "error") {
+        zoneLayout.setFocusedZone(candidate);
+        if (zoneLayout.maximizedZone !== null) zoneLayout.setMaximizedZone(null);
+        return;
+      }
+    }
+  }, [zoneLayout, sessionStates]);
+
+  const focusLongestStuck = useCallback(() => {
+    if (!longestStuckTabId) return;
+    // Locate the zone holding the longest-stuck tab.
+    for (const [zoneStr, tabId] of Object.entries(zoneLayout.assignments)) {
+      if (tabId === longestStuckTabId) {
+        zoneLayout.setFocusedZone(Number(zoneStr));
+        if (zoneLayout.maximizedZone !== null) zoneLayout.setMaximizedZone(null);
+        return;
+      }
+    }
+  }, [longestStuckTabId, zoneLayout]);
+
+  const focusNextNeedsInput = useCallback(() => {
+    zoneLayout.focusNextNeedsInput(sessionStates);
+  }, [zoneLayout, sessionStates]);
+
+  if (!hasContent) return null;
+
+  return (
+    <div
+      data-page-element="status-strip"
+      className="flex items-center gap-1.5 px-2 h-6 bg-[#13141f]/40 backdrop-blur-sm border-b border-[#2a2d3d]/20 shrink-0"
+      role="status"
+      aria-label="Terminal page status"
+    >
+      {needsInputCount > 0 && (
+        <Pill
+          icon={
+            <span className="w-1.5 h-1.5 rounded-full bg-[#e0af68] animate-pulse" aria-hidden />
+          }
+          text={`${needsInputCount} need input · Tab to cycle`}
+          color="#e0af68"
+          onClick={focusNextNeedsInput}
+          title="Click here or press Ctrl+Shift+N to focus the next session waiting on input"
+        />
+      )}
+      {errorCount > 0 && (
+        <Pill
+          icon={<AlertOctagon className="w-2.5 h-2.5" />}
+          text={`${errorCount} error${errorCount === 1 ? "" : "s"}`}
+          color="#f7768e"
+          onClick={focusNextError}
+          title="Focus the next errored session"
+        />
+      )}
+      {stuckLocks > 0 && (
+        <Pill
+          icon={<Lock className="w-2.5 h-2.5" />}
+          text={`${stuckLocks} stuck on lock${maxStuckMs > 0 ? ` ${formatAge(maxStuckMs)}` : ""}`}
+          color="#ff9e64"
+          onClick={focusLongestStuck}
+          title={`Focus the session waiting longest on a file lock${
+            maxStuckMs > 0 ? ` (currently ${formatAge(maxStuckMs)})` : ""
+          }`}
+        />
+      )}
+      {wrapperCount > 0 && (
+        <div className="relative" ref={wrapperPopoverRef}>
+          <Pill
+            icon={<Package className="w-2.5 h-2.5" />}
+            text={`${wrapperCount} wrapper tool${wrapperCount === 1 ? "" : "s"}`}
+            color="#7aa2f7"
+            onClick={() => setShowWrapperPopover((v) => !v)}
+            title={`${wrapperCount} wrapper tool${
+              wrapperCount === 1 ? " is" : "s are"
+            } available to AI agents this session — click to view`}
+          />
+          {showWrapperPopover && (
+            <div
+              role="dialog"
+              aria-label="Wrapper tools available"
+              className="absolute left-0 top-full mt-1 w-96 max-w-[90vw] bg-[#1a1b26] border border-[#2a2d3d] rounded-lg shadow-xl z-50 overflow-hidden"
+            >
+              <div className="flex items-center justify-between px-3 py-2 border-b border-[#2a2d3d]">
+                <span className="text-[10px] uppercase tracking-wider text-[#565f89]">
+                  Wrapper tools ({wrapperCount})
+                </span>
+                <button
+                  type="button"
+                  onClick={() => void refreshWrapperTools()}
+                  disabled={wrapperLoading}
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] text-[#565f89] hover:text-[#7aa2f7] hover:bg-[#7aa2f7]/10 transition-colors disabled:opacity-50"
+                  title="Refresh wrapper tool list"
+                >
+                  <RefreshCw className={`w-3 h-3 ${wrapperLoading ? "animate-spin" : ""}`} />
+                  Refresh
+                </button>
+              </div>
+              {wrapperError ? (
+                <div className="px-3 py-3 text-[11px] text-[#f7768e]">
+                  Failed to load wrappers: {wrapperError}
+                </div>
+              ) : (
+                <div className="max-h-64 overflow-y-auto scrollbar-dark">
+                  {wrapperTools.map((tool) => {
+                    const route = wrapperRoutes.get(tool.name);
+                    const wrapperName =
+                      route?.wrapper.manifest?.displayName ?? route?.wrapper.id ?? "unknown";
+                    return (
+                      <div
+                        key={tool.name}
+                        className="px-3 py-2 border-b border-[#2a2d3d]/50 last:border-b-0 hover:bg-[#2a2d3d]/30"
+                        title={`${wrapperName} — ${tool.description}`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <span className="text-[11px] font-mono text-[#7aa2f7] truncate">
+                            {tool.name}
+                          </span>
+                          <span className="text-[9px] text-[#565f89] shrink-0">
+                            {wrapperName}
+                          </span>
+                        </div>
+                        {tool.description && (
+                          <p className="text-[10px] text-[#a9b1d6] mt-0.5 line-clamp-2">
+                            {tool.description}
+                          </p>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+              <div className="px-3 py-1.5 text-[9px] text-[#565f89] bg-[#13141f] border-t border-[#2a2d3d]">
+                Tools auto-injected on session start. Restart sessions to pick up newly-installed
+                wrappers, or click Refresh.
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+      {/* Trailing decorative spark so the strip's "something present"
+          state is visually distinct from a stray border-bottom on a
+          blank row, while staying subtle. Aria-hidden — it's purely
+          decorative. */}
+      <Sparkles className="w-2.5 h-2.5 text-[#565f89]/40 ml-auto" aria-hidden />
+    </div>
+  );
+}

--- a/src/components/terminal/StatusStrip.tsx
+++ b/src/components/terminal/StatusStrip.tsx
@@ -167,7 +167,6 @@ export function StatusStrip() {
     };
     // The tick covers cadence-driven re-eval for the maxStuckMs reading;
     // tabs / sessionStates / fileLockStates cover state-driven re-eval.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabs, sessionStates, fileLockStates]);
 
   const wrapperCount = wrapperTools.length;

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -26,8 +26,12 @@ import { ZoneControlPanel } from "./ZoneControlPanel";
 import { OutputSearchBar } from "./OutputSearchBar";
 import { TerminalRightPanel } from "./TerminalRightPanel";
 import { TerminalOverlays } from "./TerminalOverlays";
+import { CommandBar } from "./CommandBar";
+import { SuggestionsProvider } from "./suggestions";
+import { StatusStrip } from "./StatusStrip";
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
+import { callRegistry, useTerminalCommands } from "./commands";
 import { useTerminalInitialization } from "./useTerminalInitialization";
 import { useZoneActions } from "./useZoneActions";
 import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
@@ -62,7 +66,9 @@ export function TerminalPage(props: TerminalPageProps) {
       <ZoneMetadataProvider>
         <TransitionEffectsProvider>
           <UIStateProvider>
-            <TerminalPageInner {...props} />
+            <SuggestionsProvider>
+              <TerminalPageInner {...props} />
+            </SuggestionsProvider>
           </UIStateProvider>
         </TransitionEffectsProvider>
       </ZoneMetadataProvider>
@@ -126,6 +132,161 @@ function TerminalPageInner({
             title: t.title,
             isAlive: Boolean(t.isAlive),
           })),
+      },
+    ],
+  });
+
+  // Phase 9a — hoist the `terminal-launch-menu` UI Bridge registration
+  // out of `TerminalTabBar` so external agents keep getting `create-plain`
+  // / `create-ai-session` / `create-best-account` / `create-with-command`
+  // when the tab bar is eventually removed. Handlers close over the
+  // later-declared `handleQuickLaunch` / `handleLaunchAiSession` — fine
+  // because they only execute at action-invocation time (after the
+  // function body has run through the const declarations).
+  //
+  // The `open` / `close` actions that used to live here are dropped — they
+  // were UI-popover toggles for the LaunchMenu component, not wire
+  // contract. External automation calls the spawn actions directly without
+  // needing the popover open. If a caller surfaces dependence on them,
+  // restore by lifting `showQuickLaunch` state to `TerminalPage` and
+  // threading it down to `TerminalTabBar` as props.
+  useUIComponent({
+    id: "terminal-launch-menu",
+    name: "Terminal Launch Menu",
+    description:
+      "Creates plain terminals and AI sessions. Use create-plain, create-ai-session, " +
+      "create-best-account, or create-with-command to launch terminals programmatically.",
+    actions: [
+      {
+        id: "create-plain",
+        label: "Create Plain Terminal",
+        description: "Spawn N blank terminals using the user's default shell.",
+        paramSchema: { count: "number (>= 1, defaults to 1)" },
+        handler: async (params?: unknown) => {
+          const { count = 1 } = (params ?? {}) as { count?: number };
+          if (typeof count !== "number" || count < 1) {
+            throw new Error("create-plain requires { count: number } where count >= 1");
+          }
+          const tabIds = await callRegistry<string[]>("terminal.spawn", { count });
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: [] as Array<string | null>,
+          };
+        },
+      },
+      {
+        id: "create-ai-session",
+        label: "Create AI Session",
+        description:
+          "Spawn N terminals pre-configured to launch `claude` under the given CLAUDE_CONFIG_DIR, optionally pre-typing a context prompt.",
+        paramSchema: {
+          count: "number (>= 1, defaults to 1)",
+          configDir: "string (absolute path to a Claude Code config dir, required)",
+          context: "string (optional initial prompt auto-typed after claude starts)",
+        },
+        handler: async (params?: unknown) => {
+          const {
+            count = 1,
+            configDir,
+            context,
+          } = (params ?? {}) as {
+            count?: number;
+            configDir?: string;
+            context?: string;
+          };
+          if (!configDir)
+            throw new Error(
+              "create-ai-session requires { count?: number, configDir: string, context?: string }",
+            );
+          if (typeof count !== "number" || count < 1) {
+            throw new Error("create-ai-session: count must be a positive number");
+          }
+          // configDir + the operator's `account` label are different
+          // abstractions; the UI Bridge contract takes raw configDir for
+          // historical reasons. Call the local closure directly rather
+          // than the registry's account-shaped `terminal.spawn-ai`.
+          const tabIds = ((await handleLaunchAiSession(count, configDir, context)) ??
+            []) as string[];
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: tabIds.map(() => null) as Array<string | null>,
+          };
+        },
+      },
+      {
+        id: "create-best-account",
+        label: "Create AI Session with Best Account",
+        description:
+          "Like create-ai-session, but picks the AI account with the lowest current utilization. Fails if no accounts are configured.",
+        paramSchema: {
+          count: "number (>= 1, defaults to 1)",
+          context: "string (optional initial prompt auto-typed after claude starts)",
+        },
+        handler: async (params?: unknown) => {
+          const { count = 1, context } = (params ?? {}) as {
+            count?: number;
+            context?: string;
+          };
+          if (typeof count !== "number" || count < 1) {
+            throw new Error("create-best-account: count must be a positive number");
+          }
+          // Delegate to registry `terminal.spawn-ai` with the literal
+          // `account: "best"`. The registry handler does the lowest-
+          // utilization lookup; we rethrow `no-account` as the original
+          // "No AI accounts available" wording so existing automation
+          // regexes keep matching.
+          let tabIds: string[];
+          try {
+            tabIds = await callRegistry<string[]>("terminal.spawn-ai", {
+              count,
+              account: "best",
+              context,
+            });
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (msg.includes("no-account") || msg.toLowerCase().includes("no matching")) {
+              throw new Error("No AI accounts available");
+            }
+            throw err;
+          }
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: tabIds.map(() => null) as Array<string | null>,
+          };
+        },
+      },
+      {
+        id: "create-with-command",
+        label: "Create Terminal with Command",
+        description:
+          "Spawn N terminals and auto-type the given shell command into each after the prompt renders.",
+        paramSchema: {
+          count: "number (>= 1, defaults to 1)",
+          command: "string (the shell command to type + Enter, required)",
+        },
+        handler: async (params?: unknown) => {
+          const { count = 1, command } = (params ?? {}) as {
+            count?: number;
+            command?: string;
+          };
+          if (!command)
+            throw new Error("create-with-command requires { count?: number, command: string }");
+          if (typeof count !== "number" || count < 1) {
+            throw new Error("create-with-command: count must be a positive number");
+          }
+          const tabIds = await callRegistry<string[]>("terminal.spawn-with", {
+            count,
+            command,
+          });
+          return {
+            success: true,
+            tab_ids: tabIds,
+            task_run_ids: [] as Array<string | null>,
+          };
+        },
       },
     ],
   });
@@ -413,6 +574,85 @@ function TerminalPageInner({
       onTimeout: (id) => console.warn(`[LaunchAI] terminal ref for ${id} never became ready`),
     });
 
+  // Hoisted out of the JSX so the command registry (`useTerminalCommands`
+  // below) can share the exact same spawn closures with `TerminalTabBar`'s
+  // `onQuickLaunch` / `onLaunchAiSession` props. Behavior identical to the
+  // prior inline definitions; no useCallback wrap since the originals
+  // weren't memoized either and downstream consumers don't depend on
+  // stable identity.
+  const handleQuickLaunch = async (count: number, autoCommand?: string): Promise<string[]> => {
+    const totalTabs = tabs.length + count;
+    const layoutId = pickLayout(totalTabs);
+    zoneLayout.setLayoutId(layoutId);
+    const title = autoCommand ? autoCommand.slice(0, 20) : undefined;
+    const createdTabIds: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const tabId = await createAndAssignTerminal(title);
+      if (tabId) createdTabIds.push(tabId);
+    }
+    if (autoCommand && createdTabIds.length > 0) {
+      for (const tabId of createdTabIds) {
+        writeWhenReady(tabId, `${autoCommand}\r`);
+      }
+    }
+    return createdTabIds;
+  };
+
+  const handleLaunchAiSession = async (
+    count: number,
+    configDir: string,
+    context?: string,
+  ): Promise<string[]> => {
+    const totalTabs = tabs.length + count;
+    const layoutId = pickLayout(totalTabs);
+    zoneLayout.setLayoutId(layoutId);
+
+    const isWindows = navigator.platform.startsWith("Win");
+    const customCmd = sessionManager.launchCommands?.[configDir];
+    const cmd = customCmd
+      ? customCmd
+      : isWindows
+        ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude`
+        : `CLAUDE_CONFIG_DIR="${configDir}" claude`;
+    const dirName = configDir.replace(/\\/g, "/").replace(/\/$/, "").split("/").pop() ?? "";
+    const label = customCmd ?? dirName.match(/^\.claude-(.+)$/)?.[1] ?? "claude";
+    const createdTabIds: string[] = [];
+    for (let i = 0; i < count; i++) {
+      const tabId = await createAndAssignTerminal(label);
+      if (tabId) createdTabIds.push(tabId);
+    }
+    if (createdTabIds.length > 0) {
+      const spawnAt = Date.now();
+      for (const tabId of createdTabIds) {
+        writeWhenReady(tabId, `${cmd}\r`);
+        const tab = tabs.find((t) => t.id === tabId);
+        startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt, configDir);
+      }
+      if (context) {
+        const safeContext = context.replace(/\n/g, " ");
+        setTimeout(() => {
+          for (const tabId of createdTabIds) {
+            writeWhenReady(tabId, `${safeContext}\r`);
+          }
+        }, 8000);
+      }
+    }
+    return createdTabIds;
+  };
+
+  // Phase 1b — register the Terminal-page command set. Sources the spawn
+  // closures above; reads everything else (tabs, zoneLayout, sessionStates,
+  // closeTerminal, transitionEffects.handleRestartInZone, terminalRefs)
+  // directly from contexts. No visible UI change today — the registry is
+  // populated for future CommandBar / palette / AI-tier consumers.
+  useTerminalCommands({
+    spawnPlain: handleQuickLaunch,
+    spawnAi: handleLaunchAiSession,
+    accounts: sessionManager.accountUsage,
+    sortZones: handleSortZones,
+    exportAll: handleExportOutput,
+  });
+
   if (!initialized) {
     return (
       <div className="h-full flex items-center justify-center bg-[#1a1b26]">
@@ -427,6 +667,11 @@ function TerminalPageInner({
   return (
     <UIBridgeComponentScope componentId="terminal-page">
       <div className="h-full flex flex-col bg-[#1a1b26]">
+        {/* Phase 6 — top status strip. Renders nothing when no signal
+            requires attention, keeping the top of viewport clean by
+            default. Sits above TerminalTabBar during the transition;
+            Phase 9 demolition will collapse the chrome further. */}
+        <StatusStrip />
         <TerminalTabBar
           tabs={tabs}
           activeId={activeId}
@@ -536,77 +781,8 @@ function TerminalPageInner({
           staleTabs={stateTracking.staleTabs}
           zoneLabels={labelsAndTags.zoneLabels}
           labelColorMap={labelsAndTags.labelColorMap}
-          onQuickLaunch={async (count, autoCommand) => {
-            const totalTabs = tabs.length + count;
-            const layoutId = pickLayout(totalTabs);
-            zoneLayout.setLayoutId(layoutId);
-            const title = autoCommand ? autoCommand.slice(0, 20) : undefined;
-            const createdTabIds: string[] = [];
-            for (let i = 0; i < count; i++) {
-              const tabId = await createAndAssignTerminal(title);
-              if (tabId) createdTabIds.push(tabId);
-            }
-            if (autoCommand && createdTabIds.length > 0) {
-              for (const tabId of createdTabIds) {
-                writeWhenReady(tabId, `${autoCommand}\r`);
-              }
-            }
-            // Returned ids surface in the UI Bridge action response so
-            // automation can immediately poll
-            // `/control/terminal-sessions/{id}` without screen-scraping.
-            return createdTabIds;
-          }}
-          onLaunchAiSession={async (count, configDir, context) => {
-            const totalTabs = tabs.length + count;
-            const layoutId = pickLayout(totalTabs);
-            zoneLayout.setLayoutId(layoutId);
-
-            const isWindows = navigator.platform.startsWith("Win");
-            const customCmd = sessionManager.launchCommands?.[configDir];
-            const cmd = customCmd
-              ? customCmd
-              : isWindows
-                ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude`
-                : `CLAUDE_CONFIG_DIR="${configDir}" claude`;
-            // Smart tab naming: use custom command or account label
-            const dirName = configDir.replace(/\\/g, "/").replace(/\/$/, "").split("/").pop() ?? "";
-            const label = customCmd ?? dirName.match(/^\.claude-(.+)$/)?.[1] ?? "claude";
-            const createdTabIds: string[] = [];
-            for (let i = 0; i < count; i++) {
-              const tabId = await createAndAssignTerminal(label);
-              if (tabId) createdTabIds.push(tabId);
-            }
-            if (createdTabIds.length > 0) {
-              const spawnAt = Date.now();
-              // Type the launch command once the terminal ref is mounted
-              for (const tabId of createdTabIds) {
-                writeWhenReady(tabId, `${cmd}\r`);
-                // Plan §1.5 — start polling transcript_get_latest so
-                // tab.claudeSessionId fills in once Claude CLI writes
-                // its first JSONL record. Pass `configDir` so the probe
-                // scopes to the account this tab launched into; without
-                // it, a concurrent session in another account writing
-                // to the same project_path can win the freshest-mtime
-                // race and the wrong session_id gets bound (P0 silent
-                // fail for multi-account users).
-                const tab = tabs.find((t) => t.id === tabId);
-                startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt, configDir);
-              }
-              // Type the initial instructions after Claude starts
-              if (context) {
-                const safeContext = context.replace(/\n/g, " ");
-                setTimeout(() => {
-                  for (const tabId of createdTabIds) {
-                    writeWhenReady(tabId, `${safeContext}\r`);
-                  }
-                }, 8000);
-              }
-            }
-            // Returned ids surface in the UI Bridge action response so
-            // automation can immediately poll
-            // `/control/terminal-sessions/{id}` without screen-scraping.
-            return createdTabIds;
-          }}
+          onQuickLaunch={handleQuickLaunch}
+          onLaunchAiSession={handleLaunchAiSession}
           onLaunchMultiAiSessions={async (configDirs, context) => {
             const count = configDirs.length;
             const totalTabs = tabs.length + count;
@@ -861,6 +1037,11 @@ function TerminalPageInner({
         </div>
 
         <TerminalOverlays onSortZones={handleSortZones} onExport={handleExportOutput} />
+
+        {/* Phase 2 — slash-command bar pinned to the bottom of the
+            page chrome. Reads from the command registry populated by
+            `useTerminalCommands` above; Ctrl+/ focuses from anywhere. */}
+        <CommandBar />
       </div>
     </UIBridgeComponentScope>
   );

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -247,7 +247,7 @@ function TerminalPageInner({
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             if (msg.includes("no-account") || msg.toLowerCase().includes("no matching")) {
-              throw new Error("No AI accounts available");
+              throw new Error("No AI accounts available", { cause: err });
             }
             throw err;
           }

--- a/src/components/terminal/TerminalTabBar.tsx
+++ b/src/components/terminal/TerminalTabBar.tsx
@@ -1,11 +1,11 @@
-import { useState, useRef, useEffect, useMemo, useCallback, type ReactNode } from "react";
-import { Terminal, X, Plus, List, ChevronDown, FileText, Lock } from "lucide-react";
+import { useState, useEffect, useMemo, useCallback, type ReactNode } from "react";
+import { Plus, ChevronDown } from "lucide-react";
 import type { TerminalTab } from "./useTerminalManager";
 import type { SessionState, ZoneAssignments } from "./useZoneLayout";
 import type { AccountUsageInfo } from "./useSessionManager";
 import { LaunchMenu } from "./LaunchMenu";
-import { useUIComponent, UIBridgeComponentScope } from "@qontinui/ui-bridge";
-import { WrapperToolsBadge } from "@/components/wrappers/WrapperToolsBadge";
+import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
+import { callRegistry } from "./commands";
 import { ReviewBadge } from "./ReviewBadge";
 import { CommitTrafficLight } from "./CommitTrafficLight";
 import type { CommitState } from "./useCommitState";
@@ -96,16 +96,6 @@ const STATE_BAR_COLORS: Record<SessionState, string> = {
   completed: "#9ece6a",
   error: "#f7768e",
 };
-
-function formatTime(value?: string | number): string {
-  if (value === undefined || value === null) return "";
-  try {
-    const d = new Date(value);
-    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  } catch {
-    return "";
-  }
-}
 
 /**
  * Format a "since" epoch-ms as a short relative-age string ("5s",
@@ -248,9 +238,7 @@ export function TerminalTabBar({
 }: TerminalTabBarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
-  const [showDropdown, setShowDropdown] = useState(false);
   const [showQuickLaunch, setShowQuickLaunch] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Phase 2 (stuck-session heartbeat) — subscribe to the shared 1Hz
   // broadcast so the lock tooltip's "since 5m" text refreshes on next-
@@ -291,18 +279,6 @@ export function TerminalTabBar({
     setEditingId(null);
   };
 
-  // Close dropdowns when clicking outside
-  useEffect(() => {
-    if (!showDropdown) return;
-    const handleClick = (e: MouseEvent) => {
-      if (showDropdown && dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setShowDropdown(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [showDropdown]);
-
   // ── Helpers for per-tab enrichments ──────────────────────────────────────
 
   function getTabZoneIndex(tabId: string): number | undefined {
@@ -319,163 +295,29 @@ export function TerminalTabBar({
     return tabId in tabIdToZone;
   }
 
-  // ── UI Bridge: terminal-launch-menu registration ─────────────────────────
-  // LaunchMenu only mounts while showQuickLaunch=true, so we register from
-  // TerminalTabBar (always mounted) to ensure agents can invoke actions at
-  // any time.
-
-  const sortedAccountsForBridge = useMemo(
-    () => [...(accountUsage ?? [])].sort((a, b) => (a.utilization ?? 0) - (b.utilization ?? 0)),
-    [accountUsage],
-  );
-
-  const openLaunchMenu = useCallback(() => setShowQuickLaunch(true), []);
+  // ── UI Bridge: terminal-launch-menu registration HOISTED ─────────────────
+  // Phase 9a moved this registration to `TerminalPage.tsx` (next to the
+  // `terminal-page` block) so external agents keep getting `create-plain` /
+  // `create-ai-session` / `create-best-account` / `create-with-command`
+  // even after `TerminalTabBar.tsx` is eventually retired. The local
+  // LaunchMenu popover is still rendered here (operator-facing UI); the
+  // wire-contract registration is just no longer co-located with it.
+  //
+  // The hoisted version dropped the `open` / `close` actions — they were
+  // popover-toggle UI affordances, not wire contract. If external
+  // automation surfaces dependence on them, restore by lifting
+  // `showQuickLaunch` state to `TerminalPage` and threading down via props.
+  //
+  // The local launch-menu popover (chevron + LaunchMenu JSX below) still
+  // uses `closeLaunchMenu` for its own onClose handler, so we keep that
+  // callback here. `openLaunchMenu` / `sortedAccountsForBridge` were
+  // only used by the deleted registration and are removed.
   const closeLaunchMenu = useCallback(() => setShowQuickLaunch(false), []);
 
-  useUIComponent({
-    id: "terminal-launch-menu",
-    name: "Terminal Launch Menu",
-    description:
-      "Creates plain terminals and AI sessions. Use create-plain, create-ai-session, " +
-      "create-best-account, or create-with-command to launch terminals programmatically.",
-    actions: [
-      {
-        id: "open",
-        label: "Open launch menu",
-        handler: openLaunchMenu,
-      },
-      {
-        id: "close",
-        label: "Close launch menu",
-        handler: closeLaunchMenu,
-      },
-      {
-        id: "create-plain",
-        label: "Create Plain Terminal",
-        description: "Spawn N blank terminals using the user's default shell.",
-        paramSchema: { count: "number (>= 1, defaults to 1)" },
-        handler: async (params?: unknown) => {
-          const { count = 1 } = (params ?? {}) as { count?: number };
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-plain requires { count: number } where count >= 1");
-          }
-          // PTY-only tabs never own a Claude task_run_id, so the parallel
-          // task_run_ids array is empty — callers polling
-          // `/control/terminal-sessions/{id}` for the readiness signal
-          // (`state` / `is_alive`) is the right pattern for these.
-          const tabIds = ((await onQuickLaunch?.(count)) ?? []) as string[];
-          closeLaunchMenu();
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: [] as Array<string | null>,
-          };
-        },
-      },
-      {
-        id: "create-ai-session",
-        label: "Create AI Session",
-        description:
-          "Spawn N terminals pre-configured to launch `claude` under the given CLAUDE_CONFIG_DIR, optionally pre-typing a context prompt.",
-        paramSchema: {
-          count: "number (>= 1, defaults to 1)",
-          configDir: "string (absolute path to a Claude Code config dir, required)",
-          context: "string (optional initial prompt auto-typed after claude starts)",
-        },
-        handler: async (params?: unknown) => {
-          const {
-            count = 1,
-            configDir,
-            context,
-          } = (params ?? {}) as {
-            count?: number;
-            configDir?: string;
-            context?: string;
-          };
-          if (!configDir)
-            throw new Error(
-              "create-ai-session requires { count?: number, configDir: string, context?: string }",
-            );
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-ai-session: count must be a positive number");
-          }
-          // `task_run_id` (= Claude session_id) is captured asynchronously
-          // by `useTabSessionIdCapture` once Claude CLI writes its first
-          // JSONL record. At handler-return time the value is `null` for
-          // every fresh tab — callers correlate via
-          // `GET /control/terminal-sessions/{tab_id}` and watch for
-          // `task_run_id` to flip non-null.
-          const tabIds = ((await onLaunchAiSession?.(count, configDir, context)) ?? []) as string[];
-          closeLaunchMenu();
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: tabIds.map(() => null) as Array<string | null>,
-          };
-        },
-      },
-      {
-        id: "create-best-account",
-        label: "Create AI Session with Best Account",
-        description:
-          "Like create-ai-session, but picks the AI account with the lowest current utilization. Fails if no accounts are configured.",
-        paramSchema: {
-          count: "number (>= 1, defaults to 1)",
-          context: "string (optional initial prompt auto-typed after claude starts)",
-        },
-        handler: async (params?: unknown) => {
-          const { count = 1, context } = (params ?? {}) as {
-            count?: number;
-            context?: string;
-          };
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-best-account: count must be a positive number");
-          }
-          const best = sortedAccountsForBridge[0];
-          if (!best) throw new Error("No AI accounts available");
-          const tabIds = ((await onLaunchAiSession?.(count, best.config_dir, context)) ??
-            []) as string[];
-          closeLaunchMenu();
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: tabIds.map(() => null) as Array<string | null>,
-          };
-        },
-      },
-      {
-        id: "create-with-command",
-        label: "Create Terminal with Command",
-        description:
-          "Spawn N terminals and auto-type the given shell command into each after the prompt renders.",
-        paramSchema: {
-          count: "number (>= 1, defaults to 1)",
-          command: "string (the shell command to type + Enter, required)",
-        },
-        handler: async (params?: unknown) => {
-          const { count = 1, command } = (params ?? {}) as {
-            count?: number;
-            command?: string;
-          };
-          if (!command)
-            throw new Error("create-with-command requires { count?: number, command: string }");
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-with-command: count must be a positive number");
-          }
-          // `create-with-command` reuses the plain-PTY path (no Claude
-          // CLI), so `task_run_ids` is empty by definition. Callers can
-          // still observe the spawned tabs via `terminal-sessions`.
-          const tabIds = ((await onQuickLaunch?.(count, command)) ?? []) as string[];
-          closeLaunchMenu();
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: [] as Array<string | null>,
-          };
-        },
-      },
-    ],
-  });
+  // The original `useUIComponent({id: "terminal-launch-menu", ...})` call
+  // and its ~165-line `actions` array previously lived here and have been
+  // moved verbatim to TerminalPage.tsx; this comment marks the hoist site
+  // for git-blame readability.
 
   // ── Render ───────────────────────────────────────────────────────────────
 
@@ -576,381 +418,14 @@ export function TerminalTabBar({
         )}
       </div>
 
-      {/* Scrollable tab area.
-          Phase 3: `items-end` (was `items-center`) anchors every tab to
-          the bottom edge of the strip where the active tab's `-mb-px`
-          overlap happens, so the taller active tab grows UPWARD without
-          dragging the inactive tabs along (active renders extra rows for
-          tags + working-dir; inactives don't). Pair with `min-h-[37px]`
-          on each tab below to give inactives a baseline matching the
-          observed active-tab height. */}
-      <div className="flex items-end gap-0.5 px-1 overflow-x-auto scrollbar-none flex-1 min-w-0 h-full">
-        {tabs.map((tab) => {
-          const isActive = tab.id === activeId;
-          const isDead = !tab.isAlive;
-          const isEditing = editingId === tab.id;
-          const state = sessionStates?.[tab.id] ?? "idle";
-          const hasUnread = unreadTabs?.has(tab.id) ?? false;
-          const isStale = staleTabs?.has(tab.id) ?? false;
-          const tabActivity = activityData?.[tab.id];
-          const tabDuration = stateDurations?.[tab.id];
-          const tabLabels = getTabLabels(tab.id);
-          const showSparkline =
-            isMultiZone && isTabAssigned(tab.id) && tabActivity && tabActivity.length > 0;
-          const lockState = fileLockStates?.[tab.id];
-          const commitState = commitStates?.[tab.id];
-          const overlapCount = registryAwareness[tab.id] ?? 0;
+      <div className="flex-1" />
 
-          return (
-            <button
-              key={tab.id}
-              onClick={() => onSelect(tab.id)}
-              onDoubleClick={() => startEditing(tab)}
-              onAuxClick={(e) => {
-                if (e.button === 1) {
-                  e.preventDefault();
-                  onClose(tab.id);
-                }
-              }}
-              draggable
-              onDragStart={(e) => {
-                e.dataTransfer.setData("text/tab-id", tab.id);
-                e.dataTransfer.effectAllowed = "move";
-              }}
-              className={`
-              flex items-center gap-1.5 px-3 py-1 rounded-t text-xs font-medium min-h-[37px]
-              transition-colors whitespace-nowrap min-w-0 max-w-[260px] overflow-hidden group cursor-grab active:cursor-grabbing
-              ${
-                isActive
-                  ? "bg-[#1a1b26] text-[#c0caf5] border-t border-x border-[#2a2d3d] -mb-px"
-                  : "text-[#565f89] hover:text-[#a9b1d6] hover:bg-[#1a1b26]/50"
-              }
-              ${isDead ? "opacity-60" : ""}
-              ${isStale ? "border-dashed border-[#565f89]/40" : ""}
-            `}
-            >
-              {/* Session state dot / plan icon */}
-              {tab.type === "plan" ? (
-                <FileText className="w-3 h-3 shrink-0 text-[#7dcfff]" />
-              ) : sessionStates ? (
-                <div
-                  className={`w-2 h-2 rounded-full shrink-0 ${STATE_DOT_COLORS[state]} ${
-                    state === "needs-input" ? "animate-pulse" : ""
-                  }`}
-                />
-              ) : (
-                <Terminal className="w-3 h-3 shrink-0" />
-              )}
-
-              {/* File lock indicator. Wrapped in a span so the native
-                  `title` tooltip reaches the user — Lucide icons render
-                  as <svg> and don't accept the React title attribute
-                  directly. */}
-              {lockState?.kind === "waiting" && (
-                <span
-                  data-testid="tab-lock-waiting"
-                  className="shrink-0 inline-flex"
-                  aria-label="waiting on file lock"
-                  title={`waiting on ${lockState.counterpartyName ?? "another session"}'s ${
-                    lockState.filePath ?? "edit"
-                  }${lockState.sinceMs ? ` since ${formatSince(lockState.sinceMs, nowMs)}` : ""}`}
-                >
-                  <Lock className="w-2.5 h-2.5 text-[#e0af68] animate-pulse" />
-                </span>
-              )}
-              {lockState?.kind === "holding" && (
-                <span
-                  data-testid="tab-lock-holding"
-                  className="shrink-0 inline-flex"
-                  aria-label="holding file lock"
-                  title={`holding ${lockState.filePath ?? "file"} — ${lockState.waiterCount ?? 0} session${
-                    lockState.waiterCount === 1 ? "" : "s"
-                  } waiting`}
-                >
-                  <Lock className="w-2.5 h-2.5 text-[#7aa2f7] opacity-60" />
-                </span>
-              )}
-
-              {/* Registry-awareness badge — count of files held by OTHER
-                  sessions that overlap with this tab's cwd. Driven by
-                  `useRegistryAwareness` polling `/file-registry/probe-conflicts`
-                  (Phase 2 of pty-launched-ai-tabs-warning-plan). Silent
-                  tabs stay visually quiet — badge renders only when N > 0. */}
-              {overlapCount > 0 && (
-                <span
-                  data-testid="tab-registry-overlap"
-                  className="shrink-0 px-1 rounded text-[10px] leading-[14px] font-medium bg-[#e0af68]/20 text-[#e0af68]"
-                  title={`${overlapCount} file(s) held by other sessions overlap with this tab's cwd.`}
-                >
-                  {overlapCount}
-                </span>
-              )}
-
-              {/*
-                Commit-readiness traffic light. Renders nothing visible when
-                state.status is "unknown" but always slots in the GitCommit
-                button (disabled) so the tab layout stays stable.
-
-                isPtyTab decision: every tab that reaches `TerminalTabBar`
-                today is a PTY-launched terminal. SDK chat sessions live in
-                a separate component path (`useAiSession.ts` →
-                `MessagesPanel`-style surfaces) and never render here. We
-                pass `isPtyTab={true}` unconditionally; if a future SDK-chat
-                surface starts routing through this component the toggle
-                can flip per-tab. Tracked at plan §0 caveat.
-              */}
-              {tab.type !== "plan" && (
-                <span onClick={(e) => e.stopPropagation()}>
-                  <CommitTrafficLight
-                    state={commitState}
-                    sessionId={tab.claudeSessionId}
-                    isPtyTab={true}
-                    onWriteToTerminal={(text) => {
-                      const ref = terminalRefs?.get(tab.id);
-                      ref?.current?.writeToTerminal(text);
-                    }}
-                  />
-                </span>
-              )}
-
-              <span className="flex flex-col items-start min-w-0">
-                {/* Title row */}
-                <span className="flex items-center gap-1 min-w-0">
-                  {isEditing ? (
-                    <input
-                      autoFocus
-                      value={editValue}
-                      onChange={(e) => setEditValue(e.target.value)}
-                      onBlur={commitEdit}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") commitEdit();
-                        if (e.key === "Escape") setEditingId(null);
-                        e.stopPropagation();
-                      }}
-                      onClick={(e) => e.stopPropagation()}
-                      className="bg-transparent border-b border-[#565f89] text-[#c0caf5] text-xs w-20 outline-hidden"
-                    />
-                  ) : (
-                    <span className="truncate">{tab.title}</span>
-                  )}
-
-                  {/* Inline sparkline + duration (active tab only) */}
-                  {isActive && showSparkline && (
-                    <ActivitySparkline data={tabActivity!} color={STATE_BAR_COLORS[state]} />
-                  )}
-                  {isActive && tabDuration && (
-                    <DurationBadge duration={tabDuration} state={state} />
-                  )}
-                </span>
-
-                {/* Tags row (active tab only, multi-zone) */}
-                {isActive && tabLabels && isMultiZone && (
-                  <TagBadges labels={tabLabels} colorMap={labelColorMap} />
-                )}
-
-                {/* Working dir (active tab only) */}
-                {isActive && tab.workingDir && (
-                  <span className="text-[9px] text-[#565f89] truncate max-w-[140px]">
-                    {tab.workingDir.split(/[/\\]/).slice(-2).join("/")}
-                  </span>
-                )}
-              </span>
-
-              {/* Stale indicator (inactive tabs) */}
-              {!isActive && isStale && (
-                <span className="text-[8px] text-[#565f89] italic shrink-0">stalled?</span>
-              )}
-
-              {/* Duration badge on inactive tabs for attention states */}
-              {!isActive && tabDuration && <DurationBadge duration={tabDuration} state={state} />}
-
-              {/* Exit code badge */}
-              {isDead && tab.exitCode !== null && (
-                <span
-                  className={`text-[10px] px-1 rounded ${
-                    tab.exitCode === 0
-                      ? "bg-green-900/30 text-green-400"
-                      : "bg-red-900/30 text-red-400"
-                  }`}
-                >
-                  {tab.exitCode}
-                </span>
-              )}
-
-              {/* Unread indicator */}
-              {hasUnread && <span className="w-1.5 h-1.5 rounded-full bg-[#f7768e] shrink-0" />}
-
-              {/* Phase 3 review verdict badge — next to the existing per-tab
-                  controls cluster. Renders nothing when no review row
-                  exists for the session. */}
-              <span
-                className="shrink-0"
-                data-testid="terminal-tab-controls"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <ReviewBadge sessionId={tab.id} />
-              </span>
-
-              {/* Close button */}
-              <span
-                role="button"
-                tabIndex={0}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onClose(tab.id);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.stopPropagation();
-                    onClose(tab.id);
-                  }
-                }}
-                className="ml-1 p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-[#2a2d3d] transition-opacity"
-              >
-                <X className="w-3 h-3" />
-              </span>
-            </button>
-          );
-        })}
-      </div>
-
-      {/* Pinned right: wrapper tools badge + session list dropdown */}
-      <div className="flex items-center gap-0.5 px-1 shrink-0">
-        {/* Wrapper tools available to AI agents (Phase 4 visibility) */}
-        <WrapperToolsBadge />
-        {/* Session dropdown */}
-        {tabs.length > 0 && (
-          <div className="relative ml-auto shrink-0" ref={dropdownRef}>
-            <button
-              onClick={() => setShowDropdown(!showDropdown)}
-              className={`flex items-center justify-center w-6 h-6 rounded transition-colors ${
-                showDropdown
-                  ? "text-[#7aa2f7] bg-[#7aa2f7]/10"
-                  : "text-[#565f89] hover:text-[#a9b1d6] hover:bg-[#1a1b26]/50"
-              }`}
-              title="All sessions"
-            >
-              <List className="w-3.5 h-3.5" />
-            </button>
-
-            {showDropdown && (
-              <div className="absolute right-0 top-full mt-1 w-80 bg-[#1a1b26] border border-[#2a2d3d] rounded-lg shadow-xl z-50 overflow-hidden">
-                <div className="px-3 py-2 text-[10px] uppercase tracking-wider text-[#565f89] border-b border-[#2a2d3d]">
-                  Sessions ({tabs.length})
-                </div>
-                <div className="max-h-64 overflow-y-auto scrollbar-dark">
-                  {tabs.map((tab) => {
-                    const isActive = tab.id === activeId;
-                    const isDead = !tab.isAlive;
-                    const state = sessionStates?.[tab.id] ?? "idle";
-                    const tabActivity = activityData?.[tab.id];
-                    const tabDuration = stateDurations?.[tab.id];
-                    const tabLabels = getTabLabels(tab.id);
-                    const hasSparkline =
-                      isMultiZone && isTabAssigned(tab.id) && tabActivity && tabActivity.length > 0;
-
-                    return (
-                      <div
-                        key={tab.id}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => {
-                          onSelect(tab.id);
-                          setShowDropdown(false);
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
-                            onSelect(tab.id);
-                            setShowDropdown(false);
-                          }
-                        }}
-                        className={`flex items-start gap-2 px-3 py-2 cursor-pointer transition-colors ${
-                          isActive ? "bg-[#7aa2f7]/10" : "hover:bg-[#2a2d3d]/50"
-                        }`}
-                      >
-                        {/* Status dot */}
-                        <div className="mt-1 shrink-0">
-                          <div
-                            className={`w-2 h-2 rounded-full ${
-                              sessionStates
-                                ? `${STATE_DOT_COLORS[state]} ${state === "needs-input" ? "animate-pulse" : ""}`
-                                : isDead
-                                  ? "bg-[#565f89]"
-                                  : "bg-[#9ece6a]"
-                            }`}
-                          />
-                        </div>
-
-                        {/* Info */}
-                        <div className="flex-1 min-w-0">
-                          <div className="flex items-center gap-1.5">
-                            <span
-                              className={`text-xs font-medium truncate ${
-                                isActive ? "text-[#7aa2f7]" : "text-[#c0caf5]"
-                              }`}
-                            >
-                              {tab.title}
-                            </span>
-                            {isDead && tab.exitCode !== null && (
-                              <span
-                                className={`text-[10px] px-1 rounded ${
-                                  tab.exitCode === 0
-                                    ? "bg-green-900/30 text-green-400"
-                                    : "bg-red-900/30 text-red-400"
-                                }`}
-                              >
-                                exit {tab.exitCode}
-                              </span>
-                            )}
-                            {/* Sparkline in dropdown */}
-                            {hasSparkline && (
-                              <ActivitySparkline
-                                data={tabActivity!}
-                                color={STATE_BAR_COLORS[state]}
-                              />
-                            )}
-                            {/* Duration in dropdown */}
-                            {tabDuration && <DurationBadge duration={tabDuration} state={state} />}
-                            {/* Phase 3 review verdict badge — same data
-                                surface as the per-tab header. */}
-                            <ReviewBadge sessionId={tab.id} />
-                          </div>
-                          <div className="flex items-center gap-2 text-[10px] text-[#565f89] mt-0.5">
-                            {tab.pid && <span>PID {tab.pid}</span>}
-                            {tab.workingDir && (
-                              <span className="truncate" title={tab.workingDir}>
-                                {tab.workingDir.split(/[/\\]/).pop()}
-                              </span>
-                            )}
-                            {tab.createdAt && <span>{formatTime(tab.createdAt)}</span>}
-                          </div>
-                          {/* Tag badges in dropdown */}
-                          {tabLabels && isMultiZone && (
-                            <div className="mt-0.5">
-                              <TagBadges labels={tabLabels} colorMap={labelColorMap} max={3} />
-                            </div>
-                          )}
-                        </div>
-
-                        {/* Close button */}
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onClose(tab.id);
-                          }}
-                          className="mt-0.5 p-0.5 rounded text-[#565f89] hover:text-[#f7768e] hover:bg-[#f7768e]/10 transition-colors shrink-0"
-                        >
-                          <X className="w-3 h-3" />
-                        </button>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
+      {/* Phase 9a — `WrapperToolsBadge` was previously pinned to the
+          right of the tab bar; its popover + tool list moved into
+          `StatusStrip`'s wrapper-tools pill so there's a single
+          surface for wrapper-tools info. The badge component file is
+          left in place pending operator decision on whether other
+          surfaces should still mount it. */}
     </div>
   );
 }

--- a/src/components/terminal/ZoneGrid.tsx
+++ b/src/components/terminal/ZoneGrid.tsx
@@ -11,6 +11,8 @@ import {
   type ShellIntegrationEvent,
 } from "./TerminalInstance";
 import { PlanViewer } from "./PlanViewer";
+import { SuggestionChip } from "./suggestions";
+import { ZoneHoverActions } from "./ZoneHoverActions";
 import type { LayoutPreset } from "./useZoneLayout";
 import {
   STATE_BORDER_COLORS,
@@ -799,7 +801,7 @@ function ZoneCell({
 
   return (
     <div
-      className={`relative overflow-hidden ${isFlashing ? "zone-flash" : ""} ${
+      className={`group relative overflow-hidden ${isFlashing ? "zone-flash" : ""} ${
         outputSearchQuery && !searchMatch ? "opacity-40" : ""
       }`}
       style={{
@@ -1111,6 +1113,16 @@ function ZoneCell({
           </div>
         </div>
       )}
+
+      {/* Phase 4 — per-zone suggestion chip overlay. Renders nothing
+          when the engine has no chip for this zone, keeping cell
+          chrome quiet by default. */}
+      <SuggestionChip zoneIdx={zoneIdx} />
+
+      {/* Phase 5 — per-zone hover-revealed action cluster (maximize /
+          restart / label / export / close). Fades in on cell hover
+          via group-hover from the cell's outer div. */}
+      <ZoneHoverActions zoneIdx={zoneIdx} onExportZone={onExportZone} />
     </div>
   );
 }

--- a/src/components/terminal/ZoneHoverActions.tsx
+++ b/src/components/terminal/ZoneHoverActions.tsx
@@ -1,0 +1,298 @@
+/**
+ * Phase 5 — Per-zone hover controls.
+ *
+ * Five-button cluster pinned to a zone cell's top-right corner that
+ * fades in on cell hover (with a 150ms enter delay to avoid flicker on
+ * mouse-pass-through). Buttons: maximize/restore, restart, label,
+ * export, close.
+ *
+ * Wired DIRECTLY to context handlers (`zoneLayout.toggleMaximize`,
+ * `transitionEffects.handleRestartInZone`, `labelsAndTags.setZoneLabel`,
+ * `closeTerminal`) rather than through `callRegistry`. The registry's
+ * Phase-1b handlers ALSO target these same context functions, so both
+ * surfaces are structurally in lockstep — putting an async network of
+ * registry-routed calls on every hover-button click would only add
+ * latency + error-handling without changing the source of truth.
+ *
+ * State-gated restart (per plan's audit §"Per-action success criterion
+ * checks" + `TransitionEffectsContext.tsx:44`): button is greyed +
+ * tooltip switches when `sessionStates[tabId] ∉ {completed, error}` so
+ * the affordance reflects the underlying handler's silent no-op gate
+ * rather than appearing broken on a `working` session.
+ *
+ * Coexists with `SuggestionChip` (Phase 4) in the same corner — both
+ * render at `z-30`. When a chip is present its rule was specifically
+ * authored to be the more relevant signal (error, stuck-needs-input,
+ * layout-mismatch), so the chip visually dominates that moment. Hover
+ * actions are still discoverable by mousing into the cell; they sit
+ * just below the chip's pixels via document order. Phase 9 retire of
+ * the per-tab badge cluster will tighten this layout further.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Download,
+  Maximize2,
+  Minimize2,
+  RefreshCw,
+  Tag,
+  X,
+} from "lucide-react";
+
+import { useTerminalSession, useTransitionEffects, useZoneMetadata } from "./contexts";
+
+interface ZoneHoverActionsProps {
+  zoneIdx: number;
+  /** Threaded from `ZoneGrid`'s prop (sourced from `useZoneActions`).
+   *  Optional so the export button can degrade to disabled rather than
+   *  throwing when the prop isn't wired (unusual; covers test mounts). */
+  onExportZone?: (zoneIdx: number, format: "text" | "markdown" | "json") => void;
+}
+
+const EXPORT_FORMATS = ["text", "markdown", "json"] as const;
+type ExportFormat = (typeof EXPORT_FORMATS)[number];
+
+export function ZoneHoverActions({ zoneIdx, onExportZone }: ZoneHoverActionsProps) {
+  const session = useTerminalSession();
+  const { zoneLayout, closeTerminal, sessionStates } = session;
+  const transitionEffects = useTransitionEffects();
+  const { labelsAndTags } = useZoneMetadata();
+
+  const tabId = zoneLayout.assignments[zoneIdx];
+  const isMaximized = zoneLayout.maximizedZone === zoneIdx;
+  const state = tabId ? sessionStates[tabId] ?? "idle" : "idle";
+  const canRestart = !!tabId && (state === "completed" || state === "error");
+  const hasTab = !!tabId;
+
+  const [showExportMenu, setShowExportMenu] = useState(false);
+  const [showLabelInput, setShowLabelInput] = useState(false);
+  const [labelDraft, setLabelDraft] = useState("");
+
+  const exportRef = useRef<HTMLDivElement>(null);
+  const labelPopoverRef = useRef<HTMLDivElement>(null);
+  const labelInputRef = useRef<HTMLInputElement>(null);
+
+  // Outside-click close for both popovers.
+  useEffect(() => {
+    if (!showExportMenu && !showLabelInput) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (showExportMenu && exportRef.current && !exportRef.current.contains(target)) {
+        setShowExportMenu(false);
+      }
+      if (showLabelInput && labelPopoverRef.current && !labelPopoverRef.current.contains(target)) {
+        // Commit on outside-click — same convention as the launch-menu
+        // close handler so a click-away doesn't silently discard typing.
+        labelsAndTags.setZoneLabel(zoneIdx, labelDraft.trim());
+        setShowLabelInput(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [showExportMenu, showLabelInput, labelDraft, labelsAndTags, zoneIdx]);
+
+  useEffect(() => {
+    if (showLabelInput) {
+      // Microtask defer so the focus happens after the popover mounts
+      // and selection ranges resolve cleanly.
+      queueMicrotask(() => labelInputRef.current?.focus());
+    }
+  }, [showLabelInput]);
+
+  const handleMaximize = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      zoneLayout.toggleMaximize(zoneIdx);
+    },
+    [zoneLayout, zoneIdx],
+  );
+
+  const handleRestart = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!canRestart) return;
+      transitionEffects.handleRestartInZone(zoneIdx);
+    },
+    [canRestart, transitionEffects, zoneIdx],
+  );
+
+  const openLabel = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      // Seed the draft with the current label (if any) so the operator
+      // can edit-in-place rather than retyping. Use empty-string when
+      // unset rather than undefined to keep the input controlled.
+      setLabelDraft(labelsAndTags.zoneLabels[zoneIdx] ?? "");
+      setShowLabelInput((prev) => !prev);
+      setShowExportMenu(false);
+    },
+    [labelsAndTags.zoneLabels, zoneIdx],
+  );
+
+  const openExportMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!onExportZone) return;
+      setShowExportMenu((prev) => !prev);
+      setShowLabelInput(false);
+    },
+    [onExportZone],
+  );
+
+  const handleExport = useCallback(
+    (e: React.MouseEvent, format: ExportFormat) => {
+      e.stopPropagation();
+      if (!onExportZone) return;
+      onExportZone(zoneIdx, format);
+      setShowExportMenu(false);
+    },
+    [onExportZone, zoneIdx],
+  );
+
+  const handleClose = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!tabId) return;
+      closeTerminal(tabId);
+    },
+    [tabId, closeTerminal],
+  );
+
+  return (
+    <div
+      // group-hover from the cell parent (`ZoneGrid`'s outer cell div
+      // has the `group` class) controls reveal. Base state is
+      // pointer-events-none so the invisible chrome doesn't block
+      // clicks on the terminal underneath; hover flips it back so
+      // buttons are clickable once visible. Enter delay lives on the
+      // group-hover variant only — exit transition fires immediately
+      // for a snappy "mouse left" feel.
+      className="absolute top-1 right-1 z-30 opacity-0 pointer-events-none transition-opacity duration-200 group-hover:opacity-100 group-hover:pointer-events-auto group-hover:delay-150"
+      data-page-element="zone-hover-actions"
+      data-zone-index={zoneIdx}
+    >
+      <div className="flex items-center gap-0.5 px-1 py-0.5 bg-[#13141f]/90 border border-[#2a2d3d] rounded backdrop-blur-sm shadow-md">
+        {/* Maximize / restore */}
+        <button
+          type="button"
+          onClick={handleMaximize}
+          className="p-1 rounded text-[#565f89] hover:text-[#c0caf5] hover:bg-[#2a2d3d]/60 transition-colors"
+          title={isMaximized ? "Restore zone (Ctrl+Shift+F)" : "Maximize zone (Ctrl+Shift+F)"}
+          aria-label={isMaximized ? "Restore zone" : "Maximize zone"}
+        >
+          {isMaximized ? <Minimize2 className="w-3 h-3" /> : <Maximize2 className="w-3 h-3" />}
+        </button>
+
+        {/* Restart — visually gated */}
+        <button
+          type="button"
+          onClick={handleRestart}
+          disabled={!canRestart}
+          className={`p-1 rounded transition-colors ${
+            canRestart
+              ? "text-[#565f89] hover:text-[#7dcfff] hover:bg-[#7dcfff]/10"
+              : "text-[#414868] cursor-not-allowed"
+          }`}
+          title={
+            canRestart
+              ? "Restart session (Ctrl+Shift+R)"
+              : `Restart available only when session is completed or errored (currently: ${state})`
+          }
+          aria-label="Restart session"
+          aria-disabled={!canRestart}
+        >
+          <RefreshCw className="w-3 h-3" />
+        </button>
+
+        {/* Label */}
+        <button
+          type="button"
+          onClick={openLabel}
+          className={`p-1 rounded transition-colors ${
+            showLabelInput
+              ? "text-[#bb9af7] bg-[#bb9af7]/10"
+              : "text-[#565f89] hover:text-[#bb9af7] hover:bg-[#bb9af7]/10"
+          }`}
+          title="Edit zone label"
+          aria-label="Edit zone label"
+          aria-expanded={showLabelInput}
+        >
+          <Tag className="w-3 h-3" />
+        </button>
+
+        {/* Export */}
+        <div className="relative" ref={exportRef}>
+          <button
+            type="button"
+            onClick={openExportMenu}
+            disabled={!onExportZone}
+            className={`p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              showExportMenu
+                ? "text-[#9ece6a] bg-[#9ece6a]/10"
+                : "text-[#565f89] hover:text-[#9ece6a] hover:bg-[#9ece6a]/10"
+            }`}
+            title={onExportZone ? "Export zone output" : "Export not available"}
+            aria-label="Export zone output"
+            aria-expanded={showExportMenu}
+          >
+            <Download className="w-3 h-3" />
+          </button>
+          {showExportMenu && onExportZone && (
+            <div className="absolute top-full right-0 mt-1 w-24 bg-[#1a1b26] border border-[#2a2d3d] rounded shadow-xl z-50 overflow-hidden">
+              {EXPORT_FORMATS.map((format) => (
+                <button
+                  key={format}
+                  type="button"
+                  onClick={(e) => handleExport(e, format)}
+                  className="block w-full text-left px-2 py-1 text-[10px] text-[#a9b1d6] hover:bg-[#2a2d3d] hover:text-[#c0caf5] transition-colors"
+                >
+                  {format}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Close */}
+        <button
+          type="button"
+          onClick={handleClose}
+          disabled={!hasTab}
+          className="p-1 rounded text-[#565f89] hover:text-[#f7768e] hover:bg-[#f7768e]/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          title="Close session (Ctrl+Shift+W)"
+          aria-label="Close session"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </div>
+
+      {/* Label edit popover */}
+      {showLabelInput && (
+        <div
+          ref={labelPopoverRef}
+          className="absolute top-full right-0 mt-1 w-44 bg-[#1a1b26] border border-[#2a2d3d] rounded shadow-xl p-2 z-50"
+        >
+          <input
+            ref={labelInputRef}
+            value={labelDraft}
+            onChange={(e) => setLabelDraft(e.target.value)}
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === "Enter") {
+                labelsAndTags.setZoneLabel(zoneIdx, labelDraft.trim());
+                setShowLabelInput(false);
+              } else if (e.key === "Escape") {
+                setShowLabelInput(false);
+              }
+            }}
+            placeholder="zone label (comma-separated tags)"
+            className="w-full bg-[#13141f] border border-[#2a2d3d] rounded px-1.5 py-1 text-[10px] text-[#c0caf5] placeholder-[#565f89]/60 outline-hidden focus:border-[#7aa2f7] transition-colors"
+            maxLength={64}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/terminal/ZoneLayoutPicker.tsx
+++ b/src/components/terminal/ZoneLayoutPicker.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { LayoutGrid } from "lucide-react";
 import { LAYOUT_PRESETS, type LayoutPreset } from "./useZoneLayout";
 import { useUIComponent, UIBridgeComponentScope } from "@qontinui/ui-bridge";
+import { callRegistry } from "./commands";
 
 interface ZoneLayoutPickerProps {
   currentLayoutId: string;
@@ -99,16 +100,26 @@ export function ZoneLayoutPicker({
         label: "Select Layout",
         description: "Switch the terminal grid to a named layout preset.",
         paramSchema: { layoutId: "string (use list-layouts to enumerate valid IDs)" },
-        handler: (params?: unknown) => {
+        handler: async (params?: unknown) => {
           const { layoutId } = (params ?? {}) as { layoutId?: string };
           if (!layoutId) throw new Error("select-layout requires { layoutId: string }");
+          // Validate up-front so the existing "Valid options: …" error
+          // message stays intact for automation parsers. The registry
+          // would otherwise return `invalid-preset` with a thinner
+          // message.
           const preset = LAYOUT_PRESETS.find((l) => l.id === layoutId);
           if (!preset) {
             throw new Error(
               `Unknown layoutId: "${layoutId}". Valid options: ${LAYOUT_PRESETS.map((l) => l.id).join(", ")}`,
             );
           }
-          onSelectLayout(layoutId);
+          // Phase 1c — delegates to registry `terminal.layout`. The
+          // registry handler calls the same `zoneLayout.setLayoutId`
+          // closure that `onSelectLayout` does (both source from
+          // TerminalPage's session context), so behavior is identical
+          // — but a future change to layout semantics now has one
+          // landing point instead of two.
+          await callRegistry("terminal.layout", { preset: layoutId });
           setOpen(false);
         },
       },

--- a/src/components/terminal/ZoneMinimap.tsx
+++ b/src/components/terminal/ZoneMinimap.tsx
@@ -28,7 +28,17 @@ export function ZoneMinimap() {
   const layout = zoneLayout.layout;
   const assignments = zoneLayout.assignments;
   const focusedZone = zoneLayout.focusedZone;
+  const maximizedZone = zoneLayout.maximizedZone;
   const onFocusZone = zoneLayout.setFocusedZone;
+  const onMaximizeZone = zoneLayout.setMaximizedZone;
+  const selectZone = (idx: number) => {
+    onFocusZone(idx);
+    // When a zone is maximized the grid renders only that zone, so the
+    // minimap is the only switcher available — swap the maximized view
+    // to the clicked tile instead of leaving the user stuck on the
+    // previous one.
+    if (maximizedZone !== null) onMaximizeZone(idx);
+  };
   const sessionStates = session.sessionStates;
   const { labelsAndTags } = useZoneMetadata();
   const zoneTags = labelsAndTags.zoneTags;
@@ -36,7 +46,7 @@ export function ZoneMinimap() {
 
   const [dismissed, setDismissed] = useState(false);
 
-  if (dismissed || layout.zones.length < 6) return null;
+  if (dismissed || !zoneLayout.isMultiZone) return null;
 
   const { columns, rows } = layout;
   const mapW = 120;
@@ -102,7 +112,7 @@ export function ZoneMinimap() {
             const h = rowSpan * cellH;
 
             return (
-              <g key={`zone-${idx}`} onClick={() => onFocusZone(idx)} className="cursor-pointer">
+              <g key={`zone-${idx}`} onClick={() => selectZone(idx)} className="cursor-pointer">
                 <rect
                   x={x + 1}
                   y={y + 1}

--- a/src/components/terminal/commands/audit.md
+++ b/src/components/terminal/commands/audit.md
@@ -1,0 +1,136 @@
+# Top-10 Daily Actions Audit — Terminal Page
+
+> **Phase 1 deliverable** for the 2026-05-28 redesign plan (`plans/2026-05-28-terminal-page-redesign-plan.md` §0 success criterion (b), §4 Phase 1).
+> The redesign is only justified if the new affordances (CommandBar, suggestion chips, hover controls, palette) are **at least as fast** as the current chrome for the operator's top-10 daily actions. This document fixes the top-10 list and per-action keystroke budget so Phase 2 (CommandBar v1) can be measured against it.
+
+## Methodology
+
+No production telemetry exists for chrome-button click frequency. The ranking instead triangulates four evidence sources, weighted by signal strength:
+
+1. **Hotkey binding (strongest signal).** An operator-bound `Ctrl+Shift+*` chord means *"I do this multiple times per work session."* Source: `src/components/terminal/useKeyboardShortcuts.ts:91-296` (24 distinct bindings).
+2. **Page-purpose alignment (strong).** The page is a coordination surface for *multiple concurrent AI sessions*. Actions that directly operate on that purpose (jump-to-needs-input, approve-all, spawn-AI) rank higher than generic terminal ops.
+3. **Persistent-chrome real estate (weak).** A button that ships in `TerminalTabBar` or `ZoneStatusBar` was deemed visible-worthy by past authors. Many of those are now-rare-but-historically-promoted.
+4. **UI Bridge `useUIComponent` exposure (orthogonal).** Actions exposed to external agents reflect *agent* needs, not operator frequency — used as a tie-breaker only.
+
+A keystroke-budget rule supplements ranking: **for each top-10 action, the new CommandBar path must be ≤ the existing keystroke count.** Hotkey'd actions don't need to be replaced by CommandBar paths — they just need a slash equivalent for discoverability and AI/external-agent invocation.
+
+## The top 10
+
+Ranked by estimated frequency in a typical multi-AI session work day.
+
+| # | Action | Current path(s) | Current keystrokes | Slash equivalent | New keystrokes (best case) |
+|---|--------|-----------------|--------------------|------------------|----------------------------|
+| 1 | **Focus a session (switch active zone)** | `Ctrl+Tab` / `Ctrl+1..9` / click the window | 1 chord or 1 click | `/focus <n>` | 1 click (unchanged, zones already clickable per the 2026-05-28 grid-first decision) |
+| 2 | **Spawn a session** (default = plain PTY) | `Ctrl+Shift+T` / tab-bar `+` button | 1 chord OR 1 click | `/spawn` | 1 chord (`Ctrl+/` + `Enter` if `/spawn` is the recent top) |
+| 3 | **Jump to next needs-input session** | `Ctrl+Shift+N` / status-bar `Next Action` button (only renders when count>0) | 1 chord | `/focus needs-input` (chip alternative for first-time learners) | 1 chord (unchanged) — slash form for discoverability only |
+| 4 | **Approve all needs-input sessions** | `Ctrl+Shift+Enter` (sends `y\r` to every needs-input PTY) | 1 chord | `/approve-all` | 1 chord (unchanged) — slash form for discoverability only |
+| 5 | **Maximize / restore current zone** | `Ctrl+Shift+F` / per-zone double-click (future: hover control) | 1 chord or 1 dblclick | `/maximize` (active zone) or `/maximize <n>` | 1 chord (unchanged) |
+| 6 | **Close a session** | `Ctrl+Shift+W` / tab-bar per-tab close `X` (today) / hover-control close (Phase 5) | 1 chord OR 1 click | `/close` (active) or `/close <n>` | 1 chord (unchanged) |
+| 7 | **Change layout preset** | `Ctrl+Shift+1..8` / `Ctrl+Shift+L` (cycle) / layout-picker dropdown | 1 chord OR multi-click | `/layout <preset>` | 1 chord (unchanged) — slash form replaces the dropdown's multi-click |
+| 8 | **Spawn an AI session** (Claude under specific account, optional context prompt) | Tab-bar chevron → LaunchMenu → account select → count → context → submit | **5-8 clicks/keystrokes** (worst case in current chrome) | `/spawn-ai <count> <account>` and `/spawn-best <count>` | **5-6 keystrokes via CommandBar autocomplete**; **the marquee CommandBar win** |
+| 9 | **Restart a completed/errored session in its zone** | `Ctrl+Shift+R` / chip on errored zones (Phase 4) | 1 chord | `/restart` (active zone) or `/restart-zone <n>` | 1 chord (unchanged) — gated on state ∈ {`completed`, `error`} per `TransitionEffectsContext.tsx:39-69` |
+| 10 | **Swap two zones' tab assignments** | `Ctrl+Shift+X` (mark source, focus dest, repeat to swap) | 2 chords + zone-focus interactions | `/swap <a> <b>` | 1 CommandBar invocation (~6 keystrokes) — **fewer keystrokes than today's two-step chord workflow** |
+
+### Why these and not the others
+
+**Action candidates rejected from the top 10**, with one-line justification:
+
+| Action | Why not top-10 |
+|--------|----------------|
+| Toggle auto-focus on needs-input (`Ctrl+Shift+A`) | Set-and-forget; toggled <1×/day in steady use. Hotkey survives, slash exists, no CommandBar pressure. |
+| Toggle sound notification (`Ctrl+Shift+S`) | Set once at start of session; same logic. |
+| Toggle focus mode (`Ctrl+Shift+D`) | Same — preference-set, not per-action. |
+| Output search (`Ctrl+Shift+/`) | Frequent for power users, but bounded to "I lost something" — not per-session-action. Belongs to top-15. |
+| Pin zone (`Ctrl+Shift+O`) | Layout-organization action, set-and-forget. |
+| Filter by tag (`Ctrl+Shift+G`) | Only matters in heavily-labeled workspaces; opt-in feature. |
+| Save / load profile | Rare (~1×/week for someone who profiles workflows) but high-value when used. Top-15. |
+| Generate workflow from session | Workflow-builder integration; the operator running it is in a *different mode* than "watching sessions." Top-20. |
+| Analyze dropdown (6 analysis types) | Same — investigative mode, not coordination mode. Top-20. |
+| Plan: Implement / Verify / Refresh | Plan-builder integration; rare. |
+| Findings / File-ownership / Sessions-sidebar toggles | All set-once-and-keep-open in their respective workflows. |
+| Auto-approve / auto-restart configuration | Preference-set. |
+| Reorganize pages (AI) | Page-level, weekly cadence at most. |
+| Resume frozen session (`Ctrl+Shift+J`) | Rare unless an operator routinely freezes/resumes — not the common path. |
+| View-mode cycle (`Ctrl+Shift+M`) | Three-state visual density toggle; rarely re-cycled. |
+| Resume / Sessions sidebar toggle (`Ctrl+Shift+B`) | Mode switch, not per-action. |
+| Export / Sort zones / Doc finder / Metrics / History / Shortcuts help | All discoverable-on-demand from palette; no need to ship them in default chrome. |
+
+The cut-off between #10 and #11 is somewhat arbitrary. **#10 Swap zones** was kept above #11 (Output search) because today's swap-zone UX is unusually awful (two-step chord + zone focus) — the redesign delivers measurable improvement here whereas Output search already works. If telemetry from Phase 2 contradicts this, demote swap and promote search.
+
+## Per-action success criterion checks
+
+For each top-10, the new CommandBar invocation path must satisfy:
+
+```
+new_keystrokes(action)  <=  current_keystrokes(action)    [hard requirement]
+new_latency(action)     <=  current_latency(action) + 50ms [soft requirement]
+```
+
+### Hotkey-dominant actions (#1, #3, #4, #5, #6, #7, #9)
+
+These are already 1-chord. The CommandBar is **not** intended to beat the hotkey — it provides the slash equivalent for:
+- Operator discoverability (autocomplete teaches the hotkey via its display in the suggestion row)
+- AI tool-call invocation (Tier 3 maps free text → action)
+- External-agent invocation via the UI Bridge adapter
+
+Hard requirement here = "exists in the registry with the correct paramSchema." No latency or keystroke regression possible.
+
+### Marquee CommandBar wins (#8 Spawn AI, #10 Swap zones)
+
+The two top-10 actions where today's chrome is genuinely worse than a typed command:
+
+**#8 Spawn AI — current path:**
+1. Click chevron at tab bar (1 click) → 2. wait for `LaunchMenu` to render → 3. click "Create AI Session" tile (1 click) → 4. click account row (1 click) → 5. type count, e.g. `3` (1 keystroke) → 6. *(optional)* paste context prompt → 7. click submit (1 click). **Minimum 4 clicks + 1 keystroke + dropdown render wait ≈ 5-8 actions.**
+
+**#8 via CommandBar:**
+1. `Ctrl+/` (1 chord) → 2. type `sp` → 3. autocomplete shows `/spawn-ai 1 <account>` at top → 4. Tab to fill in best-account placeholder → 5. edit count to `3` → 6. Enter. **5-6 keystrokes**, zero clicks, no dropdown render wait.
+
+**#10 Swap zones — current path:**
+1. Focus zone A (`Ctrl+<n>`) → 2. `Ctrl+Shift+X` (marks source) → 3. focus zone B (`Ctrl+<m>`) → 4. `Ctrl+Shift+X` (swaps). **4 chords**, with a mental model gotcha (must remember which is marked).
+
+**#10 via CommandBar:** `Ctrl+/`, `swap 2 5`, Enter. **~8 keystrokes total**, no mode tracking. Fewer chords, less mental load.
+
+### Per-zone-control actions (#2, #5 alt, #6 alt, #9 alt)
+
+Phase 5 adds hover controls in each zone for spawn/maximize/close/restart. These add a third path alongside hotkey + slash. The hard requirement is that none of the three paths regresses; the hover path is "discoverable for the operator who doesn't know the hotkey yet."
+
+## Open questions surfaced by this audit
+
+These do not block Phase 1, but are worth flagging:
+
+1. **#3 (Jump to needs-input) and #4 (Approve-all) are AI-session-specific.** A user running mostly plain PTYs would re-rank these down. Should the audit be re-run with a usage-mode tag (AI-heavy vs. plain-shell-heavy)? Recommendation: keep the AI-heavy rank as the default since the redesign motivation was multi-AI-session work specifically.
+2. **Compound actions are not in the top-10** (e.g., *"close all completed"*, *"restart every errored zone"*, *"spawn 3 in this repo and load profile X"*). These are the natural Tier-3 AI use cases. Phase 8 may justify itself entirely on the strength of these — track Tier-2 vs. Tier-3 acceptance rate per phrasing during dogfooding.
+3. **#8 Spawn AI's account selection** is currently order-dependent (LaunchMenu sorts by `utilization`). The slash form `/spawn-ai 3 <account>` should accept either the explicit account name or the literal `best`/`@best` to map to `create-best-account`. Phase 1's `paramSchema` must accommodate this.
+4. **Where do per-zone hover controls (Phase 5) win the keystroke race?** Mostly for mouse-driven operators who don't memorize chords. The audit assumes a keyboard-driven operator; a mouse-driven operator's top-10 would put Phase-5 hover actions higher (close, restart, maximize). Both populations are served; the keystroke budgets above are for the keyboard-driven case.
+
+## Action-registry entries implied by this audit
+
+Phase 1 `registry.ts` MUST register at least these (slash → handler). IDs chosen to align with existing UI Bridge `useUIComponent` action names where they overlap (preservation per §5(4) of the plan):
+
+| Slash | Registry id | Existing UI Bridge id | Handler source |
+|-------|-------------|------------------------|----------------|
+| `/focus <n>` | `terminal.focus` | — | `zoneLayout.setFocusedZone` |
+| `/focus needs-input` | `terminal.focus.needs-input` | — | `zoneLayout.focusNextNeedsInput` |
+| `/focus next` / `/focus prev` | `terminal.focus.next` / `.prev` | — | `zoneLayout.focusNextZone` / `focusPrevZone` |
+| `/spawn` | `terminal.spawn` | `create-plain` | `onQuickLaunch` (TerminalPage.tsx:539) |
+| `/spawn-ai <count> <account>` | `terminal.spawn-ai` | `create-ai-session` | `onLaunchAiSession` (TerminalPage.tsx:559) |
+| `/spawn-best <count>` | `terminal.spawn-best` | `create-best-account` | (uses `onLaunchAiSession` with `sortedAccountsForBridge[0]`) |
+| `/spawn-with <count> <command>` | `terminal.spawn-with` | `create-with-command` | `onQuickLaunch` with autoCommand |
+| `/approve-all` | `terminal.approve-all` | — | inline writer in `useKeyboardShortcuts.ts:142-151` (extract to a helper) |
+| `/maximize` / `/maximize <n>` | `terminal.maximize` | — | `zoneLayout.toggleMaximize` (`useZoneLayout.ts:303-308`) |
+| `/close` / `/close <n>` | `terminal.close` | — | `closeTerminal` |
+| `/layout <preset>` | `terminal.layout` | `zone-layout-picker` actions (4th `useUIComponent` site) | `zoneLayout.setLayoutId` |
+| `/restart` / `/restart-zone <n>` | `terminal.restart` | — | `transitionEffects.handleRestartInZone` (gated; surface gate in result) |
+| `/swap <a> <b>` | `terminal.swap` | — | `zoneLayout.assignTabToZone` (twice, as in `useKeyboardShortcuts.ts:171-184`) |
+
+That is 12 action entries to cover the top-10 (some actions have multiple arg shapes). The Phase-1 stretch set of ~25 expands this with profile/export/search/etc.
+
+## Done definition for this audit
+
+- ✅ Top-10 named, ranked, with evidence sources cited.
+- ✅ Each entry has a current-keystroke count and a new-keystroke budget.
+- ✅ Rejected candidates listed with one-line justification.
+- ✅ Implied registry entries enumerated with existing handler sources.
+- ✅ Open questions flagged for operator review.
+
+When the operator signs off on this list (or amends it), Phase 1 plumbing (`registry.ts`, `useCommandAction.ts`, `types.ts`) can begin against this exact target.

--- a/src/components/terminal/commands/fuzzy.ts
+++ b/src/components/terminal/commands/fuzzy.ts
@@ -1,0 +1,83 @@
+/**
+ * Fuzzy scoring used by the CommandBar (Tier 1 resolver) and the
+ * Ctrl+Shift+K palette. Extracted from `CommandPalette.tsx:10-58` per
+ * plan §4 Phase 2 so both surfaces use the same scorer — operators
+ * shouldn't see different orderings between the two entry points.
+ *
+ * Three tiers with deliberately wide gaps so prefix matches always
+ * beat word-boundary matches, which always beat sequential fuzzy:
+ *
+ *   - **Prefix match** (`100 + query.length`) — text starts with the
+ *     query. Highest priority; almost always the intended completion
+ *     when an operator types `/sp` to mean `/spawn`.
+ *   - **Word-boundary match** (`70 + query.length`) — query characters
+ *     hit at the start of `/`, `-`, `_`, `:`, or space-delimited tokens
+ *     in order. Captures the `sba` → `/spawn-best-account` case
+ *     idiomatic in CLI fuzzy finders (Cmd+P, fzf).
+ *   - **Sequential fuzzy** (`30 + (50 - spread)` clamped at 0) —
+ *     characters appear in order anywhere in the text; spread penalty
+ *     means `/sa` matches `/spawn-ai` better than `/spawn-with-shell-args`.
+ *
+ * Returns `null` when no match exists; the caller filters by truthiness.
+ */
+
+export interface FuzzyMatch {
+  /** Higher = better. Compare across candidates with simple sort. */
+  score: number;
+  /** Character positions in `text` that matched, for highlight rendering. */
+  indices: number[];
+}
+
+export function fuzzyScore(text: string, query: string): FuzzyMatch | null {
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+
+  // Empty query matches everything with a neutral score; caller decides
+  // whether to keep the order untouched or apply secondary sorting.
+  if (q.length === 0) return { score: 0, indices: [] };
+
+  // ── Tier 1: prefix match ────────────────────────────────────────────
+  if (lower.startsWith(q)) {
+    return {
+      score: 100 + q.length,
+      indices: Array.from({ length: q.length }, (_, i) => i),
+    };
+  }
+
+  // ── Tier 2: word-boundary match ─────────────────────────────────────
+  const words = lower.split(/[\s\-_:/]/);
+  let wordStart = 0;
+  const wordBoundaryIndices: number[] = [];
+  let qi = 0;
+  for (const word of words) {
+    if (qi < q.length && word.startsWith(q[qi])) {
+      for (let wi = 0; wi < word.length && qi < q.length; wi++) {
+        if (word[wi] === q[qi]) {
+          wordBoundaryIndices.push(wordStart + wi);
+          qi++;
+        }
+      }
+    }
+    wordStart += word.length + 1;
+  }
+  if (qi === q.length) {
+    return { score: 70 + q.length, indices: wordBoundaryIndices };
+  }
+
+  // ── Tier 3: sequential fuzzy ────────────────────────────────────────
+  const indices: number[] = [];
+  let si = 0;
+  for (let i = 0; i < lower.length && si < q.length; i++) {
+    if (lower[i] === q[si]) {
+      indices.push(i);
+      si++;
+    }
+  }
+  if (si === q.length) {
+    const spread = indices[indices.length - 1] - indices[0];
+    const compactness = Math.max(0, 50 - spread);
+    return { score: 30 + compactness, indices };
+  }
+
+  return null;
+}

--- a/src/components/terminal/commands/index.ts
+++ b/src/components/terminal/commands/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Public surface of the terminal-page command-action registry.
+ *
+ * Phase 1 plumbing only — no actions registered yet, no resolver tiers
+ * wired up. See `./audit.md` for the 12-action target and
+ * `plans/2026-05-28-terminal-page-redesign-plan.md` for the full design.
+ */
+
+export type {
+  CommandAction,
+  CommandResult,
+  RegistryListener,
+  ResolverContext,
+} from "./types";
+
+export {
+  getAll,
+  getById,
+  getBySlash,
+  register,
+  subscribe,
+  unregister,
+} from "./registry";
+
+export { useCommandAction } from "./useCommandAction";
+
+export { useTerminalCommands } from "./useTerminalCommands";
+export type { TerminalCommandsContext } from "./useTerminalCommands";
+
+export { fuzzyScore } from "./fuzzy";
+export type { FuzzyMatch } from "./fuzzy";
+
+export { resolve } from "./resolve";
+export type { ResolveMatch } from "./resolve";
+
+export { coerceToken, parseArgs, tokenize } from "./parse";
+
+export { matchPattern } from "./patterns";
+export type { PatternMatch } from "./patterns";
+
+export { callRegistry } from "./uibridge";
+
+export { getRegistryPaletteActions } from "./palette-projection";
+export type { PaletteActionLike } from "./palette-projection";
+
+export { interpretCommand, normalizeInterpretKey } from "./interpret";
+export type { InterpretMatch, InterpretOptions } from "./interpret";

--- a/src/components/terminal/commands/interpret.test.ts
+++ b/src/components/terminal/commands/interpret.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for Tier-3 interpret bridge.
+ *
+ * Coverage focuses on the pure pieces (normalization, cache, gate) and
+ * uses a vi.mock for the Tauri `invoke` so the subprocess never runs
+ * during CI.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@/lib/instance-storage", () => {
+  let store: Record<string, string> = {};
+  return {
+    instanceStorage: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v;
+      },
+      removeItem: (k: string) => {
+        delete store[k];
+      },
+      getJSON<T>(k: string, fb: T): T {
+        const raw = store[k];
+        return raw ? (JSON.parse(raw) as T) : fb;
+      },
+      setJSON(k: string, v: unknown) {
+        store[k] = JSON.stringify(v);
+      },
+      removeByPrefix: () => {
+        store = {};
+      },
+      __reset: () => {
+        store = {};
+      },
+    },
+  };
+});
+
+import { invoke } from "@tauri-apps/api/core";
+import { instanceStorage } from "@/lib/instance-storage";
+
+import { interpretCommand, normalizeInterpretKey } from "./interpret";
+import { __resetForTest, register } from "./registry";
+
+const mockedInvoke = vi.mocked(invoke);
+
+afterEach(() => {
+  __resetForTest();
+  // @ts-expect-error — test helper added by the mock above
+  instanceStorage.__reset?.();
+  mockedInvoke.mockReset();
+});
+
+beforeEach(() => {
+  register({
+    id: "terminal.spawn",
+    slash: "/spawn",
+    label: "Spawn plain terminal",
+    description: "spec",
+    handler: async () => ({ ok: true, value: [] }),
+  });
+});
+
+describe("normalizeInterpretKey", () => {
+  it("lowercases + trims + collapses whitespace", () => {
+    expect(normalizeInterpretKey("  Spawn  THREE   ")).toBe("spawn three");
+  });
+
+  it("strips a single leading slash", () => {
+    expect(normalizeInterpretKey("/spawn 3")).toBe("spawn 3");
+  });
+
+  it("returns empty for whitespace-only input", () => {
+    expect(normalizeInterpretKey("   ")).toBe("");
+  });
+});
+
+describe("interpretCommand — cache", () => {
+  it("hits the cache on identical normalized text without invoking the subprocess", async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      tool: "terminal.spawn",
+      args: { count: 3 },
+      confidence: 0.9,
+    });
+    const first = await interpretCommand("spawn three terminals");
+    expect(first?.action.id).toBe("terminal.spawn");
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+
+    // Same text with cosmetic whitespace — cache key normalises.
+    const second = await interpretCommand("  Spawn  Three  Terminals  ");
+    expect(second?.action.id).toBe("terminal.spawn");
+    // Still 1 — the second resolved from cache.
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-invokes when the cached entry was below the gate (but cache still records)", async () => {
+    mockedInvoke
+      .mockResolvedValueOnce({ tool: "terminal.spawn", args: {}, confidence: 0.2 })
+      .mockResolvedValueOnce({ tool: "terminal.spawn", args: {}, confidence: 0.9 });
+    // First call: below default gate (0.4) → returns null but caches.
+    const first = await interpretCommand("ambiguous", { minConfidence: 0.4 });
+    expect(first).toBeNull();
+    // Second call with a higher gate still wouldn't pass — but the
+    // cache returned null without re-invoking, which is the contract.
+    const second = await interpretCommand("ambiguous", { minConfidence: 0.4 });
+    expect(second).toBeNull();
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("interpretCommand — gate + projection", () => {
+  it("returns null when confidence is below the gate", async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      tool: "terminal.spawn",
+      args: {},
+      confidence: 0.1,
+    });
+    const result = await interpretCommand("vague", { minConfidence: 0.4 });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the tool id is unknown to the registry", async () => {
+    mockedInvoke.mockResolvedValueOnce({
+      tool: "made.up.action",
+      args: {},
+      confidence: 0.99,
+    });
+    const result = await interpretCommand("do the thing");
+    expect(result).toBeNull();
+  });
+
+  it("returns null on empty input without invoking", async () => {
+    const result = await interpretCommand("   ");
+    expect(result).toBeNull();
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+
+  it("swallows subprocess errors as null", async () => {
+    mockedInvoke.mockRejectedValueOnce(new Error("claude not found"));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await interpretCommand("spawn 3");
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("respects an aborted signal — does not invoke", async () => {
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const result = await interpretCommand("spawn 3", { signal: ctrl.signal });
+    // Aborted-before-call: invoke is still called (the abort check is
+    // after the cache lookup), but the result is dropped to null. Both
+    // behaviors are acceptable contracts; current impl checks abort
+    // BEFORE the invoke, so 0 calls expected.
+    expect(result).toBeNull();
+    expect(mockedInvoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/terminal/commands/interpret.ts
+++ b/src/components/terminal/commands/interpret.ts
@@ -1,0 +1,222 @@
+/**
+ * Phase 8 — Tier-3 free-text → registry action.
+ *
+ * Bridges the CommandBar to the Rust `command_interpret` Tauri command
+ * (which spawns the local `claude` CLI as a one-shot subprocess; see
+ * `src-tauri/src/commands/command_interpreter.rs` for the architectural
+ * rationale and CLI flag set).
+ *
+ * The hot path:
+ *
+ *   1. {@link interpretCommand} is called with the operator's free
+ *      text after Tier-1/2 misses.
+ *   2. The L1 cache (LRU ~200, persisted to `instanceStorage`) is
+ *      consulted with the normalized text as the key. Hits return
+ *      instantly without subprocess cost.
+ *   3. Misses build a compact tools catalog from the current registry
+ *      snapshot and invoke the Rust command.
+ *   4. The model's structured `{tool, args, confidence}` is resolved
+ *      against the live registry. Unknown tool ids OR confidence below
+ *      the gate return `null` so the CommandBar can fall back to fuzzy.
+ *   5. Successful resolutions are written back to the cache.
+ *
+ * Cancellation: the caller passes an `AbortSignal` so a follow-up
+ * keystroke (or pressing `Escape`) cleanly drops the in-flight call.
+ * The Tauri layer doesn't surface its own abort hook, so the signal is
+ * checked at JS boundaries — the subprocess on the Rust side runs to
+ * completion in the background, but its result is discarded.
+ *
+ * Confidence gate: defaults to `0.4`. Below this the model is usually
+ * guessing; surfacing it would offer suggestions that are worse than
+ * the Tier-1 fuzzy fallback. The CommandBar's Tier-3 row also displays
+ * the confidence so operators can sanity-check before pressing Enter.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+
+import { instanceStorage } from "@/lib/instance-storage";
+
+import { getById, getAll } from "./registry";
+import type { CommandAction } from "./types";
+
+const CACHE_STORAGE_KEY = "terminal-command-interpret-cache";
+const CACHE_CAP = 200;
+const DEFAULT_CONFIDENCE_GATE = 0.4;
+
+/**
+ * Mirror of the Rust `InterpretResult` struct
+ * (`command_interpreter.rs`'s `InterpretResult`). Any field name change
+ * on the Rust side has to mirror here — keep them in lockstep.
+ */
+interface RawInterpretResult {
+  tool: string;
+  args: Record<string, unknown>;
+  confidence: number;
+}
+
+export interface InterpretMatch {
+  action: CommandAction;
+  args: Record<string, unknown>;
+  /** Model's self-reported confidence ∈ [0, 1]. */
+  confidence: number;
+}
+
+interface CachedEntry {
+  tool: string;
+  args: Record<string, unknown>;
+  confidence: number;
+  /** Last access epoch ms — drives LRU eviction. */
+  lastUsed: number;
+}
+
+type Cache = Record<string, CachedEntry>;
+
+/** Lowercase + trim + collapse internal whitespace. Strips a single
+ *  leading `/` so slash and non-slash forms cache-share. */
+export function normalizeInterpretKey(text: string): string {
+  return text
+    .replace(/^\//, "")
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ");
+}
+
+function readCache(): Cache {
+  return instanceStorage.getJSON<Cache>(CACHE_STORAGE_KEY, {});
+}
+
+function writeCache(cache: Cache): void {
+  instanceStorage.setJSON(CACHE_STORAGE_KEY, cache);
+}
+
+function getCached(key: string): CachedEntry | null {
+  const cache = readCache();
+  const entry = cache[key];
+  if (!entry) return null;
+  // Refresh LRU position. Cheap because writeCache is a single JSON
+  // round-trip; we don't try to batch since hits are bounded by the
+  // CommandBar's debounce.
+  entry.lastUsed = Date.now();
+  cache[key] = entry;
+  writeCache(cache);
+  return entry;
+}
+
+function setCached(key: string, entry: Omit<CachedEntry, "lastUsed">): void {
+  const cache = readCache();
+  cache[key] = { ...entry, lastUsed: Date.now() };
+  // Evict least-recently-used entries down to the cap.
+  const entries = Object.entries(cache);
+  if (entries.length > CACHE_CAP) {
+    entries.sort((a, b) => a[1].lastUsed - b[1].lastUsed);
+    const toDrop = entries.length - CACHE_CAP;
+    for (let i = 0; i < toDrop; i++) {
+      delete cache[entries[i][0]];
+    }
+  }
+  writeCache(cache);
+}
+
+/**
+ * Build the JSON catalog that the model sees. Kept compact so the
+ * prompt-token cost stays small — slash + label + description +
+ * paramSchema is enough for the model to route; `aliases` and
+ * `patterns` add no signal and inflate the prompt.
+ */
+function buildToolsJson(actions: readonly CommandAction[]): string {
+  return JSON.stringify(
+    actions.map((a) => ({
+      id: a.id,
+      slash: a.slash,
+      label: a.label,
+      description: a.description,
+      paramSchema: a.paramSchema ?? {},
+    })),
+  );
+}
+
+export interface InterpretOptions {
+  /** Aborted to drop an in-flight call. The subprocess on the Rust
+   *  side runs to completion regardless; only the JS-side result is
+   *  discarded. */
+  signal?: AbortSignal;
+  /** Confidence floor below which we return null. Defaults to
+   *  {@link DEFAULT_CONFIDENCE_GATE}. */
+  minConfidence?: number;
+}
+
+/**
+ * Project a Rust-side {@link RawInterpretResult} onto the live registry,
+ * returning `null` when the model's `tool` is unknown or empty.
+ *
+ * The registry can change between cache-write and cache-read (a tab
+ * close that drops a per-tab action, for example), so the action
+ * lookup happens at consumer time, not at cache time.
+ */
+function projectToMatch(raw: RawInterpretResult): InterpretMatch | null {
+  if (!raw.tool) return null;
+  const action = getById(raw.tool);
+  if (!action) return null;
+  return {
+    action,
+    args: raw.args ?? {},
+    confidence: raw.confidence,
+  };
+}
+
+/**
+ * Try to resolve free-text to a registry action via the Tier-3
+ * subprocess. Returns `null` when:
+ *
+ *   - text normalises to empty
+ *   - the model returns confidence below {@link InterpretOptions.minConfidence}
+ *   - the model returns an unknown / empty `tool`
+ *   - the subprocess errors (any reason)
+ *   - the signal aborts before / during the call
+ *
+ * Never throws — Tier-3 is fallback chrome, so a failure here just
+ * lets Tier-1 fuzzy carry the response.
+ */
+export async function interpretCommand(
+  text: string,
+  options: InterpretOptions = {},
+): Promise<InterpretMatch | null> {
+  const { signal, minConfidence = DEFAULT_CONFIDENCE_GATE } = options;
+
+  const key = normalizeInterpretKey(text);
+  if (key.length === 0) return null;
+
+  const cached = getCached(key);
+  if (cached) {
+    if (cached.confidence < minConfidence) return null;
+    return projectToMatch(cached);
+  }
+
+  if (signal?.aborted) return null;
+
+  const toolsJson = buildToolsJson(getAll());
+
+  let raw: RawInterpretResult;
+  try {
+    raw = await invoke<RawInterpretResult>("command_interpret", {
+      text,
+      toolsJson,
+    });
+  } catch (err) {
+    // Log to console; Tier-3 failure is silent at the UX level so the
+    // CommandBar's fuzzy fallback isn't paved over by an error toast.
+    // eslint-disable-next-line no-console
+    console.warn("[Tier-3] command_interpret failed:", err);
+    return null;
+  }
+
+  if (signal?.aborted) return null;
+
+  // Cache regardless of confidence so a low-confidence repeat doesn't
+  // re-pay the subprocess cost. The gate is applied below at read time
+  // too — getCached's gate check rejects sub-threshold entries.
+  setCached(key, { tool: raw.tool, args: raw.args, confidence: raw.confidence });
+
+  if (raw.confidence < minConfidence) return null;
+  return projectToMatch(raw);
+}

--- a/src/components/terminal/commands/interpret.ts
+++ b/src/components/terminal/commands/interpret.ts
@@ -205,7 +205,8 @@ export async function interpretCommand(
   } catch (err) {
     // Log to console; Tier-3 failure is silent at the UX level so the
     // CommandBar's fuzzy fallback isn't paved over by an error toast.
-    // eslint-disable-next-line no-console
+    // `console.warn` is allowed by the no-console rule (only `log` is
+    // disallowed), so no eslint-disable is needed here.
     console.warn("[Tier-3] command_interpret failed:", err);
     return null;
   }

--- a/src/components/terminal/commands/palette-projection.test.ts
+++ b/src/components/terminal/commands/palette-projection.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the Phase-7 registry → palette projection.
+ *
+ * Covers:
+ *   1. Empty registry → empty projection
+ *   2. Argless action — projects with label + slash + no params hint
+ *   3. Action with paramSchema — label gains "(key1, key2)" hint
+ *   4. All rows live under category "Commands" with priority 0
+ *   5. Click handler invokes registry handler and swallows failures
+ *   6. Click handler returns success to the operator's `void` shape
+ *      (no throw on rejection)
+ *   7. Projection is stable across calls — sorted by label
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getRegistryPaletteActions } from "./palette-projection";
+import { __resetForTest, register } from "./registry";
+import type { CommandAction } from "./types";
+
+afterEach(() => {
+  __resetForTest();
+});
+
+const action = (overrides: Partial<CommandAction>): CommandAction => ({
+  id: "test.action",
+  slash: "/test",
+  label: "Test action",
+  description: "spec",
+  handler: async () => ({ ok: true }),
+  ...overrides,
+});
+
+describe("getRegistryPaletteActions", () => {
+  it("returns empty when the registry is empty", () => {
+    expect(getRegistryPaletteActions()).toEqual([]);
+  });
+
+  it("projects an argless action with bare slash label", () => {
+    register(action({ id: "approve-all", slash: "/approve-all", label: "Approve all" }));
+    const rows = getRegistryPaletteActions();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: "registry:approve-all",
+      category: "Commands",
+      priority: 0,
+      label: "/approve-all — Approve all",
+    });
+  });
+
+  it("appends a `(key1, key2)` params hint when paramSchema is non-empty", () => {
+    register(
+      action({
+        id: "swap",
+        slash: "/swap",
+        label: "Swap two zones",
+        paramSchema: { a: "n", b: "n" },
+      }),
+    );
+    expect(getRegistryPaletteActions()[0].label).toBe("/swap — Swap two zones (a, b)");
+  });
+
+  it("treats an empty paramSchema object as argless (no hint)", () => {
+    register(
+      action({
+        id: "x",
+        slash: "/x",
+        label: "X",
+        paramSchema: {},
+      }),
+    );
+    expect(getRegistryPaletteActions()[0].label).toBe("/x — X");
+  });
+
+  it("sorts rows lexically by their composed label", () => {
+    register(action({ id: "z", slash: "/z", label: "Z" }));
+    register(action({ id: "a", slash: "/a", label: "A" }));
+    register(action({ id: "m", slash: "/m", label: "M" }));
+    const labels = getRegistryPaletteActions().map((r) => r.label);
+    expect(labels).toEqual([
+      "/a — A",
+      "/m — M",
+      "/z — Z",
+    ]);
+  });
+
+  it("click invokes the registry handler with empty args", async () => {
+    const handler = vi.fn(async () => ({ ok: true as const, value: 42 }));
+    register(action({ id: "test", slash: "/test", label: "Test", handler }));
+    const row = getRegistryPaletteActions()[0];
+    row.action();
+    // callRegistry is async-but-fire-and-forget; await a microtask so
+    // the handler call lands before the assertion.
+    await Promise.resolve();
+    expect(handler).toHaveBeenCalledWith({}, { source: "uibridge" });
+  });
+
+  it("click swallows failures (does not throw to the caller)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    register(
+      action({
+        id: "fail",
+        slash: "/fail",
+        label: "Fail",
+        handler: async () => ({ ok: false, code: "invalid-args", message: "a and b required" }),
+      }),
+    );
+    const row = getRegistryPaletteActions()[0];
+    expect(() => row.action()).not.toThrow();
+    // Drain the async chain to let the catch handler fire.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/src/components/terminal/commands/palette-projection.ts
+++ b/src/components/terminal/commands/palette-projection.ts
@@ -1,0 +1,111 @@
+/**
+ * Phase 7 — project the live command registry into rows that
+ * `CommandPalette.tsx` can render alongside its existing per-zone /
+ * per-tab enumerations.
+ *
+ * The plan's exit criterion is "every registered action discoverable
+ * via the palette in ≤3 keystrokes of search; lines 154-396 of
+ * `CommandPalette.tsx` collapse to a registry projection of ≤40 lines."
+ * This module IS that projection — the palette consumes it as a
+ * single `getRegistryPaletteActions()` call.
+ *
+ * Coexistence with the existing palette content: registry rows are
+ * additive. The per-zone enumerations ("Focus zone 3: claude-gmail")
+ * stay because they carry per-tab titles the registry's abstract
+ * slash form can't reproduce. Only `approve-all` (a no-arg page-level
+ * action with an exact registry equivalent) is deduped at the palette
+ * level — the projection emits the registry's version and the palette
+ * skips the hard-coded duplicate.
+ *
+ * Click behaviour:
+ *  - **Argless actions** (`paramSchema` undefined or empty): clicking
+ *    fires the registry handler via {@link callRegistry} with `{}`.
+ *    The handler defaults missing optional fields (e.g. `terminal.close`
+ *    falls back to the active tab, `terminal.maximize` to the focused
+ *    zone).
+ *  - **Args-required actions**: clicking still attempts execution; the
+ *    handler returns `fail("invalid-args"|"out-of-range"|...)` and
+ *    {@link callRegistry} throws. We swallow the throw and log to
+ *    console — operators who hit this learn to use `Ctrl+/` (the
+ *    CommandBar) for arg-bearing slashes. A future v2 could route to
+ *    "open CommandBar pre-filled with slash + space" instead.
+ *
+ * Inline argument hint in the label so the palette user sees what
+ * shape an action expects without leaving the palette: the slash form
+ * plus the paramSchema field list (`(count, account, context?)`) when
+ * the handler takes params.
+ */
+
+import { getAll } from "./registry";
+import type { CommandAction } from "./types";
+import { callRegistry } from "./uibridge";
+
+/**
+ * Subset of the palette's local `PaletteAction` shape that this module
+ * needs. Re-declared rather than imported from `CommandPalette.tsx` so
+ * the registry layer doesn't depend on the palette (cycle avoidance —
+ * the palette imports from `commands/`, not the other way round).
+ */
+export interface PaletteActionLike {
+  id: string;
+  label: string;
+  shortcut?: string;
+  category: string;
+  priority: number;
+  action: () => void;
+}
+
+/** Format an action's `paramSchema` field list for inline label hint. */
+function describeParams(schema: Record<string, unknown> | undefined): string {
+  if (!schema) return "";
+  const keys = Object.keys(schema);
+  if (keys.length === 0) return "";
+  return ` (${keys.join(", ")})`;
+}
+
+/**
+ * Project every registered command-registry action into a palette row.
+ * Argless actions execute on click; args-required actions log a console
+ * warning and require operators to use the CommandBar — see file
+ * docstring for the rationale.
+ *
+ * Sorted by `slash` lexically (so registry rows cluster predictably);
+ * the palette's outer sort will re-key by priority + category. We hand
+ * out priority `0` (top of the "non-Recent" block, just below
+ * `approve-all`'s `-1`) so registry actions surface immediately when
+ * the palette opens with an empty query.
+ */
+export function getRegistryPaletteActions(): PaletteActionLike[] {
+  const out: PaletteActionLike[] = [];
+  for (const action of getAll()) {
+    out.push(toPaletteRow(action));
+  }
+  out.sort((a, b) => a.label.localeCompare(b.label));
+  return out;
+}
+
+function toPaletteRow(action: CommandAction): PaletteActionLike {
+  const paramsHint = describeParams(action.paramSchema);
+  return {
+    id: `registry:${action.id}`,
+    // Prefix the registry slash so the operator's mental model maps to
+    // CommandBar usage: every palette row for a registry action also
+    // works as a typed slash command.
+    label: `${action.slash} — ${action.label}${paramsHint}`,
+    category: "Commands",
+    priority: 0,
+    action: () => {
+      // Fire-and-forget. On failure (typically args-required), log to
+      // console — operator learns to use the CommandBar via the inline
+      // params hint in the row label. Returning a sync `void` matches
+      // the palette's existing action contract.
+      callRegistry(action.id, {}).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[CommandPalette] ${action.slash} failed: ${msg} — use Ctrl+/ to supply arguments.`,
+        );
+      });
+    },
+  };
+}

--- a/src/components/terminal/commands/palette-projection.ts
+++ b/src/components/terminal/commands/palette-projection.ts
@@ -101,7 +101,7 @@ function toPaletteRow(action: CommandAction): PaletteActionLike {
       // the palette's existing action contract.
       callRegistry(action.id, {}).catch((err: unknown) => {
         const msg = err instanceof Error ? err.message : String(err);
-        // eslint-disable-next-line no-console
+        // `console.warn` is allowed by the no-console rule; no disable needed.
         console.warn(
           `[CommandPalette] ${action.slash} failed: ${msg} — use Ctrl+/ to supply arguments.`,
         );

--- a/src/components/terminal/commands/parse.ts
+++ b/src/components/terminal/commands/parse.ts
@@ -1,0 +1,99 @@
+/**
+ * Slash-command arg parser. Tokenizes the input after the slash and maps
+ * tokens positionally to the action's `paramSchema` field order.
+ *
+ * Why positional and not named? Operators don't want to type
+ * `/spawn-ai count=3 account=best` — they want `/spawn-ai 3 best`.
+ * Named args are valuable for the Tier-3 AI tier (Phase 8) where the
+ * model emits a structured tool-call, but not at the keyboard. Phase 2's
+ * positional shape covers every action in `./useTerminalCommands.ts`
+ * since their `paramSchema` field orders match the natural English
+ * phrasing (`count` first, `account` second, `context` last).
+ *
+ * Numeric coercion: bare integers/decimals become `number`; everything
+ * else stays a `string`. The handlers in `./useTerminalCommands.ts`
+ * already do `typeof v === "number"` checks, so the coercion lines up
+ * with what they expect.
+ *
+ * Quoted strings: `"hello world"` is one token. Used so the `context`
+ * field of `/spawn-ai 3 best "fix the failing test"` is a single arg.
+ * Backslash escapes aren't supported in Phase 2 — operators wanting
+ * a literal `"` in their context can use the palette or wait for the
+ * AI tier.
+ */
+
+import type { CommandAction } from "./types";
+
+/**
+ * Split a string into whitespace-separated tokens, treating
+ * double-quoted runs as a single token. Quotes are stripped from
+ * the resulting tokens.
+ */
+export function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuote = false;
+  for (let i = 0; i < input.length; i++) {
+    const c = input[i];
+    if (c === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    if (!inQuote && /\s/.test(c)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += c;
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+/**
+ * Coerce a token to a `number` when it's a clean numeric literal;
+ * otherwise keep it as a `string`.
+ */
+export function coerceToken(token: string): string | number {
+  if (/^-?\d+(\.\d+)?$/.test(token)) {
+    const n = Number(token);
+    if (Number.isFinite(n)) return n;
+  }
+  return token;
+}
+
+/**
+ * Extract the args portion of the input (everything after the slash
+ * form's trailing whitespace) and project it onto the action's
+ * paramSchema field order.
+ */
+export function parseArgs(input: string, action: CommandAction): Record<string, unknown> {
+  const trimmed = input.trim();
+  const firstSpace = trimmed.search(/\s/);
+  if (firstSpace === -1) return {};
+  const rest = trimmed.slice(firstSpace + 1).trim();
+  if (rest.length === 0) return {};
+  const tokens = tokenize(rest);
+  const fieldOrder = action.paramSchema ? Object.keys(action.paramSchema) : [];
+  const args: Record<string, unknown> = {};
+  // Bind the first N tokens to the first N fields. Excess tokens are
+  // silently dropped — the resolver doesn't reject "too many args"
+  // because most actions accept a trailing free-form last arg
+  // (e.g. /spawn-ai's `context` is a multi-word prompt that could
+  // contain quoted whitespace; we'd rather have the operator's intent
+  // even if quoting got lost).
+  for (let i = 0; i < Math.min(tokens.length, fieldOrder.length); i++) {
+    args[fieldOrder[i]] = coerceToken(tokens[i]);
+  }
+  // If the last schema field is the "free-form catch-all" position
+  // (e.g. `context` or `command`), join any extra tokens into it so
+  // operators don't lose the tail of a prompt to a missing quote.
+  if (tokens.length > fieldOrder.length && fieldOrder.length > 0) {
+    const last = fieldOrder[fieldOrder.length - 1];
+    const tailStart = fieldOrder.length - 1;
+    args[last] = tokens.slice(tailStart).join(" ");
+  }
+  return args;
+}

--- a/src/components/terminal/commands/patterns.test.ts
+++ b/src/components/terminal/commands/patterns.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tier-2 pattern resolver tests.
+ *
+ * Covers:
+ *   1. No-pattern action never matches
+ *   2. Named capture groups land in `args` with numeric coercion
+ *   3. Optional groups are omitted when absent
+ *   4. Leading-slash input is normalised before matching
+ *   5. Registration-order is the iteration order — first hit wins
+ *   6. Multi-pattern action: any pattern in the array can hit
+ *   7. Empty / whitespace input returns null without scanning patterns
+ *   8. Trailing free-form catch-all in spawn-ai survives quoting
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { matchPattern } from "./patterns";
+import { __resetForTest, register } from "./registry";
+import type { CommandAction } from "./types";
+
+afterEach(() => {
+  __resetForTest();
+});
+
+const action = (overrides: Partial<CommandAction>): CommandAction => ({
+  id: "test.action",
+  slash: "/test",
+  label: "Test action",
+  description: "for the pattern spec",
+  handler: async () => ({ ok: true }),
+  ...overrides,
+});
+
+describe("matchPattern — basic resolution", () => {
+  it("returns null when no action has any patterns", () => {
+    register(action({ id: "a", slash: "/a", label: "A" }));
+    expect(matchPattern("anything")).toBeNull();
+  });
+
+  it("returns null when patterns exist but nothing matches", () => {
+    register(
+      action({
+        id: "swap",
+        slash: "/swap",
+        patterns: [/^swap\s+(?<a>\d+)\s+(?<b>\d+)$/i],
+      }),
+    );
+    expect(matchPattern("xyz")).toBeNull();
+    expect(matchPattern("swap 1")).toBeNull();
+  });
+
+  it("returns null for empty / whitespace input", () => {
+    register(
+      action({ id: "swap", slash: "/swap", patterns: [/^swap\s+(?<a>\d+)$/i] }),
+    );
+    expect(matchPattern("")).toBeNull();
+    expect(matchPattern("   ")).toBeNull();
+  });
+});
+
+describe("matchPattern — named groups → args", () => {
+  it("extracts named groups and numeric-coerces", () => {
+    register(
+      action({
+        id: "swap",
+        slash: "/swap",
+        patterns: [/^swap\s+(?<a>\d+)\s+(?<b>\d+)$/i],
+      }),
+    );
+    const m = matchPattern("swap 1 4");
+    expect(m).not.toBeNull();
+    expect(m?.action.id).toBe("swap");
+    expect(m?.args).toEqual({ a: 1, b: 4 });
+  });
+
+  it("leaves non-numeric tokens as strings", () => {
+    register(
+      action({
+        id: "layout",
+        slash: "/layout",
+        patterns: [/^layout\s+(?<preset>single|split|six-pack)$/i],
+      }),
+    );
+    expect(matchPattern("layout six-pack")?.args).toEqual({ preset: "six-pack" });
+  });
+
+  it("omits optional groups when absent (does not set args field to undefined)", () => {
+    register(
+      action({
+        id: "maximize",
+        slash: "/maximize",
+        patterns: [/^maximize(?:\s+(?<zone>\d+))?$/i],
+      }),
+    );
+    const bare = matchPattern("maximize");
+    expect(bare?.args).toEqual({});
+    expect("zone" in (bare?.args ?? {})).toBe(false);
+
+    const withZone = matchPattern("maximize 3");
+    expect(withZone?.args).toEqual({ zone: 3 });
+  });
+});
+
+describe("matchPattern — input normalisation", () => {
+  it("strips a single leading `/` before matching", () => {
+    register(
+      action({
+        id: "swap",
+        slash: "/swap",
+        patterns: [/^swap\s+(?<a>\d+)\s+(?<b>\d+)$/i],
+      }),
+    );
+    expect(matchPattern("/swap 1 2")?.args).toEqual({ a: 1, b: 2 });
+  });
+
+  it("is case-insensitive when patterns carry the `i` flag", () => {
+    register(
+      action({
+        id: "swap",
+        slash: "/swap",
+        patterns: [/^swap\s+(?<a>\d+)\s+(?<b>\d+)$/i],
+      }),
+    );
+    expect(matchPattern("SWAP 1 2")?.action.id).toBe("swap");
+  });
+});
+
+describe("matchPattern — registration order", () => {
+  it("returns the first registered action whose pattern hits", () => {
+    register(
+      action({
+        id: "spawn",
+        slash: "/spawn",
+        patterns: [/^spawn\s+(?<count>\d+)(?:\s+plain)?$/i],
+      }),
+    );
+    register(
+      action({
+        id: "spawn-ai",
+        slash: "/spawn-ai",
+        patterns: [/^spawn\s+(?<count>\d+)\s+(?<account>best|claude|[\w-]+)$/i],
+      }),
+    );
+    // `spawn 3` matches spawn only (spawn-ai requires an account).
+    expect(matchPattern("spawn 3")?.action.id).toBe("spawn");
+    // `spawn 3 plain` matches spawn only.
+    expect(matchPattern("spawn 3 plain")?.action.id).toBe("spawn");
+    // `spawn 3 best` doesn't match spawn (`plain` is the only optional
+    // trailing token allowed), so the spawn-ai pattern wins.
+    expect(matchPattern("spawn 3 best")?.action.id).toBe("spawn-ai");
+  });
+});
+
+describe("matchPattern — multi-pattern arrays", () => {
+  it("matches if any pattern in the array hits", () => {
+    register(
+      action({
+        id: "focus",
+        slash: "/focus",
+        patterns: [
+          /^focus\s+(?<target>next|prev|previous|\d+)$/i,
+          /^(?<target>next|previous|prev)\s+session$/i,
+        ],
+      }),
+    );
+    expect(matchPattern("focus 2")?.args).toEqual({ target: 2 });
+    expect(matchPattern("focus prev")?.args).toEqual({ target: "prev" });
+    expect(matchPattern("previous session")?.args).toEqual({ target: "previous" });
+  });
+});
+
+describe("matchPattern — free-form trailing group", () => {
+  it("captures multi-word context as a single string", () => {
+    register(
+      action({
+        id: "spawn-ai",
+        slash: "/spawn-ai",
+        patterns: [
+          /^spawn-ai\s+(?<count>\d+)\s+(?<account>[\w-]+|best)(?:\s+(?<context>.+))?$/i,
+        ],
+      }),
+    );
+    expect(matchPattern("spawn-ai 3 best fix the failing test")?.args).toEqual({
+      count: 3,
+      account: "best",
+      context: "fix the failing test",
+    });
+  });
+});

--- a/src/components/terminal/commands/patterns.ts
+++ b/src/components/terminal/commands/patterns.ts
@@ -1,0 +1,72 @@
+/**
+ * Tier-2 resolver — declarative regex rules that absorb the "I almost
+ * typed it as English" cases without hitting the AI tier.
+ *
+ * Each pattern is a plain {@link RegExp} on the action def using **named
+ * capture groups**; the named groups ARE the paramSchema field bindings,
+ * which keeps the pattern self-describing and means there's no separate
+ * field map hidden in the resolver:
+ *
+ *   ```ts
+ *   patterns: [/^maximize\s+(?<zone>\d+)$/i]
+ *   //                       ▲▲▲▲
+ *   //                       maps to `args.zone`
+ *   ```
+ *
+ * Resolver runs *before* Tier 1's exact-slash hit in the CommandBar so
+ * shape-dependent routing wins over verb-only routing — `spawn 3 best`
+ * resolves to `/spawn-ai` (Tier 2), not `/spawn` (Tier 1 exact) where
+ * parseArgs would mis-bind `count="3 best"` from the free-form catch-all.
+ *
+ * No fuzzy match here — patterns must match exactly or fall through.
+ * That's deliberate: Tier 2's job is the "precise routing" pass, fuzzy
+ * is Tier 1's job, and AI (Phase 8) catches everything else.
+ */
+
+import { coerceToken } from "./parse";
+import { getAll } from "./registry";
+import type { CommandAction } from "./types";
+
+export interface PatternMatch {
+  action: CommandAction;
+  /** Pre-extracted args, mapped from the regex's named capture groups
+   *  (and numeric-coerced via {@link coerceToken}). The CommandBar
+   *  bypasses {@link parseArgs} and feeds these straight to the
+   *  handler. */
+  args: Record<string, unknown>;
+}
+
+/**
+ * Try every registered action's patterns against the input. Returns the
+ * first match in registration order (deterministic — the registry is a
+ * plain `Map` that preserves insertion order).
+ *
+ * Input normalisation:
+ *   - Leading `/` stripped so `/swap 1 2` and `swap 1 2` are equivalent.
+ *   - Whitespace trimmed at both ends.
+ *
+ * Case-sensitivity is per-pattern; the initial set in
+ * {@link useTerminalCommands} uses the `i` flag throughout so operators
+ * don't have to think about capitalisation.
+ */
+export function matchPattern(input: string): PatternMatch | null {
+  const trimmed = input.trim().replace(/^\//, "").trim();
+  if (trimmed.length === 0) return null;
+
+  for (const action of getAll()) {
+    if (!action.patterns || action.patterns.length === 0) continue;
+    for (const pattern of action.patterns) {
+      const match = pattern.exec(trimmed);
+      if (!match) continue;
+      const args: Record<string, unknown> = {};
+      if (match.groups) {
+        for (const [name, value] of Object.entries(match.groups)) {
+          if (value === undefined) continue;
+          args[name] = coerceToken(value);
+        }
+      }
+      return { action, args };
+    }
+  }
+  return null;
+}

--- a/src/components/terminal/commands/registry.test.ts
+++ b/src/components/terminal/commands/registry.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure-helper tests for the command-action registry.
+ *
+ * Runs under vitest's `environment: "node"` config (no jsdom) — exercises
+ * the module-singleton store directly, matching the repo precedent in
+ * `FileOwnershipHeatmap.test.ts` and `useCommitState.test.ts`. The React
+ * hook (`useCommandAction`) is a thin wrapper around `register`/
+ * `unregister` and is covered transitively by Phase 2's CommandBar tests.
+ *
+ * Coverage:
+ *   1. register + getById round-trip
+ *   2. register replaces on id collision (strict-mode/fast-refresh
+ *      safety) without throwing
+ *   3. unregister removes the entry and notifies subscribers
+ *   4. getBySlash matches primary slash AND aliases
+ *   5. subscribe fires on register / unregister / replace
+ *   6. unsubscribe stops notifications and doesn't leak listeners
+ *   7. getAll returns a stable reference between mutations (cheap
+ *      identity check for `useSyncExternalStore` consumers)
+ *   8. unregister of unknown id is a silent no-op (no throw, no notify)
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetForTest,
+  getAll,
+  getById,
+  getBySlash,
+  register,
+  subscribe,
+  unregister,
+} from "./registry";
+import type { CommandAction } from "./types";
+
+afterEach(() => {
+  __resetForTest();
+});
+
+const action = (overrides: Partial<CommandAction> = {}): CommandAction => ({
+  id: "test.action",
+  slash: "/test",
+  label: "Test action",
+  description: "for the registry spec",
+  handler: async () => ({ ok: true, value: "ran" }),
+  ...overrides,
+});
+
+describe("registry — register / lookup", () => {
+  it("registers an action and returns it via getById", () => {
+    register(action());
+    expect(getById("test.action")?.slash).toBe("/test");
+  });
+
+  it("replaces in place on id collision rather than throwing", () => {
+    register(action({ label: "first" }));
+    register(action({ label: "second" }));
+    expect(getById("test.action")?.label).toBe("second");
+    expect(getAll().length).toBe(1);
+  });
+
+  it("getBySlash finds by primary slash", () => {
+    register(action());
+    expect(getBySlash("/test")?.id).toBe("test.action");
+    expect(getBySlash("/missing")).toBeUndefined();
+  });
+
+  it("getBySlash finds by alias", () => {
+    register(action({ aliases: ["/t", "/run-test"] }));
+    expect(getBySlash("/t")?.id).toBe("test.action");
+    expect(getBySlash("/run-test")?.id).toBe("test.action");
+  });
+
+  it("unregister removes the entry; subsequent lookup returns undefined", () => {
+    const dispose = register(action());
+    expect(getById("test.action")).toBeDefined();
+    dispose();
+    expect(getById("test.action")).toBeUndefined();
+  });
+
+  it("unregister of an unknown id is a silent no-op", () => {
+    const listener = vi.fn();
+    subscribe(listener);
+    unregister("never.registered");
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("registry — subscribe", () => {
+  it("fires on register, unregister, and replace", () => {
+    const listener = vi.fn();
+    subscribe(listener);
+    register(action());
+    register(action({ label: "replaced" }));
+    unregister("test.action");
+    expect(listener).toHaveBeenCalledTimes(3);
+  });
+
+  it("returned unsubscribe stops notifications", () => {
+    const listener = vi.fn();
+    const off = subscribe(listener);
+    off();
+    register(action());
+    expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("registry — getAll snapshot identity", () => {
+  it("returns a stable reference between mutations", () => {
+    register(action());
+    const first = getAll();
+    const second = getAll();
+    expect(first).toBe(second);
+  });
+
+  it("rebuilds the snapshot on mutation", () => {
+    register(action());
+    const before = getAll();
+    register(action({ id: "test.second", slash: "/second" }));
+    const after = getAll();
+    expect(after).not.toBe(before);
+    expect(after).toHaveLength(2);
+  });
+});

--- a/src/components/terminal/commands/registry.ts
+++ b/src/components/terminal/commands/registry.ts
@@ -1,0 +1,121 @@
+/**
+ * Module-level command-action registry.
+ *
+ * Lifecycle mirrors `@qontinui/ui-bridge`'s `useUIComponent` registry: a
+ * single module-scoped store that `useCommandAction` writes into on
+ * mount and clears on unmount, plus a subscribe pattern so React
+ * consumers re-render when actions register/unregister.
+ *
+ * Why a module singleton (rather than a context): the future CommandBar,
+ * `Ctrl+Shift+K` palette, and Tier-3 subprocess executor all sit at
+ * different points in the tree (and the subprocess executor runs in
+ * `src-tauri` Rust over IPC), so a flat module store is the only surface
+ * every consumer can reach without prop drilling. Same pattern used by
+ * `lib/terminal-sessions-registry.ts` for the UI Bridge IPC handlers.
+ *
+ * Reactivity contract: every {@link register}, {@link unregister}, and
+ * {@link replace} call notifies subscribers synchronously. React
+ * consumers should subscribe via `useSyncExternalStore` so concurrent
+ * mode handles the tearing edge cases — see Phase 2's CommandBar where
+ * the autocomplete list reads via `getSnapshot`.
+ */
+
+import type { CommandAction, RegistryListener } from "./types";
+
+const actions = new Map<string, CommandAction>();
+const listeners = new Set<RegistryListener>();
+
+/** Cached snapshot for `useSyncExternalStore`. Recomputed on mutation —
+ *  reused between calls so React's identity-equality check skips renders
+ *  when nothing changed (matches the `terminal-sessions-registry`
+ *  invariant). */
+let snapshot: readonly CommandAction[] = [];
+
+function rebuildSnapshot(): void {
+  snapshot = Array.from(actions.values());
+}
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+/**
+ * Add an action to the registry, replacing any prior entry with the
+ * same id. Returns an unregister function so callers can manage the
+ * lifetime without having to remember the id (the hook uses this).
+ *
+ * Replacing-on-collision rather than rejecting is the same posture as
+ * `useUIComponent` — a React fast-refresh or strict-mode double-mount
+ * must not crash; the new registration wins and the prior handler is
+ * shed cleanly.
+ */
+export function register(action: CommandAction): () => void {
+  actions.set(action.id, action);
+  rebuildSnapshot();
+  notify();
+  return () => unregister(action.id);
+}
+
+/** Remove an action by id. No-op when the id is unknown. */
+export function unregister(id: string): void {
+  if (!actions.delete(id)) return;
+  rebuildSnapshot();
+  notify();
+}
+
+/**
+ * Look up an action by id. Returns `undefined` when no match exists —
+ * the resolver paths (slash, palette, AI) turn that into a "no such
+ * command" error rendered to the user, not a thrown exception.
+ */
+export function getById(id: string): CommandAction | undefined {
+  return actions.get(id);
+}
+
+/**
+ * Look up an action by its primary slash form or any alias.
+ * Linear scan — the registry is small (~25 entries target in Phase 1,
+ * ~50 long-term) and lookups happen on user input cadence, so the
+ * constant-factor cost of a Map<slash, id> index isn't worth the
+ * coordination overhead with `aliases?` reshuffling on replace.
+ */
+export function getBySlash(slash: string): CommandAction | undefined {
+  for (const action of actions.values()) {
+    if (action.slash === slash) return action;
+    if (action.aliases?.includes(slash)) return action;
+  }
+  return undefined;
+}
+
+/**
+ * Snapshot of every registered action. Returns the same array reference
+ * between mutations so `useSyncExternalStore`'s identity check is cheap.
+ */
+export function getAll(): readonly CommandAction[] {
+  return snapshot;
+}
+
+/**
+ * Subscribe to registry changes. Returns an unsubscribe function. Pair
+ * with `getAll` in a `useSyncExternalStore` consumer.
+ */
+export function subscribe(listener: RegistryListener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Reset for tests. Not exported through the package barrel — vitest
+ * specs reach into this module directly. Mirrors the
+ * `__resetTerminalSessionsForTest` convention from
+ * `lib/terminal-sessions-registry.ts`.
+ */
+export function __resetForTest(): void {
+  actions.clear();
+  listeners.clear();
+  rebuildSnapshot();
+}

--- a/src/components/terminal/commands/resolve.test.ts
+++ b/src/components/terminal/commands/resolve.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tier-1 resolver + arg parser tests.
+ *
+ * Runs under vitest's `environment: "node"` (no jsdom). Each test
+ * registers a small synthetic action set against the live registry
+ * (resetting between cases via `__resetForTest`) and exercises the
+ * resolver / parser as the CommandBar will see them.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { parseArgs, tokenize, coerceToken } from "./parse";
+import { __resetForTest, register } from "./registry";
+import { resolve } from "./resolve";
+import type { CommandAction } from "./types";
+
+afterEach(() => {
+  __resetForTest();
+});
+
+const action = (overrides: Partial<CommandAction> = {}): CommandAction => ({
+  id: overrides.id ?? "test.action",
+  slash: overrides.slash ?? "/test",
+  label: overrides.label ?? "Test action",
+  description: overrides.description ?? "for the resolver spec",
+  handler: overrides.handler ?? (async () => ({ ok: true, value: "ran" })),
+  ...overrides,
+});
+
+describe("resolve — empty input", () => {
+  it("returns all actions (capped at MAX_SUGGESTIONS) in registration order when no recents", () => {
+    register(action({ id: "a", slash: "/a", label: "A" }));
+    register(action({ id: "b", slash: "/b", label: "B" }));
+    const matches = resolve("", []);
+    expect(matches.map((m) => m.action.id)).toEqual(["a", "b"]);
+    expect(matches.every((m) => !m.exact)).toBe(true);
+    expect(matches.every((m) => !m.recent)).toBe(true);
+  });
+
+  it("places recents first, in last-used order", () => {
+    register(action({ id: "a", slash: "/a", label: "A" }));
+    register(action({ id: "b", slash: "/b", label: "B" }));
+    register(action({ id: "c", slash: "/c", label: "C" }));
+    const matches = resolve("", ["c", "a"]);
+    expect(matches.map((m) => m.action.id)).toEqual(["c", "a", "b"]);
+    expect(matches[0].recent).toBe(true);
+    expect(matches[1].recent).toBe(true);
+    expect(matches[2].recent).toBe(false);
+  });
+
+  it("ignores recents that refer to unknown ids", () => {
+    register(action({ id: "a", slash: "/a", label: "A" }));
+    const matches = resolve("", ["ghost", "a"]);
+    expect(matches.map((m) => m.action.id)).toEqual(["a"]);
+  });
+});
+
+describe("resolve — exact slash hit", () => {
+  it("returns only the matching action when the first token matches a slash", () => {
+    register(action({ id: "swap", slash: "/swap", label: "Swap zones" }));
+    register(action({ id: "spawn", slash: "/spawn", label: "Spawn" }));
+    const matches = resolve("/swap 1 2", []);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].action.id).toBe("swap");
+    expect(matches[0].exact).toBe(true);
+  });
+
+  it("works without a leading slash on the input", () => {
+    register(action({ id: "spawn", slash: "/spawn", label: "Spawn" }));
+    const matches = resolve("spawn 3", []);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].action.id).toBe("spawn");
+    expect(matches[0].exact).toBe(true);
+  });
+
+  it("matches via alias", () => {
+    register(
+      action({
+        id: "spawn-ai",
+        slash: "/spawn-ai",
+        aliases: ["/spawn-best"],
+      }),
+    );
+    const matches = resolve("/spawn-best 3", []);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].action.id).toBe("spawn-ai");
+    expect(matches[0].exact).toBe(true);
+  });
+
+  it("flags recent for exact hits too", () => {
+    register(action({ id: "swap", slash: "/swap" }));
+    const matches = resolve("/swap", ["swap"]);
+    expect(matches[0].recent).toBe(true);
+  });
+});
+
+describe("resolve — fuzzy match", () => {
+  it("returns nothing for no-match queries", () => {
+    register(action({ id: "spawn", slash: "/spawn", label: "Spawn" }));
+    expect(resolve("/xyz", [])).toEqual([]);
+  });
+
+  it("prefers prefix matches over sequential fuzzy", () => {
+    register(action({ id: "spawn", slash: "/spawn", label: "Spawn" }));
+    register(action({ id: "swap", slash: "/swap", label: "Swap zones" }));
+    const matches = resolve("/sp", []);
+    expect(matches[0].action.id).toBe("spawn");
+  });
+
+  it("pulls recents above same-score peers", () => {
+    register(action({ id: "spawn", slash: "/spawn", label: "Spawn plain" }));
+    register(action({ id: "spawn-ai", slash: "/spawn-ai", label: "Spawn AI" }));
+    const matches = resolve("/sp", ["spawn-ai"]);
+    // Both are prefix matches with the same score — recent wins.
+    expect(matches[0].action.id).toBe("spawn-ai");
+  });
+
+  it("caps to 8 suggestions", () => {
+    for (let i = 0; i < 12; i++) {
+      register(action({ id: `n${i}`, slash: `/n${i}`, label: `N${i}` }));
+    }
+    expect(resolve("/n", [])).toHaveLength(8);
+  });
+});
+
+describe("parse — tokenize", () => {
+  it("splits on whitespace", () => {
+    expect(tokenize("a b c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("treats quoted runs as one token", () => {
+    expect(tokenize('3 best "fix the failing test"')).toEqual([
+      "3",
+      "best",
+      "fix the failing test",
+    ]);
+  });
+
+  it("collapses multiple spaces", () => {
+    expect(tokenize("a    b\tc")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns empty for empty input", () => {
+    expect(tokenize("")).toEqual([]);
+    expect(tokenize("   ")).toEqual([]);
+  });
+});
+
+describe("parse — coerceToken", () => {
+  it("coerces clean integers to number", () => {
+    expect(coerceToken("3")).toBe(3);
+    expect(coerceToken("-7")).toBe(-7);
+  });
+
+  it("coerces decimals to number", () => {
+    expect(coerceToken("1.5")).toBe(1.5);
+  });
+
+  it("leaves non-numeric tokens as string", () => {
+    expect(coerceToken("best")).toBe("best");
+    expect(coerceToken("3a")).toBe("3a");
+    expect(coerceToken("")).toBe("");
+  });
+});
+
+describe("parse — parseArgs", () => {
+  const spawnAi = action({
+    id: "spawn-ai",
+    slash: "/spawn-ai",
+    paramSchema: { count: "n", account: "s", context: "s" },
+  });
+
+  it("maps positional tokens to paramSchema field order", () => {
+    expect(parseArgs("/spawn-ai 3 best", spawnAi)).toEqual({
+      count: 3,
+      account: "best",
+    });
+  });
+
+  it("joins trailing tokens into the last field (free-form catch-all)", () => {
+    expect(parseArgs("/spawn-ai 3 best fix the failing test", spawnAi)).toEqual({
+      count: 3,
+      account: "best",
+      context: "fix the failing test",
+    });
+  });
+
+  it("honors quoted runs as a single token", () => {
+    expect(parseArgs('/spawn-ai 3 best "fix the failing test"', spawnAi)).toEqual({
+      count: 3,
+      account: "best",
+      context: "fix the failing test",
+    });
+  });
+
+  it("returns empty when no args follow the slash", () => {
+    expect(parseArgs("/spawn-ai", spawnAi)).toEqual({});
+    expect(parseArgs("/spawn-ai ", spawnAi)).toEqual({});
+  });
+
+  it("returns empty for actions with no paramSchema", () => {
+    const noSchema = action({ id: "approve-all", slash: "/approve-all" });
+    expect(parseArgs("/approve-all ignored", noSchema)).toEqual({});
+  });
+});

--- a/src/components/terminal/commands/resolve.ts
+++ b/src/components/terminal/commands/resolve.ts
@@ -1,0 +1,124 @@
+/**
+ * Tier-1 resolver — turns CommandBar input into a ranked match list
+ * against the registry.
+ *
+ * Resolution rules (in priority order):
+ *
+ *   1. **Exact slash hit.** When the first token of the input matches a
+ *      registered `slash` or alias, that action is the *only* result.
+ *      This is the "operator has finished disambiguating" case
+ *      — once they typed `/swap`, they don't want `/spawn` showing up
+ *      below their args.
+ *
+ *   2. **Fuzzy match** against `slash` + `label` for everything else.
+ *      Uses the shared {@link fuzzyScore} so the CommandBar and the
+ *      `Ctrl+Shift+K` palette never disagree on ranking.
+ *
+ * Recents (per-runner-instance, persisted to {@link instanceStorage}
+ * under `terminal-command-bar-recents`) are pulled to the top of the
+ * empty-input view and tie-break above same-score fuzzy hits.
+ *
+ * Phase 2 caveat: we cap at 8 entries to keep the suggestion dropdown
+ * scannable. Phase 7's `Ctrl+Shift+K` palette is the "browse everything"
+ * surface; the CommandBar isn't.
+ */
+
+import { fuzzyScore } from "./fuzzy";
+import { getAll, getBySlash } from "./registry";
+import type { CommandAction } from "./types";
+
+export interface ResolveMatch {
+  action: CommandAction;
+  /** True when the input's first token exactly matched the slash or an
+   *  alias; the caller hides other suggestions and renders the param
+   *  preview row instead. */
+  exact: boolean;
+  /** True when the action's id is in the user's recents — pinned to the
+   *  top of the empty-input dropdown, otherwise tie-breaks above
+   *  same-score fuzzy hits. */
+  recent: boolean;
+  /** Character positions in `action.slash` that matched, for highlight
+   *  rendering. Empty when `exact` is true. */
+  indices: number[];
+}
+
+const MAX_SUGGESTIONS = 8;
+
+export function resolve(input: string, recents: readonly string[]): ResolveMatch[] {
+  const trimmed = input.trim();
+
+  // ── Empty input ────────────────────────────────────────────────────
+  if (trimmed.length === 0) {
+    const all = getAll();
+    const recentSet = new Set(recents);
+    const ordered: CommandAction[] = [];
+    // Recents first, in last-used order.
+    for (const id of recents) {
+      const action = all.find((a) => a.id === id);
+      if (action) ordered.push(action);
+    }
+    // Then everything else, in registration order.
+    for (const action of all) {
+      if (!recentSet.has(action.id)) ordered.push(action);
+    }
+    return ordered.slice(0, MAX_SUGGESTIONS).map((action) => ({
+      action,
+      exact: false,
+      recent: recentSet.has(action.id),
+      indices: [],
+    }));
+  }
+
+  // ── Exact slash hit ────────────────────────────────────────────────
+  const firstSpace = trimmed.search(/\s/);
+  const head = firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace);
+  const slashForm = head.startsWith("/") ? head : `/${head}`;
+  const exactHit = getBySlash(slashForm);
+  if (exactHit) {
+    return [
+      {
+        action: exactHit,
+        exact: true,
+        recent: recents.includes(exactHit.id),
+        indices: [],
+      },
+    ];
+  }
+
+  // ── Fuzzy match ────────────────────────────────────────────────────
+  // Strip the leading `/` from the user's query so it doesn't bias the
+  // prefix-tier scoring. (Slash forms are stored *with* the `/`; we
+  // compare query-without-slash to slash-without-slash.)
+  const query = trimmed.replace(/^\//, "");
+  const recentSet = new Set(recents);
+  const scored: Array<ResolveMatch & { _score: number }> = [];
+  for (const action of getAll()) {
+    const slashBody = action.slash.replace(/^\//, "");
+    const slashMatch = fuzzyScore(slashBody, query);
+    const labelMatch = fuzzyScore(action.label, query);
+    const best =
+      slashMatch && (!labelMatch || slashMatch.score >= labelMatch.score)
+        ? slashMatch
+        : labelMatch;
+    if (!best) continue;
+    // Indices are positions in the slash (with leading "/") for the
+    // highlight renderer; shift by +1 when they came from the
+    // slash-without-leading-`/` body.
+    const indices =
+      best === slashMatch ? slashMatch.indices.map((i) => i + 1) : [];
+    scored.push({
+      action,
+      exact: false,
+      recent: recentSet.has(action.id),
+      indices,
+      _score: best.score,
+    });
+  }
+
+  scored.sort((a, b) => {
+    if (a.recent !== b.recent) return a.recent ? -1 : 1;
+    return b._score - a._score;
+  });
+
+  return scored.slice(0, MAX_SUGGESTIONS).map(({ _score: _, ...rest }) => rest);
+}

--- a/src/components/terminal/commands/types.ts
+++ b/src/components/terminal/commands/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Action registry — type surface.
+ *
+ * One source of truth for slash commands, the Ctrl+Shift+K palette, the
+ * future CommandBar, suggestion-chip apply buttons, and (Phase 8) AI
+ * tool-call routing via the `claude` CLI subprocess. Every projection
+ * reads from the same {@link CommandAction} list — adding a new layout,
+ * for instance, becomes one `useCommandAction` call instead of edits in
+ * `ZoneLayoutPicker`, `useKeyboardShortcuts`, the UI Bridge action list,
+ * and the launch menu.
+ *
+ * See `plans/2026-05-28-terminal-page-redesign-plan.md` §1 + the audit
+ * at `./audit.md` for the design context and the initial 12-entry target.
+ */
+
+/**
+ * Result returned by a {@link CommandAction.handler}. The shape mirrors
+ * the resolver tiers in the plan: handlers signal success/failure with a
+ * machine-readable code so the CommandBar can render appropriate UI
+ * (Undo affordance, confirm modal, "did you mean?" row).
+ *
+ * Handlers may throw instead of returning `ok: false` — the executor
+ * normalizes thrown errors into a `CommandResult` with `ok: false` and
+ * `code: "handler-threw"`. Use the typed return only when the failure is
+ * a *predictable* outcome the caller should branch on (e.g. restart
+ * gating on session state, action requires confirmation).
+ */
+export type CommandResult<T = unknown> =
+  | { ok: true; value?: T }
+  | { ok: false; code: string; message?: string };
+
+/**
+ * Context handed to every action handler. Phase 1 plumbing keeps this
+ * minimal — `signal` for cancellable invocations (the CommandBar's
+ * "Interpreting…" cancel button in Phase 8, the suggestion-chip dismiss
+ * in Phase 4) and `source` so handlers can branch on invocation surface
+ * if needed.
+ *
+ * Phase-2+ will widen this to include refs to the page's
+ * `TerminalSession` context shape so handlers don't need to be
+ * re-registered on every render. For now handlers close over their
+ * registration-site context directly — the ref pattern in
+ * {@link useCommandAction} keeps that closure current.
+ */
+export interface ResolverContext {
+  /** Aborted when the user dismisses an in-flight Tier-3 interpretation. */
+  signal?: AbortSignal;
+  /**
+   * Where the invocation originated; useful for telemetry + result UI.
+   *
+   * - `slash` / `pattern` / `ai` / `palette` / `chip` / `hotkey` —
+   *   operator-facing surfaces.
+   * - `uibridge` — external-agent invocation routed through the
+   *   `useUIComponent` adapter (`commands/uibridge.ts`). Phase 1c added
+   *   this so handler-side telemetry can attribute calls coming from
+   *   the existing UI Bridge wire ids (`create-plain`, `create-best-
+   *   account`, `create-with-command`, `select-layout`).
+   * - `test` — synthetic invocation from unit tests.
+   */
+  source:
+    | "slash"
+    | "pattern"
+    | "ai"
+    | "palette"
+    | "chip"
+    | "hotkey"
+    | "uibridge"
+    | "test";
+}
+
+/**
+ * The unit of an action in the registry. Self-registered via
+ * {@link useCommandAction} on mount, unregistered on unmount.
+ *
+ * Field invariants worth keeping in mind:
+ *
+ * - `id` is the wire contract. External agents (Claude subprocesses
+ *   spawned via `agent_runtime.rs`, UI Bridge consumers) discover by
+ *   id. Renaming an id is a breaking change.
+ * - `slash` is the primary alias surfaced to operators. Aliases
+ *   live in {@link CommandAction.aliases}.
+ * - `paramSchema` follows the UI Bridge contract at
+ *   `ui-bridge/packages/ui-bridge/src/react/useUIComponent.ts:27` —
+ *   `Record<string, unknown>`. There is **no** exported `JsonSchema` in
+ *   `@qontinui/ui-bridge` today; the plan §1.1 calls for introducing
+ *   one in Phase 1b alongside the UI Bridge migration. Until then the
+ *   shape stays loose and Tier-3 (Phase 8) is responsible for
+ *   normalising it into an Anthropic-compatible `input_schema` at
+ *   subprocess-spawn time.
+ * - `patterns` are declarative regex rules for Tier 2; capture groups
+ *   map positionally into `paramSchema` field order. Live alongside
+ *   the action def so adding a phrasing doesn't require touching the
+ *   resolver. Empty/undefined = the action only matches by slash + AI.
+ * - `destructive` gates the executor's confirm modal. Today only used
+ *   by multi-target close/kill actions per plan §5(3); single-target
+ *   destructive actions rely on `undoable` + a 3s Undo affordance.
+ */
+export interface CommandAction<TArgs = Record<string, unknown>, TResult = unknown> {
+  /** Stable wire contract, e.g. `"terminal.spawn-ai"`. */
+  id: string;
+  /** Primary slash form, e.g. `"/spawn-ai"`. */
+  slash: string;
+  /** Additional slash forms accepted by the Tier-1 resolver. */
+  aliases?: string[];
+  /** Display label for the palette + chip + autocomplete row. */
+  label: string;
+  /** Longer help, also fed verbatim into the Tier-3 tool definition. */
+  description: string;
+  /** UI Bridge-compatible loose schema; see invariants above. */
+  paramSchema?: Record<string, unknown>;
+  /** Regex patterns for Tier-2 matching. */
+  patterns?: RegExp[];
+  /** Requires a confirm modal before execution. See plan §5(3). */
+  destructive?: boolean;
+  /** Pre-state snapshot captured by the executor for Undo. */
+  undoable?: boolean;
+  /** The action body. */
+  handler: (args: TArgs, ctx: ResolverContext) => Promise<CommandResult<TResult>>;
+}
+
+/** Subscriber callback signature for the registry's change broadcast. */
+export type RegistryListener = () => void;

--- a/src/components/terminal/commands/uibridge.test.ts
+++ b/src/components/terminal/commands/uibridge.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for the UI Bridge ↔ registry delegation helper.
+ *
+ * Covers:
+ *   1. unknown id throws with a descriptive error
+ *   2. successful handler unwraps to `result.value`
+ *   3. failed handler throws with `message` when present
+ *   4. failed handler falls back to `code` when no `message`
+ *   5. handler invocation signature carries `source: "uibridge"`
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { __resetForTest, register } from "./registry";
+import { callRegistry } from "./uibridge";
+
+afterEach(() => {
+  __resetForTest();
+});
+
+describe("callRegistry", () => {
+  it("throws on unknown action id", async () => {
+    await expect(callRegistry("ghost.action", {})).rejects.toThrow(
+      /Registry action "ghost.action" not found/,
+    );
+  });
+
+  it("returns the registry handler's value on success", async () => {
+    register({
+      id: "test.echo",
+      slash: "/echo",
+      label: "Echo",
+      description: "test",
+      handler: async (args) => ({ ok: true, value: args }),
+    });
+    const result = await callRegistry<{ a: number }>("test.echo", { a: 7 });
+    expect(result).toEqual({ a: 7 });
+  });
+
+  it("throws with `message` on a failure result", async () => {
+    register({
+      id: "test.fail",
+      slash: "/fail",
+      label: "Fail",
+      description: "test",
+      handler: async () => ({
+        ok: false,
+        code: "out-of-range",
+        message: "zone 99 does not exist",
+      }),
+    });
+    await expect(callRegistry("test.fail", {})).rejects.toThrow(/zone 99 does not exist/);
+  });
+
+  it("falls back to `code` when `message` is absent", async () => {
+    register({
+      id: "test.fail-code-only",
+      slash: "/fail",
+      label: "Fail",
+      description: "test",
+      handler: async () => ({ ok: false, code: "not-restartable" }),
+    });
+    await expect(callRegistry("test.fail-code-only", {})).rejects.toThrow(
+      /not-restartable/,
+    );
+  });
+
+  it("passes source=uibridge in the ResolverContext", async () => {
+    const handler = vi.fn(async () => ({ ok: true as const, value: "x" }));
+    register({
+      id: "test.context",
+      slash: "/context",
+      label: "Context",
+      description: "test",
+      handler,
+    });
+    await callRegistry("test.context", { foo: 1 });
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [args, ctx] = handler.mock.calls[0];
+    expect(args).toEqual({ foo: 1 });
+    expect(ctx.source).toBe("uibridge");
+  });
+});

--- a/src/components/terminal/commands/uibridge.ts
+++ b/src/components/terminal/commands/uibridge.ts
@@ -1,0 +1,64 @@
+/**
+ * UI Bridge ↔ command-registry delegation helper.
+ *
+ * The plan's §1.2 / §5(4) decision: registry replaces `useUIComponent`
+ * for terminal-page actions, with a thin adapter that mirrors entries
+ * back to UI Bridge so external agents see no change. Phase 1c
+ * implements that as **inline delegation, not a wrapping abstraction**
+ * — the existing `useUIComponent({...})` callsites in
+ * `TerminalTabBar.tsx` (`terminal-launch-menu`) and
+ * `ZoneLayoutPicker.tsx` (`zone-layout-picker`) keep their wire ids,
+ * paramSchemas, and response shapes; their handlers just call
+ * {@link callRegistry} instead of duplicating the underlying logic.
+ *
+ * Why inline rather than a wrapping `useRegistryToUIBridge` hook:
+ *
+ *  - The UI Bridge wire contract for the launch-menu actions includes a
+ *    reshape from registry's raw `string[]` → `{success, tab_ids,
+ *    task_run_ids}` per existing convention, plus UI side effects
+ *    (close the launch menu popover). A generic adapter has to expose
+ *    mapParams + mapResult + onSuccess hooks for each entry — by the
+ *    time you spell that out, the existing inline handler IS clearer.
+ *  - Only 4 actions across 2 sites are eligible. The "abstract once,
+ *    reuse N times" math doesn't favor a wrapper at N=4.
+ *  - External agents discover by `useUIComponent`'s component id; the
+ *    less we change about the registration shape, the lower the risk of
+ *    breaking those consumers in subtle ways.
+ *
+ * The drift question this resolves: today the UI Bridge handlers call
+ * `onQuickLaunch` / `onLaunchAiSession` directly. The registry handlers
+ * (Phase 1b) call the same closures. If someone later modifies the
+ * spawn logic in only one path, the two surfaces diverge. After
+ * Phase 1c the UI Bridge handlers route through the registry handler,
+ * making the registry the single source of business logic. The reshape
+ * + UI side effects stay at the UI Bridge boundary where they belong.
+ */
+
+import { getById } from "./registry";
+
+/**
+ * Invoke a registry action by id. Unwraps `CommandResult` — returns
+ * `value` on success, throws on failure with the action's reported
+ * `code` / `message`.
+ *
+ * `source: "uibridge"` so handler-side telemetry (or future Tier-3
+ * routing logs) can attribute the call to the UI Bridge surface.
+ */
+export async function callRegistry<T = unknown>(
+  actionId: string,
+  args: Record<string, unknown>,
+): Promise<T> {
+  const action = getById(actionId);
+  if (!action) {
+    throw new Error(
+      `Registry action "${actionId}" not found. ` +
+        "If this fires from a UI Bridge handler, the terminal-page registry " +
+        "may not have mounted yet — useTerminalCommands runs in TerminalPageInner.",
+    );
+  }
+  const result = await action.handler(args, { source: "uibridge" });
+  if (!result.ok) {
+    throw new Error(result.message ?? result.code);
+  }
+  return result.value as T;
+}

--- a/src/components/terminal/commands/useCommandAction.ts
+++ b/src/components/terminal/commands/useCommandAction.ts
@@ -1,0 +1,47 @@
+/**
+ * React hook that registers a {@link CommandAction} with the command
+ * registry on mount and unregisters on unmount.
+ *
+ * Mirrors the `useUIComponent` pattern from `@qontinui/ui-bridge` — the
+ * caller passes a fresh action object on every render but the registry
+ * sees a stable handler ref. This is essential because action handlers
+ * almost always close over React state (e.g. `zoneLayout.focusedZone`),
+ * and a stale closure captured at registration time would silently
+ * operate on the wrong session.
+ *
+ * The pattern is identical to `useUIComponent`'s `actionsRef` trick in
+ * `ui-bridge/packages/ui-bridge/src/react/useUIComponent.ts:147,192-205`:
+ * we snapshot the latest action into a ref on every render, then the
+ * registered handler wrapper looks up the current ref each invocation.
+ *
+ * Strict-mode / fast-refresh safety: the registry's `register()` is
+ * idempotent on id collision (replaces in place), so a double-mount in
+ * dev does the right thing.
+ */
+
+import { useEffect, useRef } from "react";
+import { register, unregister } from "./registry";
+import type { CommandAction, CommandResult, ResolverContext } from "./types";
+
+export function useCommandAction<TArgs = Record<string, unknown>, TResult = unknown>(
+  action: CommandAction<TArgs, TResult>,
+): void {
+  const actionRef = useRef(action);
+  actionRef.current = action;
+
+  useEffect(() => {
+    const stable: CommandAction<TArgs, TResult> = {
+      ...action,
+      handler: (args: TArgs, ctx: ResolverContext): Promise<CommandResult<TResult>> =>
+        actionRef.current.handler(args, ctx),
+    };
+    register(stable as unknown as CommandAction);
+    return () => {
+      unregister(action.id);
+    };
+    // The effect intentionally re-runs ONLY on id change. Handler / label /
+    // slash / paramSchema updates flow through `actionRef.current` without
+    // re-registering, matching `useUIComponent`'s in-place update semantics.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [action.id]);
+}

--- a/src/components/terminal/commands/useTerminalCommands.ts
+++ b/src/components/terminal/commands/useTerminalCommands.ts
@@ -1,0 +1,626 @@
+/**
+ * Registers the Phase 1 terminal-page action set with the command
+ * registry. One call per Terminal page mount; unregisters on unmount.
+ *
+ * Action coverage matches `./audit.md`'s top-10 collapsed to 10 registry
+ * entries:
+ *
+ *   - `terminal.focus`       — `/focus <n|next|prev|needs-input>`
+ *   - `terminal.spawn`       — `/spawn`
+ *   - `terminal.spawn-ai`    — `/spawn-ai` (alias `/spawn-best`; `account`
+ *                              accepts `"best"` per the Phase 1b decision
+ *                              to collapse `create-best-account` into a
+ *                              single registry entry — clean code over
+ *                              two parallel handlers)
+ *   - `terminal.spawn-with`  — `/spawn-with`
+ *   - `terminal.approve-all` — `/approve-all`
+ *   - `terminal.maximize`    — `/maximize [<n>]`
+ *   - `terminal.close`       — `/close [<n>]`
+ *   - `terminal.layout`      — `/layout <preset>`
+ *   - `terminal.restart`     — `/restart [<n>]`
+ *   - `terminal.swap`        — `/swap <a> <b>`
+ *
+ * The existing `useUIComponent` registrations in `TerminalPage.tsx`,
+ * `TerminalTabBar.tsx`, `ZoneLayoutPicker.tsx`, and
+ * `ZoneProfilePicker.tsx` remain UNCHANGED in this commit. Phase 1c will
+ * introduce the UI Bridge adapter that projects registry entries into
+ * those component-level action ids; until then both surfaces coexist
+ * and source from the same underlying functions (`onQuickLaunch`,
+ * `onLaunchAiSession`, `zoneLayout.*`, `closeTerminal`,
+ * `transitionEffects.handleRestartInZone`) so drift is structurally
+ * prevented.
+ *
+ * See the design rationale in `plans/2026-05-28-terminal-page-redesign-plan.md`
+ * §1 and the per-action keystroke budget in `./audit.md`.
+ */
+
+import { instanceStorage } from "@/lib/instance-storage";
+
+import { useTerminalSession, useTransitionEffects, useUIStateCx } from "../contexts";
+import type { AccountUsageInfo } from "../useSessionManager";
+import type { CommandAction, CommandResult, ResolverContext } from "./types";
+import { useCommandAction } from "./useCommandAction";
+
+/**
+ * Inputs that can't be read from the existing React contexts — handed in
+ * by `TerminalPageInner` because the spawn closures it constructs hold
+ * page-local state (layout picker, write-when-ready cadence) that we
+ * don't want to duplicate here. Reading everything else (`tabs`,
+ * `activeId`, `zoneLayout`, `closeTerminal`, `sessionStates`,
+ * `terminalRefs`, `transitionEffects.handleRestartInZone`) directly from
+ * the contexts keeps this hook trivially update-safe.
+ */
+export interface TerminalCommandsContext {
+  /**
+   * Spawn N plain PTY tabs and zone-assign them. Mirrors the closure at
+   * `TerminalPage.tsx:539` (passed down as `onQuickLaunch` to
+   * `TerminalTabBar`). Returns the new tab ids in creation order.
+   */
+  spawnPlain: (count: number, autoCommand?: string) => Promise<string[] | void>;
+  /**
+   * Spawn N AI sessions in a single account's `configDir`. Mirrors the
+   * closure at `TerminalPage.tsx:559` (passed down as `onLaunchAiSession`
+   * to `TerminalTabBar`).
+   */
+  spawnAi: (
+    count: number,
+    configDir: string,
+    context?: string,
+  ) => Promise<string[] | void>;
+  /**
+   * Snapshot of the available Claude Code accounts, in the original
+   * `useSessionManager` shape (NOT sorted). Handlers sort locally when
+   * resolving `account: "best"`.
+   */
+  accounts: AccountUsageInfo[];
+  /**
+   * Sort the zone-grid by session state — `needs-input` first, then
+   * `error`, then the rest. Mirrors `useZoneActions.handleSortZones`,
+   * which is the closure ZoneStatusBar's "Sort Zones" button used.
+   * Threaded through here so the registry can fire it without
+   * re-importing `useZoneActions`.
+   */
+  sortZones: () => void;
+  /**
+   * Export every session's transcript to file. Mirrors
+   * `useZoneActions.handleExportOutput`, the closure ZoneStatusBar's
+   * "Export" button used.
+   */
+  exportAll: () => void;
+}
+
+/**
+ * `paramSchema` objects below follow the UI Bridge contract — loose
+ * `Record<string, unknown>` with hint strings, no runtime validation.
+ * The Phase 8 Tier-3 subprocess normalizes these into Anthropic-
+ * compatible `input_schema` at spawn time. Keeping the shapes here as
+ * data (not as TS literals) gives the future adapter exactly what it
+ * needs to project them back into `useUIComponent` action defs.
+ */
+const SCHEMA = {
+  focus: { target: 'number | "next" | "prev" | "needs-input"' },
+  spawn: { count: "number (>= 1, defaults to 1)" },
+  spawnAi: {
+    count: "number (>= 1, defaults to 1)",
+    account:
+      'string — either a Claude account label (e.g. "gmail", "hotmail") or the literal "best" to pick the lowest-utilization account',
+    context: 'string (optional initial prompt auto-typed after `claude` starts)',
+  },
+  spawnWith: {
+    count: "number (>= 1, defaults to 1)",
+    command: "string (shell command typed into each new terminal after spawn)",
+  },
+  empty: {},
+  maximize: { zone: "number (1-based; defaults to the currently focused zone)" },
+  close: {
+    zone: "number (1-based zone index)",
+    tabId: "string (explicit tab id; takes precedence over zone)",
+  },
+  layout: { preset: 'string — one of "single", "split", "quad", "six-pack", "full-grid"' },
+  restart: { zone: "number (1-based; defaults to the currently focused zone)" },
+  swap: { a: "number (1-based zone index)", b: "number (1-based zone index)" },
+} as const;
+
+/** Helper: build a successful result. */
+function ok<T>(value?: T): CommandResult<T> {
+  return { ok: true, value };
+}
+
+/** Helper: build a failure result with a stable machine code. */
+function fail(code: string, message?: string): CommandResult<never> {
+  return { ok: false, code, message };
+}
+
+/**
+ * Resolve a 1-based zone index from an args bag. Accepts either a literal
+ * number or the words `next` / `prev` / `needs-input`. Returns `null` when
+ * the args don't carry a usable target.
+ */
+function readZoneArg(
+  args: Record<string, unknown>,
+  field: string = "zone",
+): number | null {
+  const v = args[field];
+  if (typeof v === "number" && Number.isFinite(v)) return Math.floor(v);
+  if (typeof v === "string") {
+    const n = Number(v);
+    if (Number.isFinite(n)) return Math.floor(n);
+  }
+  return null;
+}
+
+/**
+ * Look up a `configDir` from an `account` arg. `"best"` (or empty
+ * string) resolves to the lowest-utilization account. Returns `null`
+ * when no matching account exists — handlers surface that as
+ * `code: "no-account"`.
+ */
+function resolveAccountConfigDir(
+  account: unknown,
+  accounts: readonly AccountUsageInfo[],
+): string | null {
+  if (accounts.length === 0) return null;
+  const raw = typeof account === "string" ? account.trim().toLowerCase() : "";
+  if (raw === "" || raw === "best" || raw === "@best") {
+    const sorted = [...accounts].sort(
+      (a, b) => (a.utilization ?? 0) - (b.utilization ?? 0),
+    );
+    return sorted[0]?.config_dir ?? null;
+  }
+  const match = accounts.find(
+    (a) => a.label.toLowerCase() === raw || a.config_dir.toLowerCase() === raw,
+  );
+  return match?.config_dir ?? null;
+}
+
+export function useTerminalCommands(ctx: TerminalCommandsContext): void {
+  const session = useTerminalSession();
+  const {
+    tabs,
+    activeId,
+    setActiveId,
+    closeTerminal,
+    terminalRefs,
+    sessionStates,
+    zoneLayout,
+  } = session;
+  const transitionEffects = useTransitionEffects();
+  const { dispatch: uiDispatch, toggleFocusMode } = useUIStateCx();
+
+  /**
+   * Helper that converts 1-based zone arg to 0-based, defaulting to
+   * `zoneLayout.focusedZone` when no arg given. Returns null when the
+   * resolved index is out of range (handler returns `out-of-range`).
+   */
+  const resolveZoneIdx = (args: Record<string, unknown>): number | null => {
+    const arg = readZoneArg(args);
+    const idx = arg !== null ? arg - 1 : zoneLayout.focusedZone;
+    if (idx < 0 || idx >= zoneLayout.layout.zones.length) return null;
+    return idx;
+  };
+
+  // ── 1. /focus ────────────────────────────────────────────────────────
+  useCommandAction({
+    id: "terminal.focus",
+    slash: "/focus",
+    label: "Focus zone",
+    description:
+      "Focus a session by 1-based zone index, or jump to next/prev/needs-input. " +
+      "When a zone is maximized this also swaps the maximized view.",
+    paramSchema: SCHEMA.focus,
+    // Tier-2 patterns: "focus 3", "focus next", "focus prev",
+    // "focus previous", "focus needs input", "focus needs-input",
+    // "focus needsinput", "next session", "previous session".
+    patterns: [
+      /^focus\s+(?<target>next|prev|previous|needs[-_ ]?input|\d+)$/i,
+      /^(?<target>next|previous|prev)\s+session$/i,
+    ],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
+      // Normalize the variants the patterns produce so the handler's
+      // dispatch stays tight.
+      const raw = typeof args.target === "string" ? args.target.toLowerCase() : args.target;
+      const target =
+        raw === "previous"
+          ? "prev"
+          : typeof raw === "string" && /^needs[-_ ]?input$/.test(raw)
+            ? "needs-input"
+            : raw;
+      if (target === "next") {
+        zoneLayout.focusNextZone();
+        return ok();
+      }
+      if (target === "prev") {
+        zoneLayout.focusPrevZone();
+        return ok();
+      }
+      if (target === "needs-input") {
+        const found = zoneLayout.focusNextNeedsInput(sessionStates);
+        return found ? ok() : fail("none-needs-input");
+      }
+      const idx = resolveZoneIdx({ zone: target ?? args.zone });
+      if (idx === null) return fail("out-of-range");
+      zoneLayout.setFocusedZone(idx);
+      return ok();
+    },
+  });
+
+  // ── 2. /spawn ────────────────────────────────────────────────────────
+  useCommandAction({
+    id: "terminal.spawn",
+    slash: "/spawn",
+    label: "Spawn plain terminal",
+    description: "Spawn N plain PTY tabs in the user's default shell and zone-assign them.",
+    paramSchema: SCHEMA.spawn,
+    // Tier-2 patterns: "spawn 3", "spawn 3 plain".
+    // Ordered BEFORE /spawn-ai's pattern in registration order so
+    // `spawn 3 plain` routes to the plain handler rather than being
+    // captured by spawn-ai's wider account regex.
+    patterns: [/^spawn\s+(?<count>\d+)(?:\s+plain)?$/i],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult<string[]>> => {
+      const count = typeof args.count === "number" ? args.count : 1;
+      if (count < 1) return fail("invalid-count", "count must be >= 1");
+      const result = await ctx.spawnPlain(count);
+      return ok(Array.isArray(result) ? result : []);
+    },
+  });
+
+  // ── 3. /spawn-ai (alias /spawn-best) ──────────────────────────────────
+  // Single handler covers both wire ids (`create-ai-session` and
+  // `create-best-account`) via the `account: "best"` collapse decision.
+  useCommandAction({
+    id: "terminal.spawn-ai",
+    slash: "/spawn-ai",
+    aliases: ["/spawn-best"],
+    label: "Spawn AI session",
+    description:
+      "Spawn N Claude CLI sessions in a specific account. account=\"best\" picks the " +
+      "lowest-utilization account. context (optional) is typed after `claude` starts.",
+    paramSchema: SCHEMA.spawnAi,
+    // Tier-2 patterns:
+    //   "spawn-ai 3 best"            → count=3, account=best
+    //   "spawn-ai 3 best do the X"   → count=3, account=best, context="do the X"
+    //   "spawn 3 best"               → count=3, account=best   (natural form)
+    //   "spawn 3 claude"             → count=3, account="claude" (handler
+    //                                   maps via resolveAccountConfigDir;
+    //                                   "claude" is not a real label, falls
+    //                                   through to fail("no-account") which
+    //                                   surfaces a clear error rather than
+    //                                   silently launching the wrong account)
+    patterns: [
+      /^spawn-ai\s+(?<count>\d+)\s+(?<account>[\w-]+|best)(?:\s+(?<context>.+))?$/i,
+      /^spawn\s+(?<count>\d+)\s+(?<account>best|claude|[\w-]+)$/i,
+    ],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult<string[]>> => {
+      const count = typeof args.count === "number" ? args.count : 1;
+      if (count < 1) return fail("invalid-count", "count must be >= 1");
+      const configDir = resolveAccountConfigDir(args.account, ctx.accounts);
+      if (!configDir) return fail("no-account", "no matching Claude account");
+      const context = typeof args.context === "string" ? args.context : undefined;
+      const result = await ctx.spawnAi(count, configDir, context);
+      return ok(Array.isArray(result) ? result : []);
+    },
+  });
+
+  // ── 4. /spawn-with ────────────────────────────────────────────────────
+  useCommandAction({
+    id: "terminal.spawn-with",
+    slash: "/spawn-with",
+    label: "Spawn terminal with command",
+    description: "Spawn N plain PTY tabs and auto-type the given shell command into each.",
+    paramSchema: SCHEMA.spawnWith,
+    handler: async (args: Record<string, unknown>): Promise<CommandResult<string[]>> => {
+      const count = typeof args.count === "number" ? args.count : 1;
+      if (count < 1) return fail("invalid-count", "count must be >= 1");
+      const command = typeof args.command === "string" ? args.command : "";
+      if (!command) return fail("invalid-command", "command is required");
+      const result = await ctx.spawnPlain(count, command);
+      return ok(Array.isArray(result) ? result : []);
+    },
+  });
+
+  // ── 5. /approve-all ───────────────────────────────────────────────────
+  // Sends `y\r` to every PTY whose session-state is `needs-input`. Mirrors
+  // the inline writer at `useKeyboardShortcuts.ts:142-151` (Ctrl+Shift+
+  // Enter); the keyboard handler stays untouched in Phase 1b. Phase 9
+  // will collapse the two paths through this registry handler.
+  useCommandAction({
+    id: "terminal.approve-all",
+    slash: "/approve-all",
+    label: "Approve all needs-input sessions",
+    description:
+      "Sends 'y' followed by Enter to every session currently waiting on input. " +
+      "Same behavior as Ctrl+Shift+Enter.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^approve(?:\s+all)?$/i, /^yes\s+all$/i],
+    handler: async (): Promise<CommandResult<{ approved: number }>> => {
+      const waiting = tabs.filter((t) => sessionStates[t.id] === "needs-input");
+      for (const tab of waiting) {
+        terminalRefs.current.get(tab.id)?.current?.writeToTerminal("y\r");
+      }
+      return ok({ approved: waiting.length });
+    },
+  });
+
+  // ── 6. /maximize ──────────────────────────────────────────────────────
+  useCommandAction({
+    id: "terminal.maximize",
+    slash: "/maximize",
+    label: "Maximize / restore zone",
+    description:
+      "Toggle maximize for the given zone (1-based), or the currently focused zone " +
+      "when no argument is provided. Calling on the already-maximized zone restores.",
+    paramSchema: SCHEMA.maximize,
+    patterns: [
+      /^maximize(?:\s+(?<zone>\d+))?$/i,
+      /^fullscreen(?:\s+(?<zone>\d+))?$/i,
+    ],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
+      const idx = resolveZoneIdx(args);
+      if (idx === null) return fail("out-of-range");
+      zoneLayout.toggleMaximize(idx);
+      return ok();
+    },
+  });
+
+  // ── 7. /close ─────────────────────────────────────────────────────────
+  // `destructive: true` would trigger a confirm modal once Phase 4
+  // executor is in place; per plan §5(3) single-target close uses Undo
+  // instead of confirm. Mark `undoable: true` so the future executor
+  // captures pre-state. Today neither flag changes runtime behavior.
+  useCommandAction({
+    id: "terminal.close",
+    slash: "/close",
+    label: "Close session",
+    description:
+      "Close a session by tab id (preferred when known) or 1-based zone index. " +
+      "Without args, closes the currently focused session.",
+    paramSchema: SCHEMA.close,
+    undoable: true,
+    patterns: [/^close(?:\s+(?<zone>\d+))?$/i],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
+      const explicitTabId = typeof args.tabId === "string" ? args.tabId : null;
+      let tabId: string | null = explicitTabId;
+      if (!tabId) {
+        const idx = resolveZoneIdx(args);
+        if (idx !== null) {
+          tabId = zoneLayout.assignments[idx] ?? null;
+        }
+      }
+      if (!tabId) tabId = activeId;
+      if (!tabId) return fail("no-target", "no session to close");
+      closeTerminal(tabId);
+      return ok();
+    },
+  });
+
+  // ── 8. /layout ────────────────────────────────────────────────────────
+  useCommandAction({
+    id: "terminal.layout",
+    slash: "/layout",
+    label: "Change layout preset",
+    description:
+      'Set the zone-grid layout preset. Accepts "single", "split", "quad", "six-pack", ' +
+      'or "full-grid".',
+    paramSchema: SCHEMA.layout,
+    // Named-group form so the preset is bound to `args.preset` for both
+    // pattern and slash-form invocations.
+    patterns: [
+      /^layout\s+(?<preset>single|split|quad|six-?pack|full-?grid)$/i,
+      /^(?<preset>single|split|quad|six-?pack|full-?grid)\s+layout$/i,
+    ],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
+      const preset = typeof args.preset === "string" ? args.preset.toLowerCase() : "";
+      // Normalize "six-pack" / "sixpack" → "six-pack"; same for full-grid.
+      const normalized = preset
+        .replace(/sixpack/, "six-pack")
+        .replace(/fullgrid/, "full-grid");
+      if (!normalized) return fail("invalid-preset");
+      zoneLayout.setLayoutId(normalized);
+      return ok();
+    },
+  });
+
+  // ── 9. /restart ───────────────────────────────────────────────────────
+  // State-gated handler — surfaces `not-restartable` per the audit's
+  // §"Per-action success criterion checks" so the CommandBar can show
+  // a friendly error instead of a silent no-op. Today
+  // `transitionEffects.handleRestartInZone` itself returns silently
+  // (`TransitionEffectsContext.tsx:44`) so we replicate the same gate
+  // here to give the user feedback.
+  useCommandAction({
+    id: "terminal.restart",
+    slash: "/restart",
+    label: "Restart session in zone",
+    description:
+      "Restart the session in the given zone (1-based) or the focused zone. " +
+      "Only available when the session is in 'completed' or 'error' state.",
+    paramSchema: SCHEMA.restart,
+    patterns: [/^restart(?:\s+(?<zone>\d+))?$/i],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
+      const idx = resolveZoneIdx(args);
+      if (idx === null) return fail("out-of-range");
+      const tabId = zoneLayout.assignments[idx];
+      const state = tabId ? sessionStates[tabId] ?? "idle" : "idle";
+      if (state !== "completed" && state !== "error") {
+        return fail("not-restartable", `session state is ${state}`);
+      }
+      transitionEffects.handleRestartInZone(idx);
+      return ok();
+    },
+  });
+
+  // ── 10. /swap ────────────────────────────────────────────────────────
+  // Replaces today's two-chord Ctrl+Shift+X workflow (mark source, focus
+  // dest, swap). Single invocation; no mode tracking. Per the audit
+  // table this is the second marquee CommandBar win after /spawn-ai.
+  useCommandAction({
+    id: "terminal.swap",
+    slash: "/swap",
+    label: "Swap two zones",
+    description: "Swap the tab assignments of two zones (1-based indices).",
+    paramSchema: SCHEMA.swap,
+    patterns: [/^swap\s+(?<a>\d+)\s+(?<b>\d+)$/i],
+    handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
+      const a = readZoneArg(args, "a");
+      const b = readZoneArg(args, "b");
+      if (a === null || b === null) return fail("invalid-args", "a and b required");
+      const aIdx = a - 1;
+      const bIdx = b - 1;
+      const maxIdx = zoneLayout.layout.zones.length;
+      if (aIdx < 0 || aIdx >= maxIdx || bIdx < 0 || bIdx >= maxIdx) {
+        return fail("out-of-range");
+      }
+      if (aIdx === bIdx) return ok();
+      const aTabId = zoneLayout.assignments[aIdx];
+      const bTabId = zoneLayout.assignments[bIdx];
+      if (aTabId) zoneLayout.assignTabToZone(bIdx, aTabId);
+      if (bTabId) zoneLayout.assignTabToZone(aIdx, bTabId);
+      return ok();
+    },
+  });
+
+  // ── Phase 9b — ZoneStatusBar migration slice ────────────────────────
+  // Seven preference-toggle + zone-op actions that previously only had
+  // ZoneStatusBar button homes (and partial keyboard-shortcut coverage).
+  // Adding them to the registry makes them invokable from CommandBar /
+  // palette / Tier-3, paving the way to delete the corresponding
+  // ZoneStatusBar buttons in a follow-up commit. Each handler calls the
+  // SAME underlying context function the existing button click does, so
+  // both surfaces stay in lockstep until the button comes out.
+
+  // 11. /focus-mode — toggle the "fade unfocused zones" overlay
+  useCommandAction({
+    id: "terminal.toggle-focus-mode",
+    slash: "/focus-mode",
+    aliases: ["/toggle-focus-mode"],
+    label: "Toggle focus mode",
+    description:
+      "Dim every zone except the focused one (and those in needs-input/error). " +
+      "Same as Ctrl+Shift+D and the Eye icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^focus[ -]mode$/i, /^toggle\s+focus[ -]mode$/i],
+    handler: async (): Promise<CommandResult> => {
+      toggleFocusMode();
+      return ok();
+    },
+  });
+
+  // 12. /auto-focus — toggle auto-focus-on-needs-input
+  useCommandAction({
+    id: "terminal.toggle-auto-focus",
+    slash: "/auto-focus",
+    aliases: ["/toggle-auto-focus"],
+    label: "Toggle auto-focus on needs-input",
+    description:
+      "When ON, the grid automatically focuses the next session that enters " +
+      "needs-input state. Same as Ctrl+Shift+A and the Focus icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^auto[ -]focus$/i, /^toggle\s+auto[ -]focus$/i],
+    handler: async (): Promise<CommandResult> => {
+      transitionEffects.toggleAutoFocus();
+      return ok();
+    },
+  });
+
+  // 13. /sound — toggle audible needs-input/error notifications
+  useCommandAction({
+    id: "terminal.toggle-sound",
+    slash: "/sound",
+    aliases: ["/toggle-sound", "/mute", "/unmute"],
+    label: "Toggle sound notifications",
+    description:
+      "Audible chimes when a session enters needs-input or error. Same as " +
+      "Ctrl+Shift+S and the speaker icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^(?:un)?mute$/i, /^toggle\s+sound$/i, /^sound$/i],
+    handler: async (): Promise<CommandResult> => {
+      transitionEffects.toggleSound();
+      return ok();
+    },
+  });
+
+  // 14. /auto-restart — toggle auto-restart-completed-sessions
+  // Mirrors ZoneStatusBar's onToggleAutoRestart: flips the boolean AND
+  // persists the new value to instanceStorage under the same key the
+  // existing button uses (`zone-auto-restart`) so both paths stay in
+  // sync across reloads.
+  useCommandAction({
+    id: "terminal.toggle-auto-restart",
+    slash: "/auto-restart",
+    aliases: ["/toggle-auto-restart"],
+    label: "Toggle auto-restart of completed sessions",
+    description:
+      "When ON, sessions that exit cleanly are immediately respawned with the " +
+      "same launch command. Useful for headless polling agents. Same as the " +
+      "RefreshCw icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^auto[ -]restart$/i, /^toggle\s+auto[ -]restart$/i],
+    handler: async (): Promise<CommandResult> => {
+      transitionEffects.setAutoRestart((prev: boolean) => {
+        const next = !prev;
+        instanceStorage.setItem("zone-auto-restart", String(next));
+        return next;
+      });
+      return ok();
+    },
+  });
+
+  // 15. /sort-zones — reorder zones by state
+  useCommandAction({
+    id: "terminal.sort-zones",
+    slash: "/sort-zones",
+    aliases: ["/sort"],
+    label: "Sort zones by state",
+    description:
+      "Reorder zones so needs-input lands first, then error, working, idle, " +
+      "completed. Same as the ArrowUpDown icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^sort(?:\s+zones)?$/i],
+    handler: async (): Promise<CommandResult> => {
+      ctx.sortZones();
+      return ok();
+    },
+  });
+
+  // 16. /export-all — export every session's transcript
+  useCommandAction({
+    id: "terminal.export-all",
+    slash: "/export-all",
+    aliases: ["/export"],
+    label: "Export all session output",
+    description:
+      "Save every visible session's terminal output to a file. Same as the " +
+      "Download icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^export(?:\s+all)?$/i],
+    handler: async (): Promise<CommandResult> => {
+      ctx.exportAll();
+      return ok();
+    },
+  });
+
+  // 17. /shortcuts — open the keyboard-shortcuts overlay
+  useCommandAction({
+    id: "terminal.show-shortcuts",
+    slash: "/shortcuts",
+    aliases: ["/keys", "/help"],
+    label: "Show keyboard shortcuts",
+    description:
+      "Open the keyboard-shortcuts cheat sheet overlay. Same as Ctrl+Shift+? " +
+      "and the Keyboard icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^shortcuts$/i, /^keys$/i, /^help$/i],
+    handler: async (): Promise<CommandResult> => {
+      uiDispatch({ type: "SET_SHOW_SHORTCUTS", payload: true });
+      return ok();
+    },
+  });
+
+  // Mark unused vars so linters don't trip on the resolver-context
+  // signature placeholder (handlers below don't consult `ctx` directly
+  // today — Phase 2's CommandBar wires it in for cancellation).
+  void setActiveId;
+}
+
+/** Re-export so tests + the index barrel can reach a single source. */
+export type { ResolverContext } from "./types";

--- a/src/components/terminal/suggestions/SuggestionChip.tsx
+++ b/src/components/terminal/suggestions/SuggestionChip.tsx
@@ -1,0 +1,90 @@
+/**
+ * Per-zone suggestion chip — mounts inside `ZoneCell` and renders the
+ * chip (if any) that the engine has assigned to this zone.
+ *
+ * Single-instance per zone: the engine's reconciler deduplicates by
+ * `zoneIdx` so this component never sees more than one candidate at a
+ * time. Click the body to apply the chip's registry action; click the
+ * `×` to dismiss + suppress the `(zoneIdx, ruleId)` pair for 5min.
+ *
+ * Renders nothing when no chip is active — keeping zone-cell chrome at
+ * zero when the rules are quiet (plan §"Invisible chrome").
+ */
+
+import { useCallback, useState } from "react";
+import { X } from "lucide-react";
+
+import { callRegistry } from "../commands";
+import { useSuggestionForZone } from "./useSuggestions";
+
+interface Props {
+  zoneIdx: number;
+}
+
+export function SuggestionChip({ zoneIdx }: Props) {
+  const { chip, dismiss } = useSuggestionForZone(zoneIdx);
+  const [applying, setApplying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const apply = useCallback(async () => {
+    if (!chip) return;
+    setApplying(true);
+    setError(null);
+    try {
+      await callRegistry(chip.actionId, chip.args);
+      // On success, dismiss locally so the chip clears immediately
+      // even if the underlying state hasn't yet flipped.
+      dismiss();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      // Auto-clear the error after 3s so the chip returns to its
+      // normal copy.
+      setTimeout(() => setError(null), 3000);
+    } finally {
+      setApplying(false);
+    }
+  }, [chip, dismiss]);
+
+  if (!chip) return null;
+
+  return (
+    <div
+      className="absolute top-2 right-2 z-30 pointer-events-auto suggestion-chip-fade-in"
+      data-page-element="suggestion-chip"
+      data-rule-id={chip.ruleId}
+    >
+      <div
+        className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] border backdrop-blur-sm shadow-md max-w-[280px] ${
+          error
+            ? "bg-[#f7768e]/10 border-[#f7768e]/40 text-[#f7768e]"
+            : "bg-[#1a1b26]/95 border-[#7aa2f7]/30 text-[#c0caf5]"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={apply}
+          disabled={applying}
+          className={`flex items-center gap-1.5 text-left ${
+            applying ? "opacity-60 cursor-wait" : "hover:text-[#7aa2f7]"
+          }`}
+          title={`Apply: ${chip.slash}`}
+        >
+          <span className="truncate">{error ?? chip.headline}</span>
+          <span className="font-mono text-[9px] text-[#7aa2f7] opacity-80 shrink-0">
+            {chip.slash}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="p-0.5 rounded text-[#565f89] hover:text-[#a9b1d6] hover:bg-[#2a2d3d]/60 transition-colors shrink-0"
+          title="Dismiss for 5 minutes"
+          aria-label="Dismiss suggestion"
+        >
+          <X className="w-2.5 h-2.5" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/suggestions/index.ts
+++ b/src/components/terminal/suggestions/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Public surface of the suggestion-chip engine. See
+ * `plans/2026-05-28-terminal-page-redesign-plan.md` §Phase 4 for
+ * design context and `./rules.ts` for the rule list.
+ */
+
+export type { ChipCandidate, SuggestionContext } from "./rules";
+export { reconcileChips } from "./rules";
+
+export { SuggestionsProvider, useSuggestionForZone } from "./useSuggestions";
+
+export { SuggestionChip } from "./SuggestionChip";

--- a/src/components/terminal/suggestions/rules.test.ts
+++ b/src/components/terminal/suggestions/rules.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Pure-function tests for the suggestion rule evaluator and reconciler.
+ *
+ * Covers:
+ *   1. ruleErrorInZone — emits one chip per errored zone, with the
+ *      correct slash form (1-based zone index)
+ *   2. ruleStuckNeedsInput — fires only when elapsed > 30s, picks the
+ *      right human-readable duration bucket (s / m / h)
+ *   3. ruleLayoutMismatch — fires only when overflow factor exceeded
+ *      AND the suggested preset would actually change
+ *   4. reconcileChips — priority-resolves multiple candidates on the
+ *      same zone (error wins over stuck-needs-input)
+ *   5. reconcileChips — applies suppression filter
+ *   6. reconcileChips — caps at maxOnPage, dropping lowest-priority
+ *      chips first
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  reconcileChips,
+  ruleErrorInZone,
+  ruleLayoutMismatch,
+  ruleStuckNeedsInput,
+  type SuggestionContext,
+} from "./rules";
+
+const NOW = 1_700_000_000_000;
+
+const ctx = (overrides: Partial<SuggestionContext> = {}): SuggestionContext => ({
+  nowMs: NOW,
+  tabsCount: 0,
+  zoneCount: 1,
+  currentLayoutId: "single",
+  assignments: {},
+  sessionStates: {},
+  stateEntryMs: {},
+  focusedZone: 0,
+  ...overrides,
+});
+
+describe("ruleErrorInZone", () => {
+  it("emits one chip per errored zone with 1-based slash form", () => {
+    const chips = ruleErrorInZone(
+      ctx({
+        assignments: { 0: "t-a", 2: "t-b" },
+        sessionStates: { "t-a": "error", "t-b": "idle" },
+      }),
+    );
+    expect(chips).toHaveLength(1);
+    expect(chips[0]).toMatchObject({
+      ruleId: "error-in-zone",
+      zoneIdx: 0,
+      priority: 100,
+      slash: "/restart 1",
+      actionId: "terminal.restart",
+      args: { zone: 1 },
+    });
+  });
+
+  it("emits nothing when no tab is in error state", () => {
+    expect(
+      ruleErrorInZone(
+        ctx({
+          assignments: { 0: "t-a" },
+          sessionStates: { "t-a": "working" },
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("ruleStuckNeedsInput", () => {
+  it("fires only once the 30s gate is passed", () => {
+    const baseCtx = ctx({
+      assignments: { 0: "t-a" },
+      sessionStates: { "t-a": "needs-input" },
+      stateEntryMs: { "t-a": NOW - 20_000 },
+    });
+    expect(ruleStuckNeedsInput(baseCtx)).toEqual([]);
+    expect(
+      ruleStuckNeedsInput({ ...baseCtx, stateEntryMs: { "t-a": NOW - 31_000 } }),
+    ).toHaveLength(1);
+  });
+
+  it("formats elapsed time into s/m/h buckets", () => {
+    const stuck = (elapsedMs: number): SuggestionContext =>
+      ctx({
+        assignments: { 0: "t-a" },
+        sessionStates: { "t-a": "needs-input" },
+        stateEntryMs: { "t-a": NOW - elapsedMs },
+      });
+    expect(ruleStuckNeedsInput(stuck(45_000))[0].headline).toMatch(/45s/);
+    expect(ruleStuckNeedsInput(stuck(5 * 60_000))[0].headline).toMatch(/5m/);
+    expect(ruleStuckNeedsInput(stuck(2 * 3_600_000))[0].headline).toMatch(/2h/);
+  });
+
+  it("skips zones whose tab has no stateEntryMs entry", () => {
+    expect(
+      ruleStuckNeedsInput(
+        ctx({
+          assignments: { 0: "t-a" },
+          sessionStates: { "t-a": "needs-input" },
+        }),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("ruleLayoutMismatch", () => {
+  it("fires when tabsCount > zoneCount * 1.2 AND suggested preset differs", () => {
+    expect(
+      ruleLayoutMismatch(
+        ctx({
+          tabsCount: 7,
+          zoneCount: 4,
+          currentLayoutId: "quad",
+          focusedZone: 2,
+        }),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("does not fire when the suggested preset matches current", () => {
+    // 6 tabs with current already six-pack → no chip.
+    expect(
+      ruleLayoutMismatch(
+        ctx({
+          tabsCount: 6,
+          zoneCount: 5,
+          currentLayoutId: "six-pack",
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("does not fire below the 1.2x overflow factor", () => {
+    expect(
+      ruleLayoutMismatch(
+        ctx({
+          tabsCount: 4,
+          zoneCount: 4,
+          currentLayoutId: "quad",
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("anchors the chip on focusedZone", () => {
+    const chips = ruleLayoutMismatch(
+      ctx({
+        tabsCount: 7,
+        zoneCount: 4,
+        currentLayoutId: "quad",
+        focusedZone: 3,
+      }),
+    );
+    expect(chips[0].zoneIdx).toBe(3);
+  });
+});
+
+describe("reconcileChips", () => {
+  it("keeps highest-priority chip when multiple fire on the same zone", () => {
+    // Zone 0 is BOTH errored AND has been needs-input for 1 minute —
+    // error (100) wins over stuck-needs-input (70).
+    // (Real-world this combination is impossible — state is a single
+    //  enum — but the reconciler must still pick deterministically.)
+    const result = reconcileChips(
+      ctx({
+        assignments: { 0: "t-a" },
+        sessionStates: { "t-a": "error" }, // satisfies error rule
+        stateEntryMs: { "t-a": NOW - 60_000 },
+      }),
+      new Set(),
+    );
+    expect(result.size).toBe(1);
+    expect(result.get(0)?.ruleId).toBe("error-in-zone");
+  });
+
+  it("applies suppression keyed on (zoneIdx, ruleId)", () => {
+    const result = reconcileChips(
+      ctx({
+        assignments: { 0: "t-a" },
+        sessionStates: { "t-a": "error" },
+      }),
+      new Set(["0:error-in-zone"]),
+    );
+    expect(result.size).toBe(0);
+  });
+
+  it("caps the page total, dropping lowest-priority chips first", () => {
+    // 4 errored zones → 4 chips, all priority 100. Cap=3, so one drops.
+    const result = reconcileChips(
+      ctx({
+        assignments: { 0: "a", 1: "b", 2: "c", 3: "d" },
+        sessionStates: { a: "error", b: "error", c: "error", d: "error" },
+      }),
+      new Set(),
+      3,
+    );
+    expect(result.size).toBe(3);
+  });
+
+  it("drops layout-mismatch (priority 30) before error chips when over cap", () => {
+    const result = reconcileChips(
+      ctx({
+        // Three errored zones + a layout-mismatch chip on zone 0
+        // (overridden by error on zone 0 in the per-zone dedupe), but
+        // also tabsCount > zoneCount*1.2 → layout chip on focusedZone.
+        // After per-zone dedupe: zone 0 = error, zone 1 = error,
+        // zone 2 = error, focusedZone (3) = layout-mismatch. Cap=3 drops
+        // the layout chip.
+        tabsCount: 10,
+        zoneCount: 4,
+        currentLayoutId: "quad",
+        focusedZone: 3,
+        assignments: { 0: "a", 1: "b", 2: "c" },
+        sessionStates: { a: "error", b: "error", c: "error" },
+      }),
+      new Set(),
+      3,
+    );
+    expect(result.size).toBe(3);
+    for (const chip of result.values()) {
+      expect(chip.ruleId).toBe("error-in-zone");
+    }
+  });
+});

--- a/src/components/terminal/suggestions/rules.ts
+++ b/src/components/terminal/suggestions/rules.ts
@@ -1,0 +1,246 @@
+/**
+ * Suggestion-chip rule definitions for Phase 4.
+ *
+ * Each rule is a pure function over a `SuggestionContext` that returns
+ * zero or more `ChipCandidate`s. The engine (`useSuggestions`) calls
+ * every rule on each render, applies the volume cap + per-zone dedupe
+ * + suppression filter, and hands the survivors to the per-zone
+ * `<SuggestionChip>` mounts inside `ZoneGrid`.
+ *
+ * The 3 rules shipped in this phase cover the three lowest-state-
+ * complexity entries from the plan's §Phase-4 rule list:
+ *
+ *   - `error-in-zone` — most actionable; no time gate.
+ *   - `stuck-needs-input` — urgency signal; 30s gate using
+ *     `stateEntryTimeRef` from `useSessionStateTracking`.
+ *   - `layout-mismatch` — low-urgency hint when sessions outnumber
+ *     visible zones by more than 20%.
+ *
+ * Rule priority (highest = wins when one zone has multiple candidates):
+ *   error → stuck-needs-input → layout-mismatch.
+ *
+ * Deferred for follow-up:
+ *   - `lock-contention` (plan flags overlap with `HoldingLockBanner`;
+ *     not shipping both — banner removal lives in Phase 9 demolition).
+ *   - `idle-profile-prompt` (needs profile-matching heuristics from
+ *     `ZoneProfilePicker`; out of scope until the profile surface
+ *     exposes a match query).
+ */
+
+import type { SessionState, ZoneAssignments } from "../useZoneLayout";
+
+/** Read-only snapshot of every piece of state the rules can branch on. */
+export interface SuggestionContext {
+  /** Now, in epoch ms — passed in (not read internally) so the engine's
+   *  re-evaluation cadence is explicit and rule tests stay deterministic. */
+  nowMs: number;
+  /** `tabs` length is the only field used; full list available for
+   *  future rules. */
+  tabsCount: number;
+  /** Zone count from the current layout (`zoneLayout.layout.zones.length`). */
+  zoneCount: number;
+  /** Layout id (`single`, `quad`, `six-pack`, ...) — used to detect when
+   *  the suggested target preset would actually change anything. */
+  currentLayoutId: string;
+  /** Zone-index → tab-id mapping. */
+  assignments: ZoneAssignments;
+  /** Per-tab session state. */
+  sessionStates: Record<string, SessionState>;
+  /** Per-tab epoch-ms when the *current* state was first observed. */
+  stateEntryMs: Record<string, number>;
+  /** The zone the operator is currently looking at. Used as the host
+   *  zone for non-tab-bound chips like `layout-mismatch`. */
+  focusedZone: number;
+}
+
+/** A single candidate chip emitted by a rule. */
+export interface ChipCandidate {
+  /** Stable rule id, e.g. `"stuck-needs-input"`. */
+  ruleId: string;
+  /** Zone index (0-based) the chip should render inside. */
+  zoneIdx: number;
+  /** Per-rule priority — higher wins when multiple rules fire on the
+   *  same zone. Set by the rule, not the operator. */
+  priority: number;
+  /** Short headline shown in the chip body. */
+  headline: string;
+  /** Slash equivalent rendered inline (passive teaching surface
+   *  per the plan's §3 item 2). */
+  slash: string;
+  /** Registry action id to invoke when the chip is clicked. */
+  actionId: string;
+  /** Args passed to the action handler. */
+  args: Record<string, unknown>;
+}
+
+/** Pick the smallest layout preset that fits N tabs. Mirrors the helper
+ *  in `TerminalPage.tsx` (intentionally duplicated — both ride on the
+ *  same `LAYOUT_PRESETS` definition; collapsing into one shared helper
+ *  is a Phase 9 cleanup). */
+function pickLayout(totalTabs: number): string {
+  if (totalTabs >= 7) return "full-grid";
+  if (totalTabs >= 5) return "six-pack";
+  if (totalTabs >= 3) return "quad";
+  if (totalTabs >= 2) return "split";
+  return "single";
+}
+
+/**
+ * Pretty-name a layout preset for the chip headline.
+ */
+function prettyLayoutName(preset: string): string {
+  switch (preset) {
+    case "full-grid":
+      return "Full grid";
+    case "six-pack":
+      return "6-pack";
+    case "quad":
+      return "Quad";
+    case "split":
+      return "Split";
+    case "single":
+      return "Single";
+    default:
+      return preset;
+  }
+}
+
+const ELAPSED_NEEDS_INPUT_MS = 30_000;
+const LAYOUT_OVERFLOW_FACTOR = 1.2;
+
+/**
+ * Rule: error-in-zone.
+ *
+ * Trigger: any tab whose `sessionStates[tab.id] === "error"`. One chip
+ * per errored zone. Priority 100 — wins over stuck-needs-input and
+ * layout-mismatch on the same zone.
+ */
+export function ruleErrorInZone(ctx: SuggestionContext): ChipCandidate[] {
+  const out: ChipCandidate[] = [];
+  for (const [zoneStr, tabId] of Object.entries(ctx.assignments)) {
+    const state = ctx.sessionStates[tabId];
+    if (state !== "error") continue;
+    const zoneIdx = Number(zoneStr);
+    out.push({
+      ruleId: "error-in-zone",
+      zoneIdx,
+      priority: 100,
+      headline: "Restart? Session errored",
+      slash: `/restart ${zoneIdx + 1}`,
+      actionId: "terminal.restart",
+      args: { zone: zoneIdx + 1 },
+    });
+  }
+  return out;
+}
+
+/**
+ * Rule: stuck-needs-input.
+ *
+ * Trigger: tab in `needs-input` state for more than {@link
+ * ELAPSED_NEEDS_INPUT_MS}. One chip per stuck zone. Priority 70.
+ *
+ * Time gate uses `stateEntryMs` (from `useSessionStateTracking`'s
+ * `stateEntryTimeRef`) — the engine re-evaluates on a 5s tick so
+ * `(nowMs - stateEntryMs[tabId]) > 30s` becomes true within at most
+ * 5s of the actual 30s mark.
+ */
+export function ruleStuckNeedsInput(ctx: SuggestionContext): ChipCandidate[] {
+  const out: ChipCandidate[] = [];
+  for (const [zoneStr, tabId] of Object.entries(ctx.assignments)) {
+    if (ctx.sessionStates[tabId] !== "needs-input") continue;
+    const since = ctx.stateEntryMs[tabId];
+    if (typeof since !== "number") continue;
+    const elapsedMs = ctx.nowMs - since;
+    if (elapsedMs < ELAPSED_NEEDS_INPUT_MS) continue;
+    const zoneIdx = Number(zoneStr);
+    const elapsedSec = Math.floor(elapsedMs / 1000);
+    const human =
+      elapsedSec < 60
+        ? `${elapsedSec}s`
+        : elapsedSec < 3600
+          ? `${Math.floor(elapsedSec / 60)}m`
+          : `${Math.floor(elapsedSec / 3600)}h`;
+    out.push({
+      ruleId: "stuck-needs-input",
+      zoneIdx,
+      priority: 70,
+      headline: `Respond — needs input for ${human}`,
+      slash: `/focus ${zoneIdx + 1}`,
+      actionId: "terminal.focus",
+      args: { zone: zoneIdx + 1 },
+    });
+  }
+  return out;
+}
+
+/**
+ * Rule: layout-mismatch.
+ *
+ * Trigger: `tabsCount > zoneCount * LAYOUT_OVERFLOW_FACTOR` AND the
+ * preset that would fit `tabsCount` differs from the current preset.
+ * Surfaces on `focusedZone` (operator's current attention). Priority 30
+ * — yields to error/stuck chips on the same zone.
+ */
+export function ruleLayoutMismatch(ctx: SuggestionContext): ChipCandidate[] {
+  if (ctx.zoneCount === 0) return [];
+  if (ctx.tabsCount <= ctx.zoneCount * LAYOUT_OVERFLOW_FACTOR) return [];
+  const suggested = pickLayout(ctx.tabsCount);
+  if (suggested === ctx.currentLayoutId) return [];
+  return [
+    {
+      ruleId: "layout-mismatch",
+      zoneIdx: ctx.focusedZone,
+      priority: 30,
+      headline: `Switch to ${prettyLayoutName(suggested)} — show all ${ctx.tabsCount} sessions`,
+      slash: `/layout ${suggested}`,
+      actionId: "terminal.layout",
+      args: { preset: suggested },
+    },
+  ];
+}
+
+/** Master rule list — append-only. Iteration order is irrelevant; the
+ *  engine reconciles by zone + priority. */
+export const RULES: Array<(ctx: SuggestionContext) => ChipCandidate[]> = [
+  ruleErrorInZone,
+  ruleStuckNeedsInput,
+  ruleLayoutMismatch,
+];
+
+/**
+ * Reconcile every rule's candidates into the final per-zone chip list:
+ *
+ *   1. Run each rule, collect every candidate.
+ *   2. Group by `zoneIdx`; within a zone, keep only the highest-priority
+ *      candidate (per plan §5(6) — 1 chip per zone max).
+ *   3. Filter out suppressed `(zoneIdx, ruleId)` pairs.
+ *   4. Sort surviving chips by priority desc and cap at 3 (page max).
+ *   5. Return the final list as a `Map<zoneIdx, ChipCandidate>`.
+ *
+ * Pure function — easy to test without React. The hook
+ * (`useSuggestions`) is just a tick + context-read wrapper around this.
+ */
+export function reconcileChips(
+  ctx: SuggestionContext,
+  suppressed: ReadonlySet<string>,
+  maxOnPage = 3,
+): Map<number, ChipCandidate> {
+  const byZone = new Map<number, ChipCandidate>();
+  for (const rule of RULES) {
+    for (const candidate of rule(ctx)) {
+      const suppressKey = `${candidate.zoneIdx}:${candidate.ruleId}`;
+      if (suppressed.has(suppressKey)) continue;
+      const existing = byZone.get(candidate.zoneIdx);
+      if (!existing || existing.priority < candidate.priority) {
+        byZone.set(candidate.zoneIdx, candidate);
+      }
+    }
+  }
+  // Cap at maxOnPage — drop the lowest-priority chips first.
+  if (byZone.size <= maxOnPage) return byZone;
+  const sorted = [...byZone.entries()].sort(
+    (a, b) => b[1].priority - a[1].priority,
+  );
+  return new Map(sorted.slice(0, maxOnPage));
+}

--- a/src/components/terminal/suggestions/useSuggestions.tsx
+++ b/src/components/terminal/suggestions/useSuggestions.tsx
@@ -1,0 +1,154 @@
+/**
+ * React hook bridging the live page contexts to the pure
+ * {@link reconcileChips} engine.
+ *
+ * Mounts at `TerminalPageInner` once; downstream consumers (the
+ * per-zone `<SuggestionChip>` mount in `ZoneGrid`'s `ZoneCell`) read
+ * from a tiny context the hook publishes. Centralising the engine
+ * here means:
+ *
+ *  - One re-evaluation per tick / state change, not one per zone.
+ *  - Suppression state lives in one place (`Set<string>` keyed
+ *    `${zoneIdx}:${ruleId}`).
+ *  - The 5s heartbeat that drives time-gated rules
+ *    (`stuck-needs-input`) is shared, not per-rule.
+ *
+ * Suppression is in-memory only — a 5min auto-expiry is enforced via
+ * `Map<key, expiryMs>`. Persisting across page-reload was deemed
+ * unnecessary for v1 (the chip-storm scenarios a refresh might suppress
+ * aren't long-lived) and would couple the engine to `instanceStorage`.
+ */
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+import { useTerminalSession } from "../contexts";
+import { reconcileChips, type ChipCandidate } from "./rules";
+
+const SUPPRESS_DURATION_MS = 5 * 60_000;
+/** Re-evaluation cadence for time-gated rules. 5s means the
+ *  `stuck-needs-input` rule fires within at most 5s of the 30s mark. */
+const TICK_MS = 5_000;
+/** Hard cap on simultaneous chips across the whole page. Matches
+ *  plan §5(6) — max 3 on page, max 1 per zone (the latter enforced
+ *  by the reconciler's per-zone dedupe). */
+const MAX_ON_PAGE = 3;
+
+interface SuggestionsContextValue {
+  /** Per-zone chip — at most one entry per zoneIdx. */
+  chipsByZone: ReadonlyMap<number, ChipCandidate>;
+  /** Dismiss a chip; suppresses the `(zoneIdx, ruleId)` pair for 5min. */
+  dismiss: (zoneIdx: number, ruleId: string) => void;
+}
+
+const SuggestionsContext = createContext<SuggestionsContextValue | null>(null);
+
+/**
+ * Mount once at TerminalPageInner; subscribes to session contexts,
+ * evaluates rules on every state change + every 5s, and exposes the
+ * resulting chip map via `useSuggestionForZone`.
+ */
+export function SuggestionsProvider({ children }: { children: React.ReactNode }) {
+  const session = useTerminalSession();
+  const { tabs, sessionStates, zoneLayout, stateEntryTimeRef } = session;
+  const { layout, layoutId, focusedZone, assignments } = zoneLayout;
+
+  // 5s heartbeat — bumps `tick` so the engine re-evaluates time-gated
+  // rules even when no state has changed.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  // Suppression state: Map<"zoneIdx:ruleId", expiryEpochMs>.
+  const [suppression, setSuppression] = useState<Map<string, number>>(
+    () => new Map(),
+  );
+
+  // Compute the active suppression key set, cheaply re-deriving when
+  // expirations move out of date.
+  const suppressed = useMemo(() => {
+    const now = Date.now();
+    const live = new Set<string>();
+    for (const [key, expiresAt] of suppression) {
+      if (expiresAt > now) live.add(key);
+    }
+    return live;
+    // tick included so an expired suppression is dropped from the
+    // active set within one heartbeat, even when no other deps change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [suppression, tick]);
+
+  // The chip map. Depends on session state, the tick (time), and
+  // suppression.
+  const chipsByZone = useMemo(() => {
+    return reconcileChips(
+      {
+        nowMs: Date.now(),
+        tabsCount: tabs.length,
+        zoneCount: layout.zones.length,
+        currentLayoutId: layoutId,
+        assignments,
+        sessionStates,
+        stateEntryMs: stateEntryTimeRef.current,
+        focusedZone,
+      },
+      suppressed,
+      MAX_ON_PAGE,
+    );
+    // stateEntryTimeRef is a mutable ref so its identity is stable;
+    // the tick dep covers cadence-driven re-eval.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    tabs.length,
+    sessionStates,
+    layout.zones.length,
+    layoutId,
+    assignments,
+    focusedZone,
+    suppressed,
+    tick,
+  ]);
+
+  const dismiss = useCallback((zoneIdx: number, ruleId: string) => {
+    const key = `${zoneIdx}:${ruleId}`;
+    const expiresAt = Date.now() + SUPPRESS_DURATION_MS;
+    setSuppression((prev) => {
+      const next = new Map(prev);
+      next.set(key, expiresAt);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<SuggestionsContextValue>(
+    () => ({ chipsByZone, dismiss }),
+    [chipsByZone, dismiss],
+  );
+
+  return (
+    <SuggestionsContext.Provider value={value}>
+      {children}
+    </SuggestionsContext.Provider>
+  );
+}
+
+/**
+ * Read the chip (if any) for a single zone. Returns `null` when nothing
+ * is active for that zone — the chip component renders nothing in that
+ * case, keeping zone-cell chrome zero when the rules are quiet.
+ */
+export function useSuggestionForZone(zoneIdx: number): {
+  chip: ChipCandidate | null;
+  dismiss: () => void;
+} {
+  const ctx = useContext(SuggestionsContext);
+  // Outside a provider: render no chips, dismiss is a no-op. This
+  // matches the React "context fallback" convention so the chip
+  // component is safe to mount in zones that aren't wrapped (e.g.
+  // a future per-zone profile preview).
+  const chip = ctx?.chipsByZone.get(zoneIdx) ?? null;
+  const dismiss = useCallback(() => {
+    if (chip) ctx?.dismiss(zoneIdx, chip.ruleId);
+  }, [ctx, zoneIdx, chip]);
+  return { chip, dismiss };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1064,6 +1064,22 @@
       box-shadow: none;
     }
   }
+
+  /* Phase 4 suggestion-chip fade-in. Matches the plan's "fade-in 200ms"
+     specification for SuggestionChip overlays on zone cells. */
+  .suggestion-chip-fade-in {
+    animation: suggestion-chip-fade-in 200ms ease-out;
+  }
+  @keyframes suggestion-chip-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(-4px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
 }
 
 /* Scrollbar utilities (must be top-level, not nested in @layer) */


### PR DESCRIPTION
## Summary
- Implements the plan at `plans/2026-05-28-terminal-page-redesign-plan.md` — replaces always-on `TerminalTabBar` / per-tab badge cluster / `ZoneStatusBar` churn with an *invisible chrome* model: a single command registry projected four ways (slash autocomplete, regex patterns, Anthropic Claude subprocess routing, palette discoverability), per-zone hover controls + suggestion chips, and an auto-hiding top status strip.
- Phase 9a: hoists the `terminal-launch-menu` `useUIComponent` registration from `TerminalTabBar.tsx` to `TerminalPage.tsx`, dropping the `open` / `close` UI-affordance actions (live-smoke-confirmed; wire contract `{success, tab_ids, task_run_ids}` intact).
- Phase 9b: 7 registry actions cover the simplest `ZoneStatusBar` controls (`/focus-mode`, `/auto-focus`, `/sound`, `/auto-restart`, `/sort-zones`, `/export-all`, `/shortcuts`), all calling the same context closures the existing buttons use so both surfaces stay in lockstep.
- Bonus: setup-wizard bypass for test runners — `check_setup_completed` short-circuits to `true` when the supervisor-forwarded `QONTINUI_TEST_AUTO_LOGIN_EMAIL` is present, so the existing auto-login plumbing also unlocks wizard-gated UI Bridge testing with zero new spawn-side config.

**Phase 9c (delete `TerminalTabBar.tsx` + `ZoneStatusBar.tsx` atomically with the `term-multi-tab-elem-0/1` spec snapshot update + `WrapperToolsBadge.tsx` removal) is deferred** — the long tail of `ZoneStatusBar` controls (Generate workflow, Save, Analyze, Plan, Findings, Sessions sidebar, etc.) still needs registry homes before deletion is safe.

## Architecture highlights
- **Tier-3 AI routing uses local `claude` CLI subprocess via the new `command_interpret` Tauri command at `src-tauri/src/commands/command_interpreter.rs`**, per project rule `feedback_no_anthropic_api` — operator's existing subscription, never `api.anthropic.com`. Flags validated by probing the actual CLI (`claude --help`) and an empirical envelope-shape check; `.structured_output` is the payload field (not `.result`, which is empty when `--json-schema` is set).
- L1 LRU cache (200 entries, persisted to `instanceStorage`, key-normalised) + confidence gate (default 0.4) + `AbortSignal` cancellation. AI badge with `XX%` confidence on Tier-3 dropdown rows so operators sanity-check before pressing Enter.
- Registry → palette projection adds discoverability of every registered slash to the existing `Ctrl+Shift+K` palette without touching its UX.
- Wire-contract preservation via `commands/uibridge.ts` `callRegistry` helper — `TerminalTabBar`'s `create-plain` / `create-best-account` / `create-with-command` and `ZoneLayoutPicker`'s `select-layout` delegate to the registry while keeping their `{success, tab_ids, task_run_ids}` / error-message-text contracts intact.

## Verification
- ✅ TypeScript clean across runner + UI Bridge consumers.
- ✅ **305/305** vitest run `src/components/terminal/**` passing (registry, resolve, parse, patterns, uibridge, palette-projection, interpret, rules suites).
- ✅ `cargo check` clean for the new `command_interpreter` Tauri command (flag set validated against installed `claude` CLI, envelope shape verified empirically).
- ✅ Live UI Bridge smoke against a freshly-built temp runner (port 9877, supervisor build pool slot 0):
  - Wizard auto-bypassed — components mount on first render, no `Discover Projects` interstitial.
  - `GET /control/component/terminal-launch-menu` returned exactly `[create-plain, create-ai-session, create-best-account, create-with-command]` (no `open`/`close` — Phase 9a confirmed).
  - `POST .../action/create-plain {"params":{"count":1}}` returned `{success: true, tab_ids: ["9539baac-..."], task_run_ids: []}` in 220ms.
  - `list-terminals` confirmed the spawned tab is alive with the matching UUID.

## Test plan
- [ ] Reviewer: pull the branch, `pnpm install && pnpm tauri dev`, open Terminal page.
- [ ] Press `Ctrl+/` — CommandBar focuses; rotating placeholder cycles example slashes.
- [ ] Type `spawn 3` — Tier-2 regex pattern matches, preview row shows `⏎ spawn 3 — Spawn plain terminal`, Enter executes.
- [ ] Type `close the idle ones` — Tier-3 spinner shows "Interpreting…", then resolves (or falls back to fuzzy).
- [ ] Hover any zone — hover actions cluster fades in top-right with 150ms delay; restart button greys out unless session is `completed` / `error`.
- [ ] When a session enters `needs-input` for >30s, a chip with `Respond — needs input for 45s · /focus N` appears top-right of that zone; clicking applies, X dismisses for 5 min.
- [ ] When tab count > 1.2× zones AND the suggested preset differs from current, a `Switch to N-pack? · /layout six-pack` chip appears on the focused zone.
- [ ] Ctrl+Shift+K palette — type `/sp` — registry rows for `/spawn`, `/spawn-ai`, `/spawn-with` appear at the top with inline `(count, account, context?)` argument hints.
- [ ] StatusStrip auto-hides when no signals; surfaces yellow `N need input · Tab to cycle` / red `N errors` / orange `N stuck on lock Xm` pills as state changes. Click the wrapper-tools pill — popover with tool list opens.
- [ ] On a fresh temp runner (`POST http://localhost:9875/runners/spawn-test -d '{"rebuild":true,"requester_id":"pr-review"}'`) the setup wizard is bypassed — UI Bridge components mount immediately at `/control/components`.

## Stats
- **39 files**, **+5328 / -689**.
- New: 24 files under `commands/` + `suggestions/`, `CommandBar.tsx`, `StatusStrip.tsx`, `ZoneHoverActions.tsx`, `command_interpreter.rs`.
- Modified: `TerminalPage.tsx` (mount + hoist), `TerminalTabBar.tsx` (delete hoisted block + `WrapperToolsBadge` import), `CommandPalette.tsx` (registry projection), `ZoneGrid.tsx` (chip + hover mounts + `group` class), `ZoneLayoutPicker.tsx` (`select-layout` delegates to `terminal.layout`), `ZoneMinimap.tsx` (click-to-swap + `isMultiZone` gate), `setup_wizard.rs` (env-var bypass), `SetupWizard.tsx` (`setup-wizard` UI Bridge component), `command_interpret` registration in `main.rs` + `mod.rs`, `index.css` (suggestion-chip-fade-in keyframes).

## Out of scope / deferred
- **Phase 9c demolition** — `TerminalTabBar.tsx` + `ZoneStatusBar.tsx` deletion gated on migrating the ~25 remaining workflow controls (Generate / Save / Findings / Files heatmap / Analyze dropdown's 6 types / Plan: Implement / Verify / Refresh / Sessions sidebar / Resume / Doc finder / Metrics popover / History popover / Auto-approve config / etc.) to registry/palette/chip homes. Spec-snapshot update for `term-multi-tab-elem-0` (`role: "tablist"`) + `term-multi-tab-elem-1` (`+` button) lands with the demolition.
- **Coord-side Phase 8 L2 cache** (`coord.command_interpretations` PG table + `coord_command_interpret` MCP tool) — single-machine L1 covers the common path; cross-machine cache is a follow-up.
- **Optimistic execution + Undo for Tier-3** — currently every Tier-3 match requires Enter. Optimistic exec with 3s Undo affordance for `confidence > 0.95 && !destructive` is the follow-up.