### PR TITLE
feat(terminal): VS Code-parity keyboard scrolling (Shift+PgUp/PgDn, Ctrl+Home/End, Ctrl+Alt+PgUp/PgDn)

### DIFF
--- a/src/components/terminal/KeyboardShortcutsOverlay.tsx
+++ b/src/components/terminal/KeyboardShortcutsOverlay.tsx
@@ -27,6 +27,18 @@ const SHORTCUT_GROUPS: { title: string; shortcuts: ShortcutDef[] }[] = [
     ],
   },
   {
+    title: "Scrolling (focused terminal)",
+    shortcuts: [
+      { keys: "Shift+Wheel", description: "Scroll scrollback even when an app captures the wheel" },
+      { keys: "Shift+PageUp", description: "Scroll up one page" },
+      { keys: "Shift+PageDown", description: "Scroll down one page" },
+      { keys: "Ctrl+Alt+PageUp", description: "Scroll up one line" },
+      { keys: "Ctrl+Alt+PageDown", description: "Scroll down one line" },
+      { keys: "Ctrl+Home", description: "Scroll to top" },
+      { keys: "Ctrl+End", description: "Scroll to bottom" },
+    ],
+  },
+  {
     title: "Layouts",
     shortcuts: [
       { keys: "Ctrl+Shift+1", description: "Single layout" },

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -10,6 +10,7 @@ import { paintGrid, type GridSnapshot } from "./paintGrid";
 import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
 import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
+import { matchScrollShortcut } from "./scrollKeys";
 
 export interface TerminalInstanceHandle {
   getSelection: () => string;
@@ -431,6 +432,33 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
               })
               .catch(() => {});
             return false; // prevent terminal default handling
+          }
+
+          // VS Code-parity scrollback navigation: Shift+PageUp/PageDown,
+          // Ctrl+Alt+PageUp/PageDown, Ctrl+Home/End. Scroll the focused
+          // terminal locally and swallow the key so it isn't forwarded to the
+          // PTY (xterm doesn't preventDefault on a `false` return, so we do it
+          // here to also stop any browser-default scroll/caret motion).
+          if (event.type === "keydown") {
+            const action = matchScrollShortcut(event);
+            if (action) {
+              event.preventDefault();
+              switch (action.kind) {
+                case "lines":
+                  backend.scrollLines(action.amount);
+                  break;
+                case "pages":
+                  backend.scrollPages(action.amount);
+                  break;
+                case "top":
+                  backend.scrollToTop();
+                  break;
+                case "bottom":
+                  backend.scrollToBottom();
+                  break;
+              }
+              return false;
+            }
           }
           return true;
         });

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -132,6 +132,16 @@ export class GhosttyBackend implements ITerminalBackend {
     t.scrollLines?.(amount);
   }
 
+  scrollPages(pageCount: number): void {
+    const t = this.term as unknown as { scrollPages?: (n: number) => void };
+    t.scrollPages?.(pageCount);
+  }
+
+  scrollToTop(): void {
+    const t = this.term as unknown as { scrollToTop?: () => void };
+    t.scrollToTop?.();
+  }
+
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
     this.term.attachCustomKeyEventHandler(handler);
   }

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -129,6 +129,14 @@ export class XtermBackend implements ITerminalBackend {
     this.term.scrollLines(amount);
   }
 
