### PR TITLE
runner: window-aware UI Bridge dispatch + windowed registry opt-in (Phase 0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.6.0",
-    "@qontinui/ui-bridge": "^0.14.0",
+    "@qontinui/ui-bridge": "^0.15.0",
     "@qontinui/ui-bridge-auto": "^0.1.6",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.15.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.6.0
         version: 0.6.0
       '@qontinui/ui-bridge':
-        specifier: ^0.14.0
-        version: 0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+        specifier: ^0.15.0
+        version: 0.15.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.6
         version: 0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
@@ -1149,8 +1149,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  '@qontinui/ui-bridge@0.14.0':
-    resolution: {integrity: sha512-ssn4vpO3fwJEYtstQT7+QZdCDGKXtVAzOgMRc9frmQ0H2JoE+y/Vop4UVnSR71R5w9d+U6zGW3O2wVXgreAlkw==}
+  '@qontinui/ui-bridge@0.15.0':
+    resolution: {integrity: sha512-LS6ozdAn2x4fEqT7IBUNJbmXsc03DkzmDZAogJ8h8y7RfdjDODOrjd6UPf+COX+XcY8QpzohfZxAT1SFi3/gGg==}
     hasBin: true
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
@@ -6166,9 +6166,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.15.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
+      '@qontinui/ui-bridge': 0.15.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.6.0': {}
@@ -6195,7 +6195,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.14.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
+  '@qontinui/ui-bridge@0.15.0(@qontinui/ui-bridge-auto@0.1.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.20.0)':
     dependencies:
       dom-accessibility-api: 0.5.16
       react: 19.2.5

--- a/src-tauri/src/commands/logging.rs
+++ b/src-tauri/src/commands/logging.rs
@@ -483,6 +483,12 @@ pub struct RenderLogEntry {
     /// Optional: task run ID if applicable
     #[serde(skip_serializing_if = "Option::is_none")]
     pub task_run_id: Option<i64>,
+    /// Window that produced this entry ("main" for the primary window; "term-N"
+    /// for pop-out windows in Phase 1). Optional + skipped when None so existing
+    /// entries and readers are unaffected; consumers treat a missing value as
+    /// "main". See plan `2026-06-03-runner-popout-terminal-windows.md` Phase 0.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub window_label: Option<String>,
 }
 
 /// Get the path to the render log file

--- a/src-tauri/src/mcp/ui_bridge/capabilities.rs
+++ b/src-tauri/src/mcp/ui_bridge/capabilities.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
 };
