### PR TITLE
feat(runner): context pre-hydration + rule-file ingestion — Track C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,4 +138,5 @@ target-run/
 .build-state/
 target-rebuild/
 target-types-task/
+target-wt/
 *.log.err

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -435,6 +435,14 @@ pub struct AppState {
     /// `/wrappers/*` routes can resolve via the same OnceCell pattern as
     /// `app_registry` / `app_dispatcher`.
     pub wrapper_state: Arc<tokio::sync::OnceCell<Arc<crate::wrappers::WrapperState>>>,
+    /// Speculative MCP / link pre-hydration cache (Track C3), keyed by
+    /// `execution_id`. Populated best-effort before the first agentic turn with
+    /// a timestamped, prompt-ready summary of available MCP tools + the gist of
+    /// any URLs/issue-refs in the task description. Read once to prime the
+    /// first prompt; cleared on execution completion. Never on the task's
+    /// critical path — a pre-fetch failure leaves this empty and the task
+    /// proceeds unchanged.
+    pub prehydration_cache: Arc<crate::unified_workflow_executor::prehydration::PrehydrationCache>,
 }
 
 impl AppState {

--- a/src-tauri/src/context/mod.rs
+++ b/src-tauri/src/context/mod.rs
@@ -42,8 +42,9 @@ pub use metadata::{record_context_use, set_context_enabled, set_web_sync_status}
 
 // Re-export resolution and formatting
 pub use resolution::{
-    format_contexts_for_prompt, format_observation_memory_for_prompt, format_single_context,
-    inject_contexts, record_contexts_used, resolve_contexts,
+    context_matches_touched_paths, format_contexts_for_prompt,
+    format_observation_memory_for_prompt, format_single_context, inject_contexts,
+    inject_contexts_scoped, record_contexts_used, resolve_contexts, resolve_contexts_scoped,
 };
 
 // Re-export built-in contexts
@@ -53,7 +54,7 @@ pub use builtins::get_builtin_contexts;
 pub use project_contexts::{
     add_project_context_to_config, create_project_context, delete_project_context_from_config,
     get_project_context_from_config, get_project_contexts, get_project_contexts_from_config,
-    load_project_contexts_from_dir, update_project_context_in_config,
+    load_project_contexts_from_dir, update_project_context_in_config, MAX_TOTAL_CONTEXT_CHARS,
 };
 
 // Re-export special context handling

--- a/src-tauri/src/context/project_contexts.rs
+++ b/src-tauri/src/context/project_contexts.rs
@@ -10,10 +10,27 @@
 
 #![allow(dead_code)]
 
+use std::collections::HashSet;
 use std::path::Path;
+
+use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 use super::types::{Context, ContextAutoInclude};
+
+/// Hard cap on the total size (in chars) of all ingested project + rule-file
+/// context content combined. This is a context-window guard mandated by the
+/// Track C risk section: a project with many large rule files must never be
+/// allowed to blow up the prompt. When the running total would exceed this
+/// cap, the offending context's content is deterministically truncated and a
+/// marker is appended (rather than silently dropping the context entirely).
+///
+/// 80_000 chars ≈ 20K tokens — generous enough for real rule sets while
+/// leaving room for the rest of the agentic prompt under typical 100K+ budgets.
+pub const MAX_TOTAL_CONTEXT_CHARS: usize = 80_000;
+
+/// Marker appended to content that was truncated by the size cap.
+const TRUNCATION_MARKER: &str = "\n\n[...truncated by Qontinui context size cap...]";
 
 /// Get all contexts from a loaded configuration.
 ///
@@ -143,6 +160,27 @@ pub fn create_project_context(
 /// The context name is derived from the filename (e.g., `api-guidelines.md` → "api-guidelines").
 /// Context IDs are deterministic: `proj-ctx-{filename_stem}` so they remain stable across loads.
 pub fn load_project_contexts_from_dir(project_path: &str) -> Vec<Context> {
+    // Canonical Qontinui-native source.
+    let mut contexts = load_qontinui_contexts_dir(project_path);
+
+    // Additive interop: root CLAUDE.md / AGENTS.md / .cursorrules and
+    // .cursor/rules/*.mdc. Path/glob-scoped where applicable.
+    contexts.extend(load_rule_file_contexts(project_path));
+
+    // De-dupe by content hash: the same file content ingested via two
+    // conventions (e.g. a symlinked CLAUDE.md == AGENTS.md) collapses to one.
+    dedupe_by_content(&mut contexts);
+
+    // Hard size cap (context-window guard, MANDATORY per the plan's risk
+    // section). Deterministically truncate rather than silently drop.
+    enforce_total_size_cap(&mut contexts);
+
+    contexts
+}
+
+/// Load the canonical `.qontinui/contexts/*.md` contexts (the original
+/// behavior of `load_project_contexts_from_dir`).
+fn load_qontinui_contexts_dir(project_path: &str) -> Vec<Context> {
     let ctx_dir = Path::new(project_path).join(".qontinui").join("contexts");
 
     if !ctx_dir.is_dir() {
@@ -234,6 +272,310 @@ pub fn load_project_contexts_from_dir(project_path: &str) -> Vec<Context> {
     }
 
     contexts
+}
+
+// ============================================================================
+// Rule-file interop ingestion (CLAUDE.md / AGENTS.md / .cursorrules / .mdc)
+// ============================================================================
+//
+// These are additive, best-effort interop sources mirroring Minions'
+// rule-file conventions. The canonical Qontinui-native source remains
+// `.qontinui/contexts/*.md`; everything here augments it.
+//
+// ## Path/glob scoping model
+//
+// Each ingested rule-file context may carry an optional path scope, encoded
+// into the standard [`ContextAutoInclude::file_patterns`] field:
+//
+// - **Root-level** rule files (root `CLAUDE.md` / `AGENTS.md` / `.cursorrules`)
+//   are *always-attached*: no `file_patterns` ⇒ no scope filter.
+// - A rule file located **under a subdirectory** (e.g. `src/foo/CLAUDE.md`)
+//   attaches only when the task touches that subdirectory. Its scope glob is
+//   derived as `<reldir>/**` (e.g. `src/foo/**`).
+// - `.cursor/rules/*.mdc` files may declare explicit `globs:` frontmatter;
+//   those are honored verbatim as the scope.
+//
+// Resolution-time filtering against the task's touched paths lives in
+// `resolution.rs` (`context_matches_touched_paths`). A context with a scope
+// attaches iff at least one touched path matches one of its globs. A context
+// with no scope is unconditionally attached.
+
+/// Ingest interop rule files from `project_path`.
+fn load_rule_file_contexts(project_path: &str) -> Vec<Context> {
+    let root = Path::new(project_path);
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut contexts = Vec::new();
+
+    // Root-level always-attached rule files. (file, id-suffix, name)
+    for (rel, id_suffix, name) in [
+        ("CLAUDE.md", "claude-md", "CLAUDE.md"),
+        ("AGENTS.md", "agents-md", "AGENTS.md"),
+        (".cursorrules", "cursorrules", ".cursorrules"),
+    ] {
+        let path = root.join(rel);
+        if let Some(content) = read_nonempty(&path) {
+            contexts.push(Context {
+                id: format!("rule-{}", id_suffix),
+                name: name.to_string(),
+                content,
+                category: Some("rule-file".to_string()),
+                tags: vec!["rule-file".to_string()],
+                // No file_patterns ⇒ always-attached.
+                auto_include: None,
+                created_at: now.clone(),
+                modified_at: now.clone(),
+            });
+        }
+    }
+
+    // .cursor/rules/*.mdc — may carry explicit `globs:` frontmatter scope.
+    let mdc_dir = root.join(".cursor").join("rules");
+    if mdc_dir.is_dir() {
+        if let Ok(entries) = std::fs::read_dir(&mdc_dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("mdc") {
+                    continue;
+                }
+                let stem = match path.file_stem().and_then(|s| s.to_str()) {
+                    Some(s) => s.to_string(),
+                    None => continue,
+                };
+                let Some(raw) = read_nonempty(&path) else {
+                    continue;
+                };
+                let (globs, content) = parse_mdc_frontmatter(&raw);
+                let auto_include = globs.map(|patterns| ContextAutoInclude {
+                    file_patterns: Some(patterns),
+                    ..Default::default()
+                });
+                contexts.push(Context {
+                    id: format!("rule-mdc-{}", stem),
+                    name: format!(".cursor/rules/{}.mdc", stem),
+                    content,
+                    category: Some("rule-file".to_string()),
+                    tags: vec!["rule-file".to_string(), "cursor".to_string()],
+                    auto_include,
+                    created_at: now.clone(),
+                    modified_at: now.clone(),
+                });
+            }
+        }
+    }
+
+    // Subdirectory-scoped CLAUDE.md / AGENTS.md: a rule file under a subdir
+    // attaches only when the task touches that subdir. Scope = "<reldir>/**".
+    for nested in find_nested_rule_files(root) {
+        let Some(content) = read_nonempty(&nested) else {
+            continue;
+        };
+        let rel = match nested.strip_prefix(root) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let rel_str = rel.to_string_lossy().replace('\\', "/");
+        let reldir = rel
+            .parent()
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .filter(|s| !s.is_empty());
+        let scope_glob = reldir.map(|d| format!("{}/**", d));
+        let auto_include = scope_glob.map(|g| ContextAutoInclude {
+            file_patterns: Some(vec![g]),
+            ..Default::default()
+        });
+        // Sanitize the relative path into a deterministic, stable id.
+        let id_part: String = rel_str
+            .chars()
+            .map(|c| if c.is_alphanumeric() { c } else { '-' })
+            .collect();
+        contexts.push(Context {
+            id: format!("rule-nested-{}", id_part),
+            name: rel_str,
+            content,
+            category: Some("rule-file".to_string()),
+            tags: vec!["rule-file".to_string(), "scoped".to_string()],
+            auto_include,
+            created_at: now.clone(),
+            modified_at: now.clone(),
+        });
+    }
+
+    if !contexts.is_empty() {
+        info!(
+            "Ingested {} interop rule-file context(s) from {}",
+            contexts.len(),
+            root.display()
+        );
+    }
+
+    contexts
+}
+
+/// Read a file, returning `Some(content)` only if it exists and is non-empty.
+fn read_nonempty(path: &Path) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(c) if !c.trim().is_empty() => Some(c),
+        Ok(_) => None,
+        Err(_) => None,
+    }
+}
+
+/// Find subdirectory-scoped `CLAUDE.md` / `AGENTS.md` rule files.
+///
+/// Walks the tree (bounded depth, skipping VCS/dependency dirs) and returns
+/// every `CLAUDE.md` / `AGENTS.md` that is NOT at the repo root (root ones are
+/// handled as always-attached above).
+fn find_nested_rule_files(root: &Path) -> Vec<std::path::PathBuf> {
+    const MAX_DEPTH: usize = 8;
+    const SKIP_DIRS: &[&str] = &[
+        ".git",
+        "node_modules",
+        "target",
+        ".venv",
+        "venv",
+        "dist",
+        "build",
+        ".qontinui",
+        ".cursor",
+        "__pycache__",
+    ];
+
+    let mut found = Vec::new();
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(root.to_path_buf(), 0)];
+
+    while let Some((dir, depth)) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if file_type.is_dir() {
+                if depth + 1 > MAX_DEPTH {
+                    continue;
+                }
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                if SKIP_DIRS.contains(&name) || name.starts_with('.') {
+                    continue;
+                }
+                stack.push((path, depth + 1));
+            } else if file_type.is_file() && depth >= 1 {
+                // depth >= 1 ⇒ not the repo root, so this is a nested rule file.
+                let name = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or_default();
+                if name == "CLAUDE.md" || name == "AGENTS.md" {
+                    found.push(path);
+                }
+            }
+        }
+    }
+
+    found.sort();
+    found
+}
+
+/// Parse `.mdc` frontmatter, extracting an optional `globs:` scope.
+///
+/// Cursor `.mdc` files use YAML-ish frontmatter delimited by `---`. The
+/// `globs` key may be a YAML list or a single comma-separated string. Returns
+/// `(Some(globs), body)` when a non-empty `globs:` is present, else
+/// `(None, full_content)`.
+fn parse_mdc_frontmatter(raw: &str) -> (Option<Vec<String>>, String) {
+    let trimmed = raw.trim_start();
+    if !trimmed.starts_with("---") {
+        return (None, raw.to_string());
+    }
+    let after_first = &trimmed[3..];
+    let Some(pos) = after_first.find("\n---") else {
+        return (None, raw.to_string());
+    };
+    let yaml_str = &after_first[..pos];
+    let body = after_first[pos + 4..].trim_start_matches('\n').to_string();
+
+    #[derive(serde::Deserialize, Default)]
+    struct MdcFrontmatter {
+        #[serde(default)]
+        globs: Option<serde_yaml::Value>,
+    }
+
+    let fm: MdcFrontmatter = serde_yaml::from_str(yaml_str).unwrap_or_default();
+    let globs = match fm.globs {
+        Some(serde_yaml::Value::String(s)) => {
+            let parts: Vec<String> = s
+                .split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts)
+            }
+        }
+        Some(serde_yaml::Value::Sequence(seq)) => {
+            let parts: Vec<String> = seq
+                .into_iter()
+                .filter_map(|v| v.as_str().map(|s| s.trim().to_string()))
+                .filter(|s| !s.is_empty())
+                .collect();
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts)
+            }
+        }
+        _ => None,
+    };
+
+    (globs, body)
+}
+
+/// De-dupe contexts by content hash. The first occurrence wins (ordering:
+/// `.qontinui/contexts` first, then root rule files, then `.mdc`, then nested),
+/// so the canonical Qontinui-native source is preferred when content collides.
+fn dedupe_by_content(contexts: &mut Vec<Context>) {
+    let mut seen: HashSet<[u8; 32]> = HashSet::new();
+    contexts.retain(|ctx| {
+        let mut hasher = Sha256::new();
+        hasher.update(ctx.content.as_bytes());
+        let digest: [u8; 32] = hasher.finalize().into();
+        seen.insert(digest)
+    });
+}
+
+/// Enforce [`MAX_TOTAL_CONTEXT_CHARS`] across all ingested contexts.
+///
+/// Walks contexts in order, accumulating char counts. Once the running total
+/// reaches the cap, the current context's content is deterministically
+/// truncated to fit (with a marker) and all subsequent contexts are truncated
+/// to empty-with-marker. Nothing is dropped from the list (so IDs/names remain
+/// stable and visible), but oversized content never reaches the prompt.
+fn enforce_total_size_cap(contexts: &mut [Context]) {
+    let mut used = 0usize;
+    for ctx in contexts.iter_mut() {
+        let len = ctx.content.chars().count();
+        if used >= MAX_TOTAL_CONTEXT_CHARS {
+            ctx.content = TRUNCATION_MARKER.trim_start().to_string();
+            continue;
+        }
+        let remaining = MAX_TOTAL_CONTEXT_CHARS - used;
+        if len > remaining {
+            let keep = remaining.saturating_sub(TRUNCATION_MARKER.chars().count());
+            let truncated: String = ctx.content.chars().take(keep).collect();
+            ctx.content = format!("{}{}", truncated, TRUNCATION_MARKER);
+            used = MAX_TOTAL_CONTEXT_CHARS;
+        } else {
+            used += len;
+        }
+    }
 }
 
 /// Load project contexts from the current working directory.
