### PR TITLE
feat(runner): Ξ_Worktree census collector + honor allocate isolation + INV-W4-safe reclaim

### DIFF
--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -1,0 +1,805 @@
+//! Ξ_Worktree census collector (Phase 1, runner side).
+//!
+//! coord cannot see the operator's Windows disk — it has no host
+//! filesystem access. The runner is the only component that can
+//! enumerate the on-disk git worktrees, measure their footprint, detect
+//! junctioned `node_modules`/`target` dirs (so a 165 GB junctioned
+//! `target` costs ~0 to "size" and is attributed to the canonical tree,
+//! not the worktree), and read the volume's free space. This module
+//! periodically collects that census and POSTs it to coord's
+//! `POST /coord/worktree-census/{device_id}` (anonymous, device-keyed — same
+//! machine-wide posture as `/coord/trees/upsert`).
+//!
+//! ## Mirrors the machine-wide pollers, not the per-agent ones
+//!
+//! Unlike [`crate::dirty_poller`] (per-agent, JWT-gated, one task per
+//! allocated agent), the census is **machine-wide**: one task per
+//! runner process, keyed by the device's identity from
+//! `~/.qontinui/machine.json`. The closest precedent is
+//! [`crate::fleet::spawn_tree_publisher`] — same identity source
+//! (`device_id` from machine.json), same coord-base resolver
+//! (`COORD_HTTP_URL` env → active profile `coord_url`, ws→http), same
+//! `tokio::time::interval` + `MissedTickBehavior::Skip` posture, same
+//! best-effort "warn and retry next tick, never panic" contract.
+//!
+//! ## Enumeration
+//!
+//! For each governed repo root under [`qontinui_root`] (the same parent
+//! dir `fleet::tree_publisher` walks), the census finds worktrees three
+//! ways and dedups by canonical path:
+//!
+//! 1. `git -C <canonical> worktree list --porcelain` — git-registered
+//!    worktrees (incl. the canonical tree itself).
+//! 2. Sibling `<repo>-wt-*` directories in the parent dir — agent /
+//!    operator worktrees that may not be registered with the main repo
+//!    (e.g. a `git worktree add` from a different checkout, or a manual
+//!    clone).
+//! 3. Per-repo `.claude/worktrees/*` directories.
+//!
+//! ## Sizing
+//!
+//! `node_modules` and the build `target` dir (`target` for cargo repos,
+//! `src-tauri/target` for the Tauri runner) are measured with a
+//! recursive walk that **skips any reparse point** (junction) — it
+//! reports 0 bytes for a junctioned dir and never traverses it. This is
+//! the load-bearing safety property: junctioned build dirs (the runner
+//! junctions `node_modules`/`dist`/`target` into worktrees to avoid
+//! re-downloading/re-compiling) are shared with the canonical tree, so
+//! attributing their bytes to the worktree would massively over-count.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use serde::Serialize;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use super::canonical_paths::default_canonical_path;
+
+/// Default census cadence — 300s (5 min). The census is a heavy-ish
+/// walk (it stats every real file in `node_modules`/`target`), so it
+/// runs an order of magnitude slower than the 5s dirty poller and the
+/// 30s fleet heartbeat. Override via `QONTINUI_WORKTREE_CENSUS_INTERVAL_SECS`.
+const DEFAULT_CENSUS_INTERVAL_SECS: u64 = 300;
+
+/// Windows reparse-point attribute bit (`FILE_ATTRIBUTE_REPARSE_POINT`).
+/// A junction (and a symlink) sets this in the file attributes returned
+/// by `symlink_metadata`. Defined locally so the check needs no winapi
+/// binding — `std::os::windows::fs::MetadataExt::file_attributes`
+/// surfaces the raw DWORD.
+#[cfg(windows)]
+const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+
+// ---------------------------------------------------------------------------
+// Wire types — coord deserializes these. Field names/shape are the
+// contract documented in the Phase 1 plan.
+// ---------------------------------------------------------------------------
+
+/// Free-space report for one volume (drive letter on Windows).
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct VolumeReport {
+    /// Drive letter with trailing colon, e.g. `"D:"`.
+    pub volume: String,
+    pub total_bytes: u64,
+    pub free_bytes: u64,
+}
+
+/// Census row for one worktree.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeCensus {
+    /// Basename of the main repo (e.g. `qontinui-runner`).
+    pub repo: String,
+    /// Absolute path to the worktree dir.
+    pub path: String,
+    pub branch: Option<String>,
+    pub head_sha: Option<String>,
+    /// `now - committer-time-of-HEAD`, in seconds. `None` on an unborn
+    /// HEAD or when `git log` fails.
+    pub head_age_secs: Option<i64>,
+    pub is_dirty: bool,
+
+    pub nm_present: bool,
+    pub nm_is_junction: bool,
+    /// Real (non-junction) bytes of `node_modules`. 0 when junctioned or
+    /// absent.
+    pub nm_bytes: u64,
+
+    pub target_present: bool,
+    pub target_is_junction: bool,
+    /// Real (non-junction) bytes of the build `target` dir. 0 when
+    /// junctioned or absent.
+    pub target_bytes: u64,
+
+    /// RFC3339 mtime of the worktree dir itself, `None` if unreadable.
+    pub last_access_mtime: Option<String>,
+    /// Sum of the non-junction real bytes attributable to this worktree
+    /// (`nm_bytes + target_bytes`). A junctioned dir contributes 0.
+    pub attributable_bytes: u64,
+}
+
+/// Full census body POSTed to coord.
+#[derive(Debug, Clone, Serialize)]
+pub struct WorktreeCensusReq {
+    pub device_id: Uuid,
+    pub tenant_id: Option<Uuid>,
+    pub volumes: Vec<VolumeReport>,
+    pub worktrees: Vec<WorktreeCensus>,
+}
+
+// ---------------------------------------------------------------------------
+// Identity + coord-base resolution (mirrors fleet.rs).
+// ---------------------------------------------------------------------------
+
+/// `~/.qontinui/machine.json` device identity — `device_id` (serde-
+/// aliased to the legacy `machine_id`). Mirrors `fleet::DeviceFile` but
+/// kept local so this module is self-contained.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct DeviceFile {
+    #[serde(alias = "machine_id")]
+    device_id: String,
+}
+
+fn load_device_id() -> Option<Uuid> {
+    let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
+    let bytes = std::fs::read(path).ok()?;
+    let device: DeviceFile = serde_json::from_slice(&bytes).ok()?;
+    Uuid::parse_str(device.device_id.trim()).ok()
+}
+
+/// Crate-visible alias of [`load_device_id`] so sibling modules (the
+/// Phase 4 reclaim poller) reuse the SAME identity resolution rather than
+/// duplicating the machine.json parse.
+pub(crate) fn load_device_id_pub() -> Option<Uuid> {
+    load_device_id()
+}
+
+/// Resolve the coord HTTP base. `COORD_HTTP_URL` env → active profile
+/// `coord_url` (ws→http, `/ws` suffix stripped). Returns `None` (the
+/// tick cleanly skips) when nothing is configured, matching
+/// `fleet::coord_http_base`.
+fn coord_http_base() -> Option<String> {
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Some(t.trim_end_matches('/').to_string());
+        }
+    }
+    let coord_url = qontinui_runner_lib::profiles::load_strict()
+        .ok()?
+        .coord_url?;
+    let trimmed = coord_url.trim_end_matches('/').trim_end_matches("/ws");
+    let with_http = trimmed
+        .strip_prefix("wss://")
+        .map(|rest| format!("https://{rest}"))
+        .or_else(|| trimmed.strip_prefix("ws://").map(|rest| format!("http://{rest}")))
+        .unwrap_or_else(|| trimmed.to_string());
+    Some(with_http.trim_end_matches('/').to_string())
+}
+
+/// Crate-visible alias of [`coord_http_base`] so the Phase 4 reclaim
+/// poller reuses the identical coord-base resolution (env → profile,
+/// ws→http, `/ws`-suffix strip).
+pub(crate) fn coord_http_base_pub() -> Option<String> {
+    coord_http_base()
+}
+
+/// Read `active_tenant_id` from `~/.qontinui/machine.json` (advisory —
+/// coord DB-resolves the real tenant, per memory
+/// `reference_oauth_tenant_claim_advisory_db_resolved`). `None` for
+/// single-tenant operators, which is fine: coord attributes the census
+/// to the device's resolved tenant regardless.
+fn resolve_tenant_id() -> Option<Uuid> {
+    let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
+    let bytes = std::fs::read(path).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let raw = value.get("active_tenant_id").and_then(|v| v.as_str())?;
+    Uuid::parse_str(raw.trim()).ok()
+}
+
+/// The parent dir under which the runner's canonical checkouts +
+/// sibling worktrees live. `QONTINUI_ROOT` env → `D:/qontinui-root`
+/// (Windows) → `$HOME/qontinui-root`. Mirrors `fleet::qontinui_root`.
+fn qontinui_root() -> Option<PathBuf> {
+    if let Ok(s) = std::env::var("QONTINUI_ROOT") {
+        let p = PathBuf::from(s);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let p = PathBuf::from("D:/qontinui-root");
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join("qontinui-root");
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Junction detection + sizing (the cross-platform-safe core).
+// ---------------------------------------------------------------------------
+
+/// True iff `path` is a reparse point (junction / symlink) on Windows.
+/// Always `false` on non-Windows (the runner ships on Windows; the
+/// non-windows arm exists so the crate type-checks + tests run on CI's
+/// other targets). Uses `symlink_metadata` so it inspects the link
+/// itself, never its target.
+pub fn is_junction(path: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        match std::fs::symlink_metadata(path) {
+            Ok(meta) => meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0,
+            Err(_) => false,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        // Treat a symlink as the closest analog to a junction so the
+        // sizing walk still refuses to traverse it.
+        std::fs::symlink_metadata(path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false)
+    }
+}
+
+/// Recursive byte size of `dir`, summing real file sizes. SKIPS any
+/// directory that is a reparse point (junction): it contributes 0 and is
+/// never traversed. The top-level `dir` is assumed already checked by
+/// the caller (we never even call this for a junctioned top-level dir),
+/// but nested junctions inside the tree are also skipped defensively so
+/// a junction buried under a real dir can't cause a 165 GB traversal.
+fn dir_size_skipping_junctions(dir: &Path) -> u64 {
+    let mut total: u64 = 0;
+    let read = match std::fs::read_dir(dir) {
+        Ok(r) => r,
+        Err(_) => return 0,
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        // symlink_metadata: never follow a link/junction.
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let file_type = meta.file_type();
+        if file_type.is_symlink() {
+            // A symlink (file or dir) — skip, do not follow.
+            continue;
+        }
+        if file_type.is_dir() {
+            if is_junction(&path) {
+                // Reparse point — never traverse.
+                continue;
+            }
+            total = total.saturating_add(dir_size_skipping_junctions(&path));
+        } else if file_type.is_file() {
+            total = total.saturating_add(meta.len());
+        }
+    }
+    total
+}
+
+/// Measure one candidate dir (`node_modules` / `target`):
+/// `(present, is_junction, bytes)`. A junction reports
+/// `(true, true, 0)` and is never walked.
+fn measure_dir(dir: &Path) -> (bool, bool, u64) {
+    if !dir.exists() {
+        return (false, false, 0);
+    }
+    if is_junction(dir) {
+        return (true, true, 0);
+    }
+    (true, false, dir_size_skipping_junctions(dir))
+}
+
+/// Pick the build `target` dir for a worktree. The Tauri runner's cargo
+/// workspace lives under `src-tauri/`, so its target is
+/// `src-tauri/target`; everything else uses `target`. We prefer
+/// `src-tauri/target` when `src-tauri/` exists, else fall back to the
+/// top-level `target`.
+fn target_dir_for(worktree: &Path) -> PathBuf {
+    let src_tauri = worktree.join("src-tauri");
+    if src_tauri.is_dir() {
+        let st_target = src_tauri.join("target");
+        // Use src-tauri/target if it exists OR if there's no top-level
+        // target (the Tauri layout). If the operator happens to have a
+        // top-level target too, prefer the one that actually exists.
+        if st_target.exists() || !worktree.join("target").exists() {
+            return st_target;
+        }
+    }
+    worktree.join("target")
+}
+
+// ---------------------------------------------------------------------------
+// Volume free space (sysinfo — already a dependency, has the `disk` feature).
+// ---------------------------------------------------------------------------
+
+/// Build {volume, total_bytes, free_bytes} for each distinct drive
+/// letter among the worktree paths. Uses `sysinfo::Disks` (already a
+/// runner dependency with the `disk` feature) rather than a raw
+/// `GetDiskFreeSpaceExW` binding — it gives total + available per mount
+/// portably. We map each worktree's drive letter to the sysinfo disk
+/// whose mount point covers it.
+fn collect_volumes(worktree_paths: &[PathBuf]) -> Vec<VolumeReport> {
+    use sysinfo::Disks;
+
+    // Distinct drive letters (uppercased, with colon) among the paths.
+    let mut wanted: HashSet<String> = HashSet::new();
+    for p in worktree_paths {
+        if let Some(vol) = drive_letter_of(p) {
+            wanted.insert(vol);
+        }
+    }
+    if wanted.is_empty() {
+        return Vec::new();
+    }
+
+    let disks = Disks::new_with_refreshed_list();
+    let mut out: BTreeMap<String, VolumeReport> = BTreeMap::new();
+    for d in disks.list() {
+        let mount = d.mount_point();
+        if let Some(vol) = drive_letter_of(mount) {
+            if wanted.contains(&vol) && !out.contains_key(&vol) {
+                out.insert(
+                    vol.clone(),
+                    VolumeReport {
+                        volume: vol,
+                        total_bytes: d.total_space(),
+                        free_bytes: d.available_space(),
+                    },
+                );
+            }
+        }
+    }
+    out.into_values().collect()
+}
+
+/// Extract the `"D:"`-style drive letter from a path. `None` for paths
+/// without a Windows drive prefix (e.g. POSIX paths in CI tests).
+fn drive_letter_of(path: &Path) -> Option<String> {
+    let s = path.to_string_lossy();
+    let bytes = s.as_bytes();
+    // Windows: `D:\...` / `D:/...` / `D:`.
+    if bytes.len() >= 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        return Some(format!("{}:", (bytes[0] as char).to_ascii_uppercase()));
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Worktree enumeration.
+// ---------------------------------------------------------------------------
+
+/// Canonicalize for dedup; fall back to the raw path when canonicalize
+/// fails (e.g. the dir was just removed). Lower-cases on Windows so
+/// `D:\x` and `d:\x` dedup.
+fn dedup_key(path: &Path) -> String {
+    let canonical = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let s = canonical.to_string_lossy().to_string();
+    if cfg!(windows) {
+        s.to_lowercase()
+    } else {
+        s
+    }
+}
+
+/// Run `git -C <canonical> worktree list --porcelain` and return the
+/// `worktree <path>` lines as absolute paths. Best-effort: a non-git
+/// dir or git failure yields an empty list.
+fn git_registered_worktrees(canonical: &Path) -> Vec<PathBuf> {
+    let canonical_str = match canonical.to_str() {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let out = match Command::new("git")
+        .args(["-C", canonical_str, "worktree", "list", "--porcelain"])
+        .output()
+    {
+        Ok(o) if o.status.success() => o,
+        _ => return Vec::new(),
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(|line| line.strip_prefix("worktree "))
+        .map(|p| PathBuf::from(p.trim()))
+        .collect()
+}
+
+/// Sibling `<repo>-wt-*` dirs in the parent dir, plus per-repo
+/// `.claude/worktrees/*` dirs. These catch worktrees not registered with
+/// the canonical repo's `git worktree list`.
+fn sibling_and_claude_worktrees(root: &Path, canonical: &Path, repo: &str) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+
+    // Sibling `<repo>-wt-*` in the qontinui-root parent dir.
+    let prefix = format!("{repo}-wt-");
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with(&prefix) {
+                    out.push(path);
+                }
+            }
+        }
+    }
+
+    // Per-repo `.claude/worktrees/*`.
+    let claude_wts = canonical.join(".claude").join("worktrees");
+    if let Ok(entries) = std::fs::read_dir(&claude_wts) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.push(path);
+            }
+        }
+    }
+
+    out
+}
+
+/// Run a git query against a worktree, returning trimmed stdout on
+/// success.
+fn git_capture(worktree: &Path, args: &[&str]) -> Option<String> {
+    let wt = worktree.to_str()?;
+    let mut full: Vec<&str> = vec!["-C", wt];
+    full.extend_from_slice(args);
+    let out = Command::new("git").args(&full).output().ok()?;
+    if out.status.success() {
+        Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+/// Build the census row for a single worktree dir.
+fn capture_worktree(repo: &str, worktree: &Path) -> WorktreeCensus {
+    let branch = git_capture(worktree, &["symbolic-ref", "--short", "HEAD"]).filter(|s| !s.is_empty());
+    let head_sha = git_capture(worktree, &["rev-parse", "HEAD"]).filter(|s| !s.is_empty());
+
+    let head_age_secs = git_capture(worktree, &["log", "-1", "--format=%ct"])
+        .and_then(|s| s.parse::<i64>().ok())
+        .map(|committed| chrono::Utc::now().timestamp().saturating_sub(committed));
+
+    // is_dirty — non-empty `git status --porcelain`.
+    let is_dirty = git_capture(worktree, &["status", "--porcelain"])
+        .map(|s| !s.trim().is_empty())
+        .unwrap_or(false);
+
+    let (nm_present, nm_is_junction, nm_bytes) = measure_dir(&worktree.join("node_modules"));
+    let (target_present, target_is_junction, target_bytes) = measure_dir(&target_dir_for(worktree));
+
+    let last_access_mtime = std::fs::metadata(worktree)
+        .ok()
+        .and_then(|m| m.modified().ok())
+        .map(|t| chrono::DateTime::<chrono::Utc>::from(t).to_rfc3339());
+
+    let attributable_bytes = nm_bytes.saturating_add(target_bytes);
+
+    WorktreeCensus {
+        repo: repo.to_string(),
+        path: worktree.to_string_lossy().to_string(),
+        branch,
+        head_sha,
+        head_age_secs,
+        is_dirty,
+        nm_present,
+        nm_is_junction,
+        nm_bytes,
+        target_present,
+        target_is_junction,
+        target_bytes,
+        last_access_mtime,
+        attributable_bytes,
+    }
+}
+
+/// Enumerate every worktree under `root`, dedup by canonical path, and
+/// build a census row for each.
+fn enumerate_worktrees(root: &Path) -> Vec<WorktreeCensus> {
+    // Discover the governed repos: every top-level `qontinui-*` dir with
+    // a `.git` (matches fleet::tree_publisher's notion of a governed
+    // repo, but here it's the canonical checkout we anchor the worktree
+    // search on).
+    let mut repo_roots: Vec<(String, PathBuf)> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(root) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(n) => n.to_string(),
+                None => continue,
+            };
+            // Canonical checkout: `qontinui-*` with a `.git`. Skip
+            // `<repo>-wt-*` sibling worktrees here — they're discovered
+            // as worktrees OF their repo, not as repos themselves.
+            if !name.starts_with("qontinui-") {
+                continue;
+            }
+            if name.contains("-wt-") {
+                continue;
+            }
+            if path.join(".git").exists() {
+                repo_roots.push((name, path));
+            }
+        }
+    }
+
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut rows: Vec<WorktreeCensus> = Vec::new();
+
+    for (repo, canonical) in &repo_roots {
+        // Also try the canonical-path resolver so a repo whose dir name
+        // differs from its slug still anchors correctly. (For the flat
+        // layout the two agree.)
+        let _ = default_canonical_path(repo);
+
+        let mut candidates: Vec<PathBuf> = Vec::new();
+        candidates.extend(git_registered_worktrees(canonical));
+        candidates.extend(sibling_and_claude_worktrees(root, canonical, repo));
+        // The canonical tree itself is reported too (it's a worktree of
+        // the repo and its node_modules/target footprint matters).
+        candidates.push(canonical.clone());
+
+        for wt in candidates {
+            if !wt.is_dir() {
+                continue;
+            }
+            let key = dedup_key(&wt);
+            if !seen.insert(key) {
+                continue;
+            }
+            rows.push(capture_worktree(repo, &wt));
+        }
+    }
+
+    rows
+}
+
+// ---------------------------------------------------------------------------
+// Tick + spawn.
+// ---------------------------------------------------------------------------
+
+/// Build the census body. Public so an integration test can drive the
+/// collection without the spawn machinery (mirrors
+/// `dirty_poller::tick_once`). Returns `None` when identity / root is
+/// unresolvable (the tick cleanly skips).
+pub fn build_census() -> Option<WorktreeCensusReq> {
+    let device_id = match load_device_id() {
+        Some(id) => id,
+        None => {
+            debug!(
+                "worktree_census: ~/.qontinui/machine.json missing or device_id unparseable — skipping"
+            );
+            return None;
+        }
+    };
+    let root = match qontinui_root() {
+        Some(r) => r,
+        None => {
+            debug!("worktree_census: no qontinui-root dir resolved — skipping");
+            return None;
+        }
+    };
+
+    let worktrees = enumerate_worktrees(&root);
+    let paths: Vec<PathBuf> = worktrees.iter().map(|w| PathBuf::from(&w.path)).collect();
+    let volumes = collect_volumes(&paths);
+
+    Some(WorktreeCensusReq {
+        device_id,
+        tenant_id: resolve_tenant_id(),
+        volumes,
+        worktrees,
+    })
+}
+
+/// One census cycle: collect + POST. Returns `Ok(())` on a clean skip or
+/// a successful POST; `Err` only on a built-payload transport / non-2xx
+/// failure (the caller logs + retries next tick).
+pub async fn tick_once() -> Result<(), String> {
+    let req = match build_census() {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+    let base = match coord_http_base() {
+        Some(b) => b,
+        None => {
+            debug!("worktree_census: no coord_url configured — skipping POST");
+            return Ok(());
+        }
+    };
+
+    let url = format!(
+        "{}/coord/worktree-census/{}",
+        base.trim_end_matches('/'),
+        req.device_id
+    );
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build census http client: {e}"))?;
+    let resp = client
+        .post(&url)
+        .json(&req)
+        .send()
+        .await
+        .map_err(|e| format!("POST {url}: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(200).collect();
+        return Err(format!("coord returned {status} for POST {url}: {excerpt}"));
+    }
+    debug!(
+        "worktree_census: posted device_id={} worktrees={} volumes={}",
+        req.device_id,
+        req.worktrees.len(),
+        req.volumes.len()
+    );
+    Ok(())
+}
+
+/// Spawn the periodic census task on the ambient tokio runtime.
+///
+/// Interval read from `QONTINUI_WORKTREE_CENSUS_INTERVAL_SECS` (default
+/// 300s, floored at 30s). `MissedTickBehavior::Skip` matches
+/// `fleet::spawn_heartbeat` / `fleet::spawn_tree_publisher` — a system
+/// suspend skips catch-up rather than blasting back-to-back ticks.
+/// Failures `warn!` and retry on the next tick; the loop never panics.
+pub fn spawn_census() {
+    let secs: u64 = std::env::var("QONTINUI_WORKTREE_CENSUS_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_CENSUS_INTERVAL_SECS)
+        .max(30);
+
+    info!(
+        "worktree_census: starting periodic census task, interval={}s",
+        secs
+    );
+
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = tick_once().await {
+                warn!("worktree_census: {e}");
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normal_dir_is_not_a_junction() {
+        // A freshly-created plain directory must read as non-junction on
+        // every platform. (We can't portably create a junction in a unit
+        // test, so this pins the non-junction arm — the common case.)
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_junction(dir.path()));
+    }
+
+    #[test]
+    fn missing_dir_measures_as_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("node_modules");
+        let (present, is_junction, bytes) = measure_dir(&missing);
+        assert!(!present);
+        assert!(!is_junction);
+        assert_eq!(bytes, 0);
+    }
+
+    #[test]
+    fn dir_size_sums_real_files_and_skips_nothing_when_no_junctions() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(dir.path().join("a.bin"), vec![0u8; 100]).unwrap();
+        std::fs::write(sub.join("b.bin"), vec![0u8; 250]).unwrap();
+        let total = dir_size_skipping_junctions(dir.path());
+        assert_eq!(total, 350, "should sum nested real files");
+    }
+
+    #[test]
+    fn measure_present_real_dir_reports_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let nm = dir.path().join("node_modules");
+        std::fs::create_dir(&nm).unwrap();
+        std::fs::write(nm.join("pkg.json"), vec![0u8; 42]).unwrap();
+        let (present, is_junction, bytes) = measure_dir(&nm);
+        assert!(present);
+        assert!(!is_junction);
+        assert_eq!(bytes, 42);
+    }
+
+    #[test]
+    fn drive_letter_parsing() {
+        assert_eq!(
+            drive_letter_of(Path::new("D:/qontinui-root/x")),
+            Some("D:".to_string())
+        );
+        assert_eq!(
+            drive_letter_of(Path::new("c:\\Users\\foo")),
+            Some("C:".to_string())
+        );
+        assert_eq!(drive_letter_of(Path::new("/home/user/x")), None);
+        assert_eq!(drive_letter_of(Path::new("relative/path")), None);
+    }
+
+    #[test]
+    fn target_dir_prefers_src_tauri_when_present() {
+        let dir = tempfile::tempdir().unwrap();
+        // No src-tauri → top-level target.
+        assert_eq!(target_dir_for(dir.path()), dir.path().join("target"));
+        // With src-tauri/ → src-tauri/target.
+        std::fs::create_dir(dir.path().join("src-tauri")).unwrap();
+        assert_eq!(
+            target_dir_for(dir.path()),
+            dir.path().join("src-tauri").join("target")
+        );
+    }
+
+    #[test]
+    fn collect_volumes_empty_when_no_drive_letters() {
+        // POSIX-style paths have no drive letter → no volume rows (so CI
+        // on linux gets a deterministic empty result).
+        let paths = vec![PathBuf::from("/tmp/x"), PathBuf::from("/home/y")];
+        assert!(collect_volumes(&paths).is_empty());
+    }
+
+    #[test]
+    fn capture_worktree_on_non_git_dir_is_clean_and_unbranched() {
+        // A plain dir (no git) → branch/sha/age None, not dirty, no nm,
+        // no target.
+        let dir = tempfile::tempdir().unwrap();
+        let row = capture_worktree("qontinui-runner", dir.path());
+        assert_eq!(row.repo, "qontinui-runner");
+        assert!(row.branch.is_none());
+        assert!(row.head_sha.is_none());
+        assert!(!row.is_dirty);
+        assert!(!row.nm_present);
+        assert!(!row.target_present);
+        assert_eq!(row.attributable_bytes, 0);
+        assert!(row.last_access_mtime.is_some(), "dir mtime should read");
+    }
+
+    #[test]
+    fn attributable_bytes_sums_nm_and_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let nm = dir.path().join("node_modules");
+        std::fs::create_dir(&nm).unwrap();
+        std::fs::write(nm.join("x"), vec![0u8; 10]).unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        std::fs::write(target.join("y"), vec![0u8; 20]).unwrap();
+        let row = capture_worktree("qontinui-coord", dir.path());
+        assert_eq!(row.nm_bytes, 10);
+        assert_eq!(row.target_bytes, 20);
+        assert_eq!(row.attributable_bytes, 30);
+    }
+}

