### PR TITLE
feat(terminal): ResultCardContext + ResultCardMount scaffolding (PR-A)

### DIFF
--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -29,6 +29,7 @@ import { TerminalOverlays } from "./TerminalOverlays";
 import { CommandBar } from "./CommandBar";
 import { SuggestionsProvider } from "./suggestions";
 import { StatusStrip } from "./StatusStrip";
+import { ResultCardProvider, ResultCardMount } from "./result-card";
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { callRegistry, useTerminalCommands } from "./commands";
@@ -67,7 +68,9 @@ export function TerminalPage(props: TerminalPageProps) {
         <TransitionEffectsProvider>
           <UIStateProvider>
             <SuggestionsProvider>
-              <TerminalPageInner {...props} />
+              <ResultCardProvider>
+                <TerminalPageInner {...props} />
+              </ResultCardProvider>
             </SuggestionsProvider>
           </UIStateProvider>
         </TransitionEffectsProvider>
@@ -893,6 +896,7 @@ function TerminalPageInner({
             page chrome. Reads from the command registry populated by
             `useTerminalCommands` above; Ctrl+/ focuses from anywhere. */}
         <CommandBar />
+        <ResultCardMount />
 
         {/* Phase 9c — TerminalTabBar demolished. ZoneLayoutPicker and
             ZoneProfilePicker carry their own `useUIComponent`

--- a/src/components/terminal/result-card/ResultCardContext.test.ts
+++ b/src/components/terminal/result-card/ResultCardContext.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the result-card surface.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom, no React
+ * Testing Library) — see HoldingLockBanner.test.tsx / useNow1Hz.test.tsx for
+ * the precedent. We CANNOT render the provider, so we:
+ *   1. Tripwire-import `ResultCardProvider`, `useResultCard`,
+ *      `resultCardReducer` so an accidental rename fails here (and so the
+ *      `.tsx` participates in `tsc --noEmit`).
+ *   2. Exercise the EXPORTED pure reducer directly — that's the state machine
+ *      the provider consumes via `useReducer`.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  ResultCardProvider,
+  useResultCard,
+  resultCardReducer,
+  type ResultCardSpec,
+} from "./ResultCardContext";
+
+// Tripwire: importing the provider + hook must succeed. They can't be invoked
+// outside a React render — that's why the reducer below is the unit under test.
+void ResultCardProvider;
+void useResultCard;
+
+describe("result-card surface (tripwire)", () => {
+  it("exports the provider, hook, and reducer by their canonical names", () => {
+    expect(typeof ResultCardProvider).toBe("function");
+    expect(typeof useResultCard).toBe("function");
+    expect(typeof resultCardReducer).toBe("function");
+  });
+});
+
+describe("resultCardReducer", () => {
+  const specA: ResultCardSpec = {
+    title: "Metrics",
+    subtitle: "session a",
+    sections: [{ rows: [{ label: "sessions", value: "3" }] }],
+  };
+  const specB: ResultCardSpec = {
+    title: "Doc",
+    sections: [{ heading: "Files", rows: [{ label: "README.md", value: "ok" }] }],
+  };
+
+  it("'show' from null sets the spec", () => {
+    expect(resultCardReducer(null, { type: "show", spec: specA })).toBe(specA);
+  });
+
+  it("'show' over an existing card replaces it", () => {
+    const next = resultCardReducer(specA, { type: "show", spec: specB });
+    expect(next).toBe(specB);
+    expect(next).not.toBe(specA);
+  });
+
+  it("'dismiss' from a shown card returns null", () => {
+    expect(resultCardReducer(specA, { type: "dismiss" })).toBeNull();
+  });
+
+  it("'dismiss' from null stays null (no-op)", () => {
+    expect(resultCardReducer(null, { type: "dismiss" })).toBeNull();
+  });
+});

--- a/src/components/terminal/result-card/ResultCardContext.tsx
+++ b/src/components/terminal/result-card/ResultCardContext.tsx
@@ -1,0 +1,102 @@
+/**
+ * ResultCardContext
+ *
+ * A result-card surface independent of the CommandBar: a context that owns a
+ * single, optional `ResultCardSpec`. A producer calls `showCard(spec)` to
+ * present a card; `dismissCard()` clears it. The card itself is rendered by
+ * `ResultCardMount` (a separate component) so producers and the mount can both
+ * read the surface.
+ *
+ * State is a pure, EXPORTED reducer (`resultCardReducer`) consumed by the
+ * provider via `useReducer`. The reducer is exported so the runner's
+ * node-environment vitest (no jsdom, no @testing-library/react — see
+ * vitest.config.ts + HoldingLockBanner.test.tsx) can exercise the state
+ * machine without rendering React. Mirrors the provider/createContext +
+ * null-context-guard style of `contexts/ZoneMetadataContext.tsx`.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useReducer,
+  type ReactNode,
+} from "react";
+
+export interface ResultCardSection {
+  heading?: string;
+  rows: { label: string; value: string; valueColor?: string }[];
+}
+
+export interface ResultCardSpec {
+  title: string;
+  subtitle?: string;
+  sections?: ResultCardSection[];
+  body?: React.ReactNode;
+  footer?: { label: string; onClick: () => void | Promise<void> };
+}
+
+export interface ResultCardContextValue {
+  showCard: (spec: ResultCardSpec) => void;
+  dismissCard: () => void;
+  card: ResultCardSpec | null;
+}
+
+export type ResultCardAction = { type: "show"; spec: ResultCardSpec } | { type: "dismiss" };
+
+/**
+ * Pure reducer for the result-card surface.
+ *   - "show"    → action.spec (replaces any current card)
+ *   - "dismiss" → null
+ */
+export function resultCardReducer(
+  state: ResultCardSpec | null,
+  action: ResultCardAction,
+): ResultCardSpec | null {
+  switch (action.type) {
+    case "show":
+      return action.spec;
+    case "dismiss":
+      return null;
+    default:
+      return state;
+  }
+}
+
+export const ResultCardContext = createContext<ResultCardContextValue | null>(null);
+
+interface ResultCardProviderProps {
+  children: ReactNode;
+}
+
+export function ResultCardProvider({ children }: ResultCardProviderProps) {
+  const [card, dispatch] = useReducer(resultCardReducer, null);
+
+  const showCard = useCallback((spec: ResultCardSpec) => {
+    dispatch({ type: "show", spec });
+  }, []);
+
+  const dismissCard = useCallback(() => {
+    dispatch({ type: "dismiss" });
+  }, []);
+
+  const value = useMemo<ResultCardContextValue>(
+    () => ({ showCard, dismissCard, card }),
+    [showCard, dismissCard, card],
+  );
+
+  return <ResultCardContext.Provider value={value}>{children}</ResultCardContext.Provider>;
+}
+
+/**
+ * Read the result-card surface. Throws if used outside `ResultCardProvider`
+ * (mirrors the null-context guard used across the terminal contexts).
+ */
+export function useResultCard(): ResultCardContextValue {
+  const ctx = useContext(ResultCardContext);
+  if (ctx === null) {
+    throw new Error("useResultCard must be used within a ResultCardProvider");
+  }
+  return ctx;
+}

--- a/src/components/terminal/result-card/ResultCardMount.tsx
+++ b/src/components/terminal/result-card/ResultCardMount.tsx
@@ -1,0 +1,123 @@
+/**
+ * ResultCardMount
+ *
+ * Renders the active result card (if any) from `useResultCard()`. Bottom-pinned,
+ * positioned above the CommandBar (`absolute bottom-2 ... z-40 w-[420px]`, see
+ * CommandBar.tsx:421) but below full-screen modals — DocFinderModal is
+ * `fixed inset-0 z-50` (DocFinderModal.tsx:418), so the card uses `z-[45]` to
+ * sit above CommandBar (z-40) yet below the modal (z-50).
+ *
+ * Dark-theme tokens + visual rhythm mirror the popovers in ZoneStatusBar.tsx
+ * (MetricsPopover, ~884-997). Dismiss affordances are self-owned (document
+ * mousedown for outside-click + document keydown for Escape), mirroring the
+ * popover pattern at ZoneStatusBar.tsx:719-726 — deliberately NOT
+ * `useKeyboardShortcuts`.
+ */
+
+import { useEffect, useRef } from "react";
+import { X } from "lucide-react";
+import { useResultCard } from "./ResultCardContext";
+
+export function ResultCardMount() {
+  const { card, dismissCard } = useResultCard();
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  // Outside-click dismiss: any mousedown outside the card ref closes it.
+  useEffect(() => {
+    if (card === null) return;
+    const handler = (e: MouseEvent) => {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+        dismissCard();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [card, dismissCard]);
+
+  // Esc dismiss.
+  useEffect(() => {
+    if (card === null) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        dismissCard();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [card, dismissCard]);
+
+  if (card === null) return null;
+
+  return (
+    <div className="absolute bottom-14 left-1/2 -translate-x-1/2 z-[45] w-[420px]">
+      <div
+        ref={cardRef}
+        data-page-element="result-card"
+        role="dialog"
+        aria-label={card.title}
+        className="bg-[#1a1b26] border border-[#2a2d3d] rounded-lg shadow-xl overflow-hidden"
+      >
+        {/* Header */}
+        <div className="flex items-start gap-2 px-3 py-2 border-b border-[#2a2d3d]">
+          <div className="flex-1 min-w-0">
+            <div className="text-[10px] uppercase tracking-wider text-[#565f89] truncate">
+              {card.title}
+            </div>
+            {card.subtitle && (
+              <div className="text-[11px] text-[#a9b1d6] truncate mt-0.5">{card.subtitle}</div>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={dismissCard}
+            aria-label="Dismiss result card"
+            title="Dismiss"
+            className="text-[#565f89] hover:text-[#a9b1d6] hover:bg-[#2a2d3d]/50 rounded p-0.5 transition-colors shrink-0"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="max-h-[60vh] overflow-y-auto scrollbar-dark p-3 text-[11px] space-y-2">
+          {card.sections?.map((section, si) => (
+            <div key={si} className="space-y-1.5">
+              {section.heading && (
+                <div className="text-[9px] uppercase tracking-wider text-[#565f89] mb-1">
+                  {section.heading}
+                </div>
+              )}
+              {section.rows.map((row, ri) => (
+                <div key={ri} className="flex justify-between gap-3">
+                  <span className="text-[#a9b1d6] truncate">{row.label}</span>
+                  <span
+                    className="font-mono text-right break-all"
+                    style={row.valueColor ? { color: row.valueColor } : { color: "#c0caf5" }}
+                  >
+                    {row.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ))}
+          {card.body}
+        </div>
+
+        {/* Footer */}
+        {card.footer && (
+          <div className="px-3 py-2 border-t border-[#2a2d3d]">
+            <button
+              type="button"
+              onClick={() => {
+                void card.footer?.onClick();
+              }}
+              className="w-full text-[10px] py-1 rounded transition-colors text-[#565f89] hover:text-[#a9b1d6] hover:bg-[#2a2d3d]/50"
+            >
+              {card.footer.label}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/result-card/index.ts
+++ b/src/components/terminal/result-card/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Barrel for the result-card surface.
+ */
+
+export {
+  ResultCardProvider,
+  useResultCard,
+  ResultCardContext,
+  resultCardReducer,
+} from "./ResultCardContext";
+export type {
+  ResultCardSpec,
+  ResultCardSection,
+  ResultCardContextValue,
+  ResultCardAction,
+} from "./ResultCardContext";
+export { ResultCardMount } from "./ResultCardMount";


### PR DESCRIPTION
**Stack 1/3** — base is PR #323 (`chore/doc-finder-and-statusstrip-pills`). PR-B (`/metrics`+`/history`) stacks on this; PR-C (ZSB demolition) stacks on PR-B.

Adds a result-card surface independent of the CommandBar: a context provider owning a single optional `ResultCardSpec` (`showCard` / `dismissCard` / `card`) and a bottom-pinned dismissable `ResultCardMount` dialog.

- State is a pure exported `resultCardReducer` consumed via `useReducer`, so the node-environment vitest (no jsdom) exercises the state machine without rendering.
- Mount: `z-[45]` (above CommandBar `z-40`, below DocFinderModal `z-50`), 420px, `data-page-element="result-card"` + `role=dialog` for UI Bridge snapshot discoverability; self-owned Esc + outside-click dismiss mirroring the ZoneStatusBar popover pattern. Renders `sections` (label/value rows) or a custom `body` node, plus optional footer.

**Idle this PR** — nothing consumes `showCard` yet (+0 user-visible behavior). Provider wraps `TerminalPageInner`; mount sits after `<CommandBar />`.

vitest 5/5 (tripwire + reducer show/replace/dismiss/no-op), tsc clean, eslint 0.

Plan: `qontinui-dev-notes/plans/2026-05-30-commandbar-result-cards-plan.md`.