### PR TITLE
spec(runner): register the dag resize divider + enrich weak SM states from live registries

### DIFF
--- a/specs/pages/dag-workflow-editor/spec.uibridge.json
+++ b/specs/pages/dag-workflow-editor/spec.uibridge.json
@@ -1075,7 +1075,14 @@
       },
       {
         "description": "A draggable vertical divider between the YAML editor and graph panes allows the user to adjust the width ratio. The minimum pane width is 20% and the maximum is 80% (of the total container width). The initial split is 50/50.",
-        "elements": [],
+        "elements": [
+          {
+            "role": "separator",
+            "ariaLabel": "Resize editor panes",
+            "tagName": "div",
+            "id": "dag-resize-handle"
+          }
+        ],
         "id": "dag-resize-handle",
         "isInitial": false,
         "name": "Split-Pane Resize Handle",

--- a/specs/pages/help/spec.uibridge.json
+++ b/specs/pages/help/spec.uibridge.json
@@ -206,6 +206,11 @@
         "elements": [
           {
             "textContent": "Shortcuts"
+          },
+          {
+            "role": "tab",
+            "textContent": "Shortcuts",
+            "tagName": "button"
           }
         ],
         "id": "help-shortcuts",

--- a/specs/pages/settings-self-healing/spec.uibridge.json
+++ b/specs/pages/settings-self-healing/spec.uibridge.json
@@ -1178,6 +1178,11 @@
         "elements": [
           {
             "textContent": "passed to qontinui Python when executing workflows"
+          },
+          {
+            "role": "tab",
+            "textContent": "Self-Healing",
+            "tagName": "button"
           }
         ],
         "id": "sh-settings-persistence",

--- a/specs/pages/skills/spec.uibridge.json
+++ b/specs/pages/skills/spec.uibridge.json
@@ -747,6 +747,11 @@
           {
             "role": "button",
             "textContains": "Rejected"
+          },
+          {
+            "role": "button",
+            "textContent": "All",
+            "tagName": "button"
           }
         ],
         "id": "skills-element-presence",

--- a/specs/pages/state-machine/spec.uibridge.json
+++ b/specs/pages/state-machine/spec.uibridge.json
@@ -2889,6 +2889,11 @@
         "elements": [
           {
             "textContent": "captures"
+          },
+          {
+            "role": "button",
+            "textContent": "Discovery",
+            "tagName": "button"
           }
         ],
         "id": "sm-discovery-algorithm",

--- a/specs/pages/terminal/spec.uibridge.json
+++ b/specs/pages/terminal/spec.uibridge.json
@@ -909,6 +909,11 @@
         "elements": [
           {
             "textContent": "Ctrl+Shift+T"
+          },
+          {
+            "role": "tab",
+            "textContent": "Terminal",
+            "tagName": "button"
           }
         ],
         "id": "term-multi-tab",

--- a/specs/pages/watchers/spec.uibridge.json
+++ b/specs/pages/watchers/spec.uibridge.json
@@ -702,6 +702,11 @@
         "elements": [
           {
             "textContent": "Watchers"
+          },
+          {
+            "role": "button",
+            "ariaLabel": "Watchers",
+            "tagName": "button"
           }
         ],
         "id": "watchers-navigation",

--- a/specs/pages/wrappers/spec.uibridge.json
+++ b/specs/pages/wrappers/spec.uibridge.json
@@ -1392,6 +1392,11 @@
           {
             "role": "button",
             "textContains": "onnect"
+          },
+          {
+            "role": "button",
+            "textContent": "AI Clients",
+            "tagName": "button"
           }
         ],
         "id": "ai-clients-status-pills",

--- a/src/components/dag-workflow-editor/DagWorkflowEditor.tsx
+++ b/src/components/dag-workflow-editor/DagWorkflowEditor.tsx
@@ -340,6 +340,10 @@ export function DagWorkflowEditor() {
 
         {/* Resize handle */}
         <div
+          role="separator"
+          aria-label="Resize editor panes"
+          aria-orientation="vertical"
+          data-ui-bridge-id="dag-resize-handle"
           onMouseDown={handleMouseDown}
           className={cn(
             "flex-shrink-0 w-1.5 cursor-col-resize relative group flex items-center justify-center",


### PR DESCRIPTION
## What
Closes the two remaining follow-ups from #393's spec-quality pass.

### 1. dag resize divider is now UI-Bridge-detectable (+ its spec state grounded)
The bare `cursor-col-resize` div had no registration signal. `role="separator"` alone is **not** in the auto-registrar's `INTERACTIVE_SELECTORS`, so the fix adds the author-tag **`data-ui-bridge-id="dag-resize-handle"`** (designed to register regardless of role/tag/interactivity) alongside proper a11y semantics (`role="separator"`, `aria-label="Resize editor panes"`, `aria-orientation="vertical"`).

**Live-verified** on an isolated temp runner (hash-gated worktree build): registers as `{id: dag-resize-handle, role: separator, ariaLabel: "Resize editor panes"}`. The `dag-resize-handle` spec state (one of the 16 documented empties — now 15) gets that element.

### 2. Enrich 7 weak (1-element) SM states with a second discriminating element
Read verbatim from live temp-runner registries (27 pages captured). Survivors of a two-stage review:
- a **chrome filter** (elements present in ≥20/27 page registries = sidebar/app chrome) killed 44 sidebar false-positives;
- **manual review** killed 9 more, incl. two same-element-different-key-spelling traps that would double-claim a physical element under a second canonical key.

Kept: `help::help-shortcuts` (Shortcuts tab), `settings-self-healing::sh-settings-persistence` (Self-Healing tab), `skills::skills-element-presence` (All filter), `state-machine::sm-discovery-algorithm` (Discovery tab), `terminal::term-multi-tab` (Terminal page tab), `watchers::watchers-navigation` (Watchers nav), `wrappers::ai-clients-status-pills` (AI Clients tab) — all page-local and named by their state's own prose.

**Honest scope note:** of 90 weak states corpus-wide, only these 7 enrich with high confidence — most weak states describe data-dependent/behavioral content with no static on-page anchor (same story as the documented empties). Heavy mechanical enrichment isn't supported by this corpus.

## Gates
`specs.compile` uniqueness green · tsc clean · full vitest 702/702 · divider registration verified on the page.