### PR TITLE
fix(sessions): close coord session on PTY exit + resume across restarts

### DIFF
--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1181,6 +1181,22 @@ pub async fn spawn_worker_session(
                     coord_session_id = Some(coord_id);
                     if let Some(session) = terminal_manager.get(&info.id) {
                         session.set_coord_session_id(coord_id);
+
+                        // R1 (session-lifecycle-cleanup) — close the coord
+                        // session mirror immediately when the worker PTY
+                        // exits, instead of waiting out the coord_sync 180s
+                        // autoclose. Idempotent with any explicit close.
+                        let close_registry = registry.clone();
+                        session.set_on_exit(Box::new(move |coord_id| {
+                            if let Err(e) = close_registry.close_by_id(coord_id) {
+                                warn!(
+                                    coord_session = %coord_id,
+                                    error = %e,
+                                    "spawn_worker_session exit hook: coord session close failed"
+                                );
+                            }
+                        }));
+
                         let rx = session.subscribe_output();
                         registry.attach_output_pipe(coord_id, rx, true);
                     }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -10,6 +10,7 @@ use tracing::{info, warn};
 use crate::claude_session::SessionManager;
 use crate::commands::CommandResponse;
 use crate::error::AppError;
+use crate::session::pane_store::{PaneKey, PaneSessionStore};
 use crate::session::{Intent, SessionKind, SessionRegistry};
 use crate::terminal::{strip_ansi, TerminalManager};
 
@@ -28,6 +29,7 @@ use crate::terminal::{strip_ansi, TerminalManager};
 pub async fn terminal_create(
     terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
     session_registry: tauri::State<'_, Arc<SessionRegistry>>,
+    pane_store: tauri::State<'_, Arc<PaneSessionStore>>,
     app_handle: tauri::AppHandle,
     title: Option<String>,
     working_dir: Option<String>,
@@ -36,6 +38,20 @@ pub async fn terminal_create(
     rows: Option<u16>,
     intent_repo: Option<String>,
 ) -> Result<CommandResponse, String> {
+    // R2 (session-lifecycle-cleanup) — derive the STABLE pane identity from
+    // the create-time triple the frontend round-trips on restore
+    // (`page_id`, `title`, original `working_dir`). Computed BEFORE
+    // `acquire_for_terminal` reassigns `working_dir` to a freshly-allocated
+    // isolated worktree path (which is NOT stable across restarts) and
+    // before `page_id` is moved into `terminal_manager.create`. Used to
+    // look up / persist this pane's coord session id so a restart RESUMES
+    // the prior coord row instead of orphaning it.
+    let pane_key = PaneKey::from_create(
+        page_id.as_deref().unwrap_or("default"),
+        title.as_deref().unwrap_or(""),
+        working_dir.as_deref().unwrap_or(""),
+    );
+
     // Phase 2 — route through the shared `acquire_for_terminal` helper
     // so this entry point + the HTTP-proxy / backend-relay siblings stay
     // in lockstep. When `intent_repo` is `None`, the helper is a no-op;
@@ -88,23 +104,59 @@ pub async fn terminal_create(
         share_output: true,
         redact_secrets: None,
     };
+    // R2 — RESUME the pane's prior coord session if one is persisted,
+    // otherwise register fresh. Resuming PATCHes the EXISTING coord row
+    // (state=active + heartbeat) so a runner restart no longer orphans the
+    // old row + mints a duplicate. On a persisted-but-GC'd row the resume
+    // falls back to a fresh register (new id), which we persist over the
+    // stale one. Either way the pane ends with a live coord session id.
+    let registry = session_registry.inner().clone();
+    let persisted = pane_store.get(&pane_key);
+    let registration: Result<uuid::Uuid, crate::session::SessionError> = match persisted {
+        Some(prior_id) => registry.resume_external(prior_id, intent).await,
+        None => registry.register_external(intent),
+    };
+
     let mut coord_session_id: Option<uuid::Uuid> = None;
-    match session_registry.inner().register_external(intent) {
+    match registration {
         Ok(coord_id) => {
             coord_session_id = Some(coord_id);
+            // Persist (or refresh) the pane → coord-id mapping so the NEXT
+            // restart resumes this same row. On the fallback path `coord_id`
+            // is a fresh id replacing the stale GC'd one.
+            pane_store.put(&pane_key, coord_id);
+
             // Store the coord session id on the terminal so close can clean up.
             if let Some(session) = terminal_manager.get(&info.id) {
                 session.set_coord_session_id(coord_id);
+
+                // R1 — install the on-exit hook so the PTY waiter thread
+                // closes the coord session mirror the instant the process
+                // exits, instead of leaving a ~3-minute ghost until the
+                // coord_sync 180s autoclose. Shares the idempotent
+                // `close_by_id` path with the frontend `terminal_close`
+                // command, so a double-close (exit + explicit close) is a
+                // no-op.
+                let close_registry = registry.clone();
+                session.set_on_exit(Box::new(move |coord_id| {
+                    if let Err(e) = close_registry.close_by_id(coord_id) {
+                        warn!(
+                            coord_session = %coord_id,
+                            error = %e,
+                            "terminal exit hook: coord session close failed"
+                        );
+                    }
+                }));
+
                 // Attach the output pipe so PTY output streams to coord.
                 let rx = session.subscribe_output();
-                session_registry
-                    .inner()
-                    .attach_output_pipe(coord_id, rx, true);
+                registry.attach_output_pipe(coord_id, rx, true);
             }
             info!(
                 terminal_id = %info.id,
                 coord_session = %coord_id,
-                "terminal_create: registered coord session"
+                resumed = persisted.is_some(),
+                "terminal_create: coord session ready"
             );
         }
         Err(e) => {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1848,6 +1848,34 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     coord_sync_facade.clone(),
                 );
                 coord_sync_facade.attach_registry(&registry);
+
+                // R2 (session-lifecycle-cleanup) — pane → coord-session-id
+                // store, so a restored terminal pane RESUMES its prior coord
+                // session instead of orphaning the row + minting a duplicate.
+                // Co-located with the session outbox under `.qontinui/runner`.
+                let pane_store_path = dirs::home_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    .join(".qontinui")
+                    .join("runner")
+                    .join("pane-sessions.json");
+                let pane_store = std::sync::Arc::new(
+                    match session::pane_store::PaneSessionStore::open(&pane_store_path) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                path = %pane_store_path.display(),
+                                "session: pane store open failed — using ephemeral fallback"
+                            );
+                            let fallback = std::env::temp_dir()
+                                .join("qontinui-runner-pane-sessions.json");
+                            session::pane_store::PaneSessionStore::open(&fallback)
+                                .expect("session: ephemeral pane store open failed")
+                        }
+                    },
+                );
+                app.manage(pane_store);
+
                 // Plan §Phase 3/7/10 — start the coord-sync background loops
                 // (drain, heartbeat, Phase 7 handoff receiver, Phase 10
                 // cutover-flag poll). `.setup()` runs synchronously with no

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -350,6 +350,54 @@ impl CoordSync {
         self.inner.dual_write.enabled()
     }
 
+    /// R2 (session-lifecycle-cleanup) — probe coord to decide whether a
+    /// persisted session id can be RESUMED (PATCH) or must be re-registered
+    /// fresh (POST). Issues `PATCH /sessions/:id` with
+    /// `{state:"active", heartbeat:true}` — the same body the drain loop's
+    /// `state_change` push sends, so a successful probe also re-activates +
+    /// heartbeats the row (the resume is effectively done coord-side on a
+    /// 2xx). Coord already supports `state` + `heartbeat` on
+    /// `UpdateSessionRequest`, so **no coord-side change is required**.
+    ///
+    /// Maps the response to a coarse [`ResumeProbe`]:
+    /// - 2xx → [`ResumeProbe::Found`] (row exists, now re-activated)
+    /// - 404 / 410 → [`ResumeProbe::NotFound`] (GC'd or never existed)
+    /// - everything else (network, timeout, 5xx, other 4xx) →
+    ///   [`ResumeProbe::Unreachable`] (treat as transient; caller resumes
+    ///   optimistically and the drain loop retries).
+    ///
+    /// Called by [`SessionRegistry::resume_external`].
+    pub async fn probe_resume(&self, session_id: Uuid) -> ResumeProbe {
+        let base = self.inner.coord_url.trim_end_matches('/');
+        let url = format!("{base}/sessions/{session_id}");
+        let body = json!({ "state": SessionState::Active.as_str(), "heartbeat": true });
+        match self.inner.http.patch(&url).json(&body).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    ResumeProbe::Found
+                } else if status == StatusCode::NOT_FOUND || status == StatusCode::GONE {
+                    ResumeProbe::NotFound
+                } else {
+                    tracing::debug!(
+                        session = %session_id,
+                        %status,
+                        "coord_sync: resume probe got non-2xx/non-404 — treating as unreachable"
+                    );
+                    ResumeProbe::Unreachable
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    session = %session_id,
+                    error = %e,
+                    "coord_sync: resume probe transport error — treating as unreachable"
+                );
+                ResumeProbe::Unreachable
+            }
+        }
+    }
+
     /// Test-only: force the cutover gate to a given value, simulating
     /// what the poll loop does when a tenant flips the flag.
     #[cfg(test)]
