### PR TITLE
feat(code-semantics): cargo/mypy Ξ_Type typecheck parity (Phase A of edit-effect-subspace-verifiers)

### DIFF
--- a/src-tauri/src/mcp/code_semantics/CONTRACT.md
+++ b/src-tauri/src/mcp/code_semantics/CONTRACT.md
@@ -45,10 +45,38 @@ the code_graph fallback).
   `{"references": [ {"file","line","col","kind": "call|import|impl|reference|definition"} ]}`
 
 - `typecheck {"file": "<abs>", "overlay_patch?": {"file": "<abs>", "new_text": "<str>"}}` →
-  `{"ok": <bool>, "errors": [ {"file","line","col","code": <int>, "message"} ], "overlay": <bool>,
+  `{"ok": <bool>, "errors": [ {"file","line","col","code": <int|str|null>, "message"} ], "overlay": <bool>,
+    "coverage": <float>,
     "changed_signatures": [ {"name","before_hash","after_hash"} ],
     "removed_symbols": [ {"name","kind","referenced_by": [ {"file","line"} ]} ] }`
-  With `overlay_patch`: apply `new_text` for `overlay_patch.file` **in-memory only**
+
+  **Language dispatch (Phase A).** `typecheck` dispatches by the target file's
+  extension to one of three checkers; the result shape above is uniform across all
+  three (the `code` field typing differs — see below):
+  - **TypeScript / JavaScript** (default, any non-`.rs`/`.py`/`.pyi` file) → the TS
+    **Language Service** with a **true in-memory overlay** (this §A stdio command).
+    `code` is the numeric TS diagnostic code (`<int>`).
+  - **Python** (`.py`/`.pyi`) → **`mypy`**. Post-write observe runs mypy on the
+    on-disk file; predict (`overlay_patch`) uses **`mypy --shadow-file`** — a TRUE
+    overlay, the real file is never modified. `code` is the bracketed mypy error
+    code **string** (e.g. `"assignment"`, `"name-defined"`), or `null`. Only
+    `error:`-severity lines count into `errors[]` (`note:`/`warning:` ignored). Both
+    paths report `coverage: 1.0` / provenance `mypy`.
+  - **Rust** (`.rs`) → **`cargo check --message-format=json`**. Post-write observe is
+    full fidelity (`coverage: 1.0` / provenance `cargo-check`); `code` is the rustc
+    code string (e.g. `"E0308"`) or `null`. Predict (`overlay_patch`) has **no
+    in-memory overlay** (a write-then-restore mutation window in a live working tree
+    is unacceptable), so it returns a **syntactic-only** prediction of changed/removed
+    `pub` items with `errors: []`, `overlay: true`, and **`coverage: 0.5`** /
+    provenance `cargo-syntactic`. The honest coverage<1 routes coord's
+    `classify_edit_outcome` to **Partial** rather than asserting a clean predict.
+
+  The §A `coverage` field mirrors the envelope's `coverage` (§C); coord's
+  `EditPrediction::from_typecheck_result` reads coverage from the **result body**
+  (defaulting 0.0 when absent), so all three checkers include it in the body and the
+  TS dispatch lifts the envelope coverage into the body if absent.
+
+  With `overlay_patch` (TS): apply `new_text` for `overlay_patch.file` **in-memory only**
   (never write disk), recompute diagnostics for `file`, then clear the overlay. This is
   D3 `predict-effect`. `changed_signatures`/`removed_symbols` compare the overlaid
   file's exported symbol set against the on-disk version (2b). `removed_symbols`
@@ -66,11 +94,17 @@ TS frontend). v1 supports the single default TS scope but the code is structured
 a scope registry (map scope → helper child).
 
 - `GET  /code-semantics/health` →
-  `{"status": "ok", "scopes": [ {"scope","language","indexed","file_count","provenance"} ]}`
+  `{"status": "ok", "scopes": [ {"scope","language","indexed","file_count","provenance"} ],
+    "engines": [ {"language": "rust"|"python", "available": <bool>} ]}`
+  The `scopes[]` entries are the per-scope TS index state (unchanged). The new
+  `engines[]` array reports Phase-A *engine* availability for the Rust (`cargo
+  check`) and Python (`mypy`) typecheck dispatchers (not per-scope index state).
 - `POST /code-semantics/symbol-lookup`  body `{"scope?","file?","name","kind?"}`
 - `POST /code-semantics/signature`      body `{"scope?","file","name?","kind?","line?","col?"}`
 - `POST /code-semantics/find-references` body `{"scope?","file","name?","line?","col?","cross_repo?": false}`
 - `POST /code-semantics/typecheck`      body `{"scope?","file","overlay_patch?": {"file","new_text"}}`
+  — dispatches by `file` extension (§A): `.rs` → `cargo check`, `.py`/`.pyi` → `mypy`,
+  else the TS Language Service.
 
 ### Cold-index / coverage (D4) — load-bearing
 
@@ -88,6 +122,20 @@ a scope registry (map scope → helper child).
   (symbol-lookup) / `coverage=0` `provenance="engine_unavailable"` (resolution queries).
   Never 500 on a missing engine.
 
+#### Rust / Python typecheck dispatch (Phase A) — same honest posture
+
+- **Rust** (`.rs`): `cargo`/manifest unavailable → `engine_unavailable` (coverage 0,
+  never a fabricated clean). Observe (no overlay) → real `cargo check` → coverage 1.0,
+  `provenance="cargo-check"`, `credibility=(high,high,high)`. A nonzero cargo exit
+  **with** parsed error diagnostics is a valid "observed errors" result; a nonzero exit
+  with **no** diagnostics (bad manifest / toolchain) → `engine_unavailable`. Predict
+  (overlay) → syntactic-only, `errors:[]`, `overlay:true`, **coverage 0.5**,
+  `provenance="cargo-syntactic"`, boundary `medium`.
+- **Python** (`.py`/`.pyi`): `mypy` unavailable → `engine_unavailable`. Observe / predict
+  → `mypy` (predict via `--shadow-file`, true overlay) → coverage 1.0,
+  `provenance="mypy"`, `credibility=(high,high,high)`. `mypy` exit ≥2 (crash) →
+  `engine_unavailable`, never a fabricated clean; exit 0/1 are clean/has-errors.
+
 ---
 
 ## C. Uniform observation envelope (both sidecar HTTP responses and coord MCP output)
@@ -99,7 +147,7 @@ a scope registry (map scope → helper child).
   "result": { ...query-specific payload (the §A result body, lifted) ... },
   "posterior": 1.0,
   "coverage": 1.0,
-  "provenance": "ts-language-service|code_graph_fallback|indexing|engine_unavailable",
+  "provenance": "ts-language-service|code_graph_fallback|code_graph_resolved|indexing|engine_unavailable|mypy|cargo-check|cargo-syntactic",
   "credibility": { "causal": "high", "authorial": "high", "boundary": "high" },
   "staleness_seconds": null,
   "kernel": false
@@ -117,6 +165,13 @@ a scope registry (map scope → helper child).
   resolver) is boundary **`medium`**; the LSP `ts-language-service` is boundary
   **`high`**. Reserving `medium` for the resolved tier keeps the low/medium/high
   triple unambiguously orderable across all three observers.
+- **Phase-A typecheck provenances** slot onto the same ladder: `mypy` and
+  `cargo-check` are full-fidelity type-checker observations → boundary **`high`** /
+  coverage 1.0 (peers of `ts-language-service`). `cargo-syntactic` (the Rust
+  overlay-predict fallback, no compile) sits at boundary **`medium`** / coverage 0.5,
+  alongside `code_graph_resolved` — above raw syntactic, below a real type-check — so
+  coord's `classify_edit_outcome` honestly routes a Rust predict to **Partial** rather
+  than asserting a clean answer it never compiled.
 
 ---
 

--- a/src-tauri/src/mcp/code_semantics/cargo_check.rs
+++ b/src-tauri/src/mcp/code_semantics/cargo_check.rs
@@ -1,0 +1,627 @@
+//! Rust `cargo check` checker for the code-semantics `typecheck` surface (Phase A).
+//!
+//! Posture (decided in the plan, for robustness):
+//!   - **No write-then-restore overlay.** A minutes-long mutation window in a live
+//!     working tree is unacceptable, so the predict (overlay) path does NOT mutate
+//!     the tree. Instead:
+//!       - post-write **observe** (no `overlay_patch`) → real `cargo check
+//!         --message-format=json`, full fidelity → `coverage: 1.0`, provenance
+//!         `cargo-check`.
+//!       - **predict** (with `overlay_patch`) → a SYNTACTIC-only prediction of
+//!         changed/removed `pub` items (no compile runs) → `coverage: 0.5`,
+//!         provenance `cargo-syntactic`, boundary `medium`. The honest coverage<1
+//!         makes coord's `classify_edit_outcome` route to **Partial** rather than
+//!         asserting a clean predict — that is the designed behavior.
+//!
+//! `cargo check` runs with an isolated `CARGO_TARGET_DIR` under
+//! `temp_dir()/qontinui-cargo-typecheck/<hash-of-manifest>` so repeated calls reuse
+//! incremental state but never clobber the project's own `target/`.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use tokio::process::Command;
+
+use super::lang::nearest_cargo_manifest;
+use super::syntactic::{self, sig_hash, Decl};
+use super::{Credibility, Envelope, PROV_CARGO, PROV_CARGO_SYNTACTIC};
+
+/// Cached `cargo --version` availability probe.
+static CARGO_AVAILABLE: Lazy<Result<(), String>> = Lazy::new(probe_cargo);
+
+/// Is a `cargo` toolchain available (cached probe)? Used by the health endpoint.
+pub fn is_available() -> bool {
+    CARGO_AVAILABLE.is_ok()
+}
+
+fn probe_cargo() -> Result<(), String> {
+    match std::process::Command::new("cargo")
+        .arg("--version")
+        .output()
+    {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => Err(format!(
+            "cargo --version exited {}",
+            out.status.code().unwrap_or(-1)
+        )),
+        Err(e) => Err(format!("cargo not found: {e}")),
+    }
+}
+
+/// A parsed cargo error diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CargoError {
+    file: String,
+    line: u32,
+    col: u32,
+    code: Option<String>,
+    message: String,
+}
+
+/// Parse `cargo check --message-format=json` stdout (one JSON object per line).
+/// Collects `compiler-message` diagnostics with `message.level == "error"`,
+/// reading the first primary span. `crate_dir` is used to keep only errors whose
+/// file resolves within the crate (relative paths are resolved against it).
+fn parse_cargo_json(stdout: &str, crate_dir: &Path) -> Vec<CargoError> {
+    let mut errors = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() || !line.starts_with('{') {
+            continue;
+        }
+        let v: Value = match serde_json::from_str(line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        if v.get("reason").and_then(|r| r.as_str()) != Some("compiler-message") {
+            continue;
+        }
+        let msg = match v.get("message") {
+            Some(m) => m,
+            None => continue,
+        };
+        if msg.get("level").and_then(|l| l.as_str()) != Some("error") {
+            continue;
+        }
+        if let Some(e) = parse_compiler_message(msg, crate_dir) {
+            errors.push(e);
+        }
+    }
+    errors
+}
+
+/// Extract a `CargoError` from a single `message` object (the first primary span).
+fn parse_compiler_message(msg: &Value, crate_dir: &Path) -> Option<CargoError> {
+    let text = msg
+        .get("message")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
+    let code = msg
+        .get("code")
+        .and_then(|c| c.get("code"))
+        .and_then(|c| c.as_str())
+        .map(|s| s.to_string());
+
+    let spans = msg.get("spans").and_then(|s| s.as_array());
+    let primary = spans.and_then(|arr| {
+        arr.iter()
+            .find(|s| s.get("is_primary").and_then(|p| p.as_bool()) == Some(true))
+    });
+
+    // A diagnostic with no primary span (e.g. a crate-level error) still counts,
+    // but we can only attribute file/line when a span exists.
+    let (file, line, col) = match primary {
+        Some(span) => {
+            let file = span
+                .get("file_name")
+                .and_then(|f| f.as_str())
+                .unwrap_or("")
+                .to_string();
+            // Filter to spans inside the crate.
+            if !file_in_crate(&file, crate_dir) {
+                return None;
+            }
+            let line = span.get("line_start").and_then(|l| l.as_u64()).unwrap_or(0) as u32;
+            let col = span
+                .get("column_start")
+                .and_then(|c| c.as_u64())
+                .unwrap_or(0) as u32;
+            (file, line, col)
+        }
+        None => return None,
+    };
+
+    Some(CargoError {
+        file,
+        line,
+        col,
+        code,
+        message: text,
+    })
+}
+
+/// True if `file` (relative or absolute, as cargo reports it) resolves within the
+/// crate directory. Cargo reports paths relative to the manifest dir.
+fn file_in_crate(file: &str, crate_dir: &Path) -> bool {
+    let p = Path::new(file);
+    let resolved = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        crate_dir.join(p)
+    };
+    // Canonicalize both when possible; fall back to a prefix check.
+    match (resolved.canonicalize(), crate_dir.canonicalize()) {
+        (Ok(r), Ok(c)) => r.starts_with(c),
+        _ => resolved.starts_with(crate_dir),
+    }
+}
+
+fn errors_json(errors: &[CargoError]) -> Vec<Value> {
+    errors
+        .iter()
+        .map(|e| {
+            json!({
+                "file": e.file,
+                "line": e.line,
+                "col": e.col,
+                "code": e.code,
+                "message": e.message,
+            })
+        })
+        .collect()
+}
+
+/// Per-manifest isolated target dir under temp_dir so repeated calls reuse
+/// incremental state without clobbering the project's `target/`.
+fn isolated_target_dir(manifest: &Path) -> std::path::PathBuf {
+    let key = sig_hash(&manifest.to_string_lossy());
+    std::env::temp_dir()
+        .join("qontinui-cargo-typecheck")
+        .join(key)
+}
+
+/// Warm `cargo-check` envelope (observe path), lifting coverage into the body.
+fn warm_envelope(result: Value) -> Envelope {
+    Envelope {
+        observer: "code_semantics".into(),
+        query: "typecheck".into(),
+        result,
+        posterior: 1.0,
+        coverage: 1.0,
+        provenance: PROV_CARGO.into(),
+        credibility: Credibility::high(),
+        staleness_seconds: None,
+        kernel: false,
+    }
+}
+
+/// Syntactic-predict envelope (overlay path): coverage 0.5, boundary medium.
+fn syntactic_envelope(result: Value) -> Envelope {
+    Envelope {
+        observer: "code_semantics".into(),
+        query: "typecheck".into(),
+        result,
+        posterior: 0.5,
+        coverage: 0.5,
+        provenance: PROV_CARGO_SYNTACTIC.into(),
+        credibility: Credibility::fallback(),
+        staleness_seconds: None,
+        kernel: false,
+    }
+}
+
+/// Public entrypoint: typecheck a Rust `file`, optionally with an `overlay_patch`.
+pub async fn typecheck(file: &Path, overlay_patch: Option<Value>) -> Envelope {
+    if let Err(reason) = &*CARGO_AVAILABLE {
+        return Envelope::unavailable("typecheck", reason);
+    }
+    let manifest = match nearest_cargo_manifest(file) {
+        Some(m) => m,
+        None => {
+            return Envelope::unavailable(
+                "typecheck",
+                "no enclosing Cargo.toml for the target file",
+            )
+        }
+    };
+
+    match overlay_patch {
+        None => observe(file, &manifest).await,
+        Some(patch) => predict(file, &manifest, patch),
+    }
+}
+
+/// Post-write observe: run a real `cargo check`.
+async fn observe(file: &Path, manifest: &Path) -> Envelope {
+    let crate_dir = manifest.parent().unwrap_or(Path::new("."));
+    let target_dir = isolated_target_dir(manifest);
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("check")
+        .arg("--message-format=json")
+        .arg("--manifest-path")
+        .arg(manifest)
+        .env("CARGO_TARGET_DIR", &target_dir)
+        .current_dir(crate_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => return Envelope::unavailable("typecheck", &format!("cargo spawn failed: {e}")),
+    };
+
+    let out = match tokio::time::timeout(Duration::from_secs(240), child.wait_with_output()).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            return Envelope::unavailable("typecheck", &format!("cargo check failed: {e}"))
+        }
+        Err(_) => return Envelope::unavailable("typecheck", "cargo check timed out"),
+    };
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let errors = parse_cargo_json(&stdout, crate_dir);
+
+    // A nonzero exit WITH parsed error diagnostics is a valid "observed errors"
+    // result. A nonzero exit with NO parsed errors means cargo itself failed to
+    // run (bad manifest, toolchain) — that is unavailable, not a clean answer.
+    if !out.status.success() && errors.is_empty() {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Envelope::unavailable(
+            "typecheck",
+            &format!(
+                "cargo check produced no diagnostics and failed: {}",
+                stderr.trim().chars().take(400).collect::<String>()
+            ),
+        );
+    }
+
+    // Keep only this file's errors? The contract is about the edited file, but
+    // cargo errors elsewhere in the crate are still real breakage — surface all
+    // in-crate errors (already filtered to the crate). Ensure `file` is the one
+    // we anchored on by leaving the full in-crate set.
+    let _ = file;
+    let errs = errors_json(&errors);
+    let ok = errs.is_empty();
+    warm_envelope(json!({
+        "ok": ok,
+        "errors": errs,
+        "overlay": false,
+        "changed_signatures": [],
+        "removed_symbols": [],
+        "coverage": 1.0,
+    }))
+}
+
+/// Predict (overlay): syntactic-only diff of `pub` items. No compile runs, so
+/// `errors: []` and `coverage: 0.5` (honest — coord routes this to Partial).
+fn predict(file: &Path, manifest: &Path, patch: Value) -> Envelope {
+    let crate_dir = manifest.parent().unwrap_or(Path::new(".")).to_path_buf();
+    let overlay_file = patch.get("file").and_then(|v| v.as_str());
+    let new_text = patch.get("new_text").and_then(|v| v.as_str());
+    let (overlay_file, new_text) = match (overlay_file, new_text) {
+        (Some(f), Some(t)) => (f.to_string(), t.to_string()),
+        _ => return Envelope::unavailable("typecheck", "overlay_patch requires {file, new_text}"),
+    };
+
+    let on_disk = extract_pub_items(&syntactic::read_or_empty(Path::new(&overlay_file)));
+    let overlaid = extract_pub_items(&new_text);
+
+    let changed = changed_pub_signatures(&on_disk, &overlaid);
+    let removed = syntactic::removed_decls(&on_disk, &overlaid);
+    let removed_syms = syntactic::removed_symbols(&removed, &crate_dir, file, "rs", 2000, 20);
+
+    syntactic_envelope(json!({
+        "ok": true,
+        "errors": [],
+        "overlay": true,
+        "changed_signatures": changed,
+        "removed_symbols": removed_syms,
+        "coverage": 0.5,
+    }))
+}
+
+/// `changed_signatures` for Rust pub items: same name+kind, different normalized
+/// declaration line.
+fn changed_pub_signatures(on_disk: &[Decl], overlay: &[Decl]) -> Vec<Value> {
+    let mut out = Vec::new();
+    for d in on_disk {
+        if let Some(o) = overlay
+            .iter()
+            .find(|o| o.name == d.name && o.kind == d.kind)
+        {
+            if o.normalized != d.normalized {
+                out.push(json!({
+                    "name": d.name,
+                    "before_hash": sig_hash(&d.normalized),
+                    "after_hash": sig_hash(&o.normalized),
+                }));
+            }
+        }
+    }
+    out
+}
+
+/// The pub item kinds we recognize.
+const PUB_KINDS: [&str; 7] = ["fn", "struct", "enum", "trait", "type", "const", "static"];
+
+/// Extract `pub`/`pub(...)` items (fn/struct/enum/trait/type/const/static) from
+/// Rust source with a small line parser. The declaration line is normalized up to
+/// the body delimiter (`{`, `;`, or `=`) so signature changes are detected without
+/// a full parser.
+fn extract_pub_items(src: &str) -> Vec<Decl> {
+    let mut decls = Vec::new();
+    for raw in src.lines() {
+        let line = raw.trim_start();
+        let after_pub = match strip_pub(line) {
+            Some(rest) => rest,
+            None => continue,
+        };
+        // after_pub may have `async `/`unsafe `/`extern "C" ` qualifiers before `fn`.
+        let kw_line = strip_fn_qualifiers(after_pub);
+        for kind in PUB_KINDS {
+            if let Some(rest) = kw_line.strip_prefix(kind) {
+                // Require a separator after the keyword so `fnord` != `fn`.
+                let sep_ok = rest
+                    .chars()
+                    .next()
+                    .map(|c| c.is_whitespace())
+                    .unwrap_or(false);
+                if !sep_ok {
+                    continue;
+                }
+                if let Some(name) = item_name(rest.trim_start(), kind) {
+                    decls.push(Decl {
+                        name,
+                        kind: kind.to_string(),
+                        normalized: normalize_rust_decl(raw),
+                    });
+                }
+                break;
+            }
+        }
+    }
+    decls
+}
+
+/// Strip a leading `pub` / `pub(crate)` / `pub(in ...)` visibility from a line,
+/// returning the remainder. `None` if the line is not `pub`.
+fn strip_pub(line: &str) -> Option<&str> {
+    let rest = line.strip_prefix("pub")?;
+    // Must be followed by whitespace or `(`.
+    match rest.chars().next() {
+        Some('(') => {
+            // pub(...) — skip to the matching close paren.
+            let close = rest.find(')')?;
+            Some(rest[close + 1..].trim_start())
+        }
+        Some(c) if c.is_whitespace() => Some(rest.trim_start()),
+        _ => None,
+    }
+}
+
+/// Strip `async`/`unsafe`/`extern "..."` qualifiers that may precede `fn`.
+fn strip_fn_qualifiers(line: &str) -> String {
+    let mut s = line.to_string();
+    loop {
+        let trimmed = s.trim_start();
+        if let Some(r) = trimmed.strip_prefix("async ") {
+            s = r.to_string();
+        } else if let Some(r) = trimmed.strip_prefix("unsafe ") {
+            s = r.to_string();
+        } else if let Some(r) = trimmed.strip_prefix("extern ") {
+            // optional ABI string e.g. extern "C"
+            let r = r.trim_start();
+            if let Some(after_q) = r.strip_prefix('"') {
+                if let Some(end) = after_q.find('"') {
+                    s = after_q[end + 1..].trim_start().to_string();
+                    continue;
+                }
+            }
+            s = r.to_string();
+        } else {
+            break;
+        }
+    }
+    s.trim_start().to_string()
+}
+
+/// The item's identifier after its keyword. For most kinds the name is the next
+/// identifier; for `fn` it's up to `(`/`<`/whitespace.
+fn item_name(rest: &str, _kind: &str) -> Option<String> {
+    let end = rest
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(rest.len());
+    if end == 0 {
+        None
+    } else {
+        Some(rest[..end].to_string())
+    }
+}
+
+/// Normalize a Rust declaration line for signature comparison: take everything up
+/// to the body/terminator (`{`, `;`, or ` = `), collapse whitespace.
+fn normalize_rust_decl(line: &str) -> String {
+    let head = line
+        .split('{')
+        .next()
+        .unwrap_or(line)
+        .split(';')
+        .next()
+        .unwrap_or(line);
+    // Drop a trailing ` = value` for const/static.
+    let head = match head.find(" = ") {
+        Some(i) => &head[..i],
+        None => head,
+    };
+    head.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn err_line(reason: &str, level: &str, file: &str) -> String {
+        json!({
+            "reason": reason,
+            "message": {
+                "level": level,
+                "message": "mismatched types",
+                "code": { "code": "E0308" },
+                "spans": [
+                    { "is_primary": true, "file_name": file, "line_start": 4, "column_start": 9 }
+                ]
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn parse_cargo_json_picks_errors_ignores_warnings_and_other_reasons() {
+        // Use absolute crate dir so file_in_crate's prefix path holds.
+        let tmp = tempfile::tempdir().unwrap();
+        let crate_dir = tmp.path();
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        let abs = crate_dir.join("src").join("lib.rs");
+        std::fs::write(&abs, "fn x(){}\n").unwrap();
+        let abs_s = abs.to_string_lossy().to_string();
+
+        let artifact = json!({"reason": "compiler-artifact", "package_id": "x"}).to_string();
+        let lines = format!(
+            "{}\n{}\n{}\n",
+            err_line("compiler-message", "error", &abs_s),
+            err_line("compiler-message", "warning", &abs_s),
+            artifact,
+        );
+        let errors = parse_cargo_json(&lines, crate_dir);
+        assert_eq!(errors.len(), 1, "only the error-level compiler-message");
+        assert_eq!(errors[0].code.as_deref(), Some("E0308"));
+        assert_eq!(errors[0].line, 4);
+        assert_eq!(errors[0].col, 9);
+    }
+
+    #[test]
+    fn parse_cargo_json_filters_out_of_crate_spans() {
+        let tmp = tempfile::tempdir().unwrap();
+        let crate_dir = tmp.path();
+        // span points at an absolute path outside the crate dir
+        let outside = "/elsewhere/dep/src/lib.rs";
+        let line = err_line("compiler-message", "error", outside);
+        let errors = parse_cargo_json(&line, crate_dir);
+        assert!(errors.is_empty(), "out-of-crate span must be filtered");
+    }
+
+    #[test]
+    fn extract_pub_items_truth_table() {
+        let src = "\
+pub fn alpha(x: i32) -> i32 { x }
+fn private_fn() {}
+pub struct Beta { a: u8 }
+pub(crate) enum Gamma { A, B }
+pub trait Delta {}
+pub const K: u32 = 3;
+pub async fn ep() {}
+pub fnord() {}
+";
+        let decls = extract_pub_items(src);
+        let names: Vec<&str> = decls.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"alpha"));
+        assert!(names.contains(&"Beta"));
+        assert!(names.contains(&"Gamma"));
+        assert!(names.contains(&"Delta"));
+        assert!(names.contains(&"K"));
+        assert!(names.contains(&"ep"));
+        // private fn is ignored
+        assert!(!names.contains(&"private_fn"));
+        // `fnord` must not be parsed as a `fn` named "ord"
+        assert!(!decls.iter().any(|d| d.name == "ord"));
+    }
+
+    #[test]
+    fn removed_pub_fn_referenced_is_flagged_private_ignored() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+        let file = tmp.path().join("src").join("lib.rs");
+        std::fs::write(&file, "// edited\n").unwrap();
+        // sibling references `gone`
+        std::fs::write(
+            tmp.path().join("src").join("other.rs"),
+            "fn use_it() { gone(); }\n",
+        )
+        .unwrap();
+
+        let on_disk = extract_pub_items("pub fn gone() {}\nfn private_gone() {}\n");
+        let overlay = extract_pub_items("");
+        let removed = syntactic::removed_decls(&on_disk, &overlay);
+        // private_gone is not a pub item, so it was never extracted.
+        assert!(removed.iter().all(|d| d.name != "private_gone"));
+        let syms = syntactic::removed_symbols(&removed, tmp.path(), &file, "rs", 2000, 20);
+        assert_eq!(syms.len(), 1);
+        assert_eq!(syms[0]["name"], "gone");
+    }
+
+    #[test]
+    fn changed_pub_signature_detected() {
+        let on_disk = extract_pub_items("pub fn f(x: i32) -> i32 { x }\n");
+        let overlay = extract_pub_items("pub fn f(x: i64) -> i64 { x }\n");
+        let changed = changed_pub_signatures(&on_disk, &overlay);
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0]["name"], "f");
+        assert_ne!(changed[0]["before_hash"], changed[0]["after_hash"]);
+    }
+
+    #[test]
+    fn syntactic_predict_envelope_is_coverage_half_boundary_medium() {
+        let env = syntactic_envelope(json!({"ok": true, "errors": [], "coverage": 0.5}));
+        assert_eq!(env.provenance, PROV_CARGO_SYNTACTIC);
+        assert_eq!(env.coverage, 0.5);
+        assert_eq!(env.credibility.boundary, "medium");
+    }
+
+    #[test]
+    fn observe_envelope_has_cargo_provenance() {
+        let env = warm_envelope(json!({"ok": true, "errors": []}));
+        assert_eq!(env.provenance, PROV_CARGO);
+        assert_eq!(env.coverage, 1.0);
+        assert_eq!(env.credibility.boundary, "high");
+    }
+
+    /// LIVE: requires a cargo toolchain. Skips (passes) when unavailable.
+    #[tokio::test]
+    async fn live_cargo_check_finds_deliberate_type_error() {
+        if let Err(reason) = &*CARGO_AVAILABLE {
+            eprintln!("skipping live cargo test: {reason}");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let crate_dir = tmp.path().join("tinycrate");
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::write(
+            crate_dir.join("Cargo.toml"),
+            "[package]\nname=\"tinycrate\"\nversion=\"0.1.0\"\nedition=\"2021\"\n",
+        )
+        .unwrap();
+        // deliberate type error: assign &str to i32
+        let main_rs = crate_dir.join("src").join("main.rs");
+        std::fs::write(&main_rs, "fn main() { let _x: i32 = \"oops\"; }\n").unwrap();
+
+        let env = typecheck(&main_rs, None).await;
+        // If cargo couldn't run (offline crate registry etc.) we tolerate an
+        // unavailable envelope; otherwise we must see the error.
+        if env.provenance == PROV_CARGO {
+            assert_eq!(env.coverage, 1.0);
+            let errs = env.result["errors"].as_array().unwrap();
+            assert!(!errs.is_empty(), "cargo should flag the type mismatch");
+            assert_eq!(env.result["ok"], false);
+        } else {
+            eprintln!(
+                "live cargo test: tolerating non-observe envelope provenance={}",
+                env.provenance
+            );
+        }
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/lang.rs
+++ b/src-tauri/src/mcp/code_semantics/lang.rs
@@ -1,0 +1,151 @@
+//! Language dispatch for the code-semantics `typecheck` surface (Phase A).
+//!
+//! The `/code-semantics/typecheck` endpoint dispatches by the target file's
+//! extension to one of three checkers:
+//!   - TypeScript / JavaScript → the TS Language Service (true in-memory overlay),
+//!   - Python (`.py`/`.pyi`) → `mypy` with `--shadow-file` (true overlay),
+//!   - Rust (`.rs`) → `cargo check` (full-fidelity observe; syntactic predict for
+//!     overlay, coverage 0.5).
+//!
+//! Project-root resolution walks up from the file:
+//!   - Rust: nearest enclosing `Cargo.toml` (the crate, not the workspace root —
+//!     `cargo check --manifest-path` points at that crate's manifest).
+//!   - Python: nearest dir containing `pyproject.toml`, `mypy.ini`, `setup.cfg`,
+//!     or `setup.py`; else the file's parent dir.
+
+use std::path::{Path, PathBuf};
+
+/// The language a `typecheck` request dispatches to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lang {
+    /// TypeScript / JavaScript (the existing Language-Service path).
+    Ts,
+    /// Rust (`cargo check`).
+    Rust,
+    /// Python (`mypy`).
+    Python,
+}
+
+/// Detect the dispatch language from a file's extension. Anything that is not
+/// recognized as Rust or Python is treated as `Ts`, which exactly preserves the
+/// pre-Phase-A behavior for every non-Rust/Python file.
+pub fn detect_language(file: &Path) -> Lang {
+    match file
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("rs") => Lang::Rust,
+        Some("py") | Some("pyi") => Lang::Python,
+        _ => Lang::Ts,
+    }
+}
+
+/// Walk up from `file` to the nearest enclosing `Cargo.toml` (the crate
+/// manifest). Returns the manifest path, or `None` if none is found.
+pub fn nearest_cargo_manifest(file: &Path) -> Option<PathBuf> {
+    let mut dir = start_dir(file);
+    while let Some(d) = dir {
+        let candidate = d.join("Cargo.toml");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = d.parent().map(|p| p.to_path_buf());
+    }
+    None
+}
+
+/// Markers that delimit a Python project root.
+const PY_PROJECT_MARKERS: [&str; 4] = ["pyproject.toml", "mypy.ini", "setup.cfg", "setup.py"];
+
+/// Walk up from `file` to the nearest dir containing a Python project marker.
+/// Falls back to the file's parent dir when no marker is found.
+pub fn python_project_root(file: &Path) -> PathBuf {
+    let mut dir = start_dir(file);
+    while let Some(d) = &dir {
+        if PY_PROJECT_MARKERS.iter().any(|m| d.join(m).exists()) {
+            return d.clone();
+        }
+        dir = d.parent().map(|p| p.to_path_buf());
+    }
+    // No marker anywhere up the tree → the file's parent dir.
+    file.parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// The directory to start an upward walk from (the file's parent, or the dir
+/// itself if `file` is a directory).
+fn start_dir(file: &Path) -> Option<PathBuf> {
+    if file.is_dir() {
+        Some(file.to_path_buf())
+    } else {
+        file.parent().map(|p| p.to_path_buf())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_language_extension_table() {
+        assert_eq!(detect_language(Path::new("/a/b/foo.rs")), Lang::Rust);
+        assert_eq!(detect_language(Path::new("/a/b/foo.py")), Lang::Python);
+        assert_eq!(detect_language(Path::new("/a/b/foo.pyi")), Lang::Python);
+        assert_eq!(detect_language(Path::new("/a/b/foo.PY")), Lang::Python);
+        assert_eq!(detect_language(Path::new("/a/b/foo.RS")), Lang::Rust);
+        // Everything else is the (unchanged) TS path.
+        assert_eq!(detect_language(Path::new("/a/b/foo.ts")), Lang::Ts);
+        assert_eq!(detect_language(Path::new("/a/b/foo.tsx")), Lang::Ts);
+        assert_eq!(detect_language(Path::new("/a/b/foo.js")), Lang::Ts);
+        assert_eq!(detect_language(Path::new("/a/b/foo")), Lang::Ts);
+        assert_eq!(detect_language(Path::new("/a/b/foo.txt")), Lang::Ts);
+    }
+
+    #[test]
+    fn python_root_falls_back_to_parent_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("lonely.py");
+        std::fs::write(&file, "x = 1\n").unwrap();
+        // No marker anywhere → the file's parent dir.
+        let root = python_project_root(&file);
+        assert_eq!(root, tmp.path());
+    }
+
+    #[test]
+    fn python_root_finds_nearest_marker() {
+        let tmp = tempfile::tempdir().unwrap();
+        let pkg = tmp.path().join("pkg");
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(tmp.path().join("pyproject.toml"), "[tool.mypy]\n").unwrap();
+        let file = pkg.join("mod.py");
+        std::fs::write(&file, "x = 1\n").unwrap();
+        let root = python_project_root(&file);
+        assert_eq!(root, tmp.path());
+    }
+
+    #[test]
+    fn cargo_manifest_picks_nearest_crate_not_workspace() {
+        let tmp = tempfile::tempdir().unwrap();
+        // workspace root Cargo.toml
+        std::fs::write(tmp.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+        let crate_dir = tmp.path().join("crates").join("inner");
+        std::fs::create_dir_all(crate_dir.join("src")).unwrap();
+        std::fs::write(crate_dir.join("Cargo.toml"), "[package]\nname=\"inner\"\n").unwrap();
+        let file = crate_dir.join("src").join("lib.rs");
+        std::fs::write(&file, "pub fn f() {}\n").unwrap();
+        let manifest = nearest_cargo_manifest(&file).unwrap();
+        // Nearest = the inner crate manifest, NOT the workspace root.
+        assert_eq!(manifest, crate_dir.join("Cargo.toml"));
+    }
+
+    #[test]
+    fn cargo_manifest_none_when_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("orphan.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+        assert!(nearest_cargo_manifest(&file).is_none());
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/mod.rs
+++ b/src-tauri/src/mcp/code_semantics/mod.rs
@@ -25,9 +25,13 @@
 //! - Node/TS permanently unavailable → degrade (symbol-lookup → code_graph_fallback;
 //!   resolution → `engine_unavailable`, coverage 0). Never 500 on a missing engine.
 
+pub mod cargo_check;
 pub mod code_graph_api;
+pub mod lang;
+pub mod mypy_check;
 pub mod node_bridge;
 pub mod scope;
+pub mod syntactic;
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -120,6 +124,16 @@ pub const PROV_INDEXING: &str = "indexing";
 pub const PROV_UNAVAILABLE: &str = "engine_unavailable";
 /// Resolved-import `Ξ_AST` provenance (Phase 1/2): deterministic file binding.
 pub const PROV_RESOLVED: &str = "code_graph_resolved";
+/// Python `mypy` typecheck provenance (Phase A): full-fidelity, true overlay via
+/// `--shadow-file`. Boundary `high` (crosses the type checker).
+pub const PROV_MYPY: &str = "mypy";
+/// Rust `cargo check` observe provenance (Phase A): full-fidelity post-write
+/// diagnostics. Boundary `high`.
+pub const PROV_CARGO: &str = "cargo-check";
+/// Rust syntactic-only overlay-predict provenance (Phase A): no compile ran, so
+/// `coverage=0.5` and boundary `medium` (mirrors the resolved-import tier). coord
+/// routes this honestly to `Partial`.
+pub const PROV_CARGO_SYNTACTIC: &str = "cargo-syntactic";
 
 impl Envelope {
     /// Warm, resolved answer: posterior=1, coverage=1, credibility=(high,high,high).
@@ -414,8 +428,17 @@ async fn health(State(_state): State<Arc<ApiState>>) -> Json<Value> {
             "provenance": provenance,
         }));
     }
+    drop(reg);
 
-    Json(json!({ "status": "ok", "scopes": scopes }))
+    // Phase A: report engine availability for the Rust (`cargo check`) and Python
+    // (`mypy`) typecheck dispatchers alongside the TS scopes. These are *engine*
+    // availability probes, not per-scope index state.
+    let engines = json!([
+        { "language": "rust", "available": cargo_check::is_available() },
+        { "language": "python", "available": mypy_check::is_available() },
+    ]);
+
+    Json(json!({ "status": "ok", "scopes": scopes, "engines": engines }))
 }
 
 /// POST /code-semantics/symbol-lookup
@@ -534,20 +557,51 @@ async fn find_references(
     .await
 }
 
-/// POST /code-semantics/typecheck (with overlay_patch ⇒ 2b predict-effect)
+/// POST /code-semantics/typecheck (with overlay_patch ⇒ 2b predict-effect).
+///
+/// Dispatches by the target file's extension (Phase A): Rust (`.rs`) →
+/// `cargo check`; Python (`.py`/`.pyi`) → `mypy`; everything else → the TS
+/// Language-Service path (unchanged). All three lift `coverage` into the §A
+/// result body (coord reads coverage from the body).
 async fn typecheck(
     State(_state): State<Arc<ApiState>>,
     Json(req): Json<TypecheckReq>,
 ) -> Json<Envelope> {
     let q = "typecheck";
-    let scope = req.scope.clone();
-    let file = req.file.clone();
-    resolution_query(q, scope.as_deref(), Some(&file), move |bridge| {
-        let file = req.file.clone();
-        let overlay = req.overlay_patch.clone();
-        async move { bridge.typecheck(&file, overlay).await }
-    })
-    .await
+    let file_path = Path::new(&req.file);
+    match lang::detect_language(file_path) {
+        lang::Lang::Rust => {
+            Json(cargo_check::typecheck(file_path, req.overlay_patch.clone()).await)
+        }
+        lang::Lang::Python => {
+            Json(mypy_check::typecheck(file_path, req.overlay_patch.clone()).await)
+        }
+        lang::Lang::Ts => {
+            let scope = req.scope.clone();
+            let file = req.file.clone();
+            let mut env = resolution_query(q, scope.as_deref(), Some(&file), move |bridge| {
+                let file = req.file.clone();
+                let overlay = req.overlay_patch.clone();
+                async move { bridge.typecheck(&file, overlay).await }
+            })
+            .await;
+            // Mirror the envelope coverage into the §A result body if absent, so
+            // coord's `EditPrediction::from_typecheck_result` (which reads
+            // coverage FROM the body) sees it for the TS path too.
+            lift_coverage_into_body(&mut env.0);
+            env
+        }
+    }
+}
+
+/// Ensure the typecheck result body carries a `coverage` field mirroring the
+/// envelope's. coord reads coverage from the body (defaulting 0.0 when absent);
+/// the Rust/Python checkers set it themselves, this covers the TS path.
+fn lift_coverage_into_body(env: &mut Envelope) {
+    let coverage = env.coverage;
+    if let Value::Object(map) = &mut env.result {
+        map.entry("coverage").or_insert_with(|| json!(coverage));
+    }
 }
 
 /// Shared driver for resolution queries (signature / find-references /

--- a/src-tauri/src/mcp/code_semantics/mypy_check.rs
+++ b/src-tauri/src/mcp/code_semantics/mypy_check.rs
@@ -1,0 +1,585 @@
+//! Python `mypy` checker for the code-semantics `typecheck` surface (Phase A).
+//!
+//! Same honest-coverage observation-envelope posture as the TS path:
+//!   - mypy unavailable on the machine → `Envelope::unavailable` (never a 500,
+//!     never a fabricated clean answer).
+//!   - post-write observe (no `overlay_patch`) → run mypy on the on-disk file
+//!     → `coverage: 1.0`, provenance `mypy`.
+//!   - predict (with `overlay_patch`) → a TRUE overlay via `mypy --shadow-file`
+//!     (the real file is never modified) → `coverage: 1.0`, provenance `mypy`,
+//!     plus a best-effort syntactic `changed_signatures`/`removed_symbols` diff.
+//!
+//! The §A result body carries a `coverage` field mirroring the envelope's (coord's
+//! `EditPrediction::from_typecheck_result` reads coverage FROM the result body).
+
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
+
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use tokio::process::Command;
+
+use super::lang::python_project_root;
+use super::syntactic::{self, Decl};
+use super::{Credibility, Envelope, PROV_MYPY};
+
+/// How mypy is invoked on this machine (resolved once).
+#[derive(Debug, Clone)]
+enum MypyInvocation {
+    /// `mypy ...`
+    Direct,
+    /// `python -m mypy ...` (the python binary that worked).
+    Module(String),
+    /// mypy is not available at all (with a reason).
+    Unavailable(String),
+}
+
+/// Cached availability probe. We run a blocking probe once at first use.
+static MYPY: Lazy<MypyInvocation> = Lazy::new(probe_mypy);
+
+/// Is `mypy` available (cached probe)? Used by the health endpoint.
+pub fn is_available() -> bool {
+    !matches!(&*MYPY, MypyInvocation::Unavailable(_))
+}
+
+/// Probe `mypy --version`, then `python -m mypy --version` / `python3 -m mypy`.
+fn probe_mypy() -> MypyInvocation {
+    use std::process::Command as StdCommand;
+
+    // 1. direct `mypy`
+    if let Ok(out) = StdCommand::new("mypy").arg("--version").output() {
+        if out.status.success() {
+            return MypyInvocation::Direct;
+        }
+    }
+    // 2. `<python> -m mypy`
+    for py in ["python", "python3"] {
+        if let Ok(out) = StdCommand::new(py)
+            .args(["-m", "mypy", "--version"])
+            .output()
+        {
+            if out.status.success() {
+                return MypyInvocation::Module(py.to_string());
+            }
+        }
+    }
+    MypyInvocation::Unavailable("mypy not found (tried `mypy` and `python -m mypy`)".to_string())
+}
+
+/// Build a `tokio::process::Command` for the resolved invocation with `args`.
+fn mypy_command(inv: &MypyInvocation, args: &[String]) -> Option<Command> {
+    match inv {
+        MypyInvocation::Direct => {
+            let mut c = Command::new("mypy");
+            c.args(args);
+            Some(c)
+        }
+        MypyInvocation::Module(py) => {
+            let mut c = Command::new(py);
+            c.arg("-m").arg("mypy").args(args);
+            Some(c)
+        }
+        MypyInvocation::Unavailable(_) => None,
+    }
+}
+
+/// The common mypy flags for machine-readable, no-summary output.
+fn base_flags() -> Vec<String> {
+    [
+        "--no-error-summary",
+        "--show-column-numbers",
+        "--show-error-codes",
+        "--no-color-output",
+        "--no-pretty",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+/// A parsed mypy error diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MypyError {
+    file: String,
+    line: u32,
+    col: u32,
+    code: Option<String>,
+    message: String,
+}
+
+/// Parse mypy stdout lines of the shape
+/// `path:line:col: error: message [code]`. Only `error:`-severity lines are
+/// collected (notes/warnings are ignored). `col` is optional in some configs but
+/// `--show-column-numbers` provides it; we tolerate its absence.
+fn parse_mypy_output(stdout: &str) -> Vec<MypyError> {
+    let mut errors = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim_end();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(e) = parse_mypy_line(line) {
+            errors.push(e);
+        }
+    }
+    errors
+}
+
+/// Parse a single mypy diagnostic line. Returns `None` for non-error severities
+/// and malformed lines.
+fn parse_mypy_line(line: &str) -> Option<MypyError> {
+    // Split into the leading `path:line:col` locator and the remainder.
+    // The path may contain Windows drive colons, so we parse from the RIGHT of
+    // the locator: find ": error:" / ": note:" / ": warning:".
+    let sev_idx = line.find(": error:")?;
+    // Reject if a higher-priority `note`/`warning` precedes (shouldn't, but be safe).
+    let locator = &line[..sev_idx];
+    let rest = &line[sev_idx + ": error:".len()..];
+
+    // locator = "<path>:<line>:<col>" possibly "<path>:<line>" (no col).
+    let (file, line_no, col_no) = parse_locator(locator)?;
+
+    // rest = " message [code]" — peel a trailing bracketed code.
+    let msg_full = rest.trim();
+    let (message, code) = split_trailing_code(msg_full);
+    Some(MypyError {
+        file,
+        line: line_no,
+        col: col_no,
+        code,
+        message,
+    })
+}
+
+/// Parse `<path>:<line>:<col>` (or `<path>:<line>`). The path can itself contain
+/// colons (Windows drive), so we take the last 1-2 colon-separated numeric
+/// fields as line/col and the rest as the path.
+fn parse_locator(locator: &str) -> Option<(String, u32, u32)> {
+    let parts: Vec<&str> = locator.rsplitn(3, ':').collect();
+    // parts is reversed: [col?, line?, path...]
+    match parts.as_slice() {
+        // path:line:col
+        [col, line, path] => {
+            let col_n = col.trim().parse::<u32>().ok()?;
+            let line_n = line.trim().parse::<u32>().ok()?;
+            Some((path.trim().to_string(), line_n, col_n))
+        }
+        // path:line  (no column)
+        [line, path] => {
+            let line_n = line.trim().parse::<u32>().ok()?;
+            Some((path.trim().to_string(), line_n, 0))
+        }
+        _ => None,
+    }
+}
+
+/// Split a trailing ` [code]` from a mypy message. Returns `(message, code)`.
+fn split_trailing_code(s: &str) -> (String, Option<String>) {
+    if s.ends_with(']') {
+        if let Some(open) = s.rfind('[') {
+            let code = &s[open + 1..s.len() - 1];
+            // mypy codes are identifier-ish (`name-of-code`); guard against `[i]`-style
+            // text in messages by requiring no spaces in the bracket body.
+            if !code.is_empty() && !code.contains(' ') {
+                let message = s[..open].trim_end().to_string();
+                return (message, Some(code.to_string()));
+            }
+        }
+    }
+    (s.to_string(), None)
+}
+
+/// Build the §A `errors[]` array from parsed mypy errors, filtered to the file
+/// we asked about (mypy may surface follow-on errors in imported modules; we keep
+/// the checked file's errors, which is what the predict/observe contract is about).
+fn errors_json(errors: &[MypyError]) -> Vec<Value> {
+    errors
+        .iter()
+        .map(|e| {
+            json!({
+                "file": e.file,
+                "line": e.line,
+                "col": e.col,
+                "code": e.code,
+                "message": e.message,
+            })
+        })
+        .collect()
+}
+
+/// Extract top-level + class-level Python declarations (`def name(...)` /
+/// `class name`) from source text. A small line-based parser — no heavy deps.
+fn extract_py_decls(src: &str) -> Vec<Decl> {
+    let mut decls = Vec::new();
+    for raw in src.lines() {
+        let line = raw.trim_start();
+        if let Some(rest) = line.strip_prefix("def ") {
+            if let Some(name) = ident_prefix(rest) {
+                decls.push(Decl {
+                    name,
+                    kind: "def".into(),
+                    normalized: normalize_decl(raw),
+                });
+            }
+        } else if let Some(rest) = line.strip_prefix("async def ") {
+            if let Some(name) = ident_prefix(rest) {
+                decls.push(Decl {
+                    name,
+                    kind: "def".into(),
+                    normalized: normalize_decl(raw),
+                });
+            }
+        } else if let Some(rest) = line.strip_prefix("class ") {
+            if let Some(name) = ident_prefix(rest) {
+                decls.push(Decl {
+                    name,
+                    kind: "class".into(),
+                    normalized: normalize_decl(raw),
+                });
+            }
+        }
+    }
+    decls
+}
+
+/// The leading identifier of `s` (up to `(`, `:`, whitespace, or `=`).
+fn ident_prefix(s: &str) -> Option<String> {
+    let end = s
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+        .unwrap_or(s.len());
+    if end == 0 {
+        None
+    } else {
+        Some(s[..end].to_string())
+    }
+}
+
+/// Normalize a declaration line for signature-change comparison: collapse
+/// internal whitespace, drop a trailing `:` and any trailing comment.
+fn normalize_decl(line: &str) -> String {
+    let no_comment = match line.find(" #") {
+        Some(i) => &line[..i],
+        None => line,
+    };
+    let collapsed: String = no_comment.split_whitespace().collect::<Vec<_>>().join(" ");
+    collapsed.trim_end_matches(':').trim().to_string()
+}
+
+/// Run mypy and parse diagnostics. `extra_args` are appended before the target
+/// path. Returns `(errors, exit_code)` or an `Envelope::unavailable` on a
+/// spawn/timeout/crash failure.
+async fn run_mypy(
+    inv: &MypyInvocation,
+    cwd: &Path,
+    extra_args: &[String],
+    target: &str,
+) -> Result<(Vec<MypyError>, i32), Envelope> {
+    let mut args = base_flags();
+    args.extend(extra_args.iter().cloned());
+    args.push(target.to_string());
+
+    let mut cmd = match mypy_command(inv, &args) {
+        Some(c) => c,
+        None => return Err(Envelope::unavailable("typecheck", "mypy unavailable")),
+    };
+    cmd.current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            return Err(Envelope::unavailable(
+                "typecheck",
+                &format!("mypy spawn failed: {e}"),
+            ))
+        }
+    };
+
+    let out = match tokio::time::timeout(Duration::from_secs(60), child.wait_with_output()).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(e)) => {
+            return Err(Envelope::unavailable(
+                "typecheck",
+                &format!("mypy failed: {e}"),
+            ))
+        }
+        Err(_) => return Err(Envelope::unavailable("typecheck", "mypy timed out")),
+    };
+
+    let code = out.status.code().unwrap_or(-1);
+    // mypy: 0 = clean, 1 = type errors found, >=2 = crash/usage error.
+    if !(0..=1).contains(&code) {
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        return Err(Envelope::unavailable(
+            "typecheck",
+            &format!("mypy crashed (exit {code}): {}", stderr.trim()),
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    Ok((parse_mypy_output(&stdout), code))
+}
+
+/// Build the warm `mypy` envelope, lifting `coverage` into the result body.
+fn warm_envelope(result: Value) -> Envelope {
+    Envelope {
+        observer: "code_semantics".into(),
+        query: "typecheck".into(),
+        result,
+        posterior: 1.0,
+        coverage: 1.0,
+        provenance: PROV_MYPY.into(),
+        credibility: Credibility::high(),
+        staleness_seconds: None,
+        kernel: false,
+    }
+}
+
+/// The public entrypoint: typecheck a Python `file`, optionally under an
+/// `overlay_patch` (`{file, new_text}`) which is applied via `--shadow-file`
+/// (a true overlay — the real file is never written).
+pub async fn typecheck(file: &Path, overlay_patch: Option<Value>) -> Envelope {
+    let inv: &MypyInvocation = &MYPY;
+    if let MypyInvocation::Unavailable(reason) = inv {
+        return Envelope::unavailable("typecheck", reason);
+    }
+
+    let root = python_project_root(file);
+    let target = file.to_string_lossy().to_string();
+
+    match overlay_patch {
+        None => observe(inv, &root, &target).await,
+        Some(patch) => predict(inv, &root, file, &target, patch).await,
+    }
+}
+
+/// Post-write observe: run mypy on the on-disk file.
+async fn observe(inv: &MypyInvocation, root: &Path, target: &str) -> Envelope {
+    match run_mypy(inv, root, &[], target).await {
+        Ok((errors, _code)) => {
+            let errs = errors_json(&errors);
+            let ok = errs.is_empty();
+            warm_envelope(json!({
+                "ok": ok,
+                "errors": errs,
+                "overlay": false,
+                "changed_signatures": [],
+                "removed_symbols": [],
+                "coverage": 1.0,
+            }))
+        }
+        Err(env) => env,
+    }
+}
+
+/// Predict (overlay): write `new_text` to a temp file, run mypy with
+/// `--shadow-file <overlay.file> <tempfile>`, and compute a syntactic diff.
+async fn predict(
+    inv: &MypyInvocation,
+    root: &Path,
+    file: &Path,
+    target: &str,
+    patch: Value,
+) -> Envelope {
+    let overlay_file = patch.get("file").and_then(|v| v.as_str());
+    let new_text = patch.get("new_text").and_then(|v| v.as_str());
+    let (overlay_file, new_text) = match (overlay_file, new_text) {
+        (Some(f), Some(t)) => (f.to_string(), t.to_string()),
+        _ => return Envelope::unavailable("typecheck", "overlay_patch requires {file, new_text}"),
+    };
+
+    // True overlay: write new_text to a temp file; --shadow-file substitutes it
+    // for the real path during this run only.
+    let tmp = match tempfile::Builder::new()
+        .prefix("qontinui-mypy-overlay-")
+        .suffix(".py")
+        .tempfile()
+    {
+        Ok(t) => t,
+        Err(e) => return Envelope::unavailable("typecheck", &format!("temp file failed: {e}")),
+    };
+    if let Err(e) = std::fs::write(tmp.path(), new_text.as_bytes()) {
+        return Envelope::unavailable("typecheck", &format!("temp write failed: {e}"));
+    }
+
+    let shadow_target = tmp.path().to_string_lossy().to_string();
+    let extra = vec![
+        "--shadow-file".to_string(),
+        overlay_file.clone(),
+        shadow_target,
+    ];
+
+    let run = run_mypy(inv, root, &extra, target).await;
+    // tmp drops (and deletes) at end of scope regardless.
+
+    let (errors, _code) = match run {
+        Ok(v) => v,
+        Err(env) => return env,
+    };
+
+    // Syntactic diff between on-disk text and the overlay text.
+    let on_disk = extract_py_decls(&syntactic::read_or_empty(Path::new(&overlay_file)));
+    let overlaid = extract_py_decls(&new_text);
+    let changed = syntactic::changed_signatures(&on_disk, &overlaid);
+    let removed = syntactic::removed_decls(&on_disk, &overlaid);
+    let removed_syms = syntactic::removed_symbols(&removed, root, file, "py", 2000, 20);
+
+    let errs = errors_json(&errors);
+    let ok = errs.is_empty();
+    warm_envelope(json!({
+        "ok": ok,
+        "errors": errs,
+        "overlay": true,
+        "changed_signatures": changed,
+        "removed_symbols": removed_syms,
+        "coverage": 1.0,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_mypy_error_line_with_code() {
+        let e = parse_mypy_line(
+            "app/foo.py:12:5: error: Incompatible types in assignment [assignment]",
+        )
+        .unwrap();
+        assert_eq!(e.file, "app/foo.py");
+        assert_eq!(e.line, 12);
+        assert_eq!(e.col, 5);
+        assert_eq!(e.code.as_deref(), Some("assignment"));
+        assert_eq!(e.message, "Incompatible types in assignment");
+    }
+
+    #[test]
+    fn parse_mypy_line_windows_path() {
+        let e = parse_mypy_line(
+            "C:/proj/app/foo.py:3:1: error: Name \"x\" is not defined [name-defined]",
+        )
+        .unwrap();
+        assert_eq!(e.file, "C:/proj/app/foo.py");
+        assert_eq!(e.line, 3);
+        assert_eq!(e.col, 1);
+        assert_eq!(e.code.as_deref(), Some("name-defined"));
+    }
+
+    #[test]
+    fn parse_ignores_note_and_warning_and_malformed() {
+        let out = "\
+app/foo.py:12:5: error: Bad thing [assignment]
+app/foo.py:12:5: note: this is just a note
+app/foo.py:9:1: warning: a warning line
+not a diagnostic at all
+app/foo.py: error: missing line number";
+        let errs = parse_mypy_output(out);
+        assert_eq!(errs.len(), 1);
+        assert_eq!(errs[0].code.as_deref(), Some("assignment"));
+    }
+
+    #[test]
+    fn parse_error_without_column() {
+        let e = parse_mypy_line("app/foo.py:7: error: oops [misc]").unwrap();
+        assert_eq!(e.line, 7);
+        assert_eq!(e.col, 0);
+        assert_eq!(e.code.as_deref(), Some("misc"));
+    }
+
+    #[test]
+    fn split_trailing_code_handles_no_code() {
+        let (msg, code) = split_trailing_code("just a message");
+        assert_eq!(msg, "just a message");
+        assert!(code.is_none());
+    }
+
+    #[test]
+    fn extract_py_decls_truth_table() {
+        let src = "\
+import os
+
+def top_level(x):
+    return x
+
+async def async_fn():
+    pass
+
+class Thing:
+    def method(self):
+        pass
+
+x = 5
+";
+        let decls = extract_py_decls(src);
+        let names: Vec<&str> = decls.iter().map(|d| d.name.as_str()).collect();
+        assert!(names.contains(&"top_level"));
+        assert!(names.contains(&"async_fn"));
+        assert!(names.contains(&"Thing"));
+        assert!(names.contains(&"method"));
+        // module-level assignment is not a decl
+        assert!(!names.contains(&"x"));
+    }
+
+    #[test]
+    fn py_def_removal_referenced_elsewhere_is_flagged() {
+        let on_disk = "\
+def gone():
+    pass
+
+def kept():
+    pass
+";
+        let overlay = "\
+def kept():
+    pass
+";
+        let on_disk_decls = extract_py_decls(on_disk);
+        let overlay_decls = extract_py_decls(overlay);
+        let removed = syntactic::removed_decls(&on_disk_decls, &overlay_decls);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "gone");
+    }
+
+    #[test]
+    fn py_changed_signature_detected() {
+        let on_disk = extract_py_decls("def f(x: int) -> int:\n    return x\n");
+        let overlay = extract_py_decls("def f(x: str) -> str:\n    return x\n");
+        let changed = syntactic::changed_signatures(&on_disk, &overlay);
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0]["name"], "f");
+    }
+
+    /// LIVE: requires mypy. Skips (passes) when unavailable.
+    #[tokio::test]
+    async fn live_mypy_detects_type_error_and_overlay_fixes_it() {
+        if let MypyInvocation::Unavailable(reason) = &*MYPY {
+            eprintln!("skipping live mypy test: {reason}");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("m.py");
+        std::fs::write(&file, "x: int = \"s\"\n").unwrap();
+
+        // observe: error present
+        let env = typecheck(&file, None).await;
+        assert_eq!(env.provenance, PROV_MYPY);
+        assert_eq!(env.coverage, 1.0);
+        let errs = env.result["errors"].as_array().unwrap();
+        assert!(!errs.is_empty(), "mypy should flag x: int = \"s\"");
+        assert_eq!(env.result["ok"], false);
+
+        // overlay that fixes it → clean
+        let patch = json!({"file": file.to_string_lossy(), "new_text": "x: int = 5\n"});
+        let env2 = typecheck(&file, Some(patch)).await;
+        assert_eq!(env2.result["overlay"], true);
+        assert_eq!(
+            env2.result["ok"], true,
+            "fixed overlay should typecheck clean"
+        );
+
+        // the real file is untouched (true overlay)
+        let on_disk = std::fs::read_to_string(&file).unwrap();
+        assert_eq!(on_disk, "x: int = \"s\"\n");
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/syntactic.rs
+++ b/src-tauri/src/mcp/code_semantics/syntactic.rs
@@ -1,0 +1,342 @@
+//! Shared syntactic helpers for the overlay-predict path of the Rust and Python
+//! checkers (Phase A).
+//!
+//! Neither `cargo check` (no in-memory overlay) nor the post-write mypy path
+//! produces a `changed_signatures` / `removed_symbols` diff for the *predict*
+//! (overlay) case directly, so both checkers fall back to a small, dependency-light
+//! syntactic differ: extract top-level declarations from the on-disk text and the
+//! overlay text, diff them by name, and — for removed declarations — search sibling
+//! source files for word-boundary references. This module owns the language-neutral
+//! pieces (hashing + bounded reference search); each checker supplies its own
+//! declaration extractor.
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+/// A top-level (or class-level) declaration extracted syntactically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Decl {
+    /// The bare symbol name (e.g. `foo`, `MyStruct`).
+    pub name: String,
+    /// A coarse kind label for the §A `removed_symbols.kind` field
+    /// (e.g. `fn`, `struct`, `def`, `class`).
+    pub kind: String,
+    /// The normalized declaration text used for signature-change detection.
+    pub normalized: String,
+}
+
+/// Stable opaque hex hash of a signature string (the §A `before_hash`/`after_hash`
+/// values are opaque, so any stable hash is acceptable). Truncated to 16 hex
+/// chars to keep the wire payload small.
+pub fn sig_hash(s: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let digest = h.finalize();
+    let mut out = String::with_capacity(16);
+    for b in digest.iter().take(8) {
+        out.push_str(&format!("{b:02x}"));
+    }
+    out
+}
+
+/// A `changed_signatures` entry: a declaration present in both versions whose
+/// normalized text changed.
+pub fn changed_signatures(on_disk: &[Decl], overlay: &[Decl]) -> Vec<serde_json::Value> {
+    let mut out = Vec::new();
+    for d in on_disk {
+        if let Some(o) = overlay
+            .iter()
+            .find(|o| o.name == d.name && o.kind == d.kind)
+        {
+            if o.normalized != d.normalized {
+                out.push(serde_json::json!({
+                    "name": d.name,
+                    "before_hash": sig_hash(&d.normalized),
+                    "after_hash": sig_hash(&o.normalized),
+                }));
+            }
+        }
+    }
+    out
+}
+
+/// Names of declarations present on disk but absent in the overlay (candidates
+/// for `removed_symbols`).
+pub fn removed_decls(on_disk: &[Decl], overlay: &[Decl]) -> Vec<Decl> {
+    on_disk
+        .iter()
+        .filter(|d| !overlay.iter().any(|o| o.name == d.name))
+        .cloned()
+        .collect()
+}
+
+/// Directory names never descended into during the reference search.
+fn is_skipped_dir(name: &str) -> bool {
+    matches!(
+        name,
+        ".git"
+            | ".venv"
+            | "venv"
+            | "__pycache__"
+            | "node_modules"
+            | "target"
+            | ".mypy_cache"
+            | ".pytest_cache"
+    ) || name.starts_with("target")
+}
+
+/// Search sibling source files under `root` (bounded) for word-boundary
+/// references to `name`. Returns up to `max_refs` `{file,line}` entries.
+///
+/// `exclude` is the path of the edited file itself (its own references don't
+/// count as "referenced elsewhere"). `ext` is the source extension to scan
+/// (e.g. `"py"` or `"rs"`). At most `file_cap` files are inspected.
+pub fn references_in_siblings(
+    root: &Path,
+    exclude: &Path,
+    name: &str,
+    ext: &str,
+    file_cap: usize,
+    max_refs: usize,
+) -> Vec<serde_json::Value> {
+    let exclude_canon = exclude.canonicalize().ok();
+    let mut refs: Vec<serde_json::Value> = Vec::new();
+    let mut files_seen = 0usize;
+
+    let walker = WalkDir::new(root).into_iter().filter_entry(|e| {
+        if e.file_type().is_dir() {
+            // Always descend the root itself.
+            if e.depth() == 0 {
+                return true;
+            }
+            return !e.file_name().to_str().map(is_skipped_dir).unwrap_or(false);
+        }
+        true
+    });
+
+    for entry in walker.flatten() {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        if entry.path().extension().and_then(|e| e.to_str()) != Some(ext) {
+            continue;
+        }
+        if files_seen >= file_cap {
+            break;
+        }
+        files_seen += 1;
+
+        // Skip the edited file itself.
+        if let Some(ex) = &exclude_canon {
+            if entry.path().canonicalize().ok().as_ref() == Some(ex) {
+                continue;
+            }
+        }
+
+        let text = match std::fs::read_to_string(entry.path()) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        for (i, line) in text.lines().enumerate() {
+            if line_has_word(line, name) {
+                refs.push(serde_json::json!({
+                    "file": path_str(entry.path()),
+                    "line": i + 1,
+                }));
+                if refs.len() >= max_refs {
+                    return refs;
+                }
+                break; // one ref per file is enough to prove "referenced".
+            }
+        }
+    }
+    refs
+}
+
+/// Forward-slash-normalized path string for the wire.
+fn path_str(p: &Path) -> String {
+    p.to_string_lossy().replace('\\', "/")
+}
+
+/// True if `line` contains `name` as a whole identifier (ASCII word boundary on
+/// both sides). Avoids matching substrings of longer identifiers.
+pub fn line_has_word(line: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let bytes = line.as_bytes();
+    let nb = name.as_bytes();
+    let mut start = 0;
+    while let Some(pos) = find_from(bytes, nb, start) {
+        let before_ok = pos == 0 || !is_ident_byte(bytes[pos - 1]);
+        let after_idx = pos + nb.len();
+        let after_ok = after_idx >= bytes.len() || !is_ident_byte(bytes[after_idx]);
+        if before_ok && after_ok {
+            return true;
+        }
+        start = pos + 1;
+    }
+    false
+}
+
+fn find_from(hay: &[u8], needle: &[u8], from: usize) -> Option<usize> {
+    if needle.is_empty() || from + needle.len() > hay.len() {
+        return None;
+    }
+    (from..=hay.len() - needle.len()).find(|&i| &hay[i..i + needle.len()] == needle)
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Build a `removed_symbols` array from removed declarations that are still
+/// referenced in sibling files of `root` (the Contradiction / active-negation
+/// signal). Declarations with no surviving references are dropped.
+pub fn removed_symbols(
+    removed: &[Decl],
+    root: &Path,
+    edited_file: &Path,
+    ext: &str,
+    file_cap: usize,
+    max_refs: usize,
+) -> Vec<serde_json::Value> {
+    let mut out = Vec::new();
+    for d in removed {
+        let referenced_by =
+            references_in_siblings(root, edited_file, &d.name, ext, file_cap, max_refs);
+        if !referenced_by.is_empty() {
+            out.push(serde_json::json!({
+                "name": d.name,
+                "kind": d.kind,
+                "referenced_by": referenced_by,
+            }));
+        }
+    }
+    out
+}
+
+/// Read a file to a string, returning empty on error (an unreadable on-disk file
+/// just yields no decls — honest, never a panic).
+pub fn read_or_empty(p: &Path) -> String {
+    std::fs::read_to_string(p).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn word_boundary_match_is_exact() {
+        assert!(line_has_word("    foo()", "foo"));
+        assert!(line_has_word("x = foo", "foo"));
+        assert!(line_has_word("foo", "foo"));
+        // substring of a longer identifier must NOT match
+        assert!(!line_has_word("foobar()", "foo"));
+        assert!(!line_has_word("my_foo()", "foo"));
+        assert!(!line_has_word("foo_bar", "foo"));
+    }
+
+    #[test]
+    fn sig_hash_is_stable_and_distinct() {
+        assert_eq!(sig_hash("a"), sig_hash("a"));
+        assert_ne!(sig_hash("a"), sig_hash("b"));
+        assert_eq!(sig_hash("a").len(), 16);
+    }
+
+    #[test]
+    fn changed_signatures_detects_normalized_change() {
+        let on_disk = vec![Decl {
+            name: "f".into(),
+            kind: "fn".into(),
+            normalized: "fn f(x: i32)".into(),
+        }];
+        let overlay = vec![Decl {
+            name: "f".into(),
+            kind: "fn".into(),
+            normalized: "fn f(x: i64)".into(),
+        }];
+        let changed = changed_signatures(&on_disk, &overlay);
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0]["name"], "f");
+        assert_ne!(changed[0]["before_hash"], changed[0]["after_hash"]);
+    }
+
+    #[test]
+    fn changed_signatures_ignores_unchanged() {
+        let d = vec![Decl {
+            name: "f".into(),
+            kind: "fn".into(),
+            normalized: "fn f()".into(),
+        }];
+        assert!(changed_signatures(&d, &d).is_empty());
+    }
+
+    #[test]
+    fn removed_decls_lists_only_deletions() {
+        let on_disk = vec![
+            Decl {
+                name: "a".into(),
+                kind: "fn".into(),
+                normalized: "fn a()".into(),
+            },
+            Decl {
+                name: "b".into(),
+                kind: "fn".into(),
+                normalized: "fn b()".into(),
+            },
+        ];
+        let overlay = vec![Decl {
+            name: "a".into(),
+            kind: "fn".into(),
+            normalized: "fn a()".into(),
+        }];
+        let removed = removed_decls(&on_disk, &overlay);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].name, "b");
+    }
+
+    #[test]
+    fn removed_symbols_only_when_referenced_in_siblings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let edited = tmp.path().join("mod.rs");
+        std::fs::write(&edited, "// edited\n").unwrap();
+        // sibling references `gone` and `kept_private`.
+        std::fs::write(tmp.path().join("other.rs"), "fn caller() { gone(); }\n").unwrap();
+        let removed = vec![
+            Decl {
+                name: "gone".into(),
+                kind: "fn".into(),
+                normalized: "pub fn gone()".into(),
+            },
+            Decl {
+                name: "unused".into(),
+                kind: "fn".into(),
+                normalized: "pub fn unused()".into(),
+            },
+        ];
+        let syms = removed_symbols(&removed, tmp.path(), &edited, "rs", 2000, 20);
+        // only `gone` is referenced elsewhere.
+        assert_eq!(syms.len(), 1);
+        assert_eq!(syms[0]["name"], "gone");
+        let refs = syms[0]["referenced_by"].as_array().unwrap();
+        assert_eq!(refs.len(), 1);
+        assert_eq!(refs[0]["line"], 1);
+    }
+
+    #[test]
+    fn reference_search_skips_target_and_self() {
+        let tmp = tempfile::tempdir().unwrap();
+        let edited = tmp.path().join("mod.rs");
+        // self references the name — must NOT count.
+        std::fs::write(&edited, "fn gone() {}\n").unwrap();
+        // a build-artifact dir that must be skipped.
+        let target = tmp.path().join("target").join("debug");
+        std::fs::create_dir_all(&target).unwrap();
+        std::fs::write(target.join("art.rs"), "gone();\n").unwrap();
+        let refs = references_in_siblings(tmp.path(), &edited, "gone", "rs", 2000, 20);
+        assert!(refs.is_empty(), "self + target/ refs must be excluded");
+    }
+}


