### PR TITLE
feat(terminal): /metrics + /history result-card actions (PR-B)

### DIFF
--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -29,7 +29,7 @@ import { TerminalOverlays } from "./TerminalOverlays";
 import { CommandBar } from "./CommandBar";
 import { SuggestionsProvider } from "./suggestions";
 import { StatusStrip } from "./StatusStrip";
-import { ResultCardProvider, ResultCardMount } from "./result-card";
+import { ResultCardProvider, ResultCardMount, useResultCard } from "./result-card";
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { callRegistry, useTerminalCommands } from "./commands";
@@ -103,6 +103,10 @@ function TerminalPageInner({
     terminalRefs,
     pendingProfileSessionsRef,
   } = session;
+
+  // Result-card surface — the ResultCardProvider wraps TerminalPageInner
+  // (see line ~71). `/metrics` + `/history` slash actions pop a card here.
+  const { showCard } = useResultCard();
 
   // Register page-level UI Bridge actions so AI agents can discover
   // and invoke terminal operations without knowing element IDs.
@@ -663,6 +667,7 @@ function TerminalPageInner({
     sortZones: handleSortZones,
     exportAll: handleExportOutput,
     openDocFinder: () => setShowDocFinder(true),
+    showCard,
   });
 
   if (!initialized) {

--- a/src/components/terminal/commands/useTerminalCommands.ts
+++ b/src/components/terminal/commands/useTerminalCommands.ts
@@ -38,6 +38,8 @@ import { instanceStorage } from "@/lib/instance-storage";
 
 import { useTerminalSession, useTransitionEffects, useUIStateCx, useZoneMetadata } from "../contexts";
 import type { AccountUsageInfo } from "../useSessionManager";
+import type { ResultCardSpec } from "../result-card";
+import { buildMetricsCardSpec, buildHistoryCardSpec } from "../result-card";
 import type { CommandAction, CommandResult, ResolverContext } from "./types";
 import { useCommandAction } from "./useCommandAction";
 
@@ -94,6 +96,12 @@ export interface TerminalCommandsContext {
    * `showDocFinder` state).
    */
   openDocFinder: () => void;
+  /**
+   * Pop a result card. Threaded in from `TerminalPageInner` (which holds
+   * the `ResultCardProvider`'s `showCard`). Used by `/metrics` and
+   * `/history` to present the ZoneStatusBar popover bodies as a card.
+   */
+  showCard: (spec: ResultCardSpec) => void;
 }
 
 /**
@@ -189,6 +197,9 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
     closeTerminal,
     terminalRefs,
     sessionStates,
+    stateDurations,
+    lastOutputLines,
+    stateTimeAccum: stateTimeAccumRef,
     zoneLayout,
     workflowGen,
     findingsActions,
@@ -196,7 +207,7 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
   } = session;
   const transitionEffects = useTransitionEffects();
   const { dispatch: uiDispatch, toggleFocusMode } = useUIStateCx();
-  const { labelsAndTags } = useZoneMetadata();
+  const { labelsAndTags, metrics: metricsRef, eventHistory } = useZoneMetadata();
 
   /**
    * Helper that converts 1-based zone arg to 0-based, defaulting to
@@ -1001,6 +1012,55 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
     patterns: [/^docs?$/i, /^doc-finder$/i],
     handler: async (): Promise<CommandResult> => {
       ctx.openDocFinder();
+      return ok();
+    },
+  });
+
+  // 34. /metrics — pop the session-metrics result card (same data the
+  // ZoneStatusBar chart-icon MetricsPopover shows).
+  useCommandAction({
+    id: "terminal.metrics",
+    slash: "/metrics",
+    aliases: ["/stats"],
+    label: "Show session metrics",
+    description:
+      "Show session metrics (approvals, rejections, broadcasts, state breakdown, " +
+      "time-in-state, top keywords). Same as the chart icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^(?:metrics|stats)$/i],
+    handler: async (): Promise<CommandResult> => {
+      ctx.showCard(
+        buildMetricsCardSpec({
+          metrics: metricsRef.current,
+          sessionStates,
+          tabs,
+          autoApproveCount: transitionEffects.autoApproveCount ?? 0,
+          autoRestartCount: transitionEffects.autoRestartCount ?? 0,
+          stateTimeAccum: stateTimeAccumRef.current,
+          lastOutputLines,
+          assignments: zoneLayout.assignments,
+          zoneLabels: labelsAndTags.zoneLabels,
+          stateDurations,
+        }),
+      );
+      return ok();
+    },
+  });
+
+  // 35. /history — pop the event-history result card (same data the
+  // ZoneStatusBar clock-icon HistoryPopover shows).
+  useCommandAction({
+    id: "terminal.history",
+    slash: "/history",
+    aliases: ["/events"],
+    label: "Show event history",
+    description:
+      "Show recent event history (state transitions, etc.). " +
+      "Same as the clock icon in ZoneStatusBar.",
+    paramSchema: SCHEMA.empty,
+    patterns: [/^(?:history|events)$/i],
+    handler: async (): Promise<CommandResult> => {
+      ctx.showCard(buildHistoryCardSpec(eventHistory ?? []));
       return ok();
     },
   });

--- a/src/components/terminal/result-card/ResultCardContext.tsx
+++ b/src/components/terminal/result-card/ResultCardContext.tsx
@@ -26,7 +26,7 @@ import {
 
 export interface ResultCardSection {
   heading?: string;
-  rows: { label: string; value: string; valueColor?: string }[];
+  rows: { label: string; value: string; valueColor?: string; labelColor?: string }[];
 }
 
 export interface ResultCardSpec {

--- a/src/components/terminal/result-card/ResultCardMount.tsx
+++ b/src/components/terminal/result-card/ResultCardMount.tsx
@@ -89,7 +89,12 @@ export function ResultCardMount() {
               )}
               {section.rows.map((row, ri) => (
                 <div key={ri} className="flex justify-between gap-3">
-                  <span className="text-[#a9b1d6] truncate">{row.label}</span>
+                  <span
+                    className={row.labelColor ? "truncate" : "text-[#a9b1d6] truncate"}
+                    style={row.labelColor ? { color: row.labelColor } : undefined}
+                  >
+                    {row.label}
+                  </span>
                   <span
                     className="font-mono text-right break-all"
                     style={row.valueColor ? { color: row.valueColor } : { color: "#c0caf5" }}

--- a/src/components/terminal/result-card/builders.test.tsx
+++ b/src/components/terminal/result-card/builders.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Tests for the result-card builders.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom, no React
+ * Testing Library) — see ResultCardContext.test.ts / useNow1Hz.test.tsx. We
+ * therefore test the PURE builder functions only: assert the returned spec's
+ * `title` / `subtitle` / `sections` / footer fields. The `/history` card's
+ * `body` is a React node — we only assert it is truthy, never render it.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { buildMetricsCardSpec, buildHistoryCardSpec } from "./builders";
+import type { BuildMetricsCardInput, HistoryCardEntry } from "./builders";
+import type { SessionState } from "../useZoneLayout";
+import type { TerminalTab } from "../useTerminalManager";
+
+function tab(id: string, title = id): TerminalTab {
+  return { id, title, pid: null } as TerminalTab;
+}
+
+const baseMetrics = {
+  totalApprovals: 5,
+  totalRejections: 2,
+  totalBroadcasts: 1,
+  sessionsCreated: 7,
+};
+
+function baseInput(overrides: Partial<BuildMetricsCardInput> = {}): BuildMetricsCardInput {
+  return {
+    metrics: baseMetrics,
+    sessionStates: {},
+    tabs: [],
+    autoApproveCount: 0,
+    autoRestartCount: 0,
+    ...overrides,
+  };
+}
+
+describe("buildMetricsCardSpec", () => {
+  it("titles the card 'Session Metrics'", () => {
+    expect(buildMetricsCardSpec(baseInput()).title).toBe("Session Metrics");
+  });
+
+  it("first counters row is Sessions created matching metrics.sessionsCreated", () => {
+    const spec = buildMetricsCardSpec(baseInput());
+    const row = spec.sections![0].rows[0];
+    expect(row.label).toBe("Sessions created");
+    expect(row.value).toBe("7");
+    expect(row.labelColor).toBe("#a9b1d6");
+    expect(row.valueColor).toBeUndefined();
+  });
+
+  it("emits the approvals/rejections/broadcasts counters in order", () => {
+    const rows = buildMetricsCardSpec(baseInput()).sections![0].rows;
+    expect(rows.map((r) => [r.label, r.value])).toEqual([
+      ["Sessions created", "7"],
+      ["Approvals sent", "5"],
+      ["Rejections sent", "2"],
+      ["Broadcasts sent", "1"],
+    ]);
+  });
+
+  it("omits Auto-approved / Auto-restarted when counts are 0", () => {
+    const rows = buildMetricsCardSpec(baseInput()).sections![0].rows;
+    expect(rows.find((r) => r.label === "Auto-approved")).toBeUndefined();
+    expect(rows.find((r) => r.label === "Auto-restarted")).toBeUndefined();
+  });
+
+  it("includes Auto-approved / Auto-restarted when counts > 0", () => {
+    const rows = buildMetricsCardSpec(
+      baseInput({ autoApproveCount: 3, autoRestartCount: 4 }),
+    ).sections![0].rows;
+    const auto = rows.filter((r) => r.label.startsWith("Auto-"));
+    expect(auto).toEqual([
+      { label: "Auto-approved", labelColor: "#9ece6a", value: "3" },
+      { label: "Auto-restarted", labelColor: "#7dcfff", value: "4" },
+    ]);
+  });
+
+  it("derives Current state counts from sessionStates + tabs (2 working, 1 error)", () => {
+    const sessionStates: Record<string, SessionState> = {
+      a: "working",
+      b: "working",
+      c: "error",
+      // d has no entry -> defaults to idle (omitted from the section)
+    };
+    const spec = buildMetricsCardSpec(
+      baseInput({
+        sessionStates,
+        tabs: [tab("a"), tab("b"), tab("c"), tab("d")],
+      }),
+    );
+    const current = spec.sections!.find((s) => s.heading === "Current state")!;
+    const byLabel = Object.fromEntries(current.rows.map((r) => [r.label, r.value]));
+    expect(byLabel["Working"]).toBe("2");
+    expect(byLabel["Errored"]).toBe("1");
+    expect(byLabel["Waiting for input"]).toBe("0");
+    expect(byLabel["Idle (done responding)"]).toBe("0");
+    // The standalone "idle" row is intentionally OMITTED (matches ZSB) —
+    // only the four working/needs-input/completed/error rows are present.
+    expect(current.rows).toHaveLength(4);
+    expect(current.rows.find((r) => r.label === "Idle")).toBeUndefined();
+  });
+
+  it("omits Time-in-state when stateTimeAccum is all-zero", () => {
+    const stateTimeAccum: Record<SessionState, number> = {
+      idle: 0,
+      working: 0,
+      "needs-input": 0,
+      completed: 0,
+      error: 0,
+    };
+    const spec = buildMetricsCardSpec(baseInput({ stateTimeAccum }));
+    expect(spec.sections!.find((s) => s.heading === "Time in state")).toBeUndefined();
+  });
+
+  it("includes + formats Time-in-state when working > 1000ms", () => {
+    const stateTimeAccum: Record<SessionState, number> = {
+      idle: 0,
+      working: 65_000, // 1m5s
+      "needs-input": 0,
+      completed: 0,
+      error: 0,
+    };
+    const spec = buildMetricsCardSpec(baseInput({ stateTimeAccum }));
+    const section = spec.sections!.find((s) => s.heading === "Time in state")!;
+    expect(section).toBeDefined();
+    // STATE_LABELS.working === "working"; 65000ms -> "1m5s"
+    expect(section.rows).toEqual([{ label: "working", labelColor: "#7aa2f7", value: "1m5s" }]);
+  });
+
+  it("footer is 'Copy summary as Markdown' when tabs + assignments present", () => {
+    const spec = buildMetricsCardSpec(
+      baseInput({ tabs: [tab("a")], assignments: { 0: "a" } }),
+    );
+    expect(spec.footer?.label).toBe("Copy summary as Markdown");
+  });
+
+  it("footer is undefined when assignments absent", () => {
+    const spec = buildMetricsCardSpec(baseInput({ tabs: [tab("a")] }));
+    expect(spec.footer).toBeUndefined();
+  });
+
+  it("footer is undefined when tabs absent", () => {
+    // tabs defaults to [] (truthy), so explicitly clear assignments to prove
+    // the AND guard; an empty-tabs+assignments still produces a footer.
+    const spec = buildMetricsCardSpec(baseInput({ tabs: [], assignments: undefined }));
+    expect(spec.footer).toBeUndefined();
+  });
+
+  it("Top Keywords section is omitted when there is no output", () => {
+    const spec = buildMetricsCardSpec(baseInput());
+    expect(spec.sections!.find((s) => s.heading === "Top Keywords")).toBeUndefined();
+  });
+
+  it("Top Keywords section is present + sorted when output has repeated words", () => {
+    const lastOutputLines = {
+      a: ["deploy deploy build", "deploy verify"],
+    };
+    const spec = buildMetricsCardSpec(baseInput({ lastOutputLines }));
+    const section = spec.sections!.find((s) => s.heading === "Top Keywords")!;
+    expect(section).toBeDefined();
+    expect(section.rows[0]).toEqual({ label: "deploy", labelColor: "#a9b1d6", value: "3" });
+  });
+});
+
+describe("buildHistoryCardSpec", () => {
+  const entries: HistoryCardEntry[] = [
+    { time: 1_700_000_000_000, type: "spawn", session: "alpha", zone: 0, color: "#7aa2f7" },
+    { time: 1_700_000_060_000, type: "error", session: "beta", color: "#f7768e" },
+  ];
+
+  it("titles the card 'Event History' with the count as subtitle", () => {
+    const spec = buildHistoryCardSpec(entries);
+    expect(spec.title).toBe("Event History");
+    expect(spec.subtitle).toBe("(2)");
+  });
+
+  it("builds a truthy React body node", () => {
+    expect(buildHistoryCardSpec(entries).body).toBeTruthy();
+  });
+
+  it("renders subtitle '(0)' for an empty list and still has a body", () => {
+    const spec = buildHistoryCardSpec([]);
+    expect(spec.subtitle).toBe("(0)");
+    expect(spec.body).toBeTruthy();
+  });
+});

--- a/src/components/terminal/result-card/builders.tsx
+++ b/src/components/terminal/result-card/builders.tsx
@@ -1,0 +1,378 @@
+/**
+ * builders — pure factory functions that turn terminal-page context state
+ * into a `ResultCardSpec`. These reproduce the bodies of the ZoneStatusBar
+ * `MetricsPopover` and `HistoryPopover` (ZoneStatusBar.tsx:685-1081) so the
+ * `/metrics` and `/history` slash actions can pop a result card whose content
+ * matches the popover exactly.
+ *
+ * Test constraint: the runner's vitest runs `environment: "node"` (no jsdom,
+ * no @testing-library/react). These builders are PURE — tests assert the
+ * returned spec's `title` / `subtitle` / `sections` / footer fields. The
+ * `body` React node (used by `/history`) is built but not rendered in tests.
+ *
+ * `STATE_COLORS` / `STATE_LABELS` are LOCAL copies ported verbatim from
+ * ZoneStatusBar.tsx:59-72 — deliberately NOT imported from ZoneStatusBar
+ * because PR-C deletes that file.
+ */
+
+import type { SessionState, ZoneAssignments } from "../useZoneLayout";
+import type { TerminalTab } from "../useTerminalManager";
+import type { ResultCardSpec, ResultCardSection } from "./ResultCardContext";
+
+// Ported verbatim from ZoneStatusBar.tsx:59-72.
+const STATE_COLORS: Record<SessionState, string> = {
+  idle: "#565f89",
+  working: "#7aa2f7",
+  "needs-input": "#e0af68",
+  completed: "#9ece6a",
+  error: "#f7768e",
+};
+
+const STATE_LABELS: Record<SessionState, string> = {
+  idle: "idle",
+  working: "working",
+  "needs-input": "waiting",
+  completed: "done",
+  error: "error",
+};
+
+export interface BuildMetricsCardInput {
+  metrics: {
+    totalApprovals: number;
+    totalRejections: number;
+    totalBroadcasts: number;
+    sessionsCreated: number;
+  };
+  sessionStates: Record<string, SessionState>;
+  tabs: TerminalTab[];
+  autoApproveCount: number;
+  autoRestartCount: number;
+  stateTimeAccum?: Record<SessionState, number>;
+  lastOutputLines?: Record<string, string[]>;
+  assignments?: ZoneAssignments;
+  zoneLabels?: Record<number, string>;
+  stateDurations?: Record<string, string>;
+}
+
+/**
+ * Build the `/metrics` result-card spec. Reproduces MetricsPopover
+ * (ZoneStatusBar.tsx:685-1001) section-for-section.
+ */
+export function buildMetricsCardSpec(input: BuildMetricsCardInput): ResultCardSpec {
+  const {
+    metrics,
+    sessionStates,
+    tabs,
+    autoApproveCount,
+    autoRestartCount,
+    stateTimeAccum,
+    lastOutputLines,
+    assignments,
+    zoneLabels,
+    stateDurations,
+  } = input;
+
+  const sections: ResultCardSection[] = [];
+
+  // ── Counters (no heading; first section) ──────────────────────────────
+  const counterRows: ResultCardSection["rows"] = [
+    { label: "Sessions created", labelColor: "#a9b1d6", value: String(metrics.sessionsCreated) },
+    { label: "Approvals sent", labelColor: "#9ece6a", value: String(metrics.totalApprovals) },
+    { label: "Rejections sent", labelColor: "#f7768e", value: String(metrics.totalRejections) },
+    { label: "Broadcasts sent", labelColor: "#7aa2f7", value: String(metrics.totalBroadcasts) },
+  ];
+  if (autoApproveCount > 0) {
+    counterRows.push({ label: "Auto-approved", labelColor: "#9ece6a", value: String(autoApproveCount) });
+  }
+  if (autoRestartCount > 0) {
+    counterRows.push({ label: "Auto-restarted", labelColor: "#7dcfff", value: String(autoRestartCount) });
+  }
+  sections.push({ rows: counterRows });
+
+  // ── Current state ─────────────────────────────────────────────────────
+  // Replicate the stateCounts useMemo at ZoneStatusBar.tsx:140-154.
+  const stateCounts: Record<SessionState, number> = {
+    idle: 0,
+    working: 0,
+    "needs-input": 0,
+    completed: 0,
+    error: 0,
+  };
+  for (const tab of tabs) {
+    const state = sessionStates[tab.id] ?? "idle";
+    stateCounts[state]++;
+  }
+  // idle row OMITTED, matching ZSB.
+  sections.push({
+    heading: "Current state",
+    rows: [
+      { label: "Working", labelColor: "#a9b1d6", valueColor: "#7aa2f7", value: String(stateCounts.working) },
+      {
+        label: "Waiting for input",
+        labelColor: "#a9b1d6",
+        valueColor: "#e0af68",
+        value: String(stateCounts["needs-input"]),
+      },
+      {
+        label: "Idle (done responding)",
+        labelColor: "#a9b1d6",
+        valueColor: "#9ece6a",
+        value: String(stateCounts.completed),
+      },
+      { label: "Errored", labelColor: "#a9b1d6", valueColor: "#f7768e", value: String(stateCounts.error) },
+    ],
+  });
+
+  // ── Time in state ─────────────────────────────────────────────────────
+  if (stateTimeAccum && (stateTimeAccum.working > 0 || stateTimeAccum["needs-input"] > 0)) {
+    const timeRows: ResultCardSection["rows"] = [];
+    for (const s of ["working", "needs-input", "idle", "completed", "error"] as SessionState[]) {
+      const ms = stateTimeAccum[s];
+      if (ms < 1000) continue;
+      const sec = Math.floor(ms / 1000);
+      const min = Math.floor(sec / 60);
+      const hr = Math.floor(min / 60);
+      const label =
+        hr > 0 ? `${hr}h${min % 60}m` : min > 0 ? `${min}m${sec % 60}s` : `${sec}s`;
+      timeRows.push({ label: STATE_LABELS[s], labelColor: STATE_COLORS[s], value: label });
+    }
+    if (timeRows.length > 0) {
+      sections.push({ heading: "Time in state", rows: timeRows });
+    }
+  }
+
+  // ── Top Keywords ──────────────────────────────────────────────────────
+  // Replicate topKeywords from ZoneStatusBar.tsx:728-843 verbatim.
+  const topKeywords = computeTopKeywords(lastOutputLines);
+  if (topKeywords.length > 0) {
+    sections.push({
+      heading: "Top Keywords",
+      rows: topKeywords.map(([word, count]) => ({
+        label: word,
+        labelColor: "#a9b1d6",
+        value: String(count),
+      })),
+    });
+  }
+
+  const spec: ResultCardSpec = {
+    title: "Session Metrics",
+    sections,
+  };
+
+  // ── Footer: Copy summary as Markdown ──────────────────────────────────
+  // Ports handleCopySummary from ZoneStatusBar.tsx:845-869. Guard: omit the
+  // footer entirely if tabs or assignments are absent.
+  if (tabs && assignments) {
+    spec.footer = {
+      label: "Copy summary as Markdown",
+      onClick: () => {
+        const rows: string[] = [];
+        rows.push("| Zone | Title | State | Duration | Lines | Tags |");
+        rows.push("|------|-------|-------|----------|-------|------|");
+
+        const sortedEntries = Object.entries(assignments)
+          .map(([z, tabId]) => ({ zone: Number(z), tabId }))
+          .sort((a, b) => a.zone - b.zone);
+
+        for (const { zone, tabId } of sortedEntries) {
+          const tab = tabs.find((t) => t.id === tabId);
+          if (!tab) continue;
+          const state = (sessionStates as Record<string, string>)?.[tabId] ?? "idle";
+          const duration = (stateDurations as Record<string, string>)?.[tabId] ?? "-";
+          const lineCount = (lastOutputLines as Record<string, unknown[]>)?.[tabId]?.length ?? 0;
+          const tags = zoneLabels?.[zone] ?? "-";
+          rows.push(
+            `| ${zone + 1} | ${tab.title} | ${state} | ${duration} | ${lineCount} | ${tags} |`,
+          );
+        }
+
+        return navigator.clipboard.writeText(rows.join("\n"));
+      },
+    };
+  }
+
+  return spec;
+}
+
+/**
+ * Compute the top-5 keywords across `lastOutputLines`. Replicates the
+ * `topKeywords` useMemo at ZoneStatusBar.tsx:728-843 verbatim (same stopword
+ * set, the `[^a-z0-9\s]` split, the len>=3 && !stopword && !/^\d+$/ filter,
+ * freq sort desc, `.slice(0, 5)`).
+ */
+function computeTopKeywords(
+  lastOutputLines?: Record<string, string[]>,
+): [string, number][] {
+  if (!lastOutputLines) return [];
+  const stopWords = new Set([
+    "the",
+    "a",
+    "an",
+    "is",
+    "are",
+    "was",
+    "were",
+    "be",
+    "been",
+    "being",
+    "have",
+    "has",
+    "had",
+    "do",
+    "does",
+    "did",
+    "will",
+    "would",
+    "could",
+    "should",
+    "may",
+    "might",
+    "shall",
+    "can",
+    "need",
+    "dare",
+    "ought",
+    "used",
+    "to",
+    "of",
+    "in",
+    "for",
+    "on",
+    "with",
+    "at",
+    "by",
+    "from",
+    "as",
+    "into",
+    "through",
+    "during",
+    "before",
+    "after",
+    "above",
+    "below",
+    "between",
+    "out",
+    "off",
+    "over",
+    "under",
+    "again",
+    "further",
+    "then",
+    "once",
+    "here",
+    "there",
+    "when",
+    "where",
+    "why",
+    "how",
+    "all",
+    "each",
+    "every",
+    "both",
+    "few",
+    "more",
+    "most",
+    "other",
+    "some",
+    "such",
+    "no",
+    "nor",
+    "not",
+    "only",
+    "own",
+    "same",
+    "so",
+    "than",
+    "too",
+    "very",
+    "just",
+    "because",
+    "but",
+    "and",
+    "or",
+    "if",
+    "while",
+    "that",
+    "this",
+    "these",
+    "those",
+    "it",
+    "its",
+  ]);
+
+  const freq: Record<string, number> = {};
+  for (const lines of Object.values(lastOutputLines)) {
+    for (const line of lines) {
+      const words = line
+        .toLowerCase()
+        .replace(/[^a-z0-9\s]/g, " ")
+        .split(/\s+/);
+      for (const w of words) {
+        if (w.length >= 3 && !stopWords.has(w) && !/^\d+$/.test(w)) {
+          freq[w] = (freq[w] ?? 0) + 1;
+        }
+      }
+    }
+  }
+  return Object.entries(freq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+}
+
+export interface HistoryCardEntry {
+  time: number;
+  type: string;
+  session: string;
+  zone?: number;
+  color: string;
+}
+
+/**
+ * Build the `/history` result-card spec. The list body is lifted verbatim
+ * from HistoryPopover (ZoneStatusBar.tsx:1043-1076). The card header already
+ * shows the title + count, so the body need NOT repeat the "Event History (N)"
+ * header bar — just the list.
+ */
+export function buildHistoryCardSpec(entries: HistoryCardEntry[]): ResultCardSpec {
+  const formatTime = (ts: number) => {
+    const d = new Date(ts);
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  };
+
+  const body = (
+    <div className="max-h-64 overflow-y-auto scrollbar-dark">
+      {entries.length === 0 ? (
+        <div className="px-3 py-4 text-center text-[10px] text-[#565f89]">No events yet</div>
+      ) : (
+        [...entries].reverse().map((entry, i) => (
+          <div
+            key={`event-${entry.type}-${i}`}
+            className="flex items-start gap-2 px-3 py-1.5 hover:bg-[#2a2d3d]/30 transition-colors"
+          >
+            <span className="text-[9px] text-[#565f89] font-mono shrink-0 mt-0.5">
+              {formatTime(entry.time)}
+            </span>
+            <div className="flex-1 min-w-0">
+              <span className="text-[10px] font-medium" style={{ color: entry.color }}>
+                {entry.type}
+              </span>
+              <span className="text-[10px] text-[#a9b1d6] ml-1 truncate">{entry.session}</span>
+            </div>
+            {entry.zone !== undefined && (
+              <span className="text-[9px] text-[#565f89] font-mono shrink-0">
+                Z{entry.zone + 1}
+              </span>
+            )}
+          </div>
+        ))
+      )}
+    </div>
+  );
+
+  return {
+    title: "Event History",
+    subtitle: `(${entries.length})`,
+    body,
+  };
+}

--- a/src/components/terminal/result-card/index.ts
+++ b/src/components/terminal/result-card/index.ts
@@ -15,3 +15,5 @@ export type {
   ResultCardAction,
 } from "./ResultCardContext";
 export { ResultCardMount } from "./ResultCardMount";
+export { buildMetricsCardSpec, buildHistoryCardSpec } from "./builders";
+export type { BuildMetricsCardInput, HistoryCardEntry } from "./builders";


### PR DESCRIPTION
**Stack 2/3** — base is PR-A (#326, `feat/result-card-surface`). Review/merge #326 first. PR-C (ZSB demolition) stacks on this.

Wires two registry slash actions that pop a result card via `showCard`:
- `/metrics` (alias `/stats`) — reproduces the ZoneStatusBar `MetricsPopover` body section-for-section: counters, current-state breakdown (idle omitted), conditional time-in-state ladder, conditional top-keywords (full stopword set), and the "Copy summary as Markdown" footer (`handleCopySummary` ported verbatim).
- `/history` (alias `/events`) — reproduces the `HistoryPopover` body: newest-first scrollable event list (HH:MM:SS + colored type + session + `Z{n}` badge), "No events yet" empty state.

Card content is built by pure factories in `result-card/builders.tsx` so the node-env vitest asserts the spec shape without rendering. `stateCounts` is derived locally (replicating the ZSB `useMemo`) since it isn't a context value; `metrics`/`stateTimeAccum` are read as `ref.current` at handler call-time → snapshot-at-`showCard` semantics for free. Threads `showCard` through `TerminalCommandsContext`; widens the `useZoneMetadata` destructure; adds an additive `labelColor?` to the card row type for faithful colored-label parity.

The ZSB popovers stay in place this PR (both surfaces source the same context state).

**On-page verified** (temp runner): both cards pop with content matching the popovers; all 3 dismiss affordances (X / outside-click / Esc) work; real data flows (Sessions created→1, Time-in-state "working 11s"); 0 console errors.

vitest 87/87 (builders 16/16), tsc clean, eslint 0.