### PR TITLE
fix(sdk): send the Cognito user bearer (not the device JWT) to the relay

### DIFF
--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -462,37 +462,50 @@ pub async fn connect_sdk_app(
         .timeout(std::time::Duration::from_secs(30))
         .connect_timeout(std::time::Duration::from_secs(5));
 
-    // Attach the operator's Cognito access token as a default `Authorization:
+    // Attach the operator's *Cognito* user bearer as a default `Authorization:
     // Bearer` header on EVERY request this connection makes (health probe +
     // every `/control/*` / `/sdk/*` relay call all go through `conn.client`).
     //
     // The web UI Bridge relay (`/api/ui-bridge/[...path]/_auth.ts`) gates all
-    // paths behind a verified Cognito bearer when `UI_BRIDGE_REQUIRE_AUTH=1`
-    // (prod, as of the 2026-05 Cognito relay-gating) — including `/health`.
-    // Without this header the runner's connect handshake 401s and the SDK can
-    // never attach. This is the "transport-side Authorization header" the relay
-    // auth comment says the consumer must add before the flag is flipped.
+    // paths behind a verified **Cognito** bearer when `UI_BRIDGE_REQUIRE_AUTH=1`
+    // (prod, as of the 2026-05 Cognito relay-gating) — including `/health`. It
+    // verifies the token against the web backend (`/users/me`), so it must be
+    // the Cognito access token, NOT the coord device-JWT in the `access_token`
+    // slot (`AuthManager::get_access_token`) — that slot is a coord-minted
+    // device JWT the Cognito-gated relay rejects (the bug in the first cut of
+    // this fix: it sent the device JWT and still 401'd).
     //
-    // Token is read from secure storage at connect time; reconnect (or
-    // auto-connect) picks up a refreshed token. Absent token (runner not signed
-    // in) → connect without it, preserving local/dev relays where the gate is
-    // off (they ignore the header) and surfacing a clean 401 against a gated
-    // relay rather than failing to build the client.
-    match crate::auth::AuthManager::new().get_access_token() {
-        Ok(token) if !token.is_empty() => {
+    // `ensure_fresh_cognito_bearer` is the single source of truth for the
+    // web-backend user bearer (same derivation `commands::auth` uses): it
+    // refreshes the Cognito access token first when it's near expiry, then
+    // returns it — or `None` for legacy/local-login installs with no Cognito
+    // session, in which case we connect without the header (local/dev relays
+    // with the gate off ignore it; a gated relay then surfaces a clean 401
+    // rather than a client-build failure).
+    match crate::mcp::device_jwt_refresher::ensure_fresh_cognito_bearer(
+        &crate::auth::AuthManager::new(),
+    )
+    .await
+    {
+        Some(token) if !token.is_empty() => {
             match reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)) {
                 Ok(mut value) => {
                     value.set_sensitive(true);
                     let mut headers = reqwest::header::HeaderMap::new();
                     headers.insert(reqwest::header::AUTHORIZATION, value);
                     builder = builder.default_headers(headers);
-                    debug!("SDK relay client: attached operator bearer for {}", url);
+                    debug!(
+                        "SDK relay client: attached fresh Cognito bearer for {}",
+                        url
+                    );
                 }
                 Err(e) => warn!("SDK relay client: malformed bearer, connecting without auth: {e}"),
             }
         }
-        Ok(_) => debug!("SDK relay client: empty access token; connecting without auth"),
-        Err(e) => debug!("SDK relay client: no access token ({e}); connecting without auth"),
+        _ => debug!(
+            "SDK relay client: no Cognito session (legacy/local install or not signed in); \
+             connecting without auth"
+        ),
     }
 
     let client = builder


### PR DESCRIPTION
## Follow-up to #356 (which was incomplete)
A runner built **with #356** still 401'd connecting its SDK to the auth-gated prod relay (verified live via a temp runner: `sdk/connect` → `/health → 401`). Root cause: **wrong token slot.**

Secure storage holds two bearers (`secure_storage.rs:44-53`):
- `access_token` → the **coord device-JWT** (what `AuthManager::get_access_token()` returns — what #356 sent).
- `oauth_access_token` → the **Cognito** user token.

The web relay (`_auth.ts`) verifies a **Cognito** bearer against the backend (`/users/me`). The coord device-JWT isn't a Cognito token → rejected. Proven: a freshly-minted Cognito operator token gets `/api/ui-bridge/health → 200`, while #356's device-JWT got 401.

## Fix
Use `device_jwt_refresher::ensure_fresh_cognito_bearer(&AuthManager::new())` — the documented single-source-of-truth for the web-backend user bearer (same derivation `commands::auth::check_auth_status`/`get_user_projects` use). It refreshes the Cognito access token if near expiry, then returns it; `None` for legacy/local-login installs (→ connect without auth, unchanged). One block in `connect_sdk_app`.

`cargo check --lib` + `clippy --lib` clean, `cargo fmt`.

## Verify after deploy
Temp runner built from this → `sdk/connect {url: qontinui.io/api/ui-bridge}` → `sdk/status` reports `connected:true`.