### PR TITLE
feat(runner): deserialize tenant_id on ApiUserInfo from /users/me

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -114,6 +114,8 @@ struct ApiUserInfo {
     full_name: Option<String>,
     is_verified: bool,
     is_active: bool,
+    #[serde(default)]
+    tenant_id: Option<String>,
 }
 
 /// Gets the current platform name


### PR DESCRIPTION
## Summary

`/api/v1/auth/users/me` started returning `tenant_id` once unified identity Phase 5 (#321) landed on the backend, but the runner's `ApiUserInfo` struct (the local DTO for `UserRead`) silently dropped the field on deserialization. Anywhere the runner uses the result of that endpoint to surface or persist tenant state, the value was a no-op.

Add `tenant_id: Option<String>` with `#[serde(default)]` so the field flows through. Option-typed + serde-default keeps the change backwards-compatible against backends that haven't been upgraded.

## Scope

One file, two lines. No call-site consumes `tenant_id` from `ApiUserInfo` yet — this PR just stops the field from being thrown away at the deserialization boundary, so future work can read it. (The session-handoff path already resolves `tenant_id` through coord's device-JWT claim; this is the second leg, for the chat/user side.)

## Provenance

Surfaced from a working-tree stash during `/pull-all`. Sibling PRs from the same stash: #385 (re-apply of #307 — hostname canonicalization, WS 401), #386 (OAuth refresh panic fix), #388 (backend_relay observability + URL helper).

The original stash also added `tenant_id` to `LoginResponse` and threaded it through `login_impl_inner`, but #321 has already added `tenant_id` to `LoginResponse` upstream, so those hunks are dropped from this PR.

## Test plan
- [ ] CI green
- [ ] Inspect with `cargo test commands::auth` (no behavior tests touched; serde derive is the contract)