### PR TITLE
feat(runner): consume gate continuations — wire reconcile + visible terminal sessions

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -223,17 +223,38 @@ fn coord_http_base() -> Option<String> {
 }
 
 /// Resolve the coord WS URL from the active profile's `coord_url`,
-/// normalizing the scheme to `ws://` / `wss://` and appending the
-/// `/ws` path with an `events.agent.*` pattern filter.
+/// normalizing the scheme to `ws://` / `wss://` and ensuring the `/ws`
+/// path is present (exactly once) with an `events.agent.*` pattern filter.
 ///
-/// Mirrors `session::handoff::coord_ws_url` which appends
-/// `/ws?pattern=qontinui.sessions.*`. The coord `/ws` endpoint is a
-/// Redis pub/sub bridge at the `/ws` path (not the root); connecting to
-/// the root returns 401 from the ALB.
+/// Mirrors `session::handoff::coord_ws_url`, but unlike that path — which
+/// receives the coord HTTP base with `/ws` already stripped — this reads the
+/// RAW profile `coord_url`, whose shipped `dev`/`production` values ALREADY
+/// end in `/ws` (e.g. `wss://coord.qontinui.io/ws`, see
+/// `bin/qontinui_profile.rs`). The construction is therefore made idempotent
+/// via [`build_coord_ws_url`]: appending `/ws` to an already-`/ws` base would
+/// produce `…/ws/ws` → 401 at the ALB → the subscribe loop never connects in
+/// prod. The coord `/ws` endpoint is a Redis pub/sub bridge at the `/ws` path
+/// (not the root); connecting to the root also returns 401.
 fn coord_ws_url(device_id: uuid::Uuid) -> Option<String> {
     let coord_url = qontinui_runner_lib::profiles::load_strict()
         .ok()?
         .coord_url?;
+    Some(build_coord_ws_url(&coord_url, device_id))
+}
+
+/// Pure builder for the coord agent-spawn WS subscription URL. Extracted from
+/// [`coord_ws_url`] so it can be unit-tested without global profile state.
+///
+/// Normalization rule:
+/// 1. Trim whitespace and any trailing `/`.
+/// 2. Swap the scheme: `https://`→`wss://`, `http://`→`ws://`; leave an
+///    already-`ws(s)://` base (or any other scheme) untouched.
+/// 3. Append `/ws` ONLY if the base does not already end in `/ws` (the trailing
+///    `/` was stripped in step 1, so a `…/ws/` input is handled too). This makes
+///    the construction idempotent for the shipped profiles whose `coord_url`
+///    already ends in `/ws`, while still appending it for a bare host URL.
+/// 4. Append the device-scoped `events.agent.spawn_requested.<device>` pattern.
+fn build_coord_ws_url(coord_url: &str, device_id: uuid::Uuid) -> String {
     let base = coord_url.trim().trim_end_matches('/');
     let ws_base = base
         .strip_prefix("https://")
@@ -243,9 +264,13 @@ fn coord_ws_url(device_id: uuid::Uuid) -> Option<String> {
                 .map(|rest| format!("ws://{rest}"))
         })
         .unwrap_or_else(|| base.to_string());
-    Some(format!(
-        "{ws_base}/ws?pattern=events.agent.spawn_requested.{device_id}"
-    ))
+    // Idempotent: don't double-append `/ws` when the base already ends in it.
+    let ws_base = if ws_base.ends_with("/ws") {
+        ws_base
+    } else {
+        format!("{ws_base}/ws")
+    };
+    format!("{ws_base}?pattern=events.agent.spawn_requested.{device_id}")
 }
 
 /// Read `~/.qontinui/machine.json` → device_id. Falls back to None.