@@ -836,17 +836,48 @@ pub async fn ui_bridge_get_element_state_handler(
 // Render log
 // ============================================================================
 
-/// Get render log entries.
+/// Optional query params for the render-log GET endpoint.
+#[derive(Debug, Default, Deserialize)]
+pub struct RenderLogQuery {
+    /// Filter to entries from this window. Unlabeled entries are treated as
+    /// `"main"`. Omit to return all entries (single-window default).
+    #[serde(rename = "windowLabel")]
+    pub window_label: Option<String>,
+}
+
+/// Get render log entries, optionally filtered by `?windowLabel=`.
 pub async fn ui_bridge_get_render_log_handler(
     State(state): State<Arc<ApiState>>,
+    Query(params): Query<RenderLogQuery>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     info!("UI Bridge API: Getting render log");
 
     let log = state.ui_bridge_render_log.lock().await;
-    Ok(Json(ApiResponse::success(serde_json::json!({
-        "entries": *log,
-        "count": log.len()
-    }))))
+    match params.window_label.as_deref() {
+        // No filter — return the log verbatim (byte-identical to pre-window
+        // behavior; existing single-window callers are unaffected).
+        None => Ok(Json(ApiResponse::success(serde_json::json!({
+            "entries": *log,
+            "count": log.len()
+        })))),
+        // Filter to one window; an entry with no `windowLabel` counts as "main".
+        Some(want) => {
+            let entries: Vec<serde_json::Value> = log
+                .iter()
+                .filter(|e| {
+                    e.get("windowLabel")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or(super::request::MAIN_WINDOW_LABEL)
+                        == want
+                })
+                .cloned()
+                .collect();
+            Ok(Json(ApiResponse::success(serde_json::json!({
+                "count": entries.len(),
+                "entries": entries,
+            }))))
+        }
+    }
 }
 
 /// Append an entry to the render log.
@@ -862,6 +893,52 @@ pub async fn ui_bridge_append_render_log_handler(
     log.push(entry);
     Ok(Json(ApiResponse::success(serde_json::json!({
         "count": log.len()
+    }))))
+}
+
+// ============================================================================
+// Runner-owned windows
+// ============================================================================
+
+/// Enumerate the runner process's OWN Tauri webview windows.
+///
+/// Distinct from `/ui-bridge/control/windows`, which enumerates OS desktop
+/// windows (Chrome, VS Code, …) for desktop automation. This lists the
+/// webviews THIS runner process hosts — just the main window today, plus the
+/// pop-out terminal windows that Phase 1 of
+/// `plans/2026-06-03-runner-popout-terminal-windows.md` will add — so UI Bridge
+/// clients can discover and address them by `windowLabel`.
+pub async fn ui_bridge_list_runner_windows_handler(
+    State(state): State<Arc<ApiState>>,
+) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
+    use tauri::Manager;
+    let main_label = qontinui_runner_lib::get_main_window_label();
+    let mut windows: Vec<serde_json::Value> = state
+        .app_handle
+        .webview_windows()
+        .into_iter()
+        .map(|(label, win)| {
+            let kind = if label.as_str() == main_label {
+                "main"
+            } else {
+                "secondary"
+            };
+            serde_json::json!({
+                "label": label,
+                "kind": kind,
+                "title": win.title().ok(),
+            })
+        })
+        .collect();
+    // Deterministic ordering so callers/tests get stable output.
+    windows.sort_by(|a, b| {
+        a.get("label")
+            .and_then(|v| v.as_str())
+            .cmp(&b.get("label").and_then(|v| v.as_str()))
+    });
+    Ok(Json(ApiResponse::success(serde_json::json!({
+        "count": windows.len(),
+        "windows": windows,
     }))))
 }
 
@@ -1352,6 +1429,12 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             post(handle_render_log_snapshot),
         )
         .route("/ui-bridge/render-log/path", get(handle_render_log_path))
+        // Runner-owned webview windows (this process's own windows; distinct
+        // from the OS-window enumerator at `/ui-bridge/control/windows`).
+        .route(
+            "/ui-bridge/control/runner-windows",
+            get(ui_bridge_list_runner_windows_handler),
+        )
         // SDK relay liveness ping (distinct from `/ui-bridge/pong`)
         .route("/ui-bridge/heartbeat", post(ui_bridge_heartbeat_handler))
         // Pong + IPC response
@@ -1396,6 +1479,7 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("DELETE", "/ui-bridge/render-log"),
         ("POST", "/ui-bridge/render-log/snapshot"),
         ("GET", "/ui-bridge/render-log/path"),
+        ("GET", "/ui-bridge/control/runner-windows"),
         ("POST", "/ui-bridge/heartbeat"),
         ("POST", "/ui-bridge/pong"),
         ("POST", "/ui-bridge/ipc-response"),

