### PR TITLE
feat(twin): code-semantics observer (Ξ_Type) — TS language-service sidecar (Phase 2a/2b)

### DIFF
--- a/src-tauri/resources/code-semantics/ts-language-service.mjs
+++ b/src-tauri/resources/code-semantics/ts-language-service.mjs
@@ -1,0 +1,806 @@
+#!/usr/bin/env node
+// @ts-nocheck
+//
+// TypeScript Language-Service helper for the Code-Semantics twin observer
+// (Phase 2a + 2b). Long-lived Node process speaking the newline-delimited
+// JSON stdio protocol defined in
+//   src-tauri/src/mcp/code_semantics/CONTRACT.md  §A
+//
+// It is supervised by the Rust sidecar (`src-tauri/src/mcp/code_semantics/`).
+// One helper child per (repo, language) scope; v1 default scope = the runner's
+// own TS frontend project.
+//
+// Engine = the TypeScript **Language Service API** (resolved types + in-memory
+// overlay documents for predict-effect). Overlays NEVER touch disk.
+//
+// Protocol (one JSON object per line on stdin/stdout):
+//   Request:  {"id": <int>, "cmd": "<command>", ...args}
+//   Response: {"id": <int>, "ok": true,  ...result}
+//          |  {"id": <int>, "ok": false, "error": "<msg>"}
+//
+// `typescript` is resolved from (in order): $QONTINUI_TS_PATH, the runner
+// frontend node_modules/typescript, then the global require resolution. If TS
+// cannot be resolved the helper exits non-zero with a clear stderr message so
+// the sidecar can degrade to the code_graph fallback.
+
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as crypto from 'node:crypto';
+import * as readline from 'node:readline';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// --------------------------------------------------------------------------
+// Resolve the `typescript` package (CONTRACT §A resolution order).
+// --------------------------------------------------------------------------
+function resolveTypeScript() {
+  const candidates = [];
+
+  // 1. Explicit override.
+  if (process.env.QONTINUI_TS_PATH) {
+    candidates.push(process.env.QONTINUI_TS_PATH);
+  }
+
+  // 2. The runner frontend node_modules/typescript. The helper lives at
+  //    src-tauri/resources/code-semantics/, so the frontend root is two dirs
+  //    up from src-tauri (../../../). Also try CWD as a fallback root.
+  const frontendRoots = [
+    path.resolve(__dirname, '..', '..', '..'), // <repo>/ (frontend root)
+    process.cwd(),
+  ];
+  for (const root of frontendRoots) {
+    candidates.push(path.join(root, 'node_modules', 'typescript'));
+  }
+
+  for (const cand of candidates) {
+    try {
+      // Resolve the package's main entry from its directory.
+      const pkgJson = path.join(cand, 'package.json');
+      if (fs.existsSync(pkgJson)) {
+        const req = createRequire(path.join(cand, 'index.js'));
+        // typescript's main is lib/typescript.js
+        const ts = req('./lib/typescript.js');
+        if (ts && ts.version) {
+          return { ts, from: cand };
+        }
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+
+  // 3. Global / ambient require resolution relative to this helper.
+  try {
+    const req = createRequire(__filename);
+    const ts = req('typescript');
+    if (ts && ts.version) {
+      return { ts, from: req.resolve('typescript') };
+    }
+  } catch {
+    // fall through to failure
+  }
+
+  return null;
+}
+
+const resolved = resolveTypeScript();
+if (!resolved) {
+  process.stderr.write(
+    'code-semantics helper: cannot resolve the `typescript` package. ' +
+      'Tried $QONTINUI_TS_PATH, the runner frontend node_modules/typescript, ' +
+      'and global require resolution. Install TypeScript or set QONTINUI_TS_PATH.\n'
+  );
+  process.exit(2);
+}
+
+const ts = resolved.ts;
+process.stderr.write(
+  `code-semantics helper: typescript ${ts.version} from ${resolved.from}\n`
+);
+
+// --------------------------------------------------------------------------
+// Scope state: a single LanguageService + its overlay map.
+// --------------------------------------------------------------------------
+const scriptVersions = new Map(); // fileName -> integer version
+const overlay = new Map(); // fileName -> overlaid content (predict-effect)
+let parsedConfig = null; // ts.ParsedCommandLine
+let languageService = null;
+let projectPath = null; // resolved tsconfig path
+let indexed = false;
+
+function norm(p) {
+  // Canonicalize to the LS's preferred separators (forward slashes).
+  return p.replace(/\\/g, '/');
+}
+
+function bumpVersion(fileName) {
+  const key = norm(fileName);
+  const v = (scriptVersions.get(key) || 0) + 1;
+  scriptVersions.set(key, v);
+}
+
+function getVersion(fileName) {
+  const key = norm(fileName);
+  if (!scriptVersions.has(key)) scriptVersions.set(key, 1);
+  return String(scriptVersions.get(key));
+}
+
+function readFileWithOverlay(fileName) {
+  const key = norm(fileName);
+  if (overlay.has(key)) return overlay.get(key);
+  try {
+    return ts.sys.readFile(fileName);
+  } catch {
+    return undefined;
+  }
+}
+
+function createLanguageServiceHost(config) {
+  const host = {
+    getScriptFileNames: () => {
+      // Union of the project's file list and any overlaid files.
+      const set = new Set(config.fileNames.map(norm));
+      for (const f of overlay.keys()) set.add(f);
+      return Array.from(set);
+    },
+    getScriptVersion: (fileName) => getVersion(fileName),
+    getScriptSnapshot: (fileName) => {
+      const text = readFileWithOverlay(fileName);
+      if (text === undefined) return undefined;
+      return ts.ScriptSnapshot.fromString(text);
+    },
+    getCurrentDirectory: () => path.dirname(projectPath),
+    getCompilationSettings: () => config.options,
+    getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+    fileExists: (fileName) => {
+      if (overlay.has(norm(fileName))) return true;
+      return ts.sys.fileExists(fileName);
+    },
+    readFile: (fileName) => readFileWithOverlay(fileName),
+    readDirectory: ts.sys.readDirectory,
+    directoryExists: ts.sys.directoryExists,
+    getDirectories: ts.sys.getDirectories,
+    realpath: ts.sys.realpath,
+    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
+  };
+  return host;
+}
+
+// --------------------------------------------------------------------------
+// Helpers: signatures, hashes, locations.
+// --------------------------------------------------------------------------
+function sha1(s) {
+  return crypto.createHash('sha1').update(s, 'utf8').digest('hex');
+}
+
+function lineColOf(sourceFile, pos) {
+  const lc = ts.getLineAndCharacterOfPosition(sourceFile, pos);
+  return { line: lc.line + 1, col: lc.character + 1 }; // 1-based
+}
+
+function symbolKind(decl) {
+  if (ts.isFunctionDeclaration(decl) || ts.isFunctionExpression(decl)) return 'function';
+  if (ts.isMethodDeclaration(decl) || ts.isMethodSignature(decl)) return 'method';
+  if (ts.isClassDeclaration(decl)) return 'class';
+  if (ts.isInterfaceDeclaration(decl)) return 'interface';
+  if (ts.isTypeAliasDeclaration(decl)) return 'type';
+  if (ts.isEnumDeclaration(decl)) return 'enum';
+  if (ts.isVariableDeclaration(decl) || ts.isVariableStatement(decl)) return 'variable';
+  if (ts.isArrowFunction(decl)) return 'function';
+  return 'variable';
+}
+
+// Produce a resolved signature string for a symbol at a declaration node.
+function resolveSignature(checker, symbol, node) {
+  try {
+    const type = checker.getTypeOfSymbolAtLocation(symbol, node);
+    // Prefer call signatures for callables.
+    const callSigs = type.getCallSignatures();
+    if (callSigs.length > 0) {
+      return callSigs.map((s) => checker.signatureToString(s)).join(' | ');
+    }
+    return checker.typeToString(
+      type,
+      node,
+      ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.WriteArrayAsGenericType
+    );
+  } catch {
+    return checker.symbolToString(symbol);
+  }
+}
+
+// Walk all top-level + nested declarations of a source file, calling cb(node, name).
+function forEachNamedDeclaration(sourceFile, cb) {
+  function visit(node) {
+    let name;
+    if (
+      ts.isFunctionDeclaration(node) ||
+      ts.isClassDeclaration(node) ||
+      ts.isInterfaceDeclaration(node) ||
+      ts.isTypeAliasDeclaration(node) ||
+      ts.isEnumDeclaration(node)
+    ) {
+      name = node.name && node.name.getText(sourceFile);
+      if (name) cb(node, name);
+    } else if (ts.isVariableStatement(node)) {
+      for (const d of node.declarationList.declarations) {
+        if (d.name && ts.isIdentifier(d.name)) cb(d, d.name.getText(sourceFile));
+      }
+    } else if (ts.isMethodDeclaration(node) && node.name) {
+      cb(node, node.name.getText(sourceFile));
+    }
+    ts.forEachChild(node, visit);
+  }
+  ts.forEachChild(sourceFile, visit);
+}
+
+function nameNodeOf(decl) {
+  if (decl.name) return decl.name;
+  return decl;
+}
+
+function isExportedDecl(decl) {
+  // Walk modifiers; also treat module-level `export` statements.
+  const mods = ts.canHaveModifiers(decl) ? ts.getModifiers(decl) : undefined;
+  if (mods && mods.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) return true;
+  // VariableDeclaration: the export keyword is on the parent VariableStatement.
+  let n = decl;
+  while (n) {
+    if (ts.isVariableStatement(n)) {
+      const m = ts.getModifiers(n);
+      if (m && m.some((x) => x.kind === ts.SyntaxKind.ExportKeyword)) return true;
+    }
+    n = n.parent;
+  }
+  return false;
+}
+
+// Collect exported symbols of a source file => Map(name -> {kind, signatureHash, node}).
+function exportedSymbolMap(program, sourceFile) {
+  const checker = program.getTypeChecker();
+  const out = new Map();
+  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+  if (moduleSymbol) {
+    const exports = checker.getExportsOfModule(moduleSymbol);
+    for (const sym of exports) {
+      const decls = sym.getDeclarations() || [];
+      const decl = decls[0];
+      if (!decl) continue;
+      const sig = resolveSignature(checker, sym, decl);
+      out.set(sym.getName(), {
+        kind: decl ? symbolKind(decl) : 'variable',
+        signatureHash: sha1(sig),
+        signature: sig,
+      });
+    }
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------
+// Command handlers.
+// --------------------------------------------------------------------------
+function cmdInit(args) {
+  const project = args.project;
+  if (!project) throw new Error('init: missing "project"');
+
+  let tsconfigPath;
+  if (project.endsWith('.json')) {
+    tsconfigPath = path.resolve(project);
+  } else {
+    tsconfigPath = path.join(path.resolve(project), 'tsconfig.json');
+  }
+  if (!fs.existsSync(tsconfigPath)) {
+    throw new Error(`init: tsconfig not found at ${tsconfigPath}`);
+  }
+
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  if (configFile.error) {
+    throw new Error(
+      `init: failed to read tsconfig: ${ts.flattenDiagnosticMessageText(
+        configFile.error.messageText,
+        '\n'
+      )}`
+    );
+  }
+  const basePath = path.dirname(tsconfigPath);
+  parsedConfig = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    basePath,
+    undefined,
+    tsconfigPath
+  );
+
+  projectPath = tsconfigPath;
+  scriptVersions.clear();
+  overlay.clear();
+
+  const host = createLanguageServiceHost(parsedConfig);
+  languageService = ts.createLanguageService(host, ts.createDocumentRegistry());
+  // Force a program build so subsequent queries are warm.
+  const program = languageService.getProgram();
+  indexed = true;
+
+  return {
+    ready: true,
+    file_count: program ? program.getSourceFiles().length : parsedConfig.fileNames.length,
+    project: norm(projectPath),
+  };
+}
+
+function requireReady() {
+  if (!languageService || !indexed) {
+    throw new Error('not initialized: send "init" first');
+  }
+}
+
+function cmdStatus() {
+  let fileCount = 0;
+  if (languageService) {
+    const program = languageService.getProgram();
+    fileCount = program ? program.getSourceFiles().length : 0;
+  }
+  return {
+    indexed,
+    file_count: fileCount,
+    project: projectPath ? norm(projectPath) : null,
+  };
+}
+
+function cmdSymbolLookup(args) {
+  requireReady();
+  const wantName = args.name;
+  if (!wantName) throw new Error('symbol_lookup: missing "name"');
+  const wantKind = args.kind || null;
+  const wantFile = args.file ? norm(path.resolve(args.file)) : null;
+
+  const program = languageService.getProgram();
+  const checker = program.getTypeChecker();
+  const resolvedList = [];
+
+  for (const sourceFile of program.getSourceFiles()) {
+    if (sourceFile.isDeclarationFile) continue;
+    const sfName = norm(sourceFile.fileName);
+    if (wantFile && sfName !== wantFile) continue;
+
+    forEachNamedDeclaration(sourceFile, (decl, name) => {
+      if (name !== wantName) return;
+      const kind = symbolKind(decl);
+      if (wantKind && kind !== wantKind) return;
+      const nameNode = nameNodeOf(decl);
+      const sym = checker.getSymbolAtLocation(nameNode) || checker.getSymbolAtLocation(decl);
+      const sig = sym ? resolveSignature(checker, sym, decl) : decl.getText(sourceFile);
+      const loc = lineColOf(sourceFile, nameNode.getStart(sourceFile));
+      resolvedList.push({
+        file: sfName,
+        name,
+        kind,
+        signature: sig,
+        signature_hash: sha1(sig),
+        def_location: { file: sfName, line: loc.line, col: loc.col },
+      });
+    });
+  }
+
+  return { exists: resolvedList.length > 0, resolved: resolvedList };
+}
+
+function findDeclByNameKind(program, file, name, kind) {
+  const wantFile = norm(path.resolve(file));
+  for (const sourceFile of program.getSourceFiles()) {
+    if (norm(sourceFile.fileName) !== wantFile) continue;
+    let found = null;
+    forEachNamedDeclaration(sourceFile, (decl, dn) => {
+      if (found) return;
+      if (dn !== name) return;
+      if (kind && symbolKind(decl) !== kind) return;
+      found = { sourceFile, decl };
+    });
+    return found;
+  }
+  return null;
+}
+
+function offsetOfLineCol(sourceFile, line, col) {
+  // line/col are 1-based.
+  return ts.getPositionOfLineAndCharacter(sourceFile, line - 1, col - 1);
+}
+
+function cmdSignature(args) {
+  requireReady();
+  if (!args.file) throw new Error('signature: missing "file"');
+  const program = languageService.getProgram();
+  const checker = program.getTypeChecker();
+
+  let sourceFile;
+  let node;
+  if (typeof args.line === 'number' && typeof args.col === 'number') {
+    const wantFile = norm(path.resolve(args.file));
+    sourceFile = program
+      .getSourceFiles()
+      .find((sf) => norm(sf.fileName) === wantFile);
+    if (!sourceFile) return { found: false };
+    const pos = offsetOfLineCol(sourceFile, args.line, args.col);
+    node = findNodeAtPosition(sourceFile, pos);
+  } else if (args.name) {
+    const found = findDeclByNameKind(program, args.file, args.name, args.kind || null);
+    if (!found) return { found: false };
+    sourceFile = found.sourceFile;
+    node = nameNodeOf(found.decl);
+  } else {
+    throw new Error('signature: provide either (name[,kind]) or (line,col)');
+  }
+
+  if (!node) return { found: false };
+  const sym = checker.getSymbolAtLocation(node);
+  if (!sym) return { found: false };
+
+  const decl = (sym.getDeclarations() || [])[0] || node;
+  const type = checker.getTypeOfSymbolAtLocation(sym, decl);
+  const callSigs = type.getCallSignatures();
+
+  let signature;
+  let generics = [];
+  let params = [];
+  let returnType = '';
+
+  if (callSigs.length > 0) {
+    const s = callSigs[0];
+    signature = checker.signatureToString(s);
+    const typeParams = s.getTypeParameters() || [];
+    generics = typeParams.map((tp) => checker.typeToString(tp));
+    params = s.getParameters().map((p) => {
+      const pdecl = (p.getDeclarations() || [])[0] || decl;
+      const pt = checker.getTypeOfSymbolAtLocation(p, pdecl);
+      return { name: p.getName(), type: checker.typeToString(pt) };
+    });
+    returnType = checker.typeToString(s.getReturnType());
+  } else {
+    signature = checker.typeToString(type, decl, ts.TypeFormatFlags.NoTruncation);
+    returnType = signature;
+  }
+
+  const docParts = sym.getDocumentationComment(checker);
+  const doc = ts.displayPartsToString(docParts);
+
+  return {
+    found: true,
+    signature,
+    signature_hash: sha1(signature),
+    generics,
+    params,
+    return_type: returnType,
+    doc,
+  };
+}
+
+function findNodeAtPosition(sourceFile, pos) {
+  function find(node) {
+    if (pos >= node.getStart(sourceFile) && pos < node.getEnd()) {
+      const child = ts.forEachChild(node, (c) => (find(c) ? c : undefined));
+      if (child) {
+        const deeper = find(child);
+        if (deeper) return deeper;
+      }
+      return node;
+    }
+    return undefined;
+  }
+  // Prefer the innermost identifier.
+  let best;
+  function visit(node) {
+    if (pos >= node.getStart(sourceFile) && pos < node.getEnd()) {
+      if (ts.isIdentifier(node)) best = node;
+      ts.forEachChild(node, visit);
+    }
+  }
+  visit(sourceFile);
+  return best || find(sourceFile);
+}
+
+function classifyRefKind(sourceFile, node) {
+  let n = node;
+  // definition: the name node of a declaration.
+  const parent = n.parent;
+  if (
+    parent &&
+    ((ts.isFunctionDeclaration(parent) ||
+      ts.isClassDeclaration(parent) ||
+      ts.isInterfaceDeclaration(parent) ||
+      ts.isTypeAliasDeclaration(parent) ||
+      ts.isEnumDeclaration(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isVariableDeclaration(parent)) &&
+      parent.name === n)
+  ) {
+    return 'definition';
+  }
+  // import: inside an import declaration / specifier.
+  while (n) {
+    if (ts.isImportDeclaration(n) || ts.isImportSpecifier(n) || ts.isImportClause(n)) {
+      return 'import';
+    }
+    if (ts.isCallExpression(n) && n.expression && isWithin(n.expression, node)) {
+      return 'call';
+    }
+    if (
+      ts.isHeritageClause(n) ||
+      ts.isClassDeclaration(n) && n.heritageClauses && containsNode(n.heritageClauses, node)
+    ) {
+      return 'impl';
+    }
+    n = n.parent;
+  }
+  return 'reference';
+}
+
+function isWithin(outer, inner) {
+  return inner.getStart() >= outer.getStart() && inner.getEnd() <= outer.getEnd();
+}
+function containsNode(arr, node) {
+  for (const el of arr) {
+    if (node.getStart() >= el.getStart() && node.getEnd() <= el.getEnd()) return true;
+  }
+  return false;
+}
+
+function cmdFindReferences(args) {
+  requireReady();
+  if (!args.file) throw new Error('find_references: missing "file"');
+  const program = languageService.getProgram();
+  const wantFile = norm(path.resolve(args.file));
+  const sourceFile = program.getSourceFiles().find((sf) => norm(sf.fileName) === wantFile);
+  if (!sourceFile) return { references: [] };
+
+  let pos;
+  if (typeof args.line === 'number' && typeof args.col === 'number') {
+    pos = offsetOfLineCol(sourceFile, args.line, args.col);
+  } else if (args.name) {
+    const found = findDeclByNameKind(program, args.file, args.name, args.kind || null);
+    if (!found) return { references: [] };
+    pos = nameNodeOf(found.decl).getStart(found.sourceFile);
+  } else {
+    throw new Error('find_references: provide either name or (line,col)');
+  }
+
+  const refs = languageService.getReferencesAtPosition(sourceFile.fileName, pos) || [];
+  const out = [];
+  for (const ref of refs) {
+    const refSf = program.getSourceFiles().find((sf) => norm(sf.fileName) === norm(ref.fileName));
+    let kind = 'reference';
+    if (refSf) {
+      const node = findNodeAtPosition(refSf, ref.textSpan.start);
+      if (node) {
+        if (ref.isDefinition) kind = 'definition';
+        else kind = classifyRefKind(refSf, node);
+      } else if (ref.isDefinition) {
+        kind = 'definition';
+      }
+      const lc = lineColOf(refSf, ref.textSpan.start);
+      out.push({ file: norm(ref.fileName), line: lc.line, col: lc.col, kind });
+    } else {
+      out.push({ file: norm(ref.fileName), line: 0, col: 0, kind: ref.isDefinition ? 'definition' : 'reference' });
+    }
+  }
+  return { references: out };
+}
+
+function diagnosticsToErrors(diags) {
+  const out = [];
+  for (const d of diags) {
+    let line = 0;
+    let col = 0;
+    if (d.file && typeof d.start === 'number') {
+      const lc = ts.getLineAndCharacterOfPosition(d.file, d.start);
+      line = lc.line + 1;
+      col = lc.character + 1;
+    }
+    out.push({
+      file: d.file ? norm(d.file.fileName) : '',
+      line,
+      col,
+      code: d.code,
+      message: ts.flattenDiagnosticMessageText(d.messageText, '\n'),
+    });
+  }
+  return out;
+}
+
+function computeDiagnostics(file) {
+  const semantic = languageService.getSemanticDiagnostics(file);
+  const syntactic = languageService.getSyntacticDiagnostics(file);
+  return [...syntactic, ...semantic];
+}
+
+function cmdTypecheck(args) {
+  requireReady();
+  if (!args.file) throw new Error('typecheck: missing "file"');
+  const file = path.resolve(args.file);
+
+  if (!args.overlay_patch) {
+    const diags = computeDiagnostics(file);
+    const errors = diagnosticsToErrors(diags);
+    return {
+      ok: errors.length === 0,
+      errors,
+      overlay: false,
+      changed_signatures: [],
+      removed_symbols: [],
+    };
+  }
+
+  // --- 2b predict-effect overlay path ---
+  const patch = args.overlay_patch;
+  if (!patch.file || typeof patch.new_text !== 'string') {
+    throw new Error('typecheck: overlay_patch requires {file, new_text}');
+  }
+  const overlayFile = norm(path.resolve(patch.file));
+
+  // Capture BEFORE state of the overlaid file's exported symbols.
+  const program0 = languageService.getProgram();
+  const beforeSf = program0
+    .getSourceFiles()
+    .find((sf) => norm(sf.fileName) === overlayFile);
+  const beforeExports = beforeSf ? exportedSymbolMap(program0, beforeSf) : new Map();
+
+  // Apply overlay in-memory only.
+  overlay.set(overlayFile, patch.new_text);
+  bumpVersion(overlayFile);
+
+  let result;
+  try {
+    // Recompute diagnostics for the requested file under the overlay.
+    const diags = computeDiagnostics(file);
+    const errors = diagnosticsToErrors(diags);
+
+    const program1 = languageService.getProgram();
+    const afterSf = program1
+      .getSourceFiles()
+      .find((sf) => norm(sf.fileName) === overlayFile);
+    const afterExports = afterSf ? exportedSymbolMap(program1, afterSf) : new Map();
+
+    // changed_signatures: exported symbols present in both whose hash changed.
+    const changedSignatures = [];
+    for (const [name, before] of beforeExports) {
+      const after = afterExports.get(name);
+      if (after && after.signatureHash !== before.signatureHash) {
+        changedSignatures.push({
+          name,
+          before_hash: before.signatureHash,
+          after_hash: after.signatureHash,
+        });
+      }
+    }
+
+    // removed_symbols: exported symbols deleted by the overlay that are still
+    // referenced elsewhere (the Contradiction / active-negation signal).
+    const removedSymbols = [];
+    for (const [name, before] of beforeExports) {
+      if (afterExports.has(name)) continue;
+      // Find references to the now-removed symbol using its pre-overlay
+      // definition position. We must look at the BEFORE program's def site,
+      // but the overlay has bumped the version — so query references against
+      // the overlaid LS which will report external (non-overlay-file) usages.
+      const referencedBy = findExternalReferencesByName(overlayFile, name);
+      if (referencedBy.length > 0) {
+        removedSymbols.push({ name, kind: before.kind, referenced_by: referencedBy });
+      }
+    }
+
+    result = {
+      ok: errors.length === 0,
+      errors,
+      overlay: true,
+      changed_signatures: changedSignatures,
+      removed_symbols: removedSymbols,
+    };
+  } finally {
+    // Always clear the overlay so disk-truth is restored.
+    overlay.delete(overlayFile);
+    bumpVersion(overlayFile);
+  }
+  return result;
+}
+
+// Find references to `name` (exported by overlayFile) that live OUTSIDE
+// overlayFile, by scanning identifier nodes across the program and resolving
+// each to a symbol whose declaration is in overlayFile. Used for the
+// removed_symbols contradiction signal — the overlay has removed the decl,
+// so we resolve against the BEFORE-on-disk content by reading the file fresh.
+function findExternalReferencesByName(overlayFile, name) {
+  const program = languageService.getProgram();
+  const out = [];
+  for (const sf of program.getSourceFiles()) {
+    if (sf.isDeclarationFile) continue;
+    if (norm(sf.fileName) === overlayFile) continue;
+    const sfName = norm(sf.fileName);
+    function visit(node) {
+      if (ts.isIdentifier(node) && node.text === name) {
+        // Heuristic: a usage of this identifier in another file that imports
+        // from the overlay file. We confirm by checking the file's imports
+        // resolve to the overlay file OR simply record name-matched usages in
+        // files that import the overlay module.
+        const lc = lineColOf(sf, node.getStart(sf));
+        out.push({ file: sfName, line: lc.line });
+      }
+      ts.forEachChild(node, visit);
+    }
+    // Only scan files that import from the overlay file (binding-accurate-ish).
+    if (fileImportsFrom(sf, overlayFile)) {
+      visit(sf);
+    }
+  }
+  return out;
+}
+
+function fileImportsFrom(sourceFile, overlayFile) {
+  const program = languageService.getProgram();
+  let imports = false;
+  ts.forEachChild(sourceFile, (node) => {
+    if (imports) return;
+    if (ts.isImportDeclaration(node) && node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+      const spec = node.moduleSpecifier.text;
+      const resolved = ts.resolveModuleName(
+        spec,
+        sourceFile.fileName,
+        program.getCompilerOptions(),
+        ts.sys
+      );
+      if (
+        resolved.resolvedModule &&
+        norm(resolved.resolvedModule.resolvedFileName) === overlayFile
+      ) {
+        imports = true;
+      }
+    }
+  });
+  return imports;
+}
+
+// --------------------------------------------------------------------------
+// Dispatch + stdio loop.
+// --------------------------------------------------------------------------
+function handle(req) {
+  switch (req.cmd) {
+    case 'init':
+      return cmdInit(req);
+    case 'status':
+      return cmdStatus(req);
+    case 'symbol_lookup':
+      return cmdSymbolLookup(req);
+    case 'signature':
+      return cmdSignature(req);
+    case 'find_references':
+      return cmdFindReferences(req);
+    case 'typecheck':
+      return cmdTypecheck(req);
+    default:
+      throw new Error(`unknown cmd: ${req.cmd}`);
+  }
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let req;
+  try {
+    req = JSON.parse(trimmed);
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ id: null, ok: false, error: `bad JSON: ${e.message}` }) + '\n');
+    return;
+  }
+  const id = req.id != null ? req.id : null;
+  try {
+    const result = handle(req);
+    process.stdout.write(JSON.stringify({ id, ok: true, ...result }) + '\n');
+  } catch (e) {
+    process.stdout.write(JSON.stringify({ id, ok: false, error: e && e.message ? e.message : String(e) }) + '\n');
+  }
+});
+
+rl.on('close', () => process.exit(0));

--- a/src-tauri/src/mcp/code_semantics/CONTRACT.md
+++ b/src-tauri/src/mcp/code_semantics/CONTRACT.md
@@ -1,0 +1,150 @@
+# Code-Semantics Observer — Cross-Repo Contract (Phase 2a/2b)
+
+Twin sub-space `Ξ_Type` (resolved code semantics), implemented as a **pure observer**
+(no declared-vs-actual drift pair, no Φ predicate). The TS engine is the TypeScript
+**Language Service API** driven by a long-lived Node helper, supervised by a Rust
+sidecar module in the runner that hosts the HTTP query surface. coord-native MCP
+tools (`phase11()`) proxy to that surface. Plan:
+`plans/2026-05-30-twin-code-semantics-lsp-layer.md`.
+
+This file is the single source of truth for the wire contracts the runner side and
+the coord side build against independently.
+
+---
+
+## A. Node helper ⇄ Rust sidecar — stdio JSON protocol (runner-internal)
+
+Newline-delimited JSON (one object per line) over the helper child's stdin/stdout.
+
+**Request:** `{"id": <int>, "cmd": "<command>", ...args}`
+**Response:** `{"id": <int>, "ok": true, ...result}` | `{"id": <int>, "ok": false, "error": "<msg>"}`
+
+The helper resolves the `typescript` package from (in order): `$QONTINUI_TS_PATH`,
+the runner frontend `node_modules/typescript`, then global. If TS cannot be resolved
+the helper exits non-zero with a clear stderr message (the sidecar then degrades to
+the code_graph fallback).
+
+### Commands
+
+- `init {"project": "<abs dir or tsconfig.json>"}` →
+  `{"ready": true, "file_count": <int>, "project": "<resolved tsconfig path>"}`
+  Builds the LanguageService + Program. Until this returns, the scope is **cold**.
+
+- `status {}` → `{"indexed": <bool>, "file_count": <int>, "project": "<path|null>"}`
+
+- `symbol_lookup {"name": "<str>", "kind?": "<function|class|interface|type|variable|method|enum>", "file?": "<abs>"}` →
+  `{"exists": <bool>, "resolved": [ {"file","name","kind","signature","signature_hash","def_location":{"file","line","col"}} ]}`
+  Resolved via the type checker; searches program declarations matching name (+ kind/file filters).
+
+- `signature {"file": "<abs>", "name?": "<str>", "kind?": "<str>"}` **or**
+  `{"file": "<abs>", "line": <int>, "col": <int>}` →
+  `{"found": <bool>, "signature": "<str>", "signature_hash": "<sha1>", "generics": ["<str>"], "params": [{"name","type"}], "return_type": "<str>", "doc": "<str>"}`
+  (`line`/`col` are 1-based.)
+
+- `find_references {"file": "<abs>", "name?": "<str>"}` **or** `{"file","line","col"}` →
+  `{"references": [ {"file","line","col","kind": "call|import|impl|reference|definition"} ]}`
+
+- `typecheck {"file": "<abs>", "overlay_patch?": {"file": "<abs>", "new_text": "<str>"}}` →
+  `{"ok": <bool>, "errors": [ {"file","line","col","code": <int>, "message"} ], "overlay": <bool>,
+    "changed_signatures": [ {"name","before_hash","after_hash"} ],
+    "removed_symbols": [ {"name","kind","referenced_by": [ {"file","line"} ]} ] }`
+  With `overlay_patch`: apply `new_text` for `overlay_patch.file` **in-memory only**
+  (never write disk), recompute diagnostics for `file`, then clear the overlay. This is
+  D3 `predict-effect`. `changed_signatures`/`removed_symbols` compare the overlaid
+  file's exported symbol set against the on-disk version (2b). `removed_symbols`
+  lists exported symbols the overlay deletes that are still referenced elsewhere
+  (the Contradiction / active-negation signal).
+
+---
+
+## B. Rust sidecar HTTP surface (runner, axum, port 9876) — `/code-semantics/*`
+
+All POST bodies are JSON; all responses are the **uniform observation envelope** (§C).
+`scope` is an optional `(repo,language)` selector; when omitted the sidecar resolves
+the scope from the file's nearest `tsconfig.json` (v1 default scope = the runner's own
+TS frontend). v1 supports the single default TS scope but the code is structured for
+a scope registry (map scope → helper child).
+
+- `GET  /code-semantics/health` →
+  `{"status": "ok", "scopes": [ {"scope","language","indexed","file_count","provenance"} ]}`
+- `POST /code-semantics/symbol-lookup`  body `{"scope?","file?","name","kind?"}`
+- `POST /code-semantics/signature`      body `{"scope?","file","name?","kind?","line?","col?"}`
+- `POST /code-semantics/find-references` body `{"scope?","file","name?","line?","col?","cross_repo?": false}`
+- `POST /code-semantics/typecheck`      body `{"scope?","file","overlay_patch?": {"file","new_text"}}`
+
+### Cold-index / coverage (D4) — load-bearing
+
+- Scope **cold** (helper not yet `init`-returned):
+  - `symbol-lookup`: fall back to the syntactic `code_graph.rs` observer →
+    `provenance="code_graph_fallback"`, `coverage≈0.5`, `posterior` high for *declared*
+    but `credibility` reflects syntactic-only. If code_graph also finds nothing while
+    cold → `coverage=0.0`, `provenance="indexing"`, **result MUST NOT assert
+    `exists:false`** (honest "I can't see", not "absent").
+  - `signature` / `find-references` / `typecheck` (need resolution): if cold →
+    `coverage=0.0`, `provenance="indexing"`, result flagged not-yet-available.
+- Scope **warm**: resolved answer → `posterior=1.0`, `coverage=1.0`,
+  `provenance="ts-language-service"`, `credibility=(high,high,high)`.
+- Node/TS unavailable on the machine → permanent degrade to `code_graph_fallback`
+  (symbol-lookup) / `coverage=0` `provenance="engine_unavailable"` (resolution queries).
+  Never 500 on a missing engine.
+
+---
+
+## C. Uniform observation envelope (both sidecar HTTP responses and coord MCP output)
+
+```json
+{
+  "observer": "code_semantics",
+  "query": "symbol_lookup|signature|find_references|typecheck",
+  "result": { ...query-specific payload (the §A result body, lifted) ... },
+  "posterior": 1.0,
+  "coverage": 1.0,
+  "provenance": "ts-language-service|code_graph_fallback|indexing|engine_unavailable",
+  "credibility": { "causal": "high", "authorial": "high", "boundary": "high" },
+  "staleness_seconds": null,
+  "kernel": false
+}
+```
+
+- `kernel` is always `false` in v1 (only deterministic gate-worthy queries ship; fuzzy
+  completion is Phase 3).
+- `credibility` is the triple from the theory (Phase 1): definitional/structural code
+  queries are `(high,high,high)` — the LSP crosses the compiler boundary and is
+  authorially independent. The `code_graph_fallback` provenance lowers the *boundary*
+  axis to `medium` (syntactic, no resolution) and `coverage<1`.
+
+---
+
+## D. coord MCP tools (`phase11()`) — proxy, credential-light
+
+Tools call the sidecar over HTTP at `$QONTINUI_LSP_SIDECAR_URL` (default
+`http://127.0.0.1:9876`). They wrap the sidecar's envelope into the coord
+`ObservationEnvelope` and return it. coord hosts **no** language server.
+
+| Tool | Inputs | Maps to |
+|---|---|---|
+| `coord_symbol_lookup`  | `{scope?, file?, name, kind?}` | POST /code-semantics/symbol-lookup |
+| `coord_signature`      | `{scope?, file, name?, kind?, line?, col?}` | POST /code-semantics/signature |
+| `coord_find_references`| `{scope?, file, name?, line?, col?, cross_repo?}` | POST /code-semantics/find-references |
+| `coord_typecheck_file` | `{scope?, file, overlay_patch?}` | POST /code-semantics/typecheck |
+
+- Sidecar **unreachable** (connection refused / timeout) → `ToolError` with a clear
+  message ("code-semantics sidecar unreachable at <url>"). coord stays credential-light.
+- Sidecar reachable but scope cold → pass the `coverage<1` / `provenance:"indexing"`
+  envelope through (honest, not an error).
+- `coord_typecheck_file` with `overlay_patch` = D3 `predict-effect` (2b): never writes a
+  file; returns would-typecheck + new errors + changed signatures + removed-referenced
+  symbols.
+
+### Five-outcome verification map (2b, coord-side pure classifier)
+
+`classify_edit_outcome(predicted, observed) -> {outcome, rationale}` where
+`predicted` = overlay typecheck result, `observed` = post-write typecheck result:
+
+- predicted clean **&** observed clean → **Confirmed**
+- predicted clean **&** observed has new errors → **Surprise** (predict missed it)
+- predicted errors **&** observed errors (match) → **Confirmed** (knowingly partial)
+- overlay removes a symbol still referenced elsewhere → **Contradiction** (active negation)
+- index settling / coverage<1 on either side → **Partial**
+
+Unit-tested with a small truth table.

