### PR TITLE
chore(specs): terminal — sync IR + projection, drop dead states, add 2 new

### DIFF
--- a/scripts/generate-all-specs.ps1
+++ b/scripts/generate-all-specs.ps1
@@ -5,11 +5,12 @@
 # Usage: powershell -File scripts/generate-all-specs.ps1 [-MaxMinutes 40]
 
 param(
-    [int]$MaxMinutes = 40
+    [int]$MaxMinutes = 40,
+    [int]$Port = 9876
 )
 
-$BASE = "http://localhost:9876/ui-bridge"
-$RUNNER_API = "http://localhost:9876"
+$BASE = "http://localhost:$Port/ui-bridge"
+$RUNNER_API = "http://localhost:$Port"
 $SPEC_DIR = "$env:APPDATA\com.qontinui.runner\user-specs"
 $logFile = "$PSScriptRoot\spec-gen.log"
 $UTF8_NO_BOM = New-Object System.Text.UTF8Encoding $false  # WriteAllText default adds BOM; Rust serde_json rejects BOM

--- a/specs/pages/terminal/spec.uibridge.json
+++ b/specs/pages/terminal/spec.uibridge.json
@@ -6,67 +6,15 @@
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 0 for state Multi-Tab Terminal Sessions",
-          "enabled": true,
-          "id": "term-multi-tab-elem-0",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "ai-generated",
-          "target": {
-            "criteria": {
-              "role": "tablist"
-            },
-            "label": "Required element for Multi-Tab Terminal Sessions",
-            "type": "search"
-          }
-        },
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 1 for state Multi-Tab Terminal Sessions",
-          "enabled": true,
-          "id": "term-multi-tab-elem-1",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "ai-generated",
-          "target": {
-            "criteria": {
-              "role": "button",
-              "textContent": "+"
-            },
-            "label": "Required element for Multi-Tab Terminal Sessions",
-            "type": "search"
-          }
-        },
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 2 for state Multi-Tab Terminal Sessions",
-          "enabled": true,
-          "id": "term-multi-tab-elem-2",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "ai-generated",
-          "target": {
-            "criteria": {
-              "textContent": "No terminals open"
-            },
-            "label": "Required element for Multi-Tab Terminal Sessions",
-            "type": "search"
-          }
-        },
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
           "description": "Required element 3 for state Multi-Tab Terminal Sessions",
           "enabled": true,
           "id": "term-multi-tab-elem-3",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
-              "textContent": "Ctrl+Shift+T"
+              "text": "Ctrl+Shift+T"
             },
             "label": "Required element for Multi-Tab Terminal Sessions",
             "type": "search"
@@ -89,10 +37,10 @@
           "id": "term-workflow-preview-elem-0",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
-              "textContent": "Workflow"
+              "text": "Workflow"
             },
             "label": "Required element for Workflow Generation and Preview",
             "type": "search"
@@ -106,11 +54,11 @@
           "id": "term-workflow-preview-elem-1",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Execute"
+              "text": "Execute"
             },
             "label": "Required element for Workflow Generation and Preview",
             "type": "search"
@@ -124,11 +72,11 @@
           "id": "term-workflow-preview-elem-2",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Save"
+              "text": "Save"
             },
             "label": "Required element for Workflow Generation and Preview",
             "type": "search"
@@ -142,11 +90,11 @@
           "id": "term-workflow-preview-elem-3",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Edit"
+              "text": "Edit"
             },
             "label": "Required element for Workflow Generation and Preview",
             "type": "search"
@@ -169,10 +117,10 @@
           "id": "term-findings-tracking-elem-0",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
-              "textContent": "Findings"
+              "text": "Findings"
             },
             "label": "Required element for Real-Time Findings Detection",
             "type": "search"
@@ -186,11 +134,11 @@
           "id": "term-findings-tracking-elem-1",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Fix"
+              "text": "Fix"
             },
             "label": "Required element for Real-Time Findings Detection",
             "type": "search"
@@ -204,11 +152,11 @@
           "id": "term-findings-tracking-elem-2",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Generate Workflow"
+              "text": "Generate Workflow"
             },
             "label": "Required element for Real-Time Findings Detection",
             "type": "search"
@@ -222,11 +170,11 @@
           "id": "term-findings-tracking-elem-3",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Respond"
+              "text": "Respond"
             },
             "label": "Required element for Real-Time Findings Detection",
             "type": "search"
@@ -249,10 +197,10 @@
           "id": "term-analysis-elem-0",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
-              "textContent": "Architecture"
+              "text": "Architecture"
             },
             "label": "Required element for AI-Powered Terminal Analysis",
             "type": "search"
@@ -266,10 +214,10 @@
           "id": "term-analysis-elem-1",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
-              "textContent": "Summary"
+              "text": "Summary"
             },
             "label": "Required element for AI-Powered Terminal Analysis",
             "type": "search"
@@ -283,10 +231,10 @@
           "id": "term-analysis-elem-2",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
-              "textContent": "Analyzing"
+              "text": "Analyzing"
             },
             "label": "Required element for AI-Powered Terminal Analysis",
             "type": "search"
@@ -307,10 +255,9 @@
           "description": "Required element 0 for state File Conflict Detection Banner",
           "enabled": true,
           "id": "term-file-conflict-banner-elem-0",
-          "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "under concurrent"
@@ -325,10 +272,9 @@
           "description": "Required element 1 for state File Conflict Detection Banner",
           "enabled": true,
           "id": "term-file-conflict-banner-elem-1",
-          "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "under concurrent development"
@@ -343,10 +289,9 @@
           "description": "Required element 2 for state File Conflict Detection Banner",
           "enabled": true,
           "id": "term-file-conflict-banner-elem-2",
-          "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "under concurrent development"
@@ -361,10 +306,9 @@
           "description": "Required element 3 for state File Conflict Detection Banner",
           "enabled": true,
           "id": "term-file-conflict-banner-elem-3",
-          "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "Conflict:"
@@ -379,10 +323,9 @@
           "description": "Required element 4 for state File Conflict Detection Banner",
           "enabled": true,
           "id": "term-file-conflict-banner-elem-4",
-          "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "under concurrent"
@@ -406,10 +349,9 @@
           "description": "Required element 0 for state Per-Session File Conflict Indicators",
           "enabled": true,
           "id": "term-session-conflict-indicator-elem-0",
-          "precondition": "At least one session has files overlapping with another session in the file registry",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "shared with other sessions"
@@ -424,10 +366,9 @@
           "description": "Required element 1 for state Per-Session File Conflict Indicators",
           "enabled": true,
           "id": "term-session-conflict-indicator-elem-1",
-          "precondition": "At least one session has files overlapping with another session in the file registry",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "shared with other sessions"
@@ -442,10 +383,9 @@
           "description": "Required element 2 for state Per-Session File Conflict Indicators",
           "enabled": true,
           "id": "term-session-conflict-indicator-elem-2",
-          "precondition": "At least one session has files overlapping with another session in the file registry",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "shared with other sessions"
@@ -460,10 +400,9 @@
           "description": "Required element 3 for state Per-Session File Conflict Indicators",
           "enabled": true,
           "id": "term-session-conflict-indicator-elem-3",
-          "precondition": "At least one session has files overlapping with another session in the file registry",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "shared with other sessions"
@@ -487,10 +426,9 @@
           "description": "Required element 0 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-0",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "tab"
@@ -505,10 +443,9 @@
           "description": "Required element 1 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-1",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "accessibleName": "Add terminal page",
@@ -524,10 +461,9 @@
           "description": "Required element 2 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-2",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "tab"
@@ -542,10 +478,9 @@
           "description": "Required element 3 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-3",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "tab"
@@ -560,10 +495,9 @@
           "description": "Required element 4 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-4",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "accessibleName": "Close page"
@@ -578,10 +512,9 @@
           "description": "Required element 5 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-5",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "tab"
@@ -596,10 +529,9 @@
           "description": "Required element 6 for state Multiple Terminal Pages",
           "enabled": true,
           "id": "term-multi-page-elem-6",
-          "precondition": "At least two pages exist with different numbers of terminals",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "Loading terminals"
@@ -623,10 +555,9 @@
           "description": "Required element 0 for state Session Persistence & Auto-Resume",
           "enabled": true,
           "id": "term-session-persistence-elem-0",
-          "precondition": "Runner was restarted after Claude sessions were running in terminal zones",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "textbox"
@@ -641,10 +572,9 @@
           "description": "Required element 1 for state Session Persistence & Auto-Resume",
           "enabled": true,
           "id": "term-session-persistence-elem-1",
-          "precondition": "Runner was restarted after Claude sessions were running in terminal zones",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "Zone"
@@ -659,30 +589,13 @@
           "description": "Required element 2 for state Session Persistence & Auto-Resume",
           "enabled": true,
           "id": "term-session-persistence-elem-2",
-          "precondition": "Runner was restarted after Claude sessions were running in terminal zones",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "accessibleName": "Zone profiles"
             },
-            "label": "Required element for Session Persistence & Auto-Resume",
-            "type": "search"
-          }
-        },
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 3 for state Session Persistence & Auto-Resume",
-          "enabled": true,
-          "id": "term-session-persistence-elem-3",
-          "precondition": "Runner was restarted after Claude sessions were running in terminal zones",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "ai-generated",
-          "target": {
-            "criteria": {},
             "label": "Required element for Session Persistence & Auto-Resume",
             "type": "search"
           }
