### PR TITLE
feat(terminal): VS Code-parity options — Alt+click cursor move + word separators

### DIFF
--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -95,6 +95,13 @@ const TERMINAL_OPTIONS = {
     "'Cascadia Code', 'Fira Code', 'JetBrains Mono', Menlo, Monaco, 'Courier New', monospace",
   lineHeight: 1.2,
   scrollback: 10000,
+  // VS Code parity: Alt+click moves the shell cursor to the clicked column
+  // (synthesized arrow keys; `terminal.integrated.altClickMovesCursor` is ON
+  // by default in VS Code), and double-click word selection uses VS Code's
+  // separator set (adds backtick, box-drawing dash, smart quotes, pipe to
+  // xterm's default).
+  altClickMovesCursor: true,
+  wordSeparator: " ()[]{}',\"`─‘’“”|",
   theme: {
     background: "#1a1b26",
     foreground: "#c0caf5",

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -45,6 +45,8 @@ export class XtermBackend implements ITerminalBackend {
       cursorBlink: options.cursorBlink,
       cursorStyle: options.cursorStyle,
       theme: options.theme,
+      altClickMovesCursor: options.altClickMovesCursor,
+      wordSeparator: options.wordSeparator,
       allowProposedApi: true,
     });
 

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -71,6 +71,14 @@ export interface TerminalBackendOptions {
   cursorBlink?: boolean;
   cursorStyle?: "block" | "underline" | "bar";
   theme?: ITerminalTheme;
+  /**
+   * Alt+click repositions the shell cursor by synthesizing arrow-key
+   * presses (VS Code `terminal.integrated.altClickMovesCursor`, default ON
+   * there). Only meaningful on backends that support it (xterm).
+   */
+  altClickMovesCursor?: boolean;
+  /** Word-boundary characters for double-click selection (VS Code parity). */
+  wordSeparator?: string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two config-level behaviors VS Code terminal users expect, fifth piece of the parity stack (on #405 → #379 → #378 → #377):

- **`altClickMovesCursor: true`** — Alt+click repositions the shell cursor at the clicked column via synthesized arrow keys. ON by default in VS Code (`terminal.integrated.altClickMovesCursor`); xterm ships it off. xterm automatically gates it to the normal buffer with no app mouse mode, so TUIs are unaffected.
- **`wordSeparator`** — VS Code's double-click word-selection separator set (adds backtick, box-drawing dash `─`, smart quotes, pipe to xterm's default), so double-clicking paths/identifiers selects the same span as in the VS Code terminal.

Plumbed through `TerminalBackendOptions` → `XtermBackend`; ghostty-web ignores unsupported fields (unchanged).

## Verification

Terminal-suite vitest 390/390, `tsc --noEmit`, ESLint, Prettier, `vite build` — green. Config-only; no logic to unit-test.

## Stacking

Base is `feat/terminal-command-nav` (#405). Retarget after the stack merges below it.
