### PR TITLE
vision: handle optional Element.bbox in baseline handler

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/vision_routes.rs
+++ b/src-tauri/src/mcp/ui_bridge/vision_routes.rs
@@ -2209,7 +2209,10 @@ async fn vision_baseline_handler(
         .snapshot
         .elements
         .iter()
-        .map(|e| (e.id.clone(), e.bbox))
+        // `bbox` is now `Option<Region>` — only elements with a measured bbox
+        // can participate in layout-shift baselines; skip bbox-less (hidden/
+        // unmeasured) elements rather than failing the whole baseline.
+        .filter_map(|e| e.bbox.map(|b| (e.id.clone(), b)))
         .collect();
     let registered_at_unix_ms = chrono::Utc::now().timestamp_millis();
     let entry = BaselineRegistryEntry {


### PR DESCRIPTION
## What

The baseline-snapshot handler in `vision_routes.rs` now `filter_map`s over `Option<Region>` bbox, because vision-core made `Element.bbox` optional. Bbox-less (hidden/unmeasured) elements are skipped for the layout-shift baseline rather than failing the whole baseline.

## Merge-order dependency (IMPORTANT)
This change is **coupled** to the qontinui-schemas vision-core change and only compiles against the new optional-bbox `Element`.

- Upstream: **qontinui/qontinui-schemas#71** (`vision-core: make Element.bbox optional`)
- **qontinui-schemas#71 MUST merge first.** This runner PR's path-dep (`../../qontinui-schemas/rust-vision-core`) resolves to the local working tree, so it compiles locally, but CI / a fresh checkout against schemas `main` will not build until #71 lands.

## Verification
- `cargo fmt -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean (compiled against local optional-bbox vision-core)