### PR TITLE
feat(specs): re-author meta-optimizer, settings-debug, llm-analytics under canonical ids

### DIFF
--- a/specs/pages/llm-analytics/notes.md
+++ b/specs/pages/llm-analytics/notes.md
@@ -1,0 +1,14 @@
+# LlmObservabilityDashboard
+
+Re-authored under the canonical `llm-analytics` page id (the prior spec was
+retired in the 2026-06-04 page-spec gap cleanup for using a wrong page id). This
+page is rendered by `LlmObservabilityDashboard` from `../llm-observability`, so
+`metadata.component` is `llm-observability` while the page id is `llm-analytics`.
+
+Authored against a live snapshot and validated via `POST /spec-check` on a temp
+runner built from main `8c2fc7e8`: `full_match`, overallMatchRate 1.0, 6 states,
+16 assertions, zero `no_candidates` misses.
+
+All criteria are ID-first against stable UI Bridge ids (page root, time-range +
+refresh toolbar, token-usage empty state, Scripted Output panel, emitter-provider
+cascade controls, and the one-shot fallbacks-by-reason table).

--- a/specs/pages/llm-analytics/spec.uibridge.json
+++ b/specs/pages/llm-analytics/spec.uibridge.json
@@ -1,0 +1,470 @@
+{
+  "description": "LLM Analytics page -- the runner's LLM observability dashboard. It reports token usage, cost, and provider performance over a selectable time range, and exposes two productivity surfaces: the Scripted Output (think-in-code) panel with its emitter-provider cascade controls, and the One-shot LLM productivity stack with a fallbacks-by-reason breakdown. The page is rendered by the LlmObservabilityDashboard component (component dir: llm-observability) under the canonical llm-analytics tab.",
+  "groups": [
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "LLM Analytics page root container is present",
+          "enabled": true,
+          "id": "la-page-root-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "llm-analytics-root"
+            },
+            "label": "LLM Analytics page root",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "LLM Analytics page heading is present",
+          "enabled": true,
+          "id": "la-page-root-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-2-llm-analytics",
+              "role": "heading"
+            },
+            "label": "LLM Analytics heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Page sub-title paragraph is present",
+          "enabled": true,
+          "id": "la-page-root-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-paragraph-token-usage-costs-an-0"
+            },
+            "label": "Page sub-title",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The dashboard mounts a page root container with the page heading (LLM Analytics) and a sub-title describing its scope (token usage, costs, and provider performance). The root carries a UI Bridge id so consumers can anchor to the page even before any data loads.",
+      "id": "la-page-root",
+      "name": "LLM Analytics Page Root",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Time-range selector control is present",
+          "enabled": true,
+          "id": "la-toolbar-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "llm-analytics-time-range"
+            },
+            "label": "Time-range selector",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Refresh-analytics button is present",
+          "enabled": true,
+          "id": "la-toolbar-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "llm-analytics-refresh",
+              "role": "button"
+            },
+            "label": "Refresh analytics button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "A toolbar lets the user scope analytics to a rolling window via a time-range selector and re-pull the data via a Refresh control. Both are instrumented with stable UI Bridge ids.",
+      "id": "la-toolbar",
+      "name": "Time-Range & Refresh Toolbar",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "No-usage-data message is present",
+          "enabled": true,
+          "id": "la-usage-empty-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-paragraph-no-llm-usage-data-av-0"
+            },
+            "label": "No-usage-data message",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Run-workflows guidance message is present",
+          "enabled": true,
+          "id": "la-usage-empty-elem-1",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-paragraph-run-some-workflows-t-1"
+            },
+            "label": "Run-workflows guidance",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "Until workflows have produced LLM telemetry, the token-usage / cost panel shows an empty state explaining that no LLM usage data is available yet and prompting the user to run some workflows to start collecting analytics.",
+      "id": "la-usage-empty",
+      "name": "Token Usage Empty State",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Scripted Output panel root is present",
+          "enabled": true,
+          "id": "la-scripted-output-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "scripted-output-root"
+            },
+            "label": "Scripted Output panel root",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Scripted Output metric tiles strip is present",
+          "enabled": true,
+          "id": "la-scripted-output-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "scripted-output-tiles"
+            },
+            "label": "Scripted Output metric tiles",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Scripted Output refresh button is present",
+          "enabled": true,
+          "id": "la-scripted-output-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "scripted-output-refresh",
+              "role": "button"
+            },
+            "label": "Scripted Output refresh button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The Scripted Output panel tracks the think-in-code emitter path: a panel root, a metric-tiles strip (attempts / emitter calls / cache), and a Refresh control to re-pull scripted-output stats. Its heading reads 'Scripted Output (think-in-code)'.",
+      "id": "la-scripted-output",
+      "name": "Scripted Output (think-in-code) Panel",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Emitter provider selector is present",
+          "enabled": true,
+          "id": "la-emitter-provider-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "emitter-provider-select",
+              "role": "combobox"
+            },
+            "label": "Emitter provider selector",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Emitter provider Save button is present",
+          "enabled": true,
+          "id": "la-emitter-provider-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "emitter-provider-save",
+              "role": "button"
+            },
+            "label": "Save emitter provider button",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Gemma local endpoint field is present",
+          "enabled": true,
+          "id": "la-emitter-provider-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "emitter-gemma-endpoint",
+              "role": "textbox"
+            },
+            "label": "Gemma endpoint field",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The Emitter provider section configures the LLM cascade (Auto: Claude then Gemma local, force-Claude, etc.). It exposes a provider selector, a Save action, and Gemma-local endpoint / model-alias fields with a reachability indicator.",
+      "id": "la-emitter-provider",
+      "name": "Emitter Provider Cascade Controls",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Fallbacks-by-reason heading is present",
+          "enabled": true,
+          "id": "la-oneshot-fallbacks-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-4-fallbacks-by-reason",
+              "role": "heading"
+            },
+            "label": "Fallbacks by reason heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Fallbacks table Reason column header is present",
+          "enabled": true,
+          "id": "la-oneshot-fallbacks-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "cell-r0-c0-table",
+              "role": "columnheader"
+            },
+            "label": "Reason column header",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "One-shot stats refresh button is present",
+          "enabled": true,
+          "id": "la-oneshot-fallbacks-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-refresh-one-shot-stats",
+              "role": "button"
+            },
+            "label": "One-shot stats refresh button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The One-shot LLM (productivity stack) section includes a Fallbacks by reason breakdown rendered as a table with Reason / Count / Share columns, plus a Refresh control for one-shot stats. The column headers are stable UI Bridge cells.",
+      "id": "la-oneshot-fallbacks",
+      "name": "One-shot LLM Fallbacks Breakdown",
+      "source": "ai-generated"
+    }
+  ],
+  "metadata": {
+    "component": "llm-observability",
+    "tags": [
+      "llm-analytics",
+      "llm-observability",
+      "token-usage",
+      "cost-tracking",
+      "provider-performance",
+      "scripted-output",
+      "one-shot",
+      "emitter-provider",
+      "tier-2"
+    ]
+  },
+  "stateMachine": {
+    "states": [
+      {
+        "description": "The dashboard mounts a page root container with the page heading (LLM Analytics) and a sub-title describing its scope (token usage, costs, and provider performance). The root carries a UI Bridge id so consumers can anchor to the page even before any data loads.",
+        "elements": [
+          {
+            "id": "llm-analytics-root"
+          },
+          {
+            "id": "heading-2-llm-analytics",
+            "role": "heading"
+          },
+          {
+            "id": "content-paragraph-token-usage-costs-an-0"
+          }
+        ],
+        "id": "la-page-root",
+        "isInitial": true,
+        "name": "LLM Analytics Page Root",
+        "transitions": []
+      },
+      {
+        "description": "A toolbar lets the user scope analytics to a rolling window via a time-range selector and re-pull the data via a Refresh control. Both are instrumented with stable UI Bridge ids.",
+        "elements": [
+          {
+            "id": "llm-analytics-time-range"
+          },
+          {
+            "id": "llm-analytics-refresh",
+            "role": "button"
+          }
+        ],
+        "id": "la-toolbar",
+        "isInitial": false,
+        "name": "Time-Range & Refresh Toolbar",
+        "transitions": []
+      },
+      {
+        "description": "Until workflows have produced LLM telemetry, the token-usage / cost panel shows an empty state explaining that no LLM usage data is available yet and prompting the user to run some workflows to start collecting analytics.",
+        "elements": [
+          {
+            "id": "content-paragraph-no-llm-usage-data-av-0"
+          },
+          {
+            "id": "content-paragraph-run-some-workflows-t-1"
+          }
+        ],
+        "id": "la-usage-empty",
+        "isInitial": false,
+        "name": "Token Usage Empty State",
+        "transitions": []
+      },
+      {
+        "description": "The Scripted Output panel tracks the think-in-code emitter path: a panel root, a metric-tiles strip (attempts / emitter calls / cache), and a Refresh control to re-pull scripted-output stats. Its heading reads 'Scripted Output (think-in-code)'.",
+        "elements": [
+          {
+            "id": "scripted-output-root"
+          },
+          {
+            "id": "scripted-output-tiles"
+          },
+          {
+            "id": "scripted-output-refresh",
+            "role": "button"
+          }
+        ],
+        "id": "la-scripted-output",
+        "isInitial": false,
+        "name": "Scripted Output (think-in-code) Panel",
+        "transitions": []
+      },
+      {
+        "description": "The Emitter provider section configures the LLM cascade (Auto: Claude then Gemma local, force-Claude, etc.). It exposes a provider selector, a Save action, and Gemma-local endpoint / model-alias fields with a reachability indicator.",
+        "elements": [
+          {
+            "id": "emitter-provider-select",
+            "role": "combobox"
+          },
+          {
+            "id": "emitter-provider-save",
+            "role": "button"
+          },
+          {
+            "id": "emitter-gemma-endpoint",
+            "role": "textbox"
+          }
+        ],
+        "id": "la-emitter-provider",
+        "isInitial": false,
+        "name": "Emitter Provider Cascade Controls",
+        "transitions": []
+      },
+      {
+        "description": "The One-shot LLM (productivity stack) section includes a Fallbacks by reason breakdown rendered as a table with Reason / Count / Share columns, plus a Refresh control for one-shot stats. The column headers are stable UI Bridge cells.",
+        "elements": [
+          {
+            "id": "heading-4-fallbacks-by-reason",
+            "role": "heading"
+          },
+          {
+            "id": "cell-r0-c0-table",
+            "role": "columnheader"
+          },
+          {
+            "id": "button-refresh-one-shot-stats",
+            "role": "button"
+          }
+        ],
+        "id": "la-oneshot-fallbacks",
+        "isInitial": false,
+        "name": "One-shot LLM Fallbacks Breakdown",
+        "transitions": []
+      }
+    ]
+  },
+  "version": "1.0.0"
+}

