### PR TITLE
feat(terminal): Ctrl+Up/Down previous/next-command navigation (VS Code parity)

### DIFF
--- a/src/components/terminal/KeyboardShortcutsOverlay.tsx
+++ b/src/components/terminal/KeyboardShortcutsOverlay.tsx
@@ -45,6 +45,8 @@ const SHORTCUT_GROUPS: { title: string; shortcuts: ShortcutDef[] }[] = [
       { keys: "Ctrl+Alt+PageDown", description: "Scroll down one line" },
       { keys: "Ctrl+Home", description: "Scroll to top" },
       { keys: "Ctrl+End", description: "Scroll to bottom" },
+      { keys: "Ctrl+↑", description: "Jump to previous command prompt" },
+      { keys: "Ctrl+↓", description: "Jump to next command prompt" },
     ],
   },
   {

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -549,10 +549,11 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
           }
 
           // VS Code-parity scrollback navigation: Shift+PageUp/PageDown,
-          // Ctrl+Alt+PageUp/PageDown, Ctrl+Home/End. Scroll the focused
-          // terminal locally and swallow the key so it isn't forwarded to the
-          // PTY (xterm doesn't preventDefault on a `false` return, so we do it
-          // here to also stop any browser-default scroll/caret motion).
+          // Ctrl+Alt+PageUp/PageDown, Ctrl+Home/End, Ctrl+Up/Down (prev/next
+          // command via OSC 633;A marks). Scroll the focused terminal locally
+          // and swallow the key so it isn't forwarded to the PTY (xterm
+          // doesn't preventDefault on a `false` return, so we do it here to
+          // also stop any browser-default scroll/caret motion).
           if (event.type === "keydown") {
             const action = matchScrollShortcut(event);
             if (action) {
@@ -569,6 +570,12 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
                   break;
                 case "bottom":
                   backend.scrollToBottom();
+                  break;
+                case "prevCommand":
+                  backend.scrollToPreviousCommand();
+                  break;
+                case "nextCommand":
+                  backend.scrollToNextCommand();
                   break;
               }
               return false;

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -142,6 +142,12 @@ export class GhosttyBackend implements ITerminalBackend {
     t.scrollToTop?.();
   }
 
+  // ghostty-web has no marker API — command navigation degrades to a no-op
+  // (same posture as find below: the binding simply does nothing here).
+  scrollToPreviousCommand(): void {}
+
+  scrollToNextCommand(): void {}
+
   // ghostty-web has no search addon — find-in-terminal degrades to "no
   // matches" and the find bar simply shows 0 results on this backend.
   findNext(): boolean {

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -1,4 +1,4 @@
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type IMarker } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { CanvasAddon } from "@xterm/addon-canvas";
@@ -33,6 +33,8 @@ export class XtermBackend implements ITerminalBackend {
   private readonly fitAddon: FitAddon;
   private readonly searchAddon: SearchAddon;
   private container: HTMLElement | null = null;
+  /** OSC 633;A prompt-start markers, in registration (= buffer) order. */
+  private promptMarkers: IMarker[] = [];
 
   constructor(options: TerminalBackendOptions = {}) {
     this.term = new Terminal({
@@ -50,6 +52,27 @@ export class XtermBackend implements ITerminalBackend {
     this.term.loadAddon(this.fitAddon);
     this.searchAddon = new SearchAddon();
     this.term.loadAddon(this.searchAddon);
+
+    // Track shell-prompt positions for Ctrl+Up/Ctrl+Down command navigation
+    // (VS Code "Scroll to Previous/Next Command"). OSC 633;A fires at every
+    // prompt start when shell integration is installed; registerMarker pins
+    // the cursor's buffer line and keeps it stable as scrollback trims (the
+    // marker disposes itself when its line scrolls out of the buffer).
+    // Registered as a SECOND OSC 633 handler — returning false lets the
+    // `onOsc633` subscriber (TerminalInstance shell-integration wiring) run
+    // for the same payload.
+    this.term.parser.registerOscHandler(633, (data: string) => {
+      if (data === "A") {
+        this.promptMarkers.push(this.term.registerMarker(0));
+      }
+      return false;
+    });
+  }
+
+  /** Drop disposed markers (line === -1) and return the live, sorted list. */
+  private livePromptMarkers(): IMarker[] {
+    this.promptMarkers = this.promptMarkers.filter((m) => !m.isDisposed && m.line >= 0);
+    return this.promptMarkers;
   }
 
   open(container: HTMLElement): void {
@@ -154,6 +177,35 @@ export class XtermBackend implements ITerminalBackend {
 
   scrollToTop(): void {
     this.term.scrollToTop();
+  }
+
+  scrollToPreviousCommand(): void {
+    const viewportTop = this.term.buffer.active.viewportY;
+    const markers = this.livePromptMarkers();
+    // Last prompt strictly above the current viewport top. When the earliest
+    // prompt is already at/above the top, fall through to the very top so
+    // repeated presses still make progress (matches VS Code).
+    for (let i = markers.length - 1; i >= 0; i--) {
+      if (markers[i].line < viewportTop) {
+        this.term.scrollToLine(markers[i].line);
+        return;
+      }
+    }
+    if (markers.length > 0) this.term.scrollToTop();
+    // No markers at all (no shell integration): deliberate no-op — a blind
+    // jump to the top of 10k lines of scrollback would be a surprise.
+  }
+
+  scrollToNextCommand(): void {
+    const viewportTop = this.term.buffer.active.viewportY;
+    const markers = this.livePromptMarkers();
+    for (const m of markers) {
+      if (m.line > viewportTop) {
+        this.term.scrollToLine(m.line);
+        return;
+      }
+    }
+    if (markers.length > 0) this.term.scrollToBottom();
   }
 
   findNext(term: string, options?: TerminalSearchOptions): boolean {

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -164,6 +164,15 @@ export interface ITerminalBackend {
   scrollPages(pageCount: number): void;
   /** Scroll the viewport to the very top of the scrollback (VS Code Ctrl+Home). */
   scrollToTop(): void;
+  /**
+   * Jump the viewport to the previous shell prompt (VS Code Ctrl+Up "Scroll
+   * to Previous Command"). Prompt positions come from OSC 633;A shell
+   * integration marks tracked by the backend; no-op when no marks exist
+   * (shell integration not installed, or a backend without marker support).
+   */
+  scrollToPreviousCommand(): void;
+  /** Jump to the next shell prompt (VS Code Ctrl+Down); bottom when none ahead. */
+  scrollToNextCommand(): void;
 
   // -- Find-in-terminal (VS Code Ctrl+F parity) ------------------------------
   /**

--- a/src/components/terminal/scrollKeys.test.ts
+++ b/src/components/terminal/scrollKeys.test.ts
@@ -39,12 +39,24 @@ describe("matchScrollShortcut", () => {
     expect(matchScrollShortcut(k({ key: "End", ctrlKey: true }))).toEqual({ kind: "bottom" });
   });
 
+  it("maps Ctrl+Up / Ctrl+Down to previous / next command navigation", () => {
+    expect(matchScrollShortcut(k({ key: "ArrowUp", ctrlKey: true }))).toEqual({
+      kind: "prevCommand",
+    });
+    expect(matchScrollShortcut(k({ key: "ArrowDown", ctrlKey: true }))).toEqual({
+      kind: "nextCommand",
+    });
+  });
+
   it("accepts Cmd (metaKey) as a Ctrl alias for macOS", () => {
     expect(matchScrollShortcut(k({ key: "Home", metaKey: true }))).toEqual({ kind: "top" });
     expect(matchScrollShortcut(k({ key: "End", metaKey: true }))).toEqual({ kind: "bottom" });
     expect(matchScrollShortcut(k({ key: "PageUp", metaKey: true, altKey: true }))).toEqual({
       kind: "lines",
       amount: -1,
+    });
+    expect(matchScrollShortcut(k({ key: "ArrowUp", metaKey: true }))).toEqual({
+      kind: "prevCommand",
     });
   });
 
@@ -63,5 +75,12 @@ describe("matchScrollShortcut", () => {
     expect(matchScrollShortcut(k({ key: "Home", shiftKey: true }))).toBeNull();
     // Ctrl+Shift+Home should not scroll (Shift disqualifies the top binding).
     expect(matchScrollShortcut(k({ key: "Home", ctrlKey: true, shiftKey: true }))).toBeNull();
+    // Bare arrows belong to the app (history navigation in shells/TUIs).
+    expect(matchScrollShortcut(k({ key: "ArrowUp" }))).toBeNull();
+    expect(matchScrollShortcut(k({ key: "ArrowDown" }))).toBeNull();
+    // Ctrl+Shift+Arrows are page-level focus-history shortcuts — leave them.
+    expect(matchScrollShortcut(k({ key: "ArrowUp", ctrlKey: true, shiftKey: true }))).toBeNull();
+    // Ctrl+Alt+Arrows are not bound — leave them for the app.
+    expect(matchScrollShortcut(k({ key: "ArrowDown", ctrlKey: true, altKey: true }))).toBeNull();
   });
 });

--- a/src/components/terminal/scrollKeys.ts
+++ b/src/components/terminal/scrollKeys.ts
@@ -8,6 +8,7 @@
  *   Scroll page up / down    Shift+PageUp     / Shift+PageDown
  *   Scroll line up / down    Ctrl+Alt+PageUp  / Ctrl+Alt+PageDown
  *   Scroll to top / bottom   Ctrl+Home        / Ctrl+End
+ *   Prev / next command      Ctrl+Up          / Ctrl+Down
  *
  * Wired into the per-terminal `attachCustomKeyEventHandler` in
  * `TerminalInstance`, which scrolls the focused terminal's scrollback and
@@ -24,7 +25,9 @@ export type ScrollAction =
   | { kind: "lines"; amount: number }
   | { kind: "pages"; amount: number }
   | { kind: "top" }
-  | { kind: "bottom" };
+  | { kind: "bottom" }
+  | { kind: "prevCommand" }
+  | { kind: "nextCommand" };
 
 /** The subset of `KeyboardEvent` the mapping depends on. */
 export interface KeyLike {
@@ -58,9 +61,14 @@ export function matchScrollShortcut(e: KeyLike): ScrollAction | null {
   }
 
   // Top / bottom — Ctrl+Home / Ctrl+End (⌘ on macOS), no Alt/Shift.
+  // Command navigation — Ctrl+Up / Ctrl+Down (⌘ on macOS): jump between
+  // shell prompts (VS Code "Scroll to Previous/Next Command", driven by
+  // OSC 633;A shell-integration marks).
   if (cmdOrCtrl && !altKey && !shiftKey) {
     if (key === "Home") return { kind: "top" };
     if (key === "End") return { kind: "bottom" };
+    if (key === "ArrowUp") return { kind: "prevCommand" };
+    if (key === "ArrowDown") return { kind: "nextCommand" };
   }
 
   return null;


### PR DESCRIPTION
## What

**`Ctrl+Up` / `Ctrl+Down` previous/next-command navigation** — the fourth piece of VS Code terminal parity, stacked on #379 (find) → #378 (keyboard scroll) → #377 (Shift+wheel). Matches VS Code's `workbench.action.terminal.scrollToPreviousCommand` / `scrollToNextCommand` ([docs](https://code.visualstudio.com/docs/terminal/basics)); Cmd works as the Ctrl alias on macOS.

## How

- `XtermBackend` registers a second OSC `633;A` parser handler that pins an xterm **marker** at every prompt start — exactly how VS Code tracks command positions via shell integration. Markers self-dispose as scrollback trims; the list is pruned on use. Both 633 handlers return `false`, so the existing `onOsc633` shell-integration subscription (prompt-state tracking, command history) is unaffected.
- `scrollToPreviousCommand()`: jumps to the last mark above the viewport top; if marks exist but none above, goes to top (repeated presses keep making progress, like VS Code). **Deliberate no-op when there are no marks at all** (shell integration absent) — a blind jump through 10k lines of scrollback would violate the no-surprise rule.
- `scrollToNextCommand()`: first mark below the viewport top, else bottom.
- Ghostty backend: no-ops (no marker API) — same graceful-degradation posture as find.
- `matchScrollShortcut` gains `prevCommand`/`nextCommand`; tests pin that bare arrows (shell history) and `Ctrl+Shift+arrows` (page-level focus-history shortcuts) remain untouched.
- `KeyboardShortcutsOverlay` documents both bindings.

## Verification

- Full vitest suite **728/728**, `tsc --noEmit`, ESLint, Prettier, `vite build` — all green.
- Not yet driven live; manual check: in a shell-integrated terminal run a few commands, scroll anywhere, `Ctrl+Up` hops up one prompt at a time, `Ctrl+Down` hops back down.

## Stacking

Base is `feat/terminal-find` (#379). Retarget after the stack merges below it.
