### PR TITLE
fix(sdk): fall back to the coord device-JWT when there's no Cognito session

### DIFF
--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -482,29 +482,44 @@ pub async fn connect_sdk_app(
     // session, in which case we connect without the header (local/dev relays
     // with the gate off ignore it; a gated relay then surfaces a clean 401
     // rather than a client-build failure).
-    match crate::mcp::device_jwt_refresher::ensure_fresh_cognito_bearer(
-        &crate::auth::AuthManager::new(),
-    )
-    .await
-    {
-        Some(token) if !token.is_empty() => {
+    // Pick the bearer: prefer the Cognito user token; fall back to the coord
+    // device-JWT. The relay accepts BOTH as of qontinui-web #412 — it tries
+    // `/users/me` (Cognito) then `/api/v1/devices/me` (coord device-JWT) — so a
+    // device-paired runner with NO Cognito session (`ensure_fresh_cognito_bearer`
+    // == None — the common headless/fleet case) authenticates via the device-JWT
+    // in the `access_token` slot. Without this fallback such runners send no
+    // bearer and the gated relay 401s their connect handshake.
+    let auth_manager = crate::auth::AuthManager::new();
+    let bearer: Option<(String, &str)> =
+        match crate::mcp::device_jwt_refresher::ensure_fresh_cognito_bearer(&auth_manager).await {
+            Some(token) if !token.is_empty() => Some((token, "Cognito user")),
+            _ => match auth_manager.get_access_token() {
+                // Only a real JWT (the coord device-JWT) — never the legacy
+                // `qontinui_runner_<random>` opaque slot value, which the relay
+                // can't verify.
+                Ok(token) if crate::auth::looks_like_jwt(&token) => {
+                    Some((token, "coord device-JWT"))
+                }
+                _ => None,
+            },
+        };
+
+    match bearer {
+        Some((token, kind)) => {
             match reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token)) {
                 Ok(mut value) => {
                     value.set_sensitive(true);
                     let mut headers = reqwest::header::HeaderMap::new();
                     headers.insert(reqwest::header::AUTHORIZATION, value);
                     builder = builder.default_headers(headers);
-                    debug!(
-                        "SDK relay client: attached fresh Cognito bearer for {}",
-                        url
-                    );
+                    debug!("SDK relay client: attached {kind} bearer for {}", url);
                 }
                 Err(e) => warn!("SDK relay client: malformed bearer, connecting without auth: {e}"),
             }
         }
-        _ => debug!(
-            "SDK relay client: no Cognito session (legacy/local install or not signed in); \
-             connecting without auth"
+        None => debug!(
+            "SDK relay client: no Cognito session and no device-JWT (legacy/local install or \
+             not paired); connecting without auth"
         ),
     }
 


### PR DESCRIPTION
## Completes the runner side of "relay accepts runner device auth"
The web side shipped in **qontinui-web #412** — the UI Bridge relay now verifies a coord **device-JWT** via `/api/v1/devices/me` in addition to the Cognito user path. This PR makes the runner actually *send* that token.

**Problem:** #368 sends the Cognito **user** bearer, but device-paired/headless runners have **no Cognito session** (`ensure_fresh_cognito_bearer → None`) → they sent **no bearer** → the gated relay 401'd their SDK connect handshake (confirmed live: a #368 temp runner still got `/health → 401`, no Cognito-refresh log → None).

**Fix:** in `connect_sdk_app`, pick the bearer — prefer the Cognito user token; else fall back to the coord device-JWT in the `access_token` slot (`AuthManager::get_access_token`), gated on `auth::looks_like_jwt` so the legacy opaque `qontinui_runner_<random>` slot value is never sent. #368's Cognito-first path is preserved.

`cargo check --lib` + `clippy --lib` clean, `cargo fmt`.

## Verify after deploy
Temp runner built from this + the relay (#412, deployed) → `sdk/connect {url: qontinui.io/api/ui-bridge}` → `sdk/status` `connected:true` **on a device-only runner** (no Cognito session) — the case that's failed end-to-end until now.

Plan: `2026-06-03-relay-accept-runner-device-auth` (Phase 2; Phase 1 = web #412).