### PR TITLE
fix(runner): surface coord's unknown_tenant rejection on both register paths

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -991,6 +991,28 @@ fn register_with_coord(
     let body_text = resp
         .text()
         .unwrap_or_else(|_| "<unable to read response body>".to_string());
+    // Phase 2 of the unknown-tenant plan: coord now returns HTTP 400 with
+    // `{"error":"unknown_tenant","tenant_id":"<uuid>", ...}` when the supplied
+    // tenant_id is not present in coord.tenants. Surface an actionable recovery
+    // hint instead of the raw body. Any other 400 / non-2xx keeps the generic
+    // error below.
+    if status.as_u16() == 400 {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body_text) {
+            if json.get("error").and_then(|v| v.as_str()) == Some("unknown_tenant") {
+                let body_tenant = json
+                    .get("tenant_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(tenant_id);
+                return Err(format!(
+                    "coord rejected device registration — tenant_id {body_tenant} is not registered. \
+                     Common cause: paired_user.json carries a stale tenant_id from a re-paired session. \
+                     Re-pair the device (`qontinui_profile device pair --tenant-id {body_tenant}`) or \
+                     update the runner's paired_user.json to the current tenant_id (look up via web UI \
+                     Settings → Account)."
+                ));
+            }
+        }
+    }
     Err(format!(
         "POST {} returned HTTP {}: {}",
         url, status, body_text

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -201,6 +201,34 @@ fn warn_tenant_id_unresolvable_once() {
     }
 }
 
+/// Dedupe the "coord rejected our tenant_id as unknown" heartbeat warning.
+/// coord returns HTTP 400 `{"error":"unknown_tenant", ...}` when our
+/// tenant_id is not present in `coord.tenants`; the heartbeat ticks every 30s
+/// so a stale `paired_user.json` would otherwise flood the journal forever.
+/// Fires exactly once per process lifetime.
+static UNKNOWN_TENANT_WARNED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Atomic gate behind [`warn_unknown_tenant_once`]: returns `true` exactly
+/// once per process (the first caller), `false` thereafter. Factored out so
+/// the once-per-process semantics are unit-testable without asserting on the
+/// `warn!` side effect.
+fn should_warn_unknown_tenant() -> bool {
+    !UNKNOWN_TENANT_WARNED.swap(true, std::sync::atomic::Ordering::Relaxed)
+}
+
+fn warn_unknown_tenant_once() {
+    if should_warn_unknown_tenant() {
+        warn!(
+            "fleet::heartbeat: coord rejected this device's tenant_id as unknown \
+             (not present in coord.tenants); heartbeats will keep being rejected \
+             until paired_user.json carries a valid tenant_id. Re-run \
+             `qontinui_profile device pair --tenant-id <uuid>` to recover. \
+             Logging once per process."
+        );
+    }
+}
+
 /// Cache file for the last successful budget payload. Inspectable when
 /// coord is unreachable; lets operators verify "what was advertised" from
 /// the runner side without coord access. Path: `~/.qontinui/last_budget.json`.
@@ -587,6 +615,27 @@ pub async fn heartbeat_to_coord() -> Result<(), String> {
         Ok(())
     } else {
         let body = resp.text().await.unwrap_or_default();
+        // Phase 2 of the unknown-tenant plan: coord returns HTTP 400
+        // `{"error":"unknown_tenant","tenant_id":"<uuid>", ...}` when our
+        // tenant_id is not present in coord.tenants. A stale paired_user.json
+        // would 400 here forever (30s cadence) — warn once, then keep
+        // returning Err so the caller logs+swallows (same posture as the
+        // tenant_id-unresolvable skip; we never exit the runner).
+        if status.as_u16() == 400 {
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&body) {
+                if json.get("error").and_then(|v| v.as_str()) == Some("unknown_tenant") {
+                    warn_unknown_tenant_once();
+                    let body_tenant = json
+                        .get("tenant_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("<unknown>");
+                    return Err(format!(
+                        "coord rejected heartbeat: unknown_tenant (tenant_id={body_tenant}); \
+                         see warn-once log"
+                    ));
+                }
+            }
+        }
         let excerpt: String = body.chars().take(200).collect();
         Err(format!("coord returned {status} for POST {url}: {excerpt}"))
     }
@@ -1166,6 +1215,28 @@ pub fn spawn_tree_publisher() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Phase 2 unknown-tenant warn-once dedupe: across N successive
+    /// invocations the gate must return `true` exactly once (the first
+    /// caller) and `false` thereafter. We assert on the atomic gate rather
+    /// than the `warn!` side effect for determinism. Reset the flag first so
+    /// the test is independent of any earlier in-process call.
+    #[test]
+    fn unknown_tenant_warn_fires_exactly_once() {
+        UNKNOWN_TENANT_WARNED.store(false, std::sync::atomic::Ordering::Relaxed);
+        let mut fired = 0usize;
+        for _ in 0..5 {
+            if should_warn_unknown_tenant() {
+                fired += 1;
+            }
+        }
+        assert_eq!(
+            fired, 1,
+            "expected the warn gate to open exactly once across 5 calls"
+        );
+        // Reset so we don't leak state into other tests sharing the process.
+        UNKNOWN_TENANT_WARNED.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
 
     #[test]
     fn derive_max_agents_examples() {


### PR DESCRIPTION
## What

coord now returns `400 {"error":"unknown_tenant","tenant_id":...}` when a device registers with a `tenant_id` absent from `coord.tenants` (see qontinui-coord#180). Both runner `POST /coord/devices/register` call sites learn the code:

- **`register_with_coord`** (device init CLI): on `400 unknown_tenant`, parse the body and return an actionable error naming the stale `tenant_id` and the recovery path (re-pair, or fix `paired_user.json`). The caller still exits `SUCCESS` — coord rejection is non-fatal; `machine.json` was written.
- **`heartbeat_to_coord`** (30s loop): on `400 unknown_tenant`, warn **exactly once per process** via the new `warn_unknown_tenant_once` helper (mirrors `warn_tenant_id_unresolvable_once`) so a stale `paired_user.json` doesn't flood the journal, and keep returning `Err` without exiting the runner.

## Why

Without this, a runner carrying a stale `paired_user.json` tenant_id would 400 on every heartbeat indefinitely with an opaque error and no recovery guidance.

## Tests

- `unknown_tenant_warn_fires_exactly_once` — asserts the once-per-process gate (`should_warn_unknown_tenant`) opens exactly once across N calls.
- Both bins compile; `cargo test --bin qontinui-runner fleet::tests::unknown_tenant` passes.

Plan: `2026-05-29-coord-device-registration-tenant-validation`. coord counterpart: qontinui-coord#180.