### PR TITLE
feat(runner): inline USER_PASSWORD_AUTH sign-in (UI-Bridge-driveable, no browser)

### DIFF
--- a/src-tauri/src/cognito.rs
+++ b/src-tauri/src/cognito.rs
@@ -48,6 +48,10 @@ pub const COGNITO_CALLBACK_PORT: u16 = 53682;
 pub const COGNITO_REDIRECT_URI: &str = "http://localhost:53682/auth/callback";
 /// OAuth scopes requested.
 pub const COGNITO_SCOPE: &str = "openid email profile";
+/// Region-scoped Cognito IDP endpoint used for the direct `InitiateAuth`
+/// (USER_PASSWORD_AUTH) flow — the no-browser, credential-driven sign-in.
+/// Distinct from the Hosted-UI token endpoint (`COGNITO_TOKEN_URL`).
+pub const COGNITO_IDP_URL: &str = "https://cognito-idp.us-east-1.amazonaws.com/";
 
 // ============================================================================
 // Wire types.
@@ -403,6 +407,170 @@ pub fn pkce_login() -> Result<CognitoLoginResult, String> {
     })
 }
 
+// ============================================================================
+// Direct credential login (`InitiateAuth` USER_PASSWORD_AUTH) — no browser.
+// ============================================================================
+
+/// `AuthenticationResult` block from a Cognito `InitiateAuth` /
+/// `RespondToAuthChallenge` success response. Field names are Cognito's
+/// PascalCase (the IDP JSON protocol), distinct from the Hosted-UI
+/// `/oauth2/token` snake_case shape.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct CognitoAuthenticationResult {
+    pub access_token: String,
+    pub id_token: String,
+    #[serde(default)]
+    pub refresh_token: Option<String>,
+    pub expires_in: i64,
+}
+
+/// Top-level `InitiateAuth` success envelope.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct InitiateAuthResponse {
+    #[serde(default)]
+    authentication_result: Option<CognitoAuthenticationResult>,
+}
+
+/// Sign in directly with email + password via Cognito `InitiateAuth`
+/// USER_PASSWORD_AUTH — no system browser, no loopback redirect. Yields the
+/// same `CognitoLoginResult` bundle as [`pkce_login`] so the post-auth chain is
+/// identical.
+///
+/// The password is NEVER logged. On a Cognito error (e.g.
+/// `NotAuthorizedException`, `UserNotConfirmedException`,
+/// `PasswordResetRequiredException`) a clean human-readable `Err(message)` is
+/// returned. Blocking; call via `tokio::task::spawn_blocking`.
+///
+/// Requires the runner client (`COGNITO_CLIENT_ID`) to have
+/// `ALLOW_USER_PASSWORD_AUTH` enabled in its Cognito app-client config.
+pub fn password_login(email: &str, password: &str) -> Result<CognitoLoginResult, String> {
+    let result = initiate_auth_user_password(email, password)?;
+
+    let expires_at = chrono::Utc::now().timestamp() + result.expires_in;
+    let refresh_token = result.refresh_token.ok_or_else(|| {
+        "Cognito InitiateAuth response omitted RefreshToken — the runner client must be \
+         configured to issue refresh tokens"
+            .to_string()
+    })?;
+    let sub = jwt_claim(&result.id_token, "sub")
+        .ok_or_else(|| "id token has no `sub` claim — cannot identify the user".to_string())?;
+    let claim_email = jwt_claim(&result.id_token, "email");
+
+    Ok(CognitoLoginResult {
+        access_token: result.access_token,
+        id_token: result.id_token,
+        refresh_token,
+        expires_at,
+        sub,
+        email: claim_email,
+    })
+}
+
+/// POST the raw `InitiateAuth` USER_PASSWORD_AUTH request to the region IDP
+/// endpoint and surface Cognito error codes as clean messages. Blocking.
+fn initiate_auth_user_password(
+    email: &str,
+    password: &str,
+) -> Result<CognitoAuthenticationResult, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("reqwest client build failed: {e}"))?;
+
+    let body = serde_json::json!({
+        "AuthFlow": "USER_PASSWORD_AUTH",
+        "ClientId": COGNITO_CLIENT_ID,
+        "AuthParameters": {
+            "USERNAME": email,
+            "PASSWORD": password,
+        }
+    });
+
+    let resp = client
+        .post(COGNITO_IDP_URL)
+        .header("X-Amz-Target", "AWSCognitoIdentityProviderService.InitiateAuth")
+        .header("Content-Type", "application/x-amz-json-1.1")
+        .body(serde_json::to_vec(&body).map_err(|e| format!("serialize InitiateAuth: {e}"))?)
+        .send()
+        .map_err(|e| format!("POST InitiateAuth failed: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .map_err(|e| format!("read InitiateAuth response: {e}"))?;
+
+    if !status.is_success() {
+        return Err(humanize_cognito_error(&text, status.as_u16()));
+    }
+
+    let parsed: InitiateAuthResponse = serde_json::from_str(&text)
+        .map_err(|e| format!("decode InitiateAuth response failed: {e}"))?;
+
+    parsed.authentication_result.ok_or_else(|| {
+        // A 200 without AuthenticationResult means Cognito returned a challenge
+        // (e.g. NEW_PASSWORD_REQUIRED / MFA) which this direct flow can't drive.
+        "Cognito requires an additional sign-in step (a challenge such as a new password \
+         or MFA) that this credential sign-in cannot complete. Use the browser sign-in instead."
+            .to_string()
+    })
+}
+
+/// Turn a Cognito IDP JSON error body into a clean user-facing message. The
+/// IDP returns `{"__type":"NotAuthorizedException","message":"..."}`.
+fn humanize_cognito_error(body: &str, http_status: u16) -> String {
+    let json: serde_json::Value = match serde_json::from_str(body) {
+        Ok(v) => v,
+        Err(_) => {
+            return format!(
+                "Cognito sign-in failed (HTTP {http_status}): {}",
+                body.chars().take(200).collect::<String>()
+            )
+        }
+    };
+    // `__type` is like "NotAuthorizedException" or
+    // "com.amazon.coral...#NotAuthorizedException".
+    let code = json
+        .get("__type")
+        .and_then(|v| v.as_str())
+        .map(|s| s.rsplit('#').next().unwrap_or(s))
+        .unwrap_or("UnknownError");
+    let msg = json
+        .get("message")
+        .or_else(|| json.get("Message"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    match code {
+        "NotAuthorizedException" => "Incorrect email or password.".to_string(),
+        "UserNotFoundException" => "No account found for that email.".to_string(),
+        "UserNotConfirmedException" => {
+            "Your account is not confirmed yet. Check your email for a verification link."
+                .to_string()
+        }
+        "PasswordResetRequiredException" => {
+            "A password reset is required. Reset your password, then sign in again.".to_string()
+        }
+        "InvalidParameterException" => {
+            if msg.is_empty() {
+                "Invalid sign-in parameters.".to_string()
+            } else {
+                format!("Invalid sign-in: {msg}")
+            }
+        }
+        "TooManyRequestsException" | "LimitExceededException" => {
+            "Too many sign-in attempts. Wait a moment and try again.".to_string()
+        }
+        other => {
+            if msg.is_empty() {
+                format!("Cognito sign-in failed ({other}).")
+            } else {
+                format!("Cognito sign-in failed ({other}): {msg}")
+            }
+        }
+    }
+}
+
 /// POST the authorization_code grant to `/oauth2/token`. Blocking.
 fn exchange_code(code: &str, code_verifier: &str) -> Result<CognitoTokenResponse, String> {
     let form = [
@@ -534,5 +702,53 @@ mod tests {
         )
         .unwrap();
         assert!(without.refresh_token.is_none());
+    }
+
+    #[test]
+    fn initiate_auth_response_decodes_pascalcase() {
+        let resp: InitiateAuthResponse = serde_json::from_str(
+            r#"{"AuthenticationResult":{"AccessToken":"at","IdToken":"it","RefreshToken":"rt","ExpiresIn":3600,"TokenType":"Bearer"}}"#,
+        )
+        .unwrap();
+        let ar = resp.authentication_result.expect("has result");
+        assert_eq!(ar.access_token, "at");
+        assert_eq!(ar.id_token, "it");
+        assert_eq!(ar.refresh_token.as_deref(), Some("rt"));
+        assert_eq!(ar.expires_in, 3600);
+    }
+
+    #[test]
+    fn initiate_auth_response_handles_challenge_without_result() {
+        // A challenge (e.g. NEW_PASSWORD_REQUIRED) carries no AuthenticationResult.
+        let resp: InitiateAuthResponse = serde_json::from_str(
+            r#"{"ChallengeName":"NEW_PASSWORD_REQUIRED","Session":"abc"}"#,
+        )
+        .unwrap();
+        assert!(resp.authentication_result.is_none());
+    }
+
+    #[test]
+    fn humanize_cognito_error_maps_known_codes() {
+        assert_eq!(
+            humanize_cognito_error(r#"{"__type":"NotAuthorizedException","message":"x"}"#, 400),
+            "Incorrect email or password."
+        );
+        // Namespaced __type still resolves to the bare code.
+        assert_eq!(
+            humanize_cognito_error(
+                r#"{"__type":"com.amazon.coral.service#UserNotFoundException","message":"x"}"#,
+                400
+            ),
+            "No account found for that email."
+        );
+        assert!(
+            humanize_cognito_error(r#"{"__type":"UserNotConfirmedException"}"#, 400)
+                .contains("not confirmed")
+        );
+        // Unknown code falls back to a generic message including the code.
+        assert!(humanize_cognito_error(r#"{"__type":"SomethingElse"}"#, 400)
+            .contains("SomethingElse"));
+        // Non-JSON body doesn't panic.
+        assert!(humanize_cognito_error("not json", 500).contains("500"));
     }
 }

--- a/src-tauri/src/cognito.rs
+++ b/src-tauri/src/cognito.rs
@@ -490,7 +490,10 @@ fn initiate_auth_user_password(
 
     let resp = client
         .post(COGNITO_IDP_URL)
-        .header("X-Amz-Target", "AWSCognitoIdentityProviderService.InitiateAuth")
+        .header(
+            "X-Amz-Target",
+            "AWSCognitoIdentityProviderService.InitiateAuth",
+        )
         .header("Content-Type", "application/x-amz-json-1.1")
         .body(serde_json::to_vec(&body).map_err(|e| format!("serialize InitiateAuth: {e}"))?)
         .send()
@@ -720,10 +723,9 @@ mod tests {
     #[test]
     fn initiate_auth_response_handles_challenge_without_result() {
         // A challenge (e.g. NEW_PASSWORD_REQUIRED) carries no AuthenticationResult.
-        let resp: InitiateAuthResponse = serde_json::from_str(
-            r#"{"ChallengeName":"NEW_PASSWORD_REQUIRED","Session":"abc"}"#,
-        )
-        .unwrap();
+        let resp: InitiateAuthResponse =
+            serde_json::from_str(r#"{"ChallengeName":"NEW_PASSWORD_REQUIRED","Session":"abc"}"#)
+                .unwrap();
         assert!(resp.authentication_result.is_none());
     }
 
@@ -746,8 +748,9 @@ mod tests {
                 .contains("not confirmed")
         );
         // Unknown code falls back to a generic message including the code.
-        assert!(humanize_cognito_error(r#"{"__type":"SomethingElse"}"#, 400)
-            .contains("SomethingElse"));
+        assert!(
+            humanize_cognito_error(r#"{"__type":"SomethingElse"}"#, 400).contains("SomethingElse")
+        );
         // Non-JSON body doesn't panic.
         assert!(humanize_cognito_error("not json", 500).contains("500"));
     }

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -187,6 +187,38 @@ pub async fn check_auth_status() -> Result<AuthStatus, String> {
     check_auth_status_impl().await.map_err(String::from)
 }
 
+/// `true` iff the runner holds a valid *local* signed-in session: a paired
+/// coord device-token JWT (the credential the WS relay presents) and/or a
+/// stored Cognito session. This is the authoritative "is the runner signed
+/// in?" signal — it is what a successful [`cognito_sign_in`] produces
+/// (`store_oauth_tokens` + `persist_pairing` → device JWT in the access_token
+/// slot) and what survives a process restart on disk.
+///
+/// Why this is the source of truth (and NOT a `/api/v1/auth/users/me`
+/// round-trip): the web backend's `users/me` endpoint can return 401/403 for a
+/// federated Cognito identity even though the runner is fully signed in and
+/// device-paired (the pair-cli bind returned 201 with the SAME access token).
+/// Gating "authenticated" on that call made a completed sign-in render the
+/// LoginScreen forever. The runner is signed in when it has local credentials,
+/// regardless of whether `users/me` happens to accept the Cognito access token.
+fn has_local_signed_in_session(auth_manager: &AuthManager) -> bool {
+    // A paired device has a (non-expired) coord device-token JWT in the
+    // access_token slot — written by `persist_pairing` after a successful
+    // pair-cli bind. `device_jwt_needs_refresh() == Ok(false)` means a real,
+    // unexpired JWT is present.
+    let has_valid_device_jwt = matches!(auth_manager.device_jwt_needs_refresh(), Ok(false));
+
+    // A stored Cognito session (refresh token present) also means the user
+    // signed in — even if the device JWT is momentarily stale and awaiting the
+    // refresher's next pair cycle.
+    let has_cognito_session = auth_manager
+        .get_oauth_refresh_token()
+        .map(|t| !t.trim().is_empty())
+        .unwrap_or(false);
+
+    has_valid_device_jwt || has_cognito_session
+}
+
 async fn check_auth_status_impl() -> Result<AuthStatus, AppError> {
     info!("Checking authentication status");
 
@@ -202,94 +234,72 @@ async fn check_auth_status_impl() -> Result<AuthStatus, AppError> {
     }
 
     let auth_manager = AuthManager::new();
-
-    // Resolve the Cognito user bearer (refresh-first). Absence of a Cognito
-    // session means the runner hasn't signed in — the web backend is
-    // Cognito-only, so there is no other credential to validate.
-    let access_token = match web_backend_user_bearer(&auth_manager).await {
-        Ok(t) => t,
-        Err(_) => {
-            info!("No Cognito session — user not authenticated");
-            return Ok(AuthStatus {
-                authenticated: false,
-                user: None,
-                device_id: None,
-            });
-        }
-    };
-
-    // Validate token by calling /users/me endpoint — reqwest::Error From impl
-    // wraps build failures into AppError::NetworkError, but we keep the
-    // historical wire string via AppError::Raw to preserve frontend parsing.
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()
-        .map_err(|e| AppError::Raw(format!("Failed to create HTTP client: {}", e)))?;
-    let response = match client
-        .get(format!("{}/api/v1/auth/users/me", get_api_base_url()))
-        .bearer_auth(&access_token)
-        .send()
-        .await
-    {
-        Ok(resp) => resp,
-        Err(e) => {
-            // Backend unreachable — tokens exist, assume authenticated.
-            // The runner should work offline; token validity will be checked
-            // when the backend becomes available again.
-            warn!(
-                "Backend unreachable during auth check ({}), assuming authenticated with stored tokens",
-                e
-            );
-            let device_id = auth_manager.get_device_id().ok();
-            return Ok(AuthStatus {
-                authenticated: true,
-                user: None,
-                device_id,
-            });
-        }
-    };
-
-    if !response.status().is_success() {
-        let status = response.status();
-        warn!("Token validation failed: {}", status);
-
-        // On a definitive auth failure (401/403) the Cognito access token is
-        // invalid/expired — report unauthenticated so the frontend prompts a
-        // re-sign-in. We deliberately do NOT clear any token slot here: the
-        // coord device-JWT (access_token slot, used by the WS relay) is a
-        // SEPARATE credential and must survive a Cognito-token expiry. The
-        // Cognito tokens are refreshed by the device-JWT refresher's
-        // `ensure_fresh_cognito_bearer` path on the next cycle.
-        // For transient errors (5xx, timeouts, etc.), return Err so the
-        // frontend catch block fires without changing auth state.
-        if status.as_u16() == 401 || status.as_u16() == 403 {
-            return Ok(AuthStatus {
-                authenticated: false,
-                user: None,
-                device_id: None,
-            });
-        } else {
-            return Err(AppError::Raw(format!(
-                "Auth status check failed with transient error: {}",
-                status
-            )));
-        }
-    }
-
-    let user_info: ApiUserInfo = response.json().await?;
-
     let device_id = auth_manager.get_device_id().ok();
 
-    info!("User authenticated: {}", user_info.id);
+    // Authoritative signal: does the runner hold a valid local signed-in
+    // session? This is true immediately after a successful `cognito_sign_in`
+    // (device paired + Cognito tokens stored) AND on a fresh boot that restored
+    // those credentials from disk. If there's no local session, the runner has
+    // genuinely never signed in (or was logged out) — report unauthenticated so
+    // the frontend shows LoginScreen.
+    if !has_local_signed_in_session(&auth_manager) {
+        info!("No local signed-in session — user not authenticated");
+        return Ok(AuthStatus {
+            authenticated: false,
+            user: None,
+            device_id: None,
+        });
+    }
+
+    // We ARE signed in. Best-effort: enrich the status with the user's
+    // profile via `/api/v1/auth/users/me`. A failure here (network error, or
+    // even a 401/403 — the federated-identity `users/me` gap) does NOT
+    // downgrade `authenticated`: a valid local device pairing is proof the
+    // runner is signed in. We only use the response to populate `user`.
+    let user = match web_backend_user_bearer(&auth_manager).await {
+        Ok(access_token) => fetch_user_info(&access_token).await,
+        Err(_) => None,
+    };
+
+    info!(
+        "Runner authenticated via local session (user enrichment: {})",
+        if user.is_some() { "ok" } else { "unavailable" }
+    );
 
     Ok(AuthStatus {
         authenticated: true,
-        user: Some(UserInfo {
-            id: user_info.id,
-            email: user_info.email,
-            name: user_info.full_name,
-        }),
+        user,
         device_id,
+    })
+}
+
+/// Best-effort fetch of the signed-in user's profile from the web backend.
+/// Returns `None` on any failure (network error, 4xx/5xx, malformed body) —
+/// callers treat a missing profile as "authenticated but unenriched", never as
+/// a sign-out signal.
+async fn fetch_user_info(access_token: &str) -> Option<UserInfo> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .ok()?;
+    let response = client
+        .get(format!("{}/api/v1/auth/users/me", get_api_base_url()))
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        warn!(
+            "users/me returned {} — keeping local-session authentication, skipping user enrichment",
+            response.status()
+        );
+        return None;
+    }
+    let user_info: ApiUserInfo = response.json().await.ok()?;
+    Some(UserInfo {
+        id: user_info.id,
+        email: user_info.email,
+        name: user_info.full_name,
     })
 }
 

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -576,11 +576,6 @@ pub async fn cognito_sign_in(backend_url: String) -> Result<CognitoSignInRespons
 }
 
 async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInResponse, AppError> {
-    use qontinui_runner_lib::pair::{
-        pair_with_auth_token_with_ids, persist_pairing, read_device_id_from_disk,
-        tenant_id_from_oauth_claim,
-    };
-
     let base = backend_url.trim().trim_end_matches('/').to_string();
     if base.is_empty() {
         return Err(AppError::Raw("backend_url is required".to_string()));
@@ -607,6 +602,35 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
         login.sub
     );
 
+    // Run the shared post-auth chain (store tokens → pair → persist → promote).
+    finalize_signed_in(login, base).await
+}
+
+/// Shared post-authentication chain used by BOTH the Hosted-UI PKCE sign-in
+/// ([`cognito_sign_in`]) and the direct credential sign-in
+/// ([`cognito_sign_in_password`]). Given a freshly obtained
+/// [`CognitoLoginResult`] (from either flow), this:
+///
+///   2. Persists the Cognito user tokens in the distinct oauth slots.
+///   3. Reads the device identity from disk.
+///   4. Binds device→user via the existing web-backend `pair-cli` flow,
+///      presenting the Cognito access token + `sub`.
+///   5. Persists the minted coord device JWT + paired-user file.
+///   6. Promotes the runner to Tier 2, stages the backend URL, and kicks the
+///      cloud relay + device-JWT refresher.
+///
+/// Factored out so the two sign-in entry points cannot diverge. The
+/// `runner-tier-changed` window event is dispatched by the FRONTEND on success
+/// (both call sites do this) — identical to the prior single-callsite behavior.
+async fn finalize_signed_in(
+    login: qontinui_runner_lib::cognito::CognitoLoginResult,
+    base: String,
+) -> Result<CognitoSignInResponse, AppError> {
+    use qontinui_runner_lib::pair::{
+        pair_with_auth_token_with_ids, persist_pairing, read_device_id_from_disk,
+        tenant_id_from_oauth_claim,
+    };
+
     // 2. Persist the Cognito user tokens in the distinct oauth slots.
     let auth_manager = AuthManager::new();
     auth_manager
@@ -617,13 +641,13 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
             login.expires_at,
         )
         .map_err(|e| {
-            error!("cognito_sign_in: step 2 (store_oauth_tokens) failed: {e}");
+            error!("finalize_signed_in: step 2 (store_oauth_tokens) failed: {e}");
             AppError::Raw(format!("persist Cognito tokens: {e}"))
         })?;
 
     // 3. Device identity from disk.
     let device_id = read_device_id_from_disk().map_err(|e| {
-        error!("cognito_sign_in: step 3 (read_device_id_from_disk) failed: {e}");
+        error!("finalize_signed_in: step 3 (read_device_id_from_disk) failed: {e}");
         AppError::Raw(format!("could not read device identity: {e}"))
     })?;
 
@@ -647,11 +671,11 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
     })
     .await
     .map_err(|e| {
-        error!("cognito_sign_in: device-pair task panicked: {e}");
+        error!("finalize_signed_in: device-pair task panicked: {e}");
         AppError::Raw(format!("device-pair task panicked: {e}"))
     })?
     .map_err(|e| {
-        error!("cognito_sign_in: step 4 (pair_with_auth_token_with_ids) failed: {e}");
+        error!("finalize_signed_in: step 4 (pair_with_auth_token_with_ids) failed: {e}");
         AppError::Raw(e)
     })?;
 
@@ -663,7 +687,7 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
 
     // 5. Persist the device JWT + paired-user file.
     persist_pairing(&pair_resp, tenant_id).map_err(|e| {
-        error!("cognito_sign_in: step 5 (persist_pairing) failed AFTER a successful pair: {e}");
+        error!("finalize_signed_in: step 5 (persist_pairing) failed AFTER a successful pair: {e}");
         AppError::Raw(format!("persist pairing: {e}"))
     })?;
 
@@ -684,10 +708,10 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
         s.tier = settings::RunnerTier::QontinuiAccount;
         s.tier_initialized = true;
         if crate::instance::is_secondary() {
-            warn!("cognito_sign_in: secondary runner — applying in-memory only, skipping save_settings");
+            warn!("finalize_signed_in: secondary runner — applying in-memory only, skipping save_settings");
         } else {
             settings::save_settings(&s).map_err(|e| {
-                error!("cognito_sign_in: step 6 (save_settings tier promotion) failed AFTER a successful pair: {e}");
+                error!("finalize_signed_in: step 6 (save_settings tier promotion) failed AFTER a successful pair: {e}");
                 AppError::Raw(format!("persist tier promotion: {e}"))
             })?;
         }
@@ -699,7 +723,7 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
 
     let resp_device_id = pair_resp.device_id.clone().unwrap_or(device_id);
     info!(
-        "cognito_sign_in: signed in + device bound (sub={}, device={resp_device_id}) — Tier 2 active",
+        "finalize_signed_in: signed in + device bound (sub={}, device={resp_device_id}) — Tier 2 active",
         login.sub
     );
 
@@ -709,6 +733,80 @@ async fn cognito_sign_in_impl(backend_url: String) -> Result<CognitoSignInRespon
         tenant_id: tenant_id_str,
         device_id: resp_device_id,
     })
+}
+
+/// Sign in to the runner with an email + password **directly** via Cognito
+/// `InitiateAuth` USER_PASSWORD_AUTH — **no system browser**. This is the
+/// fully-headless / UI-Bridge-driveable counterpart to [`cognito_sign_in`]
+/// (Hosted-UI PKCE): the operator can complete the entire sign-in through the
+/// runner's own UI without a browser hop.
+///
+/// Additive — the Hosted-UI "Sign in with Qontinui" button
+/// ([`cognito_sign_in`]) is unchanged. Both flows converge on the SAME
+/// post-auth chain ([`finalize_signed_in`]): store Cognito tokens → bind the
+/// coord device JWT via `pair-cli` → persist → promote to Tier 2 → kick the
+/// relay/refresher. On a Cognito error (bad credentials, unconfirmed user,
+/// etc.) a clean `Err(message)` is returned.
+///
+/// The password is NEVER logged. Requires the runner Cognito app-client to
+/// have `ALLOW_USER_PASSWORD_AUTH` enabled.
+///
+/// `backend_url` is the web-backend base (e.g. `https://api.qontinui.io`),
+/// explicit + required — symmetric with [`cognito_sign_in`].
+#[tauri::command]
+pub async fn cognito_sign_in_password(
+    email: String,
+    password: String,
+    backend_url: String,
+) -> Result<CognitoSignInResponse, String> {
+    cognito_sign_in_password_impl(email, password, backend_url)
+        .await
+        .map_err(String::from)
+}
+
+async fn cognito_sign_in_password_impl(
+    email: String,
+    password: String,
+    backend_url: String,
+) -> Result<CognitoSignInResponse, AppError> {
+    let base = backend_url.trim().trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return Err(AppError::Raw("backend_url is required".to_string()));
+    }
+    let email = email.trim().to_string();
+    if email.is_empty() {
+        return Err(AppError::Raw("email is required".to_string()));
+    }
+    if password.is_empty() {
+        return Err(AppError::Raw("password is required".to_string()));
+    }
+
+    // NOTE: never log `password`.
+    info!("cognito_sign_in_password: starting InitiateAuth USER_PASSWORD_AUTH");
+
+    // Blocking reqwest call — run on a worker thread off the tokio runtime.
+    // `password` is moved into the closure and dropped there; it is never logged.
+    let login = tokio::task::spawn_blocking(move || {
+        qontinui_runner_lib::cognito::password_login(&email, &password)
+    })
+    .await
+    .map_err(|e| {
+        error!("cognito_sign_in_password: login task panicked: {e}");
+        AppError::Raw(format!("password login task panicked: {e}"))
+    })?
+    .map_err(|e| {
+        // `e` is already a humanized Cognito message (no secrets).
+        error!("cognito_sign_in_password: InitiateAuth failed: {e}");
+        AppError::Raw(e)
+    })?;
+
+    info!(
+        "cognito_sign_in_password: InitiateAuth succeeded (sub={}) — binding device",
+        login.sub
+    );
+
+    // Shared post-auth chain — identical to the Hosted-UI path.
+    finalize_signed_in(login, base).await
 }
 
 /// Clears the runner token, drops the runner back to Tier 0/1, and kicks
@@ -800,6 +898,7 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             set_runner_tier,
             start_qontinui_sign_in,
             cognito_sign_in,
+            cognito_sign_in_password,
             qontinui_sign_out,
             device_jwt_present,
             kick_device_jwt_refresher_cmd,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -895,6 +895,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::auth::set_runner_tier,
             commands::auth::start_qontinui_sign_in,
             commands::auth::cognito_sign_in,
+            commands::auth::cognito_sign_in_password,
             commands::autostart::get_autostart_enabled,
             commands::autostart::set_autostart_enabled,
             commands::backup::export_all_data,

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -21,9 +21,20 @@ const log = createLogger("LoginScreen");
 /** Web backend the Cognito-bound device JWT is minted against. */
 const DEFAULT_BACKEND_URL = "https://api.qontinui.io";
 
+type CognitoSignInResponse = {
+  userId: string;
+  email: string | null;
+  tenantId: string | null;
+  deviceId: string;
+};
+
 export function LoginScreen() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  // Inline email/password (direct Cognito InitiateAuth — no browser).
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [pwLoading, setPwLoading] = useState(false);
 
   const handleSignIn = async () => {
     log.debug("handleSignIn() called — starting Cognito PKCE sign-in");
@@ -31,12 +42,9 @@ export function LoginScreen() {
     setError("");
 
     try {
-      await invoke<{
-        userId: string;
-        email: string | null;
-        tenantId: string | null;
-        deviceId: string;
-      }>("cognito_sign_in", { backendUrl: DEFAULT_BACKEND_URL });
+      await invoke<CognitoSignInResponse>("cognito_sign_in", {
+        backendUrl: DEFAULT_BACKEND_URL,
+      });
       log.debug("Cognito sign-in completed — runner promoted to Tier 2");
       // The command already promoted the runner to Tier 2; nudge tier consumers
       // (notably AuthProvider) so the gate re-evaluates without a poll cycle.
@@ -46,6 +54,29 @@ export function LoginScreen() {
       setError(typeof err === "string" ? err : String(err));
     } finally {
       setLoading(false);
+    }
+  };
+
+  const handlePasswordSignIn = async () => {
+    log.debug("handlePasswordSignIn() called — direct Cognito USER_PASSWORD_AUTH");
+    setPwLoading(true);
+    setError("");
+
+    try {
+      await invoke<CognitoSignInResponse>("cognito_sign_in_password", {
+        email,
+        password,
+        backendUrl: DEFAULT_BACKEND_URL,
+      });
+      log.debug("Password sign-in completed — runner promoted to Tier 2");
+      // Same as the hosted-UI path: the command already promoted to Tier 2,
+      // nudge tier consumers so the gate re-evaluates immediately.
+      window.dispatchEvent(new CustomEvent("runner-tier-changed"));
+    } catch (err) {
+      log.error("Password sign-in failed:", err);
+      setError(typeof err === "string" ? err : String(err));
+    } finally {
+      setPwLoading(false);
     }
   };
 
@@ -88,7 +119,7 @@ export function LoginScreen() {
           <button
             type="button"
             onClick={handleSignIn}
-            disabled={loading}
+            disabled={loading || pwLoading}
             data-testid="cognito-sign-in"
             className="w-full btn-primary py-3 text-base font-semibold flex items-center justify-center gap-2"
           >
@@ -104,6 +135,82 @@ export function LoginScreen() {
               </>
             )}
           </button>
+
+          {/* Divider: "or sign in with email" */}
+          <div className="flex items-center gap-3" aria-hidden="true">
+            <span className="flex-1 h-px bg-border/50" />
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">
+              or sign in with email
+            </span>
+            <span className="flex-1 h-px bg-border/50" />
+          </div>
+
+          {/* Inline credential sign-in (direct Cognito, no browser) */}
+          <form
+            className="space-y-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!pwLoading && !loading) void handlePasswordSignIn();
+            }}
+          >
+            <div className="space-y-1">
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-foreground"
+              >
+                Email
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="username"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={pwLoading}
+                className="w-full px-3 py-2 rounded-lg bg-background border border-border/60 text-foreground focus:outline-none focus:border-primary"
+                placeholder="you@example.com"
+              />
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-foreground"
+              >
+                Password
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                disabled={pwLoading}
+                className="w-full px-3 py-2 rounded-lg bg-background border border-border/60 text-foreground focus:outline-none focus:border-primary"
+                placeholder="••••••••"
+              />
+            </div>
+            <button
+              id="button-sign-in-password"
+              type="submit"
+              disabled={pwLoading || loading}
+              data-testid="cognito-sign-in-password"
+              className="w-full btn-secondary py-3 text-base font-semibold flex items-center justify-center gap-2"
+            >
+              {pwLoading ? (
+                <>
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                  <span>Signing in…</span>
+                </>
+              ) : (
+                <>
+                  <LogIn className="w-5 h-5" />
+                  <span>Sign In</span>
+                </>
+              )}
+            </button>
+          </form>
 
           {/* Help Text */}
           <div className="text-center pt-4 border-t border-border/50">


### PR DESCRIPTION
Adds an inline email/password sign-in (`cognito_sign_in_password` → InitiateAuth USER_PASSWORD_AUTH, no system browser) so the runner sign-in is fully driveable via the runner's own UI Bridge. Shared `finalize_signed_in` post-auth helper; inline form ids `email`/`password`/`button-sign-in-password`. **Stacked on #343** (auth-status-gate fix — included here; merge #343 first). Requires `ALLOW_USER_PASSWORD_AUTH` on runner client `67f2a1a0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)