### PR TITLE
fix(runner): sign-out returns to LoginScreen instead of local-guest

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -809,13 +809,28 @@ async fn cognito_sign_in_password_impl(
     finalize_signed_in(login, base).await
 }
 
-/// Clears the runner token, drops the runner back to Tier 0/1, and kicks
-/// the relay so the WS connection closes cleanly.
+/// Clears the runner token but KEEPS the runner at Tier 2
+/// (`QontinuiAccount`) in an *unauthenticated* state, and kicks the relay
+/// so the WS connection closes cleanly.
 ///
-/// Used by `AccountSettings.tsx`'s "Sign out" button. The FE is expected
-/// to dispatch a `runner-tier-changed` window event after this call
-/// returns Ok so `useRunnerTier` consumers (notably `AuthProvider`)
-/// re-read and switch back to the synthesized local-guest auth.
+/// Used by `AccountSettings.tsx`'s "Sign out" button. An explicit "Sign
+/// out" is a deliberate "I want to sign in again / switch accounts"
+/// action, so the runner must land on the `LoginScreen` rather than
+/// silently continue as a local guest. The App gate
+/// (`isTier2 && !authStatus.authenticated → LoginScreen`) renders the
+/// login screen precisely for this Tier-2-unauthenticated state, so we
+/// clear the token (→ `check_auth_status` reports `authenticated: false`)
+/// while leaving `tier = QontinuiAccount`.
+///
+/// This intentionally does NOT drop to `RunnerTier::Local`: the
+/// local-guest tier is a *separate, deliberate* entry point chosen at
+/// first-run via the SetupWizard's tier selector, not a side effect of
+/// signing out of an account.
+///
+/// The FE is expected to dispatch a `runner-tier-changed` window event
+/// after this call returns Ok so `useRunnerTier` consumers (notably
+/// `AuthProvider`) re-read the tier and re-run `check_auth_status`, which
+/// now returns unauthenticated → the gate shows `LoginScreen`.
 ///
 /// # Errors
 ///
