### PR TITLE
feat(ui-bridge): vision cache freshness + page-summary GET + honest focus failure

### DIFF
--- a/src-tauri/src/mcp/gui_config.rs
+++ b/src-tauri/src/mcp/gui_config.rs
@@ -99,15 +99,17 @@ fn detect_window_geometry(
 /// Screenshots capture the full screen, so the runner window must be on top.
 /// Without this, other windows (terminals, editors) covering the runner would
 /// be captured instead of the runner's UI.
-fn focus_runner_window(app_handle: &tauri::AppHandle) {
+fn focus_runner_window(app_handle: &tauri::AppHandle) -> Result<(), String> {
     use tauri::Manager;
-    if let Some(win) = app_handle.get_webview_window(qontinui_runner_lib::get_main_window_label()) {
-        if let Err(e) = win.set_focus() {
-            error!("GUI Config: Failed to focus runner window: {}", e);
-        } else {
-            info!("GUI Config: Runner window focused for screenshot capture");
-        }
-    }
+    let win = app_handle
+        .get_webview_window(qontinui_runner_lib::get_main_window_label())
+        .ok_or_else(|| "runner main window not found".to_string())?;
+    win.set_focus().map_err(|e| {
+        error!("GUI Config: Failed to focus runner window: {}", e);
+        format!("failed to focus runner window: {e}")
+    })?;
+    info!("GUI Config: Runner window focused for screenshot capture");
+    Ok(())
 }
 
 // ============================================================================
@@ -353,10 +355,17 @@ pub async fn capture_multi_state(
 ///
 /// Brings the runner window to the foreground. Called by the Python bridge
 /// before each screenshot capture to ensure the runner's content is visible.
+///
+/// Reports focus failure honestly: if the runner window can't be found or
+/// `set_focus()` errors, this returns 500 rather than a false success. (A
+/// Windows foreground-lock that makes `set_focus()` a *silent* no-op — Ok
+/// returned but the window never comes forward — is only fully addressed by
+/// occlusion-immune per-window capture; see the follow-up capture plan.)
 pub async fn focus_window(
     State(state): State<Arc<ApiState>>,
 ) -> Result<Json<ApiResponse<()>>, (StatusCode, Json<ApiResponse<()>>)> {
-    focus_runner_window(&state.app_handle);
+    focus_runner_window(&state.app_handle)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e))))?;
     // Small delay to let the window manager finish the focus transition
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     Ok(Json(ApiResponse::success(())))

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -754,6 +754,12 @@ mod manifest_drift_tests {
             ("POST", "/ui-bridge/ai/fill-form"),
             ("POST", "/ui-bridge/ai/image-diff"),
             ("POST", "/ui-bridge/ai/media/audit/{}"),
+            // page-summary is a runner-only `/ai/*` read extension (not in the
+            // SDK contract). It accepts GET as well as POST so verification
+            // drivers can read it with GET without tripping the auto-405 →
+            // envelope_audit panic (plan
+            // 2026-06-05-ui-bridge-verification-read-freshness).
+            ("GET", "/ui-bridge/ai/page-summary"),
             ("POST", "/ui-bridge/ai/page-summary"),
             ("POST", "/ui-bridge/ai/wait-for-idle"),
             ("POST", "/ui-bridge/ai/wait-for-navigation"),

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -1547,8 +1547,14 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
             get(ui_bridge_page_playbook_handler),
         )
         .route(
+            // GET + POST: page-summary is a pure read, so verification drivers
+            // reach it with GET. Without the GET method axum returns a
+            // framework 405 (no `text/plain` body), which slips past
+            // `envelope_rewrite_middleware` and trips the debug-only
+            // `envelope_audit` panic. See plan
+            // 2026-06-05-ui-bridge-verification-read-freshness.
             "/ui-bridge/ai/page-summary",
-            post(ui_bridge_page_summary_handler),
+            get(ui_bridge_page_summary_handler).post(ui_bridge_page_summary_handler),
         )
 }
 
@@ -1757,6 +1763,7 @@ pub fn route_entries() -> &'static [(&'static str, &'static str)] {
         ("POST", "/ui-bridge/control/navigate-and-wait"),
         ("POST", "/ui-bridge/control/page/summary"),
         ("GET", "/ui-bridge/control/page/playbook"),
+        ("GET", "/ui-bridge/ai/page-summary"),
         ("POST", "/ui-bridge/ai/page-summary"),
     ]
 }

