### PR TITLE
refactor(runner): thread project_path through context resolution, drop CWD mutation

### DIFF
--- a/src-tauri/src/context/resolution.rs
+++ b/src-tauri/src/context/resolution.rs
@@ -4,7 +4,7 @@
 
 use super::builtins::get_builtin_contexts;
 use super::metadata::record_context_use;
-use super::project_contexts::get_project_contexts;
+use super::project_contexts::{get_project_contexts, load_project_contexts_from_dir};
 use super::storage::load_user_context_library;
 use super::types::{AutoDetectReason, Context, ResolvedContexts};
 use super::user_contexts::get_all_user_contexts;
@@ -58,25 +58,44 @@ pub fn should_auto_include(
     false
 }
 
+/// Select the project-context source.
+///
+/// `Some(path)` loads `.qontinui/contexts/` + interop rule files from that
+/// explicit workspace directory; `None` falls back to the process CWD
+/// (`get_project_contexts`). Threading an explicit path lets callers (e.g. the
+/// agentic verification loop) point the loaders at a task's workspace WITHOUT
+/// mutating the global process CWD — eliminating a chdir side-effect that could
+/// race across concurrent in-process resolutions.
+fn project_contexts_for(project_path: Option<&str>) -> Vec<Context> {
+    match project_path {
+        Some(p) => load_project_contexts_from_dir(p),
+        None => get_project_contexts(),
+    }
+}
+
 /// Resolve which contexts should be included in a prompt.
 ///
 /// This function:
 /// 1. Looks up explicit context IDs from user, project, and builtin sources
 /// 2. If auto_detect is true, evaluates all enabled contexts against the task/config
 /// 3. Merges and deduplicates the results