@@ -424,6 +472,26 @@ impl CoordSync {
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Resume probe outcome (R2)
+// ---------------------------------------------------------------------------
+
+/// Coarse outcome of [`CoordSync::probe_resume`], driving
+/// [`super::SessionRegistry::resume_external`]'s PATCH-vs-fresh-POST
+/// decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResumeProbe {
+    /// The coord row exists and was re-activated by the probe PATCH.
+    Found,
+    /// Coord returned 404/410 — the row was GC'd or never existed. The
+    /// caller registers a fresh session.
+    NotFound,
+    /// Coord was unreachable / returned a transient error. The caller
+    /// resumes optimistically under the persisted id; the drain loop
+    /// retries.
+    Unreachable,
 }
 
 // ---------------------------------------------------------------------------
@@ -1002,6 +1070,9 @@ mod tests {
         next_post_conflict: bool,
         /// When >0, the next N POSTs return 500.
         next_post_5xx: usize,
+        /// When true, every PATCH returns 404 (simulates a GC'd / missing
+        /// coord row — drives the R2 resume 404-fallback path).
+        patch_returns_404: bool,
     }
 
     impl CoordRecorder {
@@ -1054,7 +1125,15 @@ mod tests {
                     |AxumState(state): AxumState<Arc<TokMutex<CoordRecorder>>>,
                      AxumPath(id): AxumPath<Uuid>,
                      Json(body): Json<JsonValue>| async move {
-                        state.lock().await.patches.push((id, body.clone()));
+                        let mut g = state.lock().await;
+                        g.patches.push((id, body.clone()));
+                        if g.patch_returns_404 {
+                            return (
+                                AxumStatus::NOT_FOUND,
+                                Json(json!({"error": "session not found"})),
+                            )
+                                .into_response();
+                        }
                         (AxumStatus::OK, Json(json!({"id": id}))).into_response()
                     },
                 )
@@ -1495,5 +1574,200 @@ mod tests {
         std::env::set_var(var, "not-a-number");
         assert_eq!(env_u64(var, 42), 42);
         std::env::remove_var(var);
+    }
+
+    // -----------------------------------------------------------------
+    // R2 — probe_resume + resume_external (PATCH-vs-POST + 404 fallback)
+    // -----------------------------------------------------------------
+
+    /// `probe_resume` against an existing row returns `Found` and the
+    /// probe itself issues the re-activating PATCH (state=active +
+    /// heartbeat).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_resume_found_emits_activating_patch() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let (base, rec) = spawn_fake_coord().await;
+        let coord = CoordSync::new_for_test(
+            outbox,
+            base,
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let id = Uuid::new_v4();
+        let probe = coord.probe_resume(id).await;
+        assert_eq!(probe, ResumeProbe::Found);
+        let g = rec.lock().await;
+        assert_eq!(g.patches.len(), 1, "probe issues exactly one PATCH");
+        let (patched_id, body) = &g.patches[0];
+        assert_eq!(*patched_id, id);
+        assert_eq!(body["state"], "active");
+        assert_eq!(body["heartbeat"], true);
+    }
+
+    /// `probe_resume` maps a 404 to `NotFound` (drives the fresh-register
+    /// fallback).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_resume_404_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let (base, rec) = spawn_fake_coord().await;
+        rec.lock().await.patch_returns_404 = true;
+        let coord = CoordSync::new_for_test(
+            outbox,
+            base,
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let probe = coord.probe_resume(Uuid::new_v4()).await;
+        assert_eq!(probe, ResumeProbe::NotFound);
+    }
+
+    /// `probe_resume` maps an unreachable coord (connection refused) to
+    /// `Unreachable` (drives the optimistic-resume path).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn probe_resume_transport_error_is_unreachable() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        // Port 1 is reserved/unbindable — connection refused.
+        let coord = CoordSync::new_for_test(
+            outbox,
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let probe = coord.probe_resume(Uuid::new_v4()).await;
+        assert_eq!(probe, ResumeProbe::Unreachable);
+    }
+
+    /// `resume_external` on an existing row REUSES the persisted id (no new
+    /// id, no `Started` POST) and emits a `state_change` outbox row.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_external_reuses_id_when_row_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let (base, _rec) = spawn_fake_coord().await;
+        let coord = CoordSync::new_for_test(
+            outbox.clone(),
+            base,
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let registry = build_registry(coord.clone());
+
+        let persisted = Uuid::new_v4();
+        let resumed = registry
+            .resume_external(persisted, make_test_intent())
+            .await
+            .unwrap();
+        assert_eq!(resumed, persisted, "resume must reuse the persisted id");
+
+        // The in-memory mirror exists under the persisted id.
+        let desc = registry.describe_by_id(persisted).unwrap();
+        assert_eq!(desc.state, SessionState::Active);
+        assert_eq!(desc.transport_handle_kind, "external");
+
+        // A state_change (NOT started) row is queued for the drain loop.
+        let pending = outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].event_kind,
+            SessionEventKind::StateChange.as_str()
+        );
+        assert_eq!(pending[0].session_id, persisted);
+    }
+
+    /// `resume_external` on a GC'd row (PATCH 404) falls back to a fresh
+    /// `register_external`: a NEW id + a `Started` POST row.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_external_falls_back_to_fresh_on_404() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let (base, rec) = spawn_fake_coord().await;
+        rec.lock().await.patch_returns_404 = true;
+        let coord = CoordSync::new_for_test(
+            outbox.clone(),
+            base,
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let registry = build_registry(coord.clone());
+
+        let persisted = Uuid::new_v4();
+        let fresh = registry
+            .resume_external(persisted, make_test_intent())
+            .await
+            .unwrap();
+        assert_ne!(fresh, persisted, "404 fallback mints a NEW id");
+
+        // The fresh id has a mirror; the stale persisted id does not.
+        assert!(registry.describe_by_id(fresh).is_ok());
+        assert!(registry.describe_by_id(persisted).is_err());
+
+        // A `started` row (fresh register), keyed by the new id.
+        let pending = outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].event_kind, SessionEventKind::Started.as_str());
+        assert_eq!(pending[0].session_id, fresh);
+    }
+
+    /// `resume_external` against an unreachable coord resumes optimistically
+    /// under the persisted id (idempotent reconnect; a fresh POST would
+    /// fail identically while coord is down).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_external_optimistic_when_unreachable() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let coord = CoordSync::new_for_test(
+            outbox.clone(),
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let registry = build_registry(coord.clone());
+
+        let persisted = Uuid::new_v4();
+        let resumed = registry
+            .resume_external(persisted, make_test_intent())
+            .await
+            .unwrap();
+        assert_eq!(resumed, persisted);
+        assert!(registry.describe_by_id(persisted).is_ok());
+        // Still emits a state_change for the drain loop to retry.
+        let pending = outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(
+            pending[0].event_kind,
+            SessionEventKind::StateChange.as_str()
+        );
+    }
+
+    /// `resume_external` rejects an invalid intent up front (before any
+    /// network probe).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resume_external_rejects_invalid_intent() {
+        let dir = tempfile::tempdir().unwrap();
+        let outbox = build_outbox(dir.path());
+        let coord = CoordSync::new_for_test(
+            outbox,
+            "http://127.0.0.1:1".to_string(),
+            Duration::from_millis(50),
+            Duration::from_secs(10),
+            Duration::from_secs(60),
+        );
+        let registry = build_registry(coord.clone());
+        let mut intent = make_test_intent();
+        intent.purpose = "x".into();
+        let err = registry
+            .resume_external(Uuid::new_v4(), intent)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, crate::session::SessionError::Intent(_)));
     }
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -62,6 +62,7 @@ pub mod handoff;
 pub mod intent;
 pub mod local_store;
 pub mod output_pipe;
