### PR TITLE
feat(auth): surface bearer choice + token freshness; never overwrite a corrupt token store

### DIFF
--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -33,6 +33,57 @@ struct JwtExpClaim {
     exp: i64,
 }
 
+/// Leeway (seconds) applied when deciding whether a device-JWT is expired
+/// for *attach* purposes. A small clock-skew margin so a token that's a few
+/// seconds from expiry is treated as already-dead rather than attached and
+/// 401'd a moment later by the relay.
+const EXPIRY_LEEWAY_SECS: i64 = 30;
+
+/// Decode the `exp` (unix seconds) claim from a JWT *without* verifying its
+/// signature. Returns `None` when the input is not a 3-segment JWT or the
+/// payload fails to base64/JSON-decode (e.g. a legacy opaque
+/// `qontinui_runner_<random>` bearer).
+///
+/// This is the single decode site shared by [`AuthManager::device_jwt_needs_refresh`]
+/// (refresher staleness), the SDK-connect expired-token guard, and the
+/// `/auth/freshness` introspection route. Signature verification is
+/// intentionally out of scope — coord re-verifies the JWT on every WS
+/// handshake; the only thing read here is the unverified `exp` for staleness
+/// decisions and operator introspection.
+pub(crate) fn decode_jwt_exp(token: &str) -> Option<i64> {
+    let token = token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    // Try URL_SAFE_NO_PAD first (the JWT spec mandates no-padding), but
+    // accept URL_SAFE defensively too.
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(parts[1]))
+        .ok()?;
+    let claim: JwtExpClaim = serde_json::from_slice(&payload_bytes).ok()?;
+    Some(claim.exp)
+}
+
+/// Returns `true` iff `token` is a JWT whose `exp` is already in the past
+/// (with [`EXPIRY_LEEWAY_SECS`] of leeway). A non-JWT / undecodable token
+/// returns `false` — callers that want a shape check should use
+/// [`looks_like_jwt`] first; this helper answers only "is this decodable
+/// JWT past its expiry?" and never claims an opaque token is expired.
+pub(crate) fn jwt_is_expired(token: &str) -> bool {
+    match decode_jwt_exp(token) {
+        Some(exp) => {
+            let now = chrono::Utc::now().timestamp();
+            now - EXPIRY_LEEWAY_SECS >= exp
+        }
+        None => false,
+    }
+}
+
 /// When `QONTINUI_DISABLE_KEYCHAIN` is set, keychain reads return an error
 /// (callers fall back to file storage) and keychain writes are no-ops. The
 /// keychain path is best-effort migration backup; file storage is the source
