### PR TITLE
chore(terminal): /doc-finder action + StatusStrip pills for visual indicators

### DIFF
--- a/src/components/terminal/StatusStrip.tsx
+++ b/src/components/terminal/StatusStrip.tsx
@@ -43,7 +43,17 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { AlertOctagon, Lock, Package, RefreshCw, Sparkles } from "lucide-react";
+import {
+  AlertOctagon,
+  ClipboardList,
+  Lock,
+  Package,
+  RefreshCw,
+  Sparkles,
+  TerminalSquare,
+} from "lucide-react";
+
+import type { SessionState } from "./useZoneLayout";
 
 import { useTerminalSession } from "./contexts";
 import { useWrapperTools } from "@/hooks/useWrapperTools";
@@ -92,9 +102,21 @@ function Pill({ icon, text, color, onClick, title }: PillProps) {
   );
 }
 
+/** Color codes mirror the per-state palette in ZoneStatusBar so the
+ *  visual identity stays consistent across the lifted-out pills. */
+const STATE_COLORS: Record<SessionState, string> = {
+  idle: "#565f89",
+  working: "#7aa2f7",
+  "needs-input": "#e0af68",
+  completed: "#9ece6a",
+  error: "#f7768e",
+};
+
 export function StatusStrip() {
   const session = useTerminalSession();
-  const { tabs, sessionStates, fileLockStates, zoneLayout } = session;
+  const { tabs, sessionStates, fileLockStates, zoneLayout, workflowGen } = session;
+  const planFileName = workflowGen.planFileName;
+  const isPlanLoading = workflowGen.isPlanLoading;
   const {
     tools: wrapperTools,
     routes: wrapperRoutes,
@@ -133,14 +155,31 @@ export function StatusStrip() {
   }, []);
 
   // Counts + derived signals. Reused across the pill list AND the
-  // outer auto-hide gate.
-  const { needsInputCount, errorCount, stuckLocks, maxStuckMs, longestStuckTabId } = useMemo(() => {
+  // outer auto-hide gate. Working/completed/idle feed the Phase-9f
+  // state-breakdown pill (sibling to the existing needs-input / error
+  // pills, which keep their own callsites because they're clickable).
+  const {
+    needsInputCount,
+    errorCount,
+    workingCount,
+    completedCount,
+    idleCount,
+    stuckLocks,
+    maxStuckMs,
+    longestStuckTabId,
+  } = useMemo(() => {
     let needsInput = 0;
     let errors = 0;
+    let working = 0;
+    let completed = 0;
+    let idle = 0;
     for (const tab of tabs) {
-      const state = sessionStates[tab.id];
+      const state = sessionStates[tab.id] ?? "idle";
       if (state === "needs-input") needsInput++;
       else if (state === "error") errors++;
+      else if (state === "working") working++;
+      else if (state === "completed") completed++;
+      else if (state === "idle") idle++;
     }
     let stuck = 0;
     let maxMs = 0;
@@ -161,6 +200,9 @@ export function StatusStrip() {
     return {
       needsInputCount: needsInput,
       errorCount: errors,
+      workingCount: working,
+      completedCount: completed,
+      idleCount: idle,
       stuckLocks: stuck,
       maxStuckMs: maxMs,
       longestStuckTabId: longestTabId,
@@ -169,12 +211,30 @@ export function StatusStrip() {
     // tabs / sessionStates / fileLockStates cover state-driven re-eval.
   }, [tabs, sessionStates, fileLockStates]);
 
+  const sessionCount = tabs.length;
+  const isMultiZone = sessionCount > 1;
+
   const wrapperCount = wrapperTools.length;
 
-  // Auto-hide gate — when nothing requires attention, the strip
-  // disappears entirely so the top of viewport is fully clean.
+  // Phase 9f — visual indicators lifted from ZoneStatusBar. These
+  // surface ambient session-shape info (count, non-attention state
+  // breakdown, loaded plan file) so the strip carries the operator
+  // context ZSB used to. The attention-pills above keep their bright
+  // colors; these new pills render in muted shades so they don't
+  // compete visually with "needs attention" signals.
+  const hasBreakdown = workingCount > 0 || completedCount > 0 || idleCount > 0;
+
+  // Auto-hide gate — when nothing requires attention AND nothing
+  // informational is worth showing either, the strip disappears
+  // entirely so the top of viewport is fully clean.
   const hasContent =
-    needsInputCount > 0 || errorCount > 0 || stuckLocks > 0 || wrapperCount > 0;
+    needsInputCount > 0 ||
+    errorCount > 0 ||
+    stuckLocks > 0 ||
+    wrapperCount > 0 ||
+    isMultiZone ||
+    planFileName !== null ||
+    isPlanLoading;
 
   const focusNextError = useCallback(() => {
     // Inline mirror of `useZoneLayout.focusNextNeedsInput`'s walk,
@@ -324,6 +384,87 @@ export function StatusStrip() {
           )}
         </div>
       )}
+      {/* Phase 9f — session count pill. Multi-zone only; informational. */}
+      {isMultiZone && (
+        <Pill
+          icon={<TerminalSquare className="w-2.5 h-2.5" />}
+          text={`${sessionCount} sessions`}
+          color="#565f89"
+          title={`${sessionCount} terminal sessions open in this page`}
+        />
+      )}
+
+      {/* Phase 9f — state-breakdown pill. Single combined pill listing
+          the non-attention states (working / completed / idle); the
+          attention-grabbing needs-input / error counts already have
+          dedicated pills above. Renders dot-then-count per state in
+          its native color so the dense layout stays legible. */}
+      {isMultiZone && hasBreakdown && (
+        <span
+          className="flex items-center gap-2 px-1.5 py-0.5 text-[10px] leading-none whitespace-nowrap text-[#565f89]"
+          title="Session state breakdown"
+        >
+          {workingCount > 0 && (
+            <span className="flex items-center gap-1" style={{ color: STATE_COLORS.working }}>
+              <span
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: STATE_COLORS.working }}
+                aria-hidden
+              />
+              {workingCount} working
+            </span>
+          )}
+          {completedCount > 0 && (
+            <span className="flex items-center gap-1" style={{ color: STATE_COLORS.completed }}>
+              <span
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: STATE_COLORS.completed }}
+                aria-hidden
+              />
+              {completedCount} done
+            </span>
+          )}
+          {idleCount > 0 && (
+            <span className="flex items-center gap-1" style={{ color: STATE_COLORS.idle }}>
+              <span
+                className="w-1.5 h-1.5 rounded-full"
+                style={{ backgroundColor: STATE_COLORS.idle }}
+                aria-hidden
+              />
+              {idleCount} idle
+            </span>
+          )}
+        </span>
+      )}
+
+      {/* Phase 9f — plan-file pill. Mirrors ZSB's plan-file indicator:
+          loaded chip when a PLAN*.md / TODO*.md was found, a muted
+          spinner while scanning, and a "no plan" hint otherwise. */}
+      {isPlanLoading ? (
+        <Pill
+          icon={
+            <span className="w-2.5 h-2.5 border border-[#565f89] border-t-transparent rounded-full animate-spin" />
+          }
+          text="scanning plan…"
+          color="#565f89"
+          title="Looking for PLAN*.md / TODO*.md in the workspace"
+        />
+      ) : planFileName ? (
+        <Pill
+          icon={<ClipboardList className="w-2.5 h-2.5" />}
+          text={planFileName}
+          color="#9ece6a"
+          title={`Plan loaded: ${planFileName} — used by /plan-implement, /plan-verify, Architecture, and Plan Progress analyses`}
+        />
+      ) : (
+        <Pill
+          icon={<ClipboardList className="w-2.5 h-2.5" />}
+          text="no plan"
+          color="#414868"
+          title="No PLAN*.md / TODO*.md file found in workspace"
+        />
+      )}
+
       {/* Trailing decorative spark so the strip's "something present"
           state is visually distinct from a stray border-bottom on a
           blank row, while staying subtle. Aria-hidden — it's purely

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -6,6 +6,7 @@ import { SessionManagerPanel } from "./SessionManagerPanel";
 import { ZoneGrid } from "./ZoneGrid";
 import { ZoneLayoutPicker } from "./ZoneLayoutPicker";
 import { ZoneStatusBar } from "./ZoneStatusBar";
+import { DocFinderModal } from "./DocFinderModal";
 import { BatchOperationsBar } from "./BatchOperationsBar";
 import { ZoneMinimap } from "./ZoneMinimap";
 import { ZoneProfilePicker } from "./ZoneProfilePicker";
@@ -335,6 +336,7 @@ function TerminalPageInner({
   // plan flagged this ambiguity; the cleaner placement is here next to
   // the contention toast, matching its visual language.
   const [dismissedBanners, setDismissedBanners] = useState<Set<string>>(new Set());
+  const [showDocFinder, setShowDocFinder] = useState(false);
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional sync: drop stale dismissals whenever fileLockStates changes so the banner re-shows on a fresh waiter wave (count 0 → 1 after a "Hold" click). The same React-rules exception pattern is used at lib/runner-api.ts:61 / :79 for the port-listener sync.
     setDismissedBanners((prev) => {
@@ -657,6 +659,7 @@ function TerminalPageInner({
     accounts: sessionManager.accountUsage,
     sortZones: handleSortZones,
     exportAll: handleExportOutput,
+    openDocFinder: () => setShowDocFinder(true),
   });
 
   if (!initialized) {
@@ -682,8 +685,16 @@ function TerminalPageInner({
         <ZoneStatusBar
           onExport={handleExportOutput}
           onSortZones={handleSortZones}
-          onOpenDocFile={handleOpenDocFile}
         />
+        {showDocFinder && (
+          <DocFinderModal
+            onSelect={(filePath) => {
+              handleOpenDocFile(filePath);
+              setShowDocFinder(false);
+            }}
+            onClose={() => setShowDocFinder(false)}
+          />
+        )}
         <TerminalNotification
           message={workflowGen.notification?.message ?? null}
           type={workflowGen.notification?.type ?? "success"}

--- a/src/components/terminal/ZoneStatusBar.tsx
+++ b/src/components/terminal/ZoneStatusBar.tsx
@@ -7,7 +7,6 @@ import {
   Clock,
   Download,
   Eye,
-  FileText,
   Focus,
   Keyboard,
   ListChecks,
@@ -20,7 +19,6 @@ import {
   Wand2,
 } from "lucide-react";
 import type { AnalysisType } from "./TerminalAnalysisPanel";
-import { DocFinderModal } from "./DocFinderModal";
 import type { SessionState, ZoneAssignments } from "./useZoneLayout";
 import type { TerminalTab } from "./useTerminalManager";
 import { instanceStorage } from "@/lib/instance-storage";
@@ -56,7 +54,6 @@ interface ZoneStatusBarProps {
   /** Callbacks from useZoneActions — kept as props until that hook moves to context */
   onExport?: () => void;
   onSortZones?: () => void;
-  onOpenDocFile?: (filePath: string) => void;
 }
 
 const STATE_COLORS: Record<SessionState, string> = {
@@ -75,7 +72,7 @@ const STATE_LABELS: Record<SessionState, string> = {
   error: "error",
 };
 
-export function ZoneStatusBar({ onExport, onSortZones, onOpenDocFile }: ZoneStatusBarProps) {
+export function ZoneStatusBar({ onExport, onSortZones }: ZoneStatusBarProps) {
   // Read all data from contexts instead of props
   const session = useTerminalSession();
   const { tabs, zoneLayout } = session;
@@ -140,7 +137,6 @@ export function ZoneStatusBar({ onExport, onSortZones, onOpenDocFile }: ZoneStat
       return next;
     });
   };
-  const [showDocFinder, setShowDocFinder] = useState(false);
   const stateCounts = useMemo(() => {
     const counts: Record<SessionState, number> = {
       idle: 0,
@@ -220,16 +216,9 @@ export function ZoneStatusBar({ onExport, onSortZones, onOpenDocFile }: ZoneStat
           to find the toggle now invoke the action directly via UI Bridge
           components. */}
 
-      {onOpenDocFile && (
-        <button
-          onClick={() => setShowDocFinder(true)}
-          className="flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium transition-colors text-[#7dcfff] hover:bg-[#7dcfff]/10 hover:text-[#89d4ff] shrink-0"
-          title="Open a document file in a zone"
-        >
-          <FileText className="w-3 h-3" />
-          Doc
-        </button>
-      )}
+      {/* Phase 9f — Doc button migrated to /doc-finder registry action.
+          DocFinderModal mount + showDocFinder state lifted to TerminalPage
+          so the registry action and modal share a single source of truth. */}
 
       <div className="w-px h-4 bg-[#2a2d3d]" />
 
@@ -582,16 +571,6 @@ export function ZoneStatusBar({ onExport, onSortZones, onOpenDocFile }: ZoneStat
         {/* Phase 9d — plan-refresh icon button replaced by
             /plan-refresh registry action. */}
       </div>
-
-      {showDocFinder && onOpenDocFile && (
-        <DocFinderModal
-          onSelect={(filePath) => {
-            onOpenDocFile(filePath);
-            setShowDocFinder(false);
-          }}
-          onClose={() => setShowDocFinder(false)}
-        />
-      )}
     </div>
   );
 }

--- a/src/components/terminal/commands/useTerminalCommands.ts
+++ b/src/components/terminal/commands/useTerminalCommands.ts
@@ -87,6 +87,13 @@ export interface TerminalCommandsContext {
    * "Export" button used.
    */
   exportAll: () => void;
+  /**
+   * Open the DocFinder modal. Mirrors the closure ZoneStatusBar's
+   * "Doc" button used (now lifted into `TerminalPage` so the modal
+   * mount and the `/doc-finder` registry action share a single
+   * `showDocFinder` state).
+   */
+  openDocFinder: () => void;
 }
 
 /**
@@ -977,6 +984,23 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
         return fail("no-plan", "no PLAN*.md / TODO*.md file detected in workspace");
       }
       await workflowGen.handleBuildPlanFromFile();
+      return ok();
+    },
+  });
+
+  // 33. /doc-finder — open the doc-picker modal
+  useCommandAction({
+    id: "terminal.doc-finder",
+    slash: "/doc-finder",
+    aliases: ["/doc", "/docs"],
+    label: "Open doc-finder",
+    description:
+      "Open the doc-picker modal to load a documentation file into a zone. " +
+      "Same as the Doc button in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^docs?$/i, /^doc-finder$/i],
+    handler: async (): Promise<CommandResult> => {
+      ctx.openDocFinder();
       return ok();
     },
   });


### PR DESCRIPTION
## Summary

Closes 3 of the 4 ZSB-demolition preconditions identified in the on-page verification report following PR #320.

1. **`/doc-finder` registry action** — lifts `DocFinderModal` mount + `showDocFinder` state from ZoneStatusBar to TerminalPage so the modal and the new registry action share a single source of truth (same pattern Phase 9d used for the AutoApprovePopover lift). Removes Doc button + DocFinderModal mount + showDocFinder state + DocFinderModal import + onOpenDocFile prop + FileText icon from ZSB. Aliases: `/doc`, `/docs`.

2. **StatusStrip session-count pill** — `{tabs.length} sessions`, multi-zone only, muted (#565f89).

3. **StatusStrip state-breakdown pill** — single combined pill listing the non-attention states (`working`, `done`, `idle`); needs-input / error already have dedicated attention pills above. Per-state colors lifted from ZSB.

4. **StatusStrip plan-file pill** — `ClipboardList` chip with the loaded plan name (#9ece6a), spinner while scanning, dim "no plan" hint otherwise.

The strip's auto-hide gate widens to keep it hidden only when nothing — attention, multi-zone, or plan state — is worth showing.

ZoneStatusBar JSX stays in place for the items the StatusStrip now mirrors; lifting the visible duplicates out of ZSB happens in the demolition PR once the `/metrics` + `/history` result-cards land (the 4th and final precondition).

## On-page verification (temp runner from latest)

Spawned a temp runner from `78c001fa` and ran:

- StatusStrip with 1 tab: `"5 wrapper tools\nno plan"` — plan pill present, multi-zone pills hidden.
- StatusStrip after `/spawn 3`: `"5 wrapper tools\n3 sessions\n3 working\nno plan"` — all 3 new pills present and showing live state.
- ZSB Doc button query: `doc-buttons present: 0` — removed.
- `/doc-finder` fired: DocFinderModal mounted (new input with `placeholder="Search by filename..."` in DOM).

## Test plan

- [x] tsc clean
- [x] vitest 305/305 green
- [x] lint 0 errors / 3 pre-existing warnings
- [x] On-page verification (above)
- [ ] CI: ubuntu + windows test + Spec CI green