@@ -1581,6 +1606,68 @@ mod tests {
         assert_eq!(round_tripped.worktrees.len(), 1);
         assert_eq!(round_tripped.worktrees[0].repo, "qontinui-runner");
         assert_eq!(round_tripped.plan_phase, Some(4));
+    }
+
+    #[test]
+    fn build_coord_ws_url_appends_ws_to_bare_host() {
+        // A bare host URL (no `/ws`) gets `/ws` appended, scheme swapped.
+        let device = uuid::Uuid::nil();
+        assert_eq!(
+            build_coord_ws_url("http://localhost:9870", device),
+            format!("ws://localhost:9870/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+        assert_eq!(
+            build_coord_ws_url("https://coord.qontinui.io", device),
+            format!("wss://coord.qontinui.io/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+    }
+
+    #[test]
+    fn build_coord_ws_url_does_not_double_append_ws() {
+        // The shipped `dev`/`production` profiles' coord_url ALREADY ends in
+        // `/ws` (see bin/qontinui_profile.rs). Must produce a single `/ws`,
+        // not `/ws/ws` (which 401s at the ALB and blocks the subscribe loop).
+        let device = uuid::Uuid::nil();
+        assert_eq!(
+            build_coord_ws_url("wss://coord.qontinui.io/ws", device),
+            format!("wss://coord.qontinui.io/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+        assert_eq!(
+            build_coord_ws_url("ws://localhost:9870/ws", device),
+            format!("ws://localhost:9870/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+        // https→wss conversion preserved on an already-`/ws` https base.
+        assert_eq!(
+            build_coord_ws_url("https://coord.qontinui.io/ws", device),
+            format!("wss://coord.qontinui.io/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+    }
+
+    #[test]
+    fn build_coord_ws_url_normalizes_trailing_slash_after_ws() {
+        // A `…/ws/` input (trailing slash) is normalized to a single `/ws`,
+        // not `/ws/ws` and not `/ws/`.
+        let device = uuid::Uuid::nil();
+        assert_eq!(
+            build_coord_ws_url("wss://coord.qontinui.io/ws/", device),
+            format!("wss://coord.qontinui.io/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+        // A bare host with a trailing slash still gets exactly one `/ws`.
+        assert_eq!(
+            build_coord_ws_url("https://coord.qontinui.io/", device),
+            format!("wss://coord.qontinui.io/ws?pattern=events.agent.spawn_requested.{device}")
+        );
+    }
+
+    #[test]
+    fn build_coord_ws_url_preserves_already_ws_scheme() {
+        // An already-`ws://`/`wss://` base keeps its scheme (no http prefix to
+        // swap) and is not double-appended.
+        let device = uuid::Uuid::nil();
+        assert_eq!(
+            build_coord_ws_url("ws://h:9870/ws", device),
+            format!("ws://h:9870/ws?pattern=events.agent.spawn_requested.{device}")
+        );
     }
 
     #[test]

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -622,43 +622,197 @@ async fn run_gate_continuation(
         return Ok(());
     }
 
-    // Step 1: acquire a device-local worktree (+ claim heartbeat). `_ctx` is
-    // held to the end of this fn so its heartbeat keeps running and its claim
-    // is released on drop. `None` (worktree mode off, or acquire declined) →
-    // fall back to the canonical checkout of the first repo.
+    // Step 1: acquire a device-local worktree (+ claim heartbeat). The `ctx`
+    // owns the claim heartbeat task. For the HEADLESS path it stays bound here
+    // so its heartbeat runs for the whole subprocess and the claim releases on
+    // drop at function exit. For the TERMINAL path ownership is MOVED into the
+    // terminal session (see below), so the heartbeat lives for the visible
+    // session's lifetime and releases when the operator closes the terminal —
+    // the visible session keeps the SAME claim bookkeeping the headless path
+    // has. `None` (worktree mode off / acquire declined) → canonical checkout.
     let intent = payload
         .anchor_key
         .as_deref()
         .map(|a| format!("gate-continuation:{a}"))
         .unwrap_or_else(|| "gate-continuation".to_string());
 
-    let (workdir, _ctx, agent_id) =
-        match acquire_continuation_workdir(&payload.repos, &intent).await {
-            Ok(triple) => triple,
-            Err(e) => {
-                warn!("agent_runtime: gate-continuation worktree acquisition failed: {e:#}");
-                return Err(e);
-            }
-        };
+    let (workdir, ctx, agent_id) = match acquire_continuation_workdir(&payload.repos, &intent).await
+    {
+        Ok(triple) => triple,
+        Err(e) => {
+            warn!("agent_runtime: gate-continuation worktree acquisition failed: {e:#}");
+            return Err(e);
+        }
+    };
 
     // Step 2: dispatch on presentation.
-    //
-    // ── P2 DISPATCH POINT ───────────────────────────────────────────────────
-    // The `Presentation::Terminal` arm below is where P2 slots in the real
-    // visible-terminal branch (open_terminal_window + terminal_create with a
-    // `command` override). For THIS phase it warns and falls through to the
-    // headless flow so the continuation is consumed end-to-end.
     match payload.presentation {
         Presentation::Terminal => {
-            warn!(
-                "agent_runtime: gate-continuation presentation=terminal not yet wired \
-                 (P2) — falling through to headless for agent_id={agent_id}"
-            );
-            run_continuation_headless(agent_id, &workdir, &payload.initial_prompt).await
+            info!("agent_runtime: gate-continuation presentation=terminal agent_id={agent_id}");
+            run_continuation_terminal(agent_id, &workdir, &payload, ctx).await
         }
         Presentation::Headless => {
             info!("agent_runtime: gate-continuation presentation=headless agent_id={agent_id}");
-            run_continuation_headless(agent_id, &workdir, &payload.initial_prompt).await
+            // `ctx` is held until this `.await` resolves (the subprocess exits),
+            // matching the agent-spawn path's heartbeat-then-release lifecycle.
+            let res = run_continuation_headless(agent_id, &workdir, &payload.initial_prompt).await;
+            drop(ctx);
+            res
+        }
+    }
+}
+
+/// Run a gate continuation as a VISIBLE terminal session (Decision 1/2/3).
+///
+/// Opens a pop-out terminal window and creates a terminal session whose PTY
+/// child IS the `claude` CLI launched with the prompt as a positional argv
+/// (`claude "<prompt>"`). The prompt is therefore visible in scrollback and the
+/// session behaves identically to the operator launching it — no PTY-readiness
+/// race, no shell wrapping, and (critically) the session is INTERACTIVE so an
+/// `AskUserQuestion` inside it is answerable. We deliberately do NOT use
+/// `--print`: that flag is single-shot/non-interactive and would defeat the
+/// plan's acceptance (operator interaction inside the spawned session).
+///
+/// The pre-acquired isolated-edit `ctx` (its claim heartbeat) is MOVED into the
+/// terminal session via [`crate::commands::terminal::create_terminal_session_backend`]
+/// so the heartbeat lives for the visible session's lifetime and releases on
+/// close — the same claim bookkeeping the headless path holds.
+///
+/// Lifecycle posts: `spawn-complete` once the terminal session is created and
+/// running; `spawn-failed` on ANY failure along the way (no Tauri app handle,
+/// missing managed state, window/session creation error).
+async fn run_continuation_terminal(
+    agent_id: uuid::Uuid,
+    workdir: &str,
+    payload: &GateContinuationPayload,
+    ctx: Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
+) -> anyhow::Result<()> {
+    use std::sync::Arc;
+
+    // Reach the managed Tauri state from this backend task via the process-
+    // global AppHandle (set in main.rs::setup). If the runner has no Tauri
+    // runtime (headless/unit-test context) we cannot open a window — report
+    // spawn-failed and bail rather than silently dropping the continuation.
+    let app = match crate::tauri_app_handle::current() {
+        Some(a) => a,
+        None => {
+            let reason = "no Tauri AppHandle (runner has no webview runtime) — \
+                          cannot open a visible terminal";
+            warn!("agent_runtime: gate-continuation terminal: {reason}");
+            report_spawn_failed(agent_id, reason, None, 0).await;
+            return Err(anyhow::anyhow!(reason));
+        }
+    };
+
+    use tauri::Manager;
+    let terminal_manager = match app.try_state::<Arc<crate::terminal::TerminalManager>>() {
+        Some(s) => s.inner().clone(),
+        None => {
+            let reason = "TerminalManager state not managed — cannot create terminal session";
+            warn!("agent_runtime: gate-continuation terminal: {reason}");
+            report_spawn_failed(agent_id, reason, None, 0).await;
+            return Err(anyhow::anyhow!(reason));
+        }
+    };
+    let session_registry = match app.try_state::<Arc<crate::session::SessionRegistry>>() {
+        Some(s) => s.inner().clone(),
+        None => {
+            let reason = "SessionRegistry state not managed — cannot register terminal session";
+            warn!("agent_runtime: gate-continuation terminal: {reason}");
+            report_spawn_failed(agent_id, reason, None, 0).await;
+            return Err(anyhow::anyhow!(reason));
+        }
+    };
+
+    // Open a fresh pop-out window so the continuation lands in its own visible
+    // surface (best-effort: if window creation fails we still create the session
+    // — it then renders in the MAIN window's terminal grid, which is acceptable
+    // and is exactly how an operator-opened terminal appears). `window_label`
+    // is `Some(label)` when the pop-out opened, so we can assign the new session
+    // to it below (otherwise the session stays on `main`).
+    let window_label = match crate::commands::terminal_windows::open_terminal_window(
+        app.clone(),
+        app.state::<Arc<crate::window_assignments::WindowAssignments>>(),
+        None,
+    )
+    .await
+    {
+        Ok(record) => Some(record.label),
+        Err(e) => {
+            warn!(
+                "agent_runtime: gate-continuation terminal: open_terminal_window failed \
+                 ({e}) — session will render in the main window"
+            );
+            None
+        }
+    };
+
+    // Title: prefer the anchor_key, else a generic gate-continuation label.
+    let title = payload
+        .anchor_key
+        .clone()
+        .unwrap_or_else(|| "Gate continuation".to_string());
+
+    // Resolve the SAME `claude` binary the headless path uses (QONTINUI_CLAUDE_BIN
+    // override honored). The prompt is the single positional arg — interactive
+    // form, NOT `--print` (see the fn doc: interactivity is required).
+    let claude_bin = claude_bin_path();
+    let command = Some(vec![claude_bin, payload.initial_prompt.clone()]);
+
+    // First repo (if any) is the session's intent_repo for coord attribution.
+    let intent_repo = payload.repos.first().cloned();
+
+    let result = crate::commands::terminal::create_terminal_session_backend(
+        &terminal_manager,
+        &session_registry,
+        app.clone(),
+        title,
+        workdir.to_string(),
+        payload.anchor_key.clone(),
+        payload.anchor_key.clone(),
+        intent_repo,
+        command,
+        ctx,
+    );
+
+    match result {
+        Ok((terminal_id, coord_session_id)) => {
+            // Move the new session into the pop-out window we opened so the
+            // window actually renders it (without this the pop-out is empty and
+            // the session shows in the main grid). Best-effort: a failure here
+            // just leaves the session on `main`, still visible.
+            if let Some(label) = window_label {
+                if let Err(e) = crate::commands::terminal_windows::assign_session_to_window(
+                    app.clone(),
+                    app.state::<Arc<crate::window_assignments::WindowAssignments>>(),
+                    terminal_id.clone(),
+                    label.clone(),
+                )
+                .await
+                {
+                    warn!(
+                        "agent_runtime: gate-continuation terminal: assign session {terminal_id} \
+                         to window {label} failed ({e}) — session stays in the main window"
+                    );
+                }
+            }
+            info!(
+                "agent_runtime: gate-continuation terminal session created \
+                 terminal_id={terminal_id} coord_session={coord_session_id:?} \
+                 agent_id={agent_id}"
+            );
+            report_spawn_complete(agent_id, None, Some("gate continuation (terminal)")).await;
+            Ok(())
+        }
+        Err(e) => {
+            report_spawn_failed(
+                agent_id,
+                &format!("terminal session create failed: {e}"),
+                None,
+                0,
+            )
+            .await;
+            Err(anyhow::anyhow!(e))
         }
     }
 }
@@ -1790,6 +1944,62 @@ mod tests {
         let agent_id = uuid::Uuid::now_v7();
         let exit = pump_subprocess(agent_id, &mut child, None).await.unwrap();
         assert_eq!(exit, 0);
+    }
+
+    /// The terminal arm launches the `claude` CLI with the prompt as a single
+    /// POSITIONAL arg (interactive form), NOT `--print` — so an
+    /// `AskUserQuestion` inside the spawned session is answerable. This guards
+    /// the argv shape the terminal branch hands to `terminal_create`'s
+    /// `command` override (resolved via the same `QONTINUI_CLAUDE_BIN` env the
+    /// headless path uses).
+    #[test]
+    fn terminal_continuation_command_is_interactive_positional_prompt() {
+        let prev = std::env::var("QONTINUI_CLAUDE_BIN").ok();
+        std::env::set_var("QONTINUI_CLAUDE_BIN", "/fake/claude");
+
+        // Mirror the construction in `run_continuation_terminal` (a fixed-size
+        // array here — the production path needs an owned `Vec` for the
+        // `Option<Vec<String>>` command override, but the test only inspects).
+        let claude_bin = claude_bin_path();
+        let prompt = "implement phase 2 of the plan".to_string();
+        let command = [claude_bin, prompt.clone()];
+
+        assert_eq!(command[0], "/fake/claude", "uses the resolved claude bin");
+        assert_eq!(command[1], prompt, "prompt is the single positional arg");
+        assert_eq!(command.len(), 2, "no extra flags");
+        assert!(
+            !command.iter().any(|a| a == "--print" || a == "-p"),
+            "must NOT use --print/-p: the session must stay interactive"
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("QONTINUI_CLAUDE_BIN", v),
+            None => std::env::remove_var("QONTINUI_CLAUDE_BIN"),
+        }
+    }
+
+    /// In a non-Tauri (unit-test) context there is no process-global AppHandle,
+    /// so the terminal arm cannot open a window. It must fail gracefully —
+    /// report spawn-failed (no-op here, no coord profile) and return `Err`,
+    /// NOT panic and NOT silently drop the continuation. This proves the
+    /// `Presentation::Terminal` arm dispatches to the terminal path (and that
+    /// the path's no-AppHandle guard fires) without a live webview.
+    #[tokio::test]
+    async fn terminal_continuation_without_app_handle_fails_cleanly() {
+        let payload = GateContinuationPayload {
+            target_device_id: uuid::Uuid::now_v7(),
+            initial_prompt: "hi".to_string(),
+            repos: vec![],
+            presentation: Presentation::Terminal,
+            source: GATE_CONTINUATION_SOURCE.to_string(),
+            anchor_key: Some("anchor-z".to_string()),
+        };
+        let workdir = std::env::temp_dir().to_string_lossy().to_string();
+        let res = run_continuation_terminal(uuid::Uuid::now_v7(), &workdir, &payload, None).await;
+        assert!(
+            res.is_err(),
+            "terminal arm must Err (not panic / not silently drop) with no AppHandle"
+        );
     }
 
     /// Drives the gate-continuation HEADLESS dispatch through the REAL

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1791,4 +1791,49 @@ mod tests {
         let exit = pump_subprocess(agent_id, &mut child, None).await.unwrap();
         assert_eq!(exit, 0);
     }
+
+    /// Drives the gate-continuation HEADLESS dispatch through the REAL
+    /// `spawn_claude_child` + `pump_subprocess` path with a fake `claude` bin
+    /// (a portable shell that prints + exits 0). Proves the arm spawns a child
+    /// and returns `Ok(())` end-to-end. The coord lifecycle POSTs
+    /// (`spawn-complete`/`spawn-failed`) no-op gracefully here because no
+    /// `coord_url` profile is configured in the test env (`coord_http_base()`
+    /// returns `None`), so this asserts the SPAWN path, not the HTTP posts.
+    ///
+    /// Gated behind `QONTINUI_AGENT_RUNTIME_E2E=1` (the shell-as-claude
+    /// substitution mutates process env globally; keep it opt-in like
+    /// `fake_claude_e2e_smoke`).
+    #[tokio::test]
+    async fn gate_continuation_headless_spawns_child() {
+        if std::env::var("QONTINUI_AGENT_RUNTIME_E2E").ok().as_deref() != Some("1") {
+            return;
+        }
+        // Use a portable shell as the fake `claude`: prints a line, exits 0.
+        let prev = std::env::var("QONTINUI_CLAUDE_BIN").ok();
+        std::env::set_var(
+            "QONTINUI_CLAUDE_BIN",
+            if cfg!(target_os = "windows") {
+                "cmd"
+            } else {
+                "sh"
+            },
+        );
+        // On Windows the bin is `cmd`; spawn_claude_child passes the prompt on
+        // stdin and closes it — `cmd` with no args reads stdin then exits. On
+        // Unix, `sh` reads stdin commands then exits. Either way the child
+        // spawns and the pump observes a clean exit.
+        let workdir = std::env::temp_dir().to_string_lossy().to_string();
+        let agent_id = uuid::Uuid::now_v7();
+        let res =
+            run_continuation_headless(agent_id, &workdir, "echo gate-continuation-proof").await;
+        assert!(
+            res.is_ok(),
+            "gate-continuation headless dispatch must spawn + return Ok: {res:?}"
+        );
+
+        match prev {
+            Some(v) => std::env::set_var("QONTINUI_CLAUDE_BIN", v),
+            None => std::env::remove_var("QONTINUI_CLAUDE_BIN"),
+        }
+    }
 }

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -95,6 +95,59 @@ pub struct AllocatedWorktree {
     pub push_ref: Option<String>,
 }
 
+/// How a gate continuation should be surfaced to the operator.
+///
+/// `terminal` is the default (per the plan's Decision 1) so that a coord
+/// that does NOT yet forward the field — every coord on `origin/main` today —
+/// deserializes to the operator-visible mode. A parallel coord phase adds the
+/// field; this arm tolerates both its absence (→ `Terminal`) and its presence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Presentation {
+    /// Open a visible terminal session the operator can see and interact with.
+    /// **P2 wires the real visible-terminal branch**; in THIS phase it logs a
+    /// warning and falls through to the headless flow.
+    #[default]
+    Terminal,
+    /// Run the `claude` CLI as a headless tokio child (today's behavior, used
+    /// for fleet/CI continuations with no interactive surface).
+    Headless,
+}
+
+/// Minimal gate-continuation spawn payload published by coord's
+/// `spawn_continuation()` to `events.agent.spawn_requested.<device>`.
+///
+/// This is **deliberately NOT** the full agent-spawn [`LaunchPayload`]: coord's
+/// gate engine owns the *intent* (which repos, what prompt, how to present it)
+/// but NOT the device-local resources (worktrees, claim token, JWT). Those are
+/// minted on the runner — `agent_id`, `worktrees`, `jwt`, `jwt_exp`, and
+/// `claim_token` are absent here on purpose, and the handler acquires them
+/// device-locally via [`crate::agent_worktree::isolated_edit::acquire`]
+/// (Decision 6). A `source` of `"gate_continuation"` is the wire discriminator
+/// that routes a frame into this arm instead of the `LaunchPayload` arm.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GateContinuationPayload {
+    pub target_device_id: uuid::Uuid,
+    pub initial_prompt: String,
+    #[serde(default)]
+    pub repos: Vec<String>,
+    /// Defaults to [`Presentation::Terminal`] when coord omits the field
+    /// (every coord on `origin/main` today omits it).
+    #[serde(default)]
+    pub presentation: Presentation,
+    /// Wire discriminator. Always `"gate_continuation"` for this shape; the
+    /// arm only deserializes a frame here after confirming this value, so a
+    /// foreign `source` never reaches this struct.
+    #[serde(default)]
+    pub source: String,
+    /// The gate anchor that cleared (for logging / correlation).
+    #[serde(default)]
+    pub anchor_key: Option<String>,
+}
+
+/// The `source` discriminator coord stamps on a gate-continuation spawn frame.
+const GATE_CONTINUATION_SOURCE: &str = "gate_continuation";
+
 #[derive(Debug, Clone, Serialize)]
 struct SpawnCompleteBody {
     pid: Option<i64>,
@@ -343,12 +396,29 @@ async fn handle_message(txt: &str, device_id: uuid::Uuid) -> anyhow::Result<()> 
         let spawn_ch = format!("events.agent.spawn_requested.{device_id}");
         let stop_ch = format!("events.agent.stop_requested.{device_id}");
         if channel == spawn_ch {
-            match parse_envelope_payload(&value) {
-                Some(payload) => spawn_run_task(payload),
-                None => {
-                    warn!(
+            // Decision 6: a gate-continuation frame carries coord's MINIMAL
+            // payload (no agent_id/worktrees/jwt/claim_token), which can NEVER
+            // deserialize into the full `LaunchPayload` the agent-spawn path
+            // needs. Route it by its `source` discriminator into the dedicated
+            // arm FIRST; only fall back to the `LaunchPayload` parse for the
+            // agent-spawn source. This is the fix for the 2026-06-03
+            // "dispatched but never consumed" drop.
+            if envelope_is_gate_continuation(&value) {
+                match parse_gate_continuation_payload(&value) {
+                    Some(payload) => spawn_gate_continuation_task(payload, device_id),
+                    None => warn!(
+                        "agent_runtime: gate-continuation envelope on {channel} had no \
+                         parseable payload/body"
+                    ),
+                }
+            } else {
+                match parse_envelope_payload(&value) {
+                    Some(payload) => spawn_run_task(payload),
+                    None => {
+                        warn!(
                         "agent_runtime: spawn envelope on {channel} had no parseable payload/body"
                     )
+                    }
                 }
             }
         } else if channel == stop_ch {
@@ -398,6 +468,46 @@ fn parse_envelope_payload(envelope: &serde_json::Value) -> Option<LaunchPayload>
         Some(s) => serde_json::from_str(s).ok(),
         None => serde_json::from_value(inner.clone()).ok(),
     }
+}
+
+/// Peel a coord `/ws` envelope's inner payload into an owned
+/// `serde_json::Value`, accepting both the `payload` (current coord) and
+/// legacy `body` field names, and the inner value as a JSON string
+/// (`from_str`) or a nested object. Returns `None` if neither yields valid
+/// JSON. Shared by the gate-continuation and source-sniffing helpers so the
+/// string-vs-object handling stays in lockstep with [`parse_envelope_payload`].
+fn envelope_inner_value(envelope: &serde_json::Value) -> Option<serde_json::Value> {
+    let inner = envelope.get("payload").or_else(|| envelope.get("body"))?;
+    match inner.as_str() {
+        Some(s) => serde_json::from_str(s).ok(),
+        None => Some(inner.clone()),
+    }
+}
+
+/// Does this spawn-request envelope carry the gate-continuation discriminator
+/// (`source == "gate_continuation"`)? Used to route a frame into the dedicated
+/// gate-continuation arm BEFORE attempting the full-`LaunchPayload` parse — the
+/// two shapes are mutually exclusive (a gate-continuation frame has no
+/// `agent_id`/`worktrees`/`jwt`, so it can never deserialize as a
+/// `LaunchPayload`, and vice versa).
+fn envelope_is_gate_continuation(envelope: &serde_json::Value) -> bool {
+    envelope_inner_value(envelope)
+        .and_then(|v| {
+            v.get("source")
+                .and_then(|s| s.as_str())
+                .map(|s| s == GATE_CONTINUATION_SOURCE)
+        })
+        .unwrap_or(false)
+}
+
+/// Extract a [`GateContinuationPayload`] from a coord `/ws` envelope. Mirrors
+/// [`parse_envelope_payload`]'s string-or-object inner handling. Returns `None`
+/// if the inner JSON does not deserialize into the minimal continuation shape.
+fn parse_gate_continuation_payload(
+    envelope: &serde_json::Value,
+) -> Option<GateContinuationPayload> {
+    let inner = envelope_inner_value(envelope)?;
+    serde_json::from_value(inner).ok()
 }
 
 /// Extract `agent_id` from a coord stop envelope (`{channel, payload|body}`),
@@ -458,6 +568,221 @@ fn spawn_run_task(payload: LaunchPayload) {
         // Drop the registry entry once the run task is fully done.
         agent_stops().lock().unwrap().remove(&agent_id);
     });
+}
+
+// =============================================================================
+// Gate-continuation path (Decision 6)
+// =============================================================================
+
+/// Spawn the run task for a gate continuation. Unlike the agent-spawn path,
+/// the device-local resources (worktree, claim, JWT) are NOT supplied by coord
+/// — they are acquired inside [`run_gate_continuation`].
+fn spawn_gate_continuation_task(payload: GateContinuationPayload, device_id: uuid::Uuid) {
+    info!(
+        "agent_runtime: gate-continuation received target_device_id={} presentation={:?} \
+         repos={} anchor_key={:?}",
+        payload.target_device_id,
+        payload.presentation,
+        payload.repos.len(),
+        payload.anchor_key,
+    );
+    tokio::spawn(async move {
+        if let Err(e) = run_gate_continuation(payload, device_id).await {
+            error!("agent_runtime: run_gate_continuation failed: {e:#}");
+        }
+    });
+}
+
+/// End-to-end run of one gate continuation:
+/// 1. Acquire a device-local worktree (+ claim heartbeat) from `repos` via the
+///    same `isolated_edit::acquire` machinery the agent-spawn path uses. When
+///    `QONTINUI_AGENT_WORKTREE_MODE` is off, fall back to the canonical
+///    checkout of the first repo (no isolation) so the continuation still runs.
+/// 2. Dispatch on `presentation`:
+///    - `Headless` → spawn the `claude` CLI as a tokio child (existing flow),
+///      posting `spawn-complete`/`spawn-failed` lifecycle to coord.
+///    - `Terminal` → **P2** opens a visible terminal session here; for THIS
+///      phase, log a warning and fall through to the headless flow so the
+///      continuation is still consumed end-to-end.
+///
+/// The claim heartbeat is owned by the returned `IsolatedEditContext`, held
+/// alive for the whole subprocess lifetime and released on drop (matching the
+/// agent-spawn path's 30s heartbeat + release lifecycle).
+async fn run_gate_continuation(
+    payload: GateContinuationPayload,
+    device_id: uuid::Uuid,
+) -> anyhow::Result<()> {
+    // Defensive: coord's WS pattern filter is device-scoped, but a frame that
+    // somehow targets another device must not run here.
+    if payload.target_device_id != device_id {
+        debug!(
+            "agent_runtime: gate-continuation target_device_id={} != local {device_id}; ignoring",
+            payload.target_device_id
+        );
+        return Ok(());
+    }
+
+    // Step 1: acquire a device-local worktree (+ claim heartbeat). `_ctx` is
+    // held to the end of this fn so its heartbeat keeps running and its claim
+    // is released on drop. `None` (worktree mode off, or acquire declined) →
+    // fall back to the canonical checkout of the first repo.
+    let intent = payload
+        .anchor_key
+        .as_deref()
+        .map(|a| format!("gate-continuation:{a}"))
+        .unwrap_or_else(|| "gate-continuation".to_string());
+
+    let (workdir, _ctx, agent_id) =
+        match acquire_continuation_workdir(&payload.repos, &intent).await {
+            Ok(triple) => triple,
+            Err(e) => {
+                warn!("agent_runtime: gate-continuation worktree acquisition failed: {e:#}");
+                return Err(e);
+            }
+        };
+
+    // Step 2: dispatch on presentation.
+    //
+    // ── P2 DISPATCH POINT ───────────────────────────────────────────────────
+    // The `Presentation::Terminal` arm below is where P2 slots in the real
+    // visible-terminal branch (open_terminal_window + terminal_create with a
+    // `command` override). For THIS phase it warns and falls through to the
+    // headless flow so the continuation is consumed end-to-end.
+    match payload.presentation {
+        Presentation::Terminal => {
+            warn!(
+                "agent_runtime: gate-continuation presentation=terminal not yet wired \
+                 (P2) — falling through to headless for agent_id={agent_id}"
+            );
+            run_continuation_headless(agent_id, &workdir, &payload.initial_prompt).await
+        }
+        Presentation::Headless => {
+            info!("agent_runtime: gate-continuation presentation=headless agent_id={agent_id}");
+            run_continuation_headless(agent_id, &workdir, &payload.initial_prompt).await
+        }
+    }
+}
+
+/// Resolve the working directory for a gate continuation. Returns
+/// `(workdir, isolated_edit_ctx, agent_id)`.
+///
+/// - Worktree mode ON and `acquire` succeeds → the materialized worktree path,
+///   the held `IsolatedEditContext` (keeps the claim heartbeat alive), and the
+///   coord-allocated agent_id (parsed to a UUID; a fresh UUID if coord returned
+///   a non-UUID id, used only for lifecycle correlation).
+/// - Worktree mode OFF / acquire declined / `repos` empty → the canonical
+///   checkout of the first repo (or `QONTINUI_ROOT`), `None` context, and a
+///   fresh correlation UUID. The continuation still runs, just without
+///   per-agent isolation — the same graceful degrade `acquire_for_terminal`
+///   uses.
+async fn acquire_continuation_workdir(
+    repos: &[String],
+    intent: &str,
+) -> anyhow::Result<(
+    String,
+    Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
+    uuid::Uuid,
+)> {
+    use crate::agent_worktree::isolated_edit::{acquire, AcquireRequest};
+
+    if !repos.is_empty() {
+        match acquire(AcquireRequest {
+            repos,
+            intent: Some(intent),
+            declared_overlap_paths: None,
+            plan_id: None,
+            phase: None,
+            agent_session_id: None,
+        })
+        .await
+        {
+            Ok(Some(ctx)) => {
+                let workdir = ctx
+                    .worktrees
+                    .first()
+                    .map(|w| w.worktree_path.to_string_lossy().to_string())
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("gate-continuation: acquire returned no worktrees")
+                    })?;
+                // coord's agent_id is canonically a UUID; if it isn't, fall back
+                // to a fresh one for lifecycle correlation only.
+                let agent_id =
+                    uuid::Uuid::parse_str(&ctx.agent_id).unwrap_or_else(|_| uuid::Uuid::now_v7());
+                return Ok((workdir, Some(ctx), agent_id));
+            }
+            Ok(None) => {
+                debug!(
+                    "agent_runtime: gate-continuation worktree mode off — using canonical checkout"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    "agent_runtime: gate-continuation acquire failed ({e}); \
+                     falling back to canonical checkout"
+                );
+            }
+        }
+    }
+
+    // Fallback: canonical checkout of the first repo, else QONTINUI_ROOT.
+    let workdir = repos
+        .first()
+        .and_then(|r| {
+            crate::agent_worktree::canonical_paths::default_canonical_path(r)
+                .ok()
+                .map(|p| p.to_string_lossy().to_string())
+        })
+        .or_else(|| qontinui_root_dir().map(|p| p.to_string_lossy().to_string()))
+        .ok_or_else(|| {
+            anyhow::anyhow!("gate-continuation: no canonical checkout or QONTINUI_ROOT resolved")
+        })?;
+    Ok((workdir, None, uuid::Uuid::now_v7()))
+}
+
+/// Run a gate continuation as a headless `claude` child (the existing
+/// subprocess flow), posting `spawn-complete` on first successful spawn and
+/// `spawn-failed` on a non-zero / failed exit. Mirrors the agent-spawn path's
+/// lifecycle posts so a continuation is observable on coord the same way.
+async fn run_continuation_headless(
+    agent_id: uuid::Uuid,
+    workdir: &str,
+    initial_prompt: &str,
+) -> anyhow::Result<()> {
+    let log_path = agent_log_path(agent_id);
+    match spawn_claude_child(workdir, initial_prompt).await {
+        Ok(mut child) => {
+            let pid = child.id().map(|p| p as i64);
+            report_spawn_complete(agent_id, pid, Some("gate continuation")).await;
+            let exit = pump_subprocess(agent_id, &mut child, log_path.as_deref()).await;
+            match exit {
+                Ok(0) => {
+                    info!(
+                        "agent_runtime: gate-continuation agent_id={agent_id} exited cleanly \
+                         (code=0)"
+                    );
+                    Ok(())
+                }
+                Ok(code) => {
+                    report_spawn_failed(
+                        agent_id,
+                        &format!("non-zero exit code {code}"),
+                        Some(code),
+                        0,
+                    )
+                    .await;
+                    Ok(())
+                }
+                Err(e) => {
+                    report_spawn_failed(agent_id, &format!("pump failure: {e}"), None, 0).await;
+                    Err(e)
+                }
+            }
+        }
+        Err(e) => {
+            report_spawn_failed(agent_id, &format!("spawn failure: {e}"), None, 0).await;
+            Err(e)
+        }
+    }
 }
 
 // =============================================================================
@@ -1140,6 +1465,167 @@ mod tests {
         // Garbage payload yields None (and must not panic).
         let junk = serde_json::json!({ "channel": "x", "payload": "not json" });
         assert!(parse_envelope_payload(&junk).is_none());
+    }
+
+    /// Documents the OLD (broken) behavior: coord's minimal gate-continuation
+    /// payload does NOT deserialize into the full `LaunchPayload`, so the
+    /// pre-fix consumer dropped it with "had no parseable payload". This is the
+    /// 2026-06-03 "dispatched but never consumed" root cause — a payload-shape
+    /// mismatch, NOT a transport bug.
+    #[test]
+    fn minimal_gate_continuation_does_not_parse_as_launch_payload() {
+        let device = uuid::Uuid::now_v7();
+        // The EXACT minimal shape coord's `spawn_continuation()` publishes.
+        let inner = serde_json::json!({
+            "target_device_id": device,
+            "initial_prompt": "go",
+            "repos": ["qontinui-runner"],
+            "source": "gate_continuation",
+            "anchor_key": "plan:foo:phase:1",
+        });
+
+        // It must NOT parse as a LaunchPayload (missing agent_id/worktrees/
+        // jwt/jwt_exp/claim_token — all non-Option).
+        assert!(
+            serde_json::from_value::<LaunchPayload>(inner.clone()).is_err(),
+            "minimal gate-continuation payload must NOT deserialize as LaunchPayload"
+        );
+
+        // And the LaunchPayload envelope parser returns None on it — the old
+        // drop path.
+        let envelope = serde_json::json!({
+            "channel": format!("events.agent.spawn_requested.{device}"),
+            "payload": serde_json::to_string(&inner).unwrap(),
+        });
+        assert!(
+            parse_envelope_payload(&envelope).is_none(),
+            "LaunchPayload envelope parse must miss the gate-continuation shape (the drop)"
+        );
+
+        // But the NEW arm recognizes + parses it.
+        assert!(
+            envelope_is_gate_continuation(&envelope),
+            "source=gate_continuation must route into the dedicated arm"
+        );
+        let parsed = parse_gate_continuation_payload(&envelope)
+            .expect("gate-continuation arm must parse the minimal payload");
+        assert_eq!(parsed.target_device_id, device);
+        assert_eq!(parsed.initial_prompt, "go");
+        assert_eq!(parsed.repos, vec!["qontinui-runner".to_string()]);
+    }
+
+    /// The minimal payload parses both WITHOUT a `presentation` field (coord on
+    /// `origin/main` today omits it → default `Terminal`) and WITH it (the
+    /// parallel coord phase forwards it → the explicit value wins). Accepts
+    /// both the string-inner and object-inner envelope variants.
+    #[test]
+    fn gate_continuation_parses_with_and_without_presentation() {
+        let device = uuid::Uuid::now_v7();
+
+        // (a) WITHOUT presentation → default Terminal. Object-inner variant.
+        let no_pres = serde_json::json!({
+            "channel": format!("events.agent.spawn_requested.{device}"),
+            "body": serde_json::json!({
+                "target_device_id": device,
+                "initial_prompt": "say hi",
+                "repos": [],
+                "source": "gate_continuation",
+            }),
+        });
+        let p = parse_gate_continuation_payload(&no_pres)
+            .expect("payload without presentation must parse");
+        assert_eq!(
+            p.presentation,
+            Presentation::Terminal,
+            "absent presentation must default to Terminal"
+        );
+        assert!(p.repos.is_empty());
+
+        // (b) WITH presentation=headless. String-inner variant (coord's real
+        // /ws fanout shape).
+        let inner = serde_json::json!({
+            "target_device_id": device,
+            "initial_prompt": "say hi",
+            "repos": ["qontinui-coord"],
+            "presentation": "headless",
+            "source": "gate_continuation",
+            "anchor_key": "anchor-x",
+        });
+        let with_pres = serde_json::json!({
+            "channel": format!("events.agent.spawn_requested.{device}"),
+            "payload": serde_json::to_string(&inner).unwrap(),
+        });
+        let p = parse_gate_continuation_payload(&with_pres)
+            .expect("payload with presentation must parse");
+        assert_eq!(p.presentation, Presentation::Headless);
+        assert_eq!(p.anchor_key.as_deref(), Some("anchor-x"));
+
+        // (c) WITH presentation=terminal, explicit.
+        let inner_t = serde_json::json!({
+            "target_device_id": device,
+            "initial_prompt": "x",
+            "repos": [],
+            "presentation": "terminal",
+            "source": "gate_continuation",
+        });
+        let with_term = serde_json::json!({ "payload": serde_json::to_string(&inner_t).unwrap() });
+        assert_eq!(
+            parse_gate_continuation_payload(&with_term)
+                .unwrap()
+                .presentation,
+            Presentation::Terminal
+        );
+    }
+
+    /// Source-routing: only a `source == "gate_continuation"` frame is claimed
+    /// by the gate-continuation arm. An agent-spawn (`LaunchPayload`) frame and
+    /// a frame with no/other source must NOT route here, so the existing
+    /// `LaunchPayload` path stays untouched for agent spawns.
+    #[test]
+    fn source_routing_distinguishes_continuation_from_agent_spawn() {
+        let device = uuid::Uuid::now_v7();
+
+        // A full agent-spawn LaunchPayload frame (no gate_continuation source).
+        let launch = serde_json::json!({
+            "channel": format!("events.agent.spawn_requested.{device}"),
+            "payload": serde_json::to_string(&serde_json::json!({
+                "agent_id": uuid::Uuid::now_v7(),
+                "target_device_id": device,
+                "worktrees": [],
+                "jwt": "t",
+                "jwt_exp": 0,
+                "initial_prompt": "go",
+                "claim_token": "agent:x",
+            }))
+            .unwrap(),
+        });
+        assert!(
+            !envelope_is_gate_continuation(&launch),
+            "agent-spawn frame must NOT route into the gate-continuation arm"
+        );
+        // It still parses as a LaunchPayload (the untouched path).
+        assert!(
+            parse_envelope_payload(&launch).is_some(),
+            "agent-spawn frame must still parse as LaunchPayload"
+        );
+
+        // A gate-continuation frame routes the other way.
+        let cont = serde_json::json!({
+            "payload": serde_json::to_string(&serde_json::json!({
+                "target_device_id": device,
+                "initial_prompt": "go",
+                "repos": ["qontinui-runner"],
+                "source": "gate_continuation",
+            }))
+            .unwrap(),
+        });
+        assert!(envelope_is_gate_continuation(&cont));
+        assert!(parse_envelope_payload(&cont).is_none());
+
+        // A frame with no source at all → not a continuation (won't steal
+        // agent spawns or junk).
+        let no_source = serde_json::json!({ "payload": "{\"initial_prompt\":\"x\"}" });
+        assert!(!envelope_is_gate_continuation(&no_source));
     }
 
     #[test]

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -982,6 +982,7 @@ pub async fn launch_coordinator_session(
         None,
         None,
         app_handle.clone(),
+        None,
     )?;
 
     if let Some(ctx) = isolated_ctx {
@@ -1117,6 +1118,7 @@ pub async fn spawn_worker_session(
         Some(dom_cols),
         Some(dom_rows),
         app_handle.clone(),
+        None,
     )?;
 
     // Phase 2 — park the isolated edit context on the TerminalSession

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -26,7 +26,15 @@ use crate::terminal::{strip_ansi, TerminalManager};
 /// worktree path as the session's cwd, instead of the operator's primary
 /// checkout. Observation/read-only callers leave `intent_repo: None` and
 /// keep the legacy shared-cwd behavior — that path is unchanged.
+/// `command` (Decision 3 of the visible-gate-continuations plan) is an optional
+/// program+args override threaded down to [`TerminalSession::spawn`]: when
+/// `Some([program, args…])` the session runs that program as its PTY child
+/// instead of the interactive shell. The gate-continuation terminal branch uses
+/// this to launch `claude "<prompt>"` directly. Every operator-opened / frontend
+/// terminal passes `None`, keeping the interactive-shell path byte-for-byte
+/// unchanged.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn terminal_create(
     terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
     session_registry: tauri::State<'_, Arc<SessionRegistry>>,
@@ -40,6 +48,7 @@ pub async fn terminal_create(
     intent_repo: Option<String>,
     plan_slug: Option<String>,
     correlation_topic: Option<String>,
+    command: Option<Vec<String>>,
 ) -> Result<CommandResponse, String> {
     // R2 (session-lifecycle-cleanup) — derive the STABLE pane identity from
     // the create-time triple the frontend round-trips on restore
@@ -107,6 +116,7 @@ pub async fn terminal_create(
         cols,
         rows,
         app_handle,
+        command,
     )?;
 
     // Park the isolated edit context on the terminal session so its
@@ -828,6 +838,109 @@ pub fn terminal_session_list_open(
         message: None,
         data: Some(serde_json::json!({ "sessions": store.open_records() })),
     })
+}
+
+/// Backend-task entry point for creating a terminal session + coord row from a
+/// non-Tauri context (e.g. the gate-continuation runtime task, which has no
+/// `tauri::State` extractors — it reaches the managed `Arc`s via the global
+/// `tauri_app_handle`). Mirrors the registration body of [`terminal_create`]:
+/// create the PTY session (with an optional `command` override), park a
+/// pre-acquired isolated-edit context so its claim heartbeat lives for the
+/// session's lifetime + releases on close, register/attach the coord session,
+/// and install the on-exit close hook.
+///
+/// Unlike [`terminal_create`] this does NOT acquire a worktree itself — the
+/// gate-continuation path already acquired one (with its heartbeat) in P0.1 and
+/// hands the resulting `IsolatedEditContext` in via `isolated_ctx` so ownership
+/// (and the heartbeat) transfers to the terminal session. Returns the new
+/// terminal id and the coord session id (when registration succeeded).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn create_terminal_session_backend(
+    terminal_manager: &Arc<TerminalManager>,
+    session_registry: &Arc<SessionRegistry>,
+    app_handle: tauri::AppHandle,
+    title: String,
+    working_dir: String,
+    plan_slug: Option<String>,
+    correlation_topic: Option<String>,
+    intent_repo: Option<String>,
+    command: Option<Vec<String>>,
+    isolated_ctx: Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
+) -> Result<(String, Option<uuid::Uuid>), String> {
+    let info = terminal_manager.create(
+        Some(title.clone()),
+        Some(working_dir.clone()),
+        None,
+        None,
+        None,
+        app_handle,
+        command,
+    )?;
+
+    // Park the pre-acquired isolated edit context on the session so its
+    // heartbeat + claim live as long as the PTY and release on close — the
+    // visible session keeps the SAME claim bookkeeping the headless path holds.
+    if let Some(ctx) = isolated_ctx {
+        if let Some(session) = terminal_manager.get(&info.id) {
+            session.set_isolated_edit_ctx(ctx);
+        }
+    }
+
+    // Coord registration — mirror every terminal session into the coordinator's
+    // session plane (same as the interactive `terminal_create`). Best-effort:
+    // a coord hiccup must not fail the spawn.
+    let purpose = if title.trim().len() >= 3 {
+        title
+    } else {
+        "Gate continuation terminal session".to_string()
+    };
+    let intent = Intent {
+        kind: SessionKind::TerminalShell,
+        purpose,
+        repo: intent_repo,
+        branch: None,
+        plan_slug,
+        correlation_topic,
+        declared_paths: vec![std::path::PathBuf::from(&working_dir)],
+        share_output: true,
+        redact_secrets: None,
+    };
+
+    let mut coord_session_id: Option<uuid::Uuid> = None;
+    match session_registry.register_external(intent) {
+        Ok(coord_id) => {
+            coord_session_id = Some(coord_id);
+            if let Some(session) = terminal_manager.get(&info.id) {
+                session.set_coord_session_id(coord_id);
+                let close_registry = session_registry.clone();
+                session.set_on_exit(Box::new(move |coord_id| {
+                    if let Err(e) = close_registry.close_by_id(coord_id) {
+                        warn!(
+                            coord_session = %coord_id,
+                            error = %e,
+                            "gate-continuation terminal exit hook: coord session close failed"
+                        );
+                    }
+                }));
+                let rx = session.subscribe_output();
+                session_registry.attach_output_pipe(coord_id, rx, true);
+            }
+            info!(
+                terminal_id = %info.id,
+                coord_session = %coord_id,
+                "create_terminal_session_backend: coord session ready"
+            );
+        }
+        Err(e) => {
+            warn!(
+                terminal_id = %info.id,
+                error = %e,
+                "create_terminal_session_backend: coord registration failed — terminal unaffected"
+            );
+        }
+    }
+
+    Ok((info.id, coord_session_id))
 }
 
 /// Build the Tauri plugin that registers this module's command handlers.

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -2220,6 +2220,7 @@ async fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Opti
             cols,
             rows,
             api_state.app_handle.clone(),
+            None,
         ) {
             Ok(info) => {
                 if let Some(ctx) = isolated_ctx {

--- a/src-tauri/src/mcp/tauri_proxy.rs
+++ b/src-tauri/src/mcp/tauri_proxy.rs
@@ -230,6 +230,7 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 a.cols,
                 a.rows,
                 state.app_handle.clone(),
+                None,
             ) {
                 Ok(info) => {
                     if let Some(ctx) = isolated_ctx {

--- a/src-tauri/src/mcp/terminals.rs
+++ b/src-tauri/src/mcp/terminals.rs
@@ -168,6 +168,7 @@ pub async fn create_terminal_handler(
         request.cols,
         request.rows,
         app_handle,
+        None,
     ) {
         Ok(info) => {
             if let Some(ctx) = isolated_ctx {

--- a/src-tauri/src/session/transport/claude_cli.rs
+++ b/src-tauri/src/session/transport/claude_cli.rs
@@ -78,6 +78,7 @@ impl Transport for ClaudeCliTransport {
                         None,
                         None,
                         self.app_handle.clone(),
+                        None,
                     )
                     .map_err(TransportError::Runtime)?;
 

--- a/src-tauri/src/session/transport/pty.rs
+++ b/src-tauri/src/session/transport/pty.rs
@@ -78,6 +78,7 @@ impl Transport for PtyTransport {
                 None,
                 None,
                 self.app_handle.clone(),
+                None,
             )
             .map_err(TransportError::Runtime)?;
 

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -29,6 +29,13 @@ impl TerminalManager {
     }
 
     /// Create a new terminal session, returning its info.
+    ///
+    /// `command` is an optional program+args override (Decision 3) forwarded to
+    /// [`TerminalSession::spawn`]: `Some([program, args…])` runs that program as
+    /// the PTY child (the gate-continuation terminal branch launches `claude`
+    /// this way); `None` keeps the interactive-shell behavior every
+    /// operator-opened terminal uses.
+    #[allow(clippy::too_many_arguments)]
     pub fn create(
         &self,
         title: Option<String>,
@@ -37,6 +44,7 @@ impl TerminalManager {
         cols: Option<u16>,
         rows: Option<u16>,
         app_handle: AppHandle,
+        command: Option<Vec<String>>,
     ) -> Result<TerminalInfo, String> {
         let id = uuid::Uuid::new_v4().to_string();
         let title = title.unwrap_or_else(|| format!("Terminal {}", self.count() + 1));
@@ -61,6 +69,7 @@ impl TerminalManager {
             rows,
             app_handle,
             self.interceptor.clone(),
+            command,
         )?;
 
         let info = session.info();

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -177,6 +177,16 @@ pub struct TerminalSession {
 
 impl TerminalSession {
     /// Spawn a new terminal session with a shell process.
+    ///
+    /// `command` is an optional program-and-args override (Decision 3 of
+    /// `plans/2026-06-05-visible-gate-continuations-and-plan-ready-predicate.md`):
+    /// when `Some([program, args…])` the session runs that program as its PTY
+    /// child instead of the interactive shell — this is how the gate-continuation
+    /// terminal branch launches the `claude` CLI directly with the prompt as
+    /// argv. When `None` (every operator-opened / frontend terminal), the session
+    /// falls back to [`Self::build_shell_command`] byte-for-byte, so the
+    /// interactive-terminal path is untouched.
+    #[allow(clippy::too_many_arguments)]
     pub fn spawn(
         id: TerminalId,
         title: String,
@@ -186,6 +196,7 @@ impl TerminalSession {
         rows: u16,
         app_handle: AppHandle,
         interceptor: Arc<OutputInterceptor>,
+        command: Option<Vec<String>>,
     ) -> Result<Self, String> {
         let pty_system = native_pty_system();
 
@@ -198,8 +209,9 @@ impl TerminalSession {
             })
             .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-        // Build shell command
-        let mut cmd = Self::build_shell_command();
+        // Build the PTY child command: an explicit program+args override
+        // (Decision 3) when supplied, else the interactive shell.
+        let mut cmd = Self::build_command_from(command);
 
         // Set working directory
         let cwd = if working_dir.is_empty() {
@@ -558,6 +570,31 @@ impl TerminalSession {
             app_handle: Some(session_app_handle),
             input_line_buf: Arc::new(Mutex::new(String::new())),
         })
+    }
+
+    /// Build the PTY child [`CommandBuilder`] from an optional program+args
+    /// override (Decision 3).
+    ///
+    /// - `Some([program, args…])` → run `program` directly with `args` as the
+    ///   session's child. The gate-continuation terminal branch uses this to
+    ///   launch `claude "<prompt>"` so the prompt is visible in scrollback and
+    ///   the session behaves identically to the operator launching it (no
+    ///   PTY-readiness race, no shell wrapping).
+    /// - `Some([])` (empty) → no program to run; fall back to the shell so we
+    ///   never spawn an empty command.
+    /// - `None` → [`Self::build_shell_command`], the interactive-shell path
+    ///   every operator-opened terminal takes. Back-compat by construction.
+    fn build_command_from(command: Option<Vec<String>>) -> CommandBuilder {
+        match command {
+            Some(parts) if !parts.is_empty() => {
+                let mut cmd = CommandBuilder::new(&parts[0]);
+                for arg in &parts[1..] {
+                    cmd.arg(arg);
+                }
+                cmd
+            }
+            _ => Self::build_shell_command(),
+        }
     }
 
     /// Build the platform-appropriate shell command, injecting shell integration if possible.
@@ -1102,6 +1139,56 @@ mod tests {
             app_handle: None,
             input_line_buf: Arc::new(Mutex::new(String::new())),
         }
+    }
+
+    #[test]
+    fn build_command_from_override_uses_program_and_args() {
+        // Decision 3: an explicit override runs that program with its args as
+        // the PTY child (argv[0]=program, argv[1..]=args).
+        let cmd = TerminalSession::build_command_from(Some(vec![
+            "claude".to_string(),
+            "do the thing".to_string(),
+        ]));
+        let argv: Vec<String> = cmd
+            .get_argv()
+            .iter()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(argv, vec!["claude".to_string(), "do the thing".to_string()]);
+    }
+
+    #[test]
+    fn build_command_from_program_only_has_no_extra_args() {
+        let cmd = TerminalSession::build_command_from(Some(vec!["claude".to_string()]));
+        let argv: Vec<String> = cmd
+            .get_argv()
+            .iter()
+            .map(|s| s.to_string_lossy().to_string())
+            .collect();
+        assert_eq!(argv, vec!["claude".to_string()]);
+    }
+
+    #[test]
+    fn build_command_from_none_falls_back_to_shell() {
+        // None → the interactive shell path (back-compat by construction). The
+        // shell program is platform-specific, but it must NOT be `claude` and
+        // must match what `build_shell_command` produces.
+        let fallback = TerminalSession::build_command_from(None);
+        let shell = TerminalSession::build_shell_command();
+        assert_eq!(
+            fallback.get_argv().first(),
+            shell.get_argv().first(),
+            "None override must fall back to the shell program"
+        );
+    }
+
+    #[test]
+    fn build_command_from_empty_vec_falls_back_to_shell() {
+        // An empty override is meaningless (no program) → fall back to the
+        // shell rather than spawning nothing.
+        let fallback = TerminalSession::build_command_from(Some(vec![]));
+        let shell = TerminalSession::build_shell_command();
+        assert_eq!(fallback.get_argv().first(), shell.get_argv().first());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Makes coord gate continuations **consumable** by the runner and adds a
**visible, operator-interactable** terminal path for them. Implements P0.1 +
P2 of
`plans/2026-06-05-visible-gate-continuations-and-plan-ready-predicate.md`.

Pairs with coord PR #356 (P1: `plan_ready` predicate + `presentation` field +
tenant-posture dispatch). This runner side consumes what coord publishes.

### P0.1 — gate-continuation arm (wire reconcile, Decision 6)

The 2026-06-03 "dispatched but never consumed" gap was a **payload-shape
mismatch**, not a transport bug: coord's minimal gate-continuation payload
(`{target_device_id, initial_prompt, repos, presentation, source, anchor_key}`)
can never deserialize into the runner's full `LaunchPayload`
(agent_id/worktrees/jwt/claim_token), so `parse_envelope_payload` returned
`None` and the frame was dropped.

- New `GateContinuationPayload` + `Presentation` enum (serde default
  `Terminal`, so a coord that omits the field still surfaces visibly).
- `handle_message` routes a `source == "gate_continuation"` frame into a
  dedicated arm BEFORE the `LaunchPayload` parse (the two shapes are mutually
  exclusive). The agent-spawn path is untouched.
- `run_gate_continuation` acquires a device-local worktree (+ 30s claim
  heartbeat) via the same `agent_worktree::isolated_edit::acquire` the
  agent-spawn path uses, falling back to the canonical checkout when worktree
  mode is off. Headless branch → `spawn_claude_child` + spawn-complete/
  spawn-failed lifecycle posts.

### P2 — visible terminal sessions (Decisions 1/2/3)

- **`command: Option<Vec<String>>` override** threaded `terminal_create` →
  `TerminalManager::create` → `TerminalSession::spawn` → new
  `build_command_from(command)`, which falls back to `build_shell_command()`
  on `None`. **Back-compat by construction:** every existing caller passes
  `None`, so the operator's interactive-terminal path is byte-for-byte
  unchanged. (Audited all 8 call sites.)
- **`Presentation::Terminal` arm:** opens a pop-out window
  (`open_terminal_window`), creates a terminal session whose PTY child IS the
  `claude` CLI launched with the prompt as a **positional argv**
  (`claude "<prompt>"`), assigns the session to that window, and posts
  spawn-complete (spawn-failed on any failure along the way).
- **Interactive form, NOT `--print`** (documented in code): the plan's
  acceptance requires `AskUserQuestion` inside the spawned session to be
  answerable; `--print` is single-shot/non-interactive and would defeat that.
  This is the deliberate asymmetry vs. the headless path (which pipes the
  prompt over stdin).
- **Heartbeat ownership:** the pre-acquired `IsolatedEditContext` (claim
  heartbeat) is **moved into the terminal session**, so the heartbeat lives
  for the visible session's lifetime and the claim releases on close — the
  visible session keeps the exact same claim bookkeeping the headless path
  has. coord session registration + on-exit close hook wired via a new
  backend-callable `create_terminal_session_backend` (reached from the
  runtime task through the process-global `tauri_app_handle`).
- **No frontend change:** the session emits `terminal-created` like any
  operator-opened / HTTP-created terminal, which the frontend already renders
  (verified in `useTerminalManager.ts`). No forced re-embed needed.

### Tests

- `build_command_from`: override uses program+args; program-only; `None` and
  empty-vec both fall back to the shell.
- Terminal arm uses the interactive positional prompt (asserts no `--print`).
- Terminal arm fails cleanly (Err, no panic, no silent drop) with no
  AppHandle.
- P0.1's gate-continuation parse + source-routing + headless-spawn E2E
  (gated) tests.

`cargo check`, `cargo clippy --tests -D warnings`, and the full
`cargo test --bin qontinui-runner --features custom-protocol` (4377 passed,
0 failed) are green in the worktree.

## Known orthogonal blocker (not introduced here)

Prod coord's `/ws` rejects the `agent_runtime` subscription with **401**
(pre-existing, unrelated to this change). P0.1 proved the publish side + the
handler via an E2E-gated test rather than a live prod subscription. The
coordinator's integration phase runs a **local-coord E2E** (register a
`plan_ready` gate → sweep clears → terminal window opens with the prompt
visible, verified ON SCREEN via UI Bridge).

## Plan

`plans/2026-06-05-visible-gate-continuations-and-plan-ready-predicate.md`
(P0.1 + P2). Do **not** merge — coordinator reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