+pub mod pane_store;
 pub mod transport;
 
 use std::collections::HashMap;
@@ -73,6 +74,7 @@ use serde_json::{json, Value as JsonValue};
 use thiserror::Error;
 use uuid::Uuid;
 
+pub use coord_sync::ResumeProbe;
 pub use intent::{Intent, IntentError};
 pub use transport::{DynTransport, ExternalTransport, Transport, TransportError, TransportHandle};
 
@@ -521,6 +523,135 @@ impl SessionRegistry {
         sessions.insert(id, record);
 
         Ok(id)
+    }
+
+    /// R2 (session-lifecycle-cleanup) — RESUME a previously-registered
+    /// external session by its persisted coord id instead of minting a
+    /// fresh one. Used on runner restart when a restored terminal pane has
+    /// a coord session id persisted in
+    /// [`crate::session::pane_store::PaneSessionStore`].
+    ///
+    /// ## Why this exists
+    ///
+    /// [`Self::register_external`] always allocates a new `uuid_v7`, so a
+    /// pane that re-launches across restarts orphans its old `coord.sessions`
+    /// row and accumulates duplicates. Resuming re-activates the EXISTING
+    /// row via a PATCH (`state=active` + `heartbeat`) — coord already
+    /// supports both on `UpdateSessionRequest`, so **no coord-side change
+    /// is required**.
+    ///
+    /// ## PATCH-vs-fresh decision + 404 fallback
+    ///
+    /// We probe coord synchronously with `PATCH /sessions/:id`
+    /// `{state:"active", heartbeat:true}`:
+    ///
+    /// - **2xx** → the row exists; re-insert the in-memory [`SessionRecord`]
+    ///   under `persisted_id`, emit a `StateChange` outbox row (so the drain
+    ///   loop keeps coord fresh and the local state is consistent), and
+    ///   return `persisted_id`. The session id is unchanged across the
+    ///   restart — no duplicate.
+    /// - **404 / 410** → the row was GC'd (or never existed). Fall back to a
+    ///   fresh [`Self::register_external`] (new id, `Started` POST) so the
+    ///   pane is never left without a coord session, and return the NEW id.
+    ///   The caller persists the new id over the stale one.
+    /// - **transport error / 5xx** (coord temporarily unreachable) → resume
+    ///   OPTIMISTICALLY: re-insert under `persisted_id` and emit a
+    ///   `StateChange` row. The drain loop retries the PATCH on reconnect;
+    ///   if the row turns out to be gone, the next heartbeat PATCH 404s and
+    ///   the row is treated as permanently-failed locally (the dashboard
+    ///   simply won't show it until the operator re-launches). A fresh POST
+    ///   here would fail identically while coord is down, so re-using the
+    ///   persisted id is the strictly-better choice (idempotent reconnect).
+    ///
+    /// Returns the coord session id the pane should now persist (either the
+    /// resumed `persisted_id` or the fresh fallback id).
+    pub async fn resume_external(
+        self: &Arc<Self>,
+        persisted_id: Uuid,
+        intent: Intent,
+    ) -> Result<Uuid, SessionError> {
+        intent.validate()?;
+
+        let probe = self.coord_sync.probe_resume(persisted_id).await;
+
+        match probe {
+            ResumeProbe::Found => {
+                self.insert_resumed_record(persisted_id, intent);
+                tracing::info!(
+                    session = %persisted_id,
+                    "session: resumed existing coord session (PATCH 2xx)"
+                );
+                Ok(persisted_id)
+            }
+            ResumeProbe::NotFound => {
+                tracing::info!(
+                    session = %persisted_id,
+                    "session: persisted coord session gone (404) — registering fresh"
+                );
+                self.register_external(intent)
+            }
+            ResumeProbe::Unreachable => {
+                // Optimistic resume — coord is down, not the row. Re-use the
+                // persisted id so reconnect is idempotent.
+                self.insert_resumed_record(persisted_id, intent);
+                tracing::warn!(
+                    session = %persisted_id,
+                    "session: coord unreachable during resume — resuming optimistically, drain loop will retry"
+                );
+                Ok(persisted_id)
+            }
+        }
+    }
+
+    /// Re-insert the in-memory mirror record for a resumed session under the
+    /// persisted id, and emit a `StateChange` (→ PATCH `state=active`) so
+    /// the drain loop reconciles coord. Mirrors [`Self::register_external`]'s
+    /// record shape but reuses `persisted_id` and emits `StateChange`
+    /// instead of `Started`.
+    fn insert_resumed_record(self: &Arc<Self>, persisted_id: Uuid, intent: Intent) {
+        let now = chrono::Utc::now();
+        let claude_code_session_id = ambient_claude_code_session_id();
+        let transport: DynTransport = Arc::new(transport::ExternalTransport);
+
+        let record = SessionRecord {
+            id: persisted_id,
+            kind: intent.kind,
+            state: SessionState::Active,
+            intent: intent.clone(),
+            started_at: now,
+            last_heartbeat_at: Some(now),
+            closed_at: None,
+            parent_session_id: None,
+            claude_code_session_id,
+            transport,
+            transport_handle: TransportHandle::External,
+            output_pipe: None,
+        };
+
+        // Emit a state_change → PATCH so the drain loop re-activates the row
+        // (state=active + heartbeat). state_change_body always stamps
+        // heartbeat:true, refreshing last_heartbeat_at coord-side.
+        let payload = json!({
+            "id": persisted_id,
+            "state": SessionState::Active.as_str(),
+            "repo": intent.repo,
+            "branch": intent.branch,
+        });
+        if let Err(e) = self.coord_sync.outbox().record(
+            self.machine_id,
+            persisted_id,
+            SessionEventKind::StateChange,
+            payload,
+        ) {
+            tracing::warn!(
+                session = %persisted_id,
+                error = %e,
+                "session: resume state_change outbox write failed"
+            );
+        }
+
+        let mut sessions = self.sessions.lock().expect("session registry poisoned");
+        sessions.insert(persisted_id, record);
     }
 
     fn with_record<R>(

--- a/src-tauri/src/session/pane_store.rs
+++ b/src-tauri/src/session/pane_store.rs
@@ -1,0 +1,277 @@
+//! Pane → coord-session-id persistence (R2, session-lifecycle-cleanup).
+//!
+//! ## Problem
+//!
+//! Every runner restart re-creates terminal panes, and the legacy
+//! `terminal_create` → [`crate::session::SessionRegistry::register_external`]
+//! path mints a **fresh** `uuid_v7` per pane each time. The old coord
+//! `coord.sessions` rows orphan and accumulate — the dashboard fills with
+//! duplicate "Terminal shell session" rows, one per (restart × pane).
+//!
+//! ## Fix
+//!
+//! Persist each pane's coord session id keyed by a **stable pane identity**
+//! and, on restore, RESUME the prior coord session (PATCH `state=active` +
+//! heartbeat) instead of POSTing a brand-new row. See
+//! [`crate::session::SessionRegistry::resume_external`].
+//!
+//! ## Stable pane identity
+//!
+//! The runner's terminal panes are NOT persisted backend-side — the
+//! frontend (`components/terminal/useSessionPersistence.ts`) saves each
+//! tab's `{title, workingDir, zoneIndex, …}` into `localStorage` and, on
+//! restore, re-invokes `terminal_create` with the same `title` / `pageId`
+//! / `workingDir`. The terminal `id` is a fresh `uuid_v4` each launch, so
+//! it is NOT stable. The stable triple available at the `terminal_create`
+//! boundary — and the one the frontend round-trips verbatim on restore —
+//! is `(page_id, title, working_dir)`. We derive a deterministic
+//! [`PaneKey`] from it so a restored pane maps back to its prior coord id.
+//!
+//! Collisions: two panes with the identical `(page_id, title, working_dir)`
+//! triple are genuinely indistinguishable to the operator and to coord's
+//! intent; mapping them to the same resumed row is the desired behavior
+//! (one logical "Terminal 1 in workspace X" session), not a bug.
+//!
+//! ## Storage
+//!
+//! Mirrors the [`crate::session::local_store`] precedent: a single JSON
+//! file at `<.qontinui>/runner/pane-sessions.json` (an object map
+//! `pane_key -> uuid`), rewritten atomically via temp-file + rename. The
+//! map is tiny (one entry per live pane), so we read+rewrite the whole
+//! file per mutation rather than appending.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use tracing::warn;
+use uuid::Uuid;
+
+/// Deterministic, stable-across-restart identity for a terminal pane,
+/// derived from the `(page_id, title, working_dir)` triple the frontend
+/// round-trips through its `localStorage` layout on restore.
+///
+/// Stored as the JSON object key in the pane-session map. We use a
+/// delimiter that cannot appear in a normalized field (`\u{1f}`, unit
+/// separator) so distinct triples never alias.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PaneKey(String);
+
+impl PaneKey {
+    /// Build a key from the create-time triple. `None` fields normalize to
+    /// the empty string so a pane created with `working_dir: None` maps to
+    /// the same key on restore (the frontend persists `workingDir` and
+    /// replays it, but tolerate the absent case).
+    pub fn from_create(page_id: &str, title: &str, working_dir: &str) -> Self {
+        // Unit separator (0x1F) — not a legal char in any of these fields
+        // as the operator would type them, so the join is unambiguous.
+        const SEP: char = '\u{1f}';
+        PaneKey(format!(
+            "{}{SEP}{}{SEP}{}",
+            page_id.trim(),
+            title.trim(),
+            working_dir.trim()
+        ))
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Append-/rewrite-style JSON map persisting `PaneKey -> coord session id`.
+///
+/// Cheap to clone-share via `Arc`; all mutations take the internal lock and
+/// rewrite the backing file atomically. Resilient to a missing / corrupt
+/// file (treated as empty — a fresh map is the safe default, the resume
+/// path falls back to a fresh register).
+#[derive(Debug)]
+pub struct PaneSessionStore {
+    path: PathBuf,
+    map: Mutex<HashMap<String, Uuid>>,
+}
+
+impl PaneSessionStore {
+    /// Open (or initialize) the store at `path`, loading any existing map.
+    pub fn open(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let map = load_map(&path);
+        Ok(Self {
+            path,
+            map: Mutex::new(map),
+        })
+    }
+
+    /// Look up the persisted coord session id for a pane, if any.
+    pub fn get(&self, key: &PaneKey) -> Option<Uuid> {
+        self.map
+            .lock()
+            .ok()
+            .and_then(|m| m.get(key.as_str()).copied())
+    }
+
+    /// Persist (or overwrite) the coord session id for a pane and flush to
+    /// disk. Best-effort: a write failure is logged, not propagated — the
+    /// in-memory map still reflects the mapping for this process's lifetime.
+    pub fn put(&self, key: &PaneKey, id: Uuid) {
+        let snapshot = {
+            let mut m = match self.map.lock() {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(error = %e, "pane_store: map lock poisoned on put");
+                    return;
+                }
+            };
+            m.insert(key.as_str().to_string(), id);
+            m.clone()
+        };
+        if let Err(e) = write_map(&self.path, &snapshot) {
+            warn!(
+                error = %e,
+                path = %self.path.display(),
+                "pane_store: persist failed — mapping kept in memory only"
+            );
+        }
+    }
+
+    /// Drop a pane's mapping (e.g. when its coord row was GC'd and the
+    /// resume fell back to a fresh id — the fresh id is `put` over the top,
+    /// so explicit removal is only needed if a caller wants to forget a
+    /// pane entirely). Best-effort flush.
+    #[allow(dead_code)]
+    pub fn remove(&self, key: &PaneKey) {
+        let snapshot = {
+            let mut m = match self.map.lock() {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(error = %e, "pane_store: map lock poisoned on remove");
+                    return;
+                }
+            };
+            m.remove(key.as_str());
+            m.clone()
+        };
+        if let Err(e) = write_map(&self.path, &snapshot) {
+            warn!(error = %e, "pane_store: persist failed on remove");
+        }
+    }
+}
+
+fn load_map(path: &Path) -> HashMap<String, Uuid> {
+    if !path.exists() {
+        return HashMap::new();
+    }
+    match std::fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice::<HashMap<String, Uuid>>(&bytes) {
+            Ok(m) => m,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "pane_store: corrupt map file — starting empty (resume falls back to fresh register)"
+                );
+                HashMap::new()
+            }
+        },
+        Err(e) => {
+            warn!(error = %e, "pane_store: read failed — starting empty");
+            HashMap::new()
+        }
+    }
+}
+
+fn write_map(path: &Path, map: &HashMap<String, Uuid>) -> std::io::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(map).map_err(std::io::Error::other)?;
+    std::fs::write(&tmp, &bytes)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn pane_key_is_stable_for_same_triple() {
+        let a = PaneKey::from_create("default", "Terminal 1", "C:/repo");
+        let b = PaneKey::from_create("default", "Terminal 1", "C:/repo");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn pane_key_trims_and_differs_on_distinct_triples() {
+        let a = PaneKey::from_create(" default ", " Terminal 1 ", " C:/repo ");
+        let b = PaneKey::from_create("default", "Terminal 1", "C:/repo");
+        assert_eq!(a, b, "leading/trailing whitespace must not change identity");
+
+        let c = PaneKey::from_create("page-2", "Terminal 1", "C:/repo");
+        assert_ne!(a, c, "distinct page_id → distinct pane");
+
+        // Field-boundary aliasing guard: "a|b" + "c" must not equal "a" + "b|c".
+        let x = PaneKey::from_create("a", "b", "c");
+        let y = PaneKey::from_create("ab", "", "c");
+        assert_ne!(x, y);
+    }
+
+    #[test]
+    fn put_get_round_trips_and_persists() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("pane-sessions.json");
+        let key = PaneKey::from_create("default", "Terminal 1", "C:/repo");
+        let id = Uuid::new_v4();
+
+        {
+            let store = PaneSessionStore::open(&path).unwrap();
+            assert!(store.get(&key).is_none());
+            store.put(&key, id);
+            assert_eq!(store.get(&key), Some(id));
+        }
+
+        // Reopen — the mapping survives a "restart".
+        let store = PaneSessionStore::open(&path).unwrap();
+        assert_eq!(store.get(&key), Some(id));
+    }
+
+    #[test]
+    fn put_overwrites_prior_id() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("pane-sessions.json");
+        let store = PaneSessionStore::open(&path).unwrap();
+        let key = PaneKey::from_create("default", "Terminal 1", "");
+        let id1 = Uuid::new_v4();
+        let id2 = Uuid::new_v4();
+        store.put(&key, id1);
+        store.put(&key, id2);
+        assert_eq!(store.get(&key), Some(id2));
+    }
+
+    #[test]
+    fn remove_forgets_mapping() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("pane-sessions.json");
+        let store = PaneSessionStore::open(&path).unwrap();
+        let key = PaneKey::from_create("default", "T", "");
+        store.put(&key, Uuid::new_v4());
+        store.remove(&key);
+        assert!(store.get(&key).is_none());
+    }
+
+    #[test]
+    fn corrupt_file_starts_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("pane-sessions.json");
+        std::fs::write(&path, b"{not valid json").unwrap();
+        let store = PaneSessionStore::open(&path).unwrap();
+        let key = PaneKey::from_create("default", "T", "");
+        assert!(store.get(&key).is_none());
+        // Still usable after recovery.
+        let id = Uuid::new_v4();
+        store.put(&key, id);
+        assert_eq!(store.get(&key), Some(id));
+    }
+}

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -140,6 +140,18 @@ pub struct TerminalSession {
     /// terminal into the coordinator's session plane. `None` until wired;
     /// read by `terminal_close` so it can close the coord mirror.
     coord_session_id: Arc<Mutex<Option<uuid::Uuid>>>,
+    /// R1 (session-lifecycle-cleanup) — best-effort hook invoked by the
+    /// waiter thread the instant the backing PTY process exits, BEFORE the
+    /// 180s coord_sync autoclose would otherwise fire. Wired by
+    /// `terminal_create` alongside [`Self::set_coord_session_id`]: it
+    /// closes the coord session mirror for `coord_session_id` so a process
+    /// that dies (operator types `exit`, shell crashes, etc.) doesn't leave
+    /// a ~3-minute ghost `active` row on the dashboard. Held in a shared
+    /// slot so the already-spawned waiter thread can read it once the
+    /// registration completes; cloned into the waiter at spawn time.
+    /// Idempotent against the frontend `terminal_close` path because
+    /// `SessionRegistry::close` is itself idempotent.
+    on_exit: Arc<Mutex<Option<Box<dyn Fn(uuid::Uuid) + Send + Sync>>>>,
     /// Phase 2 of `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md`.
     /// When the session declared edit intent on a registered repo and
     /// `worktree_mode_enabled()` was true at spawn time, this carries
@@ -391,12 +403,24 @@ impl TerminalSession {
             })
             .map_err(|e| format!("Failed to spawn reader thread: {}", e))?;
 