--- a/specs/pages/llm-analytics/spec.uibridge.json
+++ b/specs/pages/llm-analytics/spec.uibridge.json
@@ -361,7 +361,8 @@
           },
           {
             "id": "heading-2-llm-analytics",
-            "role": "heading"
+            "role": "heading",
+            "textContent": "LLM Analytics"
           },
           {
             "id": "content-paragraph-token-usage-costs-an-0"
@@ -380,7 +381,8 @@
           },
           {
             "id": "llm-analytics-refresh",
-            "role": "button"
+            "role": "button",
+            "accessibleName": "Refresh analytics"
           }
         ],
         "id": "la-toolbar",
@@ -414,7 +416,8 @@
           },
           {
             "id": "scripted-output-refresh",
-            "role": "button"
+            "role": "button",
+            "accessibleName": "Refresh scripted-output stats"
           }
         ],
         "id": "la-scripted-output",
@@ -431,7 +434,8 @@
           },
           {
             "id": "emitter-provider-save",
-            "role": "button"
+            "role": "button",
+            "textContent": "Save"
           },
           {
             "id": "emitter-gemma-endpoint",
@@ -448,15 +452,18 @@
         "elements": [
           {
             "id": "heading-4-fallbacks-by-reason",
-            "role": "heading"
+            "role": "heading",
+            "textContent": "Fallbacks by reason"
           },
           {
             "id": "cell-r0-c0-table",
-            "role": "columnheader"
+            "role": "columnheader",
+            "textContent": "Reason"
           },
           {
             "id": "button-refresh-one-shot-stats",
-            "role": "button"
+            "role": "button",
+            "accessibleName": "Refresh one-shot stats"
           }
         ],
         "id": "la-oneshot-fallbacks",

--- a/specs/pages/llm-analytics/state-machine.derived.json
+++ b/specs/pages/llm-analytics/state-machine.derived.json
@@ -1,0 +1,351 @@
+{
+  "version": "1.0",
+  "id": "llm-analytics",
+  "name": "LlmObservabilityDashboard",
+  "description": "LLM Analytics page -- the runner's LLM observability dashboard. It reports token usage, cost, and provider performance over a selectable time range, and exposes two productivity surfaces: the Scripted Output (think-in-code) panel with its emitter-provider cascade controls, and the One-shot LLM productivity stack with a fallbacks-by-reason breakdown. The page is rendered by the LlmObservabilityDashboard component (component dir: llm-observability) under the canonical llm-analytics tab.",
+  "metadata": {
+    "purpose": "llm-observability",
+    "tags": [
+      "llm-analytics",
+      "llm-observability",
+      "token-usage",
+      "cost-tracking",
+      "provider-performance",
+      "scripted-output",
+      "one-shot",
+      "emitter-provider",
+      "tier-2"
+    ]
+  },
+  "provenance": {
+    "source": "ai-generated",
+    "appId": "qontinui-runner"
+  },
+  "states": [
+    {
+      "id": "la-page-root",
+      "name": "LLM Analytics Page Root",
+      "description": "The dashboard mounts a page root container with the page heading (LLM Analytics) and a sub-title describing its scope (token usage, costs, and provider performance). The root carries a UI Bridge id so consumers can anchor to the page even before any data loads.",
+      "assertions": [
+        {
+          "id": "la-page-root-elem-0",
+          "description": "LLM Analytics page root container is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "llm-analytics-root"
+            },
+            "label": "LLM Analytics page root"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-page-root-elem-1",
+          "description": "LLM Analytics page heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-2-llm-analytics",
+              "role": "heading"
+            },
+            "label": "LLM Analytics heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-page-root-elem-2",
+          "description": "Page sub-title paragraph is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-paragraph-token-usage-costs-an-0"
+            },
+            "label": "Page sub-title"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "isInitial": true
+    },
+    {
+      "id": "la-toolbar",
+      "name": "Time-Range & Refresh Toolbar",
+      "description": "A toolbar lets the user scope analytics to a rolling window via a time-range selector and re-pull the data via a Refresh control. Both are instrumented with stable UI Bridge ids.",
+      "assertions": [
+        {
+          "id": "la-toolbar-elem-0",
+          "description": "Time-range selector control is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "llm-analytics-time-range"
+            },
+            "label": "Time-range selector"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-toolbar-elem-1",
+          "description": "Refresh-analytics button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "llm-analytics-refresh",
+              "role": "button"
+            },
+            "label": "Refresh analytics button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "la-usage-empty",
+      "name": "Token Usage Empty State",
+      "description": "Until workflows have produced LLM telemetry, the token-usage / cost panel shows an empty state explaining that no LLM usage data is available yet and prompting the user to run some workflows to start collecting analytics.",
+      "assertions": [
+        {
+          "id": "la-usage-empty-elem-0",
+          "description": "No-usage-data message is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-paragraph-no-llm-usage-data-av-0"
+            },
+            "label": "No-usage-data message"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-usage-empty-elem-1",
+          "description": "Run-workflows guidance message is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-paragraph-run-some-workflows-t-1"
+            },
+            "label": "Run-workflows guidance"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "la-scripted-output",
+      "name": "Scripted Output (think-in-code) Panel",
+      "description": "The Scripted Output panel tracks the think-in-code emitter path: a panel root, a metric-tiles strip (attempts / emitter calls / cache), and a Refresh control to re-pull scripted-output stats. Its heading reads 'Scripted Output (think-in-code)'.",
+      "assertions": [
+        {
+          "id": "la-scripted-output-elem-0",
+          "description": "Scripted Output panel root is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "scripted-output-root"
+            },
+            "label": "Scripted Output panel root"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-scripted-output-elem-1",
+          "description": "Scripted Output metric tiles strip is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "scripted-output-tiles"
+            },
+            "label": "Scripted Output metric tiles"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-scripted-output-elem-2",
+          "description": "Scripted Output refresh button is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "scripted-output-refresh",
+              "role": "button"
+            },
+            "label": "Scripted Output refresh button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "la-emitter-provider",
+      "name": "Emitter Provider Cascade Controls",
+      "description": "The Emitter provider section configures the LLM cascade (Auto: Claude then Gemma local, force-Claude, etc.). It exposes a provider selector, a Save action, and Gemma-local endpoint / model-alias fields with a reachability indicator.",
+      "assertions": [
+        {
+          "id": "la-emitter-provider-elem-0",
+          "description": "Emitter provider selector is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "emitter-provider-select",
+              "role": "combobox"
+            },
+            "label": "Emitter provider selector"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-emitter-provider-elem-1",
+          "description": "Emitter provider Save button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "emitter-provider-save",
+              "role": "button"
+            },
+            "label": "Save emitter provider button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-emitter-provider-elem-2",
+          "description": "Gemma local endpoint field is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "emitter-gemma-endpoint",
+              "role": "textbox"
+            },
+            "label": "Gemma endpoint field"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "la-oneshot-fallbacks",
+      "name": "One-shot LLM Fallbacks Breakdown",
+      "description": "The One-shot LLM (productivity stack) section includes a Fallbacks by reason breakdown rendered as a table with Reason / Count / Share columns, plus a Refresh control for one-shot stats. The column headers are stable UI Bridge cells.",
+      "assertions": [
+        {
+          "id": "la-oneshot-fallbacks-elem-0",
+          "description": "Fallbacks-by-reason heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-4-fallbacks-by-reason",
+              "role": "heading"
+            },
+            "label": "Fallbacks by reason heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-oneshot-fallbacks-elem-1",
+          "description": "Fallbacks table Reason column header is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "cell-r0-c0-table",
+              "role": "columnheader"
+            },
+            "label": "Reason column header"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "la-oneshot-fallbacks-elem-2",
+          "description": "One-shot stats refresh button is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-refresh-one-shot-stats",
+              "role": "button"
+            },
+            "label": "One-shot stats refresh button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "transitions": []
+}

