### PR TITLE
chore(test): migrate headless-launcher to Cognito + drain dead auto-login

### DIFF
--- a/scripts/headless-launcher.js
+++ b/scripts/headless-launcher.js
@@ -3,26 +3,28 @@
  * Headless browser launcher for Spec-CI testing.
  *
  * Launches a Playwright Chromium browser, optionally signs in to a
- * qontinui-web instance via the backend auth API (cookies get set into
- * the browser context automatically), navigates to a target URL, and
- * holds the browser open so the runner-side UI Bridge SDK can connect.
+ * qontinui-web instance, navigates to a target URL, and holds the browser
+ * open so the runner-side UI Bridge SDK can connect.
  *
- * Programmatic login (the Bucket C7 piece) uses
- * `context.request.post()` so the response's `Set-Cookie` HttpOnly
- * cookies attach to the same browser context the page runs in. This is
- * the only way to satisfy qontinui-web's auth middleware without
- * filling out the login form — the frontend's `AuthService.login` does
- * the same `fetch(..., { credentials: "include" })` shape and reads the
- * cookies back transparently.
+ * Authentication (the Bucket C7 piece) is Cognito-only after the legacy-auth
+ * teardown (T3): the web backend's local `/api/v1/auth/jwt/login` endpoint was
+ * DELETED. We mint a Cognito **id token** via the public CI app-client's
+ * USER_PASSWORD_AUTH `InitiateAuth` API (no AWS creds, no client secret), then
+ * seed it as the `access_token` cookie on the browser context. The backend
+ * routes that cookie to its Cognito verifier by the token's `iss`. There is NO
+ * local-password form to fall back to — sign-in is otherwise a redirect to the
+ * Cognito hosted UI (an external origin we can't drive headlessly). This mirrors
+ * `qontinui-web/frontend/tests/e2e/auth.setup.ts`.
  *
  * Usage:
  *   node headless-launcher.js --url=URL [--headless] [--timeout=30000]
- *                             [--api-base=URL] [--email=X] [--password=Y]
+ *                             [--email=X] [--password=Y]
  *
  * Env fallbacks:
- *   QONTINUI_TEST_AUTO_LOGIN_EMAIL    same as --email
- *   QONTINUI_TEST_AUTO_LOGIN_PASSWORD same as --password
- *   QONTINUI_API_BASE_URL             same as --api-base
+ *   QONTINUI_TEST_AUTO_LOGIN_EMAIL     same as --email (a Cognito user)
+ *   QONTINUI_TEST_AUTO_LOGIN_PASSWORD  same as --password (a Cognito user)
+ *   QONTINUI_COGNITO_CI_CLIENT_ID      override the public CI app-client id
+ *   QONTINUI_COGNITO_REGION            override the Cognito region
  *
  * Writes JSON status lines to stdout:
  *   {"status":"launching","url":"..."}
@@ -38,6 +40,13 @@
  */
 
 const { chromium } = require("@playwright/test");
+
+// Cognito CI app client — mirrors qontinui-web/frontend/tests/e2e/auth.setup.ts
+// and frontend/tests/spec-ci/run-spec-ci.ts. The id is a PUBLIC app-client id
+// (USER_PASSWORD_AUTH, no secret), not a secret.
+const COGNITO_CI_CLIENT_ID =
+  process.env.QONTINUI_COGNITO_CI_CLIENT_ID || "tb0epbojige1900ipu6q80j6b";
+const COGNITO_REGION = process.env.QONTINUI_COGNITO_REGION || "us-east-1";
 
 function parseArgs() {
   const args = {};
@@ -55,96 +64,51 @@ function emit(obj) {
 }
 
 /**
- * Resolve the auth API base URL from CLI, env, or — as a last resort —
- * derive it from the target URL (replace the port with the canonical
- * backend's URL). The derive path covers the "I forgot to pass anything"
- * dev case but warns explicitly so CI never silently hits the wrong env.
- */
-function resolveApiBase(targetUrl, cliApiBase) {
-  if (cliApiBase) return cliApiBase;
-  if (process.env.QONTINUI_API_BASE_URL) return process.env.QONTINUI_API_BASE_URL;
-
-  // Heuristic: if target is localhost:3001 (canonical dev frontend) and no
-  // override was given, assume the AWS canonical backend per the project's
-  // .env.local convention. Memory: reference_qontinui_web_backend_aws.
-  try {
-    const t = new URL(targetUrl);
-    if (t.hostname === "localhost" || t.hostname === "127.0.0.1") {
-      emit({
-        status: "api-base-inferred",
-        target: targetUrl,
-        inferred: "https://api.qontinui.io",
-        note: "no --api-base supplied; defaulting to AWS canonical backend",
-      });
-      return "https://api.qontinui.io";
-    }
-    // Production / staging — auth API typically lives at the same host
-    // with no port change.
-    return `${t.protocol}//${t.hostname.replace(/^demo\.staging\./, "api.").replace(/^/, "api.").replace(/^api\.api\./, "api.")}`;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Perform a programmatic sign-in against `/api/v1/auth/jwt/login` using
- * the browser context's request stack so cookies attach to the page's
- * cookie jar. The endpoint expects `application/x-www-form-urlencoded`
- * with `username` + `password` fields (fastapi-users convention).
+ * Mint a Cognito **id token** via the public InitiateAuth API
+ * (USER_PASSWORD_AUTH, no secret → unauthenticated POST, no AWS creds needed).
  *
- * Returns a structured result so the launcher can keep going (and emit
- * a sensible status) even when auth fails — Spec-CI then aborts on the
- * snapshot precondition check, surfacing the same "session expired"
- * error path that catches a stale token in any other context.
+ * Returns a structured result so the launcher can emit a sensible status. On
+ * any failure the result is `{ ok: false, reason }` — the caller decides
+ * whether to fail loudly (it does: there is no `/jwt/login` fallback anymore).
  */
-async function programmaticLogin(context, apiBase, email, password) {
-  if (!apiBase) {
-    return { ok: false, reason: "no_api_base" };
-  }
+async function mintCognitoIdToken(email, password) {
   if (!email || !password) {
     return { ok: false, reason: "no_credentials" };
   }
 
-  const url = `${apiBase.replace(/\/$/, "")}/api/v1/auth/jwt/login`;
-  const form = new URLSearchParams({ username: email, password }).toString();
-
   try {
-    const resp = await context.request.post(url, {
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      data: form,
-    });
-    if (!resp.ok()) {
+    const resp = await fetch(
+      `https://cognito-idp.${COGNITO_REGION}.amazonaws.com/`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/x-amz-json-1.1",
+          "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+        },
+        body: JSON.stringify({
+          AuthFlow: "USER_PASSWORD_AUTH",
+          ClientId: COGNITO_CI_CLIENT_ID,
+          AuthParameters: { USERNAME: email, PASSWORD: password },
+        }),
+      },
+    );
+    if (!resp.ok) {
       const body = await resp.text();
       return {
         ok: false,
-        reason: `http_${resp.status()}`,
+        reason: `http_${resp.status}`,
         bodySnippet: body.slice(0, 200),
       };
     }
-    return { ok: true };
+    const body = await resp.json();
+    const idToken = body?.AuthenticationResult?.IdToken;
+    if (!idToken) {
+      return { ok: false, reason: "no_id_token_in_response" };
+    }
+    return { ok: true, idToken };
   } catch (err) {
     return { ok: false, reason: `transport: ${err.message ?? String(err)}` };
   }
-}
-
-/**
- * Set the localStorage `is_authenticated` flag the frontend's
- * `TokenStorage` uses to short-circuit re-auth on subsequent loads.
- * Cookies alone are enough for the backend, but the frontend's
- * pre-mount auth check reads localStorage to decide whether to show
- * the LoginScreen before the cookie-backed `/users/me` call resolves.
- *
- * Run this AFTER the first navigation so the page has a window+document
- * to write into.
- */
-async function flagAuthenticated(page) {
-  await page.evaluate(() => {
-    try {
-      window.localStorage.setItem("is_authenticated", "true");
-    } catch {
-      // ignore — some embedded contexts disable localStorage
-    }
-  });
 }
 
 async function main() {
@@ -152,16 +116,16 @@ async function main() {
   const url = args.url;
   const headless = args.headless !== "false";
   const timeout = parseInt(args.timeout || "30000", 10);
-  const apiBase = resolveApiBase(url, args["api-base"]);
   const email = args.email || process.env.QONTINUI_TEST_AUTO_LOGIN_EMAIL;
-  const password = args.password || process.env.QONTINUI_TEST_AUTO_LOGIN_PASSWORD;
+  const password =
+    args.password || process.env.QONTINUI_TEST_AUTO_LOGIN_PASSWORD;
 
   if (!url) {
     emit({ status: "error", message: "Missing --url argument" });
     process.exit(1);
   }
 
-  emit({ status: "launching", url, apiBase, headless });
+  emit({ status: "launching", url, headless });
 
   let browser;
   try {
@@ -175,11 +139,44 @@ async function main() {
       ignoreHTTPSErrors: true,
     });
 
-    // Sign in BEFORE navigation so the auth cookies attach to the context.
-    // If credentials weren't supplied we skip silently — the launcher is
-    // still useful for unauthenticated pages (e.g. /login itself, marketing
-    // routes, demos).
-    const auth = await programmaticLogin(context, apiBase, email, password);
+    // Mint a Cognito id token. If credentials weren't supplied we skip the
+    // mint silently — the launcher is still useful for unauthenticated pages
+    // (e.g. /login itself, marketing routes, demos). But if creds WERE supplied
+    // and the mint fails, we fail loudly: there is no `/jwt/login` fallback
+    // after the Cognito legacy-auth teardown.
+    let auth = { ok: false, reason: "no_credentials" };
+    if (email && password) {
+      auth = await mintCognitoIdToken(email, password);
+      if (!auth.ok) {
+        throw new Error(
+          `Cognito InitiateAuth failed (reason=${auth.reason}` +
+            `${auth.bodySnippet ? `, body=${auth.bodySnippet}` : ""}). ` +
+            "There is no local /jwt/login fallback after the Cognito " +
+            "legacy-auth teardown — check the CI client id, region, and that " +
+            "the credentials are a valid Cognito user.",
+        );
+      }
+    }
+
+    // Seed the access_token cookie (backend routes it to the Cognito verifier
+    // by `iss`) BEFORE navigation so the page hydrates authenticated. We need
+    // an origin for the cookie URL; derive it from the target URL.
+    if (auth.ok) {
+      const origin = new URL(url).origin;
+      await context.addCookies([
+        { name: "access_token", value: auth.idToken, url: origin },
+      ]);
+      // Set the client-side `is_authenticated` flag the route guard reads,
+      // before any document loads, via an init script on the context.
+      await context.addInitScript(() => {
+        try {
+          window.localStorage.setItem("is_authenticated", "true");
+        } catch {
+          // ignore — some embedded contexts disable localStorage
+        }
+      });
+    }
+
     emit({
       status: "auth-attempted",
       ok: auth.ok,
@@ -189,18 +186,11 @@ async function main() {
 
     const page = await context.newPage();
 
-    // First navigation may itself be redirected to /login if auth failed
-    // or wasn't attempted. We don't fight that here — the consumer (the
-    // Spec-CI executor) detects the login-page footprint via its
-    // precondition check and aborts loudly.
+    // First navigation may itself be redirected to /login if auth wasn't
+    // attempted. We don't fight that here — the consumer (the Spec-CI
+    // executor) detects the login-page footprint via its precondition check
+    // and aborts loudly.
     await page.goto(url, { waitUntil: "networkidle", timeout });
-
-    // After load, persist the auth-flag the frontend's TokenStorage
-    // expects. Harmless if we're on /login already (the flag is read by
-    // the post-auth path that's no-op here).
-    if (auth.ok) {
-      await flagAuthenticated(page);
-    }
 
     emit({ status: "ready", pid: process.pid, finalUrl: page.url() });
 

--- a/src-tauri/src/launch_env.rs
+++ b/src-tauri/src/launch_env.rs
@@ -54,51 +54,6 @@ pub struct WindowEnvHints {
     pub decorations: Option<bool>,
 }
 
-/// Test auto-login credentials, populated for temp test runners only.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct TestAutoLogin {
-    pub email: String,
-    pub password: String,
-}
-
-/// Reasons `auto_login` may be `None`. Surfaced via
-/// `auto_login_skip_reason` so `get_test_auto_login` can log the
-/// specific control-flow branch that caused the skip — the FE-facing
-/// `Option<TestAutoLoginCreds>` return type alone hides this distinction
-/// and leaves operators staring at a LoginScreen with no diagnostic.
-///
-/// `&'static str` so log queries (`grep test_auto_login_skipped runner-tauri.log`)
-/// can match exactly, and so callers don't need to allocate to emit the field.
-pub const AUTO_LOGIN_SKIP_ENV_VARS_MISSING: &str = "env_vars_missing";
-pub const AUTO_LOGIN_SKIP_ENV_EMAIL_MISSING: &str = "env_email_missing";
-pub const AUTO_LOGIN_SKIP_ENV_PASSWORD_MISSING: &str = "env_password_missing";
-pub const AUTO_LOGIN_SKIP_ENV_CREDENTIALS_EMPTY: &str = "env_credentials_empty";
-
-/// Pure helper used by both [`RunnerLaunchEnv::read`] and the unit tests.
-///
-/// Returns `Ok(TestAutoLogin)` when both env vars are present and non-empty,
-/// `Err(&'static str)` with one of the `AUTO_LOGIN_SKIP_*` reasons otherwise.
-///
-/// Extracted so the skip-reason taxonomy can be verified without mutating
-/// process env — every branch is exercised directly via `Option<&str>` inputs.
-pub(crate) fn classify_test_auto_login(
-    email: Option<&str>,
-    password: Option<&str>,
-) -> Result<TestAutoLogin, &'static str> {
-    match (email, password) {
-        (None, None) => Err(AUTO_LOGIN_SKIP_ENV_VARS_MISSING),
-        (None, Some(_)) => Err(AUTO_LOGIN_SKIP_ENV_EMAIL_MISSING),
-        (Some(_), None) => Err(AUTO_LOGIN_SKIP_ENV_PASSWORD_MISSING),
-        (Some(e), Some(p)) if e.is_empty() || p.is_empty() => {
-            Err(AUTO_LOGIN_SKIP_ENV_CREDENTIALS_EMPTY)
-        }
-        (Some(e), Some(p)) => Ok(TestAutoLogin {
-            email: e.to_string(),
-            password: p.to_string(),
-        }),
-    }
-}
-
 /// Restate runtime overrides injected by the supervisor.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RestateEnvHints {
@@ -145,17 +100,6 @@ pub struct RunnerLaunchEnv {
     /// Window placement hints (`QONTINUI_WINDOW_X/Y/WIDTH/HEIGHT/DECORATIONS`).
     pub window: WindowEnvHints,
 
-    /// Test auto-login credentials (`QONTINUI_TEST_AUTO_LOGIN_EMAIL/PASSWORD`).
-    /// Both must be set and non-empty for `Some` to be returned.
-    pub auto_login: Option<TestAutoLogin>,
-
-    /// Skip-reason tag when `auto_login` is `None`. One of the
-    /// `AUTO_LOGIN_SKIP_*` constants — see [`classify_test_auto_login`].
-    /// `None` when `auto_login` is `Some`. Surfaced by
-    /// `commands::auth::get_test_auto_login` to runner-tauri.log so an
-    /// operator stuck on a LoginScreen can grep for the exact reason.
-    pub auto_login_skip_reason: Option<&'static str>,
-
     /// Override for the panic-log directory (`QONTINUI_PANIC_LOG_DIR`).
     /// Note: `startup_panic.rs` historically reads `QONTINUI_RUNNER_LOG_DIR`
     /// for the same purpose — both are accepted; the runner-log-dir wins.
@@ -182,8 +126,6 @@ impl Default for RunnerLaunchEnv {
             primary_port: None,
             server_mode: false,
             window: WindowEnvHints::default(),
-            auto_login: None,
-            auto_login_skip_reason: Some(AUTO_LOGIN_SKIP_ENV_VARS_MISSING),
             panic_log_dir: None,
             runner_log_dir: None,
             webview2_user_data_dir: None,
@@ -223,14 +165,6 @@ impl RunnerLaunchEnv {
                 .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false"))),
         };
 
-        let email_raw = std::env::var("QONTINUI_TEST_AUTO_LOGIN_EMAIL").ok();
-        let password_raw = std::env::var("QONTINUI_TEST_AUTO_LOGIN_PASSWORD").ok();
-        let (auto_login, auto_login_skip_reason) =
-            match classify_test_auto_login(email_raw.as_deref(), password_raw.as_deref()) {
-                Ok(creds) => (Some(creds), None),
-                Err(reason) => (None, Some(reason)),
-            };
-
         let panic_log_dir = std::env::var("QONTINUI_PANIC_LOG_DIR")
             .ok()
             .filter(|s| !s.trim().is_empty())
@@ -263,8 +197,6 @@ impl RunnerLaunchEnv {
             primary_port,
             server_mode,
             window,
-            auto_login,
-            auto_login_skip_reason,
             panic_log_dir,
             runner_log_dir,
             webview2_user_data_dir,
@@ -300,15 +232,6 @@ mod tests {
         assert!(!env.server_mode);
         assert!(!env.is_secondary());
         assert_eq!(env.window, WindowEnvHints::default());
-        assert!(env.auto_login.is_none());
-        // Default = "no env vars" which is the env-vars-missing case.
-        // Phase 8 (manual-test remediation): default is the canonical
-        // representation of a primary-runner launch, where the absence of
-        // QONTINUI_TEST_AUTO_LOGIN_* must surface as a logged skip reason.
-        assert_eq!(
-            env.auto_login_skip_reason,
-            Some(AUTO_LOGIN_SKIP_ENV_VARS_MISSING)
-        );
     }
 
     #[test]
@@ -340,19 +263,6 @@ mod tests {
     }
 
     #[test]
-    fn auto_login_struct_construction() {
-        let creds = TestAutoLogin {
-            email: "test@example.com".into(),
-            password: "secret".into(),
-        };
-        let env = RunnerLaunchEnv {
-            auto_login: Some(creds.clone()),
-            ..Default::default()
-        };
-        assert_eq!(env.auto_login.as_ref().unwrap(), &creds);
-    }
-
-    #[test]
     fn restate_hints_default_empty() {
         let env = RunnerLaunchEnv::default();
         assert!(env.restate.external_admin_url.is_none());
@@ -372,76 +282,5 @@ mod tests {
         let env = RunnerLaunchEnv::read();
         let _ = env.is_secondary();
         let _ = env.kind;
-    }
-
-    // -- classify_test_auto_login: phase-8 manual-test remediation --
-    //
-    // Pure-helper tests that exercise every skip-reason branch without
-    // mutating process env. The exact reason strings are part of the
-    // operator-grep contract (`grep test_auto_login_skipped runner-tauri.log`),
-    // so the assertions check the constants verbatim.
-
-    #[test]
-    fn classify_both_missing_yields_env_vars_missing() {
-        assert_eq!(
-            classify_test_auto_login(None, None),
-            Err(AUTO_LOGIN_SKIP_ENV_VARS_MISSING)
-        );
-    }
-
-    #[test]
-    fn classify_only_password_yields_email_missing() {
-        assert_eq!(
-            classify_test_auto_login(None, Some("p")),
-            Err(AUTO_LOGIN_SKIP_ENV_EMAIL_MISSING)
-        );
-    }
-
-    #[test]
-    fn classify_only_email_yields_password_missing() {
-        assert_eq!(
-            classify_test_auto_login(Some("e@x"), None),
-            Err(AUTO_LOGIN_SKIP_ENV_PASSWORD_MISSING)
-        );
-    }
-
-    #[test]
-    fn classify_empty_strings_yield_credentials_empty() {
-        assert_eq!(
-            classify_test_auto_login(Some(""), Some("p")),
-            Err(AUTO_LOGIN_SKIP_ENV_CREDENTIALS_EMPTY)
-        );
-        assert_eq!(
-            classify_test_auto_login(Some("e@x"), Some("")),
-            Err(AUTO_LOGIN_SKIP_ENV_CREDENTIALS_EMPTY)
-        );
-        assert_eq!(
-            classify_test_auto_login(Some(""), Some("")),
-            Err(AUTO_LOGIN_SKIP_ENV_CREDENTIALS_EMPTY)
-        );
-    }
-
-    #[test]
-    fn classify_both_set_returns_creds() {
-        assert_eq!(
-            classify_test_auto_login(Some("e@x"), Some("p")),
-            Ok(TestAutoLogin {
-                email: "e@x".to_string(),
-                password: "p".to_string(),
-            })
-        );
-    }
-
-    #[test]
-    fn auto_login_skip_reason_constants_are_distinct() {
-        // Operator-grep contract: each reason must be a unique &'static str.
-        let reasons = [
-            AUTO_LOGIN_SKIP_ENV_VARS_MISSING,
-            AUTO_LOGIN_SKIP_ENV_EMAIL_MISSING,
-            AUTO_LOGIN_SKIP_ENV_PASSWORD_MISSING,
-            AUTO_LOGIN_SKIP_ENV_CREDENTIALS_EMPTY,
-        ];
-        let unique: std::collections::HashSet<_> = reasons.iter().copied().collect();
-        assert_eq!(unique.len(), reasons.len());
     }
 }


### PR DESCRIPTION
Follow-up #1 from the Cognito legacy-auth teardown ([[proj_cognito_legacy_auth_teardown_shipped]]). The web backend's `/jwt/login` is deleted, so:

- **`scripts/headless-launcher.js`** (CLI UI-Bridge test harness): `programmaticLogin` (POST `/jwt/login`) replaced with a Cognito id-token mint via the public CI app-client `tb0epbojige1900ipu6q80j6b` (USER_PASSWORD_AUTH `InitiateAuth`, no AWS creds/secret), seeding the `access_token` cookie + `is_authenticated` flag — mirrors `frontend/tests/e2e/auth.setup.ts`. Fails loud, no fallback. CI client id + region env-overridable.
- **`src-tauri/src/launch_env.rs`**: drained the orphaned auto-login plumbing (`TestAutoLogin`, `classify_test_auto_login`, `AUTO_LOGIN_SKIP_*`, the `auto_login`/`auto_login_skip_reason` fields + env reads + tests) whose only consumers were deleted in T3. No live callers remain.

Verified: `node --check` OK; `cargo check` + `cargo clippy --no-deps` clean. −171 net.