### PR TITLE
runner: pop-out terminal windows (Phase 1) — multi-window, window-scoped tabs

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -237,6 +237,7 @@ pub mod task_sync; // renamed from ai_task_reporting
 pub mod tenant; // Plan 2026-05-22-coord-native-session-coordination §D12 / Phase 4 — active tenant resolver + per-machine pin
 pub mod terminal;
 pub mod terminal_analysis; // Terminal session analysis (session summary, architecture, change impact, etc.)
+pub mod terminal_windows; // Pop-out terminal windows: open/close/move-session + assignment events (Phase 1)
 pub mod test_orchestrator; // AI-driven multi-step API test orchestration
 pub mod testing;
 pub mod tiered_info;

--- a/src-tauri/src/commands/terminal_windows.rs
+++ b/src-tauri/src/commands/terminal_windows.rs
@@ -1,0 +1,224 @@
+//! Tauri commands for pop-out terminal windows (Phase 1 of
+//! `plans/2026-06-03-runner-popout-terminal-windows.md`).
+//!
+//! A single runner process hosts multiple OS windows — `"main"` plus
+//! `"term-N"` pop-outs — each rendering its own subset of terminal tabs.
+//! These commands open/close pop-out windows and move sessions between
+//! windows, backed by the persisted [`crate::window_assignments`] state.
+//!
+//! Distinct from `commands::window_manager` (which enumerates/activates
+//! OS desktop windows for automation) — this is about the runner's OWN
+//! webview windows.
+//!
+//! ## Events (broadcast; each window's frontend filters by its own label)
+//! - `window-opened` `{ record: WindowRecord }`
+//! - `window-closed` `{ label: String }`
+//! - `session-assignment-changed` `{ session_id, from: Option<String>, to: String }`
+//!
+//! `window-closed` and the close-driven `session-assignment-changed` events are
+//! emitted from the central `on_window_event` `CloseRequested` handler in
+//! `main.rs` (so they fire for BOTH the OS close button AND a programmatic
+//! [`close_terminal_window`]); see [`handle_window_close`].
+
+use std::sync::Arc;
+
+use serde::Serialize;
+use tauri::{Emitter, Manager};
+
+use crate::settings::SpawnPlacement;
+use crate::window_assignments::{
+    WindowAssignments, WindowAssignmentsState, WindowRecord, MAIN_WINDOW_LABEL,
+};
+
+/// Unix-millis now. (Plain `std::time` — this is Rust, not a workflow script.)
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[derive(Serialize, Clone)]
+struct SessionAssignmentChanged {
+    session_id: String,
+    from: Option<String>,
+    to: String,
+}
+
+/// Open a new pop-out terminal window. Allocates the next `term-N` label,
+/// records it, builds the `WebviewWindow` (loading the same bundle with a
+/// `?view=terminal&window=term-N` boot hint), positions it via the reused
+/// placement pipeline when a `placement` is supplied, and emits `window-opened`.
+/// Returns the new window record.
+#[tauri::command]
+pub async fn open_terminal_window(
+    app: tauri::AppHandle,
+    assignments: tauri::State<'_, Arc<WindowAssignments>>,
+    placement: Option<SpawnPlacement>,
+) -> Result<WindowRecord, String> {
+    let record = assignments.create_window(None, None, now_ms());
+    let label = record.label.clone();
+
+    // Same embedded bundle; the boot hint makes it render Terminal-only and
+    // adopt `term-N` as its window identity (via getCurrentWindow().label).
+    let url = tauri::WebviewUrl::App(format!("index.html?view=terminal&window={}", label).into());
+
+    let mut builder = tauri::WebviewWindowBuilder::new(&app, label.as_str(), url)
+        .title(format!("Qontinui Terminal — {}", label))
+        .inner_size(1000.0, 720.0)
+        .min_inner_size(640.0, 400.0)
+        .resizable(true)
+        .decorations(true)
+        .on_web_resource_request(crate::asset_headers::stamp_no_store_on_index);
+
+    // Mirror the main window: inject the API port so the pop-out's frontend
+    // addresses the runner's HTTP API (location.port is empty on tauri.localhost).
+    let api_port = crate::mcp::types::get_mcp_api_port();
+    builder = builder.initialization_script(format!("window.__QONTINUI_PORT__ = {};", api_port));
+
+    let window = builder
+        .build()
+        .map_err(|e| format!("Failed to build pop-out window {}: {}", label, e))?;
+
+    // Apply placement (physical global coords) when provided; otherwise let the
+    // OS place it (cascaded near the focused window).
+    if let Some(p) = placement {
+        match crate::spawn_placement::resolve_to_global_physical(&app, &p) {
+            Ok(rp) => {
+                let _ = window.set_position(tauri::PhysicalPosition::new(rp.global_x, rp.global_y));
+                let _ = window.set_size(tauri::PhysicalSize::new(rp.width, rp.height));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    window = %label,
+                    error = %e,
+                    "open_terminal_window: placement resolve failed — using OS default position"
+                );
+            }
+        }
+    }
+
+    let _ = window.show();
+    let _ = window.set_focus();
+
+    if let Err(e) = app.emit("window-opened", &record) {
+        tracing::warn!(error = %e, "open_terminal_window: failed to emit window-opened");
+    }
+
+    tracing::info!(window = %label, "Opened pop-out terminal window");
+    Ok(record)
+}
+
+/// Close a pop-out terminal window. The actual reassignment + events happen in
+/// the central `on_window_event` `CloseRequested` handler (so the OS close
+/// button takes the same path); here we just request the close. Closing
+/// `"main"` is rejected.
+#[tauri::command]
+pub async fn close_terminal_window(app: tauri::AppHandle, label: String) -> Result<(), String> {
+    if label == MAIN_WINDOW_LABEL {
+        return Err("refusing to close the main window via close_terminal_window".to_string());
+    }
+    match app.get_webview_window(&label) {
+        Some(win) => win
+            .close()
+            .map_err(|e| format!("Failed to close window {}: {}", label, e)),
+        None => Ok(()), // already gone — idempotent
+    }
+}
+
+/// Move a session (terminalId) to a window ("move tab to window N", or back to
+/// "main"). Persists the new owner and emits `session-assignment-changed`.
+/// A no-op assignment (already owned by `window_label`) emits nothing.
+#[tauri::command]
+pub async fn assign_session_to_window(
+    app: tauri::AppHandle,
+    assignments: tauri::State<'_, Arc<WindowAssignments>>,
+    session_id: String,
+    window_label: String,
+) -> Result<(), String> {
+    if let Some(from) = assignments.assign_session(&session_id, &window_label) {
+        let payload = SessionAssignmentChanged {
+            session_id,
+            from: Some(from),
+            to: window_label,
+        };
+        if let Err(e) = app.emit("session-assignment-changed", &payload) {
+            tracing::warn!(error = %e, "assign_session_to_window: failed to emit event");
+        }
+    }
+    Ok(())
+}
+
+/// Full snapshot of window assignments, to hydrate a window on load.
+#[tauri::command]
+pub async fn get_window_assignments(
+    assignments: tauri::State<'_, Arc<WindowAssignments>>,
+) -> Result<WindowAssignmentsState, String> {
+    Ok(assignments.snapshot())
+}
+
+/// All windows this runner process owns (label + kind + title). Distinct from
+/// the OS-window enumerator in `commands::window_manager`.
+#[tauri::command]
+pub async fn list_runner_windows(
+    assignments: tauri::State<'_, Arc<WindowAssignments>>,
+) -> Result<Vec<WindowRecord>, String> {
+    Ok(assignments.window_records())
+}
+
+/// Bring a runner window to the foreground.
+#[tauri::command]
+pub async fn focus_runner_window(app: tauri::AppHandle, label: String) -> Result<(), String> {
+    match app.get_webview_window(&label) {
+        Some(win) => {
+            let _ = win.unminimize();
+            win.set_focus()
+                .map_err(|e| format!("Failed to focus window {}: {}", label, e))
+        }
+        None => Err(format!("window not found: {}", label)),
+    }
+}
+
+/// Central handling of a pop-out window closing — called from `main.rs`'s
+/// `on_window_event` `CloseRequested` for any non-`"main"` window. Reassigns
+/// the closing window's sessions to `"main"` (never orphans a PTY), emits one
+/// `session-assignment-changed` per moved session, then `window-closed`.
+///
+/// Returns `true` if `label` was a known pop-out (so the caller can skip the
+/// main-window app-quit cleanup).
+pub fn handle_window_close(app: &tauri::AppHandle, label: &str) -> bool {
+    if label == MAIN_WINDOW_LABEL {
+        return false;
+    }
+    let assignments = match app.try_state::<Arc<WindowAssignments>>() {
+        Some(s) => s,
+        None => return false,
+    };
+    let close = assignments.close_window(label);
+
+    for (session_id, from) in &close.reassigned {
+        let payload = SessionAssignmentChanged {
+            session_id: session_id.clone(),
+            from: Some(from.clone()),
+            to: MAIN_WINDOW_LABEL.to_string(),
+        };
+        if let Err(e) = app.emit("session-assignment-changed", &payload) {
+            tracing::warn!(error = %e, "handle_window_close: failed to emit reassignment");
+        }
+    }
+
+    if let Err(e) = app.emit("window-closed", &serde_json::json!({ "label": label })) {
+        tracing::warn!(error = %e, "handle_window_close: failed to emit window-closed");
+    }
+
+    // Treat any non-main window as a pop-out for the purpose of skipping the
+    // app-quit cleanup, even if its record was already removed (e.g. closed
+    // programmatically then the OS event arrives) — `removed` only tells us
+    // whether THIS call removed it.
+    tracing::info!(
+        window = %label,
+        reassigned = close.reassigned.len(),
+        "Closed pop-out terminal window"
+    );
+    true
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -197,6 +197,7 @@ mod video_recorder;
 mod vision;
 mod wake_handler; // Phase F.1 — qontinui:// custom-URL deep-link wake handler
 mod win32_compat;
+mod window_assignments;
 mod window_manager;
 mod window_placement;
 mod workflow;
@@ -1634,6 +1635,13 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::terminal_analysis::analyze_plan_progress,
             commands::terminal_analysis::analyze_session_summary,
             commands::terminal_analysis::get_latest_plan_content,
+            // Pop-out terminal windows (Phase 1)
+            commands::terminal_windows::assign_session_to_window,
+            commands::terminal_windows::close_terminal_window,
+            commands::terminal_windows::focus_runner_window,
+            commands::terminal_windows::get_window_assignments,
+            commands::terminal_windows::list_runner_windows,
+            commands::terminal_windows::open_terminal_window,
             commands::test_orchestrator::delete_orchestration_plan,
             commands::test_orchestrator::execute_test_orchestration,
             commands::test_orchestrator::generate_test_from_orchestration,
@@ -1947,6 +1955,49 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     },
                 );
                 app.manage(pane_store);