--- a/src-tauri/src/mcp/code_semantics/mod.rs
+++ b/src-tauri/src/mcp/code_semantics/mod.rs
@@ -1,0 +1,741 @@
+//! Code-Semantics twin observer — runner-side sidecar (Phase 2a + 2b).
+//!
+//! Twin sub-space `Ξ_Type` (resolved code semantics) implemented as a **pure
+//! observer** (no declared-vs-actual drift pair, no Φ predicate). The TS engine
+//! is the TypeScript Language Service API, driven by a long-lived Node helper
+//! (`resources/code-semantics/ts-language-service.mjs`) supervised by this
+//! module, which hosts the `/code-semantics/*` HTTP query surface.
+//!
+//! See `CONTRACT.md` in this directory for the authoritative wire contracts:
+//!   §A  Node helper ⇄ Rust stdio protocol
+//!   §B  Rust sidecar HTTP surface
+//!   §C  uniform observation envelope
+//!   §D  coord MCP proxy semantics (2b overlay / predict-effect)
+//!
+//! ## Cold-index / coverage (CONTRACT §B/D4) — load-bearing
+//! - Scope cold (helper not yet `init`-returned):
+//!   - `symbol-lookup` falls back to the syntactic `code_graph.rs` observer
+//!     (`provenance="code_graph_fallback"`, `coverage≈0.5`). If code_graph also
+//!     finds nothing while cold → `coverage=0`, `provenance="indexing"`, and the
+//!     result MUST NOT assert `exists:false`.
+//!   - resolution queries (signature / find-references / typecheck) → `coverage=0`,
+//!     `provenance="indexing"`, flagged not-yet-available.
+//! - Scope warm → `posterior=1.0`, `coverage=1.0`, `provenance="ts-language-service"`,
+//!   `credibility=(high,high,high)`.
+//! - Node/TS permanently unavailable → degrade (symbol-lookup → code_graph_fallback;
+//!   resolution → `engine_unavailable`, coverage 0). Never 500 on a missing engine.
+
+pub mod node_bridge;
+pub mod scope;
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::{extract::State, routing::get, routing::post, Json, Router};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::sync::Mutex;
+
+use crate::mcp::types::ApiState;
+use crate::workflow_generation::code_graph::CodeGraph;
+
+use node_bridge::{check_availability, HelperAvailability, NodeBridge};
+use scope::{resolve_scope, Scope};
+
+// ===========================================================================
+// Uniform observation envelope (CONTRACT §C)
+// ===========================================================================
+
+/// The credibility triple from the theory (Phase 1). Definitional/structural
+/// code queries are `(high,high,high)`; the code_graph fallback lowers the
+/// boundary axis to `medium`.
+#[derive(Debug, Clone, Serialize)]
+pub struct Credibility {
+    pub causal: String,
+    pub authorial: String,
+    pub boundary: String,
+}
+
+impl Credibility {
+    /// Warm, resolved LSP answer.
+    pub fn high() -> Self {
+        Credibility {
+            causal: "high".into(),
+            authorial: "high".into(),
+            boundary: "high".into(),
+        }
+    }
+
+    /// Syntactic code_graph fallback — boundary lowered to medium (no resolution).
+    pub fn fallback() -> Self {
+        Credibility {
+            causal: "high".into(),
+            authorial: "high".into(),
+            boundary: "medium".into(),
+        }
+    }
+
+    /// Cold / unavailable — boundary unknown, lowered.
+    pub fn degraded() -> Self {
+        Credibility {
+            causal: "high".into(),
+            authorial: "high".into(),
+            boundary: "low".into(),
+        }
+    }
+}
+
+/// CONTRACT §C uniform envelope. `result` carries the §A query-specific body.
+#[derive(Debug, Clone, Serialize)]
+pub struct Envelope {
+    pub observer: String,
+    pub query: String,
+    pub result: Value,
+    pub posterior: f64,
+    pub coverage: f64,
+    pub provenance: String,
+    pub credibility: Credibility,
+    pub staleness_seconds: Option<f64>,
+    pub kernel: bool,
+}
+
+/// Provenance discriminants (CONTRACT §C).
+pub const PROV_LSP: &str = "ts-language-service";
+pub const PROV_FALLBACK: &str = "code_graph_fallback";
+pub const PROV_INDEXING: &str = "indexing";
+pub const PROV_UNAVAILABLE: &str = "engine_unavailable";
+
+impl Envelope {
+    /// Warm, resolved answer: posterior=1, coverage=1, credibility=(high,high,high).
+    pub fn warm(query: &str, result: Value) -> Self {
+        Envelope {
+            observer: "code_semantics".into(),
+            query: query.into(),
+            result,
+            posterior: 1.0,
+            coverage: 1.0,
+            provenance: PROV_LSP.into(),
+            credibility: Credibility::high(),
+            staleness_seconds: None,
+            kernel: false,
+        }
+    }
+
+    /// Syntactic code_graph fallback (symbol-lookup only): coverage≈0.5.
+    pub fn fallback(query: &str, result: Value) -> Self {
+        Envelope {
+            observer: "code_semantics".into(),
+            query: query.into(),
+            result,
+            posterior: 0.7,
+            coverage: 0.5,
+            provenance: PROV_FALLBACK.into(),
+            credibility: Credibility::fallback(),
+            staleness_seconds: None,
+            kernel: false,
+        }
+    }
+
+    /// Cold index — honest "I can't see yet". MUST NOT assert exists:false.
+    pub fn indexing(query: &str, result: Value) -> Self {
+        Envelope {
+            observer: "code_semantics".into(),
+            query: query.into(),
+            result,
+            posterior: 0.0,
+            coverage: 0.0,
+            provenance: PROV_INDEXING.into(),
+            credibility: Credibility::degraded(),
+            staleness_seconds: None,
+            kernel: false,
+        }
+    }
+
+    /// Node/TS permanently unavailable for a resolution query.
+    pub fn unavailable(query: &str, msg: &str) -> Self {
+        Envelope {
+            observer: "code_semantics".into(),
+            query: query.into(),
+            result: json!({ "available": false, "reason": msg }),
+            posterior: 0.0,
+            coverage: 0.0,
+            provenance: PROV_UNAVAILABLE.into(),
+            credibility: Credibility::degraded(),
+            staleness_seconds: None,
+            kernel: false,
+        }
+    }
+}
+
+// ===========================================================================
+// Scope registry + supervisor
+// ===========================================================================
+
+/// Global registry mapping scope key → supervised helper bridge. v1 default
+/// scope is the runner's own TS frontend; the map is structured for more.
+struct Registry {
+    bridges: HashMap<String, Arc<NodeBridge>>,
+    availability: HelperAvailability,
+}
+
+static REGISTRY: Lazy<Mutex<Registry>> = Lazy::new(|| {
+    Mutex::new(Registry {
+        bridges: HashMap::new(),
+        availability: check_availability(),
+    })
+});
+
+/// Get-or-create the bridge for a scope. Returns `None` if Node/TS is
+/// permanently unavailable.
+async fn bridge_for(scope: &Scope) -> Option<Arc<NodeBridge>> {
+    let mut reg = REGISTRY.lock().await;
+    if let HelperAvailability::Unavailable(_) = &reg.availability {
+        return None;
+    }
+    if let Some(b) = reg.bridges.get(&scope.key) {
+        return Some(b.clone());
+    }
+    let (node, script) = match &reg.availability {
+        HelperAvailability::Available { node, script } => (node.clone(), script.clone()),
+        HelperAvailability::Unavailable(_) => return None,
+    };
+    let bridge = Arc::new(NodeBridge::new(node, script, scope.project.clone()));
+    reg.bridges.insert(scope.key.clone(), bridge.clone());
+    Some(bridge)
+}
+
+/// Is the Node engine permanently unavailable on this machine?
+async fn engine_unavailable_reason() -> Option<String> {
+    let reg = REGISTRY.lock().await;
+    match &reg.availability {
+        HelperAvailability::Unavailable(m) => Some(m.clone()),
+        HelperAvailability::Available { .. } => None,
+    }
+}
+
+// ===========================================================================
+// code_graph.rs syntactic fallback (Ξ_AST)
+// ===========================================================================
+
+/// Build the syntactic code-graph for a scope's project dir and look up a
+/// declared symbol by name (+ optional kind). Returns the §A-shaped
+/// `symbol_lookup` result body, or `None` if nothing matched.
+///
+/// This is the cold-index / engine-unavailable fallback for `symbol-lookup`:
+/// it is syntactic (no resolved signatures), so signatures are absent and the
+/// envelope provenance/credibility reflect that.
+pub fn code_graph_symbol_lookup(
+    project_dir: &Path,
+    name: &str,
+    kind: Option<&str>,
+) -> Option<Value> {
+    let graph = CodeGraph::build(project_dir);
+    let mut resolved: Vec<Value> = Vec::new();
+
+    let want = |k: &str| kind.is_none_or(|wk| wk == k);
+
+    if want("function") {
+        for f in graph.functions.iter().filter(|f| f.name == name) {
+            resolved.push(json!({
+                "file": f.file_path,
+                "name": f.name,
+                "kind": "function",
+                "signature": Value::Null,
+                "signature_hash": Value::Null,
+                "def_location": { "file": f.file_path, "line": f.line_start, "col": 1 },
+            }));
+        }
+    }
+    if want("class") {
+        for c in graph.classes.iter().filter(|c| c.name == name) {
+            resolved.push(json!({
+                "file": c.file_path,
+                "name": c.name,
+                "kind": "class",
+                "signature": Value::Null,
+                "signature_hash": Value::Null,
+                "def_location": { "file": c.file_path, "line": c.line_start, "col": 1 },
+            }));
+        }
+    }
+    // Exports cover interface/type/variable kinds the function/class lists miss.
+    for e in graph.exports.iter().filter(|e| e.name == name) {
+        if !want(&e.kind) {
+            continue;
+        }
+        // Avoid duplicating function/class entries already added.
+        if (e.kind == "function" || e.kind == "class")
+            && resolved.iter().any(|r| {
+                r.get("name").and_then(|v| v.as_str()) == Some(name)
+                    && r.get("file").and_then(|v| v.as_str()) == Some(e.file_path.as_str())
+            })
+        {
+            continue;
+        }
+        resolved.push(json!({
+            "file": e.file_path,
+            "name": e.name,
+            "kind": e.kind,
+            "signature": Value::Null,
+            "signature_hash": Value::Null,
+            "def_location": { "file": e.file_path, "line": e.line, "col": 1 },
+        }));
+    }
+
+    if resolved.is_empty() {
+        None
+    } else {
+        Some(json!({ "exists": true, "resolved": resolved }))
+    }
+}
+
+/// The project directory for a scope (the tsconfig's parent).
+fn scope_project_dir(scope: &Scope) -> std::path::PathBuf {
+    Path::new(&scope.project)
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| Path::new(&scope.project).to_path_buf())
+}
+
+// ===========================================================================
+// HTTP request bodies (CONTRACT §B)
+// ===========================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct SymbolLookupReq {
+    pub scope: Option<String>,
+    pub file: Option<String>,
+    pub name: String,
+    pub kind: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SignatureReq {
+    pub scope: Option<String>,
+    pub file: String,
+    pub name: Option<String>,
+    pub kind: Option<String>,
+    pub line: Option<u32>,
+    pub col: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FindReferencesReq {
+    pub scope: Option<String>,
+    pub file: String,
+    pub name: Option<String>,
+    pub line: Option<u32>,
+    pub col: Option<u32>,
+    #[serde(default)]
+    pub cross_repo: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TypecheckReq {
+    pub scope: Option<String>,
+    pub file: String,
+    pub overlay_patch: Option<Value>,
+}
+
+// ===========================================================================
+// Routes (CONTRACT §B)
+// ===========================================================================
+
+/// Routes contributed to the runner's main router from `mcp_api.rs`.
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route("/code-semantics/health", get(health))
+        .route("/code-semantics/symbol-lookup", post(symbol_lookup))
+        .route("/code-semantics/signature", post(signature))
+        .route("/code-semantics/find-references", post(find_references))
+        .route("/code-semantics/typecheck", post(typecheck))
+}
+
+/// GET /code-semantics/health — per CONTRACT §B.
+async fn health(State(_state): State<Arc<ApiState>>) -> Json<Value> {
+    let reg = REGISTRY.lock().await;
+    let mut scopes: Vec<Value> = Vec::new();
+    let unavailable = matches!(reg.availability, HelperAvailability::Unavailable(_));
+
+    for (key, bridge) in reg.bridges.iter() {
+        let indexed = bridge.is_initialized().await;
+        let file_count = bridge.file_count().await;
+        let provenance = if unavailable {
+            PROV_UNAVAILABLE
+        } else if indexed {
+            PROV_LSP
+        } else {
+            PROV_INDEXING
+        };
+        scopes.push(json!({
+            "scope": key,
+            "language": "typescript",
+            "indexed": indexed,
+            "file_count": file_count,
+            "provenance": provenance,
+        }));
+    }
+
+    Json(json!({ "status": "ok", "scopes": scopes }))
+}
+
+/// POST /code-semantics/symbol-lookup
+async fn symbol_lookup(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<SymbolLookupReq>,
+) -> Json<Envelope> {
+    let q = "symbol_lookup";
+    let scope = match resolve_scope(req.scope.as_deref(), req.file.as_deref()) {
+        Some(s) => s,
+        None => {
+            // No TS scope at all — treat as indexing (can't see), never absent.
+            return Json(Envelope::indexing(q, json!({ "resolved": [] })));
+        }
+    };
+
+    // Permanent engine-unavailable → code_graph fallback for symbol-lookup.
+    if let Some(_reason) = engine_unavailable_reason().await {
+        return Json(symbol_lookup_fallback(
+            &scope,
+            &req.name,
+            req.kind.as_deref(),
+        ));
+    }
+
+    let bridge = match bridge_for(&scope).await {
+        Some(b) => b,
+        None => {
+            return Json(symbol_lookup_fallback(
+                &scope,
+                &req.name,
+                req.kind.as_deref(),
+            ))
+        }
+    };
+
+    // Cold scope (not yet init) → try code_graph fallback first (honest partial).
+    if !bridge.is_initialized().await {
+        // Kick off init in the background so subsequent calls warm up; serve
+        // the syntactic fallback now.
+        let b2 = bridge.clone();
+        tokio::spawn(async move {
+            let _ = b2.ensure_init().await;
+        });
+        return Json(symbol_lookup_fallback(
+            &scope,
+            &req.name,
+            req.kind.as_deref(),
+        ));
+    }
+
+    match bridge
+        .symbol_lookup(&req.name, req.kind.as_deref(), req.file.as_deref())
+        .await
+    {
+        Ok(mut resp) => {
+            strip_meta(&mut resp);
+            Json(Envelope::warm(q, resp))
+        }
+        Err(_) => Json(symbol_lookup_fallback(
+            &scope,
+            &req.name,
+            req.kind.as_deref(),
+        )),
+    }
+}
+
+/// Symbol-lookup fallback: try code_graph; if it also finds nothing, return an
+/// `indexing` envelope (NOT exists:false).
+fn symbol_lookup_fallback(scope: &Scope, name: &str, kind: Option<&str>) -> Envelope {
+    let dir = scope_project_dir(scope);
+    match code_graph_symbol_lookup(&dir, name, kind) {
+        Some(result) => Envelope::fallback("symbol_lookup", result),
+        None => Envelope::indexing("symbol_lookup", json!({ "resolved": [] })),
+    }
+}
+
+/// POST /code-semantics/signature
+async fn signature(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<SignatureReq>,
+) -> Json<Envelope> {
+    let q = "signature";
+    let scope = req.scope.clone();
+    let file = req.file.clone();
+    resolution_query(q, scope.as_deref(), Some(&file), move |bridge| {
+        let file = req.file.clone();
+        let name = req.name.clone();
+        let kind = req.kind.clone();
+        async move {
+            bridge
+                .signature(&file, name.as_deref(), kind.as_deref(), req.line, req.col)
+                .await
+        }
+    })
+    .await
+}
+
+/// POST /code-semantics/find-references
+async fn find_references(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<FindReferencesReq>,
+) -> Json<Envelope> {
+    let q = "find_references";
+    let scope = req.scope.clone();
+    let file = req.file.clone();
+    resolution_query(q, scope.as_deref(), Some(&file), move |bridge| {
+        let file = req.file.clone();
+        let name = req.name.clone();
+        async move {
+            bridge
+                .find_references(&file, name.as_deref(), req.line, req.col)
+                .await
+        }
+    })
+    .await
+}
+
+/// POST /code-semantics/typecheck (with overlay_patch ⇒ 2b predict-effect)
+async fn typecheck(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<TypecheckReq>,
+) -> Json<Envelope> {
+    let q = "typecheck";
+    let scope = req.scope.clone();
+    let file = req.file.clone();
+    resolution_query(q, scope.as_deref(), Some(&file), move |bridge| {
+        let file = req.file.clone();
+        let overlay = req.overlay_patch.clone();
+        async move { bridge.typecheck(&file, overlay).await }
+    })
+    .await
+}
+
+/// Shared driver for resolution queries (signature / find-references /
+/// typecheck): these need the type checker, so a cold scope returns `indexing`
+/// and a permanently-unavailable engine returns `engine_unavailable` — never a
+/// code_graph fallback (it cannot resolve).
+async fn resolution_query<F, Fut>(
+    query: &str,
+    scope: Option<&str>,
+    file: Option<&str>,
+    run: F,
+) -> Json<Envelope>
+where
+    F: FnOnce(Arc<NodeBridge>) -> Fut,
+    Fut: std::future::Future<Output = Result<Value, node_bridge::BridgeError>>,
+{
+    if let Some(reason) = engine_unavailable_reason().await {
+        return Json(Envelope::unavailable(query, &reason));
+    }
+    let scope = match resolve_scope(scope, file) {
+        Some(s) => s,
+        None => return Json(Envelope::indexing(query, json!({}))),
+    };
+    let bridge = match bridge_for(&scope).await {
+        Some(b) => b,
+        None => {
+            let reason = engine_unavailable_reason()
+                .await
+                .unwrap_or_else(|| "no bridge".to_string());
+            return Json(Envelope::unavailable(query, &reason));
+        }
+    };
+
+    if !bridge.is_initialized().await {
+        let b2 = bridge.clone();
+        tokio::spawn(async move {
+            let _ = b2.ensure_init().await;
+        });
+        return Json(Envelope::indexing(query, json!({})));
+    }
+
+    match run(bridge).await {
+        Ok(mut resp) => {
+            strip_meta(&mut resp);
+            Json(Envelope::warm(query, resp))
+        }
+        Err(node_bridge::BridgeError::Unavailable(m)) => Json(Envelope::unavailable(query, &m)),
+        Err(e) => Json(Envelope::unavailable(query, &e.to_string())),
+    }
+}
+
+/// Strip the protocol envelope fields (`id`, `ok`) from a helper response so
+/// only the §A query body remains as the envelope `result`.
+fn strip_meta(v: &mut Value) {
+    if let Value::Object(map) = v {
+        map.remove("id");
+        map.remove("ok");
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warm_envelope_is_high_credibility_full_coverage() {
+        let env = Envelope::warm("symbol_lookup", json!({"exists": true}));
+        assert_eq!(env.provenance, PROV_LSP);
+        assert_eq!(env.coverage, 1.0);
+        assert_eq!(env.posterior, 1.0);
+        assert_eq!(env.credibility.causal, "high");
+        assert_eq!(env.credibility.authorial, "high");
+        assert_eq!(env.credibility.boundary, "high");
+        assert!(!env.kernel);
+    }
+
+    #[test]
+    fn fallback_envelope_lowers_boundary_and_coverage() {
+        let env = Envelope::fallback("symbol_lookup", json!({"exists": true}));
+        assert_eq!(env.provenance, PROV_FALLBACK);
+        assert!(env.coverage < 1.0);
+        assert_eq!(env.credibility.boundary, "medium");
+        // Author + causal stay high (the parser is third-party, syntactic).
+        assert_eq!(env.credibility.causal, "high");
+        assert_eq!(env.credibility.authorial, "high");
+    }
+
+    #[test]
+    fn indexing_envelope_does_not_assert_absence() {
+        let env = Envelope::indexing("symbol_lookup", json!({ "resolved": [] }));
+        assert_eq!(env.provenance, PROV_INDEXING);
+        assert_eq!(env.coverage, 0.0);
+        // The honest cold result must NOT contain exists:false.
+        assert!(env.result.get("exists").is_none());
+    }
+
+    #[test]
+    fn unavailable_envelope_for_resolution_query() {
+        let env = Envelope::unavailable("typecheck", "node binary not found");
+        assert_eq!(env.provenance, PROV_UNAVAILABLE);
+        assert_eq!(env.coverage, 0.0);
+        assert_eq!(
+            env.result.get("available").and_then(|v| v.as_bool()),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn credibility_serializes_as_triple() {
+        let c = Credibility::high();
+        let v = serde_json::to_value(&c).unwrap();
+        assert_eq!(v.get("causal").and_then(|x| x.as_str()), Some("high"));
+        assert_eq!(v.get("authorial").and_then(|x| x.as_str()), Some("high"));
+        assert_eq!(v.get("boundary").and_then(|x| x.as_str()), Some("high"));
+    }
+
+    #[test]
+    fn envelope_serializes_with_contract_fields() {
+        let env = Envelope::warm("signature", json!({"found": true}));
+        let v = serde_json::to_value(&env).unwrap();
+        for f in [
+            "observer",
+            "query",
+            "result",
+            "posterior",
+            "coverage",
+            "provenance",
+            "credibility",
+            "staleness_seconds",
+            "kernel",
+        ] {
+            assert!(v.get(f).is_some(), "missing envelope field {f}");
+        }
+        assert_eq!(
+            v.get("observer").and_then(|x| x.as_str()),
+            Some("code_semantics")
+        );
+        assert_eq!(v.get("staleness_seconds"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn strip_meta_removes_protocol_fields() {
+        let mut v = json!({"id": 7, "ok": true, "exists": true, "resolved": []});
+        strip_meta(&mut v);
+        assert!(v.get("id").is_none());
+        assert!(v.get("ok").is_none());
+        assert_eq!(v.get("exists").and_then(|x| x.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn code_graph_fallback_finds_a_real_exported_symbol() {
+        // The runner frontend exports `APP_VERSION` in src/lib/appInfo.ts.
+        let frontend_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let result = code_graph_symbol_lookup(frontend_root, "APP_VERSION", None);
+        // code_graph is syntactic; if it parses the export we get Some, and the
+        // signature is null (unresolved). If the build finds nothing we get
+        // None — both are valid "honest" outcomes; assert the shape when found.
+        if let Some(r) = result {
+            assert_eq!(r.get("exists").and_then(|v| v.as_bool()), Some(true));
+            let resolved = r.get("resolved").and_then(|v| v.as_array()).unwrap();
+            assert!(!resolved.is_empty());
+            // Syntactic fallback never resolves a signature.
+            assert!(resolved[0]
+                .get("signature_hash")
+                .map(|v| v.is_null())
+                .unwrap_or(true));
+        }
+    }
+
+    #[test]
+    fn code_graph_fallback_returns_none_for_hallucinated_symbol() {
+        let frontend_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let result =
+            code_graph_symbol_lookup(frontend_root, "ThisSymbolDoesNotExistAnywhere42", None);
+        assert!(result.is_none(), "hallucinated symbol must not be found");
+    }
+
+    /// Availability-gated integration test: spawn the REAL Node helper and
+    /// assert a resolved symbol lookup against the runner frontend project.
+    /// Skips (passes) if `node` or the helper script is unavailable.
+    #[tokio::test]
+    async fn live_symbol_lookup_when_node_present() {
+        let avail = check_availability();
+        let (node, script) = match avail {
+            HelperAvailability::Available { node, script } => (node, script),
+            HelperAvailability::Unavailable(reason) => {
+                eprintln!("skipping live test: {reason}");
+                return;
+            }
+        };
+        // Confirm `node` actually runs; otherwise skip.
+        let probe = tokio::process::Command::new(&node)
+            .arg("--version")
+            .output()
+            .await;
+        if probe.is_err() {
+            eprintln!("skipping live test: node not runnable");
+            return;
+        }
+
+        let scope = match scope::default_ts_scope() {
+            Some(s) => s,
+            None => {
+                eprintln!("skipping live test: no default TS scope");
+                return;
+            }
+        };
+        let bridge = Arc::new(NodeBridge::new(node, script, scope.project.clone()));
+        if let Err(e) = bridge.ensure_init().await {
+            eprintln!("skipping live test: init failed: {e}");
+            return;
+        }
+        // APP_VERSION is a real exported const in the frontend.
+        let resp = bridge
+            .symbol_lookup("APP_VERSION", None, None)
+            .await
+            .expect("symbol_lookup should succeed when warm");
+        assert_eq!(resp.get("ok").and_then(|v| v.as_bool()), Some(true));
+        // Either it resolves (exists:true) — the expected case — but at minimum
+        // the response is well-formed with an `exists` boolean.
+        assert!(resp.get("exists").and_then(|v| v.as_bool()).is_some());
+        bridge.shutdown().await;
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/node_bridge.rs
+++ b/src-tauri/src/mcp/code_semantics/node_bridge.rs
@@ -1,0 +1,428 @@
+//! Node TypeScript Language-Service helper supervisor.
+//!
+//! Spawns and supervises the long-lived `ts-language-service.mjs` child
+//! (CONTRACT.md §A), speaks the newline-delimited JSON stdio protocol with
+//! request-id correlation, and restarts the child on crash with bounded
+//! backoff. Modeled after the child-process pattern in
+//! `src-tauri/src/agent_runtime.rs` (spawn + pump stdout BufReader loop).
+//!
+//! One bridge instance per (repo, language) scope; v1 default scope is the
+//! runner's own TS frontend project. The bridge owns the child; the scope
+//! registry (`mod.rs`) maps a scope key to a bridge.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{oneshot, Mutex};
+use tracing::{debug, error, info, warn};
+
+/// Outcome of attempting to find a usable `node` + helper script.
+#[derive(Debug, Clone)]
+pub enum HelperAvailability {
+    /// `node` and the helper script are both present.
+    Available { node: String, script: PathBuf },
+    /// Permanently unavailable (no node, or no helper script) — the sidecar
+    /// degrades to the code_graph fallback / `engine_unavailable`.
+    Unavailable(String),
+}
+
+/// Resolve the helper script path: env override, then the dev path under
+/// `CARGO_MANIFEST_DIR/resources/code-semantics/ts-language-service.mjs`.
+pub fn resolve_helper_script() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("QONTINUI_CODE_SEM_HELPER") {
+        let pb = PathBuf::from(p);
+        if pb.exists() {
+            return Some(pb);
+        }
+    }
+    let dev = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("resources")
+        .join("code-semantics")
+        .join("ts-language-service.mjs");
+    if dev.exists() {
+        return Some(dev);
+    }
+    None
+}
+
+/// Locate a `node` binary. Honors `QONTINUI_NODE_PATH`, else `node` on PATH.
+fn resolve_node() -> Option<String> {
+    if let Ok(p) = std::env::var("QONTINUI_NODE_PATH") {
+        if !p.is_empty() {
+            return Some(p);
+        }
+    }
+    Some("node".to_string())
+}
+
+/// Determine whether the Node engine can be used at all (permanent degrade if
+/// not). This is a cheap check; an actual spawn failure is also treated as
+/// unavailable at request time.
+pub fn check_availability() -> HelperAvailability {
+    let script = match resolve_helper_script() {
+        Some(s) => s,
+        None => {
+            return HelperAvailability::Unavailable(
+                "code-semantics helper script not found".to_string(),
+            )
+        }
+    };
+    match resolve_node() {
+        Some(node) => HelperAvailability::Available { node, script },
+        None => HelperAvailability::Unavailable("node binary not found".to_string()),
+    }
+}
+
+/// A supervised helper child for one scope.
+pub struct NodeBridge {
+    node: String,
+    script: PathBuf,
+    project: String,
+    next_id: AtomicU64,
+    inner: Arc<Mutex<BridgeInner>>,
+}
+
+struct BridgeInner {
+    stdin: Option<ChildStdin>,
+    child: Option<Child>,
+    /// id -> responder
+    pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
+    /// Restart bookkeeping.
+    restart_count: u32,
+    /// True once `init` has returned successfully (scope warm).
+    initialized: bool,
+    /// Cached file count from the last successful init.
+    file_count: u64,
+}
+
+#[derive(Debug)]
+pub enum BridgeError {
+    /// The helper process is not reachable (spawn failed / crashed).
+    Unavailable(String),
+    /// The helper returned `{ok:false,error:...}`.
+    Helper(String),
+    /// Protocol / serialization error.
+    Protocol(String),
+}
+
+impl std::fmt::Display for BridgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BridgeError::Unavailable(m) => write!(f, "helper unavailable: {m}"),
+            BridgeError::Helper(m) => write!(f, "helper error: {m}"),
+            BridgeError::Protocol(m) => write!(f, "protocol error: {m}"),
+        }
+    }
+}
+
+impl NodeBridge {
+    /// Create (but do not yet spawn) a bridge for a scope rooted at `project`
+    /// (an abs dir or a tsconfig.json path).
+    pub fn new(node: String, script: PathBuf, project: String) -> Self {
+        NodeBridge {
+            node,
+            script,
+            project,
+            next_id: AtomicU64::new(1),
+            inner: Arc::new(Mutex::new(BridgeInner {
+                stdin: None,
+                child: None,
+                pending: Arc::new(Mutex::new(HashMap::new())),
+                restart_count: 0,
+                initialized: false,
+                file_count: 0,
+            })),
+        }
+    }
+
+    pub fn project(&self) -> &str {
+        &self.project
+    }
+
+    /// True once the scope has completed `init` (warm).
+    pub async fn is_initialized(&self) -> bool {
+        self.inner.lock().await.initialized
+    }
+
+    pub async fn file_count(&self) -> u64 {
+        self.inner.lock().await.file_count
+    }
+
+    /// Spawn the child if not already running. Wires the stdout pump that
+    /// resolves pending request ids. Does NOT send `init`.
+    async fn ensure_spawned(&self) -> Result<(), BridgeError> {
+        let mut inner = self.inner.lock().await;
+        if inner.stdin.is_some() && inner.child.is_some() {
+            // Cheap liveness check.
+            if let Some(child) = inner.child.as_mut() {
+                if let Ok(Some(_status)) = child.try_wait() {
+                    // Child exited; fall through to respawn.
+                    inner.stdin = None;
+                    inner.child = None;
+                    inner.initialized = false;
+                } else {
+                    return Ok(());
+                }
+            }
+        }
+
+        debug!(
+            "code_semantics: spawning helper node={} script={}",
+            self.node,
+            self.script.display()
+        );
+        let mut cmd = Command::new(&self.node);
+        cmd.arg(&self.script)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        // Run with cwd at the frontend root (two levels above src-tauri) so the
+        // helper's frontend-node_modules resolution works in dev.
+        if let Some(frontend_root) = self.script.ancestors().nth(3) {
+            cmd.current_dir(frontend_root);
+        }
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| BridgeError::Unavailable(format!("spawn failed: {e}")))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| BridgeError::Unavailable("no stdin handle".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| BridgeError::Unavailable("no stdout handle".to_string()))?;
+        let stderr = child.stderr.take();
+
+        let pending = inner.pending.clone();
+
+        // Pump stdout: parse each line as a response, resolve the pending id.
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Value>(trimmed) {
+                    Ok(val) => {
+                        let id = val.get("id").and_then(|v| v.as_u64());
+                        if let Some(id) = id {
+                            let tx = { pending.lock().await.remove(&id) };
+                            if let Some(tx) = tx {
+                                let _ = tx.send(val);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("code_semantics: bad helper line: {e}: {trimmed}");
+                    }
+                }
+            }
+            debug!("code_semantics: helper stdout pump ended");
+        });
+
+        // Drain stderr to logs.
+        if let Some(stderr) = stderr {
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    info!("code_semantics[helper]: {line}");
+                }
+            });
+        }
+
+        inner.stdin = Some(stdin);
+        inner.child = Some(child);
+        Ok(())
+    }
+
+    /// Send a request and await the correlated response (bounded timeout).
+    async fn request(&self, mut body: Value) -> Result<Value, BridgeError> {
+        self.ensure_spawned().await?;
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        if let Value::Object(ref mut map) = body {
+            map.insert("id".to_string(), json!(id));
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let (pending, line) = {
+            let inner = self.inner.lock().await;
+            let pending = inner.pending.clone();
+            (pending, serde_json::to_string(&body).unwrap() + "\n")
+        };
+        pending.lock().await.insert(id, tx);
+
+        {
+            let mut inner = self.inner.lock().await;
+            let stdin = inner
+                .stdin
+                .as_mut()
+                .ok_or_else(|| BridgeError::Unavailable("stdin gone".to_string()))?;
+            if let Err(e) = stdin.write_all(line.as_bytes()).await {
+                pending.lock().await.remove(&id);
+                inner.stdin = None;
+                inner.child = None;
+                inner.initialized = false;
+                return Err(BridgeError::Unavailable(format!("write failed: {e}")));
+            }
+            let _ = stdin.flush().await;
+        }
+
+        let resp = match tokio::time::timeout(Duration::from_secs(60), rx).await {
+            Ok(Ok(v)) => v,
+            Ok(Err(_)) => {
+                pending.lock().await.remove(&id);
+                return Err(BridgeError::Protocol("responder dropped".to_string()));
+            }
+            Err(_) => {
+                pending.lock().await.remove(&id);
+                return Err(BridgeError::Protocol("request timed out".to_string()));
+            }
+        };
+
+        if resp.get("ok").and_then(|v| v.as_bool()) == Some(true) {
+            Ok(resp)
+        } else {
+            let msg = resp
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown helper error")
+                .to_string();
+            Err(BridgeError::Helper(msg))
+        }
+    }
+
+    /// Ensure the scope is initialized (idempotent). Returns Ok once warm.
+    /// Restart bookkeeping with bounded backoff applies on spawn failure.
+    pub async fn ensure_init(&self) -> Result<(), BridgeError> {
+        if self.is_initialized().await {
+            return Ok(());
+        }
+        // Bounded restart backoff guard.
+        {
+            let inner = self.inner.lock().await;
+            if inner.restart_count > 5 {
+                return Err(BridgeError::Unavailable(
+                    "helper exceeded restart budget".to_string(),
+                ));
+            }
+        }
+        let resp = self
+            .request(json!({"cmd":"init","project": self.project}))
+            .await
+            .inspect_err(|_| {
+                // Count the failed attempt.
+                if let Ok(mut inner) = self.inner.try_lock() {
+                    inner.restart_count += 1;
+                }
+            })?;
+        let file_count = resp.get("file_count").and_then(|v| v.as_u64()).unwrap_or(0);
+        let mut inner = self.inner.lock().await;
+        inner.initialized = true;
+        inner.file_count = file_count;
+        inner.restart_count = 0;
+        info!(
+            "code_semantics: scope initialized project={} files={file_count}",
+            self.project
+        );
+        Ok(())
+    }
+
+    // ---- Query passthroughs (each returns the §A result body Value) ----
+
+    pub async fn symbol_lookup(
+        &self,
+        name: &str,
+        kind: Option<&str>,
+        file: Option<&str>,
+    ) -> Result<Value, BridgeError> {
+        self.ensure_init().await?;
+        let mut body = json!({"cmd":"symbol_lookup","name": name});
+        if let Some(k) = kind {
+            body["kind"] = json!(k);
+        }
+        if let Some(f) = file {
+            body["file"] = json!(f);
+        }
+        self.request(body).await
+    }
+
+    pub async fn signature(
+        &self,
+        file: &str,
+        name: Option<&str>,
+        kind: Option<&str>,
+        line: Option<u32>,
+        col: Option<u32>,
+    ) -> Result<Value, BridgeError> {
+        self.ensure_init().await?;
+        let mut body = json!({"cmd":"signature","file": file});
+        if let Some(n) = name {
+            body["name"] = json!(n);
+        }
+        if let Some(k) = kind {
+            body["kind"] = json!(k);
+        }
+        if let Some(l) = line {
+            body["line"] = json!(l);
+        }
+        if let Some(c) = col {
+            body["col"] = json!(c);
+        }
+        self.request(body).await
+    }
+
+    pub async fn find_references(
+        &self,
+        file: &str,
+        name: Option<&str>,
+        line: Option<u32>,
+        col: Option<u32>,
+    ) -> Result<Value, BridgeError> {
+        self.ensure_init().await?;
+        let mut body = json!({"cmd":"find_references","file": file});
+        if let Some(n) = name {
+            body["name"] = json!(n);
+        }
+        if let Some(l) = line {
+            body["line"] = json!(l);
+        }
+        if let Some(c) = col {
+            body["col"] = json!(c);
+        }
+        self.request(body).await
+    }
+
+    pub async fn typecheck(
+        &self,
+        file: &str,
+        overlay_patch: Option<Value>,
+    ) -> Result<Value, BridgeError> {
+        self.ensure_init().await?;
+        let mut body = json!({"cmd":"typecheck","file": file});
+        if let Some(p) = overlay_patch {
+            body["overlay_patch"] = p;
+        }
+        self.request(body).await
+    }
+
+    /// Kill the child on shutdown.
+    pub async fn shutdown(&self) {
+        let mut inner = self.inner.lock().await;
+        inner.stdin = None;
+        if let Some(mut child) = inner.child.take() {
+            let _ = child.start_kill();
+        }
+        inner.initialized = false;
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/scope.rs
+++ b/src-tauri/src/mcp/code_semantics/scope.rs
@@ -1,0 +1,138 @@
+//! Scope resolution for the code-semantics observer.
+//!
+//! A "scope" is a (repo, language) selector. v1 supports a single default TS
+//! scope (the runner's own frontend project), but the code is structured for a
+//! registry: given a file path, resolve the nearest enclosing `tsconfig.json`
+//! and use its directory as the scope key.
+
+use std::path::{Path, PathBuf};
+
+/// A resolved scope: the language and the project root (tsconfig path).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Scope {
+    /// Stable key (the resolved tsconfig.json absolute path, normalized).
+    pub key: String,
+    pub language: String,
+    /// The project descriptor passed to the helper `init` (tsconfig path).
+    pub project: String,
+}
+
+impl Scope {
+    pub fn ts(tsconfig: &Path) -> Self {
+        let key = normalize(tsconfig);
+        Scope {
+            key: key.clone(),
+            language: "typescript".to_string(),
+            project: key,
+        }
+    }
+}
+
+/// Normalize a path to forward slashes for stable cross-platform keys.
+pub fn normalize(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// The default TS scope = the runner's own frontend project. The frontend root
+/// is `CARGO_MANIFEST_DIR/..` (src-tauri's parent); its tsconfig.json is the
+/// scope descriptor.
+pub fn default_ts_scope() -> Option<Scope> {
+    let frontend_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent()?;
+    let tsconfig = frontend_root.join("tsconfig.json");
+    if tsconfig.exists() {
+        Some(Scope::ts(&tsconfig))
+    } else {
+        None
+    }
+}
+
+/// Resolve a scope from an optional explicit `scope` selector and/or a file
+/// path. Resolution order:
+///   1. explicit `scope` (interpreted as a project dir or tsconfig path),
+///   2. the file's nearest enclosing `tsconfig.json`,
+///   3. the default TS scope.
+pub fn resolve_scope(scope: Option<&str>, file: Option<&str>) -> Option<Scope> {
+    if let Some(s) = scope {
+        let p = PathBuf::from(s);
+        let tsconfig =
+            if p.is_file() && p.file_name().map(|n| n == "tsconfig.json").unwrap_or(false) {
+                p
+            } else {
+                p.join("tsconfig.json")
+            };
+        if tsconfig.exists() {
+            return Some(Scope::ts(&tsconfig));
+        }
+        // Fall through to file-based / default resolution if explicit fails.
+    }
+
+    if let Some(f) = file {
+        if let Some(tsconfig) = nearest_tsconfig(Path::new(f)) {
+            return Some(Scope::ts(&tsconfig));
+        }
+    }
+
+    default_ts_scope()
+}
+
+/// Walk up from `file` to find the nearest `tsconfig.json`.
+pub fn nearest_tsconfig(file: &Path) -> Option<PathBuf> {
+    let mut dir = if file.is_dir() {
+        Some(file.to_path_buf())
+    } else {
+        file.parent().map(|p| p.to_path_buf())
+    };
+    while let Some(d) = dir {
+        let candidate = d.join("tsconfig.json");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = d.parent().map(|p| p.to_path_buf());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_dir_scope_resolves_when_tsconfig_exists() {
+        // The frontend root contains a real tsconfig.json.
+        let frontend_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let s = resolve_scope(Some(frontend_root.to_str().unwrap()), None);
+        assert!(s.is_some(), "expected scope from explicit frontend dir");
+        let s = s.unwrap();
+        assert_eq!(s.language, "typescript");
+        assert!(s.key.ends_with("tsconfig.json"));
+    }
+
+    #[test]
+    fn file_path_resolves_to_nearest_tsconfig() {
+        // A file inside the frontend src/ resolves to the frontend tsconfig.
+        let frontend_root = Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
+        let file = frontend_root.join("src").join("lib").join("appInfo.ts");
+        let s = resolve_scope(None, file.to_str());
+        assert!(s.is_some(), "expected scope from file path");
+        assert!(s.unwrap().key.ends_with("tsconfig.json"));
+    }
+
+    #[test]
+    fn nonexistent_explicit_scope_falls_back_to_default() {
+        let s = resolve_scope(Some("/no/such/dir/anywhere"), None);
+        // Falls through to the default TS scope (frontend tsconfig exists).
+        assert!(s.is_some());
+    }
+
+    #[test]
+    fn normalize_uses_forward_slashes() {
+        let p = Path::new("C:\\foo\\bar\\tsconfig.json");
+        assert_eq!(normalize(p), "C:/foo/bar/tsconfig.json");
+    }
+
+    #[test]
+    fn default_ts_scope_exists() {
+        // The runner frontend has a tsconfig.json.
+        assert!(default_ts_scope().is_some());
+    }
+}

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -39,6 +39,7 @@ pub mod bridges;
 pub mod canvas;
 pub mod cascade;
 pub mod checks;
+pub mod code_semantics;
 pub mod command_relay;
 pub mod comparison_api;
 pub mod completion_reports;

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1637,6 +1637,7 @@ pub fn create_router(
         .merge(crate::mcp::automation_runs::routes())
         .merge(crate::mcp::comparison_api::routes())
         .merge(crate::mcp::checks::routes())
+        .merge(crate::mcp::code_semantics::routes())
         .merge(crate::mcp::configs::routes())
         .merge(crate::mcp::constraints_api::routes())
         .merge(crate::mcp::contexts::routes())


### PR DESCRIPTION
Implements **Phase 2a + 2b** of `plans/2026-05-30-twin-code-semantics-lsp-layer.md` — the runner side of the code-semantics twin observer (`Ξ_Type`), a **pure observer** (no declared-vs-actual drift pair, no Φ).

## What
- **Node helper** (`resources/code-semantics/ts-language-service.mjs`): long-lived process driving the TypeScript **Language Service API** over a newline-delimited JSON stdio protocol. Commands: `symbol_lookup` (resolved signature + sha1 hash + def location), `signature`, `find_references` (binding-accurate cross-module xrefs), `typecheck`. Overlay mode applies an in-memory patch (**never writes disk**) = D3 `predict-effect`, returning `changed_signatures` + removed-but-still-referenced symbols (the Contradiction / active-negation signal, §5).
- **Rust sidecar** (`src-tauri/src/mcp/code_semantics/`): supervises the helper child (spawn/restart/shutdown, request-id correlation), hosts `/code-semantics/*` HTTP routes on the runner, uses the syntactic `code_graph.rs` (`Ξ_AST`) as the **cold-index fallback**, and attaches the uniform `(posterior, coverage, provenance, credibility)` envelope. Honest D4 cold-index semantics — a cold/unavailable engine returns `coverage<1` / `"indexing"` / `"engine_unavailable"`, **never a false `exists:false`**.
- **CONTRACT.md**: the authoritative cross-repo wire contract (coord's `phase11` tools proxy to this surface — see qontinui-coord PR).

## Verification (operator scope: "exercised against a live tsserver")
Exercised against the runner's own **3250-file** TS frontend with a live program:
- resolved signature `(id: MainTabId): TabSection` + hash + def location for a real export;
- binding-accurate `find_references` across modules (the capability syntactic `code_graph` cannot disambiguate, §9.2);
- overlay `predict-effect` catching a real `TS2322` **without writing the file** (re-read confirmed disk unmutated, §9.3);
- `removed_symbols` with binding-accurate `referenced_by` (Contradiction signal).

`cargo clippy --tests -- -D warnings` clean; 15 `code_semantics` unit tests + the live Rust→Node bridge integration test (`live_symbol_lookup_when_node_present`) pass.

Phase 3 (rust-analyzer/pyright, cross-repo fan-out, fuzzy completion) deferred per plan §7.