### PR TITLE
fix(web-integration): point Backend-Connect links at the web frontend, not the API host

### DIFF
--- a/src-tauri/src/api_config.rs
+++ b/src-tauri/src/api_config.rs
@@ -32,6 +32,56 @@ pub const DEFAULT_BACKEND_PORT: u16 = 8000;
 /// `get_api_base_url` and `settings::default_web_integration_backend_url`.
 pub const PROD_API_BASE_URL: &str = "https://api.qontinui.io";
 
+/// Canonical Qontinui production web-frontend FQDN (the Next.js app on Vercel).
+///
+/// Production is a **split** deployment: `PROD_API_BASE_URL` (`api.qontinui.io`)
+/// serves only `/api/v1/*`, while user-facing pages like `/login` and
+/// `/connect-runner` are served by the web frontend at `qontinui.io`. The `api.`
+/// host has no login page, so any UI that sends the user "to log in" must target
+/// this origin, not the backend. See [`derive_web_base_url`].
+pub const PROD_WEB_BASE_URL: &str = "https://qontinui.io";
+
+/// Derive the user-facing web-frontend origin from an API `backend_url`.
+///
+/// Production splits the API (`https://api.qontinui.io`) from the web frontend
+/// (`https://qontinui.io`) — the only difference is the leading `api.` host
+/// label. When the backend host begins with `api.`, this strips that single
+/// label (preserving scheme and port) to yield the frontend origin. For any
+/// other host — localhost dev, a bare IP, or a unified deployment where one
+/// origin serves both — the backend URL is returned unchanged, so the
+/// long-standing "same origin serves the SPA" fallback and any explicit
+/// `web_base_url` override keep working.
+///
+/// The returned value has no trailing slash and no path.
+pub fn derive_web_base_url(backend_url: &str) -> String {
+    let trimmed = backend_url.trim().trim_end_matches('/');
+    // Canonical mapping: the production API host maps to the production web
+    // origin. The general `api.`-stripping below also yields this, but pinning
+    // it keeps the two constants coupled even if the web FQDN ever diverges
+    // from a simple label strip.
+    if trimmed == PROD_API_BASE_URL {
+        return PROD_WEB_BASE_URL.to_string();
+    }
+    let (scheme, rest) = match trimmed.split_once("://") {
+        Some(parts) => parts,
+        None => return trimmed.to_string(),
+    };
+    // Authority is everything up to the first '/'; a ':' splits off the port.
+    let authority = rest.split('/').next().unwrap_or(rest);
+    let (host, port) = match authority.split_once(':') {
+        Some((h, p)) => (h, Some(p)),
+        None => (authority, None),
+    };
+    match host.strip_prefix("api.") {
+        // Only rewrite when an `api.` label was actually present.
+        Some(frontend_host) => match port {
+            Some(p) => format!("{}://{}:{}", scheme, frontend_host, p),
+            None => format!("{}://{}", scheme, frontend_host),
+        },
+        None => trimmed.to_string(),
+    }
+}
+
 /// Get API base URL for qontinui-web backend.
 ///
 /// This is the SINGLE source of truth for the web-backend base across every
@@ -176,5 +226,47 @@ mod tests {
     #[test]
     fn prod_api_base_url_is_canonical() {
         assert_eq!(PROD_API_BASE_URL, "https://api.qontinui.io");
+    }
+
+    #[test]
+    fn derive_web_base_url_strips_prod_api_label() {
+        // The headline case: api.qontinui.io (no login page) → qontinui.io.
+        assert_eq!(derive_web_base_url(PROD_API_BASE_URL), PROD_WEB_BASE_URL);
+        assert_eq!(
+            derive_web_base_url("https://api.qontinui.io/"),
+            "https://qontinui.io"
+        );
+    }
+
+    #[test]
+    fn derive_web_base_url_preserves_non_api_hosts() {
+        // Localhost dev + unified deployments have no `api.` label to strip,
+        // so the backend origin is returned unchanged (old fallback behavior).
+        assert_eq!(
+            derive_web_base_url("http://localhost:8000"),
+            "http://localhost:8000"
+        );
+        assert_eq!(
+            derive_web_base_url("http://127.0.0.1:8000/"),
+            "http://127.0.0.1:8000"
+        );
+        assert_eq!(
+            derive_web_base_url("https://qontinui.io"),
+            "https://qontinui.io"
+        );
+    }
+
+    #[test]
+    fn derive_web_base_url_preserves_scheme_and_port() {
+        assert_eq!(
+            derive_web_base_url("http://api.example.test:8080"),
+            "http://example.test:8080"
+        );
+        // A host that merely starts with the letters "api" but has no `api.`
+        // label must NOT be rewritten.
+        assert_eq!(
+            derive_web_base_url("https://apiserver.example.test"),
+            "https://apiserver.example.test"
+        );
     }
 }