--- a/specs/pages/meta-optimizer/notes.md
+++ b/specs/pages/meta-optimizer/notes.md
@@ -1,0 +1,11 @@
+# MetaOptimizerPage
+
+Re-authored under the canonical `meta-optimizer` page id (the prior spec was
+retired in the 2026-06-04 page-spec gap cleanup for using a wrong page id).
+Authored against a live snapshot and validated via `POST /spec-check` on a temp
+runner built from main `8c2fc7e8`: `full_match`, overallMatchRate 1.0, 5 states,
+15 assertions, zero `no_candidates` misses.
+
+All criteria are ID-first against stable UI Bridge ids (sidebar sub-nav buttons,
+the workflow-class selector, Capture Baseline / Refresh, and the
+spec-compliance / snapshot empty-state content blocks).

--- a/specs/pages/meta-optimizer/spec.uibridge.json
+++ b/specs/pages/meta-optimizer/spec.uibridge.json
@@ -349,23 +349,28 @@
         "elements": [
           {
             "id": "button-progress-0",
-            "role": "button"
+            "role": "button",
+            "textContent": "Progress"
           },
           {
             "id": "button-recommendations-1",
-            "role": "button"
+            "role": "button",
+            "textContent": "Recommendations"
           },
           {
             "id": "button-prompt-optimization-2",
-            "role": "button"
+            "role": "button",
+            "textContent": "Prompt Optimization"
           },
           {
             "id": "button-adaptive-learning-11",
-            "role": "button"
+            "role": "button",
+            "textContent": "Adaptive Learning"
           },
           {
             "id": "button-prompt-evolution-13",
-            "role": "button"
+            "role": "button",
+            "textContent": "Prompt Evolution"
           }
         ],
         "id": "mo-sub-nav",
@@ -378,11 +383,13 @@
         "elements": [
           {
             "id": "button-capture-baseline",
-            "role": "button"
+            "role": "button",
+            "textContent": "Capture Baseline"
           },
           {
             "id": "button-refresh",
-            "role": "button"
+            "role": "button",
+            "textContent": "Refresh"
           }
         ],
         "id": "mo-baseline-controls",

