### PR TITLE
fix(runner): resolve coord URL from profile for spawn-from-plan + agent MCP config

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -592,15 +592,24 @@ fn qontinui_root_dir() -> Option<PathBuf> {
 /// from the validated JWT claims, so no `AGENT_NAME`/`AGENT_LANE`/`TOPIC`/
 /// `DEVICE_ID` env vars are needed in the config.
 ///
-/// DEPLOY GATING — DO NOT MERGE/DEPLOY THIS RUNNER CHANGE BEFORE the
-/// coord-native `/mcp` endpoint (coord branch `feat/coord-native-coordination-mcp`)
-/// is live on the target coord deployment (staging). If this config points at
-/// a coord that has no `/mcp` route, agents get an unreachable MCP server:
-/// Claude Code degrades gracefully and runs *without* coord tools, which is a
-/// silent coordination regression. Sequence the coord deploy first.
+/// The coord-native `/mcp` endpoint is live (coord PR #277 Phase-2 cutover),
+/// so this no longer carries the prior "do not deploy" gate. If a target coord
+/// ever lacks the `/mcp` route, agents get an unreachable MCP server: Claude
+/// Code degrades gracefully and runs *without* coord tools (a silent
+/// coordination regression) — so always sequence a coord `/mcp` deploy ahead
+/// of pointing runners at a new coord.
+///
+/// Coord base resolution: `COORD_HTTP_URL` env → active profile's `coord_url`
+/// → localhost fallback. Previously this read ONLY the env var, so a
+/// profile-configured runner (production → `coord.qontinui.io`) wrote a
+/// `localhost` MCP url into the agent's `.mcp.json`, silently pointing spawned
+/// agents at the wrong coord.
 fn write_coord_mcp_config(primary_wt: &str, payload: &LaunchPayload) {
-    let coord_url =
-        std::env::var("COORD_HTTP_URL").unwrap_or_else(|_| "http://localhost:9870".to_string());
+    let coord_url = std::env::var("COORD_HTTP_URL")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(coord_http_base)
+        .unwrap_or_else(|| "http://localhost:9870".to_string());
     let mcp_url = format!("{}/mcp", coord_url.trim_end_matches('/'));
 
     let mcp_config = serde_json::json!({

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1804,6 +1804,15 @@ fn coord_http_base_for_fleet() -> String {
     "http://localhost:9870".to_string()
 }
 
+/// `get_coord_http_base` — expose the runner's resolved coord HTTP base
+/// to the frontend so in-app surfaces (e.g. Spawn-from-Plan) reach the
+/// SAME coord the backend session-sync uses, instead of a hardcoded
+/// `localhost:9870`. Mirrors the `get_fleet_health` proxy pattern.
+#[tauri::command]
+pub fn get_coord_http_base() -> String {
+    coord_http_base_for_fleet()
+}
+
 /// `get_fleet_health` — fetch coord's fleet-health rollup + active
 /// alerts in one call for the dashboard panel. Returns the merged JSON
 /// `{ health: <coord /fleet/health>, alerts: [...], coordBase }`.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1357,6 +1357,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::productivity::get_coordinator_leader,
             commands::productivity::get_escalations,
             commands::productivity::get_fleet_health,
+            commands::productivity::get_coord_http_base,
             commands::productivity::get_plan_recommendations,
             commands::productivity::get_plan_tasks,
             commands::productivity::get_recommendations,

--- a/src/components/productivity/coordinatorApi.ts
+++ b/src/components/productivity/coordinatorApi.ts
@@ -387,13 +387,13 @@ export async function listOverlappingIntents(
 // operators an in-runner affordance so they don't have to flip to the
 // browser console to spawn agents during readiness rollouts.
 //
-// The runner reaches coord directly at `coordHttpBase()` (same fallback
-// pattern as ConflictModal.tsx); coord is LAN-trusted in the runner's
-// dev posture. A future deployment-config milestone will harden this
-// path (mTLS / signed JWT) before the runner ships to non-trusted
-// networks — at which point this helper becomes a Tauri-command proxy
-// like `getFleetHealth`. For now it's a plain `fetch` to keep the
-// surface small and reviewable.
+// The coord base is now resolved by the runner backend
+// (`get_coord_http_base`: env → profile `coord_url` → localhost), so the
+// in-app button reaches the SAME coord as backend session-sync rather than
+// a hardcoded localhost. The POST itself is still a plain `fetch` and coord
+// is LAN-trusted in the current pilot posture; the auth hardening (device
+// JWT on this call + coord-side gating, tracked in the Bar-2 / Phase-7
+// fleet-auth plan) lands separately before serving non-trusted networks.
 // ---------------------------------------------------------------------------
 
 /** Wire shape returned by coord's POST /agents/spawn. Extra fields are
@@ -407,10 +407,18 @@ export interface SpawnAgentResult {
   [k: string]: unknown;
 }
 
-/** Default coord HTTP base — same fallback as ConflictModal.tsx; a
- *  future Tauri command (`get_coord_http_base`) will replace this
- *  when production deployments need a non-default base. */
-function defaultCoordHttpBase(): string {
+/** Resolve coord's HTTP base from the runner backend (env `COORD_HTTP_URL`
+ *  → active profile `coord_url` → localhost), so in-app spawn reaches the
+ *  SAME coord the backend session-sync uses — not a hardcoded localhost.
+ *  Falls back to localhost only if the command is unavailable (e.g. unit
+ *  tests, which pass `coordBase` explicitly and never hit this path). */
+async function resolveCoordHttpBase(): Promise<string> {
+  try {
+    const base = await invoke<string>("get_coord_http_base");
+    if (base && base.trim()) return base.trim();
+  } catch {
+    // command unavailable — fall through to localhost default
+  }
   return "http://localhost:9870";
 }
 
@@ -437,7 +445,7 @@ export async function spawnFromPlan(
   declaredOverlapPaths?: string[],
   coordBase?: string,
 ): Promise<SpawnAgentResult> {
-  const base = coordBase ?? defaultCoordHttpBase();
+  const base = coordBase ?? (await resolveCoordHttpBase());
   const url = new URL("/agents/spawn", base);
   const body = {
     plan_slug: planSlug,


### PR DESCRIPTION
## Bar 1 — coord-split unification (runner daily-driver readiness)

Closes the **"two different coords"** split found while auditing runner↔coord readiness: the backend session-sync correctly follows the active profile (production → `coord.qontinui.io`), but two in-app surfaces hardcoded / env-only'd a `localhost:9870` base — so on a profile-configured runner they silently talked to the *wrong* coord.

### Changes
- **`spawnFromPlan` (frontend)** no longer hardcodes `http://localhost:9870`. New **`get_coord_http_base`** Tauri command resolves `COORD_HTTP_URL` env → active profile `coord_url` → localhost (mirrors `get_fleet_health`); the in-app Spawn-from-Plan button now reaches the same coord as session-sync.
- **`write_coord_mcp_config` (backend)** falls back to the profile `coord_url` when `COORD_HTTP_URL` is unset (was env-only → wrote a `localhost` MCP url into spawned agents' `.mcp.json`). Stale `/mcp` deploy-gate comment dropped — coord `/mcp` has been live since #277 (verified 401, i.e. mounted+JWT-gated, on prod & local).

### Not in scope (tracked for Bar 2 / Phase-7 fleet-auth)
Auth on these calls (device JWT + coord-side gating) and configurable dashboard base URL (`ConflictModal`, currently correctly pinned to prod `qontinui.io`).

### Verification
`cargo check` ✅ · `cargo clippy` ✅ · `vitest` 3/3 ✅ · `tsc` ✅ · `eslint` ✅ (local, isolated target).