@@ -339,5 +681,200 @@ mod tests {
     fn test_load_nonexistent_dir() {
         let contexts = load_project_contexts_from_dir("/nonexistent/path");
         assert!(contexts.is_empty());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Track C1: rule-file ingestion, scoping, de-dupe, size cap
+    // ────────────────────────────────────────────────────────────────────
+
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(root: &Path, rel: &str, content: &str) {
+        let path = root.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, content).unwrap();
+    }
+
+    fn find_ctx<'a>(ctxs: &'a [Context], id: &str) -> Option<&'a Context> {
+        ctxs.iter().find(|c| c.id == id)
+    }
+
+    #[test]
+    fn test_ingest_qontinui_contexts() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            ".qontinui/contexts/api.md",
+            "# API\nGuidelines here.",
+        );
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let c = find_ctx(&ctxs, "proj-ctx-api").expect("qontinui context present");
+        assert!(c.content.contains("Guidelines here"));
+    }
+
+    #[test]
+    fn test_ingest_claude_md() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "CLAUDE.md", "root claude rules");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let c = find_ctx(&ctxs, "rule-claude-md").expect("CLAUDE.md ingested");
+        assert_eq!(c.content, "root claude rules");
+        // Root rule files are always-attached (no scope).
+        assert!(c.auto_include.is_none());
+    }
+
+    #[test]
+    fn test_ingest_agents_md() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "AGENTS.md", "agents rules");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        assert!(find_ctx(&ctxs, "rule-agents-md").is_some());
+    }
+
+    #[test]
+    fn test_ingest_cursorrules() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), ".cursorrules", "legacy cursor rules");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let c = find_ctx(&ctxs, "rule-cursorrules").expect(".cursorrules ingested");
+        assert_eq!(c.content, "legacy cursor rules");
+    }
+
+    #[test]
+    fn test_ingest_mdc_with_globs() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            ".cursor/rules/backend.mdc",
+            "---\nglobs:\n  - \"src/api/**\"\n  - \"src/db/**\"\n---\nBackend conventions.",
+        );
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let c = find_ctx(&ctxs, "rule-mdc-backend").expect(".mdc ingested");
+        assert!(c.content.contains("Backend conventions"));
+        let patterns = c
+            .auto_include
+            .as_ref()
+            .and_then(|ai| ai.file_patterns.clone())
+            .expect("globs honored as file_patterns");
+        assert_eq!(patterns, vec!["src/api/**", "src/db/**"]);
+    }
+
+    #[test]
+    fn test_ingest_mdc_globs_comma_string() {
+        let dir = tempdir().unwrap();
+        write(
+            dir.path(),
+            ".cursor/rules/x.mdc",
+            "---\nglobs: \"*.rs, *.toml\"\n---\nbody",
+        );
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let c = find_ctx(&ctxs, "rule-mdc-x").unwrap();
+        let patterns = c
+            .auto_include
+            .as_ref()
+            .unwrap()
+            .file_patterns
+            .clone()
+            .unwrap();
+        assert_eq!(patterns, vec!["*.rs", "*.toml"]);
+    }
+
+    #[test]
+    fn test_nested_rule_file_is_scoped() {
+        let dir = tempdir().unwrap();
+        write(dir.path(), "src/foo/CLAUDE.md", "foo-specific rules");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let c = ctxs
+            .iter()
+            .find(|c| c.name == "src/foo/CLAUDE.md")
+            .expect("nested CLAUDE.md ingested");
+        let patterns = c
+            .auto_include
+            .as_ref()
+            .and_then(|ai| ai.file_patterns.clone())
+            .expect("nested rule file is path-scoped");
+        assert_eq!(patterns, vec!["src/foo/**"]);
+    }
+
+    #[test]
+    fn test_glob_scoping_attaches_only_for_matching_path() {
+        use crate::context::resolution::context_matches_touched_paths;
+        let dir = tempdir().unwrap();
+        write(dir.path(), "src/foo/CLAUDE.md", "foo rules");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let scoped = ctxs.iter().find(|c| c.name == "src/foo/CLAUDE.md").unwrap();
+
+        // Matches when a touched path is under src/foo/.
+        assert!(context_matches_touched_paths(
+            scoped,
+            &["src/foo/bar.rs".to_string()]
+        ));
+        // Does not match an unrelated path.
+        assert!(!context_matches_touched_paths(
+            scoped,
+            &["src/other/baz.rs".to_string()]
+        ));
+        // Does not match an empty touched set.
+        assert!(!context_matches_touched_paths(scoped, &[]));
+    }
+
+    #[test]
+    fn test_root_rule_always_attaches() {
+        use crate::context::resolution::context_matches_touched_paths;
+        let dir = tempdir().unwrap();
+        write(dir.path(), "CLAUDE.md", "root rules");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let root = find_ctx(&ctxs, "rule-claude-md").unwrap();
+        // Unscoped → attaches even with no touched paths.
+        assert!(context_matches_touched_paths(root, &[]));
+        assert!(context_matches_touched_paths(
+            root,
+            &["anything.rs".to_string()]
+        ));
+    }
+
+    #[test]
+    fn test_dedupe_identical_content() {
+        let dir = tempdir().unwrap();
+        // Same content via two conventions → collapses to one.
+        write(dir.path(), "CLAUDE.md", "identical rules body");
+        write(dir.path(), "AGENTS.md", "identical rules body");
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let count = ctxs
+            .iter()
+            .filter(|c| c.content == "identical rules body")
+            .count();
+        assert_eq!(count, 1, "duplicate content de-duped");
+    }
+
+    #[test]
+    fn test_size_cap_truncates_deterministically() {
+        let dir = tempdir().unwrap();
+        // One oversized rule file well beyond the cap.
+        let big = "x".repeat(MAX_TOTAL_CONTEXT_CHARS + 5_000);
+        write(dir.path(), "CLAUDE.md", &big);
+        let ctxs = load_project_contexts_from_dir(dir.path().to_str().unwrap());
+        let total: usize = ctxs.iter().map(|c| c.content.chars().count()).sum();
+        assert!(
+            total <= MAX_TOTAL_CONTEXT_CHARS,
+            "total {} exceeds cap {}",
+            total,
+            MAX_TOTAL_CONTEXT_CHARS
+        );
+        let c = find_ctx(&ctxs, "rule-claude-md").unwrap();
+        assert!(
+            c.content.contains("truncated by Qontinui context size cap"),
+            "truncation marker present"
+        );
+    }
+
+    #[test]
+    fn test_parse_mdc_no_frontmatter() {
+        let (globs, body) = parse_mdc_frontmatter("just a body, no fm");
+        assert!(globs.is_none());
+        assert_eq!(body, "just a body, no fm");
     }
 }