--- a/specs/pages/meta-optimizer/spec.uibridge.json
+++ b/specs/pages/meta-optimizer/spec.uibridge.json
@@ -1,0 +1,429 @@
+{
+  "description": "Meta-Optimizer page -- the runner's self-improvement control center. It captures behavioral baselines, tracks spec-compliance over time, surfaces optimization recommendations, and exposes a family of sub-views (Progress, Recommendations, Prompt Optimization, Prompt Registry, Config Suggestions, Run History, Eval Specs, Robustness, Duel Pools, Beam Runs, Span Events, Adaptive Learning, Playbook, Prompt Evolution) for inspecting and steering the agentic optimization loop. A workflow-class selector and Capture Baseline / Refresh controls drive metric collection over a rolling window.",
+  "groups": [
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Global app header title is present",
+          "enabled": true,
+          "id": "mo-page-shell-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-1-qontinui-runner"
+            },
+            "label": "App header title",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "BETA product badge is present",
+          "enabled": true,
+          "id": "mo-page-shell-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-badge-beta-1"
+            },
+            "label": "BETA badge",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Workflow-class selector combobox is present",
+          "enabled": true,
+          "id": "mo-page-shell-elem-2",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "select-main-workflows-reflections-fix",
+              "role": "combobox"
+            },
+            "label": "Workflow-class selector",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The Meta-Optimizer page renders inside the runner shell with the global app header (Qontinui Runner title + BETA badge) and a workflow-class selector that scopes which workflow family's metrics are measured (Main Workflows / Reflections / Fixers / Follow-ups).",
+      "id": "mo-page-shell",
+      "name": "Meta-Optimizer Page Shell",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Progress sub-view button is present",
+          "enabled": true,
+          "id": "mo-sub-nav-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-progress-0",
+              "role": "button"
+            },
+            "label": "Progress sub-view button",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Recommendations sub-view button is present",
+          "enabled": true,
+          "id": "mo-sub-nav-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-recommendations-1",
+              "role": "button"
+            },
+            "label": "Recommendations sub-view button",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Prompt Optimization sub-view button is present",
+          "enabled": true,
+          "id": "mo-sub-nav-elem-2",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-prompt-optimization-2",
+              "role": "button"
+            },
+            "label": "Prompt Optimization sub-view button",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Adaptive Learning sub-view button is present",
+          "enabled": true,
+          "id": "mo-sub-nav-elem-3",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-adaptive-learning-11",
+              "role": "button"
+            },
+            "label": "Adaptive Learning sub-view button",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Prompt Evolution sub-view button is present",
+          "enabled": true,
+          "id": "mo-sub-nav-elem-4",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-prompt-evolution-13",
+              "role": "button"
+            },
+            "label": "Prompt Evolution sub-view button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "A row of sub-view tabs lets the user move between the optimizer's facets: Progress (baseline + metric trends), Recommendations, Prompt Optimization, Prompt Registry, Config Suggestions, Run History, Eval Specs, Robustness, Duel Pools, Beam Runs, Span Events, Adaptive Learning, Playbook, and Prompt Evolution. Each is a button in the page-local sub-nav bar.",
+      "id": "mo-sub-nav",
+      "name": "Meta-Optimizer Sub-Navigation",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Capture Baseline button is present",
+          "enabled": true,
+          "id": "mo-baseline-controls-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-capture-baseline",
+              "role": "button"
+            },
+            "label": "Capture Baseline button",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Refresh metrics button is present",
+          "enabled": true,
+          "id": "mo-baseline-controls-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-refresh",
+              "role": "button"
+            },
+            "label": "Refresh metrics button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The Progress view's control bar exposes the baseline-capture action (Capture Baseline) and a Refresh action that re-pulls agentic metric aggregates for the selected workflow class. These drive the snapshot history and compliance panels below.",
+      "id": "mo-baseline-controls",
+      "name": "Baseline Capture & Refresh Controls",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Snapshot history empty-state message is present",
+          "enabled": true,
+          "id": "mo-snapshots-section-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-content-generic-no-snapshots-recorde-4"
+            },
+            "label": "No-snapshots empty state",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Metrics load-error advisory is present",
+          "enabled": true,
+          "id": "mo-snapshots-section-elem-1",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-content-generic-failed-to-load-metri-0"
+            },
+            "label": "Metrics load-error advisory",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The Progress view records baseline snapshots over time. Before any baseline is captured (or when the metrics query fails) the section shows an explanatory empty/error state rather than a populated history list.",
+      "id": "mo-snapshots-section",
+      "name": "Snapshot History Section",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Spec Compliance Overview heading is present",
+          "enabled": true,
+          "id": "mo-spec-compliance-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-content-generic-spec-compliance-over-0"
+            },
+            "label": "Spec Compliance Overview heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "No-compliance-data empty state is present",
+          "enabled": true,
+          "id": "mo-spec-compliance-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-content-generic-no-compliance-data-y-1"
+            },
+            "label": "No-compliance-data empty state",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "No-workflow-runs empty state is present",
+          "enabled": true,
+          "id": "mo-spec-compliance-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-content-generic-no-workflow-runs-in-0"
+            },
+            "label": "No-workflow-runs empty state",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "A Spec Compliance Overview panel summarizes how well the application matches its declared UI Bridge page specs after spec-generated workflow runs. With no compliance data yet, it shows guidance to run a spec-generated workflow; the workflow-runs sub-panel likewise shows a no-runs-in-the-last-30-days empty state until runs accumulate.",
+      "id": "mo-spec-compliance",
+      "name": "Spec Compliance Overview Section",
+      "source": "ai-generated"
+    }
+  ],
+  "metadata": {
+    "component": "meta-optimizer",
+    "tags": [
+      "meta-optimizer",
+      "self-improvement",
+      "optimization",
+      "spec-compliance",
+      "baseline",
+      "agentic-metrics",
+      "tier-2",
+      "beta"
+    ]
+  },
+  "stateMachine": {
+    "states": [
+      {
+        "description": "The Meta-Optimizer page renders inside the runner shell with the global app header (Qontinui Runner title + BETA badge) and a workflow-class selector that scopes which workflow family's metrics are measured (Main Workflows / Reflections / Fixers / Follow-ups).",
+        "elements": [
+          {
+            "id": "heading-1-qontinui-runner"
+          },
+          {
+            "id": "content-badge-beta-1"
+          },
+          {
+            "id": "select-main-workflows-reflections-fix",
+            "role": "combobox"
+          }
+        ],
+        "id": "mo-page-shell",
+        "isInitial": true,
+        "name": "Meta-Optimizer Page Shell",
+        "transitions": []
+      },
+      {
+        "description": "A row of sub-view tabs lets the user move between the optimizer's facets: Progress (baseline + metric trends), Recommendations, Prompt Optimization, Prompt Registry, Config Suggestions, Run History, Eval Specs, Robustness, Duel Pools, Beam Runs, Span Events, Adaptive Learning, Playbook, and Prompt Evolution. Each is a button in the page-local sub-nav bar.",
+        "elements": [
+          {
+            "id": "button-progress-0",
+            "role": "button"
+          },
+          {
+            "id": "button-recommendations-1",
+            "role": "button"
+          },
+          {
+            "id": "button-prompt-optimization-2",
+            "role": "button"
+          },
+          {
+            "id": "button-adaptive-learning-11",
+            "role": "button"
+          },
+          {
+            "id": "button-prompt-evolution-13",
+            "role": "button"
+          }
+        ],
+        "id": "mo-sub-nav",
+        "isInitial": false,
+        "name": "Meta-Optimizer Sub-Navigation",
+        "transitions": []
+      },
+      {
+        "description": "The Progress view's control bar exposes the baseline-capture action (Capture Baseline) and a Refresh action that re-pulls agentic metric aggregates for the selected workflow class. These drive the snapshot history and compliance panels below.",
+        "elements": [
+          {
+            "id": "button-capture-baseline",
+            "role": "button"
+          },
+          {
+            "id": "button-refresh",
+            "role": "button"
+          }
+        ],
+        "id": "mo-baseline-controls",
+        "isInitial": false,
+        "name": "Baseline Capture & Refresh Controls",
+        "transitions": []
+      },
+      {
+        "description": "The Progress view records baseline snapshots over time. Before any baseline is captured (or when the metrics query fails) the section shows an explanatory empty/error state rather than a populated history list.",
+        "elements": [
+          {
+            "id": "content-content-generic-no-snapshots-recorde-4"
+          },
+          {
+            "id": "content-content-generic-failed-to-load-metri-0"
+          }
+        ],
+        "id": "mo-snapshots-section",
+        "isInitial": false,
+        "name": "Snapshot History Section",
+        "transitions": []
+      },
+      {
+        "description": "A Spec Compliance Overview panel summarizes how well the application matches its declared UI Bridge page specs after spec-generated workflow runs. With no compliance data yet, it shows guidance to run a spec-generated workflow; the workflow-runs sub-panel likewise shows a no-runs-in-the-last-30-days empty state until runs accumulate.",
+        "elements": [
+          {
+            "id": "content-content-generic-spec-compliance-over-0"
+          },
+          {
+            "id": "content-content-generic-no-compliance-data-y-1"
+          },
+          {
+            "id": "content-content-generic-no-workflow-runs-in-0"
+          }
+        ],
+        "id": "mo-spec-compliance",
+        "isInitial": false,
+        "name": "Spec Compliance Overview Section",
+        "transitions": []
+      }
+    ]
+  },
+  "version": "1.0.0"
+}

