### PR TITLE
feat(dev-loop): "Test My Change" temp-runner dev loop (Phase 1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,34 @@ qontinui-runner/
 
 ## Testing
 
+### Dev loop — test your change without restarting the primary
+
+**Never restart the primary runner to test a code change — build it into an
+isolated temp runner instead.** The supervisor (`:9875`) can compile any
+worktree or git ref into its own throwaway runner (own port 9877–9899, own UI
+Bridge) with **zero impact on the primary** (`:9876`), so a restart is never
+the way to see your change.
+
+The first-class way to do this from the runner UI: **Settings → "Test My
+Change"**. Pick a detected worktree / a git ref / a worktree path, click
+**Build & launch test runner**, then **Open** the spawned runner to verify.
+**Stop** it when done. Under the hood this is a single
+`POST /runners/spawn-test` with a provenance selector:
+
+```bash
+# build an isolated temp runner from a branch (clean checkout) and wait for health
+curl -X POST localhost:9875/runners/spawn-test \
+  -H 'content-type: application/json' \
+  -d '{"rebuild":true,"git_ref":"feat/my-change","wait":true}'
+# …or from an existing worktree (uncommitted edits included):
+#   -d '{"rebuild":true,"worktree_path":"D:/.../qontinui-runner","wait":true}'
+curl -X POST localhost:9875/runners/<id>/stop   # clean up when done
+```
+
+Always check the response `source` field (`worktree`/`worktree_path`/`git_ref`
+vs `live_tree`) and `git_sha` to confirm what actually got built. `git_ref`
+and `worktree_path` are mutually exclusive and both require `rebuild:true`.
+
 ### Frontend Tests
 
 ```bash

--- a/src-tauri/src/commands/instances.rs
+++ b/src-tauri/src/commands/instances.rs
@@ -332,7 +332,10 @@ pub async fn list_repo_worktrees(repo_root: String) -> Result<Vec<DevLoopWorktre
                  is_main: bool|
      -> Option<DevLoopWorktree> {
         let path = path?;
-        let buildable = Path::new(&path).join("src-tauri").join("Cargo.toml").exists();
+        let buildable = Path::new(&path)
+            .join("src-tauri")
+            .join("Cargo.toml")
+            .exists();
         Some(DevLoopWorktree {
             path,
             branch,
@@ -364,11 +367,7 @@ pub async fn list_repo_worktrees(repo_root: String) -> Result<Vec<DevLoopWorktre
         } else if let Some(rest) = line.strip_prefix("HEAD ") {
             current_head = Some(rest.to_string());
         } else if let Some(rest) = line.strip_prefix("branch ") {
-            current_branch = Some(
-                rest.strip_prefix("refs/heads/")
-                    .unwrap_or(rest)
-                    .to_string(),
-            );
+            current_branch = Some(rest.strip_prefix("refs/heads/").unwrap_or(rest).to_string());
         } else if line == "detached" {
             current_detached = true;
         }

--- a/src-tauri/src/commands/instances.rs
+++ b/src-tauri/src/commands/instances.rs
@@ -251,6 +251,144 @@ pub async fn set_temp_spawn_placements(
     Ok(placements)
 }
 
+/// One worktree discovered via `git worktree list --porcelain`, surfaced to
+/// the "Test My Change" dev-loop UI so a developer can pick the checkout to
+/// build into an isolated temp runner. Mirrors the TS `DevLoopWorktree`
+/// interface in `DevLoopSettings.tsx`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DevLoopWorktree {
+    /// Absolute path to the worktree root (the `worktree <path>` line).
+    pub path: String,
+    /// Branch short name (`refs/heads/<name>` → `<name>`), or `None` when
+    /// the worktree is detached / bare.
+    pub branch: Option<String>,
+    /// The checked-out HEAD sha, if reported.
+    pub head: Option<String>,
+    /// True for the first entry — the main worktree (the live tree). The
+    /// supervisor rejects the live tree as a `worktree_path`, so the UI
+    /// steers the user to a git ref for this one.
+    pub is_main: bool,
+    /// True when the worktree has no branch (`detached` line present).
+    pub is_detached: bool,
+    /// True when `<path>/src-tauri/Cargo.toml` exists on disk — i.e. this
+    /// checkout can actually be built by the supervisor's spawn-test.
+    pub buildable: bool,
+}
+
+/// Discover the git worktrees under `repo_root` for the "Test My Change"
+/// dev-loop UI. `repo_root` is typically the supervisor's `project_dir`
+/// (`.../qontinui-runner/src-tauri`); if it ends in `src-tauri` we walk up
+/// to the repo root before asking git.
+///
+/// Returns ALL worktrees (including main, flagged `is_main`). On any git
+/// failure (non-zero exit, git not on PATH) returns `Err(String)` — the
+/// frontend treats that as "discovery unavailable" and falls back to manual
+/// entry of a git ref or path.
+#[tauri::command]
+pub async fn list_repo_worktrees(repo_root: String) -> Result<Vec<DevLoopWorktree>, String> {
+    use std::path::Path;
+
+    // Normalize: if the final path component is `src-tauri` (case-insensitive)
+    // use the parent directory as the git repo root, otherwise use as-is.
+    let root_path = Path::new(&repo_root);
+    let git_root: &Path = match root_path.file_name().and_then(|n| n.to_str()) {
+        Some(name) if name.eq_ignore_ascii_case("src-tauri") => {
+            root_path.parent().unwrap_or(root_path)
+        }
+        _ => root_path,
+    };
+
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(git_root)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .map_err(|e| format!("failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git worktree list failed ({}): {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut worktrees: Vec<DevLoopWorktree> = Vec::new();
+
+    // Porcelain format: records separated by blank lines. Each record starts
+    // with `worktree <path>` and may carry `HEAD <sha>`, `branch refs/...`,
+    // `detached`, `bare`.
+    let mut current_path: Option<String> = None;
+    let mut current_head: Option<String> = None;
+    let mut current_branch: Option<String> = None;
+    let mut current_detached = false;
+
+    let flush = |path: Option<String>,
+                 head: Option<String>,
+                 branch: Option<String>,
+                 detached: bool,
+                 is_main: bool|
+     -> Option<DevLoopWorktree> {
+        let path = path?;
+        let buildable = Path::new(&path).join("src-tauri").join("Cargo.toml").exists();
+        Some(DevLoopWorktree {
+            path,
+            branch,
+            head,
+            is_main,
+            is_detached: detached,
+            buildable,
+        })
+    };
+
+    for line in stdout.lines() {
+        if line.is_empty() {
+            // End of a record.
+            if let Some(wt) = flush(
+                current_path.take(),
+                current_head.take(),
+                current_branch.take(),
+                current_detached,
+                worktrees.is_empty(),
+            ) {
+                worktrees.push(wt);
+            }
+            current_detached = false;
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix("worktree ") {
+            current_path = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("HEAD ") {
+            current_head = Some(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix("branch ") {
+            current_branch = Some(
+                rest.strip_prefix("refs/heads/")
+                    .unwrap_or(rest)
+                    .to_string(),
+            );
+        } else if line == "detached" {
+            current_detached = true;
+        }
+        // `bare` and any other lines are ignored.
+    }
+
+    // Flush a trailing record (porcelain output may not end with a blank line).
+    if let Some(wt) = flush(
+        current_path.take(),
+        current_head.take(),
+        current_branch.take(),
+        current_detached,
+        worktrees.is_empty(),
+    ) {
+        worktrees.push(wt);
+    }
+
+    Ok(worktrees)
+}
+
 /// Get identity info about this runner instance: whether it's secondary and what primary it proxies to.
 #[tauri::command]
 pub async fn get_runner_identity(
@@ -284,6 +422,7 @@ pub fn plugin() -> TauriPlugin<tauri::Wry> {
             launch_runner_instance,
             stop_runner_instance,
             get_runner_identity,
+            list_repo_worktrees,
             preview_spawn_placement,
             list_monitors_for_placement,
             get_temp_spawn_placements,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1241,6 +1241,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::instances::get_temp_spawn_placements,
             commands::instances::launch_runner_instance,
             commands::instances::list_monitors_for_placement,
+            commands::instances::list_repo_worktrees,
             commands::instances::preview_spawn_placement,
             commands::instances::save_runner_instance,
             commands::instances::set_temp_spawn_placements,

--- a/src/components/app/TabContent.tsx
+++ b/src/components/app/TabContent.tsx
@@ -967,6 +967,7 @@ export function TabContent({
 
     case "settings":
     case "settings-account":
+    case "settings-dev-loop":
     case "settings-ai":
     case "settings-agentic":
     case "settings-self-healing":
@@ -988,6 +989,7 @@ export function TabContent({
       const settingsTabMap: Record<string, string> = {
         settings: "backend-connection",
         "settings-account": "account",
+        "settings-dev-loop": "dev-loop",
         "settings-ai": "ai",
         "settings-agentic": "agentic",
         "settings-self-healing": "self-healing",

--- a/src/components/app/tab-types.ts
+++ b/src/components/app/tab-types.ts
@@ -62,6 +62,7 @@ export type MainTabId =
   | "settings-mobile"
   | "settings-discovery"
   | "settings-backend-connection"
+  | "settings-dev-loop"
   | "settings-mcp"
   | "settings-log-sources"
   | "settings-execution-variables"
@@ -168,6 +169,7 @@ const VALID_TAB_IDS: MainTabId[] = [
   "settings-mobile",
   "settings-discovery",
   "settings-backend-connection",
+  "settings-dev-loop",
   "settings-mcp",
   "settings-log-sources",
   "settings-execution-variables",
@@ -285,6 +287,7 @@ export const TAB_LABELS: Record<MainTabId, string> = {
   "settings-mobile": "Mobile Settings",
   "settings-discovery": "Discovery Settings",
   "settings-backend-connection": "Backend Connection Settings",
+  "settings-dev-loop": "Test My Change",
   "settings-mcp": "MCP Settings",
   "settings-log-sources": "Log Sources Settings",
   "settings-execution-variables": "Execution Variables",

--- a/src/components/settings/DevLoopSettings.tsx
+++ b/src/components/settings/DevLoopSettings.tsx
@@ -1,0 +1,671 @@
+/**
+ * DevLoopSettings.tsx
+ *
+ * "Test My Change" — the canonical developer dev-loop for the runner.
+ *
+ * Build your current change (a git worktree, a git ref, or an explicit
+ * worktree path) into an ISOLATED temp runner via the supervisor's
+ * `POST /runners/spawn-test`. The primary runner is NEVER restarted — the
+ * rule is "never restart the primary to test; use a temp runner".
+ *
+ * Provenance is mutually exclusive: the request carries EITHER
+ * `{ worktree_path }` OR `{ git_ref }` — never both (the supervisor returns
+ * 400 `provenance_conflict` if both are sent).
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { FlaskConical, RefreshCw, Square, ExternalLink, Loader2 } from "lucide-react";
+import { SectionHeader } from "./SectionHeader";
+import type { LogFunction } from "./types";
+
+// ---------------------------------------------------------------------------
+// Types mirroring the Rust shapes from `commands::instances` and the
+// supervisor's spawn-test / runners contract.
+// ---------------------------------------------------------------------------
+
+/** Mirrors the Rust `DevLoopWorktree` from `commands::instances`. */
+interface DevLoopWorktree {
+  path: string;
+  branch: string | null;
+  head: string | null;
+  is_main: boolean;
+  is_detached: boolean;
+  buildable: boolean;
+}
+
+/** A single runner row from the supervisor's `GET /runners`. */
+interface SupervisorRunner {
+  id: string;
+  name: string;
+  port: number;
+  is_primary: boolean;
+  running: boolean;
+  pid: number | null;
+  api_responding: boolean;
+}
+
+/** 200 response shape from `POST /runners/spawn-test`. */
+interface SpawnTestResult {
+  id: string;
+  port: number;
+  api_url?: string;
+  ui_bridge_url?: string;
+  status: "healthy" | "timeout" | "started" | string;
+  git_sha?: string;
+  source?: "live_tree" | "worktree" | "worktree_path" | string;
+  git_ref_resolved_sha?: string;
+  git_ref_resolved_short?: string;
+  message?: string;
+}
+
+type SourceMode = "worktree" | "git_ref" | "custom_path";
+
+interface DevLoopSettingsProps {
+  onLog: LogFunction;
+}
+
+const DEFAULT_SUPERVISOR_PORT = "9875";
+
+function supervisorBase(port: string): string {
+  const p = port.trim() || DEFAULT_SUPERVISOR_PORT;
+  return `http://localhost:${p}`;
+}
+
+function shortPath(p: string): string {
+  // Show the trailing two path segments so long absolute paths stay readable.
+  const norm = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  const parts = norm.split("/");
+  if (parts.length <= 2) return p;
+  return `…/${parts.slice(-2).join("/")}`;
+}
+
+export function DevLoopSettings({ onLog }: DevLoopSettingsProps) {
+  const [supervisorPort, setSupervisorPort] = useState(DEFAULT_SUPERVISOR_PORT);
+
+  // Source picker (provenance — mutually exclusive)
+  const [sourceMode, setSourceMode] = useState<SourceMode>("worktree");
+  const [worktrees, setWorktrees] = useState<DevLoopWorktree[]>([]);
+  const [selectedWorktreePath, setSelectedWorktreePath] = useState<string>("");
+  const [gitRef, setGitRef] = useState("");
+  const [customPath, setCustomPath] = useState("");
+
+  // Discovery state
+  const [discovering, setDiscovering] = useState(false);
+  const [discoveryError, setDiscoveryError] = useState<string | null>(null);
+
+  // Build state
+  const [building, setBuilding] = useState(false);
+  const [elapsed, setElapsed] = useState(0);
+  const [result, setResult] = useState<SpawnTestResult | null>(null);
+  const [buildError, setBuildError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const elapsedTimerRef = useRef<number | null>(null);
+
+  // Running temp runners list
+  const [tempRunners, setTempRunners] = useState<SupervisorRunner[]>([]);
+
+  // -------------------------------------------------------------------------
+  // Worktree discovery: ask the supervisor for its build root, then ask the
+  // runner backend (via the Tauri command) to enumerate worktrees.
+  // -------------------------------------------------------------------------
+  const discoverWorktrees = useCallback(async () => {
+    setDiscovering(true);
+    setDiscoveryError(null);
+    try {
+      const resp = await fetch(`${supervisorBase(supervisorPort)}/health`);
+      if (!resp.ok) {
+        throw new Error(`supervisor /health: HTTP ${resp.status}`);
+      }
+      const health = (await resp.json()) as {
+        supervisor?: { project_dir?: string };
+        project_dir?: string;
+      };
+      // The supervisor reports its build root under `supervisor.project_dir`
+      // (e.g. `.../qontinui-runner/src-tauri`); older shapes put it at the top
+      // level, so accept either.
+      const projectDir = health.supervisor?.project_dir ?? health.project_dir;
+      if (!projectDir) {
+        throw new Error("supervisor /health did not report project_dir");
+      }
+      const list = await invoke<DevLoopWorktree[]>("list_repo_worktrees", {
+        repoRoot: projectDir,
+      });
+      setWorktrees(list);
+
+      // Default-select the first non-main buildable worktree, if any.
+      const firstBuildable = list.find((w) => !w.is_main && w.buildable);
+      if (firstBuildable) {
+        setSelectedWorktreePath((prev) => prev || firstBuildable.path);
+      }
+      if (list.length === 0) {
+        setDiscoveryError("No worktrees found");
+      }
+    } catch (err) {
+      setWorktrees([]);
+      setDiscoveryError(String(err));
+    } finally {
+      setDiscovering(false);
+    }
+  }, [supervisorPort]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async discovery updates state in a callback, not synchronously
+    void discoverWorktrees();
+  }, [discoverWorktrees]);
+
+  // -------------------------------------------------------------------------
+  // Poll the supervisor for temp runners every 5s.
+  // -------------------------------------------------------------------------
+  const refreshTempRunners = useCallback(async () => {
+    try {
+      const resp = await fetch(`${supervisorBase(supervisorPort)}/runners`);
+      if (!resp.ok) return;
+      const runners = (await resp.json()) as SupervisorRunner[];
+      setTempRunners(runners.filter((r) => r.id.startsWith("test-")));
+    } catch {
+      // Non-fatal — supervisor may not be up.
+    }
+  }, [supervisorPort]);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- async fetch updates state in a callback, not synchronously
+    void refreshTempRunners();
+    const interval = window.setInterval(() => {
+      void refreshTempRunners();
+    }, 5000);
+    return () => {
+      window.clearInterval(interval);
+    };
+  }, [refreshTempRunners]);
+
+  // Elapsed-seconds ticker while building.
+  useEffect(() => {
+    if (!building) {
+      if (elapsedTimerRef.current != null) {
+        window.clearInterval(elapsedTimerRef.current);
+        elapsedTimerRef.current = null;
+      }
+      return;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- reset the elapsed ticker when a build starts
+    setElapsed(0);
+    elapsedTimerRef.current = window.setInterval(() => {
+      setElapsed((e) => e + 1);
+    }, 1000);
+    return () => {
+      if (elapsedTimerRef.current != null) {
+        window.clearInterval(elapsedTimerRef.current);
+        elapsedTimerRef.current = null;
+      }
+    };
+  }, [building]);
+
+  // Abort any in-flight build on unmount.
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  // -------------------------------------------------------------------------
+  // Resolve the current provenance to EITHER { worktree_path } OR { git_ref }.
+  // Returns null when the current selection isn't valid.
+  // -------------------------------------------------------------------------
+  const resolveProvenance = useCallback((): {
+    worktree_path?: string;
+    git_ref?: string;
+  } | null => {
+    if (sourceMode === "worktree") {
+      const path = selectedWorktreePath.trim();
+      if (!path) return null;
+      const wt = worktrees.find((w) => w.path === path);
+      // The live tree can't be a worktree_path — block it here.
+      if (wt?.is_main) return null;
+      return { worktree_path: path };
+    }
+    if (sourceMode === "git_ref") {
+      const ref = gitRef.trim();
+      if (!ref) return null;
+      return { git_ref: ref };
+    }
+    // custom_path
+    const path = customPath.trim();
+    if (!path) return null;
+    return { worktree_path: path };
+  }, [sourceMode, selectedWorktreePath, worktrees, gitRef, customPath]);
+
+  const provenance = resolveProvenance();
+  const canBuild = !building && provenance !== null;
+  const expectedNonLiveSource = provenance !== null; // we never intentionally request the live tree here
+
+  // -------------------------------------------------------------------------
+  // Build & launch a test runner.
+  // -------------------------------------------------------------------------
+  const handleBuild = async () => {
+    const prov = resolveProvenance();
+    if (!prov) {
+      onLog("warning", "Select a worktree, enter a git ref, or enter a worktree path first.");
+      return;
+    }
+
+    setBuilding(true);
+    setResult(null);
+    setBuildError(null);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    const body = {
+      rebuild: true,
+      wait: true,
+      wait_timeout_secs: 180,
+      frontend_only: false,
+      requester_id: "dev-loop-ui",
+      ...prov,
+    };
+
+    try {
+      const resp = await fetch(`${supervisorBase(supervisorPort)}/runners/spawn-test`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      const text = await resp.text();
+      let parsed: unknown = null;
+      try {
+        parsed = text ? JSON.parse(text) : null;
+      } catch {
+        parsed = null;
+      }
+
+      if (!resp.ok) {
+        const errObj = (parsed ?? {}) as { error?: string; recent_logs?: string };
+        const detail =
+          errObj.error ??
+          (typeof parsed === "object" && parsed !== null ? JSON.stringify(parsed) : text);
+        const logs = errObj.recent_logs ? `\n${errObj.recent_logs}` : "";
+        const combined = `HTTP ${resp.status}: ${detail}${logs}`.slice(0, 400);
+        setBuildError(combined);
+        onLog("error", `spawn-test failed: ${combined}`);
+        return;
+      }
+
+      const data = parsed as SpawnTestResult;
+      setResult(data);
+      if (data.source === "live_tree") {
+        onLog(
+          "warning",
+          `spawn-test resolved to live_tree (provenance was dropped) — port ${data.port}`,
+        );
+      } else {
+        onLog(
+          "success",
+          `Test runner up on port ${data.port} (${data.source ?? "?"}, ${data.git_sha ?? "?"})`,
+        );
+      }
+      void refreshTempRunners();
+    } catch (err) {
+      if (controller.signal.aborted) {
+        onLog(
+          "info",
+          "Cancelled the UI wait — the build continues server-side; check the temp-runner list.",
+        );
+      } else {
+        const msg = String(err).slice(0, 400);
+        setBuildError(msg);
+        onLog("error", `spawn-test request failed: ${msg}`);
+      }
+    } finally {
+      setBuilding(false);
+      abortRef.current = null;
+    }
+  };
+
+  const handleCancel = () => {
+    abortRef.current?.abort();
+  };
+
+  const handleOpen = async (port: number) => {
+    const url = `http://localhost:${port}/`;
+    try {
+      await openUrl(url);
+    } catch {
+      window.open(url, "_blank");
+    }
+  };
+
+  const handleStop = async (id: string) => {
+    try {
+      const resp = await fetch(
+        `${supervisorBase(supervisorPort)}/runners/${encodeURIComponent(id)}/stop`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ force: false }),
+        },
+      );
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => "");
+        throw new Error(`HTTP ${resp.status}: ${body.slice(0, 200)}`);
+      }
+      onLog("success", `Stopped temp runner '${id}'`);
+      void refreshTempRunners();
+    } catch (err) {
+      onLog("error", `Failed to stop '${id}': ${err}`);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader
+        title="Test My Change"
+        description="Build your current change into an isolated temp runner — the primary runner is never restarted."
+        icon={<FlaskConical />}
+      />
+
+      <div className="flex items-start gap-2 rounded-lg border border-border bg-muted/40 p-2.5 text-xs text-muted-foreground">
+        <FlaskConical className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <span>
+          This is the canonical dev-loop:{" "}
+          <span className="font-medium text-foreground">
+            never restart the primary to test — use a temp runner.
+          </span>{" "}
+          The supervisor cold-builds the selected source on a fresh port (9877–9899); your primary
+          runner keeps running untouched.
+        </span>
+      </div>
+
+      {/* Supervisor port */}
+      <div className="flex items-center gap-2 p-3 rounded-lg border border-border bg-card">
+        <label className="text-xs text-muted-foreground w-32 shrink-0" htmlFor="dev-loop-sup-port">
+          Supervisor port
+        </label>
+        <input
+          id="dev-loop-sup-port"
+          type="text"
+          inputMode="numeric"
+          value={supervisorPort}
+          onChange={(e) => setSupervisorPort(e.target.value)}
+          placeholder={DEFAULT_SUPERVISOR_PORT}
+          className="w-24 px-2 py-1 text-xs rounded border border-border bg-background"
+        />
+        <button
+          type="button"
+          onClick={() => void discoverWorktrees()}
+          disabled={discovering}
+          className="ml-auto flex items-center gap-1.5 px-2 py-1 text-xs rounded border border-border hover:bg-accent transition-colors disabled:opacity-50"
+          title="Re-detect worktrees from the supervisor"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${discovering ? "animate-spin" : ""}`} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Source picker (provenance — mutually exclusive) */}
+      <div className="space-y-2 p-3 rounded-lg border border-border bg-card">
+        <div className="text-sm font-semibold">Source to build</div>
+
+        {/* Worktree */}
+        <label className="flex items-start gap-2 text-xs">
+          <input
+            type="radio"
+            name="dev-loop-source"
+            className="mt-1"
+            checked={sourceMode === "worktree"}
+            onChange={() => setSourceMode("worktree")}
+          />
+          <div className="flex-1 min-w-0 space-y-1">
+            <span className="font-medium text-foreground">Worktree (detected)</span>
+            {sourceMode === "worktree" && (
+              <>
+                {discovering && (
+                  <p className="text-[11px] text-muted-foreground">Detecting worktrees…</p>
+                )}
+                {!discovering && worktrees.length > 0 && (
+                  <select
+                    value={selectedWorktreePath}
+                    onChange={(e) => setSelectedWorktreePath(e.target.value)}
+                    className="w-full px-2 py-1 text-xs rounded border border-border bg-background"
+                  >
+                    <option value="">Select a worktree…</option>
+                    {worktrees.map((w) => {
+                      const disabled = w.is_main || !w.buildable;
+                      const name = w.branch || (w.is_detached ? "(detached)" : "(no branch)");
+                      let suffix = "";
+                      if (w.is_main) suffix = " — live tree, use a git ref instead";
+                      else if (!w.buildable) suffix = " — not buildable (no src-tauri)";
+                      return (
+                        <option key={w.path} value={w.path} disabled={disabled}>
+                          {name} · {shortPath(w.path)}
+                          {suffix}
+                        </option>
+                      );
+                    })}
+                  </select>
+                )}
+                {!discovering && discoveryError && (
+                  <p className="text-[11px] text-muted-foreground">
+                    Couldn&apos;t auto-detect worktrees — enter a git ref or path manually.
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+        </label>
+
+        {/* Git ref */}
+        <label className="flex items-start gap-2 text-xs">
+          <input
+            type="radio"
+            name="dev-loop-source"
+            className="mt-1"
+            checked={sourceMode === "git_ref"}
+            onChange={() => setSourceMode("git_ref")}
+          />
+          <div className="flex-1 min-w-0 space-y-1">
+            <span className="font-medium text-foreground">Git ref</span>
+            {sourceMode === "git_ref" && (
+              <input
+                type="text"
+                value={gitRef}
+                onChange={(e) => setGitRef(e.target.value)}
+                placeholder="branch / tag / SHA (e.g. feat/my-change)"
+                className="w-full px-2 py-1 text-xs rounded border border-border bg-background"
+              />
+            )}
+          </div>
+        </label>
+
+        {/* Custom worktree path */}
+        <label className="flex items-start gap-2 text-xs">
+          <input
+            type="radio"
+            name="dev-loop-source"
+            className="mt-1"
+            checked={sourceMode === "custom_path"}
+            onChange={() => setSourceMode("custom_path")}
+          />
+          <div className="flex-1 min-w-0 space-y-1">
+            <span className="font-medium text-foreground">Custom worktree path</span>
+            {sourceMode === "custom_path" && (
+              <input
+                type="text"
+                value={customPath}
+                onChange={(e) => setCustomPath(e.target.value)}
+                placeholder="absolute path to a worktree (must contain src-tauri/Cargo.toml)"
+                className="w-full px-2 py-1 text-xs rounded border border-border bg-background"
+              />
+            )}
+          </div>
+        </label>
+      </div>
+
+      {/* Build & launch */}
+      <div className="space-y-2 p-3 rounded-lg border border-border bg-card">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void handleBuild()}
+            disabled={!canBuild}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {building ? (
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            ) : (
+              <FlaskConical className="w-3.5 h-3.5" />
+            )}
+            Build &amp; launch test runner
+          </button>
+          {building && (
+            <button
+              type="button"
+              onClick={handleCancel}
+              className="px-3 py-1.5 text-xs font-medium rounded border border-border hover:bg-accent transition-colors"
+            >
+              Cancel
+            </button>
+          )}
+        </div>
+
+        {building && (
+          <p className="text-[11px] text-muted-foreground">
+            Building… {elapsed}s elapsed. Cold builds take a few minutes. The primary runner is
+            unaffected. Cancel detaches the UI from the wait — the build continues server-side.
+          </p>
+        )}
+
+        {buildError && (
+          <pre className="whitespace-pre-wrap break-words text-[11px] text-destructive font-mono p-2 rounded border border-destructive/40 bg-destructive/5">
+            {buildError}
+          </pre>
+        )}
+
+        {result && (
+          <div className="p-3 rounded-lg border border-border bg-background/40 space-y-1.5">
+            <div className="flex items-center gap-2">
+              <span
+                className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+                  result.status === "healthy"
+                    ? "bg-green-500"
+                    : result.status === "timeout"
+                      ? "bg-yellow-500"
+                      : "bg-blue-500"
+                }`}
+                title={result.status}
+              />
+              <span className="text-sm font-medium">Port {result.port}</span>
+              <span className="text-[11px] text-muted-foreground">{result.status}</span>
+            </div>
+            <div className="text-[11px] text-muted-foreground font-mono space-y-0.5">
+              <div>git_sha: {result.git_sha ?? "—"}</div>
+              <div>
+                source:{" "}
+                {result.source === "live_tree" && expectedNonLiveSource ? (
+                  <span className="text-destructive font-semibold">
+                    {result.source} — provenance was dropped! (expected a worktree/ref)
+                  </span>
+                ) : (
+                  <span>{result.source ?? "—"}</span>
+                )}
+              </div>
+              {result.git_ref_resolved_short && (
+                <div>ref resolved: {result.git_ref_resolved_short}</div>
+              )}
+            </div>
+            {result.message && <p className="text-[11px] text-muted-foreground">{result.message}</p>}
+            <p className="text-[11px] text-muted-foreground select-text break-all font-mono">
+              http://localhost:{result.port}/
+            </p>
+            <div className="flex items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => void handleOpen(result.port)}
+                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded border border-border hover:bg-accent transition-colors"
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+                Open
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleStop(result.id)}
+                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded border border-border text-destructive hover:bg-destructive/10 transition-colors"
+              >
+                <Square className="w-3.5 h-3.5" />
+                Stop
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Running temp runners */}
+      <div className="space-y-2 p-3 rounded-lg border border-border bg-card">
+        <div className="flex items-center justify-between">
+          <div className="text-sm font-semibold">Running test runners</div>
+          <button
+            type="button"
+            onClick={() => void refreshTempRunners()}
+            className="flex items-center gap-1.5 px-2 py-1 text-xs rounded border border-border hover:bg-accent transition-colors"
+          >
+            <RefreshCw className="w-3.5 h-3.5" />
+            Refresh
+          </button>
+        </div>
+        {tempRunners.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            No temp runners. Build a change above to spawn one.
+          </p>
+        ) : (
+          <div className="space-y-1.5">
+            {tempRunners.map((r) => (
+              <div
+                key={r.id}
+                className="flex items-center gap-3 p-2 rounded border border-border/60 bg-background/30"
+              >
+                <span
+                  className={`w-2.5 h-2.5 rounded-full shrink-0 ${
+                    r.running && r.api_responding
+                      ? "bg-green-500"
+                      : r.running
+                        ? "bg-yellow-500"
+                        : "bg-gray-500"
+                  }`}
+                  title={r.running ? (r.api_responding ? "Ready" : "Starting…") : "Stopped"}
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">{r.name}</div>
+                  <div className="text-xs text-muted-foreground">
+                    Port {r.port}
+                    {r.pid != null && <span className="ml-2">PID {r.pid}</span>}
+                  </div>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => void handleOpen(r.port)}
+                    className="p-1.5 rounded hover:bg-accent text-muted-foreground transition-colors"
+                    title="Open"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleStop(r.id)}
+                    className="p-1.5 rounded hover:bg-destructive/10 text-destructive transition-colors"
+                    title="Stop"
+                  >
+                    <Square className="w-4 h-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -32,6 +32,7 @@ import { LockYieldPolicySettings } from "./LockYieldPolicySettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { AccountSettings } from "./AccountSettings";
 import { CiRunnerSettings } from "./CiRunnerSettings";
+import { DevLoopSettings } from "./DevLoopSettings";
 
 interface SettingsProps {
   /** Default tab to open. If provided, overrides instanceStorage persistence. */
@@ -42,6 +43,7 @@ interface SettingsProps {
 
 type SettingsTab =
   | "account"
+  | "dev-loop"
   | "ai"
   | "agentic"
   | "self-healing"
@@ -78,6 +80,7 @@ const STORAGE_KEY = "qontinui-settings-active-tab";
  */
 const SETTINGS_TABS = [
   { id: "account", label: "Account" },
+  { id: "dev-loop", label: "Test My Change" },
   { id: "backend-connection", label: "Backend Connection" },
   { id: "ai", label: "AI Providers" },
   { id: "agentic", label: "Advanced AI" },
@@ -122,6 +125,7 @@ const VALID_TABS = SETTINGS_TABS.map((t) => t.id);
  */
 const SUB_TAB_TO_MAIN_TAB: Record<SettingsTab, string> = {
   account: "settings-account",
+  "dev-loop": "settings-dev-loop",
   "backend-connection": "settings-backend-connection",
   ai: "settings-ai",
   agentic: "settings-agentic",
@@ -264,6 +268,8 @@ export function Settings({ defaultTab, onLog, onDebugModeChange }: SettingsProps
     switch (activeTab) {
       case "account":
         return <AccountSettings onLog={onLog} />;
+      case "dev-loop":
+        return <DevLoopSettings onLog={onLog} />;
       case "backend-connection":
         return <WebIntegrationSettings onLog={onLog} />;
       case "ai":

--- a/src/lib/ui-bridge/UIBridgeHooks.tsx
+++ b/src/lib/ui-bridge/UIBridgeHooks.tsx
@@ -75,6 +75,7 @@ const TAB_GROUPS = {
   system: [
     "settings",
     "settings-account",
+    "settings-dev-loop",
     "settings-ai",
     "settings-agentic",
     "settings-self-healing",


### PR DESCRIPTION
## What

Phase 1 of **runner-dev-loop-and-restart-resilience**: a first-class **"Test My Change"** developer action in the runner UI (Settings → second tab). It builds the developer's current change — a detected git **worktree**, a **git ref**, or a custom **worktree path** — into an **isolated temp runner** via the supervisor's `POST /runners/spawn-test`, so **the primary runner is never restarted** for dev verification. This removes the main reason to self-inflict a primary restart (and the main reason to live in VS Code to test).

## Changes

- **`DevLoopSettings.tsx`** (new): the panel — mutually-exclusive source picker (worktree dropdown / git ref / custom path), build+launch with live elapsed + cancel (AbortController detaches the UI; the build continues server-side), a result card (`port` / `git_sha` / `source`, with a red warning when `source==live_tree` = provenance was dropped), and a 5s-polled running-temp-runner list with **Open** / **Stop** for cleanup.
- **`list_repo_worktrees`** (new Tauri command): enumerates git worktrees under the supervisor's `project_dir` (`git worktree list --porcelain`; `is_main` / `buildable` flags) to populate the picker. Best-effort — manual entry is always available.
- Wired the new sub-tab through `tab-types.ts`, `Settings.tsx`, `TabContent.tsx` (main router), and `UIBridgeHooks.tsx`.
- **`CONTRIBUTING.md`**: documents the temp-runner dev loop ("never restart the primary to test").

Provenance contract honored: `git_ref` and `worktree_path` are mutually exclusive and both require `rebuild:true`; the UI never sends both, blocks the live tree as a `worktree_path`, and surfaces the `source`/`git_sha` so you can confirm what actually got built.

## Verification

- `npx tsc --noEmit` clean (touched files); `cargo clippy --all-targets -D warnings` clean (default features); pre-push `cargo fmt + clippy` passed.
- **On-page drill** (the dev loop verifying itself): built this branch into temp runners via the supervisor (`git_sha ef52154884f0`), navigated to Settings → Test My Change — panel renders, worktree auto-discovery populated **31** worktrees with correct `is_main`/live-tree steering, and the **primary (pid 36860) was never restarted** throughout. Two defects were caught + fixed by spot-check/drill (the `project_dir` nesting under `supervisor.*`, and the missing `TabContent` route for `settings-dev-loop`).

## Scope / follow-ups

This PR is **Phase 1 only** (independent, ship-now). Phases 2–4 (graceful drain, lossless resume + claim re-acquire, crash auto-reattach) depend on the sibling plan `2026-06-06-session-scoped-multi-repo-workspace-coordination` (launch-provisioning) and are deferred.