### PR TITLE
feat(sessions): Intent plan linkage + defer abandonment-close to coord (P7.1+P7.2)

### DIFF
--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1172,6 +1172,8 @@ pub async fn spawn_worker_session(
                 // allocation above.
                 repo: Some(intent_repo.clone()),
                 branch: None,
+                plan_slug: None,
+                correlation_topic: None,
                 declared_paths: vec![],
                 share_output: true,
                 redact_secrets: None,
@@ -1184,8 +1186,10 @@ pub async fn spawn_worker_session(
 
                         // R1 (session-lifecycle-cleanup) — close the coord
                         // session mirror immediately when the worker PTY
-                        // exits, instead of waiting out the coord_sync 180s
-                        // autoclose. Idempotent with any explicit close.
+                        // exits, instead of leaving it for coord's stale→closed
+                        // watcher (the runner no longer self-closes abandoned
+                        // sessions; see coord_sync plan A3). Idempotent with any
+                        // explicit close.
                         let close_registry = registry.clone();
                         session.set_on_exit(Box::new(move |coord_id| {
                             if let Err(e) = close_registry.close_by_id(coord_id) {

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -29,6 +29,10 @@ pub struct StartSessionArgs {
     #[serde(default)]
     pub branch: Option<String>,
     #[serde(default)]
+    pub plan_slug: Option<String>,
+    #[serde(default)]
+    pub correlation_topic: Option<String>,
+    #[serde(default)]
     pub declared_paths: Vec<PathBuf>,
     #[serde(default)]
     pub share_output: bool,
@@ -43,6 +47,8 @@ impl From<StartSessionArgs> for Intent {
             purpose: a.purpose,
             repo: a.repo,
             branch: a.branch,
+            plan_slug: a.plan_slug,
+            correlation_topic: a.correlation_topic,
             declared_paths: a.declared_paths,
             share_output: a.share_output,
             redact_secrets: a.redact_secrets,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -37,6 +37,8 @@ pub async fn terminal_create(
     cols: Option<u16>,
     rows: Option<u16>,
     intent_repo: Option<String>,
+    plan_slug: Option<String>,
+    correlation_topic: Option<String>,
 ) -> Result<CommandResponse, String> {
     // R2 (session-lifecycle-cleanup) — derive the STABLE pane identity from
     // the create-time triple the frontend round-trips on restore
@@ -97,6 +99,8 @@ pub async fn terminal_create(
         purpose,
         repo: intent_repo,
         branch: None,
+        plan_slug,
+        correlation_topic,
         declared_paths: working_dir
             .map(std::path::PathBuf::from)
             .into_iter()
@@ -132,11 +136,12 @@ pub async fn terminal_create(
 
                 // R1 — install the on-exit hook so the PTY waiter thread
                 // closes the coord session mirror the instant the process
-                // exits, instead of leaving a ~3-minute ghost until the
-                // coord_sync 180s autoclose. Shares the idempotent
-                // `close_by_id` path with the frontend `terminal_close`
-                // command, so a double-close (exit + explicit close) is a
-                // no-op.
+                // exits, instead of leaving a ghost until coord's own
+                // stale→closed watcher reaps it (the runner no longer
+                // self-closes abandoned sessions; see coord_sync plan A3).
+                // Shares the idempotent `close_by_id` path with the frontend
+                // `terminal_close` command, so a double-close (exit +
+                // explicit close) is a no-op.
                 let close_registry = registry.clone();
                 session.set_on_exit(Box::new(move |coord_id| {
                     if let Err(e) = close_registry.close_by_id(coord_id) {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1832,7 +1832,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // Phase 3 — wire the coord-sync drain + heartbeat loops.
                 // `attach_app_handle` enables the conflict-event emit;
                 // `attach_registry` gives the heartbeat loop a way to
-                // enumerate active sessions for stale/autoclose sweeps.
+                // enumerate active sessions for the stale sweep.
                 coord_sync_facade.attach_app_handle(app_handle.clone());
                 let registry = session::SessionRegistry::new(
                     machine_id,

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -87,8 +87,6 @@ use super::{Intent, SessionEventKind, SessionRegistry, SessionState};
 const DEFAULT_HEARTBEAT_SECS: u64 = 15;
 /// Default stale threshold — 3 missed heartbeats.
 const DEFAULT_STALE_SECS: u64 = 45;
-/// Default auto-close threshold — 12 missed heartbeats.
-const DEFAULT_AUTOCLOSE_SECS: u64 = 180;
 /// Fallback coord URL when neither `COORD_HTTP_URL` env nor profile is set.
 const DEFAULT_COORD_URL: &str = "http://localhost:9870";
 
@@ -151,7 +149,6 @@ struct CoordSyncInner {
     http: reqwest::Client,
     heartbeat: Duration,
     stale: Duration,
-    autoclose: Duration,
     /// Set the first time we successfully reach coord. Used to decide
     /// whether to log a noisy "reconnected" line on the next success.
     has_been_online: AtomicBool,
@@ -179,7 +176,6 @@ impl std::fmt::Debug for CoordSync {
             .field("coord_url", &self.inner.coord_url)
             .field("heartbeat", &self.inner.heartbeat)
             .field("stale", &self.inner.stale)
-            .field("autoclose", &self.inner.autoclose)
             .finish()
     }
 }
@@ -194,10 +190,6 @@ impl CoordSync {
             DEFAULT_HEARTBEAT_SECS,
         ));
         let stale = Duration::from_secs(env_u64("QONTINUI_SESSION_STALE_SECS", DEFAULT_STALE_SECS));
-        let autoclose = Duration::from_secs(env_u64(
-            "QONTINUI_SESSION_AUTOCLOSE_SECS",
-            DEFAULT_AUTOCLOSE_SECS,
-        ));
 
         let http = reqwest::Client::builder()
             // Per-request timeout — slow enough to ride out a hiccup,
@@ -217,7 +209,6 @@ impl CoordSync {
                 http,
                 heartbeat,
                 stale,
-                autoclose,
                 has_been_online: AtomicBool::new(false),
                 app_handle: Mutex::new(None),
                 registry: Mutex::new(None),
@@ -235,7 +226,6 @@ impl CoordSync {
         coord_url: String,
         heartbeat: Duration,
         stale: Duration,
-        autoclose: Duration,
     ) -> Self {
         Self {
             inner: Arc::new(CoordSyncInner {
@@ -247,7 +237,6 @@ impl CoordSync {
                     .unwrap(),
                 heartbeat,
                 stale,
-                autoclose,
                 has_been_online: AtomicBool::new(false),
                 app_handle: Mutex::new(None),
                 registry: Mutex::new(None),
@@ -285,12 +274,6 @@ impl CoordSync {
     #[allow(dead_code)]
     pub fn stale_threshold(&self) -> Duration {
         self.inner.stale
-    }
-
-    /// Auto-close threshold (12 missed heartbeats).
-    #[allow(dead_code)]
-    pub fn autoclose_threshold(&self) -> Duration {
-        self.inner.autoclose
     }
 
     /// Attach the Tauri AppHandle so the drain loop can emit
@@ -844,7 +827,6 @@ async fn run_heartbeat_loop(inner: Arc<CoordSyncInner>) {
     tracing::info!(
         ?interval,
         stale_after = ?inner.stale,
-        autoclose_after = ?inner.autoclose,
         "coord_sync: heartbeat loop starting"
     );
 
@@ -866,7 +848,6 @@ async fn run_heartbeat_loop(inner: Arc<CoordSyncInner>) {
         let snapshot = reg.snapshot();
         let machine_id = reg.machine_id();
 
-        let mut to_close: Vec<Uuid> = Vec::new();
         let mut to_stale: Vec<Uuid> = Vec::new();
         let mut to_heartbeat: HashMap<Uuid, ()> = HashMap::new();
 
@@ -880,10 +861,13 @@ async fn run_heartbeat_loop(inner: Arc<CoordSyncInner>) {
                 .to_std()
                 .unwrap_or_else(|_| Duration::from_secs(0));
 
-            if elapsed >= inner.autoclose {
-                to_close.push(desc.id);
-                continue;
-            }
+            // NOTE (plan A3): the runner deliberately does NOT auto-close /
+            // DELETE an abandoned session here. When heartbeats cease (runner
+            // stopped/crashed/slept), coord's own watcher ages the row
+            // (Active→Stale at 600s, →Closed at 1800s). Self-closing at a
+            // shorter local threshold would race coord and prematurely DELETE
+            // a session coord still considers live. The local Stale flip below
+            // is a UI affordance only — it never emits a DELETE.
             if elapsed >= inner.stale && !matches!(desc.state, SessionState::Stale) {
                 to_stale.push(desc.id);
             }
@@ -921,23 +905,6 @@ async fn run_heartbeat_loop(inner: Arc<CoordSyncInner>) {
                     session = %id,
                     error = %e,
                     "coord_sync: heartbeat outbox write failed"
-                );
-            }
-        }
-
-        // Auto-close the truly-gone sessions. `close_by_id` records the
-        // `closed` event in the outbox, which the drain loop folds into
-        // a DELETE on its next tick.
-        for id in to_close {
-            tracing::info!(
-                session = %id,
-                "coord_sync: auto-closing session past autoclose threshold"
-            );
-            if let Err(e) = reg.close_by_id(id) {
-                tracing::warn!(
-                    session = %id,
-                    error = %e,
-                    "coord_sync: auto-close failed"
                 );
             }
         }
@@ -1052,6 +1019,8 @@ mod tests {
             purpose: "coord-sync test".into(),
             repo: Some("qontinui-runner".into()),
             branch: Some("feat/coord-sync".into()),
+            plan_slug: None,
+            correlation_topic: None,
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
@@ -1206,7 +1175,6 @@ mod tests {
             "http://127.0.0.1:1".to_string(),
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
 
@@ -1233,7 +1201,6 @@ mod tests {
             "http://127.0.0.1:1".to_string(),
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
 
@@ -1261,7 +1228,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
         // Establish the session (writes the `started` row) BEFORE starting
@@ -1306,7 +1272,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
         // See drain_pushes: start the session before the drain loop so its
@@ -1344,7 +1309,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
         // See drain_pushes: session before the drain loop to avoid the
@@ -1373,7 +1337,6 @@ mod tests {
             base,
             Duration::from_millis(100),
             Duration::from_secs(60),
-            Duration::from_secs(600),
         );
         let registry = build_registry(coord.clone());
         // Session before the heartbeat loop, consistent with the drain
@@ -1405,7 +1368,6 @@ mod tests {
             base,
             Duration::from_millis(100),
             Duration::from_secs(60),
-            Duration::from_secs(600),
         );
         let registry = build_registry(coord.clone());
         // Session before the loops (see drain_pushes).
@@ -1422,31 +1384,28 @@ mod tests {
         .await;
     }
 
+    /// Plan A3 — an ABANDONED session (heartbeats ceased) must NOT
+    /// self-delete. The runner leaves it for coord's own watcher to age;
+    /// the sweep only flips local state to Stale (a UI affordance) and keeps
+    /// emitting heartbeats. It must never emit a `closed`→DELETE.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn autoclose_fires_delete_after_threshold() {
+    async fn abandoned_session_goes_stale_but_never_self_deletes() {
         let dir = tempfile::tempdir().unwrap();
         let outbox = build_outbox(dir.path());
         let (base, rec) = spawn_fake_coord().await;
-        // Heartbeat every 50ms; stale at 60ms; autoclose at 120ms so
-        // the natural elapsed time after a session start crosses the
-        // threshold within ~half a second of wall-clock.
+        // Heartbeat every 50ms; stale at 60ms. There is no autoclose
+        // threshold any longer — abandonment is coord's job to reap.
         let coord = CoordSync::new_for_test(
             outbox.clone(),
             base,
             Duration::from_millis(50),
             Duration::from_millis(60),
-            Duration::from_millis(120),
         );
         let registry = build_registry(coord.clone());
 
-        // Start the session and force its last_heartbeat far into the past
-        // BEFORE spawning the heartbeat/drain loops. On a multi_thread
-        // runtime the loops run concurrently: if they were started first,
-        // the heartbeat sweep could race ahead of the force, see the
-        // session as still "active", and emit a fresh heartbeat row — so
-        // the autoclose never fires and the DELETE never lands (observed
-        // ~65% flake). Forcing it stale first makes the very first sweep
-        // autoclose it deterministically.
+        // Start the session and shove its last_heartbeat 10s into the past —
+        // well beyond the OLD 180s/120ms autoclose window — so we prove that
+        // even a long-abandoned session is never self-DELETEd.
         let handle = registry.start(make_test_intent()).unwrap();
         let id = handle.id();
         registry.force_heartbeat_to_for_test(id, Utc::now() - chrono::Duration::seconds(10));
@@ -1454,14 +1413,29 @@ mod tests {
         let _drain = coord.start_drain_task();
         let _hb = coord.start_heartbeat_task();
 
+        // The sweep should flip the session to Stale locally.
         wait_until(Duration::from_secs(5), || {
-            let r = rec.try_lock();
-            r.map(|g| g.deletes.contains(&id)).unwrap_or(false)
+            registry
+                .describe_by_id(id)
+                .map(|d| d.state == SessionState::Stale)
+                .unwrap_or(false)
         })
         .await;
 
+        // Give the loops several more ticks to (NOT) self-delete.
+        tokio::time::sleep(Duration::from_millis(400)).await;
+
+        let g = rec.lock().await;
+        assert!(
+            !g.deletes.contains(&id),
+            "abandoned session must NOT be self-DELETEd by the runner — coord reaps it"
+        );
+        drop(g);
+
+        // Local state stays Stale (never Closed) — only an explicit close
+        // would flip it to Closed + emit a DELETE.
         let desc = registry.describe_by_id(id).unwrap();
-        assert_eq!(desc.state, SessionState::Closed);
+        assert_eq!(desc.state, SessionState::Stale);
     }
 
     /// Smoke test: rebuild_create_body honors the payload's intent +
@@ -1593,7 +1567,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let id = Uuid::new_v4();
         let probe = coord.probe_resume(id).await;
@@ -1619,7 +1592,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let probe = coord.probe_resume(Uuid::new_v4()).await;
         assert_eq!(probe, ResumeProbe::NotFound);
@@ -1637,7 +1609,6 @@ mod tests {
             "http://127.0.0.1:1".to_string(),
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let probe = coord.probe_resume(Uuid::new_v4()).await;
         assert_eq!(probe, ResumeProbe::Unreachable);
@@ -1655,7 +1626,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
 
@@ -1694,7 +1664,6 @@ mod tests {
             base,
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
 
@@ -1728,7 +1697,6 @@ mod tests {
             "http://127.0.0.1:1".to_string(),
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
 
@@ -1759,7 +1727,6 @@ mod tests {
             "http://127.0.0.1:1".to_string(),
             Duration::from_millis(50),
             Duration::from_secs(10),
-            Duration::from_secs(60),
         );
         let registry = build_registry(coord.clone());
         let mut intent = make_test_intent();

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -620,12 +620,22 @@ fn build_child_intent(state: &HandoffState) -> Result<Intent, HandoffError> {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let redact_secrets = src.get("redact_secrets").and_then(|v| v.as_bool());
+    let plan_slug = src
+        .get("plan_slug")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let correlation_topic = src
+        .get("correlation_topic")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
 
     Ok(Intent {
         kind,
         purpose,
         repo: state.repo.clone(),
         branch: state.branch.clone(),
+        plan_slug,
+        correlation_topic,
         declared_paths,
         share_output,
         redact_secrets,

--- a/src-tauri/src/session/intent.rs
+++ b/src-tauri/src/session/intent.rs
@@ -45,6 +45,15 @@ pub struct Intent {
     /// Optional branch name. See [`Intent::repo`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub branch: Option<String>,
+    /// Optional plan slug this session is working on. Forwarded into
+    /// `coord.sessions.intent` so coord can group sessions by plan and
+    /// drive plan-scoped multi-repo dispatch.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub plan_slug: Option<String>,
+    /// Optional correlation topic for cross-machine peer discovery /
+    /// rendezvous. Forwarded into `coord.sessions.intent`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub correlation_topic: Option<String>,
     /// Paths the session intends to touch. The plan calls this out as the
     /// hook for fine-grained claim narrowing in later phases; for now the
     /// list is persisted verbatim in the intent JSON.
@@ -124,6 +133,8 @@ mod tests {
             purpose: "fix the thing".into(),
             repo: None,
             branch: None,
+            plan_slug: None,
+            correlation_topic: None,
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
@@ -200,6 +211,8 @@ mod tests {
             purpose: "drive the agentic loop".into(),
             repo: Some("qontinui-web".into()),
             branch: Some("main".into()),
+            plan_slug: Some("2026-05-22-coord-native-session-coordination".into()),
+            correlation_topic: Some("by-correlation-topic/demo".into()),
             declared_paths: vec![PathBuf::from("/repo/path")],
             share_output: true,
             redact_secrets: Some(false),

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -856,14 +856,14 @@ impl SessionRegistry {
     }
 
     /// Test-only: rewind a session's `last_heartbeat_at` so the
-    /// heartbeat-loop's elapsed-time check trips deterministically
-    /// without sleeping for the real autoclose interval.
+    /// heartbeat-loop's elapsed-time check (the local stale flip) trips
+    /// deterministically without sleeping for the real stale interval.
     #[cfg(test)]
     pub fn force_heartbeat_to_for_test(&self, id: Uuid, when: chrono::DateTime<chrono::Utc>) {
         let mut sessions = self.sessions.lock().expect("session registry poisoned");
         if let Some(rec) = sessions.get_mut(&id) {
             rec.last_heartbeat_at = Some(when);
-            // The autoclose path uses `last_heartbeat_at.unwrap_or(started_at)`,
+            // The sweep uses `last_heartbeat_at.unwrap_or(started_at)`,
             // so also rewind started_at to match — otherwise a brand-new
             // session with `started_at = now` would clamp elapsed to ~0.
             rec.started_at = when;
@@ -1046,6 +1046,8 @@ mod tests {
             purpose: "smoke test".into(),
             repo: None,
             branch: None,
+            plan_slug: None,
+            correlation_topic: None,
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -141,12 +141,13 @@ pub struct TerminalSession {
     /// read by `terminal_close` so it can close the coord mirror.
     coord_session_id: Arc<Mutex<Option<uuid::Uuid>>>,
     /// R1 (session-lifecycle-cleanup) — best-effort hook invoked by the
-    /// waiter thread the instant the backing PTY process exits, BEFORE the
-    /// 180s coord_sync autoclose would otherwise fire. Wired by
+    /// waiter thread the instant the backing PTY process exits. Wired by
     /// `terminal_create` alongside [`Self::set_coord_session_id`]: it
     /// closes the coord session mirror for `coord_session_id` so a process
     /// that dies (operator types `exit`, shell crashes, etc.) doesn't leave
-    /// a ~3-minute ghost `active` row on the dashboard. Held in a shared
+    /// a ghost `active` row on the dashboard until coord's own stale→closed
+    /// watcher reaps it (the runner no longer self-closes abandoned
+    /// sessions; see coord_sync plan A3). Held in a shared
     /// slot so the already-spawned waiter thread can read it once the
     /// registration completes; cloned into the waiter at spawn time.
     /// Idempotent against the frontend `terminal_close` path because
@@ -404,8 +405,9 @@ impl TerminalSession {
             .map_err(|e| format!("Failed to spawn reader thread: {}", e))?;
 
         // R1 — shared slots the waiter thread reads on PTY exit so it can
-        // close the coord session mirror immediately (vs. waiting out the
-        // 180s coord_sync autoclose). Both are populated AFTER spawn by
+        // close the coord session mirror immediately (vs. leaving it for
+        // coord's stale→closed watcher; see coord_sync plan A3). Both are
+        // populated AFTER spawn by
         // `terminal_create` once `register_external` returns the coord id,
         // so the waiter reads them at exit time rather than capturing a
         // value that isn't known yet at spawn.
@@ -481,8 +483,9 @@ impl TerminalSession {
 
                 // R1 — close the coord session mirror the instant the PTY
                 // process exits, instead of letting it linger `active`
-                // until the coord_sync heartbeat loop's 180s autoclose
-                // fires (~3-minute ghost session). Read the coord id + hook
+                // until coord's own stale→closed watcher reaps it (the
+                // runner no longer self-closes abandoned sessions; see
+                // coord_sync plan A3). Read the coord id + hook
                 // populated by `terminal_create` after registration; if the
                 // terminal was never wired into coord (registration failed,
                 // or close raced ahead via the frontend `terminal_close`
@@ -796,7 +799,8 @@ impl TerminalSession {
     /// R1 — install the on-exit hook the waiter thread fires the instant
     /// the PTY process exits. `terminal_create` wires this (alongside
     /// [`Self::set_coord_session_id`]) to close the coord session mirror
-    /// immediately rather than waiting out the 180s coord_sync autoclose.
+    /// immediately rather than leaving it for coord's stale→closed watcher
+    /// (the runner no longer self-closes abandoned sessions; coord_sync A3).
     /// The callback receives the coord session id and must be idempotent
     /// (it shares the close path with the frontend `terminal_close`
     /// command — `SessionRegistry::close_by_id` is already idempotent).


### PR DESCRIPTION
## Phases 7.1 + 7.2 — Intent plan linkage + defer abandonment-close to coord

Part of **coord-push-wiring** (Decision Engine Phase 7). Plan: `qontinui-dev-notes/plans/2026-05-30-coord-push-wiring.md`.

### P7.1 — Intent gains plan linkage
`Intent` gains optional `plan_slug` / `correlation_topic` (mirrors `repo`/`branch`). Surfaced in `terminal_create` + `StartSessionArgs` so an operator terminal can declare the plan it's working on; `handoff.rs` forwards them across handoff. They reach coord automatically via the whole-`Intent` serde in `rebuild_create_body` (POST `/sessions`). This is how a **root / multi-repo** terminal (no single repo) gets a coordination unit.

### P7.2 — remove the 180s autoclose→DELETE race
Per the plan's A3 decision, the runner must **not** DELETE an abandoned session at 180s — that races coord's staleness watcher and the session goes straight to Closed, so the `SessionStale`-only next-step trigger never fires. Removed the `elapsed >= autoclose` self-close path and all now-dead `autoclose` machinery (`DEFAULT_AUTOCLOSE_SECS`, the env read, the struct field + accessor, the close loop). An abandoned session now simply stops heartbeating and **coord** owns the Active→Stale (600s) → Closed (1800s) lifecycle + the next-step consult.

**Kept:** the explicit-close → `closed` → DELETE path (a deliberate terminal close still reflects immediately, and is intentionally NOT auto-continued — predictability), and the 45s local-Stale UI flip.

Validation: `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt -- --check` clean; `coord_sync` tests (20) green, incl. the new `abandoned_session_goes_stale_but_never_self_deletes`.

### Merge ordering
Merge **after** `qontinui-web#350` + the coord PR. No schema dependency in the runner itself, but the end-to-end loop needs both upstream sides live.
