### PR TITLE
feat(terminal): Ctrl+F find-in-terminal with match highlighting (VS Code parity)

### DIFF
--- a/src/components/terminal/KeyboardShortcutsOverlay.tsx
+++ b/src/components/terminal/KeyboardShortcutsOverlay.tsx
@@ -27,6 +27,15 @@ const SHORTCUT_GROUPS: { title: string; shortcuts: ShortcutDef[] }[] = [
     ],
   },
   {
+    title: "Find (focused terminal)",
+    shortcuts: [
+      { keys: "Ctrl+F", description: "Find in terminal scrollback" },
+      { keys: "Enter / F3", description: "Next match" },
+      { keys: "Shift+Enter / Shift+F3", description: "Previous match" },
+      { keys: "Escape", description: "Close find (clears highlights)" },
+    ],
+  },
+  {
     title: "Scrolling (focused terminal)",
     shortcuts: [
       { keys: "Shift+Wheel", description: "Scroll scrollback even when an app captures the wheel" },

--- a/src/components/terminal/TerminalFindBar.test.ts
+++ b/src/components/terminal/TerminalFindBar.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure-helper tests for `TerminalFindBar`.
+ *
+ * The runner's vitest config uses `environment: "node"` — JSX rendering
+ * isn't available (same precedent as `MidSessionToast.test.tsx`), so we
+ * exercise the exported pure helpers: the find-input key interpreter and
+ * the VS Code-style match counter.
+ */
+
+import { describe, expect, it } from "vitest";
+import { interpretFindKey, formatMatchCount } from "./TerminalFindBar";
+
+describe("interpretFindKey", () => {
+  it("maps Enter / F3 to next", () => {
+    expect(interpretFindKey({ key: "Enter", shiftKey: false })).toBe("next");
+    expect(interpretFindKey({ key: "F3", shiftKey: false })).toBe("next");
+  });
+
+  it("maps Shift+Enter / Shift+F3 to prev", () => {
+    expect(interpretFindKey({ key: "Enter", shiftKey: true })).toBe("prev");
+    expect(interpretFindKey({ key: "F3", shiftKey: true })).toBe("prev");
+  });
+
+  it("maps Escape to close", () => {
+    expect(interpretFindKey({ key: "Escape", shiftKey: false })).toBe("close");
+    expect(interpretFindKey({ key: "Escape", shiftKey: true })).toBe("close");
+  });
+
+  it("ignores ordinary typing", () => {
+    expect(interpretFindKey({ key: "a", shiftKey: false })).toBeNull();
+    expect(interpretFindKey({ key: "Backspace", shiftKey: false })).toBeNull();
+    expect(interpretFindKey({ key: "ArrowDown", shiftKey: false })).toBeNull();
+  });
+});
+
+describe("formatMatchCount", () => {
+  it("is empty with no query", () => {
+    expect(formatMatchCount(-1, 0, "")).toBe("");
+    expect(formatMatchCount(3, 10, "")).toBe("");
+  });
+
+  it("shows 'No results' for a query with zero matches", () => {
+    expect(formatMatchCount(-1, 0, "nope")).toBe("No results");
+  });
+
+  it("shows 'k of n' with a 1-based active index", () => {
+    expect(formatMatchCount(0, 17, "x")).toBe("1 of 17");
+    expect(formatMatchCount(16, 17, "x")).toBe("17 of 17");
+  });
+
+  it("falls back to the bare total when the index is unavailable (-1 over highlight limit)", () => {
+    expect(formatMatchCount(-1, 1234, "x")).toBe("1234");
+  });
+});

--- a/src/components/terminal/TerminalFindBar.tsx
+++ b/src/components/terminal/TerminalFindBar.tsx
@@ -1,0 +1,183 @@
+/**
+ * TerminalFindBar — VS Code-parity find widget for a single terminal.
+ *
+ * Overlays the top-right of a `TerminalInstance` (the same spot VS Code's
+ * terminal find widget occupies). State lives in `TerminalInstance`; this
+ * component is purely presentational + keyboard interpretation:
+ *
+ *   Enter / F3              find next
+ *   Shift+Enter / Shift+F3  find previous
+ *   Escape                  close (clears highlights, refocuses terminal)
+ *
+ * Toggles mirror VS Code's three: match case (Aa), whole word (ab), regex (.*).
+ * The match counter renders "k of n" like VS Code, or "No results".
+ *
+ * All keydown events stop propagation so the page-level shortcut handler
+ * (`useKeyboardShortcuts`) and the terminal itself never see keystrokes meant
+ * for the find input.
+ */
+
+import { useEffect, useRef } from "react";
+import { ChevronUp, ChevronDown, X } from "lucide-react";
+
+/** Resolved find-bar key action — pure + unit-testable (node env, no JSX). */
+export type FindKeyAction = "next" | "prev" | "close" | null;
+
+/** Interpret a keydown inside the find input. */
+export function interpretFindKey(e: { key: string; shiftKey: boolean }): FindKeyAction {
+  if (e.key === "Escape") return "close";
+  if (e.key === "Enter" || e.key === "F3") return e.shiftKey ? "prev" : "next";
+  return null;
+}
+
+/** Format the VS Code-style match counter. */
+export function formatMatchCount(resultIndex: number, resultCount: number, query: string): string {
+  if (!query) return "";
+  if (resultCount <= 0) return "No results";
+  // resultIndex is -1 when the addon exceeded its highlight limit — fall back
+  // to a bare total rather than a bogus "0 of n".
+  if (resultIndex < 0) return `${resultCount}`;
+  return `${resultIndex + 1} of ${resultCount}`;
+}
+
+interface TerminalFindBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  resultIndex: number;
+  resultCount: number;
+  caseSensitive: boolean;
+  wholeWord: boolean;
+  regex: boolean;
+  onToggleCase: () => void;
+  onToggleWholeWord: () => void;
+  onToggleRegex: () => void;
+  onNext: () => void;
+  onPrev: () => void;
+  onClose: () => void;
+}
+
+function ToggleButton({
+  active,
+  label,
+  title,
+  onClick,
+}: {
+  active: boolean;
+  label: string;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      title={title}
+      onClick={onClick}
+      onMouseDown={(e) => e.preventDefault()} // keep focus in the find input
+      className={`px-1 py-0.5 rounded text-[10px] font-mono transition-colors ${
+        active
+          ? "bg-[#3d59a1] text-[#c0caf5]"
+          : "text-[#565f89] hover:text-[#a9b1d6] hover:bg-[#2a2d3d]"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+export function TerminalFindBar({
+  query,
+  onQueryChange,
+  resultIndex,
+  resultCount,
+  caseSensitive,
+  wholeWord,
+  regex,
+  onToggleCase,
+  onToggleWholeWord,
+  onToggleRegex,
+  onNext,
+  onPrev,
+  onClose,
+}: TerminalFindBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus + select the query on open so typing replaces a stale term —
+  // matches VS Code, which seeds the find widget with the previous query.
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const count = formatMatchCount(resultIndex, resultCount, query);
+  const hasMatches = resultCount > 0;
+
+  return (
+    <div
+      className="absolute top-1 right-2 z-30 flex items-center gap-1 px-2 py-1 rounded border border-[#2a2d3d] bg-[#16161e] shadow-lg"
+      data-testid="terminal-find-bar"
+      onMouseDown={(e) => e.stopPropagation()} // don't steal zone focus-click
+    >
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+          const action = interpretFindKey(e);
+          if (!action) return;
+          e.preventDefault();
+          if (action === "next") onNext();
+          else if (action === "prev") onPrev();
+          else onClose();
+        }}
+        placeholder="Find"
+        spellCheck={false}
+        className="w-40 bg-transparent text-[12px] text-[#c0caf5] placeholder-[#565f89] outline-hidden font-mono"
+      />
+      <span
+        className={`text-[10px] whitespace-nowrap min-w-[52px] text-right ${
+          query && !hasMatches ? "text-[#f7768e]" : "text-[#565f89]"
+        }`}
+      >
+        {count}
+      </span>
+      <ToggleButton active={caseSensitive} label="Aa" title="Match case" onClick={onToggleCase} />
+      <ToggleButton
+        active={wholeWord}
+        label="ab"
+        title="Match whole word"
+        onClick={onToggleWholeWord}
+      />
+      <ToggleButton
+        active={regex}
+        label=".*"
+        title="Use regular expression"
+        onClick={onToggleRegex}
+      />
+      <button
+        title="Previous match (Shift+Enter)"
+        onClick={onPrev}
+        onMouseDown={(e) => e.preventDefault()}
+        disabled={!hasMatches}
+        className="p-0.5 rounded text-[#565f89] hover:text-[#c0caf5] hover:bg-[#2a2d3d] disabled:opacity-40 disabled:hover:bg-transparent"
+      >
+        <ChevronUp className="w-3.5 h-3.5" />
+      </button>
+      <button
+        title="Next match (Enter)"
+        onClick={onNext}
+        onMouseDown={(e) => e.preventDefault()}
+        disabled={!hasMatches}
+        className="p-0.5 rounded text-[#565f89] hover:text-[#c0caf5] hover:bg-[#2a2d3d] disabled:opacity-40 disabled:hover:bg-transparent"
+      >
+        <ChevronDown className="w-3.5 h-3.5" />
+      </button>
+      <button
+        title="Close (Escape)"
+        onClick={onClose}
+        className="p-0.5 rounded text-[#565f89] hover:text-[#f7768e] hover:bg-[#2a2d3d]"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useCallback, forwardRef, useImperativeHandle } from "react";
+import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from "react";
 import { FilePathLinkProvider } from "./FilePathLinkProvider";
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { useUIBridgeOptional } from "@qontinui/ui-bridge";
 import type { TerminalOutputEvent, TerminalExitEvent } from "@qontinui/shared-types/tauri-events";
 import { createTerminalBackend } from "./backends";
-import type { BackendType, ITerminalBackend } from "./backends";
+import type { BackendType, ITerminalBackend, TerminalSearchResults } from "./backends";
+import { TerminalFindBar } from "./TerminalFindBar";
 import { paintGrid, type GridSnapshot } from "./paintGrid";
 import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
@@ -175,6 +176,79 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     // pixel deltas (trackpads) accumulate here so slow scrolling advances
     // smoothly instead of snapping a whole line per tick. See `wheelScroll.ts`.
     const wheelScrollAccumRef = useRef(0);
+
+    // ── Find-in-terminal (VS Code Ctrl+F parity) ─────────────────────────
+    // State drives the TerminalFindBar overlay; the refs mirror it so the
+    // backend key handler (created once in the init effect) and runFind can
+    // read fresh values without re-running the effect.
+    const [findOpen, setFindOpen] = useState(false);
+    // Bumped on every Ctrl+F so a re-press while already open remounts the
+    // bar (key prop), refocusing + selecting the query like VS Code.
+    const [findFocusSeq, setFindFocusSeq] = useState(0);
+    const [findQuery, setFindQuery] = useState("");
+    const [findOpts, setFindOpts] = useState({
+      caseSensitive: false,
+      wholeWord: false,
+      regex: false,
+    });
+    const [findResults, setFindResults] = useState<TerminalSearchResults>({
+      resultIndex: -1,
+      resultCount: 0,
+    });
+    const findQueryRef = useRef(findQuery);
+    findQueryRef.current = findQuery;
+    const findOptsRef = useRef(findOpts);
+    findOptsRef.current = findOpts;
+
+    /**
+     * Run a search pass against the backend. `incremental` keeps the active
+     * match anchored while the operator types (VS Code behavior); plain
+     * next/prev navigation passes false to advance. Invalid regexes are
+     * swallowed — the addon throws on bad patterns mid-typing (e.g. "[").
+     */
+    const runFind = useCallback((direction: "next" | "prev", incremental = false) => {
+      const b = backendRef.current;
+      if (!b) return;
+      const q = findQueryRef.current;
+      if (!q) {
+        b.clearSearch();
+        setFindResults({ resultIndex: -1, resultCount: 0 });
+        return;
+      }
+      const opts = { ...findOptsRef.current, incremental };
+      try {
+        if (direction === "next") b.findNext(q, opts);
+        else b.findPrevious(q, opts);
+      } catch {
+        // Invalid regex while typing — leave previous results in place.
+      }
+    }, []);
+
+    const handleFindQueryChange = useCallback(
+      (q: string) => {
+        setFindQuery(q);
+        findQueryRef.current = q; // searchable immediately, before re-render
+        runFind("next", true);
+      },
+      [runFind],
+    );
+
+    const toggleFindOpt = useCallback(
+      (key: "caseSensitive" | "wholeWord" | "regex") => {
+        const next = { ...findOptsRef.current, [key]: !findOptsRef.current[key] };
+        findOptsRef.current = next;
+        setFindOpts(next);
+        runFind("next", true);
+      },
+      [runFind],
+    );
+
+    const closeFind = useCallback(() => {
+      setFindOpen(false);
+      setFindResults({ resultIndex: -1, resultCount: 0 });
+      backendRef.current?.clearSearch();
+      backendRef.current?.focus();
+    }, []);
 
     // Expose selection, write, and scrollback API to parent components
     useImperativeHandle(ref, () => ({
@@ -399,6 +473,13 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
           }),
         );
 
+        // Find-in-terminal match counts → TerminalFindBar ("k of n").
+        disposables.push(
+          backend.onSearchResults((results) => {
+            setFindResults(results);
+          }),
+        );
+
         // Handle Ctrl+C copy (when text is selected) and Ctrl+V paste.
         // Tauri's webview doesn't fire the browser clipboard events that xterm.js
         // relies on, so we intercept the keys and use the clipboard API manually.
@@ -432,6 +513,39 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
               })
               .catch(() => {});
             return false; // prevent terminal default handling
+          }
+
+          // VS Code-parity find: Ctrl+F opens the find bar; F3 / Shift+F3
+          // jump to the next/previous match (opening the bar if needed).
+          // Swallowed so the keys never reach the PTY — Ctrl+F would
+          // otherwise be forward-char in readline/PSReadLine.
+          if (
+            event.type === "keydown" &&
+            (event.ctrlKey || event.metaKey) &&
+            !event.altKey &&
+            !event.shiftKey &&
+            event.key.toLowerCase() === "f"
+          ) {
+            event.preventDefault();
+            setFindOpen(true);
+            setFindFocusSeq((s) => s + 1);
+            return false;
+          }
+          if (
+            event.type === "keydown" &&
+            event.key === "F3" &&
+            !event.ctrlKey &&
+            !event.altKey &&
+            !event.metaKey
+          ) {
+            event.preventDefault();
+            setFindOpen(true);
+            if (findQueryRef.current) {
+              runFind(event.shiftKey ? "prev" : "next");
+            } else {
+              setFindFocusSeq((s) => s + 1);
+            }
+            return false;
           }
 
           // VS Code-parity scrollback navigation: Shift+PageUp/PageDown,
@@ -838,11 +952,31 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     prevVisibleRef.current = visible;
 
     return (
-      <div
-        ref={containerRef}
-        className={`h-full w-full ${visible ? "" : "hidden"}`}
-        style={{ padding: "4px 0 0 4px" }}
-      />
+      // Wrapper exists so the find bar can overlay as a React-managed
+      // sibling: xterm imperatively appends its own DOM into the inner
+      // container div, and mixing React children with foreign nodes in the
+      // same parent invites reconciliation surprises.
+      <div className={`relative h-full w-full ${visible ? "" : "hidden"}`}>
+        <div ref={containerRef} className="h-full w-full" style={{ padding: "4px 0 0 4px" }} />
+        {findOpen && (
+          <TerminalFindBar
+            key={findFocusSeq}
+            query={findQuery}
+            onQueryChange={handleFindQueryChange}
+            resultIndex={findResults.resultIndex}
+            resultCount={findResults.resultCount}
+            caseSensitive={findOpts.caseSensitive}
+            wholeWord={findOpts.wholeWord}
+            regex={findOpts.regex}
+            onToggleCase={() => toggleFindOpt("caseSensitive")}
+            onToggleWholeWord={() => toggleFindOpt("wholeWord")}
+            onToggleRegex={() => toggleFindOpt("regex")}
+            onNext={() => runFind("next")}
+            onPrev={() => runFind("prev")}
+            onClose={closeFind}
+          />
+        )}
+      </div>
     );
   },
 );

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -142,6 +142,24 @@ export class GhosttyBackend implements ITerminalBackend {
     t.scrollToTop?.();
   }
 
+  // ghostty-web has no search addon — find-in-terminal degrades to "no
+  // matches" and the find bar simply shows 0 results on this backend.
+  findNext(): boolean {
+    return false;
+  }
+
+  findPrevious(): boolean {
+    return false;
+  }
+
+  clearSearch(): void {
+    // no-op — nothing was highlighted
+  }
+
+  onSearchResults(): IDisposable {
+    return { dispose: () => {} };
+  }
+
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
     this.term.attachCustomKeyEventHandler(handler);
   }

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -3,6 +3,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { CanvasAddon } from "@xterm/addon-canvas";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { SearchAddon } from "@xterm/addon-search";
 import "@xterm/xterm/css/xterm.css";
 
 import type {
@@ -10,11 +11,27 @@ import type {
   ITerminalBackend,
   ITerminalLinkProvider,
   TerminalBackendOptions,
+  TerminalSearchOptions,
+  TerminalSearchResults,
 } from "./types";
+
+/**
+ * Match-highlight colors for find-in-terminal, aligned with the Tokyo Night
+ * theme in `TerminalInstance.TERMINAL_OPTIONS`. The two `*OverviewRuler`
+ * fields are required by the addon's types even though the runner doesn't
+ * render an overview ruler.
+ */
+const SEARCH_DECORATIONS = {
+  matchBackground: "#3d59a1",
+  matchOverviewRuler: "#3d59a1",
+  activeMatchBackground: "#ff9e64",
+  activeMatchColorOverviewRuler: "#ff9e64",
+};
 
 export class XtermBackend implements ITerminalBackend {
   private readonly term: Terminal;
   private readonly fitAddon: FitAddon;
+  private readonly searchAddon: SearchAddon;
   private container: HTMLElement | null = null;
 
   constructor(options: TerminalBackendOptions = {}) {
@@ -31,6 +48,8 @@ export class XtermBackend implements ITerminalBackend {
 
     this.fitAddon = new FitAddon();
     this.term.loadAddon(this.fitAddon);
+    this.searchAddon = new SearchAddon();
+    this.term.loadAddon(this.searchAddon);
   }
 
   open(container: HTMLElement): void {
@@ -135,6 +154,23 @@ export class XtermBackend implements ITerminalBackend {
 
   scrollToTop(): void {
     this.term.scrollToTop();
+  }
+
+  findNext(term: string, options?: TerminalSearchOptions): boolean {
+    return this.searchAddon.findNext(term, { ...options, decorations: SEARCH_DECORATIONS });
+  }
+
+  findPrevious(term: string, options?: TerminalSearchOptions): boolean {
+    return this.searchAddon.findPrevious(term, { ...options, decorations: SEARCH_DECORATIONS });
+  }
+
+  clearSearch(): void {
+    this.searchAddon.clearDecorations();
+    this.term.clearSelection();
+  }
+
+  onSearchResults(cb: (results: TerminalSearchResults) => void): IDisposable {
+    return this.searchAddon.onDidChangeResults(cb);
   }
 
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {

--- a/src/components/terminal/backends/index.ts
+++ b/src/components/terminal/backends/index.ts
@@ -1,5 +1,6 @@
 export type { BackendType, ITerminalBackend, TerminalBackendOptions } from "./types";
 export type { ITerminalLinkProvider, ITerminalLink, IDisposable } from "./types";
+export type { TerminalSearchOptions, TerminalSearchResults } from "./types";
 
 export { XtermBackend } from "./XtermBackend";
 

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -74,6 +74,33 @@ export interface TerminalBackendOptions {
 }
 
 // ---------------------------------------------------------------------------
+// Find-in-terminal (backend-agnostic subset of xterm's ISearchOptions)
+// ---------------------------------------------------------------------------
+
+export interface TerminalSearchOptions {
+  /** Treat the term as a regular expression. */
+  regex?: boolean;
+  /** Match whole words only. */
+  wholeWord?: boolean;
+  /** Case-sensitive matching. */
+  caseSensitive?: boolean;
+  /**
+   * Incremental search: expand the current selection if it still matches —
+   * used while the operator types so the active match doesn't jump ahead.
+   * Only affects findNext.
+   */
+  incremental?: boolean;
+}
+
+/** Fired when highlighted search results change (see `onSearchResults`). */
+export interface TerminalSearchResults {
+  /** Index of the active match, or -1 when none / over the highlight limit. */
+  resultIndex: number;
+  /** Total number of matches. */
+  resultCount: number;
+}
+
+// ---------------------------------------------------------------------------
 // Terminal backend interface
 // ---------------------------------------------------------------------------
 
@@ -137,6 +164,20 @@ export interface ITerminalBackend {
   scrollPages(pageCount: number): void;
   /** Scroll the viewport to the very top of the scrollback (VS Code Ctrl+Home). */
   scrollToTop(): void;
+
+  // -- Find-in-terminal (VS Code Ctrl+F parity) ------------------------------
+  /**
+   * Find the next match for `term` (wraps at the end). Returns false when no
+   * match exists. Highlights all matches when the backend supports
+   * decorations. Backends without search support return false.
+   */
+  findNext(term: string, options?: TerminalSearchOptions): boolean;
+  /** Find the previous match for `term` (wraps at the start). */
+  findPrevious(term: string, options?: TerminalSearchOptions): boolean;
+  /** Clear search highlights and the active-match selection. */
+  clearSearch(): void;
+  /** Subscribe to match-count changes while a search is active. */
+  onSearchResults(cb: (results: TerminalSearchResults) => void): IDisposable;
 
   // -- Key handling ---------------------------------------------------------
   /** Intercept key events before the terminal processes them. Return false to prevent default. */


### PR DESCRIPTION
## What

**`Ctrl+F` find-in-terminal** — the third piece of VS Code terminal parity, stacked on #378 (keyboard scrolling) → #377 (Shift+wheel).

| Binding | Action |
|---|---|
| `Ctrl+F` | Open find bar (seeds + selects the previous query) |
| `Enter` / `F3` | Next match |
| `Shift+Enter` / `Shift+F3` | Previous match |
| `Escape` | Close, clear highlights, refocus terminal |
| `Aa` / `ab` / `.*` | Match-case / whole-word / regex toggles |

Backed by `@xterm/addon-search` (already a dependency — zero new packages): all matches highlighted (Tokyo Night palette, active match orange), VS Code-style `k of n` counter via `onDidChangeResults`, incremental search while typing so the active match doesn't jump ahead, wrap-around navigation.

## Mechanics

- `ITerminalBackend` gains `findNext` / `findPrevious` / `clearSearch` / `onSearchResults`; Xterm implements via `SearchAddon`, Ghostty degrades gracefully to "No results".
- `Ctrl+F` / `F3` intercepted in the per-terminal `attachCustomKeyEventHandler` and swallowed — `Ctrl+F` is forward-char in readline/PSReadLine, so it must not reach the PTY (matches VS Code `commandsToSkipShell`).
- The find bar renders as a React-managed **sibling** of the xterm container (new wrapper div in `TerminalInstance`) — xterm appends its DOM imperatively, and mixing React children with foreign nodes in one parent invites reconciliation surprises.
- Re-pressing `Ctrl+F` while open remounts the bar (`key` prop) to refocus + select the query, like VS Code.
- Find-bar keystrokes `stopPropagation()` so the page-level zone shortcuts (`useKeyboardShortcuts`) and the terminal never see them; Escape in the bar closes find without un-maximizing the zone.
- Invalid regexes mid-typing (e.g. `[`) are swallowed; previous results stay.
- `KeyboardShortcutsOverlay` gains a "Find (focused terminal)" section.

## Verification

- `vitest` 32/32 (new: `interpretFindKey` + `formatMatchCount` pure-helper tests, per the node-env test convention), `tsc --noEmit`, ESLint, Prettier, `vite build` — all green.
- Not yet driven live on a running runner. Manual check: focus a terminal with output, `Ctrl+F`, type a term → matches highlight + counter shows `k of n`; `Enter`/`Shift+Enter` cycle; `Esc` clears and returns focus.

## Stacking

Base is `feat/terminal-keyboard-scroll` (#378). Retarget after the stack merges below it.
