### PR TITLE
fix(terminal): restore Claude sessions to their zones on close→reopen

### DIFF
--- a/src/components/terminal/SessionCard.tsx
+++ b/src/components/terminal/SessionCard.tsx
@@ -139,7 +139,14 @@ export function SessionCard({
   onSetLabel,
   onAfterPromote,
 }: SessionCardProps) {
-  const statusInfo = STATUS_DOT[session.liveStatus];
+  const baseStatusInfo = STATUS_DOT[session.liveStatus];
+  // An orphaned "frozen" session has no live PTY in this window — it's simply
+  // not running here, so relabel the chip away from the alarming "Frozen" to a
+  // neutral, resumable read (color stays muted to match).
+  const statusInfo =
+    session.liveStatus === "frozen" && session.isOrphaned
+      ? { color: "#565f89", pulse: false, label: "Not running" }
+      : baseStatusInfo;
   const accountBadge = ACCOUNT_BADGE_COLORS[session.accountLabel];
   const durationLabel = formatDuration(session.durationMs);
 
@@ -396,13 +403,23 @@ export function SessionCard({
             </div>
           )}
 
-        {/* Frozen warning badge */}
-        {session.liveStatus === "frozen" && (
-          <div className="mt-1 ml-3.5 flex items-center gap-1 text-[10px] text-[#f7768e]/80">
-            <AlertTriangle className="w-3 h-3" />
-            <span>Session appears frozen — may need resume</span>
-          </div>
-        )}
+        {/* Frozen / orphaned badge.
+            - Orphaned (no live PTY in this window): the transcript just isn't
+              open anywhere — it's resumable, not failed. Neutral copy + color.
+            - Genuinely stuck live session (a stale in-zone tab): keep the
+              warning treatment. */}
+        {session.liveStatus === "frozen" &&
+          (session.isOrphaned ? (
+            <div className="mt-1 ml-3.5 flex items-center gap-1 text-[10px] text-[#565f89]">
+              <TerminalSquare className="w-3 h-3" />
+              <span>Not open in a window — click Resume to continue</span>
+            </div>
+          ) : (
+            <div className="mt-1 ml-3.5 flex items-center gap-1 text-[10px] text-[#f7768e]/80">
+              <AlertTriangle className="w-3 h-3" />
+              <span>Session appears stuck — may need resume</span>
+            </div>
+          ))}
 
         {/* File-lock waiting subtitle — sourced from useFileLockTracking
             via `sessionLockStates`. Same orange color convention as the

--- a/src/components/terminal/lastKnownSessionIds.test.ts
+++ b/src/components/terminal/lastKnownSessionIds.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the durable per-tab "last-known Claude session id" store
+ * (`lastKnownSessionIds`). This is what keeps a restored tab resumable
+ * across a close→reopen even when the live tab object transiently loses its
+ * `claudeSessionId` (capture lag / state churn).
+ *
+ * The runner's vitest env is `node` (no `localStorage`), so we mock
+ * `@/lib/instance-storage` with an in-memory JSON store mirroring its
+ * `getJSON`/`setJSON` contract.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// In-memory backing store for the mocked instanceStorage.
+const mem = new Map<string, unknown>();
+
+vi.mock("@/lib/instance-storage", () => ({
+  instanceStorage: {
+    getJSON<T>(key: string, fallback: T): T {
+      return mem.has(key) ? (mem.get(key) as T) : fallback;
+    },
+    setJSON(key: string, value: unknown): void {
+      mem.set(key, value);
+    },
+  },
+}));
+
+import { rememberSessionId, recallSessionId, pruneSessionIds } from "./lastKnownSessionIds";
+
+beforeEach(() => {
+  mem.clear();
+  vi.useRealTimers();
+});
+
+describe("rememberSessionId / recallSessionId", () => {
+  it("round-trips a remembered id for a tab", () => {
+    rememberSessionId("tab-1", "sess-A", "C:/claude/.claude-gmail");
+    const recalled = recallSessionId("tab-1");
+    expect(recalled?.claudeSessionId).toBe("sess-A");
+    expect(recalled?.claudeConfigDir).toBe("C:/claude/.claude-gmail");
+  });
+
+  it("returns null for an unknown tab", () => {
+    expect(recallSessionId("nope")).toBeNull();
+  });
+
+  it("is a no-op for an empty/undefined id (never stores blanks)", () => {
+    rememberSessionId("tab-1", undefined, "C:/claude/.claude-gmail");
+    expect(recallSessionId("tab-1")).toBeNull();
+  });
+
+  it("keeps entries isolated per tab id", () => {
+    rememberSessionId("tab-1", "sess-A", undefined);
+    rememberSessionId("tab-2", "sess-B", undefined);
+    expect(recallSessionId("tab-1")?.claudeSessionId).toBe("sess-A");
+    expect(recallSessionId("tab-2")?.claudeSessionId).toBe("sess-B");
+  });
+
+  it("refreshes (overwrites) an existing entry", () => {
+    rememberSessionId("tab-1", "sess-OLD", undefined);
+    rememberSessionId("tab-1", "sess-NEW", "C:/claude/.claude-hotmail");
+    const recalled = recallSessionId("tab-1");
+    expect(recalled?.claudeSessionId).toBe("sess-NEW");
+    expect(recalled?.claudeConfigDir).toBe("C:/claude/.claude-hotmail");
+  });
+});
+
+describe("staleness", () => {
+  it("does not recall an entry older than the max age", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    rememberSessionId("tab-1", "sess-A", undefined);
+
+    // Advance 8 days (> 7-day ceiling).
+    vi.setSystemTime(new Date("2026-01-09T00:00:01Z"));
+    expect(recallSessionId("tab-1")).toBeNull();
+  });
+
+  it("prunes stale entries from the store", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    rememberSessionId("old", "sess-OLD", undefined);
+
+    vi.setSystemTime(new Date("2026-01-08T00:00:01Z"));
+    rememberSessionId("fresh", "sess-FRESH", undefined);
+
+    pruneSessionIds();
+
+    expect(recallSessionId("old")).toBeNull();
+    expect(recallSessionId("fresh")?.claudeSessionId).toBe("sess-FRESH");
+  });
+});

--- a/src/components/terminal/lastKnownSessionIds.ts
+++ b/src/components/terminal/lastKnownSessionIds.ts
@@ -1,0 +1,85 @@
+/**
+ * Durable per-tab "last-known Claude session id" store.
+ *
+ * The `claudeSessionId` for a PTY-launched AI tab is captured best-effort by a
+ * transcript poll (`useTabSessionIdCapture`). Two failure modes made tabs
+ * unresumable at save time:
+ *   1. The poll never landed (timed out) before the user closed the window.
+ *   2. A live `tab` object transiently lost the id (state churn / remount).
+ *
+ * To make capture resilient we persist the last-known id per `tab.id` to
+ * `instanceStorage` the moment it's observed, and let `saveSessionLayout`
+ * fall back to it when the live tab object has no id. Best-effort: any storage
+ * failure is swallowed (resumability is an enhancement, never load-bearing).
+ *
+ * Entries are pruned on read once older than {@link MAX_AGE_MS} so the map
+ * can't grow unbounded across many sessions.
+ */
+
+import { instanceStorage } from "@/lib/instance-storage";
+
+const STORAGE_KEY = "qontinui-terminal-last-known-session-ids";
+const MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export interface LastKnownSessionId {
+  claudeSessionId: string;
+  claudeConfigDir?: string;
+  savedAt: number;
+}
+
+type Store = Record<string, LastKnownSessionId>;
+
+function readStore(): Store {
+  return instanceStorage.getJSON<Store>(STORAGE_KEY, {});
+}
+
+function writeStore(store: Store): void {
+  instanceStorage.setJSON(STORAGE_KEY, store);
+}
+
+/** Record (or refresh) the last-known session id for a tab. No-op for empty ids. */
+export function rememberSessionId(
+  tabId: string,
+  claudeSessionId: string | undefined,
+  claudeConfigDir: string | undefined,
+): void {
+  if (!claudeSessionId) return;
+  try {
+    const store = readStore();
+    store[tabId] = { claudeSessionId, claudeConfigDir, savedAt: Date.now() };
+    writeStore(store);
+  } catch {
+    // Best-effort only.
+  }
+}
+
+/** Look up the last-known session id for a tab, or null if none / too old. */
+export function recallSessionId(tabId: string): LastKnownSessionId | null {
+  try {
+    const store = readStore();
+    const entry = store[tabId];
+    if (!entry) return null;
+    if (Date.now() - entry.savedAt >= MAX_AGE_MS) return null;
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+/** Drop entries older than {@link MAX_AGE_MS}. Best-effort housekeeping. */
+export function pruneSessionIds(): void {
+  try {
+    const store = readStore();
+    const now = Date.now();
+    let changed = false;
+    for (const [id, entry] of Object.entries(store)) {
+      if (now - entry.savedAt >= MAX_AGE_MS) {
+        delete store[id];
+        changed = true;
+      }
+    }
+    if (changed) writeStore(store);
+  } catch {
+    // Best-effort only.
+  }
+}

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -224,6 +224,14 @@ export interface UnifiedSession {
   lastMessagePreview: string;
   workSummaryHint: string;
   likelyFrozen: boolean;
+  /**
+   * True when this session has NO live PTY in the current window (it isn't
+   * open in any zone) — i.e. it's an orphaned transcript that can simply be
+   * resumed, as opposed to a genuinely stuck *live* session. Drives the
+   * "click to resume" copy instead of a "looks stuck" warning. Only
+   * meaningful when `liveStatus === "frozen"`.
+   */
+  isOrphaned: boolean;
 
   // Original transcript session (for resume)
   _transcript: TranscriptSession;
@@ -674,6 +682,9 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
             lastMessagePreview: "",
             workSummaryHint: "",
             likelyFrozen: liveStatus === "frozen",
+            // Injected fakes carry no real PTY tab — treat a frozen inject as
+            // orphaned so the resume affordance shows in debug demos.
+            isOrphaned: liveStatus === "frozen",
             _transcript: s,
           };
         }
@@ -744,6 +755,11 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
           lastMessagePreview: digest?.last_message_preview ?? "",
           workSummaryHint: digest?.work_summary_hint ?? "",
           likelyFrozen: digest?.likely_frozen ?? false,
+          // "frozen" reached without a live PTY tab in this window means the
+          // transcript is merely orphaned (resumable), not a stuck live run.
+          // The `if (tab)` branch above is the only one that sets `frozen`
+          // *with* a live tab (a genuinely stale/stuck session).
+          isOrphaned: liveStatus === "frozen" && !tab,
           _transcript: s,
         };
       });

