### PR TITLE
feat(terminal): Shift+wheel scrolls scrollback even under app mouse capture

### DIFF
--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -3,15 +3,13 @@ import { FilePathLinkProvider } from "./FilePathLinkProvider";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useUIBridgeOptional } from "@qontinui/ui-bridge";
-import type {
-  TerminalOutputEvent,
-  TerminalExitEvent,
-} from "@qontinui/shared-types/tauri-events";
+import type { TerminalOutputEvent, TerminalExitEvent } from "@qontinui/shared-types/tauri-events";
 import { createTerminalBackend } from "./backends";
 import type { BackendType, ITerminalBackend } from "./backends";
 import { paintGrid, type GridSnapshot } from "./paintGrid";
 import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
+import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
 
 export interface TerminalInstanceHandle {
   getSelection: () => string;
@@ -172,6 +170,10 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     const outputDecoderRef = useRef(new TextDecoder());
     const firstInputReportedRef = useRef(false);
     const inputAccumulatorRef = useRef("");
+    // Fractional carry for the Shift+wheel local-scroll override — sub-line
+    // pixel deltas (trackpads) accumulate here so slow scrolling advances
+    // smoothly instead of snapping a whole line per tick. See `wheelScroll.ts`.
+    const wheelScrollAccumRef = useRef(0);
 
     // Expose selection, write, and scrollback API to parent components
     useImperativeHandle(ref, () => ({
@@ -238,6 +240,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       let ackTimer: ReturnType<typeof setInterval> | null = null;
       let observer: ResizeObserver | null = null;
       let blockNativePaste: ((e: Event) => void) | null = null;
+      let wheelScrollOverride: ((e: WheelEvent) => void) | null = null;
       // Layer 2 bootstrap: idle-debounced grid re-paint. The live listener
       // resets this timer on every received byte; when the stream goes
       // quiet for IDLE_REPAINT_MS we re-fetch the Rust grid and overlay
@@ -354,6 +357,36 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         if (viewport) {
           viewport.classList.add("scrollbar-dark");
         }
+
+        // Shift+wheel → always scroll the local scrollback, even when the
+        // foreground program has captured the wheel via a mouse-tracking mode
+        // (DECSET 1000/1002/1003). xterm.js sets `handleMouseWheel: false` in
+        // that state and forwards the wheel to the app, so a plain wheel can't
+        // scroll the buffer; its `attachCustomWheelEventHandler` is also
+        // bypassed once mouse mode is on. We intercept on the container in the
+        // CAPTURE phase (before xterm's own bubble-phase listeners on the
+        // viewport/screen) and, only when Shift is held, take the event over.
+        // Un-modified wheel events are left untouched so the app keeps its
+        // mouse interaction — matching the Konsole / GNOME Terminal / Windows
+        // Terminal "Shift bypasses application mouse reporting" convention.
+        wheelScrollOverride = (e: WheelEvent) => {
+          if (!e.shiftKey) return;
+          const b = backendRef.current;
+          if (!b) return;
+          // Take over: stop xterm (and the app) from also seeing this wheel.
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          wheelScrollAccumRef.current += wheelToLineDelta(e, b.rows, DEFAULT_CELL_HEIGHT_PX);
+          const whole = Math.trunc(wheelScrollAccumRef.current);
+          if (whole !== 0) {
+            wheelScrollAccumRef.current -= whole;
+            b.scrollLines(whole);
+          }
+        };
+        container.addEventListener("wheel", wheelScrollOverride, {
+          capture: true,
+          passive: false,
+        });
 
         // Initial fit after layout settles
         requestAnimationFrame(() => fitTerminal());
@@ -741,6 +774,9 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         if (idleTimer) clearTimeout(idleTimer);
         if (fitTimerRef.current) clearTimeout(fitTimerRef.current);
         observer?.disconnect();
+        if (wheelScrollOverride) {
+          container.removeEventListener("wheel", wheelScrollOverride, { capture: true });
+        }
         for (const d of disposables) d.dispose();
         const inputEl = backendRef.current?.getInputElement();
         if (inputEl && blockNativePaste) {

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -124,6 +124,14 @@ export class GhosttyBackend implements ITerminalBackend {
     this.term.scrollToBottom();
   }
 
+  scrollLines(amount: number): void {
+    // ghostty-web mirrors xterm's scroll API, but guard defensively so a
+    // build lacking `scrollLines` degrades the Shift+wheel override to a
+    // no-op instead of throwing.
+    const t = this.term as unknown as { scrollLines?: (n: number) => void };
+    t.scrollLines?.(amount);
+  }
+
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
     this.term.attachCustomKeyEventHandler(handler);
   }

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -125,6 +125,10 @@ export class XtermBackend implements ITerminalBackend {
     this.term.scrollToBottom();
   }
 
+  scrollLines(amount: number): void {
+    this.term.scrollLines(amount);
+  }
+
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
     this.term.attachCustomKeyEventHandler(handler);
   }

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -121,6 +121,14 @@ export interface ITerminalBackend {
 
   // -- Scrolling ------------------------------------------------------------
   scrollToBottom(): void;
+  /**
+   * Scroll the viewport by `amount` lines through the scrollback. Positive
+   * scrolls DOWN (toward newest output), negative scrolls UP (into history).
+   * Used by the Shift+wheel local-scroll override in `TerminalInstance` to
+   * scroll even when the foreground app has captured the wheel via a mouse
+   * tracking mode. No-op when there is no scrollback to move through.
+   */
+  scrollLines(amount: number): void;
 
   // -- Key handling ---------------------------------------------------------
   /** Intercept key events before the terminal processes them. Return false to prevent default. */

--- a/src/components/terminal/wheelScroll.test.ts
+++ b/src/components/terminal/wheelScroll.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
+
+describe("wheelToLineDelta", () => {
+  it("returns 0 when there is no vertical or horizontal delta", () => {
+    expect(wheelToLineDelta({ deltaY: 0, deltaX: 0, deltaMode: 0 }, 40)).toBe(0);
+    expect(wheelToLineDelta({ deltaY: NaN, deltaX: 0, deltaMode: 0 }, 40)).toBe(0);
+  });
+
+  it("treats line-mode (deltaMode 1) deltaY as a direct line count", () => {
+    expect(wheelToLineDelta({ deltaY: 3, deltaX: 0, deltaMode: 1 }, 40)).toBe(3);
+    expect(wheelToLineDelta({ deltaY: -3, deltaX: 0, deltaMode: 1 }, 40)).toBe(-3);
+  });
+
+  it("converts pixel-mode (deltaMode 0) deltaY to lines via cell height", () => {
+    // 100px / 20px-per-line = 5 lines.
+    expect(wheelToLineDelta({ deltaY: 100, deltaX: 0, deltaMode: 0 }, 40, 20)).toBe(5);
+    expect(wheelToLineDelta({ deltaY: -100, deltaX: 0, deltaMode: 0 }, 40, 20)).toBe(-5);
+  });
+
+  it("uses the default cell height when none is supplied", () => {
+    expect(
+      wheelToLineDelta({ deltaY: DEFAULT_CELL_HEIGHT_PX, deltaX: 0, deltaMode: 0 }, 40),
+    ).toBeCloseTo(1);
+  });
+
+  it("preserves the sign of deltaY (scrollLines convention: + down, - up)", () => {
+    expect(wheelToLineDelta({ deltaY: 50, deltaX: 0, deltaMode: 0 }, 40, 20)).toBeGreaterThan(0);
+    expect(wheelToLineDelta({ deltaY: -50, deltaX: 0, deltaMode: 0 }, 40, 20)).toBeLessThan(0);
+  });
+
+  it("falls back to deltaX when deltaY is 0 (Windows/Chromium Shift→horizontal remap)", () => {
+    // Shift+wheel on Windows arrives as horizontal scroll: deltaY 0, deltaX set.
+    expect(wheelToLineDelta({ deltaY: 0, deltaX: 100, deltaMode: 0 }, 40, 20)).toBe(5);
+    expect(wheelToLineDelta({ deltaY: 0, deltaX: -100, deltaMode: 0 }, 40, 20)).toBe(-5);
+  });
+
+  it("prefers deltaY over deltaX when both are present", () => {
+    expect(wheelToLineDelta({ deltaY: 40, deltaX: 999, deltaMode: 0 }, 40, 20)).toBe(2);
+  });
+
+  it("returns a fractional delta for sub-line pixel scrolls (trackpad)", () => {
+    // 4px with a 20px line is 0.2 of a line — the caller accumulates these.
+    expect(wheelToLineDelta({ deltaY: 4, deltaX: 0, deltaMode: 0 }, 40, 20)).toBeCloseTo(0.2);
+  });
+
+  it("scrolls nearly a full screen in page mode (deltaMode 2), keeping 1 row overlap", () => {
+    expect(wheelToLineDelta({ deltaY: 1, deltaX: 0, deltaMode: 2 }, 40)).toBe(39);
+    expect(wheelToLineDelta({ deltaY: -2, deltaX: 0, deltaMode: 2 }, 40)).toBe(-78);
+  });
+
+  it("falls back to the default cell height when given a non-positive one", () => {
+    expect(
+      wheelToLineDelta({ deltaY: DEFAULT_CELL_HEIGHT_PX, deltaX: 0, deltaMode: 0 }, 40, 0),
+    ).toBeCloseTo(1);
+    expect(
+      wheelToLineDelta({ deltaY: DEFAULT_CELL_HEIGHT_PX, deltaX: 0, deltaMode: 0 }, 40, -5),
+    ).toBeCloseTo(1);
+  });
+
+  it("accumulates to a whole line across several trackpad ticks", () => {
+    // Simulate the caller's fractional-carry loop: five 0.2-line ticks → 1 line.
+    let accum = 0;
+    let scrolled = 0;
+    for (let i = 0; i < 5; i++) {
+      accum += wheelToLineDelta({ deltaY: 4, deltaX: 0, deltaMode: 0 }, 40, 20);
+      const whole = Math.trunc(accum);
+      accum -= whole;
+      scrolled += whole;
+    }
+    expect(scrolled).toBe(1);
+  });
+});

--- a/src/components/terminal/wheelScroll.ts
+++ b/src/components/terminal/wheelScroll.ts
@@ -1,0 +1,94 @@
+/**
+ * wheelScroll — pure helpers for the Shift+wheel "force local scrollback"
+ * gesture.
+ *
+ * Why this exists: xterm.js disables its own viewport wheel-scrolling whenever
+ * the foreground program enables a mouse-tracking protocol that reports wheel
+ * events (DECSET 1000/1002/1003 → the VT200/DRAG/ANY protocols, all of which
+ * include `CoreMouseEventType.WHEEL`). See `@xterm/xterm` `Viewport.ts`:
+ *
+ *   coreMouseService.onProtocolChange(type =>
+ *     scrollableElement.updateOptions({ handleMouseWheel: !(type & WHEEL) }))
+ *
+ * In that state a plain wheel event is forwarded to the program instead of
+ * scrolling the local scrollback — so terminals running a mouse-mode TUI
+ * (an AI session, lazygit, htop, `less --mouse`, vim with `set mouse=a`, …)
+ * appear "stuck" while plain-shell terminals scroll fine. xterm's
+ * `attachCustomWheelEventHandler` can't help here because the wheel listener
+ * `return`s early (`if (requestedEvents.wheel) return;`) before the custom
+ * handler runs once mouse mode is active.
+ *
+ * The fix (wired in `TerminalInstance`) is a capture-phase `wheel` listener on
+ * the terminal container that, when Shift is held, takes the event over and
+ * scrolls the xterm scrollback directly via `backend.scrollLines()`. This
+ * matches the long-standing "modifier bypasses application mouse reporting"
+ * convention in Konsole / GNOME Terminal / Windows Terminal, giving the
+ * operator a reliable "always scroll the terminal" gesture regardless of what
+ * the inner program does with the mouse.
+ *
+ * This module is a leaf (no xterm / DOM imports beyond the `WheelEvent` shape)
+ * so vitest can exercise the delta math without loading the WASM backend —
+ * same rationale as `consumeInputChunk.ts`.
+ */
+
+/**
+ * Approximate cell height in CSS px, used to convert pixel-mode wheel deltas
+ * (the common case in WebView2 / Chromium) into a line count. Derived from the
+ * shared TERMINAL_OPTIONS (`fontSize: 14` × `lineHeight: 1.2` ≈ 16.8). A small
+ * error here only affects scroll speed, never correctness — the fractional
+ * accumulator in the caller absorbs the remainder.
+ */
+export const DEFAULT_CELL_HEIGHT_PX = 17;
+
+/** The subset of `WheelEvent` the delta math depends on. */
+export interface WheelLike {
+  deltaY: number;
+  /** Horizontal delta — carries the value when Shift+wheel is remapped to
+   * horizontal scroll (Windows/Chromium). Used only when `deltaY` is 0. */
+  deltaX: number;
+  /** 0 = pixels (DOM_DELTA_PIXEL), 1 = lines, 2 = pages. */
+  deltaMode: number;
+}
+
+/**
+ * Convert a wheel event into a signed scrollback line delta.
+ *
+ * Sign convention matches `Terminal.scrollLines(amount)`: positive scrolls
+ * DOWN (toward newest output), negative scrolls UP (into history) — i.e. the
+ * result carries the same sign as `deltaY`.
+ *
+ * Returns a FRACTIONAL value on purpose: pixel-mode deltas from a trackpad are
+ * often well under one line, and the caller accumulates the remainder across
+ * events so slow scrolling still advances smoothly instead of snapping a whole
+ * line per tick (or, with naive rounding, never moving at all).
+ *
+ * Critically for this codebase's runtime (Tauri WebView2 / Chromium on
+ * Windows): holding Shift while turning the wheel is remapped by the browser
+ * to HORIZONTAL scroll, so the event arrives with `deltaY === 0` and the
+ * magnitude in `deltaX`. Since the override gesture is *specifically*
+ * Shift+wheel, we fold `deltaX` in (preferring `deltaY` when present, e.g. on
+ * macOS / trackpads) so it works on every platform.
+ *
+ * @param e            wheel event (`deltaY`/`deltaX`/`deltaMode` are read)
+ * @param rows         current terminal row count (for page-mode deltas)
+ * @param cellHeightPx px height of one row, for pixel-mode deltas
+ */
+export function wheelToLineDelta(
+  e: WheelLike,
+  rows: number,
+  cellHeightPx: number = DEFAULT_CELL_HEIGHT_PX,
+): number {
+  // Prefer the vertical delta; fall back to the horizontal one for the
+  // Windows/Chromium Shift+wheel→horizontal-scroll remapping (see above).
+  const raw = e.deltaY !== 0 ? e.deltaY : e.deltaX;
+  if (!raw || !Number.isFinite(raw)) return 0;
+  const px = cellHeightPx > 0 ? cellHeightPx : DEFAULT_CELL_HEIGHT_PX;
+  switch (e.deltaMode) {
+    case 1: // DOM_DELTA_LINE — delta already counts lines.
+      return raw;
+    case 2: // DOM_DELTA_PAGE — scroll (nearly) a full screen, keeping 1 row of overlap.
+      return raw * Math.max(1, rows - 1);
+    default: // DOM_DELTA_PIXEL (0) and anything unknown — convert px → lines.
+      return raw / px;
+  }
+}


### PR DESCRIPTION
## Problem

Some terminal windows scroll with the mouse wheel and others don't. Root cause is standard xterm.js / VT behavior, not a runner bug: when the foreground program enables a mouse-tracking mode (DECSET `1000`/`1002`/`1003` — the VT200/DRAG/ANY protocols, **all of which report wheel events**), xterm.js sets `handleMouseWheel: false` and forwards the wheel to the program instead of scrolling its scrollback (`@xterm/xterm` `Viewport.ts`). So mouse-mode TUIs (AI sessions, `lazygit`, `htop`, `less --mouse`, `vim`) look "stuck" while plain-shell panes scroll fine.

## Fix

A capture-phase `wheel` listener on the terminal container: when **Shift** is held, it takes the event over (`preventDefault` + `stopImmediatePropagation`) and scrolls the local scrollback via a new `ITerminalBackend.scrollLines(amount)`. This matches the long-standing "modifier bypasses application mouse reporting" convention in Konsole / GNOME Terminal / Windows Terminal, giving a reliable "always scroll the terminal" gesture.

- **Plain (un-modified) wheel is unchanged** — apps keep their mouse interaction, exactly like VS Code.
- Capture phase is required: xterm's `attachCustomWheelEventHandler` is bypassed (`if (requestedEvents.wheel) return;`) before it runs once mouse mode is active, so it can't fix this case.
- Folds in `deltaX`: on Windows/Chromium (WebView2) Shift+wheel is remapped to **horizontal** scroll (`deltaY === 0`, magnitude in `deltaX`) — without this the gesture would silently no-op on the primary runtime.
- Fractional accumulator so sub-line trackpad deltas scroll smoothly.

## Files

| File | Change |
|---|---|
| `wheelScroll.ts` | New pure leaf module: wheel event → signed line delta (mirrors the `consumeInputChunk` testability pattern) |
| `wheelScroll.test.ts` | 11 unit tests (incl. the Windows `deltaX` path) |
| `TerminalInstance.tsx` | Capture-phase Shift+wheel handler + fractional carry, cleaned up on unmount |
| `backends/{types,XtermBackend,GhosttyBackend}.ts` | `scrollLines(amount)` on the interface + both backends (Ghostty guarded) |

## Verification

- `vitest` 11/11, `tsc --noEmit`, ESLint, Prettier, `vite build` — all green.
- Not yet driven live on a running runner (a physical Shift+wheel gesture is hard to automate). Manual check: hold **Shift** and scroll over a pane running a mouse-mode app — the scrollback now moves.

## Note

For scrolling specifically this slightly *exceeds* VS Code (its terminal has no Shift-bypass). Ctrl+wheel font-zoom was deliberately skipped — off by default in VS Code and historically conflicts with scrolling.