--- a/specs/pages/meta-optimizer/state-machine.derived.json
+++ b/specs/pages/meta-optimizer/state-machine.derived.json
@@ -1,0 +1,325 @@
+{
+  "version": "1.0",
+  "id": "meta-optimizer",
+  "name": "MetaOptimizerPage",
+  "description": "Meta-Optimizer page -- the runner's self-improvement control center. It captures behavioral baselines, tracks spec-compliance over time, surfaces optimization recommendations, and exposes a family of sub-views (Progress, Recommendations, Prompt Optimization, Prompt Registry, Config Suggestions, Run History, Eval Specs, Robustness, Duel Pools, Beam Runs, Span Events, Adaptive Learning, Playbook, Prompt Evolution) for inspecting and steering the agentic optimization loop. A workflow-class selector and Capture Baseline / Refresh controls drive metric collection over a rolling window.",
+  "metadata": {
+    "purpose": "meta-optimizer",
+    "tags": [
+      "meta-optimizer",
+      "self-improvement",
+      "optimization",
+      "spec-compliance",
+      "baseline",
+      "agentic-metrics",
+      "tier-2",
+      "beta"
+    ]
+  },
+  "provenance": {
+    "source": "ai-generated",
+    "appId": "qontinui-runner"
+  },
+  "states": [
+    {
+      "id": "mo-page-shell",
+      "name": "Meta-Optimizer Page Shell",
+      "description": "The Meta-Optimizer page renders inside the runner shell with the global app header (Qontinui Runner title + BETA badge) and a workflow-class selector that scopes which workflow family's metrics are measured (Main Workflows / Reflections / Fixers / Follow-ups).",
+      "assertions": [
+        {
+          "id": "mo-page-shell-elem-0",
+          "description": "Global app header title is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-1-qontinui-runner"
+            },
+            "label": "App header title"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-page-shell-elem-1",
+          "description": "BETA product badge is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-badge-beta-1"
+            },
+            "label": "BETA badge"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-page-shell-elem-2",
+          "description": "Workflow-class selector combobox is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "select-main-workflows-reflections-fix",
+              "role": "combobox"
+            },
+            "label": "Workflow-class selector"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "isInitial": true
+    },
+    {
+      "id": "mo-sub-nav",
+      "name": "Meta-Optimizer Sub-Navigation",
+      "description": "A row of sub-view tabs lets the user move between the optimizer's facets: Progress (baseline + metric trends), Recommendations, Prompt Optimization, Prompt Registry, Config Suggestions, Run History, Eval Specs, Robustness, Duel Pools, Beam Runs, Span Events, Adaptive Learning, Playbook, and Prompt Evolution. Each is a button in the page-local sub-nav bar.",
+      "assertions": [
+        {
+          "id": "mo-sub-nav-elem-0",
+          "description": "Progress sub-view button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-progress-0",
+              "role": "button"
+            },
+            "label": "Progress sub-view button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-sub-nav-elem-1",
+          "description": "Recommendations sub-view button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-recommendations-1",
+              "role": "button"
+            },
+            "label": "Recommendations sub-view button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-sub-nav-elem-2",
+          "description": "Prompt Optimization sub-view button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-prompt-optimization-2",
+              "role": "button"
+            },
+            "label": "Prompt Optimization sub-view button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-sub-nav-elem-3",
+          "description": "Adaptive Learning sub-view button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-adaptive-learning-11",
+              "role": "button"
+            },
+            "label": "Adaptive Learning sub-view button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-sub-nav-elem-4",
+          "description": "Prompt Evolution sub-view button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-prompt-evolution-13",
+              "role": "button"
+            },
+            "label": "Prompt Evolution sub-view button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "mo-baseline-controls",
+      "name": "Baseline Capture & Refresh Controls",
+      "description": "The Progress view's control bar exposes the baseline-capture action (Capture Baseline) and a Refresh action that re-pulls agentic metric aggregates for the selected workflow class. These drive the snapshot history and compliance panels below.",
+      "assertions": [
+        {
+          "id": "mo-baseline-controls-elem-0",
+          "description": "Capture Baseline button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-capture-baseline",
+              "role": "button"
+            },
+            "label": "Capture Baseline button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-baseline-controls-elem-1",
+          "description": "Refresh metrics button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-refresh",
+              "role": "button"
+            },
+            "label": "Refresh metrics button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "mo-snapshots-section",
+      "name": "Snapshot History Section",
+      "description": "The Progress view records baseline snapshots over time. Before any baseline is captured (or when the metrics query fails) the section shows an explanatory empty/error state rather than a populated history list.",
+      "assertions": [
+        {
+          "id": "mo-snapshots-section-elem-0",
+          "description": "Snapshot history empty-state message is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-content-generic-no-snapshots-recorde-4"
+            },
+            "label": "No-snapshots empty state"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-snapshots-section-elem-1",
+          "description": "Metrics load-error advisory is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-content-generic-failed-to-load-metri-0"
+            },
+            "label": "Metrics load-error advisory"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "mo-spec-compliance",
+      "name": "Spec Compliance Overview Section",
+      "description": "A Spec Compliance Overview panel summarizes how well the application matches its declared UI Bridge page specs after spec-generated workflow runs. With no compliance data yet, it shows guidance to run a spec-generated workflow; the workflow-runs sub-panel likewise shows a no-runs-in-the-last-30-days empty state until runs accumulate.",
+      "assertions": [
+        {
+          "id": "mo-spec-compliance-elem-0",
+          "description": "Spec Compliance Overview heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-content-generic-spec-compliance-over-0"
+            },
+            "label": "Spec Compliance Overview heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-spec-compliance-elem-1",
+          "description": "No-compliance-data empty state is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-content-generic-no-compliance-data-y-1"
+            },
+            "label": "No-compliance-data empty state"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "mo-spec-compliance-elem-2",
+          "description": "No-workflow-runs empty state is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-content-generic-no-workflow-runs-in-0"
+            },
+            "label": "No-workflow-runs empty state"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "transitions": []
+}

