### PR TITLE
feat(code-graph): cross-repo Ξ_AST scope registry for the diff-impact surface

### DIFF
--- a/src-tauri/src/mcp/code_semantics/code_graph_api.rs
+++ b/src-tauri/src/mcp/code_semantics/code_graph_api.rs
@@ -448,24 +448,39 @@ fn strip_diff_prefix(s: &str) -> String {
 // Scope / helpers
 // ===========================================================================
 
-/// Resolve a scope to a project directory, reusing the sidecar's scope model.
-/// Order: explicit `scope` (project dir or tsconfig) → the first changed file's
-/// nearest enclosing tsconfig → the default scope. For a non-TS scope given an
-/// explicit project dir that has no tsconfig, fall back to treating that dir as
-/// the project root directly (the single default-scope degenerate case, Q7).
+/// Resolve a scope to a project directory for the multi-language `Ξ_AST` graph.
+/// An explicit `scope` selector is checked FIRST — as a repo name (cross-repo
+/// registry), then a tsconfig path, then an existing dir — so a non-TS repo
+/// (coord/Rust, web/Python) resolves to its OWN root instead of silently falling
+/// back to the runner's default TS frontend (the prior behavior, which made the
+/// surface single-repo). Only when no explicit selector resolves do we fall back
+/// to the file hint's nearest tsconfig and then the default scope.
 fn resolve_project_scope(scope: Option<&str>, hint_file: Option<&String>) -> Option<Scope> {
-    if let Some(s) = scope::resolve_scope(scope, hint_file.map(|f| f.as_str())) {
-        return Some(s);
-    }
-    // No tsconfig anywhere — if an explicit scope dir was given and exists, use it
-    // as a raw project root (language-agnostic; CodeGraph::build walks any of TS/Py/Rust).
     if let Some(s) = scope {
+        // (a) Repo NAME / `owner/name` slug → local checkout dir (cross-repo
+        //     Ξ_AST; CodeGraph::build walks TS/JS/Python/Rust under it).
+        if let Some(dir) = scope::repo_dir(s) {
+            return Some(raw_dir_scope(&dir));
+        }
         let p = Path::new(s);
+        // (b) Explicit tsconfig.json file → TS scope (LSP-compatible).
+        if p.is_file() && p.file_name().map(|n| n == "tsconfig.json").unwrap_or(false) {
+            return Some(Scope::ts(p));
+        }
+        // (c) Explicit existing dir → TS scope if it has a tsconfig, else a raw
+        //     multi-language project root.
         if p.is_dir() {
+            let tsconfig = p.join("tsconfig.json");
+            if tsconfig.exists() {
+                return Some(Scope::ts(&tsconfig));
+            }
             return Some(raw_dir_scope(p));
         }
+        // An explicit selector that is neither a known repo nor a path falls
+        // through to the file-hint / default resolution below.
     }
-    None
+    // No explicit scope resolved: the file hint's nearest tsconfig, then default.
+    scope::resolve_scope(None, hint_file.map(|f| f.as_str()))
 }
 
 /// A degenerate scope whose `project` descriptor is a raw directory (no tsconfig).
@@ -789,5 +804,29 @@ new file mode 100644
         let s = raw_dir_scope(Path::new("/some/project"));
         let dir = scope_project_dir(&s);
         assert_eq!(scope::normalize(&dir), "/some/project");
+    }
+
+    #[test]
+    fn explicit_dir_without_tsconfig_resolves_to_raw_multilang_root() {
+        // The core cross-repo fix: an explicit existing dir with NO tsconfig must
+        // resolve to a raw multi-language project root AT that dir — not silently
+        // fall back to the runner's default TS frontend (the prior single-repo bug).
+        let tmp = std::env::temp_dir().join("qontinui_xrepo_api_test_root");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let s = resolve_project_scope(Some(tmp.to_str().unwrap()), None).expect("scope resolves");
+        assert_eq!(s.language, "mixed");
+        assert_eq!(s.key, scope::normalize(&tmp));
+        // scope_project_dir of a raw scope returns the real dir (synthetic tsconfig parent).
+        assert_eq!(scope_project_dir(&s), tmp);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn unknown_selector_falls_through_to_default_scope() {
+        // A selector that is neither a known repo nor an existing path falls
+        // through to the default scope (the runner frontend tsconfig), never erroring.
+        let s = resolve_project_scope(Some("not-a-real-repo-or-path-xyz"), None);
+        assert!(s.is_some(), "should fall back to default TS scope");
+        assert!(s.unwrap().key.ends_with("tsconfig.json"));
     }
 }

--- a/src-tauri/src/mcp/code_semantics/scope.rs
+++ b/src-tauri/src/mcp/code_semantics/scope.rs
@@ -1,10 +1,13 @@
 //! Scope resolution for the code-semantics observer.
 //!
