### PR TITLE
runner: fix Terminal page session-count + needs-input data

### DIFF
--- a/src/components/terminal/StatusStrip.tsx
+++ b/src/components/terminal/StatusStrip.tsx
@@ -114,7 +114,7 @@ const STATE_COLORS: Record<SessionState, string> = {
 
 export function StatusStrip() {
   const session = useTerminalSession();
-  const { tabs, sessionStates, fileLockStates, zoneLayout, workflowGen } = session;
+  const { sessionStates, fileLockStates, zoneLayout, workflowGen, sessionManager } = session;
   const planFileName = workflowGen.planFileName;
   const isPlanLoading = workflowGen.isPlanLoading;
   const {
@@ -154,33 +154,28 @@ export function StatusStrip() {
     return () => clearInterval(id);
   }, []);
 
-  // Counts + derived signals. Reused across the pill list AND the
-  // outer auto-hide gate. Working/completed/idle feed the Phase-9f
-  // state-breakdown pill (sibling to the existing needs-input / error
-  // pills, which keep their own callsites because they're clickable).
+  // Session-shape counts come from the Claude-session model
+  // (`useSessionManager.statusCounts`), scoped to the LIVE / actively-managed
+  // set — NOT raw PTY tabs and NOT every historical on-disk transcript.
+  // Counting raw tabs inflated the total (18 tabs → "18 sessions"); counting
+  // ALL `allSessions` inflated it the other way (hundreds of dormant
+  // historical transcripts → "438 sessions / 436 idle"). statusCounts keeps
+  // only sessions tied to a live PTY tab in this window (or active-external),
+  // so working = active-in-zone + active-external, idle = stale-tab `frozen`
+  // still open here, and dormant/orphaned historical transcripts are dropped.
   const {
+    sessionCount,
     needsInputCount,
     errorCount,
     workingCount,
     completedCount,
     idleCount,
-    stuckLocks,
-    maxStuckMs,
-    longestStuckTabId,
-  } = useMemo(() => {
-    let needsInput = 0;
-    let errors = 0;
-    let working = 0;
-    let completed = 0;
-    let idle = 0;
-    for (const tab of tabs) {
-      const state = sessionStates[tab.id] ?? "idle";
-      if (state === "needs-input") needsInput++;
-      else if (state === "error") errors++;
-      else if (state === "working") working++;
-      else if (state === "completed") completed++;
-      else if (state === "idle") idle++;
-    }
+  } = sessionManager;
+
+  // File-lock "stuck" pill still operates on PTY tabs (a lock is held by
+  // a terminal, not a transcript session), so it keeps its tab-scoped
+  // derivation here.
+  const { stuckLocks, maxStuckMs, longestStuckTabId } = useMemo(() => {
     let stuck = 0;
     let maxMs = 0;
     let longestTabId: string | null = null;
@@ -198,20 +193,14 @@ export function StatusStrip() {
       }
     }
     return {
-      needsInputCount: needsInput,
-      errorCount: errors,
-      workingCount: working,
-      completedCount: completed,
-      idleCount: idle,
       stuckLocks: stuck,
       maxStuckMs: maxMs,
       longestStuckTabId: longestTabId,
     };
     // The tick covers cadence-driven re-eval for the maxStuckMs reading;
-    // tabs / sessionStates / fileLockStates cover state-driven re-eval.
-  }, [tabs, sessionStates, fileLockStates]);
+    // fileLockStates covers state-driven re-eval.
+  }, [fileLockStates]);
 
-  const sessionCount = tabs.length;
   const isMultiZone = sessionCount > 1;
 
   const wrapperCount = wrapperTools.length;
@@ -390,7 +379,7 @@ export function StatusStrip() {
           icon={<TerminalSquare className="w-2.5 h-2.5" />}
           text={`${sessionCount} sessions`}
           color="#565f89"
-          title={`${sessionCount} terminal sessions open in this page`}
+          title={`${sessionCount} Claude sessions tracked on this page`}
         />
       )}
 

