### PR TITLE
feat(sdk): fall back to the coord device-JWT when no Cognito session exists

### DIFF
--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -502,10 +502,44 @@ pub async fn connect_sdk_app(
                 Err(e) => warn!("SDK relay client: malformed bearer, connecting without auth: {e}"),
             }
         }
-        _ => debug!(
-            "SDK relay client: no Cognito session (legacy/local install or not signed in); \
-             connecting without auth"
-        ),
+        _ => {
+            // No Cognito user session (device-paired runner, or legacy/local
+            // install). A device-paired runner DOES hold a coord-minted
+            // device-JWT in the access_token slot (`AuthManager::get_access_token`).
+            // The relay accepts a verified device-JWT as a fallback bearer, so
+            // attach it here — gated on `looks_like_jwt` so a legacy opaque
+            // `qontinui_runner_<random>` slot value is never sent (it would just
+            // 401). If there's no token, or it isn't JWT-shaped, fall through to
+            // today's behavior: connect with no Authorization header.
+            let device_jwt = crate::auth::AuthManager::new()
+                .get_access_token()
+                .ok()
+                .filter(|t| crate::auth::looks_like_jwt(t));
+            match device_jwt {
+                Some(token) => {
+                    match reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)) {
+                        Ok(mut value) => {
+                            value.set_sensitive(true);
+                            let mut headers = reqwest::header::HeaderMap::new();
+                            headers.insert(reqwest::header::AUTHORIZATION, value);
+                            builder = builder.default_headers(headers);
+                            debug!(
+                                "SDK relay client: no Cognito session; attached device-JWT \
+                                 fallback bearer for {}",
+                                url
+                            );
+                        }
+                        Err(e) => warn!(
+                            "SDK relay client: malformed device-JWT bearer, connecting without auth: {e}"
+                        ),
+                    }
+                }
+                None => debug!(
+                    "SDK relay client: no Cognito session and no JWT-shaped device token \
+                     (legacy/local install or not paired); connecting without auth"
+                ),
+            }
+        }
     }
 
     let client = builder


### PR DESCRIPTION
## Summary

`connect_sdk_app` sends the Cognito user bearer first (#368), but a device-paired runner has no Cognito user session — the no-Cognito arm connected with **no** Authorization header and every relay call 401'd against the auth-gated `qontinui.io/api/ui-bridge` relay.

In that arm, attach the coord-minted device-JWT from `AuthManager`'s `access_token` slot as the Bearer, gated on `auth::looks_like_jwt` so a legacy opaque `qontinui_runner_<random>` slot value is never sent. `set_sensitive(true)` matches the Cognito arm. Cognito user-token-first ordering is unchanged — the device-JWT is strictly the no-Cognito fallback (#356's token, restored only as fallback).

**Depends on qontinui-web #412** (the relay must accept device-JWTs). Safe to merge in either order — until the web side deploys, the fallback bearer just 401s exactly like today's missing header — but the feature only goes live once web #412 is deployed.

Plan: `2026-06-03-relay-accept-runner-device-auth`

## Test plan
- `cargo check` clean on the changed code (pre-existing, orthogonal vision_routes path-dep drift in the local worktree noted; CI is the gate)
- Live verify (post-merge): device-paired temp runner with no Cognito session → `sdk/connect` → `sdk/status` `connected:true`