+        // R1 — shared slots the waiter thread reads on PTY exit so it can
+        // close the coord session mirror immediately (vs. waiting out the
+        // 180s coord_sync autoclose). Both are populated AFTER spawn by
+        // `terminal_create` once `register_external` returns the coord id,
+        // so the waiter reads them at exit time rather than capturing a
+        // value that isn't known yet at spawn.
+        let coord_session_id: Arc<Mutex<Option<uuid::Uuid>>> = Arc::new(Mutex::new(None));
+        let on_exit: Arc<Mutex<Option<Box<dyn Fn(uuid::Uuid) + Send + Sync>>>> =
+            Arc::new(Mutex::new(None));
+
         // Spawn waiter thread: detects process exit
         let waiter_id = id.clone();
         let waiter_title = title.clone();
         let waiter_alive = is_alive.clone();
         let waiter_exit = exit_code.clone();
         let waiter_app = app_handle;
+        let waiter_coord_session_id = coord_session_id.clone();
+        let waiter_on_exit = on_exit.clone();
         let waiter_handle = thread::Builder::new()
             .name(format!("terminal-waiter-{}", &id))
             .spawn(move || {
@@ -454,6 +478,34 @@ impl TerminalSession {
                     &waiter_title,
                     code,
                 );
+
+                // R1 — close the coord session mirror the instant the PTY
+                // process exits, instead of letting it linger `active`
+                // until the coord_sync heartbeat loop's 180s autoclose
+                // fires (~3-minute ghost session). Read the coord id + hook
+                // populated by `terminal_create` after registration; if the
+                // terminal was never wired into coord (registration failed,
+                // or close raced ahead via the frontend `terminal_close`
+                // path which clears nothing here but is idempotent on the
+                // registry side), there's simply nothing to do. The hook
+                // calls `SessionRegistry::close_by_id`, which is idempotent
+                // — a no-op when the session is already Closed.
+                let coord_id = waiter_coord_session_id
+                    .lock()
+                    .ok()
+                    .and_then(|slot| *slot);
+                if let Some(coord_id) = coord_id {
+                    if let Ok(slot) = waiter_on_exit.lock() {
+                        if let Some(cb) = slot.as_ref() {
+                            debug!(
+                                terminal_id = %waiter_id,
+                                coord_session = %coord_id,
+                                "terminal exit — closing coord session mirror"
+                            );
+                            cb(coord_id);
+                        }
+                    }
+                }
             })
             .map_err(|e| format!("Failed to spawn waiter thread: {}", e))?;
 
