### PR TITLE
feat(reclaim): G6 shadow mode — probe every instruction, report building in census

### DIFF
--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -134,6 +134,16 @@ pub struct WorktreeCensus {
     /// covers squashes independently via the PR `close_cause='merged'`
     /// signal; this field is only the ancestry/patch-id half of G2.
     pub landed_in_main: Option<bool>,
+
+    /// G6 shadow-mode probe — whether this worktree is currently building
+    /// per [`super::reclaim::worktree_is_building`] (cargo `.cargo-lock`
+    /// exclusive-open probe + recent-activity mtime window). Reported every
+    /// census tick regardless of reclaim arming, so coord can gauge
+    /// "instructions that WOULD have been G6-skipped" while arming is still
+    /// OFF — the passive prove-out feed for the Q1 rejunction graduation.
+    /// `Some(_)` is the live probe result; old runners omit the field and
+    /// coord reads NULL (honest unknown).
+    pub building: Option<bool>,
 }
 
 /// Full census body POSTed to coord.
@@ -585,6 +595,10 @@ fn capture_worktree(repo: &str, worktree: &Path) -> WorktreeCensus {
     // None when undeterminable (no origin/main, git failure).
     let landed_in_main = compute_landed_in_main(worktree);
 
+    // G6 shadow-mode: the same build probe the reclaim executor uses,
+    // reported every tick regardless of arming (the passive prove-out feed).
+    let building = Some(super::reclaim::probe_building(worktree));
+
     WorktreeCensus {
         repo: repo.to_string(),
         path: worktree.to_string_lossy().to_string(),
@@ -601,6 +615,7 @@ fn capture_worktree(repo: &str, worktree: &Path) -> WorktreeCensus {
         last_access_mtime,
         attributable_bytes,
         landed_in_main,
+        building,
     }
 }
 
@@ -893,6 +908,9 @@ mod tests {
         // No git repo → no origin/main ref → landed_in_main is the honest
         // unknown `None` (which coord's gate reads as not-landed).
         assert!(row.landed_in_main.is_none());
+        // G6 shadow probe always reports: a freshly-created tempdir has a
+        // root mtime inside the activity window → Some(true).
+        assert_eq!(row.building, Some(true));
     }
 
     #[test]

--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -526,6 +526,14 @@ fn cargo_lock_held(target_dir: &Path) -> bool {
     false
 }
 
+/// G6 probe with the env-resolved activity window — the shared entrypoint
+/// for the executor AND the census shadow-mode report
+/// ([`super::census`] pushes the result per worktree per tick as
+/// `building`, so coord can gauge would-be G6 skips while arming is OFF).
+pub(super) fn probe_building(worktree: &Path) -> bool {
+    worktree_is_building(worktree, Duration::from_secs(activity_window_secs()))
+}
+
 /// G6: is this worktree currently being built? Either signal → skip.
 /// Injectable (takes the worktree root) so tests drive it with tempdirs.
 ///
@@ -569,9 +577,23 @@ fn execute_pull(pull: &ReclaimPull) {
             ReclaimAction::Unknown(_) => false,
         };
 
+        // G6 — evaluated for EVERY instruction, armed or not. Unarmed
+        // ("shadow mode") logs the would-skip so the census-carried
+        // `building` fact + these lines give the Q1 graduation its
+        // prove-out data while arming is still OFF; armed skips for real.
+        let building = worktree_is_building(&wt, window);
+        if building && !armed {
+            info!(
+                "worktree_reclaim: {} building — WOULD skip (reason=building, shadow/unarmed)",
+                instr.worktree_path
+            );
+            // fall through: the unarmed plan still logs its advisory
+            // "would do X" Skip step below.
+        }
+
         if armed {
             // G6 — never act on a worktree that is currently building.
-            if worktree_is_building(&wt, window) {
+            if building {
                 info!(
                     "worktree_reclaim: {} building — skipping (reason=building)",
                     instr.worktree_path


### PR DESCRIPTION
## Summary
Follow-up to #421 / plan `2026-06-05-twin-worktree-phase6-lifecycle-reclaim` (SHIPPED). G6 only evaluated when an action was armed, and its outcomes were runner-local logs — no passive prove-out feed for the Q1 rejunction graduation.

- `execute_pull`: `worktree_is_building()` now evaluated for **every** instruction; unarmed + building logs `WOULD skip (reason=building, shadow/unarmed)`; armed behavior unchanged.
- census: per-worktree `building` field (`probe_building()`, same env window as the executor), pushed every tick regardless of arming. Coord gauges it as `coord_worktree_reclaim_would_skip_building` (coord #366; column via web #474).

fmt clean; clippy `--bin --features custom-protocol -D warnings` green; 65 agent_worktree tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)