+  scrollPages(pageCount: number): void {
+    this.term.scrollPages(pageCount);
+  }
+
+  scrollToTop(): void {
+    this.term.scrollToTop();
+  }
+
   attachCustomKeyEventHandler(handler: (event: KeyboardEvent) => boolean): void {
     this.term.attachCustomKeyEventHandler(handler);
   }

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -129,6 +129,14 @@ export interface ITerminalBackend {
    * tracking mode. No-op when there is no scrollback to move through.
    */
   scrollLines(amount: number): void;
+  /**
+   * Scroll the viewport by `pageCount` pages (one page ≈ one screen height).
+   * Positive scrolls DOWN, negative UP. Backs the Shift+PageUp/PageDown
+   * keyboard shortcuts (VS Code "Scroll Up/Down (Page)").
+   */
+  scrollPages(pageCount: number): void;
+  /** Scroll the viewport to the very top of the scrollback (VS Code Ctrl+Home). */
+  scrollToTop(): void;
 
   // -- Key handling ---------------------------------------------------------
   /** Intercept key events before the terminal processes them. Return false to prevent default. */

--- a/src/components/terminal/scrollKeys.test.ts
+++ b/src/components/terminal/scrollKeys.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { matchScrollShortcut, type KeyLike } from "./scrollKeys";
+
+const base: KeyLike = {
+  key: "",
+  shiftKey: false,
+  ctrlKey: false,
+  altKey: false,
+  metaKey: false,
+};
+
+const k = (over: Partial<KeyLike>): KeyLike => ({ ...base, ...over });
+
+describe("matchScrollShortcut", () => {
+  it("maps Shift+PageUp / Shift+PageDown to page scroll", () => {
+    expect(matchScrollShortcut(k({ key: "PageUp", shiftKey: true }))).toEqual({
+      kind: "pages",
+      amount: -1,
+    });
+    expect(matchScrollShortcut(k({ key: "PageDown", shiftKey: true }))).toEqual({
+      kind: "pages",
+      amount: 1,
+    });
+  });
+
+  it("maps Ctrl+Alt+PageUp / Ctrl+Alt+PageDown to line scroll", () => {
+    expect(matchScrollShortcut(k({ key: "PageUp", ctrlKey: true, altKey: true }))).toEqual({
+      kind: "lines",
+      amount: -1,
+    });
+    expect(matchScrollShortcut(k({ key: "PageDown", ctrlKey: true, altKey: true }))).toEqual({
+      kind: "lines",
+      amount: 1,
+    });
+  });
+
+  it("maps Ctrl+Home / Ctrl+End to top / bottom", () => {
+    expect(matchScrollShortcut(k({ key: "Home", ctrlKey: true }))).toEqual({ kind: "top" });
+    expect(matchScrollShortcut(k({ key: "End", ctrlKey: true }))).toEqual({ kind: "bottom" });
+  });
+
+  it("accepts Cmd (metaKey) as a Ctrl alias for macOS", () => {
+    expect(matchScrollShortcut(k({ key: "Home", metaKey: true }))).toEqual({ kind: "top" });
+    expect(matchScrollShortcut(k({ key: "End", metaKey: true }))).toEqual({ kind: "bottom" });
+    expect(matchScrollShortcut(k({ key: "PageUp", metaKey: true, altKey: true }))).toEqual({
+      kind: "lines",
+      amount: -1,
+    });
+  });
+
+  it("does not match a bare PageUp/PageDown/Home/End (left for the app)", () => {
+    expect(matchScrollShortcut(k({ key: "PageUp" }))).toBeNull();
+    expect(matchScrollShortcut(k({ key: "PageDown" }))).toBeNull();
+    expect(matchScrollShortcut(k({ key: "Home" }))).toBeNull();
+    expect(matchScrollShortcut(k({ key: "End" }))).toBeNull();
+  });
+
+  it("does not match unrelated keys or wrong modifier combos", () => {
+    expect(matchScrollShortcut(k({ key: "a", ctrlKey: true }))).toBeNull();
+    // Ctrl+PageUp (no Alt) is NOT a scroll shortcut — leave it for the app/tabs.
+    expect(matchScrollShortcut(k({ key: "PageUp", ctrlKey: true }))).toBeNull();
+    // Shift+Home is selection in most apps, not a terminal scroll binding.
+    expect(matchScrollShortcut(k({ key: "Home", shiftKey: true }))).toBeNull();
+    // Ctrl+Shift+Home should not scroll (Shift disqualifies the top binding).
+    expect(matchScrollShortcut(k({ key: "Home", ctrlKey: true, shiftKey: true }))).toBeNull();
+  });
+});

--- a/src/components/terminal/scrollKeys.ts
+++ b/src/components/terminal/scrollKeys.ts
@@ -1,0 +1,67 @@
+/**
+ * scrollKeys — pure mapping from a keyboard event to a terminal scroll action,
+ * matching VS Code's integrated-terminal scroll keybindings.
+ *
+ * VS Code defaults (Windows/Linux; macOS uses ⌘ for Ctrl and ⌥⌘ for the line
+ * variants — handled here by accepting Cmd as an alias for Ctrl):
+ *
+ *   Scroll page up / down    Shift+PageUp     / Shift+PageDown
+ *   Scroll line up / down    Ctrl+Alt+PageUp  / Ctrl+Alt+PageDown
+ *   Scroll to top / bottom   Ctrl+Home        / Ctrl+End
+ *
+ * Wired into the per-terminal `attachCustomKeyEventHandler` in
+ * `TerminalInstance`, which scrolls the focused terminal's scrollback and
+ * swallows the key (so it isn't forwarded to the PTY) — VS Code's
+ * `commandsToSkipShell` behavior for these bindings.
+ *
+ * Leaf module (no xterm / DOM imports beyond the `KeyboardEvent` shape) so the
+ * mapping is unit-testable without the WASM backend — same rationale as
+ * `wheelScroll.ts` / `consumeInputChunk.ts`.
+ */
+
+/** A resolved scroll intent. `amount` sign: positive = DOWN, negative = UP. */
+export type ScrollAction =
+  | { kind: "lines"; amount: number }
+  | { kind: "pages"; amount: number }
+  | { kind: "top" }
+  | { kind: "bottom" };
+
+/** The subset of `KeyboardEvent` the mapping depends on. */
+export interface KeyLike {
+  key: string;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}
+
+/**
+ * Map a keydown event to a VS Code-parity terminal scroll action, or `null`
+ * when the combo isn't a scroll shortcut (so the caller leaves the key alone).
+ * The caller must gate on `keydown` — this does not inspect event type.
+ */
+export function matchScrollShortcut(e: KeyLike): ScrollAction | null {
+  const { key, shiftKey, ctrlKey, altKey, metaKey } = e;
+  // Accept Cmd as a Ctrl alias so macOS ⌘Home/⌘End and ⌥⌘PageUp/Down also work.
+  const cmdOrCtrl = ctrlKey || metaKey;
+
+  // Page scroll — Shift+PageUp / Shift+PageDown (Shift only).
+  if (shiftKey && !ctrlKey && !altKey && !metaKey) {
+    if (key === "PageUp") return { kind: "pages", amount: -1 };
+    if (key === "PageDown") return { kind: "pages", amount: 1 };
+  }
+
+  // Line scroll — Ctrl+Alt+PageUp / Ctrl+Alt+PageDown (⌥⌘ on macOS).
+  if (cmdOrCtrl && altKey && !shiftKey) {
+    if (key === "PageUp") return { kind: "lines", amount: -1 };
+    if (key === "PageDown") return { kind: "lines", amount: 1 };
+  }
+
+  // Top / bottom — Ctrl+Home / Ctrl+End (⌘ on macOS), no Alt/Shift.
+  if (cmdOrCtrl && !altKey && !shiftKey) {
+    if (key === "Home") return { kind: "top" };
+    if (key === "End") return { kind: "bottom" };
+  }
+
+  return null;
+}


### PR DESCRIPTION
**Supersedes #378** — that PR was auto-closed when its base branch (`feat/terminal-shift-wheel-scroll`, #377) was deleted on merge; GitHub can't reopen a PR whose base is gone. Same branch, now rebased onto main (which contains #377).

## What

VS Code-parity **keyboard scrolling** for the focused terminal — second piece of the terminal-parity stack.

| Binding | Action | VS Code command |
|---|---|---|
| `Shift+PageUp` / `Shift+PageDown` | Scroll one page | `scrollUpPage` / `scrollDownPage` |
| `Ctrl+Alt+PageUp` / `Ctrl+Alt+PageDown` | Scroll one line | `scrollUp` / `scrollDown` |
| `Ctrl+Home` / `Ctrl+End` | Scroll to top / bottom | `scrollToTop` / `scrollToBottom` |

Bindings verified against the official [VS Code terminal docs](https://code.visualstudio.com/docs/terminal/basics); Cmd accepted as Ctrl alias for macOS.

## How

- `scrollKeys.ts` — pure key→scroll-action matcher (leaf module, unit-tested).
- Wired into the per-terminal `attachCustomKeyEventHandler`: scrolls the **focused** terminal, swallows the key (VS Code `commandsToSkipShell` default), explicit `preventDefault()`.
- `ITerminalBackend.scrollPages` / `scrollToTop` + Xterm impl, Ghostty guarded.
- `KeyboardShortcutsOverlay` gains a "Scrolling (focused terminal)" section.

Bare `PageUp`/`Home`/`End` still go to the app — only the exact VS Code combos are intercepted (pinned by tests).

## Verification

- **Live-verified on a temp runner** (slot-staged stack-tip binary, synthetic keydown battery with a unique-match find-decoration as the scroll-position oracle): `Ctrl+Alt+PageDown`/`PageUp` moved the viewport exactly off/back onto the anchor, `Shift+PageDown` paged it away, `Ctrl+Home` returned from a page away, `Ctrl+End` reached new buffer regions.
- vitest full suite, `tsc`, ESLint, Prettier, `vite build` — green.
