### PR TITLE
feat: Cognito user sign-in via RFC 8252 PKCE (unified identity Phase 5)

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -406,6 +406,67 @@ impl AuthManager {
         let now = chrono::Utc::now().timestamp();
         Ok(now + REFRESH_BEFORE_EXPIRY_SECS >= claim.exp)
     }
+
+    // ========================================================================
+    // Cognito (oauth) user-token slots — Phase 5 unified-Cognito-identity.
+    //
+    // These are stored in slots DISTINCT from the coord device-JWT
+    // (`access_token`) slot so the WS relay keeps using the device JWT while
+    // user-facing calls (and the device→user re-bind) use the Cognito token.
+    // Keychain backup is intentionally NOT mirrored here: the keychain path
+    // proved unreliable on Windows (see module docs) and the encrypted file
+    // is the source of truth.
+    // ========================================================================
+
+    /// Store the Cognito user tokens. `expires_at` is the absolute
+    /// unix-seconds expiry of the Cognito access token (now + expires_in).
+    pub fn store_oauth_tokens(
+        &self,
+        access_token: &str,
+        id_token: &str,
+        refresh_token: &str,
+        expires_at: i64,
+    ) -> Result<()> {
+        self.secure_storage
+            .store_oauth_tokens(access_token, id_token, refresh_token, expires_at)
+            .context("Failed to store Cognito tokens in secure storage")?;
+        info!("Cognito tokens stored successfully in secure storage");
+        Ok(())
+    }
+
+    /// Retrieve the Cognito access token.
+    pub fn get_oauth_access_token(&self) -> Result<String> {
+        self.secure_storage.get_oauth_access_token()
+    }
+
+    /// Retrieve the Cognito id token.
+    pub fn get_oauth_id_token(&self) -> Result<String> {
+        self.secure_storage.get_oauth_id_token()
+    }
+
+    /// Retrieve the Cognito refresh token.
+    pub fn get_oauth_refresh_token(&self) -> Result<String> {
+        self.secure_storage.get_oauth_refresh_token()
+    }
+
+    /// Absolute unix-seconds expiry of the Cognito access token, if stored.
+    pub fn get_oauth_expires_at(&self) -> Option<i64> {
+        self.secure_storage.get_oauth_expires_at()
+    }
+
+    /// `true` iff the Cognito access token is missing OR within
+    /// [`REFRESH_BEFORE_EXPIRY_SECS`] of expiry. Used by the device-JWT
+    /// refresher to refresh the Cognito token *first* when it's stale (so the
+    /// subsequent device re-bind presents a fresh user bearer).
+    pub fn cognito_token_needs_refresh(&self) -> bool {
+        match self.secure_storage.get_oauth_expires_at() {
+            Some(exp) => chrono::Utc::now().timestamp() + REFRESH_BEFORE_EXPIRY_SECS >= exp,
+            // No stored expiry → either never signed in via Cognito, or a
+            // partial write. Treat as "needs refresh" only if we actually
+            // hold a refresh token; otherwise there's nothing to refresh.
+            None => self.secure_storage.get_oauth_refresh_token().is_ok(),
+        }
+    }
 }
 
 impl Default for AuthManager {

--- a/src-tauri/src/cognito.rs
+++ b/src-tauri/src/cognito.rs
@@ -1,0 +1,467 @@
+//! Cognito Hosted-UI sign-in via RFC 8252 (OAuth 2.0 for Native Apps).
+//!
+//! Phase 5 of the unified-Cognito-identity plan. The runner is a **public**
+//! OAuth client (no secret) using the Authorization Code + PKCE flow against
+//! the Cognito Hosted UI at `https://auth.qontinui.io`.
+//!
+//! ## Flow (`pkce_login`)
+//!
+//! 1. Generate a high-entropy `code_verifier` (RFC 7636 §4.1, 43–128
+//!    unreserved chars), its `code_challenge = base64url(SHA256(verifier))`,
+//!    and a random anti-CSRF `state`.
+//! 2. Bind a loopback HTTP server on the **fixed** `127.0.0.1:53682`. Cognito
+//!    does exact `redirect_uri` matching, so the port is fixed (not the
+//!    OS-assigned `:0` used by the coord browser-pair in `pair.rs`); the two
+//!    registered callbacks are `http://localhost:53682/auth/callback` and
+//!    `http://127.0.0.1:53682/auth/callback`.
+//! 3. Open the system browser to `/oauth2/authorize?...` and wait for the
+//!    redirect to `/auth/callback?code=...&state=...`.
+//! 4. Validate `state`, exchange `code` + `code_verifier` at `/oauth2/token`
+//!    for `{access_token, id_token, refresh_token, expires_in}`.
+//!
+//! This module reuses the loopback + system-browser pattern from
+//! [`crate::pair::pair_via_browser`] but talks to Cognito directly rather than
+//! to coord. The captured tokens are **not** persisted here — the caller
+//! (`commands::auth`) stores them in the distinct oauth slots and then binds
+//! the coord device-JWT to the Cognito user.
+
+use serde::Deserialize;
+
+// ============================================================================
+// Cognito constants — runner public client (PKCE, no secret).
+// ============================================================================
+
+/// Cognito Hosted-UI base (authorize + token endpoints hang off this).
+pub const COGNITO_BASE: &str = "https://auth.qontinui.io";
+/// Authorize endpoint.
+pub const COGNITO_AUTHORIZE_URL: &str = "https://auth.qontinui.io/oauth2/authorize";
+/// Token endpoint.
+pub const COGNITO_TOKEN_URL: &str = "https://auth.qontinui.io/oauth2/token";
+/// Runner app client id — PUBLIC client, no secret, PKCE.
+pub const COGNITO_CLIENT_ID: &str = "67f2a1a0cmgileob23lniud5t7";
+/// Fixed loopback callback port. Cognito does exact `redirect_uri` matching,
+/// so this MUST equal the registered callback's port (do NOT use `:0`).
+pub const COGNITO_CALLBACK_PORT: u16 = 53682;
+/// Registered redirect URI. `localhost` (not `127.0.0.1`) form is used for the
+/// authorize request; both forms are registered in Cognito so the loopback
+/// server — bound to `127.0.0.1` — still receives the redirect.
+pub const COGNITO_REDIRECT_URI: &str = "http://localhost:53682/auth/callback";
+/// OAuth scopes requested.
+pub const COGNITO_SCOPE: &str = "openid email profile";
+
+// ============================================================================
+// Wire types.
+// ============================================================================
+
+/// Successful `/oauth2/token` response (authorization_code or refresh_token
+/// grant). On a refresh grant Cognito omits `refresh_token` (the existing one
+/// stays valid), hence `Option`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CognitoTokenResponse {
+    pub access_token: String,
+    pub id_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    pub expires_in: i64,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub token_type: Option<String>,
+}
+
+/// The bundle returned to the caller after a successful PKCE login: the raw
+/// tokens plus the Cognito `sub` (decoded from the id token) used as the
+/// `X-Qontinui-User-Id` when binding the device JWT.
+#[derive(Debug, Clone)]
+pub struct CognitoLoginResult {
+    pub access_token: String,
+    pub id_token: String,
+    pub refresh_token: String,
+    /// Absolute unix-seconds expiry (now + expires_in).
+    pub expires_at: i64,
+    /// `sub` claim from the id token (the Cognito user id).
+    pub sub: String,
+    /// `email` claim from the id token, if present.
+    pub email: Option<String>,
+}
+
+// ============================================================================
+// PKCE helpers (RFC 7636).
+// ============================================================================
+
+/// Unreserved characters per RFC 3986 §2.3 — the legal alphabet for a PKCE
+/// `code_verifier`.
+const UNRESERVED: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+
+/// Generate a 64-char (RFC 7636 allows 43–128) high-entropy `code_verifier`
+/// from the unreserved alphabet using a CSPRNG.
+pub fn generate_code_verifier() -> String {
+    use rand::Rng;
+    let mut rng = rand::rng();
+    (0..64)
+        .map(|_| {
+            let idx = rng.random_range(0..UNRESERVED.len());
+            UNRESERVED[idx] as char
+        })
+        .collect()
+}
+
+/// `code_challenge = base64url-no-pad(SHA256(code_verifier))` (S256 method).
+pub fn code_challenge_s256(verifier: &str) -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(verifier.as_bytes());
+    URL_SAFE_NO_PAD.encode(digest)
+}
+
+/// Random URL-safe `state` nonce (anti-CSRF).
+pub fn generate_state() -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use rand::RngCore;
+    let mut bytes = [0u8; 24];
+    rand::rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Build the `/oauth2/authorize` URL for the PKCE flow.
+pub fn build_authorize_url(state: &str, code_challenge: &str) -> String {
+    format!(
+        "{COGNITO_AUTHORIZE_URL}?response_type=code&client_id={client_id}\
+         &redirect_uri={redirect}&scope={scope}&state={state}\
+         &code_challenge={challenge}&code_challenge_method=S256",
+        client_id = COGNITO_CLIENT_ID,
+        redirect = urlencoding::encode(COGNITO_REDIRECT_URI),
+        scope = urlencoding::encode(COGNITO_SCOPE),
+        state = urlencoding::encode(state),
+        challenge = code_challenge,
+    )
+}
+
+/// Decode an unverified string claim from a JWT payload (the id token). We do
+/// NOT verify the signature — the token was just received over TLS directly
+/// from Cognito's token endpoint; the web backend / coord re-validate on use.
+pub(crate) fn jwt_claim(token: &str, claim: &str) -> Option<String> {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    let mut parts = token.splitn(3, '.');
+    let _header = parts.next()?;
+    let payload_b64 = parts.next()?;
+    let _sig = parts.next()?;
+    let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    json.get(claim).and_then(|v| v.as_str()).map(String::from)
+}
+
+// ============================================================================
+// Callback capture.
+// ============================================================================
+
+/// Query params Cognito appends to the loopback redirect. On the error path
+/// Cognito sends `error` / `error_description` instead of `code`, so both
+/// `code` and `state` are optional and validated by the handler.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CognitoCallbackQuery {
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
+    #[serde(default)]
+    pub error: Option<String>,
+    #[serde(default)]
+    pub error_description: Option<String>,
+}
+
+// ============================================================================
+// PKCE login (browser + loopback) — blocking.
+// ============================================================================
+
+/// Run the full RFC-8252 PKCE login: open the system browser, capture the
+/// loopback redirect, validate `state`, and exchange the code at the token
+/// endpoint. Blocking (mirrors `pair::pair_via_browser`); call via
+/// `tokio::task::spawn_blocking` from async contexts.
+pub fn pkce_login() -> Result<CognitoLoginResult, String> {
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    let code_verifier = generate_code_verifier();
+    let code_challenge = code_challenge_s256(&code_verifier);
+    let state = generate_state();
+
+    // Bind the FIXED loopback port. Cognito exact-matches redirect_uri, so we
+    // cannot use an OS-assigned port here. If the port is busy, surface a
+    // clear, actionable error rather than silently falling back.
+    let std_listener =
+        std::net::TcpListener::bind(("127.0.0.1", COGNITO_CALLBACK_PORT)).map_err(|e| {
+            format!(
+                "could not bind loopback callback on 127.0.0.1:{COGNITO_CALLBACK_PORT} ({e}). \
+                 Another sign-in may be in progress, or another app is holding the port. \
+                 Close it and try again."
+            )
+        })?;
+    std_listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("set_nonblocking failed: {e}"))?;
+
+    let received: Arc<Mutex<Option<Result<String, String>>>> = Arc::new(Mutex::new(None));
+    let received_clone = received.clone();
+    let state_expected = state.clone();
+
+    let (server_done_tx, server_done_rx) = std::sync::mpsc::channel::<()>();
+    let _server_handle = std::thread::spawn(move || -> Result<(), String> {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("runtime build failed: {e}"))?;
+        rt.block_on(async move {
+            use axum::{extract::Query, response::Html, routing::get, Router};
+            let state_for_route = state_expected.clone();
+            let received_for_route = received_clone.clone();
+            let app = Router::new().route(
+                "/auth/callback",
+                get(move |Query(q): Query<CognitoCallbackQuery>| {
+                    let state_for_route = state_for_route.clone();
+                    let received_for_route = received_for_route.clone();
+                    async move {
+                        // Error path: Cognito reported a problem.
+                        if let Some(err) = q.error {
+                            let desc = q.error_description.unwrap_or_default();
+                            *received_for_route.lock().expect("mutex") =
+                                Some(Err(format!("Cognito returned error `{err}`: {desc}")));
+                            return Html(
+                                "<h1>Sign-in failed</h1><p>You can close this tab and try \
+                                 again.</p>"
+                                    .to_string(),
+                            );
+                        }
+                        // Anti-CSRF: state must match.
+                        if q.state.as_deref() != Some(state_for_route.as_str()) {
+                            *received_for_route.lock().expect("mutex") = Some(Err(
+                                "callback state did not match the pending sign-in".to_string(),
+                            ));
+                            return Html(
+                                "<h1>State mismatch</h1><p>The sign-in could not be verified. \
+                                 Close this tab and try again.</p>"
+                                    .to_string(),
+                            );
+                        }
+                        match q.code {
+                            Some(code) if !code.is_empty() => {
+                                *received_for_route.lock().expect("mutex") = Some(Ok(code));
+                                Html(
+                                    "<h1>&#10003; Signed in to Qontinui</h1>\
+                                     <p>You can close this tab and return to the runner.</p>\
+                                     <script>setTimeout(()=>window.close(),2000);</script>"
+                                        .to_string(),
+                                )
+                            }
+                            _ => {
+                                *received_for_route.lock().expect("mutex") =
+                                    Some(Err("callback carried no authorization code".to_string()));
+                                Html(
+                                    "<h1>Sign-in failed</h1><p>No authorization code was \
+                                     returned. Close this tab and try again.</p>"
+                                        .to_string(),
+                                )
+                            }
+                        }
+                    }
+                }),
+            );
+            let tokio_listener = tokio::net::TcpListener::from_std(std_listener)
+                .map_err(|e| format!("tokio listener wrap failed: {e}"))?;
+            let serve = axum::serve(tokio_listener, app);
+            let timeout = tokio::time::sleep(Duration::from_secs(300));
+            tokio::pin!(timeout);
+            tokio::select! {
+                res = serve => { res.map_err(|e| format!("axum serve failed: {e}"))?; }
+                _ = &mut timeout => {
+                    return Err("sign-in timed out after 5 minutes waiting for the browser \
+                                callback".to_string());
+                }
+            }
+            let _ = server_done_tx.send(());
+            Ok(())
+        })
+    });
+
+    let authorize_url = build_authorize_url(&state, &code_challenge);
+    tracing::info!("opening browser for Cognito sign-in (callback {COGNITO_REDIRECT_URI})");
+    if let Err(e) = open::that(&authorize_url) {
+        tracing::warn!(
+            "failed to open browser ({e}); user must open this URL manually: {authorize_url}"
+        );
+    }
+
+    // Poll the slot up to 5 minutes.
+    let deadline = Instant::now() + Duration::from_secs(300);
+    let code = loop {
+        if let Some(result) = received.lock().expect("mutex").take() {
+            break result?;
+        }
+        if Instant::now() >= deadline {
+            return Err(
+                "sign-in timed out after 5 minutes waiting for the browser callback".to_string(),
+            );
+        }
+        std::thread::sleep(Duration::from_millis(200));
+        if server_done_rx.try_recv().is_ok() {
+            if let Some(result) = received.lock().expect("mutex").take() {
+                break result?;
+            }
+            return Err("sign-in callback server stopped before capturing a code".to_string());
+        }
+    };
+
+    // Exchange the authorization code for tokens.
+    let token_resp = exchange_code(&code, &code_verifier)?;
+    let expires_at = chrono::Utc::now().timestamp() + token_resp.expires_in;
+    let refresh_token = token_resp.refresh_token.ok_or_else(|| {
+        "Cognito token response omitted refresh_token — the runner client must be configured \
+         to issue refresh tokens"
+            .to_string()
+    })?;
+    let sub = jwt_claim(&token_resp.id_token, "sub")
+        .ok_or_else(|| "id token has no `sub` claim — cannot identify the user".to_string())?;
+    let email = jwt_claim(&token_resp.id_token, "email");
+
+    Ok(CognitoLoginResult {
+        access_token: token_resp.access_token,
+        id_token: token_resp.id_token,
+        refresh_token,
+        expires_at,
+        sub,
+        email,
+    })
+}
+
+/// POST the authorization_code grant to `/oauth2/token`. Blocking.
+fn exchange_code(code: &str, code_verifier: &str) -> Result<CognitoTokenResponse, String> {
+    let form = [
+        ("grant_type", "authorization_code"),
+        ("client_id", COGNITO_CLIENT_ID),
+        ("code", code),
+        ("redirect_uri", COGNITO_REDIRECT_URI),
+        ("code_verifier", code_verifier),
+    ];
+    post_token_form(&form)
+}
+
+/// Exchange a refresh token for a fresh access + id token. Cognito does NOT
+/// return a new refresh_token on this grant; the caller keeps the existing
+/// one. Blocking; call via `spawn_blocking`.
+pub fn refresh_tokens(refresh_token: &str) -> Result<CognitoTokenResponse, String> {
+    let form = [
+        ("grant_type", "refresh_token"),
+        ("client_id", COGNITO_CLIENT_ID),
+        ("refresh_token", refresh_token),
+    ];
+    post_token_form(&form)
+}
+
+/// Shared form POST to the token endpoint with status/error surfacing.
+fn post_token_form(form: &[(&str, &str)]) -> Result<CognitoTokenResponse, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("reqwest client build failed: {e}"))?;
+    let resp = client
+        .post(COGNITO_TOKEN_URL)
+        .form(form)
+        .send()
+        .map_err(|e| format!("POST {COGNITO_TOKEN_URL} failed: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp
+            .text()
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
+        return Err(format!(
+            "token endpoint returned HTTP {status}: {}",
+            body.chars().take(300).collect::<String>()
+        ));
+    }
+    resp.json::<CognitoTokenResponse>()
+        .map_err(|e| format!("decode token response failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn code_verifier_is_unreserved_and_right_length() {
+        let v = generate_code_verifier();
+        assert_eq!(v.len(), 64, "verifier must be 64 chars (within 43..=128)");
+        assert!(
+            v.bytes().all(|b| UNRESERVED.contains(&b)),
+            "verifier must use only RFC 3986 unreserved chars"
+        );
+    }
+
+    #[test]
+    fn code_verifiers_are_unique() {
+        // Astronomically unlikely to collide; guards against a constant.
+        assert_ne!(generate_code_verifier(), generate_code_verifier());
+    }
+
+    #[test]
+    fn code_challenge_matches_rfc7636_test_vector() {
+        // RFC 7636 Appendix B canonical vector.
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let challenge = code_challenge_s256(verifier);
+        assert_eq!(challenge, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    }
+
+    #[test]
+    fn state_is_url_safe_and_nonempty() {
+        let s = generate_state();
+        assert!(!s.is_empty());
+        assert!(s
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert_ne!(generate_state(), generate_state());
+    }
+
+    #[test]
+    fn authorize_url_has_required_params() {
+        let url = build_authorize_url("st-ate", "chal-lenge");
+        assert!(url.starts_with(COGNITO_AUTHORIZE_URL));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains(&format!("client_id={COGNITO_CLIENT_ID}")));
+        assert!(url.contains("code_challenge=chal-lenge"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("state=st-ate"));
+        // redirect_uri must be percent-encoded.
+        assert!(url.contains("redirect_uri=http%3A%2F%2Flocalhost%3A53682%2Fauth%2Fcallback"));
+        // scope is space-separated → encoded as %20.
+        assert!(url.contains("scope=openid%20email%20profile"));
+    }
+
+    #[test]
+    fn jwt_claim_extracts_sub_and_email() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"RS256","typ":"JWT"}"#);
+        let payload =
+            URL_SAFE_NO_PAD.encode(br#"{"sub":"user-123","email":"a@b.co","token_use":"id"}"#);
+        let token = format!("{header}.{payload}.sig");
+        assert_eq!(jwt_claim(&token, "sub").as_deref(), Some("user-123"));
+        assert_eq!(jwt_claim(&token, "email").as_deref(), Some("a@b.co"));
+        assert_eq!(jwt_claim(&token, "missing"), None);
+        assert_eq!(jwt_claim("not-a-jwt", "sub"), None);
+    }
+
+    #[test]
+    fn token_response_decodes_with_and_without_refresh_token() {
+        // authorization_code grant: includes refresh_token.
+        let with: CognitoTokenResponse = serde_json::from_str(
+            r#"{"access_token":"a","id_token":"i","refresh_token":"r","expires_in":3600,"token_type":"Bearer"}"#,
+        )
+        .unwrap();
+        assert_eq!(with.refresh_token.as_deref(), Some("r"));
+        assert_eq!(with.expires_in, 3600);
+
+        // refresh_token grant: Cognito omits refresh_token.
+        let without: CognitoTokenResponse = serde_json::from_str(
+            r#"{"access_token":"a2","id_token":"i2","expires_in":3600,"token_type":"Bearer"}"#,
+        )
+        .unwrap();
+        assert!(without.refresh_token.is_none());
+    }
+}

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -1146,6 +1146,165 @@ async fn pair_with_credentials_impl(
     })
 }
 
