### PR TITLE
feat(terminal): worktree-isolation intent_repo + PTY branch-switch soft-warn (L2/L3)

### DIFF
--- a/src-tauri/src/agent_worktree/canonical_paths.rs
+++ b/src-tauri/src/agent_worktree/canonical_paths.rs
@@ -12,7 +12,7 @@
 //! directory segment, so callers no longer need per-callsite
 //! `repo_canonical_paths` overrides for the standard layout.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use qontinui_runner_lib::observable_bridge::git_ops::repo_basename_from_url;
 
@@ -76,6 +76,79 @@ pub fn default_canonical_path(repo: &str) -> Result<PathBuf, String> {
     let segment = canonical_segment(repo)?;
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
     Ok(PathBuf::from(format!("{home}/qontinui-root/{segment}")))
+}
+
+/// Reverse of [`default_canonical_path`]: given an absolute filesystem
+/// `path`, return the bare repo slug whose canonical checkout owns it, or
+/// `None` if `path` is not under any known canonical checkout in the
+/// runner's flat `<root>/<name>/` layout.
+///
+/// Algorithm (no hard-coded repo list — the layout is uniform):
+/// 1. Take the first path segment under the workspace root (`<root>/<seg>`).
+/// 2. Reconstruct that segment's canonical path via [`default_canonical_path`].
+/// 3. Confirm `path` is the canonical path itself or a descendant of it
+///    (an ancestor check that tolerates trailing components, worktree
+///    subdirs, etc.).
+///
+/// Comparison is best-effort case-insensitive on the prefix to tolerate
+/// Windows' case-insensitive drive paths (`D:/` vs `d:/`) without needing
+/// the path to exist on disk (so this works for not-yet-materialized
+/// paths and in unit tests). Both inputs are compared after lexical
+/// normalization of separators.
+///
+/// Used by Layer 2 of the shared-checkout coordination plan
+/// (`2026-06-03-shared-checkout-coordination-gap-fix.md`): when a terminal
+/// session's `intent_repo` is `None`, derive it from the session's
+/// `working_dir` so `acquire_for_terminal` can route through isolated
+/// worktree acquisition when `QONTINUI_AGENT_WORKTREE_MODE` is on. Also
+/// used by Layer 3 to resolve a Terminal-PTY session's repo for the coord
+/// worktree-claim lookup.
+pub fn repo_slug_for_path(path: &Path) -> Option<String> {
+    // Lexically normalize `path` to forward slashes + lowercase for a
+    // robust, on-disk-independent prefix comparison.
+    let norm = normalize_for_compare(&path.to_string_lossy());
+
+    // The first path segment under the workspace root is the candidate
+    // slug. We don't know the workspace root abstractly here, so we lean
+    // on `default_canonical_path` round-tripping: try each leading segment
+    // of `path` as a candidate slug and accept the one whose canonical
+    // path is an ancestor of `path`.
+    //
+    // In practice the canonical path is `<root>/<seg>`, so the candidate
+    // is the single segment immediately following the workspace root. We
+    // recover it by walking ancestors: for each ancestor `a` of `path`,
+    // `a.file_name()` is a candidate slug, and `default_canonical_path`
+    // of that slug must equal `a` (normalized) for it to be the owning
+    // checkout root.
+    let mut ancestor = Some(path);
+    while let Some(a) = ancestor {
+        if let Some(name) = a.file_name().and_then(|n| n.to_str()) {
+            if let Ok(canonical) = default_canonical_path(name) {
+                let canon_norm = normalize_for_compare(&canonical.to_string_lossy());
+                // `a` is the canonical checkout root for `name` iff its
+                // normalized path equals the reconstructed canonical path,
+                // AND the original `path` is that root or a descendant
+                // (guaranteed because `a` is an ancestor of `path`).
+                if canon_norm == normalize_for_compare(&a.to_string_lossy())
+                    && (norm == canon_norm || norm.starts_with(&format!("{canon_norm}/")))
+                {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        ancestor = a.parent();
+    }
+    None
+}
+
+/// Lowercase + forward-slash normalization for case/separator-insensitive
+/// path-prefix comparison that does NOT require the path to exist on disk
+/// (so it works for not-yet-created worktree paths and in unit tests).
+/// Strips a single trailing slash so `<root>/<name>` and `<root>/<name>/`
+/// compare equal.
+fn normalize_for_compare(s: &str) -> String {
+    let lowered = s.replace('\\', "/").to_lowercase();
+    lowered.trim_end_matches('/').to_string()
 }
 
 #[cfg(test)]
@@ -178,5 +251,49 @@ mod tests {
     fn default_path_propagates_validation_error() {
         assert!(default_canonical_path("").is_err());
         assert!(default_canonical_path("qontinui/").is_err());
+    }
+
+    #[test]
+    fn repo_slug_for_checkout_root() {
+        let root = default_canonical_path("qontinui-runner").unwrap();
+        assert_eq!(
+            repo_slug_for_path(&root),
+            Some("qontinui-runner".to_string())
+        );
+    }
+
+    #[test]
+    fn repo_slug_for_descendant_path() {
+        let mut p = default_canonical_path("qontinui-runner").unwrap();
+        p.push("src-tauri");
+        p.push("src");
+        p.push("commands");
+        p.push("terminal.rs");
+        assert_eq!(repo_slug_for_path(&p), Some("qontinui-runner".to_string()));
+    }
+
+    #[test]
+    fn repo_slug_for_another_repo() {
+        let mut p = default_canonical_path("qontinui-coord").unwrap();
+        p.push("src");
+        assert_eq!(repo_slug_for_path(&p), Some("qontinui-coord".to_string()));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn repo_slug_is_case_insensitive_on_windows() {
+        // Windows drive paths are case-insensitive; a `d:/` working_dir
+        // must still resolve against the `D:/` canonical path.
+        let p = PathBuf::from("d:/qontinui-root/qontinui-runner/src-tauri");
+        assert_eq!(repo_slug_for_path(&p), Some("qontinui-runner".to_string()));
+    }
+
+    #[test]
+    fn repo_slug_outside_workspace_is_none() {
+        // A path that doesn't sit under any `<root>/<name>/` checkout must
+        // not falsely match. Use a path whose segments don't reconstruct
+        // to themselves via `default_canonical_path` (a temp dir).
+        let p = PathBuf::from("/some/unrelated/place/foo/bar");
+        assert_eq!(repo_slug_for_path(&p), None);
     }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -54,13 +54,38 @@ pub async fn terminal_create(
         working_dir.as_deref().unwrap_or(""),
     );
 
+    // L2 (shared-checkout coordination gap fix) — when the caller did
+    // NOT declare an `intent_repo`, derive it from the session's
+    // `working_dir`: if that directory sits inside a known canonical
+    // checkout (`<root>/<repo>/...`), treat the session as editing that
+    // repo. This makes `acquire_for_terminal` route through isolated
+    // worktree acquisition when `QONTINUI_AGENT_WORKTREE_MODE` is on.
+    // SAFE: when the flag is off (the default), `acquire_for_terminal`
+    // still returns `(working_dir, None)`, so the derivation has ZERO
+    // effect until the operator flips the flag.
+    let effective_intent_repo: Option<String> = intent_repo.clone().or_else(|| {
+        working_dir.as_deref().and_then(|wd| {
+            let derived = crate::agent_worktree::canonical_paths::repo_slug_for_path(
+                std::path::Path::new(wd),
+            );
+            if let Some(ref repo) = derived {
+                tracing::debug!(
+                    working_dir = %wd,
+                    derived_intent_repo = %repo,
+                    "terminal_create: derived intent_repo from working_dir"
+                );
+            }
+            derived
+        })
+    });
+
     // Phase 2 — route through the shared `acquire_for_terminal` helper
     // so this entry point + the HTTP-proxy / backend-relay siblings stay
     // in lockstep. When `intent_repo` is `None`, the helper is a no-op;
     // when it's `Some(_)` but worktree mode is off or allocation fails,
     // the helper returns the original `working_dir` and logs.
     let (working_dir, isolated_ctx) = crate::agent_worktree::isolated_edit::acquire_for_terminal(
-        intent_repo.as_deref(),
+        effective_intent_repo.as_deref(),
         title.as_deref().unwrap_or("Terminal edit session"),
         working_dir,
     )
@@ -97,7 +122,7 @@ pub async fn terminal_create(
     let intent = Intent {
         kind: SessionKind::TerminalShell,
         purpose,
-        repo: intent_repo,
+        repo: effective_intent_repo,
         branch: None,
         plan_slug,
         correlation_topic,
@@ -213,6 +238,12 @@ pub fn terminal_write(
     })?;
 
     session.write(&bytes)?;
+
+    // L3 (shared-checkout coordination gap fix) — observe typed input for
+    // branch-mutating git so a soft coord-conflict warning can surface
+    // when a peer holds the worktree claim. Best-effort + non-blocking;
+    // runs AFTER the write so it never delays keystroke delivery.
+    session.observe_input_for_warn(&bytes);
 
     Ok(CommandResponse {
         success: true,

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -2145,9 +2145,28 @@ async fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Opti
             .and_then(|v| v.as_str())
             .map(String::from);
 
+        // L2 (shared-checkout coordination gap fix) — derive `intent_repo`
+        // from `working_dir` when the caller didn't declare one (no-op
+        // until `QONTINUI_AGENT_WORKTREE_MODE` is on).
+        let effective_intent_repo: Option<String> = intent_repo.clone().or_else(|| {
+            working_dir.as_deref().and_then(|wd| {
+                let derived = crate::agent_worktree::canonical_paths::repo_slug_for_path(
+                    std::path::Path::new(wd),
+                );
+                if let Some(ref repo) = derived {
+                    tracing::debug!(
+                        working_dir = %wd,
+                        derived_intent_repo = %repo,
+                        "backend_relay terminal_create: derived intent_repo from working_dir"
+                    );
+                }
+                derived
+            })
+        });
+
         let (working_dir, isolated_ctx) =
             crate::agent_worktree::isolated_edit::acquire_for_terminal(
-                intent_repo.as_deref(),
+                effective_intent_repo.as_deref(),
                 title.as_deref().unwrap_or("Terminal edit session"),
                 working_dir,
             )

--- a/src-tauri/src/mcp/tauri_proxy.rs
+++ b/src-tauri/src/mcp/tauri_proxy.rs
@@ -188,9 +188,28 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 .inner()
                 .clone();
 
+            // L2 (shared-checkout coordination gap fix) — derive
+            // `intent_repo` from `working_dir` when the caller didn't
+            // declare one (no-op until `QONTINUI_AGENT_WORKTREE_MODE` is on).
+            let effective_intent_repo: Option<String> = a.intent_repo.clone().or_else(|| {
+                a.working_dir.as_deref().and_then(|wd| {
+                    let derived = crate::agent_worktree::canonical_paths::repo_slug_for_path(
+                        std::path::Path::new(wd),
+                    );
+                    if let Some(ref repo) = derived {
+                        tracing::debug!(
+                            working_dir = %wd,
+                            derived_intent_repo = %repo,
+                            "tauri_proxy terminal_create: derived intent_repo from working_dir"
+                        );
+                    }
+                    derived
+                })
+            });
+
             let (working_dir, isolated_ctx) =
                 crate::agent_worktree::isolated_edit::acquire_for_terminal(
-                    a.intent_repo.as_deref(),
+                    effective_intent_repo.as_deref(),
                     a.title.as_deref().unwrap_or("Terminal edit session"),
                     a.working_dir,
                 )

--- a/src-tauri/src/terminal/coord_warn.rs
+++ b/src-tauri/src/terminal/coord_warn.rs
@@ -1,0 +1,325 @@
+//! Layer 3 of `plans/2026-06-03-shared-checkout-coordination-gap-fix.md` —
+//! soft warning for branch-mutating git typed into the runner's Terminal
+//! PTY.
+//!
+//! Branch-mutating git typed directly into a Terminal PTY (`git switch`,
+//! `git checkout <branch>`, `git reset --hard`) bypasses every Claude Code
+//! hook, so a session can clobber a *peer's* in-flight work in a shared
+//! checkout with no warning. This module:
+//!
+//! 1. Recognizes a completed input line as branch-mutating git
+//!    ([`is_branch_mutating_git`]) — cheap, only runs when a line is
+//!    submitted (CR/LF), never per keystroke.
+//! 2. If so, asynchronously asks coord whether a *peer* holds the
+//!    `worktree` claim on this session's repo and, if so, emits a soft
+//!    `terminal-coord-warning` Tauri event for the frontend to surface a
+//!    dismissible banner ([`spawn_check_and_warn`]).
+//!
+//! Everything here is best-effort and SOFT: it never blocks input, never
+//! touches terminal output, and swallows all failures (coord unreachable,
+//! parse errors, missing repo). The frontend banner is dismissible and
+//! advisory only.
+
+use std::path::{Path, PathBuf};
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+use tracing::debug;
+
+/// Branch-mutating git matcher. Matches (optionally prefixed by a
+/// `cd <dir> &&`):
+///   - `git [-C <dir>] switch ...`
+///   - `git [-C <dir>] checkout <branch>` but NOT `git checkout -- <file>`
+///   - `git [-C <dir>] reset --hard ...`
+///
+/// This is a soft heuristic, not a shell parser — false negatives are
+/// acceptable (a missed warning is no worse than today); false positives
+/// only ever produce an advisory banner the user can dismiss.
+static BRANCH_MUTATING_GIT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\s*(cd\s+[^&]+&&\s*)?git\s+(-C\s+\S+\s+)?(switch\b|checkout\b|reset\s+--hard\b)")
+        .expect("BRANCH_MUTATING_GIT regex is a compile-time constant")
+});
+
+/// Excludes `git checkout -- <file>` (a working-tree file restore, which is
+/// NOT branch-mutating). The Rust `regex` crate (RE2) has no look-around, so
+/// this case is filtered in [`is_branch_mutating_git`] rather than inline in
+/// [`BRANCH_MUTATING_GIT`]. Matches a `checkout` whose first argument is the
+/// `--` path separator (`--` followed by whitespace or end-of-line); a
+/// double-dash option like `--force` is NOT matched and stays branch-mutating.
+static CHECKOUT_FILE_RESTORE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\bcheckout\s+--(\s|$)")
+        .expect("CHECKOUT_FILE_RESTORE regex is a compile-time constant")
+});
+
+/// Returns true iff `line` is a branch-mutating git command per
+/// [`BRANCH_MUTATING_GIT`], excluding the `git checkout -- <file>` file-restore
+/// form (see [`CHECKOUT_FILE_RESTORE`]).
+pub fn is_branch_mutating_git(line: &str) -> bool {
+    BRANCH_MUTATING_GIT.is_match(line) && !CHECKOUT_FILE_RESTORE.is_match(line)
+}
+
+/// Payload for the `terminal-coord-warning` Tauri event.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoordWarning {
+    pub terminal_id: String,
+    /// Repo slug (canonical-path basename) the warning is about.
+    pub repo: String,
+    /// `machine_id` of the peer holding the worktree claim.
+    pub holder_machine_id: String,
+    /// `session_id` of the holder, when coord reports one.
+    pub holder_session_id: Option<String>,
+    /// The branch-mutating command line that triggered the warning.
+    pub command: String,
+}
+
+/// Best-effort: resolve the session's repo, ask coord for the live
+/// `worktree` claim holder, and — if a PEER holds it — emit a soft
+/// `terminal-coord-warning` event. Spawns a detached tokio task so the
+/// caller (the PTY write hot path) never blocks. All failures are
+/// swallowed.
+///
+/// `our_session_id` is this terminal's coord session id (if wired); it is
+/// used to distinguish a same-machine peer (different session) from
+/// ourselves.
+pub fn spawn_check_and_warn(
+    app_handle: AppHandle,
+    terminal_id: String,
+    working_dir: String,
+    our_session_id: Option<uuid::Uuid>,
+    command: String,
+) {
+    tokio::spawn(async move {
+        if let Err(e) = check_and_warn(
+            &app_handle,
+            &terminal_id,
+            &working_dir,
+            our_session_id,
+            &command,
+        )
+        .await
+        {
+            // Soft + best-effort: debug-only, never surfaced to the user.
+            debug!(
+                terminal_id = %terminal_id,
+                error = %e,
+                "terminal coord-warn: lookup skipped"
+            );
+        }
+    });
+}
+
+/// Inner fallible body of [`spawn_check_and_warn`]. A returned `Err` is
+/// purely observability — the caller logs it at debug and moves on.
+async fn check_and_warn(
+    app_handle: &AppHandle,
+    terminal_id: &str,
+    working_dir: &str,
+    our_session_id: Option<uuid::Uuid>,
+    command: &str,
+) -> Result<(), String> {
+    // 1. Resolve the repo's canonical path → the coord `worktree`
+    //    resource key.
+    let (repo_slug, resource_key) = resolve_repo(working_dir)
+        .ok_or_else(|| "working_dir not under a known repo / no git toplevel".to_string())?;
+
+    // 2. Resolve coord HTTP base + our device id.
+    let coord_base = crate::mcp::agent_worktrees::coord_http_base()
+        .map_err(|e| format!("coord URL not configured: {e}"))?;
+    let our_machine_id = read_device_id().map_err(|e| format!("device_id unavailable: {e}"))?;
+
+    // 3. GET the live worktree-claim holder for this repo.
+    let url = format!(
+        "{}/coord/claims/by-resource?kind=worktree&key={}",
+        coord_base.trim_end_matches('/'),
+        urlencoding::encode(&resource_key),
+    );
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("build client: {e}"))?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("GET by-resource {}", resp.status().as_u16()));
+    }
+    let body: serde_json::Value = resp.json().await.map_err(|e| format!("parse body: {e}"))?;
+
+    // `null` => no holder; nothing to warn about.
+    if body.is_null() {
+        return Ok(());
+    }
+
+    let holder_machine = body
+        .get("machine_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "holder missing machine_id".to_string())?;
+    let holder_session = body
+        .get("session_id")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // 4. Decide whether the holder is a PEER (someone else) or us.
+    //    - Foreign machine => always a peer.
+    //    - Same machine but a different coord session => a same-machine
+    //      peer (another terminal/agent on this host).
+    //    - Same machine + same session (or our session unknown but the
+    //      machine is ours with no session distinction) => it's us; no
+    //      warning.
+    let our_machine_str = our_machine_id.to_string();
+    let is_peer = if holder_machine != our_machine_str {
+        true
+    } else {
+        match (our_session_id, holder_session.as_deref()) {
+            (Some(ours), Some(theirs)) => ours.to_string() != theirs,
+            // Same machine, holder reports no session: can't prove it's a
+            // peer, so stay quiet (avoid warning on our own claim).
+            (Some(_), None) => false,
+            // We have no session id: same-machine holder is ambiguous —
+            // treat as us to avoid false positives.
+            (None, _) => false,
+        }
+    };
+
+    if !is_peer {
+        return Ok(());
+    }
+
+    // 5. Emit the soft warning event.
+    let payload = CoordWarning {
+        terminal_id: terminal_id.to_string(),
+        repo: repo_slug,
+        holder_machine_id: holder_machine.to_string(),
+        holder_session_id: holder_session,
+        command: command.to_string(),
+    };
+    app_handle
+        .emit("terminal-coord-warning", &payload)
+        .map_err(|e| format!("emit terminal-coord-warning: {e}"))?;
+    Ok(())
+}
+
+/// Resolve `working_dir` to `(repo_slug, resource_key)` where
+/// `resource_key` is the canonical-path string coord stores for the
+/// `worktree` claim.
+///
+/// Preference order:
+///   1. If `working_dir` maps to a known canonical repo (L2 helper), use
+///      that repo's canonical path (slug = repo name).
+///   2. Otherwise fall back to `git rev-parse --show-toplevel` and use the
+///      toplevel path as the key (slug = its basename).
+fn resolve_repo(working_dir: &str) -> Option<(String, String)> {
+    let wd = Path::new(working_dir);
+    if let Some(slug) = crate::agent_worktree::canonical_paths::repo_slug_for_path(wd) {
+        if let Ok(canonical) = crate::agent_worktree::canonical_paths::default_canonical_path(&slug)
+        {
+            return Some((slug, canonical.to_string_lossy().to_string()));
+        }
+    }
+    let toplevel = git_toplevel(wd)?;
+    let slug = toplevel
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("")
+        .to_string();
+    Some((slug, toplevel.to_string_lossy().to_string()))
+}
+
+/// `git -C <dir> rev-parse --show-toplevel`, or `None` if `dir` isn't in a
+/// git repo / git is unavailable.
+fn git_toplevel(dir: &Path) -> Option<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if s.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(s))
+    }
+}
+
+/// Read the device UUID from `~/.qontinui/machine.json`. Mirrors
+/// `agent_worktree::isolated_edit::read_device_id` (which is private to
+/// that module) — accepts `device_id` and falls back to legacy
+/// `machine_id`.
+fn read_device_id() -> Result<uuid::Uuid, String> {
+    let path = dirs::home_dir()
+        .map(|h| h.join(".qontinui").join("machine.json"))
+        .ok_or_else(|| "no HOME dir".to_string())?;
+    let bytes = std::fs::read(&path).map_err(|e| format!("read {}: {}", path.display(), e))?;
+    let v: serde_json::Value =
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {}", path.display(), e))?;
+    let id_str = v
+        .get("device_id")
+        .or_else(|| v.get("machine_id"))
+        .and_then(|s| s.as_str())
+        .ok_or_else(|| format!("{}: missing device_id (or machine_id)", path.display()))?;
+    uuid::Uuid::parse_str(id_str).map_err(|e| format!("invalid UUID: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn matches_git_switch() {
+        assert!(is_branch_mutating_git("git switch main"));
+        assert!(is_branch_mutating_git("  git switch -c feature"));
+    }
+
+    #[test]
+    fn matches_git_checkout_branch() {
+        assert!(is_branch_mutating_git("git checkout main"));
+        assert!(is_branch_mutating_git("git checkout -b feature/x"));
+    }
+
+    #[test]
+    fn does_not_match_checkout_file() {
+        // `git checkout -- <file>` restores a file; not branch-mutating.
+        assert!(!is_branch_mutating_git("git checkout -- src/main.rs"));
+    }
+
+    #[test]
+    fn matches_reset_hard() {
+        assert!(is_branch_mutating_git("git reset --hard origin/main"));
+    }
+
+    #[test]
+    fn does_not_match_soft_reset() {
+        assert!(!is_branch_mutating_git("git reset --soft HEAD~1"));
+        assert!(!is_branch_mutating_git("git reset HEAD~1"));
+    }
+
+    #[test]
+    fn matches_cd_prefixed() {
+        assert!(is_branch_mutating_git(
+            "cd /d/qontinui-root/qontinui-runner && git switch main"
+        ));
+    }
+
+    #[test]
+    fn matches_dash_c_form() {
+        assert!(is_branch_mutating_git("git -C /repo switch main"));
+        assert!(is_branch_mutating_git("git -C /repo reset --hard HEAD"));
+    }
+
+    #[test]
+    fn does_not_match_unrelated() {
+        assert!(!is_branch_mutating_git("git status"));
+        assert!(!is_branch_mutating_git("git log --oneline"));
+        assert!(!is_branch_mutating_git("ls -la"));
+        assert!(!is_branch_mutating_git("git commit -m 'switch things up'"));
+    }
+}

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -4,6 +4,7 @@
 //! Each session spawns a native shell (PowerShell on Windows, $SHELL on Unix)
 //! with proper environment for running Claude CLI and other dev tools.
 
+pub mod coord_warn;
 pub mod grid;
 pub mod interceptor;
 pub mod manager;

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -162,6 +162,17 @@ pub struct TerminalSession {
     /// teardown.
     isolated_edit_ctx:
         Arc<Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>>,
+    /// App handle, retained so the input-line warn hook
+    /// ([`Self::observe_input_for_warn`]) can emit the soft
+    /// `terminal-coord-warning` Tauri event off the PTY write path.
+    /// `None` only in unit-test fixtures that don't drive a real app.
+    app_handle: Option<AppHandle>,
+    /// L3 (shared-checkout coordination gap fix) — accumulates printable
+    /// keystroke bytes between line submits so a completed line can be
+    /// matched against branch-mutating git. Soft heuristic: backspace is
+    /// handled approximately, control sequences are dropped. Drained on
+    /// CR/LF. Cheap to keep on the hot path (a few bytes per keystroke).
+    input_line_buf: Arc<Mutex<String>>,
 }
 
 impl TerminalSession {
@@ -420,6 +431,9 @@ impl TerminalSession {
         let waiter_title = title.clone();
         let waiter_alive = is_alive.clone();
         let waiter_exit = exit_code.clone();
+        // Retain a clone for the session struct (input-line warn hook)
+        // before the original handle is moved into the waiter thread.
+        let session_app_handle = app_handle.clone();
         let waiter_app = app_handle;
         let waiter_coord_session_id = coord_session_id.clone();
         let waiter_on_exit = on_exit.clone();
@@ -541,6 +555,8 @@ impl TerminalSession {
             coord_session_id,
             on_exit,
             isolated_edit_ctx: Arc::new(Mutex::new(None)),
+            app_handle: Some(session_app_handle),
+            input_line_buf: Arc::new(Mutex::new(String::new())),
         })
     }
 
@@ -609,6 +625,70 @@ impl TerminalSession {
             .flush()
             .map_err(|e| format!("Failed to flush PTY: {}", e))?;
         Ok(())
+    }
+
+    /// L3 (shared-checkout coordination gap fix) — feed raw keystroke
+    /// bytes through the input-line buffer and, on a completed line
+    /// (CR/LF), evaluate it for a branch-mutating git command. If it
+    /// matches, kick off a best-effort coord lookup that emits a soft
+    /// `terminal-coord-warning` event when a PEER holds the worktree
+    /// claim on this session's repo.
+    ///
+    /// SOFT + CHEAP: this NEVER blocks, NEVER affects the actual PTY
+    /// write, and only does the (rare) coord lookup once a line that
+    /// matches the branch-mutating regex is submitted. Backspace handling
+    /// is approximate — this is a heuristic warn, not a parser. Called
+    /// from `terminal_write` AFTER the bytes are written to the PTY.
+    pub fn observe_input_for_warn(&self, data: &[u8]) {
+        // Collect any completed lines this chunk produced. We hold the
+        // buffer lock only for the cheap byte-walk, then release before
+        // spawning the async lookup.
+        let mut completed: Vec<String> = Vec::new();
+        if let Ok(mut buf) = self.input_line_buf.lock() {
+            for &b in data {
+                match b {
+                    // CR or LF — submit the line.
+                    0x0D | 0x0A => {
+                        if !buf.trim().is_empty() {
+                            completed.push(std::mem::take(&mut *buf));
+                        } else {
+                            buf.clear();
+                        }
+                    }
+                    // Backspace / DEL — approximate edit handling.
+                    0x08 | 0x7F => {
+                        buf.pop();
+                    }
+                    // Printable ASCII (incl. space). Control chars and
+                    // non-ASCII (escape sequences, arrow keys, UTF-8
+                    // multibyte) are dropped — this is a heuristic over
+                    // simple typed commands, not a full line editor.
+                    0x20..=0x7E => buf.push(b as char),
+                    _ => {}
+                }
+            }
+            // Cap the buffer so a pathological no-newline stream can't grow
+            // unbounded (e.g. a paste of a huge blob). 4 KiB is far beyond
+            // any real command line.
+            if buf.len() > 4096 {
+                buf.clear();
+            }
+        }
+
+        let Some(app_handle) = self.app_handle.clone() else {
+            return;
+        };
+        for line in completed {
+            if super::coord_warn::is_branch_mutating_git(&line) {
+                super::coord_warn::spawn_check_and_warn(
+                    app_handle.clone(),
+                    self.id.clone(),
+                    self.working_dir.clone(),
+                    self.coord_session_id(),
+                    line,
+                );
+            }
+        }
     }
 
     /// Submit `message` to a Claude-style interactive prompt running in
@@ -1017,6 +1097,10 @@ mod tests {
             coord_session_id: Arc::new(Mutex::new(None)),
             on_exit: Arc::new(Mutex::new(None)),
             isolated_edit_ctx: Arc::new(Mutex::new(None)),
+            // No real Tauri app in unit fixtures — the input-line warn
+            // hook no-ops when this is `None`.
+            app_handle: None,
+            input_line_buf: Arc::new(Mutex::new(String::new())),
         }
     }
 