+
+                // Phase 1 (pop-out terminal windows) — persisted window↔session
+                // ownership + the runner's own window registry. Co-located with
+                // the pane store under `.qontinui/runner`, same atomic-write
+                // pattern. `ensure_main` records the "main" window on boot.
+                // Namespaced by API port (mirrors the lifecycle store above) so
+                // each runner instance owns its own windows — without this a
+                // temp runner (9877+) would read/clobber the primary's
+                // window-assignments and try to render its pop-outs.
+                let wa_api_port = crate::mcp::types::get_mcp_api_port();
+                let wa_file_name = if wa_api_port == 9876 {
+                    "window-assignments.json".to_string()
+                } else {
+                    format!("window-assignments-{wa_api_port}.json")
+                };
+                let window_assignments_path = dirs::home_dir()
+                    .unwrap_or_else(|| std::path::PathBuf::from("."))
+                    .join(".qontinui")
+                    .join("runner")
+                    .join(&wa_file_name);
+                let window_assignments = std::sync::Arc::new(
+                    match window_assignments::WindowAssignments::open(&window_assignments_path) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                path = %window_assignments_path.display(),
+                                "window_assignments: open failed — using ephemeral fallback"
+                            );
+                            let fallback = std::env::temp_dir()
+                                .join(format!("qontinui-runner-{wa_file_name}"));
+                            window_assignments::WindowAssignments::open(&fallback)
+                                .expect("window_assignments: ephemeral open failed")
+                        }
+                    },
+                );
+                window_assignments.ensure_main(
+                    std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as i64)
+                        .unwrap_or(0),
+                );
+                app.manage(window_assignments);
 
                 // Durable, backend-owned terminal-session lifecycle registry,
                 // keyed by `claudeSessionId`. Source of truth for "which