--- a/src/components/terminal/useSessionPersistence.test.ts
+++ b/src/components/terminal/useSessionPersistence.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the session-persistence anti-degradation guard
+ * (`isDegradingSave`) — the defense-in-depth that prevents the
+ * session-restore race from clobbering a good saved Claude layout with a
+ * degraded one (plain shells that haven't re-attached their
+ * `claudeSessionId` yet).
+ *
+ * `isDegradingSave` is pure (no storage / React), so we exercise it directly.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isDegradingSave } from "./useSessionPersistence";
+import type { SavedSessionLayout, SavedSessionConfig } from "./useSessionPersistence";
+
+const NOW = 1_000_000_000_000;
+const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+function session(overrides: Partial<SavedSessionConfig> = {}): SavedSessionConfig {
+  return {
+    title: "t",
+    zoneIndex: 0,
+    savedAt: NOW,
+    ...overrides,
+  };
+}
+
+function layout(sessions: SavedSessionConfig[], savedAt = NOW): SavedSessionLayout {
+  return { layoutId: "quad", sessions, savedAt, focusedZone: 0 };
+}
+
+describe("isDegradingSave — degenerate restore-race patterns (should skip)", () => {
+  it("skips when same tab count but Claude ids were lost (2 → 0)", () => {
+    const existing = layout([
+      session({ claudeSessionId: "sess-A" }),
+      session({ claudeSessionId: "sess-B" }),
+    ]);
+    const incoming = layout([session(), session()]); // same 2 tabs, no ids
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(true);
+  });
+
+  it("skips a partial degradation (2 → 1) when tab count did not drop", () => {
+    const existing = layout([
+      session({ claudeSessionId: "sess-A" }),
+      session({ claudeSessionId: "sess-B" }),
+    ]);
+    const incoming = layout([session({ claudeSessionId: "sess-A" }), session()]);
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(true);
+  });
+
+  it("skips when tab count GREW but Claude ids were lost", () => {
+    const existing = layout([session({ claudeSessionId: "sess-A" })]);
+    const incoming = layout([session(), session()]); // 2 plain tabs
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(true);
+  });
+});
+
+describe("isDegradingSave — legitimate saves (should allow)", () => {
+  it("allows when the user actually closed a Claude tab (count drops with ids)", () => {
+    const existing = layout([
+      session({ claudeSessionId: "sess-A" }),
+      session({ claudeSessionId: "sess-B" }),
+    ]);
+    // One tab genuinely closed: total count dropped to 1.
+    const incoming = layout([session({ claudeSessionId: "sess-A" })]);
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(false);
+  });
+
+  it("allows when the user closed ALL Claude tabs (2 → 0 tabs total)", () => {
+    const existing = layout([
+      session({ claudeSessionId: "sess-A" }),
+      session({ claudeSessionId: "sess-B" }),
+    ]);
+    const incoming = layout([]); // everything closed
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(false);
+  });
+
+  it("allows an equal save (same ids, same count)", () => {
+    const existing = layout([session({ claudeSessionId: "sess-A" })]);
+    const incoming = layout([session({ claudeSessionId: "sess-A" })]);
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(false);
+  });
+
+  it("allows an improvement (0 → 1 Claude id)", () => {
+    const existing = layout([session()]);
+    const incoming = layout([session({ claudeSessionId: "sess-A" })]);
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(false);
+  });
+
+  it("allows when there is no existing layout", () => {
+    const incoming = layout([session()]);
+    expect(isDegradingSave(incoming, null, NOW)).toBe(false);
+  });
+
+  it("allows when the existing layout had zero Claude sessions", () => {
+    const existing = layout([session(), session()]);
+    const incoming = layout([session()]);
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(false);
+  });
+
+  it("allows (does not guard against) a stale existing layout", () => {
+    const existing = layout(
+      [session({ claudeSessionId: "sess-A" }), session({ claudeSessionId: "sess-B" })],
+      NOW - STALE_THRESHOLD_MS - 1, // older than the stale threshold
+    );
+    const incoming = layout([session(), session()]);
+    expect(isDegradingSave(incoming, existing, NOW)).toBe(false);
+  });
+});