@@ -702,10 +615,9 @@
           "description": "Required element 0 for state Per-Page Storage Isolation",
           "enabled": true,
           "id": "term-page-storage-isolation-elem-0",
-          "precondition": "Multiple pages exist, at least one has saved profiles",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "accessibleName": "Zone profiles"
@@ -720,10 +632,9 @@
           "description": "Required element 1 for state Per-Page Storage Isolation",
           "enabled": true,
           "id": "term-page-storage-isolation-elem-1",
-          "precondition": "Multiple pages exist, at least one has saved profiles",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "tab"
@@ -738,10 +649,9 @@
           "description": "Required element 2 for state Per-Page Storage Isolation",
           "enabled": true,
           "id": "term-page-storage-isolation-elem-2",
-          "precondition": "Multiple pages exist, at least one has saved profiles",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "tab"
@@ -765,14 +675,13 @@
           "description": "Required element 0 for state Plan Implementation Workflow",
           "enabled": true,
           "id": "term-plan-implementation-elem-0",
-          "precondition": "Transcript panel is open with messages selected",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Implement"
+              "text": "Implement"
             },
             "label": "Required element for Plan Implementation Workflow",
             "type": "search"
@@ -784,14 +693,13 @@
           "description": "Required element 1 for state Plan Implementation Workflow",
           "enabled": true,
           "id": "term-plan-implementation-elem-1",
-          "precondition": "Transcript panel is open with messages selected",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Verify"
+              "text": "Verify"
             },
             "label": "Required element for Plan Implementation Workflow",
             "type": "search"
@@ -803,14 +711,13 @@
           "description": "Required element 2 for state Plan Implementation Workflow",
           "enabled": true,
           "id": "term-plan-implementation-elem-2",
-          "precondition": "Transcript panel is open with messages selected",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Implement"
+              "text": "Implement"
             },
             "label": "Required element for Plan Implementation Workflow",
             "type": "search"
@@ -822,14 +729,13 @@
           "description": "Required element 3 for state Plan Implementation Workflow",
           "enabled": true,
           "id": "term-plan-implementation-elem-3",
-          "precondition": "Transcript panel is open with messages selected",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "role": "button",
-              "textContent": "Verify"
+              "text": "Verify"
             },
             "label": "Required element for Plan Implementation Workflow",
             "type": "search"
@@ -841,10 +747,9 @@
           "description": "Required element 4 for state Plan Implementation Workflow",
           "enabled": true,
           "id": "term-plan-implementation-elem-4",
-          "precondition": "Transcript panel is open with messages selected",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "Plan Implementation"
@@ -859,10 +764,9 @@
           "description": "Required element 5 for state Plan Implementation Workflow",
           "enabled": true,
           "id": "term-plan-implementation-elem-5",
-          "precondition": "Transcript panel is open with messages selected",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "accessibleName": "Reload plan file from disk"
@@ -888,7 +792,7 @@
           "id": "term-plan-cli-script-elem-0",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "Parsed"
@@ -905,7 +809,7 @@
           "id": "term-plan-cli-script-elem-1",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "execute-inline"
@@ -922,7 +826,7 @@
           "id": "term-plan-cli-script-elem-2",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "textContains": "follow"
@@ -946,10 +850,9 @@
           "description": "Required element 0 for state Per-Tab Commit Traffic Light",
           "enabled": true,
           "id": "term-commit-traffic-light-elem-0",
-          "precondition": "At least one terminal tab has an active Claude Code AI session (tab.claudeSessionId is populated, either from a resumed session or the post-spawn transcript_get_latest polling)",
           "reviewed": false,
           "severity": "critical",
-          "source": "ai-generated",
+          "source": "migrated",
           "target": {
             "criteria": {
               "accessibleName": "Commit progress",
@@ -971,24 +874,23 @@
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 0 for state Lock-Yield Protocol Banners",
+          "description": "WaitingLockBanner UI Bridge component renders when a tab is waiting on a contended file lock.",
           "enabled": true,
           "id": "term-lock-yield-banners-elem-0",
-          "precondition": "At least two active AI sessions contend on the same file: one holds an exclusive lock via FileLockManager, another is blocked on `acquire()`. Verifiable via GET /file-locks/info returning at least one entry whose holder_task_run_id corresponds to a live tab, while another tab's lockState.kind === 'waiting' on the same file_path.",
           "reviewed": false,
           "severity": "critical",
           "source": "ai-generated",
           "target": {
             "criteria": {
-              "dataUiBridgeId": "terminal.waiting-lock-banner"
+              "id": "terminal.waiting-lock-banner"
             },
-            "label": "Required element for Lock-Yield Protocol Banners",
+            "label": "WaitingLockBanner component",
             "type": "search"
           }
         }
       ],
       "category": "element-presence",
-      "description": "When two AI sessions contend on the same file, the holder and the waiter each see an in-tab banner driven by `<HoldingLockBanner>` (qontinui-runner/src/components/terminal/HoldingLockBanner.tsx) and `<WaitingLockBanner>` (qontinui-runner/src/components/terminal/WaitingLockBanner.tsx). The banners share placement: absolutely-positioned `top-2 right-2 z-30 w-[340px]` overlays inside the active tab's pane. They are gated to active AI tabs only (per `proj_holding_banner_pty_gate.md` — PTY tabs without `claudeSessionId` never render either banner). Banner mounting is driven by `useFileLockTracking` (qontinui-runner/src/components/terminal/useFileLockTracking.ts) exposing `lockStates: Record<tabId, LockState>` and `pendingYieldRequests: Record<holderTabId, IncomingYieldRequest[]>`. HoldingLockBanner shows above the active tab's pane when `lockState.kind === 'holding'` AND (`waiterCount > 0` OR pending yield requests exist for this tab). Its three buttons are `terminal.holding-lock-banner-yield` (calls POST `/file-locks/yield` to release this lock without ending the session), `terminal.holding-lock-banner-hold` (dismisses the banner locally until the next waiter event), and `terminal.holding-lock-banner-signal-long-wait` (Stuck-Session Heartbeat surface — see `term-heartbeat-idle-status`). WaitingLockBanner shows above the active tab's pane when `lockState.kind === 'waiting'` and exposes one primary action `terminal.waiting-lock-banner-request-yield` (POST `/file-locks/yield-request`). After click, the button enters a 30-second cooldown matching `REQUEST_YIELD_COOLDOWN_MS` (re-exported from `@/lib/lock-yield` for consumer tripwires) — local state, not server-tracked, reload resets it. Disabled state: when `blockerTaskRunId` is undefined the parent couldn't resolve the holder session by name, so there's nothing to route the request to and the button is disabled with a guidance tooltip. Backend wiring lives in `qontinui-runner/src-tauri/src/mcp/file_registry.rs::yield_lock` and `::request_yield` (registered in `routes()` at `/file-locks/yield` and `/file-locks/yield-request` POST). Both emit via the dual-emit pattern: `state.app_handle.emit(name, &payload)` for the Tauri webview AND `state.app_state.event_broadcast.send(payload)` for SSE/headless consumers, matching the dispatcher's wait emit at `claude_session/dispatcher.rs:436-441`. The yield endpoint emits `file-lock-released` (same shape used by session.rs, ai_session.rs, graphql/mutation.rs, task_runs.rs). The yield-request endpoint emits `file-lock-yield-requested` `{type, file_path, requester_task_run_id, requester_name, holder_task_run_id, requested_at}` which `useFileLockTracking`'s third listener routes to the holder's tab by matching `tab.claudeSessionId === payload.holder_task_run_id` (via `findTabByTaskRunId`). The pending-yield list is deduped by `(requesterTaskRunId, filePath)` so a holder doesn't see N entries from spam clicks. Entries clear automatically on `file-lock-released` for the matching `(holder_task_run_id, file_path)` pair. Banner-side 1Hz seconds-tick uses `useNow1Hz` (see `term-heartbeat-idle-status`).",
+      "description": "When two AI sessions contend on the same file, the holder and the waiter each see an in-tab banner (`HoldingLockBanner` / `WaitingLockBanner`, terminal/HoldingLockBanner.tsx + terminal/WaitingLockBanner.tsx). Mounted only on active AI tabs with an active lock conflict. Exposes the lock-yield/request-yield/signal-long-wait actions via `terminal.holding-lock-banner-*` and `terminal.waiting-lock-banner-*` UI Bridge components.",
       "id": "term-lock-yield-banners",
       "name": "Lock-Yield Protocol Banners",
       "source": "ai-generated"