@@ -483,7 +535,8 @@ impl TerminalSession {
             grid,
             first_osc_title_tx,
             first_osc_title_rx,
-            coord_session_id: Arc::new(Mutex::new(None)),
+            coord_session_id,
+            on_exit,
             isolated_edit_ctx: Arc::new(Mutex::new(None)),
         })
     }
@@ -740,6 +793,19 @@ impl TerminalSession {
         self.coord_session_id.lock().ok().and_then(|g| *g)
     }
 
+    /// R1 — install the on-exit hook the waiter thread fires the instant
+    /// the PTY process exits. `terminal_create` wires this (alongside
+    /// [`Self::set_coord_session_id`]) to close the coord session mirror
+    /// immediately rather than waiting out the 180s coord_sync autoclose.
+    /// The callback receives the coord session id and must be idempotent
+    /// (it shares the close path with the frontend `terminal_close`
+    /// command — `SessionRegistry::close_by_id` is already idempotent).
+    pub fn set_on_exit(&self, hook: Box<dyn Fn(uuid::Uuid) + Send + Sync>) {
+        if let Ok(mut slot) = self.on_exit.lock() {
+            *slot = Some(hook);
+        }
+    }
+
     /// Phase 2 of the worktree-isolation plan — park the
     /// `IsolatedEditContext` returned by
     /// `agent_worktree::isolated_edit::acquire` so its heartbeat task
