### PR TITLE
feat(ai-session): register authenticated sessions into coord.sessions — session automation Phase 0 (R1-R6)

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -72,7 +72,10 @@ use crate::session::SessionEventKind;
 /// (including unset) leaves it ON.
 fn registration_enabled() -> bool {
     match std::env::var("QONTINUI_SESSION_AUTOMATION_REGISTER") {
-        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off"),
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off"
+        ),
         Err(_) => true,
     }
 }
@@ -216,9 +219,7 @@ impl AiCoordRegistrar {
         }
 
         // Record the R4 index only after the durable outbox write succeeds.
-        if let (Ok(mut fwd), Ok(mut rev)) =
-            (self.inner.forward.lock(), self.inner.reverse.lock())
-        {
+        if let (Ok(mut fwd), Ok(mut rev)) = (self.inner.forward.lock(), self.inner.reverse.lock()) {
             fwd.insert(session_id, task_run_id.to_string());
             rev.insert(task_run_id.to_string(), session_id);
         }
@@ -324,7 +325,10 @@ mod tests {
         let coord_id = reg.register_session(&trid, "fix the thing", None).unwrap();
 
         // R4 index resolves both ways.
-        assert_eq!(reg.task_run_id_for(&coord_id).as_deref(), Some(trid.as_str()));
+        assert_eq!(
+            reg.task_run_id_for(&coord_id).as_deref(),
+            Some(trid.as_str())
+        );
         assert_eq!(reg.session_id_for(&trid), Some(coord_id));
 
         // Exactly one Started row in the outbox, carrying task_run_id + agentic.
@@ -403,13 +407,10 @@ mod tests {
         assert!(reg.session_id_for(&trid).is_none());
 
         // A Closed row was written for the coord id.
-        let closed = reg
-            .inner
-            .outbox
-            .pending()
-            .unwrap()
-            .into_iter()
-            .any(|r| r.event_kind == SessionEventKind::Closed.as_str() && r.session_id == coord_id);
+        let closed =
+            reg.inner.outbox.pending().unwrap().into_iter().any(|r| {
+                r.event_kind == SessionEventKind::Closed.as_str() && r.session_id == coord_id
+            });
         assert!(closed, "a Closed outbox row must be emitted on close");
     }
 

--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -1,0 +1,428 @@
+//! Session-automation Phase 0 — register authenticated `ClaudeSession`s into
+//! `coord.sessions` so they become visible, addressable, and correctly stale to
+//! coord.
+//!
+//! Plan: `D:/qontinui-root/qontinui-dev-notes/plans/
+//! 2026-06-04-session-automation-injection-engine-design.md` §0/F1 +
+//! `2026-06-04-session-automation-phase0-checklist.md` §3 (R1–R6).
+//!
+//! ## Why a dedicated registrar (not `SessionRegistry::register_external`)
+//!
+//! The operator's authenticated AI sessions live in
+//! [`crate::claude_session::manager::SessionManager`], keyed by `task_run_id`
+//! (UUIDv4) — **not** in [`crate::session::SessionRegistry`] (keyed by coord
+//! UUIDv7). Two consequences drive this module's shape:
+//!
+//! 1. **Staleness must reflect operator inactivity, not process liveness
+//!    (P0.2 / R3).** `SessionRegistry`'s heartbeat loop
+//!    (`coord_sync::run_heartbeat_loop`) PATCHes coord `{heartbeat:true}` for
+//!    **every** active registry session every ~15s, unconditionally — a session
+//!    mirrored through it would refresh `last_heartbeat_at=now()` forever and
+//!    **never** age to `stale` (the 600s `session_staleness_watcher` trigger
+//!    would never fire). By registering AI sessions **directly via the outbox**
+//!    (bypassing `SessionRegistry`), the only heartbeats they ever get are the
+//!    ones this module emits **on operator interaction** (see
+//!    [`AiCoordRegistrar::heartbeat_on_interaction`], called from
+//!    `send_user_message`). An idle session therefore ages to `stale`, which is
+//!    the entire point of Phase 0.
+//!
+//! 2. **`register_external` has no usable inject transport (P0.4).** It backs
+//!    the mirror with the no-op `ExternalTransport` — `write_input` does
+//!    nothing. Inject (Phase 1) must route to the live `ClaudeSession` via
+//!    `SessionManager.get(task_run_id)`. So coord stores the durable
+//!    `session_id ↔ task_run_id` mapping (the new `coord.sessions.task_run_id`
+//!    column) and this registrar keeps the runner-local hot-path index (R4).
+//!
+//! ## Wire path
+//!
+//! This module writes rows to the **same** [`OutboxWriter`] the `CoordSync`
+//! drain loop reads, so registration reuses the entire existing drain → auth →
+//! retry → 409-idempotency machinery with no new HTTP code:
+//!
+//! - **R1/R2 register** → `Started` outbox row (`POST /sessions`) carrying
+//!   `session_kind="agentic"`, `task_run_id`, and a nil `tenant_id` (coord
+//!   resolves the real tenant from the device, exactly like every other
+//!   runner-originated session).
+//! - **R3 heartbeat** → `Heartbeat` outbox row (`PATCH {heartbeat:true}`) on
+//!   operator interaction only.
+//! - **R5 close** → `Closed` outbox row (`DELETE /sessions/:id`) + index evict.
+//!
+//! ## Gating (P0.3)
+//!
+//! Registration is gated on `QONTINUI_SESSION_AUTOMATION_REGISTER` (default
+//! **ON**) — **independent** of the dormant per-tenant
+//! `session_coordination_enabled` dual-write burn-in. Coupling the automation
+//! foundation to that unrelated rollout knob would make Phase 0 inert in prod
+//! (the flag is dormant). Setting the env to `0`/`false`/`off` disables
+//! registration cleanly (a kill switch); the AI session itself is never
+//! affected — every coord write here is best-effort and swallows errors.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use serde_json::json;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::session::local_store::OutboxWriter;
+use crate::session::SessionEventKind;
+
+/// Default-ON env gate for AI-session coord registration (P0.3). Any of
+/// `0` / `false` / `off` (case-insensitive) disables it; anything else
+/// (including unset) leaves it ON.
+fn registration_enabled() -> bool {
+    match std::env::var("QONTINUI_SESSION_AUTOMATION_REGISTER") {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off"),
+        Err(_) => true,
+    }
+}
+
+/// Registers authenticated `ClaudeSession`s into `coord.sessions` and owns the
+/// runner-local `coord session_id (UUIDv7) ↔ task_run_id (UUIDv4)` index (R4).
+///
+/// Managed as Tauri state; cheap to clone (everything `Arc`/shared). Holds the
+/// same [`OutboxWriter`] the `CoordSync` drain loop drains, so a write here is
+/// pushed to coord by the existing loop.
+#[derive(Clone)]
+pub struct AiCoordRegistrar {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    outbox: Arc<OutboxWriter>,
+    machine_id: Uuid,
+    /// R4 index — coord `session_id` (UUIDv7) → runner `task_run_id` (UUIDv4),
+    /// plus the reverse map so close-by-`task_run_id` can evict without a scan.
+    /// `forward` is the inject resolver Phase 1 consumes; `reverse` is the
+    /// lifecycle/heartbeat path keyed by what the AI-session commands already
+    /// hold (`task_run_id`).
+    forward: Mutex<HashMap<Uuid, String>>,
+    reverse: Mutex<HashMap<String, Uuid>>,
+}
+
+impl AiCoordRegistrar {
+    /// Construct from the shared session outbox + this device's `machine_id`.
+    /// The outbox MUST be the same `Arc` the `CoordSync` drain loop reads.
+    pub fn new(outbox: Arc<OutboxWriter>, machine_id: Uuid) -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                outbox,
+                machine_id,
+                forward: Mutex::new(HashMap::new()),
+                reverse: Mutex::new(HashMap::new()),
+            }),
+        }
+    }
+
+    /// R4 — resolve a coord `session_id` to its runner `task_run_id`. The
+    /// hot-path resolver Phase 1's inject consumer will call before
+    /// `SessionManager.get(task_run_id)`.
+    pub fn task_run_id_for(&self, session_id: &Uuid) -> Option<String> {
+        self.inner
+            .forward
+            .lock()
+            .ok()
+            .and_then(|g| g.get(session_id).cloned())
+    }
+
+    /// R4 — resolve a runner `task_run_id` to its coord `session_id` (the
+    /// durable handle). Useful for the inject-audit / observability path.
+    #[allow(dead_code)]
+    pub fn session_id_for(&self, task_run_id: &str) -> Option<Uuid> {
+        self.inner
+            .reverse
+            .lock()
+            .ok()
+            .and_then(|g| g.get(task_run_id).copied())
+    }
+
+    /// R1/R2 — register (or idempotently re-register) an authenticated AI
+    /// session with coord. Mints a fresh coord `session_id` (UUIDv7), writes a
+    /// `Started` outbox row carrying `task_run_id`, and records the R4 index.
+    ///
+    /// **R6 idempotency:** a re-register for a `task_run_id` already in the
+    /// index is a no-op (returns the existing coord id) — a reconnect/restart
+    /// never writes a duplicate `Started` row. (Coord additionally treats a
+    /// 409 on `POST /sessions` as success in the drain loop.)
+    ///
+    /// Best-effort: a disabled gate or an outbox write error returns `None`
+    /// and never disturbs the live AI session. `purpose` surfaces in the
+    /// dashboard Live Sessions panel; `repo` is the optional session repo.
+    pub fn register_session(
+        &self,
+        task_run_id: &str,
+        purpose: &str,
+        repo: Option<String>,
+    ) -> Option<Uuid> {
+        if !registration_enabled() {
+            debug!(
+                "ai_coord_register: disabled via QONTINUI_SESSION_AUTOMATION_REGISTER — skipping {}",
+                task_run_id
+            );
+            return None;
+        }
+
+        // R6 — already registered? Return the existing coord id, write nothing.
+        if let Some(existing) = self.session_id_for(task_run_id) {
+            debug!(
+                "ai_coord_register: {} already registered as coord session {} — no-op",
+                task_run_id, existing
+            );
+            return Some(existing);
+        }
+
+        let session_id = crate::session::uuid_v7();
+        let now = chrono::Utc::now();
+        // Intent shape mirrors `coord.sessions.intent` (JSONB) — purpose is
+        // required (min 3 chars coord-side); fall back to a stable default so a
+        // blank chat name never trips coord's intent validation.
+        let purpose = {
+            let t = purpose.trim();
+            if t.len() >= 3 {
+                t.to_string()
+            } else {
+                "AI session".to_string()
+            }
+        };
+        let mut intent = json!({ "purpose": purpose });
+        if let Some(r) = repo.as_ref() {
+            intent["repo"] = json!(r);
+        }
+
+        // The `Started` payload is the create-body shape `rebuild_create_body`
+        // relabels for `POST /sessions`. `tenant_id` is omitted (nil) so coord
+        // resolves the real tenant from the device registration — the same path
+        // every runner-originated session uses.
+        let payload = json!({
+            "id": session_id,
+            "kind": SessionKind::Agentic.as_str(),
+            "intent": intent,
+            "state": "active",
+            "started_at": now,
+            "task_run_id": task_run_id,
+        });
+
+        if let Err(e) = self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::Started,
+            payload,
+        ) {
+            warn!(
+                "ai_coord_register: outbox Started write failed for {} (best-effort): {}",
+                task_run_id, e
+            );
+            return None;
+        }
+
+        // Record the R4 index only after the durable outbox write succeeds.
+        if let (Ok(mut fwd), Ok(mut rev)) =
+            (self.inner.forward.lock(), self.inner.reverse.lock())
+        {
+            fwd.insert(session_id, task_run_id.to_string());
+            rev.insert(task_run_id.to_string(), session_id);
+        }
+
+        info!(
+            "ai_coord_register: registered AI session {} as coord session {} (kind=agentic)",
+            task_run_id, session_id
+        );
+        Some(session_id)
+    }
+
+    /// R3 — emit a coord heartbeat for the AI session backing `task_run_id`,
+    /// driven by **operator interaction** (called from `send_user_message`).
+    /// This is the ONLY heartbeat these sessions ever get, so an idle session
+    /// ages to `stale` at coord's threshold. No-op (silently) if the session
+    /// was never registered or the gate is off.
+    pub fn heartbeat_on_interaction(&self, task_run_id: &str) {
+        let Some(session_id) = self.session_id_for(task_run_id) else {
+            return;
+        };
+        let payload = json!({ "id": session_id, "at": chrono::Utc::now() });
+        if let Err(e) = self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::Heartbeat,
+            payload,
+        ) {
+            warn!(
+                "ai_coord_register: outbox Heartbeat write failed for {} (best-effort): {}",
+                task_run_id, e
+            );
+        } else {
+            debug!(
+                "ai_coord_register: interaction heartbeat for {} (coord {})",
+                task_run_id, session_id
+            );
+        }
+    }
+
+    /// R5 — on AI-session end, emit a `Closed` outbox row (`DELETE
+    /// /sessions/:id`) and evict the R4 index entry so coord.sessions doesn't
+    /// leak a ghost row and the resolver doesn't keep a dangling mapping.
+    /// No-op if the session wasn't registered.
+    pub fn close_session(&self, task_run_id: &str) {
+        let session_id = {
+            // Evict reverse first, capturing the coord id.
+            let Some(id) = self
+                .inner
+                .reverse
+                .lock()
+                .ok()
+                .and_then(|mut g| g.remove(task_run_id))
+            else {
+                return;
+            };
+            if let Ok(mut fwd) = self.inner.forward.lock() {
+                fwd.remove(&id);
+            }
+            id
+        };
+
+        // A `Closed` row carries no body — the drain loop maps it to
+        // `DELETE /sessions/:id`. Best-effort; a missing coord row DELETEs as
+        // idempotent success.
+        if let Err(e) = self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::Closed,
+            json!({ "id": session_id }),
+        ) {
+            warn!(
+                "ai_coord_register: outbox Closed write failed for {} (best-effort): {}",
+                task_run_id, e
+            );
+        } else {
+            info!(
+                "ai_coord_register: closed AI session {} (coord {})",
+                task_run_id, session_id
+            );
+        }
+    }
+}
+
+use crate::session::SessionKind;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn registrar() -> (AiCoordRegistrar, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let outbox = Arc::new(OutboxWriter::open(dir.path().join("outbox.jsonl")).unwrap());
+        (AiCoordRegistrar::new(outbox, Uuid::new_v4()), dir)
+    }
+
+    #[test]
+    fn register_writes_started_row_and_indexes_both_directions() {
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        let coord_id = reg.register_session(&trid, "fix the thing", None).unwrap();
+
+        // R4 index resolves both ways.
+        assert_eq!(reg.task_run_id_for(&coord_id).as_deref(), Some(trid.as_str()));
+        assert_eq!(reg.session_id_for(&trid), Some(coord_id));
+
+        // Exactly one Started row in the outbox, carrying task_run_id + agentic.
+        let pending = reg.inner.outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].event_kind, SessionEventKind::Started.as_str());
+        assert_eq!(pending[0].payload["task_run_id"], json!(trid));
+        assert_eq!(pending[0].payload["kind"], json!("agentic"));
+        assert_eq!(pending[0].payload["id"], json!(coord_id));
+    }
+
+    #[test]
+    fn reregister_is_idempotent_no_duplicate_started_row() {
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        let first = reg.register_session(&trid, "purpose", None).unwrap();
+        let second = reg.register_session(&trid, "purpose", None).unwrap();
+        assert_eq!(first, second, "re-register returns the same coord id");
+
+        // Still exactly one Started row — R6 idempotency.
+        let started = reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.event_kind == SessionEventKind::Started.as_str())
+            .count();
+        assert_eq!(started, 1);
+    }
+
+    #[test]
+    fn heartbeat_only_after_register_and_keyed_by_session() {
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        // Heartbeat before registration is a no-op (no row).
+        reg.heartbeat_on_interaction(&trid);
+        assert!(reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .iter()
+            .all(|r| r.event_kind != SessionEventKind::Heartbeat.as_str()));
+
+        let coord_id = reg.register_session(&trid, "purpose", None).unwrap();
+        reg.heartbeat_on_interaction(&trid);
+
+        let hb: Vec<_> = reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .into_iter()
+            .filter(|r| r.event_kind == SessionEventKind::Heartbeat.as_str())
+            .collect();
+        assert_eq!(hb.len(), 1, "exactly one interaction heartbeat");
+        assert_eq!(hb[0].session_id, coord_id);
+    }
+
+    #[test]
+    fn close_emits_closed_row_and_evicts_index() {
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        let coord_id = reg.register_session(&trid, "purpose", None).unwrap();
+        reg.close_session(&trid);
+
+        // Index evicted both ways.
+        assert!(reg.task_run_id_for(&coord_id).is_none());
+        assert!(reg.session_id_for(&trid).is_none());
+
+        // A Closed row was written for the coord id.
+        let closed = reg
+            .inner
+            .outbox
+            .pending()
+            .unwrap()
+            .into_iter()
+            .any(|r| r.event_kind == SessionEventKind::Closed.as_str() && r.session_id == coord_id);
+        assert!(closed, "a Closed outbox row must be emitted on close");
+    }
+
+    #[test]
+    fn disabled_gate_registers_nothing() {
+        std::env::set_var("QONTINUI_SESSION_AUTOMATION_REGISTER", "0");
+        let (reg, _dir) = registrar();
+        let trid = Uuid::new_v4().to_string();
+
+        assert!(reg.register_session(&trid, "purpose", None).is_none());
+        assert!(reg.inner.outbox.pending().unwrap().is_empty());
+        assert!(reg.session_id_for(&trid).is_none());
+
+        std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
+    }
+}

