### PR TITLE
fix(terminal): autonomous AI spawn (bypassPermissions) + best-account by usage headroom

### DIFF
--- a/src/components/settings/ai-settings/ClaudeCliSection.tsx
+++ b/src/components/settings/ai-settings/ClaudeCliSection.tsx
@@ -24,6 +24,7 @@ import type {
 } from "./types";
 import { EXECUTION_MODE_OPTIONS } from "./types";
 import type { CliExecutionMode } from "../types";
+import { compareByUsageHeadroom } from "../types";
 
 interface ClaudeCliSectionProps {
   settings: AiSettings;
@@ -219,7 +220,7 @@ export function ClaudeCliSection({
         setAccountUsages(result.data);
         const best = result.data
           .filter((a) => !a.error)
-          .sort((a, b) => a.utilization - b.utilization)[0];
+          .sort(compareByUsageHeadroom)[0];
         if (best) {
           onLog(
             "success",
@@ -395,7 +396,7 @@ export function ClaudeCliSection({
                   accountUsages.length > 0 &&
                   accountUsages
                     .filter((a) => !a.error)
-                    .sort((a, b) => a.utilization - b.utilization)[0]?.config_dir === dir;
+                    .sort(compareByUsageHeadroom)[0]?.config_dir === dir;
 
                 return (
                   <div

--- a/src/components/settings/compareByUsageHeadroom.test.ts
+++ b/src/components/settings/compareByUsageHeadroom.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for `compareByUsageHeadroom` — the "best account" selection
+ * comparator. The picker must choose the account with the most headroom
+ * relative to its PROJECTED usage (most-negative `usage_delta`), not the
+ * one with the lowest raw utilization.
+ */
+import { describe, expect, it } from "vitest";
+import { compareByUsageHeadroom } from "./types";
+
+type A = { utilization: number; usage_delta?: number | null; label?: string };
+
+const best = (accounts: A[]): string =>
+  [...accounts].sort(compareByUsageHeadroom)[0]?.label ?? "";
+
+describe("compareByUsageHeadroom", () => {
+  it("prefers the account furthest UNDER its projection, not lowest utilization", () => {
+    // 'busy' has lower raw utilization (0.40) but is OVER projection (+0.10);
+    // 'idle' is higher utilization (0.50) but well UNDER projection (-0.30).
+    const accounts: A[] = [
+      { label: "busy", utilization: 0.4, usage_delta: 0.1 },
+      { label: "idle", utilization: 0.5, usage_delta: -0.3 },
+    ];
+    expect(best(accounts)).toBe("idle");
+  });
+
+  it("orders by usage_delta ascending (most under budget first)", () => {
+    const accounts: A[] = [
+      { label: "a", utilization: 0.6, usage_delta: -0.1 },
+      { label: "b", utilization: 0.6, usage_delta: -0.5 },
+      { label: "c", utilization: 0.6, usage_delta: 0.2 },
+    ];
+    const ordered = [...accounts].sort(compareByUsageHeadroom).map((x) => x.label);
+    expect(ordered).toEqual(["b", "a", "c"]);
+  });
+
+  it("falls back to raw utilization when usage_delta is null/absent", () => {
+    const accounts: A[] = [
+      { label: "high", utilization: 0.9, usage_delta: null },
+      { label: "low", utilization: 0.2 },
+    ];
+    expect(best(accounts)).toBe("low");
+  });
+});

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -125,6 +125,26 @@ export interface AccountUsageInfo {
   period_remaining_days: number | null;
 }
 
+/**
+ * Comparator for "best account" selection. Prefers the account furthest
+ * UNDER its projected usage — i.e. the most-negative `usage_delta`
+ * (actual minus expected), which is "least usage relative to its
+ * projected usage". Falls back to raw `utilization` when `usage_delta`
+ * is unavailable (e.g. `expected_utilization` is null). Ascending: the
+ * best (most headroom) account sorts first.
+ *
+ * Structurally typed so both `AccountUsageInfo` shapes (settings + the
+ * terminal subset in `useSessionManager`) can use the one comparator.
+ */
+export function compareByUsageHeadroom(
+  a: { utilization: number; usage_delta?: number | null },
+  b: { utilization: number; usage_delta?: number | null },
+): number {
+  const ka = a.usage_delta ?? a.utilization ?? 0;
+  const kb = b.usage_delta ?? b.utilization ?? 0;
+  return ka - kb;
+}
+
 export interface ClaudeApiSettings {
   model: string;
   max_tokens: number;

--- a/src/components/terminal/LaunchMenu.tsx
+++ b/src/components/terminal/LaunchMenu.tsx
@@ -11,6 +11,7 @@ import type {
   FileRegistryInfoEntry,
   PredictedCollision,
 } from "./useSessionManager";
+import { compareByUsageHeadroom } from "../settings/types";
 
 interface LaunchMenuProps {
   onCreatePlain: (count: number) => void;
@@ -521,7 +522,7 @@ export function LaunchMenu({
   }, [runProbe]);
 
   const sortedAccounts = useMemo(
-    () => [...accountUsage].sort((a, b) => (a.utilization ?? 0) - (b.utilization ?? 0)),
+    () => [...accountUsage].sort(compareByUsageHeadroom),
     [accountUsage],
   );
 

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -623,11 +623,16 @@ function TerminalPageInner({
 
     const isWindows = navigator.platform.startsWith("Win");
     const customCmd = sessionManager.launchCommands?.[configDir];
+    // Default to autonomous mode (`--permission-mode bypassPermissions`),
+    // matching the operator's `clg`/`clh`/`clp` wrappers — runner-spawned
+    // AI sessions are for autonomous development and must not stall on a
+    // permission prompt. An explicit per-account launch command (if
+    // configured in settings) still overrides.
     const cmd = customCmd
       ? customCmd
       : isWindows
-        ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude`
-        : `CLAUDE_CONFIG_DIR="${configDir}" claude`;
+        ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude --permission-mode bypassPermissions`
+        : `CLAUDE_CONFIG_DIR="${configDir}" claude --permission-mode bypassPermissions`;
     const dirName = configDir.replace(/\\/g, "/").replace(/\/$/, "").split("/").pop() ?? "";
     const label = customCmd ?? dirName.match(/^\.claude-(.+)$/)?.[1] ?? "claude";
     const createdTabIds: string[] = [];

--- a/src/components/terminal/commands/useTerminalCommands.ts
+++ b/src/components/terminal/commands/useTerminalCommands.ts
@@ -38,6 +38,7 @@ import { instanceStorage } from "@/lib/instance-storage";
 
 import { useTerminalSession, useTransitionEffects, useUIStateCx, useZoneMetadata } from "../contexts";
 import type { AccountUsageInfo } from "../useSessionManager";
+import { compareByUsageHeadroom } from "../../settings/types";
 import type { ResultCardSpec } from "../result-card";
 import { buildMetricsCardSpec, buildHistoryCardSpec } from "../result-card";
 import type { CommandAction, CommandResult, ResolverContext } from "./types";
@@ -166,9 +167,10 @@ function readZoneArg(
 
 /**
  * Look up a `configDir` from an `account` arg. `"best"` (or empty
- * string) resolves to the lowest-utilization account. Returns `null`
- * when no matching account exists — handlers surface that as
- * `code: "no-account"`.
+ * string) resolves to the account with the most headroom relative to its
+ * projected usage (most-negative `usage_delta`; see
+ * `compareByUsageHeadroom`). Returns `null` when no matching account
+ * exists — handlers surface that as `code: "no-account"`.
  */
 function resolveAccountConfigDir(
   account: unknown,
@@ -177,9 +179,7 @@ function resolveAccountConfigDir(
   if (accounts.length === 0) return null;
   const raw = typeof account === "string" ? account.trim().toLowerCase() : "";
   if (raw === "" || raw === "best" || raw === "@best") {
-    const sorted = [...accounts].sort(
-      (a, b) => (a.utilization ?? 0) - (b.utilization ?? 0),
-    );
+    const sorted = [...accounts].sort(compareByUsageHeadroom);
     return sorted[0]?.config_dir ?? null;
   }
   const match = accounts.find(

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -234,7 +234,9 @@ export function TerminalSessionProvider({
 
     const isWindows = navigator.platform.startsWith("Win");
     const buildResumeCmd = (sessionId: string, configDir: string | undefined) => {
-      const base = `claude --resume ${sessionId}`;
+      // Autonomous resume (matches clg/clh/clp) so a re-attached session
+      // doesn't stall on a permission prompt.
+      const base = `claude --permission-mode bypassPermissions --resume ${sessionId}`;
       if (!configDir) return `${base}\r`;
       return isWindows
         ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; ${base}\r`

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -54,6 +54,13 @@ export interface AccountUsageInfo {
   resets_at: number | null;
   status: string | null;
   error: string | null;
+  /**
+   * Actual minus expected utilization (negative = under projected usage).
+   * Supplied by the `check_accounts_usage` backend; used to pick the
+   * account with the most headroom relative to its projection. Optional
+   * because older probe results / error rows may omit it.
+   */
+  usage_delta?: number | null;
 }
 
 export interface FileLockInfo {

--- a/src/components/terminal/useShellIntegration.ts
+++ b/src/components/terminal/useShellIntegration.ts
@@ -145,13 +145,16 @@ export function useShellIntegration({
       // Windows terminals use PowerShell ($env:VAR), others use bash (VAR=val cmd).
       const configDir = session.config_dir;
       const isWindows = navigator.platform.startsWith("Win");
+      // Resume autonomously (`--permission-mode bypassPermissions`) to match
+      // the operator's clg/clh/clp wrappers — a resumed session shouldn't
+      // stall on a permission prompt either.
       let resumeCmd: string;
       if (configDir) {
         resumeCmd = isWindows
-          ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude --resume ${session.session_id}`
-          : `CLAUDE_CONFIG_DIR="${configDir}" claude --resume ${session.session_id}`;
+          ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude --permission-mode bypassPermissions --resume ${session.session_id}`
+          : `CLAUDE_CONFIG_DIR="${configDir}" claude --permission-mode bypassPermissions --resume ${session.session_id}`;
       } else {
-        resumeCmd = `claude --resume ${session.session_id}`;
+        resumeCmd = `claude --permission-mode bypassPermissions --resume ${session.session_id}`;
       }
       pendingResumeRef.current = { tabId, resumeCmd };
 


### PR DESCRIPTION
## Problem
After the Terminal-page menu refactor, `/spawn-ai` / `/spawn-best` (and resume) launched **bare `claude`** — no `--permission-mode bypassPermissions` — so AI sessions prompted for permissions/login instead of running autonomously. Root cause: per-account launch commands moved into a settings map (`claude_account_launch_commands`) that's empty by default, so `handleLaunchAiSession` hit a bare-`claude` fallback. Separately, the "best account" picker sorted by **raw utilization**, ignoring projected usage.

## Fix
**A. Autonomous by default** — the AI-launch fallback (`TerminalPage.tsx`) and both resume paths (`useShellIntegration.ts`, `TerminalSessionContext.tsx`) now run `claude --permission-mode bypassPermissions`, matching the operator's `clg`/`clh`/`clp` wrappers. An explicit per-account launch command still overrides.

**B. Best = most headroom vs PROJECTED usage** — new shared `compareByUsageHeadroom` sorts by `usage_delta` (actual − expected; most-negative = furthest under budget), falling back to raw utilization when `usage_delta` is null. Routed through all four selection sites (`useTerminalCommands.resolveAccountConfigDir` "best", `LaunchMenu`, `ClaudeCliSection` ×2). Added `usage_delta` to the terminal `AccountUsageInfo` subset (the backend already returns it).

## Verification
`vitest` 340/340 (3 new comparator tests) · `tsc --noEmit` clean · `eslint` 0 errors.

Takes effect after a runner rebuild. Follows #347 in the runner-as-daily-driver readiness work.