### PR TITLE
fix(agent_worktree): wire remaining two terminal_create entry points

### DIFF
--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -946,7 +946,7 @@ pub async fn launch_coordinator_session(
 
     // mode == "claude_skill": legacy pty-spawn path.
     let runner_port = crate::mcp::types::runner_api_port(&app_state);
-    let repo_path = resolve_runner_repo_path()
+    let primary_repo_path = resolve_runner_repo_path()
         .ok_or_else(|| "Failed to resolve qontinui-runner repo path".to_string())?;
     let initial_command = build_coordinator_initial_command(runner_port, plan_path.as_deref())?;
     let title = title_hint.unwrap_or_else(|| "Coordinator".to_string());
@@ -957,6 +957,19 @@ pub async fn launch_coordinator_session(
         .inner()
         .clone();
 
+    // Phase 2 round 2 — Coordinator sessions always edit qontinui-runner
+    // (same class as `spawn_worker_session`). Route through the shared
+    // facade so flag-on lands in a worktree, flag-off keeps the primary
+    // checkout.
+    let (effective_repo_path, isolated_ctx) =
+        crate::agent_worktree::isolated_edit::acquire_for_terminal(
+            Some("qontinui-runner"),
+            "Coordinator session",
+            Some(primary_repo_path.clone()),
+        )
+        .await;
+    let repo_path = effective_repo_path.unwrap_or(primary_repo_path);
+
     let info = terminal_manager.create(
         Some(title),
         Some(repo_path),
@@ -965,6 +978,12 @@ pub async fn launch_coordinator_session(
         None,
         app_handle.clone(),
     )?;
+
+    if let Some(ctx) = isolated_ctx {
+        if let Some(session) = terminal_manager.get(&info.id) {
+            session.set_isolated_edit_ctx(ctx);
+        }
+    }
 
     schedule_initial_command(terminal_manager, info.id.clone(), initial_command);
 

--- a/src-tauri/src/mcp/terminals.rs
+++ b/src-tauri/src/mcp/terminals.rs
@@ -43,6 +43,13 @@ pub struct CreateTerminalRequest {
     /// Optional command to execute immediately after shell initialization.
     #[serde(default)]
     pub initial_command: Option<String>,
+    /// Phase 2 round 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
+    /// When `Some(repo_slug)` AND `QONTINUI_AGENT_WORKTREE_MODE` is on,
+    /// allocate an isolated worktree for that repo and use it as the
+    /// PTY cwd instead of `working_dir`. Mirrors the `intent_repo`
+    /// argument on the `terminal_create` Tauri command + HTTP-SDK proxy.
+    #[serde(default)]
+    pub intent_repo: Option<String>,
 }
 
 /// Request body for writing data to a terminal.
@@ -129,19 +136,38 @@ pub async fn create_terminal_handler(
     let app_handle = state.app_handle.clone();
 
     info!(
-        "HTTP: Creating terminal session (title={:?}, working_dir={:?})",
-        request.title, request.working_dir
+        "HTTP: Creating terminal session (title={:?}, working_dir={:?}, intent_repo={:?})",
+        request.title, request.working_dir, request.intent_repo
     );
+
+    // Phase 2 round 2 — route through the shared `acquire_for_terminal`
+    // helper so this entry point matches the other five
+    // terminal_manager.create call sites. `intent_repo == None` is a
+    // no-op (helper returns the original working_dir, no allocation).
+    let (working_dir, isolated_ctx) = crate::agent_worktree::isolated_edit::acquire_for_terminal(
+        request.intent_repo.as_deref(),
+        request
+            .title
+            .as_deref()
+            .unwrap_or("HTTP terminal edit session"),
+        request.working_dir,
+    )
+    .await;
 
     match terminal_manager.create(
         request.title,
-        request.working_dir,
+        working_dir,
         request.page_id,
         request.cols,
         request.rows,
         app_handle,
     ) {
         Ok(info) => {
+            if let Some(ctx) = isolated_ctx {
+                if let Some(session) = terminal_manager.get(&info.id) {
+                    session.set_isolated_edit_ctx(ctx);
+                }
+            }
             info!("HTTP: Created terminal session: {}", info.id);
 
             // Send initial command after a short delay for shell initialization


### PR DESCRIPTION
## Summary

Phase 2 round 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`. The flag-flip dogfood with `QONTINUI_AGENT_WORKTREE_MODE=1` enumerated every `terminal_manager.create` call site and surfaced two still bypassing the `acquire_for_terminal` facade. Both edit the operator's primary checkout under flag-on conditions.

Mechanically identical to the wireup PR #313 applied to `tauri_proxy` + `backend_relay`. Same four-line idiom at each site:

```rust
let (working_dir, isolated_ctx) =
    acquire_for_terminal(intent_repo, purpose, working_dir).await;
let info = tm.create(..., working_dir, ...)?;
if let Some(ctx) = isolated_ctx {
    tm.get(&info.id).map(|s| s.set_isolated_edit_ctx(ctx));
}
```

- **`mcp/terminals.rs::create_terminal_handler`** (`POST /terminals`): adds optional `intent_repo` field to `CreateTerminalRequest`. Mirrors the proxy/relay shape exactly.
- **`commands/productivity.rs::launch_coordinator_session`** (`mode="claude_skill"`): hardcodes `intent_repo = "qontinui-runner"` — Coordinator sessions always edit the runner repo, same class as `spawn_worker_session`.

After this PR, all **six** `terminal_manager.create` call sites match the `acquire_for_terminal` call-site count — the substrate covers every terminal-creation path uniformly. The "every new entry point bypasses the wireup" pattern still exists in principle (see the plan's open question about pushing the facade INTO `TerminalManager::create` itself), but no current site is unwired.

Plan: `plans/2026-05-29-worktree-isolation-phase2-round2.md` (DRAFT in workspace plans; will archive on merge).

## Test plan

- [x] `cargo check` + `cargo clippy -D warnings` + `cargo fmt --check` clean locally
- [ ] Re-run the flag-flip dogfood once merged: `POST /terminals` with `intent_repo: "qontinui/qontinui-runner"` should land in an agent worktree; without `intent_repo` should keep primary cwd (observation invariant)
- [ ] Coordinator session via `launch_coordinator_session(mode="claude_skill")` with flag on should land in a worktree, not the primary
- [ ] Regression-resistance grep: `terminal_manager.create(` count == `acquire_for_terminal` call-site count == 6