--- a/specs/pages/settings-debug/notes.md
+++ b/specs/pages/settings-debug/notes.md
@@ -1,0 +1,17 @@
+# SettingsDebugPage
+
+Re-authored under the canonical `settings-debug` page id (the prior spec was
+retired in the 2026-06-04 page-spec gap cleanup for using a wrong page id). This
+is the shared Settings arm with the `advanced` sub-tab active (the
+`settings-debug` tab maps to Settings → "advanced"), so `metadata.component` is
+`Settings`.
+
+Authored against a live snapshot and validated via `POST /spec-check` on a temp
+runner built from main `8c2fc7e8`: `full_match`, overallMatchRate 1.0, 5 states,
+15 assertions, 1 read-only transition (open the Debug sub-tab), zero
+`no_candidates` misses.
+
+All criteria are ID-first against stable UI Bridge ids (the settings sub-tab
+rail, the Advanced/Debug section headings, Save Debug Settings, the debug
+option labels, the Device Information block + Refresh device info, and the
+Experimental section).

--- a/specs/pages/settings-debug/spec.uibridge.json
+++ b/specs/pages/settings-debug/spec.uibridge.json
@@ -1,0 +1,451 @@
+{
+  "description": "Debug Settings -- the Settings page with the Advanced/Debug sub-tab active. It surfaces developer and debugging options (image-match debug mode, top-matches-to-display), device information for support (device id, name, platform), and experimental feature toggles. The page is the shared Settings arm (component dir: Settings); the canonical settings-debug tab maps to the Settings 'advanced' sub-tab. A horizontal settings tab rail lets the user move between all settings sub-views.",
+  "groups": [
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Advanced section heading is present",
+          "enabled": true,
+          "id": "sd-debug-content-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-3-advanced",
+              "role": "heading"
+            },
+            "label": "Advanced section heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Debug sub-section heading is present",
+          "enabled": true,
+          "id": "sd-debug-content-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-4-debug",
+              "role": "heading"
+            },
+            "label": "Debug sub-section heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Save Debug Settings button is present",
+          "enabled": true,
+          "id": "sd-debug-content-elem-2",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-save-debug-settings",
+              "role": "button"
+            },
+            "label": "Save Debug Settings button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "With the Advanced (debug) sub-tab active, the settings body shows an Advanced section containing a Debug sub-section (developer + debugging options such as image-match debug mode and top-matches-to-display) and a Save Debug Settings action.",
+      "id": "sd-debug-content",
+      "name": "Advanced / Debug Settings Content",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Developer/debugging options descriptive paragraph is present",
+          "enabled": true,
+          "id": "sd-debug-options-elem-0",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-paragraph-developer-and-debugg-0"
+            },
+            "label": "Developer options description",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Enable Image Match Debug Mode label is present",
+          "enabled": true,
+          "id": "sd-debug-options-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-label-enable-image-match-d-0"
+            },
+            "label": "Image Match Debug Mode label",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Top Matches to Display label is present",
+          "enabled": true,
+          "id": "sd-debug-options-elem-2",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-label-top-matches-to-displ-0"
+            },
+            "label": "Top Matches to Display label",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "The Debug sub-section exposes the actual developer toggles and inputs: an Enable Image Match Debug Mode toggle (collects and displays detailed match diagnostics) and a Top Matches to Display numeric control bounding how many top match candidates are shown.",
+      "id": "sd-debug-options",
+      "name": "Debug Options Controls",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Device Information heading is present",
+          "enabled": true,
+          "id": "sd-device-info-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-4-device-information",
+              "role": "heading"
+            },
+            "label": "Device Information heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Device ID field label is present",
+          "enabled": true,
+          "id": "sd-device-info-elem-1",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-label-device-id-0"
+            },
+            "label": "Device ID label",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Refresh device info button is present",
+          "enabled": true,
+          "id": "sd-device-info-elem-2",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-refresh-device-info",
+              "role": "button"
+            },
+            "label": "Refresh device info button",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "A Device Information section shows system information useful for debugging and support: device id, device name, and platform, with a Refresh device info action to re-read the values.",
+      "id": "sd-device-info",
+      "name": "Device Information Section",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Experimental section heading is present",
+          "enabled": true,
+          "id": "sd-experimental-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "heading-4-experimental",
+              "role": "heading"
+            },
+            "label": "Experimental section heading",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Experimental warning paragraph is present",
+          "enabled": true,
+          "id": "sd-experimental-elem-1",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "content-paragraph-these-features-are-e-0"
+            },
+            "label": "Experimental warning",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "xterm.js default terminal-renderer option is present",
+          "enabled": true,
+          "id": "sd-experimental-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "button-xtermjs-0",
+              "role": "button"
+            },
+            "label": "xterm.js renderer option",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "An Experimental section warns that the features below are experimental and may be unstable, and houses experimental toggles such as the alternate terminal renderer (xterm.js default vs ghostty-web experimental).",
+      "id": "sd-experimental",
+      "name": "Experimental Features Section",
+      "source": "ai-generated"
+    },
+    {
+      "assertions": [
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Debug settings sub-tab is present",
+          "enabled": true,
+          "id": "sd-tab-rail-elem-0",
+          "reviewed": false,
+          "severity": "critical",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "tab-debug-22",
+              "role": "tab"
+            },
+            "label": "Debug sub-tab",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "Account settings sub-tab is present",
+          "enabled": true,
+          "id": "sd-tab-rail-elem-1",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "tab-account-0",
+              "role": "tab"
+            },
+            "label": "Account sub-tab",
+            "type": "search"
+          }
+        },
+        {
+          "assertionType": "exists",
+          "category": "element-presence",
+          "description": "AI Providers settings sub-tab is present",
+          "enabled": true,
+          "id": "sd-tab-rail-elem-2",
+          "reviewed": false,
+          "severity": "warning",
+          "source": "ai-generated",
+          "target": {
+            "criteria": {
+              "id": "tab-ai-providers-2",
+              "role": "tab"
+            },
+            "label": "AI Providers sub-tab",
+            "type": "search"
+          }
+        }
+      ],
+      "category": "element-presence",
+      "description": "A horizontal tab rail lists every settings sub-view (Account, Backend Connection, AI Providers, Advanced AI, Self-Healing, ... Debug, Updates). The Debug tab activates this page's advanced/debug content; the Account and AI Providers tabs are representative sibling sub-views.",
+      "id": "sd-tab-rail",
+      "name": "Settings Sub-Tab Rail",
+      "source": "ai-generated"
+    }
+  ],
+  "metadata": {
+    "component": "Settings",
+    "tags": [
+      "settings",
+      "debug",
+      "advanced",
+      "developer-options",
+      "device-info",
+      "experimental",
+      "diagnostics"
+    ]
+  },
+  "stateMachine": {
+    "states": [
+      {
+        "description": "With the Advanced (debug) sub-tab active, the settings body shows an Advanced section containing a Debug sub-section (developer + debugging options such as image-match debug mode and top-matches-to-display) and a Save Debug Settings action.",
+        "elements": [
+          {
+            "id": "heading-3-advanced",
+            "role": "heading"
+          },
+          {
+            "id": "heading-4-debug",
+            "role": "heading"
+          },
+          {
+            "id": "button-save-debug-settings",
+            "role": "button"
+          }
+        ],
+        "id": "sd-debug-content",
+        "isInitial": true,
+        "name": "Advanced / Debug Settings Content",
+        "transitions": []
+      },
+      {
+        "description": "The Debug sub-section exposes the actual developer toggles and inputs: an Enable Image Match Debug Mode toggle (collects and displays detailed match diagnostics) and a Top Matches to Display numeric control bounding how many top match candidates are shown.",
+        "elements": [
+          {
+            "id": "content-paragraph-developer-and-debugg-0"
+          },
+          {
+            "id": "content-label-enable-image-match-d-0"
+          },
+          {
+            "id": "content-label-top-matches-to-displ-0"
+          }
+        ],
+        "id": "sd-debug-options",
+        "isInitial": false,
+        "name": "Debug Options Controls",
+        "transitions": []
+      },
+      {
+        "description": "A Device Information section shows system information useful for debugging and support: device id, device name, and platform, with a Refresh device info action to re-read the values.",
+        "elements": [
+          {
+            "id": "heading-4-device-information",
+            "role": "heading"
+          },
+          {
+            "id": "content-label-device-id-0"
+          },
+          {
+            "id": "button-refresh-device-info",
+            "role": "button"
+          }
+        ],
+        "id": "sd-device-info",
+        "isInitial": false,
+        "name": "Device Information Section",
+        "transitions": []
+      },
+      {
+        "description": "An Experimental section warns that the features below are experimental and may be unstable, and houses experimental toggles such as the alternate terminal renderer (xterm.js default vs ghostty-web experimental).",
+        "elements": [
+          {
+            "id": "heading-4-experimental",
+            "role": "heading"
+          },
+          {
+            "id": "content-paragraph-these-features-are-e-0"
+          },
+          {
+            "id": "button-xtermjs-0",
+            "role": "button"
+          }
+        ],
+        "id": "sd-experimental",
+        "isInitial": false,
+        "name": "Experimental Features Section",
+        "transitions": []
+      },
+      {
+        "description": "A horizontal tab rail lists every settings sub-view (Account, Backend Connection, AI Providers, Advanced AI, Self-Healing, ... Debug, Updates). The Debug tab activates this page's advanced/debug content; the Account and AI Providers tabs are representative sibling sub-views.",
+        "elements": [
+          {
+            "id": "tab-debug-22",
+            "role": "tab"
+          },
+          {
+            "id": "tab-account-0",
+            "role": "tab"
+          },
+          {
+            "id": "tab-ai-providers-2",
+            "role": "tab"
+          }
+        ],
+        "id": "sd-tab-rail",
+        "isInitial": false,
+        "name": "Settings Sub-Tab Rail",
+        "transitions": [
+          {
+            "activateStates": [
+              "sd-debug-content"
+            ],
+            "deactivateStates": [],
+            "id": "sd-open-debug-subtab",
+            "name": "Open Debug Sub-Tab",
+            "process": [
+              {
+                "action": "click",
+                "target": {
+                  "id": "tab-debug-22",
+                  "role": "tab"
+                }
+              }
+            ],
+            "staysVisible": true
+          }
+        ]
+      }
+    ]
+  },
+  "version": "1.0.0"
+}