-//! A "scope" is a (repo, language) selector. v1 supports a single default TS
-//! scope (the runner's own frontend project), but the code is structured for a
-//! registry: given a file path, resolve the nearest enclosing `tsconfig.json`
-//! and use its directory as the scope key.
+//! A "scope" is a (repo, language) selector. The TS `Ξ_Type` language service
+//! uses the tsconfig-anchored default scope (the runner's own frontend project).
+//! The multi-language `Ξ_AST` code-graph surface additionally resolves a scope
+//! to ANY sibling repo checkout via [`repo_dir`] (a repo→dir registry), so
+//! `coord_diff_impact` / `coord_change_conflict` can answer for coord (Rust),
+//! web (Python), etc. — not only the runner's TS frontend.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 /// A resolved scope: the language and the project root (tsconfig path).
@@ -44,6 +47,94 @@ pub fn default_ts_scope() -> Option<Scope> {
     } else {
         None
     }
+}
+
+/// The workspace root holding the sibling repo checkouts. Resolution order:
+///   1. env `QONTINUI_WORKSPACE_ROOT` (explicit, for non-standard layouts /
+///      deployed binaries),
+///   2. the runner checkout's grandparent (`CARGO_MANIFEST_DIR/../..` — the dir
+///      that contains `qontinui-runner` and its sibling repos, the dev layout).
+pub fn workspace_root() -> Option<PathBuf> {
+    if let Ok(r) = std::env::var("QONTINUI_WORKSPACE_ROOT") {
+        let p = PathBuf::from(r);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent() // qontinui-runner
+        .and_then(Path::parent) // workspace root (contains the sibling repos)
+        .map(Path::to_path_buf)
+}
+
+/// Explicit `repo-name → dir` overrides parsed from `QONTINUI_CODE_GRAPH_ROOTS`
+/// (`name=dir,name=dir,…`). Takes precedence over the sibling convention so a
+/// non-standard checkout layout can still be mapped.
+fn registry_overrides() -> HashMap<String, PathBuf> {
+    let mut map = HashMap::new();
+    if let Ok(raw) = std::env::var("QONTINUI_CODE_GRAPH_ROOTS") {
+        for entry in raw.split(',') {
+            if let Some((name, dir)) = entry.split_once('=') {
+                let (name, dir) = (name.trim(), dir.trim());
+                if !name.is_empty() && !dir.is_empty() {
+                    map.insert(name.to_string(), PathBuf::from(dir));
+                }
+            }
+        }
+    }
+    map
+}
+
+/// Resolve a repo selector to a local checkout directory for the multi-language
+/// `Ξ_AST` code graph. Accepts a bare repo name (`qontinui-coord`, `coord`) or an
+/// `owner/name` slug (`qontinui/qontinui-coord`). Resolution: the
+/// `QONTINUI_CODE_GRAPH_ROOTS` override, then `<workspace_root>/<name>`, then
+/// `<workspace_root>/qontinui-<name>`. Returns `None` for an unknown repo or any
+/// path-like selector (so the caller resolves real paths as directories and an
+/// unknown selector falls back to the default scope — never an error).
+pub fn repo_dir(selector: &str) -> Option<PathBuf> {
+    repo_dir_with(selector, &registry_overrides(), workspace_root().as_deref())
+}
+
+/// Pure core of [`repo_dir`] (the overrides + workspace root are injected so the
+/// resolution rules are unit-testable against a temp layout, no env / no real
+/// sibling checkouts).
+fn repo_dir_with(
+    selector: &str,
+    overrides: &HashMap<String, PathBuf>,
+    root: Option<&Path>,
+) -> Option<PathBuf> {
+    let sel = selector.trim();
+    // Reject path-like selectors — those are resolved as directories by the
+    // caller, not as repo names. (`:` rejects Windows drive paths like `D:/…`.)
+    if sel.is_empty()
+        || sel.starts_with('.')
+        || sel.starts_with('/')
+        || sel.contains('\\')
+        || sel.contains(':')
+    {
+        return None;
+    }
+    // Accept an `owner/name` slug by taking the trailing name component.
+    let name = sel.rsplit('/').next().unwrap_or(sel);
+    if name.is_empty() {
+        return None;
+    }
+    if let Some(dir) = overrides.get(name) {
+        if dir.is_dir() {
+            return Some(dir.clone());
+        }
+    }
+    let root = root?;
+    let direct = root.join(name);
+    if direct.is_dir() {
+        return Some(direct);
+    }
+    let prefixed = root.join(format!("qontinui-{name}"));
+    if prefixed.is_dir() {
+        return Some(prefixed);
+    }
+    None
 }
 
 /// Resolve a scope from an optional explicit `scope` selector and/or a file
@@ -134,5 +225,66 @@ mod tests {
     fn default_ts_scope_exists() {
         // The runner frontend has a tsconfig.json.
         assert!(default_ts_scope().is_some());
+    }
+
+    #[test]
+    fn repo_dir_rejects_path_like_selectors() {
+        let empty = HashMap::new();
+        let root = std::env::temp_dir();
+        for sel in [
+            "",
+            "D:/qontinui-root/qontinui-coord", // Windows drive path
+            "/abs/path",
+            "./rel",
+            "a\\b",
+            "C:\\x",
+        ] {
+            assert_eq!(
+                repo_dir_with(sel, &empty, Some(&root)),
+                None,
+                "should reject path-like selector {sel:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn repo_dir_resolves_name_slug_prefix_and_override() {
+        // A temp workspace: a `qontinui-coord` sibling + a `qontinui-web` override
+        // pointing at a non-conventional dir.
+        let base = std::env::temp_dir().join("qontinui_xrepo_scope_test");
+        let coord = base.join("qontinui-coord");
+        std::fs::create_dir_all(&coord).unwrap();
+        let web = base.join("custom-web-dir");
+        std::fs::create_dir_all(&web).unwrap();
+        let mut overrides = HashMap::new();
+        overrides.insert("qontinui-web".to_string(), web.clone());
+
+        // bare exact name → <root>/qontinui-coord
+        assert_eq!(
+            repo_dir_with("qontinui-coord", &overrides, Some(&base)).as_deref(),
+            Some(coord.as_path())
+        );
+        // short name → <root>/qontinui-<name> (prefix convention)
+        assert_eq!(
+            repo_dir_with("coord", &overrides, Some(&base)).as_deref(),
+            Some(coord.as_path())
+        );
+        // owner/name slug → trailing component
+        assert_eq!(
+            repo_dir_with("qontinui/qontinui-coord", &overrides, Some(&base)).as_deref(),
+            Some(coord.as_path())
+        );
+        // override beats the sibling convention
+        assert_eq!(
+            repo_dir_with("qontinui-web", &overrides, Some(&base)).as_deref(),
+            Some(web.as_path())
+        );
+        // unknown repo → None (honest miss; caller falls back to default scope)
+        assert_eq!(
+            repo_dir_with("definitely-absent-repo", &overrides, Some(&base)),
+            None
+        );
+        // no workspace root + no override → None
+        assert_eq!(repo_dir_with("coord", &HashMap::new(), None), None);
     }
 }


### PR DESCRIPTION
Unblocks twin **Phase 2.6** (dependency-aware cross-repo `coord_merge_order`) and makes `coord_diff_impact` / `coord_change_conflict` actually answer for repos other than the runner's own frontend.

## Problem
The `/code-graph/diff-impact` + `/code-graph/resolve-import` surface resolved scopes **TS-only** (tsconfig-anchored). For a non-TS repo (coord/Rust, web/Python) `scope::resolve_scope` returned the runner's **default TS frontend** *before* the existing `raw_dir_scope` fallback could fire — so the fallback was dead code and the surface was effectively single-repo. `CodeGraph::build` already walks Rust/Python/TS via tree-sitter; the only gap was scope resolution.

## Change
- **`scope::repo_dir`** — resolves a repo name (`qontinui-coord`, `coord`) or `owner/name` slug to a local checkout via the `QONTINUI_CODE_GRAPH_ROOTS` override, then the `<workspace_root>/<repo>` (and `qontinui-<repo>`) sibling convention. `workspace_root` = `QONTINUI_WORKSPACE_ROOT` or the runner checkout's grandparent. Path-like selectors are rejected (the caller resolves real paths as dirs); unknown repos return `None` (caller falls back to the default scope — never an error). Pure `repo_dir_with` core (injected overrides + root) is unit-tested.
- **`resolve_project_scope`** — checks an explicit selector (repo name → existing dir → tsconfig) **before** the TS default, so coord/web resolve to their own root (a raw multi-language project) instead of the frontend. The previously-unreachable `raw_dir_scope` path is now reachable.

## Scope
- **Ξ_AST only** (tree-sitter, multi-language). The **Ξ_Type LSP** path (`/code-semantics/*`, symbol-lookup/typecheck) is **untouched** — still tsconfig-anchored, as it must be (the TS language service needs a tsconfig).
- This is the Ξ_AST slice of the LSP-plan Phase 3 "cross-repo scoping"; rust-analyzer/pyright Ξ_Type cross-repo remains separate/deferred.

## Tests
4 new unit tests (green locally): `repo_dir_rejects_path_like_selectors`, `repo_dir_resolves_name_slug_prefix_and_override`, `explicit_dir_without_tsconfig_resolves_to_raw_multilang_root`, `unknown_selector_falls_through_to_default_scope`. Live-verified the diff-impact/resolve-import HTTP routes against a running sidecar (real blast radius + Contradiction + resolved import).

Plan: `2026-06-02-twin-ast-import-resolution-and-semantic-observers.md`.