+///
+/// `project_path` selects the project-context source: `Some(dir)` reads that
+/// workspace; `None` uses the process CWD (back-compat default).
 pub fn resolve_contexts(
     explicit_ids: &[String],
     auto_detect: bool,
     task_prompt: &str,
     action_types: &[String],
     recent_errors: &[String],
+    project_path: Option<&str>,
 ) -> ResolvedContexts {
     let mut result = ResolvedContexts::default();
     let mut included_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     // Gather all available contexts (user + project + builtin)
     let user_contexts = get_all_user_contexts();
-    let project_contexts = get_project_contexts();
+    let project_contexts = project_contexts_for(project_path);
     let builtin_contexts = get_builtin_contexts();
     let library = load_user_context_library();
 
@@ -264,6 +283,7 @@ pub fn resolve_contexts_scoped(
     action_types: &[String],
     recent_errors: &[String],
     touched_paths: &[String],
+    project_path: Option<&str>,
 ) -> ResolvedContexts {
     let mut resolved = resolve_contexts(
         explicit_ids,
@@ -271,6 +291,7 @@ pub fn resolve_contexts_scoped(
         task_prompt,
         action_types,
         recent_errors,
+        project_path,
     );
 
     // Attach always-on project rule-file contexts that the trigger-based pass
@@ -284,7 +305,7 @@ pub fn resolve_contexts_scoped(
         .chain(resolved.auto_detected.iter())
         .map(|c| c.id.clone())
         .collect();
-    for ctx in get_project_contexts() {
+    for ctx in project_contexts_for(project_path) {
         if ctx.category.as_deref() != Some(RULE_FILE_CATEGORY) {
             continue;
         }
@@ -337,6 +358,7 @@ pub fn inject_contexts_scoped(
     action_types: &[String],
     recent_errors: &[String],
     touched_paths: &[String],
+    project_path: Option<&str>,
 ) -> (String, Vec<String>) {
     let resolved = resolve_contexts_scoped(
         context_ids,
@@ -345,6 +367,7 @@ pub fn inject_contexts_scoped(
         action_types,
         recent_errors,
         touched_paths,
+        project_path,
     );
 
     let used_ids: Vec<String> = resolved
@@ -421,6 +444,7 @@ pub fn inject_contexts(
     task_prompt: &str,
     action_types: &[String],
     recent_errors: &[String],
+    project_path: Option<&str>,
 ) -> (String, Vec<String>) {
     let resolved = resolve_contexts(
         context_ids,
@@ -428,6 +452,7 @@ pub fn inject_contexts(
         task_prompt,
         action_types,
         recent_errors,
+        project_path,
     );
 
     // Collect all context IDs that were used

--- a/src-tauri/src/mcp/ai_session.rs
+++ b/src-tauri/src/mcp/ai_session.rs
@@ -1737,6 +1737,7 @@ pub async fn run_prompt(
                 &prompt_content, // Use original prompt for auto-detection matching
                 &action_types,
                 &recent_errors,
+                None, // CWD-based project contexts (no explicit workspace path here)
             );
 
             if !used_ids.is_empty() {

--- a/src-tauri/src/mcp/unified_workflows.rs
+++ b/src-tauri/src/mcp/unified_workflows.rs
@@ -902,7 +902,7 @@ pub async fn generate_unified_workflow_async_handler(
     let mut resolved_contexts = String::new();
     if let Some(ref ids) = request.context_ids {
         if !ids.is_empty() {
-            let resolved = crate::context::resolve_contexts(ids, false, "", &[], &[]);
+            let resolved = crate::context::resolve_contexts(ids, false, "", &[], &[], None);
             if let Some(formatted) = crate::context::format_contexts_for_prompt(&resolved) {
                 resolved_contexts.push_str(&formatted);
             }

--- a/src-tauri/src/unified_workflow_executor/agentic_verification_loop.rs
+++ b/src-tauri/src/unified_workflow_executor/agentic_verification_loop.rs
@@ -322,9 +322,12 @@ fn extract_iteration_summary(
 /// This is the same plumbing the unified-workflow and generator paths use; the
 /// agentic loop previously injected NO project contexts at all.
 ///
-/// `project_path`, when set, is used as the CWD so the rule-file ingestion
-/// (CLAUDE.md / AGENTS.md / .cursorrules / .mdc + .qontinui/contexts) reads the
-/// task's actual workspace rather than the runner process CWD.
+/// `project_path`, when set, is passed straight through the resolution API so
+/// rule-file ingestion (CLAUDE.md / AGENTS.md / .cursorrules / .mdc +
+/// .qontinui/contexts) reads the task's actual workspace. It does NOT mutate
+/// the process CWD — the path is threaded as an explicit argument, so
+/// concurrent in-process resolutions can't race on a shared global directory.
+/// When `None`, resolution falls back to the process CWD.
 ///
 /// Returns `None` when no contexts resolve (no rule files / nothing matches),
 /// so callers can cheaply skip injection.
@@ -333,18 +336,6 @@ fn build_project_context_section(
     touched_paths: &[String],
     project_path: Option<&str>,
 ) -> Option<String> {
-    // Scope rule-file ingestion to the task workspace if known. The context
-    // loaders key off the process CWD, so temporarily set it. Best-effort:
-    // if the chdir fails we fall back to the current CWD.
-    let restore_cwd = project_path.and_then(|p| {
-        let prev = std::env::current_dir().ok();
-        if std::env::set_current_dir(p).is_ok() {
-            prev
-        } else {
-            None
-        }
-    });
-
     let resolved = crate::context::resolve_contexts_scoped(
         &[],  // no explicit IDs — agentic loop relies on auto-detect + always-attached rules
         true, // auto_detect against the goal text
@@ -352,11 +343,8 @@ fn build_project_context_section(
         &[],  // action_types — n/a for the agentic loop
         &[],  // recent_errors — verifier feeds these separately
         touched_paths,
+        project_path, // scope rule-file ingestion to the task workspace, no chdir
     );
-
-    if let Some(prev) = restore_cwd {
-        let _ = std::env::set_current_dir(prev);
-    }
 
     crate::context::format_contexts_for_prompt(&resolved)
 }

--- a/src-tauri/src/workflow_generation/generator.rs
+++ b/src-tauri/src/workflow_generation/generator.rs
@@ -811,7 +811,7 @@ pub fn generate_workflow(
         // Resolve explicitly selected context IDs (user + builtin + project)
         if let Some(ref ids) = request.context_ids {
             if !ids.is_empty() {
-                let resolved = context::resolve_contexts(ids, false, "", &[], &[]);
+                let resolved = context::resolve_contexts(ids, false, "", &[], &[], None);
                 if let Some(formatted) = context::format_contexts_for_prompt(&resolved) {
                     ctx.push_str(&formatted);
                 }
@@ -2424,7 +2424,7 @@ fn run_builder_agent(
 
     if let Some(ref ids) = request.context_ids {
         if !ids.is_empty() {
-            let resolved = context::resolve_contexts(ids, false, "", &[], &[]);
+            let resolved = context::resolve_contexts(ids, false, "", &[], &[], None);
             if let Some(formatted) = context::format_contexts_for_prompt(&resolved) {
                 context_section.push_str(&formatted);
             }


### PR DESCRIPTION
## Follow-up to Track C (#361): eliminate the agentic-loop CWD mutation

The Track C agentic-loop wiring (#361) noted a known follow-up: `build_project_context_section` set/restored the **process CWD** around `resolve_contexts_scoped`, because the context loaders bottom out at `get_project_contexts()` which reads `std::env::current_dir()`. That global-CWD mutation is a side-effect that could race across concurrent in-process resolutions.

### Change
Thread an explicit `project_path: Option<&str>` through the resolution API instead of mutating CWD:
- New private `project_contexts_for(project_path)` helper in `resolution.rs` — `Some(dir)` → `load_project_contexts_from_dir(dir)`, `None` → CWD fallback (`get_project_contexts()`).
- Param added to `resolve_contexts`, `resolve_contexts_scoped`, `inject_contexts`, `inject_contexts_scoped`.
- `build_project_context_section` (agentic loop) now passes `Some(project_path)` — **no `set_current_dir`**.
- The other callers (`mcp/unified_workflows.rs`, `workflow_generation/generator.rs` ×2, `mcp/ai_session.rs`) pass `None`, preserving their existing read-only CWD behavior **exactly** — no behavior change there.

Still exactly one resolution model (`resolve_contexts` underpins all of it); the only difference is the project-context *source* is now an explicit argument rather than ambient global state.

### Verification
- `cargo clippy --bin qontinui-runner --features custom-protocol -- -D warnings` — clean (built the worktree via isolated `CARGO_TARGET_DIR`).
- `cargo test … context::` — **58 passed, 0 failed**.

No dependency changes (Cargo.lock left untouched). Scope is the resolution API + its 6 call sites only.