--- a/src-tauri/src/mcp/ui_bridge/helpers.rs
+++ b/src-tauri/src/mcp/ui_bridge/helpers.rs
@@ -194,10 +194,17 @@ pub(super) async fn direct_webview_evaluate_with_result(
     let request_id = uuid::Uuid::new_v4().to_string();
     let (tx, rx) = tokio::sync::oneshot::channel::<serde_json::Value>();
 
+    // This direct-eval path always targets the main window, and the injected JS
+    // POSTs its response back without a `windowLabel` — so it must register and
+    // clean up under the SAME composite (main, id) key the response dispatcher
+    // computes (it defaults a missing label to "main"). See
+    // `super::request::pending_key`.
+    let pkey = super::request::pending_key(super::request::MAIN_WINDOW_LABEL, &request_id);
+
     // Register the pending request
     {
         let mut pending = state.ui_bridge_pending.lock().await;
-        pending.insert(request_id.clone(), tx);
+        pending.insert(pkey.clone(), tx);
         state
             .ui_bridge_pending_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -213,7 +220,7 @@ pub(super) async fn direct_webview_evaluate_with_result(
     if api_port == 0 {
         // Remove the pending request we just registered
         let mut pending = state.ui_bridge_pending.lock().await;
-        pending.remove(&request_id);
+        pending.remove(&pkey);
         state
             .ui_bridge_pending_count
             .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
@@ -307,7 +314,7 @@ pub(super) async fn direct_webview_evaluate_with_result(
         Err(_) => {
             // Clean up pending request
             let mut pending = state.ui_bridge_pending.lock().await;
-            if pending.remove(&request_id).is_some() {
+            if pending.remove(&pkey).is_some() {
                 state
                     .ui_bridge_pending_count
                     .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -708,6 +708,11 @@ mod manifest_drift_tests {
             // Pairs with `terminal-launch-menu` component actions.
             ("GET", "/ui-bridge/control/terminal-sessions"),
             ("GET", "/ui-bridge/control/terminal-sessions/{}"),
+            // Runner-owned webview windows — runner-only (enumerates THIS
+            // process's own Tauri windows; the SDK contract and the OS-window
+            // enumerator at /control/windows don't cover them). Phase 0 of the
+            // pop-out terminal-windows plan (2026-06-03).
+            ("GET", "/ui-bridge/control/runner-windows"),
             // /control/ai/* aliases mirroring SDK /ai/* (runner-side dual mount)
             ("DELETE", "/ui-bridge/control/ai/bookmark/{}"),
             ("DELETE", "/ui-bridge/control/ai/bookmarks/{}"),

--- a/src-tauri/src/mcp/ui_bridge/request.rs
+++ b/src-tauri/src/mcp/ui_bridge/request.rs
@@ -21,6 +21,39 @@ pub(super) fn get_ui_bridge_timeout_ms() -> u64 {
     Timeouts::ui_bridge_ipc().as_millis() as u64
 }
 
+/// Default window label for single-window operation. Phase 0 of the pop-out
+/// terminal-windows plan (`plans/2026-06-03-runner-popout-terminal-windows.md`):
+/// every request currently targets the main window; a windowed dispatch overload
+/// arrives with Phase 1's pop-out windows.
+pub(crate) const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Build the `ui_bridge_pending` map key.
+///
+/// Keying by `(window_label, request_id)` rather than `request_id` alone makes a
+/// response from a window the request was NOT addressed to a no-op (its computed
+/// key can't match the stored one), which structurally eliminates the broadcast
+/// response race once multiple windows mount the SDK. `request_id` is a UUID, so
+/// the delimiter can never collide with a (simple `main`/`term-N`) window label.
+/// Both dispatch paths (this module and `helpers::direct_webview_evaluate_with_result`)
+/// and the response dispatcher route through this single helper so the key shape
+/// can never drift between producer and consumer.
+pub(crate) fn pending_key(window_label: &str, request_id: &str) -> String {
+    format!("{window_label}\u{1f}{request_id}")
+}
+
+/// Whether targeted per-window `ui-bridge-request` emit is enabled.
+///
+/// Default OFF — the shipping single-window behavior broadcasts the event to all
+/// windows exactly as before (`app_handle.emit`), so Phase 0 is byte-identical to
+/// pre-window-aware behavior. Phase 1 flips this on (env `QONTINUI_UI_BRIDGE_MULTI_WINDOW=1`)
+/// once pop-out windows mount the SDK, so each request reaches only its target
+/// window. Read per-call so it can be toggled without a restart during rollout.
+fn multi_window_dispatch_enabled() -> bool {
+    std::env::var("QONTINUI_UI_BRIDGE_MULTI_WINDOW")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// Gather structured readiness diagnostics when the frontend readiness gate
 /// times out. Returns a JSON object with all available diagnostic fields so
 /// agents can diagnose why the WebView never became ready.
@@ -276,6 +309,29 @@ async fn ui_bridge_request_inner(
 ) -> Result<serde_json::Value, String> {
     let request_id = uuid::Uuid::new_v4().to_string();
 
+    // Phase 0: every request targets the main window. A windowed dispatch
+    // overload (carrying an explicit target label) arrives with Phase 1's
+    // pop-out windows; until then this is always "main", so the wire shape and
+    // pending key are identical to pre-window-aware behavior.
+    let window_label = MAIN_WINDOW_LABEL.to_string();
+
+    // Carry the target window in the (flattened) envelope payload ONLY when it
+    // is non-default, so the default single-window request is byte-identical on
+    // the wire. The frontend listener reads `windowLabel` and ignores events not
+    // addressed to its own `getCurrentWindow().label`.
+    let additional_payload = if window_label != MAIN_WINDOW_LABEL {
+        let mut p = additional_payload;
+        if let Some(obj) = p.as_object_mut() {
+            obj.insert(
+                "windowLabel".to_string(),
+                serde_json::Value::String(window_label.clone()),
+            );
+        }
+        p
+    } else {
+        additional_payload
+    };
+
     // Build the typed envelope (Stage 1 of the ui-bridge-request envelope
     // concretization — see commit ea5d9a61f deferral note). Wire shape:
     // `{ requestId, type, ...additional_payload }`. Empty `Value::Object`
@@ -300,20 +356,33 @@ async fn ui_bridge_request_inner(
     // Create oneshot channel for the response
     let (tx, rx) = tokio::sync::oneshot::channel::<serde_json::Value>();
 
-    // Store the sender in the pending map
+    // Store the sender in the pending map under the composite (window, id) key.
+    let pkey = pending_key(&window_label, &request_id);
     {
         let mut pending = state.ui_bridge_pending.lock().await;
-        pending.insert(request_id.clone(), tx);
+        pending.insert(pkey.clone(), tx);
         state
             .ui_bridge_pending_count
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     }
 
-    // Emit request to React frontend
-    if let Err(e) = state.app_handle.emit("ui-bridge-request", &event_payload) {
+    // Emit request to the React frontend. Default (flag off): broadcast to all
+    // windows exactly as before. Flag on (Phase 1): target the specific window,
+    // falling back to broadcast if its webview can't be resolved (e.g. mid
+    // teardown) so a request is never silently dropped.
+    let emit_result = if multi_window_dispatch_enabled() {
+        use tauri::Manager;
+        match state.app_handle.get_webview_window(&window_label) {
+            Some(win) => win.emit("ui-bridge-request", &event_payload),
+            None => state.app_handle.emit("ui-bridge-request", &event_payload),
+        }
+    } else {
+        state.app_handle.emit("ui-bridge-request", &event_payload)
+    };
+    if let Err(e) = emit_result {
         // Clean up the pending entry
         let mut pending = state.ui_bridge_pending.lock().await;
-        if pending.remove(&request_id).is_some() {
+        if pending.remove(&pkey).is_some() {
             state
                 .ui_bridge_pending_count
                 .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
@@ -341,7 +410,7 @@ async fn ui_bridge_request_inner(
         Err(_) => {
             // Timeout - clean up the pending entry
             let mut pending = state.ui_bridge_pending.lock().await;
-            if pending.remove(&request_id).is_some() {
+            if pending.remove(&pkey).is_some() {
                 state
                     .ui_bridge_pending_count
                     .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
@@ -371,9 +440,18 @@ pub async fn handle_ui_bridge_response(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    // The responding window echoes its own label; absent for the single-window
+    // default (and for any pre-window-aware frontend), so fall back to "main" —
+    // which is exactly the key both dispatch paths store under in Phase 0.
+    let window_label = response
+        .get("windowLabel")
+        .and_then(|v| v.as_str())
+        .unwrap_or(MAIN_WINDOW_LABEL);
+
     if let Some(request_id) = request_id {
+        let pkey = pending_key(window_label, &request_id);
         let mut pending_map = pending.lock().await;
-        if let Some(sender) = pending_map.remove(&request_id) {
+        if let Some(sender) = pending_map.remove(&pkey) {
             pending_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
             // Extract the data portion of the response
             let data = response.get("data").cloned().unwrap_or(response.clone());
@@ -464,10 +542,78 @@ mod wrap_ipc_result_tests {
     //! `wrap_ipc_result` helper. Lock down each decision point: inner
     //! success, inner failure (with/without error field), absent success
     //! field, and non-bool success values.
-    use super::wrap_ipc_result;
+    use super::{handle_ui_bridge_response, pending_key, wrap_ipc_result, MAIN_WINDOW_LABEL};
     use axum::http::StatusCode;
     use serde_json::json;
+    use std::collections::HashMap;
     use std::ops::Deref;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::{oneshot, Mutex};
+
+    // ── Window-aware dispatch (Phase 0) ─────────────────────────────────────
+
+    #[test]
+    fn pending_key_is_distinct_per_window_for_same_request_id() {
+        let id = "11111111-2222-3333-4444-555555555555";
+        // Same request id in two windows must NOT collide on the pending map.
+        assert_ne!(pending_key("main", id), pending_key("term-1", id));
+        // Same (window, id) is stable so insert and remove agree.
+        assert_eq!(pending_key("main", id), pending_key("main", id));
+    }
+
+    #[tokio::test]
+    async fn response_routes_only_to_the_addressed_window() {
+        // Two windows registered the SAME request id; a response from one must
+        // resolve only that window's sender and leave the other pending.
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+        let id = "req-abc";
+        let (tx_main, rx_main) = oneshot::channel::<serde_json::Value>();
+        let (tx_term, rx_term) = oneshot::channel::<serde_json::Value>();
+        {
+            let mut p = pending.lock().await;
+            p.insert(pending_key("main", id), tx_main);
+            p.insert(pending_key("term-1", id), tx_term);
+        }
+        count.store(2, Ordering::Relaxed);
+
+        let response = json!({ "requestId": id, "windowLabel": "term-1", "data": { "ok": true } });
+        handle_ui_bridge_response(pending.clone(), count.clone(), response).await;
+
+        // term-1's sender fired with the unwrapped data...
+        assert_eq!(
+            rx_term.await.expect("term-1 sender fired"),
+            json!({ "ok": true })
+        );
+        // ...main's entry is untouched (still pending, count decremented by one).
+        let p = pending.lock().await;
+        assert!(p.contains_key(&pending_key("main", id)));
+        assert!(!p.contains_key(&pending_key("term-1", id)));
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+        drop(rx_main);
+    }
+
+    #[tokio::test]
+    async fn response_without_label_defaults_to_main() {
+        // A response that omits windowLabel (pre-window-aware frontend, or the
+        // direct-eval path) must resolve the "main" key it was stored under.
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let count = Arc::new(AtomicUsize::new(0));
+        let id = "req-xyz";
+        let (tx, rx) = oneshot::channel::<serde_json::Value>();
+        {
+            let mut p = pending.lock().await;
+            p.insert(pending_key(MAIN_WINDOW_LABEL, id), tx);
+        }
+        count.store(1, Ordering::Relaxed);
+
+        let response = json!({ "requestId": id, "data": { "v": 1 } });
+        handle_ui_bridge_response(pending.clone(), count.clone(), response).await;
+
+        assert_eq!(rx.await.expect("main sender fired"), json!({ "v": 1 }));
+        assert_eq!(count.load(Ordering::Relaxed), 0);
+    }
 
     #[test]
     fn inner_success_returns_http_200() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,8 @@ import { ContextualTutorial } from "./components/tutorial";
 import { DemoVisualOverlay } from "./components/demo-video/DemoVisualOverlay";
 import { getGraphQLClient } from "./lib/graphql-client";
 
-import { UIBridgeProvider, AutoRegisterProvider } from "@qontinui/ui-bridge";
+import { UIBridgeProvider, AutoRegisterProvider, UIBridgeWindowProvider } from "@qontinui/ui-bridge";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { setupEventHandlers, eventRouter } from "./managers";
 import {
@@ -905,6 +906,14 @@ export default function App() {
           just dev. Use [data-no-register] on any element you want to opt
           out individually.
         */}
+        {/*
+          Phase 0 of plans/2026-06-03-runner-popout-terminal-windows.md.
+          Declare this window's label once at the bridge root so every
+          `useUIElement` below registers under it. For the main window this
+          is "main" — the registry's default — so registration is byte-
+          identical to before; pop-out windows (Phase 1) supply "term-N".
+        */}
+        <UIBridgeWindowProvider windowLabel={getCurrentWindow().label}>
         <AutoRegisterProvider
           enabled
           idStrategy="prefer-existing"
@@ -940,6 +949,7 @@ export default function App() {
             </TenantProvider>
           </AuthProvider>
         </AutoRegisterProvider>
+        </UIBridgeWindowProvider>
       </UIBridgeProvider>
     </ApolloProvider>
   );

--- a/src/hooks/ui-bridge-events/types.ts
+++ b/src/hooks/ui-bridge-events/types.ts
@@ -492,6 +492,14 @@ void _handledCoversUnion;
 export interface UIBridgeRequestPayload {
   requestId: string;
   type: UIBridgeRequestType;
+  /**
+   * Target window for this request (multi-window hosts, Phase 0 of the pop-out
+   * terminal-windows plan). Absent for the single-window default — the runner's
+   * Rust dispatcher only stamps it when targeting a non-`"main"` window. Each
+   * window's listener ignores events whose `windowLabel` is set and differs
+   * from its own `getCurrentWindow().label`.
+   */
+  windowLabel?: string;
   elementId?: string;
   componentId?: string;
   actionId?: string;
@@ -575,6 +583,14 @@ export interface UIBridgeRequestPayload {
 export interface UIBridgeResponsePayload {
   requestId: string;
   type: UIBridgeRequestType;
+  /**
+   * The responding window's own label (`getCurrentWindow().label`). The Rust
+   * response dispatcher pairs `(windowLabel, requestId)` against its pending
+   * map; omitting it falls back to `"main"`, which is exactly the key the
+   * single-window default registers under. Always stamped by the runner's
+   * `sendResponse` so multi-window responses can't be mis-routed.
+   */
+  windowLabel?: string;
   success: boolean;
   data?: unknown;
   error?: string;

--- a/src/hooks/useUIBridgeEventHandler.ts
+++ b/src/hooks/useUIBridgeEventHandler.ts
@@ -27,6 +27,7 @@
 
 import { useEffect, useLayoutEffect, useCallback, useRef } from "react";
 import { listen, emit, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useUIBridge } from "@qontinui/ui-bridge";
 import type { StyleGuideConfig } from "@qontinui/ui-bridge";
 import { createLogger } from "@/lib/logger";
@@ -60,6 +61,12 @@ import { httpSendResponse, httpSendPong } from "./ui-bridge-events/utils";
  */
 export function useUIBridgeEventHandler(): void {
   const bridge = useUIBridge();
+  // This window's own Tauri webview label ("main" for the primary window).
+  // Stable for the window's lifetime — captured once in a ref. Used to (a)
+  // ignore `ui-bridge-request` events addressed to a different window and
+  // (b) stamp every response so the Rust dispatcher pairs it under the right
+  // (windowLabel, requestId) key. See Phase 0 of the pop-out terminal plan.
+  const myWindowLabelRef = useRef<string>(getCurrentWindow().label);
   const bridgeRef = useRef(bridge);
   const loadedStyleGuideRef = useRef<StyleGuideConfig | null>(null);
   const changeTrackerRef = useRef<InstanceType<
@@ -83,6 +90,14 @@ export function useUIBridgeEventHandler(): void {
    * Send a response back to the Rust backend
    */
   const sendResponse = useCallback(async (response: UIBridgeResponsePayload) => {
+    // Stamp this window's label so the Rust dispatcher pairs the response
+    // under the same (windowLabel, requestId) key the request was stored
+    // under. Defaulting omitted labels to "main" on the Rust side keeps this
+    // backward-compatible, but stamping explicitly is what makes multi-window
+    // routing unambiguous.
+    if (response.windowLabel === undefined) {
+      response = { ...response, windowLabel: myWindowLabelRef.current };
+    }
     // Send via HTTP first (primary). The Tauri emit path suffers from
     // double-serialization: Tauri serializes the payload to JSON for IPC,
     // then the Rust listener deserializes via serde_json::from_str(event.payload()).
@@ -228,6 +243,20 @@ export function useUIBridgeEventHandler(): void {
           }
 
           const payload = event.payload;
+
+          // Multi-window addressing (Phase 0): the Rust dispatcher stamps a
+          // target `windowLabel` only when it isn't "main". A window ignores
+          // any request addressed to a different window. When the field is
+          // absent (single-window default) every window — i.e. just "main"
+          // today — processes it, so behavior is unchanged.
+          const target = payload.windowLabel;
+          if (target && target !== myWindowLabelRef.current) {
+            log.debug(
+              `Ignoring request for window '${target}' (this window is '${myWindowLabelRef.current}')`,
+            );
+            return;
+          }
+
           log.debug("Received event:", payload.type, payload.requestId);
 
           // Handle the request asynchronously

--- a/src/lib/ui-bridge/TauriRenderLogStorage.ts
+++ b/src/lib/ui-bridge/TauriRenderLogStorage.ts
@@ -7,6 +7,7 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { RenderLogStorage, RenderLogEntry, RenderLogEntryType } from "@qontinui/ui-bridge";
 
 /**
@@ -20,6 +21,8 @@ interface BackendRenderLogEntry {
   data: Record<string, unknown>;
   visible_sections?: string[];
   task_run_id?: number;
+  /** Window that produced this entry ("main" for the primary window). */
+  window_label?: string;
 }
 
 function convertToBackendFormat(entry: RenderLogEntry, taskRunId?: number): BackendRenderLogEntry {
@@ -40,6 +43,9 @@ function convertToBackendFormat(entry: RenderLogEntry, taskRunId?: number): Back
     trigger: (entry.metadata?.trigger as string) || entry.type,
     data: entry.data as Record<string, unknown>,
     task_run_id: taskRunId,
+    // Stamp the producing window so multi-window render logs can be filtered
+    // by `?windowLabel=`. "main" for the primary window (Phase 0).
+    window_label: getCurrentWindow().label,
   };
 }
 

--- a/src/utils/renderLogger.ts
+++ b/src/utils/renderLogger.ts
@@ -22,6 +22,7 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 // Type for component render log entries
 export interface ComponentRenderLogEntry {
@@ -43,6 +44,8 @@ interface RenderLogEntryWire {
   data: Record<string, unknown>;
   visible_sections?: string[];
   task_run_id?: number;
+  /** Window that produced this entry ("main" for the primary window). */
+  window_label?: string;
 }
 
 /**
@@ -75,6 +78,8 @@ export async function logRender(
     data,
     visible_sections: options?.visibleSections,
     task_run_id: options?.taskRunId,
+    // Stamp the producing window so multi-window render logs are filterable.
+    window_label: getCurrentWindow().label,
   };
 
   try {


### PR DESCRIPTION
## What

Phase 0 of `plans/2026-06-03-runner-popout-terminal-windows.md` — make the runner's UI Bridge safe for **>1 Tauri window in one process** so pop-out terminal windows (Phase 1) won't collide. **Additive and OFF by default**: with a single (`"main"`) window everything is byte-identical to today. Pins `@qontinui/ui-bridge` `^0.15.0` (the window-aware SDK, qontinui/ui-bridge#78) and opts in.

**Depends on** `@qontinui/ui-bridge@0.15.0` (published to npm).

## Rust dispatch (`mcp/ui_bridge/request.rs`, `helpers.rs`)
- `ui_bridge_pending` keyed by composite `(window_label, request_id)` via a shared `pending_key` helper, routed through **both** dispatch paths (main IPC + the direct-webview-eval fallback) and the response dispatcher. A response carries the window's own label; missing → `"main"`. A response from a non-targeted window can't match a stored key → **kills the broadcast race**.
- Targeted emit (`get_webview_window(label).emit`) behind `QONTINUI_UI_BRIDGE_MULTI_WINDOW` (**default OFF → broadcast, exactly as today**).
- `window_label` rides in the **flattened** envelope payload only when non-`"main"`, so the default request wire shape is unchanged — and **no `qontinui-schemas` change** is needed (honoring the two-PR scope; the response side reads the label off the `Value`).
- 3 integration tests: distinct per-window keys, response routes only to the addressed window, missing label defaults to `"main"`.

## render-log (`mcp/ui_bridge/capabilities.rs`, `commands/logging.rs`)
- `GET /ui-bridge/control/render-log` accepts `?windowLabel=` (unlabeled = `"main"`); the no-filter path returns the log **verbatim** (byte-identical).
- Entries carry optional `window_label` (skipped when `None`); stamped by both frontend producers.

## list_runner_windows (`mcp/ui_bridge/capabilities.rs`)
- New `GET /ui-bridge/control/runner-windows` enumerates the process's **own** Tauri webviews (`label` + `kind`), distinct from the OS-window `/control/windows`.

## Frontend (`src/`)
- `useUIBridgeEventHandler` ignores requests addressed to another window and stamps each response with `getCurrentWindow().label`.
- App root wraps the element tree in `UIBridgeWindowProvider(getCurrentWindow().label)` so `useUIElement` registers under the window (`"main"` today → registry default).
- Request/response payload types gain optional `windowLabel`.

## Gates
- `cargo fmt` ✓, `cargo check --tests` ✓, **`cargo clippy --workspace --tests -- -D warnings` ✓** (9m35s clean), 3 new Rust tests ✓.
- Frontend `tsc --noEmit` ✓, `vite build` ✓, `eslint` ✓.

## Regression posture (most important)
With no second window: snapshot shape unchanged (no `byRoutePerWindow`, no per-element `windowLabel`), broadcast emit unchanged, pending key is `("main", id)`, render-log no-filter path verbatim. Existing UI-Bridge automation/skills (page-health, visual-audit, ui-bridge-debug) work against the `"main"` window unchanged.

## Out of scope / deferred
Pop-out windows, `WindowAssignments`, per-window tab/layout state (Phase 1+). Console-error capture is process-global in Phase 0 (single window → all `"main"`); per-window attribution lands with Phase 1's windowed providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Same verified commit as the stuck #394 (whose branch GitHub stopped firing pull_request events for, while other branches trigger normally). Fresh branch to get CI to run._