@@ -3159,6 +3210,19 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::CloseRequested { .. } = event {
                 info!("Window close requested");
+
+                // Phase 1: a pop-out terminal window ("term-N") closing must NOT
+                // run the main-window app-quit cleanup below. Reassign its
+                // sessions back to "main" (never orphan a PTY), emit the
+                // window-closed / session-assignment-changed events, and return.
+                // Only the "main" window falls through to the shutdown path.
+                let win_label = window.label().to_string();
+                if win_label != window_assignments::MAIN_WINDOW_LABEL
+                    && commands::terminal_windows::handle_window_close(window.app_handle(), &win_label)
+                {
+                    return;
+                }
+
                 let app_state = window.state::<Arc<AppState>>();
 
                 // Intentional close — clear the session file so instances are NOT

--- a/src-tauri/src/window_assignments.rs
+++ b/src-tauri/src/window_assignments.rs
@@ -1,0 +1,468 @@
+//! Window → terminal-session ownership + the runner's own window registry.
+//!
+//! Phase 1 of the pop-out terminal-windows plan
+//! (`plans/2026-06-03-runner-popout-terminal-windows.md`). A single runner
+//! process can host multiple OS windows (`"main"` + `"term-N"` pop-outs),
+//! each rendering its own subset of terminal tabs. This is the authoritative,
+//! persisted source of truth for **which window owns which session** and the
+//! set of known windows.
+//!
+//! ## Design
+//!
+//! Mirrors the atomic-write persistence of [`crate::session::pane_store`]: the
+//! whole [`WindowAssignmentsState`] is serialized to a single JSON file
+//! (`<.qontinui>/runner/window-assignments.json`), rewritten atomically via
+//! temp-file + rename on every mutation. The map is tiny (one entry per live
+//! window / assigned session), so read+rewrite-whole is fine.
+//!
+//! **Decoupled from Tauri on purpose.** Mutators persist and RETURN the change
+//! (the new record, the prior owner, the list of reassigned sessions); the
+//! command layer (`commands::window_manager`) is responsible for emitting the
+//! `window-opened` / `window-closed` / `session-assignment-changed` events. This
+//! keeps the module unit-testable without an `AppHandle`.
+//!
+//! ## Invariants
+//! - **Exactly one owner per session.** [`WindowAssignments::assign_session`] is
+//!   the only mutator of `session_owner`; a move is unmount-in-source /
+//!   mount-in-target driven by one `session-assignment-changed` event.
+//! - **No orphaned PTYs.** Closing a window reassigns its sessions to `"main"`
+//!   (never drops them); PTYs live in the process-global `TerminalManager`,
+//!   independent of window lifetime.
+//! - **Default to `"main"`.** [`WindowAssignments::owner_of`] returns `"main"`
+//!   for any unknown session id, so unassigned tabs render in the main window —
+//!   backward-compatible with the single-window world.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// A window label: `"main"` for the primary window, `"term-N"` for pop-outs.
+pub type WindowLabel = String;
+
+/// The primary window's label (matches `get_main_window_label()` and the
+/// UI Bridge `MAIN_WINDOW_LABEL`).
+pub const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Prefix for allocated pop-out window labels (`term-1`, `term-2`, …).
+const POPOUT_LABEL_PREFIX: &str = "term-";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowKind {
+    Main,
+    PopOut,
+}
+
+/// Window geometry, persisted for Phase-2 restore. Logical pixels.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowGeometry {
+    pub x: i32,
+    pub y: i32,
+    pub w: u32,
+    pub h: u32,
+    #[serde(default)]
+    pub maximized: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WindowRecord {
+    pub label: WindowLabel,
+    pub kind: WindowKind,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub title: Option<String>,
+    /// Last-known geometry, for Phase-2 restore. Optional today.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub geometry: Option<WindowGeometry>,
+    /// Unix-millis creation time.
+    pub created_at: i64,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct WindowAssignmentsState {
+    /// `session_id`/terminalId → owning window. Exactly one owner per session.
+    /// Sessions absent from this map are owned by `"main"` by default.
+    #[serde(default)]
+    pub session_owner: HashMap<String, WindowLabel>,
+    /// Known windows, including `"main"`.
+    #[serde(default)]
+    pub windows: HashMap<WindowLabel, WindowRecord>,
+}
+
+/// Result of closing a window: the sessions that were reassigned to `"main"`
+/// (each with its prior owner — always the closed label), so the command layer
+/// can emit one `session-assignment-changed` per moved session.
+#[derive(Debug, Clone, Default)]
+pub struct WindowClose {
+    /// `(session_id, from_label)` for each session moved to `"main"`.
+    pub reassigned: Vec<(String, WindowLabel)>,
+    /// Whether a window record was actually removed.
+    pub removed: bool,
+}
+
+/// Tauri managed state. Cheap to share via the managed-state `State<'_, _>`.
+#[derive(Debug)]
+pub struct WindowAssignments {
+    path: PathBuf,
+    inner: Mutex<WindowAssignmentsState>,
+}
+
+impl WindowAssignments {
+    /// Open (or initialize) the store at `path`, loading any existing state.
+    /// A missing/corrupt file is treated as empty (the safe default).
+    pub fn open(path: impl AsRef<Path>) -> std::io::Result<Self> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let state = load_state(&path);
+        Ok(Self {
+            path,
+            inner: Mutex::new(state),
+        })
+    }
+
+    /// Register the `"main"` window record on boot if absent. Returns `true`
+    /// if it was created. Persists on change.
+    pub fn ensure_main(&self, now_ms: i64) -> bool {
+        let snapshot = {
+            let mut s = match self.inner.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "window_assignments: lock poisoned on ensure_main");
+                    return false;
+                }
+            };
+            if s.windows.contains_key(MAIN_WINDOW_LABEL) {
+                return false;
+            }
+            s.windows.insert(
+                MAIN_WINDOW_LABEL.to_string(),
+                WindowRecord {
+                    label: MAIN_WINDOW_LABEL.to_string(),
+                    kind: WindowKind::Main,
+                    title: None,
+                    geometry: None,
+                    created_at: now_ms,
+                },
+            );
+            s.clone()
+        };
+        self.persist(&snapshot);
+        true
+    }
+
+    /// Allocate the next monotonic `term-N` label and insert a pop-out window
+    /// record. Persists and returns the new record (the command layer creates
+    /// the actual `WebviewWindow` and emits `window-opened`).
+    pub fn create_window(
+        &self,
+        title: Option<String>,
+        geometry: Option<WindowGeometry>,
+        now_ms: i64,
+    ) -> WindowRecord {
+        let (record, snapshot) = {
+            let mut s = match self.inner.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    // Poisoned lock: still return a usable label derived from
+                    // the count so the caller can proceed; persistence is
+                    // skipped this round.
+                    warn!(error = %e, "window_assignments: lock poisoned on create_window");
+                    let label = format!("{POPOUT_LABEL_PREFIX}{}", now_ms);
+                    return WindowRecord {
+                        label,
+                        kind: WindowKind::PopOut,
+                        title,
+                        geometry,
+                        created_at: now_ms,
+                    };
+                }
+            };
+            let label = next_popout_label(&s.windows);
+            let record = WindowRecord {
+                label: label.clone(),
+                kind: WindowKind::PopOut,
+                title,
+                geometry,
+                created_at: now_ms,
+            };
+            s.windows.insert(label, record.clone());
+            (record, s.clone())
+        };
+        self.persist(&snapshot);
+        record
+    }
+
+    /// The atomic move primitive: set `session_id`'s owner to `to`. Returns the
+    /// PRIOR owner (`from`), which is `"main"` (the default) when the session
+    /// wasn't explicitly owned before. Returns `None` only when the assignment
+    /// is a no-op (already owned by `to`). Persists on change.
+    pub fn assign_session(&self, session_id: &str, to: &str) -> Option<WindowLabel> {
+        let (from, snapshot) = {
+            let mut s = match self.inner.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "window_assignments: lock poisoned on assign_session");
+                    return None;
+                }
+            };
+            let prior = s
+                .session_owner
+                .get(session_id)
+                .cloned()
+                .unwrap_or_else(|| MAIN_WINDOW_LABEL.to_string());
+            if prior == to {
+                return None; // no-op
+            }
+            // Assigning back to "main" is represented by REMOVING the explicit
+            // entry, so the default-to-main rule keeps the map minimal.
+            if to == MAIN_WINDOW_LABEL {
+                s.session_owner.remove(session_id);
+            } else {
+                s.session_owner
+                    .insert(session_id.to_string(), to.to_string());
+            }
+            (prior, s.clone())
+        };
+        self.persist(&snapshot);
+        Some(from)
+    }
+
+    /// Close a window: reassign every session it owned to `"main"` and remove
+    /// its record. Never orphans a PTY. Returns the moves so the caller can
+    /// emit `session-assignment-changed` per session then `window-closed`.
+    /// Closing `"main"` is a no-op (the main window is never removed here).
+    pub fn close_window(&self, label: &str) -> WindowClose {
+        if label == MAIN_WINDOW_LABEL {
+            return WindowClose::default();
+        }
+        let (result, snapshot) = {
+            let mut s = match self.inner.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "window_assignments: lock poisoned on close_window");
+                    return WindowClose::default();
+                }
+            };
+            let reassigned: Vec<(String, WindowLabel)> = s
+                .session_owner
+                .iter()
+                .filter(|(_, owner)| owner.as_str() == label)
+                .map(|(sid, owner)| (sid.clone(), owner.clone()))
+                .collect();
+            for (sid, _) in &reassigned {
+                s.session_owner.remove(sid); // back to default "main"
+            }
+            let removed = s.windows.remove(label).is_some();
+            (
+                WindowClose {
+                    reassigned,
+                    removed,
+                },
+                s.clone(),
+            )
+        };
+        self.persist(&snapshot);
+        result
+    }
+
+    /// The owning window of a session, defaulting to `"main"` for unknown ids.
+    pub fn owner_of(&self, session_id: &str) -> WindowLabel {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|s| s.session_owner.get(session_id).cloned())
+            .unwrap_or_else(|| MAIN_WINDOW_LABEL.to_string())
+    }
+
+    /// Sessions a window should render. For `"main"` this is only the sessions
+    /// EXPLICITLY mapped to main (the default-to-main rule means the frontend
+    /// derives main's full set as "all tabs minus those owned elsewhere").
+    #[allow(dead_code)]
+    pub fn sessions_for(&self, label: &str) -> Vec<String> {
+        self.inner
+            .lock()
+            .ok()
+            .map(|s| {
+                s.session_owner
+                    .iter()
+                    .filter(|(_, owner)| owner.as_str() == label)
+                    .map(|(sid, _)| sid.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// A full snapshot for hydrating a window on load.
+    pub fn snapshot(&self) -> WindowAssignmentsState {
+        self.inner.lock().map(|s| s.clone()).unwrap_or_default()
+    }
+
+    /// All known window records (for `list_runner_windows`).
+    pub fn window_records(&self) -> Vec<WindowRecord> {
+        self.inner
+            .lock()
+            .map(|s| s.windows.values().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn persist(&self, state: &WindowAssignmentsState) {
+        if let Err(e) = write_state(&self.path, state) {
+            warn!(
+                error = %e,
+                path = %self.path.display(),
+                "window_assignments: persist failed — state kept in memory only"
+            );
+        }
+    }
+}
+
+/// Next monotonic `term-N` label: one greater than the highest existing
+/// `term-N` (so labels are stable and reused on restore — a closed `term-2`
+/// frees its number only if it's the highest). Starts at `term-1`.
+fn next_popout_label(windows: &HashMap<WindowLabel, WindowRecord>) -> WindowLabel {
+    let max_n = windows
+        .keys()
+        .filter_map(|k| k.strip_prefix(POPOUT_LABEL_PREFIX))
+        .filter_map(|n| n.parse::<u32>().ok())
+        .max()
+        .unwrap_or(0);
+    format!("{POPOUT_LABEL_PREFIX}{}", max_n + 1)
+}
+
+fn load_state(path: &Path) -> WindowAssignmentsState {
+    if !path.exists() {
+        return WindowAssignmentsState::default();
+    }
+    match std::fs::read(path) {
+        Ok(bytes) => serde_json::from_slice::<WindowAssignmentsState>(&bytes).unwrap_or_else(|e| {
+            warn!(
+                error = %e,
+                path = %path.display(),
+                "window_assignments: corrupt state file — starting empty"
+            );
+            WindowAssignmentsState::default()
+        }),
+        Err(e) => {
+            warn!(error = %e, "window_assignments: read failed — starting empty");
+            WindowAssignmentsState::default()
+        }
+    }
+}
+
+fn write_state(path: &Path, state: &WindowAssignmentsState) -> std::io::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(state).map_err(std::io::Error::other)?;
+    std::fs::write(&tmp, &bytes)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn store() -> (tempfile::TempDir, WindowAssignments) {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("window-assignments.json");
+        let wa = WindowAssignments::open(&path).unwrap();
+        (dir, wa)
+    }
+
+    #[test]
+    fn owner_of_defaults_to_main() {
+        let (_d, wa) = store();
+        assert_eq!(wa.owner_of("unknown-session"), "main");
+    }
+
+    #[test]
+    fn create_window_allocates_monotonic_term_labels() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        let a = wa.create_window(None, None, 10);
+        let b = wa.create_window(None, None, 20);
+        assert_eq!(a.label, "term-1");
+        assert_eq!(b.label, "term-2");
+        assert_eq!(a.kind, WindowKind::PopOut);
+    }
+
+    #[test]
+    fn assign_session_moves_owner_and_reports_prior() {
+        let (_d, wa) = store();
+        // First move from default main → term-1.
+        let from = wa.assign_session("sess-A", "term-1");
+        assert_eq!(from.as_deref(), Some("main"));
+        assert_eq!(wa.owner_of("sess-A"), "term-1");
+        // Re-assigning to the same window is a no-op.
+        assert_eq!(wa.assign_session("sess-A", "term-1"), None);
+        // Move back to main removes the explicit entry (default rule).
+        let from = wa.assign_session("sess-A", "main");
+        assert_eq!(from.as_deref(), Some("term-1"));
+        assert_eq!(wa.owner_of("sess-A"), "main");
+        assert!(!wa.snapshot().session_owner.contains_key("sess-A"));
+    }
+
+    #[test]
+    fn close_window_reassigns_all_its_sessions_to_main() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        let w = wa.create_window(None, None, 10);
+        wa.assign_session("sess-A", &w.label);
+        wa.assign_session("sess-B", &w.label);
+        wa.assign_session("sess-C", "term-2"); // a different window
+
+        let closed = wa.close_window(&w.label);
+        assert!(closed.removed);
+        let moved: std::collections::HashSet<_> =
+            closed.reassigned.iter().map(|(s, _)| s.clone()).collect();
+        assert_eq!(moved, ["sess-A".to_string(), "sess-B".to_string()].into());
+        assert!(closed.reassigned.iter().all(|(_, from)| from == &w.label));
+        assert_eq!(wa.owner_of("sess-A"), "main");
+        assert_eq!(wa.owner_of("sess-B"), "main");
+        assert_eq!(wa.owner_of("sess-C"), "term-2"); // untouched
+        assert!(!wa.snapshot().windows.contains_key(&w.label));
+    }
+
+    #[test]
+    fn close_main_is_noop() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        wa.assign_session("sess-A", "main"); // no-op (default)
+        let closed = wa.close_window("main");
+        assert!(!closed.removed);
+        assert!(closed.reassigned.is_empty());
+        assert!(wa.snapshot().windows.contains_key("main"));
+    }
+
+    #[test]
+    fn state_persists_across_reopen() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("window-assignments.json");
+        {
+            let wa = WindowAssignments::open(&path).unwrap();
+            wa.ensure_main(1);
+            let w = wa.create_window(Some("Pop 1".into()), None, 10);
+            wa.assign_session("sess-A", &w.label);
+        }
+        let wa = WindowAssignments::open(&path).unwrap();
+        assert_eq!(wa.owner_of("sess-A"), "term-1");
+        assert!(wa.snapshot().windows.contains_key("term-1"));
+        // Next allocation continues monotonically after restore.
+        assert_eq!(wa.create_window(None, None, 20).label, "term-2");
+    }
+
+    #[test]
+    fn corrupt_file_starts_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("window-assignments.json");
+        std::fs::write(&path, b"{not valid json").unwrap();
+        let wa = WindowAssignments::open(&path).unwrap();
+        assert_eq!(wa.owner_of("x"), "main");
+        wa.ensure_main(1);
+        assert!(wa.snapshot().windows.contains_key("main"));
+    }
+}