### PR DESCRIPTION
## What

`/code-semantics/typecheck` now dispatches by file extension:

| Language | Observe (post-write) | Predict (`overlay_patch`) |
|---|---|---|
| TS/JS (default) | TS Language Service (unchanged) | true in-memory overlay (unchanged) |
| Python `.py`/`.pyi` | `mypy` — coverage 1.0, provenance `mypy` | **true overlay** via `mypy --shadow-file` (real file never touched) |
| Rust `.rs` | `cargo check --message-format=json` — coverage 1.0, provenance `cargo-check`, isolated `CARGO_TARGET_DIR` | **syntactic-only** pub-item diff — coverage **0.5**, provenance `cargo-syntactic` (no write-then-restore mutation window in a live tree; honest coverage<1 routes coord's `classify_edit_outcome` to Partial) |

- All three checkers mirror `coverage` into the §A result body (coord's `EditPrediction::from_typecheck_result` reads it from the body; TS path lifts it at dispatch).
- `changed_signatures`/`removed_symbols` populated for Rust/Python via a bounded syntactic differ + sibling-reference search, so the Contradiction (removed-referenced-symbol) signal works beyond TS.
- Honest posture preserved: engine unavailable / timeout / crash → `engine_unavailable` envelope (coverage 0), never a fabricated clean, never a 500.
- `GET /code-semantics/health` gains `engines[]` (cargo/mypy availability).
- CONTRACT.md §A/§B/§C/§D updated.

## Coord side

**No coord changes needed** — `typecheck_file_handler` (coord `mcp/tools.rs:6334`) forwards `{file, overlay_patch}` opaquely and `from_sidecar` passes provenance through string-typed. Verified during implementation pre-flight.

## Tests

52 code_semantics tests green, including availability-gated **live** cargo + mypy integration tests (both ran for real). `cargo clippy -p qontinui-runner --tests -- -D warnings` clean. `cargo fmt --check` clean.

## Plan

Phase A of `plans/2026-06-03-edit-effect-subspace-verifiers-plan.md` (operator-scoped to Phase A; Phases B/C blocked on unbuilt producers, split into follow-up plans).