### PR TITLE
feat(coord-http): attach device-JWT on the 6 device-keyed coord GET reads (P2)

### DIFF
--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -647,8 +647,7 @@ pub async fn tick_once() -> Result<(), String> {
         .timeout(Duration::from_secs(15))
         .build()
         .map_err(|e| format!("build reclaim http client: {e}"))?;
-    let resp = client
-        .get(&url)
+    let resp = crate::coord_http::coord_get(&client, &url)
         .send()
         .await
         .map_err(|e| format!("GET {url}: {e}"))?;

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1859,18 +1859,13 @@ pub async fn get_fleet_health() -> Result<serde_json::Value, String> {
     // device has no token — we still issue the GETs anonymously (coord is
     // anonymous today); the `have_token` flag lets us distinguish
     // "unpaired" from "token present but rejected" if coord 401/403s.
-    let device_token = qontinui_runner_lib::auth::AuthManager::new()
-        .get_access_token()
-        .ok();
-    let have_token = device_token.is_some();
+    //
+    // The bearer is attached by the shared [`crate::coord_http::coord_get`]
+    // helper (same token source as the write-path `attach_device_auth`);
+    // `have_token` reads the same availability check.
+    let have_token = crate::coord_http::have_device_token();
 
-    let auth_get = |url: String| {
-        let mut req = client.get(url);
-        if let Some(tok) = device_token.as_deref() {
-            req = req.header("Authorization", format!("Bearer {tok}"));
-        }
-        req
-    };
+    let auth_get = |url: String| crate::coord_http::coord_get(&client, url);
 
     // Tracks whether either GET returned an auth rejection (401/403).
     let mut unauthorized = false;

--- a/src-tauri/src/coord_http.rs
+++ b/src-tauri/src/coord_http.rs
@@ -1,0 +1,44 @@
+//! Shared coord data-plane GET helper.
+//!
+//! Phase P2 (plan `2026-06-05-coord-fleet-auth-followup-gaps`): the runner's
+//! coord GET readers were issued with RAW unauthenticated `reqwest` even
+//! though the process already holds a fresh device-JWT (minted by pairing,
+//! stored in the access_token slot). Coord is about to gate these reader
+//! routes with `FleetPrincipal`, so the runner must attach the device-JWT
+//! NOW. This is backward-compatible: coord still accepts anonymous calls
+//! today, so attaching a Bearer is safe to ship ahead of the coord gate.
+//!
+//! Both helpers delegate to [`qontinui_runner_lib::auth`] — the SAME token
+//! source the write-path [`attach_device_auth`] uses — so reads and writes
+//! present the identical bearer and feed the one auth-coverage metric.
+//!
+//! [`attach_device_auth`]: qontinui_runner_lib::auth::attach_device_auth
+
+/// Build a coord GET request with the device-JWT bearer attached when one is
+/// available, otherwise return the builder unchanged.
+///
+/// The bearer comes from [`qontinui_runner_lib::auth::attach_device_auth`],
+/// which reads `AuthManager::get_access_token()` per call (no caching, since
+/// the JWT has a short TTL) and is NEVER fatal: an unpaired runner / empty
+/// keychain / IO error all collapse to "send anonymously" — exactly the
+/// pre-Phase-P2 behavior. Pre-pairing callers (credential-helper setup, the
+/// tenant-policy poll, early handoff catch-up) thus keep working before any
+/// token exists; coord 401/403 once it gates is a retry-after-auth signal,
+/// not a fatal error.
+///
+/// Passing through `attach_device_auth` also drives the data-plane
+/// auth-coverage metric, so these reads now count toward the same
+/// unpaired→paired dogfood signal the write path reports.
+pub fn coord_get(client: &reqwest::Client, url: impl reqwest::IntoUrl) -> reqwest::RequestBuilder {
+    qontinui_runner_lib::auth::attach_device_auth(client.get(url))
+}
+
+/// True iff a non-empty device-JWT is currently stored.
+///
+/// Callers that must distinguish "unpaired" (no token locally) from
+/// "token present but rejected" (coord 401/403) use this — e.g.
+/// `get_fleet_health`'s structured `auth` state. Mirrors the availability
+/// check inside [`coord_get`]; never fatal, never panics.
+pub fn have_device_token() -> bool {
+    qontinui_runner_lib::auth::device_bearer().is_some()
+}

--- a/src-tauri/src/credential_helper.rs
+++ b/src-tauri/src/credential_helper.rs
@@ -86,17 +86,24 @@ async fn fetch_registered_repos(coord_base: &str) -> Result<Vec<String>, String>
         .build()
         .map_err(|e| format!("build http client: {e}"))?;
 
-    let resp = client
-        .get(&url)
+    let resp = crate::coord_http::coord_get(&client, &url)
         .send()
         .await
         .map_err(|e| format!("GET {url}: {e}"))?;
 
     if !resp.status().is_success() {
-        return Err(format!(
-            "GET /coord/canonical-repos returned {}",
-            resp.status().as_u16()
-        ));
+        let code = resp.status().as_u16();
+        if code == 401 || code == 403 {
+            // Credential-helper setup can fire BEFORE the device-JWT exists
+            // (early in session setup / before pairing completes). Once coord
+            // gates canonical-repos with FleetPrincipal, the anonymous GET is
+            // rejected until the token lands. Not fatal — the caller skips
+            // helper install this time and retries on the next session setup.
+            warn!(
+                "credential_helper: canonical-repos GET unauthorized ({code}) — retrying after device pairing/auth"
+            );
+        }
+        return Err(format!("GET /coord/canonical-repos returned {code}"));
     }
 
     let body: serde_json::Value = resp

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -44,6 +44,7 @@ mod config_storage;
 mod constraint_engine;
 mod container;
 mod context;
+mod coord_http;
 mod coord_questions;
 mod coordinator;
 mod cost_management;

--- a/src-tauri/src/mcp/file_registry.rs
+++ b/src-tauri/src/mcp/file_registry.rs
@@ -473,8 +473,8 @@ async fn get_heatmap_live(
         "{}/coord/worktree-dirty?heatmap=true",
         base.trim_end_matches('/')
     );
-    match reqwest::Client::new()
-        .get(&url)
+    let client = reqwest::Client::new();
+    match crate::coord_http::coord_get(&client, &url)
         .timeout(std::time::Duration::from_secs(3))
         .send()
         .await

--- a/src-tauri/src/repo_detection.rs
+++ b/src-tauri/src/repo_detection.rs
@@ -81,8 +81,7 @@ async fn fetch_registered_repos() -> Result<HashSet<String>, String> {
         .build()
         .map_err(|e| format!("build http client: {e}"))?;
 
-    let resp = client
-        .get(&url)
+    let resp = crate::coord_http::coord_get(&client, &url)
         .send()
         .await
         .map_err(|e| format!("GET {url}: {e}"))?;

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -975,14 +975,24 @@ async fn fetch_session_coordination_flag(
 ) -> Result<bool, String> {
     let base = inner.coord_url.trim_end_matches('/');
     let url = format!("{base}/tenant-policy?tenant_id={tenant_id}");
-    let resp = inner
-        .http
-        .get(&url)
+    let resp = crate::coord_http::coord_get(&inner.http, &url)
         .send()
         .await
         .map_err(|e| format!("transport: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("status {}", resp.status()));
+    let status = resp.status();
+    if !status.is_success() {
+        if status.as_u16() == 401 || status.as_u16() == 403 {
+            // The tenant-policy poll can spin up before the device-JWT
+            // exists (it starts as soon as a tenant resolves). Once coord
+            // gates /tenant-policy with FleetPrincipal, the anonymous GET is
+            // rejected until the token lands. Not fatal — the loop keeps the
+            // cached cutover flag and re-ticks. One line.
+            tracing::warn!(
+                "coord_sync: tenant-policy GET unauthorized ({}) — retrying after device pairing/auth",
+                status.as_u16()
+            );
+        }
+        return Err(format!("status {status}"));
     }
     let body: JsonValue = resp.json().await.map_err(|e| format!("decode: {e}"))?;
     body.get("session_coordination_enabled")

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -350,6 +350,15 @@ async fn run_catchup(
                 materialize_logged(registry, http, coord_url, &handoff).await;
             }
         }
+        Err(HandoffError::Status(401 | 403, _)) => {
+            // Pre-pairing / early-reconnect window: coord (once it gates the
+            // handoff readers with FleetPrincipal) rejects the anonymous GET
+            // until the device-JWT lands. Not fatal — the catch-up re-runs on
+            // the next (re)connect, and the push path stays active. One line.
+            tracing::warn!(
+                "session handoff: catch-up GET unauthorized (401/403) — retrying after device pairing/auth"
+            );
+        }
         Err(e) => {
             tracing::debug!(error = %e, "session handoff: catch-up GET failed (push path still active)");
         }
@@ -472,8 +481,7 @@ async fn fetch_pending(
         coord_url.trim_end_matches('/'),
         device_id
     );
-    let resp = http
-        .get(&url)
+    let resp = crate::coord_http::coord_get(http, &url)
         .send()
         .await
         .map_err(|e| HandoffError::Http(format!("GET {url}: {e}")))?;
@@ -503,8 +511,7 @@ async fn fetch_state(
         coord_url.trim_end_matches('/'),
         source_session_id
     );
-    let resp = http
-        .get(&url)
+    let resp = crate::coord_http::coord_get(http, &url)
         .send()
         .await
         .map_err(|e| HandoffError::Http(format!("GET {url}: {e}")))?;


### PR DESCRIPTION
Phase P2 (runner, expand side) of plan `2026-06-05-coord-fleet-auth-followup-gaps`. Factors `get_fleet_health`'s `auth_get` into a shared `coord_http::coord_get` helper and wires it into the 7 raw coord GET call sites (worktree-reclaim, worktree-dirty, handoff-requests/state, canonical-repos ×2, tenant-policy) so coord can FleetPrincipal-gate them (companion coord PR). Pre-pairing windows treat 401/403 as retry-after-auth (warn + re-tick), never fatal. Backward-compatible. Verified: cargo check + clippy -D warnings clean, 4367 tests pass.