+/// Wire response for [`cognito_sign_in`]. Mirrors the credentials/pair-code
+/// confirmation shape so the FE shows a uniform "signed in" panel.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CognitoSignInResponse {
+    /// Cognito `sub` (the user id used to bind the device).
+    pub user_id: String,
+    /// `email` claim from the Cognito id token, if present.
+    pub email: Option<String>,
+    /// Tenant the coord device JWT was minted under (decoded from the minted
+    /// device JWT — coord stamps it; the Cognito token does not carry it).
+    pub tenant_id: Option<String>,
+    /// The paired device id.
+    pub device_id: String,
+}
+
+/// Sign in to the runner with a **Cognito** account via RFC 8252 (system
+/// browser + PKCE + loopback redirect), then bind the coord device-token JWT
+/// to that user.
+///
+/// Phase 5 of the unified-Cognito-identity plan. Flow:
+///   1. RFC-8252 PKCE login against the Cognito Hosted UI
+///      (`cognito::pkce_login` — system browser + fixed-port loopback). Yields
+///      `{access_token, id_token, refresh_token, expires_at, sub, email}`.
+///   2. Persist the Cognito tokens in the distinct oauth slots
+///      (`AuthManager::store_oauth_tokens`) — kept separate from the coord
+///      device-JWT slot so the WS relay keeps using the device JWT while
+///      user-facing calls use the Cognito token.
+///   3. Bind device→user: reuse the EXISTING web-backend `pair-cli` flow
+///      (`pair::pair_with_auth_token_with_ids`) with the Cognito **access
+///      token** as the user bearer and the Cognito `sub` as
+///      `X-Qontinui-User-Id`, so the minted device JWT is user-bound. (Swaps
+///      the token *source* — Cognito instead of local-login JWT — not the
+///      endpoint.) The web backend resolves `tenant_id` server-side.
+///   4. Persist the device JWT, promote to Tier 2, kick the relay + refresher.
+///
+/// `backend_url` is the web-backend base (e.g. `https://api.qontinui.io`). It
+/// is required and explicit (NOT `get_api_base_url()`) so a debug build can
+/// target prod — symmetric with [`pair_with_credentials`].
+#[tauri::command]
+pub async fn cognito_sign_in(backend_url: String) -> Result<CognitoSignInResponse, String> {
+    cognito_sign_in_impl(backend_url)
+        .await
+        .map_err(String::from)
+}
+
+async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInResponse, AppError> {
+    use qontinui_runner_lib::pair::{
+        pair_with_auth_token_with_ids, persist_pairing, read_device_id_from_disk,
+        tenant_id_from_oauth_claim,
+    };
+
+    let base = backend_url.trim().trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return Err(AppError::Raw("backend_url is required".to_string()));
+    }
+
+    // 1. RFC-8252 PKCE login (blocking — browser + loopback). Run on a
+    //    worker thread so it doesn't block the tokio runtime.
+    info!("cognito_sign_in: starting RFC-8252 PKCE login");
+    let login = tokio::task::spawn_blocking(qontinui_runner_lib::cognito::pkce_login)
+        .await
+        .map_err(|e| AppError::Raw(format!("PKCE login task panicked: {e}")))?
+        .map_err(AppError::Raw)?;
+
+    info!(
+        "cognito_sign_in: PKCE login succeeded (sub={}) — binding device",
+        login.sub
+    );
+
+    // 2. Persist the Cognito user tokens in the distinct oauth slots.
+    let auth_manager = AuthManager::new();
+    auth_manager
+        .store_oauth_tokens(
+            &login.access_token,
+            &login.id_token,
+            &login.refresh_token,
+            login.expires_at,
+        )
+        .map_err(|e| AppError::Raw(format!("persist Cognito tokens: {e}")))?;
+
+    // 3. Device identity from disk.
+    let device_id = read_device_id_from_disk()
+        .map_err(|e| AppError::Raw(format!("could not read device identity: {e}")))?;
+
+    // 4. Bind device→user via the existing pair-cli flow. The web backend
+    //    resolves tenant_id server-side from the authenticated user, so the
+    //    body tenant_id is a placeholder (nil) — same as the headless path.
+    //    The user bearer is the Cognito ACCESS token; the user id is the
+    //    Cognito `sub`.
+    let base_b = base.clone();
+    let cognito_access = login.access_token.clone();
+    let device_b = device_id.clone();
+    let sub_b = login.sub.clone();
+    let pair_resp = tokio::task::spawn_blocking(move || {
+        pair_with_auth_token_with_ids(
+            &base_b,
+            &cognito_access,
+            &device_b,
+            &sub_b,
+            uuid::Uuid::nil(),
+        )
+    })
+    .await
+    .map_err(|e| AppError::Raw(format!("device-pair task panicked: {e}")))?
+    .map_err(AppError::Raw)?;
+
+    // Coord stamps the real tenant_id on the minted device JWT; decode it for
+    // persistence + display (the Cognito token does not carry tenant_id).
+    let tenant_id = tenant_id_from_oauth_claim(&pair_resp.token)
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
+        .unwrap_or(uuid::Uuid::nil());
+
+    // 5. Persist the device JWT + paired-user file.
+    persist_pairing(&pair_resp, tenant_id)
+        .map_err(|e| AppError::Raw(format!("persist pairing: {e}")))?;
+
+    let tenant_id_str = if tenant_id.is_nil() {
+        None
+    } else {
+        Some(tenant_id.to_string())
+    };
+
+    // 6. Promote to Tier 2 + stage backend, then kick the relay/refresher.
+    {
+        let mut s = settings::load_settings();
+        if s.web_integration.backend_url.trim() != base {
+            s.web_integration.backend_url = base.clone();
+        }
+        s.web_integration.enabled = true;
+        s.qontinui_user_id = Some(login.sub.clone());
+        s.tier = settings::RunnerTier::QontinuiAccount;
+        s.tier_initialized = true;
+        if crate::instance::is_secondary() {
+            warn!("cognito_sign_in: secondary runner — applying in-memory only, skipping save_settings");
+        } else {
+            settings::save_settings(&s)
+                .map_err(|e| AppError::Raw(format!("persist tier promotion: {e}")))?;
+        }
+    }
+    tokio::spawn(async {
+        crate::mcp::backend_relay::commands::kick_cloud_relay().await;
+        crate::mcp::device_jwt_refresher::commands::kick_device_jwt_refresher().await;
+    });
+
+    let resp_device_id = pair_resp.device_id.clone().unwrap_or(device_id);
+    info!(
+        "cognito_sign_in: signed in + device bound (sub={}, device={resp_device_id}) — Tier 2 active",
+        login.sub
+    );
+
+    Ok(CognitoSignInResponse {
+        user_id: login.sub,
+        email: login.email,
+        tenant_id: tenant_id_str,
+        device_id: resp_device_id,
+    })
+}
+
 /// Clears the runner token, drops the runner back to Tier 0/1, and kicks
 /// the relay so the WS connection closes cleanly.
 ///
