### PR TITLE
test(runner): make the vitest suite real — gate it in CI, fix every latent red

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,16 @@ jobs:
       - name: Typecheck frontend code
         run: pnpm run typecheck
 
+      # Frontend unit tests (vitest). Until 2026-06-03 nothing in CI ran the
+      # vitest suite, so frontend-logic regressions (e.g. the
+      # ui-bridge-auto@0.1.6 regression-generator field drift that broke
+      # generateRegressionSuite for every IR, or the specs.compile guard
+      # silently walking an empty directory) merged green and rotted on main.
+      # Runs after typecheck (cheap fail-fast first) and before the vite
+      # build / cargo steps.
+      - name: Run frontend unit tests
+        run: pnpm test
+
       # Build the frontend before any cargo step. tauri::generate_context!()
       # in src-tauri/src/lib.rs reads tauri.conf.json at compile time and
       # panics if frontendDist (../dist) is missing — which broke `Clippy

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.6.0",
     "@qontinui/ui-bridge": "^0.14.0",
-    "@qontinui/ui-bridge-auto": "^0.1.6",
+    "@qontinui/ui-bridge-auto": "^0.1.7",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,16 +25,16 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.6.0
         version: 0.6.0
       '@qontinui/ui-bridge':
         specifier: ^0.14.0
