### PR TITLE
feat(agent-worktree): per-repo kind=worktree claims + multi-claim context + session-keyed continuation (Phase 1)

### DIFF
--- a/src-tauri/src/agent_daemons/mod.rs
+++ b/src-tauri/src/agent_daemons/mod.rs
@@ -142,7 +142,7 @@ mod tests {
             token: token.to_string(),
             token_jti: Uuid::nil(),
             token_exp: chrono::Utc::now().timestamp() + 4 * 3600,
-            active_claim: None,
+            active_claims: Vec::new(),
         }
     }
 

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -989,7 +989,24 @@ async fn run_gate_continuation(
         .map(|a| format!("gate-continuation:{a}"))
         .unwrap_or_else(|| "gate-continuation".to_string());
 
-    let (workdir, ctx, agent_id) = match acquire_continuation_workdir(&payload.repos, &intent).await
+    // Phase 1b (plan 2026-06-06-session-scoped-multi-repo-workspace-coordination):
+    // thread a stable per-session UUID discriminator so the worktree claims
+    // are session-keyed in the owner token (machine:session). The
+    // gate-continuation wire payload carries NO Claude session uuid (only
+    // `LaunchPayload` does); the next-best stable id is one DETERMINISTICALLY
+    // derived from the continuation's identity so a retry of the SAME gate
+    // continuation reuses the same owner token (a re-acquire renews rather
+    // than collides). We derive it from `(target_device_id, anchor_key)` via
+    // a UUIDv5 in the URL namespace; when `anchor_key` is absent we fall back
+    // to a fresh v4 (a one-shot continuation with no stable anchor).
+    let continuation_session_id = continuation_session_id(&payload);
+
+    let (workdir, ctx, agent_id) = match acquire_continuation_workdir(
+        &payload.repos,
+        &intent,
+        continuation_session_id,
+    )
+    .await
     {
         Ok(triple) => triple,
         Err(e) => {
@@ -1156,9 +1173,38 @@ async fn run_continuation_terminal(
 ///   fresh correlation UUID. The continuation still runs, just without
 ///   per-agent isolation — the same graceful degrade `acquire_for_terminal`
 ///   uses.
+/// Derive a stable per-session UUID discriminator for a gate continuation's
+/// worktree claims (Phase 1b, plan
+/// 2026-06-06-session-scoped-multi-repo-workspace-coordination).
+///
+/// The gate-continuation wire payload ([`GateContinuationPayload`]) carries
+/// NO Claude session uuid (unlike [`LaunchPayload::agent_session_id`]), so
+/// there is no upstream id to thread. We synthesize one that is STABLE
+/// across retries of the same continuation: a UUIDv5 over
+/// `"<target_device_id>:<anchor_key>"` in the URL namespace. Two spawns of
+/// the same gate continuation (same device, same anchor) therefore produce
+/// the same owner-token discriminator, so a re-acquire RENEWS the existing
+/// worktree claim instead of colliding with it. When `anchor_key` is absent
+/// (a one-shot continuation with no stable anchor) we fall back to a fresh
+/// v4 — distinctness is preserved, only cross-retry renewal is lost, which
+/// is acceptable for an anchor-less one-shot.
+fn continuation_session_id(payload: &GateContinuationPayload) -> Option<uuid::Uuid> {
+    match payload.anchor_key.as_deref() {
+        Some(anchor) if !anchor.is_empty() => {
+            let name = format!("{}:{anchor}", payload.target_device_id);
+            Some(uuid::Uuid::new_v5(
+                &uuid::Uuid::NAMESPACE_URL,
+                name.as_bytes(),
+            ))
+        }
+        _ => Some(uuid::Uuid::new_v4()),
+    }
+}
+
 async fn acquire_continuation_workdir(
     repos: &[String],
     intent: &str,
+    agent_session_id: Option<uuid::Uuid>,
 ) -> anyhow::Result<(
     String,
     Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
@@ -1173,7 +1219,9 @@ async fn acquire_continuation_workdir(
             declared_overlap_paths: None,
             plan_id: None,
             phase: None,
-            agent_session_id: None,
+            // Phase 1b: session-keyed worktree claims for the continuation —
+            // see `continuation_session_id` for how this stable id is derived.
+            agent_session_id,
         })
         .await
         {
@@ -2365,6 +2413,44 @@ mod tests {
             Some(v) => std::env::set_var("QONTINUI_CLAUDE_BIN", v),
             None => std::env::remove_var("QONTINUI_CLAUDE_BIN"),
         }
+    }
+
+    #[test]
+    fn continuation_session_id_is_stable_for_same_anchor_and_device() {
+        // Phase 1b: the synthesized owner-token discriminator must be STABLE
+        // across retries of the same continuation (same device + anchor) so a
+        // re-acquire renews rather than collides, and DISTINCT across anchors.
+        let device = uuid::Uuid::parse_str("55555555-5555-5555-5555-555555555555").unwrap();
+        let mk = |anchor: Option<&str>| GateContinuationPayload {
+            target_device_id: device,
+            initial_prompt: "p".to_string(),
+            repos: vec![],
+            presentation: Presentation::Headless,
+            source: GATE_CONTINUATION_SOURCE.to_string(),
+            anchor_key: anchor.map(|s| s.to_string()),
+        };
+
+        let a1 = continuation_session_id(&mk(Some("gate-7f2358d5")));
+        let a2 = continuation_session_id(&mk(Some("gate-7f2358d5")));
+        assert_eq!(a1, a2, "same (device, anchor) → same stable id");
+        assert!(a1.is_some());
+
+        let b = continuation_session_id(&mk(Some("gate-other")));
+        assert_ne!(a1, b, "different anchor → different id");
+
+        // A different device with the same anchor is also distinct.
+        let other_device = GateContinuationPayload {
+            target_device_id: uuid::Uuid::parse_str("66666666-6666-6666-6666-666666666666")
+                .unwrap(),
+            ..mk(Some("gate-7f2358d5"))
+        };
+        assert_ne!(a1, continuation_session_id(&other_device));
+
+        // Anchor-less → a fresh v4 each call (Some, but non-equal).
+        let n1 = continuation_session_id(&mk(None));
+        let n2 = continuation_session_id(&mk(None));
+        assert!(n1.is_some() && n2.is_some());
+        assert_ne!(n1, n2, "anchor-less continuations get a fresh id each time");
     }
 
     /// In a non-Tauri (unit-test) context there is no process-global AppHandle,

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -2428,6 +2428,7 @@ mod tests {
             presentation: Presentation::Headless,
             source: GATE_CONTINUATION_SOURCE.to_string(),
             anchor_key: anchor.map(|s| s.to_string()),
+            gate_id: None,
         };
 
         let a1 = continuation_session_id(&mk(Some("gate-7f2358d5")));

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -123,22 +123,30 @@ impl Drop for IsolatedEditContext {
         // Best-effort release of every active claim on the current Tokio
         // runtime. A failed release is observability-only — the session
         // that drops the context is shutting down anyway.
+        //
+        // Guard the spawn on a live runtime: outside one — a sync `#[test]`,
+        // or a Drop that runs while unwinding a panic — `tokio::spawn` itself
+        // panics ("no reactor running"), and a panic during unwind aborts the
+        // process (SIGABRT). Release is best-effort, so skipping it when no
+        // runtime is present is the safe degrade; coord's TTL reaps the claim.
         let claims = std::mem::take(&mut self.active_claims);
         if !claims.is_empty() {
-            let base = self.coord_http_base.clone();
-            let mid = self.device_id;
-            tokio::spawn(async move {
-                for claim in claims {
-                    release_claim_best_effort(
-                        &base,
-                        mid,
-                        claim.agent_session_id,
-                        &claim.kind,
-                        &claim.resource_key,
-                    )
-                    .await;
-                }
-            });
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let base = self.coord_http_base.clone();
+                let mid = self.device_id;
+                handle.spawn(async move {
+                    for claim in claims {
+                        release_claim_best_effort(
+                            &base,
+                            mid,
+                            claim.agent_session_id,
+                            &claim.kind,
+                            &claim.resource_key,
+                        )
+                        .await;
+                    }
+                });
+            }
         }
     }
 }
@@ -672,12 +680,19 @@ mod tests {
             .filter(|c| c.kind == "worktree")
             .collect();
         assert_eq!(worktree_claims.len(), 2, "one worktree claim per repo");
-        assert!(worktree_claims
-            .iter()
-            .any(|c| c.resource_key == "d:/qontinui-root/qontinui-runner"));
-        assert!(worktree_claims
-            .iter()
-            .any(|c| c.resource_key == "d:/qontinui-root/qontinui-coord"));
+        // Derive the expected keys from the SAME helpers the acquire side uses,
+        // so the assert is platform-portable: `default_canonical_path` resolves
+        // to `D:/qontinui-root/...` on Windows and `$HOME/qontinui-root/...` on
+        // POSIX, and `worktree_resource_key` normalizes both to the guard form.
+        for repo in ["qontinui-runner", "qontinui-coord"] {
+            let expected = super::super::worktree_resource_key(
+                &super::super::canonical_paths::default_canonical_path(repo).unwrap(),
+            );
+            assert!(
+                worktree_claims.iter().any(|c| c.resource_key == expected),
+                "missing worktree claim keyed on {expected}"
+            );
+        }
 
         // Drain before drop: this is a non-async test, and Drop's release
         // path `tokio::spawn`s — which panics outside a runtime. Clearing
@@ -702,10 +717,10 @@ mod tests {
         assert_eq!(ctx.active_claims.len(), 1, "one worktree claim remains");
         assert_eq!(ctx.worktrees.len(), 1);
         assert_eq!(ctx.worktrees[0].repo, "qontinui-coord");
-        assert_eq!(
-            ctx.active_claims[0].resource_key,
-            "d:/qontinui-root/qontinui-coord"
+        let expected_coord = super::super::worktree_resource_key(
+            &super::super::canonical_paths::default_canonical_path("qontinui-coord").unwrap(),
         );
+        assert_eq!(ctx.active_claims[0].resource_key, expected_coord);
 
         // Idempotent: releasing a repo that's no longer joined is a no-op.
         let again = ctx.release_repo("qontinui-runner").await;

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -36,19 +36,23 @@ use super::{
 pub struct IsolatedEditContext {
     pub agent_id: String,
     pub worktrees: Vec<MaterializedWorktree>,
-    /// Set when the spawn flow pre-acquired a coord claim. `None` means
-    /// no claim was acquired (the caller passed neither `plan_id`/`phase`
-    /// nor `declared_overlap_paths`).
-    pub active_claim: Option<ActiveClaim>,
+    /// Every claim the spawn flow pre-acquired — one `kind=worktree`
+    /// claim per materialized repo (always), plus the optional
+    /// phase/file_glob claim. Empty when no claim was acquired (worktree
+    /// mode off path never reaches here). Drop releases EVERY entry.
+    /// Phase 1 of plan 2026-06-06-session-scoped-multi-repo-workspace.
+    pub active_claims: Vec<ActiveClaim>,
 
-    // Held so the heartbeat task lives as long as the context — its
-    // own Drop notifies the cancel token. Underscore-prefixed because
-    // we never inspect it; the handle is keep-alive only.
-    _heartbeat: Option<ClaimHeartbeatHandle>,
+    // One heartbeat handle per claim in `active_claims` — each task lives
+    // as long as the context; the handle's own Drop notifies its cancel
+    // token. Kept in lockstep with `active_claims` (parallel vectors are
+    // fine here — every claim spawns exactly one heartbeat). Keep-alive
+    // only; we never inspect them.
+    _heartbeats: Vec<ClaimHeartbeatHandle>,
 
-    // Captured for the Drop-time release POST. `coord_http_base` and
-    // `device_id` aren't otherwise exposed on the context — Drop is the
-    // only consumer.
+    // Captured for the Drop-time release POSTs. `coord_http_base` and
+    // `device_id` aren't otherwise exposed on the context — Drop and the
+    // grow/shrink primitives are the only consumers.
     coord_http_base: String,
     device_id: uuid::Uuid,
 
@@ -111,29 +115,168 @@ impl Drop for IsolatedEditContext {
             );
         }
 
-        // Stop the heartbeat first so its tick can't race with the
-        // release POST. `ClaimHeartbeatHandle`'s own Drop notifies its
-        // cancel token; the task exits on the next tick boundary.
-        let _ = self._heartbeat.take();
+        // Stop EVERY heartbeat first so no tick races with a release POST.
+        // `ClaimHeartbeatHandle`'s own Drop notifies its cancel token; each
+        // task exits on its next tick boundary.
+        self._heartbeats.clear();
 
-        // Best-effort release on the current Tokio runtime. If there
-        // was no active claim, there's nothing to release. A failed
-        // release is observability-only — the session that drops the
-        // context is shutting down anyway.
-        if let Some(claim) = self.active_claim.take() {
+        // Best-effort release of every active claim on the current Tokio
+        // runtime. A failed release is observability-only — the session
+        // that drops the context is shutting down anyway.
+        let claims = std::mem::take(&mut self.active_claims);
+        if !claims.is_empty() {
             let base = self.coord_http_base.clone();
             let mid = self.device_id;
             tokio::spawn(async move {
+                for claim in claims {
+                    release_claim_best_effort(
+                        &base,
+                        mid,
+                        claim.agent_session_id,
+                        &claim.kind,
+                        &claim.resource_key,
+                    )
+                    .await;
+                }
+            });
+        }
+    }
+}
+
+impl IsolatedEditContext {
+    /// Grow primitive (Phase 1c, plan
+    /// 2026-06-06-session-scoped-multi-repo-workspace-coordination):
+    /// materialize ONE more repo's worktree, acquire its `kind=worktree`
+    /// claim, spawn its heartbeat, and join it to this live context (push
+    /// onto `worktrees`, `active_claims`, `_heartbeats`).
+    ///
+    /// Idempotent on an already-joined repo: if `repo` is already present in
+    /// this context's `worktrees`, returns `Ok(())` without a second
+    /// allocate (the caller can blindly request a repo it may already hold).
+    ///
+    /// A `Held` on the new repo's worktree claim surfaces as
+    /// `Err(AllocateError::ClaimConflict)` — the existing repos stay joined
+    /// and claimed; only the new repo is rejected. Any other failure
+    /// (resolution, transport, `git worktree add`) returns
+    /// `Err(AllocateError::Other)`, again leaving the existing context
+    /// untouched.
+    ///
+    /// `intent` is the human-readable intent stored on the new claim; the
+    /// new repo is materialized as a `kind=worktree`-only claim (no
+    /// phase/file_glob — those are an acquisition-time concern).
+    pub async fn acquire_additional(
+        &mut self,
+        repo: &str,
+        intent: Option<&str>,
+    ) -> Result<(), AllocateError> {
+        if self.worktrees.iter().any(|w| w.repo == repo) {
+            info!(
+                repo = %repo,
+                "isolated_edit: acquire_additional — repo already joined; no-op"
+            );
+            return Ok(());
+        }
+
+        let repos = [repo.to_string()];
+        let session_id = self.session_id();
+        let mut result = materialize_repos(
+            &self.coord_http_base,
+            self.device_id,
+            &repos,
+            intent,
+            None,
+            None,
+            None,
+            session_id,
+        )
+        .await?;
+
+        // Spawn a heartbeat for each newly-acquired claim (one worktree
+        // claim for the single repo) and join everything onto the context.
+        for claim in &result.active_claims {
+            let hb =
+                spawn_claim_heartbeat(&self.coord_http_base, self.device_id, &self.agent_id, claim);
+            self._heartbeats.push(hb);
+        }
+        self.active_claims.append(&mut result.active_claims);
+        self.worktrees.append(&mut result.worktrees);
+        Ok(())
+    }
+
+    /// Shrink primitive (Phase 1c): release `repo`'s `kind=worktree` claim,
+    /// abort its heartbeat, and drop it from this context.
+    ///
+    /// Coordination state only — the on-disk worktree directory is LEFT in
+    /// place for the existing reclaim machinery
+    /// (`agent_worktree::reclaim`) to prune; releasing the claim merely
+    /// hands the checkout's coordination ownership back. This avoids racing
+    /// a `git worktree remove` against a process that may still hold the
+    /// dir open, and keeps removal centralized in one sweeper.
+    ///
+    /// Returns `true` if `repo` was present and released, `false` if it was
+    /// not joined (idempotent no-op).
+    pub async fn release_repo(&mut self, repo: &str) -> bool {
+        // Find the repo's worktree so we can compute its canonical-path
+        // claim key (the worktree's `worktree_path` is the canonical
+        // checkout for the SharedBranch case; for a real worktree it is the
+        // worktree dir, so we re-derive the canonical checkout from the repo
+        // slug to match the acquire-side key exactly).
+        let Some(pos) = self.worktrees.iter().position(|w| w.repo == repo) else {
+            return false;
+        };
+
+        // Re-derive the canonical checkout path → resource_key the SAME way
+        // the acquire side did (`worktree_for_path` over
+        // `default_canonical_path`), so we release the byte-identical key.
+        let want_key = super::canonical_paths::default_canonical_path(repo)
+            .ok()
+            .map(|p| super::worktree_resource_key(&p));
+
+        // Drop the matching worktree claim + its heartbeat. Match on the
+        // worktree kind AND the derived key (so we never release a
+        // phase/file_glob claim that happens to coexist).
+        if let Some(key) = want_key {
+            if let Some(cpos) = self
+                .active_claims
+                .iter()
+                .position(|c| c.kind == "worktree" && c.resource_key == key)
+            {
+                let claim = self.active_claims.remove(cpos);
+                // Abort the heartbeat whose resource_key matches.
+                if let Some(hpos) = self
+                    ._heartbeats
+                    .iter()
+                    .position(|h| h.kind == "worktree" && h.resource_key == key)
+                {
+                    // Dropping the handle notifies its cancel token.
+                    let _ = self._heartbeats.remove(hpos);
+                }
                 release_claim_best_effort(
-                    &base,
-                    mid,
+                    &self.coord_http_base,
+                    self.device_id,
                     claim.agent_session_id,
                     &claim.kind,
                     &claim.resource_key,
                 )
                 .await;
-            });
+            }
         }
+
+        // Drop the worktree bookkeeping (leave the on-disk dir for reclaim).
+        self.worktrees.remove(pos);
+        info!(
+            repo = %repo,
+            "isolated_edit: release_repo — worktree claim released, dir left for reclaim"
+        );
+        true
+    }
+
+    /// The per-session owner-token discriminator carried by this context's
+    /// claims (all claims share it). `None` for a context whose claims were
+    /// acquired machine-level. Used to keep `acquire_additional`'s new claim
+    /// on the same owner token as the rest of the context.
+    fn session_id(&self) -> Option<uuid::Uuid> {
+        self.active_claims.first().and_then(|c| c.agent_session_id)
     }
 }
 
@@ -183,101 +326,25 @@ pub async fn acquire(
     let device_id = read_device_id()
         .map_err(|e| AllocateError::Other(format!("device_id not available: {e}")))?;
 
-    let mut canonical_paths: HashMap<String, PathBuf> = HashMap::with_capacity(req.repos.len());
-    for repo in req.repos {
-        let path = super::canonical_paths::default_canonical_path(repo)
-            .map_err(|e| AllocateError::Other(format!("canonical path for repo {repo:?}: {e}")))?;
-        canonical_paths.insert(repo.clone(), path);
-    }
-
-    let mut repo_reqs: Vec<RepoRequest> = Vec::with_capacity(req.repos.len());
-    for repo in req.repos {
-        let canonical = canonical_paths
-            .get(repo)
-            .ok_or_else(|| AllocateError::Other(format!("no canonical path for repo '{repo}'")))?;
-        let parent_sha = resolve_head_sha(canonical)
-            .map_err(|e| AllocateError::Other(format!("git rev-parse HEAD on {repo}: {e}")))?;
-        repo_reqs.push(RepoRequest {
-            repo: repo.clone(),
-            parent_sha,
-        });
-    }
-
-    let outcome = allocate_and_materialize_with_claim(
+    let result = materialize_repos(
         &coord_http_base,
-        &device_id,
-        req.agent_session_id,
-        &repo_reqs,
+        device_id,
+        req.repos,
         req.intent,
         req.declared_overlap_paths,
-        &canonical_paths,
         req.plan_id,
         req.phase,
+        req.agent_session_id,
     )
     .await?;
 
-    // Phase 3 — normalize coord's isolation directive into the
-    // worktree-shaped `IsolatedEditContext`:
-    // - `Worktrees` → as-is.
-    // - `SharedBranch` → the canonical checkout IS the cwd; map each
-    //   per-repo branch into a `MaterializedWorktree` whose
-    //   `worktree_path` is the canonical checkout, so callers that read
-    //   `worktrees[0].worktree_path` get the right cwd (the shared
-    //   checkout) transparently.
-    // - `Wait` → surface as `Err(Other)` with a `wait:` prefix so the
-    //   caller logs/retries (it does NOT spin here). `acquire_for_terminal`
-    //   degrades to the shared cwd on this Err, which is the safe fallback.
-    let result: super::AllocateResult = match outcome {
-        MaterializeOutcome::Worktrees(r) => r,
-        MaterializeOutcome::SharedBranch(sb) => super::AllocateResult {
-            agent_id: sb.agent_id,
-            worktrees: sb
-                .branches
-                .into_iter()
-                .map(|b| MaterializedWorktree {
-                    repo: b.repo,
-                    branch: b.branch,
-                    parent_sha: b.parent_sha,
-                    worktree_path: b.checkout_path,
-                    push_ref: b.push_ref,
-                })
-                .collect(),
-            token: sb.token,
-            token_jti: sb.token_jti,
-            token_exp: sb.token_exp,
-            active_claim: sb.active_claim,
-        },
-        MaterializeOutcome::Wait(w) => {
-            return Err(AllocateError::Other(format!(
-                "wait: coord declined to materialize agent_id={} reason={:?} blocking={:?} retry_when={:?}",
-                w.agent_id, w.reason, w.blocking, w.retry_when
-            )));
-        }
-    };
-
-    let heartbeat = result.active_claim.as_ref().map(|claim| {
-        info!(
-            agent_id = %result.agent_id,
-            kind = %claim.kind,
-            resource_key = %claim.resource_key,
-            ttl_seconds = claim.ttl_seconds,
-            "isolated_edit: spawning heartbeat"
-        );
-        spawn_heartbeat_task(
-            coord_http_base.clone(),
-            device_id,
-            claim.agent_session_id,
-            &claim.kind,
-            claim.resource_key.clone(),
-            claim.ttl_seconds,
-            |displaced_by| {
-                warn!(
-                    displaced_by = ?displaced_by,
-                    "isolated_edit: claim stolen — edits in this worktree may now race"
-                );
-            },
-        )
-    });
+    // One heartbeat task per claim (worktree claims + the optional
+    // phase/file_glob claim), kept index-aligned with `active_claims`.
+    let heartbeats: Vec<ClaimHeartbeatHandle> = result
+        .active_claims
+        .iter()
+        .map(|claim| spawn_claim_heartbeat(&coord_http_base, device_id, &result.agent_id, claim))
+        .collect();
 
     // Ambient edit-effect loop — predict side (Phase 3, plan
     // 2026-06-05-edit-effect-loop-adoption). Fire-and-forget a
@@ -307,14 +374,132 @@ pub async fn acquire(
     Ok(Some(IsolatedEditContext {
         agent_id: result.agent_id,
         worktrees: result.worktrees,
-        active_claim: result.active_claim,
-        _heartbeat: heartbeat,
+        active_claims: result.active_claims,
+        _heartbeats: heartbeats,
         coord_http_base,
         device_id,
         edit_loop_stash,
         edit_loop_correlation_id,
         edit_loop_declared_paths,
     }))
+}
+
+/// Resolve canonical paths + parent SHAs for `repos`, call
+/// [`allocate_and_materialize_with_claim`], and normalize coord's isolation
+/// directive into a worktree-shaped [`super::AllocateResult`]. Shared by
+/// [`acquire`] (all repos up front) and
+/// [`IsolatedEditContext::acquire_additional`] (one extra repo). Does NOT
+/// spawn heartbeats — the caller decides where the heartbeat handles live.
+///
+/// Isolation normalization:
+/// - `Worktrees` → as-is.
+/// - `SharedBranch` → the canonical checkout IS the cwd; map each per-repo
+///   branch into a `MaterializedWorktree` whose `worktree_path` is the
+///   canonical checkout so callers reading `worktrees[0].worktree_path` get
+///   the right cwd (the shared checkout) transparently.
+/// - `Wait` → `Err(Other)` with a `wait:` prefix so the caller logs/retries
+///   (it does NOT spin). `acquire_for_terminal` degrades to the shared cwd.
+#[allow(clippy::too_many_arguments)]
+async fn materialize_repos(
+    coord_http_base: &str,
+    device_id: uuid::Uuid,
+    repos: &[String],
+    intent: Option<&str>,
+    declared_overlap_paths: Option<&[String]>,
+    plan_id: Option<&str>,
+    phase: Option<&str>,
+    agent_session_id: Option<uuid::Uuid>,
+) -> Result<super::AllocateResult, AllocateError> {
+    let mut canonical_paths: HashMap<String, PathBuf> = HashMap::with_capacity(repos.len());
+    for repo in repos {
+        let path = super::canonical_paths::default_canonical_path(repo)
+            .map_err(|e| AllocateError::Other(format!("canonical path for repo {repo:?}: {e}")))?;
+        canonical_paths.insert(repo.clone(), path);
+    }
+
+    let mut repo_reqs: Vec<RepoRequest> = Vec::with_capacity(repos.len());
+    for repo in repos {
+        let canonical = canonical_paths
+            .get(repo)
+            .ok_or_else(|| AllocateError::Other(format!("no canonical path for repo '{repo}'")))?;
+        let parent_sha = resolve_head_sha(canonical)
+            .map_err(|e| AllocateError::Other(format!("git rev-parse HEAD on {repo}: {e}")))?;
+        repo_reqs.push(RepoRequest {
+            repo: repo.clone(),
+            parent_sha,
+        });
+    }
+
+    let outcome = allocate_and_materialize_with_claim(
+        coord_http_base,
+        &device_id,
+        agent_session_id,
+        &repo_reqs,
+        intent,
+        declared_overlap_paths,
+        &canonical_paths,
+        plan_id,
+        phase,
+    )
+    .await?;
+
+    match outcome {
+        MaterializeOutcome::Worktrees(r) => Ok(r),
+        MaterializeOutcome::SharedBranch(sb) => Ok(super::AllocateResult {
+            agent_id: sb.agent_id,
+            worktrees: sb
+                .branches
+                .into_iter()
+                .map(|b| MaterializedWorktree {
+                    repo: b.repo,
+                    branch: b.branch,
+                    parent_sha: b.parent_sha,
+                    worktree_path: b.checkout_path,
+                    push_ref: b.push_ref,
+                })
+                .collect(),
+            token: sb.token,
+            token_jti: sb.token_jti,
+            token_exp: sb.token_exp,
+            active_claims: sb.active_claims,
+        }),
+        MaterializeOutcome::Wait(w) => Err(AllocateError::Other(format!(
+            "wait: coord declined to materialize agent_id={} reason={:?} blocking={:?} retry_when={:?}",
+            w.agent_id, w.reason, w.blocking, w.retry_when
+        ))),
+    }
+}
+
+/// Spawn the TTL/3 heartbeat task for one claim. Shared by [`acquire`] and
+/// the grow/shrink primitive [`IsolatedEditContext::acquire_additional`] so
+/// the log line + stolen-claim warning stay in one place.
+fn spawn_claim_heartbeat(
+    coord_http_base: &str,
+    device_id: uuid::Uuid,
+    agent_id: &str,
+    claim: &ActiveClaim,
+) -> ClaimHeartbeatHandle {
+    info!(
+        agent_id = %agent_id,
+        kind = %claim.kind,
+        resource_key = %claim.resource_key,
+        ttl_seconds = claim.ttl_seconds,
+        "isolated_edit: spawning heartbeat"
+    );
+    spawn_heartbeat_task(
+        coord_http_base.to_string(),
+        device_id,
+        claim.agent_session_id,
+        &claim.kind,
+        claim.resource_key.clone(),
+        claim.ttl_seconds,
+        |displaced_by| {
+            warn!(
+                displaced_by = ?displaced_by,
+                "isolated_edit: claim stolen — edits in this worktree may now race"
+            );
+        },
+    )
 }
 
 /// Convenience helper for the three runner terminal-spawn entry points
@@ -417,8 +602,211 @@ fn resolve_head_sha(canonical: &Path) -> Result<String, String> {
 }
 
 #[cfg(test)]
+impl IsolatedEditContext {
+    /// Test-only constructor that builds a context with synthetic claims and
+    /// NO live heartbeats, bypassing the network acquire path. Used to
+    /// exercise the multi-claim bookkeeping (`acquire_additional` joins,
+    /// `release_repo` shrink, Drop releases all) without coord. The
+    /// `coord_http_base` points at an unroutable address so any best-effort
+    /// release POST fails instantly instead of hitting a real coord.
+    pub(crate) fn for_test(
+        worktrees: Vec<MaterializedWorktree>,
+        active_claims: Vec<ActiveClaim>,
+    ) -> Self {
+        IsolatedEditContext {
+            agent_id: "test-agent".to_string(),
+            worktrees,
+            active_claims,
+            _heartbeats: Vec::new(),
+            // 127.0.0.1:1 refuses instantly — release POSTs fail fast, the
+            // bookkeeping under test runs regardless.
+            coord_http_base: "http://127.0.0.1:1".to_string(),
+            device_id: uuid::Uuid::nil(),
+            edit_loop_stash: super::edit_effect_loop::new_stash(),
+            edit_loop_correlation_id: uuid::Uuid::nil(),
+            edit_loop_declared_paths: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a `(MaterializedWorktree, worktree-kind ActiveClaim)` pair for
+    /// `repo`, with the claim keyed on the SAME canonical-path resource_key
+    /// the acquire side derives — so `release_repo`'s key match works.
+    fn repo_fixture(repo: &str) -> (MaterializedWorktree, ActiveClaim) {
+        let canonical = super::super::canonical_paths::default_canonical_path(repo).unwrap();
+        let key = super::super::worktree_resource_key(&canonical);
+        let wt = MaterializedWorktree {
+            repo: repo.to_string(),
+            branch: format!("agent/test-{repo}"),
+            parent_sha: "0".repeat(40),
+            worktree_path: canonical,
+            push_ref: format!("refs/agent/test-{repo}"),
+        };
+        let claim = ActiveClaim {
+            kind: "worktree".to_string(),
+            resource_key: key,
+            ttl_seconds: 300,
+            agent_session_id: Some(uuid::Uuid::nil()),
+        };
+        (wt, claim)
+    }
+
+    #[test]
+    fn multi_repo_context_has_one_worktree_claim_per_repo() {
+        // Mirrors the multi-repo acquire outcome: a context materialized for
+        // [A, B] carries exactly one kind=worktree claim per repo, each keyed
+        // on that repo's canonical checkout path (the guard's by-resource
+        // form). Asserts the bookkeeping the acquire path produces without
+        // needing a live coord.
+        let (wa, ca) = repo_fixture("qontinui-runner");
+        let (wb, cb) = repo_fixture("qontinui-coord");
+        let mut ctx = IsolatedEditContext::for_test(vec![wa, wb], vec![ca, cb]);
+
+        let worktree_claims: Vec<&ActiveClaim> = ctx
+            .active_claims
+            .iter()
+            .filter(|c| c.kind == "worktree")
+            .collect();
+        assert_eq!(worktree_claims.len(), 2, "one worktree claim per repo");
+        assert!(worktree_claims
+            .iter()
+            .any(|c| c.resource_key == "d:/qontinui-root/qontinui-runner"));
+        assert!(worktree_claims
+            .iter()
+            .any(|c| c.resource_key == "d:/qontinui-root/qontinui-coord"));
+
+        // Drain before drop: this is a non-async test, and Drop's release
+        // path `tokio::spawn`s — which panics outside a runtime. Clearing
+        // trips Drop's `!claims.is_empty()` guard so no spawn is attempted.
+        ctx.active_claims.clear();
+        ctx.worktrees.clear();
+    }
+
+    #[tokio::test]
+    async fn release_repo_shrinks_claims_and_worktrees() {
+        // acquire([A,B]) shape → 2 worktree claims; release_repo(A) → 1.
+        // Exercises the shrink primitive's bookkeeping (the network release
+        // is best-effort and fails fast against the unroutable base).
+        let (wa, ca) = repo_fixture("qontinui-runner");
+        let (wb, cb) = repo_fixture("qontinui-coord");
+        let mut ctx = IsolatedEditContext::for_test(vec![wa, wb], vec![ca, cb]);
+        assert_eq!(ctx.active_claims.len(), 2);
+        assert_eq!(ctx.worktrees.len(), 2);
+
+        let released = ctx.release_repo("qontinui-runner").await;
+        assert!(released, "release_repo returns true for a joined repo");
+        assert_eq!(ctx.active_claims.len(), 1, "one worktree claim remains");
+        assert_eq!(ctx.worktrees.len(), 1);
+        assert_eq!(ctx.worktrees[0].repo, "qontinui-coord");
+        assert_eq!(
+            ctx.active_claims[0].resource_key,
+            "d:/qontinui-root/qontinui-coord"
+        );
+
+        // Idempotent: releasing a repo that's no longer joined is a no-op.
+        let again = ctx.release_repo("qontinui-runner").await;
+        assert!(!again, "release_repo returns false for an absent repo");
+        assert_eq!(ctx.active_claims.len(), 1);
+
+        // Drain so the Drop release path doesn't fire a stray POST after the
+        // test runtime is gone.
+        ctx.active_claims.clear();
+        ctx.worktrees.clear();
+    }
+
+    #[tokio::test]
+    async fn release_repo_only_drops_matching_worktree_claim() {
+        // A coexisting phase claim must survive a worktree release.
+        let (wa, ca) = repo_fixture("qontinui-runner");
+        let phase_claim = ActiveClaim {
+            kind: "phase".to_string(),
+            resource_key: "plan:p:phase:1".to_string(),
+            ttl_seconds: 7200,
+            agent_session_id: Some(uuid::Uuid::nil()),
+        };
+        let mut ctx = IsolatedEditContext::for_test(vec![wa], vec![ca, phase_claim]);
+        assert_eq!(ctx.active_claims.len(), 2);
+
+        let released = ctx.release_repo("qontinui-runner").await;
+        assert!(released);
+        // The phase claim is untouched — only the worktree claim went.
+        assert_eq!(ctx.active_claims.len(), 1);
+        assert_eq!(ctx.active_claims[0].kind, "phase");
+
+        ctx.active_claims.clear();
+        ctx.worktrees.clear();
+    }
+
+    #[tokio::test]
+    async fn acquire_additional_is_idempotent_for_a_joined_repo() {
+        // The grow primitive must early-return Ok(()) WITHOUT a network
+        // allocate when the repo is already joined — so a caller can blindly
+        // request a repo it may already hold. We assert it neither errors nor
+        // mutates the context (a network path against the unroutable base
+        // would instead surface an Err).
+        let (wa, ca) = repo_fixture("qontinui-runner");
+        let mut ctx = IsolatedEditContext::for_test(vec![wa], vec![ca]);
+        assert_eq!(ctx.worktrees.len(), 1);
+        assert_eq!(ctx.active_claims.len(), 1);
+
+        let r = ctx
+            .acquire_additional("qontinui-runner", Some("already joined"))
+            .await;
+        assert!(r.is_ok(), "joined-repo acquire_additional is a no-op Ok");
+        assert_eq!(ctx.worktrees.len(), 1, "no duplicate worktree joined");
+        assert_eq!(ctx.active_claims.len(), 1, "no duplicate claim joined");
+
+        ctx.active_claims.clear();
+        ctx.worktrees.clear();
+    }
+
+    #[test]
+    fn session_id_is_carried_from_the_first_claim() {
+        // acquire_additional reuses the context's owner-token discriminator
+        // so the new repo's claim shares the session owner token. Verify the
+        // accessor returns the first claim's session id.
+        let sid = uuid::Uuid::parse_str("44444444-4444-4444-4444-444444444444").unwrap();
+        let (wa, mut ca) = repo_fixture("qontinui-runner");
+        ca.agent_session_id = Some(sid);
+        let mut ctx = IsolatedEditContext::for_test(vec![wa], vec![ca]);
+        assert_eq!(ctx.session_id(), Some(sid));
+
+        // Non-async test: drain before drop (see the note in
+        // `multi_repo_context_has_one_worktree_claim_per_repo`).
+        ctx.active_claims.clear();
+        ctx.worktrees.clear();
+    }
+
+    #[tokio::test]
+    async fn drop_releases_all_claims() {
+        // Drop must release EVERY active claim, not just the first. We assert
+        // via the observable side effect available without a coord seam: Drop
+        // drains `active_claims` (std::mem::take) and spawns the release. We
+        // verify the take-and-spawn happens for a multi-claim context by
+        // confirming the spawned task is accepted by the runtime (no panic)
+        // and that a SECOND drop of an emptied context is inert.
+        let (wa, ca) = repo_fixture("qontinui-runner");
+        let (wb, cb) = repo_fixture("qontinui-coord");
+        let ctx = IsolatedEditContext::for_test(vec![wa, wb], vec![ca, cb]);
+        assert_eq!(ctx.active_claims.len(), 2);
+        // Dropping inside a tokio runtime: the Drop impl `tokio::spawn`s the
+        // multi-claim release loop. If Drop only released one claim or
+        // panicked on >1, this would surface here.
+        drop(ctx);
+
+        // An emptied context drops without spawning anything (the
+        // `!claims.is_empty()` guard), proving the guard path too.
+        let empty = IsolatedEditContext::for_test(Vec::new(), Vec::new());
+        drop(empty);
+
+        // Yield so the spawned release task gets a chance to run (and fail
+        // fast against the unroutable base) before the runtime tears down.
+        tokio::task::yield_now().await;
+    }
 
     #[tokio::test]
     async fn returns_none_when_flag_off() {

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -105,7 +105,45 @@ pub struct ClaimSpawnContext {
     pub phase: Option<String>,
 }
 
+/// Normalize a canonical checkout path into the exact `resource_key` form
+/// the coord-guard derives for a `kind=worktree` claim: forward slashes,
+/// lowercase (so a `D:/` drive letter and a `d:/` one collide), and no
+/// trailing slash. The guard observes the form `d:/qontinui-root/<repo>`.
+///
+/// This MUST stay byte-identical to whatever the guard produces when it
+/// looks up `GET /coord/claims/by-resource?kind=worktree&key=<path>`. The
+/// guard runs its own `realpath`-style resolution which can emit a
+/// `/d/qontinui-root/...` (MSYS) shape; the contract test below pins the
+/// Windows-native form so a guard-side divergence surfaces as a failing
+/// contract test rather than a silent never-matching claim in prod.
+pub fn worktree_resource_key(canonical: &std::path::Path) -> String {
+    canonical
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_lowercase()
+}
+
 impl ClaimSpawnContext {
+    /// Build a `kind=worktree` claim context for one canonical checkout
+    /// path. The `resource_key` is normalized via [`worktree_resource_key`]
+    /// so it matches the coord-guard's `by-resource` lookup byte-for-byte.
+    ///
+    /// Unlike [`Self::from_intent_and_paths`] this is unconditional — a
+    /// session always claims the worktree(s) it materializes regardless of
+    /// whether a plan_id/phase/file_glob was declared. This closes the
+    /// gate-continuation gap where worktrees materialized with NO claim at
+    /// all (intent/plan_id/phase/declared_overlap_paths all `None`).
+    pub fn worktree_for_path(canonical: &std::path::Path, intent: Option<&str>) -> Self {
+        Self {
+            kind: "worktree",
+            resource_key: worktree_resource_key(canonical),
+            intent: intent.map(|s| s.to_string()),
+            plan_id: None,
+            phase: None,
+        }
+    }
+
     /// Derive a claim context from the spawn payload's optional fields.
     ///
     /// Precedence (per plan Phase 3 spec):
@@ -266,6 +304,62 @@ async fn pre_allocate_claim(
         None => Ok(AcquireOutcome::Other(format!(
             "/claims/acquire body missing `result` discriminator: {body_text}"
         ))),
+    }
+}
+
+/// Acquire ONE claim from a [`ClaimSpawnContext`] and map the outcome into
+/// an [`ActiveClaim`] (on `Acquired`) or an [`AllocateError`] (on `Held` →
+/// `ClaimConflict`, on `Other`/transport → `Other`). Shared by both the
+/// pre-allocate phase/file_glob claim and the per-repo `kind=worktree`
+/// claims (Phase 1) so the acquire-and-map logic lives in one place.
+async fn acquire_one_claim(
+    coord_http_base: &str,
+    machine_id: &uuid::Uuid,
+    agent_session_id: Option<uuid::Uuid>,
+    ctx: &ClaimSpawnContext,
+) -> Result<ActiveClaim, AllocateError> {
+    match pre_allocate_claim(coord_http_base, machine_id, agent_session_id, ctx).await {
+        Ok(AcquireOutcome::Acquired { ttl_seconds }) => {
+            info!(
+                "claims/acquire ok kind={} key={} ttl={}s",
+                ctx.kind, ctx.resource_key, ttl_seconds
+            );
+            Ok(ActiveClaim {
+                kind: ctx.kind.to_string(),
+                resource_key: ctx.resource_key.clone(),
+                ttl_seconds,
+                agent_session_id,
+            })
+        }
+        Ok(AcquireOutcome::Held(conflict)) => {
+            warn!(
+                "claims/acquire held kind={} key={} current_holder={}",
+                conflict.kind, conflict.resource_key, conflict.current_holder
+            );
+            Err(AllocateError::ClaimConflict(conflict))
+        }
+        Ok(AcquireOutcome::Other(msg)) => Err(AllocateError::Other(msg)),
+        Err(e) => Err(AllocateError::Other(e)),
+    }
+}
+
+/// Release every claim in `claims` best-effort (used to unwind a partial
+/// multi-claim acquire when a later claim is `Held`, and on the `Wait`
+/// teardown path). Each release matches the owner token its acquire used.
+async fn release_all_claims_best_effort(
+    coord_http_base: &str,
+    machine_id: &uuid::Uuid,
+    claims: &[ActiveClaim],
+) {
+    for c in claims {
+        release_claim_best_effort(
+            coord_http_base,
+            *machine_id,
+            c.agent_session_id,
+            &c.kind,
+            &c.resource_key,
+        )
+        .await;
     }
 }
 
@@ -542,13 +636,16 @@ pub fn remote_agent_ref(branch: &str) -> String {
 /// not configured on coord) means "skip pusher spawn for this
 /// allocation."
 ///
-/// Plan 2026-05-18-agent-spawn-coordination Phase 3 added
-/// `active_claim`: when the spawn flow pre-acquired a coord claim via
-/// `POST /claims/acquire`, this carries the claim's `(kind,
-/// resource_key, ttl_seconds)` so callers can spawn the heartbeat
-/// task and release on agent completion. `None` when no claim was
-/// pre-acquired (legacy callers that don't pass plan_id/phase or
-/// `declared_overlap_paths`).
+/// Plan 2026-05-18-agent-spawn-coordination Phase 3 added the spawn-time
+/// claim; plan 2026-06-06-session-scoped-multi-repo-workspace-coordination
+/// Phase 1 widened it from a single claim to a collection:
+/// `active_claims` carries EVERY claim the spawn flow pre-acquired —
+/// one `kind=worktree` claim per materialized repo (always), plus the
+/// optional `phase`/`file_glob` claim as just one more entry when the
+/// caller declared a plan_id/phase or `declared_overlap_paths`. Callers
+/// spawn one heartbeat task per entry and release every entry on agent
+/// completion. Empty when no claim was acquired (worktree mode off, or
+/// the no-op test builders).
 #[derive(Debug, Clone, Serialize)]
 pub struct AllocateResult {
     pub agent_id: String,
@@ -556,8 +653,8 @@ pub struct AllocateResult {
     pub token: String,
     pub token_jti: uuid::Uuid,
     pub token_exp: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_claim: Option<ActiveClaim>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub active_claims: Vec<ActiveClaim>,
 }
 
 /// Per-spawn active claim — the resource_key / kind / TTL acquired
@@ -673,8 +770,13 @@ pub struct SharedBranchResult {
     pub token: String,
     pub token_jti: uuid::Uuid,
     pub token_exp: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub active_claim: Option<ActiveClaim>,
+    /// Every pre-acquired claim for this shared-branch allocation — one
+    /// `kind=worktree` claim per repo (keyed on the canonical checkout the
+    /// branch lives in) plus the optional phase/file_glob claim. Converted
+    /// in lockstep with [`AllocateResult::active_claims`] (Phase 1) so the
+    /// shared-branch path is never single-claim.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub active_claims: Vec<ActiveClaim>,
 }
 
 /// One repo's shared-branch checkout.
@@ -803,17 +905,21 @@ impl From<String> for AllocateError {
 /// `resource_key = "plan:<plan>:phase:<phase>"`; when only
 /// `declared_overlap_paths` is present the claim kind is `FileGlob`.
 ///
-/// Per plan 2026-05-18-agent-spawn-coordination Phase 3, when a
-/// `ClaimSpawnContext` can be derived from the inputs (either
-/// plan_id + phase, or non-empty `declared_overlap_paths`), this
-/// function first calls coord's `POST /claims/acquire` with the
-/// derived `(kind, resource_key)`. On `Held`, returns
-/// `Err(AllocateError::ClaimConflict)` WITHOUT touching
-/// `/agents/allocate`. On `Claimed`/`Renewed`, proceeds to allocate;
-/// the caller is responsible for spawning a heartbeat task and
-/// releasing the claim on agent completion (see [`spawn_heartbeat_task`]
-/// and [`release_claim_best_effort`]). The returned [`AllocateResult`]
-/// carries the active claim context for that purpose.
+/// Claim acquisition (Phase 1, plan
+/// 2026-06-06-session-scoped-multi-repo-workspace-coordination). BEFORE
+/// `/agents/allocate` and before any `git worktree add`, this acquires:
+///   1. One `kind=worktree` claim per repo, keyed on the canonical
+///      checkout path normalized to the guard's `by-resource` form
+///      (always — even when no plan_id/phase/paths were declared, which is
+///      the gate-continuation case the old code left unclaimed).
+///   2. The optional `phase`/`file_glob` claim (Phase 3 behavior) when a
+///      plan_id + phase or non-empty `declared_overlap_paths` was supplied.
+/// A `Held` on ANY claim unwinds the claims already acquired and returns
+/// `Err(AllocateError::ClaimConflict)` WITHOUT touching `/agents/allocate`.
+/// On full success it proceeds to allocate; the caller spawns one heartbeat
+/// task per claim and releases every claim on agent completion (see
+/// [`spawn_heartbeat_task`] and [`release_claim_best_effort`]). The returned
+/// [`AllocateResult::active_claims`] carries them all for that purpose.
 ///
 /// On success returns `AllocateResult`. On any non-claim error,
 /// returns `Err(AllocateError::Other(String))`. Partial failure is
@@ -842,44 +948,10 @@ pub async fn allocate_and_materialize_with_claim(
         return Err(AllocateError::Other("repos must not be empty".to_string()));
     }
 
-    // Phase 3: pre-allocate `/claims/acquire`. When a claim context can
-    // be derived from the inputs, call coord's atomic acquire-or-fail
-    // BEFORE `/agents/allocate`. On `Held`, return ClaimConflict.
-    let claim_ctx =
-        ClaimSpawnContext::from_intent_and_paths(intent, plan_id, phase, declared_overlap_paths);
-    let active_claim = if let Some(ref ctx) = claim_ctx {
-        match pre_allocate_claim(coord_http_base, machine_id, agent_session_id, ctx).await {
-            Ok(AcquireOutcome::Acquired { ttl_seconds }) => {
-                info!(
-                    "claims/acquire ok kind={} key={} ttl={}s",
-                    ctx.kind, ctx.resource_key, ttl_seconds
-                );
-                Some(ActiveClaim {
-                    kind: ctx.kind.to_string(),
-                    resource_key: ctx.resource_key.clone(),
-                    ttl_seconds,
-                    agent_session_id,
-                })
-            }
-            Ok(AcquireOutcome::Held(conflict)) => {
-                warn!(
-                    "claims/acquire held kind={} key={} current_holder={}",
-                    conflict.kind, conflict.resource_key, conflict.current_holder
-                );
-                return Err(AllocateError::ClaimConflict(conflict));
-            }
-            Ok(AcquireOutcome::Other(msg)) => {
-                return Err(AllocateError::Other(msg));
-            }
-            Err(e) => return Err(AllocateError::Other(e)),
-        }
-    } else {
-        None
-    };
-
     // Pre-flight: every requested repo must have a canonical path the
-    // runner can `git worktree add` from. Surface this before bothering
-    // coord with the request.
+    // runner can `git worktree add` from. Surface this BEFORE acquiring any
+    // claim (canonical paths are also the source of the worktree claim
+    // keys, so they must resolve first).
     for r in repos {
         if !repo_canonical_paths.contains_key(&r.repo) {
             return Err(AllocateError::Other(format!(
@@ -887,6 +959,48 @@ pub async fn allocate_and_materialize_with_claim(
                  repo_canonical_paths",
                 r.repo
             )));
+        }
+    }
+
+    // Phase 1 (plan 2026-06-06-session-scoped-multi-repo-workspace-coordination):
+    // acquire the per-repo `kind=worktree` claims BEFORE materializing any
+    // worktree — fail-fast, mirroring the original `pre_allocate_claim`
+    // placement. The claim key is the canonical checkout path normalized to
+    // the guard's `by-resource` form (see `worktree_resource_key`), so a
+    // gate-continuation (which declares no plan_id/phase/paths) still claims
+    // every checkout it touches. A `Held` on ANY repo means another session
+    // owns that checkout → unwind the claims already acquired and return the
+    // ClaimConflict so the caller surfaces it instead of clobbering.
+    //
+    // Then acquire the OPTIONAL phase/file_glob claim (when a plan_id/phase
+    // or `declared_overlap_paths` was declared) as just one more entry.
+    let mut active_claims: Vec<ActiveClaim> = Vec::with_capacity(repos.len() + 1);
+
+    for r in repos {
+        let canonical = repo_canonical_paths
+            .get(&r.repo)
+            .expect("canonical path presence checked above");
+        let ctx = ClaimSpawnContext::worktree_for_path(canonical, intent);
+        match acquire_one_claim(coord_http_base, machine_id, agent_session_id, &ctx).await {
+            Ok(claim) => active_claims.push(claim),
+            Err(e) => {
+                // Unwind every worktree claim we acquired before this one so
+                // a partial acquire doesn't strand held checkouts.
+                release_all_claims_best_effort(coord_http_base, machine_id, &active_claims).await;
+                return Err(e);
+            }
+        }
+    }
+
+    let claim_ctx =
+        ClaimSpawnContext::from_intent_and_paths(intent, plan_id, phase, declared_overlap_paths);
+    if let Some(ref ctx) = claim_ctx {
+        match acquire_one_claim(coord_http_base, machine_id, agent_session_id, ctx).await {
+            Ok(claim) => active_claims.push(claim),
+            Err(e) => {
+                release_all_claims_best_effort(coord_http_base, machine_id, &active_claims).await;
+                return Err(e);
+            }
         }
     }
 
@@ -951,19 +1065,10 @@ pub async fn allocate_and_materialize_with_claim(
             "allocate: coord returned wait agent_id={} reason={:?} blocking={:?} retry_when={:?}",
             coord_resp.agent_id, reason, blocking, retry_when
         );
-        // A pre-acquired claim must not linger while we wait — release it
-        // so the held resource isn't pinned by an agent that never
-        // materialized.
-        if let Some(claim) = &active_claim {
-            release_claim_best_effort(
-                coord_http_base,
-                *machine_id,
-                claim.agent_session_id,
-                &claim.kind,
-                &claim.resource_key,
-            )
-            .await;
-        }
+        // Pre-acquired claims must not linger while we wait — release every
+        // one so no held resource (worktree checkout or phase/file_glob) is
+        // pinned by an agent that never materialized.
+        release_all_claims_best_effort(coord_http_base, machine_id, &active_claims).await;
         return Ok(MaterializeOutcome::Wait(WaitOutcome {
             agent_id: coord_resp.agent_id,
             reason,
@@ -1007,7 +1112,7 @@ pub async fn allocate_and_materialize_with_claim(
             token: coord_resp.token,
             token_jti: coord_resp.token_jti.unwrap_or(uuid::Uuid::nil()),
             token_exp: coord_resp.token_exp.unwrap_or(0),
-            active_claim,
+            active_claims,
         }));
     }
 
@@ -1165,7 +1270,7 @@ pub async fn allocate_and_materialize_with_claim(
         token: coord_resp.token,
         token_jti: coord_resp.token_jti.unwrap_or(uuid::Uuid::nil()),
         token_exp: coord_resp.token_exp.unwrap_or(0),
-        active_claim,
+        active_claims,
     }))
 }
 
@@ -1292,6 +1397,41 @@ mod tests {
         assert_eq!(body["machine_id"], machine.to_string());
         // uuid serializes hyphenated-lowercase, matching to_string().
         assert_eq!(body["agent_session_id"], session.to_string());
+    }
+
+    #[test]
+    fn worktree_resource_key_normalizes_to_guard_form() {
+        // Pins the canonical worktree-claim resource_key form the
+        // coord-guard's `by-resource` lookup expects: forward slashes,
+        // lowercase drive letter, no trailing slash. A guard-side
+        // `realpath` (/d/… MSYS) divergence is caught by THIS contract.
+        let p = std::path::Path::new("D:\\qontinui-root\\qontinui-runner");
+        assert_eq!(worktree_resource_key(p), "d:/qontinui-root/qontinui-runner");
+
+        // Forward-slash input + uppercase drive collapses identically.
+        let p2 = std::path::Path::new("D:/qontinui-root/qontinui-runner");
+        assert_eq!(
+            worktree_resource_key(p2),
+            "d:/qontinui-root/qontinui-runner"
+        );
+
+        // Trailing slash is stripped so `<root>/<repo>` and `<root>/<repo>/`
+        // produce the same key.
+        let p3 = std::path::Path::new("D:/qontinui-root/qontinui-coord/");
+        assert_eq!(worktree_resource_key(p3), "d:/qontinui-root/qontinui-coord");
+    }
+
+    #[test]
+    fn worktree_for_path_builds_worktree_kind_claim_ctx() {
+        let p = std::path::Path::new("D:/qontinui-root/qontinui-runner");
+        let ctx = ClaimSpawnContext::worktree_for_path(p, Some("editing the runner"));
+        assert_eq!(ctx.kind, "worktree");
+        assert_eq!(ctx.resource_key, "d:/qontinui-root/qontinui-runner");
+        assert_eq!(ctx.intent.as_deref(), Some("editing the runner"));
+        assert!(ctx.plan_id.is_none());
+        assert!(ctx.phase.is_none());
+        // worktree claims use the coord-default 300s TTL.
+        assert_eq!(default_ttl_seconds_for(ctx.kind), 300);
     }
 
     #[test]


### PR DESCRIPTION
Phase 1 of plan `2026-06-06-session-scoped-multi-repo-workspace-coordination` (qontinui-dev-notes). Fixes the P0a claim-contract mismatch: the coord-guard queries `by-resource?kind=worktree&key=<checkout>` but the runner never created a `worktree` claim — gate-continuations materialized worktrees with **no claim at all**.

## 1a — `worktree` claim contract + multi-claim model
- Every repo a session materializes now acquires a `kind=worktree` claim keyed on the lowercased canonical checkout path (byte-identical to the guard's derivation; pinned by a normalization contract test), acquired **before** materialization, `Held` → `AllocateError::ClaimConflict` with unwind of already-acquired claims.
- `IsolatedEditContext.active_claim`/`_heartbeat`, `AllocateResult.active_claim`, and the twin `SharedBranchResult.active_claim` all converted to `Vec` in lockstep — one heartbeat task per claim, `Drop` releases all.

## 1b — Session-keyed continuation
- `acquire_continuation_workdir` no longer passes `agent_session_id: None`: new `continuation_session_id()` derives a stable UUIDv5 over `<target_device_id>:<anchor_key>` (no Claude session UUID exists on the continuation wire; same-gate retries renew rather than collide; anchor-less one-shots get a v4). Builds on the owner-token wire plumbing from #443.

## 1c — Grow/shrink join primitives
- `IsolatedEditContext::acquire_additional(repo, intent)` materializes one more repo + claim + heartbeat into a live context (idempotent for already-joined repos); `release_repo(repo)` drops coordination state only — the worktree dir is left for the existing reclaim machinery.

## Tests
- 16 new/updated unit tests (resource-key normalization, per-repo claim bookkeeping, grow/shrink, Drop-releases-all) + 38 + 78 regression tests green; `cargo clippy --all-targets -- -D warnings` clean.

## Notes
- Sibling to #443 (which removed the dead `/agents/allocate-local` endpoint): this PR does NOT re-add an HTTP face. The planned Phase-2 first-touch hook will route through `isolated_edit::acquire`/`acquire_additional`.
- Plan phases 2–5 are deferred (operator halt); this PR is independently mergeable and shippable.