@@ -998,51 +900,23 @@
         {
           "assertionType": "exists",
           "category": "element-presence",
-          "description": "Required element 0 for state Deconflict Advisory Banner",
-          "enabled": true,
-          "id": "term-deconflict-advisory-banner-elem-0",
-          "precondition": "At least one unresolved `coord.coordinator_decisions` row exists where `rule = 'deconflict'`, `target_id` equals the active tab's `claudeSessionId`, and `resolved = false`. Verifiable via GET `/coordinator/decisions?rule=deconflict` returning a row whose `targetId` matches the active tab.",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "ai-generated",
-          "target": {
-            "criteria": {
-              "dataUiBridgeId": "terminal.deconflict-advisory-banner"
-            },
-            "label": "Required element for Deconflict Advisory Banner",
-            "type": "search"
-          }
-        }
-      ],
-      "category": "element-presence",
-      "description": "When the Rust deconflicter loop (qontinui-runner/src-tauri/src/coordinator/deconflicter.rs, started from `main.rs::setup` via `tauri::async_runtime::spawn`) detects that another live AI session has recently touched the same file the active session is editing, it inserts a `coord.coordinator_decisions` row `{session_id: 'deconflicter-rust', rule: 'deconflict', action: 'advise-with-text', target_id: <touching session's task_run_id>, reasoning: <one-line advisory text>}` and emits a `coordinator-decision-created` Tauri event with the same payload. The active tab subscribes via `<DeconflictAdvisoryBanner>` (qontinui-runner/src/components/terminal/DeconflictAdvisoryBanner.tsx), mounted in TerminalPage.tsx as a sibling of `<HoldingLockBanner>`/`<WaitingLockBanner>` inside the existing `claudeSessionId`-gated section. The banner gates on `props.taskRunId === active tab's claudeSessionId` AND `decision.target_id === taskRunId` AND `decision.session_id.startsWith('deconflicter-')` AND `decision.resolved === false`. PTY-only tabs without `claudeSessionId` never render the banner. Banner placement matches the lock-yield surface (absolutely-positioned overlay inside the active tab's pane); each unresolved deconflict advisory renders one row carrying `data-ui-bridge-id=\"terminal.deconflict-advisory-banner\"` and `data-advisory-decision-id=<decision.id>`. The Dismiss action invokes the pre-existing `resolve_escalation` Tauri command (commands/productivity.rs:294) with `{decisionId, resolution: 'dismissed'}`, which flips `resolved=true, resolution='dismissed'` on the row via `PgDb::resolve_coordinator_decision`. Emergent-task rows underpin the cross-session conflict signal: every AI session gets a `coord.tasks` row with `origin='session_emergent'` so the deconflicter's SQL (`JOIN coord.tasks t ON t.assigned_session_id = stf.task_run_id WHERE stf.recorded_at > now() - interval '15 minutes' AND t.status IN ('in_progress','assigned','running')`) can find the other live session. Worker-spawn writes emergent rows at `commands/productivity.rs:1084`; user-launched AI sessions write them at `commands/ai_session.rs:368` (create_ai_session) and the resume-from-log loop at `:1309`. Touch events flow `auto_register_file` (dispatcher.rs) → `broadcast::Sender<TouchEvent>` in `AppState.touch_events_tx` → the deconflicter loop's receiver. The loop deduplicates `(session, path)` pairs for 5 minutes to keep noise low and is restricted by `must_advise_only` (coordinator/act.rs:61-72) to `AdviseWithText` actions only: any other action attempted with a `session_id` starting `deconflicter-` is rejected at `/coordinator/act` with HTTP 403 \"deconflicter restricted to advisory actions.\"",
-      "id": "term-deconflict-advisory-banner",
-      "name": "Deconflict Advisory Banner",
-      "source": "ai-generated"
-    },
-    {
-      "assertions": [
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 0 for state Stuck-Session Heartbeat",
+          "description": "Waiter-side holder-idle marker renders when waiting on a contended lock with idle-status telemetry.",
           "enabled": true,
           "id": "term-heartbeat-idle-status-elem-0",
-          "precondition": "At least two active AI sessions contend on the same file: one holds an exclusive lock via FileLockManager, another is blocked on `acquire()`. Verifiable via GET /file-locks/info returning at least one entry whose holder_task_run_id corresponds to a live tab, while another tab's lockState.kind === 'waiting' on the same file_path.",
           "reviewed": false,
           "severity": "critical",
           "source": "ai-generated",
           "target": {
             "criteria": {
-              "dataUiBridgeId": "terminal.waiting-lock-banner-holder-idle"
+              "id": "terminal.waiting-lock-banner-holder-idle"
             },
-            "label": "Required element for Stuck-Session Heartbeat",
+            "label": "WaitingLockBanner holder-idle marker",
             "type": "search"
           }
         }
       ],
       "category": "element-presence",
-      "description": "On top of the Lock-Yield Protocol surface, the terminal page exposes live idle telemetry so a waiter can tell whether the holder is busy or sitting in Ready, and the holder can broadcast 'I'll be a while' to current waiters. Backend: `GET /sessions/idle-status` (registered in `qontinui-runner/src-tauri/src/mcp/ai_session.rs::routes()` as `/sessions/idle-status`) returns `[{task_run_id, holder_name, last_activity_ms, idle_ms}]` for every registered Claude Code session. The handler iterates `SessionManager::snapshot()` (returns `Vec<(task_run_id, holder_name, Arc<AtomicU64>)>` triples without holding the manager lock during reads), reads each session's `last_activity_tracker().load(Ordering::Relaxed)` atomic (epoch seconds, written by `last_activity_stdout.store(now, Ordering::Relaxed)` on every stdout line in `claude_session/session.rs`), converts to ms at the response boundary, and computes `idle_ms = now_ms.saturating_sub(last_activity_ms)` (saturating to 0 on future-skew). `holder_name` is cached on `ClaudeSession` at spawn from the same source as the file-lock dispatcher (`session_ctx.session_name` for workflow sessions, `session_id` as the terminal fallback) so the response joins by-name with `file-lock-*` events. POST `/file-locks/signal-long-wait` (registered alongside the yield routes in `mcp/file_registry.rs::routes()`) accepts `{file_path, holder_task_run_id, holder_name, estimated_remaining_ms?: number}` and returns `{signaled: true}`. It dual-emits `file-lock-long-wait-signaled` `{type, file_path, holder_task_run_id, holder_name, estimated_remaining_ms, signaled_at}` to the Tauri webview AND the broadcast channel, mirroring the yield-request shape. Frontend: `<Now1HzProvider>` (qontinui-runner/src/components/terminal/useNow1Hz.tsx) mounts at the runner-app root inside `<PromptExecutionProvider>` in `AppWithTutorials` and broadcasts `Date.now()` once per second via React context. Every consumer of `useNow1Hz()` subscribes to the shared interval; a private per-component fallback fires only when no provider is in the tree (test isolation). Pre-existing component-local 1Hz tickers in `HoldingLockBanner`, `WaitingLockBanner`, and `productivity/FileActivityPanel` were collapsed onto the singleton. Tab-icon tooltips use the native HTML `title` attribute — the next hover sees fresh text but the OS-rendered popup does NOT refresh its visible text while open; the banner-side seconds-tick (real JSX) ticks fully live. `formatSince(sinceMs, nowMs)` (helper in `TerminalTabBar.tsx`) takes both arguments explicitly — promoted from a single-arg `Date.now()`-internal variant to match the established `formatBannerSeconds` pattern. `useFileLockTracking`'s 10s `/file-locks/info` poll now runs in parallel with `/sessions/idle-status` via `Promise.allSettled`; the join indexes idle entries by `holder_name` (waiters know the holder's friendly name from `file-lock-waiting`'s `blocked_by`, not its task_run_id) and attaches `holderIdleMs: number | undefined` to each waiting `LockState`. Idle-fetch failure is silent — `holderIdleMs` stays undefined; the lock-info loop is unaffected. WaitingLockBanner renders an inline `(holder idle Xm)` suffix (subdued via `text-[#a9b1d6]/70`, `data-ui-bridge-id=\"terminal.waiting-lock-banner-holder-idle\"`) inside the headline when `holderIdleMs > HOLDER_IDLE_DISPLAY_THRESHOLD_MS` (60_000 — exported for tripwire tests). `file-lock-long-wait-signaled` is consumed by `useFileLockTracking`'s fourth listener: it routes the signal to every waiter tab whose `lockState.kind === 'waiting' && lockState.filePath === payload.file_path`, deduping per `(holder_task_run_id, file_path)` and clearing on `file-lock-released` (for the file) or `file-lock-acquired` (for that waiter tab). Waiting tabs whose `pendingLongWaitSignals[tab.id]` has entries render an advisory `\"<strong>B</strong> says they'll be a while.\"` line below the main headline, plus `(~Xm)` when the holder included an estimate. The HoldingLockBanner's `terminal.holding-lock-banner-signal-long-wait` button (previously disabled) is enabled and POSTs to the new endpoint on click; the button enters a 30s cooldown using `SIGNAL_LONG_WAIT_COOLDOWN_MS` (exported constant) with the same UX as the waiter's yield-request cooldown.",
+      "description": "On top of the Lock-Yield Protocol surface, the terminal page exposes live idle telemetry so waiters can tell whether the holder is busy or sitting at Ready. Backend: `GET /sessions/idle-status`. Frontend: `Now1HzProvider` + a `terminal.waiting-lock-banner-holder-idle` UI Bridge marker on the waiter side showing the holder's last_activity_ms / idle_ms.",
       "id": "term-heartbeat-idle-status",
       "name": "Stuck-Session Heartbeat",
       "source": "ai-generated"
@@ -1237,8 +1111,7 @@
           },
           {
             "accessibleName": "Zone profiles"
-          },
-          {}
+          }
         ],
         "id": "term-session-persistence",
         "isInitial": false,
