### PR TITLE
fix(fs-observer): attach device-JWT bearer on /coord/fs/observations pushes

### DIFF
--- a/src-tauri/src/agent_worktree/fs_observer.rs
+++ b/src-tauri/src/agent_worktree/fs_observer.rs
@@ -368,7 +368,13 @@ async fn post_observations(coord_http_base: &str, body: &FsObservationsRequest) 
             return;
         }
     };
-    match client.post(&url).json(body).send().await {
+    // Attach the device-JWT bearer when one is available (never fatal —
+    // unpaired / empty keychain collapses to the anonymous send coord accepts
+    // today). Same write-path attach the credential-helper uses, and it feeds
+    // the data-plane auth-coverage metric ahead of multiuser Phase-2
+    // enforcement on `/coord/fs/observations`.
+    let req = qontinui_runner_lib::auth::attach_device_auth(client.post(&url));
+    match req.json(body).send().await {
         Ok(resp) => {
             let status = resp.status();
             if status.is_success() {


### PR DESCRIPTION
## What

`fs_observer::post_observations()` was the one coord data-plane caller sending a bare unauthenticated POST — every sibling write/read path (`coord_get`, `credential_helper`) routes through `auth::attach_device_auth`. This attaches the same never-fatal bearer: unpaired / empty keychain degrades to today's anonymous send, and the push now feeds the data-plane auth-coverage metric ahead of multiuser Phase-2 enforcement on `/coord/fs/observations`.

One call site, 7 lines: `src-tauri/src/agent_worktree/fs_observer.rs` (`post_observations`).

## Why now

Flagged during the 2026-06-05 vet of `2026-06-05-runner-install-wrapper-producer-plan` — the producer was told to NOT copy this gap (its §2 substrate table documents it); this closes it at the source so the edit-path and install-path observation pushes present the identical bearer.

## Verification

- `cargo clippy --bin qontinui-runner --features custom-protocol -- -D warnings` clean (isolated worktree + isolated CARGO_TARGET_DIR; `Finished` in 6m48s, 0 findings)
- Behavior identical when unpaired (attach helper is never-fatal by contract, `auth.rs:620`); coord route is anonymous today so this is forward-compat only
- Note: local pre-push guard failed against the MAIN checkout's build env (not this diff) — pushed with `QONTINUI_PREPUSH_SKIP=1` per the hook's own CI-gates escape; CI on this PR is the gate