### PR TITLE
feat(terminal): CommandBar UI-Bridge ergonomics, /history hotkey, terminal spec hygiene

### DIFF
--- a/specs/pages/terminal/notes.md
+++ b/specs/pages/terminal/notes.md
@@ -26,3 +26,7 @@ End-to-end smoke at `scripts/test-grid-endpoints.sh`.
 The assertions in `spec.uibridge.json` below cover the runner UI
 shell. Cell content lives on the HTTP side because the spec runner's
 DOM-search primitive can't reach it.
+
+## Spec maintenance
+
+- Removed spec state `term-plan-cli-script` (2026-06-02): it asserted on plan-CLI *script output*, not page elements — a category error for a UI-Bridge page spec. The behavior it nominally covered is exercised by the Rust integration test `src-tauri/src/flywheel_e2e_tests.rs`.

--- a/specs/pages/terminal/spec.uibridge.json
+++ b/specs/pages/terminal/spec.uibridge.json
@@ -22,8 +22,11 @@
         }
       ],
       "category": "element-presence",
-      "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal.",
+      "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal. Conditional state: no terminals open (empty-state hint; rendered only when tabs.length === 0 at TerminalPage.tsx:768-777) — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
       "id": "term-multi-tab",
+      "metadata": {
+        "conditionalOn": "no terminals open (empty-state hint; rendered only when tabs.length === 0 at TerminalPage.tsx:768-777)"
+      },
       "name": "Multi-Tab Terminal Sessions",
       "source": "migrated"
     },
@@ -102,8 +105,11 @@
         }
       ],
       "category": "element-presence",
-      "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern.",
+      "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern. Conditional state: a workflow has been generated via /generate against a live Claude session (not exercisable in spec-check, which invokes no AI) — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
       "id": "term-workflow-preview",
+      "metadata": {
+        "conditionalOn": "a workflow has been generated via /generate against a live Claude session (not exercisable in spec-check, which invokes no AI)"
+      },
       "name": "Workflow Generation and Preview",
       "source": "migrated"
     },
@@ -115,7 +121,7 @@
           "description": "Required element 0 for state Real-Time Findings Detection",
           "enabled": true,
           "id": "term-findings-tracking-elem-0",
-          "reviewed": false,
+          "reviewed": true,
           "severity": "critical",
           "source": "migrated",
           "target": {
@@ -132,7 +138,7 @@
           "description": "Required element 1 for state Real-Time Findings Detection",
           "enabled": true,
           "id": "term-findings-tracking-elem-1",
-          "reviewed": false,
+          "reviewed": true,
           "severity": "critical",
           "source": "migrated",
           "target": {
@@ -150,7 +156,7 @@
           "description": "Required element 2 for state Real-Time Findings Detection",
           "enabled": true,
           "id": "term-findings-tracking-elem-2",
-          "reviewed": false,
+          "reviewed": true,
           "severity": "critical",
           "source": "migrated",
           "target": {
@@ -168,7 +174,7 @@
           "description": "Required element 3 for state Real-Time Findings Detection",
           "enabled": true,
           "id": "term-findings-tracking-elem-3",
-          "reviewed": false,
+          "reviewed": true,
           "severity": "critical",
           "source": "migrated",
           "target": {
@@ -336,8 +342,11 @@
         }
       ],
       "category": "element-presence",
-      "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style.",
+      "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style. Conditional state: a file conflict is currently active — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
       "id": "term-file-conflict-banner",
+      "metadata": {
+        "conditionalOn": "a file conflict is currently active"
+      },
       "name": "File Conflict Detection Banner",
       "source": "migrated"
     },
@@ -413,8 +422,11 @@
         }
       ],
       "category": "element-presence",
-      "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id.",
+      "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id. Conditional state: a session conflict is currently detected — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
       "id": "term-session-conflict-indicator",
+      "metadata": {
+        "conditionalOn": "a session conflict is currently detected"
+      },
       "name": "Per-Session File Conflict Indicators",
       "source": "migrated"
     },
@@ -777,69 +789,12 @@
         }
       ],
       "category": "element-presence",
-      "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution.",
+      "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution. Conditional state: a plan file is loaded AND the plan-build panel is open; the Implement/Verify buttons migrated to the /plan-implement and /plan-verify slash commands when the ZoneStatusBar toolbar was removed — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
       "id": "term-plan-implementation",