--- a/src/components/terminal/computeStatusCounts.test.ts
+++ b/src/components/terminal/computeStatusCounts.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for `computeStatusCounts` — the pure bucketing behind the
+ * Terminal-page StatusStrip pills.
+ *
+ * Regression target: the strip used to count EVERY on-disk transcript
+ * (`allSessions.length`), inflating the operator's real "3 sessions / 2 idle"
+ * to "18 sessions / 14 idle" (and a fresh runner to "438 / 436"). The fix
+ * drops `dormant` historical transcripts and orphaned (tab-less) `frozen`
+ * transcripts, counting only the live / actively-managed set.
+ */
+
+import { describe, it, expect } from "vitest";
+import { computeStatusCounts, type StatusCountsInput } from "./useSessionManager";
+
+// Small builder so each case reads as a list of (status, orphaned) tuples.
+function s(liveStatus: StatusCountsInput["liveStatus"], isOrphaned = false): StatusCountsInput {
+  return { liveStatus, isOrphaned };
+}
+
+describe("computeStatusCounts", () => {
+  it("excludes a dormant session from the total and from idle", () => {
+    const counts = computeStatusCounts([s("dormant")]);
+    expect(counts.sessionCount).toBe(0);
+    expect(counts.idleCount).toBe(0);
+    expect(counts.workingCount).toBe(0);
+  });
+
+  it("excludes an orphaned (tab-less) frozen transcript", () => {
+    const counts = computeStatusCounts([s("frozen", /* isOrphaned */ true)]);
+    expect(counts.sessionCount).toBe(0);
+    expect(counts.idleCount).toBe(0);
+  });
+
+  it("counts a tab-backed (non-orphan) frozen session as idle", () => {
+    const counts = computeStatusCounts([s("frozen", /* isOrphaned */ false)]);
+    expect(counts.idleCount).toBe(1);
+    expect(counts.sessionCount).toBe(1);
+    expect(counts.workingCount).toBe(0);
+  });
+
+  it("counts active-in-zone and active-external as working", () => {
+    const counts = computeStatusCounts([s("active-in-zone"), s("active-external")]);
+    expect(counts.workingCount).toBe(2);
+    expect(counts.idleCount).toBe(0);
+    expect(counts.sessionCount).toBe(2);
+  });
+
+  it("counts needs-input toward need-input and the total", () => {
+    const counts = computeStatusCounts([s("needs-input")]);
+    // needs-input survives the dormant/orphan filter → contributes to the total
+    expect(counts.sessionCount).toBe(1);
+    expect(counts.workingCount).toBe(0);
+    expect(counts.idleCount).toBe(0);
+  });
+
+  it("counts error and completed in their own buckets and the total", () => {
+    const counts = computeStatusCounts([s("error"), s("completed")]);
+    expect(counts.errorCount).toBe(1);
+    expect(counts.completedCount).toBe(1);
+    expect(counts.sessionCount).toBe(2);
+  });
+
+  it("operator's exact scenario: 1 working + 2 idle + N historical ⇒ total=3", () => {
+    const sessions: StatusCountsInput[] = [
+      // 1 genuinely working session
+      s("active-in-zone"),
+      // 2 idle = tab-backed (non-orphan) frozen sessions still open here
+      s("frozen", /* isOrphaned */ false),
+      s("frozen", /* isOrphaned */ false),
+      // N historical noise that must NOT inflate the strip:
+      // dormant never-reopened transcripts ...
+      s("dormant"),
+      s("dormant"),
+      s("dormant"),
+      // ... and orphaned (tab-less) frozen historical transcripts.
+      s("frozen", /* isOrphaned */ true),
+      s("frozen", /* isOrphaned */ true),
+    ];
+    const counts = computeStatusCounts(sessions);
+    expect(counts.sessionCount).toBe(3);
+    expect(counts.workingCount).toBe(1);
+    expect(counts.idleCount).toBe(2);
+    // 0 needs-input in this scenario; total must reconcile with the pills.
+    expect(
+      counts.workingCount +
+        counts.idleCount +
+        counts.completedCount +
+        counts.errorCount,
+    ).toBe(counts.sessionCount);
+  });
+
+  it("returns all-zero for an empty session list", () => {
+    const counts = computeStatusCounts([]);
+    expect(counts).toEqual({
+      sessionCount: 0,
+      workingCount: 0,
+      idleCount: 0,
+      completedCount: 0,
+      errorCount: 0,
+    });
+  });
+});

