### PR TITLE
feat(auth): attach device-JWT to coord data-plane calls + device_id backfill (Phase 0)

### DIFF
--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -194,9 +194,7 @@ async fn pre_allocate_claim(
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|e| format!("build claim http client: {e}"))?;
-    let resp = client
-        .post(&url)
-        .json(&body)
+    let resp = crate::auth::attach_device_auth(client.post(&url).json(&body))
         .send()
         .await
         .map_err(|e| format!("POST {url}: {e}"))?;
@@ -385,9 +383,7 @@ async fn heartbeat_once(
         .timeout(Duration::from_secs(5))
         .build()
         .map_err(|e| format!("build heartbeat client: {e}"))?;
-    let resp = client
-        .post(&url)
-        .json(&body)
+    let resp = crate::auth::attach_device_auth(client.post(&url).json(&body))
         .send()
         .await
         .map_err(|e| format!("POST {url}: {e}"))?;
@@ -443,7 +439,10 @@ pub async fn release_claim_best_effort(
             return;
         }
     };
-    match client.post(&url).json(&body).send().await {
+    match crate::auth::attach_device_auth(client.post(&url).json(&body))
+        .send()
+        .await
+    {
         Ok(r) => {
             debug!(
                 "release_claim_best_effort: kind={kind} key={resource_key} status={}",
@@ -902,9 +901,7 @@ pub async fn allocate_and_materialize_with_claim(
     });
 
     let url = format!("{}/agents/allocate", coord_http_base.trim_end_matches('/'));
-    let resp = reqwest::Client::new()
-        .post(&url)
-        .json(&body)
+    let resp = crate::auth::attach_device_auth(reqwest::Client::new().post(&url).json(&body))
         .send()
         .await
         .map_err(|e| AllocateError::Other(format!("POST {url}: {e}")))?;

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -475,6 +475,86 @@ impl Default for AuthManager {
     }
 }
 
+// ============================================================================
+// Device-JWT data-plane bearer — Phase 0 runner↔coord multi-user readiness.
+//
+// The runner's coord data-plane HTTP calls (session register/heartbeat/state,
+// claim acquire/heartbeat/release, agent allocate) were unauthenticated. The
+// device-JWT already exists (minted by pairing, stored in the access_token
+// slot); these helpers attach it as `Authorization: Bearer <jwt>` on each call
+// when present. Coord still accepts anonymous calls, so a missing token (an
+// unpaired runner / empty keychain) is NEVER fatal — the request goes out
+// exactly as before.
+// ============================================================================
+
+/// Total data-plane calls that passed through [`attach_device_auth`].
+static DATA_PLANE_TOTAL: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Subset of those that carried the device-JWT bearer header.
+static DATA_PLANE_AUTHED: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+/// Gate so the unpaired-runner warning is logged at most once per process.
+static MISSING_TOKEN_WARNED: std::sync::Once = std::sync::Once::new();
+
+/// Returns the stored device-JWT as a bearer string, or `None` when no token
+/// is available (unpaired runner, missing keychain entry, storage IO error).
+///
+/// NEVER fatal and NEVER panics — every failure mode collapses to `None`, and
+/// callers fall back to sending the request unauthenticated (coord accepts
+/// anonymous data-plane writes). The missing-token case is logged at most once
+/// per process via [`MISSING_TOKEN_WARNED`] so the frequent heartbeat path
+/// can't spam the log.
+///
+/// No caching: `AuthManager::get_access_token()` is a cheap local encrypted-
+/// file read, and the device-JWT has only a 4-hour TTL (refreshed in place by
+/// the refresher loop), so a stale long-lived cache would risk presenting an
+/// expired bearer. Reading per-call keeps us always-current.
+pub fn device_bearer() -> Option<String> {
+    match AuthManager::new().get_access_token() {
+        Ok(token) if !token.trim().is_empty() => Some(token),
+        Ok(_) => {
+            MISSING_TOKEN_WARNED.call_once(|| {
+                warn!(
+                    "coord data-plane: no device-JWT stored (empty token) — \
+                     sending coord calls unauthenticated; pair this runner to authenticate"
+                );
+            });
+            None
+        }
+        Err(e) => {
+            MISSING_TOKEN_WARNED.call_once(|| {
+                warn!(
+                    "coord data-plane: device-JWT unavailable ({e}) — \
+                     sending coord calls unauthenticated; pair this runner to authenticate"
+                );
+            });
+            None
+        }
+    }
+}
+
+/// Attach the device-JWT bearer to a coord data-plane request when one is
+/// available, otherwise return the builder unchanged. Also drives the
+/// auth-coverage metric (the dogfood signal Phase 1 gates on): every call is
+/// counted in `DATA_PLANE_TOTAL`, and calls that carried the header in
+/// `DATA_PLANE_AUTHED`. A coverage summary is emitted at info level every 25th
+/// call so an operator can watch the unpaired→paired transition without a new
+/// dependency.
+pub fn attach_device_auth(rb: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    let total = DATA_PLANE_TOTAL.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
+    let rb = match device_bearer() {
+        Some(token) => {
+            DATA_PLANE_AUTHED.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            rb.header("Authorization", format!("Bearer {token}"))
+        }
+        None => rb,
+    };
+    if total.is_multiple_of(25) {
+        let authed = DATA_PLANE_AUTHED.load(std::sync::atomic::Ordering::Relaxed);
+        let pct = (authed as f64 / total as f64) * 100.0;
+        info!("coord data-plane auth coverage: {authed}/{total} ({pct:.0}%)");
+    }
+    rb
+}
+
 /// Returns true if `s` looks like a JWS Compact Serialization
 /// (three base64url segments separated by `.`). Used by Phase 4 of the
 /// unified-devices migration to distinguish a real device-JWT from the

--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -601,6 +601,11 @@ fn cmd_device_init(name_arg: Option<&str>) -> ExitCode {
         eprintln!("write {} failed: {}", path.display(), e);
         return ExitCode::from(2);
     }
+    // Phase 0 multi-user readiness — ensure the canonical `device_id` key
+    // lands even if a legacy `machine_id`-only file slipped past the
+    // DeviceFile serialization (e.g. a sibling reader rewrote it). No-op
+    // when already canonical.
+    qontinui_runner_lib::pair::ensure_device_id_persisted_at(&path);
     if was_new {
         println!(
             "wrote machine.json: {} (host={})",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1841,6 +1841,13 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             // the existing setup body rely on non-`move` semantics; see
             // the comment block above this closure).
             {
+                // Phase 0 multi-user readiness — normalize the operator's
+                // legacy `machine.json` so the canonical `device_id` key is
+                // present before any consumer reads it (the session machinery
+                // below + the coord data-plane bearer). No-op when the file is
+                // already canonical / missing.
+                qontinui_runner_lib::pair::ensure_device_id_persisted();
+
                 let app_handle = app.handle().clone();
                 let term_state: tauri::State<'_, std::sync::Arc<terminal::TerminalManager>> =
                     app.state();

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -146,6 +146,93 @@ fn read_device_id() -> Result<String, String> {
     Ok(parsed.device_id)
 }
 
+/// Backfill the canonical `device_id` key into `~/.qontinui/machine.json`
+/// when the file predates the `machine_id`→`device_id` rename.
+///
+/// The operator's live file is the legacy shape
+/// `{"machine_id": "...", "hostname": "...", "active_tenant_id": "..."}`.
+/// Reads already work via serde aliases, but the canonical `device_id` key is
+/// absent; this normalizes the file so readers that key off `device_id`
+/// literally (without the alias) see it too. `machine_id` is intentionally
+/// PRESERVED — other readers may still alias off it — and every sibling field
+/// is carried verbatim.
+///
+/// Resolves the path via `dirs::home_dir()` and delegates to
+/// [`ensure_device_id_persisted_at`]. Missing/unreadable machine.json is a
+/// no-op (never fatal): a runner that has never run `device init` simply has
+/// nothing to normalize.
+pub fn ensure_device_id_persisted() {
+    let Some(path) = machine_file_path() else {
+        return;
+    };
+    ensure_device_id_persisted_at(&path);
+}
+
+/// Path-parameterized core of [`ensure_device_id_persisted`] (testable
+/// without touching the real home directory).
+///
+/// If the file parses as a JSON object that has `machine_id` but no
+/// `device_id`, atomically rewrites it (temp file + rename, matching
+/// `commands::tenant::write_active_tenant_id`) adding `device_id` with the
+/// same value while preserving all other fields. Any other shape — already
+/// canonical, missing file, non-object, unparseable — is left untouched.
+pub fn ensure_device_id_persisted_at(path: &std::path::Path) {
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(_) => return, // Missing/unreadable → nothing to normalize.
+    };
+    let value: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(
+                "ensure_device_id_persisted: {} is not valid JSON ({e}) — skipping",
+                path.display()
+            );
+            return;
+        }
+    };
+    let serde_json::Value::Object(mut obj) = value else {
+        return;
+    };
+    // Already canonical, or no legacy key to backfill from → no-op.
+    if obj.contains_key("device_id") {
+        return;
+    }
+    let Some(machine_id) = obj.get("machine_id").cloned() else {
+        return;
+    };
+    obj.insert("device_id".to_string(), machine_id);
+
+    let pretty = match serde_json::to_vec_pretty(&serde_json::Value::Object(obj)) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("ensure_device_id_persisted: serialize failed: {e}");
+            return;
+        }
+    };
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, &pretty) {
+        tracing::warn!(
+            "ensure_device_id_persisted: write {} failed: {e}",
+            tmp.display()
+        );
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        tracing::warn!(
+            "ensure_device_id_persisted: rename {} → {} failed: {e}",
+            tmp.display(),
+            path.display()
+        );
+        let _ = std::fs::remove_file(&tmp);
+        return;
+    }
+    tracing::info!(
+        "machine.json: backfilled canonical device_id key at {}",
+        path.display()
+    );
+}
+
 /// Path to the paired-user JSON written by `device pair` and read by
 /// `device init` to attach a `user_id` to the register payload. Lives
 /// under the Tauri app's local data directory (alongside
