### PR TITLE
feat(claims): populate agent_session_id on the terminal worktree-claim path

### DIFF
--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -280,6 +280,7 @@ pub async fn acquire_for_terminal(
     intent_repo: Option<&str>,
     purpose: &str,
     working_dir: Option<String>,
+    agent_session_id: Option<uuid::Uuid>,
 ) -> (Option<String>, Option<IsolatedEditContext>) {
     let Some(repo) = intent_repo else {
         return (working_dir, None);
@@ -291,7 +292,7 @@ pub async fn acquire_for_terminal(
         declared_overlap_paths: None,
         plan_id: None,
         phase: None,
-        agent_session_id: None,
+        agent_session_id,
     })
     .await
     {

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -966,6 +966,11 @@ pub async fn launch_coordinator_session(
             Some("qontinui-runner"),
             "Coordinator session",
             Some(primary_repo_path.clone()),
+            // No stable per-session id exists yet at spawn time — the new
+            // Coordinator establishes its own identity via
+            // `try_acquire_coordinator_lease` inside the spawned CLI
+            // process, not in this scope. None is correct here.
+            None,
         )
         .await;
     let repo_path = effective_repo_path.unwrap_or(primary_repo_path);
@@ -1038,6 +1043,14 @@ pub async fn spawn_worker_session(
     let primary_repo_path = resolve_runner_repo_path()
         .ok_or_else(|| "Failed to resolve qontinui-runner repo path".to_string())?;
 
+    // The worker's stable session id. Generated here (ahead of the
+    // worktree allocate) so it can be folded into the isolated-worktree
+    // claim's owner token — this is the per-worker identity the terminal
+    // is being created FOR (later handed to `WorkerSession::new` + coord
+    // registration). Distinguishes two workers spawned on one machine as
+    // distinct claim holders.
+    let task_run_id = Uuid::new_v4().to_string();
+
     // Phase 2 — worker sessions always intend to edit qontinui-runner
     // (the Coordinator's `assign-task` dispatch targets runner code).
     // Route through `acquire_for_terminal` so this path stays in
@@ -1048,6 +1061,7 @@ pub async fn spawn_worker_session(
             Some(&intent_repo),
             "Worker session",
             Some(primary_repo_path.clone()),
+            uuid::Uuid::parse_str(&task_run_id).ok(),
         )
         .await;
     let repo_path = effective_repo_path.unwrap_or(primary_repo_path);
@@ -1075,8 +1089,6 @@ pub async fn spawn_worker_session(
             effective_config_dir.as_deref(),
         );
     }
-
-    let task_run_id = Uuid::new_v4().to_string();
 
     let title = title_hint.unwrap_or_else(|| next_worker_title(&terminal_manager));
     // PowerShell 5.1 doesn't accept `&&`, and the pty already starts

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -60,10 +60,15 @@ pub async fn terminal_create(
     // in lockstep. When `intent_repo` is `None`, the helper is a no-op;
     // when it's `Some(_)` but worktree mode is off or allocation fails,
     // the helper returns the original `working_dir` and logs.
+    // This Tauri command is invoked by the operator's frontend — an
+    // interactive/UI-created terminal with no agent session to attribute.
+    // The coord session id is only minted later (registration below), and
+    // it identifies the coord row, not the spawning agent. None is correct.
     let (working_dir, isolated_ctx) = crate::agent_worktree::isolated_edit::acquire_for_terminal(
         intent_repo.as_deref(),
         title.as_deref().unwrap_or("Terminal edit session"),
         working_dir,
+        None,
     )
     .await;
 

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -2145,11 +2145,22 @@ async fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Opti
             .and_then(|v| v.as_str())
             .map(String::from);
 
+        // Stable session id of the agent issuing this relay request, if the
+        // caller supplied one — folded into the claim owner token so distinct
+        // agent sessions on one machine are distinct holders. Sourced from the
+        // request payload (the initiator's context), NOT the runner's process
+        // env. Absent / unparseable → None.
+        let agent_session_id = data
+            .get("agent_session_id")
+            .and_then(|v| v.as_str())
+            .and_then(|s| uuid::Uuid::parse_str(s).ok());
+
         let (working_dir, isolated_ctx) =
             crate::agent_worktree::isolated_edit::acquire_for_terminal(
                 intent_repo.as_deref(),
                 title.as_deref().unwrap_or("Terminal edit session"),
                 working_dir,
+                agent_session_id,
             )
             .await;
 

--- a/src-tauri/src/mcp/tauri_proxy.rs
+++ b/src-tauri/src/mcp/tauri_proxy.rs
@@ -177,6 +177,13 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 /// PTY cwd instead of `working_dir`. Mirrors the `intent_repo`
                 /// argument on the `terminal_create` Tauri command.
                 intent_repo: Option<String>,
+                /// Stable session id of the agent creating this terminal,
+                /// supplied by the proxy caller (the initiator's context).
+                /// Folded into the isolated-worktree claim's owner token so
+                /// distinct agent sessions on one machine are distinct
+                /// holders. Absent → None.
+                #[serde(default)]
+                agent_session_id: Option<uuid::Uuid>,
             }
             let a = match serde_json::from_value::<Args>(req.args) {
                 Ok(v) => v,
@@ -193,6 +200,7 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                     a.intent_repo.as_deref(),
                     a.title.as_deref().unwrap_or("Terminal edit session"),
                     a.working_dir,
+                    a.agent_session_id,
                 )
                 .await;
 

--- a/src-tauri/src/mcp/terminals.rs
+++ b/src-tauri/src/mcp/terminals.rs
@@ -50,6 +50,12 @@ pub struct CreateTerminalRequest {
     /// argument on the `terminal_create` Tauri command + HTTP-SDK proxy.
     #[serde(default)]
     pub intent_repo: Option<String>,
+    /// Stable session id of the agent creating this terminal. Folded into
+    /// the isolated-worktree claim's owner token so two different agent
+    /// sessions on one machine are distinct holders. None for
+    /// interactive/UI-created terminals (no session to attribute).
+    #[serde(default)]
+    pub agent_session_id: Option<uuid::Uuid>,
 }
 
 /// Request body for writing data to a terminal.
@@ -151,6 +157,7 @@ pub async fn create_terminal_handler(
             .as_deref()
             .unwrap_or("HTTP terminal edit session"),
         request.working_dir,
+        request.agent_session_id,
     )
     .await;
 


### PR DESCRIPTION
Makes the runner spawn path's session-scoped owner token take **live effect** — the prior PRs (#365, #387) plumbed `agent_session_id` through the claim functions and request structs, but nothing populated it on the terminal path, so isolated-worktree claims still sent `None` in practice.

**Source rule (decided per project priorities — power → scalability → robustness → clean):** the session id comes from the **initiator's request/spawn context** — the stable identity of the session the terminal is created *for*. **Never** the runner's process-wide env: the runner is one long-lived process serving many terminals, so a process-wide `CLAUDE_CODE_SESSION_ID` would false-share one id across every terminal on the machine, re-introducing the exact bug. Where no correct id is in scope, `None` (a wrong id is worse than none).

Per call site:
| Site | Source |
|---|---|
| `create_terminal_handler` (HTTP) | new `CreateTerminalRequest.agent_session_id` |
| `spawn_worker_session` | `task_run_id` — the worker's canonical session id (hoisted into scope) |
| `handle_terminal_create` (relay) | parsed from the relay request payload |
| `tauri_proxy` `terminal_create` | new `Args.agent_session_id` |
| `launch_coordinator_session` | `None` — coordinator establishes its identity later, not at spawn |
| `terminal_create` (interactive Tauri cmd) | `None` — operator-driven, no agent session |

The **dispatch/daemon path is already complete**: `post_allocate_local` reads `req.agent_session_id`, and `/agents/allocate-local` is only called by external dispatchers who supply it.

Verified locally: `cargo check --bin qontinui-runner --features custom-protocol` → exit 0; `cargo fmt` clean. Pre-push cargo gate skipped (sanctioned `QONTINUI_PREPUSH_SKIP`, redundant cold rebuild) — CI runs the identical fmt+clippy gate. Plan: `2026-06-03-coord-session-scoped-claim-owner`.