--- a/src/components/app/useAppNavigation.ts
+++ b/src/components/app/useAppNavigation.ts
@@ -123,6 +123,16 @@ export function useAppNavigation(): UseAppNavigationReturn {
   const { registerNavigate } = useNavigation();
 
   const [activeTab, setActiveTab] = useState<MainTabId>(() => {
+    // Phase 1 (pop-out terminal windows): a window opened with the
+    // `?view=terminal` boot hint renders the Terminal page directly and
+    // ignores the shared persisted active-tab (which is the main window's).
+    try {
+      if (new URLSearchParams(window.location.search).get("view") === "terminal") {
+        return "terminal";
+      }
+    } catch {
+      /* non-DOM / parse failure — fall through to the persisted tab */
+    }
     const stored = instanceStorage.getItem("qontinui-main-active-tab");
     return migrateTabId(stored);
   });

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -12,6 +12,7 @@ import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
 import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
 import { matchScrollShortcut } from "./scrollKeys";
+import { useWindowAssignments } from "./contexts/WindowAssignmentsContext";
 
 export interface TerminalInstanceHandle {
   getSelection: () => string;
@@ -171,6 +172,15 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     onOutputRef.current = onOutput;
     const onTitleChangeRef = useRef(onTitleChange);
     onTitleChangeRef.current = onTitleChange;
+    // Phase 1 (pop-out windows): owner-gated stdin. Only the window that owns
+    // this session forwards user input to the PTY; during a transient
+    // double-mount (a tab moving between windows) this prevents double-SEND
+    // (output still double-renders identically — benign). Kept in a ref so the
+    // long-lived onData/onBinary closures read the freshest value. Defaults to
+    // owned (true) in the single-window / no-provider case.
+    const { isOwned } = useWindowAssignments();
+    const isOwnedRef = useRef(true);
+    isOwnedRef.current = isOwned(terminalId);
     /**
      * Most-recently reported title — guards `onTitleChange` against firing on
      * every paintGrid (200ms idle cadence) when the title is unchanged.
@@ -700,6 +710,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
               }
             }
 
+            if (!isOwnedRef.current) return; // owner-gated stdin (Phase 1)
             const bytes = encoder.encode(data);
             invoke("terminal_write", {
               terminalId,
@@ -711,6 +722,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         // Forward binary data (e.g. paste with special chars)
         disposables.push(
           backend.onBinary((data) => {
+            if (!isOwnedRef.current) return; // owner-gated stdin (Phase 1)
             const bytes = new Uint8Array(data.length);
             for (let i = 0; i < data.length; i++) {
               bytes[i] = data.charCodeAt(i);

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -12,6 +12,7 @@ import { BatchOperationsBar } from "./BatchOperationsBar";
 import { ZoneMinimap } from "./ZoneMinimap";
 import { ZoneProfilePicker } from "./ZoneProfilePicker";
 import { useTerminalPageId } from "./TerminalPageContext";
+import { WindowAssignmentsProvider } from "./contexts/WindowAssignmentsContext";
 import {
   TerminalSessionProvider,
   useTerminalSession,
@@ -64,6 +65,10 @@ interface TerminalPageProps {
 export function TerminalPage(props: TerminalPageProps) {
   const pageId = useTerminalPageId();
   return (
+    // Phase 1 (pop-out windows): WindowAssignmentsProvider sits above the
+    // session provider so tab-ownership filtering + owner-gated stdin can read
+    // "which window owns which session". A no-op in the single-window case.
+    <WindowAssignmentsProvider>
     <TerminalSessionProvider
       pageId={pageId}
       onNavigateToBuilder={props.onNavigateToBuilder}
@@ -81,6 +86,7 @@ export function TerminalPage(props: TerminalPageProps) {
         </TransitionEffectsProvider>
       </ZoneMetadataProvider>
     </TerminalSessionProvider>
+    </WindowAssignmentsProvider>
   );
 }
 
@@ -143,6 +149,60 @@ function TerminalPageInner({
             title: t.title,
             isAlive: Boolean(t.isAlive),
           })),
+      },
+      // Phase 1 (pop-out terminal windows) — open/close pop-out OS windows and
+      // move terminal tabs between them. Reachable by agents and the operator.
+      {
+        id: "open-terminal-window",
+        label: "Open Terminal Window",
+        description:
+          "Open a new pop-out OS window (same process) that hosts its own terminal tabs. Returns the new window record { label, kind, ... }.",
+        handler: async () => invoke("open_terminal_window", { placement: null }),
+      },
+      {
+        id: "pop-out-active-terminal",
+        label: "Pop Out Active Terminal",
+        description:
+          "Open a new pop-out window and move the active terminal tab into it. Returns { window, terminalId }.",
+        handler: async () => {
+          if (!activeId) throw new Error("no active terminal to pop out");
+          const rec = await invoke<{ label: string }>("open_terminal_window", {
+            placement: null,
+          });
+          await invoke("assign_session_to_window", {
+            sessionId: activeId,
+            windowLabel: rec.label,
+          });
+          return { window: rec.label, terminalId: activeId };
+        },
+      },
+      {
+        id: "move-terminal-to-window",
+        label: "Move Terminal To Window",
+        description:
+          "Move a terminal tab to a window. Params: { terminalId: string, windowLabel: string } where windowLabel is 'main' or 'term-N'.",
+        paramSchema: { terminalId: "string", windowLabel: "string ('main' | 'term-N')" },
+        handler: async (params?: unknown) => {
+          const { terminalId, windowLabel: target } = (params ?? {}) as {
+            terminalId?: string;
+            windowLabel?: string;
+          };
+          if (!terminalId || !target) {
+            throw new Error("move-terminal-to-window requires { terminalId, windowLabel }");
+          }
+          await invoke("assign_session_to_window", {
+            sessionId: terminalId,
+            windowLabel: target,
+          });
+          return { ok: true };
+        },
+      },
+      {
+        id: "list-runner-windows",
+        label: "List Runner Windows",
+        description:
+          "Return this runner process's own windows [{ label, kind, title }] (main + pop-outs).",
+        handler: async () => invoke("list_runner_windows"),
       },
     ],
   });

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -59,6 +59,7 @@ import {
   type RefObject,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { useWindowAssignments, MAIN_WINDOW_LABEL } from "./WindowAssignmentsContext";
 
 import { useTerminalManager } from "../useTerminalManager";
 import { useZoneLayout } from "../useZoneLayout";
@@ -188,11 +189,38 @@ export function TerminalSessionProvider({
 }: TerminalSessionProviderProps) {
   // ---- TerminalCore ----
   const terminalManager = useTerminalManager(pageId);
-  const { tabs, activeId, setActiveId, updateTab, renameTab, createTerminal } =
+  const { tabs: allTabs, activeId, setActiveId, updateTab, renameTab, createTerminal } =
     terminalManager;
 
+  // Phase 1 (pop-out windows): render only the tabs THIS window owns. With a
+  // single ("main") window and no assignments every tab is owned by "main", so
+  // `tabs === allTabs` and every downstream consumer behaves byte-identically.
+  const { windowLabel: myWindowLabel, isOwned } = useWindowAssignments();
+  const tabs = useMemo(() => allTabs.filter((t) => isOwned(t.id)), [allTabs, isOwned]);
+
+  // A terminal created in a pop-out window must belong to THAT window, not the
+  // default "main". Assign it immediately after creation (the broadcast event
+  // then drops it from main and claims it here). No-op in the main window.
+  const createTerminalForWindow = useCallback<typeof createTerminal>(
+    async (title?: string, workingDir?: string) => {
+      const id = await createTerminal(title, workingDir);
+      if (id && myWindowLabel !== MAIN_WINDOW_LABEL) {
+        try {
+          await invoke("assign_session_to_window", {
+            sessionId: id,
+            windowLabel: myWindowLabel,
+          });
+        } catch {
+          /* best-effort: tab still works, just stays in main */
+        }
+      }
+      return id;
+    },
+    [createTerminal, myWindowLabel],
+  );
+
   const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