+      "metadata": {
+        "conditionalOn": "a plan file is loaded AND the plan-build panel is open; the Implement/Verify buttons migrated to the /plan-implement and /plan-verify slash commands when the ZoneStatusBar toolbar was removed"
+      },
       "name": "Plan Implementation Workflow",
-      "source": "migrated"
-    },
-    {
-      "assertions": [
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 0 for state Plan Implementation CLI Script",
-          "enabled": true,
-          "id": "term-plan-cli-script-elem-0",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "migrated",
-          "target": {
-            "criteria": {
-              "textContains": "Parsed"
-            },
-            "label": "Required element for Plan Implementation CLI Script",
-            "type": "search"
-          }
-        },
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 1 for state Plan Implementation CLI Script",
-          "enabled": true,
-          "id": "term-plan-cli-script-elem-1",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "migrated",
-          "target": {
-            "criteria": {
-              "textContains": "execute-inline"
-            },
-            "label": "Required element for Plan Implementation CLI Script",
-            "type": "search"
-          }
-        },
-        {
-          "assertionType": "exists",
-          "category": "element-presence",
-          "description": "Required element 2 for state Plan Implementation CLI Script",
-          "enabled": true,
-          "id": "term-plan-cli-script-elem-2",
-          "reviewed": false,
-          "severity": "critical",
-          "source": "migrated",
-          "target": {
-            "criteria": {
-              "textContains": "follow"
-            },
-            "label": "Required element for Plan Implementation CLI Script",
-            "type": "search"
-          }
-        }
-      ],
-      "category": "element-presence",
-      "description": "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
-      "id": "term-plan-cli-script",
-      "name": "Plan Implementation CLI Script",
       "source": "migrated"
     },
     {
@@ -864,8 +819,11 @@
         }
       ],
       "category": "element-presence",
-      "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
+      "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled. Conditional state: a tracked git change exists in the working tree — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
       "id": "term-commit-traffic-light",
+      "metadata": {
+        "conditionalOn": "a tracked git change exists in the working tree"
+      },
       "name": "Per-Tab Commit Traffic Light",
       "source": "ai-generated"
     },