@@ -1326,10 +1199,10 @@
         "transitions": []
       },
       {
-        "description": "When two AI sessions contend on the same file, the holder and the waiter each see an in-tab banner driven by `<HoldingLockBanner>` (qontinui-runner/src/components/terminal/HoldingLockBanner.tsx) and `<WaitingLockBanner>` (qontinui-runner/src/components/terminal/WaitingLockBanner.tsx). The banners share placement: absolutely-positioned `top-2 right-2 z-30 w-[340px]` overlays inside the active tab's pane. They are gated to active AI tabs only (per `proj_holding_banner_pty_gate.md` — PTY tabs without `claudeSessionId` never render either banner). Banner mounting is driven by `useFileLockTracking` (qontinui-runner/src/components/terminal/useFileLockTracking.ts) exposing `lockStates: Record<tabId, LockState>` and `pendingYieldRequests: Record<holderTabId, IncomingYieldRequest[]>`. HoldingLockBanner shows above the active tab's pane when `lockState.kind === 'holding'` AND (`waiterCount > 0` OR pending yield requests exist for this tab). Its three buttons are `terminal.holding-lock-banner-yield` (calls POST `/file-locks/yield` to release this lock without ending the session), `terminal.holding-lock-banner-hold` (dismisses the banner locally until the next waiter event), and `terminal.holding-lock-banner-signal-long-wait` (Stuck-Session Heartbeat surface — see `term-heartbeat-idle-status`). WaitingLockBanner shows above the active tab's pane when `lockState.kind === 'waiting'` and exposes one primary action `terminal.waiting-lock-banner-request-yield` (POST `/file-locks/yield-request`). After click, the button enters a 30-second cooldown matching `REQUEST_YIELD_COOLDOWN_MS` (re-exported from `@/lib/lock-yield` for consumer tripwires) — local state, not server-tracked, reload resets it. Disabled state: when `blockerTaskRunId` is undefined the parent couldn't resolve the holder session by name, so there's nothing to route the request to and the button is disabled with a guidance tooltip. Backend wiring lives in `qontinui-runner/src-tauri/src/mcp/file_registry.rs::yield_lock` and `::request_yield` (registered in `routes()` at `/file-locks/yield` and `/file-locks/yield-request` POST). Both emit via the dual-emit pattern: `state.app_handle.emit(name, &payload)` for the Tauri webview AND `state.app_state.event_broadcast.send(payload)` for SSE/headless consumers, matching the dispatcher's wait emit at `claude_session/dispatcher.rs:436-441`. The yield endpoint emits `file-lock-released` (same shape used by session.rs, ai_session.rs, graphql/mutation.rs, task_runs.rs). The yield-request endpoint emits `file-lock-yield-requested` `{type, file_path, requester_task_run_id, requester_name, holder_task_run_id, requested_at}` which `useFileLockTracking`'s third listener routes to the holder's tab by matching `tab.claudeSessionId === payload.holder_task_run_id` (via `findTabByTaskRunId`). The pending-yield list is deduped by `(requesterTaskRunId, filePath)` so a holder doesn't see N entries from spam clicks. Entries clear automatically on `file-lock-released` for the matching `(holder_task_run_id, file_path)` pair. Banner-side 1Hz seconds-tick uses `useNow1Hz` (see `term-heartbeat-idle-status`).",
+        "description": "When two AI sessions contend on the same file, the holder and the waiter each see an in-tab banner (`HoldingLockBanner` / `WaitingLockBanner`, terminal/HoldingLockBanner.tsx + terminal/WaitingLockBanner.tsx). Mounted only on active AI tabs with an active lock conflict. Exposes the lock-yield/request-yield/signal-long-wait actions via `terminal.holding-lock-banner-*` and `terminal.waiting-lock-banner-*` UI Bridge components.",
         "elements": [
           {
-            "dataUiBridgeId": "terminal.waiting-lock-banner"
+            "id": "terminal.waiting-lock-banner"
           }
         ],
         "id": "term-lock-yield-banners",
@@ -1338,10 +1211,10 @@
         "transitions": []
       },
       {
-        "description": "On top of the Lock-Yield Protocol surface, the terminal page exposes live idle telemetry so a waiter can tell whether the holder is busy or sitting in Ready, and the holder can broadcast 'I'll be a while' to current waiters. Backend: `GET /sessions/idle-status` (registered in `qontinui-runner/src-tauri/src/mcp/ai_session.rs::routes()` as `/sessions/idle-status`) returns `[{task_run_id, holder_name, last_activity_ms, idle_ms}]` for every registered Claude Code session. The handler iterates `SessionManager::snapshot()` (returns `Vec<(task_run_id, holder_name, Arc<AtomicU64>)>` triples without holding the manager lock during reads), reads each session's `last_activity_tracker().load(Ordering::Relaxed)` atomic (epoch seconds, written by `last_activity_stdout.store(now, Ordering::Relaxed)` on every stdout line in `claude_session/session.rs`), converts to ms at the response boundary, and computes `idle_ms = now_ms.saturating_sub(last_activity_ms)` (saturating to 0 on future-skew). `holder_name` is cached on `ClaudeSession` at spawn from the same source as the file-lock dispatcher (`session_ctx.session_name` for workflow sessions, `session_id` as the terminal fallback) so the response joins by-name with `file-lock-*` events. POST `/file-locks/signal-long-wait` (registered alongside the yield routes in `mcp/file_registry.rs::routes()`) accepts `{file_path, holder_task_run_id, holder_name, estimated_remaining_ms?: number}` and returns `{signaled: true}`. It dual-emits `file-lock-long-wait-signaled` `{type, file_path, holder_task_run_id, holder_name, estimated_remaining_ms, signaled_at}` to the Tauri webview AND the broadcast channel, mirroring the yield-request shape. Frontend: `<Now1HzProvider>` (qontinui-runner/src/components/terminal/useNow1Hz.tsx) mounts at the runner-app root inside `<PromptExecutionProvider>` in `AppWithTutorials` and broadcasts `Date.now()` once per second via React context. Every consumer of `useNow1Hz()` subscribes to the shared interval; a private per-component fallback fires only when no provider is in the tree (test isolation). Pre-existing component-local 1Hz tickers in `HoldingLockBanner`, `WaitingLockBanner`, and `productivity/FileActivityPanel` were collapsed onto the singleton. Tab-icon tooltips use the native HTML `title` attribute — the next hover sees fresh text but the OS-rendered popup does NOT refresh its visible text while open; the banner-side seconds-tick (real JSX) ticks fully live. `formatSince(sinceMs, nowMs)` (helper in `TerminalTabBar.tsx`) takes both arguments explicitly — promoted from a single-arg `Date.now()`-internal variant to match the established `formatBannerSeconds` pattern. `useFileLockTracking`'s 10s `/file-locks/info` poll now runs in parallel with `/sessions/idle-status` via `Promise.allSettled`; the join indexes idle entries by `holder_name` (waiters know the holder's friendly name from `file-lock-waiting`'s `blocked_by`, not its task_run_id) and attaches `holderIdleMs: number | undefined` to each waiting `LockState`. Idle-fetch failure is silent — `holderIdleMs` stays undefined; the lock-info loop is unaffected. WaitingLockBanner renders an inline `(holder idle Xm)` suffix (subdued via `text-[#a9b1d6]/70`, `data-ui-bridge-id=\"terminal.waiting-lock-banner-holder-idle\"`) inside the headline when `holderIdleMs > HOLDER_IDLE_DISPLAY_THRESHOLD_MS` (60_000 — exported for tripwire tests). `file-lock-long-wait-signaled` is consumed by `useFileLockTracking`'s fourth listener: it routes the signal to every waiter tab whose `lockState.kind === 'waiting' && lockState.filePath === payload.file_path`, deduping per `(holder_task_run_id, file_path)` and clearing on `file-lock-released` (for the file) or `file-lock-acquired` (for that waiter tab). Waiting tabs whose `pendingLongWaitSignals[tab.id]` has entries render an advisory `\"<strong>B</strong> says they'll be a while.\"` line below the main headline, plus `(~Xm)` when the holder included an estimate. The HoldingLockBanner's `terminal.holding-lock-banner-signal-long-wait` button (previously disabled) is enabled and POSTs to the new endpoint on click; the button enters a 30s cooldown using `SIGNAL_LONG_WAIT_COOLDOWN_MS` (exported constant) with the same UX as the waiter's yield-request cooldown.",
+        "description": "On top of the Lock-Yield Protocol surface, the terminal page exposes live idle telemetry so waiters can tell whether the holder is busy or sitting at Ready. Backend: `GET /sessions/idle-status`. Frontend: `Now1HzProvider` + a `terminal.waiting-lock-banner-holder-idle` UI Bridge marker on the waiter side showing the holder's last_activity_ms / idle_ms.",
         "elements": [
           {
-            "dataUiBridgeId": "terminal.waiting-lock-banner-holder-idle"
+            "id": "terminal.waiting-lock-banner-holder-idle"
           }
         ],
         "id": "term-heartbeat-idle-status",

--- a/specs/pages/terminal/state-machine.derived.json
+++ b/specs/pages/terminal/state-machine.derived.json
@@ -1,1085 +1,975 @@
 {
-    "version":  "1.0",
-    "id":  "terminal",
-    "name":  "TerminalPage",
-    "description":  "Terminal page -- an integrated multi-page, multi-tab PTY terminal with workflow generation, session transcript browsing, terminal output analysis, findings tracking, and concurrent session file conflict detection. Users can create multiple terminal pages (e.g., Development, Testing, Monitoring), each with its own independent zone layout, terminals, and saved configurations. Within each page, users execute shell commands in multiple concurrent terminal sessions organized in configurable zone layouts. The terminal supports session persistence across restarts (Claude Code session IDs are saved and auto-resumed), zone profiles that capture session assignments, shell integration for structured command history, keyboard shortcuts for efficient tab management, and an advisory file registry that auto-detects file conflicts across sessions, and plan implementation workflow execution from both the UI (Implement/Verify buttons) and CLI (run-plan-implementation.ts script).",
-    "metadata":  {
-                     "tags":  [
-                                  "terminal",
-                                  "pty",
-                                  "multi-tab",
-                                  "multi-page",
-                                  "session-persistence",
-                                  "zone-profiles",
-                                  "workflow-generation",
-                                  "transcript",
-                                  "findings",
-                                  "analysis",
-                                  "file-conflicts",
-                                  "concurrent-sessions",
-                                  "run-group",
-                                  "tier-1",
-                                  "commit-traffic-light",
-                                  "git-status",
-                                  "session-touched-files"
-                              ]
-                 },
-    "provenance":  {
-                       "source":  "migrated",
-                       "appId":  "qontinui-runner"
-                   },
-    "states":  [
-                   {
-                       "id":  "term-multi-tab",
-                       "name":  "Multi-Tab Terminal Sessions",
-                       "description":  "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-multi-tab-elem-3",
-                                              "description":  "Required element 3 for state Multi-Tab Terminal Sessions",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Ctrl+Shift+T"
-                                                                          },
-                                                             "label":  "Required element for Multi-Tab Terminal Sessions"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-action-bar",
-                       "name":  "Terminal Action Bar",
-                       "description":  "Above the terminal area, an action bar provides quick access to terminal-augmented features: toggling the transcript session sidebar, triggering AI-powered analysis of terminal output, generating workflows from the latest Claude Code session, refreshing the plan file, and toggling the findings panel. The action bar adapts its button states based on context -- showing loading spinners during generation or analysis, indicating the active findings count, and highlighting the active panel mode. This bar transforms the terminal from a simple shell into an intelligent development workbench.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-action-bar-elem-0",
-                                              "description":  "Required element 0 for state Terminal Action Bar",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Sessions"
-                                                                          },
-                                                             "label":  "Required element for Terminal Action Bar"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-action-bar-elem-1",
-                                              "description":  "Required element 1 for state Terminal Action Bar",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Generate"
-                                                                          },
-                                                             "label":  "Required element for Terminal Action Bar"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-action-bar-elem-2",
-                                              "description":  "Required element 2 for state Terminal Action Bar",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Analyze"
-                                                                          },
-                                                             "label":  "Required element for Terminal Action Bar"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-action-bar-elem-3",
-                                              "description":  "Required element 3 for state Terminal Action Bar",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Findings"
-                                                                          },
-                                                             "label":  "Required element for Terminal Action Bar"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-transcript-sessions",
-                       "name":  "Claude Code Session Transcripts",
-                       "description":  "The left sidebar shows a list of Claude Code session transcripts from the local machine. Users can browse past sessions, view the full conversation transcript in a right-side content panel, and resume sessions in a new terminal tab. Session resumption creates a new tab, sets the working directory, and sends the \u0027claude --resume\u0027 command with the correct config directory. The transcript panel supports generating workflows from session content and generating-and-running workflows in a single action for rapid automation creation.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-transcript-sessions-elem-0",
-                                              "description":  "Required element 0 for state Claude Code Session Transcripts",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Sessions"
-                                                                          },
-                                                             "label":  "Required element for Claude Code Session Transcripts"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-transcript-sessions-elem-1",
-                                              "description":  "Required element 1 for state Claude Code Session Transcripts",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Transcript"
-                                                                          },
-                                                             "label":  "Required element for Claude Code Session Transcripts"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-transcript-sessions-elem-2",
-                                              "description":  "Required element 2 for state Claude Code Session Transcripts",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Resume"
-                                                                          },
-                                                             "label":  "Required element for Claude Code Session Transcripts"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-transcript-sessions-elem-3",
-                                              "description":  "Required element 3 for state Claude Code Session Transcripts",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Generate"
-                                                                          },
-                                                             "label":  "Required element for Claude Code Session Transcripts"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-workflow-preview",
-                       "name":  "Workflow Generation and Preview",
-                       "description":  "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow\u0027s phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid \u0027do it once in the terminal, then automate it\u0027 development pattern.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-workflow-preview-elem-0",
-                                              "description":  "Required element 0 for state Workflow Generation and Preview",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Workflow"
-                                                                          },
-                                                             "label":  "Required element for Workflow Generation and Preview"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-workflow-preview-elem-1",
-                                              "description":  "Required element 1 for state Workflow Generation and Preview",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Execute"
-                                                                          },
-                                                             "label":  "Required element for Workflow Generation and Preview"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-workflow-preview-elem-2",
-                                              "description":  "Required element 2 for state Workflow Generation and Preview",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Save"
-                                                                          },
-                                                             "label":  "Required element for Workflow Generation and Preview"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-workflow-preview-elem-3",
-                                              "description":  "Required element 3 for state Workflow Generation and Preview",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Edit"
-                                                                          },
-                                                             "label":  "Required element for Workflow Generation and Preview"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-findings-tracking",
-                       "name":  "Real-Time Findings Detection",
-                       "description":  "The terminal automatically analyzes output in real time to detect errors, warnings, test failures, and other notable findings. These are tracked per-session and displayed in a dedicated findings panel on the right side. Users can respond to findings (sending text back to the terminal), fix findings by spawning a new Claude Code session with the finding context pre-loaded, or batch-generate a workflow from multiple unresolved findings. The findings count badge on the action bar updates live as new issues are detected, keeping users aware of problems without interrupting their terminal workflow.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-findings-tracking-elem-0",
-                                              "description":  "Required element 0 for state Real-Time Findings Detection",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Findings"
-                                                                          },
-                                                             "label":  "Required element for Real-Time Findings Detection"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-findings-tracking-elem-1",
-                                              "description":  "Required element 1 for state Real-Time Findings Detection",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Fix"
-                                                                          },
-                                                             "label":  "Required element for Real-Time Findings Detection"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-findings-tracking-elem-2",
-                                              "description":  "Required element 2 for state Real-Time Findings Detection",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Generate Workflow"
-                                                                          },
-                                                             "label":  "Required element for Real-Time Findings Detection"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-findings-tracking-elem-3",
-                                              "description":  "Required element 3 for state Real-Time Findings Detection",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Respond"
-                                                                          },
-                                                             "label":  "Required element for Real-Time Findings Detection"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-analysis",
-                       "name":  "AI-Powered Terminal Analysis",
-                       "description":  "The terminal integrates AI analysis capabilities that process terminal scrollback, command history, and plan files to produce structured insights. Analysis types include: session summary (what happened in this terminal session), architecture review (system structure from plan files or terminal context), change impact (what files and systems were affected), progress tracking (how far along is the development plan), cross-tab analysis (correlating activity across multiple terminal sessions), and page architecture (analyzing the runner\u0027s own frontend). Analysis results appear in a dedicated panel with structured canvas-style panels. This transforms raw terminal output into actionable development intelligence.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-analysis-elem-0",
-                                              "description":  "Required element 0 for state AI-Powered Terminal Analysis",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Architecture"
-                                                                          },
-                                                             "label":  "Required element for AI-Powered Terminal Analysis"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-analysis-elem-1",
-                                              "description":  "Required element 1 for state AI-Powered Terminal Analysis",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Summary"
-                                                                          },
-                                                             "label":  "Required element for AI-Powered Terminal Analysis"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-analysis-elem-2",
-                                              "description":  "Required element 2 for state AI-Powered Terminal Analysis",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "text":  "Analyzing"
-                                                                          },
-                                                             "label":  "Required element for AI-Powered Terminal Analysis"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-file-conflict-banner",
-                       "name":  "File Conflict Detection Banner",
-                       "description":  "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner\u0027s file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the \u0027needs-input\u0027 status style.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-file-conflict-banner-elem-0",
-                                              "description":  "Required element 0 for state File Conflict Detection Banner",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "under concurrent"
-                                                                          },
-                                                             "label":  "Required element for File Conflict Detection Banner"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-file-conflict-banner-elem-1",
-                                              "description":  "Required element 1 for state File Conflict Detection Banner",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "under concurrent development"
-                                                                          },
-                                                             "label":  "Required element for File Conflict Detection Banner"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-file-conflict-banner-elem-2",
-                                              "description":  "Required element 2 for state File Conflict Detection Banner",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "under concurrent development"
-                                                                          },
-                                                             "label":  "Required element for File Conflict Detection Banner"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-file-conflict-banner-elem-3",
-                                              "description":  "Required element 3 for state File Conflict Detection Banner",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "Conflict:"
-                                                                          },
-                                                             "label":  "Required element for File Conflict Detection Banner"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-file-conflict-banner-elem-4",
-                                              "description":  "Required element 4 for state File Conflict Detection Banner",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "under concurrent"
-                                                                          },
-                                                             "label":  "Required element for File Conflict Detection Banner"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-session-conflict-indicator",
-                       "name":  "Per-Session File Conflict Indicators",
-                       "description":  "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows \u0027{N} file(s) shared with other sessions\u0027. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook\u0027s sessionConflictCounts Map, keyed by session task_run_id.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-session-conflict-indicator-elem-0",
-                                              "description":  "Required element 0 for state Per-Session File Conflict Indicators",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "shared with other sessions"
-                                                                          },
-                                                             "label":  "Required element for Per-Session File Conflict Indicators"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-session-conflict-indicator-elem-1",
-                                              "description":  "Required element 1 for state Per-Session File Conflict Indicators",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "shared with other sessions"
-                                                                          },
-                                                             "label":  "Required element for Per-Session File Conflict Indicators"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-session-conflict-indicator-elem-2",
-                                              "description":  "Required element 2 for state Per-Session File Conflict Indicators",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "shared with other sessions"
-                                                                          },
-                                                             "label":  "Required element for Per-Session File Conflict Indicators"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-session-conflict-indicator-elem-3",
-                                              "description":  "Required element 3 for state Per-Session File Conflict Indicators",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "shared with other sessions"
-                                                                          },
-                                                             "label":  "Required element for Per-Session File Conflict Indicators"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "At least one session has files overlapping with another session in the file registry",
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-multi-page",
-                       "name":  "Multiple Terminal Pages",
-                       "description":  "Users can create multiple independent terminal pages, each with its own zone layout, terminals, labels, and saved configurations. A page tab bar at the top of the terminal area shows all pages. Clicking a page tab switches to that page by unmounting the current TerminalPage and remounting a new one connected to that page\u0027s PTY sessions. Each page\u0027s state (zone layout, labels, notes, pins, zone profiles, workspaces) is stored in page-namespaced localStorage keys. The default page uses un-prefixed keys for backward compatibility. PTY sessions are tagged with a page_id in the Rust backend, so each page only sees its own terminals.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-multi-page-elem-0",
-                                              "description":  "Required element 0 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "tab"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-multi-page-elem-1",
-                                              "description":  "Required element 1 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "accessibleName":  "Add terminal page"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-multi-page-elem-2",
-                                              "description":  "Required element 2 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "tab"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-multi-page-elem-3",
-                                              "description":  "Required element 3 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "tab"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-multi-page-elem-4",
-                                              "description":  "Required element 4 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "accessibleName":  "Close page"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-multi-page-elem-5",
-                                              "description":  "Required element 5 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "tab"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-multi-page-elem-6",
-                                              "description":  "Required element 6 for state Multiple Terminal Pages",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "Loading terminals"
-                                                                          },
-                                                             "label":  "Required element for Multiple Terminal Pages"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "At least two pages exist with different numbers of terminals",
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-session-persistence",
-                       "name":  "Session Persistence \u0026 Auto-Resume",
-                       "description":  "Claude Code session IDs are persisted alongside terminal tab configurations. When the runner restarts and reconnects to existing PTY sessions, saved claudeSessionId values are merged back into the reconnected tabs and the sessions are auto-resumed with \u0027claude --resume \u003cid\u003e\u0027. This ensures that Claude Code sessions survive runner restarts without manual intervention. The saved layout includes zone assignments, labels, notes, pins, and Claude session IDs per tab.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-session-persistence-elem-0",
-                                              "description":  "Required element 0 for state Session Persistence \u0026 Auto-Resume",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "textbox"
-                                                                          },
-                                                             "label":  "Required element for Session Persistence \u0026 Auto-Resume"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-session-persistence-elem-1",
-                                              "description":  "Required element 1 for state Session Persistence \u0026 Auto-Resume",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "Zone"
-                                                                          },
-                                                             "label":  "Required element for Session Persistence \u0026 Auto-Resume"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-session-persistence-elem-2",
-                                              "description":  "Required element 2 for state Session Persistence \u0026 Auto-Resume",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "accessibleName":  "Zone profiles"
-                                                                          },
-                                                             "label":  "Required element for Session Persistence \u0026 Auto-Resume"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "Runner was restarted after Claude sessions were running in terminal zones",
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-page-storage-isolation",
-                       "name":  "Per-Page Storage Isolation",
-                       "description":  "Each terminal page has isolated storage for its configuration. Zone layouts, session persistence, zone profiles, workspaces, zone labels/notes/pins, and grid column/row ratios are all namespaced by pageId. The default page uses un-prefixed keys (backward compatible), while non-default pages use \u0027page:{pageId}:\u0027 prefixed keys. This ensures that creating a zone profile on page A does not appear when viewing page B\u0027s profiles.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-page-storage-isolation-elem-0",
-                                              "description":  "Required element 0 for state Per-Page Storage Isolation",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "accessibleName":  "Zone profiles"
-                                                                          },
-                                                             "label":  "Required element for Per-Page Storage Isolation"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-page-storage-isolation-elem-1",
-                                              "description":  "Required element 1 for state Per-Page Storage Isolation",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "tab"
-                                                                          },
-                                                             "label":  "Required element for Per-Page Storage Isolation"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-page-storage-isolation-elem-2",
-                                              "description":  "Required element 2 for state Per-Page Storage Isolation",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "tab"
-                                                                          },
-                                                             "label":  "Required element for Per-Page Storage Isolation"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "Multiple pages exist, at least one has saved profiles",
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-plan-implementation",
-                       "name":  "Plan Implementation Workflow",
-                       "description":  "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-plan-implementation-elem-0",
-                                              "description":  "Required element 0 for state Plan Implementation Workflow",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Implement"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation Workflow"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-implementation-elem-1",
-                                              "description":  "Required element 1 for state Plan Implementation Workflow",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Verify"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation Workflow"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-implementation-elem-2",
-                                              "description":  "Required element 2 for state Plan Implementation Workflow",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Implement"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation Workflow"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-implementation-elem-3",
-                                              "description":  "Required element 3 for state Plan Implementation Workflow",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "text":  "Verify"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation Workflow"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-implementation-elem-4",
-                                              "description":  "Required element 4 for state Plan Implementation Workflow",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "Plan Implementation"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation Workflow"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-implementation-elem-5",
-                                              "description":  "Required element 5 for state Plan Implementation Workflow",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "accessibleName":  "Reload plan file from disk"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation Workflow"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "Transcript panel is open with messages selected",
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-plan-cli-script",
-                       "name":  "Plan Implementation CLI Script",
-                       "description":  "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-plan-cli-script-elem-0",
-                                              "description":  "Required element 0 for state Plan Implementation CLI Script",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "Parsed"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation CLI Script"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-cli-script-elem-1",
-                                              "description":  "Required element 1 for state Plan Implementation CLI Script",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "execute-inline"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation CLI Script"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          },
-                                          {
-                                              "id":  "term-plan-cli-script-elem-2",
-                                              "description":  "Required element 2 for state Plan Implementation CLI Script",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "textContains":  "follow"
-                                                                          },
-                                                             "label":  "Required element for Plan Implementation CLI Script"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "provenance":  {
-                                          "source":  "migrated"
-                                      }
-                   },
-                   {
-                       "id":  "term-commit-traffic-light",
-                       "name":  "Per-Tab Commit Traffic Light",
-                       "description":  "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `\u003cCommitTrafficLight\u003e` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session\u0027s git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/\u003cencoded\u003e/\u003csession_id\u003e.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don\u0027t carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
-                       "assertions":  [
-                                          {
-                                              "id":  "term-commit-traffic-light-elem-0",
-                                              "description":  "Required element 0 for state Per-Tab Commit Traffic Light",
-                                              "category":  "element-presence",
-                                              "severity":  "critical",
-                                              "assertionType":  "exists",
-                                              "target":  {
-                                                             "type":  "search",
-                                                             "criteria":  {
-                                                                              "role":  "button",
-                                                                              "accessibleName":  "Commit progress"
-                                                                          },
-                                                             "label":  "Required element for Per-Tab Commit Traffic Light"
-                                                         },
-                                              "source":  "migrated",
-                                              "reviewed":  false,
-                                              "enabled":  true
-                                          }
-                                      ],
-                       "precondition":  "At least one terminal tab has an active Claude Code AI session (tab.claudeSessionId is populated, either from a resumed session or the post-spawn transcript_get_latest polling)",
-                       "provenance":  {
-                                          "source":  "ai-generated"
-                                      }
-                   }
-               ],
-    "transitions":  [
-
-                    ]
+  "version": "1.0",
+  "id": "terminal",
+  "name": "TerminalPage",
+  "description": "Terminal page -- an integrated multi-page, multi-tab PTY terminal with workflow generation, session transcript browsing, terminal output analysis, findings tracking, and concurrent session file conflict detection. Users can create multiple terminal pages (e.g., Development, Testing, Monitoring), each with its own independent zone layout, terminals, and saved configurations. Within each page, users execute shell commands in multiple concurrent terminal sessions organized in configurable zone layouts. The terminal supports session persistence across restarts (Claude Code session IDs are saved and auto-resumed), zone profiles that capture session assignments, shell integration for structured command history, keyboard shortcuts for efficient tab management, and an advisory file registry that auto-detects file conflicts across sessions, and plan implementation workflow execution from both the UI (Implement/Verify buttons) and CLI (run-plan-implementation.ts script).",
+  "metadata": {
+    "tags": [
+      "terminal",
+      "pty",
+      "multi-tab",
+      "multi-page",
+      "session-persistence",
+      "zone-profiles",
+      "workflow-generation",
+      "transcript",
+      "findings",
+      "analysis",
+      "file-conflicts",
+      "concurrent-sessions",
+      "run-group",
+      "tier-1",
+      "commit-traffic-light",
+      "git-status",
+      "session-touched-files"
+    ]
+  },
+  "provenance": {
+    "source": "migrated",
+    "appId": "qontinui-runner"
+  },
+  "states": [
+    {
+      "id": "term-multi-tab",
+      "name": "Multi-Tab Terminal Sessions",
+      "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal.",
+      "assertions": [
+        {
+          "id": "term-multi-tab-elem-3",
+          "description": "Required element 3 for state Multi-Tab Terminal Sessions",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "text": "Ctrl+Shift+T"
+            },
+            "label": "Required element for Multi-Tab Terminal Sessions"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-workflow-preview",
+      "name": "Workflow Generation and Preview",
+      "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern.",
+      "assertions": [
+        {
+          "id": "term-workflow-preview-elem-0",
+          "description": "Required element 0 for state Workflow Generation and Preview",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "text": "Workflow"
+            },
+            "label": "Required element for Workflow Generation and Preview"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-workflow-preview-elem-1",
+          "description": "Required element 1 for state Workflow Generation and Preview",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Execute"
+            },
+            "label": "Required element for Workflow Generation and Preview"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-workflow-preview-elem-2",
+          "description": "Required element 2 for state Workflow Generation and Preview",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Save"
+            },
+            "label": "Required element for Workflow Generation and Preview"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-workflow-preview-elem-3",
+          "description": "Required element 3 for state Workflow Generation and Preview",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Edit"
+            },
+            "label": "Required element for Workflow Generation and Preview"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-findings-tracking",
+      "name": "Real-Time Findings Detection",
+      "description": "The terminal automatically analyzes output in real time to detect errors, warnings, test failures, and other notable findings. These are tracked per-session and displayed in a dedicated findings panel on the right side. Users can respond to findings (sending text back to the terminal), fix findings by spawning a new Claude Code session with the finding context pre-loaded, or batch-generate a workflow from multiple unresolved findings. The findings count badge on the action bar updates live as new issues are detected, keeping users aware of problems without interrupting their terminal workflow.",
+      "assertions": [
+        {
+          "id": "term-findings-tracking-elem-0",
+          "description": "Required element 0 for state Real-Time Findings Detection",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "text": "Findings"
+            },
+            "label": "Required element for Real-Time Findings Detection"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-findings-tracking-elem-1",
+          "description": "Required element 1 for state Real-Time Findings Detection",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Fix"
+            },
+            "label": "Required element for Real-Time Findings Detection"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-findings-tracking-elem-2",
+          "description": "Required element 2 for state Real-Time Findings Detection",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Generate Workflow"
+            },
+            "label": "Required element for Real-Time Findings Detection"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-findings-tracking-elem-3",
+          "description": "Required element 3 for state Real-Time Findings Detection",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Respond"
+            },
+            "label": "Required element for Real-Time Findings Detection"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-analysis",
+      "name": "AI-Powered Terminal Analysis",
+      "description": "The terminal integrates AI analysis capabilities that process terminal scrollback, command history, and plan files to produce structured insights. Analysis types include: session summary (what happened in this terminal session), architecture review (system structure from plan files or terminal context), change impact (what files and systems were affected), progress tracking (how far along is the development plan), cross-tab analysis (correlating activity across multiple terminal sessions), and page architecture (analyzing the runner's own frontend). Analysis results appear in a dedicated panel with structured canvas-style panels. This transforms raw terminal output into actionable development intelligence.",
+      "assertions": [
+        {
+          "id": "term-analysis-elem-0",
+          "description": "Required element 0 for state AI-Powered Terminal Analysis",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "text": "Architecture"
+            },
+            "label": "Required element for AI-Powered Terminal Analysis"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-analysis-elem-1",
+          "description": "Required element 1 for state AI-Powered Terminal Analysis",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "text": "Summary"
+            },
+            "label": "Required element for AI-Powered Terminal Analysis"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-analysis-elem-2",
+          "description": "Required element 2 for state AI-Powered Terminal Analysis",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "text": "Analyzing"
+            },
+            "label": "Required element for AI-Powered Terminal Analysis"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-file-conflict-banner",
+      "name": "File Conflict Detection Banner",
+      "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style.",
+      "assertions": [
+        {
+          "id": "term-file-conflict-banner-elem-0",
+          "description": "Required element 0 for state File Conflict Detection Banner",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "under concurrent"
+            },
+            "label": "Required element for File Conflict Detection Banner"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-file-conflict-banner-elem-1",
+          "description": "Required element 1 for state File Conflict Detection Banner",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "under concurrent development"
+            },
+            "label": "Required element for File Conflict Detection Banner"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-file-conflict-banner-elem-2",
+          "description": "Required element 2 for state File Conflict Detection Banner",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "under concurrent development"
+            },
+            "label": "Required element for File Conflict Detection Banner"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-file-conflict-banner-elem-3",
+          "description": "Required element 3 for state File Conflict Detection Banner",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "Conflict:"
+            },
+            "label": "Required element for File Conflict Detection Banner"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-file-conflict-banner-elem-4",
+          "description": "Required element 4 for state File Conflict Detection Banner",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "under concurrent"
+            },
+            "label": "Required element for File Conflict Detection Banner"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "No files are registered by multiple sessions in the file registry (GET /file-registry/info returns entries with unique holder_task_run_id per file_path)",
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-session-conflict-indicator",
+      "name": "Per-Session File Conflict Indicators",
+      "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id.",
+      "assertions": [
+        {
+          "id": "term-session-conflict-indicator-elem-0",
+          "description": "Required element 0 for state Per-Session File Conflict Indicators",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "shared with other sessions"
+            },
+            "label": "Required element for Per-Session File Conflict Indicators"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-session-conflict-indicator-elem-1",
+          "description": "Required element 1 for state Per-Session File Conflict Indicators",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "shared with other sessions"
+            },
+            "label": "Required element for Per-Session File Conflict Indicators"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-session-conflict-indicator-elem-2",
+          "description": "Required element 2 for state Per-Session File Conflict Indicators",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "shared with other sessions"
+            },
+            "label": "Required element for Per-Session File Conflict Indicators"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-session-conflict-indicator-elem-3",
+          "description": "Required element 3 for state Per-Session File Conflict Indicators",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "shared with other sessions"
+            },
+            "label": "Required element for Per-Session File Conflict Indicators"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "At least one session has files overlapping with another session in the file registry",
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-multi-page",
+      "name": "Multiple Terminal Pages",
+      "description": "Users can create multiple independent terminal pages, each with its own zone layout, terminals, labels, and saved configurations. A page tab bar at the top of the terminal area shows all pages. Clicking a page tab switches to that page by unmounting the current TerminalPage and remounting a new one connected to that page's PTY sessions. Each page's state (zone layout, labels, notes, pins, zone profiles, workspaces) is stored in page-namespaced localStorage keys. The default page uses un-prefixed keys for backward compatibility. PTY sessions are tagged with a page_id in the Rust backend, so each page only sees its own terminals.",
+      "assertions": [
+        {
+          "id": "term-multi-page-elem-0",
+          "description": "Required element 0 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "tab"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-multi-page-elem-1",
+          "description": "Required element 1 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "accessibleName": "Add terminal page",
+              "role": "button"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-multi-page-elem-2",
+          "description": "Required element 2 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "tab"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-multi-page-elem-3",
+          "description": "Required element 3 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "tab"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-multi-page-elem-4",
+          "description": "Required element 4 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "accessibleName": "Close page"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-multi-page-elem-5",
+          "description": "Required element 5 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "tab"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-multi-page-elem-6",
+          "description": "Required element 6 for state Multiple Terminal Pages",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "Loading terminals"
+            },
+            "label": "Required element for Multiple Terminal Pages"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "At least two pages exist with different numbers of terminals",
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-session-persistence",
+      "name": "Session Persistence & Auto-Resume",
+      "description": "Claude Code session IDs are persisted alongside terminal tab configurations. When the runner restarts and reconnects to existing PTY sessions, saved claudeSessionId values are merged back into the reconnected tabs and the sessions are auto-resumed with 'claude --resume <id>'. This ensures that Claude Code sessions survive runner restarts without manual intervention. The saved layout includes zone assignments, labels, notes, pins, and Claude session IDs per tab.",
+      "assertions": [
+        {
+          "id": "term-session-persistence-elem-0",
+          "description": "Required element 0 for state Session Persistence & Auto-Resume",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "textbox"
+            },
+            "label": "Required element for Session Persistence & Auto-Resume"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-session-persistence-elem-1",
+          "description": "Required element 1 for state Session Persistence & Auto-Resume",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "Zone"
+            },
+            "label": "Required element for Session Persistence & Auto-Resume"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-session-persistence-elem-2",
+          "description": "Required element 2 for state Session Persistence & Auto-Resume",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "accessibleName": "Zone profiles"
+            },
+            "label": "Required element for Session Persistence & Auto-Resume"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "Runner was restarted after Claude sessions were running in terminal zones",
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-page-storage-isolation",
+      "name": "Per-Page Storage Isolation",
+      "description": "Each terminal page has isolated storage for its configuration. Zone layouts, session persistence, zone profiles, workspaces, zone labels/notes/pins, and grid column/row ratios are all namespaced by pageId. The default page uses un-prefixed keys (backward compatible), while non-default pages use 'page:{pageId}:' prefixed keys. This ensures that creating a zone profile on page A does not appear when viewing page B's profiles.",
+      "assertions": [
+        {
+          "id": "term-page-storage-isolation-elem-0",
+          "description": "Required element 0 for state Per-Page Storage Isolation",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "accessibleName": "Zone profiles"
+            },
+            "label": "Required element for Per-Page Storage Isolation"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-page-storage-isolation-elem-1",
+          "description": "Required element 1 for state Per-Page Storage Isolation",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "tab"
+            },
+            "label": "Required element for Per-Page Storage Isolation"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-page-storage-isolation-elem-2",
+          "description": "Required element 2 for state Per-Page Storage Isolation",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "tab"
+            },
+            "label": "Required element for Per-Page Storage Isolation"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "Multiple pages exist, at least one has saved profiles",
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-plan-implementation",
+      "name": "Plan Implementation Workflow",
+      "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution.",
+      "assertions": [
+        {
+          "id": "term-plan-implementation-elem-0",
+          "description": "Required element 0 for state Plan Implementation Workflow",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Implement"
+            },
+            "label": "Required element for Plan Implementation Workflow"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-implementation-elem-1",
+          "description": "Required element 1 for state Plan Implementation Workflow",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Verify"
+            },
+            "label": "Required element for Plan Implementation Workflow"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-implementation-elem-2",
+          "description": "Required element 2 for state Plan Implementation Workflow",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Implement"
+            },
+            "label": "Required element for Plan Implementation Workflow"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-implementation-elem-3",
+          "description": "Required element 3 for state Plan Implementation Workflow",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "role": "button",
+              "text": "Verify"
+            },
+            "label": "Required element for Plan Implementation Workflow"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-implementation-elem-4",
+          "description": "Required element 4 for state Plan Implementation Workflow",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "Plan Implementation"
+            },
+            "label": "Required element for Plan Implementation Workflow"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-implementation-elem-5",
+          "description": "Required element 5 for state Plan Implementation Workflow",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "accessibleName": "Reload plan file from disk"
+            },
+            "label": "Required element for Plan Implementation Workflow"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "Transcript panel is open with messages selected",
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-plan-cli-script",
+      "name": "Plan Implementation CLI Script",
+      "description": "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
+      "assertions": [
+        {
+          "id": "term-plan-cli-script-elem-0",
+          "description": "Required element 0 for state Plan Implementation CLI Script",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "Parsed"
+            },
+            "label": "Required element for Plan Implementation CLI Script"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-cli-script-elem-1",
+          "description": "Required element 1 for state Plan Implementation CLI Script",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "execute-inline"
+            },
+            "label": "Required element for Plan Implementation CLI Script"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "term-plan-cli-script-elem-2",
+          "description": "Required element 2 for state Plan Implementation CLI Script",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "textContains": "follow"
+            },
+            "label": "Required element for Plan Implementation CLI Script"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "migrated"
+      }
+    },
+    {
+      "id": "term-commit-traffic-light",
+      "name": "Per-Tab Commit Traffic Light",
+      "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
+      "assertions": [
+        {
+          "id": "term-commit-traffic-light-elem-0",
+          "description": "Required element 0 for state Per-Tab Commit Traffic Light",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "accessibleName": "Commit progress",
+              "role": "button"
+            },
+            "label": "Required element for Per-Tab Commit Traffic Light"
+          },
+          "source": "migrated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "precondition": "At least one terminal tab has an active Claude Code AI session (tab.claudeSessionId is populated, either from a resumed session or the post-spawn transcript_get_latest polling)",
+      "provenance": {
+        "source": "ai-generated"
+      }
+    },
+    {
+      "id": "term-lock-yield-banners",
+      "name": "Lock-Yield Protocol Banners",
+      "description": "When two AI sessions contend on the same file, the holder and the waiter each see an in-tab banner (`HoldingLockBanner` / `WaitingLockBanner`, terminal/HoldingLockBanner.tsx + terminal/WaitingLockBanner.tsx). Mounted only on active AI tabs with an active lock conflict. Exposes the lock-yield/request-yield/signal-long-wait actions via `terminal.holding-lock-banner-*` and `terminal.waiting-lock-banner-*` UI Bridge components.",
+      "assertions": [
+        {
+          "id": "term-lock-yield-banners-elem-0",
+          "description": "WaitingLockBanner UI Bridge component renders when a tab is waiting on a contended file lock.",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "terminal.waiting-lock-banner"
+            },
+            "label": "WaitingLockBanner component"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "ai-generated"
+      }
+    },
+    {
+      "id": "term-heartbeat-idle-status",
+      "name": "Stuck-Session Heartbeat",
+      "description": "On top of the Lock-Yield Protocol surface, the terminal page exposes live idle telemetry so waiters can tell whether the holder is busy or sitting at Ready. Backend: `GET /sessions/idle-status`. Frontend: `Now1HzProvider` + a `terminal.waiting-lock-banner-holder-idle` UI Bridge marker on the waiter side showing the holder's last_activity_ms / idle_ms.",
+      "assertions": [
+        {
+          "id": "term-heartbeat-idle-status-elem-0",
+          "description": "Waiter-side holder-idle marker renders when waiting on a contended lock with idle-status telemetry.",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "terminal.waiting-lock-banner-holder-idle"
+            },
+            "label": "WaitingLockBanner holder-idle marker"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "provenance": {
+        "source": "ai-generated"
+      }
+    }
+  ],
+  "transitions": []
 }


