### PR TITLE
fix(terminal): restrict AI-session spawn to configured accounts (no ~/.claude leak)

### DIFF
--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -664,10 +664,23 @@ function TerminalPageInner({
   // closeTerminal, transitionEffects.handleRestartInZone, terminalRefs)
   // directly from contexts. No visible UI change today — the registry is
   // populated for future CommandBar / palette / AI-tier consumers.
+  // New AI sessions must only target operator-CONFIGURED accounts. The
+  // `accountUsage` list also probes transcript-derived dirs (the default
+  // `~/.claude` from prior sessions), which previously let `/spawn-ai best`
+  // resolve to an unauthenticated default account. Restrict spawn
+  // candidates to `claude_config_dirs`; fall back to the full list only
+  // when nothing is configured yet.
+  const spawnAccounts =
+    sessionManager.savedConfigDirs.length > 0
+      ? sessionManager.accountUsage.filter((a) =>
+          sessionManager.savedConfigDirs.includes(a.config_dir),
+        )
+      : sessionManager.accountUsage;
+
   useTerminalCommands({
     spawnPlain: handleQuickLaunch,
     spawnAi: handleLaunchAiSession,
-    accounts: sessionManager.accountUsage,
+    accounts: spawnAccounts,
     sortZones: handleSortZones,
     exportAll: handleExportOutput,
     openDocFinder: () => setShowDocFinder(true),

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -284,6 +284,13 @@ export interface UseSessionManagerReturn {
 
   // Derived
   allAccounts: string[];
+  /**
+   * The operator-CONFIGURED Claude account config dirs (from
+   * `claude_config_dirs` settings) — distinct from `accountUsage`, which
+   * also probes transcript-derived dirs (e.g. the default `~/.claude`).
+   * New AI sessions must only spawn into a configured account.
+   */
+  savedConfigDirs: string[];
 
   // Stats
   frozenCount: number;
@@ -960,6 +967,7 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
     sessionLabels,
     setSessionLabel,
     allAccounts,
+    savedConfigDirs,
     frozenCount,
     needsInputCount,
     activeCount,


### PR DESCRIPTION
## Problem
After rebuilding with #348, `/spawn-ai` still launched into `CLAUDE_CONFIG_DIR=C:\Users\jspin\.claude` — the **default** dir — producing a fresh "Welcome / pick a theme" session instead of a configured account.

Root cause: `useSessionManager` builds `accountUsage` by **unioning the configured `claude_config_dirs` with transcript-derived config dirs** (`useSessionManager.ts:502`). The default `~/.claude` (from prior sessions) leaks in as a selectable "account", so `/spawn-ai best` could resolve to it.

## Fix
Restrict **new** AI-session spawn candidates to the operator-configured accounts:
- Expose `savedConfigDirs` (the `claude_config_dirs` list) from `useSessionManager`.
- `TerminalPage` filters the registry `accounts` to `savedConfigDirs` before handing them to the spawn command set (`resolveAccountConfigDir`). Falls back to the full list only when nothing is configured yet.

Combined with #348's autonomous `bypassPermissions` fallback, `/spawn-ai best` now reliably launches an **authenticated configured account in autonomous mode** — matching `clg/clh/clp`.

## Verification
`tsc` clean · `eslint` clean · `vitest` 326/326. Takes effect after a runner rebuild.

Third and final fix in the runner-daily-driver spawn chain (#347 coord-split, #348 bypassPermissions + headroom, this = account-leak).