### PR TITLE
chore(skills): drop Focus Window step from UI Bridge Health Verify

### DIFF
--- a/src-tauri/src/skills/builtin.json
+++ b/src-tauri/src/skills/builtin.json
@@ -602,14 +602,6 @@
       "steps": [
         {
           "type": "command",
-          "name": "Focus Window",
-          "command": "curl -sf -X POST http://localhost:9876/gui-config/focus-window > /dev/null && sleep 1 && echo 'Window focused'",
-          "working_directory": ".",
-          "fail_on_error": false,
-          "timeout_seconds": 5
-        },
-        {
-          "type": "command",
           "name": "Discover Elements",
           "command": "curl -sf -X POST {{base_url}}/control/discover -H \"Content-Type: application/json\" -d '{\"interactive_only\": false}' | python -c \"import sys,json; d=json.load(sys.stdin); c=d.get('count',d.get('data',{}).get('count',0)); print(f'Discovered {c} elements')\"",
           "working_directory": ".",


### PR DESCRIPTION
## Summary

Removes the `Focus Window` step from the builtin `UI Bridge Health Verify` skill. Every remaining step is a DOM IPC read (`control/discover`, `control/snapshot`, `control/console-errors`) — none capture pixels — and the page-health capture fallback is occlusion-immune since #427 (WebView2 CapturePreview), so pre-focusing the runner window serves no purpose.

`POST /gui-config/focus-window` itself stays — it remains the explicit affordance for Python HAL full-screen capture flows (`capture-elements` / `capture-multi-state`), which screenshot the monitor and legitimately need the window foregrounded.

Completes the "drop the focus dependency" item of plan `2026-06-05-occlusion-immune-window-capture-plan` (follow-up to #427).