### PR TITLE
refactor(runner): retire Runner Instances launcher as default path (Phase 3)

### DIFF
--- a/src/components/settings/RunnerInstancesSettings.tsx
+++ b/src/components/settings/RunnerInstancesSettings.tsx
@@ -13,7 +13,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
-import { Monitor, Plus, Trash2, Play, Square, ChevronDown, ChevronRight } from "lucide-react";
+import { Monitor, Plus, Trash2, Play, Square, ChevronDown, ChevronRight, Info } from "lucide-react";
 import { SectionHeader } from "./SectionHeader";
 import { getApiPort } from "@/lib/runner-api";
 import type { LogFunction } from "./types";
@@ -1054,10 +1054,26 @@ export function RunnerInstancesSettings({ onLog }: RunnerInstancesSettingsProps)
   return (
     <div className="space-y-4">
       <SectionHeader
-        title="Runner Instances"
-        description="Launch additional runner instances on different ports for concurrent AI workflow automation."
+        title="Advanced / Testing"
+        description="Supervisor-driven temp runner placements and the multi-process instance launcher. For everyday use, prefer pop-out terminal windows."
         icon={<Monitor />}
       />
+
+      {/* Phase 3 (pop-out terminal windows): steer the common case away from
+          the multi-process instance launcher below. A second terminal window
+          no longer needs a second runner process + port — the Terminal tab can
+          pop one out in-process. The launcher is retained for advanced/testing
+          (e.g. exercising secondary-runner registration) but is no longer the
+          recommended path. */}
+      <div className="flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-2.5 text-xs text-muted-foreground">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <span>
+          Want another terminal window? Use{" "}
+          <span className="font-medium text-foreground">pop-out windows</span> from the
+          Terminal tab — same process, no extra port. The multi-process instance launcher
+          below is for advanced / testing scenarios.
+        </span>
+      </div>
 
       {/* Temp runner placements (supervisor-consumed list, distinct from
           per-named-instance placements below) */}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -93,7 +93,12 @@ const SETTINGS_TABS = [
   { id: "general", label: "General" },
   { id: "storage", label: "Storage" },
   { id: "backup", label: "Backup" },
-  { id: "instances", label: "Runner Instances" },
+  // Phase 3 (pop-out terminal windows): pop-out windows supersede the
+  // multi-process instance launcher for the everyday "another terminal window"
+  // case, so this tab is relabeled to signal it's now advanced/testing surface.
+  // The `id` stays "instances" so routing / UI-Bridge sub-tab mapping / specs
+  // are unchanged.
+  { id: "instances", label: "Advanced / Testing" },
   { id: "otel", label: "OpenTelemetry" },
   { id: "containers", label: "Container Isolation" },
   { id: "ci-runner", label: "CI Runner" },


### PR DESCRIPTION
**Phase 3** of `plans/2026-06-03-runner-popout-terminal-windows.md`.

Pop-out terminal windows (Phase 1, merged in #410) supersede the multi-process **Runner Instances** launcher for the everyday "another terminal window" case — same process, no extra port. This demotes the launcher to advanced/testing surface.

### Reversible "relabel", not a removal
This is the plan's "relabel advanced/testing" reading — deliberately the reversible option — because the same panel hosts the **Temp Runner Placements** editor, which is load-bearing for the supervisor `POST /runners/spawn-test` flow. So:
- ✅ Temp Runner Placements (supervisor spawn API) — kept
- ✅ Secondary-runner registration display — kept
- ✅ Every backend Tauri command + HTTP endpoint — untouched
- ✅ The launcher itself still works for those who need it

### Changes
- **Settings.tsx**: relabel the `"Runner Instances"` tab → `"Advanced / Testing"`. The tab `id` stays `"instances"`, so routing / UI-Bridge sub-tab mapping / page specs are byte-identical.
- **RunnerInstancesSettings.tsx**: retitle the panel + add a one-line banner steering the common case to pop-out windows.

### Impact
None on behavior or backend. Purely a UX signpost. Fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)