--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -308,7 +308,21 @@ use crate::session::SessionKind;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
     use tempfile::tempdir;
+
+    /// `QONTINUI_SESSION_AUTOMATION_REGISTER` is process-global mutable
+    /// state; tests that set/remove it race when the harness runs them on
+    /// parallel threads (one test's `remove_var` lands between another's
+    /// `set_var("0")` and its assert — seen flaking on windows-latest).
+    /// Every env-touching test holds this lock for its full body. Poisoning
+    /// is harmless — each test resets the var on entry — so recover with
+    /// `into_inner`.
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner())
+    }
 
     fn registrar() -> (AiCoordRegistrar, tempfile::TempDir) {
         let dir = tempdir().unwrap();
@@ -318,6 +332,7 @@ mod tests {
 
     #[test]
     fn register_writes_started_row_and_indexes_both_directions() {
+        let _env = env_lock();
         std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
         let (reg, _dir) = registrar();
         let trid = Uuid::new_v4().to_string();
@@ -342,6 +357,7 @@ mod tests {
 
     #[test]
     fn reregister_is_idempotent_no_duplicate_started_row() {
+        let _env = env_lock();
         std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
         let (reg, _dir) = registrar();
         let trid = Uuid::new_v4().to_string();
@@ -364,6 +380,7 @@ mod tests {
 
     #[test]
     fn heartbeat_only_after_register_and_keyed_by_session() {
+        let _env = env_lock();
         std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
         let (reg, _dir) = registrar();
         let trid = Uuid::new_v4().to_string();
@@ -395,6 +412,7 @@ mod tests {
 
     #[test]
     fn close_emits_closed_row_and_evicts_index() {
+        let _env = env_lock();
         std::env::remove_var("QONTINUI_SESSION_AUTOMATION_REGISTER");
         let (reg, _dir) = registrar();
         let trid = Uuid::new_v4().to_string();
@@ -416,6 +434,7 @@ mod tests {
 
     #[test]
     fn disabled_gate_registers_nothing() {
+        let _env = env_lock();
         std::env::set_var("QONTINUI_SESSION_AUTOMATION_REGISTER", "0");
         let (reg, _dir) = registrar();
         let trid = Uuid::new_v4().to_string();

--- a/src-tauri/src/claude_session/mod.rs
+++ b/src-tauri/src/claude_session/mod.rs
@@ -10,6 +10,7 @@
 //! - Interrupt support for stopping mid-turn
 //! - Autonomous-to-interactive context switching
 
+pub mod coord_register;
 pub mod dispatcher;
 pub mod federation;
 pub mod manager;

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -123,7 +123,10 @@ pub async fn list_ai_sessions(
 pub async fn send_user_message(
     app_handle: tauri::AppHandle,
     session_manager: tauri::State<'_, Arc<SessionManager>>,
-    ai_coord_registrar: tauri::State<'_, Arc<crate::claude_session::coord_register::AiCoordRegistrar>>,
+    ai_coord_registrar: tauri::State<
+        '_,
+        Arc<crate::claude_session::coord_register::AiCoordRegistrar>,
+    >,
     task_run_id: String,
     message: String,
 ) -> Result<CommandResponse, String> {
@@ -316,7 +319,10 @@ pub async fn get_ai_session_state(
 pub async fn create_ai_session(
     app_handle: tauri::AppHandle,
     session_manager: tauri::State<'_, Arc<SessionManager>>,
-    ai_coord_registrar: tauri::State<'_, Arc<crate::claude_session::coord_register::AiCoordRegistrar>>,
+    ai_coord_registrar: tauri::State<
+        '_,
+        Arc<crate::claude_session::coord_register::AiCoordRegistrar>,
+    >,
     app_state: tauri::State<'_, StorageCompartment>,
     task_name: Option<String>,
 ) -> Result<CommandResponse, String> {
@@ -450,7 +456,10 @@ pub async fn create_ai_session(
 pub async fn close_ai_session(
     app_handle: tauri::AppHandle,
     session_manager: tauri::State<'_, Arc<SessionManager>>,
-    ai_coord_registrar: tauri::State<'_, Arc<crate::claude_session::coord_register::AiCoordRegistrar>>,
+    ai_coord_registrar: tauri::State<
+        '_,
+        Arc<crate::claude_session::coord_register::AiCoordRegistrar>,
+    >,
     app_state: tauri::State<'_, StorageCompartment>,
     task_run_id: String,
 ) -> Result<CommandResponse, String> {

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -123,6 +123,7 @@ pub async fn list_ai_sessions(
 pub async fn send_user_message(
     app_handle: tauri::AppHandle,
     session_manager: tauri::State<'_, Arc<SessionManager>>,
+    ai_coord_registrar: tauri::State<'_, Arc<crate::claude_session::coord_register::AiCoordRegistrar>>,
     task_run_id: String,
     message: String,
 ) -> Result<CommandResponse, String> {
@@ -131,6 +132,13 @@ pub async fn send_user_message(
         task_run_id,
         message.len()
     );
+
+    // Session-automation Phase 0 (R3) — operator interaction is the ONLY signal
+    // that refreshes this session's coord heartbeat. Driving the heartbeat off
+    // `send_user_message` (rather than the unconditional registry heartbeat
+    // loop) is what lets an idle session age to `stale` so the inject trigger
+    // can fire (P0.2). Best-effort + no-op when the session isn't registered.
+    ai_coord_registrar.heartbeat_on_interaction(&task_run_id);
 
     let session = session_manager
         .get(&task_run_id)
@@ -308,6 +316,7 @@ pub async fn get_ai_session_state(
 pub async fn create_ai_session(
     app_handle: tauri::AppHandle,
     session_manager: tauri::State<'_, Arc<SessionManager>>,
+    ai_coord_registrar: tauri::State<'_, Arc<crate::claude_session::coord_register::AiCoordRegistrar>>,
     app_state: tauri::State<'_, StorageCompartment>,
     task_name: Option<String>,
 ) -> Result<CommandResponse, String> {
@@ -403,6 +412,12 @@ pub async fn create_ai_session(
                 task_run_id, e
             );
         }
+
+        // Session-automation Phase 0 (R1) — register the authenticated session
+        // into coord.sessions carrying its task_run_id, so it is visible +
+        // addressable + correctly stale to coord. Best-effort: a registration
+        // failure never blocks the live AI session.
+        ai_coord_registrar.register_session(&task_run_id, &name, None);
     }
 
     // 4. Return result
@@ -435,6 +450,7 @@ pub async fn create_ai_session(
 pub async fn close_ai_session(
     app_handle: tauri::AppHandle,
     session_manager: tauri::State<'_, Arc<SessionManager>>,
+    ai_coord_registrar: tauri::State<'_, Arc<crate::claude_session::coord_register::AiCoordRegistrar>>,
     app_state: tauri::State<'_, StorageCompartment>,
     task_run_id: String,
 ) -> Result<CommandResponse, String> {
@@ -444,6 +460,10 @@ pub async fn close_ai_session(
     if let Some(session) = session_manager.remove(&task_run_id) {
         let _ = session.close();
     }
+
+    // Session-automation Phase 0 (R5) — emit the coord `closed` event + evict
+    // the R4 index so coord.sessions doesn't leak a ghost row. Best-effort.
+    ai_coord_registrar.close_session(&task_run_id);
 
     // Update DB status
     let _ = app_state
@@ -1195,6 +1215,14 @@ pub async fn resume_ai_sessions(
         }
     };
 
+    // Session-automation Phase 0 (R2) — the coord registrar (managed Tauri
+    // state). Resolved here (not injected) because this fn is called internally
+    // with bare args. `None` only before `.setup()` finished managing it, in
+    // which case resume simply doesn't register (best-effort).
+    let ai_coord_registrar = app_handle
+        .try_state::<Arc<crate::claude_session::coord_register::AiCoordRegistrar>>()
+        .map(|s| s.inner().clone());
+
     let my_port = app_state
         .api_port
         .load(std::sync::atomic::Ordering::Relaxed);
@@ -1364,6 +1392,12 @@ pub async fn resume_ai_sessions(
                     "AI session resume: create_emergent_task failed for {}: {}",
                     task_run_id, e
                 );
+            }
+
+            // R2 — re-register the resumed session with coord (idempotent;
+            // a fresh coord row is minted carrying the same task_run_id).
+            if let Some(reg) = ai_coord_registrar.as_ref() {
+                reg.register_session(&task_run_id, &task_name, None);
             }
         }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1879,6 +1879,11 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         )
                     }
                 };
+                // Session-automation Phase 0 — keep an outbox handle for the
+                // AI-session coord registrar so it writes to the SAME outbox the
+                // CoordSync drain loop drains (registration reuses the existing
+                // drain → auth → retry → 409-idempotency machinery).
+                let registrar_outbox = outbox.clone();
                 let coord_sync_facade = session::coord_sync::CoordSync::new(outbox);
                 let pty_transport: session::DynTransport =
                     std::sync::Arc::new(session::transport::pty::PtyTransport::new(
@@ -1905,6 +1910,18 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         uuid::Uuid::parse_str(s).ok()
                     })
                     .unwrap_or_else(uuid::Uuid::new_v4);
+                // Session-automation Phase 0 (R1–R6) — register authenticated
+                // AI sessions into coord.sessions with their task_run_id, so
+                // they are visible + addressable + correctly stale to coord.
+                // Managed as Tauri state so the interactive AI-session commands
+                // (create/resume/send_user_message/close) can reach it.
+                let ai_coord_registrar = std::sync::Arc::new(
+                    claude_session::coord_register::AiCoordRegistrar::new(
+                        registrar_outbox,
+                        machine_id,
+                    ),
+                );
+                app.manage(ai_coord_registrar);
                 // Phase 3 — wire the coord-sync drain + heartbeat loops.
                 // `attach_app_handle` enables the conflict-event emit;
                 // `attach_registry` gives the heartbeat loop a way to

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -741,6 +741,15 @@ fn rebuild_create_body(rec: &OutboxRecord) -> JsonValue {
             body["claude_code_session_id"] = ccsid.clone();
         }
     }
+    // Session-automation Phase 0 — forward the runner `SessionManager` key
+    // (UUIDv4 `task_run_id`) so coord persists `coord.sessions.task_run_id`
+    // for inject-target resolution. Omitted when absent/null; coord's
+    // `CreateSessionRequest.task_run_id` is `#[serde(default)]`.
+    if let Some(trid) = rec.payload.get("task_run_id") {
+        if !trid.is_null() {
+            body["task_run_id"] = trid.clone();
+        }
+    }
     body
 }
 
@@ -1519,6 +1528,42 @@ mod tests {
         };
         let body = rebuild_create_body(&without);
         assert!(body.get("claude_code_session_id").is_none());
+    }
+
+    /// Session-automation Phase 0 — `rebuild_create_body` forwards the
+    /// `task_run_id` from a Started payload into the `POST /sessions` body so
+    /// coord persists `coord.sessions.task_run_id`; absent → key omitted.
+    #[test]
+    fn rebuild_create_body_forwards_task_run_id() {
+        let with = OutboxRecord {
+            machine_id: Uuid::nil(),
+            session_id: Uuid::nil(),
+            seq: 1,
+            event_kind: "started".into(),
+            payload: json!({
+                "id": Uuid::nil(),
+                "kind": "agentic",
+                "intent": { "purpose": "ai session" },
+                "task_run_id": "11111111-2222-3333-4444-555555555555"
+            }),
+            recorded_at: Utc::now(),
+            acked_at: None,
+        };
+        let body = rebuild_create_body(&with);
+        assert_eq!(body["task_run_id"], "11111111-2222-3333-4444-555555555555");
+        assert_eq!(body["session_kind"], "agentic");
+
+        // Absent (terminal pane / peer mirror) → key omitted, not null.
+        let without = OutboxRecord {
+            payload: json!({
+                "id": Uuid::nil(),
+                "kind": "terminal_shell",
+                "intent": { "kind": "terminal_shell", "purpose": "p" }
+            }),
+            ..with
+        };
+        let body = rebuild_create_body(&without);
+        assert!(body.get("task_run_id").is_none());
     }
 
     /// state_change_body forwards only the known coord fields and

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -939,7 +939,7 @@ impl SessionHandle {
 /// explicitly so the runner-local outbox row sorts naturally with the
 /// coord row — UUIDv4 would still work for correctness but defeats the
 /// `(machine_id, session_id, seq)` "time-ordered" intuition.
-fn uuid_v7() -> Uuid {
+pub(crate) fn uuid_v7() -> Uuid {
     let now = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap_or_default();


### PR DESCRIPTION
## Session Automation — Phase 0 (R1–R6): make authenticated AI sessions coord-visible + addressable + correctly stale

Today the operator's authenticated `ClaudeSession`s (`create_ai_session`/`resume_ai_sessions` → `SessionManager`, keyed by `task_run_id`) are **never** registered to coord (vet finding F1). This PR registers them into `coord.sessions` with their `task_run_id`, so the `session_stale` trigger can fire for them and Phase 1's inject can resolve `coord session_id → live ClaudeSession`.

### Changes
- **New `AiCoordRegistrar`** (`claude_session/coord_register.rs`): writes `Started`/`Heartbeat`/`Closed` rows to the **same** session outbox the `CoordSync` drain loop drains (reusing the existing drain → auth → retry → 409-idempotency path, no new HTTP code), and owns the runner-local `coord session_id (UUIDv7) ↔ task_run_id (UUIDv4)` index (**R4** — the Phase 1 inject resolver).
- **R1/R2** — register on `create_ai_session` + `resume_ai_sessions` (`kind=agentic`, carrying `task_run_id`; nil `tenant_id` so coord resolves tenant from the device).
- **R3 (the make-or-break — P0.2)** — heartbeat coord **only on `send_user_message`** (operator interaction). These sessions are deliberately **NOT** in `SessionRegistry`, so the unconditional ~15s heartbeat loop never refreshes them → an idle session ages to `stale` and the trigger can fire. *Without this the whole feature is inert.*
- **R5** — `close_ai_session` emits the coord `closed` event + evicts the index (no ghost rows).
- **R6** — re-register is a no-op (no duplicate `Started`); coord's 409-as-success backs it up.
- `rebuild_create_body` forwards `task_run_id` into `POST /sessions`.

### Design choices (resolved via priorities)
- **P0.2 staleness:** interaction-driven heartbeat via a dedicated registrar that bypasses `SessionRegistry` — chosen for robustness/clean over reusing the dual-write mirror (whose unconditional heartbeat would never let a session go stale).
- **P0.3 dual-write gate:** registration is gated on `QONTINUI_SESSION_AUTOMATION_REGISTER` (**default ON**), **independent** of the dormant per-tenant `session_coordination_enabled` burn-in (coupling would make Phase 0 inert in prod).
- **P0.4:** confirmed `register_external` → no-op `ExternalTransport`, so inject must resolve to `SessionManager`, hence the R4 index.

### Depends on
qontinui-coord #319 (accepts/stores `task_run_id`) → qontinui-web #436 (migration). Deploy order: web → coord → runner.

### Validation
- `cargo clippy --all-targets -- -D warnings` — clean.
- New `coord_register` unit tests (5) + `rebuild_create_body_forwards_task_run_id` + existing `coord_sync` suite — green.
- **V2 (activity-staleness) and V3 (addressing resolves end-to-end → `send_user_message` lands, no 401) require a live elevated runner + real session — see PR discussion for the manual harness.** Code-side they are implemented; the R4 index resolver is unit-tested.

Plan/checklist: `2026-06-04-session-automation-*` R1–R6.

**Do not merge** — operator reviews the Phase 0 set together; merge LAST (after web + coord deploy). CI `test (windows-latest)` ~1.5h.