### PR TITLE
feat(runner): observability + URL-resolution improvements in backend relay

### DIFF
--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -112,13 +112,25 @@ pub(crate) fn should_relay_idle_with(
 pub(crate) fn should_relay_idle(settings: &crate::settings::Settings) -> bool {
     let has_device_jwt = match crate::auth::AuthManager::new().get_access_token() {
         Ok(t) => !t.trim().is_empty(),
-        Err(_) => false,
+        Err(e) => {
+            tracing::debug!(error = %e, "relay idle check: get_access_token failed");
+            false
+        }
     };
-    should_relay_idle_with(
+    let idle = should_relay_idle_with(
         settings.tier,
         settings.web_integration.enabled,
         has_device_jwt,
-    )
+    );
+    if idle {
+        tracing::info!(
+            tier = ?settings.tier,
+            enabled = settings.web_integration.enabled,
+            has_device_jwt,
+            "backend_relay: idling (gate unmet)"
+        );
+    }
+    idle
 }
 
 /// Diagnostic snapshot of the relay's idle-gating inputs + live connection
@@ -382,11 +394,7 @@ async fn relay_loop(
             }
         }
 
-        let backend_url = web_integration
-            .backend_url
-            .trim()
-            .trim_end_matches('/')
-            .to_string();
+        let backend_url = crate::api_config::get_api_base_url();
 
         let ws_url = format!(
             "{}/api/v1/devices/ws",
@@ -1265,7 +1273,11 @@ async fn handle_relay_command(
         }
 
         _ => {
-            warn!("Unknown relay command type: {}", msg_type);
+            warn!(
+                msg_type,
+                body = %serde_json::to_string(&data).unwrap_or_default(),
+                "Unknown relay command type"
+            );
             None
         }
     }


### PR DESCRIPTION
## Summary

Three small independent improvements to `backend_relay.rs`:

1. **Idle-gate logging.** `should_relay_idle` now logs at `info!` with structured fields (`tier`, `enabled`, `has_device_jwt`) whenever the relay decides to idle. The `get_access_token` error arm also logs at `debug!` instead of silently swallowing. Currently the only signal that the relay isn't connecting is the *absence* of subsequent log lines — this surfaces the gate inputs so a reader can see *why*.

2. **Single source of truth for backend URL.** Switch the relay loop's `backend_url` from a raw `web_integration.backend_url.trim()` to `crate::api_config::get_api_base_url()`. The `api_config` helper already encapsulates env-override + trim + normalization; reading the field directly was bypassing that.

3. **Better unknown-relay-command warn.** Include the message body in the structured log so diagnosing a contract drift between backend and runner doesn't require guessing what payload arrived.

## Behavior change

No change for the happy path. The `api_config` switch **does** flow env-var overrides (e.g. `QONTINUI_WEB_BASE`) into the relay's WS URL where previously they were ignored, which matches existing intent elsewhere in the runner — and matches `feedback_runner_pairing_procedure` (the override is already used to redirect runner→backend calls during local dev).

## Provenance

Surfaced from a working-tree stash during `/pull-all`. The original authoring session never opened this as a PR. Sibling PRs from the same stash: #385 (re-apply of #307 — hostname canonicalization, WS 401), #386 (OAuth refresh panic fix).

A fourth hunk in the original WIP — switching `register_runner_capabilities`'s hostname call to `crate::fleet::canonical_hostname()` — was deliberately omitted from this PR because `canonical_hostname` only exists once #385 lands. That hunk is already included in #385's diff for the same file; it does not need to be re-applied here.

## Test plan
- [ ] CI green
- [ ] Manually trigger an idle-gate transition (e.g. disable tier) and confirm structured log line appears
- [ ] Set `QONTINUI_WEB_BASE` to a non-default value and confirm the relay's WS URL picks it up