### PR TITLE
fix(terminal): restore Claude sessions after graceful restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6553,6 +6553,7 @@ dependencies = [
  "chrono",
  "image 0.25.10",
  "serde",
+ "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.18",
 ]

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -816,17 +816,24 @@ pub fn terminal_session_record_close(
     })
 }
 
-/// List every currently-open Claude terminal session from the lifecycle
-/// registry. The grid hydrates its session tiles from this instead of
+/// List every RESTORABLE Claude terminal session from the lifecycle registry.
+/// The grid hydrates its session tiles from this on boot instead of
 /// `localStorage`.
+///
+/// Returns the restorable superset (see `restorable_records`): all `open`
+/// records (hard-crash case) PLUS `closed`/`pty-exit` records still within the
+/// grace window (graceful-restart case, where `handleExit` flipped every live
+/// PTY to `closed`). User-closed and stale records are excluded so the restore
+/// path resurrects exactly the sessions that died with the runner.
 #[tauri::command]
 pub fn terminal_session_list_open(
     store: tauri::State<'_, Arc<SessionLifecycleStore>>,
 ) -> Result<CommandResponse, String> {
+    let now = chrono::Utc::now().timestamp_millis();
     Ok(CommandResponse {
         success: true,
         message: None,
-        data: Some(serde_json::json!({ "sessions": store.open_records() })),
+        data: Some(serde_json::json!({ "sessions": store.restorable_records(now) })),
     })
 }
 

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -40,6 +40,12 @@ use tracing::warn;
 const CLOSED_RETENTION_MS: i64 = 86_400_000;
 /// Open records not seen for this long are pruned (7d in millis).
 const OPEN_STALE_MS: i64 = 604_800_000;
+/// A record closed with reason `"pty-exit"` (its PTY died — e.g. a graceful
+/// runner restart firing `handleExit` on every live PTY) is still restorable
+/// for this long after the close. Beyond the window, or for any other close
+/// reason (explicit user close, `"poll-dead"`, …), it is NOT restorable.
+/// 10 minutes in millis.
+const RESTORABLE_PTY_EXIT_MS: i64 = 600_000;
 
 /// One persisted terminal-session lifecycle record, keyed by
 /// `claude_session_id`. Timestamps are unix epoch millis.