-  const zoneLayout = useZoneLayout(tabIds, pageId);
+  const zoneLayout = useZoneLayout(tabIds, pageId, myWindowLabel);
 
   // Sync focused zone → active tab.
   useEffect(() => {
@@ -486,6 +514,10 @@ export function TerminalSessionProvider({
     () => ({
       // TerminalCore
       ...terminalManager,
+      // Phase 1: override the manager's full tab set + creator with the
+      // window-scoped versions so this window renders/creates only its tabs.
+      tabs,
+      createTerminal: createTerminalForWindow,
       pageId,
       zoneLayout,
       terminalRefs,
@@ -521,6 +553,8 @@ export function TerminalSessionProvider({
     }),
     [
       terminalManager,
+      tabs,
+      createTerminalForWindow,
       pageId,
       zoneLayout,
       stateTracking,

--- a/src/components/terminal/contexts/WindowAssignmentsContext.tsx
+++ b/src/components/terminal/contexts/WindowAssignmentsContext.tsx
@@ -1,0 +1,149 @@
+/**
+ * WindowAssignmentsContext — Phase 1 pop-out terminal windows.
+ *
+ * One runner process can host multiple OS windows ("main" + "term-N" pop-outs),
+ * each rendering its own subset of terminal tabs. This context is each window's
+ * live view of "which window owns which session", sourced from the Rust
+ * `window_assignments` state.
+ *
+ * - On mount it reads `getCurrentWindow().label` (the window identity) and
+ *   fetches the assignment snapshot (`get_window_assignments`).
+ * - It subscribes to `session-assignment-changed` (broadcast to all windows) and
+ *   keeps the local owner map current, so a moved tab is dropped from its old
+ *   window and claimed by its new one.
+ *
+ * BACKWARD-COMPATIBLE: with a single ("main") window and no assignments,
+ * `ownerOf` returns "main" for everything and `isOwned` is true for every tab —
+ * so the main window renders all tabs exactly as before.
+ */
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export const MAIN_WINDOW_LABEL = "main";
+
+/** Map of sessionId/terminalId → owning window label. */
+export type SessionOwnerMap = Record<string, string>;
+
+interface WindowAssignmentsValue {
+  /** This window's own label ("main" | "term-N"). */
+  windowLabel: string;
+  /** Live sessionId → owning-window map (sessions absent default to "main"). */
+  assignments: SessionOwnerMap;
+  /** Owning window of a session, defaulting to "main". */
+  ownerOf: (sessionId: string) => string;
+  /** Whether a session is owned by THIS window. */
+  isOwned: (sessionId: string) => boolean;
+}
+
+function readWindowLabel(): string {
+  try {
+    return getCurrentWindow().label || MAIN_WINDOW_LABEL;
+  } catch {
+    // Non-Tauri env (tests / SSR) — behave as the single main window.
+    return MAIN_WINDOW_LABEL;
+  }
+}
+
+const WindowAssignmentsContext = createContext<WindowAssignmentsValue | null>(null);
+
+interface SessionAssignmentChanged {
+  session_id: string;
+  from?: string | null;
+  to: string;
+}
+
+interface WindowAssignmentsSnapshot {
+  session_owner?: SessionOwnerMap;
+}
+
+export function WindowAssignmentsProvider({ children }: { children: ReactNode }) {
+  // Stable for the window's lifetime (useState initializer, not a ref — so it's
+  // a plain render-safe value).
+  const [windowLabel] = useState<string>(readWindowLabel);
+  const [assignments, setAssignments] = useState<SessionOwnerMap>({});
+
+  useEffect(() => {
+    let mounted = true;
+
+    // Hydrate from the persisted snapshot.
+    invoke<WindowAssignmentsSnapshot>("get_window_assignments")
+      .then((snap) => {
+        if (mounted && snap?.session_owner) setAssignments(snap.session_owner);
+      })
+      .catch(() => {
+        // Command unavailable (older backend) — stay single-window safe.
+      });
+
+    // Track moves. "to === main" means the entry is cleared (default rule).
+    const unlistenPromise = listen<SessionAssignmentChanged>(
+      "session-assignment-changed",
+      (event) => {
+        if (!mounted) return;
+        const { session_id, to } = event.payload;
+        setAssignments((prev) => {
+          const next = { ...prev };
+          if (to === MAIN_WINDOW_LABEL) {
+            delete next[session_id];
+          } else {
+            next[session_id] = to;
+          }
+          return next;
+        });
+      },
+    );
+
+    return () => {
+      mounted = false;
+      unlistenPromise.then((un) => un()).catch(() => {});
+    };
+  }, []);
+
+  const ownerOf = useCallback(
+    (sessionId: string): string => assignments[sessionId] ?? MAIN_WINDOW_LABEL,
+    [assignments],
+  );
+
+  const isOwned = useCallback(
+    (sessionId: string): boolean => ownerOf(sessionId) === windowLabel,
+    [ownerOf, windowLabel],
+  );
+
+  const value = useMemo<WindowAssignmentsValue>(
+    () => ({ windowLabel, assignments, ownerOf, isOwned }),
+    [windowLabel, assignments, ownerOf, isOwned],
+  );
+
+  return (
+    <WindowAssignmentsContext value={value}>{children}</WindowAssignmentsContext>
+  );
+}
+
+/**
+ * Read the window-assignments context. When used OUTSIDE a provider (e.g. a
+ * test, or a code path that predates Phase 1) it returns a safe single-window
+ * default: label "main", everything owned by "main".
+ */
+export function useWindowAssignments(): WindowAssignmentsValue {
+  const ctx = useContext(WindowAssignmentsContext);
+  const fallback = useMemo<WindowAssignmentsValue>(
+    () => ({
+      windowLabel: readWindowLabel(),
+      assignments: {},
+      ownerOf: () => MAIN_WINDOW_LABEL,
+      isOwned: () => true,
+    }),
+    [],
+  );
+  return ctx ?? fallback;
+}

--- a/src/components/terminal/useZoneLayout.ts
+++ b/src/components/terminal/useZoneLayout.ts
@@ -149,17 +149,25 @@ interface PersistedState {
   focusedZone: number;
 }
 
-function storageKey(pageId: string): string {
-  return pageId === "default" ? BASE_STORAGE_KEY : `page:${pageId}:${BASE_STORAGE_KEY}`;
+// Phase 1 (pop-out windows): pop-out windows share the main window's
+// localStorage (same WebView2 profile per process), so each window's zone
+// layout MUST be namespaced by its `windowLabel` or they clobber each other.
+// `"main"` keeps the legacy key unchanged (existing layouts preserved).
+function storageKey(pageId: string, windowLabel: string = "main"): string {
+  const base = pageId === "default" ? BASE_STORAGE_KEY : `page:${pageId}:${BASE_STORAGE_KEY}`;
+  return windowLabel === "main" ? base : `${base}:window:${windowLabel}`;
 }
 
-function loadPersistedState(pageId: string): PersistedState | null {
-  return instanceStorage.getJSON<PersistedState | null>(storageKey(pageId), null);
+function loadPersistedState(pageId: string, windowLabel?: string): PersistedState | null {
+  return instanceStorage.getJSON<PersistedState | null>(
+    storageKey(pageId, windowLabel),
+    null,
+  );
 }
 
-function persistState(pageId: string, state: PersistedState) {
+function persistState(pageId: string, windowLabel: string | undefined, state: PersistedState) {
   try {
-    instanceStorage.setJSON(storageKey(pageId), state);
+    instanceStorage.setJSON(storageKey(pageId, windowLabel), state);
   } catch {
     // ignore storage errors
   }
@@ -224,8 +232,12 @@ export function reconcileAssignments(
 
 // ── Hook ───────────────────────────────────────────────────────────────────
 
-export function useZoneLayout(tabIds: string[], pageId: string = "default") {
-  const [persistedState] = useState(() => loadPersistedState(pageId));
+export function useZoneLayout(
+  tabIds: string[],
+  pageId: string = "default",
+  windowLabel: string = "main",
+) {
+  const [persistedState] = useState(() => loadPersistedState(pageId, windowLabel));
 
   const [layoutId, setLayoutIdState] = useState<string>(persistedState?.layoutId ?? "single");
   const [assignments, setAssignments] = useState<ZoneAssignments>(
@@ -248,8 +260,8 @@ export function useZoneLayout(tabIds: string[], pageId: string = "default") {
 
   // Persist on changes
   useEffect(() => {
-    persistState(pageId, { layoutId, assignments, focusedZone });
-  }, [pageId, layoutId, assignments, focusedZone]);
+    persistState(pageId, windowLabel, { layoutId, assignments, focusedZone });
+  }, [pageId, windowLabel, layoutId, assignments, focusedZone]);
 
   // Auto-assign tabs to empty zones when tabs change
   useEffect(() => {


### PR DESCRIPTION
## What

Phase 1 of `plans/2026-06-03-runner-popout-terminal-windows.md`, building on the Phase 0 window-aware UI Bridge (#394, shipped). **One runner process can now host multiple OS windows** — `"main"` plus `"term-N"` pop-outs — each rendering its own subset of terminal tabs, with **one `device_id` / one set of coordination loops** (the cleaner alternative to the multi-*process* Runner Instances launcher).

**ADDITIVE / backward-compatible:** with a single (`"main"`) window and no assignments, every path is byte-identical to before — the tab filter is a no-op, the zone-layout localStorage key is unchanged, and stdin is ungated.

## Backend (Rust)
- **`window_assignments.rs`** (new): persisted (atomic temp+rename, mirrors `pane_store`) `WindowAssignmentsState { session_owner, windows }` at `~/.qontinui/runner/window-assignments.json`. Methods: `ensure_main`, `create_window` (monotonic `term-N`), `assign_session` (returns prior owner; back-to-`main` clears the entry), `close_window` (**reassigns all its sessions to `"main"` — never orphans a PTY**), `owner_of` (defaults `"main"`), `snapshot`. Decoupled from Tauri (mutators return the change; the command layer emits). **7 unit tests.**
- **`commands/terminal_windows.rs`** (new): `open_terminal_window` (allocate label, build `WebviewWindow` loading `?view=terminal&window=term-N`, optional placement via the reused `spawn_placement` pipeline), `close_terminal_window`, `assign_session_to_window`, `get_window_assignments`, `list_runner_windows`, `focus_runner_window`. Emits `window-opened` / `window-closed` / `session-assignment-changed`.
- **`main.rs`**: `.manage(WindowAssignments)` + `ensure_main` on boot; register the 6 commands; the `on_window_event` `CloseRequested` handler now branches a **pop-out close** (reassign-to-main + events) away from the main-window app-quit cleanup.

## Frontend (React)
- **`WindowAssignmentsContext`** (new): each window's live view of "who owns which session" (`getCurrentWindow().label`, `get_window_assignments`, subscribes `session-assignment-changed`). Safe single-window fallback outside the provider.
- **`TerminalSessionProvider`** renders only the tabs THIS window owns; a terminal created in a pop-out auto-assigns to that window.
- **`TerminalInstance`**: owner-gated stdin (only the owning window forwards input — prevents double-send during a transient double-mount; output still double-renders identically, benign).
- **`useZoneLayout`**: zone-layout localStorage namespaced by `windowLabel` (pop-outs share the main window's WebView2 localStorage, so this prevents clobbering); `"main"` keeps the legacy key.
- **`?view=terminal` boot hint** → a pop-out window renders the Terminal page directly.
- **`terminal-page` UI Bridge actions**: `open-terminal-window`, `pop-out-active-terminal`, `move-terminal-to-window`, `list-runner-windows` (agent- + operator-reachable UX surface; the tab bar was demolished in Phase 9c).

## Gates (all green locally)
`cargo fmt` ✓, `cargo check --tests` ✓, **`cargo clippy --workspace --tests -- -D warnings` ✓**, 7 new Rust tests ✓; frontend `tsc` ✓, `vite build` ✓, `eslint` ✓, **`pnpm test` (722) ✓**.

## Regression posture
Single-window (no pop-outs): tab filter no-op, zone-layout key unchanged, stdin ungated, boot hint inert (no `?view=`), assignments empty. The main window behaves exactly as before.

## Out of scope (later phases)
Phase-2 geometry/tab restore + `PaneKey` `windowLabel`; grid-repaint on a mid-session move into an already-open window (the pop-out-to-NEW-window flow boots+reconnects fine); drag-tab-out; `EventManager`/`projectSelection` per-window isolation; retiring the Runner Instances launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)