### PR TITLE
fix(session): register sessions under the device active_tenant_id, not nil

### DIFF
--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -682,11 +682,14 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
 /// `payload` directly (`{id, kind, intent, state, started_at}`), so
 /// rebuilding for the wire is mostly relabeling.
 fn rebuild_create_body(rec: &OutboxRecord) -> JsonValue {
-    // tenant_id is *not* on the outbox row — it lives inside the intent
-    // body the operator (or future tenant-resolver) supplies. Phase 2's
-    // local-first path persists the intent into the payload, so we look
-    // for it there. If absent, fall back to nil so coord returns a clean
-    // 400 (caller fix) rather than a 500.
+    // tenant_id resolution order: the intent/payload body (if the operator
+    // or a future resolver supplied it) → the device's `active_tenant_id`
+    // from `~/.qontinui/machine.json` → nil. The machine.json fallback is
+    // what makes a single-tenant operator's sessions visible on their
+    // tenant-scoped dashboard: without it, every session registers under
+    // the nil tenant `00000000-…` and the operator's `/sessions` view (which
+    // scopes to their resolved tenant) shows nothing despite a healthy
+    // pipeline.
     let intent = rec
         .payload
         .get("intent")
@@ -696,6 +699,10 @@ fn rebuild_create_body(rec: &OutboxRecord) -> JsonValue {
         .get("tenant_id")
         .or_else(|| rec.payload.get("tenant_id"))
         .cloned()
+        .or_else(|| {
+            crate::session::dual_write::resolve_active_tenant_id()
+                .map(|u| JsonValue::String(u.to_string()))
+        })
         .unwrap_or_else(|| JsonValue::String(Uuid::nil().to_string()));
     let kind = rec
         .payload

--- a/src-tauri/src/session/dual_write.rs
+++ b/src-tauri/src/session/dual_write.rs
@@ -153,7 +153,11 @@ impl Default for DualWriteGate {
 /// Read `active_tenant_id` from `~/.qontinui/machine.json`. Returns `None`
 /// (gate stays dormant) on any failure — missing file, missing field,
 /// unparseable UUID. Single-tenant operators legitimately have no field.
-fn resolve_active_tenant_id() -> Option<Uuid> {
+///
+/// `pub(crate)` so the session-sync POST path can use the same resolved
+/// tenant to attribute sessions (otherwise they register under the nil
+/// tenant and are invisible to the operator's tenant-scoped dashboard).
+pub(crate) fn resolve_active_tenant_id() -> Option<Uuid> {
     let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
     let bytes = std::fs::read(path).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;


### PR DESCRIPTION
## Problem
The operator's web **/sessions dashboard shows 0** even though the session pipeline is 100% healthy (verified: 5734/5734 events ACKed, heartbeating). Root cause: `coord_sync` resolves `tenant_id` from the intent/payload only, falling back to the **nil tenant `00000000-…`** — and the terminal `Intent` (`commands/terminal.rs:97`) carries **no tenant field**, so the fallback fires for *every* session. The dashboard is tenant-scoped to the operator's resolved tenant, so nil-tenant sessions are invisible. Classic "plumbing healthy, page disagrees."

## Fix
Resolve `tenant_id` as: intent/payload → **`machine.json` `active_tenant_id`** (via the now-`pub(crate)` `dual_write::resolve_active_tenant_id`) → nil. A single-tenant operator who sets `active_tenant_id` gets sessions attributed to their tenant and visible on their dashboard. The change is tenant-agnostic (reads whatever value is configured at runtime). This is **Bar 2 Phase 0** (tenant-aware session registration).

## Verification
`cargo check` ✅ · `cargo clippy --lib` ✅ (clean). Takes effect after a runner rebuild; the operator's `machine.json` must carry `active_tenant_id`.