### PR TITLE
fix(runner): lift BatchOperationsBar above the prompt bar (no overlap)

### DIFF
--- a/src/components/terminal/BatchOperationsBar.tsx
+++ b/src/components/terminal/BatchOperationsBar.tsx
@@ -173,7 +173,7 @@ export function BatchOperationsBar() {
   }
 
   return (
-    <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-30 flex flex-col items-center gap-2">
+    <div className="absolute bottom-20 left-1/2 -translate-x-1/2 z-40 flex flex-col items-center gap-2">
       {/* Broadcast input row */}
       {showBroadcast && (
         <div className="flex items-center gap-2 px-3 py-2 bg-[#1a1b26] border border-[#2a2d3d] rounded-lg shadow-xl">


### PR DESCRIPTION
## What

The multi-session **BatchOperationsBar** (the bottom-center bar showing `N waiting | Approve All | Reject All | Broadcast` on the Terminal page) was rendered *behind* the CommandBar prompt bar and partially clipped by it.

## Why

Both are absolutely positioned, bottom-centered, and collided:

| Element | Position | z-index |
|---|---|---|
| `BatchOperationsBar` | `absolute bottom-4 left-1/2 -translate-x-1/2` | **z-30** |
| `CommandBar` prompt bar (`CommandBar.tsx:431`) | `absolute bottom-2 left-1/2 -translate-x-1/2 w-[420px]` | **z-40** |

Only 0.5rem apart vertically, and the prompt bar has the higher z-index, so it painted over the lower edge of the batch bar.

## Change

One-line CSS in `BatchOperationsBar.tsx`:
- `bottom-4` -> `bottom-20` so the batch bar floats clear above the 420px prompt bar.
- `z-30` -> `z-40` so the two never re-collide if positions shift.

Stays horizontally centered; no behavior change.

## Note

The same file exists in the `qontinui-runner-wt-d3v` / `qontinui-runner-wt-ctxcwd` worktrees — not touched here; they will need the same change if/when they merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
