### PR TITLE
fix(runner): register cognito_sign_in Tauri command (Sign in with Qontinui → 'Command not found')

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -894,6 +894,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::auth::qontinui_sign_out,
             commands::auth::set_runner_tier,
             commands::auth::start_qontinui_sign_in,
+            commands::auth::cognito_sign_in,
             commands::autostart::get_autostart_enabled,
             commands::autostart::set_autostart_enabled,
             commands::backup::export_all_data,


### PR DESCRIPTION
The runner login button invokes `cognito_sign_in` (LoginScreen.tsx, AccountSettings.tsx) but it was never added to `generate_handler!` — only the legacy `start_qontinui_sign_in` was registered. Result: **'Command cognito_sign_in not found'** on every sign-in attempt. `cognito_sign_in` is fully implemented in `commands::auth` (RFC-8252 PKCE Cognito login → `CognitoSignInResponse`); this one-line change wires it into the handler.

Operators must rebuild/reinstall the runner to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)