--- a/src/components/terminal/CoordWarningBanner.tsx
+++ b/src/components/terminal/CoordWarningBanner.tsx
@@ -1,0 +1,170 @@
+/**
+ * Coord worktree-claim warning banner — Layer 3 of
+ * `plans/2026-06-03-shared-checkout-coordination-gap-fix.md`.
+ *
+ * Branch-mutating git typed directly into the runner's Terminal PTY
+ * (`git switch`, `git checkout <branch>`, `git reset --hard`) bypasses
+ * every Claude Code hook, so a terminal can clobber a *peer's* in-flight
+ * work in a shared checkout with no warning. The Rust side
+ * (`src-tauri/src/terminal/coord_warn.rs`) detects such a command on the
+ * PTY input line and — if a PEER holds the coord `worktree` claim on this
+ * session's repo — emits a `terminal-coord-warning` Tauri event.
+ *
+ * This banner subscribes to that event, keeps the warnings for the
+ * currently-active terminal, and renders a soft, dismissible advisory.
+ *
+ * SOFT ONLY: this never blocks input — the keystroke was already written
+ * to the PTY before the warning fired. It is purely advisory and
+ * dismissible. Visual language mirrors {@link DeconflictAdvisoryBanner}
+ * (same soft-amber `#e0af68` accent) so it stacks consistently with the
+ * other terminal advisories.
+ */
+
+import { useEffect, useState } from "react";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { AlertTriangle, X } from "lucide-react";
+import { createLogger } from "@/lib/logger";
+
+const logger = createLogger("CoordWarningBanner");
+
+/**
+ * Payload shape emitted by the Rust `terminal-coord-warning` event
+ * (`CoordWarning` in `src-tauri/src/terminal/coord_warn.rs`,
+ * `#[serde(rename_all = "camelCase")]`).
+ */
+export interface CoordWarning {
+  terminalId: string;
+  repo: string;
+  holderMachineId: string;
+  holderSessionId?: string | null;
+  command: string;
+}
+
+/** Stable de-dup / list key for a warning. */
+function warningKey(w: CoordWarning): string {
+  return `${w.terminalId}|${w.repo}|${w.holderMachineId}|${w.holderSessionId ?? ""}|${w.command}`;
+}
+
+/** Shorten a long machine/session id for display (first 8 chars). */
+function shortId(id: string): string {
+  return id.length > 8 ? `${id.slice(0, 8)}…` : id;
+}
+
+export interface CoordWarningBannerProps {
+  /** The active terminal's id. Only warnings for this terminal render
+   *  (each terminal owns its own conflict surface). When undefined the
+   *  banner renders nothing. */
+  activeTerminalId: string | undefined;
+}
+
+export function CoordWarningBanner({ activeTerminalId }: CoordWarningBannerProps) {
+  const [warnings, setWarnings] = useState<CoordWarning[]>([]);
+
+  // Subscribe to `terminal-coord-warning`. The Rust side only emits when a
+  // branch-mutating git command was typed AND a peer holds the worktree
+  // claim, so this is rare and event-driven (never polled).
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+
+    listen<unknown>("terminal-coord-warning", (event) => {
+      if (cancelled) return;
+      const payload = event.payload;
+      if (typeof payload !== "object" || payload === null) return;
+      const p = payload as Record<string, unknown>;
+      const terminalId = typeof p.terminalId === "string" ? p.terminalId : null;
+      const repo = typeof p.repo === "string" ? p.repo : null;
+      const holderMachineId =
+        typeof p.holderMachineId === "string" ? p.holderMachineId : null;
+      const holderSessionId =
+        typeof p.holderSessionId === "string" ? p.holderSessionId : null;
+      const command = typeof p.command === "string" ? p.command : null;
+      if (!terminalId || !repo || !holderMachineId || !command) return;
+      const warning: CoordWarning = {
+        terminalId,
+        repo,
+        holderMachineId,
+        holderSessionId,
+        command,
+      };
+      setWarnings((prev) => {
+        const key = warningKey(warning);
+        if (prev.some((w) => warningKey(w) === key)) return prev;
+        return [...prev, warning];
+      });
+    })
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+          return;
+        }
+        unlisten = fn;
+      })
+      .catch((err) => {
+        logger.error("listen('terminal-coord-warning') failed", err);
+      });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  const handleDismiss = (key: string) => {
+    setWarnings((prev) => prev.filter((w) => warningKey(w) !== key));
+  };
+
+  const visible = activeTerminalId
+    ? warnings.filter((w) => w.terminalId === activeTerminalId)
+    : [];
+
+  if (visible.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-ui-bridge-id="terminal.coord-warning-banner"
+      data-terminal-id={activeTerminalId}
+      className="absolute top-24 right-2 z-30 w-[340px] space-y-1.5"
+    >
+      {visible.map((w) => {
+        const key = warningKey(w);
+        const holder = w.holderSessionId
+          ? `session ${shortId(w.holderSessionId)}`
+          : `machine ${shortId(w.holderMachineId)}`;
+        return (
+          <div
+            key={key}
+            data-ui-bridge-id="terminal.coord-warning-banner-card"
+            data-repo={w.repo}
+            className="p-2.5 rounded border bg-[#e0af68]/10 border-[#e0af68]/35 shadow-lg"
+          >
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0 text-[#e0af68] mt-0.5" />
+              <div className="text-[11px] text-[#c0caf5] leading-snug flex-1">
+                <div>
+                  Another session is editing <span className="font-semibold">{w.repo}</span>{" "}
+                  (held by {holder}). A branch switch here may clobber their work.
+                </div>
+                <div className="mt-1 font-mono text-[10px] text-[#e0af68]/80 break-all">
+                  {w.command}
+                </div>
+              </div>
+              <button
+                type="button"
+                aria-label="Dismiss warning"
+                data-ui-bridge-id="terminal.coord-warning-banner-dismiss"
+                data-repo={w.repo}
+                onClick={() => handleDismiss(key)}
+                className="text-[#e0af68] hover:text-[#c0caf5] leading-none px-1"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -48,6 +48,7 @@ import { MidSessionToast } from "./MidSessionToast";
 import { HoldingLockBanner, shouldShowHoldingBanner } from "./HoldingLockBanner";
 import { WaitingLockBanner } from "./WaitingLockBanner";
 import { DeconflictAdvisoryBanner } from "./DeconflictAdvisoryBanner";
+import { CoordWarningBanner } from "./CoordWarningBanner";
 
 interface TerminalPageProps {
   onNavigateToBuilder?: () => void;
@@ -899,6 +900,17 @@ function TerminalPageInner({
             {activeTab?.claudeSessionId && (
               <DeconflictAdvisoryBanner taskRunId={activeTab.claudeSessionId} />
             )}
+
+            {/* L3 (shared-checkout coordination gap fix) — soft warning
+                when branch-mutating git is typed into THIS terminal's PTY
+                while a coord peer holds the worktree claim on the repo.
+                NOT gated on `claudeSessionId` (it applies to any terminal,
+                including plain shells where an operator types `git
+                switch` by hand). `activeId` is the active tab id, which
+                equals the backend terminal id (ZoneGrid passes
+                `terminalId={zoneTab.id}`). Soft + dismissible; never
+                blocks input. */}
+            <CoordWarningBanner activeTerminalId={activeId ?? undefined} />
           </div>
 
           {uiState.showControlPanel && zoneLayout.isMultiZone && (


### PR DESCRIPTION
Layers 2 (runner side) + 3 of plan `2026-06-03-shared-checkout-coordination-gap-fix.md`.

**L2 — intent_repo derivation.** `repo_slug_for_path()` maps a terminal's `working_dir` to its owning repo slug (validated via `default_canonical_path`, no hardcoded list). Wired into `terminal_create` + `tauri_proxy`/`backend_relay`: when `intent_repo` is `None`, derive it so `acquire_for_terminal` can route into an isolated worktree. **Safe no-op until `QONTINUI_AGENT_WORKTREE_MODE` is on** (`acquire` returns `None` when off).

**L3 — Terminal-PTY soft-warn.** `TerminalSession` buffers PTY input; on CR/LF, branch-mutating git (`switch`/`checkout <branch>`/`reset --hard`, not `checkout -- file`) triggers a detached coord `worktree`-claim lookup; if a peer holds it, a dismissible `terminal-coord-warning` banner appears. Soft only — never blocks input. Closes the Terminal-PTY blind spot.

Pairs with stack#35, claude-config#52, supervisor L4. Verified via isolated-target `cargo check` (only error was pre-existing stale `vision_routes` codegen that CI regenerates; main CI green) + added unit tests.