### PR TITLE
fix(runner): avoid runtime-drop panic in OAuth refresh blocking client

### DIFF
--- a/src-tauri/src/ai_provider/oauth_refresh.rs
+++ b/src-tauri/src/ai_provider/oauth_refresh.rs
@@ -70,35 +70,50 @@ pub(crate) fn try_refresh_credentials(creds_path: &Path) -> Option<String> {
 
     // The token endpoint requires JSON body (not form-encoded) and a Node-like
     // User-Agent to pass Cloudflare's bot detection on platform.claude.com.
-    let client = reqwest::blocking::Client::new();
-    let response = match client
-        .post(TOKEN_URL)
-        .header("Content-Type", "application/json")
-        .header("User-Agent", "node/22.13.1")
-        .header("Accept", "application/json, text/plain, */*")
-        .json(&serde_json::json!({
-            "grant_type": "refresh_token",
-            "refresh_token": refresh_token,
-            "client_id": CLIENT_ID,
-            "scope": scope_str,
-        }))
-        .send()
-    {
-        Ok(r) => r,
+    //
+    // Run the blocking HTTP call on a dedicated OS thread so that
+    // `reqwest::blocking::Client`'s internal tokio runtime is created and
+    // dropped outside any existing async runtime context. Without this,
+    // dropping the client inside `tokio::task::spawn_blocking` panics with
+    // "Cannot drop a runtime in a context where blocking is not allowed".
+    let request_body = serde_json::json!({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": CLIENT_ID,
+        "scope": scope_str,
+    });
+    let http_result: Result<(bool, u16, String), String> = std::thread::spawn(move || {
+        let client = reqwest::blocking::Client::new();
+        let response = client
+            .post(TOKEN_URL)
+            .header("Content-Type", "application/json")
+            .header("User-Agent", "node/22.13.1")
+            .header("Accept", "application/json, text/plain, */*")
+            .json(&request_body)
+            .send()
+            .map_err(|e| format!("{e}"))?;
+        let status = response.status();
+        let body = response.text().unwrap_or_default();
+        Ok((status.is_success(), status.as_u16(), body))
+    })
+    .join()
+    .map_err(|_| "OAuth refresh thread panicked".to_string())
+    .and_then(|r| r);
+
+    let (success, status_code, body) = match http_result {
+        Ok(t) => t,
         Err(e) => {
             warn!("OAuth refresh: request failed: {}", e);
             return None;
         }
     };
 
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().unwrap_or_default();
-        warn!("OAuth refresh: server returned {}: {}", status, body);
+    if !success {
+        warn!("OAuth refresh: server returned {}: {}", status_code, body);
         return None;
     }
 
-    let token_response: serde_json::Value = match response.json() {
+    let token_response: serde_json::Value = match serde_json::from_str(&body) {
         Ok(v) => v,
         Err(e) => {
             warn!("OAuth refresh: response parse failed: {}", e);


### PR DESCRIPTION
## Summary

`reqwest::blocking::Client::new()` instantiates an internal tokio current-thread runtime. When `try_refresh_credentials` is called from inside `tokio::task::spawn_blocking` (or any other async-runtime context), dropping the blocking client panics with:

> "Cannot drop a runtime in a context where blocking is not allowed"

because the inner runtime tries to perform a blocking drop while the outer runtime forbids it. The OAuth refresh path silently aborted via panic instead of returning a usable token — the Claude CLI account would appear non-refreshable until the next manual sign-in.

## Fix

Move the entire blocking HTTP call onto a dedicated OS thread via `std::thread::spawn(...).join()`. The client and its runtime now live and die outside any tokio context, so the drop is unconditionally safe. Response state (success flag, status code, body) is marshalled back as plain data; JSON parsing happens on the caller thread.

No behavior change for callers — same `Option<String>` return shape, same warn-log messages on each failure mode.

## Provenance

Surfaced from a working-tree stash during `/pull-all`. The original authoring session never opened this as a PR; the fix has been sitting uncommitted alongside #307's hostname work. See sibling PR #385 for the related #307 re-apply.

## Test plan
- [ ] CI green
- [ ] Trigger an OAuth refresh from inside the warm-emit path (which runs on `spawn_blocking`) and confirm no panic in the runner log