@@ -1108,6 +1195,98 @@ mod tests {
         let parsed: PairedUserFile = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(parsed.user_id, original.user_id);
         assert_eq!(parsed.tenant_id, original.tenant_id);
+    }
+
+    // ------------------------------------------------------------------------
+    // ensure_device_id_persisted_at — machine.json device_id backfill
+    // (Phase 0 multi-user readiness). All variants operate on a tempdir path
+    // so they never touch the operator's real ~/.qontinui.
+    // ------------------------------------------------------------------------
+
+    fn read_json(path: &std::path::Path) -> serde_json::Value {
+        let bytes = std::fs::read(path).expect("read machine.json");
+        serde_json::from_slice(&bytes).expect("parse machine.json")
+    }
+
+    #[test]
+    fn backfill_adds_device_id_and_preserves_siblings() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        // Legacy shape — exactly the operator's live file.
+        std::fs::write(
+            &path,
+            r#"{"machine_id":"abc-123","hostname":"laptop","active_tenant_id":"tenant-9"}"#,
+        )
+        .unwrap();
+
+        ensure_device_id_persisted_at(&path);
+
+        let v = read_json(&path);
+        // Canonical key added with the same value...
+        assert_eq!(v.get("device_id").and_then(|x| x.as_str()), Some("abc-123"));
+        // ...legacy key preserved (other readers may still alias off it)...
+        assert_eq!(
+            v.get("machine_id").and_then(|x| x.as_str()),
+            Some("abc-123")
+        );
+        // ...and every sibling field carried verbatim.
+        assert_eq!(v.get("hostname").and_then(|x| x.as_str()), Some("laptop"));
+        assert_eq!(
+            v.get("active_tenant_id").and_then(|x| x.as_str()),
+            Some("tenant-9")
+        );
+    }
+
+    #[test]
+    fn backfill_leaves_canonical_file_untouched() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        let canonical = r#"{"device_id":"keep-me","hostname":"box"}"#;
+        std::fs::write(&path, canonical).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        ensure_device_id_persisted_at(&path);
+
+        // Byte-for-byte identical — no rewrite when device_id already present.
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn backfill_missing_file_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        // File does not exist.
+        ensure_device_id_persisted_at(&path);
+        assert!(!path.exists(), "must not create the file");
+    }
+
+    #[test]
+    fn backfill_file_without_machine_id_is_noop() {
+        // Neither canonical nor legacy id key → nothing to backfill from.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        let original = r#"{"hostname":"box"}"#;
+        std::fs::write(&path, original).unwrap();
+        let before = std::fs::read_to_string(&path).unwrap();
+
+        ensure_device_id_persisted_at(&path);
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn backfill_unparseable_file_is_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("machine.json");
+        std::fs::write(&path, b"not json at all {{{").unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        ensure_device_id_persisted_at(&path);
+
+        let after = std::fs::read(&path).unwrap();
+        assert_eq!(before, after, "unparseable file left untouched");
     }
 }
 

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -614,28 +614,38 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // session start; we just forward it.
             let body = rebuild_create_body(rec);
             let url = format!("{base}/sessions");