@@ -139,23 +190,50 @@ impl AuthManager {
     ///
     /// Returns an error if the token is not found in any storage.
     pub fn get_access_token(&self) -> Result<String> {
-        // Try file storage first (primary)
+        // Try file storage first (primary).
+        //
+        // Distinguish two failure modes (item 5 of the auth-friction plan):
+        //   - file ABSENT  → first-run / never-paired; keychain fallback +
+        //     migration (overwrite the `.enc`) is the correct bootstrap.
+        //   - file PRESENT but load failed → the store is malformed (parse /
+        //     decrypt error). We STILL fall back to the keychain for an
+        //     in-memory token (availability), but we must NOT overwrite the
+        //     `.enc` file — doing so would mask the corruption (no forensics)
+        //     and resurrect potentially-stale keychain tokens over a present
+        //     store. So we suppress the migrate-write in this case.
+        let store_present = self.secure_storage.store_file_exists();
         match self.secure_storage.get_access_token() {
             Ok(token) => {
                 debug!("Retrieved access token from secure storage");
                 return Ok(token);
             }
             Err(e) => {
-                debug!("Access token not in secure storage: {}", e);
+                if store_present {
+                    warn!(
+                        "Secure storage present but access token could not be loaded \
+                         (malformed/undecryptable store): {}. Falling back to keychain WITHOUT \
+                         overwriting the .enc file (left intact for forensics).",
+                        e
+                    );
+                } else {
+                    debug!("Access token not in secure storage (no store file): {}", e);
+                }
             }
         }
 
-        // Fall back to keychain (for migration)
+        // Fall back to keychain (for migration).
         match self.get_access_token_from_keychain() {
             Ok(token) => {
-                info!("Retrieved access token from keychain (migrating to secure storage)");
-                // Migrate: try to get refresh token too and store both in secure storage
-                if let Ok(refresh) = self.get_refresh_token_from_keychain() {
+                info!("Retrieved access token from keychain");
+                // Only migrate (overwrite the `.enc`) when the store file is
+                // ABSENT — first-run bootstrap. When the store is present but
+                // unreadable, leave it untouched (see above).
+                if store_present {
+                    warn!(
+                        "Skipping keychain→secure-storage migration: a malformed store file is \
+                         present and must not be overwritten."
+                    );
+                } else if let Ok(refresh) = self.get_refresh_token_from_keychain() {
                     if let Err(e) = self.secure_storage.store_tokens(&token, &refresh) {
                         warn!("Failed to migrate tokens to secure storage: {}", e);
                     } else {
@@ -373,38 +451,39 @@ impl AuthManager {
         if token.is_empty() {
             return Ok(true);
         }
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            debug!("device_jwt_needs_refresh: token is not a 3-segment JWT (likely legacy opaque) — treating as needs-refresh");
-            return Ok(true);
+        // Unparseable tokens (non-3-segment legacy opaque bearers, or a
+        // payload that fails base64/JSON-decode) get treated as needs-refresh
+        // so the refresher heals legacy installs.
+        match crate::auth::decode_jwt_exp(&token) {
+            Some(exp) => {
+                let now = chrono::Utc::now().timestamp();
+                Ok(now + REFRESH_BEFORE_EXPIRY_SECS >= exp)
+            }
+            None => {
+                debug!(
+                    "device_jwt_needs_refresh: access_token is not a decodable JWT \
+                     (likely legacy opaque) — treating as needs-refresh"
+                );
+                Ok(true)
+            }
         }
-        // Try URL_SAFE_NO_PAD first (the JWT spec mandates no-padding), but
-        // accept URL_SAFE defensively too.
-        let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(parts[1])
-            .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(parts[1]));
-        let payload_bytes = match payload_bytes {
-            Ok(b) => b,
-            Err(e) => {
-                debug!(
-                    "device_jwt_needs_refresh: middle segment base64-decode failed ({e}) \
-                     — treating as needs-refresh"
-                );
-                return Ok(true);
-            }
-        };
-        let claim: JwtExpClaim = match serde_json::from_slice(&payload_bytes) {
-            Ok(c) => c,
-            Err(e) => {
-                debug!(
-                    "device_jwt_needs_refresh: payload JSON-decode failed ({e}) \
-                     — treating as needs-refresh"
-                );
-                return Ok(true);
-            }
-        };
-        let now = chrono::Utc::now().timestamp();
-        Ok(now + REFRESH_BEFORE_EXPIRY_SECS >= claim.exp)
+    }
+
+    /// Returns the decoded (unverified) `exp` of the device-JWT in the
+    /// `access_token` slot, or `None` if the slot is empty, missing, or holds
+    /// a non-decodable (legacy opaque) bearer. Used by the `/auth/freshness`
+    /// introspection route to compute an expiry delta without exposing the
+    /// token. Reuses the shared [`decode_jwt_exp`] machinery.
+    pub fn access_token_exp(&self) -> Option<i64> {
+        let token = self.get_access_token().ok()?;
+        crate::auth::decode_jwt_exp(&token)
+    }
+
+    /// Returns the absolute Cognito (oauth) access-token expiry in unix
+    /// seconds, if a Cognito session is present. Thin pass-through to
+    /// `SecureStorage::get_oauth_expires_at`.
+    pub fn oauth_expires_at(&self) -> Option<i64> {
+        self.secure_storage.get_oauth_expires_at()
     }
 
     // ========================================================================
@@ -628,6 +707,71 @@ mod looks_like_jwt_tests {
 }
 
 #[cfg(test)]
+mod jwt_exp_tests {
+    use super::{decode_jwt_exp, jwt_is_expired, EXPIRY_LEEWAY_SECS};
+    use base64::Engine;
+
+    /// Build a syntactically-valid (unsigned) JWT with the given `exp` claim.
+    /// Header/signature are throwaway — only the middle segment is decoded.
+    fn jwt_with_exp(exp: i64) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(format!(r#"{{"exp":{exp}}}"#).as_bytes());
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn decodes_exp_from_valid_jwt() {
+        let token = jwt_with_exp(1_900_000_000);
+        assert_eq!(decode_jwt_exp(&token), Some(1_900_000_000));
+    }
+
+    #[test]
+    fn decode_returns_none_for_opaque_token() {
+        assert_eq!(decode_jwt_exp("qontinui_runner_abc123"), None);
+    }
+
+    #[test]
+    fn decode_returns_none_for_empty() {
+        assert_eq!(decode_jwt_exp(""), None);
+        assert_eq!(decode_jwt_exp("   "), None);
+    }
+
+    #[test]
+    fn decode_returns_none_for_malformed_payload() {
+        // Three segments but the middle is not valid base64url JSON.
+        assert_eq!(decode_jwt_exp("aaa.!!!.ccc"), None);
+        // Valid base64 but not JSON with an `exp` field.
+        let not_json = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"not json");
+        assert_eq!(decode_jwt_exp(&format!("aaa.{not_json}.ccc")), None);
+    }
+
+    #[test]
+    fn expired_token_is_expired() {
+        let now = chrono::Utc::now().timestamp();
+        // Comfortably past expiry (beyond the leeway window).
+        let token = jwt_with_exp(now - EXPIRY_LEEWAY_SECS - 60);
+        assert!(jwt_is_expired(&token));
+    }
+
+    #[test]
+    fn fresh_token_is_not_expired() {
+        let now = chrono::Utc::now().timestamp();
+        let token = jwt_with_exp(now + 3600);
+        assert!(!jwt_is_expired(&token));
+    }
+
+    #[test]
+    fn malformed_token_is_not_reported_expired() {
+        // A non-decodable token must NOT be claimed expired — only a
+        // decodable-past-exp JWT counts. (looks_like_jwt is the shape gate.)
+        assert!(!jwt_is_expired("qontinui_runner_abc123"));
+        assert!(!jwt_is_expired(""));
+        assert!(!jwt_is_expired("aaa.!!!.ccc"));
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use std::env;
@@ -685,6 +829,42 @@ mod tests {
         // Clear and verify
         auth_manager.clear_tokens().unwrap();
         assert!(!auth_manager.has_tokens());
+    }
+
+    /// Item 5: a malformed-but-PRESENT store file must NOT be overwritten by
+    /// the keychain-migration fallback. `get_access_token` may fall back to
+    /// the keychain for availability, but the `.enc` bytes stay byte-identical
+    /// (left intact for forensics) rather than being clobbered with a fresh
+    /// store derived from (potentially stale) keychain tokens.
+    #[test]
+    fn malformed_store_present_is_not_overwritten() {
+        // Keep keychain out of the picture so the test is deterministic on
+        // every platform: with no keychain entry, get_access_token returns
+        // Err — exactly the case where the OLD code would have re-migrated
+        // and overwritten the file had a keychain token existed.
+        let temp_dir = env::temp_dir().join("qontinui_test_auth");
+        let storage_path = temp_dir.join("malformed_store_present_is_not_overwritten.enc");
+        let _ = fs::remove_file(&storage_path);
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        // Write garbage bytes — present, but neither decryptable nor parseable.
+        let garbage = b"this-is-not-a-valid-encrypted-token-store\x00\x01\x02".to_vec();
+        fs::write(&storage_path, &garbage).unwrap();
+
+        let storage = SecureStorage::with_path(storage_path.clone()).unwrap();
+        let mgr = AuthManager::with_storage(storage);
+
+        // Load attempt: with no keychain token available this errors, but the
+        // important invariant is the file-untouched check below.
+        let _ = mgr.get_access_token();
+
+        let after = fs::read(&storage_path).expect("store file must still exist");
+        assert_eq!(
+            after, garbage,
+            "malformed store file must be left byte-identical (not overwritten)"
+        );
+
+        let _ = fs::remove_file(&storage_path);
     }
 }
 

--- a/src-tauri/src/mcp/ai_session.rs
+++ b/src-tauri/src/mcp/ai_session.rs
@@ -249,6 +249,66 @@ pub async fn idle_status(State(state): State<Arc<ApiState>>) -> Json<Vec<Session
 }
 
 // ============================================================================
+// Token freshness introspection (`GET /auth/freshness`)
+// ============================================================================
+
+/// Response for `GET /auth/freshness` — token staleness as *deltas from now*,
+/// never the tokens or any absolute secret.
+///
+/// All deltas are seconds-from-now (negative = already expired). `None` means
+/// the corresponding token is absent (no Cognito session, or no decodable
+/// device-JWT). This lets an operator ask a running runner "how stale are
+/// your tokens?" over HTTP without decrypting `auth_tokens.enc` out-of-band.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FreshnessResponse {
+    /// The device-JWT/access-token `exp` minus now (seconds). `None` when the
+    /// `access_token` slot is empty or holds a non-decodable (legacy opaque)
+    /// bearer.
+    pub access_token_exp_in_s: Option<i64>,
+    /// The Cognito `oauth_expires_at` minus now (seconds). `None` when no
+    /// Cognito session is present.
+    pub oauth_expires_in_s: Option<i64>,
+    /// Whether this runner is paired (a `paired_user.json` exists on disk).
+    pub paired: bool,
+}
+
+/// Pure delta computation, extracted so it can be unit-tested without disk
+/// I/O. Converts absolute unix-second expiries into seconds-from-`now`
+/// deltas; `None` inputs pass through as `None`.
+fn compute_freshness_deltas(
+    access_token_exp: Option<i64>,
+    oauth_expires_at: Option<i64>,
+    now: i64,
+    paired: bool,
+) -> FreshnessResponse {
+    FreshnessResponse {
+        access_token_exp_in_s: access_token_exp.map(|exp| exp - now),
+        oauth_expires_in_s: oauth_expires_at.map(|exp| exp - now),
+        paired,
+    }
+}
+
+/// `GET /auth/freshness` — local-only token-freshness introspection.
+///
+/// Returns expiry deltas for the device-JWT (`access_token` slot) and the
+/// Cognito access token, plus whether the runner is paired. NEVER returns
+/// tokens or absolute secrets — only seconds-from-now deltas. This is a
+/// top-level local route (outside the `/ui-bridge/*` family), reachable only
+/// on the runner's local server.
+pub async fn auth_freshness(State(_state): State<Arc<ApiState>>) -> Json<FreshnessResponse> {
+    let auth_manager = crate::auth::AuthManager::new();
+    let now = chrono::Utc::now().timestamp();
+    let paired = qontinui_runner_lib::pair::read_paired_user_id_from_disk().is_some();
+    Json(compute_freshness_deltas(
+        auth_manager.access_token_exp(),
+        auth_manager.oauth_expires_at(),
+        now,
+        paired,
+    ))
+}
+
+// ============================================================================
 // Routes
 // ============================================================================
 
@@ -268,6 +328,7 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/restart-runner", post(restart_runner))
         .route("/prompts/run", post(run_prompt))
         .route("/sessions/idle-status", get(idle_status))
+        .route("/auth/freshness", get(auth_freshness))
         .route(
             "/sessions/{session_id}/promote-to-worktree",
             post(promote_session_to_worktree_handler),
@@ -2383,5 +2444,38 @@ mod tests {
         let now_ms_2 = now_ms_1 + 1_000;
         let second = build_idle_entries(snapshot, now_ms_2);
         assert_eq!(second[0].idle_ms, 1_000);
+    }
+
+    // ------------------------------------------------------------------
+    // `GET /auth/freshness` — compute_freshness_deltas (item 4)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn freshness_computes_positive_and_negative_deltas() {
+        let now = 1_700_000_000_i64;
+        // access token expires 1h from now; oauth already expired 5m ago.
+        let r = compute_freshness_deltas(Some(now + 3_600), Some(now - 300), now, true);
+        assert_eq!(r.access_token_exp_in_s, Some(3_600));
+        assert_eq!(r.oauth_expires_in_s, Some(-300));
+        assert!(r.paired);
+    }
+
+    #[test]
+    fn freshness_passes_none_through() {
+        let now = 1_700_000_000_i64;
+        let r = compute_freshness_deltas(None, None, now, false);
+        assert_eq!(r.access_token_exp_in_s, None);
+        assert_eq!(r.oauth_expires_in_s, None);
+        assert!(!r.paired);
+    }
+
+    #[test]
+    fn freshness_never_leaks_absolute_expiry() {
+        // The delta must be relative to `now`, not the absolute unix-seconds
+        // expiry that lives in storage.
+        let now = 1_700_000_000_i64;
+        let r = compute_freshness_deltas(Some(1_700_000_050), Some(1_700_000_010), now, true);
+        assert_eq!(r.access_token_exp_in_s, Some(50));
+        assert_eq!(r.oauth_expires_in_s, Some(10));
     }
 }

--- a/src-tauri/src/mcp/sdk_client.rs
+++ b/src-tauri/src/mcp/sdk_client.rs
@@ -153,6 +153,27 @@ struct ConnectionHealthResult {
     app_name: String,
 }
 
+/// Which bearer (if any) the connect handshake attached, surfaced on the
+/// connect response so callers can see the auth choice at the default log
+/// level (it was previously only visible at `debug!`). NEVER the token —
+/// just the kind. Values:
+/// - `"cognito"` — a fresh Cognito user access token (relay `/users/me`).
+/// - `"device-jwt"` — the coord device-JWT in the `access_token` slot
+///   (relay `/api/v1/devices/me`).
+/// - `"device-jwt-expired-skipped"` — a device-JWT was present but already
+///   past its `exp`, so it was NOT attached; the connect proceeded
+///   unauthenticated (see [`connect_sdk_app`]).
+/// - `"none"` — no Cognito session and no usable device-JWT (legacy/local
+///   install or not paired); connected without auth.
+/// - `"reused"` — an existing connection was reused/switched-to; no fresh
+///   handshake ran, so the bearer choice was NOT re-evaluated (whatever was
+///   attached at original connect time is still in effect).
+const AUTH_PATH_COGNITO: &str = "cognito";
+const AUTH_PATH_DEVICE_JWT: &str = "device-jwt";
+const AUTH_PATH_DEVICE_JWT_EXPIRED: &str = "device-jwt-expired-skipped";
+const AUTH_PATH_NONE: &str = "none";
+const AUTH_PATH_REUSED: &str = "reused";
+
 /// Connect response
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -160,6 +181,26 @@ pub struct ConnectResponse {
     pub app: SdkAppInfo,
     pub url: String,
     pub base_path: String,
+    /// Which bearer the handshake attached. See the `AUTH_PATH_*` constants.
+    /// Serialized as a plain string; NEVER carries the token itself.
+    pub auth_path: String,
+}
+
+/// Error returned by [`connect_sdk_app`], carrying both the human-readable
+/// message and the `auth_path` chosen for the (failed) handshake so the
+/// caller can surface the bearer-kind in the error envelope. `Display`
+/// yields just the message, so existing `format!("{e}")` / `.to_string()`
+/// call sites keep their previous behavior.
+#[derive(Debug)]
+pub struct ConnectError {
+    pub message: String,
+    pub auth_path: String,
+}
+
+impl std::fmt::Display for ConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
 }
 
 // =============================================================================
@@ -408,6 +449,10 @@ async fn handle_connect(
                 app: conn.app_info.clone(),
                 url: conn.app_url.clone(),
                 base_path: conn.base_path.clone(),
+                // No fresh handshake was performed — we reused an existing
+                // connection — so the bearer choice was not re-evaluated.
+                // `"none"` would falsely read as "unauthenticated".
+                auth_path: AUTH_PATH_REUSED.to_string(),
             };
             info!(
                 "Switched active connection to already-connected SDK app: {}",
@@ -437,7 +482,14 @@ async fn handle_connect(
             });
             Json(ApiResponse::success(response))
         }
-        Err(e) => Json(ApiResponse::error(e)),
+        Err(e) => {
+            // Thread the chosen `auth_path` into the error envelope (item 2)
+            // via the sibling `hint` field — callers can see which bearer the
+            // failed handshake attached without it living in `error` prose.
+            let mut resp = ApiResponse::<ConnectResponse>::error(e.message);
+            resp.hint = Some(serde_json::json!({ "authPath": e.auth_path }));
+            Json(resp)
+        }
     }
 }
 
@@ -454,7 +506,7 @@ pub async fn connect_sdk_app(
     app_name: Option<String>,
     app_type: Option<String>,
     framework: Option<String>,
-) -> Result<ConnectResponse, String> {
+) -> Result<ConnectResponse, ConnectError> {
     // Create HTTP client with timeout
     // 30s request timeout matches the UI Bridge IPC timeout — the app's snapshot/elements
     // endpoints proxy through the IPC layer and can take >10s on cold pages.
@@ -490,15 +542,45 @@ pub async fn connect_sdk_app(
     // in the `access_token` slot. Without this fallback such runners send no
     // bearer and the gated relay 401s their connect handshake.
     let auth_manager = crate::auth::AuthManager::new();
+    // Pick the bearer AND record which `auth_path` we took, so the choice is
+    // visible on the connect response (item 2) rather than only at `debug!`.
+    // `bearer` carries the (token, human-readable-kind) to attach; `auth_path`
+    // is the machine-readable tag surfaced to callers (one of the
+    // `AUTH_PATH_*` constants).
+    let mut auth_path: &str = AUTH_PATH_NONE;
     let bearer: Option<(String, &str)> =
         match crate::mcp::device_jwt_refresher::ensure_fresh_cognito_bearer(&auth_manager).await {
-            Some(token) if !token.is_empty() => Some((token, "Cognito user")),
+            Some(token) if !token.is_empty() => {
+                auth_path = AUTH_PATH_COGNITO;
+                Some((token, "Cognito user"))
+            }
             _ => match auth_manager.get_access_token() {
                 // Only a real JWT (the coord device-JWT) — never the legacy
                 // `qontinui_runner_<random>` opaque slot value, which the relay
                 // can't verify.
                 Ok(token) if crate::auth::looks_like_jwt(&token) => {
-                    Some((token, "coord device-JWT"))
+                    // Item 3: the stored device-JWT can be long-expired (primary
+                    // down → refresher dead). Attaching an expired JWT yields a
+                    // flat relay 401 indistinguishable from "relay rejects device
+                    // tokens" (the relay's 401 is deliberately undifferentiated
+                    // for anti-fingerprinting). Decode the `exp` (no signature
+                    // verification — coord re-verifies on the WS handshake) and,
+                    // if past expiry, skip attachment and connect unauthenticated
+                    // so the failure mode is observable runner-side.
+                    if crate::auth::jwt_is_expired(&token) {
+                        let ago = crate::auth::decode_jwt_exp(&token)
+                            .map(|exp| chrono::Utc::now().timestamp() - exp)
+                            .unwrap_or(0);
+                        warn!(
+                            "SDK relay client: device-JWT expired {ago}s ago — skipping bearer \
+                             and connecting unauthenticated (token_expired_skipping)"
+                        );
+                        auth_path = AUTH_PATH_DEVICE_JWT_EXPIRED;
+                        None
+                    } else {
+                        auth_path = AUTH_PATH_DEVICE_JWT;
+                        Some((token, "coord device-JWT"))
+                    }
                 }
                 _ => None,
             },
@@ -512,23 +594,34 @@ pub async fn connect_sdk_app(
                     let mut headers = reqwest::header::HeaderMap::new();
                     headers.insert(reqwest::header::AUTHORIZATION, value);
                     builder = builder.default_headers(headers);
-                    debug!("SDK relay client: attached {kind} bearer for {}", url);
+                    info!("SDK relay client: attached {kind} bearer for {}", url);
                 }
                 Err(e) => warn!("SDK relay client: malformed bearer, connecting without auth: {e}"),
             }
+        }
+        None if auth_path == AUTH_PATH_DEVICE_JWT_EXPIRED => {
+            // Already logged at `warn!` above with the expiry delta.
         }
         None => debug!(
             "SDK relay client: no Cognito session and no device-JWT (legacy/local install or \
              not paired); connecting without auth"
         ),
     }
+    let auth_path = auth_path.to_string();
 
-    let client = builder
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+    let client = builder.build().map_err(|e| ConnectError {
+        message: format!("Failed to create HTTP client: {}", e),
+        auth_path: auth_path.clone(),
+    })?;
 
     // Try to hit the health endpoint to validate the app
-    let (base_path, health_data) = try_health_check(&client, url).await?;
+    let (base_path, health_data) =
+        try_health_check(&client, url)
+            .await
+            .map_err(|message| ConnectError {
+                message,
+                auth_path: auth_path.clone(),
+            })?;
 
     // Extract app info from health response or from provided hints
     let ui_bridge_meta = health_data
@@ -587,6 +680,7 @@ pub async fn connect_sdk_app(
         app: app_info.clone(),
         url: url.to_string(),
         base_path: base_path.clone(),
+        auth_path,
     };
 
     // Store connection in manager and set as active
@@ -2511,6 +2605,10 @@ async fn handle_switch(
             app: conn.app_info.clone(),
             url: conn.app_url.clone(),
             base_path: conn.base_path.clone(),
+            // Switching to an already-established connection — no handshake,
+            // so the bearer choice was not re-evaluated. `"none"` would
+            // falsely read as "unauthenticated".
+            auth_path: AUTH_PATH_REUSED.to_string(),
         };
         manager.active_url = Some(url.clone());
         manager.active_responsive = None;

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -275,6 +275,18 @@ impl SecureStorage {
             .ok_or_else(|| anyhow::anyhow!("Device ID not found in storage"))
     }
 
+    /// Returns whether the encrypted storage file is present on disk.
+    ///
+    /// Distinguishes "no store yet" (first-run / never paired) from "store
+    /// present but unreadable" (a `load_tokens()` parse/decrypt failure on an
+    /// existing file). Callers use this to avoid masking a malformed-but-present
+    /// store: a parse failure with the file PRESENT must not trigger a keychain
+    /// re-migration that overwrites the `.enc` file. See
+    /// `AuthManager::get_access_token`.
+    pub fn store_file_exists(&self) -> bool {
+        self.storage_path.exists()
+    }
+
     /// Checks if tokens exist in storage.
     pub fn has_tokens(&self) -> bool {
         match self.load_tokens() {


### PR DESCRIPTION
Implements items 2–5 of plan `2026-06-03-ui-bridge-verification-friction-improvements` (vetted 2026-06-04).

## Item 2 — `auth_path` on sdk/connect responses
Success AND error responses now carry `auth_path` (`cognito` | `device-jwt` | `device-jwt-expired-skipped` | `none` | `reused`) — never the token. Bearer-attach log promoted `debug!` → `info!`. Reused/switched connections report `reused` (no fresh handshake) rather than a misleading `none`. Error envelope threads it via the existing `hint` sibling field (`{"authPath": ...}`).

## Item 3 — device-JWT `exp` pre-check before attach
`connect_sdk_app` decodes the device-JWT `exp` (no signature verification — coord re-verifies on handshake) via a shared `decode_jwt_exp` helper that also now backs `device_jwt_needs_refresh`. Expired (30s leeway) → not attached, `warn!` `token_expired_skipping` with the expiry delta, connect proceeds unauthenticated. Resolves the "expired token" vs "relay rejects device tokens" 401 ambiguity runner-side (the relay's flat 401 is deliberate anti-fingerprinting and is unchanged).

## Item 4 — `GET /auth/freshness`
Local route (ai_session family, `/sessions/idle-status` pattern): `{accessTokenExpInS, oauthExpiresInS, paired}` as seconds-from-now deltas (negative = expired). No tokens, no absolute timestamps — answers "how stale are this runner's tokens?" without decrypting `auth_tokens.enc` out-of-band.

## Item 5 — corrupt token store is preserved, not overwritten
`AuthManager::get_access_token` distinguishes store-file-absent (first-run: keychain fallback + migrate, unchanged) from store-present-but-unreadable (`warn!` + keychain fallback for availability, **no** re-migration — the `.enc` stays byte-identical for forensics). `SecureStorage::store_file_exists()` exposes the distinction.

## Verification
- `cargo clippy --bin qontinui-runner --features custom-protocol --tests -- -D warnings` clean (bin target — mcp modules are bin-crate-only)
- `cargo test --bin` 4305 passed (1 pre-existing `process_capture` timing flake, passes serially, file untouched here); targeted auth suite 30/30 with `QONTINUI_DISABLE_KEYCHAIN=1`
- `cargo fmt --check` clean; `manifest_matches_route_calls` green (route is outside the ui-bridge family manifest)