### PR TITLE
feat(discovery): recognize and badge appType 'injected' (Phase 4)

### DIFF
--- a/src/hooks/useAppDiscovery.ts
+++ b/src/hooks/useAppDiscovery.ts
@@ -19,7 +19,7 @@ import { getApiBase, tracedFetch } from "@/lib/runner-api";
 export interface DiscoveredApp {
   appId: string;
   appName: string;
-  appType: "web" | "desktop" | "mobile" | "other" | string;
+  appType: "web" | "desktop" | "mobile" | "other" | "injected" | string;
   framework?: string;
   url: string;
   port: number;

--- a/src/pages/ui-bridge-integration/DiscoveryPanel.tsx
+++ b/src/pages/ui-bridge-integration/DiscoveryPanel.tsx
@@ -755,6 +755,16 @@ function RegisteredAppCard({
           <span className="text-[10px] px-1.5 py-0.5 rounded bg-white/5 text-muted-foreground">
             {app.appType}
           </span>
+          {app.appType === "injected" && (
+            <span
+              data-ui-bridge-test-id="injected-apptype-badge"
+              title="Injected apps run the UI Bridge SDK via an injected relay client; their actions are dispatched over the relay transport rather than a host-bundled SDK."
+              className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-cyan-500/15 text-cyan-300 font-medium"
+            >
+              <Plug className="w-3 h-3" aria-hidden="true" />
+              injected
+            </span>
+          )}
           {app.transport === "websocket" && (
             <span
               data-ui-bridge-test-id="wrapper-transport-badge"


### PR DESCRIPTION
Phase 2 of *UI Bridge Injected Transport — Phase 4 consumer wiring*.

The injected transport's relay registration sends `appType:'injected'` (`ui-bridge/src/injected/bootstrap.ts:66`). This makes the runner honest about it:
- `src/hooks/useAppDiscovery.ts`: add `"injected"` to the `DiscoveredApp.appType` union.
- `DiscoveryPanel.tsx`: cyan `injected` badge for such tabs, mirroring the existing wrapper-transport badge.

**No Rust change** — `app_type` is already a free-form string and an injected relay tab registers as a Websocket app routed through `CommandRelay` unchanged. Frontend typecheck clean.