--- a/specs/pages/settings-debug/spec.uibridge.json
+++ b/specs/pages/settings-debug/spec.uibridge.json
@@ -331,15 +331,18 @@
         "elements": [
           {
             "id": "heading-3-advanced",
-            "role": "heading"
+            "role": "heading",
+            "textContent": "Advanced"
           },
           {
             "id": "heading-4-debug",
-            "role": "heading"
+            "role": "heading",
+            "textContent": "Debug"
           },
           {
             "id": "button-save-debug-settings",
-            "role": "button"
+            "role": "button",
+            "textContent": "Save Debug Settings"
           }
         ],
         "id": "sd-debug-content",
@@ -370,14 +373,16 @@
         "elements": [
           {
             "id": "heading-4-device-information",
-            "role": "heading"
+            "role": "heading",
+            "textContent": "Device Information"
           },
           {
             "id": "content-label-device-id-0"
           },
           {
             "id": "button-refresh-device-info",
-            "role": "button"
+            "role": "button",
+            "accessibleName": "Refresh device info"
           }
         ],
         "id": "sd-device-info",
@@ -390,14 +395,16 @@
         "elements": [
           {
             "id": "heading-4-experimental",
-            "role": "heading"
+            "role": "heading",
+            "textContent": "Experimental"
           },
           {
             "id": "content-paragraph-these-features-are-e-0"
           },
           {
             "id": "button-xtermjs-0",
-            "role": "button"
+            "role": "button",
+            "textContent": "xterm.js (default)"
           }
         ],
         "id": "sd-experimental",
@@ -410,15 +417,18 @@
         "elements": [
           {
             "id": "tab-debug-22",
-            "role": "tab"
+            "role": "tab",
+            "textContent": "Debug"
           },
           {
             "id": "tab-account-0",
-            "role": "tab"
+            "role": "tab",
+            "textContent": "Account"
           },
           {
             "id": "tab-ai-providers-2",
-            "role": "tab"
+            "role": "tab",
+            "textContent": "AI Providers"
           }
         ],
         "id": "sd-tab-rail",