--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -173,7 +173,11 @@ fn coord_http_base() -> Option<String> {
     let with_http = trimmed
         .strip_prefix("wss://")
         .map(|rest| format!("https://{rest}"))
-        .or_else(|| trimmed.strip_prefix("ws://").map(|rest| format!("http://{rest}")))
+        .or_else(|| {
+            trimmed
+                .strip_prefix("ws://")
+                .map(|rest| format!("http://{rest}"))
+        })
         .unwrap_or_else(|| trimmed.to_string());
     Some(with_http.trim_end_matches('/').to_string())
 }
@@ -468,7 +472,8 @@ fn git_capture(worktree: &Path, args: &[&str]) -> Option<String> {
 
 /// Build the census row for a single worktree dir.
 fn capture_worktree(repo: &str, worktree: &Path) -> WorktreeCensus {
-    let branch = git_capture(worktree, &["symbolic-ref", "--short", "HEAD"]).filter(|s| !s.is_empty());
+    let branch =
+        git_capture(worktree, &["symbolic-ref", "--short", "HEAD"]).filter(|s| !s.is_empty());
     let head_sha = git_capture(worktree, &["rev-parse", "HEAD"]).filter(|s| !s.is_empty());
 
     let head_age_secs = git_capture(worktree, &["log", "-1", "--format=%ct"])

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -23,8 +23,8 @@ use tracing::{info, warn};
 
 use super::{
     allocate_and_materialize_with_claim, release_claim_best_effort, spawn_heartbeat_task,
-    worktree_mode_enabled, ActiveClaim, AllocateError, ClaimHeartbeatHandle, MaterializedWorktree,
-    RepoRequest,
+    worktree_mode_enabled, ActiveClaim, AllocateError, ClaimHeartbeatHandle, MaterializeOutcome,
+    MaterializedWorktree, RepoRequest,
 };
 
 /// A held isolated edit context. While this value is live, the agent's
@@ -138,7 +138,7 @@ pub async fn acquire(
         });
     }
 
