### PR TITLE
feat(ci-runner): attach coord device-JWT on supervisor enable/disable (P3 FE)

### DIFF
--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -858,6 +858,29 @@ pub fn device_jwt_present() -> Result<bool, String> {
     Ok(crate::auth::looks_like_jwt(&token))
 }
 
+/// Returns the runner's coord **device-JWT** (the token stored in
+/// `AuthManager`'s `access_token` slot), or `None` when the device is unpaired
+/// — i.e. the slot is empty or does not hold a JWT-shaped value.
+///
+/// The CI-runner settings panel attaches this as `Authorization: Bearer <jwt>`
+/// on its loopback calls to the supervisor (`:9875` enable/disable), which now
+/// require + forward the credential so coord can enforce `FleetPrincipal` on
+/// the registration-token mint. A `None` return is the FE's cue to surface a
+/// "pair this runner first" CTA rather than calling the supervisor anonymously.
+///
+/// Unlike [`get_access_token_for_websocket`], this neither requires tier-2 nor
+/// errors when unpaired: it is a credential *probe*, so a missing token is a
+/// normal `Ok(None)`, not an error.
+#[tauri::command]
+pub fn get_coord_device_token() -> Result<Option<String>, String> {
+    let token = AuthManager::new().get_access_token().unwrap_or_default();
+    if crate::auth::looks_like_jwt(&token) {
+        Ok(Some(token))
+    } else {
+        Ok(None)
+    }
+}
+
 /// Tauri-command wrapper around the device-JWT refresher's `kick` API.
 ///
 /// Used by `WebIntegrationAuthBanner`'s "retry manually" CTA when the
@@ -889,6 +912,7 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             cognito_sign_in_password,
             qontinui_sign_out,
             device_jwt_present,
+            get_coord_device_token,
             kick_device_jwt_refresher_cmd,
         ])
         .build()

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -956,6 +956,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::auth::check_auth_status,
             commands::auth::device_jwt_present,
             commands::auth::get_access_token_for_websocket,
+            commands::auth::get_coord_device_token,
             commands::auth::get_api_port,
             commands::auth::get_device_info,
             commands::auth::get_user_projects,

--- a/src/components/settings/CiRunnerSettings.tsx
+++ b/src/components/settings/CiRunnerSettings.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { Play, Square, Info, X, Check, CircleDot } from "lucide-react";
 import { SectionHeader } from "./SectionHeader";
 import { getAccentColors } from "@/design-system";
@@ -29,6 +30,32 @@ interface CiRunnerSettingsProps {
 
 const SUPERVISOR_BASE = "http://localhost:9875";
 const POLL_INTERVAL_MS = 10_000;
+
+// Shown when the runner is unpaired (no coord device-JWT). Enabling/disabling
+// the CI runner mints a GitHub Actions registration token via coord, which now
+// requires a FleetPrincipal — so we MUST present the device credential and
+// never call the supervisor anonymously.
+const UNPAIRED_ERROR =
+  "Pair this runner before enabling CI — no device credential. " +
+  "Sign in / pair under Settings → Account, then try again.";
+
+// Sentinel for the unpaired case so the catch-blocks can render the actionable
+// message verbatim (without the "Failed to …" prefix the generic path adds).
+class UnpairedError extends Error {}
+
+/**
+ * Resolve the runner's coord device-JWT via the Tauri command, or throw an
+ * {@link UnpairedError} when the device is unpaired (command returns null).
+ * Returns the `Authorization: Bearer <jwt>` value to attach to supervisor calls
+ * that perform the FleetPrincipal-gated registration-token mint.
+ */
+async function deviceBearerHeader(): Promise<string> {
+  const token = await invoke<string | null>("get_coord_device_token");
+  if (!token) {
+    throw new UnpairedError(UNPAIRED_ERROR);
+  }
+  return `Bearer ${token}`;
+}
 
 // Toggle Switch (matches ContainerSettings / SelfHealingSettings pattern)
 function ToggleSwitch({
@@ -118,9 +145,10 @@ export function CiRunnerSettings({ onLog }: CiRunnerSettingsProps) {
     setError(null);
     setActionSuccess(null);
     try {
+      const authHeader = await deviceBearerHeader();
       const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/enable`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", Authorization: authHeader },
         body: JSON.stringify({
           labels: ["self-hosted", "qontinui"],
         }),
@@ -135,6 +163,11 @@ export function CiRunnerSettings({ onLog }: CiRunnerSettingsProps) {
       await fetchStatus();
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err) {
+      if (err instanceof UnpairedError) {
+        setError(err.message);
+        onLog("error", `Cannot enable CI runner: ${err.message}`);
+        return;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       setError(`Failed to enable CI runner: ${msg}`);
       onLog("error", `Failed to enable CI runner: ${msg}`);
@@ -148,8 +181,10 @@ export function CiRunnerSettings({ onLog }: CiRunnerSettingsProps) {
     setError(null);
     setActionSuccess(null);
     try {
+      const authHeader = await deviceBearerHeader();
       const resp = await fetch(`${SUPERVISOR_BASE}/ci-runner/disable`, {
         method: "POST",
+        headers: { Authorization: authHeader },
       });
       if (!resp.ok) {
         const body = await resp.text();
@@ -160,6 +195,11 @@ export function CiRunnerSettings({ onLog }: CiRunnerSettingsProps) {
       await fetchStatus();
       setTimeout(() => setActionSuccess(null), 3000);
     } catch (err) {
+      if (err instanceof UnpairedError) {
+        setError(err.message);
+        onLog("error", `Cannot disable CI runner: ${err.message}`);
+        return;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       setError(`Failed to disable CI runner: ${msg}`);
       onLog("error", `Failed to disable CI runner: ${msg}`);


### PR DESCRIPTION
Phase P3 (runner FE, expand side) of plan `2026-06-05-coord-fleet-auth-followup-gaps`. Adds `get_coord_device_token` Tauri command and attaches the device-JWT as `Authorization: Bearer` on the `:9875/ci-runner/{enable,disable}` calls; unpaired → actionable error instead of an anonymous call. Closes (with the supervisor + coord companion PRs) the anonymous registration-token mint. Verified: tsc + eslint + cargo check + clippy clean. **Deploy before** the supervisor require-PR.