### PR TITLE
fix(runner): stop using runner_token as the 'device paired' proxy (Cognito drop-off)

### DIFF
--- a/src-tauri/src/commands/web_integration.rs
+++ b/src-tauri/src/commands/web_integration.rs
@@ -219,10 +219,9 @@ pub async fn apply_web_integration_settings<R: Runtime>(
     } else {
         info!(
             "Web-integration hot-reload: new settings do not form a valid config \
-             (enabled={}, backend_url_empty={}, runner_token_empty={}) — integration is now disabled",
+             (enabled={}, backend_url_empty={}) — integration is now disabled",
             normalized.enabled,
             normalized.backend_url.is_empty(),
-            normalized.runner_token.is_empty(),
         );
     }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -591,15 +591,11 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             );
             crate::server_mode::ServerModeState::new(cfg)
         });
-    if initial_server_mode_state.is_none()
-        && (!web_integration_settings.backend_url.is_empty()
-            || !web_integration_settings.runner_token.is_empty())
-    {
+    if initial_server_mode_state.is_none() && !web_integration_settings.backend_url.is_empty() {
         warn!(
-            "Web-integration partially configured (enabled={}, backend_url_empty={}, runner_token_empty={}) — phase events and heartbeats will NOT be reported until all three are set",
+            "Web-integration not active (enabled={}, backend_url_empty={}) — phase events and heartbeats will NOT be reported until it is enabled with a backend URL. (A runner_token is no longer required; the relay authenticates with the device JWT.)",
             web_integration_settings.enabled,
             web_integration_settings.backend_url.is_empty(),
-            web_integration_settings.runner_token.is_empty(),
         );
     }
     let server_mode_state: Arc<tokio::sync::RwLock<Option<crate::server_mode::ServerModeState>>> =

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -83,25 +83,31 @@ pub(crate) enum Decision {
     /// Tier is not `QontinuiAccount` — refresher has nothing to do.
     /// Wait for a tier-change kick before re-checking.
     IdleWrongTier,
-    /// JWT needs refresh but no `runner_token` is available to present
-    /// to coord. Wait for a settings-change kick before re-checking.
-    IdleNoToken,
-    /// JWT needs refresh and a bearer token is available — call
-    /// `pair_with_auth_token`.
+    /// JWT needs refresh — resolve a bearer in the `Pair` arm (Cognito
+    /// access token, falling back to the device-JWT slot) and re-mint.
+    /// The arm self-idles (with periodic re-check) if no bearer exists yet,
+    /// so we no longer gate this decision on a `runner_token` being present
+    /// (Cognito- and pair-code-paired runners have an empty `runner_token`
+    /// but a valid Cognito/device bearer — gating on `runner_token` here
+    /// stranded them and let their device JWT expire).
     Pair,
 }
 
-/// Pure decision predicate: given the current tier + bearer token +
-/// "does the JWT need refresh?" answer, what should the loop do?
-pub(crate) fn next_action(tier: RunnerTier, runner_token: &str, needs_refresh: bool) -> Decision {
+/// Pure decision predicate: given the current tier + "does the JWT need
+/// refresh?" answer, what should the loop do?
+///
+/// Deliberately does NOT consult `web_integration.runner_token`. Post-Cognito
+/// unification the bearer is the Cognito access token (or the device-JWT slot)
+/// — neither populates `runner_token`, so gating on it here left every
+/// Cognito-/pair-code-paired runner in a permanent "idle, no token" state and
+/// let its device JWT silently expire. The `Pair` arm resolves the real bearer
+/// and idles gracefully (with periodic re-check) when none is available yet.
+pub(crate) fn next_action(tier: RunnerTier, needs_refresh: bool) -> Decision {
     if tier != RunnerTier::QontinuiAccount {
         return Decision::IdleWrongTier;
     }
     if !needs_refresh {
         return Decision::Idle;
-    }
-    if runner_token.trim().is_empty() {
-        return Decision::IdleNoToken;
     }
     Decision::Pair
 }
@@ -340,11 +346,7 @@ async fn refresher_loop(
             }
         };
 
-        let decision = next_action(
-            settings_snapshot.tier,
-            settings_snapshot.web_integration.runner_token.trim(),
-            needs_refresh,
-        );
+        let decision = next_action(settings_snapshot.tier, needs_refresh);
 
         match decision {
             Decision::IdleWrongTier => {
@@ -353,23 +355,6 @@ async fn refresher_loop(
                 tokio::select! {
                     _ = shutdown_rx.changed() => {
                         info!("Device-JWT refresher shutting down (was idle on non-Tier2)");
-                        return;
-                    }
-                    _ = kick_rx.changed() => continue,
-                }
-            }
-            Decision::IdleNoToken => {
-                // Need to refresh but have no bearer to present. This is
-                // the "first-pair" state — the user must complete a
-                // browser pair before we can refresh. Block on
-                // shutdown/kick to avoid a hot-loop.
-                tracing::debug!(
-                    "device_jwt_refresher: needs refresh but runner_token is empty — \
-                     awaiting first browser-pair (kick on settings save)"
-                );
-                tokio::select! {
-                    _ = shutdown_rx.changed() => {
-                        info!("Device-JWT refresher shutting down (was idle on no-token)");
                         return;
                     }
                     _ = kick_rx.changed() => continue,
@@ -450,12 +435,13 @@ async fn refresher_loop(
                 let user_id = match qontinui_runner_lib::pair::read_paired_user_id_from_disk() {
                     Some(u) => u,
                     None => {
-                        // Should not happen — `Decision::IdleNoToken`
-                        // arm already gates on runner_token presence,
-                        // and a paired install always has both. Log + back off.
+                        // No paired-user record yet — this runner hasn't
+                        // completed a pairing (Cognito sign-in or pair-code),
+                        // so there's nothing to re-mint. Log + back off; the
+                        // next pairing writes the file and a kick wakes us.
                         warn!(
                             "device_jwt_refresher: paired_user.json missing — \
-                             needs first browser-pair (refresher idling until kick)"
+                             runner not paired yet (refresher idling until kick)"
                         );
                         if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx)
                             .await
@@ -576,36 +562,40 @@ mod tests {
 
     #[test]
     fn decides_no_refresh_when_jwt_fresh() {
-        // Tier 2 + token present + needs_refresh=false → Idle (no work).
-        let d = next_action(RunnerTier::QontinuiAccount, "some-runner-token", false);
+        // Tier 2 + needs_refresh=false → Idle (no work).
+        let d = next_action(RunnerTier::QontinuiAccount, false);
         assert_eq!(d, Decision::Idle);
     }
 
     #[test]
-    fn decides_pair_when_jwt_stale_and_token_present() {
-        let d = next_action(RunnerTier::QontinuiAccount, "some-runner-token", true);
+    fn decides_pair_when_jwt_stale() {
+        let d = next_action(RunnerTier::QontinuiAccount, true);
         assert_eq!(d, Decision::Pair);
     }
 
     #[test]
-    fn decides_idle_when_runner_token_empty() {
-        let d = next_action(RunnerTier::QontinuiAccount, "", true);
-        assert_eq!(d, Decision::IdleNoToken);
-        // Whitespace-only should still count as empty.
-        let d2 = next_action(RunnerTier::QontinuiAccount, "   ", true);
-        assert_eq!(d2, Decision::IdleNoToken);
+    fn decides_pair_for_cognito_runner_with_empty_runner_token() {
+        // Regression: a Cognito-/pair-code-paired runner has an EMPTY
+        // `web_integration.runner_token` but a valid Cognito/device bearer.
+        // The refresher must still attempt to re-mint (Pair) — it must NOT
+        // idle on the missing runner_token (which let the device JWT expire
+        // and silently dropped the runner off the cloud after ~one TTL).
+        // `next_action` no longer consults runner_token at all; the `Pair`
+        // arm resolves the real bearer and idles only if none exists.
+        let d = next_action(RunnerTier::QontinuiAccount, true);
+        assert_eq!(d, Decision::Pair);
     }
 
     #[test]
     fn decides_idle_when_tier_not_qontinui_account() {
         // LocalProvider: not Tier 2 — refresher idles regardless of
-        // whether the JWT is stale or a token is present.
-        let d = next_action(RunnerTier::LocalProvider, "some-runner-token", true);
+        // whether the JWT is stale.
+        let d = next_action(RunnerTier::LocalProvider, true);
         assert_eq!(d, Decision::IdleWrongTier);
-        let d2 = next_action(RunnerTier::Local, "some-runner-token", true);
+        let d2 = next_action(RunnerTier::Local, true);
         assert_eq!(d2, Decision::IdleWrongTier);
         // Even with no needs-refresh signal, wrong-tier still wins.
-        let d3 = next_action(RunnerTier::LocalProvider, "", false);
+        let d3 = next_action(RunnerTier::LocalProvider, false);
         assert_eq!(d3, Decision::IdleWrongTier);
     }
 

--- a/src-tauri/src/server_mode/mod.rs
+++ b/src-tauri/src/server_mode/mod.rs
@@ -44,29 +44,41 @@ pub struct ServerModeConfig {
     /// Base URL of the qontinui-web API, e.g. `"https://api.qontinui.io"`.
     /// No trailing slash — callers append `/api/v1/...`.
     pub web_backend_url: String,
-    /// Plaintext runner bearer token (`qontinui_runner_<64hex>`).
-    /// Never logged.
+    /// Legacy plaintext runner bearer token (`qontinui_runner_<64hex>`), or
+    /// empty for a Cognito-/pair-code-paired runner. Never logged.
+    ///
+    /// No longer consulted by the WS relay (it authenticates with the device
+    /// JWT from `AuthManager`) — retained only so legacy installs that still
+    /// carry one round-trip it unchanged.
     pub runner_token: String,
 }
 
 impl ServerModeConfig {
     /// Build from the persisted [`WebIntegrationSettings`].
     ///
-    /// Returns `None` unless `enabled=true` AND `backend_url` is non-empty
-    /// AND `runner_token` is non-empty. Trims a trailing slash from
-    /// `backend_url` so callers can safely append `/api/v1/...` paths.
+    /// Returns `None` unless `enabled=true` AND `backend_url` is non-empty.
+    /// Trims a trailing slash from `backend_url` so callers can safely append
+    /// `/api/v1/...` paths.
+    ///
+    /// Deliberately does NOT require `runner_token`. Post-Cognito unification
+    /// the relay authenticates with the device JWT, and Cognito-/pair-code-
+    /// paired runners have an empty `runner_token`. Requiring it here left
+    /// `ServerModeState` uninstalled for those runners, so the relay had
+    /// nowhere to publish its connection state and `get_web_integration_status`
+    /// reported `ws_connected=false` even while the runner was connected and
+    /// heartbeating. Gating only on `enabled` + `backend_url` installs the
+    /// state for every connectable runner.
     pub fn from_settings(settings: &WebIntegrationSettings) -> Option<Self> {
         if !settings.enabled {
             return None;
         }
         let backend_url = settings.backend_url.trim();
-        let runner_token = settings.runner_token.trim();
-        if backend_url.is_empty() || runner_token.is_empty() {
+        if backend_url.is_empty() {
             return None;
         }
         Some(Self {
             web_backend_url: backend_url.trim_end_matches('/').to_string(),
-            runner_token: runner_token.to_string(),
+            runner_token: settings.runner_token.trim().to_string(),
         })
     }
 }
@@ -270,5 +282,52 @@ mod tests {
         let c = s.clone();
         s.incr_terminal_subscribers();
         assert_eq!(c.terminal_subscriber_count(), 1);
+    }
+
+    fn web_settings(
+        enabled: bool,
+        backend_url: &str,
+        runner_token: &str,
+    ) -> WebIntegrationSettings {
+        WebIntegrationSettings {
+            enabled,
+            backend_url: backend_url.to_string(),
+            runner_token: runner_token.to_string(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn from_settings_builds_with_empty_runner_token() {
+        // Regression: a Cognito-/pair-code-paired runner has an empty
+        // runner_token but must still get a ServerModeState installed so the
+        // relay can publish connection status. Previously this returned None.
+        let cfg =
+            ServerModeConfig::from_settings(&web_settings(true, "https://api.qontinui.io/", ""))
+                .expect("should build a config without a runner_token");
+        assert_eq!(cfg.web_backend_url, "https://api.qontinui.io");
+        assert_eq!(cfg.runner_token, "");
+    }
+
+    #[test]
+    fn from_settings_still_carries_a_legacy_runner_token() {
+        let cfg = ServerModeConfig::from_settings(&web_settings(
+            true,
+            "https://api.qontinui.io",
+            "qontinui_runner_abc",
+        ))
+        .expect("should build");
+        assert_eq!(cfg.runner_token, "qontinui_runner_abc");
+    }
+
+    #[test]
+    fn from_settings_none_when_disabled_or_no_backend_url() {
+        assert!(ServerModeConfig::from_settings(&web_settings(
+            false,
+            "https://api.qontinui.io",
+            ""
+        ))
+        .is_none());
+        assert!(ServerModeConfig::from_settings(&web_settings(true, "   ", "tok")).is_none());
     }
 }

--- a/src/components/WebIntegrationAuthBanner.test.ts
+++ b/src/components/WebIntegrationAuthBanner.test.ts
@@ -26,55 +26,47 @@ const baseFreshInstall: AuthBannerStatus = {
 
 describe("shouldShowAuthBanner", () => {
   it("hides when status has not loaded yet", () => {
-    expect(shouldShowAuthBanner(null, null)).toBe(false);
+    expect(shouldShowAuthBanner(null, false, null)).toBe(false);
   });
 
-  it("shows on a fresh install (enabled, no token, never dismissed)", () => {
-    expect(shouldShowAuthBanner(baseFreshInstall, null)).toBe(true);
+  it("shows on a fresh install (enabled, not paired, never dismissed)", () => {
+    expect(shouldShowAuthBanner(baseFreshInstall, false, null)).toBe(true);
   });
 
   it("hides when the user has opted out (enabled === false)", () => {
     // Respect explicit opt-out — never bug them again until they re-enable.
-    expect(shouldShowAuthBanner({ ...baseFreshInstall, enabled: false }, null)).toBe(false);
+    expect(shouldShowAuthBanner({ ...baseFreshInstall, enabled: false }, false, null)).toBe(false);
   });
 
-  it("hides when the runner token is set", () => {
-    expect(
-      shouldShowAuthBanner(
-        { ...baseFreshInstall, runnerTokenMasked: "qontinui_runner_aaaa…bbbb" },
-        null,
-      ),
-    ).toBe(false);
+  it("hides when the runner is paired (device JWT present), even with an empty runner_token", () => {
+    // Regression: post-Cognito a paired runner has an EMPTY runner_token but a
+    // valid device JWT. The banner must NOT show — it previously keyed off
+    // runner_token and so nagged every Cognito-/pair-code-paired runner.
+    expect(shouldShowAuthBanner(baseFreshInstall, true, null)).toBe(false);
   });
 
   it("hides when the user dismissed for the current status signature", () => {
-    const sig = statusSignature(baseFreshInstall);
-    expect(shouldShowAuthBanner(baseFreshInstall, sig)).toBe(false);
+    const sig = statusSignature(baseFreshInstall, false);
+    expect(shouldShowAuthBanner(baseFreshInstall, false, sig)).toBe(false);
   });
 
   it("re-shows when status changes after a dismissal (e.g. new auth error)", () => {
-    // User dismissed a clean "needs token" banner. A subsequent registration
-    // error must resurface the banner — they need to know the runner is now
-    // actively failing to authenticate, not just unconfigured.
-    const dismissedSig = statusSignature(baseFreshInstall);
+    // User dismissed a clean "needs authorization" banner. A subsequent
+    // registration error must resurface it — they need to know the runner is
+    // now actively failing to authenticate, not just unpaired.
+    const dismissedSig = statusSignature(baseFreshInstall, false);
     const withError: AuthBannerStatus = {
       ...baseFreshInstall,
       registrationError: "401 Unauthorized",
     };
-    expect(shouldShowAuthBanner(withError, dismissedSig)).toBe(true);
+    expect(shouldShowAuthBanner(withError, false, dismissedSig)).toBe(true);
   });
 
-  it("re-shows after token gets cleared (token-revoked path)", () => {
-    // Banner was dismissed when the token was set (so `shouldShowAuthBanner`
-    // would have returned false anyway). Now the token has been cleared —
-    // the new status' signature differs, so the banner reappears.
-    const withToken: AuthBannerStatus = {
-      ...baseFreshInstall,
-      runnerTokenMasked: "qontinui_runner_xxxx…yyyy",
-    };
-    const dismissedWhenTokenSet = statusSignature(withToken);
-    // Token is now empty again:
-    expect(shouldShowAuthBanner(baseFreshInstall, dismissedWhenTokenSet)).toBe(true);
+  it("re-shows after the device un-pairs (device JWT cleared)", () => {
+    // Banner was dismissed while paired (device JWT present, so it was hidden
+    // anyway). The JWT is now gone — the signature differs, so it reappears.
+    const dismissedWhilePaired = statusSignature(baseFreshInstall, true);
+    expect(shouldShowAuthBanner(baseFreshInstall, false, dismissedWhilePaired)).toBe(true);
   });
 });
 
@@ -168,22 +160,24 @@ describe("shouldShowRePairCta (post-upgrade migration)", () => {
 
 describe("statusSignature", () => {
   it("returns an empty string for null status", () => {
-    expect(statusSignature(null)).toBe("");
+    expect(statusSignature(null, false)).toBe("");
   });
 
-  it("differentiates token-set from token-empty even at the same enabled flag", () => {
-    const a = statusSignature(baseFreshInstall);
-    const b = statusSignature({ ...baseFreshInstall, runnerTokenMasked: "qontinui_x…y" });
+  it("differentiates paired from unpaired even at the same enabled flag", () => {
+    const a = statusSignature(baseFreshInstall, false);
+    const b = statusSignature(baseFreshInstall, true);
     expect(a).not.toBe(b);
   });
 
   it("differentiates registration errors from a clean state", () => {
-    const a = statusSignature(baseFreshInstall);
-    const b = statusSignature({ ...baseFreshInstall, registrationError: "401" });
+    const a = statusSignature(baseFreshInstall, false);
+    const b = statusSignature({ ...baseFreshInstall, registrationError: "401" }, false);
     expect(a).not.toBe(b);
   });
 
   it("is stable across calls with identical input", () => {
-    expect(statusSignature(baseFreshInstall)).toBe(statusSignature({ ...baseFreshInstall }));
+    expect(statusSignature(baseFreshInstall, false)).toBe(
+      statusSignature({ ...baseFreshInstall }, false),
+    );
   });
 });

--- a/src/components/WebIntegrationAuthBanner.tsx
+++ b/src/components/WebIntegrationAuthBanner.tsx
@@ -246,10 +246,13 @@ export function WebIntegrationAuthBanner() {
   }, []);
 
   const handleDismiss = useCallback(() => {
-    const sig = statusSignature(status);
+    // `deviceJwtPresent !== false` treats the not-yet-loaded (null) state as
+    // paired so a paired runner never flashes the banner while the
+    // device_jwt_present probe is in flight.
+    const sig = statusSignature(status, deviceJwtPresent !== false);
     writeDismissedSignature(sig);
     setDismissedSignature(sig);
-  }, [status]);
+  }, [status, deviceJwtPresent]);
 
   if (tier !== "qontinui_account") return null;
 
@@ -333,7 +336,7 @@ export function WebIntegrationAuthBanner() {
     );
   }
 
-  const visible = shouldShowAuthBanner(status, dismissedSignature);
+  const visible = shouldShowAuthBanner(status, deviceJwtPresent !== false, dismissedSignature);
   if (!visible) return null;
 
   return (

--- a/src/components/web-integration-banner-logic.ts
+++ b/src/components/web-integration-banner-logic.ts
@@ -17,15 +17,20 @@ export interface AuthBannerStatus {
  * Stable signature used to decide "did the status change since the user
  * dismissed?". Any change to the bits the banner cares about resurfaces it.
  *
- * Including `registrationError` means a 401 transition (auth failure after
- * the token was revoked / rotated server-side) re-shows the banner even
- * mid-session — the user explicitly needs to know.
+ * `deviceJwtPresent` is the real "is this runner paired?" signal post-Cognito
+ * unification (Cognito sign-in / pair-code mint a device JWT; neither sets
+ * `runner_token`). Including `registrationError` means a 401 transition (auth
+ * failure after the credential was revoked / rotated server-side) re-shows the
+ * banner even mid-session — the user explicitly needs to know.
  */
-export function statusSignature(status: AuthBannerStatus | null): string {
+export function statusSignature(
+  status: AuthBannerStatus | null,
+  deviceJwtPresent: boolean,
+): string {
   if (!status) return "";
   return [
     status.enabled ? "1" : "0",
-    status.runnerTokenMasked.length > 0 ? "T" : "_",
+    deviceJwtPresent ? "P" : "_",
     status.registrationError ?? "",
   ].join("|");
 }
@@ -36,19 +41,29 @@ export function statusSignature(status: AuthBannerStatus | null): string {
  * Visibility rule:
  *   - Hide when status hasn't loaded yet (avoid flashing on every render).
  *   - Hide when `enabled === false` — user opted out, respect it.
- *   - Hide when `runnerTokenMasked` is non-empty — token is set, no action needed.
+ *   - Hide when `deviceJwtPresent` — the runner IS paired (has a device JWT
+ *     from Cognito sign-in or a pair-code), so no authorization action is
+ *     needed. NOTE: this used to key off `runnerTokenMasked`, which broke
+ *     post-Cognito: Cognito-/pair-code-paired runners have an empty
+ *     `runner_token`, so a fully-paired runner showed a perpetual "needs
+ *     authorization" banner. Callers should pass `deviceJwtPresent !== false`
+ *     so the not-yet-loaded state (null) is treated as paired (no flash).
  *   - Hide when the user dismissed it for the session AND status hasn't changed
- *     since dismissal (re-shows on reload, on token clear, or on a new
+ *     since dismissal (re-shows on reload, on un-pair, or on a new
  *     registration error).
  */
 export function shouldShowAuthBanner(
   status: AuthBannerStatus | null,
+  deviceJwtPresent: boolean,
   dismissedSignature: string | null,
 ): boolean {
   if (!status) return false;
   if (!status.enabled) return false;
-  if (status.runnerTokenMasked.length > 0) return false;
-  if (dismissedSignature !== null && dismissedSignature === statusSignature(status)) {
+  if (deviceJwtPresent) return false;
+  if (
+    dismissedSignature !== null &&
+    dismissedSignature === statusSignature(status, deviceJwtPresent)
+  ) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Problem
Post-Cognito teardown (T3), runners pair via Cognito sign-in or a pair-code — both mint a coord device JWT but leave `web_integration.runner_token` EMPTY. Three code paths still treated a non-empty `runner_token` as the "device paired/connected" signal, breaking every modern-paired runner:

1. **Silent cloud drop-off** — `device_jwt_refresher::next_action` idled (`IdleNoToken`) on empty `runner_token`, never re-minting the device JWT → the runner dropped off the cloud ~one TTL after pairing.
2. **False "disconnected" status** — `ServerModeConfig::from_settings` returned `None` on empty `runner_token`, so `ServerModeState` was never installed and `get_web_integration_status` reported `ws_connected=false` even while the runner was connected + heartbeating.
3. **Spurious "needs authorization" banner** — `shouldShowAuthBanner` keyed off `runnerTokenMasked`, nagging fully-paired runners (its button invoked the now-broken web-login stub).

## Fix
Stop treating `runner_token` as the paired/connected proxy:
- The refresher decides on `tier` + `needs_refresh`; the `Pair` arm resolves the real bearer (Cognito access token, falling back to the device-JWT slot) and idles gracefully if none. Removed the dead `IdleNoToken`.
- `from_settings` builds on `enabled` + `backend_url`, so boot installs `ServerModeState` for every connectable runner (the relay never read `config.runner_token`; field retained for legacy round-tripping).
- The auth banner keys off `deviceJwtPresent` (the real paired signal).

## Tests
- Refresher regression: Cognito runner with empty `runner_token` → `Pair` (not idle).
- `from_settings`: builds with empty token / still carries a legacy token / `None` when disabled or no backend_url.
- Updated banner-logic unit tests.
- Verified locally: `cargo test` (9 relevant pass), `tsc --noEmit` clean, vitest banner 16/16.

## Out of scope (follow-ups)
- Relay self-install for the `enabled=false`-at-boot edge.
- The runner connect-surface IA redesign (`qontinui-dev-notes/plans/2026-05-30-runner-backend-connect-ux.md`).
