### PR TITLE
feat(claims): session-scoped owner token for the agent-worktree spawn flow

### DIFF
--- a/src-tauri/src/agent_claims/mod.rs
+++ b/src-tauri/src/agent_claims/mod.rs
@@ -112,6 +112,7 @@ pub fn register_active_claim(
     let handle = spawn_heartbeat_task(
         coord_http_base,
         machine_id,
+        claim.agent_session_id,
         &kind,
         resource_key.clone(),
         ttl_seconds,
@@ -158,12 +159,20 @@ pub async fn release_for_agent(agent_id: &str) {
     };
     let coord_http_base = h.coord_http_base.clone();
     let machine_id = h.machine_id;
+    let agent_session_id = h.agent_session_id;
     let kind = h.kind.clone();
     let resource_key = h.resource_key.clone();
     // Drop the handle to cancel the heartbeat task.
     drop(h);
     // Then call /claims/release. Best-effort.
-    release_claim_best_effort(&coord_http_base, machine_id, &kind, &resource_key).await;
+    release_claim_best_effort(
+        &coord_http_base,
+        machine_id,
+        agent_session_id,
+        &kind,
+        &resource_key,
+    )
+    .await;
     info!(
         "agent_claims: released agent_id={} kind={} key={}",
         agent_id, kind, resource_key

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -91,7 +91,14 @@ impl Drop for IsolatedEditContext {
             let base = self.coord_http_base.clone();
             let mid = self.device_id;
             tokio::spawn(async move {
-                release_claim_best_effort(&base, mid, &claim.kind, &claim.resource_key).await;
+                release_claim_best_effort(
+                    &base,
+                    mid,
+                    claim.agent_session_id,
+                    &claim.kind,
+                    &claim.resource_key,
+                )
+                .await;
             });
         }
     }
@@ -114,6 +121,8 @@ pub struct AcquireRequest<'a> {
     /// precedence rules.
     pub plan_id: Option<&'a str>,
     pub phase: Option<&'a str>,
+    /// coord-assigned per-agent session id, folded into the claim owner token.
+    pub agent_session_id: Option<uuid::Uuid>,
 }
 
 /// Allocate isolated worktrees for the given repos.
@@ -164,6 +173,7 @@ pub async fn acquire(
     let outcome = allocate_and_materialize_with_claim(
         &coord_http_base,
         &device_id,
+        req.agent_session_id,
         &repo_reqs,
         req.intent,
         req.declared_overlap_paths,
@@ -223,6 +233,7 @@ pub async fn acquire(
         spawn_heartbeat_task(
             coord_http_base.clone(),
             device_id,
+            claim.agent_session_id,
             &claim.kind,
             claim.resource_key.clone(),
             claim.ttl_seconds,
@@ -280,6 +291,7 @@ pub async fn acquire_for_terminal(
         declared_overlap_paths: None,
         plan_id: None,
         phase: None,
+        agent_session_id: None,
     })
     .await
     {
@@ -360,6 +372,7 @@ mod tests {
                 declared_overlap_paths: None,
                 plan_id: None,
                 phase: None,
+                agent_session_id: None,
             })
             .await
             .expect("flag-off should return Ok(None), not Err");

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -168,6 +168,7 @@ enum AcquireOutcome {
 async fn pre_allocate_claim(
     coord_http_base: &str,
     machine_id: &uuid::Uuid,
+    agent_session_id: Option<uuid::Uuid>,
     ctx: &ClaimSpawnContext,
 ) -> Result<AcquireOutcome, String> {
     let url = format!("{}/claims/acquire", coord_http_base.trim_end_matches('/'));
@@ -185,6 +186,7 @@ async fn pre_allocate_claim(
         "kind": ctx.kind,
         "resource_key": ctx.resource_key,
         "machine_id": machine_id.to_string(),
+        "agent_session_id": agent_session_id,
         "metadata": metadata,
     });
 
@@ -267,6 +269,8 @@ pub struct ClaimHeartbeatHandle {
     pub resource_key: String,
     pub machine_id: uuid::Uuid,
     pub coord_http_base: String,
+    /// Same value carried so the release POST matches the acquire's owner token.
+    pub agent_session_id: Option<uuid::Uuid>,
 }
 
 impl Drop for ClaimHeartbeatHandle {
@@ -286,6 +290,7 @@ impl Drop for ClaimHeartbeatHandle {
 pub fn spawn_heartbeat_task<F>(
     coord_http_base: String,
     machine_id: uuid::Uuid,
+    agent_session_id: Option<uuid::Uuid>,
     kind: &str,
     resource_key: String,
     ttl_seconds: i64,
@@ -318,7 +323,15 @@ where
                     return;
                 }
             }
-            match heartbeat_once(&base_clone, machine_id, &kind_owned, &resource_clone).await {
+            match heartbeat_once(
+                &base_clone,
+                machine_id,
+                agent_session_id,
+                &kind_owned,
+                &resource_clone,
+            )
+            .await
+            {
                 Ok(HeartbeatTickOutcome::Ok) => {}
                 Ok(HeartbeatTickOutcome::Stolen { current_holder }) => {
                     warn!(
@@ -344,6 +357,7 @@ where
         resource_key,
         machine_id,
         coord_http_base,
+        agent_session_id,
     }
 }
 
@@ -355,6 +369,7 @@ enum HeartbeatTickOutcome {
 async fn heartbeat_once(
     coord_http_base: &str,
     machine_id: uuid::Uuid,
+    agent_session_id: Option<uuid::Uuid>,
     kind: &str,
     resource_key: &str,
 ) -> Result<HeartbeatTickOutcome, String> {
@@ -363,6 +378,7 @@ async fn heartbeat_once(
         "kind": kind,
         "resource_key": resource_key,
         "machine_id": machine_id.to_string(),
+        "agent_session_id": agent_session_id,
         "metadata": {},
     });
     let client = reqwest::Client::builder()
@@ -405,6 +421,7 @@ async fn heartbeat_once(
 pub async fn release_claim_best_effort(
     coord_http_base: &str,
     machine_id: uuid::Uuid,
+    agent_session_id: Option<uuid::Uuid>,
     kind: &str,
     resource_key: &str,
 ) {
@@ -413,6 +430,7 @@ pub async fn release_claim_best_effort(
         "kind": kind,
         "resource_key": resource_key,
         "machine_id": machine_id.to_string(),
+        "agent_session_id": agent_session_id,
         "metadata": {},
     });
     let client = match reqwest::Client::builder()
@@ -522,6 +540,11 @@ pub struct ActiveClaim {
     pub kind: String,
     pub resource_key: String,
     pub ttl_seconds: i64,
+    /// coord-assigned per-agent session id; folded into the claim owner
+    /// token so two agents on one machine are distinct holders. Sent
+    /// identically on acquire/heartbeat/release. Plan
+    /// 2026-06-03-coord-session-scoped-claim-owner follow-up.
+    pub agent_session_id: Option<uuid::Uuid>,
 }
 
 // =============================================================================
@@ -775,6 +798,7 @@ pub async fn allocate_and_materialize(
     allocate_and_materialize_with_claim(
         coord_http_base,
         machine_id,
+        None,
         repos,
         intent,
         declared_overlap_paths,
@@ -792,6 +816,7 @@ pub async fn allocate_and_materialize(
 pub async fn allocate_and_materialize_with_claim(
     coord_http_base: &str,
     machine_id: &uuid::Uuid,
+    agent_session_id: Option<uuid::Uuid>,
     repos: &[RepoRequest],
     intent: Option<&str>,
     declared_overlap_paths: Option<&[String]>,
@@ -815,7 +840,7 @@ pub async fn allocate_and_materialize_with_claim(
     let claim_ctx =
         ClaimSpawnContext::from_intent_and_paths(intent, plan_id, phase, declared_overlap_paths);
     let active_claim = if let Some(ref ctx) = claim_ctx {
-        match pre_allocate_claim(coord_http_base, machine_id, ctx).await {
+        match pre_allocate_claim(coord_http_base, machine_id, agent_session_id, ctx).await {
             Ok(AcquireOutcome::Acquired { ttl_seconds }) => {
                 info!(
                     "claims/acquire ok kind={} key={} ttl={}s",
@@ -825,6 +850,7 @@ pub async fn allocate_and_materialize_with_claim(
                     kind: ctx.kind.to_string(),
                     resource_key: ctx.resource_key.clone(),
                     ttl_seconds,
+                    agent_session_id,
                 })
             }
             Ok(AcquireOutcome::Held(conflict)) => {
@@ -926,6 +952,7 @@ pub async fn allocate_and_materialize_with_claim(
             release_claim_best_effort(
                 coord_http_base,
                 *machine_id,
+                claim.agent_session_id,
                 &claim.kind,
                 &claim.resource_key,
             )

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -70,6 +70,11 @@ pub struct AllocateLocalRequest {
     /// falls back to `FileGlob`; otherwise no pre-flight claim.
     #[serde(default)]
     pub phase: Option<String>,
+    /// coord-assigned per-agent session id; folded into the
+    /// phase/worktree claim owner token so two agents on one machine are
+    /// distinct holders. Threaded onto acquire/heartbeat/release.
+    #[serde(default)]
+    pub agent_session_id: Option<uuid::Uuid>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -137,6 +142,7 @@ pub async fn post_allocate_local(
     match allocate_and_materialize_with_claim(
         &coord_http_base,
         &machine_id,
+        req.agent_session_id,
         &repo_reqs,
         req.intent.as_deref(),
         req.declared_overlap_paths.as_deref(),


### PR DESCRIPTION
Follow-up #1 from plan `2026-06-03-coord-session-scoped-claim-owner`. Extends coord's session-scoped owner token to the **live** runner spawn path (`agent_worktree`), which the shipped work left on the bare-machine `None` fallback.

Each spawned agent already carries a coord-assigned `agent_session_id` (in the `events.agent.spawn_requested` payload), stable per-agent and across retries — so it's the correct owner-token session component (no per-spawn-mint idempotency hazard). Two agents on one machine claiming the same phase/worktree are now distinct holders: the second gets `Held` instead of silently renewing the first's claim.

**The invariant** (same id on acquire/heartbeat/release) is enforced structurally by storing `agent_session_id: Option<Uuid>` on `ActiveClaim` (acquire-time) and `ClaimHeartbeatHandle` (heartbeat + release-time):
- `pre_allocate_claim` / `heartbeat_once` / `release_claim_best_effort` add it to their request bodies; `spawn_heartbeat_task` carries it to the handle.
- `allocate_and_materialize_with_claim` stamps it onto `ActiveClaim`; `register_active_claim` + `release_for_agent` propagate it.
- `AllocateLocalRequest` (`/agents/allocate-local`) + isolated_edit `AcquireRequest` gain the field so callers supply the dispatch's id.

`None` preserves legacy behavior. Verified locally: `cargo check --bin qontinui-runner --features custom-protocol` finishes clean (exit 0); `cargo fmt` clean. Pre-push cargo gate skipped (sanctioned `QONTINUI_PREPUSH_SKIP`, redundant cold rebuild) — CI runs the identical fmt+clippy gate.