--- a/src-tauri/src/commands/web_integration.rs
+++ b/src-tauri/src/commands/web_integration.rs
@@ -611,11 +611,13 @@ pub async fn start_web_token_flow<R: Runtime>(
 
     let runner_name = get_hostname_for_browser();
 
-    // `/connect-runner` is a Next.js page, not an API endpoint. In unified
-    // production deployments `backend_url` serves both, but in split local
-    // dev (FastAPI on :8000, Next.js on :3001) they're different hosts.
-    // Honor an explicit `web_base_url` override when set, else fall back
-    // to `backend_url` — preserving the old behavior for production.
+    // `/connect-runner` is a Next.js page, not an API endpoint. In production
+    // the API and the web frontend are split hosts (`api.qontinui.io` vs
+    // `qontinui.io`); in split local dev they differ by port. Honor an explicit
+    // `web_base_url` override when set, else derive the frontend origin from the
+    // backend by stripping a leading `api.` label (a no-op for localhost / a
+    // unified origin), so the browser never lands on the API host — which has
+    // no `/connect-runner` page.
     let web_origin = settings::load_settings()
         .web_integration
         .web_base_url
@@ -623,7 +625,7 @@ pub async fn start_web_token_flow<R: Runtime>(
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(trim_backend_url)
-        .unwrap_or_else(|| effective_backend.clone());
+        .unwrap_or_else(|| crate::api_config::derive_web_base_url(&effective_backend));
 
     let web_url = format!(
         "{}/connect-runner?state={}&callback={}&runner_name={}",

--- a/src/components/settings/WebIntegrationSettings.tsx
+++ b/src/components/settings/WebIntegrationSettings.tsx
@@ -100,6 +100,36 @@ function truncate(text: string, max: number): string {
   return text.slice(0, Math.max(0, max - 1)) + "…";
 }
 
+/**
+ * Derive the user-facing web-frontend origin from an API backend URL.
+ *
+ * Production is a split deployment: the API host carries an `api.` label
+ * (`https://api.qontinui.io`, which serves NO login page) while the web
+ * frontend drops it (`https://qontinui.io`). When the backend host starts with
+ * `api.` we strip that single label (preserving scheme + port); otherwise
+ * (localhost dev, a bare IP, or a unified origin) we return the backend
+ * unchanged. Mirrors the Rust `api_config::derive_web_base_url` used by the
+ * one-click web-login flow so both code paths land on the same origin.
+ *
+ * Returns null if `backendUrl` is empty/unparseable, so callers can fall back
+ * to plain text rather than rendering a broken link.
+ */
+function deriveWebAppUrl(backendUrl: string): string | null {
+  const trimmed = backendUrl.trim();
+  if (!trimmed) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  const host = parsed.hostname.startsWith("api.")
+    ? parsed.hostname.slice("api.".length)
+    : parsed.hostname;
+  const portPart = parsed.port ? `:${parsed.port}` : "";
+  return `${parsed.protocol}//${host}${portPart}`;
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -256,6 +286,11 @@ export function WebIntegrationSettings({ onLog }: WebIntegrationSettingsProps) {
   })();
 
   const canSave = isDirty && !saving && !urlError;
+
+  // Web-frontend origin for the "log into qontinui-web" help link. Derived from
+  // the backend URL (api.qontinui.io → qontinui.io); null when the backend
+  // field is empty/invalid, in which case the help text renders without a link.
+  const webAppUrl = deriveWebAppUrl(formBackendUrl);
 
   // --- Handlers -------------------------------------------------------------
   const handleBackendUrlChange = (value: string) => {
@@ -810,9 +845,9 @@ export function WebIntegrationSettings({ onLog }: WebIntegrationSettingsProps) {
           <div className="text-xs text-muted-foreground pl-5 space-y-1">
             <p>
               1. Log into{" "}
-              {formBackendUrl.trim() ? (
+              {webAppUrl ? (
                 <a
-                  href={formBackendUrl.trim()}
+                  href={`${webAppUrl}/login`}
                   target="_blank"
                   rel="noreferrer"
                   className="text-primary hover:underline inline-flex items-center gap-1"


### PR DESCRIPTION
## Problem

On the runner's **Settings → Account → Backend Connect** tab, both connect links sent the user to the **API** host, which has no login or `/connect-runner` page:

- **"Or connect with a web login"** opened `https://api.qontinui.io/connect-runner` → **404**
- **"1. Log into qontinui-web"** linked `https://api.qontinui.io` → no login page

Verified against production:

| URL | Status |
|---|---|
| `https://qontinui.io/login` | **200** ✅ |
| `https://qontinui.io/connect-runner` | **200** ✅ |
| `https://api.qontinui.io/login` | **404** |

Root cause: both links derived their target from the **Backend URL** field (`api.qontinui.io`). The code assumed a *unified* deployment where one origin serves both API and web app, but production is **split**: `api.qontinui.io` serves only `/api/v1/*`, while `/login` and `/connect-runner` are served by the web frontend at `qontinui.io`.

## Fix

- `api_config::derive_web_base_url()` (+ a JS mirror `deriveWebAppUrl()`) strips a leading `api.` host label (`api.qontinui.io → qontinui.io`); a **no-op** for localhost / bare-IP / unified origins.
- `start_web_token_flow` now opens `{web}/connect-runner` instead of `{backend}/connect-runner`.
- The "Log into qontinui-web" help link targets `{web}/login`.
- The explicit `web_base_url` override still takes precedence, so split local-dev is unaffected.

## Tests / verification

- 3 new unit tests for `derive_web_base_url` (canonical prod mapping, non-api host preservation, scheme/port preservation) — pass.
- Frontend `tsc --noEmit` — passes.
- Runner bin compiles clean.