@@ -824,10 +839,10 @@ async fn cognito_sign_in_password_impl(
 /// surfaced to the caller.
 #[tauri::command]
 pub async fn qontinui_sign_out() -> Result<(), String> {
-    info!("qontinui_sign_out: clearing token + dropping to Tier Local");
+    info!("qontinui_sign_out: clearing token + staying Tier 2 (unauthenticated) so the LoginScreen shows");
 
     // Best-effort: a stale keychain entry is annoying but not fatal —
-    // the gating checks all run off the `tier` field below.
+    // the gating checks all run off the `tier` field + cleared token below.
     let auth_manager = AuthManager::new();
     if let Err(e) = auth_manager.clear_tokens() {
         warn!("qontinui_sign_out: clear_tokens failed (continuing): {}", e);
@@ -836,7 +851,10 @@ pub async fn qontinui_sign_out() -> Result<(), String> {
     let mut s = settings::load_settings();
     s.web_integration.runner_token = String::new();
     s.qontinui_user_id = None;
-    s.tier = settings::RunnerTier::Local;
+    // Keep tier == QontinuiAccount so the App gate renders LoginScreen for
+    // this Tier-2-unauthenticated state instead of falling through to the
+    // synthesized local-guest app shell.
+    s.tier = settings::RunnerTier::QontinuiAccount;
     s.tier_initialized = true;
     if crate::instance::is_secondary() {
         warn!(

--- a/src-tauri/src/tier_matrix_tests.rs
+++ b/src-tauri/src/tier_matrix_tests.rs
@@ -285,7 +285,7 @@ fn tier_promotion_local_to_qontinui_sets_user_id() {
 }
 
 #[test]
-fn tier_downgrade_qontinui_to_local_clears_state() {
+fn sign_out_stays_tier2_unauthenticated_clears_token() {
     // Starting state: signed-in Tier 2 install.
     let mut s = settings_with(RunnerTier::QontinuiAccount, "qontinui_runner_signed_in");
     s.qontinui_user_id = Some("u456".to_string());
@@ -293,32 +293,41 @@ fn tier_downgrade_qontinui_to_local_clears_state() {
     s.tier_initialized = true;
 
     // Apply the sign-out path (mirrors commands::auth::qontinui_sign_out):
+    // clear the token + user id but KEEP Tier 2 so the App gate
+    // `isTier2 && !authenticated → LoginScreen` renders the login screen
+    // rather than silently dropping to the local-guest app shell. Local
+    // guest is a separate, deliberate SetupWizard tier choice — not a
+    // side effect of signing out of an account.
     s.web_integration.runner_token = String::new();
     s.qontinui_user_id = None;
-    s.tier = RunnerTier::Local;
+    s.tier = RunnerTier::QontinuiAccount;
 
-    assert_eq!(s.tier, RunnerTier::Local);
+    assert_eq!(
+        s.tier,
+        RunnerTier::QontinuiAccount,
+        "sign-out must stay Tier 2 (unauthenticated) so the LoginScreen shows"
+    );
     assert!(s.qontinui_user_id.is_none());
     assert!(s.web_integration.runner_token.is_empty());
     assert_eq!(
         s.local_user_id, "local-uuid-keeps",
-        "local_user_id must survive downgrade — local DB rows are keyed on it \
+        "local_user_id must survive sign-out — local DB rows are keyed on it \
          per Phase 1 of the tier-decoupling plan"
     );
-    // Post-downgrade: tier wins, regardless of whether the JWT slot was
-    // cleared. Exercise both has_jwt arms to nail down the tier-precedence.
+    // Post-sign-out the device-JWT slot is cleared, so the relay idles
+    // because there is no JWT to authenticate the WS — even though tier is
+    // still Tier 2.
     assert!(
         should_relay_idle_with(s.tier, s.web_integration.enabled, false),
-        "post-downgrade (tier=Local) with cleared JWT must idle the relay"
+        "post-sign-out (tier=Tier2 but cleared JWT) must idle the relay"
     );
+    // The tier gate alone now passes (still Tier 2); actual cloud auth
+    // fails downstream on the empty token / missing JWT, which surfaces as
+    // `check_auth_status` → authenticated:false → LoginScreen.
     assert!(
-        should_relay_idle_with(s.tier, s.web_integration.enabled, true),
-        "post-downgrade (tier=Local) must idle even if a JWT lingers — \
-         tier gate is strict"
-    );
-    assert!(
-        require_tier_2_for(s.tier).is_err(),
-        "post-downgrade tier must block cloud auth commands"
+        require_tier_2_for(s.tier).is_ok(),
+        "sign-out keeps Tier 2, so the tier gate itself stays open; \
+         authentication fails on the cleared token, not the tier"
     );
 }
 

--- a/src/components/settings/AccountSettings.tsx
+++ b/src/components/settings/AccountSettings.tsx
@@ -12,7 +12,10 @@
  *     listens for indirectly via `runner-tier-changed`.
  *
  *   - Tier 2: shows the signed-in account (when available) and a "Sign
- *     out" button that drops the runner back to Tier Local.
+ *     out" button. Signing out clears the runner token but KEEPS the
+ *     runner at Tier 2 (unauthenticated), so the app returns to the
+ *     LoginScreen to sign in again / switch accounts — it does NOT drop
+ *     to local-guest (that is a separate first-run SetupWizard choice).
  *
  * The component is intentionally lean — token/runner_id/heartbeat
  * diagnostics live in the existing `WebIntegrationSettings` panel. This
@@ -123,19 +126,21 @@ export function AccountSettings({ onLog }: AccountSettingsProps) {
     setFlowError(null);
     try {
       await invoke("qontinui_sign_out");
-      // FE re-fires the tier-change event so AuthProvider re-syncs to the
-      // synthesized local-guest auth without waiting for a poll cycle.
+      // The runner stays Tier 2 but unauthenticated (token cleared), so
+      // re-fire the tier-change event: AuthProvider re-runs
+      // `check_auth_status` (now `authenticated: false`) and the App gate
+      // `isTier2 && !authenticated` renders the LoginScreen.
       window.dispatchEvent(new CustomEvent("runner-tier-changed"));
       await refreshTier();
-      // Drop the JWT-flow auth state locally as well so the LoginScreen
-      // doesn't briefly show on the next render.
+      // Clear the local JWT-flow auth state immediately so the gate flips
+      // to the LoginScreen without waiting for the re-check round-trip.
       try {
         await clearAuthState();
       } catch {
-        // clearAuthState invokes the Tier-2 `logout` command which now
-        // errors with "Tier 0/1 — no auth"; that's expected and harmless.
+        // clearAuthState invokes the `logout` command, which may error now
+        // that the token is already cleared; that's expected and harmless.
       }
-      onLog("info", "Signed out — runner returned to Tier Local");
+      onLog("info", "Signed out — sign in again on the login screen");
     } catch (err) {
       const msg = typeof err === "string" ? err : String(err);
       setFlowError(msg);
@@ -250,8 +255,8 @@ function SignedInPanel({ email, userId, name, signingOut, onSignOut }: SignedInP
         Sign out
       </button>
       <p className="text-xs text-muted-foreground">
-        Signing out clears the runner token and drops the runner to Tier Local. Local automation and
-        captures continue to work; cloud features become unavailable until you sign in again.
+        Signing out clears the runner token and returns you to the sign-in screen, where you can sign
+        in again or switch accounts.
       </p>
     </div>
   );


### PR DESCRIPTION
## Problem

Clicking **Sign out** in Account Settings dropped the runner to Tier **Local** (local-guest), so the App gate `isTier2 && !authStatus.authenticated → LoginScreen` (`src/App.tsx` ~L455–461) rendered the local-guest app shell instead of the LoginScreen. A user who explicitly signs out expects to land on the LoginScreen (to sign in again or switch accounts), not to silently keep running as a local guest.

## Root cause

`qontinui_sign_out` (`src-tauri/src/commands/auth.rs`) set `tier = RunnerTier::Local` after clearing the token. That flipped `isTier2` to `false` in `AuthProvider`, which then synthesized an **authenticated** `local-guest` auth state. The gate `isTier2 && !authenticated` became `false && …` and fell through to the main app shell.

## Fix (Option A — keep Tier 2, unauthenticated)

- `qontinui_sign_out` now clears `runner_token` + `qontinui_user_id` but **leaves `tier = QontinuiAccount`**. `check_auth_status` then reports `authenticated: false` (no token), so the existing App gate renders the LoginScreen — exactly the Tier-2-unauthenticated state that gate was designed for (AuthProvider even documents that state in a comment).
- Chosen over editing the gate because the gate already does the right thing once the tier is left at Tier 2 — no gate logic change needed.

## Local-guest path preserved

- The intentional "use the runner locally without an account" entry point is the **first-run SetupWizard tier selector** (`set_runner_tier` → local / local_provider), a deliberate setup choice — not a side effect of signing out. The LoginScreen has no "continue locally" button.
- Only sign-out behavior changed; the local-guest path is untouched.

## Restart-safety

`migrate_tier_in_place` is one-shot (gated on `tier_initialized`, which stays true), so the empty-token Tier 2 state is **not** demoted to Local on the next load — the LoginScreen persists across restarts until the user signs in.

## Also

- Renamed/rewrote `tier_matrix_tests::tier_downgrade_*` → `sign_out_stays_tier2_unauthenticated_clears_token` to assert the new semantics.
- Refreshed AccountSettings sign-out copy + doc comments.

## Verification

- `cargo check` — clean (isolated worktree target dir)
- `cargo clippy --tests -- -D warnings` — clean
- `npx tsc --noEmit` — clean