--- a/src/hooks/useVisionCacheInvalidation.ts
+++ b/src/hooks/useVisionCacheInvalidation.ts
@@ -1,0 +1,86 @@
+import { useEffect } from "react";
+
+import { getApiBase } from "../lib/runner-api";
+
+/**
+ * useVisionCacheInvalidation — keep the runner's vision read-cache fresh on
+ * event/poll-driven re-renders.
+ *
+ * The runner's `vision/extract` (OCR) read-cache keys on `vision_mutation_id`
+ * and is only bumped by control actions (click/type) — see
+ * `src-tauri/src/mcp/ui_bridge/vision_routes.rs`. A UI that re-renders from a
+ * Tauri event or a data poll (rather than a control action) keeps serving the
+ * FIRST capture's OCR blocks indefinitely, so verification reads go stale and
+ * produce false verdicts (the StatusStrip teardown "still showing" false
+ * positive — see plan 2026-06-05-ui-bridge-verification-read-freshness).
+ *
+ * This mounts a single document-wide `MutationObserver` that POSTs
+ * `POST /ui-bridge/vision/mutation-occurred` (the existing
+ * `vision_mutation_occurred_handler` → `bump_mutation_id`) whenever the DOM
+ * changes from ANY source. The cache key then rotates and the next read
+ * re-renders. The invariant becomes "the read-cache key changes iff the DOM
+ * changed", regardless of what caused the change.
+ *
+ * The POST is debounced so a burst of mutations (animations, streaming text,
+ * list re-renders) coalesces into a single bump after the DOM settles, and
+ * never overlaps a previous in-flight bump. It is best-effort: a failed bump
+ * only means a vision read may serve a slightly stale frame until the next
+ * mutation, which `{"force":true}` can still override — it is not
+ * correctness-critical for the app itself.
+ */
+export function useVisionCacheInvalidation(opts?: { debounceMs?: number }): void {
+  const debounceMs = opts?.debounceMs ?? 250;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof MutationObserver === "undefined") {
+      return;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let inFlight = false;
+    let pending = false;
+
+    const bump = async () => {
+      // Coalesce: if a bump is already in flight, mark that another is owed
+      // and let the in-flight one re-schedule on completion.
+      if (inFlight) {
+        pending = true;
+        return;
+      }
+      inFlight = true;
+      try {
+        await fetch(`${getApiBase()}/ui-bridge/vision/mutation-occurred`, {
+          method: "POST",
+        });
+      } catch {
+        /* best-effort — cache freshness is an optimization, never block on it */
+      } finally {
+        inFlight = false;
+        if (pending) {
+          pending = false;
+          schedule();
+        }
+      }
+    };
+
+    const schedule = () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        void bump();
+      }, debounceMs);
+    };
+
+    const observer = new MutationObserver(schedule);
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+      attributes: true,
+    });
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [debounceMs]);
+}

--- a/src/lib/ui-bridge/UIBridgeHooks.tsx
+++ b/src/lib/ui-bridge/UIBridgeHooks.tsx
@@ -20,6 +20,8 @@ import {
   type ShortcutDef,
 } from "@qontinui/ui-bridge";
 
+import { useVisionCacheInvalidation } from "../../hooks/useVisionCacheInvalidation";
+
 // ---------------------------------------------------------------------------
 // Props — the host component (AppContent) passes live state so hooks can
 // reference real values without pulling in unrelated contexts.
@@ -121,6 +123,10 @@ export function UIBridgeHooks({
   // -------------------------------------------------------------------------
   // 0. Route Awareness (tab-based navigation — no React Router)
   // -------------------------------------------------------------------------
+
+  // Keep the runner's vision OCR read-cache fresh on event/poll-driven
+  // re-renders (not just control actions). See useVisionCacheInvalidation.
+  useVisionCacheInvalidation();
 
   const routeInfo = useMemo(() => {
     // Derive section from TAB_GROUPS


### PR DESCRIPTION
Implements plan `2026-06-05-ui-bridge-verification-read-freshness` (Phases 1, 3, and the item-3 guard). Phase 2 (occlusion-immune WebView2 capture) is deferred to its own plan `2026-06-05-occlusion-immune-window-capture`.

## Changes
- **Phase 1 — vision read-cache freshness.** New `useVisionCacheInvalidation` hook: a debounced, document-wide `MutationObserver` that POSTs `/ui-bridge/vision/mutation-occurred` on ANY DOM change. The vision OCR read-cache key only rotated on control-action (`click`/`type`) mutation-id bumps, so a UI re-rendering from a Tauri event / data poll served the first capture's OCR indefinitely (StatusStrip teardown false-verdict). The invariant becomes "cache key rotates iff the DOM changed", for all re-render sources. Wired into `UIBridgeHooks`.
- **Phase 3 — page-summary GET.** `/ui-bridge/ai/page-summary` now accepts GET as well as POST. It's a pure read; a GET on the POST-only route produced axum's framework 405 (no `text/plain` body), which slipped past `envelope_rewrite_middleware` and tripped the debug `envelope_audit` panic (surfacing as a **500** to clients — reproduced live on the primary). Added the GET to the runner-only baseline allow-list (page-summary is an `/ai/*` runner extension, not in the SDK contract).
- **Item-3 guard — honest focus failure.** `focus_runner_window` returns `Result`; `POST /gui-config/focus-window` now returns 500 instead of a false success when the window is missing or `set_focus()` errors. (The Windows foreground-lock *silent* no-op is only fully fixed by occlusion-immune capture — deferred.)

## Verification
- `cargo check --bin qontinui-runner --features custom-protocol` ✅
- `tsc --noEmit` ✅
- `cargo test manifest_matches_route_calls` + `sdk_manifest_routes_are_exposed_by_runner` ✅
- `rustfmt --check` ✅ / pre-push clippy ✅
- Temp-runner runtime check of `GET /ui-bridge/ai/page-summary` → 200 (in progress)