--- a/src/components/terminal/sessionStateDetector.test.ts
+++ b/src/components/terminal/sessionStateDetector.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Unit tests for `detectSessionState` — terminal-output → SessionState
+ * classification behind the StatusStrip needs-input pill.
+ *
+ * Regression targets (StatusStrip session-count plan):
+ *  - Bug 2: bare generic shell tokens (`(Y/n)`, `[y/N]`, "Press enter to
+ *    continue", "Continue? [") must NOT latch a tab to `needs-input` — they
+ *    appear in ordinary non-blocking tool output (git/apt/npm). Only
+ *    Claude-specific prompt framings count.
+ *  - Bug 3: the `needs-input` latch must break back to `working` when the
+ *    session resumes producing Claude tool output.
+ */
+
+import { describe, it, expect } from "vitest";
+import { detectSessionState } from "./sessionStateDetector";
+
+describe("detectSessionState — generic shell tokens no longer flag needs-input", () => {
+  // Keep these strings short (<= 20 chars) so they don't trip the
+  // "substantial output ⇒ working" fallback; the point is purely that they
+  // do NOT classify as needs-input.
+  const generic = ["(Y/n)", "[y/N]", "Press enter", "Continue? ["];
+
+  for (const token of generic) {
+    it(`"${token}" does not flag needs-input`, () => {
+      expect(detectSessionState(token, "idle")).not.toBe("needs-input");
+    });
+  }
+});
+
+describe("detectSessionState — genuine Claude prompts DO flag needs-input", () => {
+  const claudePrompts = [
+    "Allow Read tool? (y/n)",
+    "Proceed? (yes/no)",
+    "Do you want to proceed?",
+    "Please provide the file path",
+    "waiting for your input",
+  ];
+
+  for (const prompt of claudePrompts) {
+    it(`"${prompt}" flags needs-input`, () => {
+      expect(detectSessionState(prompt, "idle")).toBe("needs-input");
+    });
+  }
+});
+
+describe("detectSessionState — needs-input latch-breaker", () => {
+  it("transitions needs-input → working when resumed Claude tool output arrives", () => {
+    expect(detectSessionState("Reading src/main.rs", "needs-input")).toBe("working");
+    expect(detectSessionState("Running command: cargo build", "needs-input")).toBe("working");
+    expect(detectSessionState("esc to interrupt", "needs-input")).toBe("working");
+  });
+
+  it("does NOT break the latch on unrelated short output", () => {
+    // No resumed-pattern match and not a fresh needs-input prompt → stay put
+    // (returns null = no state change, so the tab remains needs-input).
+    expect(detectSessionState("ok", "needs-input")).toBeNull();
+  });
+
+  it("error output does not override an active needs-input latch", () => {
+    expect(detectSessionState("Error: something failed", "needs-input")).toBeNull();
+  });
+});

--- a/src/components/terminal/sessionStateDetector.ts
+++ b/src/components/terminal/sessionStateDetector.ts
@@ -5,23 +5,41 @@ import type { SessionState } from "./useZoneLayout";
  * These are checked against raw terminal output (may include ANSI sequences).
  */
 const NEEDS_INPUT_PATTERNS = [
-  // Claude Code tool approval prompts
-  /\? \(y\/n\)/,
-  /\? \(yes\/no\)/,
+  // Claude Code tool approval prompts. These are Claude-specific framings
+  // ("Allow X? (y/n)", "Do you want to proceed?") rather than the bare
+  // `(Y/n)` / `[y/N]` tokens that ordinary shell tooling (git, apt, package
+  // managers, npm) prints in non-blocking informational output — matching
+  // those latched plain *and* Claude sessions to `needs-input` when nothing
+  // was actually awaiting input (the "N need input" phantom). See the
+  // StatusStrip session-count plan, Bug 2.
+  /\? \(y\/n\)/i,
+  /\? \(yes\/no\)/i,
   /Allow .+\? \(/, // "Allow Read tool? (y/n)"
   /Do you want to proceed/i,
-  /Press enter to continue/i,
 
   // Claude Code interactive prompts
   /\? >/, // Claude input prompt
   /waiting for your (?:input|response)/i,
   /What would you like/i,
   /Please (?:provide|enter|specify)/i,
+];
 
-  // Git/CLI interactive prompts that might appear in Claude sessions
-  /\(Y\/n\)/,
-  /\[y\/N\]/,
-  /Continue\? \[/,
+/**
+ * Patterns that indicate the session is actively producing output again —
+ * i.e. the prompt that triggered `needs-input` has been answered / superseded
+ * and the session is no longer awaiting the user. Used to break the sticky
+ * `needs-input` latch from `handleOutput` (StatusStrip plan, Bug 3): the
+ * working/error/completed branches below intentionally refuse to override
+ * `needs-input`, so without an explicit "resumed" signal a tab stays
+ * `needs-input` forever once latched.
+ */
+const RESUMED_PATTERNS = [
+  /(?:Reading|Writing|Editing|Creating) /,
+  /Running (?:command|bash|test)/i,
+  /Searching /,
+  /Analyzing /,
+  /^[│├└─]/m, // Box-drawing chars from Claude's tool output
+  /esc to interrupt/i, // Claude Code shows this only while actively working
 ];
 
 /**
@@ -77,6 +95,15 @@ export function detectSessionState(text: string, currentState: SessionState): Se
   // Needs-input has highest priority — check both raw and stripped
   if (NEEDS_INPUT_PATTERNS.some((p) => p.test(text) || p.test(stripped))) {
     return "needs-input";
+  }
+
+  // Latch-breaker (Bug 3): when already `needs-input`, a clear "session is
+  // working again" signal (Claude resumed tool output) means the prompt was
+  // answered — transition back to `working` instead of staying stuck. Without
+  // this the working/error/completed branches below all return `null` for a
+  // `needs-input` tab, so the latch never decays on its own.
+  if (currentState === "needs-input" && RESUMED_PATTERNS.some((p) => p.test(stripped))) {
+    return "working";
   }
 
   // Error patterns

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -304,6 +304,13 @@ export interface UseSessionManagerReturn {
   frozenCount: number;
   needsInputCount: number;
   activeCount: number;
+  // Session-model counts for the Terminal-page StatusStrip (Claude
+  // sessions, not PTY tabs). See `statusCounts` for the bucketing.
+  sessionCount: number;
+  workingCount: number;
+  idleCount: number;
+  completedCount: number;
+  errorCount: number;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -347,6 +354,79 @@ const STATUS_PRIORITY: Record<SessionLiveStatus, number> = {
   completed: 5,
   dormant: 6,
 };
+
+/** Counts surfaced to the Terminal-page StatusStrip pills. */
+export interface StatusCounts {
+  sessionCount: number;
+  workingCount: number;
+  idleCount: number;
+  completedCount: number;
+  errorCount: number;
+}
+
+/** Minimal shape `computeStatusCounts` needs from a {@link UnifiedSession}. */
+export interface StatusCountsInput {
+  liveStatus: SessionLiveStatus;
+  isOrphaned: boolean;
+}
+
+/**
+ * Pure bucketing for the Terminal-page StatusStrip. Counts only the
+ * *live / actively-managed* Claude sessions, dropping dormant historical
+ * transcripts and orphaned (tab-less) `frozen` transcripts. Extracted as a
+ * pure function so the bucketing rules are unit-testable without mounting the
+ * hook. See the long-form rationale on the `statusCounts` memo below.
+ *
+ * - `dormant` → excluded (the bulk historical over-count).
+ * - orphaned `frozen` (`isOrphaned`) → excluded (resumable historical session).
+ * - tab-backed `frozen` → counts as `idle`.
+ * - `active-in-zone` / `active-external` → `working`.
+ * - `needs-input` / `error` / `completed` → their own bucket, all counted in
+ *   the total.
+ */
+export function computeStatusCounts(sessions: readonly StatusCountsInput[]): StatusCounts {
+  const counts: Record<SessionLiveStatus, number> = {
+    "active-in-zone": 0,
+    "active-external": 0,
+    frozen: 0,
+    "needs-input": 0,
+    completed: 0,
+    error: 0,
+    dormant: 0,
+  };
+  // Live frozen = a stale session still open as a tab in this window.
+  // Orphaned frozen (no tab) is a resumable historical transcript → excluded.
+  let liveFrozen = 0;
+  for (const s of sessions) {
+    // Drop dormant historical transcripts and orphaned (tab-less) frozen
+    // transcripts — they are not actively-managed sessions.
+    if (s.liveStatus === "dormant") continue;
+    if (s.liveStatus === "frozen" && s.isOrphaned) continue;
+    counts[s.liveStatus]++;
+    if (s.liveStatus === "frozen") liveFrozen++;
+  }
+  // working = both running flavors (in-zone + external).
+  const workingCount = counts["active-in-zone"] + counts["active-external"];
+  // idle = genuinely-live-but-paused sessions, i.e. a stale tab still open
+  // in this window (live `frozen`). Orphaned/dormant historical transcripts
+  // were already excluded above, so this no longer balloons.
+  const idleCount = liveFrozen;
+  const completedCount = counts.completed;
+  const errorCount = counts.error;
+  const needsInputLive = counts["needs-input"];
+  // Total = the live managed set: working + idle + needs-input + error +
+  // completed. Equivalently the count of sessions that survived the
+  // dormant/orphan filter above. Reconciles with the per-bucket pills.
+  const sessionCount =
+    workingCount + idleCount + needsInputLive + errorCount + completedCount;
+  return {
+    sessionCount,
+    workingCount,
+    idleCount,
+    completedCount,
+    errorCount,
+  };
+}
 
 // ── Hook ─────────────────────────────────────────────────────────────────────
 
@@ -871,6 +951,44 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
     [allSessions],
   );
 
+  // Per-status breakdown for the Terminal-page StatusStrip pills.
+  //
+  // CRITICAL SCOPE: the strip must count only the *live / actively-managed*
+  // Claude sessions the operator currently has open — NOT every historical
+  // on-disk transcript. `allSessions` is built from `transcriptSessions`
+  // (`transcript_list_sessions` returns EVERY `.jsonl` with message_count > 0
+  // across all accounts — hundreds on a long-lived machine), so
+  // `allSessions.length` is the wrong total: it counts dormant historical
+  // transcripts that aren't running. The operator's "18 sessions / 14 idle"
+  // complaint (and a fresh runner's "438 sessions / 436 idle") is exactly
+  // this over-count — the inflation is the `dormant` bucket (every never-
+  // reopened transcript defaults to `dormant`) plus orphaned `frozen`
+  // transcripts (a `likely_frozen` digest with NO live PTY tab in this
+  // window — `isOrphaned`, i.e. a resumable historical session, not a stuck
+  // live one).
+  //
+  // A session is LIVE — and thus counted by the strip — iff it is NOT a
+  // historical/dormant transcript. Concretely it is dropped when:
+  //   - `liveStatus === "dormant"` — the default for a transcript with no
+  //     live PTY tab in this window and no recent external activity (every
+  //     never-reopened on-disk transcript), i.e. the bulk over-count; OR
+  //   - it is an orphaned `frozen` transcript (`isOrphaned` — a `likely_frozen`
+  //     digest with NO live tab: a resumable historical session, not a stuck
+  //     live one).
+  // Everything that survives is genuinely live: `active-in-zone` /
+  // `active-external` (running), `needs-input` / `error` / `completed`
+  // (always tab-backed — only the `if (tab)` branch sets them), and
+  // tab-backed (non-orphaned) `frozen` (a stale tab still open here →
+  // "idle"). This is status-semantic rather than keyed on the raw
+  // `zoneTabId` pointer so debug-injected fixtures (which carry an explicit
+  // `injected_live_status` but no real tab) are still counted when their
+  // status is a live one — matching what the operator sees rendered.
+  //
+  // Buckets are mapped explicitly over the 7 SessionLiveStatus values so
+  // adding a new status forces a compile-time decision here rather than
+  // silently dropping it.
+  const statusCounts = useMemo(() => computeStatusCounts(allSessions), [allSessions]);
+
   // ── Desktop notifications for frozen sessions ──────────────────────────────
 
   const prevFrozenCountRef = useRef(0);
@@ -987,5 +1105,11 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
     frozenCount,
     needsInputCount,
     activeCount,
+    // Session-model counts for the StatusStrip (excludes PTY-only tabs).
+    sessionCount: statusCounts.sessionCount,
+    workingCount: statusCounts.workingCount,
+    idleCount: statusCounts.idleCount,
+    completedCount: statusCounts.completedCount,
+    errorCount: statusCounts.errorCount,
   };
 }

--- a/src/components/terminal/useShellIntegration.ts
+++ b/src/components/terminal/useShellIntegration.ts
@@ -80,14 +80,18 @@ export function useShellIntegration({
             ref?.current?.writeToTerminal(`${pending.resumeCmd}\r`);
           }, 50);
         }