@@ -1238,6 +1397,7 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             set_runner_tier,
             start_qontinui_sign_in,
             pair_with_credentials,
+            cognito_sign_in,
             qontinui_sign_out,
             device_jwt_present,
             kick_device_jwt_refresher_cmd,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,11 @@ pub mod secure_storage;
 // share one code path. See `pair.rs` for the canonical wire shapes.
 pub mod pair;
 
+// Cognito Hosted-UI sign-in (RFC 8252 PKCE). Phase 5 of the
+// unified-Cognito-identity plan. Tauri-free (loopback + system browser); the
+// `cognito_sign_in` Tauri command in `commands::auth` drives it.
+pub mod cognito;
+
 // ============================================================================
 // Main window label abstraction
 // ============================================================================

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -243,6 +243,66 @@ pub(crate) async fn try_refresh_once(
     }
 }
 
+/// Ensure the Cognito (oauth) access token is fresh before it's used as the
+/// pair-cli bearer. If a Cognito refresh token is stored and the access token
+/// is within the refresh threshold (or already expired), POST the
+/// `refresh_token` grant to Cognito and persist the new access/id tokens.
+///
+/// Best-effort: a refresh failure is logged and we fall through with whatever
+/// is stored — `try_refresh_once` will surface a 401 from the web backend and
+/// keep the existing device JWT (the REPLACE-not-REVOKE invariant).
+///
+/// Returns the bearer the device pair should present: the (possibly
+/// refreshed) Cognito access token when a Cognito session exists, else `None`
+/// (the caller falls back to the legacy device-JWT-slot bearer for installs
+/// paired via local-login).
+async fn ensure_fresh_cognito_bearer(auth_manager: &crate::auth::AuthManager) -> Option<String> {
+    // No Cognito session → legacy/local-login install; let the caller use its
+    // existing bearer source.
+    let refresh_token = match auth_manager.get_oauth_refresh_token() {
+        Ok(t) if !t.trim().is_empty() => t,
+        _ => return None,
+    };
+
+    if auth_manager.cognito_token_needs_refresh() {
+        info!("device_jwt_refresher: Cognito access token stale — refreshing first");
+        let rt = refresh_token.clone();
+        let refreshed =
+            tokio::task::spawn_blocking(move || qontinui_runner_lib::cognito::refresh_tokens(&rt))
+                .await;
+        match refreshed {
+            Ok(Ok(resp)) => {
+                let expires_at = chrono::Utc::now().timestamp() + resp.expires_in;
+                // Cognito omits refresh_token on the refresh grant — keep the
+                // existing one.
+                let new_refresh = resp.refresh_token.unwrap_or(refresh_token);
+                if let Err(e) = auth_manager.store_oauth_tokens(
+                    &resp.access_token,
+                    &resp.id_token,
+                    &new_refresh,
+                    expires_at,
+                ) {
+                    warn!("device_jwt_refresher: persist refreshed Cognito tokens failed: {e}");
+                } else {
+                    info!("device_jwt_refresher: Cognito access token refreshed");
+                }
+                return Some(resp.access_token);
+            }
+            Ok(Err(e)) => {
+                warn!(
+                    "device_jwt_refresher: Cognito token refresh failed: {e} — using stored token"
+                );
+            }
+            Err(join_err) => {
+                warn!("device_jwt_refresher: Cognito refresh task join failed: {join_err}");
+            }
+        }
+    }
+
+    // Fresh enough (or refresh failed) — use whatever access token is stored.
+    auth_manager.get_oauth_access_token().ok()
+}
+
 async fn refresher_loop(
     _api_state: Arc<ApiState>,
     mut shutdown_rx: watch::Receiver<bool>,
@@ -315,29 +375,35 @@ async fn refresher_loop(
                 continue;
             }
             Decision::Pair => {
-                // Post-2026-05-22: pair-cli now goes through the web
-                // backend (`/api/v1/devices/pair-cli`), not coord directly,
-                // so the backend can resolve `tenant_id` from the
-                // authenticated user. The backend gates on the FastAPI
-                // user-JWT (`Authorization: Bearer <access_token>`) — not
-                // the legacy `runner_token`, which only coord ever
-                // accepted. Pull the user JWT that the runner stashed at
-                // sign-in time (`commands::auth::login` →
-                // `AuthManager::store_tokens`).
-                let bearer_token = match auth_manager.get_access_token() {
-                    Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
-                    _ => {
-                        warn!(
-                            "device_jwt_refresher: access_token slot empty — user must \
-                             sign in to Qontinui before the refresher can pair"
-                        );
-                        if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx)
+                // The web backend's pair-cli endpoint gates on the user
+                // bearer (`Authorization: Bearer <user-token>`). Phase 5
+                // (unified-Cognito-identity): when the runner was signed in
+                // via Cognito, the bearer is the Cognito **access token** —
+                // refreshed first if it's stale (so the re-bind presents a
+                // valid user token). For legacy/local-login installs there's
+                // no Cognito session, so we fall back to the device-JWT slot
+                // bearer (the historical Phase-2 source).
+                let bearer_token = match ensure_fresh_cognito_bearer(&auth_manager).await {
+                    Some(t) if !t.trim().is_empty() => t.trim().to_string(),
+                    _ => match auth_manager.get_access_token() {
+                        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+                        _ => {
+                            warn!(
+                                "device_jwt_refresher: no Cognito session and access_token slot \
+                                 empty — user must sign in to Qontinui before the refresher can pair"
+                            );
+                            if wait_with_signals(
+                                REFRESH_CHECK_INTERVAL,
+                                &mut shutdown_rx,
+                                &mut kick_rx,
+                            )
                             .await
-                        {
-                            return;
+                            {
+                                return;
+                            }
+                            continue;
                         }
-                        continue;
-                    }
+                    },
                 };
                 let pair_base = settings_snapshot
                     .web_integration

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -38,11 +38,36 @@ const SERVICE_NAME: &str = "com.qontinui.runner";
 const STORAGE_FILE: &str = "auth_tokens.enc";
 
 /// Stored token data structure
+///
+/// ## Token slots (Phase 5 unified-Cognito-identity)
+///
+/// - `access_token` / `refresh_token`: the **coord device-token JWT** slot.
+///   `access_token` holds the coord-minted device JWT (read by the WS relay
+///   via `AuthManager::get_access_token`); `refresh_token` is unused for the
+///   device-JWT flow (coord owns its lifecycle).
+/// - `oauth_access_token` / `oauth_id_token` / `oauth_refresh_token`: the
+///   **Cognito user-token** slots, written by the RFC-8252 PKCE sign-in
+///   (`cognito::store_cognito_tokens`). These are kept distinct from the
+///   device-JWT slot so the relay keeps using the device JWT while
+///   user-facing calls (and the device→user re-bind) use the Cognito token.
+///   `oauth_expires_at` is the absolute unix-seconds expiry of the Cognito
+///   access token, used by the refresher to decide staleness.
+///
+/// All new fields carry `#[serde(default)]` so a pre-Phase-5 `auth_tokens.enc`
+/// (only the first three keys) still deserializes.
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct StoredTokens {
     access_token: Option<String>,
     refresh_token: Option<String>,
     device_id: Option<String>,
+    #[serde(default)]
+    oauth_access_token: Option<String>,
+    #[serde(default)]
+    oauth_id_token: Option<String>,
+    #[serde(default)]
+    oauth_refresh_token: Option<String>,
+    #[serde(default)]
+    oauth_expires_at: Option<i64>,
 }
 
 /// Secure file-based storage manager.
@@ -217,11 +242,17 @@ impl SecureStorage {
             .ok_or_else(|| anyhow::anyhow!("Refresh token not found in storage"))
     }
 
-    /// Clears all tokens from storage.
+    /// Clears all tokens from storage (device-JWT slot AND the Cognito
+    /// user-token slots). `device_id` is preserved — it is a stable local
+    /// identifier, not a credential.
     pub fn clear_tokens(&self) -> Result<()> {
         let mut tokens = self.load_tokens().unwrap_or_default();
         tokens.access_token = None;
         tokens.refresh_token = None;
+        tokens.oauth_access_token = None;
+        tokens.oauth_id_token = None;
+        tokens.oauth_refresh_token = None;
+        tokens.oauth_expires_at = None;
         self.save_tokens(&tokens)?;
         info!("Tokens cleared from secure file storage");
         Ok(())
@@ -250,6 +281,71 @@ impl SecureStorage {
             Ok(tokens) => tokens.access_token.is_some() && tokens.refresh_token.is_some(),
             Err(_) => false,
         }
+    }
+
+    /// Stores the Cognito user tokens (Phase 5 unified-Cognito-identity).
+    ///
+    /// Writes the `oauth_access_token` / `oauth_id_token` /
+    /// `oauth_refresh_token` / `oauth_expires_at` slots, leaving the coord
+    /// device-JWT (`access_token`) slot untouched.
+    pub fn store_oauth_tokens(
+        &self,
+        access_token: &str,
+        id_token: &str,
+        refresh_token: &str,
+        expires_at: i64,
+    ) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens.oauth_access_token = Some(access_token.to_string());
+        tokens.oauth_id_token = Some(id_token.to_string());
+        tokens.oauth_refresh_token = Some(refresh_token.to_string());
+        tokens.oauth_expires_at = Some(expires_at);
+        self.save_tokens(&tokens)?;
+        info!("Cognito (oauth) tokens stored in secure file storage");
+        Ok(())
+    }
+
+    /// Retrieves the Cognito access token.
+    pub fn get_oauth_access_token(&self) -> Result<String> {
+        let tokens = self.load_tokens()?;
+        tokens
+            .oauth_access_token
+            .ok_or_else(|| anyhow::anyhow!("Cognito access token not found in storage"))
+    }
+
+    /// Retrieves the Cognito id token.
+    pub fn get_oauth_id_token(&self) -> Result<String> {
+        let tokens = self.load_tokens()?;
+        tokens
+            .oauth_id_token
+            .ok_or_else(|| anyhow::anyhow!("Cognito id token not found in storage"))
+    }
+
+    /// Retrieves the Cognito refresh token.
+    pub fn get_oauth_refresh_token(&self) -> Result<String> {
+        let tokens = self.load_tokens()?;
+        tokens
+            .oauth_refresh_token
+            .ok_or_else(|| anyhow::anyhow!("Cognito refresh token not found in storage"))
+    }
+
+    /// Retrieves the Cognito access-token expiry (absolute unix seconds),
+    /// if present.
+    pub fn get_oauth_expires_at(&self) -> Option<i64> {
+        self.load_tokens().ok().and_then(|t| t.oauth_expires_at)
+    }
+
+    /// Clears only the Cognito (oauth) token slots, leaving the device-JWT
+    /// slot intact. Used on Cognito sign-out.
+    pub fn clear_oauth_tokens(&self) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens.oauth_access_token = None;
+        tokens.oauth_id_token = None;
+        tokens.oauth_refresh_token = None;
+        tokens.oauth_expires_at = None;
+        self.save_tokens(&tokens)?;
+        info!("Cognito (oauth) tokens cleared from secure file storage");
+        Ok(())
     }
 
     /// Deletes the storage file entirely.
@@ -310,6 +406,41 @@ mod tests {
         storage.clear_tokens().unwrap();
         assert!(storage.get_access_token().is_err());
         assert!(storage.get_refresh_token().is_err());
+    }
+
+    #[test]
+    fn test_oauth_tokens_round_trip_and_isolation() {
+        let storage = create_test_storage("test_oauth_tokens_round_trip");
+
+        // Device-JWT slot.
+        storage.store_tokens("device.jwt.here", "").unwrap();
+        // Cognito user-token slots.
+        storage
+            .store_oauth_tokens("cog.access", "cog.id", "cog.refresh", 1_700_000_000)
+            .unwrap();
+
+        // Both slots coexist — Cognito write must not clobber the device JWT.
+        assert_eq!(storage.get_access_token().unwrap(), "device.jwt.here");
+        assert_eq!(storage.get_oauth_access_token().unwrap(), "cog.access");
+        assert_eq!(storage.get_oauth_id_token().unwrap(), "cog.id");
+        assert_eq!(storage.get_oauth_refresh_token().unwrap(), "cog.refresh");
+        assert_eq!(storage.get_oauth_expires_at(), Some(1_700_000_000));
+
+        // Clearing only the oauth slots leaves the device JWT intact.
+        storage.clear_oauth_tokens().unwrap();
+        assert!(storage.get_oauth_access_token().is_err());
+        assert_eq!(storage.get_access_token().unwrap(), "device.jwt.here");
+    }
+
+    /// A pre-Phase-5 `StoredTokens` JSON (only the original three keys) must
+    /// still deserialize — the new oauth_* fields carry `#[serde(default)]`.
+    #[test]
+    fn test_legacy_stored_tokens_without_oauth_fields_deserializes() {
+        let raw = r#"{"access_token":"a","refresh_token":"r","device_id":"d"}"#;
+        let parsed: StoredTokens = serde_json::from_str(raw).expect("legacy shape must decode");
+        assert_eq!(parsed.access_token.as_deref(), Some("a"));
+        assert!(parsed.oauth_access_token.is_none());
+        assert!(parsed.oauth_expires_at.is_none());
     }
 
     #[test]

--- a/src/components/settings/AccountSettings.tsx
+++ b/src/components/settings/AccountSettings.tsx
@@ -50,6 +50,9 @@ export function AccountSettings({ onLog }: AccountSettingsProps) {
   const [credBackendUrl, setCredBackendUrl] = useState(DEFAULT_BACKEND_URL);
   const [credState, setCredState] = useState<"idle" | "pairing">("idle");
 
+  // --- Cognito Hosted-UI sign-in (RFC 8252 PKCE) ----------------------------
+  const [cognitoState, setCognitoState] = useState<"idle" | "signing-in">("idle");
+
   const isTier2 = tier === "qontinui_account";
 
   // Listen for the `web-integration-changed` Tauri event that the loopback
@@ -113,6 +116,39 @@ export function AccountSettings({ onLog }: AccountSettingsProps) {
       setCredState("idle");
     }
   }, [credEmail, credPassword, credBackendUrl, onLog, refreshTier]);