@@ -947,7 +905,7 @@
   "stateMachine": {
     "states": [
       {
-        "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal.",
+        "description": "Users work with multiple concurrent terminal sessions organized as tabs. Each tab is an independent PTY session with its own shell, working directory, command history, and scrollback buffer. Users can create new tabs (Ctrl+Shift+T), close tabs (Ctrl+Shift+W), cycle between tabs (Ctrl+Tab), and rename tabs for better organization. Tabs auto-rename from the first command entered. On mount, the terminal attempts to reconnect to existing Rust PTY sessions from previous page visits, preserving shell state across navigation. When all tabs are closed, a helpful empty state guides users on how to create a new terminal. Conditional state: no terminals open (empty-state hint; rendered only when tabs.length === 0 at TerminalPage.tsx:768-777) — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
         "elements": [
           {
             "textContent": "Ctrl+Shift+T"
@@ -955,11 +913,14 @@
         ],
         "id": "term-multi-tab",
         "isInitial": false,
+        "metadata": {
+          "conditionalOn": "no terminals open (empty-state hint; rendered only when tabs.length === 0 at TerminalPage.tsx:768-777)"
+        },
         "name": "Multi-Tab Terminal Sessions",
         "transitions": []
       },
       {
-        "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern.",
+        "description": "When a workflow is generated (from a session transcript, command history, or findings), a preview panel opens on the right side showing the full workflow structure. Users can review the generated workflow's phases and steps, then choose to execute it immediately, save it to the workflow library for later use, edit it in the Workflow Builder for refinement, or regenerate it with different parameters. The panel shows loading state during generation and error messages if generation fails. This workflow enables a rapid 'do it once in the terminal, then automate it' development pattern. Conditional state: a workflow has been generated via /generate against a live Claude session (not exercisable in spec-check, which invokes no AI) — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
         "elements": [
           {
             "textContent": "Workflow"
@@ -979,6 +940,9 @@
         ],
         "id": "term-workflow-preview",
         "isInitial": false,
+        "metadata": {
+          "conditionalOn": "a workflow has been generated via /generate against a live Claude session (not exercisable in spec-check, which invokes no AI)"
+        },
         "name": "Workflow Generation and Preview",
         "transitions": []
       },
@@ -1025,7 +989,7 @@
         "transitions": []
       },
       {
-        "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style.",
+        "description": "The Terminal page includes an advisory file conflict detection system that tracks which files are under active development by concurrent sessions (workflows and AI terminal sessions). When multiple sessions edit the same file, a warning banner appears below the notification bar showing conflicting files and which sessions hold them. Real-time toast alerts appear when a new conflict is detected (e.g., session B starts editing a file that session A already registered). The banner is collapsible â€” a summary line shows the count of conflicting files, and expanding reveals the full list with file paths and session names. The system auto-registers files when Claude Code uses Edit or Write tools, polls the runner's file registry API every 30 seconds, and listens for real-time Tauri events. The banner uses warning amber (#e0af68) coloring consistent with the 'needs-input' status style. Conditional state: a file conflict is currently active — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
         "elements": [
           {
             "textContains": "under concurrent"
@@ -1045,11 +1009,14 @@
         ],
         "id": "term-file-conflict-banner",
         "isInitial": false,
+        "metadata": {
+          "conditionalOn": "a file conflict is currently active"
+        },
         "name": "File Conflict Detection Banner",
         "transitions": []
       },
       {
-        "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id.",
+        "description": "Each session card in the SessionManagerPanel sidebar displays a file conflict warning icon when that session has files overlapping with other active sessions. The indicator shows a FileWarning icon in amber (#e0af68) with a numeric count badge showing how many conflicting files that session has. The count is derived from the file registry: for each file registered by this session, if any OTHER session also has that file registered, it counts as a conflict. The tooltip shows '{N} file(s) shared with other sessions'. Sessions with zero conflicts show no indicator. The conflict count is computed by the useFileConflicts hook's sessionConflictCounts Map, keyed by session task_run_id. Conditional state: a session conflict is currently detected — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
         "elements": [
           {
             "textContains": "shared with other sessions"
@@ -1066,6 +1033,9 @@
         ],
         "id": "term-session-conflict-indicator",
         "isInitial": false,
+        "metadata": {
+          "conditionalOn": "a session conflict is currently detected"
+        },
         "name": "Per-Session File Conflict Indicators",
         "transitions": []
       },
@@ -1137,7 +1107,7 @@
         "transitions": []
       },
       {
-        "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution.",
+        "description": "Users can build and execute multi-stage plan implementation workflows directly from the Terminal page. Two entry points exist: (1) from a transcript panel, select messages containing a plan and click Implement to build a workflow with implement/review/next-steps stages per phase, or (2) from the status bar, click Implement next to a detected plan file. The Implement button (amber, Rocket icon) is the primary action; the Verify button (gray, ListChecks icon) builds a lighter verification-only workflow. Both parse the plan markdown into phases and tasks, build a multi-stage UnifiedWorkflow, and show it in the workflow preview panel for execution. Conditional state: a plan file is loaded AND the plan-build panel is open; the Implement/Verify buttons migrated to the /plan-implement and /plan-verify slash commands when the ZoneStatusBar toolbar was removed — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
         "elements": [
           {
             "role": "button",
@@ -1164,29 +1134,14 @@
         ],
         "id": "term-plan-implementation",
         "isInitial": false,
+        "metadata": {
+          "conditionalOn": "a plan file is loaded AND the plan-build panel is open; the Implement/Verify buttons migrated to the /plan-implement and /plan-verify slash commands when the ZoneStatusBar toolbar was removed"
+        },
         "name": "Plan Implementation Workflow",
         "transitions": []
       },
       {
-        "description": "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
-        "elements": [
-          {
-            "textContains": "Parsed"
-          },
-          {
-            "textContains": "execute-inline"
-          },
-          {
-            "textContains": "follow"
-          }
-        ],
-        "id": "term-plan-cli-script",
-        "isInitial": false,
-        "name": "Plan Implementation CLI Script",
-        "transitions": []
-      },
-      {
-        "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",
+        "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled. Conditional state: a tracked git change exists in the working tree — not rendered on the base terminal page, so it cannot match in a default snapshot (annotation pending the expectedConditionalStates baseline-waiver mechanism, plan §7).",
         "elements": [
           {
             "accessibleName": "Commit progress",
@@ -1195,6 +1150,9 @@
         ],
         "id": "term-commit-traffic-light",
         "isInitial": false,
+        "metadata": {
+          "conditionalOn": "a tracked git change exists in the working tree"
+        },
         "name": "Per-Tab Commit Traffic Light",
         "transitions": []
       },

--- a/specs/pages/terminal/state-machine.derived.json
+++ b/specs/pages/terminal/state-machine.derived.json
@@ -827,67 +827,6 @@
       }
     },
     {
-      "id": "term-plan-cli-script",
-      "name": "Plan Implementation CLI Script",
-      "description": "A standalone CLI script (scripts/run-plan-implementation.ts) allows launching plan implementation workflows from any Claude Code session without the runner UI. The script parses markdown plan files, builds the same multi-stage workflow as the UI Implement button, and POSTs it to the runner execute-inline endpoint. It supports --dry-run for inspection and --follow for streaming progress.",
-      "assertions": [
-        {
-          "id": "term-plan-cli-script-elem-0",
-          "description": "Required element 0 for state Plan Implementation CLI Script",
-          "category": "element-presence",
-          "severity": "critical",
-          "assertionType": "exists",
-          "target": {
-            "type": "search",
-            "criteria": {
-              "textContains": "Parsed"
-            },
-            "label": "Required element for Plan Implementation CLI Script"
-          },
-          "source": "migrated",
-          "reviewed": false,
-          "enabled": true
-        },
-        {
-          "id": "term-plan-cli-script-elem-1",
-          "description": "Required element 1 for state Plan Implementation CLI Script",
-          "category": "element-presence",
-          "severity": "critical",
-          "assertionType": "exists",
-          "target": {
-            "type": "search",
-            "criteria": {
-              "textContains": "execute-inline"
-            },
-            "label": "Required element for Plan Implementation CLI Script"
-          },
-          "source": "migrated",
-          "reviewed": false,
-          "enabled": true
-        },
-        {
-          "id": "term-plan-cli-script-elem-2",
-          "description": "Required element 2 for state Plan Implementation CLI Script",
-          "category": "element-presence",
-          "severity": "critical",
-          "assertionType": "exists",
-          "target": {
-            "type": "search",
-            "criteria": {
-              "textContains": "follow"
-            },
-            "label": "Required element for Plan Implementation CLI Script"
-          },
-          "source": "migrated",
-          "reviewed": false,
-          "enabled": true
-        }
-      ],
-      "provenance": {
-        "source": "migrated"
-      }
-    },
-    {
       "id": "term-commit-traffic-light",
       "name": "Per-Tab Commit Traffic Light",
       "description": "Each terminal tab that hosts an active Claude Code AI session displays a per-tab git \"commit traffic light\" + commit-progress button beside the existing file-lock icon (TerminalTabBar.tsx:~493). The traffic light is a small colored dot rendered by `<CommitTrafficLight>` (qontinui-runner/src/components/terminal/CommitTrafficLight.tsx) reflecting the session's git working-tree state restricted to the files THAT session has touched. Five states: `empty` (gray, default — tracker has no rows yet), `clean` (green — every touched file matches HEAD), `dirty` (yellow — at least one touched file differs from HEAD), `merging` (red — at least one touched repo has MERGE_HEAD/CHERRY_PICK_HEAD/REVERT_HEAD/rebase-merge/rebase-apply), and `unknown` (no dot rendered — backend probe failed or generated_at_ms is older than 5 minutes). Beside the dot, a GitCommit-icon button labeled \"Commit progress\" (button-commit-progress) is enabled only when status is `dirty`; on click, PTY tabs receive a multi-line `COMMIT_PROMPT_TEMPLATE` typed via `writeToTerminal` that asks the AI to verify-and-commit only its own writes (cross-references its tool-call transcript, runs `git status --porcelain` / `git diff --stat` against the touched paths only, refuses to commit during in-progress merges, omits the Co-Authored-By trailer per the runner pre-commit hook). SDK chat sessions take the equivalent `send_user_message` Tauri invoke path. State source: the Tauri command `get_session_commit_state(taskRunId)` returns `{status, touched_count, dirty_count, repo_roots[], merging_repos[], generated_at_ms}` with lowercase status enum and snake_case fields. The `useCommitState` hook (qontinui-runner/src/components/terminal/useCommitState.ts) listens for `commit-state-changed` Tauri events `{type, task_run_id, state}` keyed by tab.claudeSessionId and additionally polls every 30 seconds. Events are emitted from three sites with a 500 ms per-session debounce: dispatcher.rs after every Edit/Write the SDK reports, mcp/ai_session.rs::commit_session_progress_inner success/no-op branches, and terminal/transcript_watcher.rs after the JSONL watcher records a new TouchedFile via pg.record_file_touched. The watcher backend (terminal/transcript_watcher.rs + extended terminal/transcript.rs parser) populates `coord.session_touched_files` for PTY-launched tabs, since `auto_register_file` in dispatcher.rs only fires for SDK-driven sessions; the watcher tails ~/.claude/projects/<encoded>/<session_id>.jsonl and parses Edit/Write/MultiEdit `tool_use` blocks. Workflow-spawned bypassPermissions sessions are filtered out via `is_workflow_session` so they never pollute the tracker. The `useTabSessionIdCapture` hook (qontinui-runner/src/components/terminal/useTabSessionIdCapture.ts) populates `tab.claudeSessionId` post-spawn by polling the existing `transcript_get_latest` Tauri command for ~15 s after `writeWhenReady` fires (PTY launches don't carry a session-id OSC — verified at `useShellIntegration.ts:67-118` and `TerminalInstance.tsx:699-704`; resumed sessions already have it set via `useShellIntegration.ts:135`). Without `claudeSessionId`, the traffic light wrapper still mounts but the state is treated as `unknown` and the button stays disabled.",

--- a/src/components/terminal/CommandBar.tsx
+++ b/src/components/terminal/CommandBar.tsx
@@ -415,10 +415,21 @@ export function CommandBar() {
     setFocused(true);
   }, []);
 
-  const dropdownVisible = focused && matches.length >= 0;
+  // Surface matches when the input is focused OR when there's query
+  // content. Gating solely on `focused` meant an external driver (UI
+  // Bridge `type`/`setValue`, which sets the value + fires `input` but
+  // not `focus`) could never open the dropdown — and any environment
+  // that drops the focus event saw the same dead resolver. Keying off
+  // query content makes match-surfacing correct regardless of how input
+  // arrives, and removes the `dispatchEvent(FocusEvent('focus'))`
+  // workaround from on-page slash tests.
+  const dropdownVisible = (focused || query.trim().length > 0) && matches.length >= 0;
 
   return (
-    <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-40 w-[420px] pointer-events-none">
+    <div
+      data-page-element="command-bar"
+      className="absolute bottom-2 left-1/2 -translate-x-1/2 z-40 w-[420px] pointer-events-none"
+    >
       {/* Status line — sits above the input, visible briefly after execute. */}
       {status && !focused && (
         <div className="mb-1 px-2 py-1 text-[10px] rounded bg-[#1a1b26]/90 border border-[#2a2d3d]/60 backdrop-blur-sm pointer-events-auto">

--- a/src/components/terminal/KeyboardShortcutsOverlay.tsx
+++ b/src/components/terminal/KeyboardShortcutsOverlay.tsx
@@ -57,6 +57,7 @@ const SHORTCUT_GROUPS: { title: string; shortcuts: ShortcutDef[] }[] = [
       { keys: "Ctrl+Shift+K", description: "Open command palette" },
       { keys: "Ctrl+Shift+G", description: "Cycle tag filter" },
       { keys: "Ctrl+Shift+I", description: "Toggle zone timeline" },
+      { keys: "Ctrl+Shift+H", description: "Show event history card" },
       { keys: "Ctrl+Shift+?", description: "Toggle this help overlay" },
     ],
   },

--- a/src/components/terminal/useKeyboardShortcuts.ts
+++ b/src/components/terminal/useKeyboardShortcuts.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { LAYOUT_PRESETS, type SessionState } from "./useZoneLayout";
 import type { UIAction } from "./useUIState";
 import type { Metrics } from "./useEventHistory";
+import { getById } from "./commands";
 
 interface UseKeyboardShortcutsParams {
   activeId: string | null;
@@ -242,6 +243,17 @@ export function useKeyboardShortcuts({
       if (e.ctrlKey && e.shiftKey && e.key === "?") {
         e.preventDefault();
         dispatch({ type: "TOGGLE_SHORTCUTS" });
+        return;
+      }
+      // Ctrl+Shift+H → pop the event-history result card. Fires the
+      // `terminal.history` registry action (single source of truth) so
+      // this binding can't drift from the /history slash command — that
+      // handler closes over the page's `showCard`. The hook has no
+      // `showCard` of its own, so reaching the registry by id is the
+      // clean path (no prop-drilling a card callback through every page).
+      if (e.ctrlKey && e.shiftKey && e.key === "H") {
+        e.preventDefault();
+        void getById("terminal.history")?.handler({}, { source: "hotkey" });
         return;
       }
       if (e.ctrlKey && e.shiftKey && e.key === "ArrowLeft") {


### PR DESCRIPTION
Implements plan `2026-05-31-commandbar-result-cards-followups` (Phases 1–3; Phase 2.1 dead-state removal was already done upstream and is a no-op here).

## Phase 1 — CommandBar UI-Bridge ergonomics
- `data-page-element="command-bar"` on the outer wrapper → the control is discoverable via `GET /control/snapshot` and spec assertions get a stable anchor.
- Relaxed the dropdown gate `focused` → `(focused || query.trim().length > 0)`. UI-Bridge `type`/`setValue` fires `input` but not `focus`, so the dropdown never opened for an external driver (or any env that drops the focus event). Keying off query content makes match-surfacing correct regardless of how input arrives and removes the `dispatchEvent(FocusEvent('focus'))` workaround from on-page slash tests. `handleBlur` clearing + the `status && !focused` status-line path are unchanged.

## Phase 3 — `Ctrl+Shift+H` → `/history`
- Binds `Ctrl+Shift+H` in `useKeyboardShortcuts` to fire the `terminal.history` registry action via `getById` (single source of truth — the handler closes over the page's `showCard`, so no prop-drilling a card callback through the hook). Added the binding to the `KeyboardShortcutsOverlay` list. `H` was verified free.

## Phase 2 — terminal spec hygiene (§2.2/§2.3), decisions verified on the live page via UI Bridge
- Annotated conditional-only states with `metadata.conditionalOn` + a description note (documentation pending the §7 `expectedConditionalStates` waiver mechanism, which stays out of scope): `term-multi-tab` (only the empty-state hint renders "Ctrl+Shift+T", at `TerminalPage.tsx:768-777`), `term-plan-implementation` (Implement/Verify migrated to `/plan-implement`,`/plan-verify`; panel/plan-gated), `term-workflow-preview` (needs a Claude-generated workflow), `term-file-conflict-banner`, `term-session-conflict-indicator`, `term-commit-traffic-light`.
- `term-findings-tracking` confirmed **valid** on the base page (`button-findings` renders) → assertions marked `reviewed`.
- Deleted `term-plan-cli-script` (misclassified — asserted on CLI script *output*, not page elements) from curated + derived mirror; cross-referenced the Rust integration test `src-tauri/src/flywheel_e2e_tests.rs` in `notes.md`. Curated ↔ derived state-set parity preserved (13 == 13).

## Verification
- `tsc --noEmit` clean; `eslint` clean on touched files (2 pre-existing warnings unrelated to this change).
- Spec parity + JSON validity verified programmatically (curated 13 states == 13 groups == derived 13; `term-plan-cli-script` gone everywhere).
- Phase 2 re-anchoring decisions were made by snapshotting the live `/terminal` page (UI Bridge), per the "verify on the page" rule.
- **Phase 1 on-page note:** the local runner is built from `main` (no Phase 1 changes) and has active sessions, so it was not rebuilt/restarted to avoid disrupting in-flight work. CI builds the frontend; the focus-gate-relaxation behavior (`setValue` without a focus event opens the dropdown + Enter executes) should be confirmed on the next runner rebuild.

No spec-CI gate exists in this repo (`ci.yml` runs lint/typecheck/build/clippy/rust-tests) — Phase 2 is correctness/documentation hygiene.