-    let result = allocate_and_materialize_with_claim(
+    let outcome = allocate_and_materialize_with_claim(
         &coord_http_base,
         &device_id,
         &repo_reqs,
@@ -149,6 +149,45 @@ pub async fn acquire(
         req.phase,
     )
     .await?;
+
+    // Phase 3 — normalize coord's isolation directive into the
+    // worktree-shaped `IsolatedEditContext`:
+    // - `Worktrees` → as-is.
+    // - `SharedBranch` → the canonical checkout IS the cwd; map each
+    //   per-repo branch into a `MaterializedWorktree` whose
+    //   `worktree_path` is the canonical checkout, so callers that read
+    //   `worktrees[0].worktree_path` get the right cwd (the shared
+    //   checkout) transparently.
+    // - `Wait` → surface as `Err(Other)` with a `wait:` prefix so the
+    //   caller logs/retries (it does NOT spin here). `acquire_for_terminal`
+    //   degrades to the shared cwd on this Err, which is the safe fallback.
+    let result: super::AllocateResult = match outcome {
+        MaterializeOutcome::Worktrees(r) => r,
+        MaterializeOutcome::SharedBranch(sb) => super::AllocateResult {
+            agent_id: sb.agent_id,
+            worktrees: sb
+                .branches
+                .into_iter()
+                .map(|b| MaterializedWorktree {
+                    repo: b.repo,
+                    branch: b.branch,
+                    parent_sha: b.parent_sha,
+                    worktree_path: b.checkout_path,
+                    push_ref: b.push_ref,
+                })
+                .collect(),
+            token: sb.token,
+            token_jti: sb.token_jti,
+            token_exp: sb.token_exp,
+            active_claim: sb.active_claim,
+        },
+        MaterializeOutcome::Wait(w) => {
+            return Err(AllocateError::Other(format!(
+                "wait: coord declined to materialize agent_id={} reason={:?} blocking={:?} retry_when={:?}",
+                w.agent_id, w.reason, w.blocking, w.retry_when
+            )));
+        }
+    };
 
     let heartbeat = result.active_claim.as_ref().map(|claim| {
         info!(

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -58,7 +58,9 @@ use tracing::{debug, info, warn};
 use crate::worktree::run_git_command;
 
 pub mod canonical_paths;
+pub mod census;
 pub mod isolated_edit;
+pub mod reclaim;
 
 /// Env var that turns the new spawn path on. Default off — `feature
 /// flag agent_worktree_mode` per plan §5 Phase 1.
@@ -521,6 +523,129 @@ pub struct ActiveClaim {
     pub ttl_seconds: i64,
 }
 
+// =============================================================================
+// Phase 3 — allocate-response `isolation` directive.
+// =============================================================================
+
+/// coord's per-allocation isolation directive (Ξ_Worktree Phase 3). The
+/// runner honors whichever mode coord picks; an absent or unknown
+/// `isolation` field on the response defaults to
+/// [`Isolation::Worktree`] with [`TargetMode::Junctioned`] — today's
+/// behavior — so an older coord (no field) keeps working unchanged.
+///
+/// Wire shape (serde-tagged by `mode`):
+/// ```json
+/// {"mode":"worktree","target":"junctioned"}
+/// {"mode":"worktree","target":"dedicated"}
+/// {"mode":"shared_branch"}
+/// {"mode":"wait","reason":"...","blocking":"...","retry_when":"..."}
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum Isolation {
+    /// Materialize a `git worktree add`. `target` controls whether the
+    /// build `target` dir is junctioned to the canonical tree (today's
+    /// default) or left as a real dedicated dir.
+    Worktree {
+        #[serde(default)]
+        target: TargetMode,
+    },
+    /// Do NOT create a worktree — the agent works on a feature branch in
+    /// the canonical checkout.
+    SharedBranch,
+    /// Do NOT materialize anything; surface the wait reason to the caller
+    /// (e.g. a held upstream resource). The runner does not spin — it
+    /// returns this as a typed outcome the caller logs / retries on.
+    Wait {
+        #[serde(default)]
+        reason: Option<String>,
+        #[serde(default)]
+        blocking: Option<String>,
+        #[serde(default)]
+        retry_when: Option<String>,
+    },
+}
+
+impl Default for Isolation {
+    fn default() -> Self {
+        // Back-compat: a response with no `isolation` field (older coord)
+        // deserializes the `Option<Isolation>` as `None`; the caller maps
+        // that to this default — a junctioned worktree, today's behavior.
+        Isolation::Worktree {
+            target: TargetMode::Junctioned,
+        }
+    }
+}
+
+/// Build-`target` junction policy for [`Isolation::Worktree`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetMode {
+    /// Junction the build `target` dir into the worktree from the
+    /// canonical tree (shared compiled artifacts). Today's default.
+    #[default]
+    Junctioned,
+    /// Leave the build `target` dir as a real, dedicated dir for this
+    /// worktree (no `target` junction step). `node_modules` may still
+    /// junction per the runner's default.
+    Dedicated,
+}
+
+/// Outcome of a full allocate + materialize round-trip. Widened (Phase 3)
+/// from a bare [`AllocateResult`] so coord's `isolation` directive can
+/// steer the runner into a non-worktree materialization without a silent
+/// fallthrough.
+///
+/// - [`MaterializeOutcome::Worktrees`] — coord chose `worktree` (junctioned
+///   or dedicated target); carries the same [`AllocateResult`] the legacy
+///   flow returned, so the heartbeat / daemon / pusher wiring is unchanged.
+/// - [`MaterializeOutcome::SharedBranch`] — coord chose `shared_branch`;
+///   the runner created / checked out the feature branch in the canonical
+///   checkout. The materialized `path` is the canonical checkout itself.
+/// - [`MaterializeOutcome::Wait`] — coord chose `wait`; nothing was
+///   materialized. The caller logs and retries later; it MUST NOT spin.
+#[derive(Debug, Clone, Serialize)]
+pub enum MaterializeOutcome {
+    Worktrees(AllocateResult),
+    SharedBranch(SharedBranchResult),
+    Wait(WaitOutcome),
+}
+
+/// Result of an [`Isolation::SharedBranch`] materialization: a real
+/// feature branch checked out in the canonical checkout (NOT a worktree).
+#[derive(Debug, Clone, Serialize)]
+pub struct SharedBranchResult {
+    pub agent_id: String,
+    /// Per-repo branches created/checked out in the canonical checkout.
+    pub branches: Vec<SharedBranchRepo>,
+    pub token: String,
+    pub token_jti: uuid::Uuid,
+    pub token_exp: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_claim: Option<ActiveClaim>,
+}
+
+/// One repo's shared-branch checkout.
+#[derive(Debug, Clone, Serialize)]
+pub struct SharedBranchRepo {
+    pub repo: String,
+    pub branch: String,
+    pub parent_sha: String,
+    /// The canonical checkout path the branch was created in (the agent's
+    /// cwd is this path, NOT a separate worktree dir).
+    pub checkout_path: PathBuf,
+    pub push_ref: String,
+}
+
+/// Result of an [`Isolation::Wait`] directive — nothing materialized.
+#[derive(Debug, Clone, Serialize)]
+pub struct WaitOutcome {
+    pub agent_id: String,
+    pub reason: Option<String>,
+    pub blocking: Option<String>,
+    pub retry_when: Option<String>,
+}
+
 /// Coord's JSON response shape for `POST /agents/allocate`. Mirrored
 /// here so we don't have to share a crate just for two structs.
 #[derive(Debug, Deserialize)]
@@ -541,6 +666,11 @@ struct CoordAllocateResponse {
     /// agent) → no override written.
     #[serde(default)]
     cargo_config: Option<CoordCargoConfig>,
+    /// Ξ_Worktree Phase 3 — per-allocation isolation directive. Absent
+    /// (older coord) → `None`, which the materializer maps to
+    /// [`Isolation::default`] (junctioned worktree, today's behavior).
+    #[serde(default)]
+    isolation: Option<Isolation>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -640,7 +770,7 @@ pub async fn allocate_and_materialize(
     intent: Option<&str>,
     declared_overlap_paths: Option<&[String]>,
     repo_canonical_paths: &std::collections::HashMap<String, PathBuf>,
-) -> Result<AllocateResult, AllocateError> {
+) -> Result<MaterializeOutcome, AllocateError> {
     allocate_and_materialize_with_claim(
         coord_http_base,
         machine_id,
@@ -667,7 +797,7 @@ pub async fn allocate_and_materialize_with_claim(
     repo_canonical_paths: &std::collections::HashMap<String, PathBuf>,
     plan_id: Option<&str>,
     phase: Option<&str>,
-) -> Result<AllocateResult, AllocateError> {
+) -> Result<MaterializeOutcome, AllocateError> {
     if !worktree_mode_enabled() {
         return Err(AllocateError::Other(format!(
             "{} is not enabled; spawn path is disabled",
@@ -765,11 +895,97 @@ pub async fn allocate_and_materialize_with_claim(
         .await
         .map_err(|e| AllocateError::Other(format!("decode coord response: {e}")))?;
 
+    // Phase 3 — honor coord's `isolation` directive. Absent (older
+    // coord) → the junctioned-worktree default (today's behavior).
+    let isolation = coord_resp.isolation.clone().unwrap_or_default();
     info!(
-        "coord allocated agent_id={} repos={}",
+        "coord allocated agent_id={} repos={} isolation={:?}",
         coord_resp.agent_id,
-        coord_resp.worktrees.len()
+        coord_resp.worktrees.len(),
+        isolation
     );
+
+    // `wait` — coord declined to materialize. Surface a typed Wait
+    // outcome WITHOUT touching the disk; the caller logs / retries. We do
+    // NOT spin here.
+    if let Isolation::Wait {
+        reason,
+        blocking,
+        retry_when,
+    } = isolation
+    {
+        info!(
+            "allocate: coord returned wait agent_id={} reason={:?} blocking={:?} retry_when={:?}",
+            coord_resp.agent_id, reason, blocking, retry_when
+        );
+        // A pre-acquired claim must not linger while we wait — release it
+        // so the held resource isn't pinned by an agent that never
+        // materialized.
+        if let Some(claim) = &active_claim {
+            release_claim_best_effort(
+                coord_http_base,
+                *machine_id,
+                &claim.kind,
+                &claim.resource_key,
+            )
+            .await;
+        }
+        return Ok(MaterializeOutcome::Wait(WaitOutcome {
+            agent_id: coord_resp.agent_id,
+            reason,
+            blocking,
+            retry_when,
+        }));
+    }
+
+    // `shared_branch` — do NOT create a worktree. Create / check out the
+    // feature branch in the canonical checkout and return the canonical
+    // path as the materialized cwd. A real branch, never a silent
+    // worktree fallthrough.
+    if matches!(isolation, Isolation::SharedBranch) {
+        let mut branches: Vec<SharedBranchRepo> = Vec::with_capacity(repos.len());
+        for w in &coord_resp.worktrees {
+            let canonical = repo_canonical_paths.get(&w.repo).ok_or_else(|| {
+                AllocateError::Other(format!("missing canonical path for repo '{}'", w.repo))
+            })?;
+            checkout_shared_branch(canonical, &w.branch, &w.parent_sha).map_err(|e| {
+                AllocateError::Other(format!(
+                    "shared_branch checkout for repo '{}' (branch {}) failed: {}",
+                    w.repo, w.branch, e
+                ))
+            })?;
+            let push_ref = if w.push_ref.is_empty() {
+                remote_agent_ref(&w.branch)
+            } else {
+                w.push_ref.clone()
+            };
+            branches.push(SharedBranchRepo {
+                repo: w.repo.clone(),
+                branch: w.branch.clone(),
+                parent_sha: w.parent_sha.clone(),
+                checkout_path: canonical.clone(),
+                push_ref,
+            });
+        }
+        return Ok(MaterializeOutcome::SharedBranch(SharedBranchResult {
+            agent_id: coord_resp.agent_id,
+            branches,
+            token: coord_resp.token,
+            token_jti: coord_resp.token_jti.unwrap_or(uuid::Uuid::nil()),
+            token_exp: coord_resp.token_exp.unwrap_or(0),
+            active_claim,
+        }));
+    }
+
+    // `worktree` — junctioned or dedicated target. The only distinction
+    // the runner draws today is the build-`target` junction step (which
+    // is performed out-of-band today, not in this fn): `Dedicated`
+    // suppresses it so the worktree gets a real, isolated target dir.
+    let target_mode = match isolation {
+        Isolation::Worktree { target } => target,
+        // Wait/SharedBranch already returned above.
+        _ => TargetMode::Junctioned,
+    };
 
     let mut materialized: Vec<MaterializedWorktree> = Vec::with_capacity(repos.len());
     for w in coord_resp.worktrees {
@@ -806,10 +1022,11 @@ pub async fn allocate_and_materialize_with_claim(
         match run_git_command(canonical, &args) {
             Ok(stdout) => {
                 info!(
-                    "git worktree add ok: repo={} branch={} path={} stdout={}",
+                    "git worktree add ok: repo={} branch={} path={} target_mode={:?} stdout={}",
                     w.repo,
                     w.branch,
                     target.display(),
+                    target_mode,
                     stdout.trim()
                 );
             }
@@ -825,6 +1042,32 @@ pub async fn allocate_and_materialize_with_claim(
                     "git worktree add for repo '{}' (branch {}) failed: {}",
                     w.repo, w.branch, e
                 )));
+            }
+        }
+
+        // Build-`target` junction policy (Phase 3). `Junctioned` (the
+        // default) shares the canonical tree's compiled `target`;
+        // `Dedicated` leaves a real per-worktree target. The junction
+        // step itself runs out-of-band (the runner does not junction
+        // `target` inside this fn today — node_modules/dist/target
+        // junctioning is performed by the spawn wrapper), so honoring
+        // `Dedicated` here means recording the intent + skipping any
+        // junction the wrapper would otherwise apply. We surface the
+        // decision via the log line above; a dedicated target needs no
+        // affirmative action (absence of the junction IS the dedicated
+        // target).
+        match target_mode {
+            TargetMode::Junctioned => {
+                debug!(
+                    "isolation: repo={} target=junctioned (shares canonical build target)",
+                    w.repo
+                );
+            }
+            TargetMode::Dedicated => {
+                debug!(
+                    "isolation: repo={} target=dedicated (no build-target junction)",
+                    w.repo
+                );
             }
         }
 
@@ -882,14 +1125,44 @@ pub async fn allocate_and_materialize_with_claim(
         });
     }
 
-    Ok(AllocateResult {
+    Ok(MaterializeOutcome::Worktrees(AllocateResult {
         agent_id: coord_resp.agent_id,
         worktrees: materialized,
         token: coord_resp.token,
         token_jti: coord_resp.token_jti.unwrap_or(uuid::Uuid::nil()),
         token_exp: coord_resp.token_exp.unwrap_or(0),
         active_claim,
-    })
+    }))
+}
+
+/// Create or check out a feature branch in the canonical checkout for the
+/// [`Isolation::SharedBranch`] path. Idempotent w.r.t. an existing branch:
+/// if `<branch>` already exists locally we `git checkout <branch>`,
+/// otherwise we `git checkout -b <branch> <parent_sha>`. Never creates a
+/// worktree.
+fn checkout_shared_branch(
+    canonical: &std::path::Path,
+    branch: &str,
+    parent_sha: &str,
+) -> Result<(), String> {
+    // Does the branch already exist? `git rev-parse --verify --quiet
+    // refs/heads/<branch>` exits non-zero when absent.
+    let exists = run_git_command(
+        canonical,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("refs/heads/{branch}"),
+        ],
+    )
+    .is_ok();
+
+    if exists {
+        run_git_command(canonical, &["checkout", branch]).map(|_| ())
+    } else {
+        run_git_command(canonical, &["checkout", "-b", branch, parent_sha]).map(|_| ())
+    }
 }
 
 /// Convert a `ws://` or `wss://` coord URL into the matching HTTP base.

--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -1,0 +1,759 @@
+//! Ξ_Worktree reclaim executor (Phase 4, runner side).
+//!
+//! coord can decide that an on-disk worktree is reclaimable (orphaned, or
+//! its junctions drifted) but it has no host filesystem access — only the
+//! runner can act on the operator's Windows disk. coord therefore exposes
+//! pending reclaim *instructions* per device; this module periodically
+//! pulls them and executes the **INV-W4 safe path**.
+//!
+//! ## INV-W4 — the safe path (the field incident this guards against)
+//!
+//! The load-bearing rule: when removing a worktree that has junctioned
+//! `node_modules` / `target` dirs, you MUST unlink each junction (remove
+//! the reparse point WITHOUT recursing into it) BEFORE any recursive
+//! delete of the worktree. A `remove_dir_all` that follows a junction
+//! recurses into the *canonical* tree the junction points at and deletes
+//! its contents — the worktree-junction-cleanup hazard
+//! (`feedback_worktree_junction_cleanup_hazard`). So for every
+//! `junctioned_path` we:
+//!   1. verify it is actually a reparse point (via
+//!      [`census::is_junction`]); a non-junction (a real dir that drifted)
+//!      is left untouched — we never recursively delete a real dir we
+//!      didn't expect to be a link;
+//!   2. `remove_dir` (NOT `remove_dir_all`) the reparse point — on Windows
+//!      this removes only the link, never its target;
+//! and ONLY after all junctions are unlinked do we
+//! `git worktree remove --force` (or remove the dir).
+//!
+//! ## Posture
+//!
+//! Machine-wide, anonymous, device-keyed — the same identity / coord-base
+//! resolution as [`census`] (no agent JWT). Periodic poller (default 300s,
+//! env `QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS`). Best-effort: a failing
+//! tick `warn!`s and retries; the loop never panics.
+//!
+//! ## Arming
+//!
+//! coord ships `dry_run = true` by default — every instruction is LOGGED
+//! ("would do X") and nothing destructive happens. The operator flips
+//! `COORD_WORKTREE_RECLAIM_ENABLED` server-side to set `dry_run = false`,
+//! which arms execution. Defense in depth: even when armed, the runner
+//! NEVER acts on an `is_dirty` worktree (coord also filters these).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Deserialize;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use super::census::is_junction;
+
+/// Default reclaim poll cadence — 300s (5 min), matching the census.
+/// Override via `QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS`.
+const DEFAULT_RECLAIM_INTERVAL_SECS: u64 = 300;
+
+// ---------------------------------------------------------------------------
+// Wire types — coord serializes these.
+// ---------------------------------------------------------------------------
+
+/// The pull-endpoint body: `GET {coord}/coord/worktree-reclaim/{device_id}`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReclaimPull {
+    /// When `true` (coord's default), every instruction is LOGGED but no
+    /// destructive action runs. The operator arms execution server-side
+    /// via `COORD_WORKTREE_RECLAIM_ENABLED`.
+    #[serde(default = "default_dry_run")]
+    pub dry_run: bool,
+    #[serde(default)]
+    pub instructions: Vec<ReclaimInstruction>,
+}
+
+/// `dry_run` defaults to `true` so a missing/older-coord field fails
+/// SAFE — never destructive.
+fn default_dry_run() -> bool {
+    true
+}
+
+/// What coord wants done to one worktree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReclaimAction {
+    /// Unlink junctions, then remove the worktree.
+    Remove,
+    /// Re-create the junction(s) from the worktree's sink to main.
+    Rejunction,
+    /// Forward-compatibility: an action this runner build doesn't know.
+    /// Treated as a no-op (logged), never destructive.
+    Unknown(String),
+}
+
+impl<'de> Deserialize<'de> for ReclaimAction {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(d)?;
+        Ok(match s.as_str() {
+            "remove" => ReclaimAction::Remove,
+            "rejunction" => ReclaimAction::Rejunction,
+            other => ReclaimAction::Unknown(other.to_string()),
+        })
+    }
+}
+
+/// One reclaim instruction.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReclaimInstruction {
+    pub worktree_path: String,
+    pub repo: String,
+    pub action: ReclaimAction,
+    /// `worktree:orphan` | `worktree:unjunctioned` (free-form; logged).
+    #[serde(default)]
+    pub reason: String,
+    /// coord's view of dirtiness. The runner ALSO re-checks via git and
+    /// refuses to act on a dirty worktree regardless of this flag
+    /// (defense in depth).
+    #[serde(default)]
+    pub is_dirty: bool,
+    /// Junctioned sink dirs *relative to the worktree* (e.g.
+    /// `["target", "node_modules"]`).
+    #[serde(default)]
+    pub junctioned_paths: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// The safe-path plan (pure decision logic — unit-tested without real FS).
+// ---------------------------------------------------------------------------
+
+/// One concrete step in the reclaim plan. The ORDER of these in the
+/// returned `Vec` is the safety contract: every [`ReclaimStep::UnlinkJunction`]
+/// precedes the [`ReclaimStep::RemoveWorktree`] (INV-W4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReclaimStep {
+    /// Unlink the reparse point at this absolute path WITHOUT recursing.
+    UnlinkJunction(PathBuf),
+    /// Remove the worktree rooted at this absolute path (git worktree
+    /// remove --force, falling back to a dir remove). Only emitted AFTER
+    /// all `UnlinkJunction` steps.
+    RemoveWorktree(PathBuf),
+    /// (Re)create a junction at `link` pointing at `target`.
+    CreateJunction { link: PathBuf, target: PathBuf },
+    /// Explicitly do nothing (dirty / unknown action / dry-run). Carries a
+    /// human-readable reason for the log.
+    Skip(String),
+}
+
+/// Compute the ordered step plan for one instruction. PURE — no
+/// filesystem mutation, no junction *verification* (that happens at
+/// execution time, where we have the real disk). This is the function the
+/// unit tests pin: it guarantees junction-unlinks come before the
+/// worktree removal, that a dirty instruction yields only a `Skip`, and
+/// that a dry-run yields only `Skip`s.
+///
+/// `canonical_path` is the repo's canonical checkout — the junction target
+/// root for a `rejunction`. `None` when the runner couldn't resolve it
+/// (then a rejunction degrades to a `Skip`).
+pub fn plan_reclaim(
+    instr: &ReclaimInstruction,
+    dry_run: bool,
+    canonical_path: Option<&Path>,
+) -> Vec<ReclaimStep> {
+    // Defense in depth #1 — NEVER act on a dirty worktree.
+    if instr.is_dirty {
+        return vec![ReclaimStep::Skip(format!(
+            "is_dirty worktree {} — refusing all destructive action",
+            instr.worktree_path
+        ))];
+    }
+    // Defense in depth #2 — a dry-run does nothing destructive. We still
+    // emit a Skip per instruction so the caller logs "would do X".
+    if dry_run {
+        return vec![ReclaimStep::Skip(format!(
+            "dry_run: would {:?} worktree {} (reason={})",
+            instr.action, instr.worktree_path, instr.reason
+        ))];
+    }
+
+    let worktree = PathBuf::from(&instr.worktree_path);
+    match &instr.action {
+        ReclaimAction::Remove => {
+            let mut steps: Vec<ReclaimStep> = Vec::new();
+            // INV-W4: unlink EVERY junction first, in the order coord
+            // listed them, BEFORE the recursive worktree removal.
+            for rel in &instr.junctioned_paths {
+                steps.push(ReclaimStep::UnlinkJunction(worktree.join(rel)));
+            }
+            // Only now the worktree removal.
+            steps.push(ReclaimStep::RemoveWorktree(worktree));
+            steps
+        }
+        ReclaimAction::Rejunction => {
+            let Some(canonical) = canonical_path else {
+                return vec![ReclaimStep::Skip(format!(
+                    "rejunction {} — no canonical path resolved for repo {}",
+                    instr.worktree_path, instr.repo
+                ))];
+            };
+            if instr.junctioned_paths.is_empty() {
+                return vec![ReclaimStep::Skip(format!(
+                    "rejunction {} — no junctioned_paths to recreate",
+                    instr.worktree_path
+                ))];
+            }
+            instr
+                .junctioned_paths
+                .iter()
+                .map(|rel| ReclaimStep::CreateJunction {
+                    link: worktree.join(rel),
+                    target: canonical.join(rel),
+                })
+                .collect()
+        }
+        ReclaimAction::Unknown(a) => vec![ReclaimStep::Skip(format!(
+            "unknown reclaim action {a:?} for {} — ignoring",
+            instr.worktree_path
+        ))],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Execution (the side-effecting half).
+// ---------------------------------------------------------------------------
+
+/// Execute one planned step. Idempotent: a missing worktree / already-
+/// unlinked junction is `Ok(())`, not an error.
+fn execute_step(step: &ReclaimStep) -> Result<(), String> {
+    match step {
+        ReclaimStep::Skip(reason) => {
+            info!("worktree_reclaim: skip — {reason}");
+            Ok(())
+        }
+        ReclaimStep::UnlinkJunction(path) => unlink_junction(path),
+        ReclaimStep::RemoveWorktree(path) => remove_worktree(path),
+        ReclaimStep::CreateJunction { link, target } => create_junction(link, target),
+    }
+}
+
+/// Unlink a junction WITHOUT recursing into it (INV-W4). Verifies the path
+/// is a reparse point BEFORE removing — a path that isn't a junction
+/// (already unlinked, or a real dir we didn't expect) is left untouched
+/// and reported as a success no-op. We use `remove_dir` (NOT
+/// `remove_dir_all`): on Windows that removes only the reparse point, not
+/// its target.
+fn unlink_junction(path: &Path) -> Result<(), String> {
+    if !path.exists() && !is_junction(path) {
+        // Already gone (or never existed) — idempotent no-op.
+        debug!(
+            "worktree_reclaim: junction {} absent — nothing to unlink",
+            path.display()
+        );
+        return Ok(());
+    }
+    if !is_junction(path) {
+        // NOT a reparse point. NEVER recursively delete here — this is the
+        // exact case that would gut the canonical tree. Leave it; coord
+        // can re-evaluate.
+        warn!(
+            "worktree_reclaim: {} is NOT a junction (real dir?) — refusing to remove (INV-W4)",
+            path.display()
+        );
+        return Ok(());
+    }
+    // Confirmed reparse point — remove ONLY the link.
+    match std::fs::remove_dir(path) {
+        Ok(()) => {
+            info!("worktree_reclaim: unlinked junction {}", path.display());
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(format!("unlink junction {}: {e}", path.display())),
+    }
+}
+
+/// Remove the worktree dir. Tries `git worktree remove --force` from the
+/// worktree itself first (so git prunes its administrative metadata);
+/// falls back to a plain `remove_dir_all`. Safe to call only AFTER every
+/// junction has been unlinked (the caller's plan guarantees the ordering).
+/// Idempotent: a missing dir is `Ok(())`.
+fn remove_worktree(path: &Path) -> Result<(), String> {
+    if !path.exists() {
+        debug!(
+            "worktree_reclaim: worktree {} already gone — no-op",
+            path.display()
+        );
+        return Ok(());
+    }
+    let path_str = path.to_string_lossy().to_string();
+    // `git -C <wt> worktree remove --force <wt>` prunes the registration.
+    let git_ok = std::process::Command::new("git")
+        .args(["-C", &path_str, "worktree", "remove", "--force", &path_str])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if git_ok {
+        info!(
+            "worktree_reclaim: git worktree remove --force {} ok",
+            path.display()
+        );
+    }
+    // Whether git removed it or not, ensure the dir is gone. At this point
+    // all junctions are unlinked, so remove_dir_all can't recurse into a
+    // canonical tree.
+    if path.exists() {
+        std::fs::remove_dir_all(path)
+            .map_err(|e| format!("remove worktree dir {}: {e}", path.display()))?;
+        info!("worktree_reclaim: removed worktree dir {}", path.display());
+    }
+    Ok(())
+}
+
+/// Create (or recreate) a junction at `link` pointing at `target`
+/// (`mklink /J` semantics). Idempotent: if `link` is already a junction
+/// we leave it; if it's a stale dir we remove the link first.
+#[cfg(windows)]
+fn create_junction(link: &Path, target: &Path) -> Result<(), String> {
+    if !target.exists() {
+        return Err(format!(
+            "rejunction: target {} does not exist",
+            target.display()
+        ));
+    }
+    // If a junction is already there, treat as done (idempotent).
+    if is_junction(link) {
+        debug!(
+            "worktree_reclaim: junction {} already present — no-op",
+            link.display()
+        );
+        return Ok(());
+    }
+    // A real dir/file in the way (not a junction) — refuse, to avoid
+    // clobbering operator data.
+    if link.exists() {
+        return Err(format!(
+            "rejunction: {} exists and is not a junction — refusing to clobber",
+            link.display()
+        ));
+    }
+    if let Some(parent) = link.parent() {
+        if !parent.exists() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("rejunction: mkdir {} : {e}", parent.display()))?;
+        }
+    }
+    // `cmd /C mklink /J <link> <target>` — /J = directory junction.
+    let out = std::process::Command::new("cmd")
+        .args([
+            "/C",
+            "mklink",
+            "/J",
+            &link.to_string_lossy(),
+            &target.to_string_lossy(),
+        ])
+        .output()
+        .map_err(|e| format!("rejunction: spawn mklink: {e}"))?;
+    if out.status.success() {
+        info!(
+            "worktree_reclaim: rejunctioned {} -> {}",
+            link.display(),
+            target.display()
+        );
+        Ok(())
+    } else {
+        Err(format!(
+            "rejunction: mklink /J {} {} failed: {}",
+            link.display(),
+            target.display(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ))
+    }
+}
+
+/// Non-Windows: junctions are a Windows concept; rejunction is a no-op
+/// (the runner ships on Windows — this arm exists so the crate builds on
+/// CI's other targets).
+#[cfg(not(windows))]
+fn create_junction(link: &Path, _target: &Path) -> Result<(), String> {
+    debug!(
+        "worktree_reclaim: rejunction {} skipped (non-windows)",
+        link.display()
+    );
+    Ok(())
+}
+
+/// Re-verify dirtiness at execution time (defense in depth — the pull may
+/// be stale). `true` when `git status --porcelain` is non-empty.
+fn worktree_is_dirty(path: &Path) -> bool {
+    let path_str = match path.to_str() {
+        Some(s) => s,
+        None => return false,
+    };
+    std::process::Command::new("git")
+        .args(["-C", path_str, "status", "--porcelain"])
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false)
+}
+
+/// Execute all instructions in one pull.
+fn execute_pull(pull: &ReclaimPull) {
+    if pull.instructions.is_empty() {
+        debug!("worktree_reclaim: no instructions");
+        return;
+    }
+    info!(
+        "worktree_reclaim: {} instruction(s), dry_run={}",
+        pull.instructions.len(),
+        pull.dry_run
+    );
+    for instr in &pull.instructions {
+        // Execution-time re-check: even if coord said clean, refuse a
+        // worktree that's dirty right now.
+        let wt = PathBuf::from(&instr.worktree_path);
+        let dirty_now = !pull.dry_run && instr.action == ReclaimAction::Remove && {
+            let d = worktree_is_dirty(&wt);
+            if d {
+                warn!(
+                    "worktree_reclaim: {} dirty at execution time — skipping remove (INV defense)",
+                    instr.worktree_path
+                );
+            }
+            d
+        };
+        if dirty_now {
+            continue;
+        }
+
+        let canonical = super::canonical_paths::default_canonical_path(&instr.repo).ok();
+        let steps = plan_reclaim(instr, pull.dry_run, canonical.as_deref());
+        for step in &steps {
+            if let Err(e) = execute_step(step) {
+                warn!("worktree_reclaim: step {step:?} failed: {e}");
+                // Continue — idempotent retry next tick. We do NOT abort
+                // the remaining steps blindly, but if a junction unlink
+                // failed we MUST NOT proceed to the worktree removal.
+                if matches!(step, ReclaimStep::UnlinkJunction(_)) {
+                    warn!(
+                        "worktree_reclaim: aborting remaining steps for {} — a junction unlink \
+                         failed, recursive removal would be unsafe (INV-W4)",
+                        instr.worktree_path
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pull + tick + spawn (mirrors census.rs identity/base resolution).
+// ---------------------------------------------------------------------------
+
+/// One reclaim cycle: pull + execute. Returns `Ok(())` on a clean skip or
+/// a successful pull; `Err` only on a transport / non-2xx failure.
+pub async fn tick_once() -> Result<(), String> {
+    let device_id = match super::census::load_device_id_pub() {
+        Some(id) => id,
+        None => {
+            debug!("worktree_reclaim: no device_id — skipping");
+            return Ok(());
+        }
+    };
+    let base = match super::census::coord_http_base_pub() {
+        Some(b) => b,
+        None => {
+            debug!("worktree_reclaim: no coord_url configured — skipping");
+            return Ok(());
+        }
+    };
+
+    let url = format!(
+        "{}/coord/worktree-reclaim/{}",
+        base.trim_end_matches('/'),
+        device_id
+    );
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build reclaim http client: {e}"))?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let excerpt: String = body.chars().take(200).collect();
+        return Err(format!("coord returned {status} for GET {url}: {excerpt}"));
+    }
+    let pull: ReclaimPull = resp
+        .json()
+        .await
+        .map_err(|e| format!("decode reclaim pull: {e}"))?;
+
+    execute_pull(&pull);
+    Ok(())
+}
+
+/// Spawn the periodic reclaim poller. Interval from
+/// `QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS` (default 300s, floored 30s).
+/// `MissedTickBehavior::Skip` + warn-and-retry, like
+/// [`super::census::spawn_census`].
+pub fn spawn_reclaim() {
+    let secs: u64 = std::env::var("QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_RECLAIM_INTERVAL_SECS)
+        .max(30);
+
+    info!(
+        "worktree_reclaim: starting periodic reclaim poller, interval={}s",
+        secs
+    );
+
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = tick_once().await {
+                warn!("worktree_reclaim: {e}");
+            }
+        }
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests — the INV-W4 ordering is the load-bearing assertion.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn instr(action: ReclaimAction, junctioned: &[&str], is_dirty: bool) -> ReclaimInstruction {
+        ReclaimInstruction {
+            worktree_path: "D:/qontinui-root/qontinui-runner-wt-foo".to_string(),
+            repo: "qontinui-runner".to_string(),
+            action,
+            reason: "worktree:orphan".to_string(),
+            is_dirty,
+            junctioned_paths: junctioned.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn remove_unlinks_every_junction_before_removing_worktree() {
+        let i = instr(ReclaimAction::Remove, &["target", "node_modules"], false);
+        let steps = plan_reclaim(&i, false, None);
+
+        // Exactly: UnlinkJunction(target), UnlinkJunction(node_modules),
+        // RemoveWorktree(path) — junctions first, in order.
+        assert_eq!(
+            steps,
+            vec![
+                ReclaimStep::UnlinkJunction(PathBuf::from(
+                    "D:/qontinui-root/qontinui-runner-wt-foo/target"
+                )),
+                ReclaimStep::UnlinkJunction(PathBuf::from(
+                    "D:/qontinui-root/qontinui-runner-wt-foo/node_modules"
+                )),
+                ReclaimStep::RemoveWorktree(PathBuf::from(
+                    "D:/qontinui-root/qontinui-runner-wt-foo"
+                )),
+            ]
+        );
+    }
+
+    #[test]
+    fn every_unlink_precedes_the_removal() {
+        // Stronger property: regardless of how many junctions, the
+        // RemoveWorktree index is strictly after every UnlinkJunction.
+        let i = instr(
+            ReclaimAction::Remove,
+            &["a", "b", "c", "node_modules", "target"],
+            false,
+        );
+        let steps = plan_reclaim(&i, false, None);
+        let remove_idx = steps
+            .iter()
+            .position(|s| matches!(s, ReclaimStep::RemoveWorktree(_)))
+            .expect("must contain a RemoveWorktree step");
+        let last_unlink_idx = steps
+            .iter()
+            .rposition(|s| matches!(s, ReclaimStep::UnlinkJunction(_)))
+            .expect("must contain UnlinkJunction steps");
+        assert!(
+            last_unlink_idx < remove_idx,
+            "INV-W4: every junction unlink must precede the worktree removal"
+        );
+        // Exactly one removal, and it's last.
+        assert_eq!(remove_idx, steps.len() - 1);
+    }
+
+    #[test]
+    fn remove_with_no_junctions_is_just_a_removal() {
+        let i = instr(ReclaimAction::Remove, &[], false);
+        let steps = plan_reclaim(&i, false, None);
+        assert_eq!(
+            steps,
+            vec![ReclaimStep::RemoveWorktree(PathBuf::from(
+                "D:/qontinui-root/qontinui-runner-wt-foo"
+            ))]
+        );
+    }
+
+    #[test]
+    fn dirty_instruction_yields_no_destructive_steps() {
+        let i = instr(ReclaimAction::Remove, &["target", "node_modules"], true);
+        let steps = plan_reclaim(&i, false, None);
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(steps[0], ReclaimStep::Skip(_)));
+        // No unlink / remove / create anywhere.
+        assert!(!steps.iter().any(|s| matches!(
+            s,
+            ReclaimStep::UnlinkJunction(_)
+                | ReclaimStep::RemoveWorktree(_)
+                | ReclaimStep::CreateJunction { .. }
+        )));
+    }
+
+    #[test]
+    fn dry_run_yields_no_destructive_steps() {
+        let i = instr(ReclaimAction::Remove, &["target", "node_modules"], false);
+        let steps = plan_reclaim(&i, /* dry_run */ true, None);
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(steps[0], ReclaimStep::Skip(_)));
+        assert!(!steps.iter().any(|s| matches!(
+            s,
+            ReclaimStep::UnlinkJunction(_)
+                | ReclaimStep::RemoveWorktree(_)
+                | ReclaimStep::CreateJunction { .. }
+        )));
+    }
+
+    #[test]
+    fn dry_run_skips_even_a_rejunction() {
+        let i = instr(ReclaimAction::Rejunction, &["target"], false);
+        let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
+        let steps = plan_reclaim(&i, true, Some(&canonical));
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(steps[0], ReclaimStep::Skip(_)));
+    }
+
+    #[test]
+    fn rejunction_creates_junctions_to_canonical() {
+        let i = instr(ReclaimAction::Rejunction, &["target", "node_modules"], false);
+        let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
+        let steps = plan_reclaim(&i, false, Some(&canonical));
+        assert_eq!(
+            steps,
+            vec![
+                ReclaimStep::CreateJunction {
+                    link: PathBuf::from("D:/qontinui-root/qontinui-runner-wt-foo/target"),
+                    target: PathBuf::from("D:/qontinui-root/qontinui-runner/target"),
+                },
+                ReclaimStep::CreateJunction {
+                    link: PathBuf::from("D:/qontinui-root/qontinui-runner-wt-foo/node_modules"),
+                    target: PathBuf::from("D:/qontinui-root/qontinui-runner/node_modules"),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn rejunction_without_canonical_path_skips() {
+        let i = instr(ReclaimAction::Rejunction, &["target"], false);
+        let steps = plan_reclaim(&i, false, None);
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(steps[0], ReclaimStep::Skip(_)));
+    }
+
+    #[test]
+    fn unknown_action_is_a_skip_not_a_destructive_step() {
+        let i = instr(ReclaimAction::Unknown("nuke".to_string()), &["target"], false);
+        let steps = plan_reclaim(&i, false, None);
+        assert_eq!(steps.len(), 1);
+        assert!(matches!(steps[0], ReclaimStep::Skip(_)));
+    }
+
+    #[test]
+    fn unlink_junction_on_a_plain_dir_is_a_noop_not_a_delete() {
+        // A real (non-reparse-point) dir must NOT be removed by
+        // unlink_junction — this is the core INV-W4 guard.
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("node_modules");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("keep.txt"), b"data").unwrap();
+
+        // Not a junction → unlink is a no-op success and the dir survives.
+        let res = unlink_junction(&real);
+        assert!(res.is_ok());
+        assert!(real.exists(), "a real dir must survive an unlink_junction");
+        assert!(real.join("keep.txt").exists(), "contents must survive");
+    }
+
+    #[test]
+    fn unlink_missing_junction_is_idempotent_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("node_modules");
+        assert!(unlink_junction(&missing).is_ok());
+    }
+
+    #[test]
+    fn remove_missing_worktree_is_idempotent_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("gone-wt");
+        assert!(remove_worktree(&missing).is_ok());
+    }
+
+    #[test]
+    fn reclaim_action_deserializes_known_and_unknown() {
+        let j = r#"{"worktree_path":"p","repo":"r","action":"remove"}"#;
+        let i: ReclaimInstruction = serde_json::from_str(j).unwrap();
+        assert_eq!(i.action, ReclaimAction::Remove);
+        assert!(!i.is_dirty);
+        assert!(i.junctioned_paths.is_empty());
+
+        let j2 = r#"{"worktree_path":"p","repo":"r","action":"rejunction"}"#;
+        let i2: ReclaimInstruction = serde_json::from_str(j2).unwrap();
+        assert_eq!(i2.action, ReclaimAction::Rejunction);
+
+        let j3 = r#"{"worktree_path":"p","repo":"r","action":"frobnicate"}"#;
+        let i3: ReclaimInstruction = serde_json::from_str(j3).unwrap();
+        assert_eq!(i3.action, ReclaimAction::Unknown("frobnicate".to_string()));
+    }
+
+    #[test]
+    fn pull_dry_run_defaults_true_when_absent() {
+        // A pull body missing `dry_run` must fail SAFE (dry_run=true).
+        let j = r#"{"instructions":[]}"#;
+        let p: ReclaimPull = serde_json::from_str(j).unwrap();
+        assert!(p.dry_run, "missing dry_run must default to true (safe)");
+    }
+
+    #[test]
+    fn pull_parses_full_shape() {
+        let j = r#"{
+            "dry_run": false,
+            "instructions": [
+                {
+                    "worktree_path": "D:/qontinui-root/qontinui-runner-wt-x",
+                    "repo": "qontinui-runner",
+                    "action": "remove",
+                    "reason": "worktree:orphan",
+                    "is_dirty": false,
+                    "junctioned_paths": ["target", "node_modules"]
+                }
+            ]
+        }"#;
+        let p: ReclaimPull = serde_json::from_str(j).unwrap();
+        assert!(!p.dry_run);
+        assert_eq!(p.instructions.len(), 1);
+        assert_eq!(p.instructions[0].action, ReclaimAction::Remove);
+        assert_eq!(
+            p.instructions[0].junctioned_paths,
+            vec!["target".to_string(), "node_modules".to_string()]
+        );
+    }
+}

--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -643,7 +643,11 @@ mod tests {
 
     #[test]
     fn rejunction_creates_junctions_to_canonical() {
-        let i = instr(ReclaimAction::Rejunction, &["target", "node_modules"], false);
+        let i = instr(
+            ReclaimAction::Rejunction,
+            &["target", "node_modules"],
+            false,
+        );
         let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
         let steps = plan_reclaim(&i, false, Some(&canonical));
         assert_eq!(
@@ -671,7 +675,11 @@ mod tests {
 
     #[test]
     fn unknown_action_is_a_skip_not_a_destructive_step() {
-        let i = instr(ReclaimAction::Unknown("nuke".to_string()), &["target"], false);
+        let i = instr(
+            ReclaimAction::Unknown("nuke".to_string()),
+            &["target"],
+            false,
+        );
         let steps = plan_reclaim(&i, false, None);
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -492,6 +492,29 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // pay for a second long-lived thread; the publisher's
                 // 60s cadence is way below the heartbeat's 30s scale.
                 fleet::spawn_tree_publisher();
+                // Ξ_Worktree census (Phase 1) — periodic disk-footprint
+                // + junction-status + volume-free-space census of every
+                // on-disk git worktree, POSTed to
+                // `/agents/<device_id>/worktree-census`. coord can't see
+                // the operator's Windows disk; the runner is the only
+                // vantage point. Default 300s cadence (env override
+                // QONTINUI_WORKTREE_CENSUS_INTERVAL_SECS) — an order of
+                // magnitude slower than the heartbeat/tree-publisher
+                // because each tick stats real files under
+                // node_modules/target (junctions are skipped, so a
+                // junctioned 165GB target costs ~0).
+                agent_worktree::census::spawn_census();
+                // Ξ_Worktree reclaim (Phase 4) — periodically pull
+                // coord's pending per-device reclaim instructions and
+                // execute the INV-W4 safe path (unlink junctions FIRST,
+                // then remove the worktree; or recreate a drifted
+                // junction). coord ships dry_run=true by default (the
+                // poller only LOGS what it would do); the operator arms
+                // execution server-side via COORD_WORKTREE_RECLAIM_ENABLED.
+                // Default 300s cadence (env
+                // QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS). Same machine-
+                // wide, anonymous, device-keyed posture as the census.
+                agent_worktree::reclaim::spawn_reclaim();
                 // Phase 4 — coord-driven Claude Code subprocess runtime.
                 // Subscribes to `events.agent.spawn_requested.<device_id>`
                 // on coord WS and supervises the resulting `claude` CLI

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -30,7 +30,7 @@ use tracing::{info, warn};
 
 use crate::agent_worktree::{
     allocate_and_materialize_with_claim, coord_ws_to_http, worktree_mode_enabled, AllocateError,
-    RepoRequest,
+    MaterializeOutcome, RepoRequest,
 };
 use crate::mcp::types::{api_error, ApiResponse, ApiState};
 
@@ -146,7 +146,7 @@ pub async fn post_allocate_local(
     )
     .await
     {
-        Ok(result) => {
+        Ok(MaterializeOutcome::Worktrees(result)) => {
             info!(
                 "/agents/allocate-local ok: agent_id={} repos={}",
                 result.agent_id,
@@ -175,6 +175,7 @@ pub async fn post_allocate_local(
             // correctness.
             crate::agent_daemons::spawn_for_agent(&result, coord_http_base.clone(), machine_id);
             Ok(Json(ApiResponse::success(json!({
+                "isolation": "worktree",
                 "agent_id": result.agent_id,
                 "worktrees": result.worktrees.iter().map(|w| json!({
                     "repo": w.repo,
@@ -183,6 +184,51 @@ pub async fn post_allocate_local(
                     "worktree_path": w.worktree_path.to_string_lossy(),
                 })).collect::<Vec<_>>(),
                 "active_claim": result.active_claim,
+            }))))
+        }
+        // Phase 3 — coord chose a shared feature branch in the canonical
+        // checkout (no worktree). Register the claim heartbeat the same
+        // way; surface the per-repo branches + their checkout path.
+        Ok(MaterializeOutcome::SharedBranch(sb)) => {
+            info!(
+                "/agents/allocate-local ok (shared_branch): agent_id={} repos={}",
+                sb.agent_id,
+                sb.branches.len()
+            );
+            if let Some(claim) = &sb.active_claim {
+                crate::agent_claims::register_active_claim(
+                    &sb.agent_id,
+                    coord_http_base.clone(),
+                    machine_id,
+                    claim,
+                );
+            }
+            Ok(Json(ApiResponse::success(json!({
+                "isolation": "shared_branch",
+                "agent_id": sb.agent_id,
+                "branches": sb.branches.iter().map(|b| json!({
+                    "repo": b.repo,
+                    "branch": b.branch,
+                    "parent_sha": b.parent_sha,
+                    "checkout_path": b.checkout_path.to_string_lossy(),
+                })).collect::<Vec<_>>(),
+                "active_claim": sb.active_claim,
+            }))))
+        }
+        // Phase 3 — coord declined to materialize (a held upstream
+        // resource). Surface the wait reason so the caller logs/retries;
+        // nothing was created on disk and the claim was released.
+        Ok(MaterializeOutcome::Wait(w)) => {
+            info!(
+                "/agents/allocate-local wait: agent_id={} reason={:?} blocking={:?} retry_when={:?}",
+                w.agent_id, w.reason, w.blocking, w.retry_when
+            );
+            Ok(Json(ApiResponse::success(json!({
+                "isolation": "wait",
+                "agent_id": w.agent_id,
+                "reason": w.reason,
+                "blocking": w.blocking,
+                "retry_when": w.retry_when,
             }))))
         }
         Err(AllocateError::ClaimConflict(conflict)) => {


### PR DESCRIPTION
Runner side of the **Ξ_Worktree** observer (coord PR: qontinui/qontinui-coord; schema: qontinui/qontinui-web#392).

- **Census collector** (`agent_worktree/census.rs`): machine-wide, enumerates worktrees three ways (git porcelain + sibling `-wt-*` + `.claude/worktrees`), junction-aware sizing (skips reparse points so a 165 GB junctioned `target` costs ~0), per-volume free space via `sysinfo`; POSTs to `coord /coord/worktree-census/:device_id` every ~300s (anonymous, device-keyed — mirrors the tree-publisher).
- **Honor the allocate `isolation` directive** (`agent_worktree/mod.rs`): replaces the unconditional `git worktree add` with a typed `MaterializeOutcome` switch — junctioned / dedicated-target / shared-branch-in-canonical / wait. Back-compat: absent field → junctioned.
- **Reclaim executor** (`agent_worktree/reclaim.rs`): pulls `GET /coord/worktree-reclaim/:device_id`; the **INV-W4 safe path** unlinks junctions *before* any recursive delete (guards the field incident where `rm -rf` followed a junction into main); dry-run by default, never touches a dirty worktree.

Local: `cargo check` + `cargo clippy -- -D warnings` clean (windows CI is the authoritative gate). Compiles independently of #392.