+
+  const handleCognitoSignIn = useCallback(async () => {
+    const backendUrl = credBackendUrl.trim();
+    if (!backendUrl) {
+      setFlowError("Backend URL is required.");
+      return;
+    }
+    setCognitoState("signing-in");
+    setFlowError(null);
+    onLog("info", "Opening browser for Qontinui (Cognito) sign-in — complete the flow there");
+    try {
+      const result = await invoke<{
+        userId: string;
+        email: string | null;
+        tenantId: string | null;
+        deviceId: string;
+      }>("cognito_sign_in", { backendUrl });
+      // The Rust command already promoted the runner to Tier 2; nudge tier
+      // consumers so the panel flips to the signed-in view immediately.
+      window.dispatchEvent(new CustomEvent("runner-tier-changed"));
+      await refreshTier();
+      onLog(
+        "success",
+        `Signed in with Qontinui (${result.email ?? result.userId}) — Tier 2 active`,
+      );
+    } catch (err) {
+      const msg = typeof err === "string" ? err : String(err);
+      setFlowError(msg);
+      onLog("error", `Qontinui sign-in failed: ${msg}`);
+    } finally {
+      setCognitoState("idle");
+    }
+  }, [credBackendUrl, onLog, refreshTier]);
 
   const handleSignOut = useCallback(async () => {
     setSigningOut(true);
@@ -188,6 +224,8 @@ export function AccountSettings({ onLog }: AccountSettingsProps) {
         <SignedOutPanel
           flowState={flowState}
           onSignIn={handleSignIn}
+          cognitoSigningIn={cognitoState === "signing-in"}
+          onCognitoSignIn={handleCognitoSignIn}
           credEmail={credEmail}
           credPassword={credPassword}
           credBackendUrl={credBackendUrl}
@@ -260,6 +298,8 @@ function SignedInPanel({ email, userId, name, signingOut, onSignOut }: SignedInP
 interface SignedOutPanelProps {
   flowState: FlowState;
   onSignIn: () => void;
+  cognitoSigningIn: boolean;
+  onCognitoSignIn: () => void;
   credEmail: string;
   credPassword: string;
   credBackendUrl: string;
@@ -273,6 +313,8 @@ interface SignedOutPanelProps {
 function SignedOutPanel({
   flowState,
   onSignIn,
+  cognitoSigningIn,
+  onCognitoSignIn,
   credEmail,
   credPassword,
   credBackendUrl,
@@ -289,8 +331,42 @@ function SignedOutPanel({
     credPassword.length === 0 ||
     credBackendUrl.trim().length === 0;
 
+  const cognitoDisabled = cognitoSigningIn || credBackendUrl.trim().length === 0;
+
   return (
     <div className="space-y-5">
+      {/* Cognito Hosted-UI sign-in (RFC 8252 PKCE). The recommended path for
+          a human at the machine: opens the system browser, signs in with the
+          Qontinui (Cognito) account, and binds this device to that user. */}
+      <div className="space-y-3 rounded-lg border border-primary/40 bg-card/50 p-4">
+        <div>
+          <div className="text-sm font-medium">Sign in with Qontinui</div>
+          <div className="text-xs text-muted-foreground">
+            Opens your browser to sign in with your Qontinui account, then binds this runner to
+            you. Promotes the runner to Tier 2.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onCognitoSignIn}
+          disabled={cognitoDisabled}
+          className="inline-flex items-center gap-2 rounded bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {cognitoSigningIn ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <LogIn className="w-4 h-4" />
+          )}
+          {cognitoSigningIn ? "Waiting for browser…" : "Sign in with Qontinui"}
+        </button>
+        {cognitoSigningIn && (
+          <p className="text-xs text-muted-foreground">
+            Complete the sign-in in your browser. This panel will update automatically when the
+            runner is bound.
+          </p>
+        )}
+      </div>
+
       {/* In-app email/password pairing — headless, no browser, UI-Bridge
           drivable. This is the primary path for automated / remote pairing. */}
       <div className="space-y-3 rounded-lg border border-border bg-card/50 p-4">


### PR DESCRIPTION
Phase 5 of `2026-05-29-unified-cognito-identity-web-coord-runner.md`. The runner desktop app can now sign the human in with their **Cognito** account (system browser + PKCE + fixed-port loopback), and binds the coord device-token JWT to that user.

## What
- **`src-tauri/src/cognito.rs`** (new) — RFC 8252 PKCE: `code_verifier`/S256 `challenge`/`state`, `build_authorize_url`, `pkce_login` (fixed `127.0.0.1:53682` loopback + system browser, reusing `pair.rs`'s pattern), `exchange_code`, `refresh_tokens`. Public client `67f2a1a0…` on `auth.qontinui.io`, **no secret**. 7 unit tests incl. the RFC 7636 Appendix-B vector.
- **`secure_storage.rs` + `auth.rs`** — storage split: Cognito user tokens in dedicated `oauth_*` slots; coord device JWT stays in `access_token` (WS relay keeps using it). Back-compat serde defaults.
- **`commands/auth.rs`** — `cognito_sign_in`: PKCE login → store tokens → bind device via the existing `/api/v1/devices/pair-cli` (Cognito access token as bearer, `sub` as `X-Qontinui-User-Id`) → Tier 2.
- **`device_jwt_refresher.rs`** — refresh the Cognito token first when stale; prefer it as the pair-cli bearer, fall back to the device-JWT slot for legacy installs.
- **`AccountSettings.tsx`** — "Sign in with Qontinui" button.

Headless test-runner auto-login (local email/password) left untouched — still works via the backend's dual-accept (web PR #325); retiring it is deferred (Phase 4).

## Checks
`cargo check --lib`, `cargo clippy --lib`, `tsc --noEmit` clean (verified with node_modules scaffolding); 7+5+6+9 unit tests pass. **Pre-push clippy was deferred to CI** via the hook's `QONTINUI_PREPUSH_SKIP` — the bare worktree lacks `node_modules` so the lib's `build-ir` build-script can't run locally; CI has the full env and gates it.

## Scope
Google is the only IdP this run (Microsoft/GitHub pending). The live browser sign-in round-trip is human-gated (opens a real browser + Cognito login) — not claimed-passed here.