@@ -187,6 +193,44 @@ impl SessionLifecycleStore {
             Ok(m) => m.values().filter(|r| r.state == "open").cloned().collect(),
             Err(e) => {
                 warn!(error = %e, "session_lifecycle_store: lock poisoned on open_records");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Clone of every record that should be RESTORED on boot. This is the
+    /// superset of [`Self::open_records`] used by the restore path:
+    ///
+    /// - every `state == "open"` record (a hard crash leaves records open), PLUS
+    /// - every `state == "closed"` record whose `close_reason == "pty-exit"`
+    ///   (its PTY died — the case a GRACEFUL restart produces by firing
+    ///   `handleExit` on every live PTY) that closed within the
+    ///   [`RESTORABLE_PTY_EXIT_MS`] grace window.
+    ///
+    /// Records closed for any other reason (explicit user close, `"poll-dead"`,
+    /// …) or pty-exit closes older than the grace window are excluded — a user
+    /// who closes a tab does not want it resurrected, and a long-dead pty-exit
+    /// close is stale.
+    pub fn restorable_records(&self, now_ms: i64) -> Vec<TerminalSessionRecord> {
+        match self.map.lock() {
+            Ok(m) => m
+                .values()
+                .filter(|r| {
+                    if r.state == "open" {
+                        return true;
+                    }
+                    if r.state == "closed" && r.close_reason.as_deref() == Some("pty-exit") {
+                        return match r.closed_at {
+                            Some(closed_at) => now_ms - closed_at <= RESTORABLE_PTY_EXIT_MS,
+                            None => false,
+                        };
+                    }
+                    false
+                })
+                .cloned()
+                .collect(),
+            Err(e) => {
+                warn!(error = %e, "session_lifecycle_store: lock poisoned on restorable_records");
                 Vec::new()
             }
         }
@@ -424,6 +468,59 @@ mod tests {
         // Reload and confirm the closed record persisted with its reason.
         let store = SessionLifecycleStore::open(&path).unwrap();
         assert!(store.open_records().is_empty());
+    }
+
+    #[test]
+    fn restorable_records_includes_open_and_in_grace_pty_exit_only() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        // An open record (hard-crash case) — IS restorable.
+        store.record_open(rec("open-sess"));
+        // A pty-exit close (graceful-restart case) — IS restorable while in grace.
+        store.record_open(rec("pty-exit-sess"));
+        store.record_close("pty-exit-sess", "pty-exit");
+        // An explicit/user close — is NOT restorable.
+        store.record_open(rec("user-closed-sess"));
+        store.record_close("user-closed-sess", "explicit");
+        // A pty-exit close aged beyond the grace window — is NOT restorable.
+        store.record_open(rec("stale-pty-exit-sess"));
+        store.record_close("stale-pty-exit-sess", "pty-exit");
+
+        let now = Utc::now().timestamp_millis();
+
+        // Age the stale pty-exit record's closed_at past the grace window.
+        {
+            let raw = std::fs::read(&path).unwrap();
+            let mut m: HashMap<String, TerminalSessionRecord> =
+                serde_json::from_slice(&raw).unwrap();
+            m.get_mut("stale-pty-exit-sess").unwrap().closed_at =
+                Some(now - RESTORABLE_PTY_EXIT_MS - 1000);
+            let bytes = serde_json::to_vec_pretty(&m).unwrap();
+            std::fs::write(&path, bytes).unwrap();
+        }
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        let mut ids: Vec<String> = store
+            .restorable_records(now)
+            .into_iter()
+            .map(|r| r.claude_session_id)
+            .collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["open-sess".to_string(), "pty-exit-sess".to_string()],
+            "open + in-grace pty-exit restorable; explicit + stale-pty-exit excluded"
+        );
+
+        // open_records() keeps strict-open semantics (only the open one).
+        let open_ids: Vec<String> = store
+            .open_records()
+            .into_iter()
+            .map(|r| r.claude_session_id)
+            .collect();
+        assert_eq!(open_ids, vec!["open-sess".to_string()]);
     }
 
     #[test]

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -96,19 +96,24 @@ describe("fetchOpenRecords", () => {
     expect(out.map((r) => r.claudeSessionId)).toEqual(["A"]);
   });
 
-  it("excludes records that are not open", async () => {
+  it("passes through whatever the backend returns without re-filtering on state", async () => {
+    // The backend (terminal_session_list_open -> restorable_records) owns the
+    // state/reason/grace gating: it returns `open` records PLUS in-grace
+    // `closed`/`pty-exit` records (graceful-restart case). The client must NOT
+    // re-drop the non-open ones — doing so was the restore-on-graceful-restart
+    // bug. So a "closed" record the backend chose to return is kept.
     mockInvoke.mockResolvedValueOnce({
       success: true,
       message: null,
       data: {
         sessions: [
           rec({ claudeSessionId: "A", state: "open" }),
-          rec({ claudeSessionId: "B", state: "closed" }),
+          rec({ claudeSessionId: "B", state: "closed", closeReason: "pty-exit" }),
         ],
       },
     });
     const out = await fetchOpenRecords("default");
-    expect(out.map((r) => r.claudeSessionId)).toEqual(["A"]);
+    expect(out.map((r) => r.claudeSessionId).sort()).toEqual(["A", "B"]);
   });
 
   it("returns [] when the command throws", async () => {

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -10,12 +10,19 @@ import type { SaveSessionLayoutParams } from "./useSessionPersistence";
 import { rememberSessionId } from "./lastKnownSessionIds";
 
 /**
- * Fetch the durable OPEN session records for `pageId` from the backend
+ * Fetch the durable RESTORABLE session records for `pageId` from the backend
  * registry, filtered to this page and deduped by `claudeSessionId` (defensive
  * — the registry should already enforce one row per id, but a duplicate would
  * otherwise spawn two tabs for one session). This is the SOURCE OF TRUTH for
  * the zone↔session binding on restore, replacing the ephemeral-tabId
  * creation-order mapping the localStorage snapshot used to drive.
+ *
+ * `terminal_session_list_open` returns the restorable superset: `open` records
+ * (hard-crash case) PLUS in-grace `closed`/`pty-exit` records (graceful-restart
+ * case, where `handleExit` flipped every live PTY to `closed`). The backend
+ * owns the state/reason/grace gating, so we deliberately do NOT re-filter on
+ * `state === "open"` here — that would drop the pty-exit records the backend
+ * just decided are restorable.
  *
  * Exported for unit testing the restore-binding logic without booting React.
  */
@@ -33,7 +40,6 @@ export async function fetchOpenRecords(pageId: string): Promise<TerminalSessionR
   for (const rec of sessions) {
     if (!rec || typeof rec.claudeSessionId !== "string") continue;
     if ((rec.pageId ?? "default") !== pageId) continue;
-    if (rec.state && rec.state !== "open") continue;
     if (!byId.has(rec.claudeSessionId)) byId.set(rec.claudeSessionId, rec);
   }
   return [...byId.values()];


### PR DESCRIPTION
## Problem

Open Claude terminal sessions did **not** reappear after a graceful runner restart. On graceful shutdown, every live PTY exits → `handleExit` (TerminalPage.tsx) marks each session `closed` with `closeReason="pty-exit"`. The restore-on-boot path read **only** `state=="open"` records (`SessionLifecycleStore::open_records()`), so it saw zero records and restored nothing.

A hard crash already restored correctly (no graceful `handleExit` → records stay `open` → cold-create + `claude --resume`). The gap was solely the graceful path.

## Fix

- Add `RESTORABLE_PTY_EXIT_MS` (10-min grace) + `SessionLifecycleStore::restorable_records(now)` returning `open` records **plus** `closed` records whose `closeReason=="pty-exit"` within the grace window. User/explicit closes and `poll-dead` closes remain excluded, so a tab the user closed stays closed.
- Point `terminal_session_list_open` at `restorable_records`.
- Relax the `useTerminalInitialization` restore filter to trust the backend-gated set instead of re-dropping non-`open` records client-side. The existing re-assert `terminal_session_record_open` flips a restored record back to `open` under the new terminalId.

## Verification

- Rust: `cargo check` + `clippy -D warnings` clean; `cargo test session_lifecycle` 15/15 (incl. new `restorable_records` test).
- Frontend: `tsc --noEmit` clean; `vitest` 7/7.
- End-to-end (named runner, observed on the Terminal page via UI Bridge, twice): graceful restart now restores the Claude tab — record `open → pty-exit → restored open` with a new terminalId, `claude --resume` conversation continuity confirmed.