### PR TITLE
ci(specs): drop setup-node from page-spec-paths producer workflow

### DIFF
--- a/.github/workflows/page-spec-paths.yml
+++ b/.github/workflows/page-spec-paths.yml
@@ -35,12 +35,13 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: "20"
-
-      # The script is pure Node >= 18 stdlib (no npm deps) -- no install step.
+      # No setup-node: the script is pure Node >= 18 stdlib (no npm deps) and
+      # ubuntu-latest ships Node >= 20 preinstalled. setup-node@v5 would
+      # auto-detect `packageManager: pnpm` from package.json (its
+      # package-manager-cache default) and fail because pnpm isn't installed
+      # (first live run 26944789087 failed exactly there).
+      - name: Node version
+        run: node --version
       - name: Publish page-spec path map to coord
         continue-on-error: true
         env:


### PR DESCRIPTION
Follow-up to #401 (plan 2026-06-04-page-spec-path-map-producer-plan). First live run 26944789087 failed at setup-node@v5: its package-manager-cache default auto-detects packageManager: pnpm from package.json and errors because pnpm isn't installed on the job. The producer script is pure Node stdlib and ubuntu-latest ships Node >= 20, so the step is unnecessary — replaced with a node --version echo. The publish step remains continue-on-error + script exits 0 on POST failure (never gates CI).