@@ -945,6 +1011,7 @@ mod tests {
             first_osc_title_tx: Arc::new(Mutex::new(Some(osc_title_tx))),
             first_osc_title_rx: Arc::new(Mutex::new(Some(osc_title_rx))),
             coord_session_id: Arc::new(Mutex::new(None)),
+            on_exit: Arc::new(Mutex::new(None)),
             isolated_edit_ctx: Arc::new(Mutex::new(None)),
         }
     }


### PR DESCRIPTION
## What

Two runner-side fixes for the `coord.sessions` lifecycle, surfaced on `qontinui.io/sessions` 2026-05-30 (a single machine showed dozens of stale/closed duplicate `terminal_shell` rows, ~3-min ghost lifetimes, and no live session).

- **R1 — close on PTY exit.** The terminal `waiter_thread` now fires an injected `on_exit` hook that closes the pane's coord session mirror (`close_by_id`) the instant the backing process exits, instead of leaving it `active` until the coord_sync 180s auto-close (the ~192s median ghost lifetime). Idempotent with the frontend `terminal_close` path. Applied to both `commands/terminal.rs` and the worker-session path in `commands/productivity.rs`.
- **R2 — resume across restarts.** Each pane's coord session id is persisted (`~/.qontinui/runner/pane-sessions.json`) keyed by a stable `(page_id, title, working_dir)` identity. On restart `terminal_create` **resumes** the prior session via `PATCH /sessions/:id {state:active, heartbeat:true}` instead of minting a new `uuid_v7`, so a restart no longer orphans the old row + accumulates a duplicate. Falls back to a fresh register on a 404 (GC'd row) or stays optimistic when coord is unreachable. No coord-side change required. Ephemeral worker sessions get R1 but not R2 (a restart kills the worker — resuming makes no sense).

## Tests

- `cargo test -p qontinui-runner --bin qontinui-runner "session::"` → **138 passed**.
- New `coord_sync` resume tests (PATCH-vs-POST, 404 fallback, unreachable) + `pane_store` tests (key stability, persistence, corrupt-file recovery).
- `cargo check -p qontinui-runner` clean (full binary incl. `generate_context!`).

## Known follow-up (minor)

Resuming a `closed`-but-not-yet-GC'd row reactivates it without clearing `closed_at`. Invisible to the dashboard (renders by `state` + `last_heartbeat_at`); a future coord change could clear `closed_at` on any `→active` transition.
