### PR TITLE
fix(runner): self-install ServerModeState on relay connect (enabled=false-at-boot edge)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -479,6 +479,25 @@ impl AppState {
     pub async fn current_server_mode(&self) -> Option<crate::server_mode::ServerModeState> {
         self.server_mode.read().await.clone()
     }
+
+    /// Install a `ServerModeState` from current settings if none is present,
+    /// returning the live state (existing or freshly installed), or `None`
+    /// when current settings don't form a valid config.
+    ///
+    /// Closes the "integration disabled at boot" gap — see
+    /// [`crate::server_mode::install_if_absent`]. The relay calls this on a
+    /// successful connect so it always has somewhere to publish connection
+    /// state, even when boot left the slot empty and a later sign-in enabled
+    /// integration without routing through `apply_web_integration_settings`.
+    pub async fn install_server_mode_if_absent(
+        &self,
+    ) -> Option<crate::server_mode::ServerModeState> {
+        crate::server_mode::install_if_absent(
+            &self.server_mode,
+            &crate::settings::load_settings().web_integration,
+        )
+        .await
+    }
 }
 
 /// Standard response structure for command handlers.

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -767,11 +767,29 @@ async fn handle_connected_message(api_state: &Arc<ApiState>, data: &Value) {
     let sm_state = match api_state.app_state.current_server_mode().await {
         Some(s) => s,
         None => {
-            warn!(
-                "Received `connected` message but no ServerModeState is installed; \
-                 the relay will continue but state queries will return empty"
-            );
-            return;
+            // No ServerModeState was installed at boot — e.g. web integration
+            // was disabled then, and a later Cognito/pair-code sign-in enabled
+            // it via save_settings + a relay kick without routing through
+            // apply_web_integration_settings. We're demonstrably connected, so
+            // self-install from current settings; otherwise status queries
+            // would report this runner disconnected until the next restart.
+            match api_state.app_state.install_server_mode_if_absent().await {
+                Some(s) => {
+                    info!(
+                        "Backend relay: self-installed ServerModeState on connect \
+                         (none was present at boot)"
+                    );
+                    s
+                }
+                None => {
+                    warn!(
+                        "Received `connected` message but no ServerModeState is installed \
+                         and current settings don't form a valid config; the relay will \
+                         continue but state queries will return empty"
+                    );
+                    return;
+                }
+            }
         }
     };
 

--- a/src-tauri/src/server_mode/mod.rs
+++ b/src-tauri/src/server_mode/mod.rs
@@ -83,6 +83,37 @@ impl ServerModeConfig {
     }
 }
 
+/// Install a [`ServerModeState`] built from `settings` into `slot` if the slot
+/// is currently empty; return the live state (existing or freshly installed),
+/// or `None` if `settings` don't form a valid config (see
+/// [`ServerModeConfig::from_settings`]).
+///
+/// A single write-lock makes the check-then-install atomic (no TOCTOU with a
+/// concurrent installer such as `apply_web_integration_settings`). An existing
+/// state is never clobbered.
+///
+/// Closes the "integration disabled at boot" gap: boot installs a
+/// `ServerModeState` only when `from_settings` is `Some`. A later Cognito /
+/// pair-code sign-in enables integration via `save_settings` + a relay kick
+/// WITHOUT routing through `apply_web_integration_settings`, so the slot can
+/// still be empty when the relay connects. The relay calls this on a
+/// successful connect so it always has somewhere to publish `ws_connected` /
+/// `runner_id` / heartbeat — otherwise `get_web_integration_status` would
+/// report the runner disconnected until the next process restart.
+pub async fn install_if_absent(
+    slot: &RwLock<Option<ServerModeState>>,
+    settings: &WebIntegrationSettings,
+) -> Option<ServerModeState> {
+    let mut guard = slot.write().await;
+    if let Some(existing) = guard.as_ref() {
+        return Some(existing.clone());
+    }
+    let cfg = ServerModeConfig::from_settings(settings)?;
+    let state = ServerModeState::new(cfg);
+    *guard = Some(state.clone());
+    Some(state)
+}
+
 /// Shared runtime state for the runner ↔ web-backend WebSocket relay.
 ///
 /// Populated and refreshed by [`crate::mcp::backend_relay`] as the WS
@@ -329,5 +360,49 @@ mod tests {
         ))
         .is_none());
         assert!(ServerModeConfig::from_settings(&web_settings(true, "   ", "tok")).is_none());
+    }
+
+    #[tokio::test]
+    async fn install_if_absent_installs_into_empty_slot() {
+        // The enabled=false-at-boot edge: boot left the slot empty; a later
+        // sign-in enabled integration. On connect the relay self-installs.
+        let slot = RwLock::new(None);
+        let s = install_if_absent(&slot, &web_settings(true, "https://api.qontinui.io", ""))
+            .await
+            .expect("valid settings should install");
+        assert_eq!(s.config.web_backend_url, "https://api.qontinui.io");
+        assert!(
+            slot.read().await.is_some(),
+            "slot should now hold the state"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_if_absent_does_not_clobber_existing() {
+        let slot = RwLock::new(Some(ServerModeState::new(ServerModeConfig {
+            web_backend_url: "https://original.test".to_string(),
+            runner_token: String::new(),
+        })));
+        // Different settings must NOT replace the already-installed state.
+        let s = install_if_absent(&slot, &web_settings(true, "https://different.test", ""))
+            .await
+            .expect("existing state should be returned");
+        assert_eq!(s.config.web_backend_url, "https://original.test");
+        assert_eq!(
+            slot.read().await.as_ref().unwrap().config.web_backend_url,
+            "https://original.test"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_if_absent_returns_none_for_invalid_settings() {
+        let slot = RwLock::new(None);
+        // Integration disabled → no valid config → nothing installed.
+        assert!(
+            install_if_absent(&slot, &web_settings(false, "https://api.qontinui.io", ""))
+                .await
+                .is_none()
+        );
+        assert!(slot.read().await.is_none(), "slot must stay empty");
     }
 }


### PR DESCRIPTION
Follow-up to #337 — closes the documented `enabled=false`-at-boot edge.

## Problem
Boot installs a `ServerModeState` only when `ServerModeConfig::from_settings` is `Some`. If web integration was **disabled at boot** and a later Cognito/pair-code sign-in enabled it (via `save_settings` + a relay kick — which do **not** route through `apply_web_integration_settings`), the slot stayed empty. The relay then connected and heartbeated fine, but had nowhere to publish `ws_connected`/`runner_id`, so `get_web_integration_status` reported the runner **disconnected until the next restart**.

## Fix
The relay self-installs a `ServerModeState` from current settings when it receives `connected` and finds the slot empty:
- `server_mode::install_if_absent(slot, settings)` — single write-lock, atomic check-then-install, never clobbers an existing state; returns `None` for an invalid (disabled / no-backend) config.
- `AppState::install_server_mode_if_absent()` — thin wrapper that loads settings and delegates.
- `handle_connected_message` calls it on the `None` path instead of giving up.

Connectivity itself was already independent of this (the relay authenticates with the device JWT); this only fixes the **status reporting** for the disabled-at-boot path.

## Tests
`install_if_absent`: installs into an empty slot / does not clobber an existing state / returns `None` for disabled settings. Verified locally: `cargo test` 7/7 (incl. the 3 new), `cargo fmt` clean.