-            inner.http.post(&url).json(&body).send().await
+            crate::auth::attach_device_auth(inner.http.post(&url).json(&body))
+                .send()
+                .await
         }
         "heartbeat" => {
             let url = format!("{base}/sessions/{}", rec.session_id);
             let body = json!({ "heartbeat": true });
-            inner.http.patch(&url).json(&body).send().await
+            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+                .send()
+                .await
         }
         "state_change" => {
             let url = format!("{base}/sessions/{}", rec.session_id);
             // The payload carries whatever fields the runner changed —
             // forward the subset coord understands.
             let body = state_change_body(&rec.payload);
-            inner.http.patch(&url).json(&body).send().await
+            crate::auth::attach_device_auth(inner.http.patch(&url).json(&body))
+                .send()
+                .await
         }
         "closed" => {
             let url = format!("{base}/sessions/{}", rec.session_id);
-            inner.http.delete(&url).send().await
+            crate::auth::attach_device_auth(inner.http.delete(&url))
+                .send()
+                .await
         }
         "claim_stolen" => {
             let url = format!("{base}/sessions/{}/steal", rec.session_id);
             let body = steal_body(rec);
-            inner.http.post(&url).json(&body).send().await
+            crate::auth::attach_device_auth(inner.http.post(&url).json(&body))
+                .send()
+                .await
         }
         other => {
             // OutputChunk + HandoffRequest are Phase 7/8 — defined now


### PR DESCRIPTION
Phase 0 of `plans/2026-06-01-runner-coord-multiuser-readiness-roadmap` — bind the operator's runner to a real device identity, **additively** (coord still accepts anonymous; an unpaired runner is unaffected).

## What

- **`attach_device_auth()` / `device_bearer()`** (`auth.rs`): attach `Authorization: Bearer <device-JWT>` (from `AuthManager`, minted at pairing) on the 9 coord data-plane calls:
  - `coord_sync.rs`: session POST / heartbeat PATCH / state PATCH / DELETE / steal POST (5)
  - `agent_worktree/mod.rs`: claims acquire / heartbeat / release + `/agents/allocate` (4)
  - Missing token is **never fatal** — request goes out anonymous exactly as today; warn logged once per process.
- **Auth-coverage metric**: total/authed counters + info summary every 25th call — the dogfood signal Phase 1 (coord verify-when-present) gates on.
- **`ensure_device_id_persisted()`** (`pair.rs`): atomic temp+rename backfill of the canonical `device_id` key into a legacy `machine_id`-only `machine.json`, preserving all sibling fields; wired at app startup + `device init`. 5 unit tests.

## What it does NOT do

- No coord changes — coord-side verification is Phase 1, gated on fleet-auth's `FleetPrincipal` (parallel session, plan `2026-05-31-coord-phase7-fleet-auth`).
- `coord_sync` tenant-in-body resolution from #351 untouched (this is the complementary half of Phase 0).

## Verification

- `cargo check` + `cargo clippy --workspace --tests -- -D warnings` clean in an isolated worktree
- `cargo test --lib pair::tests`: 21 passed (5 new backfill tests)
- Rebased on `origin/main` (705c0a0c); all 9 call sites verified intact after merging #387's session-scoped owner-token changes