### PR TITLE
feat(runner): normalize owner/name repo slugs in canonical-path resolution

### DIFF
--- a/src-tauri/src/agent_worktree/canonical_paths.rs
+++ b/src-tauri/src/agent_worktree/canonical_paths.rs
@@ -1,0 +1,182 @@
+//! Canonical-checkout path resolution for the runner's flat worktree
+//! layout (`<root>/<name>/`).
+//!
+//! Plan: `2026-05-29-runner-canonical-path-slug-normalization.md`.
+//!
+//! Coord stores repos as `owner/name` slugs (e.g. `qontinui/qontinui-runner`,
+//! enforced at `qontinui-coord/src/canonical_repos.rs`), but the runner's
+//! on-disk layout is owner-flat — the canonical checkout for that repo lives
+//! at `D:/qontinui-root/qontinui-runner/`, not `.../qontinui/qontinui-runner/`.
+//! [`canonical_segment`] reconciles the two: it reduces any slug shape (bare,
+//! `owner/name`, or a git URL) to the bare repo name used as the single
+//! directory segment, so callers no longer need per-callsite
+//! `repo_canonical_paths` overrides for the standard layout.
+
+use std::path::PathBuf;
+
+use qontinui_runner_lib::observable_bridge::git_ops::repo_basename_from_url;
+
+/// Reduce a coord repo slug (or git URL) to the bare repo name used as a
+/// directory segment in the runner's flat canonical layout
+/// (`<root>/<name>/`).
+///
+/// Accepts: `qontinui-runner`, `qontinui/qontinui-runner`,
+/// `git@github.com:qontinui/qontinui-runner.git`,
+/// `https://github.com/qontinui/qontinui-runner.git`. Returns the bare
+/// `qontinui-runner` for all of them. Rejects empty / whitespace-only /
+/// trailing-slash inputs (`Err` so the caller surfaces a clear validation
+/// error instead of silently building `<root>/`).
+///
+/// The actual reduction is delegated to `repo_basename_from_url`
+/// (`qontinui_runner_lib::observable_bridge::git_ops`) — it already
+/// splits on both `/` and `:`, strips a `.git` suffix, and so handles the SSH
+/// `git@github.com:owner/name.git` form that a naive `rsplit_once('/')` would
+/// mishandle (returning `name.git` from the colon-delimited shape). This
+/// wrapper adds only the fail-closed validation around it.
+pub fn canonical_segment(repo_slug: &str) -> Result<String, String> {
+    let trimmed = repo_slug.trim();
+    if trimmed.is_empty() {
+        return Err(format!(
+            "repo slug {repo_slug:?} is empty or whitespace-only"
+        ));
+    }
+    // A trailing slash means the name segment is missing (e.g. `qontinui/`
+    // is owner-present, name-absent). `repo_basename_from_url` would silently
+    // trim it and reinterpret the owner as the name; fail closed instead.
+    if trimmed.ends_with('/') {
+        return Err(format!(
+            "repo slug {repo_slug:?} has an empty name segment (trailing slash)"
+        ));
+    }
+    let segment = repo_basename_from_url(trimmed);
+    if segment.is_empty() {
+        return Err(format!(
+            "repo slug {repo_slug:?} reduced to an empty path segment"
+        ));
+    }
+    Ok(segment)
+}
+
+/// Build the default canonical-checkout path for `repo` on this host.
+/// Windows: `D:/qontinui-root/<name>/`. The slug is normalized via
+/// [`canonical_segment`], so both `qontinui-runner` and
+/// `qontinui/qontinui-runner` resolve to the same on-disk location.
+#[cfg(target_os = "windows")]
+pub fn default_canonical_path(repo: &str) -> Result<PathBuf, String> {
+    let segment = canonical_segment(repo)?;
+    Ok(PathBuf::from(format!("D:/qontinui-root/{segment}")))
+}
+
+/// Build the default canonical-checkout path for `repo` on this host.
+/// POSIX: `$HOME/qontinui-root/<name>/`. The slug is normalized via
+/// [`canonical_segment`], so both `qontinui-runner` and
+/// `qontinui/qontinui-runner` resolve to the same on-disk location.
+#[cfg(not(target_os = "windows"))]
+pub fn default_canonical_path(repo: &str) -> Result<PathBuf, String> {
+    let segment = canonical_segment(repo)?;
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    Ok(PathBuf::from(format!("{home}/qontinui-root/{segment}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_slug_passes_through() {
+        assert_eq!(
+            canonical_segment("qontinui-runner").unwrap(),
+            "qontinui-runner"
+        );
+    }
+
+    #[test]
+    fn owner_name_reduces_to_name() {
+        assert_eq!(
+            canonical_segment("qontinui/qontinui-runner").unwrap(),
+            "qontinui-runner"
+        );
+    }
+
+    #[test]
+    fn fork_owner_is_ignored() {
+        // Coord's slug rule doesn't pin the owner — a fork's owner still
+        // maps to the same flat checkout name.
+        assert_eq!(
+            canonical_segment("forkowner/qontinui-runner").unwrap(),
+            "qontinui-runner"
+        );
+    }
+
+    #[test]
+    fn multi_level_takes_last_segment() {
+        assert_eq!(canonical_segment("multi/level/path").unwrap(), "path");
+    }
+
+    #[test]
+    fn ssh_url_falls_through_to_basename() {
+        // Proves reuse of repo_basename_from_url: a naive rsplit_once('/')
+        // would return "qontinui-runner.git" from the colon-delimited form.
+        assert_eq!(
+            canonical_segment("git@github.com:qontinui/qontinui-runner.git").unwrap(),
+            "qontinui-runner"
+        );
+    }
+
+    #[test]
+    fn https_url_falls_through_to_basename() {
+        assert_eq!(
+            canonical_segment("https://github.com/qontinui/qontinui-runner.git").unwrap(),
+            "qontinui-runner"
+        );
+    }
+
+    #[test]
+    fn empty_input_errors() {
+        assert!(canonical_segment("").is_err());
+    }
+
+    #[test]
+    fn whitespace_only_errors() {
+        assert!(canonical_segment("   ").is_err());
+    }
+
+    #[test]
+    fn trailing_slash_errors() {
+        // Must not silently become `<root>/` or reinterpret the owner as
+        // the name.
+        assert!(canonical_segment("qontinui/").is_err());
+    }
+
+    #[test]
+    fn default_path_normalizes_both_slug_shapes() {
+        let bare = default_canonical_path("qontinui-runner").unwrap();
+        let owner_name = default_canonical_path("qontinui/qontinui-runner").unwrap();
+        assert_eq!(bare, owner_name);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn default_path_windows_layout() {
+        assert_eq!(
+            default_canonical_path("qontinui/qontinui-runner").unwrap(),
+            PathBuf::from("D:/qontinui-root/qontinui-runner")
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn default_path_posix_layout() {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        assert_eq!(
+            default_canonical_path("qontinui/qontinui-runner").unwrap(),
+            PathBuf::from(format!("{home}/qontinui-root/qontinui-runner"))
+        );
+    }
+
+    #[test]
+    fn default_path_propagates_validation_error() {
+        assert!(default_canonical_path("").is_err());
+        assert!(default_canonical_path("qontinui/").is_err());
+    }
+}

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -118,11 +118,12 @@ pub async fn acquire(
     let device_id = read_device_id()
         .map_err(|e| AllocateError::Other(format!("device_id not available: {e}")))?;
 
-    let canonical_paths: HashMap<String, PathBuf> = req
-        .repos
-        .iter()
-        .map(|repo| (repo.clone(), default_canonical_path(repo)))
-        .collect();
+    let mut canonical_paths: HashMap<String, PathBuf> = HashMap::with_capacity(req.repos.len());
+    for repo in req.repos {
+        let path = super::canonical_paths::default_canonical_path(repo)
+            .map_err(|e| AllocateError::Other(format!("canonical path for repo {repo:?}: {e}")))?;
+        canonical_paths.insert(repo.clone(), path);
+    }
 
     let mut repo_reqs: Vec<RepoRequest> = Vec::with_capacity(req.repos.len());
     for repo in req.repos {
@@ -255,17 +256,6 @@ fn read_device_id() -> Result<uuid::Uuid, String> {
         .and_then(|s| s.as_str())
         .ok_or_else(|| format!("{}: missing device_id (or machine_id)", path.display()))?;
     uuid::Uuid::parse_str(id_str).map_err(|e| format!("invalid UUID: {e}"))
-}
-
-#[cfg(target_os = "windows")]
-fn default_canonical_path(repo: &str) -> PathBuf {
-    PathBuf::from(format!("D:/qontinui-root/{}", repo))
-}
-
-#[cfg(not(target_os = "windows"))]
-fn default_canonical_path(repo: &str) -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(format!("{}/qontinui-root/{}", home, repo))
 }
 
 fn resolve_head_sha(canonical: &Path) -> Result<String, String> {

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -57,6 +57,7 @@ use tracing::{debug, info, warn};
 
 use crate::worktree::run_git_command;
 
+pub mod canonical_paths;
 pub mod isolated_edit;
 
 /// Env var that turns the new spawn path on. Default off — `feature

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -117,7 +117,14 @@ pub async fn post_allocate_local(
         )
     })?;
 
-    let canonical_paths = build_canonical_paths(&req.repos, &req.repo_canonical_paths);
+    let canonical_paths =
+        build_canonical_paths(&req.repos, &req.repo_canonical_paths).map_err(|e| {
+            warn!("/agents/allocate-local: invalid repo slug: {e}");
+            (
+                StatusCode::BAD_REQUEST,
+                Json(api_error(format!("invalid repo slug: {e}"))),
+            )
+        })?;
     let repo_reqs: Vec<RepoRequest> = req
         .repos
         .iter()
@@ -240,31 +247,28 @@ pub(crate) fn coord_http_base() -> Result<String, String> {
     Ok("http://localhost:9870".to_string())
 }
 
+/// Resolve a canonical-checkout path per repo. Per-repo
+/// `repo_canonical_paths` overrides win for non-standard checkouts; the
+/// rest fall back to the unified
+/// [`crate::agent_worktree::canonical_paths::default_canonical_path`]
+/// resolver, which normalizes `owner/name` coord slugs into the runner's
+/// flat `<root>/<name>/` layout. A malformed slug (empty / trailing-slash)
+/// is surfaced as `Err` so the HTTP handler returns a 400 instead of
+/// attempting `git worktree add` on `<root>/`.
 fn build_canonical_paths(
     repos: &[AllocateLocalRepo],
     override_map: &HashMap<String, String>,
-) -> HashMap<String, PathBuf> {
+) -> Result<HashMap<String, PathBuf>, String> {
     let mut out: HashMap<String, PathBuf> = HashMap::new();
     for r in repos {
         let path = if let Some(p) = override_map.get(&r.repo) {
             PathBuf::from(p)
         } else {
-            default_canonical_path(&r.repo)
+            crate::agent_worktree::canonical_paths::default_canonical_path(&r.repo)?
         };
         out.insert(r.repo.clone(), path);
     }
-    out
-}
-
-#[cfg(target_os = "windows")]
-fn default_canonical_path(repo: &str) -> PathBuf {
-    PathBuf::from(format!("D:/qontinui-root/{}", repo))
-}
-
-#[cfg(not(target_os = "windows"))]
-fn default_canonical_path(repo: &str) -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(format!("{}/qontinui-root/{}", home, repo))
+    Ok(out)
 }
 
 pub fn routes() -> axum::Router<Arc<ApiState>> {

--- a/src-tauri/src/observable_bridge/git_ops.rs
+++ b/src-tauri/src/observable_bridge/git_ops.rs
@@ -204,8 +204,10 @@ fn origin_url_basename(config_path: &Path) -> Option<String> {
 }
 
 /// `git@github.com:org/repo.git` / `https://github.com/org/repo.git`
-/// → `repo`.
-fn repo_basename_from_url(url: &str) -> String {
+/// → `repo`. Also reduces a bare `owner/name` coord slug to `name`.
+/// Reused by the bin crate's `agent_worktree::canonical_paths::canonical_segment`
+/// (hence fully `pub` — it crosses the lib↔bin crate boundary).
+pub fn repo_basename_from_url(url: &str) -> String {
     let url = url.trim().trim_end_matches('/');
     let last = url.rsplit(['/', ':']).next().unwrap_or(url);
     last.strip_suffix(".git").unwrap_or(last).to_string()


### PR DESCRIPTION
## What

Collapse the two duplicated `default_canonical_path` copies into a single fallible resolver in a new `agent_worktree::canonical_paths` submodule, and normalize coord `owner/name` slugs into the runner's flat `<root>/<name>/` checkout layout.

## Why

Coord stores repos as `owner/name` slugs (e.g. `qontinui/qontinui-runner`, enforced in `qontinui-coord`), but the runner's on-disk layout is owner-flat — the canonical checkout lives at `D:/qontinui-root/qontinui-runner/`, not `.../qontinui/qontinui-runner/`. Both `default_canonical_path` copies joined `owner`+`name` as path segments, building a directory that doesn't exist, so every caller had to pass `repo_canonical_paths` overrides. This solves it once in the resolver.

## Changes

- **New `agent_worktree/canonical_paths.rs`**
  - `canonical_segment()` reduces any slug shape — bare, `owner/name`, or a git URL (`git@…` / `https://…`) — to the bare repo name, **reusing** `observable_bridge::git_ops::repo_basename_from_url` (promoted to `pub`) rather than a fresh `rsplit`. Fails closed (`Err`) on empty / whitespace / trailing-slash input.
  - `default_canonical_path()` is now fallible and normalizes before building the path.
- **Callsites unified** — `isolated_edit.rs` and `mcp/agent_worktrees.rs` both consume the resolver; the two duplicated copies are deleted.
- **`build_canonical_paths` returns `Result`**; the `/agents/allocate-local` handler maps a bad slug to **400** instead of attempting `git worktree add` on `<root>/`.

## Tests

12 unit tests: bare / owner-name / fork-owner / multi-level / SSH+HTTPS URL / empty / whitespace / trailing-slash, plus per-platform path layout. All pass; full bin compiles clean (verified from the primary checkout).

## Notes

Plan: `2026-05-29-runner-canonical-path-slug-normalization` (archived SHIPPED in qontinui-dev-notes). The same commit also rode in on the `chore/phase-9c-demolition` branch (PR #316); whichever merges second is a content no-op. Pure runner-side normalization — no coord regex change, flag-gated behind `QONTINUI_AGENT_WORKTREE_MODE`.