-        version: 0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        version: 0.14.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
-        specifier: ^0.1.6
-        version: 0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.1.7
+        version: 0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/workflow-ui':
         specifier: ^0.1.0
         version: 0.1.0(@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(lucide-react@1.14.0(react@19.2.5))(mermaid@11.14.0)(react-window@2.2.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -1134,8 +1134,8 @@ packages:
   '@qontinui/shared-types@0.6.0':
     resolution: {integrity: sha512-dnxCeekllKF5U3nK4Nlb5d1ciTi60uqZ/gDBnSG9nPHCsBdl/eawn0IGLYIIsUdaMFtMblupu67g2QYbGXD/TQ==}
 
-  '@qontinui/ui-bridge-auto@0.1.6':
-    resolution: {integrity: sha512-PpzXxaDIJN7eDyZfML+N1MR/UAKji1LFX/yw0VYf1KhAyM7yuJ4qtiHlbBx/e9IQTZo3Dws4r5CyJyL0ul+mIw==}
+  '@qontinui/ui-bridge-auto@0.1.7':
+    resolution: {integrity: sha512-u5SrrynQrhxrmop7OzsfSDrwSsIoAHhiwSdyUh62HSxV5uplzI4WaQYtGXDchB7GzHyno6Z2Evt+NLyFNTeG8w==}
     hasBin: true
     peerDependencies:
       tesseract.js: '>=5.0.0'
@@ -6166,17 +6166,17 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.14.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.6.0': {}
 
-  '@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       '@qontinui/shared-types': 0.6.0
-      '@qontinui/ui-bridge': 0.3.9(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.3.9(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - '@qontinui/ui-bridge-headless'
@@ -6195,12 +6195,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       dom-accessibility-api: 0.5.16
       react: 19.2.5
     optionalDependencies:
-      '@qontinui/ui-bridge-auto': 0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge-auto': 0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@tauri-apps/api': 2.11.0
       ioredis: 5.11.0
       react-dom: 19.2.5(react@19.2.5)
@@ -6208,11 +6208,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.3.9(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       react: 19.2.5
     optionalDependencies:
-      '@qontinui/ui-bridge-auto': 0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge-auto': 0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@tauri-apps/api': 2.11.0
       react-dom: 19.2.5(react@19.2.5)
       ws: 8.20.0

--- a/specs/pages/accessibility-explorer/spec.uibridge.json
+++ b/specs/pages/accessibility-explorer/spec.uibridge.json
@@ -880,22 +880,7 @@
         "description": "The left panel shows a hierarchical tree of accessibility nodes captured from the target application. Each node is rendered as a treeitem with: an expand/collapse chevron (for nodes with children), a color-coded role badge (blue for buttons/links, green for inputs, gray for text, transparent for containers, purple for others), the accessible name, and a monospace ref ID (e.g., '@e3'). Interactive elements have a small blue dot indicator and a subtle blue background tint. Clicking a node selects it (highlighted with primary ring) and shows its details in the right panel. Keyboard navigation supports Enter/Space to select, ArrowRight to expand, ArrowLeft to collapse.",
         "elements": [
           {
-            "textContains": "Tree View"
-          },
-          {
             "role": "tree"
-          },
-          {
-            "role": "treeitem"
-          },
-          {
-            "role": "treeitem"
-          },
-          {
-            "role": "treeitem"
-          },
-          {
-            "role": "treeitem"
           },
           {
             "textContains": "Refresh"
@@ -989,9 +974,6 @@
           },
           {
             "role": "heading"
-          },
-          {
-            "textContains": "Tree View"
           }
         ],
         "id": "a11y-visual-design",

--- a/specs/pages/action-plan/spec.uibridge.json
+++ b/specs/pages/action-plan/spec.uibridge.json
@@ -719,9 +719,6 @@
           {
             "role": "button",
             "textContent": "Terminal"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "ap-interaction-click",
@@ -735,15 +732,6 @@
           {
             "role": "button",
             "textContent": "OBSERVE"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "ap-interaction-multistep",
@@ -753,14 +741,7 @@
       },
       {
         "description": "Each planned action carries a confidence score (0.0â€“1.0, default 1.0). The plan-level confidenceThreshold (default 0.5) determines which actions execute: actions with confidence >= threshold execute normally, actions below threshold are skipped. Skipped actions appear in results with skippedLowConfidence=true and durationMs=0. The threshold is evaluated before element resolution, so skipped actions never attempt to find their target. This is an automatic behavior â€” no user interaction required.",
-        "elements": [
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ap-behavior-confidence",
         "isInitial": false,
         "name": "Confidence-Based Action Filtering",
@@ -768,14 +749,7 @@
       },
       {
         "description": "The action plan endpoint validates input before execution. Plans with more than 50 actions are rejected with HTTP 400. Empty plans (0 actions) return immediate success with executedCount=0. These are automatic behaviors enforced by the endpoint handler.",
-        "elements": [
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ap-behavior-validation",
         "isInitial": false,
         "name": "Action Plan Input Validation",
@@ -783,18 +757,7 @@
       },
       {
         "description": "The action plan response contains structured data about the execution. Each per-action result includes: index (position in array), success (boolean), action (type string), resolvedElementId (the element that was found and acted on), error (message if failed), skippedLowConfidence (boolean), durationMs (execution time), and elementState (post-action DOM state including computedStyles, rect, textContent, visible, enabled). The aggregate response includes: success (all-pass boolean), goal (echoed from request), results (array), executedCount, skippedCount, failedCount, totalDurationMs, and cached (whether stored in cache). This data format is defined in Rust as ActionPlanResponse/PlannedActionResult (mcp/ui_bridge.rs) and in TypeScript as ActionPlanResult/PlannedActionResult (qontinui-schemas/ts/src/workflow/action-plan.ts).",
-        "elements": [
-          {
-            "role": "button",
-            "textContent": "RUN"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ap-data-display-results",
         "isInitial": false,
         "name": "Action Plan Response Data Format",
@@ -802,24 +765,7 @@
       },
       {
         "description": "The action plan cache is an in-memory LRU store (max 100 entries, 1-hour TTL) that persists successful action plans for cross-run reuse. Cache state is queryable via two endpoints: GET /ui-bridge/control/action-plan/cache (lookup by URL + element fingerprint) and GET /ui-bridge/control/action-plan/cache/stats (entry count, total hits). Cache keys are derived from normalized page URL (scheme+host+path, no query/fragment) and an order-independent element fingerprint (FNV-1a hash of id+type+role+label per element, sorted). The cache is populated automatically when action plans include pageUrl and elementSnapshot fields and execution succeeds. Failed plans are evicted. The cache is backed by a global LazyLock<ActionPlanCache> singleton in mcp/action_plan_cache.rs.",
-        "elements": [
-          {
-            "role": "button",
-            "textContent": "RUN"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ap-state-cache",
         "isInitial": false,
         "name": "Action Plan Cache State",
@@ -827,20 +773,7 @@
       },
       {
         "description": "The AI snapshot endpoint (GET /ui-bridge/ai/snapshot) accepts a maxTokens query parameter. When maxTokens is a positive number, the SemanticSnapshotManager in the frontend sorts elements by region priority (main-content:100, form:90, modal:85, table:80, card:75, toolbar:70, navigation:50, sidebar:40, header:30, footer:20, unknown:10) with boosts for interactive (+20), visible (+10), and focused (+30) elements, then greedily includes elements until the token budget is exceeded. Token estimation uses ~4 characters per token. When maxTokens=0 or absent, all elements are included. The maxTokens parameter flows: HTTP query param -> Rust AiSnapshotQuery -> IPC payload.maxTokens -> React useAISearchEvents handler -> SemanticSnapshotManager({maxTokens}) -> applyTokenBudget(). Source files: mcp/ui_bridge.rs (AiSnapshotQuery, ui_bridge_ai_snapshot_handler), ui-bridge/src/ai/semantic-snapshot.ts (applyTokenBudget, REGION_PRIORITY), runner/src/hooks/ui-bridge-events/useAISearchEvents.ts (ai_snapshot case).",
-        "elements": [
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ap-state-token-budget",
         "isInitial": false,
         "name": "Token Budget Snapshot Pruning",
@@ -848,16 +781,7 @@
       },
       {
         "description": "The structured action plan system exists to bridge LLM reasoning and UI Bridge action execution without a second LLM interpretation call. In the standard flow, the agentic-phase LLM calls sdk_ai_execute with natural language, which triggers another LLM call to interpret the instruction. The action plan bypasses this: the agentic-phase LLM directly specifies typed actions with element targets, and the endpoint executes them deterministically. This reduces latency, cost, and ambiguity for multi-step UI interactions. The system was inspired by Skyvern's structured action protocol, adapted for qontinui's cooperative (instrumented) UI Bridge architecture rather than Skyvern's non-cooperative (arbitrary website) approach. The MCP tool documentation in the agentic prompt guides Claude to use sdk_execute_action_plan for 2+ step sequences and sdk_ai_execute for single exploratory actions.",
-        "elements": [
-          {
-            "role": "button",
-            "textContent": "RUN"
-          },
-          {
-            "role": "button",
-            "textContent": "Workflows"
-          }
-        ],
+        "elements": [],
         "id": "ap-semantic-purpose",
         "isInitial": false,
         "name": "System Purpose and Architecture",
@@ -865,15 +789,7 @@
       },
       {
         "description": "After a successful agentic iteration that included UI Bridge actions (action_plan or execute step types), the unified workflow executor automatically injects a goal-verification-snapshot step into the dynamic steps for the next verification phase. This is an automatic behavior that requires no user configuration. The injected step has name='goal-verification-snapshot', type='ui_bridge', action='snapshot', and carries the agentic outcome summary as ui_bridge_instruction. Previous goal-verification-snapshot steps are removed before injection to prevent accumulation. The behavior only triggers when BOTH conditions are met: the iteration included UI Bridge actions AND the agentic outcome was successful. Source: unified_workflow_executor/loop_handlers.rs handle_post_agentic().",
-        "elements": [
-          {
-            "role": "button",
-            "textContent": "Workflows"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ap-behavior-goal-verification",
         "isInitial": false,
         "name": "Post-Agentic Goal Verification",

--- a/specs/pages/activity-timeline/spec.uibridge.json
+++ b/specs/pages/activity-timeline/spec.uibridge.json
@@ -542,10 +542,6 @@
         "description": "The page always shows a search bar with input, Search button, filter toggle button, and stats button, regardless of whether any data exists in the timeline.",
         "elements": [
           {},
-          {
-            "role": "button",
-            "textContains": "Search"
-          },
           {},
           {},
           {},
@@ -612,9 +608,6 @@
           {
             "role": "button",
             "textContains": "Search"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "timeline-state-consistency",

--- a/specs/pages/adaptive-learning/spec.uibridge.json
+++ b/specs/pages/adaptive-learning/spec.uibridge.json
@@ -1193,9 +1193,6 @@
         "description": "The Adaptive Learning tab displays four stat cards at the top showing aggregate counts from the adaptive learning system.",
         "elements": [
           {
-            "textContains": "Playbook Lessons"
-          },
-          {
             "textContains": "Curated Examples"
           },
           {
@@ -1203,9 +1200,6 @@
           },
           {
             "textContains": "GEPA Optimizations"
-          },
-          {
-            "textContains": "Playbook Lessons"
           }
         ],
         "id": "dashboard-stat-cards",
@@ -1274,13 +1268,6 @@
           {
             "role": "combobox",
             "textContains": "All Domains"
-          },
-          {
-            "role": "combobox"
-          },
-          {
-            "role": "button",
-            "textContent": "Refresh"
           }
         ],
         "id": "playbook-header",
@@ -1349,9 +1336,6 @@
         "description": "Clicking a lesson row expands it to show metadata and source run context.",
         "elements": [
           {
-            "textContains": "DO"
-          },
-          {
             "textContains": "Applied"
           },
           {
@@ -1404,9 +1388,6 @@
             "textContains": "Old Score"
           },
           {
-            "textContains": "%"
-          },
-          {
             "textContains": "completed"
           }
         ],
@@ -1418,9 +1399,6 @@
       {
         "description": "Expanded GEPA run detail showing the old and new generation instructions side-by-side with score delta.",
         "elements": [
-          {
-            "textContains": "Old Score"
-          },
           {
             "textContains": "Before"
           },
@@ -1455,9 +1433,6 @@
         "description": "Consistent dark theme design across all adaptive learning panels.",
         "elements": [
           {
-            "textContains": "Playbook"
-          },
-          {
             "textContains": "Lessons"
           },
           {
@@ -1472,20 +1447,7 @@
       },
       {
         "description": "Semantic assertions verifying that the adaptive learning system produces correct, consistent data across its three panels.",
-        "elements": [
-          {
-            "textContains": "Playbook Lessons"
-          },
-          {
-            "textContains": "CRITICAL"
-          },
-          {
-            "textContains": "%"
-          },
-          {
-            "textContains": "improved"
-          }
-        ],
+        "elements": [],
         "id": "learning-loop-correctness",
         "isInitial": false,
         "name": "Learning Loop — Data Correctness",

--- a/specs/pages/architecture/spec.uibridge.json
+++ b/specs/pages/architecture/spec.uibridge.json
@@ -971,9 +971,6 @@
             "textContent": "Avg Health"
           },
           {
-            "textContent": "Most Volatile"
-          },
-          {
             "textContent": "Components"
           }
         ],
@@ -984,21 +981,7 @@
       },
       {
         "description": "When reflection data is loaded, an interactive XYFlow (ReactFlow) graph renders component nodes laid out by dagre. Each node uses a custom HealthNode: health score > 0.7 renders green, 0.4–0.7 amber, < 0.4 red. Node width scales with activity (fix_count + causal_involvement_count). Nodes display the component's basename and parent directory as a secondary label. Edges connect components that have a relationship from reflection data. Clicking a node opens the ComponentDetailPanel on the right.",
-        "elements": [
-          {
-            "role": "graphics-document"
-          },
-          {
-            "role": "graphics-document"
-          },
-          {
-            "role": "graphics-document"
-          },
-          {
-            "role": "button",
-            "textContent": "Rebuild"
-          }
-        ],
+        "elements": [],
         "id": "arch-reflection-graph",
         "isInitial": false,
         "name": "Reflection Mode — Component Dependency Graph",
@@ -1041,19 +1024,7 @@
         "description": "When SDK Projects mode is active and architecture specs are loaded from connected apps, the panel shows: optional project selector (if multiple specs), stat cards (Features count, Dependencies count, Tech Stack count), a Features/Patterns scrollable list on the left, an optional detail panel for selected nodes, and a Tech Stack + Directories panel on the right. Data comes from UI Bridge architecture spec discovery via POST /ui-bridge/sdk/discover-and-cache.",
         "elements": [
           {
-            "textContent": "Features"
-          },
-          {
-            "textContent": "Dependencies"
-          },
-          {
             "textContent": "Tech Stack"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "combobox"
           }
         ],
         "id": "arch-sdk-projects-mode",
@@ -1098,10 +1069,6 @@
           {
             "role": "button",
             "textContent": "Overview"
-          },
-          {
-            "role": "button",
-            "textContent": "Developer"
           }
         ],
         "id": "arch-developer-mode",

--- a/specs/pages/automation-health/spec.uibridge.json
+++ b/specs/pages/automation-health/spec.uibridge.json
@@ -883,10 +883,6 @@
           },
           {
             "role": "button",
-            "textContent": "24h"
-          },
-          {
-            "role": "button",
             "textContent": "7d"
           },
           {
@@ -904,11 +900,7 @@
       },
       {
         "description": "The dashboard is accessible via the 'Automation Health' item in the OBSERVE sidebar group. It appears alongside LLM Analytics, Reflection, and other observability views. The sidebar item shows an Activity icon with green accent (#10B981).",
-        "elements": [
-          {
-            "textContains": "Automation Health"
-          }
-        ],
+        "elements": [],
         "id": "health-navigation",
         "isInitial": false,
         "name": "Navigation and Tab Access",
@@ -935,9 +927,6 @@
         "description": "Large centered numeric score (0-100) with color-coded label. Breakdown section below shows 5 metrics: Element Success Rate, Regression Rate, Stall Frequency (as percentages), Total Interactions and Unique Elements (as counts). Score = 0.30 * element_success_rate + 0.25 * (1 - regression_rate) + 0.25 * (1 - stall_frequency) + 0.20 base. Backed by GET /ui-bridge/analytics/health-score.",
         "elements": [
           {
-            "textContains": "Automation Health"
-          },
-          {
             "textContains": "window"
           },
           {
@@ -945,9 +934,6 @@
           },
           {
             "textContains": "Regression Rate"
-          },
-          {
-            "textContains": "Total Interactions"
           }
         ],
         "id": "health-score-data-display",
@@ -957,14 +943,7 @@
       },
       {
         "description": "The score number and label use semantic color coding: green (>= 90, 'Excellent'), yellow (>= 70, 'Good'), orange (>= 50, 'Fair'), red (< 50, 'Poor'). These thresholds communicate automation quality at a glance and match the color coding used throughout the dashboard for success rates.",
-        "elements": [
-          {
-            "textContains": "Automation Health"
-          },
-          {
-            "textContains": "Automation Health"
-          }
-        ],
+        "elements": [],
         "id": "health-score-semantics",
         "isInitial": false,
         "name": "Health Score Color and Label Semantics",
@@ -992,9 +971,6 @@
         "description": "All 9 panels handle three states consistently: loading (centered muted text), empty (reassuring message specific to each panel), and error (destructive red text with error string). When no interaction data exists, the health score shows 100% (1.0) with 0 interactions. Recommendations show 'No recommendations â€” automation is running well'. Element reliability shows 'No flaky elements detected (all elements have >90% success rate)'. Regressions show 'No regressions detected'.",
         "elements": [
           {
-            "textContains": "Total Interactions"
-          },
-          {
             "textContains": "automation is running well"
           },
           {
@@ -1019,13 +995,7 @@
         "description": "Three tables display tabular analytics data: Action Baselines (6 columns: Action, Count, Avg/Min/Max ms, Success%), Element Reliability (5 columns: Element, Interactions, Success Rate bar, Confidence, Last Failure), and Annotation Gaps (5 columns: Element, Type, Interactions, Success%, Label). All tables use consistent styling: text-xs headers, hover:bg-muted/50 rows, tabular-nums for numbers, font-mono for element IDs.",
         "elements": [
           {
-            "textContains": "Action Performance Baselines"
-          },
-          {
             "textContains": "Avg (ms)"
-          },
-          {
-            "textContains": "Element Reliability"
           },
           {
             "textContains": "Annotation Gaps"
@@ -1083,13 +1053,6 @@
         "elements": [
           {
             "textContains": "Total Interactions"
-          },
-          {
-            "textContains": "Automation Health"
-          },
-          {
-            "role": "button",
-            "textContent": "24h"
           }
         ],
         "id": "health-behavior-data-freshness",
@@ -1099,11 +1062,7 @@
       },
       {
         "description": "Architecture: UI Bridge action handlers (mcp/ui_bridge.rs, mcp/sdk_client.rs) persist events to ui_bridge_events table via insert_ui_bridge_event() when ?task_run_id= query param is present. Events flow through 17 SQL query functions in database/ui_bridge_ops.rs, exposed via 13 MCP HTTP endpoints under /ui-bridge/analytics/*. The knowledge graph (reflection/graph_engine.rs) loads UIElement nodes and InteractedWith edges for causal analysis. The stall detector (orchestration_loop/stall_detector.rs) fetches /ui-bridge/control/health-signals to detect UIStuck patterns. Token attribution flows through phase_token_usage.target_app. CTR auto-seeding pushes reliability data to SDK apps on connect.",
-        "elements": [
-          {
-            "textContains": "Automation Health"
-          }
-        ],
+        "elements": [],
         "id": "health-backend-architecture",
         "isInitial": false,
         "name": "Backend Data Pipeline Architecture",
@@ -1111,14 +1070,7 @@
       },
       {
         "description": "All panels use bg-card rounded-lg border border-border p-4 container styling. Headings use font-semibold with a Lucide icon. Tables use text-xs text-muted-foreground headers, py-2 px-3 cell padding, hover:bg-muted/50 row highlights, and tabular-nums for numeric alignment. Charts use h-48 height with ResponsiveContainer. The responsive grid uses grid-cols-1 md:grid-cols-2 gap-4.",
-        "elements": [
-          {
-            "textContains": "Automation Health"
-          },
-          {
-            "textContains": "Automation Health"
-          }
-        ],
+        "elements": [],
         "id": "health-design-consistency",
         "isInitial": false,
         "name": "Visual Design Consistency",

--- a/specs/pages/autoresearch/spec.uibridge.json
+++ b/specs/pages/autoresearch/spec.uibridge.json
@@ -843,20 +843,11 @@
         "description": "The launch form or dialog allows the user to configure a new comparison run: select a workflow, choose a variation type (architecture or same), and optionally toggle worktree isolation. Submitting posts to POST /comparison/start via the runner HTTP API or via the Tauri qontinui_comparison.start_comparison command.",
         "elements": [
           {
-            "role": "group"
-          },
-          {
             "role": "checkbox"
           },
           {
             "role": "button",
             "textContent": "Run"
-          },
-          {
-            "role": "list"
-          },
-          {
-            "role": "list"
           }
         ],
         "id": "comparison-launch",
@@ -867,15 +858,6 @@
       {
         "description": "The page lists recent comparison runs fetched from GET /comparisons (up to 50 most recent, returned as an array of ComparisonRunView). Each run shows its ID (or short ID), workflow ID, variation type, status, and creation date. The list is the primary navigation surface for entering a run's detail view.",
         "elements": [
-          {
-            "role": "list"
-          },
-          {
-            "role": "list"
-          },
-          {
-            "role": "list"
-          },
           {
             "role": "button",
             "textContent": "Refresh"
@@ -909,15 +891,6 @@
         "elements": [
           {
             "role": "table"
-          },
-          {
-            "role": "region"
-          },
-          {
-            "role": "region"
-          },
-          {
-            "role": "region"
           }
         ],
         "id": "completed-comparison-detail",
@@ -927,23 +900,7 @@
       },
       {
         "description": "The page displays machine-readable metric comparisons across variants from StructuredComparisonReport (built by build_structured_report in comparison.rs). The HTTP API surfaces three metrics per completed entry from ComparisonEntryResultJson: success (bool → 1.0/0.0, higher=better), iterations (u32, lower=better), and duration_ms (u64, lower=better). A winner is identified by which variant wins the most metrics, with a confidence score expressed as winner_wins / total_metrics (0.0–1.0).",
-        "elements": [
-          {
-            "role": "table"
-          },
-          {
-            "role": "region"
-          },
-          {
-            "role": "table"
-          },
-          {
-            "role": "region"
-          },
-          {
-            "role": "region"
-          }
-        ],
+        "elements": [],
         "id": "metric-analysis",
         "isInitial": false,
         "name": "Structured Metric Analysis",
@@ -951,20 +908,7 @@
       },
       {
         "description": "The winner and confidence in StructuredComparisonReport are derived by a specific algorithm in build_structured_report (comparison.rs): winner = variant with the most metric wins (tie-broken by highest success_rate); confidence = winner_metric_wins / total_metrics_count (0.0–1.0). With 3 metrics, valid confidence values are 0.33, 0.67, or 1.0. An AI verification workflow can check that displayed winner and confidence match these formulas applied to the visible metric values.",
-        "elements": [
-          {
-            "role": "region"
-          },
-          {
-            "role": "region"
-          },
-          {
-            "role": "list"
-          },
-          {
-            "role": "region"
-          }
-        ],
+        "elements": [],
         "id": "comparison-algorithm-correctness",
         "isInitial": false,
         "name": "Comparison Algorithm Correctness",
@@ -999,9 +943,6 @@
           },
           {
             "role": "group"
-          },
-          {
-            "role": "region"
           }
         ],
         "id": "research-config",

--- a/specs/pages/blame-attribution/spec.uibridge.json
+++ b/specs/pages/blame-attribution/spec.uibridge.json
@@ -641,9 +641,6 @@
           },
           {
             "textContent": "revert"
-          },
-          {
-            "textContent": "iteration"
           }
         ],
         "id": "blame-summary-statistics",
@@ -655,13 +652,7 @@
         "description": "The core of the Blame tab: a chronological list of iterations that produced blame data. Each iteration section shows which verification steps failed and which previous iteration's changes caused each failure. The data comes from the blame_reports array in the GET /task-runs/{id}/blame response. Each report contains attributions (step name, blamed iteration, implicated files with line ranges, confidence score, explanation). Users read this to understand the causal chain: 'Iteration 3's TypeScript check failed because iteration 2 modified Card.tsx.'",
         "elements": [
           {
-            "textContent": "Iteration \\d+"
-          },
-          {
             "textContent": "FAILED|failed"
-          },
-          {
-            "textContent": "Iteration \\d+"
           },
           {
             "textContent": "High|Medium|Low"

--- a/specs/pages/capture/spec.uibridge.json
+++ b/specs/pages/capture/spec.uibridge.json
@@ -221,9 +221,6 @@
             "textContent": "Mouse"
           },
           {
-            "textContent": "Interaction Recording"
-          },
-          {
             "textContent": "Record your interactions"
           }
         ],

--- a/specs/pages/check-builder/spec.uibridge.json
+++ b/specs/pages/check-builder/spec.uibridge.json
@@ -275,15 +275,6 @@
         "description": "The right-panel editor provides all fields needed to define a check. Users select the check type (linter, formatter, etc.) and tool (eslint, prettier, mypy, etc.), which auto-populates sensible defaults for the name and command. Users can customize the command, set a working directory, configure a timeout, and toggle behavioral flags: auto-fix (attempt automatic fixes before reporting), fail-on-warning (treat warnings as failures), and is-critical (mark as a blocking check). Tags can be added for organization. The editor includes save and delete actions in the toolbar.",
         "elements": [
           {
-            "textContent": "Checks"
-          },
-          {
-            "textContent": "Checks"
-          },
-          {
-            "textContent": "Checks"
-          },
-          {
             "role": "button",
             "textContent": "Save"
           }
@@ -296,15 +287,6 @@
       {
         "description": "Checks are designed as reusable building blocks that integrate into the broader workflow system. Once saved, checks can be referenced by check groups (which bundle multiple checks together) and used directly as verification steps in workflows. The check type and tool categorization system ensures users can find and select appropriate checks when building workflows. Tags further aid organization and discovery across the library dashboard.",
         "elements": [
-          {
-            "textContent": "Checks"
-          },
-          {
-            "textContent": "Checks"
-          },
-          {
-            "textContent": "Checks"
-          },
           {
             "role": "button",
             "textContent": "Delete"

--- a/specs/pages/check-group-builder/spec.uibridge.json
+++ b/specs/pages/check-group-builder/spec.uibridge.json
@@ -234,9 +234,6 @@
         "description": "The left panel presents all saved check groups in a searchable list following the standard library builder layout. Users can browse existing groups, create new ones, and select a group to load into the editor. Each list item shows the group name, the number of checks it contains, and any tags. The list supports search filtering to help users find specific groups in large libraries. Creating a new group opens a blank editor with default settings (sequential execution, stop on failure).",
         "elements": [
           {
-            "textContent": "Check Groups"
-          },
-          {
             "role": "button",
             "textContent": "New"
           },
@@ -252,15 +249,6 @@
       {
         "description": "The core function of the check group editor is composing a group from existing checks in the library. Users see a list of available checks they can add to the group, and a list of currently included checks showing their order. The check selector shows check names, types, and tool information so users can identify the right checks. Users can add and remove individual checks from the group, building up a verification suite that covers all necessary validation points.",
         "elements": [
-          {
-            "textContent": "Check Groups"
-          },
-          {
-            "textContent": "Check Groups"
-          },
-          {
-            "textContent": "Check Groups"
-          },
           {
             "role": "button",
             "textContent": "Save"

--- a/specs/pages/config-findings/spec.uibridge.json
+++ b/specs/pages/config-findings/spec.uibridge.json
@@ -239,9 +239,6 @@
           },
           {
             "textContent": "Auto Fix"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "findings-category-crud",

--- a/specs/pages/config-hooks/spec.uibridge.json
+++ b/specs/pages/config-hooks/spec.uibridge.json
@@ -238,9 +238,6 @@
             "textContent": "Test"
           },
           {
-            "role": "button"
-          },
-          {
             "role": "alert"
           }
         ],

--- a/specs/pages/config-ui-bridge/spec.uibridge.json
+++ b/specs/pages/config-ui-bridge/spec.uibridge.json
@@ -218,9 +218,6 @@
             "textContent": "UI Bridge"
           },
           {
-            "textContent": "Discovery"
-          },
-          {
             "textContent": "Runtime Injection"
           },
           {

--- a/specs/pages/context-builder/spec.uibridge.json
+++ b/specs/pages/context-builder/spec.uibridge.json
@@ -182,9 +182,6 @@
         "description": "The Context Builder allows users to create and manage reusable context configurations. Contexts provide structured background information, domain knowledge, and behavioral instructions that are injected into AI prompts during workflow execution. By defining contexts separately from workflows, users can share common knowledge across multiple workflows without duplication.",
         "elements": [
           {
-            "textContent": "Context"
-          },
-          {
             "role": "button",
             "textContent": "Save"
           },

--- a/specs/pages/convergence-widget/spec.uibridge.json
+++ b/specs/pages/convergence-widget/spec.uibridge.json
@@ -500,9 +500,6 @@
       {
         "description": "A CSS-based bar chart showing failed step counts per iteration. Each bar represents one iteration, with height proportional to the number of failed steps (minimum 2px, maximum 80px, scaled to the highest failure count). Bar colors encode the change direction: green (bg-emerald-500) for zero failures, amber (bg-amber-500) for no change or improvement, red (bg-red-500) for regression. The chart displays the last 20 iterations (MAX_VISIBLE_ITERATIONS) and scrolls horizontally if more exist. Each bar has a tooltip showing 'Iteration N: X failed, Y passed'.",
         "elements": [
-          {
-            "textContent": "\\d+"
-          },
           {},
           {},
           {
@@ -547,9 +544,6 @@
         "elements": [
           {
             "textContent": "\\d+"
-          },
-          {
-            "textContent": "Convergence"
           },
           {
             "textContent": "Iteration"

--- a/specs/pages/cost-control/spec.uibridge.json
+++ b/specs/pages/cost-control/spec.uibridge.json
@@ -952,20 +952,11 @@
         "description": "Overall layout of the Cost Control panel: header with title and refresh button, followed by budget warnings, summary cards, budget gauge + phase chart, safety section, cost feed table, and optimization recommendations.",
         "elements": [
           {
-            "textContains": "Cost Control"
-          },
-          {
             "textContains": "Budget tracking, anomaly detection"
           },
           {
             "accessibleName": "Refresh cost data",
             "role": "button"
-          },
-          {
-            "tagName": "svg"
-          },
-          {
-            "textContains": "Cost Control"
           }
         ],
         "id": "cc-page-structure",
@@ -977,9 +968,6 @@
         "description": "Four metric cards in a responsive grid showing Total Cost, Total Tokens, Cache Hit Rate, and Cache Savings. Uses 2 columns on mobile, 4 on desktop.",
         "elements": [
           {
-            "textContains": "Total Cost"
-          },
-          {
             "textContains": "Total Tokens"
           },
           {
@@ -987,9 +975,6 @@
           },
           {
             "textContains": "Cache Savings"
-          },
-          {
-            "textContains": "Total Cost"
           }
         ],
         "id": "cc-summary-cards",
@@ -1005,9 +990,6 @@
           },
           {
             "textContains": "No active run"
-          },
-          {
-            "textContains": "remaining"
           },
           {
             "tagName": "svg"
@@ -1039,9 +1021,6 @@
       {
         "description": "Card showing the cost circuit breaker state: green Shield icon with 'Closed' badge when healthy, red ShieldAlert icon with 'Tripped' badge when triggered. Shows anomaly detector stats.",
         "elements": [
-          {
-            "textContains": "Circuit Breaker"
-          },
           {
             "textContains": "Closed"
           },
@@ -1104,9 +1083,6 @@
             "textContains": "No cost events yet"
           },
           {
-            "textContains": "Cumulative"
-          },
-          {
             "tagName": "tr"
           }
         ],
@@ -1143,13 +1119,7 @@
             "textContains": "Cost Control"
           },
           {
-            "textContains": "Cost by Phase"
-          },
-          {
             "textContains": "Last 30 days"
-          },
-          {
-            "textContains": "Budget Warning"
           }
         ],
         "id": "cc-visual-design",
@@ -1160,12 +1130,6 @@
       {
         "description": "Real-time event subscription behavior: cost events update the feed table, budget warnings trigger the banner, anomaly events populate the anomaly feed, and dashboard queries refresh on cost events.",
         "elements": [
-          {
-            "textContains": "Recent Cost Events"
-          },
-          {
-            "textContains": "Budget Utilization"
-          },
           {
             "textContains": "Total Cost"
           },

--- a/specs/pages/cross-run-analytics/spec.uibridge.json
+++ b/specs/pages/cross-run-analytics/spec.uibridge.json
@@ -454,9 +454,6 @@
         "description": "The CrossRunPatternsPanel renders a list of detected patterns with type badges, signature hashes, occurrence counts, timestamps, and status indicators. Each pattern row has a type badge (recurring_finding or fix_oscillation), truncated signature hash, occurrence count, last seen date, and status badge.",
         "elements": [
           {
-            "textContains": "Cross-Run Patterns"
-          },
-          {
             "textContains": "No cross-run patterns detected"
           }
         ],
@@ -470,9 +467,6 @@
         "elements": [
           {
             "textContains": "Recurring Finding|Fix Oscillation"
-          },
-          {
-            "textContains": "Cross-Run Patterns"
           }
         ],
         "id": "crossrun-data-display",
@@ -551,11 +545,7 @@
       },
       {
         "description": "The dashed line at 95% represents the reliability threshold. Elements above this line are considered reliable. Elements below need attention — their selectors may be breaking due to DOM restructuring, CSS changes, or app updates. The trend direction (rising vs falling) is more important than the absolute value.",
-        "elements": [
-          {
-            "textContains": "Selector Decay"
-          }
-        ],
+        "elements": [],
         "id": "decay-chart-semantics",
         "isInitial": false,
         "name": "Decay Chart Reference Line Semantics",
@@ -581,9 +571,6 @@
         "elements": [
           {
             "textContains": "ui_element"
-          },
-          {
-            "textContains": "Failure Chain"
           }
         ],
         "id": "failure-chain-semantics",

--- a/specs/pages/dag-workflow-editor/spec.uibridge.json
+++ b/specs/pages/dag-workflow-editor/spec.uibridge.json
@@ -941,9 +941,6 @@
         "elements": [
           {},
           {
-            "role": "textbox"
-          },
-          {
             "textContent": "YAML Editor"
           },
           {
@@ -960,25 +957,7 @@
       },
       {
         "description": "The toolbar contains a workflow name input field (aria-label='Workflow name'), an Import button, an Export button, and a validation status badge. These are the primary controls for managing a workflow file.",
-        "elements": [
-          {
-            "role": "textbox"
-          },
-          {
-            "role": "button",
-            "textContent": "Import"
-          },
-          {
-            "role": "button",
-            "textContent": "Export"
-          },
-          {
-            "textContent": "Valid"
-          },
-          {
-            "role": "textbox"
-          }
-        ],
+        "elements": [],
         "id": "dag-toolbar-controls",
         "isInitial": false,
         "name": "Toolbar Controls",
@@ -1007,9 +986,6 @@
         "elements": [
           {
             "textContent": "Checking..."
-          },
-          {
-            "textContent": "Errors"
           },
           {
             "textContent": "detected"
@@ -1068,17 +1044,7 @@
       },
       {
         "description": "The graph uses dagre top-to-bottom layout (rankdir=TB). ReactFlow controls appear at bottom-left of the graph pane (zoom in/out, fit view). A minimap appears at bottom-right. The graph supports scroll-to-zoom and drag-to-pan.",
-        "elements": [
-          {
-            "tagName": "div"
-          },
-          {
-            "tagName": "div"
-          },
-          {
-            "tagName": "div"
-          }
-        ],
+        "elements": [],
         "id": "dag-graph-layout",
         "isInitial": false,
         "name": "Graph Layout and Navigation Controls",
@@ -1086,14 +1052,7 @@
       },
       {
         "description": "A draggable vertical divider between the YAML editor and graph panes allows the user to adjust the width ratio. The minimum pane width is 20% and the maximum is 80% (of the total container width). The initial split is 50/50.",
-        "elements": [
-          {
-            "tagName": "div"
-          },
-          {
-            "tagName": "div"
-          }
-        ],
+        "elements": [],
         "id": "dag-resize-handle",
         "isInitial": false,
         "name": "Split-Pane Resize Handle",
@@ -1172,12 +1131,6 @@
         "elements": [
           {
             "textContent": "nodes"
-          },
-          {
-            "tagName": "div"
-          },
-          {
-            "tagName": "div"
           }
         ],
         "id": "dag-graph-correctness",

--- a/specs/pages/debug/spec.uibridge.json
+++ b/specs/pages/debug/spec.uibridge.json
@@ -1062,13 +1062,7 @@
         "description": "The page header displays an 'Advanced' title with a wrench icon and a description explaining the purpose of the debug settings. This uses the shared SectionHeader component.",
         "elements": [
           {
-            "textContent": "Advanced"
-          },
-          {
             "textContent": "Developer and debugging options"
-          },
-          {
-            "textContent": "Advanced"
           }
         ],
         "id": "dbg-section-header",
@@ -1081,9 +1075,6 @@
         "elements": [
           {
             "textContent": "Failed to"
-          },
-          {
-            "textContent": "Save Debug Settings"
           }
         ],
         "id": "dbg-error-state",
@@ -1321,17 +1312,7 @@
       },
       {
         "description": "The Debug page integrates with the Rust backend through three Tauri IPC commands: 'get_debug_settings' (load on mount), 'set_debug_settings' (save button), and 'get_device_info' (load on mount + refresh). These are the data sources for all displayed information.",
-        "elements": [
-          {
-            "textContent": "Advanced"
-          },
-          {
-            "textContent": "Device Information"
-          },
-          {
-            "textContent": "Device Information"
-          }
-        ],
+        "elements": [],
         "id": "dbg-tauri-ipc-integration",
         "isInitial": false,
         "name": "Tauri IPC Integration",

--- a/specs/pages/element-reliability/spec.uibridge.json
+++ b/specs/pages/element-reliability/spec.uibridge.json
@@ -438,20 +438,7 @@
     "states": [
       {
         "description": "Users need summary statistics showing how many elements are stable vs flaky vs unreliable, providing a quick assessment of automation health across all tracked elements.",
-        "elements": [
-          {
-            "textContent": "Element Reliability"
-          },
-          {
-            "textContent": "Stable"
-          },
-          {
-            "textContent": "Flaky"
-          },
-          {
-            "textContent": "Unreliable"
-          }
-        ],
+        "elements": [],
         "id": "element-reliability-overview",
         "isInitial": false,
         "name": "Reliability Overview Statistics",
@@ -460,9 +447,6 @@
       {
         "description": "Users need to see individual elements sorted by reliability, with success rates and interaction counts, to identify which specific elements need attention or alternative selectors.",
         "elements": [
-          {
-            "textContent": "Elements by Reliability"
-          },
           {
             "textContent": "%"
           },
@@ -500,9 +484,6 @@
         "description": "Reliability badges use color coding to quickly communicate element health: green for stable (>=95%), yellow for flaky (>=80%), red for unreliable (<80%).",
         "elements": [
           {
-            "textContent": "Stable"
-          },
-          {
             "textContent": "Flaky"
           },
           {
@@ -517,12 +498,6 @@
       {
         "description": "Each element row must render its element ID, total interaction count, and success rate percentage accurately from the API data. The summary cards must show correct counts of stable (>=95%), flaky (>=80%), and unreliable (<80%) elements computed from the success_rate field.",
         "elements": [
-          {
-            "textContent": "%"
-          },
-          {
-            "textContent": "interactions"
-          },
           {
             "textContent": "success"
           }

--- a/specs/pages/evaluation/spec.uibridge.json
+++ b/specs/pages/evaluation/spec.uibridge.json
@@ -1480,13 +1480,6 @@
             "textContent": "Dataset Name"
           },
           {
-            "textContent": "items"
-          },
-          {
-            "role": "button",
-            "textContent": "Confirm"
-          },
-          {
             "textContent": "No datasets yet"
           },
           {
@@ -1506,39 +1499,17 @@
         "description": "Once a dataset is selected, users need to view, add, import, export, and delete individual items. Items are displayed in a two-column table (Input / Expected Output). Users can add items by pasting a JSON array, importing a JSON or CSV file, or export existing items as JSON or CSV. Individual items can be deleted with a browser confirmation dialog.",
         "elements": [
           {
-            "textContent": "Input"
-          },
-          {
             "textContent": "Expected Output"
-          },
-          {
-            "role": "button",
-            "textContent": "Add Items"
           },
           {
             "textContent": "Paste JSON array of items"
           },
           {
             "role": "button",
-            "textContent": "Import File"
-          },
-          {
-            "role": "button",
-            "textContent": "JSON"
-          },
-          {
-            "role": "button",
             "textContent": "CSV"
           },
           {
-            "role": "button",
-            "textContent": "Delete item"
-          },
-          {
             "textContent": "No items in this dataset"
-          },
-          {
-            "textContent": "Select a dataset to view its items"
           }
         ],
         "id": "eval-dataset-items",
@@ -1550,21 +1521,11 @@
         "description": "Users create and browse experiments scoped to the selected dataset. Each experiment has a name, optional description, optional prompt variant ID, and a status badge (pending/running/completed/failed) with color coding. The experiment creation form appears inline with fields for name, description, and prompt variant ID. The experiment list shows completion progress (e.g. '3/10 completed') and creation date.",
         "elements": [
           {
-            "textContent": "Experiments"
-          },
-          {
             "role": "button",
             "textContent": "New Experiment"
           },
           {
-            "role": "status",
-            "textContent": "pending|running|completed|failed"
-          },
-          {
             "textContent": "completed"
-          },
-          {
-            "textContent": "Select a dataset to view experiments"
           },
           {
             "textContent": "No experiments yet"
@@ -1581,9 +1542,6 @@
       {
         "description": "When an experiment is selected, users see a detailed results view with summary cards at the top (average scores, total cost, total tokens, results count) and a paginated table below. The table shows Input, Output, Scores (as colored percentage badges), Duration, Cost, and Tokens columns. All numeric columns and individual score names are sortable. Pagination displays 20 results per page with Previous/Next buttons and a 'Showing X-Y of Z results' indicator.",
         "elements": [
-          {
-            "textContent": "%"
-          },
           {
             "textContent": "Total Cost"
           },
@@ -1606,9 +1564,6 @@
             "textContent": "Tokens"
           },
           {
-            "textContent": "%"
-          },
-          {
             "textContent": "Previous"
           },
           {
@@ -1619,9 +1574,6 @@
           },
           {
             "textContent": "No results yet"
-          },
-          {
-            "textContent": "Select an experiment to view results"
           },
           {
             "textContent": "Select a dataset first"
@@ -1651,17 +1603,10 @@
             "textContent": "Inline JSON"
           },
           {
-            "textContent": "Input (prompt / question)"
-          },
-          {
             "textContent": "Output (LLM response)"
           },
           {
             "textContent": "Context"
-          },
-          {
-            "role": "button",
-            "textContent": "Evaluate"
           },
           {
             "role": "button",
@@ -1742,21 +1687,8 @@
         "description": "Assertions verifying that displayed data is consistent across panels, matches backend state, and updates reactively after mutations. Covers item counts, experiment status badges, optimistic table updates after add/delete, pagination math, and score value accuracy.",
         "elements": [
           {
-            "textContent": "items"
-          },
-          {
-            "role": "status",
-            "textContent": "pending|running|completed|failed"
-          },
-          {
-            "textContent": "Input"
-          },
-          {
             "role": "button",
             "textContent": "Delete item"
-          },
-          {
-            "textContent": "Page"
           },
           {
             "textContent": "%"

--- a/specs/pages/event-history/spec.uibridge.json
+++ b/specs/pages/event-history/spec.uibridge.json
@@ -874,9 +874,6 @@
         "description": "The page header establishes the Workflow Event History identity with a Radio icon, shows aggregate counts (event count, subscription count), and auto-refreshes data every 5 seconds.",
         "elements": [
           {
-            "textContent": "Workflow Event History"
-          },
-          {
             "textContent": "event"
           },
           {
@@ -982,9 +979,6 @@
             "textContent": "workflow.completed"
           },
           {
-            "textContent": "workflow"
-          },
-          {
             "textContent": "Timestamp"
           },
           {
@@ -1012,19 +1006,10 @@
         "description": "Grid of active event subscriptions below the event table. Each card shows event pattern (monospace), green active dot, and 'once' badge. Subscriptions registered by trigger_system for WorkflowChain triggers. Polls GET /inngest/subscriptions every 15 seconds.",
         "elements": [
           {
-            "textContent": "Active Subscriptions"
-          },
-          {
             "textContent": "workflow"
           },
           {
-            "textContent": "Active Subscriptions"
-          },
-          {
             "textContent": "once"
-          },
-          {
-            "textContent": "Active Subscriptions"
           }
         ],
         "id": "evh-subscriptions",
@@ -1069,13 +1054,7 @@
         "description": "All data auto-refreshes via polling through useRunnerQuery. Events + queue + circuit-breaker poll every 5s; subscriptions every 15s. Polling is deduplicated by shared API client.",
         "elements": [
           {
-            "textContent": "Workflow Event History"
-          },
-          {
             "textContent": "Active Subscriptions"
-          },
-          {
-            "textContent": "Workflow Event History"
           }
         ],
         "id": "evh-data-freshness",

--- a/specs/pages/execute/spec.uibridge.json
+++ b/specs/pages/execute/spec.uibridge.json
@@ -347,9 +347,6 @@
             "textContent": "all"
           },
           {
-            "textContent": "Library"
-          },
-          {
             "role": "button",
             "textContent": "Refresh"
           }
@@ -407,10 +404,6 @@
           {
             "role": "button",
             "textContent": "Run Queue"
-          },
-          {
-            "role": "button",
-            "textContent": "Clear"
           }
         ],
         "id": "exec-run-queue",
@@ -423,9 +416,6 @@
         "elements": [
           {
             "textContent": "Workflow Queue"
-          },
-          {
-            "textContent": "Queue:"
           },
           {
             "textContent": "Library"

--- a/specs/pages/flow-control/spec.uibridge.json
+++ b/specs/pages/flow-control/spec.uibridge.json
@@ -643,9 +643,6 @@
         "description": "Controls max simultaneous instances of this workflow. When limit reached, new executions queue and wait (FlowControlDecision::Wait). Optionally scoped by key. Backend: FlowControl.concurrency (ConcurrencyLimit), enforced by FlowControlEnforcer.check(), tracked by record_start/record_end.",
         "elements": [
           {
-            "textContent": "Concurrency"
-          },
-          {
             "role": "spinbutton"
           },
           {
@@ -668,9 +665,6 @@
         "elements": [
           {
             "textContent": "Throttle"
-          },
-          {
-            "textContent": "Max runs"
           },
           {
             "role": "button",
@@ -732,9 +726,6 @@
         "description": "Per-phase timeout overrides in minutes. Backend: PhaseTimeouts in orchestrator/state.rs, parsed from phase_timeouts_json in types.rs, enforced by check_timeout() in loop_handlers.rs. Defaults: setup=5min, execution=30min, verification=10min, completion=5min.",
         "elements": [
           {
-            "textContent": "Phase Timeouts"
-          },
-          {
             "textContent": "Setup"
           },
           {
@@ -751,9 +742,6 @@
           },
           {
             "textContent": "Execution"
-          },
-          {
-            "role": "spinbutton"
           }
         ],
         "id": "fc-phase-timeouts",
@@ -763,20 +751,7 @@
       },
       {
         "description": "Settings serialize to JSON and persist as flow_control_json and phase_timeouts_json on unified_workflows. On save, WorkflowEditor PATCHes via MCP API. On load, LoopController reads for enforcement. Both SQLite (v147) and PostgreSQL store these fields.",
-        "elements": [
-          {
-            "textContent": "Concurrency"
-          },
-          {
-            "textContent": "Concurrency"
-          },
-          {
-            "textContent": "Flow Control"
-          },
-          {
-            "textContent": "Flow Control"
-          }
-        ],
+        "elements": [],
         "id": "fc-persistence",
         "isInitial": false,
         "name": "Configuration Persistence and State Consistency",
@@ -800,9 +775,6 @@
       {
         "description": "The FlowControlPanel communicates changes to its parent (WorkflowEditor) via callbacks. When any flow control value changes, onFlowControlChange fires with the serialized JSON. When any timeout changes, onPhaseTimeoutsChange fires. The parent is responsible for saving via updateWorkflow().",
         "elements": [
-          {
-            "textContent": "Concurrency"
-          },
           {
             "textContent": "Phase Timeouts"
           }

--- a/specs/pages/generator-eval/spec.uibridge.json
+++ b/specs/pages/generator-eval/spec.uibridge.json
@@ -215,9 +215,6 @@
             "textContent": "Dashboard"
           },
           {
-            "textContent": "Pipeline Inspector"
-          },
-          {
             "textContent": "Edit Analysis"
           }
         ],

--- a/specs/pages/graph-insights/spec.uibridge.json
+++ b/specs/pages/graph-insights/spec.uibridge.json
@@ -323,9 +323,6 @@
         "description": "The Reflection Dashboard includes a 'Graph Insights' section that embeds CrossRunPatternsPanel, RuleInfluencePanel, PipelineEventsTimeline, StepProvenanceTimeline, and WorkflowVersionLineage as sub-panels within the existing reflection view.",
         "elements": [
           {
-            "textContent": "Graph Insights"
-          },
-          {
             "textContent": "Cross-Run Patterns"
           },
           {
@@ -340,9 +337,6 @@
       {
         "description": "The Active Dashboard shows a compact TopPatternsWidget that summarizes active cross-run patterns (recurring findings and fix oscillations), auto-hiding when no patterns exist.",
         "elements": [
-          {
-            "textContent": "Cross-Run Patterns"
-          },
           {
             "textContent": "recurring"
           },
@@ -398,13 +392,7 @@
         "description": "Graph data refreshes on two cadences: React Query polling (30s stale, 60s interval) and event-driven invalidation via useGraphDataRefresh when tasks or reflections complete. The TopPatternsWidget auto-hides when no active patterns exist.",
         "elements": [
           {
-            "textContent": "Cross-Run Patterns"
-          },
-          {
             "textContent": "pattern"
-          },
-          {
-            "textContent": "Cross-Run Patterns"
           }
         ],
         "id": "graph-insights-behavior",

--- a/specs/pages/graphql-live-task/spec.uibridge.json
+++ b/specs/pages/graphql-live-task/spec.uibridge.json
@@ -538,9 +538,6 @@
         "elements": [
           {
             "textContent": "running"
-          },
-          {
-            "textContent": "Loading task run"
           }
         ],
         "id": "graphql-live-visibility",

--- a/specs/pages/knowledge-acquisition/spec.uibridge.json
+++ b/specs/pages/knowledge-acquisition/spec.uibridge.json
@@ -707,9 +707,6 @@
         "description": "The /knowledge/search-web endpoint performs general web search. DuckDuckGo results are parsed from HTML using cached regexes — titles, URLs (with DDG redirect URL decoding), and snippets are extracted. Tavily results include AI-synthesized answers with raw page content. Each result is formatted as markdown with title, snippet, and source URL. Results include provider identification so consumers know which source produced each result.",
         "elements": [
           {
-            "textContains": "results"
-          },
-          {
             "textContains": "url"
           },
           {
@@ -778,9 +775,6 @@
       {
         "description": "The knowledge acquisition system supports both SQLite (CheckpointDb) and PostgreSQL (PgDb) backends. When DATABASE_URL is set, SearchContext attempts a PG connection at creation time. All operations (Tier 0 hybrid search, Tier 3 insert/embed/dedup) prefer PG when available and fall back to SQLite. The PG schema includes task_knowledge table with content_embedding BYTEA column. Hybrid search uses the same rank_results algorithm on both backends: fetch recent candidates with embeddings, compute cosine similarity in-memory (MiniLM-L6-v2, 384-dim), rank by 30% SQL position + 70% vector similarity.",
         "elements": [
-          {
-            "textContains": "providers"
-          },
           {
             "textContains": "embedding"
           },

--- a/specs/pages/knowledge-explorer/spec.uibridge.json
+++ b/specs/pages/knowledge-explorer/spec.uibridge.json
@@ -1056,27 +1056,7 @@
       },
       {
         "description": "Three search mode buttons in the Search tab: 'Web Search' (globe icon), 'Error Research' (bug icon), 'Vuln Search' (shield icon). The active mode has primary-tinted background and border; inactive modes have muted text. Selecting a mode changes the input placeholder text and the API endpoint used for search.",
-        "elements": [
-          {
-            "role": "button",
-            "textContent": "Web Search"
-          },
-          {
-            "role": "button",
-            "textContent": "Error Research"
-          },
-          {
-            "role": "button",
-            "textContent": "Vuln Search"
-          },
-          {
-            "role": "textbox"
-          },
-          {
-            "role": "button",
-            "textContent": "Web Search"
-          }
-        ],
+        "elements": [],
         "id": "ke-search-mode-selector",
         "isInitial": false,
         "name": "Search Mode Selector",
@@ -1084,26 +1064,7 @@
       },
       {
         "description": "A text input field with a mode-specific icon (left) and a Search button (right). The input accepts text and supports Enter-to-submit. The Search button is disabled when the query is less than 2 characters or a search is in progress. During search, the button shows a spinning loader icon.",
-        "elements": [
-          {
-            "role": "textbox"
-          },
-          {
-            "role": "button",
-            "textContent": "Search"
-          },
-          {
-            "role": "button",
-            "textContent": "Search"
-          },
-          {
-            "role": "textbox"
-          },
-          {
-            "role": "button",
-            "textContent": "Search"
-          }
-        ],
+        "elements": [],
         "id": "ke-search-input",
         "isInitial": false,
         "name": "Search Input and Submit",
@@ -1178,9 +1139,6 @@
         "elements": [
           {
             "textContains": "Knowledge Acquisition"
-          },
-          {
-            "textContains": "Total Searches"
           },
           {
             "textContains": "Cache Hit Rate"

--- a/specs/pages/library/spec.uibridge.json
+++ b/specs/pages/library/spec.uibridge.json
@@ -232,16 +232,10 @@
         "description": "The Library Dashboard provides a bird's-eye view of all automation assets across every category. Users land here to quickly find recently modified items, understand what assets exist in their library, and navigate to the appropriate builder for editing. The page heading shows the total item count, and items are sorted by modification time with the most recently changed items appearing first. This makes the dashboard particularly useful for resuming work on recently edited assets.",
         "elements": [
           {
-            "textContent": "Library Dashboard"
-          },
-          {
             "textContent": "total items"
           },
           {
             "textContent": "Recently modified items across all categories"
-          },
-          {
-            "textContent": "Library Dashboard"
           }
         ],
         "id": "lib-dashboard-overview",
@@ -257,12 +251,6 @@
           },
           {
             "textContent": "All"
-          },
-          {
-            "textContent": "Library Dashboard"
-          },
-          {
-            "textContent": "Library Dashboard"
           }
         ],
         "id": "lib-search-filter",

--- a/specs/pages/llm-analytics-ui-bridge/spec.uibridge.json
+++ b/specs/pages/llm-analytics-ui-bridge/spec.uibridge.json
@@ -287,9 +287,6 @@
         "description": "Four new components are conditionally rendered in the LLM Observability Dashboard when target_app data exists in phase_token_usage: CostByTargetAppChart (horizontal bar), CostPerInteractionChart (vertical bar), PageComplexityTable (ranked table), and ModelActionMatrix (heatmap). All components are lazy-loaded.",
         "elements": [
           {
-            "textContains": "Cost by Target App"
-          },
-          {
             "textContains": "Cost per Successful Interaction"
           },
           {
@@ -351,11 +348,7 @@
       },
       {
         "description": "The LLM dashboard's existing time range selector (1d/7d/30d/all) controls the days parameter for all cost attribution queries. CostByTargetAppChart fetches from /analytics/token-usage/by-target-app?days=N. CostPerInteractionChart fetches from /analytics/token-usage/cost-per-interaction?days=N. Changing the time range should update all four new charts.",
-        "elements": [
-          {
-            "textContains": "LLM Analytics"
-          }
-        ],
+        "elements": [],
         "id": "llm-interaction-time-range",
         "isInitial": false,
         "name": "Time Range Interaction",
@@ -363,11 +356,7 @@
       },
       {
         "description": "Cost attribution data flows from the agentic phase executor. When a workflow step involves UI Bridge actions, get_active_sdk_app_name() extracts the connected app name via try_lock on the SDK connection manager, and record_phase_token_usage_with_target() writes it to phase_token_usage.target_app. This means cost attribution only appears for workflows that interact with SDK-connected apps during their agentic phase.",
-        "elements": [
-          {
-            "textContains": "LLM Analytics"
-          }
-        ],
+        "elements": [],
         "id": "llm-cost-behavior",
         "isInitial": false,
         "name": "Cost Attribution Pipeline Behavior",

--- a/specs/pages/llm-observability/spec.uibridge.json
+++ b/specs/pages/llm-observability/spec.uibridge.json
@@ -1308,13 +1308,7 @@
         "description": "Three cost visualization charts arranged in a responsive grid: (1) Cost Over Time â€” a Recharts LineChart showing daily LLM cost with date on X-axis and dollar amount on Y-axis, with tooltips showing cost, calls, input/output tokens per day; (2) Cost by Model â€” a horizontal BarChart ranking models by total cost descending, with tooltips showing cost, calls, tokens, and avg duration; (3) Cost by Phase â€” a horizontal BarChart breaking down cost by workflow phase (setup/agentic/completion), sorted by cost descending.",
         "elements": [
           {
-            "textContent": "Cost Over Time"
-          },
-          {
             "textContent": "Cost:|Calls:|Input tokens:|Output tokens:"
-          },
-          {
-            "textContent": "Cost by Model"
           },
           {
             "textContent": "Avg duration:"
@@ -1380,9 +1374,6 @@
             "textContent": "Task Run Costs"
           },
           {
-            "textContent": "Task Run|Cost|Input|Output|Calls|Started"
-          },
-          {
             "role": "button",
             "textContent": "Sort by Cost"
           },
@@ -1440,9 +1431,6 @@
           },
           {
             "textContent": "Failed to load cost trends"
-          },
-          {
-            "textContent": "Cost Trends"
           }
         ],
         "id": "llm-loading-error-states",
@@ -1482,10 +1470,6 @@
             "textContent": "Select time range"
           },
           {
-            "role": "button",
-            "textContent": "Refresh analytics"
-          },
-          {
             "textContent": "Cost Over Time|Cost by Model|Cost Trends"
           },
           {
@@ -1517,21 +1501,7 @@
         "description": "Assertions verifying that key UI elements are present and visible in the dashboard layout.",
         "elements": [
           {
-            "textContent": "Total Cost|Total Tokens|Total Calls|Avg Cost/Call"
-          },
-          {
-            "role": "combobox",
-            "textContent": "Select time range"
-          },
-          {
-            "role": "button",
-            "textContent": "Refresh analytics"
-          },
-          {
             "textContent": "Cost Over Time|Cost by Model|Cost by Phase|Cost Trends|Provider Latency|Task Run Costs"
-          },
-          {
-            "textContent": "Daily Cost|7-Day Average"
           }
         ],
         "id": "llm-element-presence",

--- a/specs/pages/memory/spec.uibridge.json
+++ b/specs/pages/memory/spec.uibridge.json
@@ -935,16 +935,7 @@
         "description": "The page container uses data-page-id='observations' and stacks MemoryHealthPanel (border-b separator) above ObservationBrowser. Both sections are simultaneously visible without page-level scrolling.",
         "elements": [
           {
-            "textContent": "Memory Health"
-          },
-          {
-            "textContent": "Observation Memory"
-          },
-          {
             "textContent": "Cross-session knowledge from past runs"
-          },
-          {
-            "textContent": "Memory Health"
           }
         ],
         "id": "mem-page-layout",
@@ -987,9 +978,6 @@
           },
           {
             "textContent": "Last Consolidation"
-          },
-          {
-            "textContent": "Memory Health"
           }
         ],
         "id": "mem-health-stats",
@@ -1050,9 +1038,6 @@
       {
         "description": "When open, the create form contains a title input (aria-label: 'Observation title', placeholder: 'Observation title...'), a content textarea (aria-label: 'Observation content', placeholder: 'Content (markdown supported)...'), a type dropdown (aria-label: 'Observation type'), and Save/Cancel buttons. Save is disabled until both title and content are non-empty.",
         "elements": [
-          {
-            "role": "textbox"
-          },
           {
             "role": "combobox"
           },
@@ -1118,9 +1103,6 @@
         "description": "Result rows each show: a chevron icon (right=collapsed, down=expanded), a color-coded type badge, truncated title, 'rev {N}' badge if revisionCount>1, 'relevance: {N}%' if rank>0, 2-line content preview (contentPreview field), and a metadata footer with [topicKey] (if non-null) and the updatedAt date.",
         "elements": [
           {
-            "textContent": "decision"
-          },
-          {
             "textContent": "rev "
           },
           {
@@ -1135,9 +1117,6 @@
       {
         "description": "Clicking a result row expands it showing full content (from GET /observations/{id}) in a <pre> block, plus: content hash (first 12 chars as 'Hash: {hash}...'), scope ('Scope: {scope}'), duplicate prevention count if >0, and a red Delete button. Only one row is expanded at a time.",
         "elements": [
-          {
-            "textContent": "Observation Memory"
-          },
           {
             "textContent": "Hash:"
           },
@@ -1177,13 +1156,7 @@
         "description": "Observations are temporal knowledge artifacts with revision history and content deduplication. The UI must accurately surface these invariants. Topic-key upsert (same topic_key → increment revisionCount, snapshot old version), content-hash deduplication (same SHA-256 within 15min → blocked, duplicates_prevented increments), and scope-based organization are backend behaviors visible through the UI.",
         "elements": [
           {
-            "textContent": "rev "
-          },
-          {
             "textContent": "Duplicates prevented"
-          },
-          {
-            "textContent": "Observation Memory"
           }
         ],
         "id": "mem-data-model",

--- a/specs/pages/meta-optimizer-page/spec.uibridge.json
+++ b/specs/pages/meta-optimizer-page/spec.uibridge.json
@@ -1010,12 +1010,6 @@
         "description": "When pools exist, the sidebar lists them with status badges, agent type, generation, and timestamps. Clicking a pool loads its candidates in the detail panel with a Copeland ranking table.",
         "elements": [
           {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
             "tagName": "tr"
           }
         ],
@@ -1029,9 +1023,6 @@
         "elements": [
           {
             "textContains": "Duel Results"
-          },
-          {
-            "tagName": "table"
           },
           {
             "textContains": "No duel results"
@@ -1080,16 +1071,7 @@
         "description": "Run list shows status, agent_type, generation. Selecting a run loads candidates grouped by generation with expandable cards showing critique, changes, and prompt content.",
         "elements": [
           {
-            "role": "button"
-          },
-          {
             "textContains": "Generation"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "beam-runs-data-display",
@@ -1107,10 +1089,6 @@
           {},
           {},
           {
-            "role": "button",
-            "textContent": "Load"
-          },
-          {
             "textContains": "No span events loaded"
           }
         ],
@@ -1123,19 +1101,7 @@
         "description": "Loaded events are grouped by execution_id with collapsible sections. Each group shows an event table with type-specific detail rendering.",
         "elements": [
           {
-            "role": "button"
-          },
-          {
-            "tagName": "table"
-          },
-          {
             "tagName": "td"
-          },
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "span-events-data-display",
@@ -1147,17 +1113,10 @@
         "description": "All three new tabs follow the runner's dark zinc theme. Background colors, text colors, borders, and interactive states must be consistent with the existing meta-optimizer tabs.",
         "elements": [
           {
-            "role": "heading",
-            "textContains": "Duel Pools"
-          },
-          {
             "role": "heading"
           },
           {
             "tagName": "span"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "visual-design-dark-theme",
@@ -1170,10 +1129,6 @@
         "elements": [
           {
             "textContains": "Refresh"
-          },
-          {
-            "role": "heading",
-            "textContains": "Beam Search Runs"
           },
           {
             "role": "button",

--- a/specs/pages/online-learning/spec.uibridge.json
+++ b/specs/pages/online-learning/spec.uibridge.json
@@ -839,9 +839,6 @@
         "description": "The page has a fixed header with title and refresh button, a sub-tab bar with 6 tabs, and a scrollable content area. The background is dark (#0a0a0f). The layout is a vertical flex column filling the available height.",
         "elements": [
           {
-            "textContent": "Online Learning"
-          },
-          {
             "role": "button",
             "textContent": "Refresh"
           },
@@ -869,12 +866,6 @@
           },
           {
             "textContent": "Overview"
-          },
-          {
-            "textContains": "Drift Detection"
-          },
-          {
-            "textContains": "Drift Detection"
           }
         ],
         "id": "ol-tab-navigation",
@@ -932,9 +923,6 @@
           },
           {
             "textContains": "No model routing data yet"
-          },
-          {
-            "tagName": "table"
           }
         ],
         "id": "ol-model-routing-table",
@@ -1013,20 +1001,7 @@
       },
       {
         "description": "The dashboard uses a dark theme consistent with the runner's design system. All text must be legible against dark backgrounds. Cards use subtle borders and transparency.",
-        "elements": [
-          {
-            "textContent": "Online Learning"
-          },
-          {
-            "textContent": "Online Learning"
-          },
-          {
-            "textContains": "Routing Entries"
-          },
-          {
-            "tagName": "table"
-          }
-        ],
+        "elements": [],
         "id": "ol-visual-design",
         "isInitial": false,
         "name": "Visual Design & Dark Theme",
@@ -1050,12 +1025,6 @@
       {
         "description": "The dashboard displays outputs from several online learning algorithms. These assertions verify that the displayed data is internally consistent and reflects correct algorithm behavior.",
         "elements": [
-          {
-            "tagName": "table"
-          },
-          {
-            "tagName": "table"
-          },
           {
             "textContains": "Extracted"
           }

--- a/specs/pages/orchestration-loop/spec.uibridge.json
+++ b/specs/pages/orchestration-loop/spec.uibridge.json
@@ -1087,9 +1087,6 @@
             "textContains": "Library"
           },
           {
-            "textContains": "Save"
-          },
-          {
             "textContent": "Saved Configurations"
           },
           {
@@ -1171,9 +1168,6 @@
         "description": "When 'Enable Diagnostic Phase' is checked, a teal-bordered configuration panel appears with fields for UI Bridge assertions, DOM snapshot capture options, and an optional model override. An exit strategy dropdown also appears with Reflection, Diagnostic Evaluation, and Fixed Iterations options.",
         "elements": [
           {
-            "textContent": "Diagnostic Configuration"
-          },
-          {
             "textContains": "Assertions (JSON array)"
           },
           {
@@ -1187,9 +1181,6 @@
           },
           {
             "textContains": "Exit"
-          },
-          {
-            "textContent": "Run Loop"
           }
         ],
         "id": "ol-diagnostic-config",
@@ -1267,16 +1258,7 @@
         "description": "The diagnostic phase runs between Execute and Reflect in the pipeline loop. It captures page health, runs UI Bridge assertions, and uses AI triage to classify failures. The phase is skipped when the workflow crashed. When diagnostics fail, the next iteration rebuilds the workflow with diagnostic context injected into the prompt.",
         "elements": [
           {
-            "tagName": "tbody"
-          },
-          {
-            "tagName": "tbody"
-          },
-          {
             "textContains": "EXIT"
-          },
-          {
-            "tagName": "tbody"
           },
           {
             "textContains": "diagnosing"

--- a/specs/pages/pipeline-events/spec.uibridge.json
+++ b/specs/pages/pipeline-events/spec.uibridge.json
@@ -404,9 +404,6 @@
             "textContent": "Pipeline Events"
           },
           {
-            "role": "listitem"
-          },
-          {
             "textContent": ":"
           }
         ],
@@ -462,17 +459,7 @@
       },
       {
         "description": "Each event row must accurately render the event type, phase, timestamp (HH:mm:ss format), duration in milliseconds, token count, and validation error delta from the API response.",
-        "elements": [
-          {
-            "textContent": ":"
-          },
-          {
-            "textContent": "ms"
-          },
-          {
-            "textContent": "errors:"
-          }
-        ],
+        "elements": [],
         "id": "pipeline-events-data-display",
         "isInitial": false,
         "name": "Event Data Rendering",
@@ -480,14 +467,7 @@
       },
       {
         "description": "The timeline is scrollable when events exceed the visible area (max-h-96), events are ordered chronologically by created_at, and the timeline connector lines visually link sequential events.",
-        "elements": [
-          {
-            "textContent": "Pipeline Events"
-          },
-          {
-            "textContent": "Pipeline Events"
-          }
-        ],
+        "elements": [],
         "id": "pipeline-events-behavior",
         "isInitial": false,
         "name": "Timeline Behavior",
@@ -495,11 +475,7 @@
       },
       {
         "description": "Each event row must contain a phase color dot, event type label, and timeline connector line. The header must show the Zap icon.",
-        "elements": [
-          {
-            "textContent": "Pipeline Events"
-          }
-        ],
+        "elements": [],
         "id": "pipeline-events-presence",
         "isInitial": false,
         "name": "Required Timeline Elements",
@@ -513,9 +489,6 @@
           },
           {
             "textContains": "Load more"
-          },
-          {
-            "textContains": "Pipeline Events"
           }
         ],
         "id": "pipeline-events-virtualization",

--- a/specs/pages/processes/spec.uibridge.json
+++ b/specs/pages/processes/spec.uibridge.json
@@ -756,12 +756,6 @@
         "description": "The output viewer toolbar includes an 'All sessions' toggle button next to the search input. When active (visually highlighted cyan), the search input's placeholder changes from 'Search output...' to 'Search all sessions...' and typing triggers a backend call to search_process_logs, which runs an ILIKE query across every persisted session's output in the runner's PostgreSQL database. Results appear in a hits panel replacing the normal output view, each row showing the session ID prefix, process name, timestamp, and the matching log line. Clicking a hit jumps to that session in the picker and switches the view to that session's full content. This turns the process manager into a full-history log search tool, not just a live viewer. Toggling the button off restores the regular in-buffer filter.",
         "elements": [
           {
-            "textContent": "All sessions"
-          },
-          {
-            "textContent": "All sessions"
-          },
-          {
             "textContent": "No matches across sessions."
           },
           {
@@ -778,20 +772,7 @@
       },
       {
         "description": "The process log DB persistence feature writes every stdout/stderr line to PostgreSQL tables (process_sessions + process_session_output) via a batched writer task in the ManagedProcess event loop. This group defines what CORRECT output looks like from that persistence algorithm, verifiable from the page: the session picker reflects every process run, the historical session content matches what was previously shown live, the line counts are consistent between live and historical views, and zombie 'running' sessions from previous runner crashes are cleaned up on startup so the picker doesn't show stale entries.",
-        "elements": [
-          {
-            "tagName": "select"
-          },
-          {
-            "textContains": "lines"
-          },
-          {
-            "tagName": "select"
-          },
-          {
-            "tagName": "select"
-          }
-        ],
+        "elements": [],
         "id": "process-log-persistence-correctness",
         "isInitial": false,
         "name": "Process Log Persistence — Algorithm Correctness",
@@ -801,15 +782,9 @@
         "description": "The Process Manager uses the runner's standard dark theme with zinc grays, cyan accents for primary actions, and red/yellow/green for status indication. Text must be legible against the panel backgrounds — muted text uses zinc-500, primary text uses zinc-200, headings use zinc-200. The toolbar uses zinc-900 backgrounds with white/10 borders. Buttons in the toolbar follow the existing runner style: small xs text, bg-zinc-800 for secondary, bg-cyan-900/40 with border-cyan-700/50 for primary (Add Process), and the 'All sessions' toggle uses bg-cyan-900/30 with text-cyan-300 when active.",
         "elements": [
           {
-            "textContent": "Process Manager"
-          },
-          {
             "textContent": "All sessions"
           },
-          {},
-          {
-            "textContains": "lines"
-          }
+          {}
         ],
         "id": "process-manager-visual-design",
         "isInitial": false,

--- a/specs/pages/product-tours/spec.uibridge.json
+++ b/specs/pages/product-tours/spec.uibridge.json
@@ -1174,12 +1174,6 @@
             "textContent": "Generate Tour"
           },
           {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
-          {
             "role": "button",
             "textContent": "Regenerate"
           },
@@ -1268,19 +1262,7 @@
             "tagName": "div"
           },
           {
-            "role": "button",
-            "textContent": "Start Tour"
-          },
-          {
             "textContent": "min"
-          },
-          {
-            "role": "button",
-            "textContent": "Start Tour"
-          },
-          {
-            "role": "button",
-            "textContent": "HTML"
           }
         ],
         "id": "pt-tour-card",
@@ -1295,17 +1277,11 @@
             "textContent": "Next"
           },
           {
-            "role": "heading"
-          },
-          {
             "textContent": "Next"
           },
           {
             "role": "button",
             "textContent": "Next"
-          },
-          {
-            "textContent": "Demonstrating..."
           },
           {
             "role": "heading",
@@ -1325,14 +1301,6 @@
         "elements": [
           {
             "textContent": "steps"
-          },
-          {
-            "role": "button",
-            "textContent": "Start Tour"
-          },
-          {
-            "role": "button",
-            "textContent": "Start Tour"
           },
           {
             "role": "heading"
@@ -1375,10 +1343,6 @@
           },
           {
             "textContent": "Interactive tours that demonstrate features automatically"
-          },
-          {
-            "role": "button",
-            "textContent": "Start Tour"
           }
         ],
         "id": "pt-help-tab-integration",

--- a/specs/pages/productivity/spec.uibridge.json
+++ b/specs/pages/productivity/spec.uibridge.json
@@ -1762,10 +1762,6 @@
         "description": "The page renders a top bar with a 'Productivity' heading, three sub-view tabs (Plans & Tasks, Coordinator, Knowledge) with lucide-react icons (ClipboardList, Bot, BookOpen), and a right-aligned 'Knowledge' button that opens the modal browser. Below the top bar the active sub-view is rendered into a flex-1 content area. The active sub-view defaults to 'plans' and can be switched by clicking a tab or by dispatching a `productivity-set-view` CustomEvent.",
         "elements": [
           {
-            "role": "heading",
-            "textContent": "Productivity"
-          },
-          {
             "dataAttributes": {
               "ui-bridge-id": "productivity.view-tab-plans"
             }

--- a/specs/pages/prompt-management/spec.uibridge.json
+++ b/specs/pages/prompt-management/spec.uibridge.json
@@ -1684,22 +1684,13 @@
         "description": "The version history list shows all versions for a prompt template sorted by version number descending. Each version row shows the version number badge (v1, v2...), the change description, a truncated SHA256 content hash, and the creation date. The list header displays a count of versions and provides Compare and Refresh controls. In compare mode, two versions can be selected as A and B with highlighted selection indicators.",
         "elements": [
           {
-            "textContent": "Version History"
-          },
-          {
             "textContent": "versions"
-          },
-          {
-            "textContent": "v\\d+"
           },
           {},
           {
             "textContent": "No description"
           },
           {},
-          {
-            "role": "button"
-          },
           {
             "textContent": "No versions recorded for this template yet."
           },
@@ -1721,12 +1712,6 @@
         "description": "The version detail view shows the full prompt content, metadata, performance metrics, and a 'Restore this version' button. It displays the version number, creation timestamp, truncated content hash, change description, and the full prompt content in a scrollable pre block. Performance metrics show success rate, average cost, and average latency when available.",
         "elements": [
           {
-            "textContent": "Back to history"
-          },
-          {
-            "textContent": "v\\d+"
-          },
-          {
             "textContent": "hash:"
           },
           {
@@ -1743,9 +1728,6 @@
           },
           {
             "textContent": "Performance Metrics"
-          },
-          {
-            "textContent": "Restore this version"
           },
           {
             "textContent": "Create new version with this content?"
@@ -1801,9 +1783,6 @@
             "textContent": "No differences found."
           },
           {
-            "textContent": "Back to history"
-          },
-          {
             "textContent": "Failed to load diff."
           }
         ],
@@ -1825,25 +1804,10 @@
             "textContent": "vs"
           },
           {
-            "textContent": "candidate traffic"
-          },
-          {
             "textContent": "Metric"
           },
           {
-            "textContent": "Success Rate"
-          },
-          {
-            "textContent": "Avg Cost"
-          },
-          {
-            "textContent": "Avg Latency"
-          },
-          {
             "textContent": "pp"
-          },
-          {
-            "textContent": "p-value"
           },
           {
             "textContent": "Verdict"
@@ -1896,9 +1860,6 @@
           {},
           {
             "textContent": "Close"
-          },
-          {
-            "textContent": "Create A/B Test"
           }
         ],
         "id": "canary-creation",
@@ -1997,9 +1958,6 @@
       {
         "description": "Assertions verifying that required UI elements are present in each view: version row metadata, diff line numbers, canary action buttons, metrics grid columns, and registry variant action buttons.",
         "elements": [
-          {
-            "role": "button"
-          },
           {},
           {
             "textContent": "Promote|Rollback"

--- a/specs/pages/rule-influence/spec.uibridge.json
+++ b/specs/pages/rule-influence/spec.uibridge.json
@@ -280,9 +280,6 @@
             "textContent": "Rule Influence"
           },
           {
-            "textContent": "Loaded"
-          },
-          {
             "textContent": "No effect"
           },
           {
@@ -326,9 +323,6 @@
         "elements": [
           {
             "textContent": "Loading rules..."
-          },
-          {
-            "textContent": "All rules appear effective"
           }
         ],
         "id": "rule-influence-states",
@@ -341,9 +335,6 @@
         "elements": [
           {
             "textContent": "Loaded"
-          },
-          {
-            "textContent": "effective"
           }
         ],
         "id": "rule-influence-data-display",

--- a/specs/pages/run-feedback-costs/spec.uibridge.json
+++ b/specs/pages/run-feedback-costs/spec.uibridge.json
@@ -1082,15 +1082,7 @@
           },
           {
             "role": "button",
-            "textContent": "Submit"
-          },
-          {
-            "role": "button",
             "textContent": "Cancel"
-          },
-          {
-            "role": "button",
-            "textContent": "Submit"
           }
         ],
         "id": "manual-score-creation",
@@ -1101,12 +1093,6 @@
       {
         "description": "Users need to drill into individual score details to understand the reasoning behind each quality assessment. Score rows that have a reason field are clickable (indicated by a chevron icon) and expand to reveal the reason text with a message icon. Rows without a reason are not interactive. This progressive disclosure keeps the default view clean while allowing detailed investigation.",
         "elements": [
-          {
-            "role": "button"
-          },
-          {
-            "role": "button"
-          },
           {
             "textContent": ".*"
           },

--- a/specs/pages/run-findings/spec.uibridge.json
+++ b/specs/pages/run-findings/spec.uibridge.json
@@ -301,9 +301,6 @@
           },
           {
             "textContent": "Category"
-          },
-          {
-            "textContent": "Clear"
           }
         ],
         "id": "findings-filtering-and-navigation",

--- a/specs/pages/run-summary/spec.uibridge.json
+++ b/specs/pages/run-summary/spec.uibridge.json
@@ -695,13 +695,7 @@
         "description": "When the Phase Timeline tab is active, the user sees one collapsible card per PhaseResult row. Each card shows the phase name (Setup / Verification / Agentic / Completion), optional iteration number, optional stage index, a success/failure badge, the phase duration, step count (successful/total), and an optional abbreviated 8-char commit hash. Iteration separators appear between cards whenever the iteration field changes, so multi-iteration runs read chronologically. The tab is backed by the get_phase_results Tauri command reading from the runner.phase_results PG table (plan: restate-port-part-a-compensation-and-phase-results.md §2.5).",
         "elements": [
           {
-            "textContent": "Phase Timeline"
-          },
-          {
             "textContains": "step"
-          },
-          {
-            "textContains": "Iteration"
           },
           {
             "textContent": "Step Breakdown"
@@ -725,19 +719,10 @@
             "textContains": "Setup"
           },
           {
-            "textContent": "Phase Timeline"
-          },
-          {
             "textContent": "Agentic"
           },
           {
             "textContains": "steps"
-          },
-          {
-            "textContent": "Phase Timeline"
-          },
-          {
-            "textContent": "Phase Timeline"
           }
         ],
         "id": "phase-timeline-correctness",

--- a/specs/pages/run-traces/spec.uibridge.json
+++ b/specs/pages/run-traces/spec.uibridge.json
@@ -1522,9 +1522,6 @@
             "textContent": "Comparison"
           },
           {
-            "textContent": "Agent Graph"
-          },
-          {
             "textContent": "Waterfall"
           }
         ],
@@ -1557,15 +1554,6 @@
       {
         "description": "The Flamechart view is a canvas-based (HTML5 Canvas) stacked visualization that shows span hierarchy by call depth, with each span's width proportional to its duration. Unlike the waterfall (which shows wall-clock position), the flamechart collapses idle gaps between sibling spans so it shows where time is *spent*. Children are packed proportionally within their parent's width range — a parent with two children of 600ms and 400ms allocates 60% and 40% of its width respectively, regardless of idle gaps between them. The canvas renders at device pixel ratio for crisp display on HiDPI screens, with a dark zinc-900 background. Phase colors use raw hex values (not Tailwind) for canvas rendering.",
         "elements": [
-          {
-            "tagName": "canvas"
-          },
-          {
-            "tagName": "canvas"
-          },
-          {
-            "tagName": "canvas"
-          },
           {
             "textContent": "Reset zoom"
           },
@@ -1603,9 +1591,6 @@
             "textContent": "Slower"
           },
           {
-            "textContent": "Run A"
-          },
-          {
             "textContent": "Duration comparison"
           },
           {
@@ -1624,13 +1609,7 @@
             "textContent": "Critical Path"
           },
           {
-            "role": "button"
-          },
-          {
             "tagName": "line"
-          },
-          {
-            "tagName": "canvas"
           },
           {
             "textContent": "Critical path"
@@ -1658,9 +1637,6 @@
           },
           {
             "textContent": "All Status"
-          },
-          {
-            "textContent": "spans"
           }
         ],
         "id": "traces-filtering-and-search",
@@ -1671,9 +1647,6 @@
       {
         "description": "When the user clicks a span in the Waterfall or Flamechart view, a 280px-wide detail panel opens on the right side showing comprehensive information about that span. The panel displays: span name (stripped of 'qontinui.' prefix), status (Success/Error), phase with colored badge, formatted duration, start and end timestamps, trace/span/parent IDs in monospace, error message (if any), and all span attributes as key-value pairs. When critical path is enabled, the panel also shows whether the span is on the critical path and its slack time. Clicking the same span again or clicking the close button deselects it.",
         "elements": [
-          {
-            "role": "button"
-          },
           {
             "textContent": "Status"
           },
@@ -1718,9 +1691,6 @@
           },
           {
             "textContent": "Input tokens"
-          },
-          {
-            "tagName": "canvas"
           },
           {
             "textContent": "tokens"
@@ -1783,9 +1753,6 @@
             "role": "toolbar"
           },
           {
-            "role": "button"
-          },
-          {
             "textContent": "Step"
           },
           {
@@ -1834,9 +1801,6 @@
             "textContent": "Min delta"
           },
           {
-            "textContent": "All Phases"
-          },
-          {
             "textContent": "Run A"
           },
           {
@@ -1856,15 +1820,6 @@
           },
           {
             "role": "separator"
-          },
-          {
-            "textContent": "Name"
-          },
-          {
-            "textContent": "setup|verification|agentic|completion|ai|python"
-          },
-          {
-            "textContent": "Search spans"
           }
         ],
         "id": "traces-visual-design",

--- a/specs/pages/scheduled-tasks/spec.uibridge.json
+++ b/specs/pages/scheduled-tasks/spec.uibridge.json
@@ -626,12 +626,6 @@
             "textContent": "New Task"
           },
           {
-            "textContent": "Scheduled"
-          },
-          {
-            "role": "button"
-          },
-          {
             "textContent": "Auto-Fix"
           }
         ],
@@ -727,12 +721,6 @@
       {
         "description": "The History sub-tab shows one row per execution. Beyond the original Pending/Running/Completed/Failed/Skipped/Cancelled, two new statuses landed in Phase B: 'launch_failed' (LaunchFailed — task could not start) and 'missed_runner_down' (MissedRunnerDown — slot was synthesized by the catch-up reconciler with policy=Skip). These need distinguishable visual treatment because they mean different things from generic Failed: launch_failed is retry-with-backoff, missed_runner_down is informational. Catch-up runs also tag the task name with '(catch-up)' so the operator can tell that a Completed row was a catch-up rather than a normal-schedule fire.",
         "elements": [
-          {
-            "textContent": "Launch failed"
-          },
-          {
-            "textContains": "Missed (runner offline)"
-          },
           {
             "textContains": "(catch-up)"
           },

--- a/specs/pages/security-settings/spec.uibridge.json
+++ b/specs/pages/security-settings/spec.uibridge.json
@@ -804,9 +804,6 @@
         "description": "Dropdown to select the active security profile. Options: Permissive, Standard, Strict, Custom. Selecting a built-in profile shows its description and AST fingerprint.",
         "elements": [
           {
-            "textContains": "Security Profile"
-          },
-          {
             "role": "combobox"
           },
           {
@@ -897,9 +894,6 @@
             "textContains": "Audit Log"
           },
           {
-            "role": "combobox"
-          },
-          {
             "role": "table"
           },
           {
@@ -907,9 +901,6 @@
           },
           {
             "textContains": "No audit events"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "sec-audit-log-viewer",
@@ -965,10 +956,6 @@
           },
           {
             "role": "button"
-          },
-          {
-            "role": "button",
-            "textContains": "Save"
           }
         ],
         "id": "sec-visual-design",

--- a/specs/pages/settings-agentic/spec.uibridge.json
+++ b/specs/pages/settings-agentic/spec.uibridge.json
@@ -790,16 +790,10 @@
         "description": "The Advanced AI tab renders a page header with Brain icon, a descriptive subtitle, four collapsible section panels, and two action buttons at the bottom. This group verifies the top-level structure after settings load.",
         "elements": [
           {
-            "textContent": "Advanced AI Features"
-          },
-          {
             "textContent": "Configure intelligent agentic features"
           },
           {
             "textContent": "Memory Compression"
-          },
-          {
-            "textContent": "Advanced AI Features"
           }
         ],
         "id": "aa-page-structure",
@@ -810,10 +804,7 @@
       {
         "description": "On mount, the page concurrently fetches agentic settings via get_agentic_settings (Tauri IPC) and reflection settings via GET /reflection/settings (HTTP). During the fetch, a loading indicator replaces the full form. This group verifies loading and transition-to-loaded behavior.",
         "elements": [
-          {},
-          {
-            "textContent": "Advanced AI Features"
-          }
+          {}
         ],
         "id": "aa-loading-state",
         "isInitial": false,
@@ -834,12 +825,6 @@
           },
           {
             "textContent": "Memory compression prevents context overflow by summarizing"
-          },
-          {
-            "textContent": "Memory Compression"
-          },
-          {
-            "textContent": "Memory Compression"
           }
         ],
         "id": "aa-memory-compression",
@@ -955,9 +940,6 @@
         "elements": [
           {
             "textContent": "Settings saved successfully!"
-          },
-          {
-            "textContent": "Advanced AI Features"
           }
         ],
         "id": "aa-feedback-alerts",

--- a/specs/pages/settings-ai/spec.uibridge.json
+++ b/specs/pages/settings-ai/spec.uibridge.json
@@ -1118,9 +1118,6 @@
           },
           {
             "role": "combobox"
-          },
-          {
-            "role": "spinbutton"
           }
         ],
         "id": "ai-claude-cli-section",
@@ -1162,16 +1159,10 @@
       {
         "description": "Visible only when claude_api provider is selected. Manages Claude API key storage in the OS keychain, model selection from four Claude model options, max tokens limit, and displays a per-token cost warning.",
         "elements": [
-          {
-            "role": "combobox"
-          },
           {},
           {
             "role": "button",
             "textContent": "Save Key"
-          },
-          {
-            "role": "combobox"
           },
           {
             "textContent": "per-token costs"
@@ -1186,18 +1177,6 @@
         "description": "Visible only when gemini_cli provider is selected. Configures authentication method (OAuth for Google account free tier, or API key), model selection from five Gemini models, execution mode, and timeout. Includes an npm install tip.",
         "elements": [
           {
-            "role": "combobox"
-          },
-          {
-            "role": "radio"
-          },
-          {
-            "role": "radio"
-          },
-          {
-            "role": "combobox"
-          },
-          {
             "textContent": "npm install -g @google/gemini-cli"
           }
         ],
@@ -1209,17 +1188,7 @@
       {
         "description": "Visible only when gemini_api provider is selected. Manages Gemini API key in the OS keychain, model selection, max output tokens, and temperature (creativity). Includes a cost savings note comparing Gemini Flash to Claude for simple tasks.",
         "elements": [
-          {
-            "role": "combobox"
-          },
           {},
-          {
-            "role": "button",
-            "textContent": "Save Key"
-          },
-          {
-            "role": "spinbutton"
-          },
           {
             "textContent": "Cost Savings"
           }

--- a/specs/pages/settings-backup/spec.uibridge.json
+++ b/specs/pages/settings-backup/spec.uibridge.json
@@ -1016,10 +1016,6 @@
           },
           {
             "textContent": "Export Options"
-          },
-          {
-            "role": "button",
-            "textContent": "Export"
           }
         ],
         "id": "bk-export-section",
@@ -1029,18 +1025,7 @@
       },
       {
         "description": "When the 'Export Options' toggle is expanded, a grid of 13 checkboxes is shown — one per data category. All 13 are checked by default (defaultExportOptions). Each checkbox label shows the category name and its current count in parentheses. Unchecking a category removes it from the export and reduces the N in 'Export (N items)'.",
-        "elements": [
-          {
-            "textContent": "Export Options"
-          },
-          {
-            "textContent": "Export Options"
-          },
-          {
-            "role": "button",
-            "textContent": "Export"
-          }
-        ],
+        "elements": [],
         "id": "bk-export-options-panel",
         "isInitial": false,
         "name": "Export Options — Category Selector",
@@ -1086,9 +1071,6 @@
       {
         "description": "After selecting a .json backup file, the page calls get_import_preview and shows an 'Import Preview' panel. The panel displays three metadata fields: Version (from manifest.version, e.g. '2.0.0'), App Version (from manifest.app_version), and Created (manifest.created_at formatted via toLocaleString()). A 'Cancel' button is visible to dismiss the preview and return to the idle state.",
         "elements": [
-          {
-            "textContent": "Import Preview"
-          },
           {
             "role": "button",
             "textContent": "Cancel"
@@ -1142,17 +1124,10 @@
         "description": "The Import Preview panel shows a grid of 13 data-count cells (same layout as the Your Data summary) and an amber warning banner. Selected categories are highlighted with a primary/10 background; deselected categories have 50% opacity. The warning banner text changes based on conflict_mode: 'overwrite' shows 'Existing items will be overwritten. This cannot be undone.' and 'skip' shows 'Existing items will be skipped. Only new items will be imported.'",
         "elements": [
           {
-            "textContent": "Import Preview"
-          },
-          {
             "textContent": "Existing items will be skipped"
           },
           {
             "textContent": "Existing items will be overwritten"
-          },
-          {
-            "role": "button",
-            "textContent": "Import Data"
           }
         ],
         "id": "bk-import-preview-grid-and-warning",
@@ -1229,9 +1204,6 @@
           },
           {
             "textContent": "Import Preview"
-          },
-          {
-            "textContent": "API keys stored in the system keychain are not included"
           }
         ],
         "id": "bk-data-model",

--- a/specs/pages/settings-general/spec.uibridge.json
+++ b/specs/pages/settings-general/spec.uibridge.json
@@ -506,12 +506,6 @@
             "textContent": "Application"
           },
           {
-            "textContent": "Auto-load Last Configuration on Startup"
-          },
-          {
-            "textContent": "Launch on System Startup"
-          },
-          {
             "textContent": "Tip:"
           }
         ],
@@ -590,13 +584,7 @@
         "description": "The 'Include AI Summary in New Workflows' toggle controls whether a completion-phase AI Summary step is automatically added when new workflows are created. This is a saved preference, not a live workflow modification.",
         "elements": [
           {
-            "textContent": "Include AI Summary in New Workflows"
-          },
-          {
             "textContent": "Automatically add an AI Summary step to the completion phase of new workflows"
-          },
-          {
-            "textContent": "Include AI Summary in New Workflows"
           }
         ],
         "id": "gen-summary-step-behavior",
@@ -610,12 +598,6 @@
           {
             "role": "button",
             "textContent": "Save"
-          },
-          {
-            "textContent": "General"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "gen-settings-persistence",

--- a/specs/pages/settings-log-sources/spec.uibridge.json
+++ b/specs/pages/settings-log-sources/spec.uibridge.json
@@ -999,19 +999,11 @@
             "textContent": "Add Source"
           },
           {
-            "role": "button",
-            "textContent": "Add"
-          },
-          {
             "role": "heading",
             "textContent": "Add Source"
           },
           {
             "textContent": "Error Monitoring"
-          },
-          {
-            "role": "button",
-            "textContent": "Add"
           }
         ],
         "id": "ls-add-source-modal",

--- a/specs/pages/settings-mcp/spec.uibridge.json
+++ b/specs/pages/settings-mcp/spec.uibridge.json
@@ -1039,12 +1039,6 @@
           },
           {
             "textContent": "Configure external MCP (Model Context Protocol) servers"
-          },
-          {
-            "textContent": "Configured Servers"
-          },
-          {
-            "textContent": "What is MCP?"
           }
         ],
         "id": "mcp-page-structure",
@@ -1169,10 +1163,6 @@
           {
             "role": "button",
             "textContent": "Cancel"
-          },
-          {
-            "role": "button",
-            "textContent": "Create"
           }
         ],
         "id": "mcp-add-form-structure",
@@ -1191,9 +1181,6 @@
           },
           {
             "textContent": "Stdio transport is not yet fully implemented"
-          },
-          {
-            "textContent": "Run as subprocess"
           }
         ],
         "id": "mcp-transport-fields",
@@ -1288,13 +1275,7 @@
       {
         "description": "McpServerConfig is the canonical data structure for a configured MCP server. It is stored in the runner's PostgreSQL database and returned by list_mcp_servers and create/update commands. Understanding this model is essential for verifying that form submissions, CRUD operations, and status displays are correct.",
         "elements": [
-          {
-            "textContent": "Configured Servers"
-          },
-          {},
-          {
-            "textContent": "Configured Servers"
-          }
+          {}
         ],
         "id": "mcp-data-model",
         "isInitial": false,

--- a/specs/pages/settings-playwright/spec.uibridge.json
+++ b/specs/pages/settings-playwright/spec.uibridge.json
@@ -582,9 +582,6 @@
           },
           {
             "textContent": "Configure authentication credentials and environment for Playwright test execution."
-          },
-          {
-            "textContent": "Playwright Tests"
           }
         ],
         "id": "pw-page-structure",
@@ -595,15 +592,6 @@
       {
         "description": "The 'Test Authentication' card contains a description explaining that credentials are passed as PLAYWRIGHT_TEST_USERNAME and PLAYWRIGHT_TEST_PASSWORD environment variables, a Username or Email text input, and a Password input with a show/hide toggle button.",
         "elements": [
-          {
-            "textContent": "Test Authentication"
-          },
-          {
-            "tagName": "input"
-          },
-          {
-            "tagName": "input"
-          },
           {
             "role": "button",
             "tagName": "button"
@@ -622,9 +610,6 @@
         "elements": [
           {
             "textContent": "Environment"
-          },
-          {
-            "tagName": "input"
           },
           {
             "textContent": "PLAYWRIGHT_BASE_URL"
@@ -721,9 +706,6 @@
       {
         "description": "Each of the four settings fields maps to an environment variable that is injected when Playwright tests run. The spec defines this mapping so workflows can verify the correct env vars are documented and the correct fields are present. The UI descriptions on the page itself expose this mapping to the user.",
         "elements": [
-          {
-            "textContent": "Playwright Tests"
-          },
           {
             "textContent": "Sets SKIP_WEB_SERVER=1"
           }

--- a/specs/pages/settings-security/spec.uibridge.json
+++ b/specs/pages/settings-security/spec.uibridge.json
@@ -1075,12 +1075,6 @@
             "textContent": "Security Profile"
           },
           {
-            "role": "combobox"
-          },
-          {
-            "role": "combobox"
-          },
-          {
             "textContent": "AST Fingerprint:"
           }
         ],
@@ -1171,10 +1165,7 @@
         "elements": [
           {},
           {},
-          {},
-          {
-            "textContent": "Security Profile"
-          }
+          {}
         ],
         "id": "ss-custom-resources-policy",
         "isInitial": false,

--- a/specs/pages/settings-self-healing/spec.uibridge.json
+++ b/specs/pages/settings-self-healing/spec.uibridge.json
@@ -856,16 +856,10 @@
         "description": "The self-healing tab renders a titled page header, a descriptive subtitle, and three collapsible section panels. This group verifies the top-level structure is present after settings have loaded.",
         "elements": [
           {
-            "textContent": "Self-Healing Configuration"
-          },
-          {
             "textContent": "Configure automation self-healing features"
           },
           {
             "textContent": "Action Caching"
-          },
-          {
-            "textContent": "Visual Validation"
           },
           {
             "textContent": "LLM Assistance"
@@ -900,9 +894,6 @@
           },
           {
             "textContent": "Action caching prevents redundant template matching"
-          },
-          {
-            "textContent": "Action Caching"
           },
           {
             "textContent": "Cache TTL (seconds)"
@@ -1175,9 +1166,6 @@
         "elements": [
           {
             "textContent": "Settings saved successfully!"
-          },
-          {
-            "textContent": "Self-Healing Configuration"
           }
         ],
         "id": "sh-feedback-alerts",
@@ -1188,12 +1176,6 @@
       {
         "description": "Self-healing settings are persisted via save_self_healing_settings and retrieved via get_self_healing_settings. The data model has exactly six fields. API keys are stored separately in the OS keychain. This group verifies the round-trip integrity and the semantic contract of the settings object.",
         "elements": [
-          {
-            "textContent": "Self-Healing Configuration"
-          },
-          {
-            "textContent": "Self-Healing Configuration"
-          },
           {
             "textContent": "passed to qontinui Python when executing workflows"
           }

--- a/specs/pages/settings-updates/spec.uibridge.json
+++ b/specs/pages/settings-updates/spec.uibridge.json
@@ -737,10 +737,6 @@
         "elements": [
           {},
           {},
-          {
-            "role": "button",
-            "textContent": "Check for Updates"
-          },
           {}
         ],
         "id": "upd-current-version-card",
@@ -754,10 +750,6 @@
           {
             "role": "button",
             "textContent": "Check for Updates"
-          },
-          {
-            "role": "button",
-            "textContent": "Checking..."
           },
           {
             "role": "button",
@@ -789,10 +781,6 @@
           {},
           {
             "textContent": "Update checking is disabled in development builds."
-          },
-          {
-            "role": "button",
-            "textContent": "Download and Install Update"
           }
         ],
         "id": "upd-dev-mode-state",
@@ -809,10 +797,6 @@
             "textContent": "Release Notes"
           },
           {
-            "role": "button",
-            "textContent": "Download and Install Update"
-          },
-          {
             "textContent": "The application will restart automatically after the update is installed."
           }
         ],
@@ -826,15 +810,7 @@
         "elements": [
           {
             "role": "button",
-            "textContent": "Download and Install Update"
-          },
-          {
-            "role": "button",
             "textContent": "Installing Update..."
-          },
-          {
-            "role": "button",
-            "textContent": "Download and Install Update"
           }
         ],
         "id": "upd-install-flow",
@@ -848,10 +824,6 @@
           {},
           {
             "textContent": "You're running the latest version of Qontinui Runner."
-          },
-          {
-            "role": "button",
-            "textContent": "Download and Install Update"
           }
         ],
         "id": "upd-up-to-date-state",
@@ -863,11 +835,7 @@
         "description": "If `check_for_updates` or `install_update` throws an exception, the component stores the error message in state and renders an error card with an AlertCircle icon and the error text. The status card is not shown when an error card is displayed.",
         "elements": [
           {},
-          {},
-          {
-            "role": "button",
-            "textContent": "Check for Updates"
-          }
+          {}
         ],
         "id": "upd-error-state",
         "isInitial": false,
@@ -877,11 +845,7 @@
       {
         "description": "Only one status card variant can be shown at a time. The four possible status card states (development mode, update available, up to date, and nothing) are mutually exclusive — they are driven by a single `updateInfo` nullable value and a single `error` nullable string. The error card and status card are also mutually exclusive.",
         "elements": [
-          {},
-          {
-            "role": "button",
-            "textContent": "Checking..."
-          }
+          {}
         ],
         "id": "upd-state-mutual-exclusion",
         "isInitial": false,

--- a/specs/pages/settings/spec.uibridge.json
+++ b/specs/pages/settings/spec.uibridge.json
@@ -1087,9 +1087,6 @@
             "textContent": "Claude Accounts"
           },
           {
-            "textContent": "Active"
-          },
-          {
             "textContent": "Switch"
           },
           {

--- a/specs/pages/shell-command-builder/spec.uibridge.json
+++ b/specs/pages/shell-command-builder/spec.uibridge.json
@@ -254,18 +254,6 @@
         "description": "The right-panel editor provides all fields for defining a shell command. The command text field is the primary input where users enter the actual shell command or script to execute. Users set a descriptive name, specify a working directory for command execution, select the target platform (any, Windows, Linux, macOS), and configure a timeout in seconds. A category field and tag input support organizational needs. The editor toolbar includes save and delete actions.",
         "elements": [
           {
-            "textContent": "Shell Commands"
-          },
-          {
-            "textContent": "Shell Commands"
-          },
-          {
-            "textContent": "Shell Commands"
-          },
-          {
-            "textContent": "Shell Commands"
-          },
-          {
             "role": "button",
             "textContent": "Save"
           }
@@ -278,12 +266,6 @@
       {
         "description": "Shell commands support organizational metadata to help users manage large command libraries. Categories group commands by function (e.g., build, test, deploy). Tags provide flexible cross-cutting labels for discovery through the library dashboard. The combination of name, category, and tags ensures commands are easy to find when building workflows, whether through the library dashboard search or the workflow builder's step picker.",
         "elements": [
-          {
-            "textContent": "Shell Commands"
-          },
-          {
-            "textContent": "Shell Commands"
-          },
           {
             "role": "button",
             "textContent": "Delete"

--- a/specs/pages/skills/spec.uibridge.json
+++ b/specs/pages/skills/spec.uibridge.json
@@ -745,23 +745,8 @@
         "description": "The page has a header bar (title + subtitle + refresh button), a filter tab bar (4 buttons: Pending, Approved, Rejected, All), and a scrollable content area showing skill rows or empty state. The refresh button shows a spinning icon during API fetch.",
         "elements": [
           {
-            "role": "button"
-          },
-          {
-            "role": "button",
-            "textContains": "Pending"
-          },
-          {
-            "role": "button",
-            "textContains": "Approved"
-          },
-          {
             "role": "button",
             "textContains": "Rejected"
-          },
-          {
-            "role": "button",
-            "textContent": "All"
           }
         ],
         "id": "skills-element-presence",
@@ -772,9 +757,6 @@
       {
         "description": "Each skill is rendered as a row with: a chevron toggle (ChevronRight when collapsed, ChevronDown when expanded), a status icon (green CheckCircle for approved, red XCircle for rejected, amber Clock for pending), the skill name (truncated via CSS text-ellipsis), and secondary metadata line showing 'category . vX.Y.Z . used Nx'. Data comes from GET /skills, filtered client-side to source='auto'.",
         "elements": [
-          {
-            "role": "button"
-          },
           {
             "textContains": "Auto:"
           },
@@ -831,13 +813,6 @@
           {
             "role": "button",
             "textContent": "Reset to Pending"
-          },
-          {
-            "role": "button",
-            "textContains": "Approved"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "skills-interaction-approval",
@@ -889,9 +864,6 @@
       {
         "description": "The panel uses a vertical flex layout (flex-col h-full): header bar with border-b, filter tab bar with border-b, and flex-1 overflow-y-auto content area. Skill rows have border-b with last:border-0. Action buttons use 10px font size with semi-transparent colored backgrounds. Status icons are 14px (w-3.5 h-3.5). The expanded detail panel is indented to pl-10 to align with the skill name.",
         "elements": [
-          {
-            "textContent": "Procedural Skills"
-          },
           {
             "role": "button",
             "textContains": "Pending"

--- a/specs/pages/state-machine/spec.uibridge.json
+++ b/specs/pages/state-machine/spec.uibridge.json
@@ -2520,21 +2520,6 @@
           },
           {
             "textContent": "State View"
-          },
-          {
-            "textContent": "Transitions"
-          },
-          {
-            "textContent": "Pathfinding"
-          },
-          {
-            "textContent": "Exploration Results"
-          },
-          {
-            "textContent": "Export"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "sm-tab-bar",
@@ -2634,9 +2619,6 @@
           },
           {
             "textContent": "Save Configuration"
-          },
-          {
-            "role": "generic"
           }
         ],
         "id": "sm-discovery-discover",
@@ -2652,18 +2634,6 @@
           },
           {
             "textContent": "No states discovered yet"
-          },
-          {
-            "role": "generic"
-          },
-          {
-            "role": "generic"
-          },
-          {
-            "role": "generic"
-          },
-          {
-            "role": "generic"
           }
         ],
         "id": "sm-graph-tab",
@@ -2682,12 +2652,6 @@
           },
           {
             "textContent": "Keyboard Shortcuts"
-          },
-          {
-            "role": "generic"
-          },
-          {
-            "role": "generic"
           }
         ],
         "id": "sm-graph-controls",
@@ -2705,15 +2669,6 @@
             "role": "textbox"
           },
           {
-            "role": "button"
-          },
-          {
-            "role": "generic"
-          },
-          {
-            "role": "generic"
-          },
-          {
             "textContent": "No capture screenshots available"
           }
         ],
@@ -2729,16 +2684,10 @@
             "textContent": "Transitions"
           },
           {
-            "role": "textbox"
-          },
-          {
             "textContent": "All from states"
           },
           {
             "textContent": "Action Playback"
-          },
-          {
-            "role": "generic"
           },
           {
             "textContent": "Select a transition to view its details"
@@ -2769,9 +2718,6 @@
           },
           {
             "textContent": "Dijkstra"
-          },
-          {
-            "role": "generic"
           }
         ],
         "id": "sm-pathfinding-tab",
@@ -2782,9 +2728,6 @@
       {
         "description": "When a state is selected in the Graph Editor, a w-80 side panel opens on the right showing the shared StateDetailPanel component. It provides a 'State Details' header with Close button, editable name, description, metadata grid, element list with type-colored badges, acceptance criteria list, domain knowledge cards, and save/delete actions.",
         "elements": [
-          {
-            "textContent": "State Details"
-          },
           {
             "textContent": "Name"
           },
@@ -2819,9 +2762,6 @@
             "textContent": "Edit Transition"
           },
           {
-            "role": "textbox"
-          },
-          {
             "textContent": "From States"
           },
           {
@@ -2829,9 +2769,6 @@
           },
           {
             "textContent": "Path Cost"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "sm-sidebar-transition-detail",
@@ -2891,9 +2828,6 @@
             "textContent": "Recent Exploration Runs"
           },
           {
-            "textContent": "Refresh"
-          },
-          {
             "textContent": "No exploration history"
           },
           {
@@ -2911,9 +2845,6 @@
       {
         "description": "When a run is selected, the detail view shows the report header (config name, strategy badge, timestamp), summary stats grid (Pass Rate, States, Transitions, Discrepancies), discrepancies by severity, expandable state detail cards with confidence scores and element verification, and an AI Analysis prompt button.",
         "elements": [
-          {
-            "role": "button"
-          },
           {
             "textContent": "Pass Rate"
           },
@@ -2946,12 +2877,6 @@
           },
           {
             "textContent": "Load into Runtime"
-          },
-          {
-            "role": "generic"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "sm-export-tab",
@@ -2962,12 +2887,6 @@
       {
         "description": "The state discovery algorithm uses fingerprint-based co-occurrence analysis to group UI elements into states. Co-occurrence data is collected via exploration (automated interaction) or recording (manual capture). Each capture produces a fingerprint of visible interactive elements. States are discovered by clustering fingerprints with similar element sets. The algorithm correctness can be verified by examining the discovered states' element lists and confidence scores.",
         "elements": [
-          {
-            "role": "generic"
-          },
-          {
-            "role": "generic"
-          },
           {
             "textContent": "captures"
           }
@@ -3047,9 +2966,6 @@
           },
           {
             "textContent": "Re-derive all"
-          },
-          {
-            "textContent": "State View"
           }
         ],
         "id": "sm-observation-pipeline",

--- a/specs/pages/step-builders/spec.uibridge.json
+++ b/specs/pages/step-builders/spec.uibridge.json
@@ -273,9 +273,6 @@
         "description": "The builder cards are arranged in a responsive grid layout that adapts to screen size, showing one to three columns depending on available width. Each card uses consistent visual structure: a color-coded icon on the left, the builder title and description on the right, and a hover-revealed arrow indicating navigability. The grid layout ensures all builder types are visible without scrolling on typical screens, providing immediate overview of all creation options.",
         "elements": [
           {
-            "textContent": "Step Builders"
-          },
-          {
             "textContent": "System commands and shell scripts"
           },
           {

--- a/specs/pages/task-builder/spec.uibridge.json
+++ b/specs/pages/task-builder/spec.uibridge.json
@@ -235,17 +235,11 @@
         "description": "The left panel displays all saved tasks in a searchable list following the standard library builder layout. Each task item shows its name, category badge, a content preview (first 60 characters of the prompt text), and tag count. Users can browse the list, search by name, create new tasks, and select a task to load into the editor. The UI labels this as 'Tasks' though the underlying API uses 'prompts' as the resource name.",
         "elements": [
           {
-            "textContent": "Tasks"
-          },
-          {
             "role": "button",
             "textContent": "New"
           },
           {
             "role": "searchbox"
-          },
-          {
-            "textContent": "Tasks"
           }
         ],
         "id": "task-list-management",
@@ -257,17 +251,8 @@
         "description": "The right-panel editor provides fields for defining a task. The name field identifies the task in lists and pickers. The content field is a textarea for entering the full prompt text or AI instructions -- this is the most important field as it defines what the AI should do when this task is used in a workflow. An optional category field supports organizational grouping. Tags can be added for flexible labeling. The editor toolbar includes save and delete actions.",
         "elements": [
           {
-            "textContent": "Tasks"
-          },
-          {
-            "textContent": "Tasks"
-          },
-          {
             "role": "button",
             "textContent": "Save"
-          },
-          {
-            "textContent": "Tasks"
           }
         ],
         "id": "task-editor-config",

--- a/specs/pages/terminal/spec.uibridge.json
+++ b/specs/pages/terminal/spec.uibridge.json
@@ -1043,23 +1043,11 @@
         "description": "Users can create multiple independent terminal pages, each with its own zone layout, terminals, labels, and saved configurations. A page tab bar at the top of the terminal area shows all pages. Clicking a page tab switches to that page by unmounting the current TerminalPage and remounting a new one connected to that page's PTY sessions. Each page's state (zone layout, labels, notes, pins, zone profiles, workspaces) is stored in page-namespaced localStorage keys. The default page uses un-prefixed keys for backward compatibility. PTY sessions are tagged with a page_id in the Rust backend, so each page only sees its own terminals.",
         "elements": [
           {
-            "role": "tab"
-          },
-          {
             "accessibleName": "Add terminal page",
             "role": "button"
           },
           {
-            "role": "tab"
-          },
-          {
-            "role": "tab"
-          },
-          {
             "accessibleName": "Close page"
-          },
-          {
-            "role": "tab"
           },
           {
             "textContains": "Loading terminals"
@@ -1091,9 +1079,6 @@
       {
         "description": "Each terminal page has isolated storage for its configuration. Zone layouts, session persistence, zone profiles, workspaces, zone labels/notes/pins, and grid column/row ratios are all namespaced by pageId. The default page uses un-prefixed keys (backward compatible), while non-default pages use 'page:{pageId}:' prefixed keys. This ensures that creating a zone profile on page A does not appear when viewing page B's profiles.",
         "elements": [
-          {
-            "accessibleName": "Zone profiles"
-          },
           {
             "role": "tab"
           },

--- a/specs/pages/triggers/spec.uibridge.json
+++ b/specs/pages/triggers/spec.uibridge.json
@@ -606,13 +606,7 @@
             "textContent": "All Triggers"
           },
           {
-            "role": "button"
-          },
-          {
             "textContent": "Test Result"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "triggers-list-management",
@@ -667,9 +661,6 @@
         "description": "When a user tests a trigger via dry run, a modal overlay displays the test result showing whether the trigger would or wouldn't execute, the trigger name, the action status, and the target workflow ID. The modal can be dismissed with a Close button.",
         "elements": [
           {
-            "textContent": "Test Result"
-          },
-          {
             "textContent": "execute"
           },
           {
@@ -689,9 +680,6 @@
         "elements": [
           {
             "textContent": "webhook"
-          },
-          {
-            "role": "button"
           },
           {
             "textContent": "webhook"

--- a/specs/pages/turix-cua-multimodal/spec.uibridge.json
+++ b/specs/pages/turix-cua-multimodal/spec.uibridge.json
@@ -918,9 +918,6 @@
         "description": "The vision pipeline serves two user needs: (1) for developers automating their own web apps (UI Bridge white-box), it provides rich element data for intelligent verification without fragile selectors; (2) for automating third-party desktop apps (visual GUI black-box), it provides screenshot-based element detection with LLM vision reasoning. Users should understand which mode is active and why the system chose it.",
         "elements": [
           {
-            "textContent": "Agentic Verification"
-          },
-          {
             "textContent": "Previous Attempts|iteration|approach"
           },
           {

--- a/specs/pages/unified-search/spec.uibridge.json
+++ b/specs/pages/unified-search/spec.uibridge.json
@@ -630,9 +630,6 @@
             "role": "dialog"
           },
           {
-            "textContent": "ESC"
-          },
-          {
             "role": "textbox"
           },
           {
@@ -664,29 +661,7 @@
       },
       {
         "description": "Users interact with the search via text input, form submission, and in the command palette via keyboard shortcuts. The search requires minimum 2 characters and the submit button is disabled until met.",
-        "elements": [
-          {
-            "textContent": "Search"
-          },
-          {
-            "role": "textbox"
-          },
-          {
-            "textContent": "ESC"
-          },
-          {
-            "textContent": "ESC"
-          },
-          {
-            "textContent": "ESC"
-          },
-          {
-            "role": "textbox"
-          },
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "unified-search-interaction",
         "isInitial": false,
         "name": "Search Interaction",
@@ -695,12 +670,6 @@
       {
         "description": "Search results display entity type icons with color coding, titles, snippet previews (2-line clamp), relevance scores as percentages, and a summary header with counts per entity type.",
         "elements": [
-          {
-            "textContent": "result"
-          },
-          {
-            "textContent": "%"
-          },
           {
             "textContent": "finding|fix|knowledge|error|rule|workflow"
           }

--- a/specs/pages/vga/spec.uibridge.json
+++ b/specs/pages/vga/spec.uibridge.json
@@ -1460,14 +1460,7 @@
       },
       {
         "description": "The Transitions tab renders TransitionsPanel showing the list of transitions with source/target states, action types, and runtime introspection data. When the tab opens with an active config, the runner API is queried for permitted and blocked triggers, surfacing the live state machine execution context alongside the static transition list.",
-        "elements": [
-          {
-            "role": "list"
-          },
-          {
-            "role": "list"
-          }
-        ],
+        "elements": [],
         "id": "vga-transitions-tab",
         "isInitial": false,
         "name": "Transitions Tab",

--- a/specs/pages/visual-dashboard/spec.uibridge.json
+++ b/specs/pages/visual-dashboard/spec.uibridge.json
@@ -1063,10 +1063,7 @@
         "elements": [
           {},
           {},
-          {},
-          {
-            "role": "region"
-          }
+          {}
         ],
         "id": "vd-page-structure",
         "isInitial": false,
@@ -1143,9 +1140,6 @@
           {
             "role": "button",
             "textContent": "Stop"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "vd-playback-controls",
@@ -1172,12 +1166,6 @@
         "elements": [
           {
             "textContent": "AI Conversation"
-          },
-          {
-            "role": "region"
-          },
-          {
-            "role": "button"
           },
           {
             "textContent": "Execution Timeline"

--- a/specs/pages/watchers/spec.uibridge.json
+++ b/specs/pages/watchers/spec.uibridge.json
@@ -728,10 +728,6 @@
         "elements": [
           {
             "role": "button",
-            "textContains": "New Watcher"
-          },
-          {
-            "role": "button",
             "textContains": "Cancel"
           },
           {},
@@ -747,10 +743,6 @@
           },
           {},
           {},
-          {
-            "role": "button",
-            "textContains": "Create Watcher"
-          },
           {},
           {}
         ],
@@ -812,9 +804,6 @@
           },
           {
             "textContains": "Last run: Never"
-          },
-          {
-            "textContains": "("
           }
         ],
         "id": "watchers-state-consistency",
@@ -825,9 +814,6 @@
       {
         "description": "The page automatically loads the watcher list on mount via useEffect calling list_watchers. After create/toggle/delete, the list is re-fetched. If PostgreSQL is unavailable, the list silently stays empty.",
         "elements": [
-          {
-            "textContent": "Watchers"
-          },
           {
             "role": "button",
             "textContains": "New Watcher"

--- a/specs/pages/workflow-versions/spec.uibridge.json
+++ b/specs/pages/workflow-versions/spec.uibridge.json
@@ -312,15 +312,6 @@
         "description": "Users need a timeline of workflow versions showing version numbers, what triggered each version (generation, reflection, manual edit, fix), and when it was created.",
         "elements": [
           {
-            "textContent": "Workflow Version Lineage"
-          },
-          {
-            "textContent": "v"
-          },
-          {
-            "role": "listitem"
-          },
-          {
             "textContent": ":"
           }
         ],
@@ -357,9 +348,6 @@
         "description": "When no workflow is selected or no versions exist, clear messages guide the user.",
         "elements": [
           {
-            "textContent": "Select a workflow to view version history"
-          },
-          {
             "textContent": "Loading versions..."
           },
           {
@@ -379,9 +367,6 @@
           },
           {
             "textContent": "generation|reflection|manual|fix"
-          },
-          {
-            "textContent": "Workflow Version Lineage"
           }
         ],
         "id": "workflow-versions-data-display",

--- a/specs/pages/workflows/spec.uibridge.json
+++ b/specs/pages/workflows/spec.uibridge.json
@@ -703,9 +703,6 @@
             "textContent": "New"
           },
           {
-            "textContent": "Workflows"
-          },
-          {
             "role": "button"
           }
         ],
@@ -717,9 +714,6 @@
       {
         "description": "When a workflow is loaded, the main content area displays a structured editor organized into four execution phases: Setup (environment preparation commands), Verification (checks and tests run between AI iterations), Agentic (AI prompts and instructions that drive the automation), and Completion (cleanup and finalization steps). Each phase section supports adding, removing, reordering, and configuring individual steps with type-specific editors. Users can expand and collapse phase sections to focus on the phase they are editing. The phase structure ensures workflows follow a predictable execution pattern.",
         "elements": [
-          {
-            "textContent": "Setup"
-          },
           {
             "textContent": "Verification"
           },
@@ -872,9 +866,6 @@
           },
           {
             "textContent": "Reflection"
-          },
-          {
-            "role": "button"
           }
         ],
         "id": "wf-settings-configuration",

--- a/specs/pages/wrappers/spec.uibridge.json
+++ b/specs/pages/wrappers/spec.uibridge.json
@@ -1172,12 +1172,7 @@
       },
       {
         "description": "The header includes a 36×36 cyan-tinted icon tile holding a Package icon — this matches the 'icon-tile' visual pattern established on the UI Bridge integration page.",
-        "elements": [
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          }
-        ],
+        "elements": [],
         "id": "header-icon-tile",
         "isInitial": false,
         "name": "Header Icon Tile",
@@ -1186,22 +1181,6 @@
       {
         "description": "The wrappers page has three tabs in this order: Installed (default), AI Clients, and Browse. The active tab is highlighted with a cyan underline and cyan-400 text; inactive tabs use muted-foreground.",
         "elements": [
-          {
-            "tagName": "button",
-            "textContent": "Installed"
-          },
-          {
-            "tagName": "button",
-            "textContent": "Browse"
-          },
-          {
-            "tagName": "button",
-            "textContent": "Browse"
-          },
-          {
-            "tagName": "button",
-            "textContent": "Installed"
-          },
           {
             "tagName": "button",
             "textContent": "AI Clients"
@@ -1251,18 +1230,6 @@
         "description": "When wrappers are installed, the Installed tab renders a 1- or 2-column grid (responsive on md+) of wrapper cards. Each card displays the wrapper's display name, package name + version, description (line-clamped to 2 lines), transport badge, status badge, action count, a three-dot menu for lifecycle actions, and an Open button.",
         "elements": [
           {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
-          {
             "textContains": "actions"
           },
           {
@@ -1271,10 +1238,6 @@
           {
             "tagName": "button",
             "textContent": "Open"
-          },
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
           }
         ],
         "id": "installed-tab-card-grid",
@@ -1331,14 +1294,6 @@
             "tagName": "li"
           },
           {
-            "tagName": "button",
-            "textContent": "Install"
-          },
-          {
-            "tagName": "button",
-            "textContent": "Installed"
-          },
-          {
             "textContent": "repo"
           }
         ],
@@ -1350,10 +1305,6 @@
       {
         "description": "Heading hierarchy: h1 'Wrappers' is text-2xl + font-bold + tracking-tight. Section headings (e.g., 'No wrappers installed yet') are h3 + text-sm + font-semibold. Body text is text-xs muted. Package names are font-mono.",
         "elements": [
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
           {
             "textContains": "Install wrapper extensions"
           }
@@ -1382,16 +1333,7 @@
       },
       {
         "description": "The content is constrained to a centered max-w-[1024px] container with px-4/sm:px-6 horizontal padding and py-8 vertical padding. Inside the container, a flex column with gap-4 spaces the header / tab bar / content. Wrapper cards in the Installed grid use gap-4 and switch from 1 column to 2 columns at md+.",
-        "elements": [
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          }
-        ],
+        "elements": [],
         "id": "visual-spacing-layout",
         "isInitial": false,
         "name": "Visual Design — Spacing & Layout",
@@ -1400,18 +1342,6 @@
       {
         "description": "The Installed tab is the user's window into the runner's wrapper subsystem. What the page shows MUST match what the backend reports. These assertions specify the contract between the UI and GET /wrappers / GET /wrappers/:id/status.",
         "elements": [
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
-          {
-            "tagName": "button",
-            "textContent": "Installed"
-          },
-          {
-            "role": "heading",
-            "textContent": "Wrappers"
-          },
           {
             "tagName": "button",
             "textContent": "Browse"
@@ -1481,11 +1411,7 @@
       },
       {
         "description": "Each card has a 'Details' disclosure button (chevron icon) that expands to reveal: (1) the absolute config file path under 'Config file:'; (2) for ConfigParseError state, a red 'Config error:' block with the path and the message 'Open this file and fix the JSON, or delete it to start fresh.'; (3) the JSON snippet that will be written or removed under the mcpServers key, with placeholders '<launcher path>' and '<port>' since the live values aren't fetched into the UI; (4) for Drifted state, the current (stale) command path and port shown alongside the new values that Reconnect will write. The note 'The runner fills in its own stable launcher path and current port.' is rendered below the JSON snippet.",
-        "elements": [
-          {
-            "role": "button"
-          }
-        ],
+        "elements": [],
         "id": "ai-clients-details-disclosure",
         "isInitial": false,
         "name": "AI Clients Tab — Details Disclosure",

--- a/src/specs/specs.compile.test.ts
+++ b/src/specs/specs.compile.test.ts
@@ -14,10 +14,14 @@
  * them — without it, the next regression only surfaces when someone
  * notices the SM is missing in a UI Bridge probe.
  *
- * Mechanism: walk every `*.spec.uibridge.json` in this directory, run each
- * `state.elements[]` through the SAME `convertElementCriteria` +
- * `elementQueryKey` helpers the runtime compiler uses, and assert no key
- * is shared across two states inside one spec.
+ * Mechanism: walk every `specs/pages/<page>/spec.uibridge.json` in the
+ * repo-root spec store (the corpus moved there from `src/specs/*.spec.uibridge.json`
+ * during the per-page spec reorg; this test originally walked its own
+ * directory, which has been empty of specs ever since — the discovery
+ * sanity check below is what caught it), run each `state.elements[]`
+ * through the SAME `convertElementCriteria` + `elementQueryKey` helpers
+ * the runtime compiler uses, and assert no key is shared across two
+ * states inside one spec.
  *
  * Source of truth for the canonical-form helpers is
  * `src/lib/compile-state-machine.ts` — this test imports them directly so
@@ -25,7 +29,7 @@
  * pass while the compiler still quarantines.
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, it, expect } from "vitest";
@@ -35,7 +39,9 @@ import {
 } from "../lib/compile-state-machine";
 import type { SpecConfig } from "../lib/spec-prompt-builder";
 
-const SPECS_DIR = dirname(fileURLToPath(import.meta.url));
+// Repo-root spec store: specs/pages/<page>/spec.uibridge.json. This test
+// file lives at src/specs/, so the store is two levels up.
+const PAGES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "specs", "pages");
 
 interface DuplicateReport {
   specFile: string;
@@ -85,8 +91,12 @@ function findIntraSpecDuplicates(spec: SpecConfig): Array<{
 }
 
 describe("spec files: intra-spec elementId uniqueness", () => {
-  const specFiles = readdirSync(SPECS_DIR)
-    .filter((f) => f.endsWith(".spec.uibridge.json"))
+  // One spec per page dir. Not every page dir necessarily carries a spec
+  // (e.g. specs/pages/runner-root/ holds only generated build-ir output),
+  // so filter on the file actually existing.
+  const specFiles = readdirSync(PAGES_DIR)
+    .map((page) => join(page, "spec.uibridge.json"))
+    .filter((rel) => existsSync(join(PAGES_DIR, rel)))
     .sort();
 
   // Sanity check — if this drops to zero the glob is broken and the test
@@ -102,7 +112,7 @@ describe("spec files: intra-spec elementId uniqueness", () => {
       // spec (settings-security.spec.uibridge.json) shipped with one and
       // we don't want a static-validator failure to depend on a separate
       // encoding fix.
-      let raw = readFileSync(join(SPECS_DIR, file), "utf8");
+      let raw = readFileSync(join(PAGES_DIR, file), "utf8");
       if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
       const spec = JSON.parse(raw) as SpecConfig;
       const dupes = findIntraSpecDuplicates(spec);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,20 +17,14 @@ export default defineConfig({
     },
   },
   resolve: {
-    alias: [
-      { find: "@", replacement: resolve(__dirname, "./src") },
-      {
-        find: /^@qontinui\/shared-types\/(.+)$/,
-        replacement: resolve(__dirname, "../qontinui-schemas/ts/dist/$1.js"),
-      },
-      {
-        find: "@qontinui/shared-types",
-        replacement: resolve(__dirname, "../qontinui-schemas/ts/dist/index.js"),
-      },
-      {
-        find: "@qontinui/workflow-utils",
-        replacement: resolve(__dirname, "../qontinui-workflow-utils/dist/index.js"),
-      },
-    ],
+    // @qontinui/* TS packages are consumed from npm (same as vite.config.ts —
+    // its alias block was removed when the packages moved to npm). The stale
+    // sibling-repo aliases that used to live here pointed at
+    // ../qontinui-schemas/ts/dist and ../qontinui-workflow-utils/dist, which
+    // don't exist on a fresh checkout (or any machine without those siblings
+    // built), so every test importing @qontinui/shared-types/* or
+    // @qontinui/workflow-utils failed to even load. node_modules has both
+    // packages with complete exports maps — no alias needed.
+    alias: [{ find: "@", replacement: resolve(__dirname, "./src") }],
   },
 });


### PR DESCRIPTION
## Why
Nothing in CI ran the frontend vitest suite (`ci.yml` runs lint/typecheck/build/cargo only) — so frontend-logic regressions merged green and rotted on `main`. Investigation of "pre-existing test failures" surfaced during the ui-bridge 0.14 bump (#364) found the suite red in three independent ways, one of which was masking **74 live quarantined page specs**.

## Fixes (dependency order)
1. **Bump `@qontinui/ui-bridge-auto` `^0.1.6`→`^0.1.7`.** 0.1.6's `regression-generator.ts:359/:380` read `state?.requiredElements.length` — a field that doesn't exist on `IRState` (the IR carries `assertions`) — so `generateRegressionSuite` threw `undefined.length` for **every** IR. Fixed upstream in 0.1.7. Unbreaks 8 tests (`regression-executor`, `CoveragePanel`).
2. **Remove stale sibling-repo aliases from `vitest.config.ts`.** They pointed `@qontinui/shared-types[/*]` / `@qontinui/workflow-utils` at `../qontinui-schemas/ts/dist` and `../qontinui-workflow-utils/dist` — absent on any fresh checkout — so two suites failed to load. `vite.config.ts` dropped its alias block when these packages moved to npm; `vitest.config.ts` was missed. Both npm packages have complete exports maps.
3. **Repoint `specs.compile.test.ts` at the real corpus.** It walked `*.spec.uibridge.json` in `src/specs/` — empty since the corpus moved to `specs/pages/<page>/spec.uibridge.json`. The guard has validated zero files since the reorg.
4. **Dedup 273 intra-spec element keys across 74 spec files** that the repointed guard immediately caught. The runtime SM compiler **quarantines** specs with cross-state duplicate element keys — those 74 pages have had no `window.__UI_BRIDGE__.stateMachine`. Rule per the `2d2430bfa` precedent: keep each duplicated key in the most discriminating claimer (fewest elements; never empty a state when avoidable). 9 degenerate keys (≥2 states sharing the key as their *only* element — mutually indistinguishable states) kept in the first claimer with the rest emptied (`elements: []` compiles cleanly; strictly better than whole-spec quarantine). Flagged for spec-quality follow-up: `action-plan`, `automation-health`, `cross-run-analytics`, `dag-workflow-editor`, `llm-analytics-ui-bridge`, `pipeline-events`, `vga`, `wrappers`.

## Gate
`ci.yml` gains **Run frontend unit tests** (`pnpm test`) after typecheck, before the vite build. This PR's own CI proves it: full suite **53 files, 677/677 green** locally on a fresh worktree (same conditions as CI).