### PR DESCRIPTION
## Summary

Closes the **IR-half** of the §9.6 follow-ups in [`qontinui-dev-notes/plans/2026-05-30-commandbar-result-cards-plan.md`](https://github.com/qontinui/qontinui-dev-notes/blob/main/plans/2026-05-30-commandbar-result-cards-plan.md).

PR-C (#328) removed `term-action-bar` + `term-transcript-sessions` from the **projection** (`spec.uibridge.json`) but left the **IR** (`state-machine.derived.json`) untouched. Per `src-tauri/src/spec_api/storage.rs:7-8` the IR is authoritative and the projection is derived from it via `POST /spec/author`. The hand-edit to the projection left the IR with dead state definitions and lost two states that had been added to the projection out-of-band.

## What changed

1. **IR — deleted `term-action-bar` + `term-transcript-sessions`.** Both asserted on ZSB-toolbar buttons that PR-C demolished.
2. **IR — added `term-lock-yield-banners` + `term-heartbeat-idle-status`.** Single skeletal `exists` assertions targeting their `dataUiBridgeId` markers (`terminal.waiting-lock-banner`, `terminal.waiting-lock-banner-holder-idle`). Both are conditional ambient states — they only render when a Claude tab is waiting on a contended file lock.
3. **Projection regenerated** via `POST /apps/qontinui-runner/spec/author` against a temp runner on post-cascade main. Both files now have the same 14 state IDs.
4. **`scripts/generate-all-specs.ps1` — added `-Port` parameter** (defaults to 9876) so the script can target a temp test runner for offline spec generation without restarting the primary.

## Why the diff is so large

Mostly format flip. The IR was previously written with PowerShell's `ConvertTo-Json` two-spaces-after-colon style; `POST /spec/author`'s `serde_json` output uses one-space style. Every future `/spec/author` call will use the new style, so this is a one-time format-flip, not ongoing drift.

## §9.6 panel-state re-validation findings (deferred follow-ups)

- **`term-findings-tracking`** — assertions are **correct** when the panel is open. Verified live: `Fix` / `Respond` / `Generate Workflow` all render when `/findings` opens. The 0.25 baseline rate reflects spec-check running with the panel CLOSED, not assertion incorrectness. **Fix = add an `IrTransition` that fires `/findings` before asserting.**
- **`term-workflow-preview`** — `Execute` / `Save` / `Edit` buttons only render after a workflow has been generated by a Claude session. Verifying these on-page requires an actual AI subprocess call; out-of-scope for the autonomous follow-up.
- **`term-plan-implementation`** — `Implement` / `Verify` buttons no longer exist as visible UI; they were demolished into the `/plan-implement` + `/plan-verify` slash registry actions by PR-C. The state's assertions are **obsolete and need a redesign** (assert on the registry-action `dataUiBridgeId`, or assert on the AI-generated plan workflow appearing in the workflow preview).

## Wider spec health (not in scope)

`spec-check` overall match rate at HEAD: `0.18`. Many states beyond §9.6 also fail (`term-file-conflict-banner` 0/5, `term-session-conflict-indicator` 0/4, `term-plan-cli-script` 0/3, `term-commit-traffic-light` 0/1). All are conditional ambient states asserting on UI that only renders for specific data; cleaning them up is a separate workstream.

## Test plan

- [x] `POST /spec/author` returned 200; projection regenerated from IR
- [x] Both files now have identical 14 state IDs (symmetric diff = empty set)
- [x] Spec-check re-run shows 14 states; new states present + dead states gone
- [x] Live verification of `term-findings-tracking` panel content
- [ ] CI: lint + typecheck + clippy