### PR TITLE
feat(test-fixtures): inject-session seam covers every StatusStrip bucket on-page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,65 @@ jobs:
         #      `--no-bundle` — compilation + link is the sanity gate we want.
         run: pnpm run tauri build --debug --no-bundle
 
+  # Phase 3 / F2 — debug test-fixtures seam gate.
+  #
+  # The `mcp::test_fixtures` module (the `/ui-bridge/test/*` session-injection
+  # seam used by the manual-UI acceptance harness) must NEVER compile into a
+  # production release build. It is gated by
+  # `#[cfg(any(debug_assertions, feature = "test-fixtures"))]` in three places.
+  # The honest "binary does not contain the route string" check needs a full
+  # `cargo build --release` (~30 min) which this repo's CI deliberately omits
+  # (the test job builds `--debug --no-bundle`). So we enforce the gate at
+  # SOURCE level here: a fast (seconds, no cargo) grep that the three cfg
+  # anchors are intact. Deleting any one of them — which is exactly how the
+  # seam would leak into release — fails this job. A complementary set of
+  # Rust unit tests (`module_cfg_gate_is_first_non_comment_line` &c. in
+  # test_fixtures.rs) asserts the same anchors from inside the debug test leg;
+  # this job additionally holds if the whole module is ever removed.
+  seam-gate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Assert test-fixtures seam stays cfg-gated out of release builds
+        shell: bash
+        run: |
+          set -euo pipefail
+          gate='#!\[cfg(any(debug_assertions, feature = "test-fixtures"))\]'
+          gate_outer='#\[cfg(any(debug_assertions, feature = "test-fixtures"))\]'
+
+          fail=0
+
+          # 1. Module-level inner attribute must be the first significant line
+          #    of test_fixtures.rs.
+          tf=src-tauri/src/mcp/test_fixtures.rs
+          first=$(grep -vE '^\s*(//|$)' "$tf" | head -n1)
+          if [ "$first" != '#![cfg(any(debug_assertions, feature = "test-fixtures"))]' ]; then
+            echo "::error file=$tf::module cfg gate missing or not the first significant line (got: $first)"
+            fail=1
+          fi
+
+          # 2. `pub mod test_fixtures;` in mcp/mod.rs must be cfg-gated on the
+          #    line directly above it.
+          if ! grep -Pzo "$gate_outer\n\s*pub mod test_fixtures;" src-tauri/src/mcp/mod.rs >/dev/null; then
+            echo "::error file=src-tauri/src/mcp/mod.rs::pub mod test_fixtures; is not immediately preceded by the cfg gate"
+            fail=1
+          fi
+
+          # 3. The routes() merge in mcp_api.rs must be cfg-gated on the line
+          #    directly above it.
+          if ! grep -Pzo "$gate_outer\n\s*let base_router = base_router.merge\(crate::mcp::test_fixtures::routes\(\)\);" src-tauri/src/mcp_api.rs >/dev/null; then
+            echo "::error file=src-tauri/src/mcp_api.rs::test_fixtures::routes() merge is not immediately preceded by the cfg gate"
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Debug test-fixtures seam gate FAILED — the /ui-bridge/test/* injection seam could leak into a release build."
+            exit 1
+          fi
+          echo "Debug test-fixtures seam gate OK — all three cfg anchors intact."
+
   security:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,15 +321,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gate='#!\[cfg(any(debug_assertions, feature = "test-fixtures"))\]'
-          gate_outer='#\[cfg(any(debug_assertions, feature = "test-fixtures"))\]'
+          # PCRE patterns — parens MUST be escaped (unescaped they're capture
+          # groups and the literal source text never matches).
+          gate_outer='#\[cfg\(any\(debug_assertions, feature = "test-fixtures"\)\)\]'
 
           fail=0
 
           # 1. Module-level inner attribute must be the first significant line
-          #    of test_fixtures.rs.
+          #    of test_fixtures.rs. NOTE: `-m1` (not `| head -n1`) — under
+          #    `pipefail`, head quitting after one line SIGPIPEs grep and
+          #    fails the job with exit 2 before any anchor is checked.
           tf=src-tauri/src/mcp/test_fixtures.rs
-          first=$(grep -vE '^\s*(//|$)' "$tf" | head -n1)
+          first=$(grep -m1 -vE '^\s*(//|$)' "$tf")
           if [ "$first" != '#![cfg(any(debug_assertions, feature = "test-fixtures"))]' ]; then
             echo "::error file=$tf::module cfg gate missing or not the first significant line (got: $first)"
             fail=1
@@ -337,14 +340,14 @@ jobs:
 
           # 2. `pub mod test_fixtures;` in mcp/mod.rs must be cfg-gated on the
           #    line directly above it.
-          if ! grep -Pzo "$gate_outer\n\s*pub mod test_fixtures;" src-tauri/src/mcp/mod.rs >/dev/null; then
+          if ! grep -Pzo "$gate_outer\r?\n\s*pub mod test_fixtures;" src-tauri/src/mcp/mod.rs >/dev/null; then
             echo "::error file=src-tauri/src/mcp/mod.rs::pub mod test_fixtures; is not immediately preceded by the cfg gate"
             fail=1
           fi
 
           # 3. The routes() merge in mcp_api.rs must be cfg-gated on the line
           #    directly above it.
-          if ! grep -Pzo "$gate_outer\n\s*let base_router = base_router.merge\(crate::mcp::test_fixtures::routes\(\)\);" src-tauri/src/mcp_api.rs >/dev/null; then
+          if ! grep -Pzo "$gate_outer\r?\n\s*let base_router = base_router.merge\(crate::mcp::test_fixtures::routes\(\)\);" src-tauri/src/mcp_api.rs >/dev/null; then
             echo "::error file=src-tauri/src/mcp_api.rs::test_fixtures::routes() merge is not immediately preceded by the cfg gate"
             fail=1
           fi

--- a/src-tauri/src/mcp/test_fixtures.rs
+++ b/src-tauri/src/mcp/test_fixtures.rs
@@ -80,9 +80,14 @@
 //!
 //! After a seed call returns 200, the strip does NOT update synchronously.
 //! Two async latencies stack before the rendered counts converge:
-//!   1. The frontend re-polls `transcript_list_sessions` on its own cadence;
-//!      only then does the seeded fake (and any derived synthetic tab) enter
-//!      `useSessionManager`.
+//!   1. The frontend must refetch `transcript_list_sessions`; only then does
+//!      the seeded fake (and any derived synthetic tab) enter
+//!      `useSessionManager`. Every mutating route here emits a
+//!      `test-fixtures-injected-changed` Tauri event that
+//!      `useTranscriptSessions` listens for and refetches on immediately —
+//!      this is what makes seeding/clearing deterministic even when the
+//!      runner window is hidden (its 30s auto-refresh poll is
+//!      visibility-gated and never ticks in a backgrounded window).
 //!   2. For a tab-backed `idle` fake, the 60s **staleness sweep tick** must
 //!      fire once more after the synthetic tab's pre-aged `lastOutput` seed is
 //!      installed before `frozen`→idle is counted. The pre-age guarantees the
@@ -437,6 +442,39 @@ pub fn injected_test_sessions() -> Vec<TestSession> {
     guard.values().cloned().collect()
 }
 
+/// AppHandle captured at router-merge time (`mcp_api::create_router`) so the
+/// mutating endpoints can emit `test-fixtures-injected-changed`.
+///
+/// `useTranscriptSessions` listens for that event and refetches immediately —
+/// its 30s auto-refresh poll is visibility-gated (a hidden/backgrounded
+/// window never ticks), so without the event a seeded or cleared scenario
+/// would stay invisible to an acceptance driver until the window regains
+/// focus. Unit tests never call `set_app_handle`, so the emit is a no-op
+/// there by construction.
+fn app_handle_slot() -> &'static OnceLock<tauri::AppHandle> {
+    static APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
+    &APP_HANDLE
+}
+
+/// Capture the AppHandle for change-event emission. Idempotent — only the
+/// first call wins (create_router runs once per process).
+pub fn set_app_handle(handle: tauri::AppHandle) {
+    let _ = app_handle_slot().set(handle);
+}
+
+/// Best-effort `test-fixtures-injected-changed` emit after a registry
+/// mutation. Never fails the request — the event is a freshness hint, not
+/// part of the route contract.
+fn emit_injected_changed(action: &str, count: usize) {
+    if let Some(handle) = app_handle_slot().get() {
+        use tauri::Emitter;
+        let _ = handle.emit(
+            "test-fixtures-injected-changed",
+            serde_json::json!({ "action": action, "count": count }),
+        );
+    }
+}
+
 /// Core insert path shared by `inject_session_handler` and the
 /// scenario-seeder. Validates the request, builds the `TestSession`, runs TTL
 /// eviction, and inserts under `task_run_id`. Returns the stored
@@ -621,11 +659,14 @@ async fn inject_session_handler(
     Json(req): Json<InjectSessionRequest>,
 ) -> Result<Json<InjectSessionResponse>, (StatusCode, Json<InjectSessionError>)> {
     match insert_session(req) {
-        Ok((task_run_id, session_id)) => Ok(Json(InjectSessionResponse {
-            success: true,
-            task_run_id,
-            session_id,
-        })),
+        Ok((task_run_id, session_id)) => {
+            emit_injected_changed("inject", 1);
+            Ok(Json(InjectSessionResponse {
+                success: true,
+                task_run_id,
+                session_id,
+            }))
+        }
         Err((code, err)) => Err((code, Json(err))),
     }
 }
@@ -641,9 +682,11 @@ pub struct ClearSessionsResponse {
 }
 
 async fn clear_sessions_handler() -> Json<ClearSessionsResponse> {
+    let cleared_count = clear_all_sessions();
+    emit_injected_changed("clear", cleared_count);
     Json(ClearSessionsResponse {
         success: true,
-        cleared_count: clear_all_sessions(),
+        cleared_count,
     })
 }
 
@@ -659,9 +702,11 @@ async fn clear_sessions_handler() -> Json<ClearSessionsResponse> {
 /// fakes are gone from the registry, `merge_with_injected` stops projecting
 /// them and the synthetic tabs cease to exist with no separate teardown.
 async fn clear_injected_handler() -> Json<ClearSessionsResponse> {
+    let cleared_count = clear_all_sessions();
+    emit_injected_changed("clear", cleared_count);
     Json(ClearSessionsResponse {
         success: true,
-        cleared_count: clear_all_sessions(),
+        cleared_count,
     })
 }
 
@@ -851,6 +896,8 @@ async fn seed_scenario_handler(
         session_ids.len(),
         session_ids,
     );
+
+    emit_injected_changed("seed", session_ids.len());
 
     Ok(Json(SeedScenarioResponse {
         success: true,

--- a/src-tauri/src/mcp/test_fixtures.rs
+++ b/src-tauri/src/mcp/test_fixtures.rs
@@ -33,17 +33,110 @@
 //! The entire module compiles only when `debug_assertions` is true OR the
 //! explicit `test-fixtures` feature is set. Production release builds with
 //! the feature off see no module, no routes, no extra compilation cost.
-//! Wiring in `mcp_api.rs` and `mcp/mod.rs` mirrors the same gate.
+//! Wiring in `mcp_api.rs` and `mcp/mod.rs` mirrors the same gate. A CI step
+//! (`seam-gate` in `.github/workflows/ci.yml`) plus in-module canary tests
+//! (`module_cfg_gate_is_first_non_comment_line` &c.) assert all three cfg
+//! anchors stay intact so this seam can never leak into a release binary.
 //!
-//! ## What this module does NOT do
+//! ============================================================================
+//! ## CONSUMER CONTRACT — read this before writing an acceptance gate
+//! ============================================================================
 //!
-//! It does not modify `transcript_list_sessions` or the React side that
-//! merges transcripts + tabs + digests into `UnifiedSession[]`. To make
-//! `SessionCard` actually render an injected fake on screen, a follow-up
-//! patch needs to merge `injected_test_sessions()` into the transcript list
-//! (or have the frontend call this endpoint directly). The plan defers that
-//! frontend wiring to a separate change; this module ships the backend
-//! storage and HTTP surface so it's ready when that wiring lands.
+//! This seam exists so a verification-loop agent can place a fake Claude
+//! session into any of the Terminal-page StatusStrip's FIVE buckets through
+//! the REAL production render path, then assert the strip renders correctly.
+//! The mechanics below are load-bearing for a gate that must not flake.
+//!
+//! ### The five buckets and how each is reached
+//!
+//! | StatusStrip bucket | `liveStatus` | mechanism | inject body |
+//! |--------------------|--------------|-----------|-------------|
+//! | working            | `active-in-zone` | short-circuit (`injected_live_status`) | `{liveStatus:"active-in-zone"}` |
+//! | needs-input        | `needs-input`    | short-circuit | `{liveStatus:"needs-input"}` |
+//! | idle               | `frozen` (live tab) | **tab-backed**: a synthetic tab pre-aged past the 60s staleness sweep | `{liveStatus:"idle", tab_backed:true}` |
+//! | error              | `error`          | **tab-backed**: a dead synthetic tab, exit_code != 0 | `{liveStatus:"error", tab_backed:true}` |
+//! | completed          | `completed`      | **tab-backed**: a dead synthetic tab, exit_code 0 | `{liveStatus:"completed", tab_backed:true}` |
+//!
+//! Two projection modes back these (see `project_test_session`):
+//!   - **short-circuit** — `working` / `needs-input` (and the orphan-demo
+//!     `frozen`, plus short-circuit `error` / `completed`): the fake carries an
+//!     `injected_live_status` string that `useSessionManager` consults INSTEAD
+//!     of correlating a tab. No synthetic tab is emitted.
+//!   - **tab-backed** — `idle` / `error` / `completed`: NO `injected_live_status`;
+//!     instead an `injected_tab` spec is emitted, from which the frontend
+//!     (`syntheticTabs.ts`) derives a synthetic `TerminalTab` that flows through
+//!     the SAME `useSessionStateTracking` staleness sweep + dead-tab branch the
+//!     real PTY tabs use. This is the ONLY way to reach `idle` and tab-backed
+//!     `error`/`completed` — the short-circuit path cannot (`idle` is dropped
+//!     by the orphan filter; tab-backed exit-code semantics need a real tab).
+//!
+//! Validation guards (enforced by `insert_session`):
+//!   - `liveStatus:"idle"` REQUIRES `tab_backed:true` (else 400) — a tab-less
+//!     injected `frozen` is forced orphaned and `computeStatusCounts` drops it.
+//!   - `tab_backed:true` is ONLY valid for `idle` / `error` / `completed`
+//!     (else 400) — the other statuses have no tab-backed mechanism.
+//!
+//! ### Seed-then-POLL contract (do NOT single-read)
+//!
+//! After a seed call returns 200, the strip does NOT update synchronously.
+//! Two async latencies stack before the rendered counts converge:
+//!   1. The frontend re-polls `transcript_list_sessions` on its own cadence;
+//!      only then does the seeded fake (and any derived synthetic tab) enter
+//!      `useSessionManager`.
+//!   2. For a tab-backed `idle` fake, the 60s **staleness sweep tick** must
+//!      fire once more after the synthetic tab's pre-aged `lastOutput` seed is
+//!      installed before `frozen`→idle is counted. The pre-age guarantees the
+//!      tab is ALREADY past threshold, so this is one sweep tick (≤ ~2s in the
+//!      test cadence), not a 60s wait — but it is NOT zero.
+//!
+//! Therefore an acceptance gate MUST POLL the rendered StatusStrip with a
+//! ~5s budget (re-read every ~500ms until the expected counts appear), never
+//! assert on a single read immediately after the seed POST. A single-read gate
+//! will false-negative on the very first tick.
+//!
+//! ### `isMultiZone = sessionCount > 1` render gate
+//!
+//! The session-count pill AND the working/done/idle breakdown pill only render
+//! when `sessionCount > 1` (`StatusStrip.tsx`: `const isMultiZone = sessionCount
+//! > 1`). A scenario that seeds exactly ONE session shows NO count pill and NO
+//! breakdown — the attention pills (needs-input / error / stuck-lock) still
+//! render, but the ambient counts do not. To exercise the count/breakdown
+//! surface, seed **≥ 2** sessions (e.g. `{working:1, idle:1}` → sessionCount 2).
+//!
+//! ### Teardown contract — TTL + clear-injected
+//!
+//! Two independent cleanup paths, so a gate can't leak fakes into a later run:
+//!   - **Explicit**: `POST /ui-bridge/test/clear-injected` (or the alias
+//!     `/clear-sessions`) drops EVERY injected fake immediately and returns the
+//!     count cleared. `/seed-terminal-scenario` is itself clear-then-seed, so a
+//!     fresh seed implicitly resets prior fakes. The derived synthetic tabs
+//!     disappear automatically on the next `transcript_list_sessions` poll
+//!     (they exist only as long as their session carries an `injected_tab`).
+//!   - **TTL backstop**: any fake older than `SESSION_TTL` (10 min) is evicted
+//!     lazily on the next registry read (`evict_expired`), so an abandoned
+//!     test's leftover fakes can't pollute a later poll even if `clear-injected`
+//!     is never called.
+//!
+//! A gate should still call `clear-injected` in teardown (don't rely on the TTL
+//! backstop) and re-poll the strip to confirm the counts returned to baseline.
+//!
+//! ### Frontend inertness (Phase 3 / F1)
+//!
+//! Synthetic tabs never render a terminal pane (excluded structurally from the
+//! rendering / zone / file-lock consumers — see `TerminalSessionContext.tsx`).
+//! Additionally, session-level process-control ops (resume / promote / commit,
+//! incl. Ctrl+Shift+J jump-to-frozen and bulk-resume) early-return a no-op with
+//! a `[test-fixtures] ignoring <op> on synthetic tab <id>` warning when the
+//! target is an injected fake (`isInjectedSession` in `syntheticTabs.ts`). So a
+//! gate that clicks Promote/Commit/Resume on a seeded card observes a console
+//! warn and NO backend call — that is the designed behavior, not a bug.
+//!
+//! ## History
+//!
+//! Phases 1+2 wired the merge: `transcript_list_sessions` now appends
+//! `merge_with_injected(real, injected_test_sessions())`, and the frontend
+//! derives synthetic tabs from the projected `injected_tab` spec. The earlier
+//! "follow-up patch still needed" caveat is resolved.
 
 #![cfg(any(debug_assertions, feature = "test-fixtures"))]
 
@@ -66,25 +159,44 @@ use super::types::ApiState;
 /// Live-status hints accepted by `/test/inject-session`.
 ///
 /// Mirrors the subset of `SessionLiveStatus` enum values from
-/// `qontinui-runner/src/components/terminal/useSessionManager.ts` that gate
-/// the Promote / Commit buttons (the `canPromote` / `canCommit` predicates in
-/// `SessionCard.tsx`). Other live-statuses (`completed`, `dormant`, etc.)
-/// are not useful for the test fixture's purpose.
+/// `qontinui-runner/src/components/terminal/useSessionManager.ts` that the
+/// StatusStrip buckets care about. The first three drive the short-circuit
+/// path (`canPromote` / `canCommit` in `SessionCard.tsx` plus the
+/// `working` / `needs-input` strip buckets). `Idle`, `Error`, and
+/// `Completed` exist so a fake can be placed in EVERY StatusStrip bucket
+/// through the real production render path — see `project_test_session` for
+/// the per-status mechanism (short-circuit vs. tab-backed correlation).
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum TestLiveStatus {
     ActiveInZone,
     NeedsInput,
     Frozen,
+    Idle,
+    Error,
+    Completed,
 }
 
 impl TestLiveStatus {
-    /// Stringified form matching the frontend `SessionLiveStatus` literal.
+    /// Stringified form matching the frontend `SessionLiveStatus` literal,
+    /// used ONLY on the non-tab-backed short-circuit path
+    /// (`injected_live_status`).
+    ///
+    /// `Idle` deliberately has no short-circuit string: the frontend forces
+    /// an injected `frozen` to be orphaned (`isOrphaned = true`), which
+    /// `computeStatusCounts` then drops, so idle is unreachable via the
+    /// short-circuit. Idle is only reachable tab-backed (a synthetic stale
+    /// tab), and the handler rejects `Idle` without `tab_backed`. We return
+    /// `"frozen"` here purely as a never-exercised fallback; callers must not
+    /// route `Idle` through the short-circuit.
     pub fn as_frontend_str(&self) -> &'static str {
         match self {
             Self::ActiveInZone => "active-in-zone",
             Self::NeedsInput => "needs-input",
             Self::Frozen => "frozen",
+            Self::Idle => "frozen",
+            Self::Error => "error",
+            Self::Completed => "completed",
         }
     }
 }
@@ -127,34 +239,116 @@ pub struct TestSession {
     /// `"C:\\claude\\.claude-test-fixture"` so `extractAccountLabel` in
     /// `useSessionManager.ts` produces the obvious label `test-fixture`.
     pub config_dir: String,
+    /// When true the fake is projected WITHOUT an `injected_live_status`
+    /// override so the frontend takes the REAL tab-correlation path; the
+    /// projection instead emits an `injected_tab` spec from which the
+    /// frontend derives a synthetic `TerminalTab`. This is how `idle`
+    /// (pre-aged stale tab) and tab-backed `error` / `completed`
+    /// (dead-tab exit-code) buckets are reached through production code.
+    pub tab_backed: bool,
+    /// Pre-age, in milliseconds, for the synthetic tab's `lastOutput`. Only
+    /// meaningful for a tab-backed `Idle` fake — the frontend seeds
+    /// `lastOutputTimeRef[tabId] = now - quiet_ms` so the existing 60s
+    /// staleness sweep marks the tab stale → `frozen` → counted as idle.
+    pub quiet_ms: Option<u64>,
 }
+
+/// Default pre-age (ms) for a tab-backed `Idle` fake's synthetic tab. The
+/// staleness sweep marks a tab stale at `> 60000`ms of quiet, so the default
+/// (and the floor enforced in `project_test_session`) is just over 60s.
+const IDLE_DEFAULT_QUIET_MS: u64 = 61_000;
+
+/// Synthetic-tab spec emitted on the wire when a fake is `tab_backed`.
+///
+/// Re-exported from `crate::terminal::transcript` (defined there because the
+/// `TranscriptSession.injected_tab` field type must resolve in release builds
+/// without the cfg-gated `test-fixtures` feature). The frontend
+/// (`syntheticTabs.ts`) turns this into a minimal `TerminalTab` that flows
+/// through the REAL `useSessionManager` tab-correlation path:
+///
+/// - `is_alive: true` + `quiet_ms` → the staleness sweep marks the synthetic
+///   tab stale → `frozen` with a live tab → counted as `idle`.
+/// - `is_alive: false` + `exit_code` → the sweep's dead-tab branch sets
+///   `sessionStates[tab.id]` to `completed` (exit 0) or `error` (exit != 0).
+pub use crate::terminal::transcript::InjectedTabSpec;
 
 /// Project a `TestSession` into the on-the-wire `TranscriptSession` shape
 /// that `transcript_list_sessions` returns to the frontend.
 ///
-/// The frontend filters out transcripts with `message_count == 0` (see
-/// `useSessionManager.ts:498`), so we hand back `1` to ensure the fake
-/// renders. `injected_live_status` is the override that
-/// `useSessionManager` consults instead of computing live-status from tab
-/// correlation — without it, fakes would all fall through to `dormant`
-/// and `canPromote` / `canCommit` would never fire (predicates at
-/// `SessionCard.tsx:143` and `:217`).
+/// The frontend filters out transcripts with `message_count == 0` (the
+/// `message_count > 0` filter in `useSessionManager.ts`), so we hand back `1`
+/// to ensure the fake renders.
+///
+/// Two projection modes:
+///
+/// - **non-tab-backed** (`tab_backed == false`): set `injected_live_status`
+///   to the kebab string. `useSessionManager` consults this override instead
+///   of computing live-status from tab correlation. Reaches `working`
+///   (`active-in-zone`), `needs-input`, and the orphan-demo `frozen` plus the
+///   short-circuit `error` / `completed` buckets.
+/// - **tab-backed** (`tab_backed == true`): leave `injected_live_status` as
+///   `None` so the frontend takes the REAL tab-correlation path, and emit an
+///   `injected_tab` spec from which the frontend derives a synthetic tab.
+///   Reaches `idle` (pre-aged stale tab) and tab-backed `error` / `completed`
+///   (dead-tab exit-code).
 pub fn project_test_session(
     session: &TestSession,
 ) -> crate::terminal::transcript::TranscriptSession {
+    let (injected_live_status, injected_tab) = if session.tab_backed {
+        let spec = match session.live_status {
+            TestLiveStatus::Idle => InjectedTabSpec {
+                is_alive: true,
+                exit_code: None,
+                quiet_ms: Some(
+                    session
+                        .quiet_ms
+                        .unwrap_or(IDLE_DEFAULT_QUIET_MS)
+                        .max(IDLE_DEFAULT_QUIET_MS),
+                ),
+            },
+            TestLiveStatus::Error => InjectedTabSpec {
+                is_alive: false,
+                exit_code: Some(1),
+                quiet_ms: None,
+            },
+            TestLiveStatus::Completed => InjectedTabSpec {
+                is_alive: false,
+                exit_code: Some(0),
+                quiet_ms: None,
+            },
+            // The handler rejects tab_backed for ActiveInZone / NeedsInput /
+            // Frozen before we ever get here; treat as a no-op spec to keep
+            // this total without an unreachable!() panic on the wire path.
+            TestLiveStatus::ActiveInZone | TestLiveStatus::NeedsInput | TestLiveStatus::Frozen => {
+                InjectedTabSpec {
+                    is_alive: true,
+                    exit_code: None,
+                    quiet_ms: None,
+                }
+            }
+        };
+        (None, Some(spec))
+    } else {
+        (
+            Some(session.live_status.as_frontend_str().to_string()),
+            None,
+        )
+    };
+
     crate::terminal::transcript::TranscriptSession {
         session_id: session.session_id.clone(),
         project_path: session.project_path.clone(),
         config_dir: session.config_dir.clone(),
-        // `> 0` so the frontend filter at `useSessionManager.ts:498`
-        // doesn't drop the fake.
+        // `> 0` so the frontend's `message_count > 0` filter doesn't drop the
+        // fake.
         message_count: 1,
         last_modified: session.injected_at.clone(),
         started_at: Some(session.injected_at.clone()),
         first_message_preview: Some(session.name.clone()),
         has_plans: false,
         display_name: session.name.clone(),
-        injected_live_status: Some(session.live_status.as_frontend_str().to_string()),
+        injected_live_status,
+        injected_tab,
     }
 }
 
@@ -189,22 +383,181 @@ fn registry() -> &'static Mutex<HashMap<String, TestSession>> {
     REGISTRY.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// TTL for an injected fake before lazy eviction removes it. Manual UI test
+/// runs are short-lived; a 10-minute ceiling means a forgotten injection from
+/// an abandoned test can't linger and pollute a later poll, while still being
+/// generous enough that a human poking at the UI by hand never races it.
+const SESSION_TTL: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// Evict entries older than `SESSION_TTL` from an already-locked registry map.
+///
+/// Lazy eviction on access (called from every public read/write) instead of a
+/// background sweep thread: this is a debug-only module, and spawning a tokio
+/// task (or std thread) purely to GC a handful of manual-test fakes would add
+/// a long-lived runtime fixture to a cfg-gated test seam for no real benefit.
+/// Bounded write volume means the linear scan here is trivially cheap, and
+/// "evict on touch" guarantees a stale entry is gone before anyone observes it
+/// (the only observers are the same read/write paths that run this first).
+///
+/// An entry whose `injected_at` fails to parse as RFC3339 is treated as
+/// non-expirable (kept) rather than silently dropped — every insert path here
+/// stamps a valid RFC3339 string, so an unparseable value would signal a bug
+/// we'd rather surface as a lingering entry than mask via eviction.
+fn evict_expired(map: &mut HashMap<String, TestSession>) {
+    let now = chrono::Utc::now();
+    map.retain(
+        |_, session| match chrono::DateTime::parse_from_rfc3339(&session.injected_at) {
+            Ok(injected) => {
+                let age = now.signed_duration_since(injected.with_timezone(&chrono::Utc));
+                match age.to_std() {
+                    // Positive age within TTL → keep.
+                    Ok(elapsed) => elapsed < SESSION_TTL,
+                    // Negative age (clock skew / future timestamp) → keep; it's
+                    // not stale yet by any reasonable reading.
+                    Err(_) => true,
+                }
+            }
+            Err(_) => true,
+        },
+    );
+}
+
 /// Read-only snapshot of every currently-injected fake.
 ///
 /// Public so a future patch can merge these into `transcript_list_sessions`
 /// (or surface them through a parallel command) without re-importing the
 /// internal `Mutex`. Returns an empty `Vec` when the registry hasn't been
 /// touched yet.
+///
+/// Evicts TTL-expired entries first so a stale fake can never appear in the
+/// merged transcript list.
 pub fn injected_test_sessions() -> Vec<TestSession> {
-    match registry().lock() {
-        Ok(guard) => guard.values().cloned().collect(),
-        Err(poisoned) => {
-            // Poisoned just means a writer panicked mid-update; the data is
-            // still readable. Return what we have so a follow-up clear()
-            // can recover the lock cleanly.
-            poisoned.into_inner().values().cloned().collect()
-        }
+    let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+    evict_expired(&mut guard);
+    guard.values().cloned().collect()
+}
+
+/// Core insert path shared by `inject_session_handler` and the
+/// scenario-seeder. Validates the request, builds the `TestSession`, runs TTL
+/// eviction, and inserts under `task_run_id`. Returns the stored
+/// `(task_run_id, session_id)` on success.
+///
+/// Factored out so there is exactly ONE place that validates + builds + stamps
+/// + inserts a fake — the seed-scenario route reuses this rather than
+/// duplicating the build/insert logic.
+fn insert_session(
+    req: InjectSessionRequest,
+) -> Result<(String, String), (StatusCode, InjectSessionError)> {
+    if req.task_run_id.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            InjectSessionError {
+                success: false,
+                error: "task_run_id must not be empty".to_string(),
+            },
+        ));
     }
+    if req.name.trim().is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            InjectSessionError {
+                success: false,
+                error: "name must not be empty".to_string(),
+            },
+        ));
+    }
+
+    // `idle` is only reachable tab-backed: the short-circuit path forces an
+    // injected `frozen` to be orphaned, which `computeStatusCounts` drops, so
+    // a tab-less idle can never land in the idle bucket.
+    if matches!(req.live_status, TestLiveStatus::Idle) && !req.tab_backed {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            InjectSessionError {
+                success: false,
+                error: "liveStatus=idle requires tab_backed=true: the orphan filter \
+                        drops a tab-less injected frozen, so idle is only reachable via \
+                        a synthetic stale tab"
+                    .to_string(),
+            },
+        ));
+    }
+
+    // tab-backed only has a defined mechanism for idle / error / completed.
+    // working (active-in-zone) / needs-input / frozen stay on the legacy
+    // short-circuit (frozen is the orphan-demo path).
+    if req.tab_backed
+        && !matches!(
+            req.live_status,
+            TestLiveStatus::Idle | TestLiveStatus::Error | TestLiveStatus::Completed
+        )
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            InjectSessionError {
+                success: false,
+                error: "tab_backed=true is only valid for liveStatus in \
+                        {idle, error, completed}; active-in-zone / needs-input / frozen \
+                        have no tab-backed mechanism and stay on the short-circuit path"
+                    .to_string(),
+            },
+        ));
+    }
+
+    let session = TestSession {
+        task_run_id: req.task_run_id.clone(),
+        // For interactive PTY sessions in this runner the Claude session id
+        // and the task_run_id are the same value (see `claudeSessionId`
+        // wiring in `useTerminalManager.ts`). Mirror that here so any
+        // downstream consumer that looks up by either key finds the fake.
+        session_id: req.task_run_id.clone(),
+        name: req.name.clone(),
+        live_status: req.live_status,
+        worktree: req.worktree.clone(),
+        injected_at: chrono::Utc::now().to_rfc3339(),
+        project_path: req
+            .project_path
+            .clone()
+            .unwrap_or_else(|| DEFAULT_TEST_PROJECT_PATH.to_string()),
+        config_dir: req
+            .config_dir
+            .clone()
+            .unwrap_or_else(|| DEFAULT_TEST_CONFIG_DIR.to_string()),
+        tab_backed: req.tab_backed,
+        quiet_ms: req.quiet_ms,
+    };
+
+    let task_run_id = session.task_run_id.clone();
+    let session_id = session.session_id.clone();
+
+    {
+        let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+        evict_expired(&mut guard);
+        guard.insert(task_run_id.clone(), session);
+    }
+
+    info!(
+        "test_fixtures: injected session task_run_id={} liveStatus={} name=\"{}\"",
+        task_run_id,
+        req.live_status.as_frontend_str(),
+        req.name,
+    );
+
+    Ok((task_run_id, session_id))
+}
+
+/// Drop ALL injected fakes. Shared core for `/clear-sessions` and
+/// `/clear-injected` (the latter is a superset alias). Returns the number of
+/// entries removed.
+fn clear_all_sessions() -> usize {
+    let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+    let n = guard.len();
+    guard.clear();
+    info!(
+        "test_fixtures: cleared {} injected session(s); real SessionManager untouched",
+        n,
+    );
+    n
 }
 
 // =============================================================================
@@ -228,6 +581,18 @@ pub struct InjectSessionRequest {
     /// what `extractAccountLabel` will produce in the UI.
     #[serde(default)]
     pub config_dir: Option<String>,
+    /// When true, project the fake WITHOUT an `injected_live_status` override
+    /// so the frontend takes the real tab-correlation path against a derived
+    /// synthetic tab. Required to reach the `idle` bucket and the tab-backed
+    /// `error` / `completed` buckets; rejected for `active-in-zone` /
+    /// `needs-input` / `frozen` (those have no tab-backed mechanism).
+    #[serde(default)]
+    pub tab_backed: bool,
+    /// Pre-age (ms) for a tab-backed `idle` fake's synthetic tab. Ignored for
+    /// non-idle statuses. Defaults to (and is floored at) 61s so the existing
+    /// 60s staleness sweep classifies the synthetic tab stale.
+    #[serde(default)]
+    pub quiet_ms: Option<u64>,
 }
 
 /// Default project path used when an inject body omits `project_path`. A
@@ -255,72 +620,14 @@ pub struct InjectSessionError {
 async fn inject_session_handler(
     Json(req): Json<InjectSessionRequest>,
 ) -> Result<Json<InjectSessionResponse>, (StatusCode, Json<InjectSessionError>)> {
-    if req.task_run_id.trim().is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(InjectSessionError {
-                success: false,
-                error: "task_run_id must not be empty".to_string(),
-            }),
-        ));
+    match insert_session(req) {
+        Ok((task_run_id, session_id)) => Ok(Json(InjectSessionResponse {
+            success: true,
+            task_run_id,
+            session_id,
+        })),
+        Err((code, err)) => Err((code, Json(err))),
     }
-    if req.name.trim().is_empty() {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(InjectSessionError {
-                success: false,
-                error: "name must not be empty".to_string(),
-            }),
-        ));
-    }
-
-    let session = TestSession {
-        task_run_id: req.task_run_id.clone(),
-        // For interactive PTY sessions in this runner the Claude session id
-        // and the task_run_id are the same value (see `claudeSessionId`
-        // wiring in `useTerminalManager.ts`). Mirror that here so any
-        // downstream consumer that looks up by either key finds the fake.
-        session_id: req.task_run_id.clone(),
-        name: req.name.clone(),
-        live_status: req.live_status,
-        worktree: req.worktree.clone(),
-        injected_at: chrono::Utc::now().to_rfc3339(),
-        project_path: req
-            .project_path
-            .clone()
-            .unwrap_or_else(|| DEFAULT_TEST_PROJECT_PATH.to_string()),
-        config_dir: req
-            .config_dir
-            .clone()
-            .unwrap_or_else(|| DEFAULT_TEST_CONFIG_DIR.to_string()),
-    };
-
-    let task_run_id = session.task_run_id.clone();
-    let session_id = session.session_id.clone();
-
-    match registry().lock() {
-        Ok(mut guard) => {
-            guard.insert(task_run_id.clone(), session);
-        }
-        Err(mut poisoned) => {
-            // Recover by overwriting with the new entry — same as Ok branch,
-            // we just had a previous panic-poisoned lock.
-            poisoned.get_mut().insert(task_run_id.clone(), session);
-        }
-    }
-
-    info!(
-        "test_fixtures: injected session task_run_id={} liveStatus={} name=\"{}\"",
-        task_run_id,
-        req.live_status.as_frontend_str(),
-        req.name,
-    );
-
-    Ok(Json(InjectSessionResponse {
-        success: true,
-        task_run_id,
-        session_id,
-    }))
 }
 
 // =============================================================================
@@ -334,29 +641,229 @@ pub struct ClearSessionsResponse {
 }
 
 async fn clear_sessions_handler() -> Json<ClearSessionsResponse> {
-    let cleared = match registry().lock() {
-        Ok(mut guard) => {
-            let n = guard.len();
-            guard.clear();
-            n
-        }
-        Err(mut poisoned) => {
-            let map = poisoned.get_mut();
-            let n = map.len();
-            map.clear();
-            n
+    Json(ClearSessionsResponse {
+        success: true,
+        cleared_count: clear_all_sessions(),
+    })
+}
+
+// =============================================================================
+// /ui-bridge/test/clear-injected
+// =============================================================================
+
+/// Drop ALL injected fakes. A superset alias of `/clear-sessions` named to
+/// match the scenario-seeder's clear-then-seed vocabulary. The derived
+/// synthetic tabs disappear automatically on the next `transcript_list_sessions`
+/// poll: `deriveSyntheticTabs` (syntheticTabs.ts) iterates the transcript list
+/// and only emits a tab when a session carries an `injected_tab`, so once the
+/// fakes are gone from the registry, `merge_with_injected` stops projecting
+/// them and the synthetic tabs cease to exist with no separate teardown.
+async fn clear_injected_handler() -> Json<ClearSessionsResponse> {
+    Json(ClearSessionsResponse {
+        success: true,
+        cleared_count: clear_all_sessions(),
+    })
+}
+
+// =============================================================================
+// /ui-bridge/test/seed-terminal-scenario
+// =============================================================================
+
+/// Per-bucket counts for the declarative scenario seeder. Every field is
+/// optional and defaults to 0, so a body of `{ "working": 3 }` seeds exactly
+/// three working fakes and nothing else.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ScenarioCounts {
+    #[serde(default)]
+    pub working: u32,
+    #[serde(default)]
+    pub idle: u32,
+    #[serde(default)]
+    pub needs_input: u32,
+    #[serde(default)]
+    pub error: u32,
+    #[serde(default)]
+    pub completed: u32,
+}
+
+impl ScenarioCounts {
+    fn is_empty(&self) -> bool {
+        self.working == 0
+            && self.idle == 0
+            && self.needs_input == 0
+            && self.error == 0
+            && self.completed == 0
+    }
+}
+
+/// Seed-scenario request body. Either declarative `counts` OR an explicit
+/// `sessions` list (`InjectSessionRequest`-shaped), never both.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SeedScenarioRequest {
+    /// Per-bucket counts. Mutually exclusive with `sessions`.
+    #[serde(default, flatten)]
+    pub counts: ScenarioCounts,
+    /// Explicit session list. Mutually exclusive with `counts`.
+    #[serde(default)]
+    pub sessions: Option<Vec<InjectSessionRequest>>,
+}
+
+/// Per-bucket seeded tally echoed back in the response.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SeededCounts {
+    pub working: u32,
+    pub idle: u32,
+    pub needs_input: u32,
+    pub error: u32,
+    pub completed: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SeedScenarioResponse {
+    pub success: bool,
+    pub cleared_count: usize,
+    pub seeded: SeededCounts,
+    pub session_ids: Vec<String>,
+}
+
+/// Default quiet pre-age (ms) for a scenario-seeded `idle` fake. Matches the
+/// inject-session idle floor so the staleness sweep marks the synthetic tab
+/// stale.
+const SCENARIO_IDLE_QUIET_MS: u64 = 61_000;
+
+/// Build the `InjectSessionRequest` list for a counts-based scenario. Ids and
+/// names are deterministic (`scenario-<bucket>-<n>`) so a test can assert exact
+/// membership.
+fn requests_from_counts(counts: &ScenarioCounts) -> Vec<InjectSessionRequest> {
+    let mut reqs = Vec::new();
+
+    let mut push = |bucket: &str,
+                    n: u32,
+                    live_status: TestLiveStatus,
+                    tab_backed: bool,
+                    quiet_ms: Option<u64>| {
+        for i in 1..=n {
+            let id = format!("scenario-{bucket}-{i}");
+            reqs.push(InjectSessionRequest {
+                task_run_id: id.clone(),
+                name: format!("Scenario {bucket} {i}"),
+                live_status,
+                worktree: None,
+                project_path: None,
+                config_dir: None,
+                tab_backed,
+                quiet_ms,
+            });
         }
     };
 
-    info!(
-        "test_fixtures: cleared {} injected session(s); real SessionManager untouched",
-        cleared,
+    // working → active-in-zone short-circuit.
+    push(
+        "working",
+        counts.working,
+        TestLiveStatus::ActiveInZone,
+        false,
+        None,
+    );
+    // needs_input → needs-input short-circuit.
+    push(
+        "needs-input",
+        counts.needs_input,
+        TestLiveStatus::NeedsInput,
+        false,
+        None,
+    );
+    // idle → tab-backed Idle (pre-aged stale tab).
+    push(
+        "idle",
+        counts.idle,
+        TestLiveStatus::Idle,
+        true,
+        Some(SCENARIO_IDLE_QUIET_MS),
+    );
+    // error → tab-backed Error (dead tab, exit != 0).
+    push("error", counts.error, TestLiveStatus::Error, true, None);
+    // completed → tab-backed Completed (dead tab, exit 0).
+    push(
+        "completed",
+        counts.completed,
+        TestLiveStatus::Completed,
+        true,
+        None,
     );
 
-    Json(ClearSessionsResponse {
+    reqs
+}
+
+async fn seed_scenario_handler(
+    Json(req): Json<SeedScenarioRequest>,
+) -> Result<Json<SeedScenarioResponse>, (StatusCode, Json<InjectSessionError>)> {
+    let has_counts = !req.counts.is_empty();
+    let has_sessions = req.sessions.as_ref().is_some_and(|s| !s.is_empty());
+
+    if has_counts && has_sessions {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(InjectSessionError {
+                success: false,
+                error: "supply either per-bucket counts OR an explicit `sessions` list, \
+                        not both"
+                    .to_string(),
+            }),
+        ));
+    }
+
+    // Track the per-bucket tally for the counts path so the response echoes
+    // what was requested.
+    let seeded = SeededCounts {
+        working: req.counts.working,
+        idle: req.counts.idle,
+        needs_input: req.counts.needs_input,
+        error: req.counts.error,
+        completed: req.counts.completed,
+    };
+
+    let requests = if has_sessions {
+        req.sessions.unwrap_or_default()
+    } else {
+        // Empty body or counts body both flow here; an all-zero counts body
+        // is a valid "clear to empty" scenario.
+        requests_from_counts(&req.counts)
+    };
+
+    // Clear-then-seed by contract: drop EVERY injected fake first, then seed
+    // exactly the requested scenario. The clear count is the pre-existing
+    // population so callers can confirm the reset happened.
+    let cleared_count = clear_all_sessions();
+
+    let mut session_ids = Vec::with_capacity(requests.len());
+    for r in requests {
+        // Reuse the Phase-1 insert primitive — one validate/build/insert path.
+        match insert_session(r) {
+            Ok((task_run_id, _session_id)) => session_ids.push(task_run_id),
+            Err((code, err)) => return Err((code, Json(err))),
+        }
+    }
+
+    info!(
+        "test_fixtures: seeded scenario cleared={} seeded={} ids={:?}",
+        cleared_count,
+        session_ids.len(),
+        session_ids,
+    );
+
+    Ok(Json(SeedScenarioResponse {
         success: true,
-        cleared_count: cleared,
-    })
+        cleared_count,
+        seeded: if has_sessions {
+            // For the explicit-sessions path we don't classify per bucket;
+            // report zeros and rely on `session_ids` for the actual set.
+            SeededCounts::default()
+        } else {
+            seeded
+        },
+        session_ids,
+    }))
 }
 
 // =============================================================================
@@ -379,6 +886,14 @@ pub fn routes() -> Router<Arc<ApiState>> {
             "/ui-bridge/test/clear-sessions",
             post(clear_sessions_handler),
         )
+        .route(
+            "/ui-bridge/test/clear-injected",
+            post(clear_injected_handler),
+        )
+        .route(
+            "/ui-bridge/test/seed-terminal-scenario",
+            post(seed_scenario_handler),
+        )
 }
 
 // =============================================================================
@@ -395,6 +910,106 @@ mod tests {
     /// sequences (cargo runs tests in parallel by default). A test-only
     /// mutex serializes them without forcing the suite-wide `--test-threads=1`.
     static TEST_LOCK: StdMutex<()> = StdMutex::new(());
+
+    // =========================================================================
+    // Phase 3 / F2: release-build gate regression canaries.
+    //
+    // A full `cargo build --release` (no `test-fixtures`) that asserts the seam
+    // is absent from the binary costs ~30 min and this repo's CI deliberately
+    // ships NO release leg (ci.yml builds `--debug --no-bundle`). So instead of
+    // a binary-string grep we anchor the gate at SOURCE level: these tests
+    // `include_str!` the three files that carry the cfg gate and assert each
+    // anchor is still present, in the right place. They FAIL the moment anyone
+    // deletes the `#![cfg(...)]` from this module, the `#[cfg(...)]` from the
+    // `pub mod test_fixtures` declaration in `mcp/mod.rs`, or the `#[cfg(...)]`
+    // from the `routes()` merge in `mcp_api.rs` — which is exactly the
+    // regression that would leak the debug seam into a release build.
+    //
+    // These compile only inside the already-cfg-gated module, so they vanish
+    // from a release build alongside the seam they protect — but CI runs the
+    // debug test leg, where they execute every PR. A complementary CI step
+    // (ci.yml `seam-gate` job) greps the same anchors so the assertion holds
+    // even if this whole module is ever removed.
+
+    /// The cfg gate must be the FIRST non-comment, non-blank line of this
+    /// module. An inner attribute (`#![cfg(...)]`) only gates the whole module
+    /// when it precedes every item; if a refactor moves a `use` or item above
+    /// it, the inner attribute becomes a hard compile error — but a subtler
+    /// regression (someone replacing `#![cfg(...)]` with a narrower
+    /// `#[cfg(test)]` on the tests only, leaving the module ungated) would
+    /// silently ship the seam. Pin the exact line.
+    #[test]
+    fn module_cfg_gate_is_first_non_comment_line() {
+        let src = include_str!("test_fixtures.rs");
+        let first_significant = src
+            .lines()
+            .map(str::trim)
+            .find(|l| !l.is_empty() && !l.starts_with("//"))
+            .expect("module must have a non-comment line");
+        assert_eq!(
+            first_significant, r#"#![cfg(any(debug_assertions, feature = "test-fixtures"))]"#,
+            "the module-level cfg gate must remain the first significant line of \
+             test_fixtures.rs — without it the debug seam compiles into release builds",
+        );
+    }
+
+    /// The `pub mod test_fixtures;` declaration in `mcp/mod.rs` must carry the
+    /// matching cfg attribute on the line immediately above it.
+    #[test]
+    fn mod_declaration_is_cfg_gated() {
+        let src = include_str!("mod.rs");
+        let lines: Vec<&str> = src.lines().map(str::trim).collect();
+        let decl_idx = lines
+            .iter()
+            .position(|l| *l == "pub mod test_fixtures;")
+            .expect("mcp/mod.rs must declare `pub mod test_fixtures;`");
+        assert!(
+            decl_idx > 0
+                && lines[decl_idx - 1]
+                    == r#"#[cfg(any(debug_assertions, feature = "test-fixtures"))]"#,
+            "`pub mod test_fixtures;` in mcp/mod.rs must be immediately preceded by the \
+             cfg gate — without it the module ships in release builds",
+        );
+    }
+
+    /// The `routes()` merge in `mcp_api.rs` must carry the matching cfg
+    /// attribute on the line immediately above it.
+    #[test]
+    fn mcp_api_routes_merge_is_cfg_gated() {
+        let src = include_str!("../mcp_api.rs");
+        let lines: Vec<&str> = src.lines().map(str::trim).collect();
+        let merge_idx = lines
+            .iter()
+            .position(|l| l.contains("crate::mcp::test_fixtures::routes()"))
+            .expect("mcp_api.rs must merge the test-fixtures routes");
+        assert!(
+            merge_idx > 0
+                && lines[merge_idx - 1]
+                    == r#"#[cfg(any(debug_assertions, feature = "test-fixtures"))]"#,
+            "the test_fixtures::routes() merge in mcp_api.rs must be immediately preceded \
+             by the cfg gate — without it the debug routes mount in release builds",
+        );
+    }
+
+    /// Regression canary: every `/ui-bridge/test/*` route this seam exposes
+    /// must stay wired in `routes()`. Asserting the literal path strings appear
+    /// in this module's source guards against a silent route deletion that
+    /// would break the acceptance harness without any compile error.
+    #[test]
+    fn all_test_routes_remain_wired() {
+        let src = include_str!("test_fixtures.rs");
+        for route in [
+            "/ui-bridge/test/inject-session",
+            "/ui-bridge/test/clear-sessions",
+            "/ui-bridge/test/clear-injected",
+            "/ui-bridge/test/seed-terminal-scenario",
+        ] {
+            assert!(
+                src.contains(&format!("\"{route}\"")),
+                "route {route} must remain wired in test_fixtures::routes()",
+            );
+        }
+    }
 
     /// Inject + clear roundtrip exercises every public path in this module
     /// without standing up a full axum server. Cleans up after itself so it
@@ -418,6 +1033,8 @@ mod tests {
             }),
             project_path: None,
             config_dir: None,
+            tab_backed: false,
+            quiet_ms: None,
         };
 
         let resp = inject_session_handler(Json(req))
@@ -454,6 +1071,8 @@ mod tests {
             worktree: None,
             project_path: None,
             config_dir: None,
+            tab_backed: false,
+            quiet_ms: None,
         };
         let err = inject_session_handler(Json(req))
             .await
@@ -481,6 +1100,8 @@ mod tests {
             worktree: None,
             project_path: Some("D:/qontinui-root".to_string()),
             config_dir: None,
+            tab_backed: false,
+            quiet_ms: None,
         };
         let _ = inject_session_handler(Json(req))
             .await
@@ -498,6 +1119,7 @@ mod tests {
             has_plans: false,
             display_name: "Real one".to_string(),
             injected_live_status: None,
+            injected_tab: None,
         };
 
         let merged = merge_with_injected(vec![real], injected_test_sessions());
@@ -533,6 +1155,534 @@ mod tests {
         );
 
         // Cleanup so we don't leak into the next test.
+        let _ = clear_sessions_handler().await;
+    }
+
+    /// Build a `TestSession` directly (bypassing the HTTP handler) so the
+    /// projection can be exercised per (status, tab_backed) combination
+    /// without touching the global registry.
+    fn make_session(
+        live_status: TestLiveStatus,
+        tab_backed: bool,
+        quiet_ms: Option<u64>,
+    ) -> TestSession {
+        TestSession {
+            task_run_id: "proj-test".to_string(),
+            session_id: "proj-test".to_string(),
+            name: "Projection test".to_string(),
+            live_status,
+            worktree: None,
+            injected_at: "2026-06-05T00:00:00Z".to_string(),
+            project_path: DEFAULT_TEST_PROJECT_PATH.to_string(),
+            config_dir: DEFAULT_TEST_CONFIG_DIR.to_string(),
+            tab_backed,
+            quiet_ms,
+        }
+    }
+
+    /// Non-tab-backed working / needs-input / frozen project to the
+    /// short-circuit override with NO synthetic tab.
+    #[test]
+    fn project_short_circuit_statuses_carry_override_no_tab() {
+        for (status, expected) in [
+            (TestLiveStatus::ActiveInZone, "active-in-zone"),
+            (TestLiveStatus::NeedsInput, "needs-input"),
+            (TestLiveStatus::Frozen, "frozen"),
+            (TestLiveStatus::Error, "error"),
+            (TestLiveStatus::Completed, "completed"),
+        ] {
+            let projected = project_test_session(&make_session(status, false, None));
+            assert_eq!(
+                projected.injected_live_status.as_deref(),
+                Some(expected),
+                "non-tab-backed {status:?} must carry the short-circuit override",
+            );
+            assert!(
+                projected.injected_tab.is_none(),
+                "non-tab-backed {status:?} must not emit a synthetic tab",
+            );
+            assert!(projected.message_count > 0);
+        }
+    }
+
+    /// Tab-backed idle projects to NO override + a live synthetic tab pre-aged
+    /// past the 60s staleness floor.
+    #[test]
+    fn project_tab_backed_idle_emits_live_pre_aged_tab() {
+        let projected = project_test_session(&make_session(TestLiveStatus::Idle, true, None));
+        assert!(
+            projected.injected_live_status.is_none(),
+            "tab-backed fake must take the real correlation path (no override)",
+        );
+        let spec = projected
+            .injected_tab
+            .expect("tab-backed idle must emit a synthetic tab");
+        assert!(
+            spec.is_alive,
+            "idle synthetic tab must be alive (gets swept stale)"
+        );
+        assert_eq!(spec.exit_code, None);
+        assert_eq!(
+            spec.quiet_ms,
+            Some(IDLE_DEFAULT_QUIET_MS),
+            "idle default quiet must be the 61s floor",
+        );
+    }
+
+    /// A caller-supplied quiet below the floor is clamped up to 61s so the
+    /// sweep still marks the tab stale; above the floor is honored.
+    #[test]
+    fn project_tab_backed_idle_clamps_quiet_to_floor() {
+        let too_small =
+            project_test_session(&make_session(TestLiveStatus::Idle, true, Some(5_000)));
+        assert_eq!(
+            too_small.injected_tab.unwrap().quiet_ms,
+            Some(IDLE_DEFAULT_QUIET_MS),
+            "quiet below the 61s floor must be clamped up",
+        );
+        let large = project_test_session(&make_session(TestLiveStatus::Idle, true, Some(120_000)));
+        assert_eq!(
+            large.injected_tab.unwrap().quiet_ms,
+            Some(120_000),
+            "quiet above the floor must be honored",
+        );
+    }
+
+    /// Tab-backed error / completed project to NO override + a DEAD synthetic
+    /// tab carrying the exit code the dead-tab sweep branch maps.
+    #[test]
+    fn project_tab_backed_error_and_completed_emit_dead_tab() {
+        let err = project_test_session(&make_session(TestLiveStatus::Error, true, None));
+        assert!(err.injected_live_status.is_none());
+        let err_spec = err.injected_tab.expect("error must emit a synthetic tab");
+        assert!(!err_spec.is_alive, "error synthetic tab must be dead");
+        assert_eq!(
+            err_spec.exit_code,
+            Some(1),
+            "error exit code must be non-zero"
+        );
+        assert_eq!(err_spec.quiet_ms, None);
+
+        let done = project_test_session(&make_session(TestLiveStatus::Completed, true, None));
+        assert!(done.injected_live_status.is_none());
+        let done_spec = done
+            .injected_tab
+            .expect("completed must emit a synthetic tab");
+        assert!(!done_spec.is_alive, "completed synthetic tab must be dead");
+        assert_eq!(
+            done_spec.exit_code,
+            Some(0),
+            "completed exit code must be zero"
+        );
+        assert_eq!(done_spec.quiet_ms, None);
+    }
+
+    /// `idle` without `tab_backed` is a 400 — the orphan filter would drop it.
+    #[tokio::test]
+    async fn inject_rejects_idle_without_tab_backed() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let req = InjectSessionRequest {
+            task_run_id: "idle-no-tab".to_string(),
+            name: "idle no tab".to_string(),
+            live_status: TestLiveStatus::Idle,
+            worktree: None,
+            project_path: None,
+            config_dir: None,
+            tab_backed: false,
+            quiet_ms: None,
+        };
+        let err = inject_session_handler(Json(req))
+            .await
+            .expect_err("idle without tab_backed should be rejected");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(!err.1.success);
+        assert!(err.1.error.contains("idle"));
+    }
+
+    /// `tab_backed` for a status with no tab-backed mechanism is a 400.
+    #[tokio::test]
+    async fn inject_rejects_tab_backed_for_short_circuit_status() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        for status in [
+            TestLiveStatus::ActiveInZone,
+            TestLiveStatus::NeedsInput,
+            TestLiveStatus::Frozen,
+        ] {
+            let req = InjectSessionRequest {
+                task_run_id: "tab-backed-bad".to_string(),
+                name: "tab backed bad".to_string(),
+                live_status: status,
+                worktree: None,
+                project_path: None,
+                config_dir: None,
+                tab_backed: true,
+                quiet_ms: None,
+            };
+            let err = inject_session_handler(Json(req))
+                .await
+                .expect_err(&format!("tab_backed {status:?} should be rejected"));
+            assert_eq!(err.0, StatusCode::BAD_REQUEST);
+            assert!(!err.1.success);
+        }
+    }
+
+    /// Tab-backed idle / error / completed all round-trip through the handler
+    /// + registry and project to `injected_live_status: None`.
+    #[tokio::test]
+    async fn tab_backed_fakes_round_trip_with_no_override() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        for (status, run_id) in [
+            (TestLiveStatus::Idle, "tb-idle"),
+            (TestLiveStatus::Error, "tb-error"),
+            (TestLiveStatus::Completed, "tb-completed"),
+        ] {
+            let req = InjectSessionRequest {
+                task_run_id: run_id.to_string(),
+                name: format!("tab-backed {run_id}"),
+                live_status: status,
+                worktree: None,
+                project_path: None,
+                config_dir: None,
+                tab_backed: true,
+                quiet_ms: None,
+            };
+            let _ = inject_session_handler(Json(req))
+                .await
+                .expect("tab-backed inject should succeed");
+        }
+
+        let merged = merge_with_injected(Vec::new(), injected_test_sessions());
+        for run_id in ["tb-idle", "tb-error", "tb-completed"] {
+            let fake = merged
+                .iter()
+                .find(|s| s.session_id == run_id)
+                .unwrap_or_else(|| panic!("{run_id} should be in merged list"));
+            assert!(
+                fake.injected_live_status.is_none(),
+                "tab-backed {run_id} must carry no short-circuit override",
+            );
+            assert!(
+                fake.injected_tab.is_some(),
+                "tab-backed {run_id} must carry a synthetic tab spec",
+            );
+        }
+
+        let _ = clear_sessions_handler().await;
+    }
+
+    // =========================================================================
+    // Phase 2: seed-scenario / clear-injected / TTL eviction
+    // =========================================================================
+
+    /// Counts-based scenario seeds exactly N per bucket with the correct
+    /// tab_backed projection for each.
+    #[tokio::test]
+    async fn seed_scenario_counts_seed_exactly_n_per_bucket() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        let req = SeedScenarioRequest {
+            counts: ScenarioCounts {
+                working: 2,
+                idle: 1,
+                needs_input: 3,
+                error: 1,
+                completed: 2,
+            },
+            sessions: None,
+        };
+
+        let resp = seed_scenario_handler(Json(req))
+            .await
+            .expect("counts scenario should seed");
+        assert!(resp.success);
+        assert_eq!(resp.seeded.working, 2);
+        assert_eq!(resp.seeded.idle, 1);
+        assert_eq!(resp.seeded.needs_input, 3);
+        assert_eq!(resp.seeded.error, 1);
+        assert_eq!(resp.seeded.completed, 2);
+        // 2 + 1 + 3 + 1 + 2 = 9 total session ids.
+        assert_eq!(resp.session_ids.len(), 9);
+
+        let sessions = injected_test_sessions();
+        assert_eq!(sessions.len(), 9, "registry must hold exactly 9 fakes");
+
+        // Deterministic ids exist.
+        for expected in [
+            "scenario-working-1",
+            "scenario-working-2",
+            "scenario-idle-1",
+            "scenario-needs-input-1",
+            "scenario-needs-input-2",
+            "scenario-needs-input-3",
+            "scenario-error-1",
+            "scenario-completed-1",
+            "scenario-completed-2",
+        ] {
+            assert!(
+                sessions.iter().any(|s| s.task_run_id == expected),
+                "{expected} must be seeded",
+            );
+        }
+
+        // Bucket-correct tab_backed projection.
+        let by_id = |id: &str| {
+            sessions
+                .iter()
+                .find(|s| s.task_run_id == id)
+                .cloned()
+                .unwrap()
+        };
+
+        // working / needs-input → short-circuit (not tab-backed).
+        assert!(!by_id("scenario-working-1").tab_backed);
+        assert_eq!(
+            by_id("scenario-working-1").live_status,
+            TestLiveStatus::ActiveInZone
+        );
+        assert!(!by_id("scenario-needs-input-1").tab_backed);
+        assert_eq!(
+            by_id("scenario-needs-input-1").live_status,
+            TestLiveStatus::NeedsInput
+        );
+
+        // idle / error / completed → tab-backed.
+        let idle = by_id("scenario-idle-1");
+        assert!(idle.tab_backed);
+        assert_eq!(idle.live_status, TestLiveStatus::Idle);
+        assert_eq!(idle.quiet_ms, Some(SCENARIO_IDLE_QUIET_MS));
+        assert!(project_test_session(&idle).injected_tab.is_some());
+        assert!(project_test_session(&idle).injected_live_status.is_none());
+
+        let error = by_id("scenario-error-1");
+        assert!(error.tab_backed);
+        assert_eq!(error.live_status, TestLiveStatus::Error);
+        let err_spec = project_test_session(&error).injected_tab.unwrap();
+        assert!(!err_spec.is_alive);
+        assert_eq!(err_spec.exit_code, Some(1));
+
+        let completed = by_id("scenario-completed-1");
+        assert!(completed.tab_backed);
+        assert_eq!(completed.live_status, TestLiveStatus::Completed);
+        let done_spec = project_test_session(&completed).injected_tab.unwrap();
+        assert!(!done_spec.is_alive);
+        assert_eq!(done_spec.exit_code, Some(0));
+
+        let _ = clear_sessions_handler().await;
+    }
+
+    /// Supplying BOTH counts and an explicit `sessions` list is a 400.
+    #[tokio::test]
+    async fn seed_scenario_both_forms_is_400() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        let req = SeedScenarioRequest {
+            counts: ScenarioCounts {
+                working: 1,
+                ..Default::default()
+            },
+            sessions: Some(vec![InjectSessionRequest {
+                task_run_id: "explicit-1".to_string(),
+                name: "explicit".to_string(),
+                live_status: TestLiveStatus::ActiveInZone,
+                worktree: None,
+                project_path: None,
+                config_dir: None,
+                tab_backed: false,
+                quiet_ms: None,
+            }]),
+        };
+
+        let err = seed_scenario_handler(Json(req))
+            .await
+            .expect_err("both forms must be rejected");
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+        assert!(!err.1.success);
+        // Nothing should have been seeded.
+        assert!(injected_test_sessions().is_empty());
+    }
+
+    /// Explicit `sessions` form seeds exactly that list (reusing the Phase-1
+    /// validation primitive).
+    #[tokio::test]
+    async fn seed_scenario_explicit_sessions_seed_that_list() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        let req = SeedScenarioRequest {
+            counts: ScenarioCounts::default(),
+            sessions: Some(vec![
+                InjectSessionRequest {
+                    task_run_id: "explicit-a".to_string(),
+                    name: "Explicit A".to_string(),
+                    live_status: TestLiveStatus::Frozen,
+                    worktree: None,
+                    project_path: None,
+                    config_dir: None,
+                    tab_backed: false,
+                    quiet_ms: None,
+                },
+                InjectSessionRequest {
+                    task_run_id: "explicit-b".to_string(),
+                    name: "Explicit B".to_string(),
+                    live_status: TestLiveStatus::Idle,
+                    worktree: None,
+                    project_path: None,
+                    config_dir: None,
+                    tab_backed: true,
+                    quiet_ms: None,
+                },
+            ]),
+        };
+
+        let resp = seed_scenario_handler(Json(req))
+            .await
+            .expect("explicit sessions should seed");
+        assert_eq!(resp.session_ids.len(), 2);
+        let sessions = injected_test_sessions();
+        assert_eq!(sessions.len(), 2);
+        assert!(sessions.iter().any(|s| s.task_run_id == "explicit-a"));
+        assert!(sessions.iter().any(|s| s.task_run_id == "explicit-b"));
+
+        let _ = clear_sessions_handler().await;
+    }
+
+    /// Clear-then-seed semantics: a pre-existing injected entry is gone after a
+    /// seed of a disjoint scenario.
+    #[tokio::test]
+    async fn seed_scenario_clears_then_seeds() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        // Pre-existing entry from a prior inject.
+        let _ = inject_session_handler(Json(InjectSessionRequest {
+            task_run_id: "pre-existing-1".to_string(),
+            name: "Pre-existing".to_string(),
+            live_status: TestLiveStatus::ActiveInZone,
+            worktree: None,
+            project_path: None,
+            config_dir: None,
+            tab_backed: false,
+            quiet_ms: None,
+        }))
+        .await
+        .expect("pre-seed inject should succeed");
+        assert!(injected_test_sessions()
+            .iter()
+            .any(|s| s.task_run_id == "pre-existing-1"));
+
+        // Seed a disjoint scenario.
+        let resp = seed_scenario_handler(Json(SeedScenarioRequest {
+            counts: ScenarioCounts {
+                working: 1,
+                ..Default::default()
+            },
+            sessions: None,
+        }))
+        .await
+        .expect("seed should succeed");
+        // The pre-existing entry must be in the cleared tally.
+        assert!(resp.cleared_count >= 1);
+
+        let sessions = injected_test_sessions();
+        assert!(
+            !sessions.iter().any(|s| s.task_run_id == "pre-existing-1"),
+            "pre-existing entry must be cleared by clear-then-seed",
+        );
+        assert!(sessions
+            .iter()
+            .any(|s| s.task_run_id == "scenario-working-1"));
+        assert_eq!(sessions.len(), 1, "only the seeded scenario should remain");
+
+        let _ = clear_sessions_handler().await;
+    }
+
+    /// `clear-injected` is a superset alias of `clear-sessions`: it drops every
+    /// injected fake and reports the count.
+    #[tokio::test]
+    async fn clear_injected_roundtrip() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        for id in ["ci-1", "ci-2"] {
+            let _ = inject_session_handler(Json(InjectSessionRequest {
+                task_run_id: id.to_string(),
+                name: format!("clear-injected {id}"),
+                live_status: TestLiveStatus::ActiveInZone,
+                worktree: None,
+                project_path: None,
+                config_dir: None,
+                tab_backed: false,
+                quiet_ms: None,
+            }))
+            .await
+            .expect("inject should succeed");
+        }
+        assert_eq!(injected_test_sessions().len(), 2);
+
+        let resp = clear_injected_handler().await;
+        assert!(resp.success);
+        assert_eq!(resp.cleared_count, 2);
+        assert!(injected_test_sessions().is_empty());
+    }
+
+    /// A session with a back-dated `injected_at` beyond the TTL is evicted on
+    /// the next registry read.
+    #[tokio::test]
+    async fn ttl_evicts_stale_entry_on_next_read() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _ = clear_sessions_handler().await;
+
+        // Insert a fresh entry the normal way.
+        let _ = inject_session_handler(Json(InjectSessionRequest {
+            task_run_id: "ttl-fresh".to_string(),
+            name: "fresh".to_string(),
+            live_status: TestLiveStatus::ActiveInZone,
+            worktree: None,
+            project_path: None,
+            config_dir: None,
+            tab_backed: false,
+            quiet_ms: None,
+        }))
+        .await
+        .expect("inject should succeed");
+
+        // Inject a stale entry directly with a back-dated injected_at (well
+        // beyond the 10-min TTL).
+        let stale_at = (chrono::Utc::now() - chrono::Duration::minutes(30)).to_rfc3339();
+        {
+            let mut guard = registry().lock().unwrap_or_else(|p| p.into_inner());
+            guard.insert(
+                "ttl-stale".to_string(),
+                TestSession {
+                    task_run_id: "ttl-stale".to_string(),
+                    session_id: "ttl-stale".to_string(),
+                    name: "stale".to_string(),
+                    live_status: TestLiveStatus::ActiveInZone,
+                    worktree: None,
+                    injected_at: stale_at,
+                    project_path: DEFAULT_TEST_PROJECT_PATH.to_string(),
+                    config_dir: DEFAULT_TEST_CONFIG_DIR.to_string(),
+                    tab_backed: false,
+                    quiet_ms: None,
+                },
+            );
+        }
+
+        // The next read evicts the stale entry but keeps the fresh one.
+        let sessions = injected_test_sessions();
+        assert!(
+            sessions.iter().any(|s| s.task_run_id == "ttl-fresh"),
+            "fresh entry must survive eviction",
+        );
+        assert!(
+            !sessions.iter().any(|s| s.task_run_id == "ttl-stale"),
+            "stale entry must be evicted on read",
+        );
+
         let _ = clear_sessions_handler().await;
     }
 }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1765,6 +1765,13 @@ pub fn create_router(
     // the `mcp::test_fixtures` module declaration in `mcp/mod.rs`, so
     // production release builds without the `test-fixtures` feature compile
     // away both the module and the merge call entirely.
+    // Hand the seam an AppHandle so its mutating endpoints can emit
+    // `test-fixtures-injected-changed` — `useTranscriptSessions` refetches on
+    // that event instead of waiting for its 30s visibility-gated poll (a
+    // hidden window never ticks, which would leave a seeded/cleared scenario
+    // invisible to the acceptance driver until refocus).
+    #[cfg(any(debug_assertions, feature = "test-fixtures"))]
+    crate::mcp::test_fixtures::set_app_handle(app_handle.clone());
     #[cfg(any(debug_assertions, feature = "test-fixtures"))]
     let base_router = base_router.merge(crate::mcp::test_fixtures::routes());
 

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -38,6 +38,38 @@ pub struct TranscriptSession {
     /// (`active-in-zone | needs-input | frozen | …`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub injected_live_status: Option<String>,
+    /// Optional synthetic-tab spec, set only by the debug-gated test-fixtures
+    /// path (`mcp::test_fixtures`) for a *tab-backed* injected fake.
+    ///
+    /// `None` for real on-disk transcripts (omitted from the serialized JSON
+    /// via `skip_serializing_if`). When `Some(...)`, the frontend derives a
+    /// minimal `TerminalTab` from it (`syntheticTabs.ts`) and feeds it through
+    /// the REAL `useSessionManager` tab-correlation path so an injected fake
+    /// can land in the `idle` / tab-backed `error` / tab-backed `completed`
+    /// StatusStrip buckets that the `injected_live_status` short-circuit
+    /// cannot reach.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub injected_tab: Option<InjectedTabSpec>,
+}
+
+/// Synthetic-tab spec carried on a *tab-backed* injected fake (see
+/// `TranscriptSession::injected_tab`). Defined here (an always-compiled
+/// module) rather than in the cfg-gated `mcp::test_fixtures` so the field type
+/// resolves in release builds without the `test-fixtures` feature. Only ever
+/// populated behind that gated seam; the frontend consumer is dead code in a
+/// release build.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InjectedTabSpec {
+    /// `true` → a live synthetic tab the staleness sweep can age into
+    /// `frozen` (idle bucket). `false` → a dead tab whose `exit_code` the
+    /// dead-tab sweep branch maps to `completed` / `error`.
+    pub is_alive: bool,
+    /// Exit code for a dead synthetic tab (`0` → completed, non-zero →
+    /// error). `None` for a live (idle) tab.
+    pub exit_code: Option<i32>,
+    /// Pre-age in ms for a live tab's `lastOutput` so the 60s staleness sweep
+    /// classifies it stale. `None` for dead tabs.
+    pub quiet_ms: Option<u64>,
 }
 
 /// A single parsed message from a Claude Code transcript.
@@ -294,6 +326,7 @@ pub fn list_sessions(
             // Real on-disk sessions never carry a status override; the
             // frontend computes `liveStatus` from tab/digest correlation.
             injected_live_status: None,
+            injected_tab: None,
         };
 
         if let Some(mt) = mtime {
@@ -792,6 +825,7 @@ pub fn get_latest_session_id(
                             display_name,
                             // Real on-disk session — no override.
                             injected_live_status: None,
+                            injected_tab: None,
                         });
                     }
                 }

--- a/src/components/terminal/SessionCard.tsx
+++ b/src/components/terminal/SessionCard.tsx
@@ -17,6 +17,7 @@ import {
 import type { UnifiedSession, SessionLiveStatus } from "./useSessionManager";
 import type { LockState } from "./useFileLockTracking";
 import type { CommandResponse } from "./types";
+import { isInjectedSession } from "./syntheticTabs";
 
 interface PromoteToWorktreeData {
   worktree_id: string;
@@ -187,6 +188,15 @@ export function SessionCard({
     async (e: React.MouseEvent) => {
       e.stopPropagation();
       if (!canPromote || promoteState.kind === "loading") return;
+      // F1 inertness: a debug-injected fake has no real ClaudeSession in the
+      // manager — `promote_session_to_worktree` would 404. No-op it (and don't
+      // flip the card into a misleading loading/error state).
+      if (isInjectedSession(session)) {
+        console.warn(
+          `[test-fixtures] ignoring promote on synthetic tab ${session.zoneTabId ?? session.sessionId}`,
+        );
+        return;
+      }
       setPromoteState({ kind: "loading" });
       try {
         const result = await invoke<CommandResponse>("promote_session_to_worktree", {
@@ -228,7 +238,7 @@ export function SessionCard({
         }, 8000);
       }
     },
-    [canPromote, promoteState.kind, session.sessionId, onAfterPromote],
+    [canPromote, promoteState.kind, session, onAfterPromote],
   );
 
   // ── Commit progress state ───────────────────────────────────────────────
@@ -255,6 +265,14 @@ export function SessionCard({
     async (e: React.MouseEvent) => {
       e.stopPropagation();
       if (!canCommit || commitState.kind === "loading") return;
+      // F1 inertness: a debug-injected fake has no real ClaudeSession —
+      // `commit_session_progress` would 404. No-op it.
+      if (isInjectedSession(session)) {
+        console.warn(
+          `[test-fixtures] ignoring commit on synthetic tab ${session.zoneTabId ?? session.sessionId}`,
+        );
+        return;
+      }
       setCommitState({ kind: "loading" });
       try {
         const result = await invoke<CommandResponse>("commit_session_progress", {
@@ -283,7 +301,7 @@ export function SessionCard({
         }, 8000);
       }
     },
-    [canCommit, commitState.kind, session.sessionId],
+    [canCommit, commitState.kind, session],
   );
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -87,6 +87,7 @@ import { useAnalysis } from "../useAnalysis";
 import { useFindingsActions } from "../useFindingsActions";
 import { useTranscriptSessions } from "../useTranscriptSessions";
 import { useSessionManager } from "../useSessionManager";
+import { deriveSyntheticTabs } from "../syntheticTabs";
 
 import { instanceStorage } from "@/lib/instance-storage";
 
@@ -299,13 +300,47 @@ export function TerminalSessionProvider({
     pendingProfileSessionsRef.current = remaining.length > 0 ? remaining : null;
   }, [zoneLayout.assignments, updateTab]);
 
+  // Transcripts are read up here (rather than in the AiFeatures block below)
+  // because the debug-gated synthetic-tab seam derives synthetic tabs from
+  // them and must feed those tabs into `useSessionStateTracking` /
+  // `useSessionManager`. Pure hook reordering — no behavioral change for the
+  // real path (transcripts with no `injected_tab` produce zero synthetic tabs).
+  const {
+    sessions: transcriptSessions,
+    loading: sessionsLoading,
+    refresh: refreshSessions,
+    loadMessages,
+  } = useTranscriptSessions();
+
+  // Synthetic tabs from tab-backed injected fakes (debug-gated test-fixtures
+  // seam). Only the MAIN window derives them — pop-out windows own a disjoint
+  // tab subset and the fakes correlate to the main window's session list.
+  // Real transcripts never carry `injected_tab`, so this is empty in
+  // production (and dead code in a release build without `test-fixtures`).
+  const { tabs: syntheticTabs, seedLastOutput: syntheticSeedLastOutput } = useMemo(
+    () =>
+      myWindowLabel === MAIN_WINDOW_LABEL
+        ? deriveSyntheticTabs(transcriptSessions)
+        : { tabs: [], seedLastOutput: {} },
+    [myWindowLabel, transcriptSessions],
+  );
+
+  // Real tabs PLUS synthetic tabs — fed ONLY to the two consumers that drive
+  // StatusStrip bucketing. Every other consumer keeps the real `tabs` so a
+  // synthetic tab never renders a terminal pane.
+  const tabsWithSynthetic = useMemo(
+    () => (syntheticTabs.length > 0 ? [...tabs, ...syntheticTabs] : tabs),
+    [tabs, syntheticTabs],
+  );
+
   // ---- SessionState ----
   const processOutputRef = useRef<((tabId: string, text: string) => void) | undefined>(
     undefined,
   );
 
   const stateTracking = useSessionStateTracking({
-    tabs,
+    tabs: tabsWithSynthetic,
+    seedLastOutput: syntheticSeedLastOutput,
     processOutput: (tabId, text) => processOutputRef.current?.(tabId, text),
     getBufferLines: (tabId, maxLines) => {
       const ref = terminalRefs.current.get(tabId);
@@ -390,13 +425,6 @@ export function TerminalSessionProvider({
     return ref?.current?.getSelection?.() ?? "";
   }, [activeId, terminalRefs]);
 
-  const {
-    sessions: transcriptSessions,
-    loading: sessionsLoading,
-    refresh: refreshSessions,
-    loadMessages,
-  } = useTranscriptSessions();
-
   // `desktopNotify` was previously read off TransitionEffectsContext
   // (which lived ABOVE AiFeaturesContext in the prior provider tree).
   // Post-collapse, TerminalSession is the OUTERMOST provider and
@@ -411,7 +439,10 @@ export function TerminalSessionProvider({
   const desktopNotifyFlag = instanceStorage.getItem("zone-desktop-notify") === "true";
 
   const sessionManager = useSessionManager({
-    tabs,
+    // Synthetic tabs included so `tabSessionMap` correlation places tab-backed
+    // injected fakes (idle / error / completed) in the right StatusStrip
+    // bucket. Empty in production (real transcripts carry no `injected_tab`).
+    tabs: tabsWithSynthetic,
     sessionStates: stateTracking.sessionStates,
     staleTabs: stateTracking.staleTabs,
     transcriptSessions,

--- a/src/components/terminal/syntheticTabs.guard.test.ts
+++ b/src/components/terminal/syntheticTabs.guard.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Phase 3 / F1 — unit tests for the synthetic-tab inertness guards.
+ *
+ * `isSyntheticTab` / `isInjectedSession` are the predicates that session-level
+ * process-control ops (resume / promote / commit) consult to no-op against a
+ * debug-injected fake. These tests pin the detection logic across both
+ * projection modes (short-circuit + tab-backed) and both call shapes
+ * (TerminalTab object + bare id string).
+ */
+
+import { describe, it, expect } from "vitest";
+import { isSyntheticTab, isInjectedSession } from "./syntheticTabs";
+import type { TerminalTab } from "./useTerminalManager";
+import type { TranscriptSession } from "./useTranscriptSessions";
+
+function tab(partial: Partial<TerminalTab> & Pick<TerminalTab, "id">): TerminalTab {
+  return {
+    title: "t",
+    pid: null,
+    isAlive: true,
+    exitCode: null,
+    ...partial,
+  } as TerminalTab;
+}
+
+function transcript(
+  partial: Partial<TranscriptSession> = {},
+): Pick<TranscriptSession, "injected_live_status" | "injected_tab"> {
+  return {
+    injected_live_status: undefined,
+    injected_tab: undefined,
+    ...partial,
+  };
+}
+
+describe("isSyntheticTab", () => {
+  it("is true for a tab carrying the __synthetic flag", () => {
+    expect(isSyntheticTab(tab({ id: "synthetic-abc", __synthetic: true }))).toBe(true);
+  });
+
+  it("is true for a tab whose id carries the synthetic- prefix even without the flag", () => {
+    expect(isSyntheticTab(tab({ id: "synthetic-abc" }))).toBe(true);
+  });
+
+  it("is false for a real tab", () => {
+    expect(isSyntheticTab(tab({ id: "terminal-1" }))).toBe(false);
+  });
+
+  it("string form: keys on the synthetic- prefix", () => {
+    expect(isSyntheticTab("synthetic-xyz")).toBe(true);
+    expect(isSyntheticTab("real-session-id")).toBe(false);
+  });
+
+  it("is false for null / undefined", () => {
+    expect(isSyntheticTab(null)).toBe(false);
+    expect(isSyntheticTab(undefined)).toBe(false);
+  });
+});
+
+describe("isInjectedSession", () => {
+  it("is true for a short-circuit fake (injected_live_status, no tab)", () => {
+    expect(
+      isInjectedSession({
+        zoneTabId: null,
+        _transcript: transcript({ injected_live_status: "active-in-zone" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("is true for a tab-backed fake (injected_tab + synthetic zoneTabId)", () => {
+    expect(
+      isInjectedSession({
+        zoneTabId: "synthetic-idle-1",
+        _transcript: transcript({
+          injected_tab: { is_alive: true, exit_code: null, quiet_ms: 61_000 },
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("is true when only the synthetic zoneTabId pointer is present", () => {
+    expect(
+      isInjectedSession({
+        zoneTabId: "synthetic-orphan",
+        _transcript: transcript(),
+      }),
+    ).toBe(true);
+  });
+
+  it("is false for a real session (no injected fields, real tab)", () => {
+    expect(
+      isInjectedSession({
+        zoneTabId: "terminal-3",
+        _transcript: transcript(),
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for a real dormant transcript with no tab", () => {
+    expect(
+      isInjectedSession({ zoneTabId: null, _transcript: transcript() }),
+    ).toBe(false);
+  });
+});

--- a/src/components/terminal/syntheticTabs.test.ts
+++ b/src/components/terminal/syntheticTabs.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for `deriveSyntheticTabs` — the pure derivation that turns a
+ * tab-backed injected fake's `injected_tab` spec into a minimal `TerminalTab`
+ * (+ pre-age seed) so it flows through the real `useSessionManager` /
+ * `useSessionStateTracking` correlation path.
+ *
+ * These tabs are how the debug-gated test-fixtures seam reaches the `idle`
+ * (pre-aged stale tab) and tab-backed `error` / `completed` (dead-tab
+ * exit-code) StatusStrip buckets that the `injected_live_status` short-circuit
+ * cannot.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { deriveSyntheticTabs } from "./syntheticTabs";
+import type { TranscriptSession } from "./useTranscriptSessions";
+
+// Minimal transcript-session builder — only the fields the derivation reads
+// matter; the rest are inert defaults.
+function session(
+  partial: Partial<TranscriptSession> & Pick<TranscriptSession, "session_id">,
+): TranscriptSession {
+  return {
+    project_path: "<test-fixture>",
+    config_dir: "C:\\claude\\.claude-test-fixture",
+    message_count: 1,
+    last_modified: "2026-06-05T00:00:00Z",
+    started_at: "2026-06-05T00:00:00Z",
+    first_message_preview: "preview",
+    has_plans: false,
+    display_name: "Fixture",
+    ...partial,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("deriveSyntheticTabs", () => {
+  it("ignores sessions without an injected_tab (the production path)", () => {
+    const result = deriveSyntheticTabs([
+      session({ session_id: "real-1" }),
+      session({ session_id: "real-2", injected_live_status: "active-in-zone" }),
+    ]);
+    expect(result.tabs).toEqual([]);
+    expect(result.seedLastOutput).toEqual({});
+  });
+
+  it("derives a live, pre-aged tab for an idle fake and seeds lastOutput", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+
+    const result = deriveSyntheticTabs([
+      session({
+        session_id: "idle-1",
+        injected_tab: { is_alive: true, exit_code: null, quiet_ms: 61_000 },
+      }),
+    ]);
+
+    expect(result.tabs).toHaveLength(1);
+    const tab = result.tabs[0];
+    expect(tab.id).toBe("synthetic-idle-1");
+    expect(tab.claudeSessionId).toBe("idle-1");
+    expect(tab.isAlive).toBe(true);
+    expect(tab.exitCode).toBeNull();
+    expect(tab.pid).toBeNull();
+    expect(tab.__synthetic).toBe(true);
+
+    // Seed is now - quiet_ms, i.e. pre-aged into the past so the 60s sweep
+    // marks it stale.
+    expect(result.seedLastOutput["synthetic-idle-1"]).toBe(1_000_000 - 61_000);
+  });
+
+  it("derives a dead tab with exit code 1 for an error fake, no seed", () => {
+    const result = deriveSyntheticTabs([
+      session({
+        session_id: "err-1",
+        injected_tab: { is_alive: false, exit_code: 1, quiet_ms: null },
+      }),
+    ]);
+
+    expect(result.tabs).toHaveLength(1);
+    expect(result.tabs[0].isAlive).toBe(false);
+    expect(result.tabs[0].exitCode).toBe(1);
+    expect(result.tabs[0].__synthetic).toBe(true);
+    // Dead tabs are not pre-aged — the dead-tab sweep branch handles them.
+    expect(result.seedLastOutput).toEqual({});
+  });
+
+  it("derives a dead tab with exit code 0 for a completed fake, no seed", () => {
+    const result = deriveSyntheticTabs([
+      session({
+        session_id: "done-1",
+        injected_tab: { is_alive: false, exit_code: 0, quiet_ms: null },
+      }),
+    ]);
+
+    expect(result.tabs).toHaveLength(1);
+    expect(result.tabs[0].isAlive).toBe(false);
+    expect(result.tabs[0].exitCode).toBe(0);
+    expect(result.seedLastOutput).toEqual({});
+  });
+
+  it("does not seed a live tab that carries no quiet_ms", () => {
+    const result = deriveSyntheticTabs([
+      session({
+        session_id: "live-no-quiet",
+        injected_tab: { is_alive: true, exit_code: null, quiet_ms: null },
+      }),
+    ]);
+    expect(result.tabs).toHaveLength(1);
+    expect(result.seedLastOutput).toEqual({});
+  });
+
+  it("handles a mix: real + idle + error in one pass", () => {
+    const result = deriveSyntheticTabs([
+      session({ session_id: "real" }),
+      session({
+        session_id: "idle",
+        injected_tab: { is_alive: true, exit_code: null, quiet_ms: 90_000 },
+      }),
+      session({
+        session_id: "err",
+        injected_tab: { is_alive: false, exit_code: 1, quiet_ms: null },
+      }),
+    ]);
+
+    expect(result.tabs.map((t) => t.id).sort()).toEqual([
+      "synthetic-err",
+      "synthetic-idle",
+    ]);
+    expect(Object.keys(result.seedLastOutput)).toEqual(["synthetic-idle"]);
+  });
+});

--- a/src/components/terminal/syntheticTabs.ts
+++ b/src/components/terminal/syntheticTabs.ts
@@ -1,0 +1,140 @@
+/**
+ * Synthetic-tab derivation for the debug-gated test-fixtures seam.
+ *
+ * A *tab-backed* injected fake (produced only by the runner's cfg-gated
+ * `/ui-bridge/test/inject-session` route) carries an `injected_tab` spec on its
+ * transcript-session record. This module turns each such spec into a minimal
+ * `TerminalTab` that is fed THROUGH the real `useSessionManager` /
+ * `useSessionStateTracking` correlation path — the only mechanism that can
+ * place a fake into the `idle` (pre-aged stale tab) or tab-backed
+ * `error` / `completed` (dead-tab exit-code) StatusStrip buckets, which the
+ * `injected_live_status` short-circuit cannot reach.
+ *
+ * No build-flag gating is needed: the function is data-driven. `injected_tab`
+ * can only be non-null when the cfg-gated Rust seam produced it, so in a
+ * release build without `test-fixtures` this path is dead.
+ *
+ * Synthetic tabs are pure StatusStrip bucketing inputs. They are NEVER passed
+ * to the terminal-rendering / zone-layout / file-lock / keyboard consumers, so
+ * they never back a real PTY pane (see `TerminalSessionContext.tsx` wiring).
+ */
+
+import type { TerminalTab } from "./useTerminalManager";
+import type { TranscriptSession } from "./useTranscriptSessions";
+
+/** Prefix for synthetic tab ids so they're greppable and collision-free. */
+const SYNTHETIC_TAB_ID_PREFIX = "synthetic-";
+
+/**
+ * True when `tabOrId` refers to a synthetic (debug test-fixture) tab.
+ *
+ * Accepts either a `TerminalTab` object or a bare tab-id string:
+ *   - Object form (preferred — call this when the tab is in scope): keys on the
+ *     authoritative `__synthetic` flag set by {@link deriveSyntheticTabs}.
+ *   - String form (fallback — when only the id is in scope, e.g. a
+ *     `UnifiedSession.zoneTabId` pointer): keys on the `synthetic-` id prefix,
+ *     which `deriveSyntheticTabs` guarantees on every synthetic tab.
+ *
+ * Phase 3 / F1: session-level process-control operations (resume, promote,
+ * commit) consult this to early-return a no-op against a synthetic-backed
+ * target — a fake has no real PTY / ClaudeSession, so driving the action
+ * through would either 404 in the backend or spawn a stray `claude --resume`
+ * against a non-existent session id.
+ */
+export function isSyntheticTab(tabOrId: TerminalTab | string | null | undefined): boolean {
+  if (tabOrId == null) return false;
+  if (typeof tabOrId === "string") {
+    return tabOrId.startsWith(SYNTHETIC_TAB_ID_PREFIX);
+  }
+  return tabOrId.__synthetic === true || tabOrId.id.startsWith(SYNTHETIC_TAB_ID_PREFIX);
+}
+
+/**
+ * Minimal shape {@link isInjectedSession} needs from a session row: the
+ * underlying transcript record plus the resolved tab pointer. Kept structural
+ * (rather than importing `UnifiedSession`) so this stays a leaf module with no
+ * cycle back into `useSessionManager`.
+ */
+export interface InjectedSessionProbe {
+  /** Synthetic tab id (`synthetic-…`) for a tab-backed fake; else a real id or null. */
+  zoneTabId: string | null;
+  /** The transcript record this session was projected from. */
+  _transcript: Pick<TranscriptSession, "injected_live_status" | "injected_tab">;
+}
+
+/**
+ * True when a unified session row is a debug-gated injected fake — covering
+ * BOTH projection modes:
+ *
+ *   - **short-circuit** fakes (working / needs-input / orphan-frozen): carry
+ *     `_transcript.injected_live_status`, `zoneTabId == null`.
+ *   - **tab-backed** fakes (idle / error / completed): carry
+ *     `_transcript.injected_tab` and resolve to a synthetic `zoneTabId`.
+ *
+ * Real transcripts set neither field and never carry a `synthetic-` tab
+ * pointer, so this is `false` for every production session.
+ *
+ * This is the guard predicate for session-level process-control ops that key
+ * off a `UnifiedSession` (resume / promote / commit) rather than a `TerminalTab`.
+ */
+export function isInjectedSession(session: InjectedSessionProbe): boolean {
+  return (
+    session._transcript.injected_live_status != null ||
+    session._transcript.injected_tab != null ||
+    isSyntheticTab(session.zoneTabId)
+  );
+}
+
+export interface DeriveSyntheticTabsResult {
+  /** Minimal `TerminalTab`s, one per session carrying an `injected_tab`. */
+  tabs: TerminalTab[];
+  /**
+   * Pre-age seed for `useSessionStateTracking`'s `lastOutputTimeRef`, keyed by
+   * synthetic tab id. Present only for live (idle) tabs that carry a
+   * `quiet_ms`: the value is `Date.now() - quiet_ms` so the existing 60s
+   * staleness sweep classifies the tab stale on its next tick.
+   */
+  seedLastOutput: Record<string, number>;
+}
+
+/**
+ * Derive synthetic tabs (and their pre-age seeds) from the transcript-session
+ * list. Sessions without an `injected_tab` are ignored. Pure — `Date.now()` is
+ * the only ambient read, evaluated once per call.
+ */
+export function deriveSyntheticTabs(
+  transcriptSessions: readonly TranscriptSession[],
+): DeriveSyntheticTabsResult {
+  const now = Date.now();
+  const tabs: TerminalTab[] = [];
+  const seedLastOutput: Record<string, number> = {};
+
+  for (const session of transcriptSessions) {
+    const spec = session.injected_tab;
+    if (!spec) continue;
+
+    const tabId = `${SYNTHETIC_TAB_ID_PREFIX}${session.session_id}`;
+
+    tabs.push({
+      id: tabId,
+      title: session.display_name,
+      pid: null,
+      isAlive: spec.is_alive,
+      exitCode: spec.exit_code ?? null,
+      // Correlate to the injected transcript so `tabSessionMap` (keyed by
+      // claudeSessionId → tab) resolves this tab for the fake.
+      claudeSessionId: session.session_id,
+      __synthetic: true,
+    });
+
+    // A live (idle) tab pre-aged past the staleness threshold needs its
+    // last-output timestamp seeded so the sweep can mark it stale. Dead tabs
+    // (error/completed) carry no quiet_ms — the dead-tab sweep branch handles
+    // them via exitCode instead.
+    if (spec.is_alive && spec.quiet_ms != null) {
+      seedLastOutput[tabId] = now - spec.quiet_ms;
+    }
+  }
+
+  return { tabs, seedLastOutput };
+}

--- a/src/components/terminal/useSessionManager.ts
+++ b/src/components/terminal/useSessionManager.ts
@@ -17,6 +17,7 @@ import type { TranscriptSession } from "./useTranscriptSessions";
 import type { TerminalTab } from "./useTerminalManager";
 import type { SessionState } from "./useZoneLayout";
 import type { CommandResponse } from "./types";
+import { isInjectedSession } from "./syntheticTabs";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -1019,6 +1020,15 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
 
   const resumeSession = useCallback(
     (session: UnifiedSession) => {
+      // F1 inertness: a debug-injected fake has no real transcript on disk —
+      // resuming it would spawn a stray `claude --resume <fake-id>` against a
+      // session id that doesn't exist. No-op it.
+      if (isInjectedSession(session)) {
+        console.warn(
+          `[test-fixtures] ignoring resume on synthetic tab ${session.zoneTabId ?? session.sessionId}`,
+        );
+        return;
+      }
       onResumeSession(session._transcript);
     },
     [onResumeSession],
@@ -1061,7 +1071,19 @@ export function useSessionManager(params: UseSessionManagerParams): UseSessionMa
   }, []);
 
   const bulkResume = useCallback(async () => {
-    const toResume = allSessions.filter((s) => selectedIds.has(s.sessionId));
+    // F1 inertness: drop synthetic-backed fakes from the bulk set — they have
+    // no real transcript to resume (see `resumeSession`).
+    const toResume = allSessions.filter(
+      (s) => selectedIds.has(s.sessionId) && !isInjectedSession(s),
+    );
+    const skipped = allSessions.filter(
+      (s) => selectedIds.has(s.sessionId) && isInjectedSession(s),
+    );
+    for (const s of skipped) {
+      console.warn(
+        `[test-fixtures] ignoring resume on synthetic tab ${s.zoneTabId ?? s.sessionId}`,
+      );
+    }
     setSelectedIds(new Set());
     // Resume sequentially with a small delay to let each tab initialize
     for (const session of toResume) {

--- a/src/components/terminal/useSessionStateTracking.ts
+++ b/src/components/terminal/useSessionStateTracking.ts
@@ -7,6 +7,14 @@ export interface UseSessionStateTrackingParams {
   processOutput?: (tabId: string, text: string) => void;
   /** Read rendered lines from the xterm buffer (handles cursor movements correctly). */
   getBufferLines?: (tabId: string, maxLines: number) => string[];
+  /**
+   * Pre-age seeds for `lastOutputTimeRef`, keyed by tab id (used by the
+   * debug-gated synthetic-tab seam, `syntheticTabs.ts`). Each entry is applied
+   * ONLY if the tab has no recorded output yet, so a real recording is never
+   * clobbered. Seeding a value in the past lets the existing 60s staleness
+   * sweep classify a synthetic "idle" tab stale on its next tick.
+   */
+  seedLastOutput?: Record<string, number>;
 }
 
 export interface UseSessionStateTrackingReturn {
@@ -26,7 +34,7 @@ export interface UseSessionStateTrackingReturn {
 export function useSessionStateTracking(
   params: UseSessionStateTrackingParams,
 ): UseSessionStateTrackingReturn {
-  const { tabs, processOutput, getBufferLines } = params;
+  const { tabs, processOutput, getBufferLines, seedLastOutput } = params;
   const getBufferLinesRef = useRef(getBufferLines);
   useEffect(() => {
     getBufferLinesRef.current = getBufferLines;
@@ -109,6 +117,22 @@ export function useSessionStateTracking(
     }, 2000);
     return () => clearInterval(interval);
   }, []); // Stable interval — reads tabs via ref
+
+  // ── Seed pre-aged lastOutput for synthetic (test-fixture) tabs ────────────
+  //
+  // Apply each seed ONLY when the tab has no recorded output yet so a real
+  // recording is never clobbered. The seeded (past) timestamp lets the 60s
+  // staleness sweep above mark a synthetic "idle" tab stale on its next tick.
+  // The dead-tab cleanup effect below removes vanished tabs' ref entries, so
+  // no extra cleanup is needed here.
+  useEffect(() => {
+    if (!seedLastOutput) return;
+    for (const [tabId, ts] of Object.entries(seedLastOutput)) {
+      if (lastOutputTimeRef.current[tabId] === undefined) {
+        lastOutputTimeRef.current[tabId] = ts;
+      }
+    }
+  }, [seedLastOutput]);
 
   // ── Clean up state for removed tabs ──────────────────────────────────────
 

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -33,6 +33,15 @@ export interface TerminalTab {
    * (`set_title_unless_worker`) on the frontend side.
    */
   taskRunId?: string;
+  /**
+   * Marks a tab synthesized from a debug-gated test-fixtures `injected_tab`
+   * spec (`syntheticTabs.ts`). Synthetic tabs are fed ONLY to
+   * `useSessionStateTracking` + `useSessionManager` for StatusStrip
+   * bucketing — they never back a real PTY and must never render a terminal
+   * pane. Phase 3 uses this flag for inertness guards. Absent/false on every
+   * real tab.
+   */
+  __synthetic?: boolean;
 }
 
 /** Tauri event payload from `commands::productivity::spawn_worker_session`. */

--- a/src/components/terminal/useTranscriptSessions.ts
+++ b/src/components/terminal/useTranscriptSessions.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import type { CommandResponse } from "./types";
 
 export interface TranscriptSession {
@@ -85,6 +86,22 @@ export function useTranscriptSessions(): UseTranscriptSessionsResult {
       didLoad.current = true;
       fetchSessions();
     }
+  }, [fetchSessions]);
+
+  // Immediate refetch when the debug-gated test-fixtures seam mutates the
+  // injected-session registry (seed / inject / clear). The 30s poll below is
+  // visibility-gated — a hidden or backgrounded window never ticks — so
+  // without this event an acceptance driver that seeds or clears a scenario
+  // would not see the StatusStrip update until the window regains focus.
+  // Real builds without the seam never emit the event, so this is inert in
+  // production.
+  useEffect(() => {
+    const unlistenPromise = listen("test-fixtures-injected-changed", () => {
+      fetchSessions();
+    });
+    return () => {
+      void unlistenPromise.then((unlisten) => unlisten());
+    };
   }, [fetchSessions]);
 
   // Auto-refresh every 30 seconds to pick up newly created sessions.

--- a/src/components/terminal/useTranscriptSessions.ts
+++ b/src/components/terminal/useTranscriptSessions.ts
@@ -22,6 +22,20 @@ export interface TranscriptSession {
    * predicates can fire without a real PTY tab being open.
    */
   injected_live_status?: string | null;
+  /**
+   * Optional synthetic-tab spec populated only by the runner's debug-gated
+   * test-fixtures path for a *tab-backed* injected fake. When present,
+   * `deriveSyntheticTabs` (`syntheticTabs.ts`) turns it into a minimal
+   * `TerminalTab` that flows through the REAL `useSessionManager`
+   * tab-correlation path — the only way to place a fake in the `idle` or
+   * tab-backed `error` / `completed` StatusStrip buckets. Real transcripts
+   * omit the field entirely.
+   */
+  injected_tab?: {
+    is_alive: boolean;
+    exit_code: number | null;
+    quiet_ms: number | null;
+  } | null;
 }
 
 export interface TranscriptMessage {


### PR DESCRIPTION
Implements plan `2026-06-04-inject-session-seam-statusstrip-coverage-plan` (Phases 1-3).

## What

The debug-gated test seam can now deterministically place injected fake sessions in **every** StatusStrip bucket — `working` / `idle` / `needs-input` / `error` / `completed` — rendered through the **real** production path (real `computeStatusCounts`, real staleness sweep, real tab correlation). Previously `idle` was architecturally unreachable: the inject short-circuit forced every frozen fake to `isOrphaned: true`, which `computeStatusCounts` drops.

## How

- **Tab-backed fakes**: `TranscriptSession.injected_tab` (new optional wire field, `None` for all real sessions) drives `deriveSyntheticTabs()` on the frontend. Synthetic tabs are main-window-only (#410 window-scoping) and fed to EXACTLY two consumers (`useSessionStateTracking`, `useSessionManager`) — never the rendering/zone/PTY paths.
- **idle** = synthetic live tab + pre-aged `lastOutput` (new `seedLastOutput` seam on the tracking hook, applied only when unset) → the real 60s sweep marks it stale on its next tick → tab-backed frozen → idle.
- **error/completed** = dead synthetic tab (`exitCode` 1/0) via the sweep's real dead-tab branch.
- **working/needs-input** keep the existing `injected_live_status` short-circuit.
- **New routes** (cfg-gated, lazy 10-min TTL): `POST /ui-bridge/test/seed-terminal-scenario` (atomic clear-then-seed) and `POST /ui-bridge/test/clear-injected`.
- **Hardening**: `isInjectedSession` guards make resume/bulk-resume/promote/commit inert on fakes; `seam-gate` CI job + source-level cfg-anchor tests prevent the seam leaking into release builds; module doc documents the seed-then-poll contract and the `isMultiZone` render gate.

## Testing

- 20 Rust unit tests (`test_fixtures`), 426 vitest (terminal suite) incl. 16 synthetic-tab tests
- `cargo clippy --all-targets -- -D warnings` + `--bin --features custom-protocol --tests` clean; `cargo fmt --check` clean; `tsc --noEmit` clean
- On-page acceptance (temp runner, in progress): seed `{working:1, idle:2, needs_input:0}` → observe "3 sessions · 1 working · 2 idle" on `data-page-element="status-strip"` → `clear-injected` → baseline