-        // Shell prompt → could be idle or needs-input
-        // If a Claude Code session is running, prompt_start typically means
-        // it's waiting for user input. For a bare shell, it's idle.
+        // Shell prompt appeared. A `prompt_start` only means "a shell prompt
+        // is being drawn" — NOT that a Claude session is awaiting the user.
+        // Claude Code redraws its prompt frequently while idle, so latching
+        // every Claude-backed prompt_start to `needs-input` produced the
+        // "N need input" phantom (3 sessions, 0 actually waiting). Treat a
+        // bare prompt as `idle`; genuine "awaiting input" is detected from
+        // the prompt *text* by `sessionStateDetector` (tool-approval / y-n
+        // prompts), not from the prompt-start marker. Don't clobber a real
+        // `needs-input`/`error` that the detector already set.
         setSessionStates((prev) => {
-          const tab = tabs.find((t) => t.id === tabId);
-          if (tab?.claudeSessionId) {
-            return { ...prev, [tabId]: "needs-input" };
-          }
+          const current = prev[tabId];
+          if (current === "needs-input" || current === "error") return prev;
           return { ...prev, [tabId]: "idle" };
         });
       }


### PR DESCRIPTION
## Summary

Fixes the Terminal page StatusStrip showing inflated/incorrect session counts and false needs-input flags.

### Files changed (all TypeScript, no Rust)
- **src/components/terminal/useSessionManager.ts** — StatusStrip session counts now filter to the live/active set, excluding dormant/orphaned-historical transcripts.
- **src/components/terminal/StatusStrip.tsx** — consumes the filtered counts.
- **src/components/terminal/sessionStateDetector.ts** — removed over-broad needs-input patterns; added a resumed-output latch-breaker so answered prompts decay.
- **src/components/terminal/useShellIntegration.ts** — `prompt_start` no longer latches a Claude tab to needs-input.

### Effect
- Session/idle counts reflect only live/active sessions (was inflating 3 sessions to 18, 2 idle to 14).
- needs-input no longer false-flags on idle Claude prompt redraws / generic shell tokens; answered prompts decay (was showing 3 need-input when 0 awaited input).
- working count unchanged (already correct).

### Verification
Verified on an isolated temp runner via seeded sessions through the UI Bridge. The primary runner was not touched.

Note: the diff is TypeScript-only; the local pre-push `cargo clippy` gate flagged a pre-existing lint in untouched `src-tauri` Rust (orthogonal to this change). Pushed with the hook's documented `QONTINUI_PREPUSH_SKIP=1`; CI's Rust gate still runs.