--- a/src/components/terminal/useSessionPersistence.ts
+++ b/src/components/terminal/useSessionPersistence.ts
@@ -1,7 +1,35 @@
 import { useCallback, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { instanceStorage } from "@/lib/instance-storage";
+import { createLogger } from "@/lib/logger";
+import { recallSessionId } from "./lastKnownSessionIds";
 import type { CommandResponse } from "./types";
+
+const logger = createLogger("SessionPersistence");
+
+/**
+ * Resolve the effective Claude session id/config-dir for a tab at save time,
+ * preferring the live tab object but falling back to the durable last-known
+ * store when the live id was dropped (state churn / capture lag). This is what
+ * keeps a tab resumable across a close→reopen even if its in-memory id was lost.
+ */
+function resolveSessionId(tab: {
+  id: string;
+  claudeSessionId?: string;
+  claudeConfigDir?: string;
+}): { claudeSessionId?: string; claudeConfigDir?: string } {
+  if (tab.claudeSessionId) {
+    return { claudeSessionId: tab.claudeSessionId, claudeConfigDir: tab.claudeConfigDir };
+  }
+  const recalled = recallSessionId(tab.id);
+  if (recalled) {
+    return {
+      claudeSessionId: recalled.claudeSessionId,
+      claudeConfigDir: tab.claudeConfigDir ?? recalled.claudeConfigDir,
+    };
+  }
+  return { claudeSessionId: undefined, claudeConfigDir: tab.claudeConfigDir };
+}
 
 // ---------------------------------------------------------------------------
 // Types
@@ -57,6 +85,41 @@ const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 function storageKey(pageId: string): string {
   return pageId === "default" ? BASE_STORAGE_KEY : `page:${pageId}:${BASE_STORAGE_KEY}`;
+}
+
+/**
+ * Anti-degradation predicate (defense-in-depth for the session-restore race).
+ *
+ * Returns true when an incoming save would DEGRADE the stored layout and must
+ * be skipped. The degenerate case the restore path produces: plain shells are
+ * recreated and `claudeSessionId` is re-attached only asynchronously, so a save
+ * that races that window persists a layout that has LOST the resumable Claude
+ * sessions — leaving nothing to resume on the next reopen.
+ *
+ * We skip iff:
+ *   - the stored layout is non-stale, AND
+ *   - it had at least one resumable Claude session, AND
+ *   - the incoming layout has strictly fewer resumable Claude sessions, AND
+ *   - the total tab count did NOT drop (same/more tabs, but they lost ids).
+ *
+ * A genuine "user closed a Claude tab" lowers the total count too and is
+ * allowed through (returns false).
+ *
+ * Exported for unit testing without booting React / the debounce timer.
+ */
+export function isDegradingSave(
+  incoming: Pick<SavedSessionLayout, "sessions">,
+  existing: SavedSessionLayout | null,
+  now: number,
+): boolean {
+  if (!existing) return false;
+  if (now - existing.savedAt >= STALE_THRESHOLD_MS) return false;
+  const existingClaude = existing.sessions.filter((s) => !!s.claudeSessionId).length;
+  if (existingClaude === 0) return false;
+  const incomingClaude = incoming.sessions.filter((s) => !!s.claudeSessionId).length;
+  if (incomingClaude >= existingClaude) return false;
+  const totalDropped = incoming.sessions.length < existing.sessions.length;
+  return !totalDropped;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +179,7 @@ export function useSessionPersistence(pageId: string = "default") {
           if (!tab) continue;
 
           assignedTabIds.add(tabId);
+          const sid = resolveSessionId(tab);
           sessions.push({
             title: tab.title,
             workingDir: tab.workingDir,
@@ -124,9 +188,9 @@ export function useSessionPersistence(pageId: string = "default") {
             notes: zoneNotes[zoneIndex] || undefined,
             pinned: pinnedZones.has(zoneIndex) || undefined,
             savedAt: now,
-            isClaudeSession: !!tab.claudeSessionId,
-            claudeSessionId: tab.claudeSessionId,
-            claudeConfigDir: tab.claudeConfigDir,
+            isClaudeSession: !!sid.claudeSessionId,
+            claudeSessionId: sid.claudeSessionId,
+            claudeConfigDir: sid.claudeConfigDir,
             type: tab.type,
             planFilePath: tab.planFilePath,
           });
@@ -135,14 +199,15 @@ export function useSessionPersistence(pageId: string = "default") {
         // Include unassigned tabs at the end with zoneIndex: -1
         for (const tab of tabs) {
           if (assignedTabIds.has(tab.id)) continue;
+          const sid = resolveSessionId(tab);
           sessions.push({
             title: tab.title,
             workingDir: tab.workingDir,
             zoneIndex: -1,
             savedAt: now,
-            isClaudeSession: !!tab.claudeSessionId,
-            claudeSessionId: tab.claudeSessionId,
-            claudeConfigDir: tab.claudeConfigDir,
+            isClaudeSession: !!sid.claudeSessionId,
+            claudeSessionId: sid.claudeSessionId,
+            claudeConfigDir: sid.claudeConfigDir,
             type: tab.type,
             planFilePath: tab.planFilePath,
           });
@@ -154,6 +219,25 @@ export function useSessionPersistence(pageId: string = "default") {
           savedAt: now,
           focusedZone,
         };
+
+        // Anti-degradation guard (defense-in-depth for the restore race) — see
+        // `isDegradingSave` for the predicate rationale.
+        try {
+          const existing = instanceStorage.getJSON<SavedSessionLayout | null>(key, null);
+          if (isDegradingSave(layout, existing, now)) {
+            const existingClaude = existing!.sessions.filter((s) => !!s.claudeSessionId).length;
+            const incomingClaude = sessions.filter((s) => !!s.claudeSessionId).length;
+            logger.debug(
+              `Skipping degraded save: incoming has ${incomingClaude} resumable Claude ` +
+                `session(s) vs stored ${existingClaude}, and tab count did not drop ` +
+                `(${sessions.length} >= ${existing!.sessions.length}) — likely a ` +
+                `restore-window race.`,
+            );
+            return;
+          }
+        } catch {
+          // If the guard read fails, fall through to the normal write.
+        }
 
         try {
           instanceStorage.setJSON(key, layout);

--- a/src/components/terminal/useShellIntegration.ts
+++ b/src/components/terminal/useShellIntegration.ts
@@ -3,6 +3,7 @@ import type { ShellIntegrationEvent } from "./TerminalInstance";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { TranscriptSession } from "./useTranscriptSessions";
 import type { SessionState } from "./useZoneLayout";
+import { rememberSessionId } from "./lastKnownSessionIds";
 
 export interface CommandHistoryEntry {
   command: string;
@@ -32,7 +33,9 @@ interface UseShellIntegrationParams {
   setSessionStates: React.Dispatch<React.SetStateAction<Record<string, SessionState>>>;
   terminalRefs: React.MutableRefObject<Map<string, React.RefObject<TerminalInstanceHandle | null>>>;
   setRightPanelMode: React.Dispatch<
-    React.SetStateAction<"transcript" | "workflow" | "analysis" | "findings" | "file-ownership" | null>
+    React.SetStateAction<
+      "transcript" | "workflow" | "analysis" | "findings" | "file-ownership" | null
+    >
   >;
   setSelectedTranscriptSessionId: React.Dispatch<React.SetStateAction<string | null>>;
 }
@@ -135,6 +138,9 @@ export function useShellIntegration({
         claudeSessionId: session.session_id,
         claudeConfigDir: session.config_dir,
       });
+      // Persist durably so the tab stays resumable across a close→reopen even
+      // if the live tab object later loses the id.
+      rememberSessionId(tabId, session.session_id, session.config_dir);
 
       // Close the transcript panel so the terminal is visible
       setRightPanelMode(null);

--- a/src/components/terminal/useTabSessionIdCapture.remember.test.ts
+++ b/src/components/terminal/useTabSessionIdCapture.remember.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Wiring test for `useTabSessionIdCapture` — proves the capture-poll
+ * SUCCESS path durably persists the session id via `rememberSessionId`.
+ *
+ * Why a dedicated file: the sibling `useTabSessionIdCapture.test.ts` only
+ * exercises a *mirror* of the claim decision (`decideClaim`), so it never
+ * runs the hook's real `tick` body and can't catch a regression where the
+ * `rememberSessionId(...)` call is missing. That blind spot is exactly the
+ * defect this test closes: the durable store read back `null` in live
+ * verification because nothing on the capture path actually wrote to it.
+ *
+ * The runner's vitest env is `node` (no DOM, no @testing-library), so we
+ * drive the *real* hook by stubbing React's primitive hooks with synchronous
+ * stand-ins. `startCapture` then runs the genuine polling loop in
+ * `useTabSessionIdCapture.ts` — including the success branch that calls
+ * `updateTab` AND `rememberSessionId`. If that line were removed, the
+ * `rememberSessionId` spy assertion below would fail.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { TerminalTab } from "./useTerminalManager";
+
+// ── IPC mock: transcript_get_latest returns a fresh, unclaimed payload ──────
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+// ── Durable-store mock: spy on rememberSessionId ────────────────────────────
+const rememberSessionId = vi.fn();
+vi.mock("./lastKnownSessionIds", () => ({
+  rememberSessionId: (...args: unknown[]) => rememberSessionId(...args),
+}));
+
+// ── React primitive stand-ins so the hook can run outside a renderer ────────
+// useRef → stable mutable box; useCallback → identity; useEffect → run now.
+vi.mock("react", () => {
+  return {
+    useRef: <T>(initial: T) => ({ current: initial }),
+    useCallback: <T>(fn: T) => fn,
+    useEffect: (fn: () => void | (() => void)) => {
+      fn();
+    },
+  };
+});
+
+import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
+
+const tab = (id: string, workingDir: string, claudeSessionId?: string): TerminalTab => ({
+  id,
+  title: id,
+  pid: 1234,
+  isAlive: true,
+  exitCode: null,
+  workingDir,
+  claudeSessionId,
+});
+
+// The hook's tick loop is async + self-scheduling; let microtasks drain.
+const flush = async (): Promise<void> => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+beforeEach(() => {
+  mockInvoke.mockReset();
+  rememberSessionId.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useTabSessionIdCapture — capture success durably persists the id", () => {
+  it("calls rememberSessionId(tabId, sessionId, configDir) on a successful capture", async () => {
+    mockInvoke.mockResolvedValue({
+      success: true,
+      data: {
+        session_id: "session-CAPTURED",
+        config_dir: "C:/claude/.claude-hotmail",
+        project_path: "D:/repo",
+        last_modified: new Date().toISOString(),
+      },
+    });
+
+    const updateTab = vi.fn();
+    const tabs = [tab("tab-1", "D:/repo")];
+
+    const { startCapture } = useTabSessionIdCapture({ updateTab, tabs });
+    startCapture("tab-1", "D:/repo", Date.now(), "C:/claude/.claude-hotmail");
+
+    await flush();
+
+    // Live binding fires…
+    expect(updateTab).toHaveBeenCalledWith("tab-1", {
+      claudeSessionId: "session-CAPTURED",
+      claudeConfigDir: "C:/claude/.claude-hotmail",
+    });
+    // …and — the actual fix — the durable store is written.
+    expect(rememberSessionId).toHaveBeenCalledWith(
+      "tab-1",
+      "session-CAPTURED",
+      "C:/claude/.claude-hotmail",
+    );
+  });
+
+  it("does NOT persist when the probe returns null (nothing captured yet)", async () => {
+    mockInvoke.mockResolvedValue({ success: true, data: null });
+
+    const updateTab = vi.fn();
+    const tabs = [tab("tab-1", "D:/repo")];
+
+    const { startCapture } = useTabSessionIdCapture({ updateTab, tabs });
+    startCapture("tab-1", "D:/repo", Date.now());
+
+    await flush();
+
+    expect(updateTab).not.toHaveBeenCalled();
+    expect(rememberSessionId).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -41,6 +41,7 @@ import { invoke } from "@tauri-apps/api/core";
 import type { CommandResponse } from "./types";
 import type { TerminalTab } from "./useTerminalManager";
 import { createLogger } from "@/lib/logger";
+import { rememberSessionId } from "./lastKnownSessionIds";
 
 const logger = createLogger("TabSessionIdCapture");
 
@@ -52,13 +53,21 @@ interface TranscriptSessionPayload {
 }
 
 const POLL_INTERVAL_MS = 500;
-const POLL_TIMEOUT_MS = 15_000;
+// Widened from 15s → 45s. Claude CLI can take a while to write its first
+// transcript line under load (cold model spin-up, slow disk, busy runner), and
+// a miss here makes the tab unresumable at the next save. The poll is cheap
+// (one `transcript_get_latest` IPC per tick) and self-cancels the moment the id
+// is bound, so a longer ceiling costs nothing in the common (fast) case.
+const POLL_TIMEOUT_MS = 45_000;
 
 interface CaptureParams {
   updateTab: (
     id: string,
     updates: Partial<
-      Pick<TerminalTab, "isAlive" | "exitCode" | "workingDir" | "claudeSessionId" | "claudeConfigDir">
+      Pick<
+        TerminalTab,
+        "isAlive" | "exitCode" | "workingDir" | "claudeSessionId" | "claudeConfigDir"
+      >
     >,
   ) => void;
   /** Used to skip capture for tabs that already have a session id
@@ -141,8 +150,7 @@ export function useTabSessionIdCapture({
       // arbitrary points still get the latest value. Production cost
       // is a single getItem per debug call site.
       const debug = (): boolean =>
-        typeof localStorage !== "undefined" &&
-        localStorage.getItem("debug:tabSidCapture") === "1";
+        typeof localStorage !== "undefined" && localStorage.getItem("debug:tabSidCapture") === "1";
 
       if (debug()) {
         logger.debug("[tabSidCapture] start", { tabId, workingDir, configDir, spawnTimestamp });
@@ -221,6 +229,9 @@ export function useTabSessionIdCapture({
               claudeSessionId: data.session_id,
               claudeConfigDir: data.config_dir,
             });
+            // Persist durably so a later state churn / remount that drops the
+            // live id off the tab object can still be recovered at save time.
+            rememberSessionId(tabId, data.session_id, data.config_dir);
             handle.cancelled = true;
             inFlight.current.delete(tabId);
             return;

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -7,6 +7,7 @@ import type { TerminalTab } from "./useTerminalManager";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { CommandResponse } from "./types";
 import type { SaveSessionLayoutParams } from "./useSessionPersistence";
+import { rememberSessionId } from "./lastKnownSessionIds";
 
 /** Build a `claude --resume <id>` command, optionally prefixed with CLAUDE_CONFIG_DIR. */
 function buildResumeCmd(sessionId: string, configDir: string | undefined): string {
@@ -40,7 +41,11 @@ interface UseTerminalInitializationParams {
   setInitialized: (v: boolean) => void;
   updateTab: (
     id: string,
-    updates: Partial<{ claudeSessionId?: string; claudeConfigDir?: string }>,
+    updates: Partial<{
+      claudeSessionId?: string;
+      claudeConfigDir?: string;
+      isReconnecting?: boolean;
+    }>,
   ) => void;
   zoneLayout: {
     layoutId: string;
@@ -132,118 +137,168 @@ export function useTerminalInitialization({
     }>
   >([]);
 
+  // Gate for the debounced auto-save effect. The restore path recreates
+  // plain shells and only *asynchronously* types `claude --resume <id>` /
+  // re-attaches `claudeSessionId`. If the debounced auto-save fires while
+  // those tabs are still plain (no claudeSessionId yet), it persists the
+  // degraded layout and clobbers the good saved Claude layout — leaving
+  // nothing to resume on the next reopen. We keep auto-save suppressed
+  // until restore has fully drained (resume commands issued / ids merged),
+  // then open the gate exactly once. The flag is opened in a `finally` so
+  // it ALWAYS flips — even when there were no saved sessions or restore
+  // threw — so brand-new sessions still persist normally.
+  const restoreCompleteRef = useRef(false);
+
   useEffect(() => {
     if (didInit.current) return;
     didInit.current = true;
 
     (async () => {
-      const reconnectedTabIds = await reconnectToExistingSessions();
+      // True once a deferred resume/scrollback drain timer is scheduled. When
+      // set, that timer owns flipping `restoreCompleteRef` (after it issues the
+      // resume commands); the `finally` below only opens the gate when NO drain
+      // was scheduled, so the flag always flips exactly once.
+      let drainScheduled = false;
+      try {
+        const reconnectedTabIds = await reconnectToExistingSessions();
 
-      // Even when reconnection succeeds, merge saved session metadata
-      // (claudeSessionId, labels, etc.) that the PTY data doesn't carry.
-      // We use the returned tab IDs directly (ordered by creation time,
-      // matching the sequential zone auto-assignment) to avoid reading
-      // stale zoneLayout.assignments from this closure.
-      if (reconnectedTabIds) {
-        const saved = sessionPersistence.hasSavedLayout()
-          ? sessionPersistence.getSavedLayout()
-          : null;
-        if (saved && saved.sessions.length > 0) {
-          // Restore layout preset if it differs
-          if (saved.layoutId !== zoneLayout.layoutId) {
-            const preset = LAYOUT_PRESETS.find((p) => p.id === saved.layoutId);
-            if (preset) zoneLayout.setLayoutId(preset.id);
-          }
-
-          for (const session of saved.sessions) {
-            // Match by zone index: tabs are auto-assigned to zones sequentially
-            const tabId =
-              session.zoneIndex >= 0 && session.zoneIndex < reconnectedTabIds.length
-                ? reconnectedTabIds[session.zoneIndex]
-                : undefined;
-
-            // Restore zone labels, notes, pins
-            if (session.zoneIndex >= 0) {
-              if (session.label) {
-                labelsAndTags.setZoneLabel(session.zoneIndex, session.label);
-              }
-              if (session.notes) {
-                labelsAndTags.setZoneNote(session.zoneIndex, session.notes);
-              }
-              if (session.pinned) {
-                labelsAndTags.setPinnedZones((prev) => new Set([...prev, session.zoneIndex]));
-              }
+        // Even when reconnection succeeds, merge saved session metadata
+        // (claudeSessionId, labels, etc.) that the PTY data doesn't carry.
+        // We use the returned tab IDs directly (ordered by creation time,
+        // matching the sequential zone auto-assignment) to avoid reading
+        // stale zoneLayout.assignments from this closure.
+        if (reconnectedTabIds) {
+          const saved = sessionPersistence.hasSavedLayout()
+            ? sessionPersistence.getSavedLayout()
+            : null;
+          if (saved && saved.sessions.length > 0) {
+            // Restore layout preset if it differs
+            if (saved.layoutId !== zoneLayout.layoutId) {
+              const preset = LAYOUT_PRESETS.find((p) => p.id === saved.layoutId);
+              if (preset) zoneLayout.setLayoutId(preset.id);
             }
 
-            // Merge Claude session ID into the reconnected tab and queue resume
-            if (tabId && session.claudeSessionId && isValidSessionId(session.claudeSessionId)) {
-              const safeConfigDir = sanitizeConfigDir(session.claudeConfigDir);
-              updateTab(tabId, {
-                claudeSessionId: session.claudeSessionId,
-                claudeConfigDir: safeConfigDir,
-              });
-              pendingRestoresRef.current.push({
-                tabId,
-                isClaudeSession: true,
-                claudeSessionId: session.claudeSessionId,
-                claudeConfigDir: safeConfigDir,
-              });
-            }
-          }
+            for (const session of saved.sessions) {
+              // Match by zone index: tabs are auto-assigned to zones sequentially
+              const tabId =
+                session.zoneIndex >= 0 && session.zoneIndex < reconnectedTabIds.length
+                  ? reconnectedTabIds[session.zoneIndex]
+                  : undefined;
 
-          if (saved.focusedZone >= 0) {
-            zoneLayout.setFocusedZone(saved.focusedZone);
-          }
-
-          // Auto-resume Claude sessions after terminals are ready
-          if (pendingRestoresRef.current.length > 0) {
-            setTimeout(async () => {
-              for (const restore of pendingRestoresRef.current) {
-                if (restore.isClaudeSession && restore.claudeSessionId) {
-                  try {
-                    const resumeCmd = buildResumeCmd(
-                      restore.claudeSessionId,
-                      restore.claudeConfigDir,
-                    );
-                    await new Promise((r) => setTimeout(r, 500));
-                    writeWhenReady(terminalRefs.current, restore.tabId, resumeCmd, {
-                      onTimeout: (id) =>
-                        console.warn(
-                          `[TerminalPage] resume: terminal ref for ${id} never became ready`,
-                        ),
-                    });
-                  } catch (err) {
-                    console.warn(
-                      `[TerminalPage] Failed to resume Claude session for ${restore.tabId}:`,
-                      err,
-                    );
-                  }
+              // Restore zone labels, notes, pins
+              if (session.zoneIndex >= 0) {
+                if (session.label) {
+                  labelsAndTags.setZoneLabel(session.zoneIndex, session.label);
+                }
+                if (session.notes) {
+                  labelsAndTags.setZoneNote(session.zoneIndex, session.notes);
+                }
+                if (session.pinned) {
+                  labelsAndTags.setPinnedZones((prev) => new Set([...prev, session.zoneIndex]));
                 }
               }
-              pendingRestoresRef.current = [];
-            }, 1500);
-          }
 
-          sessionPersistence.clearSavedLayout();
+              // Merge Claude session ID into the reconnected tab and queue resume
+              if (tabId && session.claudeSessionId && isValidSessionId(session.claudeSessionId)) {
+                const safeConfigDir = sanitizeConfigDir(session.claudeConfigDir);
+                updateTab(tabId, {
+                  claudeSessionId: session.claudeSessionId,
+                  claudeConfigDir: safeConfigDir,
+                });
+                // Persist under the restored tab's *new* id so it stays
+                // resumable even if a later churn drops the live id before
+                // the next save.
+                rememberSessionId(tabId, session.claudeSessionId, safeConfigDir);
+                pendingRestoresRef.current.push({
+                  tabId,
+                  isClaudeSession: true,
+                  claudeSessionId: session.claudeSessionId,
+                  claudeConfigDir: safeConfigDir,
+                });
+              }
+            }
+
+            if (saved.focusedZone >= 0) {
+              zoneLayout.setFocusedZone(saved.focusedZone);
+            }
+
+            // Auto-resume Claude sessions after terminals are ready
+            if (pendingRestoresRef.current.length > 0) {
+              drainScheduled = true;
+              setTimeout(async () => {
+                try {
+                  for (const restore of pendingRestoresRef.current) {
+                    if (restore.isClaudeSession && restore.claudeSessionId) {
+                      try {
+                        const resumeCmd = buildResumeCmd(
+                          restore.claudeSessionId,
+                          restore.claudeConfigDir,
+                        );
+                        await new Promise((r) => setTimeout(r, 500));
+                        writeWhenReady(terminalRefs.current, restore.tabId, resumeCmd, {
+                          onTimeout: (id) =>
+                            console.warn(
+                              `[TerminalPage] resume: terminal ref for ${id} never became ready`,
+                            ),
+                        });
+                      } catch (err) {
+                        console.warn(
+                          `[TerminalPage] Failed to resume Claude session for ${restore.tabId}:`,
+                          err,
+                        );
+                      }
+                    }
+                  }
+                  pendingRestoresRef.current = [];
+                } finally {
+                  // Resume commands have been issued (or best-effort failed):
+                  // the restored tabs now carry their claudeSessionId, so it's
+                  // safe to let the debounced auto-save persist the layout.
+                  restoreCompleteRef.current = true;
+                }
+              }, 1500);
+            }
+
+            // NOTE: deliberately do NOT clearSavedLayout() here. The prior good
+            // layout must survive until the async resume above has run and the
+            // restored tabs hold their claudeSessionId — at which point the
+            // debounced auto-save overwrites it. A failed/never-firing resume
+            // then leaves the prior layout intact for the next reopen.
+          }
         }
-      }
 
-      if (!reconnectedTabIds) {
-        const saved = sessionPersistence.hasSavedLayout()
-          ? sessionPersistence.getSavedLayout()
-          : null;
-        if (saved && saved.sessions.length > 0) {
-          if (saved.layoutId !== zoneLayout.layoutId) {
-            const preset = LAYOUT_PRESETS.find((p) => p.id === saved.layoutId);
-            if (preset) zoneLayout.setLayoutId(preset.id);
-          }
+        if (!reconnectedTabIds) {
+          const saved = sessionPersistence.hasSavedLayout()
+            ? sessionPersistence.getSavedLayout()
+            : null;
+          if (saved && saved.sessions.length > 0) {
+            if (saved.layoutId !== zoneLayout.layoutId) {
+              const preset = LAYOUT_PRESETS.find((p) => p.id === saved.layoutId);
+              if (preset) zoneLayout.setLayoutId(preset.id);
+            }
 
-          const assignedSessions = saved.sessions.filter((s) => s.zoneIndex >= 0);
-          const unassignedSessions = saved.sessions.filter((s) => s.zoneIndex < 0);
+            const assignedSessions = saved.sessions.filter((s) => s.zoneIndex >= 0);
+            const unassignedSessions = saved.sessions.filter((s) => s.zoneIndex < 0);
 
-          for (const session of assignedSessions) {
-            if (session.type === "plan" && session.planFilePath) {
-              const tabId = createPlanTab(session.planFilePath);
+            for (const session of assignedSessions) {
+              if (session.type === "plan" && session.planFilePath) {
+                const tabId = createPlanTab(session.planFilePath);
+                if (tabId && session.zoneIndex >= 0) {
+                  zoneLayout.assignTabToZone(session.zoneIndex, tabId);
+                }
+                if (session.label) {
+                  labelsAndTags.setZoneLabel(session.zoneIndex, session.label);
+                }
+                if (session.notes) {
+                  labelsAndTags.setZoneNote(session.zoneIndex, session.notes);
+                }
+                if (session.pinned) {
+                  labelsAndTags.setPinnedZones((prev) => new Set([...prev, session.zoneIndex]));
+                }
+                continue;
+              }
+
+              const tabId = await createTerminal(session.title, session.workingDir);
               if (tabId && session.zoneIndex >= 0) {
                 zoneLayout.assignTabToZone(session.zoneIndex, tabId);
               }
@@ -256,136 +311,157 @@ export function useTerminalInitialization({
               if (session.pinned) {
                 labelsAndTags.setPinnedZones((prev) => new Set([...prev, session.zoneIndex]));
               }
-              continue;
+              if (tabId && (session.scrollbackPath || session.isClaudeSession)) {
+                pendingRestoresRef.current.push({
+                  tabId,
+                  scrollbackPath: session.scrollbackPath,
+                  isClaudeSession: session.isClaudeSession,
+                  claudeSessionId: session.claudeSessionId,
+                  claudeConfigDir: sanitizeConfigDir(session.claudeConfigDir),
+                });
+              }
+              if (tabId && session.claudeSessionId) {
+                const safeConfigDir = sanitizeConfigDir(session.claudeConfigDir);
+                updateTab(tabId, {
+                  claudeSessionId: session.claudeSessionId,
+                  claudeConfigDir: safeConfigDir,
+                  // Show a "resuming" affordance instead of a bare powershell
+                  // shell until the `claude --resume` prompt lands. Cleared in
+                  // the drain loop right after the resume command is written.
+                  isReconnecting: true,
+                });
+                // Persist under the restored tab's new id (see note above).
+                rememberSessionId(tabId, session.claudeSessionId, safeConfigDir);
+              }
             }
 
-            const tabId = await createTerminal(session.title, session.workingDir);
-            if (tabId && session.zoneIndex >= 0) {
-              zoneLayout.assignTabToZone(session.zoneIndex, tabId);
+            for (const session of unassignedSessions) {
+              if (session.type === "plan" && session.planFilePath) {
+                createPlanTab(session.planFilePath);
+                continue;
+              }
+              const tabId = await createTerminal(session.title, session.workingDir);
+              if (tabId && (session.scrollbackPath || session.isClaudeSession)) {
+                pendingRestoresRef.current.push({
+                  tabId,
+                  scrollbackPath: session.scrollbackPath,
+                  isClaudeSession: session.isClaudeSession,
+                  claudeSessionId: session.claudeSessionId,
+                  claudeConfigDir: sanitizeConfigDir(session.claudeConfigDir),
+                });
+              }
+              if (tabId && session.claudeSessionId) {
+                const safeConfigDir = sanitizeConfigDir(session.claudeConfigDir);
+                updateTab(tabId, {
+                  claudeSessionId: session.claudeSessionId,
+                  claudeConfigDir: safeConfigDir,
+                  isReconnecting: true,
+                });
+                // Persist under the restored tab's new id (see note above).
+                rememberSessionId(tabId, session.claudeSessionId, safeConfigDir);
+              }
             }
-            if (session.label) {
-              labelsAndTags.setZoneLabel(session.zoneIndex, session.label);
-            }
-            if (session.notes) {
-              labelsAndTags.setZoneNote(session.zoneIndex, session.notes);
-            }
-            if (session.pinned) {
-              labelsAndTags.setPinnedZones((prev) => new Set([...prev, session.zoneIndex]));
-            }
-            if (tabId && (session.scrollbackPath || session.isClaudeSession)) {
-              pendingRestoresRef.current.push({
-                tabId,
-                scrollbackPath: session.scrollbackPath,
-                isClaudeSession: session.isClaudeSession,
-                claudeSessionId: session.claudeSessionId,
-                claudeConfigDir: sanitizeConfigDir(session.claudeConfigDir),
-              });
-            }
-            if (tabId && session.claudeSessionId) {
-              updateTab(tabId, {
-                claudeSessionId: session.claudeSessionId,
-                claudeConfigDir: sanitizeConfigDir(session.claudeConfigDir),
-              });
-            }
-          }
 
-          for (const session of unassignedSessions) {
-            if (session.type === "plan" && session.planFilePath) {
-              createPlanTab(session.planFilePath);
-              continue;
+            if (saved.focusedZone >= 0) {
+              zoneLayout.setFocusedZone(saved.focusedZone);
             }
-            const tabId = await createTerminal(session.title, session.workingDir);
-            if (tabId && (session.scrollbackPath || session.isClaudeSession)) {
-              pendingRestoresRef.current.push({
-                tabId,
-                scrollbackPath: session.scrollbackPath,
-                isClaudeSession: session.isClaudeSession,
-                claudeSessionId: session.claudeSessionId,
-                claudeConfigDir: sanitizeConfigDir(session.claudeConfigDir),
-              });
-            }
-            if (tabId && session.claudeSessionId) {
-              updateTab(tabId, {
-                claudeSessionId: session.claudeSessionId,
-                claudeConfigDir: sanitizeConfigDir(session.claudeConfigDir),
-              });
-            }
-          }
 
-          if (saved.focusedZone >= 0) {
-            zoneLayout.setFocusedZone(saved.focusedZone);
-          }
+            if (pendingRestoresRef.current.length > 0) {
+              drainScheduled = true;
+              setTimeout(async () => {
+                try {
+                  for (const restore of pendingRestoresRef.current) {
+                    const ref = terminalRefs.current.get(restore.tabId);
+                    const handle = ref?.current;
 
-          if (pendingRestoresRef.current.length > 0) {
-            setTimeout(async () => {
-              for (const restore of pendingRestoresRef.current) {
-                const ref = terminalRefs.current.get(restore.tabId);
-                const handle = ref?.current;
-
-                if (restore.scrollbackPath && handle) {
-                  try {
-                    const result = await invoke<CommandResponse>("terminal_get_saved_scrollback", {
-                      filePath: restore.scrollbackPath,
-                    });
-                    if (result.success && result.data) {
-                      const encoded = (result.data as { data: string }).data;
-                      if (encoded) {
-                        const raw = atob(encoded);
-                        const decoded = new TextDecoder().decode(
-                          Uint8Array.from(raw, (c) => c.charCodeAt(0)),
+                    if (restore.scrollbackPath && handle) {
+                      try {
+                        const result = await invoke<CommandResponse>(
+                          "terminal_get_saved_scrollback",
+                          {
+                            filePath: restore.scrollbackPath,
+                          },
                         );
-                        handle.writeToDisplay(decoded);
+                        if (result.success && result.data) {
+                          const encoded = (result.data as { data: string }).data;
+                          if (encoded) {
+                            const raw = atob(encoded);
+                            const decoded = new TextDecoder().decode(
+                              Uint8Array.from(raw, (c) => c.charCodeAt(0)),
+                            );
+                            handle.writeToDisplay(decoded);
+                          }
+                        }
+                      } catch (err) {
+                        console.warn(
+                          `[TerminalPage] Failed to restore scrollback for ${restore.tabId}:`,
+                          err,
+                        );
                       }
                     }
-                  } catch (err) {
-                    console.warn(
-                      `[TerminalPage] Failed to restore scrollback for ${restore.tabId}:`,
-                      err,
-                    );
-                  }
-                }
 
-                if (
-                  restore.isClaudeSession &&
-                  restore.claudeSessionId &&
-                  isValidSessionId(restore.claudeSessionId)
-                ) {
-                  try {
-                    const resumeCmd = buildResumeCmd(
-                      restore.claudeSessionId,
-                      restore.claudeConfigDir,
-                    );
-                    await new Promise((r) => setTimeout(r, 500));
-                    writeWhenReady(terminalRefs.current, restore.tabId, resumeCmd, {
-                      onTimeout: (id) =>
+                    if (
+                      restore.isClaudeSession &&
+                      restore.claudeSessionId &&
+                      isValidSessionId(restore.claudeSessionId)
+                    ) {
+                      try {
+                        const resumeCmd = buildResumeCmd(
+                          restore.claudeSessionId,
+                          restore.claudeConfigDir,
+                        );
+                        await new Promise((r) => setTimeout(r, 500));
+                        writeWhenReady(terminalRefs.current, restore.tabId, resumeCmd, {
+                          onTimeout: (id) =>
+                            console.warn(
+                              `[TerminalPage] resume: terminal ref for ${id} never became ready`,
+                            ),
+                        });
+                      } catch (err) {
                         console.warn(
-                          `[TerminalPage] resume: terminal ref for ${id} never became ready`,
-                        ),
-                    });
-                  } catch (err) {
-                    console.warn(
-                      `[TerminalPage] Failed to resume Claude session for ${restore.tabId}:`,
-                      err,
-                    );
+                          `[TerminalPage] Failed to resume Claude session for ${restore.tabId}:`,
+                          err,
+                        );
+                      } finally {
+                        // Resume command issued (or best-effort failed) — drop the
+                        // "resuming" affordance so the live `claude` UI shows.
+                        updateTab(restore.tabId, { isReconnecting: false });
+                      }
+                    }
                   }
+
+                  try {
+                    await invoke("terminal_cleanup_scrollback");
+                  } catch (err) {
+                    console.warn("[TerminalPage] Failed to cleanup scrollback files:", err);
+                  }
+
+                  pendingRestoresRef.current = [];
+                } finally {
+                  // Restored tabs now carry their claudeSessionId / scrollback —
+                  // safe to let the debounced auto-save persist the layout.
+                  restoreCompleteRef.current = true;
                 }
-              }
+              }, 1500);
+            }
 
-              try {
-                await invoke("terminal_cleanup_scrollback");
-              } catch (err) {
-                console.warn("[TerminalPage] Failed to cleanup scrollback files:", err);
-              }
-
-              pendingRestoresRef.current = [];
-            }, 1500);
+            // NOTE: deliberately do NOT clearSavedLayout() here — see the
+            // reconnect branch above. The auto-save overwrites the prior layout
+            // only once restore has fully drained and tabs hold their ids.
           }
-
-          sessionPersistence.clearSavedLayout();
+          // No default terminal — start empty so users can launch AI sessions via the Launch Menu
         }
-        // No default terminal — start empty so users can launch AI sessions via the Launch Menu
+        setInitialized(true);
+      } finally {
+        // Always open the auto-save gate. If a drain timer was scheduled it
+        // owns the flip (after resume commands are issued); otherwise — no
+        // saved sessions, nothing to restore, or restore threw — open it now
+        // so brand-new sessions still persist. Never leave it permanently
+        // closed (that would silently disable persistence).
+        if (!drainScheduled) {
+          restoreCompleteRef.current = true;
+        }
       }
-      setInitialized(true);
     })();
   }, [
     reconnectToExistingSessions,
@@ -402,6 +478,12 @@ export function useTerminalInitialization({
   // Auto-save session layout for persistence across app restarts
   useEffect(() => {
     if (tabs.length === 0) return;
+    // Suppress auto-save until restore has fully completed. Otherwise the
+    // debounced save can fire while the restore path still holds plain shells
+    // (no claudeSessionId yet) and clobber the good saved Claude layout. Once
+    // the gate opens, the `updateTab` calls that attach claudeSessionId mutate
+    // `tabs`, re-running this effect — so no save is permanently lost.
+    if (!restoreCompleteRef.current) return;
     sessionPersistence.saveSessionLayout({
       layoutId: layoutState.layoutId,
       tabs,

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -319,7 +319,12 @@ export function useTerminalManager(pageId: string = "default") {
       updates: Partial<
         Pick<
           TerminalTab,
-          "isAlive" | "exitCode" | "workingDir" | "claudeSessionId" | "claudeConfigDir"
+          | "isAlive"
+          | "exitCode"
+          | "workingDir"
+          | "claudeSessionId"
+          | "claudeConfigDir"
+          | "isReconnecting"
         >
       >,
     ) => {


### PR DESCRIPTION
## Problem

On close → reopen of the runner window, restored Claude (AI) sessions did not return to their zones. They showed up as "frozen" orphans in the sidebar with no live transcript, and could not be resumed.

### Root cause

- The debounced auto-save was clobbering the saved Claude layout with degraded plain-powershell tabs right after reopen — it fired before the async `claude --resume` had a chance to run.
- `clearSavedLayout()` discarded the layout before resume executed, so on reopen there were no session IDs left to resume.

## Fix

- Add a **restore-complete gate** so the auto-save cannot persist until restore finishes (wrapped in try/finally so the gate always opens, even on error).
- Add an **anti-degradation guard** in `saveSessionLayout`: skip a save that strictly reduces the number of resumable Claude sessions without a real tab-count drop.
- Remove the premature `clearSavedLayout()` calls; rely on overwrite once restore completes.
- Add a **durable last-known-session-id store** (`lastKnownSessionIds.ts`), written from the capture, resume, and restore paths, with a save-time fallback so a dropped live id no longer makes a tab unresumable.
- Add a **resuming affordance** for restored AI tabs, and reword the sidebar "frozen" copy to "Not open in a window — click Resume" for orphaned-no-PTY sessions.

## Verification

- `tsc` clean, `eslint` clean, `vitest` green (new tests: `lastKnownSessionIds.test.ts`, `useSessionPersistence.test.ts`, `useTabSessionIdCapture.remember.test.ts`).
- Live close → reopen on the runner page: zone 0 and zone 1 sessions re-rendered their transcripts on reopen (observed on the page).
- Durable last-known-session-id store populated as expected.
- Anti-degradation guard held — the degraded plain-powershell save was correctly skipped, preserving the resumable layout.

## Files

7 modified + 4 new under `src/components/terminal/`:
`SessionCard.tsx`, `useSessionManager.ts`, `useSessionPersistence.ts`, `useShellIntegration.ts`, `useTabSessionIdCapture.ts`, `useTerminalInitialization.ts`, `useTerminalManager.ts`, plus new `lastKnownSessionIds.ts`, `lastKnownSessionIds.test.ts`, `useSessionPersistence.test.ts`, `useTabSessionIdCapture.remember.test.ts`.
