### PR TITLE
feat(twin): resolved-import Ξ_AST + diff-impact predict-effect tool

### DIFF
--- a/src-tauri/src/mcp/code_semantics/CONTRACT.md
+++ b/src-tauri/src/mcp/code_semantics/CONTRACT.md
@@ -110,8 +110,13 @@ a scope registry (map scope → helper child).
   completion is Phase 3).
 - `credibility` is the triple from the theory (Phase 1): definitional/structural code
   queries are `(high,high,high)` — the LSP crosses the compiler boundary and is
-  authorially independent. The `code_graph_fallback` provenance lowers the *boundary*
-  axis to `medium` (syntactic, no resolution) and `coverage<1`.
+  authorially independent. The three `Ξ_AST`/`Ξ_Type` tiers form a clean 3-rung
+  *boundary* ladder: the syntactic `code_graph_fallback` provenance (raw, no import
+  resolution) is boundary **`low`** and `coverage<1`; the resolved-import
+  `code_graph_resolved` provenance (deterministic file binding, not the compiler's
+  resolver) is boundary **`medium`**; the LSP `ts-language-service` is boundary
+  **`high`**. Reserving `medium` for the resolved tier keeps the low/medium/high
+  triple unambiguously orderable across all three observers.
 
 ---
 

--- a/src-tauri/src/mcp/code_semantics/code_graph_api.rs
+++ b/src-tauri/src/mcp/code_semantics/code_graph_api.rs
@@ -1,0 +1,793 @@
+//! Graph-level diff blast-radius `predict-effect` surface — the `Ξ_AST` sibling
+//! of the LSP `Ξ_Type` sidecar (Pillar 2 of the twin-ast plan).
+//!
+//! Two HTTP routes, co-located with the code-semantics sidecar (same axum router,
+//! same `$QONTINUI_LSP_SIDECAR_URL` host process). Both return the **uniform
+//! observation envelope** (CONTRACT §C) via [`super::Envelope::resolved`]:
+//!
+//! - `POST /code-graph/diff-impact` — given `{scope?, changed_files}` **or**
+//!   `{scope?, diff_patch}`, build the resolved `Ξ_AST` graph for the scope's
+//!   project, compute the [`BlastRadius`], and additionally surface
+//!   `removed_exports_referenced` (exports of changed files that are still
+//!   referenced by a *resolved* import edge elsewhere). A non-empty
+//!   `removed_exports_referenced` maps to `outcome_signal:"Contradiction"`
+//!   (the §D active-negation signal); otherwise `Confirmed`/`Partial` per coverage.
+//! - `POST /code-graph/resolve-import` — `{scope?, from_file, specifier}` →
+//!   `{resolved_target, resolution}` via the Phase 1 [`ImportResolver::resolve`]
+//!   single-specifier path (debug/introspection; no per-language logic duplicated).
+//!
+//! **Scope** reuses the sidecar's `(repo, language)` model: [`scope::resolve_scope`]
+//! → [`super::scope_project_dir`] gives the project root, exactly as
+//! `/code-semantics/symbol-lookup` resolves it. v1 = single default scope (a
+//! degenerate case of the registry), no second scope abstraction.
+//!
+//! **Coverage honesty (CONTRACT §B/D4):** the resolved graph's coverage is the
+//! fraction of *internal-looking* edges that bound to a file — an `Unresolved`
+//! edge lowers coverage below 1. A cold/empty graph yields `coverage<1`, so the
+//! tool never emits a false "no impact" on a partial graph.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::{extract::State, routing::post, Json, Router};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::scope::{self, Scope};
+use super::{scope_project_dir, Envelope};
+use crate::mcp::types::ApiState;
+use crate::workflow_generation::code_graph::{BlastRadius, CodeGraph, ResolutionKind};
+use crate::workflow_generation::import_resolver::ImportResolver;
+
+// ===========================================================================
+// Request bodies (plan §3.1)
+// ===========================================================================
+
+#[derive(Debug, Deserialize, Default)]
+pub struct DiffImpactReq {
+    /// Optional `(repo,language)` scope selector (project dir or tsconfig path).
+    pub scope: Option<String>,
+    /// Repo-relative changed file paths. Mutually inclusive with `diff_patch`
+    /// (paths parsed from the patch are merged in).
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    /// A unified diff; changed file paths (and removed exports) are parsed from it.
+    pub diff_patch: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveImportReq {
+    pub scope: Option<String>,
+    pub from_file: String,
+    pub specifier: String,
+}
+
+// ===========================================================================
+// Routes
+// ===========================================================================
+
+/// Routes contributed alongside the `/code-semantics/*` surface (merged from the
+/// same `code_semantics::routes()` in `mcp_api.rs`).
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new()
+        .route("/code-graph/diff-impact", post(diff_impact))
+        .route("/code-graph/resolve-import", post(resolve_import))
+}
+
+/// POST /code-graph/diff-impact → uniform envelope wrapping `BlastRadius` +
+/// `removed_exports_referenced` + `outcome_signal`.
+async fn diff_impact(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<DiffImpactReq>,
+) -> Json<Envelope> {
+    let q = "diff_impact";
+
+    // Resolve the scope → project dir, reusing the sidecar's scope model.
+    let scope = match resolve_project_scope(req.scope.as_deref(), req.changed_files.first()) {
+        Some(s) => s,
+        None => {
+            // No resolvable scope at all → honest cold envelope (coverage 0),
+            // never a "no impact" assertion.
+            return Json(Envelope::resolved(
+                q,
+                json!({
+                    "blast_radius": empty_blast_value(),
+                    "removed_exports_referenced": [],
+                    "outcome_signal": "Partial",
+                    "reason": "no resolvable scope (cold)",
+                }),
+                0.0,
+            ));
+        }
+    };
+    let project_dir = scope_project_dir(&scope);
+
+    // Merge explicitly-listed changed files with paths parsed out of the patch.
+    let removed_from_patch = req
+        .diff_patch
+        .as_deref()
+        .map(parse_removed_exports_from_patch)
+        .unwrap_or_default();
+    let mut changed: Vec<String> = req.changed_files.clone();
+    if let Some(patch) = req.diff_patch.as_deref() {
+        for f in parse_changed_files_from_patch(patch) {
+            if !changed.contains(&f) {
+                changed.push(f);
+            }
+        }
+    }
+
+    // Build the resolved graph (CPU-bound parse) off the async runtime.
+    let dir = project_dir.clone();
+    let graph = tokio::task::spawn_blocking(move || CodeGraph::build(&dir))
+        .await
+        .unwrap_or_else(|_| empty_graph());
+
+    let coverage = graph_coverage(&graph);
+    let br = graph.blast_radius(&changed);
+
+    // Whether the patch named specific removed exports; if it didn't (or only
+    // `changed_files` was given), treat ALL exports of changed files as at-risk.
+    let removed = compute_removed_exports_referenced(&graph, &changed, &removed_from_patch);
+
+    // Outcome signal (CONTRACT §D): a removed export still referenced elsewhere is
+    // the repo-level Contradiction. Otherwise Confirmed (full coverage) / Partial.
+    let outcome_signal = if !removed.is_empty() {
+        "Contradiction"
+    } else if coverage >= 1.0 {
+        "Confirmed"
+    } else {
+        "Partial"
+    };
+
+    let result = json!({
+        "scope": scope.key,
+        "changed_files": changed,
+        "blast_radius": blast_to_value(&br),
+        "removed_exports_referenced": removed,
+        "outcome_signal": outcome_signal,
+        // Document the at-risk-export policy used (per plan §3.1).
+        "removed_exports_policy": if removed_from_patch.is_some() {
+            "patch_removed_exports"
+        } else {
+            "all_changed_file_exports_at_risk"
+        },
+    });
+
+    Json(Envelope::resolved(q, result, coverage))
+}
+
+/// POST /code-graph/resolve-import → `{resolved_target, resolution}` via the
+/// Phase 1 single-specifier `ImportResolver::resolve` (no rule duplication).
+async fn resolve_import(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<ResolveImportReq>,
+) -> Json<Envelope> {
+    let q = "resolve_import";
+
+    let scope = match resolve_project_scope(req.scope.as_deref(), Some(&req.from_file)) {
+        Some(s) => s,
+        None => {
+            return Json(Envelope::resolved(
+                q,
+                json!({ "resolved_target": Value::Null, "resolution": "unresolved",
+                        "reason": "no resolvable scope (cold)" }),
+                0.0,
+            ));
+        }
+    };
+    let project_dir = scope_project_dir(&scope);
+
+    let from_file = req.from_file.clone();
+    let specifier = req.specifier.clone();
+    let dir = project_dir.clone();
+    let (resolution, coverage) = tokio::task::spawn_blocking(move || {
+        let graph = CodeGraph::build(&dir);
+        let cov = graph_coverage(&graph);
+        let resolver = ImportResolver::new(&graph, &dir);
+        let lang = language_of(&graph, &from_file);
+        (resolver.resolve(&from_file, &specifier, &lang), cov)
+    })
+    .await
+    .unwrap_or((
+        crate::workflow_generation::import_resolver::Resolution {
+            resolved_target: None,
+            resolution: ResolutionKind::Unresolved,
+        },
+        0.0,
+    ));
+
+    let result = json!({
+        "scope": scope.key,
+        "from_file": req.from_file,
+        "specifier": req.specifier,
+        "resolved_target": resolution.resolved_target,
+        "resolution": resolution_str(resolution.resolution),
+    });
+    Json(Envelope::resolved(q, result, coverage))
+}
+
+// ===========================================================================
+// removed_exports_referenced + coverage
+// ===========================================================================
+
+/// Compute `removed_exports_referenced`: for each export of a changed file that
+/// DISAPPEARS, the resolved reference edges (an `ImportEdge` whose
+/// `resolved_target` points at the changed file AND whose `imported_names`
+/// include the export) from *other* files. A non-empty result is the
+/// Contradiction signal (a removed export still referenced elsewhere).
+///
+/// `removed_from_patch`: if `Some`, the explicit set of `(file, export_name)`
+/// the patch removes — only those are considered. If `None` (only `changed_files`
+/// given, no patch), ALL exports of changed files are treated as at-risk (the
+/// conservative policy documented in plan §3.1).
+fn compute_removed_exports_referenced(
+    graph: &CodeGraph,
+    changed_files: &[String],
+    removed_from_patch: &Option<Vec<RemovedExport>>,
+) -> Vec<Value> {
+    use std::collections::HashSet;
+    let changed_set: HashSet<&str> = changed_files.iter().map(|s| s.as_str()).collect();
+
+    // Candidate (file, export_name) pairs that are "removed / at-risk".
+    let candidates: Vec<(String, String)> = match removed_from_patch {
+        Some(removed) if !removed.is_empty() => removed
+            .iter()
+            .filter(|r| changed_set.contains(r.file.as_str()))
+            .map(|r| (r.file.clone(), r.name.clone()))
+            .collect(),
+        // No explicit patch removals → every export of a changed file is at-risk.
+        _ => graph
+            .exports
+            .iter()
+            .filter(|e| changed_set.contains(e.file_path.as_str()))
+            .map(|e| (e.file_path.clone(), e.name.clone()))
+            .collect(),
+    };
+
+    let mut out = Vec::new();
+    for (file, name) in candidates {
+        // Resolved reference edges: another file whose resolved_target is the
+        // changed file and that imports this exact name.
+        let referenced_by: Vec<Value> = graph
+            .imports
+            .iter()
+            .filter(|imp| {
+                imp.from_file != file
+                    && imp.resolved_target.as_deref() == Some(file.as_str())
+                    && imp.imported_names.iter().any(|n| n == &name)
+            })
+            .map(|imp| json!({ "file": imp.from_file, "line": imp.line }))
+            .collect();
+
+        if !referenced_by.is_empty() {
+            out.push(json!({
+                "name": name,
+                "file": file,
+                "referenced_by": referenced_by,
+            }));
+        }
+    }
+    out
+}
+
+/// Coverage = fraction of *internal-looking* import edges the resolver bound to a
+/// file. `External` edges are excluded (a third-party specifier is honestly
+/// external, not a coverage hole); `Unresolved` edges lower coverage. An empty /
+/// cold graph (no files) → coverage 0 so the tool never asserts a false "no
+/// impact" on a partial graph.
+fn graph_coverage(graph: &CodeGraph) -> f64 {
+    if graph.files.is_empty() {
+        return 0.0;
+    }
+    let internal: Vec<&ResolutionKind> = graph
+        .imports
+        .iter()
+        .map(|i| &i.resolution)
+        .filter(|k| !matches!(k, ResolutionKind::External))
+        .collect();
+    if internal.is_empty() {
+        // No internal edges to resolve — the graph is fully "covered" for the
+        // purpose of dependency fan-out (warm, files present).
+        return 1.0;
+    }
+    let bound = internal
+        .iter()
+        .filter(|k| !matches!(k, ResolutionKind::Unresolved))
+        .count();
+    bound as f64 / internal.len() as f64
+}
+
+// ===========================================================================
+// Unified-diff parsing
+// ===========================================================================
+
+/// Parse the set of changed file paths out of a unified diff. Recognizes
+/// `diff --git a/<path> b/<path>`, `+++ b/<path>`, and `--- a/<path>` headers;
+/// strips the `a/`/`b/` prefix and normalizes slashes.
+pub fn parse_changed_files_from_patch(patch: &str) -> Vec<String> {
+    let mut files: Vec<String> = Vec::new();
+    let mut push = |p: String| {
+        if !p.is_empty() && p != "/dev/null" && !files.contains(&p) {
+            files.push(p);
+        }
+    };
+    for line in patch.lines() {
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            push(strip_diff_prefix(rest.trim()));
+        } else if let Some(rest) = line.strip_prefix("--- ") {
+            push(strip_diff_prefix(rest.trim()));
+        } else if let Some(rest) = line.strip_prefix("diff --git ") {
+            // `a/foo b/foo`
+            for tok in rest.split_whitespace() {
+                push(strip_diff_prefix(tok));
+            }
+        }
+    }
+    files
+}
+
+/// A `(file, export_name)` the patch removes (a deleted `export` line).
+#[derive(Debug, Clone)]
+pub struct RemovedExport {
+    pub file: String,
+    pub name: String,
+}
+
+/// Parse removed exports from a unified diff: a `-` line (removal) that declares
+/// an export. Tracks the current file via the `+++ b/<path>` header. Recognizes
+/// TS (`export function|class|const|let|var|interface|type|enum NAME`), Python
+/// (`def NAME` / `class NAME`), and Rust (`pub fn|struct|enum|trait|const NAME`).
+/// Returns `None` if the patch contains no removed-export lines (so the caller
+/// falls back to the all-exports-at-risk policy).
+pub fn parse_removed_exports_from_patch(patch: &str) -> Option<Vec<RemovedExport>> {
+    let mut current_file: Option<String> = None;
+    let mut removed: Vec<RemovedExport> = Vec::new();
+
+    for line in patch.lines() {
+        if let Some(rest) = line.strip_prefix("+++ ") {
+            let f = strip_diff_prefix(rest.trim());
+            if f != "/dev/null" && !f.is_empty() {
+                current_file = Some(f);
+            }
+            continue;
+        }
+        // A removed line (single leading '-', not the '--- ' header).
+        if let Some(body) = line.strip_prefix('-') {
+            if body.starts_with("-- ") || line.starts_with("--- ") {
+                continue;
+            }
+            if let Some(file) = &current_file {
+                if let Some(name) = export_name_in_line(body) {
+                    removed.push(RemovedExport {
+                        file: file.clone(),
+                        name,
+                    });
+                }
+            }
+        }
+    }
+
+    if removed.is_empty() {
+        None
+    } else {
+        Some(removed)
+    }
+}
+
+/// Extract an exported/declared symbol name from a single source line, across
+/// TS/Python/Rust declaration forms. Returns the identifier, or `None`.
+fn export_name_in_line(line: &str) -> Option<String> {
+    let t = line.trim_start();
+    // TS: export [default] [async] function|class|const|let|var|interface|type|enum NAME
+    if let Some(rest) = t.strip_prefix("export ") {
+        let rest = rest
+            .trim_start_matches("default ")
+            .trim_start_matches("async ");
+        for kw in [
+            "function ",
+            "class ",
+            "const ",
+            "let ",
+            "var ",
+            "interface ",
+            "type ",
+            "enum ",
+        ] {
+            if let Some(after) = rest.strip_prefix(kw) {
+                return ident(after);
+            }
+        }
+    }
+    // Python: top-level `def NAME` / `class NAME` (module-public).
+    for kw in ["def ", "class ", "async def "] {
+        if let Some(after) = t.strip_prefix(kw) {
+            return ident(after);
+        }
+    }
+    // Rust: pub fn|struct|enum|trait|const|static NAME
+    if let Some(rest) = t.strip_prefix("pub ") {
+        let rest = rest.trim_start_matches("(crate) ").trim_start();
+        for kw in [
+            "fn ", "struct ", "enum ", "trait ", "const ", "static ", "type ", "mod ",
+        ] {
+            if let Some(after) = rest.strip_prefix(kw) {
+                return ident(after);
+            }
+        }
+    }
+    None
+}
+
+/// First identifier token (`[A-Za-z_][A-Za-z0-9_]*`) at the start of `s`.
+fn ident(s: &str) -> Option<String> {
+    let s = s.trim_start();
+    let name: String = s
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() || name.chars().next().map(|c| c.is_numeric()).unwrap_or(true) {
+        None
+    } else {
+        Some(name)
+    }
+}
+
+/// Strip a `a/` or `b/` git-diff prefix and any trailing tab-metadata, normalize slashes.
+fn strip_diff_prefix(s: &str) -> String {
+    // Drop trailing "\t<timestamp>" metadata some diffs carry.
+    let s = s.split('\t').next().unwrap_or(s).trim();
+    let s = s
+        .strip_prefix("a/")
+        .or_else(|| s.strip_prefix("b/"))
+        .unwrap_or(s);
+    s.replace('\\', "/")
+}
+
+// ===========================================================================
+// Scope / helpers
+// ===========================================================================
+
+/// Resolve a scope to a project directory, reusing the sidecar's scope model.
+/// Order: explicit `scope` (project dir or tsconfig) → the first changed file's
+/// nearest enclosing tsconfig → the default scope. For a non-TS scope given an
+/// explicit project dir that has no tsconfig, fall back to treating that dir as
+/// the project root directly (the single default-scope degenerate case, Q7).
+fn resolve_project_scope(scope: Option<&str>, hint_file: Option<&String>) -> Option<Scope> {
+    if let Some(s) = scope::resolve_scope(scope, hint_file.map(|f| f.as_str())) {
+        return Some(s);
+    }
+    // No tsconfig anywhere — if an explicit scope dir was given and exists, use it
+    // as a raw project root (language-agnostic; CodeGraph::build walks any of TS/Py/Rust).
+    if let Some(s) = scope {
+        let p = Path::new(s);
+        if p.is_dir() {
+            return Some(raw_dir_scope(p));
+        }
+    }
+    None
+}
+
+/// A degenerate scope whose `project` descriptor is a raw directory (no tsconfig).
+/// `scope_project_dir` takes the parent of `project`, so we append a synthetic
+/// `tsconfig.json` segment to make the parent equal the real dir.
+fn raw_dir_scope(dir: &Path) -> Scope {
+    let project = scope::normalize(&dir.join("tsconfig.json"));
+    Scope {
+        key: scope::normalize(dir),
+        language: "mixed".to_string(),
+        project,
+    }
+}
+
+/// The language string for `from_file`, taken from the graph (or inferred from
+/// the extension), so `ImportResolver::resolve` dispatches the right rules.
+fn language_of(graph: &CodeGraph, from_file: &str) -> String {
+    if let Some(f) = graph.files.iter().find(|f| f.path == from_file) {
+        return f.language.clone();
+    }
+    match from_file.rsplit('.').next().unwrap_or("") {
+        "ts" | "tsx" => "typescript",
+        "js" | "jsx" | "mjs" | "cjs" => "javascript",
+        "py" => "python",
+        "rs" => "rust",
+        _ => "",
+    }
+    .to_string()
+}
+
+fn resolution_str(k: ResolutionKind) -> &'static str {
+    match k {
+        ResolutionKind::Relative => "relative",
+        ResolutionKind::TsconfigPath => "tsconfig_path",
+        ResolutionKind::PackageIndex => "package_index",
+        ResolutionKind::PythonModule => "python_module",
+        ResolutionKind::RustMod => "rust_mod",
+        ResolutionKind::External => "external",
+        ResolutionKind::Unresolved => "unresolved",
+    }
+}
+
+fn blast_to_value(br: &BlastRadius) -> Value {
+    json!({
+        "directly_affected": br.directly_affected,
+        "transitively_affected": br.transitively_affected,
+        "affected_exports": br.affected_exports,
+        "risk_level": format!("{:?}", br.risk_level).to_lowercase(),
+        "total_impact_count": br.total_impact_count,
+    })
+}
+
+fn empty_blast_value() -> Value {
+    json!({
+        "directly_affected": [],
+        "transitively_affected": [],
+        "affected_exports": [],
+        "risk_level": "low",
+        "total_impact_count": 0,
+    })
+}
+
+fn empty_graph() -> CodeGraph {
+    CodeGraph {
+        files: vec![],
+        functions: vec![],
+        classes: vec![],
+        imports: vec![],
+        exports: vec![],
+        build_duration_ms: 0,
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow_generation::code_graph::{ExportNode, FileNode, ImportEdge};
+
+    fn file(path: &str, lang: &str) -> FileNode {
+        FileNode {
+            path: path.into(),
+            language: lang.into(),
+            line_count: 10,
+        }
+    }
+
+    fn export(name: &str, file: &str) -> ExportNode {
+        ExportNode {
+            name: name.into(),
+            file_path: file.into(),
+            kind: "function".into(),
+            line: 1,
+        }
+    }
+
+    fn import(from: &str, target: &str, names: &[&str], kind: ResolutionKind) -> ImportEdge {
+        ImportEdge {
+            from_file: from.into(),
+            to_module: "./x".into(),
+            imported_names: names.iter().map(|s| s.to_string()).collect(),
+            line: 3,
+            resolved_target: Some(target.into()),
+            resolution: kind,
+        }
+    }
+
+    /// (a) A diff deleting an exported symbol still imported elsewhere yields a
+    /// non-empty `removed_exports_referenced` with the `referenced_by` list —
+    /// the Contradiction signal.
+    #[test]
+    fn removed_export_still_referenced_is_contradiction() {
+        let graph = CodeGraph {
+            files: vec![
+                file("src/auth.ts", "typescript"),
+                file("src/api.ts", "typescript"),
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![import(
+                "src/api.ts",
+                "src/auth.ts",
+                &["authenticate"],
+                ResolutionKind::Relative,
+            )],
+            exports: vec![export("authenticate", "src/auth.ts")],
+            build_duration_ms: 0,
+        };
+        // Patch removes `export function authenticate` from src/auth.ts.
+        let patch = "+++ b/src/auth.ts\n-export function authenticate() {}\n";
+        let removed_from_patch = parse_removed_exports_from_patch(patch);
+        assert!(removed_from_patch.is_some());
+
+        let removed = compute_removed_exports_referenced(
+            &graph,
+            &["src/auth.ts".to_string()],
+            &removed_from_patch,
+        );
+        assert_eq!(removed.len(), 1, "the removed export is still referenced");
+        let entry = &removed[0];
+        assert_eq!(entry["name"], json!("authenticate"));
+        assert_eq!(entry["file"], json!("src/auth.ts"));
+        let refs = entry["referenced_by"].as_array().unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0]["file"], json!("src/api.ts"));
+        assert_eq!(refs[0]["line"], json!(3));
+
+        // outcome_signal computed from a non-empty removed set is Contradiction.
+        assert!(!removed.is_empty());
+    }
+
+    /// A removed export that is NOT referenced anywhere → empty (no contradiction).
+    #[test]
+    fn removed_export_not_referenced_is_clear() {
+        let graph = CodeGraph {
+            files: vec![file("src/auth.ts", "typescript")],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![],
+            exports: vec![export("authenticate", "src/auth.ts")],
+            build_duration_ms: 0,
+        };
+        let removed =
+            compute_removed_exports_referenced(&graph, &["src/auth.ts".to_string()], &None);
+        assert!(removed.is_empty());
+    }
+
+    /// (b) A cold / partial graph yields coverage < 1 (never a false "no impact").
+    #[test]
+    fn cold_graph_coverage_below_one() {
+        assert_eq!(graph_coverage(&empty_graph()), 0.0);
+
+        // A graph with one Unresolved internal edge → coverage 0.5.
+        let graph = CodeGraph {
+            files: vec![
+                file("src/a.ts", "typescript"),
+                file("src/b.ts", "typescript"),
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![
+                import("src/a.ts", "src/b.ts", &["x"], ResolutionKind::Relative),
+                ImportEdge {
+                    from_file: "src/a.ts".into(),
+                    to_module: "./missing".into(),
+                    imported_names: vec!["y".into()],
+                    line: 2,
+                    resolved_target: None,
+                    resolution: ResolutionKind::Unresolved,
+                },
+            ],
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+        let cov = graph_coverage(&graph);
+        assert!(cov < 1.0, "an unresolved internal edge must lower coverage");
+        assert!((cov - 0.5).abs() < 1e-9, "1 of 2 internal edges bound");
+    }
+
+    /// External-only edges don't count as coverage holes.
+    #[test]
+    fn external_edges_do_not_lower_coverage() {
+        let graph = CodeGraph {
+            files: vec![file("src/a.ts", "typescript")],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![ImportEdge {
+                from_file: "src/a.ts".into(),
+                to_module: "react".into(),
+                imported_names: vec!["useState".into()],
+                line: 1,
+                resolved_target: None,
+                resolution: ResolutionKind::External,
+            }],
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+        assert_eq!(graph_coverage(&graph), 1.0);
+    }
+
+    #[test]
+    fn parse_changed_files_from_unified_diff() {
+        let patch = "\
+diff --git a/src/auth.ts b/src/auth.ts
+index 111..222 100644
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -1,3 +1,2 @@
+-export function authenticate() {}
+diff --git a/src/new.ts b/src/new.ts
+new file mode 100644
+--- /dev/null
++++ b/src/new.ts
+";
+        let files = parse_changed_files_from_patch(patch);
+        assert!(files.contains(&"src/auth.ts".to_string()));
+        assert!(files.contains(&"src/new.ts".to_string()));
+        assert!(!files.contains(&"/dev/null".to_string()));
+    }
+
+    #[test]
+    fn parse_removed_exports_across_languages() {
+        let patch = "\
++++ b/src/a.ts
+-export function fooTs() {}
++++ b/pkg/b.py
+-def foo_py():
++++ b/src/c.rs
+-pub fn foo_rs() {}
+";
+        let removed = parse_removed_exports_from_patch(patch).unwrap();
+        let names: Vec<&str> = removed.iter().map(|r| r.name.as_str()).collect();
+        assert!(names.contains(&"fooTs"));
+        assert!(names.contains(&"foo_py"));
+        assert!(names.contains(&"foo_rs"));
+        // file attribution follows the +++ header.
+        assert_eq!(
+            removed.iter().find(|r| r.name == "foo_py").unwrap().file,
+            "pkg/b.py"
+        );
+    }
+
+    /// (c) resolve-import returns the right `resolved_target`/`resolution` for a
+    /// relative, an alias, and an external specifier (exercises the Phase 1
+    /// single-specifier path the route reuses).
+    #[test]
+    fn resolve_import_relative_alias_external() {
+        // relative
+        let g = CodeGraph {
+            files: vec![
+                file("src/routes.ts", "typescript"),
+                file("src/auth.ts", "typescript"),
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![],
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let rel = r.resolve("src/routes.ts", "./auth", "typescript");
+        assert_eq!(rel.resolved_target.as_deref(), Some("src/auth.ts"));
+        assert_eq!(resolution_str(rel.resolution), "relative");
+
+        // external
+        let ext = r.resolve("src/routes.ts", "react", "typescript");
+        assert_eq!(ext.resolved_target, None);
+        assert_eq!(resolution_str(ext.resolution), "external");
+
+        // alias (needs a real tsconfig on disk)
+        let tmp = std::env::temp_dir().join(format!("twinast-cgapi-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(tmp.join("src/lib"));
+        std::fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        )
+        .unwrap();
+        let g2 = CodeGraph {
+            files: vec![
+                file("src/app.ts", "typescript"),
+                file("src/lib/utils.ts", "typescript"),
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![],
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+        let r2 = ImportResolver::new(&g2, &tmp);
+        let alias = r2.resolve("src/app.ts", "@/lib/utils", "typescript");
+        assert_eq!(alias.resolved_target.as_deref(), Some("src/lib/utils.ts"));
+        assert_eq!(resolution_str(alias.resolution), "tsconfig_path");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn raw_dir_scope_parents_to_real_dir() {
+        let s = raw_dir_scope(Path::new("/some/project"));
+        let dir = scope_project_dir(&s);
+        assert_eq!(scope::normalize(&dir), "/some/project");
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/mod.rs
+++ b/src-tauri/src/mcp/code_semantics/mod.rs
@@ -25,6 +25,7 @@
 //! - Node/TS permanently unavailable → degrade (symbol-lookup → code_graph_fallback;
 //!   resolution → `engine_unavailable`, coverage 0). Never 500 on a missing engine.
 
+pub mod code_graph_api;
 pub mod node_bridge;
 pub mod scope;
 
@@ -77,6 +78,17 @@ impl Credibility {
         }
     }
 
+    /// Resolved-import `Ξ_AST` (deterministic file binding, not the compiler's
+    /// resolver). Boundary `medium` per the Phase 1 credibility ladder: above the
+    /// raw syntactic tier, below the LSP `Ξ_Type` tier.
+    pub fn resolved() -> Self {
+        Credibility {
+            causal: "high".into(),
+            authorial: "high".into(),
+            boundary: "medium".into(),
+        }
+    }
+
     /// Cold / unavailable — boundary unknown, lowered.
     pub fn degraded() -> Self {
         Credibility {
@@ -106,6 +118,8 @@ pub const PROV_LSP: &str = "ts-language-service";
 pub const PROV_FALLBACK: &str = "code_graph_fallback";
 pub const PROV_INDEXING: &str = "indexing";
 pub const PROV_UNAVAILABLE: &str = "engine_unavailable";
+/// Resolved-import `Ξ_AST` provenance (Phase 1/2): deterministic file binding.
+pub const PROV_RESOLVED: &str = "code_graph_resolved";
 
 impl Envelope {
     /// Warm, resolved answer: posterior=1, coverage=1, credibility=(high,high,high).
@@ -148,6 +162,26 @@ impl Envelope {
             coverage: 0.0,
             provenance: PROV_INDEXING.into(),
             credibility: Credibility::degraded(),
+            staleness_seconds: None,
+            kernel: false,
+        }
+    }
+
+    /// Resolved-import `Ξ_AST` answer (the diff-impact / resolve-import surface,
+    /// CONTRACT §C). `observer` is `"code_graph"` (distinct from the LSP
+    /// `code_semantics` observer); `provenance="code_graph_resolved"`, boundary
+    /// `medium`. `coverage` < 1 honestly when the graph still has `Unresolved`
+    /// edges (a partial/cold graph) — never asserts a false "no impact".
+    /// `posterior` tracks coverage (high for a fully-resolved graph).
+    pub fn resolved(query: &str, result: Value, coverage: f64) -> Self {
+        Envelope {
+            observer: "code_graph".into(),
+            query: query.into(),
+            result,
+            posterior: coverage,
+            coverage,
+            provenance: PROV_RESOLVED.into(),
+            credibility: Credibility::resolved(),
             staleness_seconds: None,
             kernel: false,
         }
@@ -343,7 +377,9 @@ pub struct TypecheckReq {
 // Routes (CONTRACT §B)
 // ===========================================================================
 
-/// Routes contributed to the runner's main router from `mcp_api.rs`.
+/// Routes contributed to the runner's main router from `mcp_api.rs`. Includes
+/// the LSP `Ξ_Type` `/code-semantics/*` surface and the resolved-import `Ξ_AST`
+/// `/code-graph/*` diff blast-radius surface (Pillar 2).
 pub fn routes() -> Router<Arc<ApiState>> {
     Router::new()
         .route("/code-semantics/health", get(health))
@@ -351,6 +387,7 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/code-semantics/signature", post(signature))
         .route("/code-semantics/find-references", post(find_references))
         .route("/code-semantics/typecheck", post(typecheck))
+        .merge(code_graph_api::routes())
 }
 
 /// GET /code-semantics/health — per CONTRACT §B.

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -110,6 +110,27 @@ pub fn get_api_images_dir() -> PathBuf {
     path
 }
 
+/// Get the code-graph cache directory (`<app_data>/qontinui-runner/code-graph`).
+///
+/// Persists the resolved `Ξ_AST` code graph keyed by repo hash, for
+/// fingerprint-incremental re-analysis. This is NOT under `dev-logs` — it is a
+/// derived analysis cache, rooted directly at the runner's app-data dir so it is
+/// independent of the dev-logs override and the per-instance scoping.
+pub fn get_code_graph_dir() -> PathBuf {
+    let base = dirs::data_local_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("qontinui-runner")
+        .join("code-graph");
+    ensure_dir_exists(&base);
+    base
+}
+
+/// Get the persisted code-graph JSON path for a given repo hash
+/// (`<app_data>/qontinui-runner/code-graph/<repo-hash>.json`).
+pub fn get_code_graph_path(repo_hash: &str) -> PathBuf {
+    get_code_graph_dir().join(format!("{}.json", repo_hash))
+}
+
 /// Get the workflow debug log path (`<dev_logs>/workflow-debug.log`).
 pub fn get_workflow_debug_log_path() -> PathBuf {
     get_dev_logs_dir().join("workflow-debug.log")

--- a/src-tauri/src/workflow_generation/code_graph.rs
+++ b/src-tauri/src/workflow_generation/code_graph.rs
@@ -59,6 +59,35 @@ pub struct ImportEdge {
     pub to_module: String,
     pub imported_names: Vec<String>,
     pub line: usize,
+    /// Repo-relative file path the specifier resolves to, or `None` if external/unresolved.
+    /// Same normalization as `FileNode.path` (forward slashes, project-prefix-stripped).
+    pub resolved_target: Option<String>,
+    /// How (or whether) `to_module` was bound to a file by the resolver pass.
+    pub resolution: ResolutionKind,
+}
+
+/// How an `ImportEdge`'s specifier was bound to a file by the deterministic resolver.
+///
+/// `External` is honest — a third-party/stdlib specifier with no in-repo target
+/// (not a failure). `Unresolved` flags an *internal-looking* specifier the resolver
+/// could not bind: a coverage hole to surface, never to hide.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolutionKind {
+    /// TS/JS relative specifier (`./`, `../`) resolved against the importing file's dir.
+    Relative,
+    /// TS/JS bare specifier resolved via tsconfig `paths`/`baseUrl` alias.
+    TsconfigPath,
+    /// TS/JS specifier resolved to a directory `index.*` entry.
+    PackageIndex,
+    /// Python dotted/relative module resolved to a `.py`/`__init__.py` file.
+    PythonModule,
+    /// Rust `mod`/`use` path resolved within the crate.
+    RustMod,
+    /// Third-party package / stdlib — honestly external, no in-repo target.
+    External,
+    /// Internal-looking specifier the resolver could not bind (a coverage hole).
+    Unresolved,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -181,6 +210,10 @@ impl CodeGraph {
             }
         }
 
+        // Resolve imports once over the fully-walked graph (the import map).
+        let resolver = super::import_resolver::ImportResolver::new(&graph, project_path);
+        resolver.resolve_graph(&mut graph);
+
         graph.build_duration_ms = start.elapsed().as_millis() as u64;
         info!(
             "CodeGraph built in {}ms: {} files, {} functions, {} classes, {} imports, {} exports",
@@ -196,6 +229,12 @@ impl CodeGraph {
     }
 
     /// Compute blast radius for a set of changed files.
+    ///
+    /// Uses the resolved import graph (`ImportEdge.resolved_target`) for exact
+    /// dependency lookups — no substring heuristics. An edge contributes to the
+    /// blast radius only when its `resolved_target` is exactly a file in the
+    /// affected set, so alias/index imports are caught and substring collisions
+    /// (e.g. `to_module:"user"` vs `user_settings.ts`) never produce false hits.
     pub fn blast_radius(&self, changed_files: &[String]) -> BlastRadius {
         let changed_set: std::collections::HashSet<&str> =
             changed_files.iter().map(|s| s.as_str()).collect();
@@ -208,21 +247,15 @@ impl CodeGraph {
             .map(|e| format!("{} ({})", e.name, e.file_path))
             .collect();
 
-        // Find files that import from changed files (1-hop)
+        // Find files that import from changed files (1-hop) via exact resolved targets.
         let directly_affected: Vec<String> = self
             .imports
             .iter()
             .filter(|imp| {
-                // Check if the import's target module resolves to any changed file
-                changed_files.iter().any(|cf| {
-                    let module = imp.to_module.replace('.', "/");
-                    cf.contains(&module)
-                        || module.contains(
-                            cf.trim_end_matches(".ts")
-                                .trim_end_matches(".py")
-                                .trim_end_matches(".rs"),
-                        )
-                })
+                imp.resolved_target
+                    .as_deref()
+                    .map(|t| changed_set.contains(t))
+                    .unwrap_or(false)
             })
             .map(|imp| imp.from_file.clone())
             .collect::<std::collections::HashSet<_>>()
@@ -230,22 +263,17 @@ impl CodeGraph {
             .filter(|f| !changed_set.contains(f.as_str()))
             .collect();
 
-        // Find files that import from directly affected files (2-hop)
+        // Find files that import from directly affected files (2-hop).
         let direct_set: std::collections::HashSet<&str> =
             directly_affected.iter().map(|s| s.as_str()).collect();
         let transitively_affected: Vec<String> = self
             .imports
             .iter()
             .filter(|imp| {
-                directly_affected.iter().any(|af| {
-                    let module = imp.to_module.replace('.', "/");
-                    af.contains(&module)
-                        || module.contains(
-                            af.trim_end_matches(".ts")
-                                .trim_end_matches(".py")
-                                .trim_end_matches(".rs"),
-                        )
-                })
+                imp.resolved_target
+                    .as_deref()
+                    .map(|t| direct_set.contains(t))
+                    .unwrap_or(false)
             })
             .map(|imp| imp.from_file.clone())
             .collect::<std::collections::HashSet<_>>()
@@ -726,6 +754,12 @@ impl CachedCodeGraph {
             }
         }
 
+        // Re-resolve imports over the updated graph. Resolution is in-memory and
+        // cheap; this reproduces the same resolved edges a full rebuild would
+        // produce (the parse count above is what's bounded to changed files).
+        let resolver = super::import_resolver::ImportResolver::new(&self.graph, &self.project_path);
+        resolver.resolve_graph(&mut self.graph);
+
         self.graph.build_duration_ms = start.elapsed().as_millis() as u64;
         self.built_at = SystemTime::now();
 
@@ -742,6 +776,310 @@ impl CachedCodeGraph {
             self.incremental_update();
         }
         &self.graph
+    }
+}
+
+// ============================================================================
+// Fingerprint-incremental persistence (resolved Ξ_AST, app-data local file)
+// ============================================================================
+
+/// Per-file content fingerprint used for incremental invalidation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FileFingerprint {
+    /// File size in bytes.
+    pub size: u64,
+    /// Modification time in seconds since the unix epoch (best-effort; 0 if unavailable).
+    pub mtime_secs: u64,
+    /// SHA-256 of the file contents (hex). The authoritative change signal —
+    /// mtime+size are a fast pre-check, the hash is the tie-breaker so a rebuild
+    /// reproduces the exact same graph regardless of clock skew.
+    pub hash: String,
+}
+
+/// The resolved code graph plus per-file fingerprints, persisted under app-data
+/// so a rebuild re-parses only changed files (UA's knowledge-graph.json pattern).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedCodeGraph {
+    /// Schema version, so a format change invalidates stale caches.
+    pub version: u32,
+    /// Absolute project path this graph was built for (sanity check on load).
+    pub project_path: String,
+    /// Repo-relative file path -> content fingerprint.
+    pub fingerprints: HashMap<String, FileFingerprint>,
+    /// The resolved graph.
+    pub graph: CodeGraph,
+    /// Count of files parsed on the most recent (incremental or full) build.
+    /// Diagnostic only — lets callers/tests assert incremental work.
+    pub last_parsed_count: usize,
+}
+
+const PERSISTED_GRAPH_VERSION: u32 = 1;
+
+/// Stable repo hash for the cache filename: SHA-256 of the normalized absolute path.
+pub fn repo_hash(project_path: &Path) -> String {
+    use sha2::{Digest, Sha256};
+    let normalized = project_path
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_lowercase();
+    let mut hasher = Sha256::new();
+    hasher.update(normalized.as_bytes());
+    let digest = hasher.finalize();
+    hex_encode(&digest)
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+fn fingerprint_content(content: &str, meta: Option<&std::fs::Metadata>) -> FileFingerprint {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let hash = hex_encode(&hasher.finalize());
+    let size = meta.map(|m| m.len()).unwrap_or(content.len() as u64);
+    let mtime_secs = meta
+        .and_then(|m| m.modified().ok())
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    FileFingerprint {
+        size,
+        mtime_secs,
+        hash,
+    }
+}
+
+impl PersistedCodeGraph {
+    /// Save this persisted graph to its app-data cache file (`<repo-hash>.json`).
+    pub fn save(&self, project_path: &Path) -> std::io::Result<()> {
+        let path = crate::paths::get_code_graph_path(&repo_hash(project_path));
+        let json = serde_json::to_string(self).map_err(std::io::Error::other)?;
+        std::fs::write(path, json)
+    }
+
+    /// Load a persisted graph from its app-data cache file, if present and valid
+    /// for this project path + schema version.
+    pub fn load(project_path: &Path) -> Option<PersistedCodeGraph> {
+        let path = crate::paths::get_code_graph_path(&repo_hash(project_path));
+        let json = std::fs::read_to_string(path).ok()?;
+        let persisted: PersistedCodeGraph = serde_json::from_str(&json).ok()?;
+        if persisted.version != PERSISTED_GRAPH_VERSION {
+            return None;
+        }
+        Some(persisted)
+    }
+}
+
+impl CodeGraph {
+    /// Build the resolved code graph using the persisted app-data cache for
+    /// fingerprint-incremental re-analysis: only files whose content fingerprint
+    /// changed (or new files) are re-parsed; deleted files are dropped; imports
+    /// are then re-resolved over the whole graph. The result is identical to a
+    /// full [`CodeGraph::build`].
+    ///
+    /// Returns the resolved graph and the number of files parsed this run
+    /// (0 if nothing changed since the last persisted build).
+    pub fn build_incremental(project_path: &Path) -> (CodeGraph, usize) {
+        let start = std::time::Instant::now();
+        let skip_dirs = [
+            "node_modules",
+            "target",
+            ".git",
+            "dist",
+            "build",
+            "__pycache__",
+            ".venv",
+            "venv",
+            ".next",
+            ".turbo",
+            "coverage",
+            ".worktrees",
+        ];
+
+        let source_files = collect_source_files(project_path, &skip_dirs);
+
+        // Build current relative-path -> (full path, content, fingerprint) map.
+        let mut current: HashMap<String, (PathBuf, String, FileFingerprint)> = HashMap::new();
+        for file_path in &source_files {
+            let rel_path = file_path
+                .strip_prefix(project_path)
+                .unwrap_or(file_path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            let ext = file_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if !matches!(ext, "ts" | "tsx" | "js" | "jsx" | "py" | "rs") {
+                continue;
+            }
+            let content = match std::fs::read_to_string(file_path) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let meta = std::fs::metadata(file_path).ok();
+            let fp = fingerprint_content(&content, meta.as_ref());
+            current.insert(rel_path, (file_path.clone(), content, fp));
+        }
+
+        // Load the previous persisted graph (if any & valid).
+        let prev = PersistedCodeGraph::load(project_path);
+
+        let (mut graph, mut fingerprints, to_parse): (
+            CodeGraph,
+            HashMap<String, FileFingerprint>,
+            Vec<String>,
+        ) = match prev {
+            Some(p) if p.project_path == project_path.to_string_lossy() => {
+                let mut graph = p.graph;
+                let mut fingerprints = p.fingerprints;
+
+                // Drop data for deleted files.
+                let deleted: Vec<String> = fingerprints
+                    .keys()
+                    .filter(|k| !current.contains_key(*k))
+                    .cloned()
+                    .collect();
+                if !deleted.is_empty() {
+                    let del_set: std::collections::HashSet<&str> =
+                        deleted.iter().map(|s| s.as_str()).collect();
+                    graph.files.retain(|f| !del_set.contains(f.path.as_str()));
+                    graph
+                        .functions
+                        .retain(|f| !del_set.contains(f.file_path.as_str()));
+                    graph
+                        .classes
+                        .retain(|c| !del_set.contains(c.file_path.as_str()));
+                    graph
+                        .imports
+                        .retain(|i| !del_set.contains(i.from_file.as_str()));
+                    graph
+                        .exports
+                        .retain(|e| !del_set.contains(e.file_path.as_str()));
+                    for d in &deleted {
+                        fingerprints.remove(d);
+                    }
+                }
+
+                // Changed + new files (fingerprint differs).
+                let to_parse: Vec<String> = current
+                    .iter()
+                    .filter(|(rel, (_, _, fp))| {
+                        fingerprints.get(*rel).map(|old| old != fp).unwrap_or(true)
+                    })
+                    .map(|(rel, _)| rel.clone())
+                    .collect();
+
+                // Remove stale per-file data for changed files before re-parsing.
+                let change_set: std::collections::HashSet<&str> =
+                    to_parse.iter().map(|s| s.as_str()).collect();
+                graph
+                    .files
+                    .retain(|f| !change_set.contains(f.path.as_str()));
+                graph
+                    .functions
+                    .retain(|f| !change_set.contains(f.file_path.as_str()));
+                graph
+                    .classes
+                    .retain(|c| !change_set.contains(c.file_path.as_str()));
+                graph
+                    .imports
+                    .retain(|i| !change_set.contains(i.from_file.as_str()));
+                graph
+                    .exports
+                    .retain(|e| !change_set.contains(e.file_path.as_str()));
+
+                (graph, fingerprints, to_parse)
+            }
+            _ => {
+                // No valid cache — full build (parse everything).
+                let graph = CodeGraph {
+                    files: Vec::new(),
+                    functions: Vec::new(),
+                    classes: Vec::new(),
+                    imports: Vec::new(),
+                    exports: Vec::new(),
+                    build_duration_ms: 0,
+                };
+                let to_parse: Vec<String> = current.keys().cloned().collect();
+                (graph, HashMap::new(), to_parse)
+            }
+        };
+
+        // Parse only the changed/new files.
+        let parsed_count = to_parse.len();
+        for rel_path in &to_parse {
+            if let Some((full_path, content, fp)) = current.get(rel_path) {
+                parse_file_into(&mut graph, rel_path, full_path, content);
+                fingerprints.insert(rel_path.clone(), fp.clone());
+            }
+        }
+
+        // Re-resolve imports over the whole (updated) graph — produces the same
+        // resolved edges as a full rebuild.
+        let resolver = super::import_resolver::ImportResolver::new(&graph, project_path);
+        resolver.resolve_graph(&mut graph);
+
+        graph.build_duration_ms = start.elapsed().as_millis() as u64;
+
+        // Persist.
+        let persisted = PersistedCodeGraph {
+            version: PERSISTED_GRAPH_VERSION,
+            project_path: project_path.to_string_lossy().to_string(),
+            fingerprints,
+            graph: graph.clone(),
+            last_parsed_count: parsed_count,
+        };
+        if let Err(e) = persisted.save(project_path) {
+            warn!("CodeGraph: failed to persist resolved graph: {}", e);
+        }
+
+        info!(
+            "CodeGraph incremental build in {}ms: {} files parsed ({} total)",
+            graph.build_duration_ms,
+            parsed_count,
+            graph.files.len()
+        );
+
+        (graph, parsed_count)
+    }
+}
+
+/// Parse a single source file into the graph (language dispatch shared by the
+/// full and incremental builders). Adds the FileNode and all parsed entities.
+fn parse_file_into(graph: &mut CodeGraph, rel_path: &str, full_path: &Path, content: &str) {
+    let ext = full_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let line_count = content.lines().count();
+    let language = match ext {
+        "ts" | "tsx" => "typescript",
+        "js" | "jsx" => "javascript",
+        "py" => "python",
+        "rs" => "rust",
+        _ => return,
+    };
+
+    graph.files.push(FileNode {
+        path: rel_path.to_string(),
+        language: language.to_string(),
+        line_count,
+    });
+
+    match (language, ext) {
+        ("typescript", "tsx") | ("javascript", "jsx") => {
+            parse_typescript(content, rel_path, graph, true);
+        }
+        ("typescript" | "javascript", _) => {
+            parse_typescript(content, rel_path, graph, false);
+        }
+        ("python", _) => {
+            parse_python(content, rel_path, graph);
+        }
+        ("rust", _) => {
+            parse_rust(content, rel_path, graph);
+        }
+        _ => {}
     }
 }
 
@@ -942,6 +1280,8 @@ fn parse_typescript(content: &str, file_path: &str, graph: &mut CodeGraph, is_ts
                         to_module: source,
                         imported_names,
                         line: node.start_position().row + 1,
+                        resolved_target: None,
+                        resolution: ResolutionKind::Unresolved,
                     });
                 }
             }
@@ -1073,6 +1413,8 @@ fn parse_python(content: &str, file_path: &str, graph: &mut CodeGraph) {
                         to_module: module,
                         imported_names: names,
                         line: node.start_position().row + 1,
+                        resolved_target: None,
+                        resolution: ResolutionKind::Unresolved,
                     });
                 }
             }
@@ -1204,7 +1546,29 @@ fn parse_rust(content: &str, file_path: &str, graph: &mut CodeGraph) {
                     to_module: module,
                     imported_names: names,
                     line: node.start_position().row + 1,
+                    resolved_target: None,
+                    resolution: ResolutionKind::Unresolved,
                 });
+            }
+            // `mod foo;` declarations — a module-tree edge the resolver binds to foo.rs/foo/mod.rs.
+            // (An inline `mod foo { ... }` has a body and is NOT a file edge — skip it.)
+            "mod_item" => {
+                let has_body = node.child_by_field_name("body").is_some();
+                if !has_body {
+                    if let Some(name_node) = node.child_by_field_name("name") {
+                        let name = name_node.utf8_text(bytes).unwrap_or("").to_string();
+                        if !name.is_empty() {
+                            graph.imports.push(ImportEdge {
+                                from_file: file_path.to_string(),
+                                to_module: format!("mod {}", name),
+                                imported_names: vec![name],
+                                line: node.start_position().row + 1,
+                                resolved_target: None,
+                                resolution: ResolutionKind::Unresolved,
+                            });
+                        }
+                    }
+                }
             }
             // impl blocks - extract methods
             "impl_item" => {
@@ -1403,10 +1767,10 @@ export class App extends React.Component {
 
     #[test]
     fn test_blast_radius_with_imports() {
-        // The blast_radius module matching checks if cf.contains(module) or module.contains(cf_stem).
-        // For "./auth" -> stripped cf is "src/auth", module is "./auth".
-        // Neither contains the other, so we use "src/auth" as the module to match the real
-        // resolution pattern where module paths mirror file paths.
+        // Resolved-edge blast radius: edges carry exact `resolved_target` file
+        // paths (as the ImportResolver pass would populate), so lookups are exact —
+        // no substring heuristic. routes.ts -> auth.ts (1-hop), app.ts -> routes.ts
+        // (2-hop from auth.ts).
         let graph = CodeGraph {
             files: vec![
                 FileNode {
@@ -1430,15 +1794,19 @@ export class App extends React.Component {
             imports: vec![
                 ImportEdge {
                     from_file: "src/routes.ts".into(),
-                    to_module: "src/auth".into(),
+                    to_module: "./auth".into(),
                     imported_names: vec!["authenticate".into()],
                     line: 1,
+                    resolved_target: Some("src/auth.ts".into()),
+                    resolution: ResolutionKind::Relative,
                 },
                 ImportEdge {
                     from_file: "src/app.ts".into(),
-                    to_module: "src/routes".into(),
+                    to_module: "./routes".into(),
                     imported_names: vec!["router".into()],
                     line: 2,
+                    resolved_target: Some("src/routes.ts".into()),
+                    resolution: ResolutionKind::Relative,
                 },
             ],
             exports: vec![ExportNode {
@@ -1452,7 +1820,7 @@ export class App extends React.Component {
 
         let br = graph.blast_radius(&["src/auth.ts".to_string()]);
         assert!(
-            !br.directly_affected.is_empty(),
+            br.directly_affected.contains(&"src/routes.ts".to_string()),
             "routes.ts should be directly affected"
         );
         assert!(
@@ -1462,8 +1830,107 @@ export class App extends React.Component {
         assert!(br.total_impact_count >= 1);
         // 2-hop: app.ts imports routes.ts which imports auth.ts
         assert!(
-            !br.transitively_affected.is_empty(),
+            br.transitively_affected.contains(&"src/app.ts".to_string()),
             "app.ts should be transitively affected"
+        );
+    }
+
+    #[test]
+    fn test_blast_radius_no_substring_false_positive() {
+        // The OLD substring heuristic matched `to_module:"user"` against any file
+        // path containing "user" (e.g. user_settings.ts). With resolved edges, an
+        // import that resolves to a *different* file produces ZERO false positives.
+        let graph = CodeGraph {
+            files: vec![
+                FileNode {
+                    path: "src/user.ts".into(),
+                    language: "typescript".into(),
+                    line_count: 10,
+                },
+                FileNode {
+                    path: "src/user_settings.ts".into(),
+                    language: "typescript".into(),
+                    line_count: 10,
+                },
+                FileNode {
+                    path: "src/profile.ts".into(),
+                    language: "typescript".into(),
+                    line_count: 10,
+                },
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![
+                // profile.ts imports user_settings.ts (NOT user.ts).
+                ImportEdge {
+                    from_file: "src/profile.ts".into(),
+                    to_module: "./user_settings".into(),
+                    imported_names: vec!["settings".into()],
+                    line: 1,
+                    resolved_target: Some("src/user_settings.ts".into()),
+                    resolution: ResolutionKind::Relative,
+                },
+            ],
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+
+        // Changing user.ts must NOT mark profile.ts as affected (old heuristic would
+        // have, because "user" is a substring of "user_settings").
+        let br = graph.blast_radius(&["src/user.ts".to_string()]);
+        assert!(
+            br.directly_affected.is_empty(),
+            "no file imports user.ts; expected zero directly-affected, got {:?}",
+            br.directly_affected
+        );
+        assert_eq!(br.total_impact_count, 0);
+
+        // Changing user_settings.ts DOES mark profile.ts as affected (exact edge).
+        let br2 = graph.blast_radius(&["src/user_settings.ts".to_string()]);
+        assert!(
+            br2.directly_affected
+                .contains(&"src/profile.ts".to_string()),
+            "profile.ts imports user_settings.ts and should be directly affected"
+        );
+    }
+
+    #[test]
+    fn test_blast_radius_catches_alias_import() {
+        // An `@/...` tsconfig alias import the OLD substring heuristic would have
+        // missed (the raw specifier "@/auth" shares no substring with "src/auth.ts").
+        // With the resolver having bound resolved_target, the edge is caught.
+        let graph = CodeGraph {
+            files: vec![
+                FileNode {
+                    path: "src/auth.ts".into(),
+                    language: "typescript".into(),
+                    line_count: 10,
+                },
+                FileNode {
+                    path: "src/page.ts".into(),
+                    language: "typescript".into(),
+                    line_count: 10,
+                },
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![ImportEdge {
+                from_file: "src/page.ts".into(),
+                to_module: "@/auth".into(),
+                imported_names: vec!["login".into()],
+                line: 1,
+                resolved_target: Some("src/auth.ts".into()),
+                resolution: ResolutionKind::TsconfigPath,
+            }],
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+
+        let br = graph.blast_radius(&["src/auth.ts".to_string()]);
+        assert!(
+            br.directly_affected.contains(&"src/page.ts".to_string()),
+            "alias import @/auth -> src/auth.ts should be caught; got {:?}",
+            br.directly_affected
         );
     }
 
@@ -1489,6 +1956,8 @@ export class App extends React.Component {
                 to_module: "./auth".into(),
                 imported_names: vec!["authenticate".into()],
                 line: 1,
+                resolved_target: Some("src/auth.ts".into()),
+                resolution: ResolutionKind::Relative,
             }],
             exports: vec![ExportNode {
                 name: "authenticate".into(),
@@ -1552,5 +2021,150 @@ impl MyService {
             methods.contains(&"get_name".to_string()),
             "Should find get_name method"
         );
+    }
+
+    // ---- resolver integration through CodeGraph::build -------------------
+
+    #[test]
+    fn test_build_resolves_imports_end_to_end() {
+        let tmp = std::env::temp_dir().join(format!(
+            "twinast-build-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(
+            tmp.join("src/auth.ts"),
+            "export function authenticate() { return true; }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.join("src/routes.ts"),
+            "import { authenticate } from './auth';\nimport axios from 'axios';\nexport const router = 1;\n",
+        )
+        .unwrap();
+
+        let graph = CodeGraph::build(&tmp);
+
+        let rel = graph
+            .imports
+            .iter()
+            .find(|i| i.to_module == "./auth")
+            .expect("relative import present");
+        assert_eq!(rel.resolved_target.as_deref(), Some("src/auth.ts"));
+        assert_eq!(rel.resolution, ResolutionKind::Relative);
+
+        let ext = graph
+            .imports
+            .iter()
+            .find(|i| i.to_module == "axios")
+            .expect("external import present");
+        assert_eq!(ext.resolved_target, None);
+        assert_eq!(ext.resolution, ResolutionKind::External);
+
+        // Blast radius via resolved edges: changing auth.ts affects routes.ts.
+        let br = graph.blast_radius(&["src/auth.ts".to_string()]);
+        assert!(br.directly_affected.contains(&"src/routes.ts".to_string()));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_file(crate::paths::get_code_graph_path(&repo_hash(&tmp)));
+    }
+
+    #[test]
+    fn test_build_incremental_reparses_only_changed_and_reproduces_full() {
+        let tmp = std::env::temp_dir().join(format!(
+            "twinast-incr-{}-{}",
+            std::process::id(),
+            now_nanos()
+        ));
+        std::fs::create_dir_all(tmp.join("src")).unwrap();
+        std::fs::write(
+            tmp.join("src/auth.ts"),
+            "export function authenticate() { return true; }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.join("src/routes.ts"),
+            "import { authenticate } from './auth';\nexport const router = 1;\n",
+        )
+        .unwrap();
+        std::fs::write(tmp.join("src/util.ts"), "export function noop() {}\n").unwrap();
+
+        // Ensure a clean cache.
+        let _ = std::fs::remove_file(crate::paths::get_code_graph_path(&repo_hash(&tmp)));
+
+        // First build: full — parses all 3 files.
+        let (_g1, parsed1) = CodeGraph::build_incremental(&tmp);
+        assert_eq!(parsed1, 3, "first incremental build parses all files");
+
+        // No-op rebuild: nothing changed -> 0 parsed.
+        let (_g_noop, parsed_noop) = CodeGraph::build_incremental(&tmp);
+        assert_eq!(parsed_noop, 0, "unchanged rebuild re-parses nothing");
+
+        // Edit ONE file (change its content so the hash differs).
+        std::fs::write(
+            tmp.join("src/auth.ts"),
+            "export function authenticate() { return false; }\nexport function logout() {}\n",
+        )
+        .unwrap();
+
+        let (g_incr, parsed2) = CodeGraph::build_incremental(&tmp);
+        assert_eq!(parsed2, 1, "editing 1 file re-parses exactly 1 file");
+
+        // Reproduces the same graph as a full rebuild from scratch.
+        let g_full = CodeGraph::build(&tmp);
+
+        assert_eq!(
+            sorted_paths(&g_incr),
+            sorted_paths(&g_full),
+            "incremental file set matches full rebuild"
+        );
+        assert_eq!(
+            g_incr.functions.len(),
+            g_full.functions.len(),
+            "incremental functions match full rebuild"
+        );
+        // The new logout export from the edited file must be present incrementally.
+        assert!(
+            g_incr.exports.iter().any(|e| e.name == "logout"),
+            "edited file's new export reflected in incremental graph"
+        );
+        // Resolved edges reproduced.
+        let incr_resolved: Vec<_> = g_incr
+            .imports
+            .iter()
+            .map(|i| (i.from_file.clone(), i.resolved_target.clone()))
+            .collect();
+        let full_resolved: Vec<_> = g_full
+            .imports
+            .iter()
+            .map(|i| (i.from_file.clone(), i.resolved_target.clone()))
+            .collect();
+        assert_eq!(
+            sorted(incr_resolved),
+            sorted(full_resolved),
+            "incremental resolved edges match full rebuild"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+        let _ = std::fs::remove_file(crate::paths::get_code_graph_path(&repo_hash(&tmp)));
+    }
+
+    fn now_nanos() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    }
+
+    fn sorted_paths(g: &CodeGraph) -> Vec<String> {
+        let mut v: Vec<String> = g.files.iter().map(|f| f.path.clone()).collect();
+        v.sort();
+        v
+    }
+
+    fn sorted<T: Ord>(mut v: Vec<T>) -> Vec<T> {
+        v.sort();
+        v
     }
 }

--- a/src-tauri/src/workflow_generation/import_resolver.rs
+++ b/src-tauri/src/workflow_generation/import_resolver.rs
@@ -1,0 +1,932 @@
+//! Deterministic, language-aware import resolution for the `Ξ_AST` code graph.
+//!
+//! This is the **cheap middle tier** between syntactic `Ξ_AST` (raw module strings)
+//! and the LSP `Ξ_Type` layer — no language server, no model. It binds each
+//! [`ImportEdge::to_module`] specifier to an actual repo-relative file path
+//! (`resolved_target`) and records *how* it was bound ([`ResolutionKind`]).
+//!
+//! Pragmatic v1 (Q1 resolved = pragmatic; mark `Unresolved` honestly):
+//! - **TS/JS:** relative (`./`, `../`) with extension inference + `index.*`;
+//!   tsconfig `paths`/`baseUrl` aliases (the pre-resolved import map); bare → `External`.
+//! - **Python:** dotted module → `pkg/mod.py` / `pkg/__init__.py`; relative (`.`, `..`)
+//!   against the file's package; stdlib/site-packages → `External`.
+//! - **Rust:** `use`/`mod` within the crate (`mod foo;` → `foo.rs`/`foo/mod.rs`);
+//!   `crate::`/`super::`/`self::` prefixes; extern crates → `External`.
+//!
+//! All resolved targets use the SAME normalization as `FileNode.path`
+//! (forward slashes, project-prefix-stripped). The resolver runs **once during
+//! `CodeGraph::build`**, producing the import map threaded into blast-radius.
+
+use super::code_graph::{CodeGraph, ResolutionKind};
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+/// The deterministic resolver. Holds the set of known repo-relative file paths
+/// (the only files the graph saw) plus the parsed tsconfig alias maps.
+pub struct ImportResolver {
+    /// Set of repo-relative file paths present in the graph (forward-slash normalized).
+    known_files: HashSet<String>,
+    /// Lowercased extension-stripped lookup: stem-with-dirs -> full path, for fast
+    /// "does `a/b/c` (without extension) name a real file" checks.
+    /// e.g. `src/auth` -> `src/auth.ts`.
+    by_stem: HashMap<String, String>,
+    /// Directory paths that contain an `index.*` (or `__init__.py`) entry file ->
+    /// the entry file path. e.g. `src/components` -> `src/components/index.ts`.
+    dir_index: HashMap<String, String>,
+    /// tsconfig alias maps, ordered most-specific (deepest dir) first.
+    /// Each entry: (config_dir, base_url_dir, [(alias_prefix, [target_prefixes])]).
+    tsconfigs: Vec<TsconfigScope>,
+}
+
+struct TsconfigScope {
+    /// Repo-relative directory containing the tsconfig.json (forward-slash, no trailing slash).
+    dir: String,
+    /// Repo-relative baseUrl directory (resolved against `dir`), if present.
+    base_url: Option<String>,
+    /// Alias entries: (pattern, [substitutions]) from compilerOptions.paths.
+    paths: Vec<(String, Vec<String>)>,
+}
+
+/// Output of a single resolution: the bound file (if any) and how it was bound.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Resolution {
+    pub resolved_target: Option<String>,
+    pub resolution: ResolutionKind,
+}
+
+const TS_EXTS: &[&str] = &["ts", "tsx", "js", "jsx", "mjs", "cjs"];
+
+impl ImportResolver {
+    /// Build a resolver from the graph's file list and the project root (to read tsconfigs).
+    pub fn new(graph: &CodeGraph, project_path: &Path) -> Self {
+        let mut known_files = HashSet::new();
+        let mut by_stem: HashMap<String, String> = HashMap::new();
+        let mut dir_index: HashMap<String, String> = HashMap::new();
+
+        for f in &graph.files {
+            let path = f.path.clone();
+            known_files.insert(path.clone());
+
+            // Stem (path without the final extension), for extension-inference lookups.
+            if let Some(stem) = strip_known_ext(&path) {
+                by_stem.entry(stem).or_insert_with(|| path.clone());
+            }
+
+            // Directory index entries: index.ts/tsx/js/jsx/__init__.py.
+            let (dir, file_name) = split_dir_file(&path);
+            let lower = file_name.to_ascii_lowercase();
+            let is_ts_index = TS_EXTS.iter().any(|e| lower == format!("index.{}", e));
+            if is_ts_index {
+                dir_index.entry(dir).or_insert_with(|| path.clone());
+            }
+        }
+
+        let tsconfigs = discover_tsconfigs(graph, project_path);
+
+        ImportResolver {
+            known_files,
+            by_stem,
+            dir_index,
+            tsconfigs,
+        }
+    }
+
+    /// Resolve a single (`from_file`, `specifier`, `language`) triple.
+    pub fn resolve(&self, from_file: &str, specifier: &str, language: &str) -> Resolution {
+        match language {
+            "typescript" | "javascript" => self.resolve_ts(from_file, specifier),
+            "python" => self.resolve_python(from_file, specifier),
+            "rust" => self.resolve_rust(from_file, specifier),
+            _ => Resolution {
+                resolved_target: None,
+                resolution: ResolutionKind::Unresolved,
+            },
+        }
+    }
+
+    /// Resolve every import edge in the graph in place. Runs once during build.
+    pub fn resolve_graph(&self, graph: &mut CodeGraph) {
+        // Map file_path -> language for quick lookup of the importing file's language.
+        let lang_of: HashMap<&str, &str> = graph
+            .files
+            .iter()
+            .map(|f| (f.path.as_str(), f.language.as_str()))
+            .collect();
+
+        // Clone the per-file languages we need first to avoid borrow conflicts.
+        let langs: Vec<String> = graph
+            .imports
+            .iter()
+            .map(|imp| {
+                lang_of
+                    .get(imp.from_file.as_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| language_from_path(&imp.from_file))
+            })
+            .collect();
+
+        for (imp, lang) in graph.imports.iter_mut().zip(langs) {
+            let r = self.resolve(&imp.from_file, &imp.to_module, &lang);
+            imp.resolved_target = r.resolved_target;
+            imp.resolution = r.resolution;
+        }
+    }
+
+    // ---- TS / JS -----------------------------------------------------------
+
+    fn resolve_ts(&self, from_file: &str, specifier: &str) -> Resolution {
+        // Relative specifier.
+        if specifier.starts_with("./") || specifier.starts_with("../") || specifier == "." {
+            let base_dir = parent_dir(from_file);
+            let joined = normalize_join(&base_dir, specifier);
+            if let Some(target) = self.resolve_ts_path(&joined) {
+                let kind = if self.known_files.contains(&target) || self.by_stem_hit(&joined) {
+                    ResolutionKind::Relative
+                } else {
+                    ResolutionKind::PackageIndex
+                };
+                // If we landed via a directory index, label PackageIndex; else Relative.
+                let kind = if self
+                    .dir_index
+                    .get(&joined)
+                    .map(|t| t == &target)
+                    .unwrap_or(false)
+                {
+                    ResolutionKind::PackageIndex
+                } else {
+                    kind
+                };
+                return Resolution {
+                    resolved_target: Some(target),
+                    resolution: kind,
+                };
+            }
+            // A relative path that doesn't resolve is an internal coverage hole.
+            return Resolution {
+                resolved_target: None,
+                resolution: ResolutionKind::Unresolved,
+            };
+        }
+
+        // Bare specifier — try tsconfig path aliases first.
+        if let Some(target) = self.resolve_tsconfig_alias(from_file, specifier) {
+            return Resolution {
+                resolved_target: Some(target),
+                resolution: ResolutionKind::TsconfigPath,
+            };
+        }
+
+        // Otherwise a third-party / stdlib package — honestly external.
+        Resolution {
+            resolved_target: None,
+            resolution: ResolutionKind::External,
+        }
+    }
+
+    fn by_stem_hit(&self, path_no_ext: &str) -> bool {
+        self.by_stem.contains_key(path_no_ext)
+    }
+
+    /// Resolve a TS module path (no extension yet) to a concrete file via extension
+    /// inference then directory-index fallback. `path` is repo-relative, normalized.
+    fn resolve_ts_path(&self, path: &str) -> Option<String> {
+        // Exact file (specifier already had an extension).
+        if self.known_files.contains(path) {
+            return Some(path.to_string());
+        }
+        // Extension inference: path + .ts/.tsx/.js/.jsx/...
+        for ext in TS_EXTS {
+            let candidate = format!("{}.{}", path, ext);
+            if self.known_files.contains(&candidate) {
+                return Some(candidate);
+            }
+        }
+        // Directory index: path/index.*
+        if let Some(idx) = self.dir_index.get(path) {
+            return Some(idx.clone());
+        }
+        None
+    }
+
+    /// Try each tsconfig scope covering `from_file`, most-specific first.
+    fn resolve_tsconfig_alias(&self, from_file: &str, specifier: &str) -> Option<String> {
+        for scope in &self.tsconfigs {
+            if !path_in_dir(from_file, &scope.dir) {
+                continue;
+            }
+            // 1) Explicit `paths` aliases.
+            for (pattern, subs) in &scope.paths {
+                if let Some(captured) = match_alias(pattern, specifier) {
+                    for sub in subs {
+                        let replaced = apply_alias(sub, &captured);
+                        // Targets in `paths` are relative to baseUrl (or config dir).
+                        let base = scope.base_url.clone().unwrap_or_else(|| scope.dir.clone());
+                        let joined = normalize_join(&base, &replaced);
+                        if let Some(target) = self.resolve_ts_path(&joined) {
+                            return Some(target);
+                        }
+                    }
+                }
+            }
+            // 2) Bare baseUrl resolution (non-relative import resolved against baseUrl).
+            if let Some(base) = &scope.base_url {
+                let joined = normalize_join(base, specifier);
+                if let Some(target) = self.resolve_ts_path(&joined) {
+                    return Some(target);
+                }
+            }
+        }
+        None
+    }
+
+    // ---- Python ------------------------------------------------------------
+
+    fn resolve_python(&self, from_file: &str, specifier: &str) -> Resolution {
+        // Relative import: leading dots (`.mod`, `..pkg.mod`, `.`).
+        if specifier.starts_with('.') {
+            let dots = specifier.chars().take_while(|c| *c == '.').count();
+            let rest = &specifier[dots..];
+            // Start from the importing file's directory, then go up (dots-1) levels.
+            let mut base = parent_dir(from_file);
+            for _ in 1..dots {
+                base = parent_dir(&base);
+            }
+            let sub = rest.replace('.', "/");
+            let target_dir = if sub.is_empty() {
+                base.clone()
+            } else {
+                normalize_join(&base, &sub)
+            };
+            if let Some(t) = self.resolve_python_path(&target_dir) {
+                return Resolution {
+                    resolved_target: Some(t),
+                    resolution: ResolutionKind::PythonModule,
+                };
+            }
+            // A relative python import that doesn't bind is an internal hole.
+            return Resolution {
+                resolved_target: None,
+                resolution: ResolutionKind::Unresolved,
+            };
+        }
+
+        // Absolute dotted module: try each package root by progressively longer prefixes.
+        let as_path = specifier.replace('.', "/");
+        if let Some(t) = self.resolve_python_path(&as_path) {
+            return Resolution {
+                resolved_target: Some(t),
+                resolution: ResolutionKind::PythonModule,
+            };
+        }
+        // Try treating the top-level package as a package root anchored under known dirs.
+        if let Some(t) = self.resolve_python_under_roots(&as_path) {
+            return Resolution {
+                resolved_target: Some(t),
+                resolution: ResolutionKind::PythonModule,
+            };
+        }
+
+        // Not found anywhere in-repo → stdlib / site-packages → External.
+        Resolution {
+            resolved_target: None,
+            resolution: ResolutionKind::External,
+        }
+    }
+
+    /// Resolve a slash-joined python module path: `pkg/mod.py` or `pkg/mod/__init__.py`.
+    fn resolve_python_path(&self, path: &str) -> Option<String> {
+        let as_file = format!("{}.py", path);
+        if self.known_files.contains(&as_file) {
+            return Some(as_file);
+        }
+        let as_init = format!("{}/__init__.py", path);
+        if self.known_files.contains(&as_init) {
+            return Some(as_init);
+        }
+        None
+    }
+
+    /// Try resolving a dotted module under any known top-level directory root, so
+    /// `app.models` binds to `backend/app/models.py` when the package root is nested.
+    fn resolve_python_under_roots(&self, as_path: &str) -> Option<String> {
+        // Candidate roots: every distinct first-segment dir of known files.
+        let roots: HashSet<&str> = self
+            .known_files
+            .iter()
+            .filter_map(|p| p.rsplit_once('/').map(|(dir, _)| dir))
+            .flat_map(|dir| {
+                // walk all ancestor dir prefixes
+                let mut acc = Vec::new();
+                let mut cur = dir;
+                acc.push(cur);
+                while let Some((parent, _)) = cur.rsplit_once('/') {
+                    acc.push(parent);
+                    cur = parent;
+                }
+                acc
+            })
+            .collect();
+        for root in roots {
+            let joined = format!("{}/{}", root, as_path);
+            if let Some(t) = self.resolve_python_path(&joined) {
+                return Some(t);
+            }
+        }
+        None
+    }
+
+    // ---- Rust --------------------------------------------------------------
+
+    fn resolve_rust(&self, from_file: &str, specifier: &str) -> Resolution {
+        // `mod foo;` declaration edge — to_module is "mod foo".
+        if let Some(name) = specifier.strip_prefix("mod ") {
+            let name = name.trim();
+            if let Some(t) = self.resolve_rust_mod(from_file, name) {
+                return Resolution {
+                    resolved_target: Some(t),
+                    resolution: ResolutionKind::RustMod,
+                };
+            }
+            return Resolution {
+                resolved_target: None,
+                resolution: ResolutionKind::Unresolved,
+            };
+        }
+
+        // `use` path: to_module is e.g. "crate::foo", "super::bar", "self::baz",
+        // "std::collections", "serde::Serialize".
+        let segs: Vec<&str> = specifier.split("::").collect();
+        let first = segs.first().copied().unwrap_or("");
+        match first {
+            "crate" => {
+                // crate::foo -> resolve `foo` module from the crate root dir.
+                if let Some(module) = segs.get(1) {
+                    let crate_root = crate_root_dir(from_file);
+                    if let Some(t) = self.resolve_rust_mod_in_dir(&crate_root, module) {
+                        return Resolution {
+                            resolved_target: Some(t),
+                            resolution: ResolutionKind::RustMod,
+                        };
+                    }
+                }
+                Resolution {
+                    resolved_target: None,
+                    resolution: ResolutionKind::Unresolved,
+                }
+            }
+            "self" => {
+                if let Some(module) = segs.get(1) {
+                    if let Some(t) = self.resolve_rust_mod(from_file, module) {
+                        return Resolution {
+                            resolved_target: Some(t),
+                            resolution: ResolutionKind::RustMod,
+                        };
+                    }
+                }
+                Resolution {
+                    resolved_target: None,
+                    resolution: ResolutionKind::Unresolved,
+                }
+            }
+            "super" => {
+                // super::foo -> module `foo` in the parent module's directory.
+                let parent = parent_dir(&module_dir_of(from_file));
+                if let Some(module) = segs.get(1) {
+                    if let Some(t) = self.resolve_rust_mod_in_dir(&parent, module) {
+                        return Resolution {
+                            resolved_target: Some(t),
+                            resolution: ResolutionKind::RustMod,
+                        };
+                    }
+                }
+                Resolution {
+                    resolved_target: None,
+                    resolution: ResolutionKind::Unresolved,
+                }
+            }
+            // Anything else is an extern crate (serde, tokio, std, ...) → External.
+            _ => Resolution {
+                resolved_target: None,
+                resolution: ResolutionKind::External,
+            },
+        }
+    }
+
+    /// Resolve `mod foo;` declared in `from_file`: foo lives in the same module dir.
+    fn resolve_rust_mod(&self, from_file: &str, name: &str) -> Option<String> {
+        let dir = module_dir_of(from_file);
+        self.resolve_rust_mod_in_dir(&dir, name)
+    }
+
+    /// `name` as a module under `dir`: `dir/name.rs` or `dir/name/mod.rs`.
+    fn resolve_rust_mod_in_dir(&self, dir: &str, name: &str) -> Option<String> {
+        let as_file = if dir.is_empty() {
+            format!("{}.rs", name)
+        } else {
+            format!("{}/{}.rs", dir, name)
+        };
+        if self.known_files.contains(&as_file) {
+            return Some(as_file);
+        }
+        let as_mod = if dir.is_empty() {
+            format!("{}/mod.rs", name)
+        } else {
+            format!("{}/{}/mod.rs", dir, name)
+        };
+        if self.known_files.contains(&as_mod) {
+            return Some(as_mod);
+        }
+        None
+    }
+}
+
+// ============================================================================
+// tsconfig discovery / parsing
+// ============================================================================
+
+fn discover_tsconfigs(graph: &CodeGraph, project_path: &Path) -> Vec<TsconfigScope> {
+    // Find candidate directories: any dir containing a TS/JS file, plus the root.
+    let mut dirs: HashSet<String> = HashSet::new();
+    dirs.insert(String::new()); // repo root
+    for f in &graph.files {
+        if f.language == "typescript" || f.language == "javascript" {
+            let mut d = parent_dir(&f.path);
+            loop {
+                dirs.insert(d.clone());
+                if d.is_empty() {
+                    break;
+                }
+                d = parent_dir(&d);
+            }
+        }
+    }
+
+    let mut scopes: Vec<TsconfigScope> = Vec::new();
+    for dir in dirs {
+        let tsconfig_rel = if dir.is_empty() {
+            "tsconfig.json".to_string()
+        } else {
+            format!("{}/tsconfig.json", dir)
+        };
+        let full = project_path.join(&tsconfig_rel);
+        let content = match std::fs::read_to_string(&full) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if let Some(scope) = parse_tsconfig(&dir, &content) {
+            scopes.push(scope);
+        }
+    }
+    // Most-specific (deepest) directory first so nested tsconfigs win.
+    scopes.sort_by_key(|s| std::cmp::Reverse(s.dir.len()));
+    scopes
+}
+
+fn parse_tsconfig(dir: &str, content: &str) -> Option<TsconfigScope> {
+    // tsconfig.json permits comments/trailing commas; do a best-effort strip then parse.
+    let cleaned = strip_jsonc(content);
+    let val: serde_json::Value = serde_json::from_str(&cleaned).ok()?;
+    let co = val.get("compilerOptions")?;
+
+    let base_url = co
+        .get("baseUrl")
+        .and_then(|v| v.as_str())
+        .map(|b| normalize_join(dir, b));
+
+    let mut paths = Vec::new();
+    if let Some(map) = co.get("paths").and_then(|p| p.as_object()) {
+        for (pattern, subs) in map {
+            let sub_list: Vec<String> = subs
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            paths.push((pattern.clone(), sub_list));
+        }
+    }
+
+    if base_url.is_none() && paths.is_empty() {
+        return None;
+    }
+
+    Some(TsconfigScope {
+        dir: dir.to_string(),
+        base_url,
+        paths,
+    })
+}
+
+/// Strip `//` and `/* */` comments and trailing commas from JSONC for serde_json.
+fn strip_jsonc(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut in_string = false;
+    let mut escape = false;
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if in_string {
+            out.push(c);
+            if escape {
+                escape = false;
+            } else if c == '\\' {
+                escape = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+        if c == '"' {
+            in_string = true;
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        if c == '/' && i + 1 < bytes.len() {
+            let n = bytes[i + 1] as char;
+            if n == '/' {
+                // line comment
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            if n == '*' {
+                // block comment
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i += 2;
+                continue;
+            }
+        }
+        out.push(c);
+        i += 1;
+    }
+    // Remove trailing commas before } or ].
+    remove_trailing_commas(&out)
+}
+
+fn remove_trailing_commas(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let chars: Vec<char> = s.chars().collect();
+    for (idx, &c) in chars.iter().enumerate() {
+        if c == ',' {
+            // peek next non-whitespace
+            let mut j = idx + 1;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j < chars.len() && (chars[j] == '}' || chars[j] == ']') {
+                continue; // drop the comma
+            }
+        }
+        out.push(c);
+    }
+    out
+}
+
+// ============================================================================
+// Path / alias helpers (all operate on forward-slash repo-relative strings)
+// ============================================================================
+
+/// Match an alias pattern (e.g. `@/*`, `@app/*`, `utils`) against a specifier.
+/// Returns the captured `*` portion (empty string for a non-wildcard exact match),
+/// or `None` if no match.
+fn match_alias(pattern: &str, specifier: &str) -> Option<String> {
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        if specifier.starts_with(prefix) {
+            return Some(specifier[prefix.len()..].to_string());
+        }
+        None
+    } else if pattern == specifier {
+        Some(String::new())
+    } else {
+        None
+    }
+}
+
+/// Apply a captured wildcard portion to a substitution template (`src/*` + `foo` -> `src/foo`).
+fn apply_alias(sub: &str, captured: &str) -> String {
+    if let Some(prefix) = sub.strip_suffix('*') {
+        format!("{}{}", prefix, captured)
+    } else {
+        sub.to_string()
+    }
+}
+
+/// Whether `file` lives inside directory `dir` (dir == "" means repo root, matches all).
+fn path_in_dir(file: &str, dir: &str) -> bool {
+    if dir.is_empty() {
+        return true;
+    }
+    file.starts_with(&format!("{}/", dir))
+}
+
+/// Parent directory of a repo-relative path (forward-slash). Root -> "".
+fn parent_dir(path: &str) -> String {
+    match path.rsplit_once('/') {
+        Some((dir, _)) => dir.to_string(),
+        None => String::new(),
+    }
+}
+
+fn split_dir_file(path: &str) -> (String, String) {
+    match path.rsplit_once('/') {
+        Some((dir, file)) => (dir.to_string(), file.to_string()),
+        None => (String::new(), path.to_string()),
+    }
+}
+
+/// For Rust: the directory that hosts sibling modules of `from_file`.
+/// `src/foo/mod.rs` and `src/lib.rs`/`src/main.rs` host modules in their OWN dir;
+/// `src/foo.rs` hosts submodules in `src/foo/`.
+fn module_dir_of(from_file: &str) -> String {
+    let (dir, file) = split_dir_file(from_file);
+    let stem = file.trim_end_matches(".rs");
+    if stem == "mod" || stem == "lib" || stem == "main" {
+        dir
+    } else {
+        // `foo.rs` declares submodules under `foo/`
+        if dir.is_empty() {
+            stem.to_string()
+        } else {
+            format!("{}/{}", dir, stem)
+        }
+    }
+}
+
+/// The crate root directory (where `crate::` modules live): the dir containing
+/// `src/lib.rs`/`src/main.rs`. Heuristic: the `src` dir prefix of `from_file`.
+fn crate_root_dir(from_file: &str) -> String {
+    // Find the last "src/" segment; crate modules live directly under that src dir.
+    if let Some(idx) = from_file.rfind("src/") {
+        return from_file[..idx + 3].to_string(); // include "src"
+    }
+    // Fallback: top-level dir.
+    let (dir, _) = split_dir_file(from_file);
+    let mut cur = dir.as_str();
+    while let Some((parent, _)) = cur.rsplit_once('/') {
+        cur = parent;
+    }
+    cur.to_string()
+}
+
+/// Strip a known source extension from a path, returning the stem-with-dirs.
+fn strip_known_ext(path: &str) -> Option<String> {
+    for ext in ["ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "rs"] {
+        let suffix = format!(".{}", ext);
+        if let Some(stem) = path.strip_suffix(&suffix) {
+            return Some(stem.to_string());
+        }
+    }
+    None
+}
+
+/// Join a base directory with a relative-ish segment, collapsing `.`/`..` and
+/// normalizing slashes. Both inputs are forward-slash repo-relative.
+fn normalize_join(base: &str, rel: &str) -> String {
+    let mut parts: Vec<&str> = if base.is_empty() {
+        Vec::new()
+    } else {
+        base.split('/').collect()
+    };
+    for seg in rel.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            other => parts.push(other),
+        }
+    }
+    parts.join("/")
+}
+
+/// Infer a language string from a file extension when not present in the graph map.
+fn language_from_path(path: &str) -> String {
+    let ext = path.rsplit('.').next().unwrap_or("");
+    match ext {
+        "ts" | "tsx" => "typescript",
+        "js" | "jsx" | "mjs" | "cjs" => "javascript",
+        "py" => "python",
+        "rs" => "rust",
+        _ => "",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow_generation::code_graph::{CodeGraph, FileNode, ImportEdge};
+
+    fn graph_with_files(paths: &[(&str, &str)]) -> CodeGraph {
+        CodeGraph {
+            files: paths
+                .iter()
+                .map(|(p, lang)| FileNode {
+                    path: p.to_string(),
+                    language: lang.to_string(),
+                    line_count: 1,
+                })
+                .collect(),
+            functions: vec![],
+            classes: vec![],
+            imports: vec![],
+            exports: vec![],
+            build_duration_ms: 0,
+        }
+    }
+
+    #[test]
+    fn ts_relative_with_extension_inference() {
+        let g = graph_with_files(&[
+            ("src/routes.ts", "typescript"),
+            ("src/auth.ts", "typescript"),
+        ]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/routes.ts", "./auth", "typescript");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/auth.ts"));
+        assert_eq!(res.resolution, ResolutionKind::Relative);
+    }
+
+    #[test]
+    fn ts_relative_parent_dir() {
+        let g = graph_with_files(&[
+            ("src/api/routes.ts", "typescript"),
+            ("src/auth.ts", "typescript"),
+        ]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/api/routes.ts", "../auth", "typescript");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/auth.ts"));
+    }
+
+    #[test]
+    fn ts_directory_index() {
+        let g = graph_with_files(&[
+            ("src/app.ts", "typescript"),
+            ("src/components/index.ts", "typescript"),
+        ]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/app.ts", "./components", "typescript");
+        assert_eq!(
+            res.resolved_target.as_deref(),
+            Some("src/components/index.ts")
+        );
+        assert_eq!(res.resolution, ResolutionKind::PackageIndex);
+    }
+
+    #[test]
+    fn ts_bare_specifier_is_external() {
+        let g = graph_with_files(&[("src/app.ts", "typescript")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/app.ts", "react", "typescript");
+        assert_eq!(res.resolved_target, None);
+        assert_eq!(res.resolution, ResolutionKind::External);
+    }
+
+    #[test]
+    fn ts_broken_relative_is_unresolved() {
+        let g = graph_with_files(&[("src/app.ts", "typescript")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/app.ts", "./does-not-exist", "typescript");
+        assert_eq!(res.resolved_target, None);
+        assert_eq!(res.resolution, ResolutionKind::Unresolved);
+    }
+
+    #[test]
+    fn python_dotted_module() {
+        let g = graph_with_files(&[("app/main.py", "python"), ("app/models.py", "python")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("app/main.py", "app.models", "python");
+        assert_eq!(res.resolved_target.as_deref(), Some("app/models.py"));
+        assert_eq!(res.resolution, ResolutionKind::PythonModule);
+    }
+
+    #[test]
+    fn python_package_init() {
+        let g = graph_with_files(&[("app/main.py", "python"), ("app/db/__init__.py", "python")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("app/main.py", "app.db", "python");
+        assert_eq!(res.resolved_target.as_deref(), Some("app/db/__init__.py"));
+    }
+
+    #[test]
+    fn python_relative_import() {
+        let g = graph_with_files(&[
+            ("app/api/routes.py", "python"),
+            ("app/api/auth.py", "python"),
+        ]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("app/api/routes.py", ".auth", "python");
+        assert_eq!(res.resolved_target.as_deref(), Some("app/api/auth.py"));
+        assert_eq!(res.resolution, ResolutionKind::PythonModule);
+    }
+
+    #[test]
+    fn python_stdlib_is_external() {
+        let g = graph_with_files(&[("app/main.py", "python")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("app/main.py", "os", "python");
+        assert_eq!(res.resolution, ResolutionKind::External);
+    }
+
+    #[test]
+    fn rust_mod_decl_to_sibling_file() {
+        let g = graph_with_files(&[("src/lib.rs", "rust"), ("src/parser.rs", "rust")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/lib.rs", "mod parser", "rust");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/parser.rs"));
+        assert_eq!(res.resolution, ResolutionKind::RustMod);
+    }
+
+    #[test]
+    fn rust_mod_decl_to_mod_rs() {
+        let g = graph_with_files(&[("src/lib.rs", "rust"), ("src/net/mod.rs", "rust")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/lib.rs", "mod net", "rust");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/net/mod.rs"));
+    }
+
+    #[test]
+    fn rust_crate_use() {
+        let g = graph_with_files(&[("src/main.rs", "rust"), ("src/config.rs", "rust")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/main.rs", "crate::config", "rust");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/config.rs"));
+        assert_eq!(res.resolution, ResolutionKind::RustMod);
+    }
+
+    #[test]
+    fn rust_extern_crate_is_external() {
+        let g = graph_with_files(&[("src/main.rs", "rust")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/main.rs", "serde", "rust");
+        assert_eq!(res.resolution, ResolutionKind::External);
+    }
+
+    #[test]
+    fn rust_submodule_from_foo_rs() {
+        // `foo.rs` declares `mod bar;` which lives in `foo/bar.rs`.
+        let g = graph_with_files(&[("src/foo.rs", "rust"), ("src/foo/bar.rs", "rust")]);
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        let res = r.resolve("src/foo.rs", "mod bar", "rust");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/foo/bar.rs"));
+    }
+
+    #[test]
+    fn tsconfig_alias_resolution() {
+        // Write a real tsconfig to a temp dir so discovery reads it.
+        let tmp = std::env::temp_dir().join(format!("twinast-tsc-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(tmp.join("src/lib"));
+        std::fs::write(
+            tmp.join("tsconfig.json"),
+            r#"{
+  // baseUrl + paths alias
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": { "@/*": ["src/*"], }
+  }
+}"#,
+        )
+        .unwrap();
+
+        let g = graph_with_files(&[
+            ("src/app.ts", "typescript"),
+            ("src/lib/utils.ts", "typescript"),
+        ]);
+        let r = ImportResolver::new(&g, &tmp);
+        let res = r.resolve("src/app.ts", "@/lib/utils", "typescript");
+        assert_eq!(res.resolved_target.as_deref(), Some("src/lib/utils.ts"));
+        assert_eq!(res.resolution, ResolutionKind::TsconfigPath);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_graph_populates_edges() {
+        let mut g = graph_with_files(&[
+            ("src/routes.ts", "typescript"),
+            ("src/auth.ts", "typescript"),
+        ]);
+        g.imports.push(ImportEdge {
+            from_file: "src/routes.ts".into(),
+            to_module: "./auth".into(),
+            imported_names: vec!["authenticate".into()],
+            line: 1,
+            resolved_target: None,
+            resolution: ResolutionKind::Unresolved,
+        });
+        let r = ImportResolver::new(&g, Path::new("/nonexistent"));
+        r.resolve_graph(&mut g);
+        assert_eq!(g.imports[0].resolved_target.as_deref(), Some("src/auth.ts"));
+        assert_eq!(g.imports[0].resolution, ResolutionKind::Relative);
+    }
+}

--- a/src-tauri/src/workflow_generation/mod.rs
+++ b/src-tauri/src/workflow_generation/mod.rs
@@ -19,6 +19,7 @@ pub mod few_shot_curator;
 pub mod generator;
 pub mod gepa_optimizer;
 pub mod hardener;
+pub mod import_resolver;
 pub mod investigator;
 pub mod meta_workflow;
 pub mod pipeline_artifacts;


### PR DESCRIPTION
Phases 1-2 of `2026-06-02-twin-ast-import-resolution-and-semantic-observers`.

**Phase 1 — resolved-import Ξ_AST:** new `ImportResolver` (TS relative+tsconfig paths+index, Python dotted/relative, Rust mod/use) binds `ImportEdge.resolved_target`/`resolution`; `blast_radius` (and `format_blast_radius_for_specification`) rewritten on exact resolved edges — eliminates `String::contains` substring collisions, alias/index/multi-language correct; fingerprint-incremental persistence to `<app_data>/qontinui-runner/code-graph/<repo-hash>.json`. CONTRACT.md credibility ladder reconciled (syntactic→low, resolved→medium, Type→high).

**Phase 2 — diff-impact tool:** sidecar routes `POST /code-graph/diff-impact` (uniform envelope + `removed_exports_referenced` + `outcome_signal:Contradiction`, honest `coverage<1` on cold/partial) and `POST /code-graph/resolve-import`; reuses the code-semantics (repo,language) scope model.

Tests (cargo --bin): code_graph 14, import_resolver 16, code_graph_api 8 — all green. Phase 3/4 (CLI-backed Ξ_Arch/Ξ_Domain observers + domain drift pair) remain future work per the plan.