--- a/src-tauri/src/context/resolution.rs
+++ b/src-tauri/src/context/resolution.rs
@@ -206,6 +206,164 @@ pub fn resolve_contexts(
     result
 }
 
+/// Does a context's path-scope (its `auto_include.file_patterns`) admit the
+/// given set of touched paths?
+///
+/// Scoping rules (see `project_contexts.rs` for the model):
+/// - A context with NO `file_patterns` is unscoped ⇒ always attaches.
+/// - A scoped context attaches iff at least one touched path matches at least
+///   one of its globs.
+/// - A scoped context with an EMPTY `touched_paths` set does NOT attach
+///   (the task touches nothing the scope cares about). Conservative: a scoped
+///   rule should only appear when its files are in play.
+pub fn context_matches_touched_paths(ctx: &Context, touched_paths: &[String]) -> bool {
+    let patterns = match ctx
+        .auto_include
+        .as_ref()
+        .and_then(|ai| ai.file_patterns.as_ref())
+    {
+        Some(p) if !p.is_empty() => p,
+        _ => return true, // unscoped → always attaches
+    };
+
+    touched_paths.iter().any(|path| {
+        let normalized = path.replace('\\', "/");
+        patterns
+            .iter()
+            .any(|pat| glob_match::glob_match(pat, &normalized))
+    })
+}
+
+/// Category marker that [`crate::context::load_project_contexts_from_dir`]
+/// stamps on every ingested interop rule file (root `CLAUDE.md` / `AGENTS.md`
+/// / `.cursorrules`, `.cursor/rules/*.mdc`, nested rule files). Used to
+/// recognize always-attached rule-file contexts at resolution time.
+const RULE_FILE_CATEGORY: &str = "rule-file";
+
+/// Resolve contexts, then attach project rule-file contexts and apply
+/// path/glob scoping by the task's touched paths (Track C1 + C2).
+///
+/// Reuses [`resolve_contexts`] verbatim for the trigger-based resolution
+/// decision (explicit IDs + auto-detect against task text/actions/errors), so
+/// there is exactly ONE resolution model. It then layers in the rule-file
+/// *attachment* semantics that trigger-matching alone cannot express:
+///
+/// - Project rule-file contexts (`category == "rule-file"`) are
+///   **always-attached** by convention, NOT trigger-gated. Root rules
+///   (`CLAUDE.md` / `AGENTS.md` / `.cursorrules`) carry no `auto_include`, so
+///   plain `resolve_contexts` would never surface them; we add any that the
+///   trigger pass missed here.
+/// - The scope filter ([`context_matches_touched_paths`]) is then applied to
+///   the WHOLE set: unscoped contexts always survive; a scoped rule (e.g. a
+///   nested `src/foo/CLAUDE.md` → `src/foo/**`, or a `.mdc` with `globs:`)
+///   survives only when a touched path matches.
+pub fn resolve_contexts_scoped(
+    explicit_ids: &[String],
+    auto_detect: bool,
+    task_prompt: &str,
+    action_types: &[String],
+    recent_errors: &[String],
+    touched_paths: &[String],
+) -> ResolvedContexts {
+    let mut resolved = resolve_contexts(
+        explicit_ids,
+        auto_detect,
+        task_prompt,
+        action_types,
+        recent_errors,
+    );
+
+    // Attach always-on project rule-file contexts that the trigger-based pass
+    // above did not already include. Root rule files have no `auto_include`,
+    // so they are invisible to trigger matching — but the convention is that
+    // they always apply (subject to the scope filter below). Push them onto
+    // `auto_detected` with an explicit reason so provenance is recorded.
+    let already: std::collections::HashSet<String> = resolved
+        .explicit
+        .iter()
+        .chain(resolved.auto_detected.iter())
+        .map(|c| c.id.clone())
+        .collect();
+    for ctx in get_project_contexts() {
+        if ctx.category.as_deref() != Some(RULE_FILE_CATEGORY) {
+            continue;
+        }
+        if already.contains(&ctx.id) {
+            continue;
+        }
+        resolved.auto_detect_reasons.push(AutoDetectReason {
+            context_id: ctx.id.clone(),
+            reason: "ruleFile".to_string(),
+            matched_trigger: ctx
+                .auto_include
+                .as_ref()
+                .and_then(|ai| ai.file_patterns.as_ref())
+                .map(|p| p.join(","))
+                .unwrap_or_else(|| "always-attached".to_string()),
+        });
+        resolved.auto_detected.push(ctx);
+    }
+
+    resolved
+        .explicit
+        .retain(|c| context_matches_touched_paths(c, touched_paths));
+    resolved
+        .auto_detected
+        .retain(|c| context_matches_touched_paths(c, touched_paths));
+    let surviving: std::collections::HashSet<&str> = resolved
+        .explicit
+        .iter()
+        .chain(resolved.auto_detected.iter())
+        .map(|c| c.id.as_str())
+        .collect();
+    resolved
+        .auto_detect_reasons
+        .retain(|r| surviving.contains(r.context_id.as_str()));
+
+    resolved
+}
+
+/// Inject contexts into a prompt with path/glob scoping applied.
+///
+/// Path-scoped variant of [`inject_contexts`]: project-rule contexts that
+/// declare a `file_patterns` scope only attach when one of `touched_paths`
+/// matches. Reuses the same `resolve → format → prepend` plumbing — there is
+/// exactly one resolution model.
+pub fn inject_contexts_scoped(
+    base_prompt: &str,
+    context_ids: &[String],
+    auto_detect: bool,
+    task_prompt: &str,
+    action_types: &[String],
+    recent_errors: &[String],
+    touched_paths: &[String],
+) -> (String, Vec<String>) {
+    let resolved = resolve_contexts_scoped(
+        context_ids,
+        auto_detect,
+        task_prompt,
+        action_types,
+        recent_errors,
+        touched_paths,
+    );
+
+    let used_ids: Vec<String> = resolved
+        .explicit
+        .iter()
+        .chain(resolved.auto_detected.iter())
+        .map(|c| c.id.clone())
+        .collect();
+
+    let context_section = format_contexts_for_prompt(&resolved);
+
+    let enhanced = match context_section {
+        Some(section) => format!("{}{}", section, base_prompt),
+        None => base_prompt.to_string(),
+    };
+
+    (enhanced, used_ids)
+}
+
 /// Format a single context for injection into a prompt.
 fn format_context(ctx: &Context) -> String {
     let category_attr = ctx
@@ -375,4 +533,62 @@ pub fn format_single_context(ctx: &Context) -> String {
         "<context name=\"{}\"{}>\n{}\n</context>",
         ctx.name, category_attr, ctx.content
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::types::{Context, ContextAutoInclude};
+
+    fn ctx_with_patterns(patterns: Option<Vec<String>>) -> Context {
+        Context {
+            id: "t".to_string(),
+            name: "t".to_string(),
+            content: "body".to_string(),
+            category: None,
+            tags: vec![],
+            auto_include: patterns.map(|p| ContextAutoInclude {
+                file_patterns: Some(p),
+                ..Default::default()
+            }),
+            created_at: String::new(),
+            modified_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn unscoped_context_always_matches() {
+        let c = ctx_with_patterns(None);
+        assert!(context_matches_touched_paths(&c, &[]));
+        assert!(context_matches_touched_paths(&c, &["x.rs".to_string()]));
+    }
+
+    #[test]
+    fn scoped_context_matches_only_in_scope() {
+        let c = ctx_with_patterns(Some(vec!["src/api/**".to_string()]));
+        assert!(context_matches_touched_paths(
+            &c,
+            &["src/api/handler.rs".to_string()]
+        ));
+        assert!(!context_matches_touched_paths(
+            &c,
+            &["src/ui/view.rs".to_string()]
+        ));
+        assert!(!context_matches_touched_paths(&c, &[]));
+    }
+
+    #[test]
+    fn scoped_context_normalizes_windows_separators() {
+        let c = ctx_with_patterns(Some(vec!["src/api/**".to_string()]));
+        assert!(context_matches_touched_paths(
+            &c,
+            &["src\\api\\handler.rs".to_string()]
+        ));
+    }
+
+    #[test]
+    fn empty_patterns_treated_as_unscoped() {
+        let c = ctx_with_patterns(Some(vec![]));
+        assert!(context_matches_touched_paths(&c, &[]));
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -677,6 +677,9 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         app_registry: Arc::new(tokio::sync::OnceCell::new()),
         app_dispatcher: Arc::new(tokio::sync::OnceCell::new()),
         wrapper_state: Arc::new(tokio::sync::OnceCell::new()),
+        prehydration_cache: Arc::new(
+            crate::unified_workflow_executor::prehydration::PrehydrationCache::new(),
+        ),
     });
     let mcp_app_state = shared_app_state.clone();
     let mcp_rag_state = rag_state.clone();

--- a/src-tauri/src/unified_workflow_executor/agentic_verification_loop.rs
+++ b/src-tauri/src/unified_workflow_executor/agentic_verification_loop.rs
@@ -257,6 +257,24 @@ impl IterationHistory {
     fn to_json(&self) -> String {
         serde_json::to_string(&self.entries).unwrap_or_else(|_| "[]".to_string())
     }
+
+    /// All distinct file paths touched across iterations so far.
+    ///
+    /// Used to drive path/glob scoping of project rule-file contexts (Track C):
+    /// a subdirectory-scoped rule attaches once the worker touches a file
+    /// matching its glob.
+    fn all_touched_paths(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::new();
+        for entry in &self.entries {
+            for f in &entry.files_touched {
+                if seen.insert(f.clone()) {
+                    out.push(f.clone());
+                }
+            }
+        }
+        out
+    }
 }
 
 /// Extract an IterationSummary from a worker's output and the verification verdict.
@@ -293,6 +311,54 @@ fn extract_iteration_summary(
         files_touched,
         confidence_delta: verdict.confidence - prev_confidence,
     }
+}
+
+/// Build the project-context section for the agentic loop's pre-LLM prompt
+/// assembly (Track C2).
+///
+/// Reuses the SINGLE resolution model from `context::resolution`:
+/// `resolve_contexts_scoped` (auto-detect against the goal text + path/glob
+/// scoping against the worker's touched paths) → `format_contexts_for_prompt`.
+/// This is the same plumbing the unified-workflow and generator paths use; the
+/// agentic loop previously injected NO project contexts at all.
+///
+/// `project_path`, when set, is used as the CWD so the rule-file ingestion
+/// (CLAUDE.md / AGENTS.md / .cursorrules / .mdc + .qontinui/contexts) reads the
+/// task's actual workspace rather than the runner process CWD.
+///
+/// Returns `None` when no contexts resolve (no rule files / nothing matches),
+/// so callers can cheaply skip injection.
+fn build_project_context_section(
+    goal: &str,
+    touched_paths: &[String],
+    project_path: Option<&str>,
+) -> Option<String> {
+    // Scope rule-file ingestion to the task workspace if known. The context
+    // loaders key off the process CWD, so temporarily set it. Best-effort:
+    // if the chdir fails we fall back to the current CWD.
+    let restore_cwd = project_path.and_then(|p| {
+        let prev = std::env::current_dir().ok();
+        if std::env::set_current_dir(p).is_ok() {
+            prev
+        } else {
+            None
+        }
+    });
+
+    let resolved = crate::context::resolve_contexts_scoped(
+        &[],  // no explicit IDs — agentic loop relies on auto-detect + always-attached rules
+        true, // auto_detect against the goal text
+        goal, // task_prompt
+        &[],  // action_types — n/a for the agentic loop
+        &[],  // recent_errors — verifier feeds these separately
+        touched_paths,
+    );
+
+    if let Some(prev) = restore_cwd {
+        let _ = std::env::set_current_dir(prev);
+    }
+
+    crate::context::format_contexts_for_prompt(&resolved)
 }
 
 impl LoopController {
@@ -376,6 +442,19 @@ impl LoopController {
         // Save original model/provider overrides so we can restore after each iteration
         let original_model_override = config.model_override.clone();
         let original_provider_override = config.provider_override.clone();
+
+        // ── Track C3: speculative MCP / link pre-hydration ─────────────────
+        // Before the first agentic turn, best-effort pre-fetch available MCP
+        // tools + any URLs/issue-refs in the goal. Strictly never-blocking:
+        // bounded + error-swallowing inside `prehydrate`. The cached summary
+        // (timestamp-labeled) is injected ONLY into the first iteration's
+        // prompts so the model is primed without paying a tool round-trip.
+        let prehydration_summary = crate::unified_workflow_executor::prehydration::prehydrate(
+            &self.app_state,
+            &config.execution_id,
+            &goal,
+        )
+        .await;
 
         loop {
             iteration += 1;
@@ -530,6 +609,26 @@ impl LoopController {
 
                 // Build context for the verifier: include previous iteration results
                 let mut verifier_context = verifier_system;
+
+                // Track C2: inject resolved project contexts (rule files +
+                // .qontinui/contexts), path/glob-scoped to the touched paths.
+                if let Some(section) = build_project_context_section(
+                    &goal,
+                    &iteration_history.all_touched_paths(),
+                    config.project_path.as_deref(),
+                ) {
+                    verifier_context.push_str("\n\n");
+                    verifier_context.push_str(&section);
+                }
+
+                // Track C3: prime the FIRST verifier turn with pre-hydrated data.
+                if iteration == 1 {
+                    if let Some(ref summary) = prehydration_summary {
+                        verifier_context.push_str("\n\n");
+                        verifier_context.push_str(summary);
+                    }
+                }
+
                 if let Some(last_result) = iteration_results.last() {
                     verifier_context.push_str(&format!(
                         "\n\n## Previous Iteration ({}) Summary\nWorker action: {}\n",
@@ -936,6 +1035,26 @@ impl LoopController {
                     goal
                 )
             };
+
+            // Track C2: inject resolved project contexts (rule files +
+            // .qontinui/contexts) into the WORKER prompt too, path/glob-scoped
+            // to whatever files have been touched so far this run.
+            if let Some(section) = build_project_context_section(
+                &goal,
+                &iteration_history.all_touched_paths(),
+                config.project_path.as_deref(),
+            ) {
+                worker_failure_context.push_str("\n\n");
+                worker_failure_context.push_str(&section);
+            }
+
+            // Track C3: prime the FIRST worker turn with pre-hydrated data.
+            if iteration == 1 {
+                if let Some(ref summary) = prehydration_summary {
+                    worker_failure_context.push_str("\n\n");
+                    worker_failure_context.push_str(summary);
+                }
+            }
 
             // Inject compressed iteration history so the worker knows what was already tried
             let history_context = iteration_history.to_context_string();

--- a/src-tauri/src/unified_workflow_executor/loop_controller.rs
+++ b/src-tauri/src/unified_workflow_executor/loop_controller.rs
@@ -1444,14 +1444,22 @@ impl LoopController {
                         "  Stage {}: Using AGENTIC VERIFICATION architecture",
                         stage_num
                     );
-                    self.run_agentic_verification_loop(
-                        &mut stage_loop_config,
-                        has_agentic,
-                        &stage.agentic_steps,
-                        &mut all_step_results,
-                        logger,
-                    )
-                    .await
+                    let agentic_result = self
+                        .run_agentic_verification_loop(
+                            &mut stage_loop_config,
+                            has_agentic,
+                            &stage.agentic_steps,
+                            &mut all_step_results,
+                            logger,
+                        )
+                        .await;
+                    // Track C3: drop the per-execution pre-hydration cache entry
+                    // now that the agentic loop has finished consuming it.
+                    self.app_state
+                        .prehydration_cache
+                        .remove(&stage_loop_config.execution_id)
+                        .await;
+                    agentic_result
                 } else if matches!(
                     stage_loop_config.workflow_architecture,
                     Some(crate::agentic_verification::WorkflowArchitecture::MultiAgentPipeline)

--- a/src-tauri/src/unified_workflow_executor/mod.rs
+++ b/src-tauri/src/unified_workflow_executor/mod.rs
@@ -77,6 +77,7 @@ pub mod output_parser;
 mod phase_configs;
 mod phase_helpers;
 mod phases;
+pub mod prehydration;
 pub mod replay;
 mod resume;
 pub mod review_subtask;

--- a/src-tauri/src/unified_workflow_executor/prehydration.rs
+++ b/src-tauri/src/unified_workflow_executor/prehydration.rs
@@ -1,0 +1,308 @@
+//! Speculative MCP / link pre-hydration (Track C3).
+//!
+//! Before the first agentic turn, the runner performs a handful of *obvious*
+//! lookups so the first prompt can be primed with context the model would
+//! otherwise have to discover via tool round-trips:
+//!
+//! 1. **coord `tools/list`** — enumerate available MCP tools so the prompt can
+//!    hint what's callable.
+//! 2. **URL / issue-ref fetch** — any `http(s)://` URLs or `#123` /
+//!    `owner/repo#123` issue refs present in the task description are fetched
+//!    (best-effort) so their gist is available up front.
+//!
+//! ## Strictly best-effort & never-blocking
+//!
+//! Every fetch here is wrapped so that a failure NEVER blocks or fails the
+//! task — errors are swallowed + logged and setup proceeds. The whole
+//! pre-hydration is also time-bounded.
+//!
+//! ## Honesty about staleness
+//!
+//! A pre-fetched tool list or URL body can go stale between pre-hydration and
+//! the moment the model reads it. Every injected block is labeled with the
+//! UTC timestamp at which it was fetched, so the model can reason about
+//! freshness rather than trusting it blindly.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use crate::commands::AppState;
+
+/// Per-fetch timeout for speculative URL fetches.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(8);
+/// Overall budget for the whole pre-hydration pass.
+const PREHYDRATION_BUDGET: Duration = Duration::from_secs(20);
+/// Max number of URLs/refs to speculatively fetch (avoid runaway prompts).
+const MAX_URLS: usize = 5;
+/// Max chars kept from a single fetched URL body in the summary.
+const MAX_URL_BODY_CHARS: usize = 1_500;
+/// Max tool names listed in the summary before eliding the tail.
+const MAX_TOOLS_LISTED: usize = 60;
+
+/// A cached, timestamped pre-hydration summary for one execution.
+#[derive(Debug, Clone)]
+pub struct PrehydrationEntry {
+    /// UTC RFC3339 timestamp at which the data was fetched.
+    pub fetched_at: String,
+    /// Compact, prompt-ready summary (already labeled with `fetched_at`).
+    pub summary: String,
+}
+
+/// In-memory cache of pre-hydration summaries, keyed by `execution_id`.
+///
+/// Lives on [`AppState`]. Cleared opportunistically; a bounded number of
+/// entries is fine since executions are short-lived and entries are small.
+#[derive(Debug, Default)]
+pub struct PrehydrationCache {
+    inner: Mutex<HashMap<String, PrehydrationEntry>>,
+}
+
+impl PrehydrationCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store a pre-hydration summary for an execution.
+    pub async fn put(&self, execution_id: &str, entry: PrehydrationEntry) {
+        self.inner
+            .lock()
+            .await
+            .insert(execution_id.to_string(), entry);
+    }
+
+    /// Fetch a previously stored summary, if any.
+    pub async fn get(&self, execution_id: &str) -> Option<PrehydrationEntry> {
+        self.inner.lock().await.get(execution_id).cloned()
+    }
+
+    /// Drop the entry for a completed execution.
+    pub async fn remove(&self, execution_id: &str) {
+        self.inner.lock().await.remove(execution_id);
+    }
+}
+
+/// Run speculative pre-hydration for an execution and cache the result.
+///
+/// Never blocks the task: the whole pass is bounded by
+/// [`PREHYDRATION_BUDGET`] and every individual lookup swallows its errors.
+/// Returns the compact summary that was cached (also retrievable later via
+/// [`PrehydrationCache::get`]), or `None` if nothing useful was gathered.
+pub async fn prehydrate(
+    app_state: &Arc<AppState>,
+    execution_id: &str,
+    task_description: &str,
+) -> Option<String> {
+    let fetched_at = chrono::Utc::now().to_rfc3339();
+
+    // Bound the whole pass. On timeout we still cache whatever the inner
+    // future managed to return before being dropped — but since `timeout`
+    // drops the future, we instead build the summary inside the bounded
+    // future and only cache on completion.
+    let built = tokio::time::timeout(
+        PREHYDRATION_BUDGET,
+        build_summary(app_state, task_description, &fetched_at),
+    )
+    .await;
+
+    let summary = match built {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            debug!(
+                "PREHYDRATION: nothing to pre-hydrate for execution {}",
+                execution_id
+            );
+            return None;
+        }
+        Err(_) => {
+            warn!(
+                "PREHYDRATION: budget ({:?}) exceeded for execution {}; proceeding without pre-hydration",
+                PREHYDRATION_BUDGET, execution_id
+            );
+            return None;
+        }
+    };
+
+    app_state
+        .prehydration_cache
+        .put(
+            execution_id,
+            PrehydrationEntry {
+                fetched_at,
+                summary: summary.clone(),
+            },
+        )
+        .await;
+
+    info!(
+        "PREHYDRATION: cached {} char summary for execution {}",
+        summary.len(),
+        execution_id
+    );
+
+    Some(summary)
+}
+
+/// Build the compact, timestamp-labeled summary. Each section is independently
+/// best-effort.
+async fn build_summary(
+    app_state: &Arc<AppState>,
+    task_description: &str,
+    fetched_at: &str,
+) -> Option<String> {
+    let mut sections: Vec<String> = Vec::new();
+
+    // (a) coord tools/list — available MCP tools.
+    let tools = crate::runtime_env::get_available_mcp_tools(app_state).await;
+    if !tools.is_empty() {
+        let mut listed: Vec<String> = tools.iter().take(MAX_TOOLS_LISTED).cloned().collect();
+        let elided = tools.len().saturating_sub(listed.len());
+        if elided > 0 {
+            listed.push(format!("…(+{} more)", elided));
+        }
+        sections.push(format!(
+            "### Available MCP tools (pre-fetched {})\n{}",
+            fetched_at,
+            listed
+                .iter()
+                .map(|t| format!("- {}", t))
+                .collect::<Vec<_>>()
+                .join("\n")
+        ));
+    }
+
+    // (b) URLs / issue refs in the task description.
+    let urls = extract_urls(task_description);
+    if !urls.is_empty() {
+        let client = reqwest::Client::builder()
+            .timeout(FETCH_TIMEOUT)
+            .user_agent("qontinui-runner-prehydration")
+            .build()
+            .ok();
+
+        if let Some(client) = client {
+            for url in urls.into_iter().take(MAX_URLS) {
+                match fetch_url_gist(&client, &url).await {
+                    Some(gist) => sections.push(format!(
+                        "### Pre-fetched link: {} (fetched {})\n{}",
+                        url, fetched_at, gist
+                    )),
+                    None => debug!("PREHYDRATION: failed to fetch {}", url),
+                }
+            }
+        }
+    }
+
+    if sections.is_empty() {
+        return None;
+    }
+
+    let mut out = String::new();
+    out.push_str("## Pre-Hydrated Context (speculative, best-effort)\n\n");
+    out.push_str(&format!(
+        "The following was fetched at {} BEFORE this turn and MAY BE STALE. \
+         Verify with a live tool call if correctness matters.\n\n",
+        fetched_at
+    ));
+    out.push_str(&sections.join("\n\n"));
+    out.push_str("\n\n---\n\n");
+    Some(out)
+}
+
+/// Fetch a URL and return a truncated text gist, or `None` on any failure.
+async fn fetch_url_gist(client: &reqwest::Client, url: &str) -> Option<String> {
+    let resp = client.get(url).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body = resp.text().await.ok()?;
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let gist: String = trimmed.chars().take(MAX_URL_BODY_CHARS).collect();
+    if gist.chars().count() < trimmed.chars().count() {
+        Some(format!("{}…", gist))
+    } else {
+        Some(gist)
+    }
+}
+
+/// Extract `http(s)://` URLs from free text. Issue refs like `owner/repo#123`
+/// are normalized to a GitHub API/issue URL when they look like a GitHub ref.
+fn extract_urls(text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for raw in text.split_whitespace() {
+        // Strip common trailing punctuation.
+        let tok = raw.trim_matches(|c: char| {
+            matches!(
+                c,
+                ',' | '.' | ';' | ')' | '(' | '"' | '\'' | '<' | '>' | ']' | '['
+            )
+        });
+
+        if (tok.starts_with("http://") || tok.starts_with("https://"))
+            && seen.insert(tok.to_string())
+        {
+            out.push(tok.to_string());
+            continue;
+        }
+
+        // owner/repo#123 → GitHub issue URL.
+        if let Some(hash) = tok.find('#') {
+            let (repo, num) = tok.split_at(hash);
+            let num = &num[1..];
+            if !num.is_empty()
+                && num.chars().all(|c| c.is_ascii_digit())
+                && repo.matches('/').count() == 1
+                && repo.split('/').all(|p| !p.is_empty())
+            {
+                let url = format!("https://github.com/{}/issues/{}", repo, num);
+                if seen.insert(url.clone()) {
+                    out.push(url);
+                }
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_plain_urls() {
+        let urls = extract_urls("see https://example.com/foo and http://bar.test/x.");
+        assert_eq!(
+            urls,
+            vec![
+                "https://example.com/foo".to_string(),
+                "http://bar.test/x".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_extract_issue_ref() {
+        let urls = extract_urls("fix qontinui/runner#318 please");
+        assert_eq!(
+            urls,
+            vec!["https://github.com/qontinui/runner/issues/318".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_extract_dedup_and_none() {
+        let urls = extract_urls("no links here, just words and a#b (not a ref)");
+        assert!(urls.is_empty());
+        let urls = extract_urls("https://a.test https://a.test");
+        assert_eq!(urls.len(), 1);
+    }
+}


### PR DESCRIPTION
## Track C — Context Pre-Hydration + Rule-File Ingestion

Implements **Track C** of the Minions-Derived Bundle plan. Independent of Tracks A/B (separate repos, no ordering dependency).

The runner already loaded `.qontinui/contexts/*.md` for the unified-workflow and generation prompts, but (a) only that hardcoded dir, and (b) the **agentic verification loop** never injected project contexts at all. This broadens ingestion and reaches the agentic prompt.

- **C1 — broaden rule-file ingestion** (`project_contexts.rs`): also ingests root `CLAUDE.md`/`AGENTS.md`/`.cursorrules` (always-attached), `.cursor/rules/*.mdc` (honors `globs:` frontmatter), and nested `CLAUDE.md`/`AGENTS.md` (path-scoped to `<reldir>/**`). De-dupe by SHA-256 content hash (canonical `.qontinui/contexts/` wins collisions). **Hard 80K-char size cap** (~20K tokens), deterministic truncation — the context-window guard the plan mandates.
- **C2 — wire into the agentic loop** (`agentic_verification_loop.rs:526`): injects resolved contexts into both worker + verifier prompts, scoped by the iteration's touched paths. **Reuses the existing `resolve_contexts()` plumbing** — one resolution model, not two.
- **C3 — speculative pre-hydration** (`prehydration.rs`): before iteration 1's Claude session, best-effort fetches coord `tools/list` + any URLs/issue-refs in the task description (20s total budget, 8s/fetch, all errors swallowed). Cached in `AppState`, injected only into iteration 1, **every block labeled with its UTC fetch time** (honesty about staleness). A pre-fetch failure never blocks the task.

### Correctness fix during review
The adopted draft's "always-attached" root rule files were silently broken in the agentic path: `resolve_contexts(auto_detect=true)` only surfaces contexts with matching `auto_include` triggers, but root rule files carry `auto_include: None` — so they were never selected. Fixed `resolve_contexts_scoped()` to additionally pull in any `category == "rule-file"` context the trigger pass missed, then apply the scope filter.

### Gate (isolated `CARGO_TARGET_DIR`, verified compiling the worktree)
- `cargo check` / `cargo clippy --features custom-protocol -- -D warnings` — exit 0, confirmed `Compiling qontinui-runner (…-wt-prehydration\src-tauri)`.
- tests: `context::` 58 passed, `prehydration` 3 passed / 0 failed.

### Known follow-up (out of scope)
`build_project_context_section` set/restores process CWD around resolution (the loaders key off `current_dir()`) — a pre-existing pattern, not new risk, but a candidate for threading a project-path param through the resolution API in a future cleanup.