--- a/specs/pages/settings-debug/state-machine.derived.json
+++ b/specs/pages/settings-debug/state-machine.derived.json
@@ -1,0 +1,348 @@
+{
+  "version": "1.0",
+  "id": "settings-debug",
+  "name": "SettingsDebugPage",
+  "description": "Debug Settings -- the Settings page with the Advanced/Debug sub-tab active. It surfaces developer and debugging options (image-match debug mode, top-matches-to-display), device information for support (device id, name, platform), and experimental feature toggles. The page is the shared Settings arm (component dir: Settings); the canonical settings-debug tab maps to the Settings 'advanced' sub-tab. A horizontal settings tab rail lets the user move between all settings sub-views.",
+  "metadata": {
+    "purpose": "Settings",
+    "tags": [
+      "settings",
+      "debug",
+      "advanced",
+      "developer-options",
+      "device-info",
+      "experimental",
+      "diagnostics"
+    ]
+  },
+  "provenance": {
+    "source": "ai-generated",
+    "appId": "qontinui-runner"
+  },
+  "states": [
+    {
+      "id": "sd-debug-content",
+      "name": "Advanced / Debug Settings Content",
+      "description": "With the Advanced (debug) sub-tab active, the settings body shows an Advanced section containing a Debug sub-section (developer + debugging options such as image-match debug mode and top-matches-to-display) and a Save Debug Settings action.",
+      "assertions": [
+        {
+          "id": "sd-debug-content-elem-0",
+          "description": "Advanced section heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-3-advanced",
+              "role": "heading"
+            },
+            "label": "Advanced section heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-debug-content-elem-1",
+          "description": "Debug sub-section heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-4-debug",
+              "role": "heading"
+            },
+            "label": "Debug sub-section heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-debug-content-elem-2",
+          "description": "Save Debug Settings button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-save-debug-settings",
+              "role": "button"
+            },
+            "label": "Save Debug Settings button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ],
+      "isInitial": true
+    },
+    {
+      "id": "sd-debug-options",
+      "name": "Debug Options Controls",
+      "description": "The Debug sub-section exposes the actual developer toggles and inputs: an Enable Image Match Debug Mode toggle (collects and displays detailed match diagnostics) and a Top Matches to Display numeric control bounding how many top match candidates are shown.",
+      "assertions": [
+        {
+          "id": "sd-debug-options-elem-0",
+          "description": "Developer/debugging options descriptive paragraph is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-paragraph-developer-and-debugg-0"
+            },
+            "label": "Developer options description"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-debug-options-elem-1",
+          "description": "Enable Image Match Debug Mode label is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-label-enable-image-match-d-0"
+            },
+            "label": "Image Match Debug Mode label"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-debug-options-elem-2",
+          "description": "Top Matches to Display label is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-label-top-matches-to-displ-0"
+            },
+            "label": "Top Matches to Display label"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "sd-device-info",
+      "name": "Device Information Section",
+      "description": "A Device Information section shows system information useful for debugging and support: device id, device name, and platform, with a Refresh device info action to re-read the values.",
+      "assertions": [
+        {
+          "id": "sd-device-info-elem-0",
+          "description": "Device Information heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-4-device-information",
+              "role": "heading"
+            },
+            "label": "Device Information heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-device-info-elem-1",
+          "description": "Device ID field label is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-label-device-id-0"
+            },
+            "label": "Device ID label"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-device-info-elem-2",
+          "description": "Refresh device info button is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-refresh-device-info",
+              "role": "button"
+            },
+            "label": "Refresh device info button"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "sd-experimental",
+      "name": "Experimental Features Section",
+      "description": "An Experimental section warns that the features below are experimental and may be unstable, and houses experimental toggles such as the alternate terminal renderer (xterm.js default vs ghostty-web experimental).",
+      "assertions": [
+        {
+          "id": "sd-experimental-elem-0",
+          "description": "Experimental section heading is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "heading-4-experimental",
+              "role": "heading"
+            },
+            "label": "Experimental section heading"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-experimental-elem-1",
+          "description": "Experimental warning paragraph is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "content-paragraph-these-features-are-e-0"
+            },
+            "label": "Experimental warning"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-experimental-elem-2",
+          "description": "xterm.js default terminal-renderer option is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "button-xtermjs-0",
+              "role": "button"
+            },
+            "label": "xterm.js renderer option"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    },
+    {
+      "id": "sd-tab-rail",
+      "name": "Settings Sub-Tab Rail",
+      "description": "A horizontal tab rail lists every settings sub-view (Account, Backend Connection, AI Providers, Advanced AI, Self-Healing, ... Debug, Updates). The Debug tab activates this page's advanced/debug content; the Account and AI Providers tabs are representative sibling sub-views.",
+      "assertions": [
+        {
+          "id": "sd-tab-rail-elem-0",
+          "description": "Debug settings sub-tab is present",
+          "category": "element-presence",
+          "severity": "critical",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "tab-debug-22",
+              "role": "tab"
+            },
+            "label": "Debug sub-tab"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-tab-rail-elem-1",
+          "description": "Account settings sub-tab is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "tab-account-0",
+              "role": "tab"
+            },
+            "label": "Account sub-tab"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        },
+        {
+          "id": "sd-tab-rail-elem-2",
+          "description": "AI Providers settings sub-tab is present",
+          "category": "element-presence",
+          "severity": "warning",
+          "assertionType": "exists",
+          "target": {
+            "type": "search",
+            "criteria": {
+              "id": "tab-ai-providers-2",
+              "role": "tab"
+            },
+            "label": "AI Providers sub-tab"
+          },
+          "source": "ai-generated",
+          "reviewed": false,
+          "enabled": true
+        }
+      ]
+    }
+  ],
+  "transitions": [
+    {
+      "id": "sd-open-debug-subtab",
+      "name": "Open Debug Sub-Tab",
+      "description": "From the settings tab rail, clicking the Debug sub-tab activates the Advanced/Debug settings content. Read-only navigation between settings sub-views.",
+      "fromStates": [
+        "sd-tab-rail"
+      ],
+      "activateStates": [
+        "sd-debug-content"
+      ],
+      "actions": [
+        {
+          "type": "click",
+          "target": {
+            "role": "tab",
+            "id": "tab-debug-22"
+          }
+        }
+      ],
+      "effect": "read"
+    }
+  ]
+}


### PR DESCRIPTION
Follow-up to #409 / plan `2026-06-04-page-spec-path-map-producer-plan`.

The `meta-optimizer`, `settings-debug`, and `llm-analytics` page specs were
retired in the 2026-06-04 page-spec gap cleanup because their prior specs used
wrong page ids. This PR re-authors all three under their canonical page ids.

## Validation

Authored against live snapshots and validated via `POST /spec-check` against a
temp runner built from main `8c2fc7e8` (isolated `.spawn-8c2fc7e8…` worktree).
Criteria are ID-first against stable UI Bridge ids.

| page | states | assertions | transitions | matchRate | matchOutcome |
| --- | --- | --- | --- | --- | --- |
| meta-optimizer | 5 | 15 | 0 | 1.00 | full_match |
| llm-analytics | 6 | 16 | 0 | 1.00 | full_match |
| settings-debug | 5 | 15 | 1 | 1.00 | full_match |

All three: zero `no_candidates` misses, all per-state matchRates 1.0.

## Canonical ids / component dirs

`metadata.component` matches the component-dir map (`projection.purpose`):

- `meta-optimizer` → `meta-optimizer` → `src/components/meta-optimizer/`
- `llm-analytics` → `llm-observability` (rendered by `LlmObservabilityDashboard`) → `src/components/llm-observability/`
- `settings-debug` → `Settings` (shared Settings arm, `advanced` sub-tab) → `src/components/Settings/`

`scripts/page_spec_paths/emit-page-spec-paths.mjs --dry-run` reports
**total 75 / mapped 75 / gaps 0**, with all three resolving via component-dir.

Each page dir carries the canonical sibling file set (`state-machine.derived.json`
IR + generated `spec.uibridge.json` projection + `notes.md`).