### PR TITLE
feat(blueprints): typed deterministic/agentic node model with per-node tool policy

### DIFF
--- a/src-tauri/src/agentic_verification.rs
+++ b/src-tauri/src/agentic_verification.rs
@@ -367,6 +367,7 @@ impl AgenticVerificationResult {
                     },
                     blame_json: None,
                     contingent_on: Vec::new(),
+                    node_rollups: Vec::new(),
                 })
                 .collect(),
             fix_attempts_exhausted: false,
@@ -375,6 +376,7 @@ impl AgenticVerificationResult {
             files_modified: Vec::new(),
             fix_attempts: 0,
             ci_auto_resumes: 0,
+            node_rollups: Vec::new(),
         }
     }
 
@@ -1183,6 +1185,7 @@ impl MultiAgentPipelineResult {
                             agentic_phase_success: Some(lr.passed),
                             blame_json: None,
                             contingent_on: Vec::new(),
+                            node_rollups: Vec::new(),
                         }
                     })
                 })
@@ -1218,6 +1221,7 @@ impl MultiAgentPipelineResult {
             fix_attempts_exhausted: false,
             fix_attempts: 0,
             ci_auto_resumes: 0,
+            node_rollups: Vec::new(),
         }
     }
 

--- a/src-tauri/src/claude_session/mod.rs
+++ b/src-tauri/src/claude_session/mod.rs
@@ -18,6 +18,7 @@ pub mod resume;
 pub mod runner;
 pub mod session;
 pub mod state;
+pub mod tool_policy_args;
 pub mod worker_session;
 pub mod writer;
 

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -41,6 +41,12 @@ pub struct CliSessionOutput {
     pub input_tokens: Option<u64>,
     /// Output tokens generated (extracted from stream-json result message).
     pub output_tokens: Option<u64>,
+    /// Blueprint telemetry (Phase 4): de-duplicated, order-preserving list of
+    /// tool names the agentic session actually used.
+    pub tools_used: Vec<String>,
+    /// Blueprint telemetry (Phase 4): tool names rejected by a FailNode
+    /// tool-policy (0 or 1 today; Vec keeps it future-proof).
+    pub tools_rejected: Vec<String>,
 }
 
 /// Output from a CLI session with retry, including token usage data.
@@ -53,6 +59,10 @@ pub struct CliSessionRetryOutput {
     pub input_tokens: Option<u64>,
     /// Output tokens generated (extracted from stream-json result message).
     pub output_tokens: Option<u64>,
+    /// Blueprint telemetry (Phase 4): de-duplicated tool names used.
+    pub tools_used: Vec<String>,
+    /// Blueprint telemetry (Phase 4): tool names rejected by a FailNode policy.
+    pub tools_rejected: Vec<String>,
 }
 
 /// Context for periodic flushing of AI output to the database during a session.
@@ -173,6 +183,16 @@ fn extract_tool_call_data(json_line: &str) -> Vec<(String, String)> {
         }
     }
     results
+}
+
+/// Push a tool name into an order-preserving, de-duplicated accumulator.
+/// Used by the agentic telemetry rollup (Phase 4 §3.3): the first
+/// occurrence of each tool name is kept in observation order; repeats are
+/// dropped. Pure helper so it can be unit-tested without the stream loop.
+fn push_tool_used(acc: &mut Vec<String>, tool_name: &str) {
+    if !acc.iter().any(|t| t == tool_name) {
+        acc.push(tool_name.to_string());
+    }
 }
 
 /// Extract token usage from a Claude CLI stream-json result message.
@@ -310,6 +330,7 @@ fn run_claude_session_inline(
     task_run_id: Option<&str>,
     cli_session_ctx: Option<&CliSessionContext>,
     db_flush_ctx: Option<&DbFlushContext>,
+    tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
 ) -> Result<CliSessionOutput, String> {
     use std::io::{BufRead, BufReader, Read, Write};
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -383,6 +404,60 @@ fn run_claude_session_inline(
             );
         }
     }
+
+    // ── Blueprint tool policy (Phase 3) ───────────────────────────────────
+    // Translate the policy into CLI flags (--allowedTools/--disallowedTools)
+    // plus, for argument-scoped denies, an ephemeral --settings <file> JSON
+    // block (the carrier that works under bypassPermissions). When the policy
+    // is None this is a complete no-op: zero extra args, no settings file —
+    // byte-for-byte identical to the historical spawn.
+    let tool_policy_args: Vec<String>;
+    let tool_policy_settings_path: Option<std::path::PathBuf>;
+    if let Some(policy) = tool_policy {
+        let (extra_args, settings_json) =
+            crate::claude_session::tool_policy_args::build_tool_policy_cli(policy);
+        tool_policy_args = extra_args;
+        tool_policy_settings_path = if let Some(json) = settings_json {
+            let settings_file =
+                temp_dir.join(format!("claude_session_settings_{}.json", session_id));
+            match std::fs::write(&settings_file, &json) {
+                Ok(()) => {
+                    info!(
+                        "Wrote tool-policy settings for session {} to {}",
+                        session_id,
+                        settings_file.display()
+                    );
+                    Some(settings_file)
+                }
+                Err(e) => {
+                    // A settings-write failure must not silently drop the
+                    // argument-scoped deny — fail the spawn loudly.
+                    return Err(format!("Failed to write tool-policy settings file: {}", e));
+                }
+            }
+        } else {
+            None
+        };
+        for a in &tool_policy_args {
+            cli_args.push(a.as_str());
+        }
+        if let Some(ref path) = tool_policy_settings_path {
+            cli_args.push("--settings");
+            // path lives until cmd.spawn(); push its &str view.
+            cli_args.push(path.to_str().unwrap_or_default());
+        }
+        info!(
+            "Applied tool policy for session {}: {} extra arg(s), settings={}",
+            session_id,
+            tool_policy_args.len(),
+            tool_policy_settings_path.is_some()
+        );
+    } else {
+        tool_policy_args = Vec::new();
+        tool_policy_settings_path = None;
+    }
+    let _ = &tool_policy_settings_path; // keep path alive for cli_args borrow
+
     let mut cmd = crate::process_helpers::cmd_no_window();
     cmd.args(&cli_args)
         .current_dir(working_dir)
@@ -552,6 +627,26 @@ fn run_claude_session_inline(
     let session_done_finding = session_done.clone();
     let session_done_progress = session_done.clone();
     let session_done_reflection = session_done.clone();
+
+    // ── Blueprint FailNode detector (Phase 3 §3.2 point 2) ────────────────
+    // Defense-in-depth for the tool-NAME layer: under bypass the CLI already
+    // blocks denied/disallowed tools, so this is post-hoc and rarely fires.
+    // Only armed when a policy is present AND on_violation == FailNode. The
+    // first violating tool name is recorded; after the stream completes the
+    // session result is marked failed. We do NOT kill the child mid-stream.
+    let failnode_policy: Option<crate::workflow::dag_schema::ToolPolicy> = tool_policy
+        .filter(|p| p.on_violation == crate::workflow::dag_schema::ViolationAction::FailNode)
+        .cloned();
+    let failnode_violation: Arc<std::sync::Mutex<Option<String>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let failnode_violation_stdout = failnode_violation.clone();
+
+    // Blueprint telemetry (Phase 4 §3.3): de-duplicated, order-preserving
+    // list of tool names observed during this session. Populated in the
+    // stdout stream thread, read after join to build `tools_used`.
+    let tools_used: Arc<std::sync::Mutex<Vec<String>>> =
+        Arc::new(std::sync::Mutex::new(Vec::new()));
+    let tools_used_stdout = tools_used.clone();
 
     // Heartbeat thread
     let app_handle_heartbeat = app_handle.clone();
@@ -736,12 +831,35 @@ fn run_claude_session_inline(
                 if let Some(activity) = extract_tool_activity_from_stream_json(&line) {
                     // Emit a tracing span for each tool call for observability
                     for (tool_name, _tool_id) in extract_tool_call_data(&line) {
+                        // Blueprint telemetry: accumulate de-duped tool names.
+                        if let Ok(mut used) = tools_used_stdout.lock() {
+                            push_tool_used(&mut used, &tool_name);
+                        }
                         let _tool_span = tracing::info_span!("qontinui.ai.tool_call",
                             ai.tool_name = %tool_name,
                         )
                         .entered();
                         // Span closes immediately — tool calls are point-in-time events
                         // since we can't track when the tool finishes from the stream
+
+                        // Blueprint FailNode detector: record the FIRST tool that
+                        // violates the policy (defense-in-depth; the CLI already
+                        // blocks it natively under bypass).
+                        if let Some(ref policy) = failnode_policy {
+                            if crate::claude_session::tool_policy_args::tool_violates_policy(
+                                policy, &tool_name,
+                            ) {
+                                if let Ok(mut slot) = failnode_violation_stdout.lock() {
+                                    if slot.is_none() {
+                                        warn!(
+                                            "Tool-policy FailNode violation: observed tool '{}'",
+                                            tool_name
+                                        );
+                                        *slot = Some(tool_name.clone());
+                                    }
+                                }
+                            }
+                        }
                     }
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                         emit_ai_output(
@@ -1732,6 +1850,9 @@ fn run_claude_session_inline(
                 let _ = handle.join();
             }
             let _ = std::fs::remove_file(&prompt_file);
+            if let Some(ref p) = tool_policy_settings_path {
+                let _ = std::fs::remove_file(p);
+            }
             remove_pid(&pid_tracker);
             return Err(format!("Failed to wait for Claude: {}", e));
         }
@@ -1877,6 +1998,9 @@ fn run_claude_session_inline(
     }
 
     let _ = std::fs::remove_file(&prompt_file);
+    if let Some(ref p) = tool_policy_settings_path {
+        let _ = std::fs::remove_file(p);
+    }
 
     // Log summary of detected findings
     if !detected_findings.is_empty() {
@@ -1935,7 +2059,38 @@ fn run_claude_session_inline(
         }
     }
 
-    let success = status.success();
+    let mut success = status.success();
+
+    // ── Blueprint FailNode enforcement (Phase 3 §3.2 point 2) ─────────────
+    // If a FailNode-mode tool policy recorded a violation during the stream,
+    // mark the session failed so the caller treats the node as a
+    // critical_failure, and surface a [FINDING:error] line (which the UI and
+    // finding pipeline render) describing the violating tool + node.
+    let failnode_tool = failnode_violation.lock().ok().and_then(|s| s.clone());
+    // Blueprint telemetry (Phase 4): surface the rejected tool (if any).
+    let tools_rejected: Vec<String> = failnode_tool.iter().cloned().collect();
+    if let Some(tool) = failnode_tool {
+        success = false;
+        let finding_line = format!(
+            "[FINDING:error] Tool-policy violation in node '{}': the agentic step \
+             used the forbidden tool '{}', which the node's tool policy blocks \
+             (on_violation: fail_node).",
+            session_id, tool
+        );
+        warn!(
+            "Session {} failed by tool-policy FailNode: forbidden tool '{}' observed",
+            session_id, tool
+        );
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            emit_ai_output(
+                app_handle,
+                &finding_line,
+                "claude",
+                None,
+                session_ctx.as_ref(),
+            );
+        }));
+    }
 
     let (cli_input_tokens, cli_output_tokens) = match cli_token_usage {
         Some((input, output)) => {
@@ -1991,12 +2146,16 @@ fn run_claude_session_inline(
         }
     }
 
+    let tools_used_final: Vec<String> = tools_used.lock().map(|v| v.clone()).unwrap_or_default();
+
     Ok(CliSessionOutput {
         success,
         output: all_output,
         injected_steps,
         input_tokens: cli_input_tokens,
         output_tokens: cli_output_tokens,
+        tools_used: tools_used_final,
+        tools_rejected,
     })
 }
 
@@ -2030,6 +2189,7 @@ pub fn run_claude_session_with_retry(
     task_run_id: Option<&str>,
     cli_session_ctx: Option<&CliSessionContext>,
     db_flush_ctx: Option<&DbFlushContext>,
+    tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
 ) -> Result<CliSessionRetryOutput, String> {
     use std::thread;
     use std::time::Duration;
@@ -2055,6 +2215,7 @@ pub fn run_claude_session_with_retry(
                 task_run_id,
                 cli_session_ctx,
                 db_flush_ctx,
+                tool_policy,
             )?;
             return Ok(CliSessionRetryOutput {
                 success: result.success,
@@ -2063,6 +2224,8 @@ pub fn run_claude_session_with_retry(
                 injected_steps: result.injected_steps,
                 input_tokens: result.input_tokens,
                 output_tokens: result.output_tokens,
+                tools_used: result.tools_used,
+                tools_rejected: result.tools_rejected,
             });
         }
     };
@@ -2108,6 +2271,7 @@ pub fn run_claude_session_with_retry(
             task_run_id,
             cli_session_ctx,
             db_flush_ctx,
+            tool_policy,
         );
 
         match result {
@@ -2126,6 +2290,8 @@ pub fn run_claude_session_with_retry(
                     injected_steps: cli_output.injected_steps,
                     input_tokens: cli_output.input_tokens,
                     output_tokens: cli_output.output_tokens,
+                    tools_used: cli_output.tools_used,
+                    tools_rejected: cli_output.tools_rejected,
                 });
             }
             Err(error) => {
@@ -2230,6 +2396,7 @@ pub fn run_claude_session_interactive(
     _reflection_fix_ctx: Option<ReflectionFixContext>,
     _step_injection_ctx: Option<StepInjectionContext>,
     model_override: Option<&str>,
+    tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
 ) -> Result<CliSessionOutput, String> {
     use crate::claude_session::ClaudeSession;
     use crate::commands::ai_session::emit_session_state;
@@ -2251,6 +2418,7 @@ pub fn run_claude_session_interactive(
         pid_tracker,
         model_override,
         None, // worktree — promoted later via ClaudeSession::promote_to_worktree
+        tool_policy,
     )?;
 
     // Register with Doctor health monitoring
@@ -2323,6 +2491,8 @@ pub fn run_claude_session_interactive(
         injected_steps: Vec::new(),
         input_tokens: None,
         output_tokens: None,
+        tools_used: Vec::new(),
+        tools_rejected: Vec::new(),
     })
 }
 
@@ -2347,6 +2517,7 @@ pub fn run_claude_session_interactive_with_retry(
     reflection_fix_ctx: Option<ReflectionFixContext>,
     step_injection_ctx: Option<StepInjectionContext>,
     model_override: Option<&str>,
+    tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
 ) -> Result<CliSessionRetryOutput, String> {
     use std::thread;
     use std::time::Duration;
@@ -2370,6 +2541,7 @@ pub fn run_claude_session_interactive_with_retry(
                 reflection_fix_ctx,
                 step_injection_ctx,
                 model_override,
+                tool_policy,
             )?;
             return Ok(CliSessionRetryOutput {
                 success: result.success,
@@ -2378,6 +2550,8 @@ pub fn run_claude_session_interactive_with_retry(
                 injected_steps: result.injected_steps,
                 input_tokens: result.input_tokens,
                 output_tokens: result.output_tokens,
+                tools_used: result.tools_used,
+                tools_rejected: result.tools_rejected,
             });
         }
     };
@@ -2417,6 +2591,7 @@ pub fn run_claude_session_interactive_with_retry(
             reflection_fix_ctx_clone,
             step_injection_ctx_clone,
             model_override,
+            tool_policy,
         );
 
         match result {
@@ -2434,6 +2609,8 @@ pub fn run_claude_session_interactive_with_retry(
                     injected_steps: cli_output.injected_steps,
                     input_tokens: cli_output.input_tokens,
                     output_tokens: cli_output.output_tokens,
+                    tools_used: cli_output.tools_used,
+                    tools_rejected: cli_output.tools_rejected,
                 });
             }
             Err(error) => {
@@ -2493,5 +2670,31 @@ pub fn run_claude_session_interactive_with_retry(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod telemetry_tests {
+    use super::push_tool_used;
+
+    #[test]
+    fn push_tool_used_dedups_preserving_order() {
+        let mut acc: Vec<String> = Vec::new();
+        push_tool_used(&mut acc, "A");
+        push_tool_used(&mut acc, "B");
+        push_tool_used(&mut acc, "A");
+        assert_eq!(acc, vec!["A".to_string(), "B".to_string()]);
+    }
+
+    #[test]
+    fn push_tool_used_keeps_first_occurrence_order() {
+        let mut acc: Vec<String> = Vec::new();
+        for t in ["Bash", "Edit", "Bash", "Read", "Edit"] {
+            push_tool_used(&mut acc, t);
+        }
+        assert_eq!(
+            acc,
+            vec!["Bash".to_string(), "Edit".to_string(), "Read".to_string()]
+        );
     }
 }

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -160,6 +160,7 @@ impl ClaudeSession {
         pid_tracker: Option<Arc<Mutex<Vec<u32>>>>,
         model_override: Option<&str>,
         worktree: Option<WorktreeInfo>,
+        tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
     ) -> Result<Self, String> {
         info!(
             "Spawning interactive Claude session: {} in {}",
@@ -189,6 +190,41 @@ impl ClaudeSession {
                 session_id, model
             );
         }
+
+        // ── Blueprint tool policy (Phase 3) ───────────────────────────────
+        // Same carrier as the inline runner: allow/deny flags plus, for
+        // argument-scoped denies, an ephemeral --settings <file> JSON block.
+        // None ⇒ no-op (no extra args, no settings file), preserving today's
+        // interactive spawn byte-for-byte.
+        let tool_policy_settings_path: Option<std::path::PathBuf>;
+        if let Some(policy) = tool_policy {
+            let (extra_args, settings_json) =
+                crate::claude_session::tool_policy_args::build_tool_policy_cli(policy);
+            cli_args.extend(extra_args);
+            tool_policy_settings_path = if let Some(json) = settings_json {
+                let settings_file = std::env::temp_dir()
+                    .join(format!("claude_session_settings_{}.json", session_id));
+                std::fs::write(&settings_file, &json)
+                    .map_err(|e| format!("Failed to write tool-policy settings file: {}", e))?;
+                cli_args.push("--settings".to_string());
+                cli_args.push(settings_file.to_string_lossy().to_string());
+                info!(
+                    "Applied tool-policy settings for interactive session {} at {}",
+                    session_id,
+                    settings_file.display()
+                );
+                Some(settings_file)
+            } else {
+                None
+            };
+        } else {
+            tool_policy_settings_path = None;
+        }
+        // The settings file is consumed by the spawned CLI at startup; it is a
+        // best-effort temp artifact left in temp_dir (mirrors the inline runner
+        // when the path can't be tracked to session end). Bind to silence the
+        // unused warning when no policy is present.
+        let _ = &tool_policy_settings_path;
 
         let cli_arg_refs: Vec<&str> = cli_args.iter().map(|s| s.as_str()).collect();
         cmd.args(&cli_arg_refs)
@@ -1549,6 +1585,7 @@ impl ClaudeSession {
             self.pid_tracker.clone(),
             None, // model_override
             Some(info.clone()),
+            None, // tool_policy — worktree promotion preserves the original spawn's policy state
         )
         .map_err(|e| format!("promote_to_worktree: respawn failed: {}", e))?;
 
@@ -1646,6 +1683,7 @@ impl ClaudeSession {
             None, // pid_tracker
             None, // model_override
             None, // worktree (rate-limit restart preserves the original cwd)
+            None, // tool_policy (rate-limit restart preserves the original policy-less spawn)
         ) {
             Ok(new_session) => {
                 let new_session = Arc::new(new_session);

--- a/src-tauri/src/claude_session/tool_policy_args.rs
+++ b/src-tauri/src/claude_session/tool_policy_args.rs
@@ -1,0 +1,235 @@
+//! Tool-policy → Claude CLI spawn-argument translation (Phase 3).
+//!
+//! Pure helpers that translate a [`ToolPolicy`] into the CLI flags and the
+//! ephemeral `--settings` JSON block the runner uses to enforce tool gating
+//! under `--permission-mode bypassPermissions`.
+//!
+//! ## Empirically-verified carrier shapes (claude 2.1.167, under bypass)
+//! - Tool-NAME allow:  `--allowedTools <t1> <t2> ...`            (honored)
+//! - Tool-NAME deny:   `--disallowedTools <n1> <n2> ...`         (honored)
+//! - Command-ARG deny: a `permissions.deny` rule `Tool(<prefix>:*)` written
+//!   into a `--settings <file>` JSON block. A bare `--disallowedTools
+//!   "Bash(...)"` specifier is IGNORED under bypass, so the settings carrier
+//!   is the only thing that works for argument-scoped denies.
+//!
+//! Because the `--settings` carrier can always be constructed, an arg-scoped
+//! deny never silently evaporates: node validation only rejects a *malformed*
+//! deny token, never "no constructible carrier".
+
+use crate::workflow::dag_schema::{DenyEntry, ToolPolicy};
+
+/// Translate a [`ToolPolicy`] into Claude CLI spawn arguments under
+/// `bypassPermissions`.
+///
+/// Returns `(extra_cli_args, optional_settings_json_string)`:
+/// - `allow`               → `["--allowedTools", t1, t2, ...]`
+/// - tool-name denies      → `["--disallowedTools", n1, n2, ...]`
+/// - arg-scoped denies     → `permissions.deny` rules `"<Tool>(<prefix>:*)"` in
+///   the returned settings JSON string (`None` when there are no arg-scoped
+///   denies).
+///
+/// An empty / `None` allow contributes no `--allowedTools`; a policy with no
+/// denies and no allow yields `(vec![], None)` — a true no-op.
+pub fn build_tool_policy_cli(policy: &ToolPolicy) -> (Vec<String>, Option<String>) {
+    let mut args: Vec<String> = Vec::new();
+
+    // ── Allow-list → --allowedTools t1 t2 ... ────────────────────────────
+    if let Some(allow) = policy.allow.as_ref() {
+        let tools: Vec<String> = allow
+            .iter()
+            .map(|t| t.trim())
+            .filter(|t| !t.is_empty())
+            .map(String::from)
+            .collect();
+        if !tools.is_empty() {
+            args.push("--allowedTools".to_string());
+            args.extend(tools);
+        }
+    }
+
+    // ── Denies: split tool-name vs command-arg-scoped via classified_denies ──
+    let mut tool_name_denies: Vec<String> = Vec::new();
+    let mut deny_rules: Vec<String> = Vec::new();
+    for entry in policy.classified_denies() {
+        match entry {
+            DenyEntry::ToolName(name) => tool_name_denies.push(name),
+            DenyEntry::CommandScoped {
+                tool,
+                command_prefix,
+            } => {
+                // Canonical settings grammar: Tool(<prefix>:*)
+                deny_rules.push(format!("{}({}:*)", tool, command_prefix));
+            }
+        }
+    }
+
+    if !tool_name_denies.is_empty() {
+        args.push("--disallowedTools".to_string());
+        args.extend(tool_name_denies);
+    }
+
+    let settings = if deny_rules.is_empty() {
+        None
+    } else {
+        let settings_json = serde_json::json!({
+            "permissions": { "deny": deny_rules }
+        });
+        Some(settings_json.to_string())
+    };
+
+    (args, settings)
+}
+
+/// Decide whether an observed tool name violates the policy (the pure core of
+/// the FailNode detector). A tool violates the policy iff:
+/// - it is NOT permitted by the allow-list (when an allow-list is present and
+///   non-empty, mirroring [`ToolGuard`] semantics — empty allow = unrestricted), OR
+/// - it matches a tool-name deny entry.
+///
+/// Command-arg-scoped denies are NOT checked here: under bypass the CLI's
+/// `--settings permissions.deny` carrier already blocks them natively (the
+/// detector is defense-in-depth for the tool-NAME layer). Tool names are
+/// compared case-sensitively, matching the Claude CLI's own tool identifiers.
+pub fn tool_violates_policy(policy: &ToolPolicy, tool_name: &str) -> bool {
+    // Allow-list check (empty/None ⇒ unrestricted).
+    if let Some(allow) = policy.allow.as_ref() {
+        let allowed: Vec<&str> = allow
+            .iter()
+            .map(|t| t.trim())
+            .filter(|t| !t.is_empty())
+            .collect();
+        if !allowed.is_empty() && !allowed.contains(&tool_name) {
+            return true;
+        }
+    }
+
+    // Tool-name deny check.
+    policy
+        .classified_denies()
+        .iter()
+        .any(|e| matches!(e, DenyEntry::ToolName(name) if name == tool_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow::dag_schema::ViolationAction;
+
+    fn policy(allow: Option<Vec<&str>>, deny: Option<Vec<&str>>) -> ToolPolicy {
+        ToolPolicy {
+            allow: allow.map(|v| v.into_iter().map(String::from).collect()),
+            deny: deny.map(|v| v.into_iter().map(String::from).collect()),
+            on_violation: ViolationAction::default(),
+        }
+    }
+
+    // ─────────────── build_tool_policy_cli: allow / deny / mixed / empty ───────
+
+    // Plan-test (a): a node denying "Write" yields --disallowedTools Write.
+    #[test]
+    fn build_cli_deny_write_yields_disallowed_tools() {
+        let (args, settings) = build_tool_policy_cli(&policy(None, Some(vec!["Write"])));
+        assert_eq!(args, vec!["--disallowedTools", "Write"]);
+        assert!(settings.is_none());
+    }
+
+    #[test]
+    fn build_cli_allow_only() {
+        let (args, settings) = build_tool_policy_cli(&policy(Some(vec!["Bash", "Read"]), None));
+        assert_eq!(args, vec!["--allowedTools", "Bash", "Read"]);
+        assert!(settings.is_none());
+    }
+
+    #[test]
+    fn build_cli_deny_only_multiple_tool_names() {
+        let (args, settings) = build_tool_policy_cli(&policy(None, Some(vec!["Write", "Edit"])));
+        assert_eq!(args, vec!["--disallowedTools", "Write", "Edit"]);
+        assert!(settings.is_none());
+    }
+
+    // Plan-test (b): allow:[Bash] + deny:["Bash:git push --force"] ⇒
+    // --allowedTools Bash AND a Bash(git push --force:*) settings deny rule.
+    #[test]
+    fn build_cli_command_scoped_deny_goes_to_settings() {
+        let (args, settings) = build_tool_policy_cli(&policy(
+            Some(vec!["Bash"]),
+            Some(vec!["Bash:git push --force"]),
+        ));
+        assert_eq!(args, vec!["--allowedTools", "Bash"]);
+        let settings = settings.expect("settings JSON expected for arg-scoped deny");
+        let v: serde_json::Value = serde_json::from_str(&settings).expect("valid JSON");
+        let deny = v["permissions"]["deny"]
+            .as_array()
+            .expect("permissions.deny array");
+        assert_eq!(deny.len(), 1);
+        assert_eq!(deny[0], "Bash(git push --force:*)");
+    }
+
+    #[test]
+    fn build_cli_mixed_tool_name_and_command_scoped() {
+        let (args, settings) = build_tool_policy_cli(&policy(
+            Some(vec!["Bash", "Read"]),
+            Some(vec!["Write", "Bash:rm -rf"]),
+        ));
+        assert_eq!(
+            args,
+            vec![
+                "--allowedTools",
+                "Bash",
+                "Read",
+                "--disallowedTools",
+                "Write",
+            ]
+        );
+        let settings = settings.expect("settings JSON expected");
+        let v: serde_json::Value = serde_json::from_str(&settings).unwrap();
+        assert_eq!(v["permissions"]["deny"][0], "Bash(rm -rf:*)");
+    }
+
+    // Back-compat: empty / None policy ⇒ zero args + no settings.
+    #[test]
+    fn build_cli_empty_policy_is_noop() {
+        let (args, settings) = build_tool_policy_cli(&policy(None, None));
+        assert!(args.is_empty(), "expected zero cli args, got {:?}", args);
+        assert!(settings.is_none());
+    }
+
+    #[test]
+    fn build_cli_empty_allow_vec_is_noop_for_allow() {
+        let (args, settings) = build_tool_policy_cli(&policy(Some(vec![]), None));
+        assert!(args.is_empty());
+        assert!(settings.is_none());
+    }
+
+    // ─────────────── tool_violates_policy (FailNode detector core) ────────────
+
+    // Plan-test (a): an observed Write under a deny:[Write] policy is a violation.
+    #[test]
+    fn violation_detected_for_denied_tool_name() {
+        let p = policy(None, Some(vec!["Write"]));
+        assert!(tool_violates_policy(&p, "Write"));
+        assert!(!tool_violates_policy(&p, "Read"));
+    }
+
+    #[test]
+    fn violation_detected_for_tool_outside_allow_list() {
+        let p = policy(Some(vec!["Bash", "Read"]), None);
+        assert!(tool_violates_policy(&p, "Write"));
+        assert!(!tool_violates_policy(&p, "Bash"));
+        assert!(!tool_violates_policy(&p, "Read"));
+    }
+
+    #[test]
+    fn empty_allow_is_unrestricted() {
+        let p = policy(Some(vec![]), None);
+        assert!(!tool_violates_policy(&p, "Write"));
+    }
+
+    #[test]
+    fn command_scoped_deny_is_not_a_tool_name_violation() {
+        // Bash is allowed; the arg-scoped deny is enforced by the CLI settings
+        // carrier, not the tool-name detector — so Bash itself is not a violation.
+        let p = policy(Some(vec!["Bash"]), Some(vec!["Bash:git push --force"]));
+        assert!(!tool_violates_policy(&p, "Bash"));
+    }
+}

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -376,6 +376,7 @@ pub async fn create_ai_session(
             None,              // pid_tracker
             None,              // model_override
             None,              // worktree
+            None,              // tool_policy
         ) {
             Ok(session) => {
                 let session = Arc::new(session);
@@ -1360,6 +1361,7 @@ pub async fn resume_ai_sessions(
                 None, // pid_tracker
                 None, // model_override
                 None, // worktree
+                None, // tool_policy
             )
             .map_err(|e| format!("spawn failed: {}", e))?;
 

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -1789,6 +1789,7 @@ async fn handle_chat_create(api_state: &Arc<ApiState>, data: &Value) -> Option<V
             None,
             None,
             None,
+            None, // tool_policy
         ) {
             Ok(session) => {
                 let session = Arc::new(session);

--- a/src-tauri/src/mcp/sessions.rs
+++ b/src-tauri/src/mcp/sessions.rs
@@ -165,6 +165,7 @@ async fn spawn_session(
             None,
             None,
             None,
+            None, // tool_policy
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => return Err(format!("spawn failed: {}", e)),

--- a/src-tauri/src/mcp/task_runs.rs
+++ b/src-tauri/src/mcp/task_runs.rs
@@ -2311,6 +2311,7 @@ pub async fn create_ai_session(
         None, // pid_tracker
         None, // model_override
         None, // worktree
+        None, // tool_policy
     ) {
         Ok(session) => {
             let session = Arc::new(session);

--- a/src-tauri/src/security/policy.rs
+++ b/src-tauri/src/security/policy.rs
@@ -256,3 +256,111 @@ impl Default for SecurityPolicy {
         Self::permissive()
     }
 }
+
+// ============================================================================
+// Blueprint tool-policy → ActionPolicy mirror (Phase 3b)
+// ============================================================================
+
+/// Overlay a node's command-arg-scoped denies onto a base [`ActionPolicy`] so
+/// the same forbidden command is also blocked if the node runs it through a
+/// runner-executed command/check step (not the CLI's `Bash` tool).
+///
+/// Synthesizes a minimal `ActionPolicy` when `base` is `None`, so the mirror is
+/// never silently absent. For each [`DenyEntry::CommandScoped`] the command
+/// prefix is appended to `blocked_commands` as a prefix-anchored regex
+/// (`^<escaped-prefix>`). Tool-name denies and the allow-list are NOT mirrored
+/// here — those are tool-layer concepts the CLI carrier owns; this builder only
+/// mirrors command-argument-scoped denies onto the command-execution layer.
+///
+/// An existing `base` policy's blocks/allows are preserved and extended.
+pub fn build_effective_action_policy(
+    base: Option<&ActionPolicy>,
+    policy: &crate::workflow::dag_schema::ToolPolicy,
+) -> ActionPolicy {
+    use crate::workflow::dag_schema::DenyEntry;
+
+    let mut effective = base.cloned().unwrap_or_default();
+
+    for entry in policy.classified_denies() {
+        if let DenyEntry::CommandScoped { command_prefix, .. } = entry {
+            let pattern = format!("^{}", regex::escape(&command_prefix));
+            if !effective.blocked_commands.contains(&pattern) {
+                effective.blocked_commands.push(pattern);
+            }
+        }
+    }
+
+    effective
+}
+
+#[cfg(test)]
+mod blueprint_action_policy_tests {
+    use super::*;
+    use crate::workflow::dag_schema::{ToolPolicy, ViolationAction};
+    use regex::Regex;
+
+    fn tool_policy(allow: Option<Vec<&str>>, deny: Option<Vec<&str>>) -> ToolPolicy {
+        ToolPolicy {
+            allow: allow.map(|v| v.into_iter().map(String::from).collect()),
+            deny: deny.map(|v| v.into_iter().map(String::from).collect()),
+            on_violation: ViolationAction::default(),
+        }
+    }
+
+    fn any_blocks(policy: &ActionPolicy, cmd: &str) -> bool {
+        policy
+            .blocked_commands
+            .iter()
+            .any(|p| Regex::new(p).map(|re| re.is_match(cmd)).unwrap_or(false))
+    }
+
+    // Plan-test (b): allow:[Bash] + deny:["Bash:git push --force"] ⇒
+    // blocked_commands gains a "git push --force" pattern; plain "git status"
+    // is NOT matched.
+    #[test]
+    fn command_scoped_deny_appends_prefix_anchored_block() {
+        let tp = tool_policy(Some(vec!["Bash"]), Some(vec!["Bash:git push --force"]));
+        let ap = build_effective_action_policy(None, &tp);
+        assert!(
+            any_blocks(&ap, "git push --force --tags"),
+            "the forbidden prefix should be blocked"
+        );
+        assert!(
+            !any_blocks(&ap, "git status"),
+            "an unrelated git command must NOT be blocked"
+        );
+    }
+
+    #[test]
+    fn base_blocks_are_preserved_and_extended() {
+        let base = ActionPolicy {
+            blocked_commands: vec!["^sudo ".to_string()],
+            ..ActionPolicy::default()
+        };
+        let tp = tool_policy(None, Some(vec!["Bash:rm -rf"]));
+        let ap = build_effective_action_policy(Some(&base), &tp);
+        assert!(any_blocks(&ap, "sudo reboot"), "base block preserved");
+        assert!(any_blocks(&ap, "rm -rf /tmp/x"), "node deny appended");
+        assert_eq!(ap.blocked_commands.len(), 2);
+    }
+
+    #[test]
+    fn tool_name_denies_are_not_mirrored_to_commands() {
+        // A bare tool-name deny (Write) has no command-prefix to mirror.
+        let tp = tool_policy(None, Some(vec!["Write"]));
+        let ap = build_effective_action_policy(None, &tp);
+        assert!(ap.blocked_commands.is_empty());
+    }
+
+    #[test]
+    fn regex_metachars_in_prefix_are_escaped() {
+        // A prefix with regex metacharacters must match literally, not as regex.
+        let tp = tool_policy(None, Some(vec!["Bash:echo a.b"]));
+        let ap = build_effective_action_policy(None, &tp);
+        assert!(any_blocks(&ap, "echo a.b"), "literal prefix matches");
+        assert!(
+            !any_blocks(&ap, "echo aXb"),
+            "the '.' must be escaped, not a wildcard"
+        );
+    }
+}

--- a/src-tauri/src/step_executor/executor.rs
+++ b/src-tauri/src/step_executor/executor.rs
@@ -522,6 +522,8 @@ impl StepExecutor {
             "step_name": step_name,
             "phase": step.phase,
             "iteration": iteration,
+            "node_id": step.id,
+            "node_kind": step.effective_node_kind().as_str(),
             "original_task_run_id": task_run_id,  // Keep original ID for debugging
             "command": step.shell_command.as_ref().or(step.check_command.as_ref()),
             "working_directory": step.shell_command_working_directory.as_ref().or(step.check_working_directory.as_ref()),
@@ -1412,6 +1414,28 @@ impl StepExecutor {
         Option<String>,
         Option<serde_json::Value>,
     ) {
+        // ── Blueprint deterministic guarantee (Phase 2) ──────────────────────────
+        // execute_single_step routes every step through the handler registry /
+        // deterministic fallback match; it NEVER constructs an AiSessionConfig
+        // (prompt steps are no-ops here — the AI session is spawned by the
+        // unified workflow executor, not this boundary). Make that an explicit,
+        // observable invariant rather than an accident.
+        let node_kind = step.effective_node_kind();
+        tracing::debug!(
+            node_id = ?step.id,
+            step_type = %step.step_type,
+            ?node_kind,
+            "execute_single_step dispatch (deterministic boundary — no AI session is created here)"
+        );
+        debug_assert!(
+            step.step_type != "prompt"
+                || node_kind == crate::workflow::dag_schema::NodeKind::Agentic,
+            "a step classified Deterministic reached execute_single_step with step_type=prompt \
+             (node_id={:?}); the deterministic guarantee would be violated if this path ever \
+             spawned an AI session",
+            step.id
+        );
+
         // Typed dispatch boundary (Session 2a).
         //
         // "test" is a backward-compat alias that predates the typed enum; it

--- a/src-tauri/src/step_executor/executor_types.rs
+++ b/src-tauri/src/step_executor/executor_types.rs
@@ -698,6 +698,17 @@ pub struct ExecutionStepConfig {
         alias = "fail_on_console_errors"
     )]
     pub fail_on_console_errors: bool,
+
+    /// Resolved blueprint node kind (Phase 2). `None` for non-DAG/legacy steps;
+    /// when absent it is inferred from `step_type` via `effective_node_kind()`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_kind: Option<crate::workflow::dag_schema::NodeKind>,
+
+    /// Resolved blueprint tool policy (Phase 3). Set only for Agentic nodes
+    /// (per-node policy, falling back to the workflow's `blueprint_defaults`).
+    /// `None` ⇒ no restriction (today's behavior).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_policy: Option<crate::workflow::dag_schema::ToolPolicy>,
 }
 
 impl ExecutionStepConfig {
@@ -793,6 +804,22 @@ impl ExecutionStepConfig {
         // Default: all steps run on each iteration for fresh data
         // Users can explicitly set run_on_subsequent_iterations: false to skip on subsequent iterations
         self.run_on_subsequent_iterations.unwrap_or(true)
+    }
+
+    /// Resolve the execution kind for this step. Prefers the explicitly-carried
+    /// `node_kind` (set from the DAG node's `effective_kind()`); otherwise infers
+    /// from `step_type` — only a "prompt" step is agentic, every other step type
+    /// runs deterministically (it never spawns an LLM session).
+    pub fn effective_node_kind(&self) -> crate::workflow::dag_schema::NodeKind {
+        use crate::workflow::dag_schema::NodeKind;
+        if let Some(k) = self.node_kind {
+            return k;
+        }
+        if self.step_type == "prompt" {
+            NodeKind::Agentic
+        } else {
+            NodeKind::Deterministic
+        }
     }
 }
 
@@ -1048,4 +1075,64 @@ pub struct CapturedRunnerLogs {
     pub actions: Vec<ActionEvent>,
     /// Image recognition events (from runner-image-recognition.jsonl)
     pub image_recognition: Vec<ImageRecognitionEvent>,
+}
+
+#[cfg(test)]
+mod node_kind_tests {
+    use super::*;
+    use crate::workflow::dag_schema::NodeKind;
+
+    fn step(step_type: &str, node_kind: Option<NodeKind>) -> ExecutionStepConfig {
+        ExecutionStepConfig {
+            step_type: step_type.to_string(),
+            node_kind,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn carried_node_kind_takes_precedence_deterministic() {
+        // Even a prompt step returns the carried kind when set.
+        let cfg = step("prompt", Some(NodeKind::Deterministic));
+        assert_eq!(cfg.effective_node_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn carried_node_kind_takes_precedence_agentic() {
+        let cfg = step("command", Some(NodeKind::Agentic));
+        assert_eq!(cfg.effective_node_kind(), NodeKind::Agentic);
+    }
+
+    #[test]
+    fn inferred_prompt_is_agentic() {
+        let cfg = step("prompt", None);
+        assert_eq!(cfg.effective_node_kind(), NodeKind::Agentic);
+    }
+
+    #[test]
+    fn inferred_non_prompt_is_deterministic() {
+        for st in ["command", "check", "ui_bridge", "shell_command"] {
+            let cfg = step(st, None);
+            assert_eq!(
+                cfg.effective_node_kind(),
+                NodeKind::Deterministic,
+                "step_type {st:?} should infer Deterministic"
+            );
+        }
+    }
+
+    /// Phase 4 telemetry: `log_step_event` stamps `node_id` and `node_kind`
+    /// onto the data JSON. The construction is a DB-side-effecting method, so
+    /// here we assert the exact values it will carry are correct on the step.
+    #[test]
+    fn step_carries_node_id_and_kind_for_telemetry_stamp() {
+        let cfg = ExecutionStepConfig {
+            id: Some("n1".to_string()),
+            step_type: "prompt".to_string(),
+            node_kind: Some(NodeKind::Agentic),
+            ..Default::default()
+        };
+        assert_eq!(cfg.id, Some("n1".to_string()));
+        assert_eq!(cfg.effective_node_kind().as_str(), "agentic");
+    }
 }

--- a/src-tauri/src/step_executor/handlers/mod.rs
+++ b/src-tauri/src/step_executor/handlers/mod.rs
@@ -680,6 +680,7 @@ impl PromptStepHandler {
                 None, // task_run_id
                 None, // cli_session_ctx — not needed for step executor
                 None, // db_flush_ctx — not needed for step executor
+                None, // tool_policy — not applied for ai_review step executor
             )
         })
         .await;

--- a/src-tauri/src/unified_ai_session.rs
+++ b/src-tauri/src/unified_ai_session.rs
@@ -93,6 +93,13 @@ pub struct AiSessionConfig {
     /// Optional DB flush context for periodic output persistence.
     /// When set, AI output is periodically flushed to the database during execution.
     pub db_flush_ctx: Option<crate::claude_session::runner::DbFlushContext>,
+    /// Optional blueprint tool policy (Phase 3). When `Some`, the Claude CLI is
+    /// spawned with allow/deny gating (and an ephemeral `--settings` block for
+    /// argument-scoped denies), a tool-policy preamble is prepended to the
+    /// prompt, and (when `on_violation == FailNode`) observed tool calls are
+    /// checked post-hoc as defense-in-depth. `None` ⇒ byte-for-byte identical
+    /// to today's spawn (back-compat).
+    pub tool_policy: Option<crate::workflow::dag_schema::ToolPolicy>,
 }
 
 impl AiSessionConfig {
@@ -120,6 +127,7 @@ impl AiSessionConfig {
             max_tokens_override: None,
             cli_session_ctx: None,
             db_flush_ctx: None,
+            tool_policy: None,
         }
     }
 
@@ -147,6 +155,7 @@ impl AiSessionConfig {
             max_tokens_override: None,
             cli_session_ctx: None,
             db_flush_ctx: None,
+            tool_policy: None,
         }
     }
 
@@ -175,6 +184,7 @@ impl AiSessionConfig {
             max_tokens_override: None,
             cli_session_ctx: None,
             db_flush_ctx: None,
+            tool_policy: None,
         }
     }
 
@@ -237,6 +247,16 @@ impl AiSessionConfig {
         self.max_tokens_override = max_tokens;
         self
     }
+
+    /// Set the blueprint tool policy for this AI session (Phase 3).
+    ///
+    /// When `Some`, the Claude CLI is spawned with allow/deny gating and a
+    /// tool-policy preamble is prepended to the prompt. `None` leaves the spawn
+    /// byte-for-byte identical to today.
+    pub fn with_tool_policy(mut self, p: Option<crate::workflow::dag_schema::ToolPolicy>) -> Self {
+        self.tool_policy = p;
+        self
+    }
 }
 
 /// Result of an AI session execution.
@@ -258,11 +278,61 @@ pub struct AiSessionResult {
     pub input_tokens: Option<u64>,
     /// Output tokens generated (available for API providers only, None for CLI).
     pub output_tokens: Option<u64>,
+    /// Blueprint telemetry (Phase 4): de-duplicated, order-preserving list of
+    /// tool names the agentic session actually used.
+    pub tools_used: Vec<String>,
+    /// Blueprint telemetry (Phase 4): tool names rejected by a FailNode policy.
+    pub tools_rejected: Vec<String>,
 }
 
 // =============================================================================
 // Helper Functions
 // =============================================================================
+
+/// Build a concise tool-policy preamble for the prompt (Phase 3 §3.2 point 3).
+///
+/// Returns `Some(preamble)` when the policy has a non-empty allow or deny;
+/// `None` otherwise (so an empty policy adds nothing). The "only these" line is
+/// omitted when allow is None/empty; the "forbidden" line is omitted when deny
+/// is None/empty. This is belt-and-suspenders alongside the hard CLI flags.
+fn build_tool_policy_preamble(policy: &crate::workflow::dag_schema::ToolPolicy) -> Option<String> {
+    let allow: Vec<&str> = policy
+        .allow
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let deny: Vec<&str> = policy
+        .deny
+        .as_deref()
+        .unwrap_or(&[])
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if allow.is_empty() && deny.is_empty() {
+        return None;
+    }
+
+    let mut out = String::from("## Tool policy for this step\n");
+    if !allow.is_empty() {
+        out.push_str(&format!(
+            "You may use ONLY these tools: {}.\n",
+            allow.join(", ")
+        ));
+    }
+    if !deny.is_empty() {
+        out.push_str(&format!(
+            "The following are forbidden and will be blocked: {}.\n",
+            deny.join(", ")
+        ));
+    }
+    out.push('\n');
+    Some(out)
+}
 
 /// Build context explaining that the AI is running autonomously without user interaction.
 ///
@@ -642,7 +712,18 @@ impl UnifiedAiSessionExecutor {
                 step_name = %config.step_name,
             )
             .entered();
-            self.transform_prompt(config, prompt)
+            let base = self.transform_prompt(config, prompt);
+            // Phase 3: belt-and-suspenders tool-policy preamble. Prepend a short
+            // generated section describing the allow/deny so the model is told
+            // the policy in-band, complementing the hard CLI flags.
+            match config
+                .tool_policy
+                .as_ref()
+                .and_then(build_tool_policy_preamble)
+            {
+                Some(preamble) => format!("{preamble}{base}"),
+                None => base,
+            }
         };
 
         // Determine whether to use interactive mode.
@@ -683,6 +764,7 @@ impl UnifiedAiSessionExecutor {
         let model_override = config.model_override.clone();
         let cli_session_ctx = config.cli_session_ctx.clone();
         let db_flush_ctx = config.db_flush_ctx.clone();
+        let tool_policy = config.tool_policy.clone();
 
         let result = tokio::task::spawn_blocking(move || {
             let doctor_ref = doctor_handle.as_ref();
@@ -704,6 +786,7 @@ impl UnifiedAiSessionExecutor {
                     reflection_fix_ctx,
                     step_injection_ctx,
                     model_override.as_deref(),
+                    tool_policy.as_ref(),
                 )
             } else {
                 // Inline mode: one-shot session (either no session manager or interactive disabled)
@@ -729,6 +812,7 @@ impl UnifiedAiSessionExecutor {
                     Some(&task_run_id_for_claude),
                     cli_session_ctx.as_ref(),
                     db_flush_ctx.as_ref(),
+                    tool_policy.as_ref(),
                 )
             }
         })
@@ -747,6 +831,8 @@ impl UnifiedAiSessionExecutor {
                 let injected_steps = cli_result.injected_steps;
                 let cli_input_tokens = cli_result.input_tokens;
                 let cli_output_tokens = cli_result.output_tokens;
+                let cli_tools_used = cli_result.tools_used;
+                let cli_tools_rejected = cli_result.tools_rejected;
                 info!(
                     "UNIFIED-AI-SESSION: {} completed (success={}, output={} chars, duration={}ms, injected_steps={}, tokens={:?}/{:?})",
                     config.phase.as_str(),
@@ -881,6 +967,8 @@ impl UnifiedAiSessionExecutor {
                     error: String::new(),
                     input_tokens: cli_input_tokens,
                     output_tokens: cli_output_tokens,
+                    tools_used: cli_tools_used,
+                    tools_rejected: cli_tools_rejected,
                 }
             }
             Ok(Err(e)) => {
@@ -906,6 +994,8 @@ impl UnifiedAiSessionExecutor {
                     error: e.to_string(),
                     input_tokens: None,
                     output_tokens: None,
+                    tools_used: Vec::new(),
+                    tools_rejected: Vec::new(),
                 }
             }
             Err(e) => {
@@ -932,6 +1022,8 @@ impl UnifiedAiSessionExecutor {
                     error: error_msg,
                     input_tokens: None,
                     output_tokens: None,
+                    tools_used: Vec::new(),
+                    tools_rejected: Vec::new(),
                 }
             }
         }

--- a/src-tauri/src/unified_workflow_executor/compensation.rs
+++ b/src-tauri/src/unified_workflow_executor/compensation.rs
@@ -1460,6 +1460,7 @@ mod tests {
             agentic_phase_success: Some(true),
             blame_json: None,
             contingent_on: Vec::new(),
+            node_rollups: Vec::new(),
         }
     }
 }

--- a/src-tauri/src/unified_workflow_executor/deferred_feedback.rs
+++ b/src-tauri/src/unified_workflow_executor/deferred_feedback.rs
@@ -396,6 +396,7 @@ mod tests {
                 agentic_phase_success: Some(true),
                 blame_json: None,
                 contingent_on: Vec::new(),
+                node_rollups: Vec::new(),
             })
             .collect();
 
@@ -418,6 +419,7 @@ mod tests {
                 agentic_phase_success: Some(true),
                 blame_json: None,
                 contingent_on: Vec::new(),
+                node_rollups: Vec::new(),
             },
             super::super::types::IterationResult {
                 iteration: 2,
@@ -430,6 +432,7 @@ mod tests {
                 agentic_phase_success: Some(false),
                 blame_json: None,
                 contingent_on: Vec::new(),
+                node_rollups: Vec::new(),
             },
         ];
 
@@ -452,6 +455,7 @@ mod tests {
             agentic_phase_success: Some(true),
             blame_json: None,
             contingent_on: Vec::new(),
+            node_rollups: Vec::new(),
         }];
 
         let healthy = compute_decision_confidence(&results, true);

--- a/src-tauri/src/unified_workflow_executor/loop_controller.rs
+++ b/src-tauri/src/unified_workflow_executor/loop_controller.rs
@@ -2964,6 +2964,8 @@ impl LoopController {
                 parsed: None,
                 input_tokens: None,
                 output_tokens: None,
+                tools_used: Vec::new(),
+                tools_rejected: Vec::new(),
             }
         } else {
             super::types::AgenticOutcome::Error {

--- a/src-tauri/src/unified_workflow_executor/loop_handlers.rs
+++ b/src-tauri/src/unified_workflow_executor/loop_handlers.rs
@@ -28,7 +28,7 @@ use super::loop_state_machine::{CompletionReason, LoopContext, LoopState};
 use super::states::UnifiedWorkflowState;
 use super::types::{
     get_parent_task_id, step_execution_to_record, AgenticOutcome, IterationResult, LoopConfig,
-    LoopResult, PhaseResult, RollbackPolicy, StepResultRecord,
+    LoopResult, NodeTelemetry, PhaseResult, RollbackPolicy, StepResultRecord,
 };
 
 use super::loop_controller::{emit_and_persist_phase_result, LoopController};
@@ -1181,6 +1181,7 @@ impl LoopController {
                 agentic_phase_success: None,
                 blame_json: None,
                 contingent_on: Vec::new(),
+                node_rollups: Vec::new(),
             };
             ctx.iteration_results.push(iter_result);
 
@@ -1207,6 +1208,7 @@ impl LoopController {
                 agentic_phase_success: None,
                 blame_json: None,
                 contingent_on: Vec::new(),
+                node_rollups: Vec::new(),
             };
             ctx.iteration_results.push(iter_result);
 
@@ -1891,6 +1893,8 @@ impl LoopController {
                             parsed: None,
                             input_tokens: None,
                             output_tokens: None,
+                            tools_used: Vec::new(),
+                            tools_rejected: Vec::new(),
                         },
                         injected_steps: vec![],
                         failure_context: failure_context.to_string(),
@@ -2508,6 +2512,32 @@ impl LoopController {
             )
             .await;
 
+        // Blueprint telemetry (Phase 4 §3.3): attribute the agentic session's
+        // token cost / tool usage / rejections to the agentic node. Only build
+        // a rollup when the agentic phase actually ran.
+        let node_rollups: Vec<NodeTelemetry> =
+            if !matches!(agentic_outcome, AgenticOutcome::Skipped) {
+                let (tools_used, tools_rejected) = agentic_outcome.tools();
+                let (in_tok, out_tok) = agentic_outcome.token_usage();
+                let tokens = match (in_tok, out_tok) {
+                    (None, None) => None,
+                    (a, b) => Some(a.unwrap_or(0) + b.unwrap_or(0)),
+                };
+                let node_id = agentic_steps
+                    .first()
+                    .and_then(|s| s.id.clone())
+                    .unwrap_or_else(|| "agentic".into());
+                vec![NodeTelemetry {
+                    node_id,
+                    node_kind: "agentic".into(),
+                    tools_used,
+                    tools_rejected,
+                    tokens,
+                }]
+            } else {
+                Vec::new()
+            };
+
         let iter_result = IterationResult {
             iteration: ctx.iteration,
             verification_passed: false,
@@ -2519,6 +2549,7 @@ impl LoopController {
             agentic_phase_success: Some(agentic_outcome.is_success()),
             blame_json: ctx.blame_json.take(),
             contingent_on: ctx.active_contingencies.clone(),
+            node_rollups,
         };
         ctx.iteration_results.push(iter_result);
 
@@ -2936,6 +2967,7 @@ impl LoopController {
             agentic_phase_success: None,
             blame_json: None,
             contingent_on: ctx.active_contingencies.clone(),
+            node_rollups: Vec::new(),
         };
         ctx.iteration_results.push(iter_result);
 

--- a/src-tauri/src/unified_workflow_executor/loop_state_machine.rs
+++ b/src-tauri/src/unified_workflow_executor/loop_state_machine.rs
@@ -22,7 +22,7 @@ use super::compensation::CompensationManager;
 use super::convergence::{
     ConvergenceAction, ConvergenceConfig, ConvergenceDetector, ConvergenceReport,
 };
-use super::types::{AgenticOutcome, IterationResult, LoopConfig, LoopResult};
+use super::types::{AgenticOutcome, IterationResult, LoopConfig, LoopResult, NodeTelemetry};
 
 /// Drop-style worktree cleanup that runs AFTER the compensation stack.
 ///
@@ -318,6 +318,15 @@ impl CompletionReason {
 
         let fix_attempts_exhausted = matches!(&self, CompletionReason::FixAttemptsExhausted { .. });
 
+        // Blueprint telemetry (Phase 4): the loop-level union is the
+        // concatenation of every iteration's per-node rollups. Dedup is not
+        // required — the meta-optimizer groups by node_id downstream.
+        let node_rollups: Vec<NodeTelemetry> = ctx
+            .iteration_results
+            .iter()
+            .flat_map(|ir| ir.node_rollups.iter().cloned())
+            .collect();
+
         LoopResult {
             verification_passed,
             iterations_run: ctx.iteration,
@@ -332,6 +341,7 @@ impl CompletionReason {
             files_modified: ctx.resource_tracker.files_modified(),
             fix_attempts: ctx.fix_attempts,
             ci_auto_resumes: ctx.ci_auto_resumes,
+            node_rollups,
         }
     }
 }
@@ -597,6 +607,7 @@ mod tests {
             agentic_phase_success: Some(true),
             blame_json: None,
             contingent_on: Vec::new(),
+            node_rollups: Vec::new(),
         });
         ctx.iteration_results.push(IterationResult {
             iteration: 2,
@@ -609,6 +620,7 @@ mod tests {
             agentic_phase_success: Some(true),
             blame_json: None,
             contingent_on: Vec::new(),
+            node_rollups: Vec::new(),
         });
         ctx.iteration_results.push(IterationResult {
             iteration: 3,
@@ -621,6 +633,7 @@ mod tests {
             agentic_phase_success: None,
             blame_json: None,
             contingent_on: Vec::new(),
+            node_rollups: Vec::new(),
         });
 
         let result = CompletionReason::VerificationPassed.into_loop_result(&ctx);

--- a/src-tauri/src/unified_workflow_executor/multi_agent_pipeline_loop.rs
+++ b/src-tauri/src/unified_workflow_executor/multi_agent_pipeline_loop.rs
@@ -825,6 +825,7 @@ impl LoopController {
                 files_modified: Vec::new(),
                 fix_attempts: 0,
                 ci_auto_resumes: 0,
+                node_rollups: Vec::new(),
             };
         }
 

--- a/src-tauri/src/unified_workflow_executor/phases/agentic.rs
+++ b/src-tauri/src/unified_workflow_executor/phases/agentic.rs
@@ -486,6 +486,10 @@ impl AgenticExecutor {
                                 parsed: None,
                                 input_tokens: resp.input_tokens,
                                 output_tokens: resp.output_tokens,
+                                // API-provider path does not surface per-tool
+                                // telemetry (Phase 4); CLI path does.
+                                tools_used: Vec::new(),
+                                tools_rejected: Vec::new(),
                             },
                             Vec::new(),
                         );
@@ -1027,10 +1031,15 @@ impl AgenticExecutor {
             .first()
             .and_then(|s| s.model.clone())
             .or_else(|| config.resolve_model_for_phase("agentic"));
+        // Blueprint tool policy: a DAG agentic node carries a resolved policy
+        // (per-node, falling back to workflow blueprint_defaults). Mirror the
+        // model-resolution idiom — read it off the first agentic step.
+        let agentic_tool_policy = agentic_steps.first().and_then(|s| s.tool_policy.clone());
         let mut ai_config =
             AiSessionConfig::agentic(&config.execution_id, &config.workflow_name, iteration)
                 .with_checkpoint_id(&checkpoint.id)
-                .with_model_override(agentic_model);
+                .with_model_override(agentic_model)
+                .with_tool_policy(agentic_tool_policy);
 
         // CLI session context for restart survival.
         // Check if there's an interrupted session we can resume via `--resume`.
@@ -1218,6 +1227,11 @@ impl AgenticExecutor {
             None
         };
 
+        // Blueprint telemetry (Phase 4): capture tool usage before `result` is
+        // partially moved into the outcome variant.
+        let session_tools_used = result.tools_used.clone();
+        let session_tools_rejected = result.tools_rejected.clone();
+
         let outcome = if result.success {
             completion_checkpoint.mark_success(Some(result.output.clone()), duration_ms);
             AgenticOutcome::Success {
@@ -1225,6 +1239,8 @@ impl AgenticExecutor {
                 parsed: parsed_output,
                 input_tokens: result.input_tokens,
                 output_tokens: result.output_tokens,
+                tools_used: session_tools_used,
+                tools_rejected: session_tools_rejected,
             }
         } else if result.output.is_empty() {
             let error_msg = if result.error.is_empty() {
@@ -1247,6 +1263,8 @@ impl AgenticExecutor {
                 parsed: parsed_output,
                 input_tokens: result.input_tokens,
                 output_tokens: result.output_tokens,
+                tools_used: session_tools_used,
+                tools_rejected: session_tools_rejected,
             }
         };
 

--- a/src-tauri/src/unified_workflow_executor/types.rs
+++ b/src-tauri/src/unified_workflow_executor/types.rs
@@ -91,6 +91,20 @@ pub struct ReplayPoint {
     pub timestamp: String,
 }
 
+/// Per-node blueprint telemetry rollup (Phase 4). Lets the meta-optimizer
+/// attribute token cost / tool usage / rejections to a specific node.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct NodeTelemetry {
+    pub node_id: String,
+    pub node_kind: String, // "agentic" | "deterministic"
+    #[serde(default)]
+    pub tools_used: Vec<String>,
+    #[serde(default)]
+    pub tools_rejected: Vec<String>,
+    #[serde(default)]
+    pub tokens: Option<u64>,
+}
+
 /// Result of a single iteration of the verification-agentic loop.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IterationResult {
@@ -118,6 +132,9 @@ pub struct IterationResult {
     /// Populated from `LoopContext.active_contingencies` at the end of each iteration.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub contingent_on: Vec<String>,
+    /// Per-node blueprint telemetry rollup for this iteration (Phase 4).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub node_rollups: Vec<NodeTelemetry>,
 }
 
 /// Final result of the entire verification-agentic loop.
@@ -156,6 +173,11 @@ pub struct LoopResult {
     /// Number of CI auto-resumes consumed at loop exit.
     #[serde(default)]
     pub ci_auto_resumes: u32,
+    /// Per-node blueprint telemetry rollups, flattened across all iterations
+    /// (Phase 4). Union the meta-optimizer reads to attribute cost/tools/
+    /// rejections per node across the whole loop.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub node_rollups: Vec<NodeTelemetry>,
 }
 
 impl LoopResult {
@@ -902,6 +924,10 @@ pub enum AgenticOutcome {
         input_tokens: Option<u64>,
         /// Output tokens generated (available for API providers only).
         output_tokens: Option<u64>,
+        /// Blueprint telemetry (Phase 4): de-duplicated tool names used.
+        tools_used: Vec<String>,
+        /// Blueprint telemetry (Phase 4): tool names rejected by a FailNode policy.
+        tools_rejected: Vec<String>,
     },
     /// AI ran but reported failure
     Failed {
@@ -912,6 +938,10 @@ pub enum AgenticOutcome {
         input_tokens: Option<u64>,
         /// Output tokens generated (available for API providers only).
         output_tokens: Option<u64>,
+        /// Blueprint telemetry (Phase 4): de-duplicated tool names used.
+        tools_used: Vec<String>,
+        /// Blueprint telemetry (Phase 4): tool names rejected by a FailNode policy.
+        tools_rejected: Vec<String>,
     },
     /// AI execution errored out
     Error { error: String },
@@ -953,6 +983,27 @@ impl AgenticOutcome {
             AgenticOutcome::Error { .. }
             | AgenticOutcome::BudgetExceeded { .. }
             | AgenticOutcome::Skipped => (None, None),
+        }
+    }
+
+    /// Blueprint telemetry (Phase 4): tools used / rejected by the AI session,
+    /// if available. Returns `(used, rejected)`, both empty for non-CLI or
+    /// non-running outcomes.
+    pub fn tools(&self) -> (Vec<String>, Vec<String>) {
+        match self {
+            AgenticOutcome::Success {
+                tools_used,
+                tools_rejected,
+                ..
+            }
+            | AgenticOutcome::Failed {
+                tools_used,
+                tools_rejected,
+                ..
+            } => (tools_used.clone(), tools_rejected.clone()),
+            AgenticOutcome::Error { .. }
+            | AgenticOutcome::BudgetExceeded { .. }
+            | AgenticOutcome::Skipped => (Vec::new(), Vec::new()),
         }
     }
 
@@ -1257,5 +1308,100 @@ mod tests {
         assert_eq!(back.phase, "setup");
         assert_eq!(back.step_results.len(), 1);
         assert_eq!(back.variables_set, None);
+    }
+
+    // ───────────────────────── Phase 4 telemetry rollups ─────────────────────
+
+    fn empty_iteration_result(iteration: u32) -> IterationResult {
+        IterationResult {
+            iteration,
+            verification_passed: false,
+            critical_failure: false,
+            passed_checks: 0,
+            failed_checks: 0,
+            failure_context: String::new(),
+            agentic_phase_ran: false,
+            agentic_phase_success: None,
+            blame_json: None,
+            contingent_on: Vec::new(),
+            node_rollups: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn node_telemetry_serde_round_trip() {
+        let nt = NodeTelemetry {
+            node_id: "agentic-1".into(),
+            node_kind: "agentic".into(),
+            tools_used: vec!["Bash".into(), "Edit".into()],
+            tools_rejected: vec!["Write".into()],
+            tokens: Some(1234),
+        };
+        let json = serde_json::to_string(&nt).unwrap();
+        let back: NodeTelemetry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.node_id, "agentic-1");
+        assert_eq!(back.node_kind, "agentic");
+        assert_eq!(back.tools_used, vec!["Bash", "Edit"]);
+        assert_eq!(back.tools_rejected, vec!["Write"]);
+        assert_eq!(back.tokens, Some(1234));
+    }
+
+    #[test]
+    fn node_telemetry_defaults_omit_empty_collections() {
+        // A minimal rollup deserializes from just node_id + node_kind.
+        let nt: NodeTelemetry =
+            serde_json::from_str(r#"{"node_id":"n","node_kind":"deterministic"}"#).unwrap();
+        assert!(nt.tools_used.is_empty());
+        assert!(nt.tools_rejected.is_empty());
+        assert_eq!(nt.tokens, None);
+    }
+
+    #[test]
+    fn iteration_result_omits_node_rollups_when_empty() {
+        let ir = empty_iteration_result(1);
+        let v = serde_json::to_value(&ir).unwrap();
+        assert!(
+            !v.as_object().unwrap().contains_key("node_rollups"),
+            "empty node_rollups must be skipped on serialize (back-compat)"
+        );
+    }
+
+    #[test]
+    fn iteration_result_includes_node_rollups_when_populated() {
+        let mut ir = empty_iteration_result(1);
+        ir.node_rollups.push(NodeTelemetry {
+            node_id: "a".into(),
+            node_kind: "agentic".into(),
+            tools_used: vec!["Bash".into()],
+            tools_rejected: Vec::new(),
+            tokens: Some(10),
+        });
+        let v = serde_json::to_value(&ir).unwrap();
+        assert!(v.as_object().unwrap().contains_key("node_rollups"));
+    }
+
+    #[test]
+    fn loop_result_omits_node_rollups_when_empty() {
+        let lr = LoopResult {
+            iterations_run: 1,
+            verification_passed: true,
+            max_iterations_reached: false,
+            critical_failure: false,
+            was_stopped: false,
+            unfixable_errors: false,
+            iteration_results: vec![],
+            total_tokens: None,
+            total_cost_usd: None,
+            fix_attempts_exhausted: false,
+            files_modified: Vec::new(),
+            fix_attempts: 0,
+            ci_auto_resumes: 0,
+            node_rollups: Vec::new(),
+        };
+        let v = serde_json::to_value(&lr).unwrap();
+        assert!(
+            !v.as_object().unwrap().contains_key("node_rollups"),
+            "empty LoopResult node_rollups must be skipped on serialize (back-compat)"
+        );
     }
 }

--- a/src-tauri/src/workflow/dag_context.rs
+++ b/src-tauri/src/workflow/dag_context.rs
@@ -157,6 +157,8 @@ mod tests {
             cancel_reason: None,
             inputs: None,
             extract: None,
+            kind: None,
+            tool_policy: None,
         }
     }
 

--- a/src-tauri/src/workflow/dag_parser.rs
+++ b/src-tauri/src/workflow/dag_parser.rs
@@ -121,6 +121,36 @@ pub fn validate_dag(def: &DagWorkflowDef) -> Result<(), Vec<DagValidationError>>
             }
         }
 
+        // Rule 8 (Phase 3): tool_policy deny tokens on an Agentic node must be
+        // well-formed, so a policy never silently no-ops. A token that contains
+        // ':' but has an EMPTY tool part or EMPTY command-prefix part (e.g.
+        // "Bash:", ":foo", ":") is malformed and unenforceable as an
+        // argument-scoped deny. Well-formed tool-name denies ("Write") and
+        // well-formed "Tool:prefix" denies pass.
+        if node.effective_kind() == NodeKind::Agentic {
+            if let Some(ref policy) = node.tool_policy {
+                if let Some(ref denies) = policy.deny {
+                    for raw in denies {
+                        let tok = raw.trim();
+                        if tok.is_empty() {
+                            continue;
+                        }
+                        if let Some((tool, prefix)) = tok.split_once(':') {
+                            if tool.trim().is_empty() || prefix.trim().is_empty() {
+                                errors.push(DagValidationError {
+                                    node_id: Some(node_id.clone()),
+                                    message: format!(
+                                        "tool_policy deny '{}' is malformed (empty tool or command prefix) and cannot be enforced",
+                                        tok
+                                    ),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         // Rule 5: approval.on_reject must reference a valid node ID
         if let Some(ref approval) = node.approval {
             if let Some(ref on_reject) = approval.on_reject {
@@ -181,6 +211,18 @@ pub fn dag_to_step_configs(def: &DagWorkflowDef) -> Result<Vec<ExecutionStepConf
             Some(node.depends_on.clone())
         };
 
+        // Tool-policy inheritance resolves HERE (purely & testably): only
+        // Agentic nodes carry a policy. A per-node policy wins; otherwise the
+        // workflow's `blueprint_defaults` is the fallback. Deterministic nodes
+        // never carry a policy (they never spawn an LLM session).
+        let resolved_tool_policy = if node.effective_kind() == NodeKind::Agentic {
+            node.tool_policy
+                .clone()
+                .or_else(|| def.blueprint_defaults.clone())
+        } else {
+            None
+        };
+
         let mut cfg = ExecutionStepConfig {
             id: Some(node_id.clone()),
             name: Some(node_name),
@@ -192,6 +234,8 @@ pub fn dag_to_step_configs(def: &DagWorkflowDef) -> Result<Vec<ExecutionStepConf
             retry_delay_ms,
             provider: effective_provider,
             model: effective_model,
+            node_kind: Some(node.effective_kind()),
+            tool_policy: resolved_tool_policy,
             ..ExecutionStepConfig::default()
         };
 
@@ -321,4 +365,160 @@ fn dfs_cycle<'a>(
 
     color.insert(node, 2); // black — done
     Ok(())
+}
+
+#[cfg(test)]
+mod node_kind_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn workflow(value: serde_json::Value) -> DagWorkflowDef {
+        serde_json::from_value(value).expect("fixture workflow should deserialize")
+    }
+
+    fn config_for<'a>(configs: &'a [ExecutionStepConfig], id: &str) -> &'a ExecutionStepConfig {
+        configs
+            .iter()
+            .find(|c| c.id.as_deref() == Some(id))
+            .unwrap_or_else(|| panic!("no config for node id {id:?}"))
+    }
+
+    #[test]
+    fn dag_to_step_configs_carries_inferred_node_kinds() {
+        let def = workflow(json!({
+            "name": "test-wf",
+            "nodes": {
+                "p": { "prompt": "do the thing" },
+                "c": { "command": "echo hi" }
+            }
+        }));
+        let configs = dag_to_step_configs(&def).expect("should build step configs");
+
+        assert_eq!(
+            config_for(&configs, "p").node_kind,
+            Some(NodeKind::Agentic),
+            "prompt node should carry Agentic"
+        );
+        assert_eq!(
+            config_for(&configs, "c").node_kind,
+            Some(NodeKind::Deterministic),
+            "command node should carry Deterministic"
+        );
+    }
+
+    // Plan-test (c): a malformed `Bash:` deny on an agentic node fails
+    // validate_dag with a named error (no silent no-op).
+    #[test]
+    fn validate_dag_rejects_malformed_deny_token_on_agentic_node() {
+        let def = workflow(json!({
+            "name": "test-wf",
+            "nodes": {
+                "p": {
+                    "prompt": "do the thing",
+                    "tool_policy": { "deny": ["Bash:"] }
+                }
+            }
+        }));
+        let errs = validate_dag(&def).expect_err("malformed deny must fail validation");
+        assert!(
+            errs.iter().any(|e| e.node_id.as_deref() == Some("p")
+                && e.message.contains("malformed")
+                && e.message.contains("Bash:")),
+            "expected a named malformed-deny error, got {errs:?}"
+        );
+    }
+
+    #[test]
+    fn validate_dag_accepts_well_formed_denies_on_agentic_node() {
+        let def = workflow(json!({
+            "name": "test-wf",
+            "nodes": {
+                "p": {
+                    "prompt": "do the thing",
+                    "tool_policy": {
+                        "allow": ["Bash"],
+                        "deny": ["Write", "Bash:git push --force"]
+                    }
+                }
+            }
+        }));
+        assert!(validate_dag(&def).is_ok());
+    }
+
+    #[test]
+    fn validate_dag_ignores_tool_policy_on_deterministic_node() {
+        // A deterministic node carrying a malformed deny is not validated as a
+        // tool policy (it would never spawn an LLM session). The discriminator
+        // rule still applies — a command node with a tool_policy is fine.
+        let def = workflow(json!({
+            "name": "test-wf",
+            "nodes": {
+                "c": {
+                    "command": "echo hi",
+                    "tool_policy": { "deny": ["Bash:"] }
+                }
+            }
+        }));
+        assert!(
+            validate_dag(&def).is_ok(),
+            "tool_policy on a deterministic node should not trigger Rule 8"
+        );
+    }
+
+    #[test]
+    fn dag_to_step_configs_resolves_tool_policy_per_node_then_blueprint_default() {
+        use crate::workflow::dag_schema::ViolationAction;
+        let def = workflow(json!({
+            "name": "test-wf",
+            "blueprint_defaults": { "deny": ["Write"] },
+            "nodes": {
+                // inherits the workflow blueprint_defaults
+                "inherit": { "prompt": "a" },
+                // overrides with its own policy
+                "own": {
+                    "prompt": "b",
+                    "tool_policy": { "allow": ["Read"], "on_violation": "fail_node" }
+                },
+                // deterministic: never carries a policy
+                "det": { "command": "echo hi" }
+            }
+        }));
+        let configs = dag_to_step_configs(&def).expect("should build step configs");
+
+        let inherit = config_for(&configs, "inherit")
+            .tool_policy
+            .as_ref()
+            .expect("inherited policy");
+        assert_eq!(inherit.deny.as_deref(), Some(&["Write".to_string()][..]));
+
+        let own = config_for(&configs, "own")
+            .tool_policy
+            .as_ref()
+            .expect("own policy");
+        assert_eq!(own.allow.as_deref(), Some(&["Read".to_string()][..]));
+        assert_eq!(own.on_violation, ViolationAction::FailNode);
+
+        assert!(
+            config_for(&configs, "det").tool_policy.is_none(),
+            "deterministic node must not carry a tool policy"
+        );
+    }
+
+    #[test]
+    fn dag_to_step_configs_honors_explicit_kind_on_prompt_node() {
+        // A prompt node explicitly marked deterministic must carry Some(Deterministic).
+        let def = workflow(json!({
+            "name": "test-wf",
+            "nodes": {
+                "p": { "prompt": "do the thing", "kind": "deterministic" }
+            }
+        }));
+        let configs = dag_to_step_configs(&def).expect("should build step configs");
+
+        assert_eq!(
+            config_for(&configs, "p").node_kind,
+            Some(NodeKind::Deterministic),
+            "explicit deterministic kind should override the prompt inference"
+        );
+    }
 }

--- a/src-tauri/src/workflow/dag_schema.rs
+++ b/src-tauri/src/workflow/dag_schema.rs
@@ -12,6 +12,10 @@ pub struct DagWorkflowDef {
     pub defaults: NodeDefaults,
     #[serde(default)]
     pub settings: WorkflowSettings,
+    /// Default tool policy inherited by agentic nodes that don't set their own.
+    /// Genuinely new — composed in Phase 3, not read here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blueprint_defaults: Option<ToolPolicy>,
 }
 
 /// Default values applied to nodes that don't specify the field themselves.
@@ -93,6 +97,33 @@ pub struct DagNodeDef {
     // ── Data flow ───────────────────────────────────────────────────────────
     pub inputs: Option<HashMap<String, String>>,
     pub extract: Option<HashMap<String, String>>,
+
+    // ── Blueprint typing (opt-in; back-compat: None ⇒ inferred) ──────────────
+    /// Explicit node kind. If `None`, inferred via [`DagNodeDef::effective_kind`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<NodeKind>,
+    /// Tool policy, applied only when the effective kind is `Agentic`.
+    /// `None` ⇒ no restriction. Inherits `DagWorkflowDef::blueprint_defaults`
+    /// at resolution time (Phase 3), not here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_policy: Option<ToolPolicy>,
+}
+
+impl DagNodeDef {
+    /// Resolve the node's execution kind. An explicit `kind` always wins;
+    /// otherwise it is inferred from the type-discriminating field — only a
+    /// `prompt` node is agentic; every other node kind runs deterministically
+    /// (it never spawns an LLM session itself).
+    pub fn effective_kind(&self) -> NodeKind {
+        if let Some(k) = self.kind {
+            return k;
+        }
+        if self.prompt.is_some() {
+            NodeKind::Agentic
+        } else {
+            NodeKind::Deterministic
+        }
+    }
 }
 
 fn default_trigger_rule() -> TriggerRule {
@@ -119,6 +150,105 @@ pub enum ContextMode {
     Shared,
 }
 
+/// Explicit node execution kind. Deterministic nodes never spawn an LLM
+/// session; agentic nodes invoke the model.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeKind {
+    Deterministic,
+    Agentic,
+}
+
+impl NodeKind {
+    /// Stable lowercase string for telemetry stamping (matches serde repr).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            NodeKind::Deterministic => "deterministic",
+            NodeKind::Agentic => "agentic",
+        }
+    }
+}
+
+/// Per-agentic-node tool policy. Applied only when the effective kind is
+/// `Agentic`. `None` on a node ⇒ no restriction (today's behavior).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolPolicy {
+    /// Allow-list of tool names. If `Some`, only these tools may be called.
+    /// Empty/None ⇒ unrestricted (matches `ToolGuard` semantics).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow: Option<Vec<String>>,
+    /// Deny-list. Two self-classifying granularities (split on the FIRST `:`):
+    ///  - bare tool name (no `:`), e.g. `"Write"` ⇒ tool-name deny.
+    ///  - `"<Tool>:<command-prefix>"`, e.g. `"Bash:git push --force"` ⇒
+    ///    command-argument-scoped deny.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deny: Option<Vec<String>>,
+    /// What to do on a violation.
+    #[serde(default)]
+    pub on_violation: ViolationAction,
+}
+
+/// Action taken when a tool-policy violation is observed.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ViolationAction {
+    /// Skip the call and let the model continue (the CLI's native behavior
+    /// under `--disallowed-tools`). This is the default.
+    #[default]
+    RejectCall,
+    /// Hard-stop the node on a violation.
+    FailNode,
+}
+
+/// A single deny entry, classified by granularity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DenyEntry {
+    /// Block the whole tool (carrier: native `--disallowed-tools <name>`).
+    ToolName(String),
+    /// Block only matching invocations of an otherwise-allowed tool
+    /// (carrier: a `Bash(<prefix>:*)` permission-rule specifier + the
+    /// node's effective `ActionPolicy.blocked_commands`).
+    CommandScoped {
+        tool: String,
+        command_prefix: String,
+    },
+}
+
+impl ToolPolicy {
+    /// Classify every deny entry by granularity. Tokens are trimmed; empty
+    /// tokens are skipped. A token splits on its FIRST `:`.
+    pub fn classified_denies(&self) -> Vec<DenyEntry> {
+        let mut out = Vec::new();
+        let Some(ref denies) = self.deny else {
+            return out;
+        };
+        for raw in denies {
+            let tok = raw.trim();
+            if tok.is_empty() {
+                continue;
+            }
+            match tok.split_once(':') {
+                Some((tool, prefix)) => {
+                    let tool = tool.trim();
+                    let prefix = prefix.trim();
+                    if tool.is_empty() || prefix.is_empty() {
+                        // Malformed (e.g. ":foo" or "Bash:") — treat the whole
+                        // token as a tool-name deny so it is never silently dropped.
+                        out.push(DenyEntry::ToolName(tok.to_string()));
+                    } else {
+                        out.push(DenyEntry::CommandScoped {
+                            tool: tool.to_string(),
+                            command_prefix: prefix.to_string(),
+                        });
+                    }
+                }
+                None => out.push(DenyEntry::ToolName(tok.to_string())),
+            }
+        }
+        out
+    }
+}
+
 /// Retry configuration for a node or workflow-level defaults.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetryConfig {
@@ -134,4 +264,323 @@ pub struct ApprovalConfig {
     pub message: String,
     pub on_reject: Option<String>,
     pub timeout_seconds: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// Build a `DagNodeDef` fixture from a JSON object, so tests stay readable
+    /// despite the struct's many fields. Any field not present defaults via serde.
+    fn node(value: serde_json::Value) -> DagNodeDef {
+        serde_json::from_value(value).expect("fixture node should deserialize")
+    }
+
+    // ───────────────────────── effective_kind inference ──────────────────────
+
+    #[test]
+    fn effective_kind_prompt_node_is_agentic() {
+        let n = node(json!({ "prompt": "do the thing" }));
+        assert_eq!(n.effective_kind(), NodeKind::Agentic);
+    }
+
+    #[test]
+    fn effective_kind_command_node_is_deterministic() {
+        let n = node(json!({ "command": "echo hi" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_check_type_node_is_deterministic() {
+        let n = node(json!({ "check_type": "lint" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_ui_bridge_node_is_deterministic() {
+        let n = node(json!({ "ui_bridge_action": "click" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_a11y_node_is_deterministic() {
+        let n = node(json!({ "a11y_action": "press" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_loop_node_is_deterministic() {
+        let n = node(json!({ "loop_body": ["a", "b"] }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_approval_node_is_deterministic() {
+        let n = node(json!({ "approval": { "message": "ok?" } }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_workflow_ref_node_is_deterministic() {
+        let n = node(json!({ "workflow_ref": "sub.yaml" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_cancel_node_is_deterministic() {
+        let n = node(json!({ "cancel_reason": "abort" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_empty_node_is_deterministic() {
+        let n = node(json!({}));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_explicit_deterministic_overrides_prompt() {
+        // Explicit kind wins even though a prompt is present.
+        let n = node(json!({ "prompt": "do the thing", "kind": "deterministic" }));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn effective_kind_explicit_agentic_overrides_command() {
+        // Explicit kind wins even though only a command is present.
+        let n = node(json!({ "command": "echo hi", "kind": "agentic" }));
+        assert_eq!(n.effective_kind(), NodeKind::Agentic);
+    }
+
+    // ───────────────────────── classified_denies ─────────────────────────────
+
+    fn policy_with_deny(deny: Option<Vec<&str>>) -> ToolPolicy {
+        ToolPolicy {
+            allow: None,
+            deny: deny.map(|v| v.into_iter().map(String::from).collect()),
+            on_violation: ViolationAction::default(),
+        }
+    }
+
+    #[test]
+    fn classified_denies_bare_tool_name() {
+        let p = policy_with_deny(Some(vec!["Write"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::ToolName("Write".to_string())]
+        );
+    }
+
+    #[test]
+    fn classified_denies_command_scoped() {
+        let p = policy_with_deny(Some(vec!["Bash:git push --force"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::CommandScoped {
+                tool: "Bash".to_string(),
+                command_prefix: "git push --force".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn classified_denies_command_scoped_simple() {
+        let p = policy_with_deny(Some(vec!["Bash:rm -rf"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::CommandScoped {
+                tool: "Bash".to_string(),
+                command_prefix: "rm -rf".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn classified_denies_mixed_preserves_order() {
+        let p = policy_with_deny(Some(vec!["Write", "Bash:git push --force", "Edit"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![
+                DenyEntry::ToolName("Write".to_string()),
+                DenyEntry::CommandScoped {
+                    tool: "Bash".to_string(),
+                    command_prefix: "git push --force".to_string(),
+                },
+                DenyEntry::ToolName("Edit".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn classified_denies_trims_whitespace() {
+        let p = policy_with_deny(Some(vec!["  Write  ", "  Bash : git push  "]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![
+                DenyEntry::ToolName("Write".to_string()),
+                DenyEntry::CommandScoped {
+                    tool: "Bash".to_string(),
+                    command_prefix: "git push".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn classified_denies_skips_empty_tokens() {
+        let p = policy_with_deny(Some(vec!["", "   ", "Write"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::ToolName("Write".to_string())]
+        );
+    }
+
+    #[test]
+    fn classified_denies_malformed_trailing_colon_falls_back_to_tool_name() {
+        // "Bash:" — empty prefix ⇒ never dropped, treated as tool-name deny.
+        let p = policy_with_deny(Some(vec!["Bash:"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::ToolName("Bash:".to_string())]
+        );
+    }
+
+    #[test]
+    fn classified_denies_malformed_leading_colon_falls_back_to_tool_name() {
+        // ":foo" — empty tool ⇒ never dropped, treated as tool-name deny.
+        let p = policy_with_deny(Some(vec![":foo"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::ToolName(":foo".to_string())]
+        );
+    }
+
+    #[test]
+    fn classified_denies_none_is_empty() {
+        let p = policy_with_deny(None);
+        assert_eq!(p.classified_denies(), Vec::<DenyEntry>::new());
+    }
+
+    #[test]
+    fn classified_denies_splits_on_first_colon_only() {
+        // A prefix may itself contain a colon; only the FIRST colon splits.
+        let p = policy_with_deny(Some(vec!["Bash:ssh user@host:cmd"]));
+        assert_eq!(
+            p.classified_denies(),
+            vec![DenyEntry::CommandScoped {
+                tool: "Bash".to_string(),
+                command_prefix: "ssh user@host:cmd".to_string(),
+            }]
+        );
+    }
+
+    // ───────────────────────── serde round-trips ─────────────────────────────
+
+    #[test]
+    fn node_without_blueprint_fields_omits_keys_on_serialize() {
+        let n = node(json!({ "command": "echo hi" }));
+        assert!(n.kind.is_none());
+        assert!(n.tool_policy.is_none());
+        let serialized = serde_json::to_value(&n).expect("serialize");
+        let obj = serialized.as_object().expect("object");
+        assert!(
+            !obj.contains_key("kind"),
+            "kind should be skipped when None"
+        );
+        assert!(
+            !obj.contains_key("tool_policy"),
+            "tool_policy should be skipped when None"
+        );
+    }
+
+    #[test]
+    fn minimal_yaml_node_without_blueprint_fields_deserializes() {
+        let yaml = r#"
+command: "echo hi"
+depends_on:
+  - prev
+"#;
+        let n: DagNodeDef = serde_yaml::from_str(yaml).expect("yaml deserialize");
+        assert!(n.kind.is_none());
+        assert!(n.tool_policy.is_none());
+        assert_eq!(n.command.as_deref(), Some("echo hi"));
+        assert_eq!(n.effective_kind(), NodeKind::Deterministic);
+    }
+
+    #[test]
+    fn node_with_tool_policy_round_trips_json() {
+        let original = node(json!({
+            "prompt": "do the thing",
+            "kind": "agentic",
+            "tool_policy": {
+                "allow": ["Read", "Edit"],
+                "deny": ["Write", "Bash:git push --force"],
+                "on_violation": "fail_node"
+            }
+        }));
+        let serialized = serde_json::to_string(&original).expect("serialize");
+        let round: DagNodeDef = serde_json::from_str(&serialized).expect("deserialize");
+        assert_eq!(round.kind, Some(NodeKind::Agentic));
+        assert_eq!(round.tool_policy, original.tool_policy);
+        let tp = round.tool_policy.as_ref().expect("tool_policy");
+        assert_eq!(tp.on_violation, ViolationAction::FailNode);
+        assert_eq!(
+            tp.classified_denies(),
+            vec![
+                DenyEntry::ToolName("Write".to_string()),
+                DenyEntry::CommandScoped {
+                    tool: "Bash".to_string(),
+                    command_prefix: "git push --force".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn violation_action_defaults_to_reject_call() {
+        let p = node(json!({
+            "prompt": "x",
+            "tool_policy": { "deny": ["Write"] }
+        }))
+        .tool_policy
+        .expect("tool_policy");
+        assert_eq!(p.on_violation, ViolationAction::RejectCall);
+    }
+
+    #[test]
+    fn workflow_without_blueprint_defaults_omits_key() {
+        let wf: DagWorkflowDef = serde_yaml::from_str(
+            r#"
+name: wf
+nodes:
+  a:
+    command: "echo hi"
+"#,
+        )
+        .expect("workflow deserialize");
+        assert!(wf.blueprint_defaults.is_none());
+        let serialized = serde_json::to_value(&wf).expect("serialize");
+        assert!(!serialized
+            .as_object()
+            .expect("object")
+            .contains_key("blueprint_defaults"));
+    }
+
+    // ───────────────────────── NodeKind::as_str (Phase 4) ────────────────────
+
+    #[test]
+    fn node_kind_as_str_returns_stable_strings() {
+        assert_eq!(NodeKind::Deterministic.as_str(), "deterministic");
+        assert_eq!(NodeKind::Agentic.as_str(), "agentic");
+    }
+
+    #[test]
+    fn node_kind_as_str_matches_serde_repr() {
+        // The telemetry string must equal the snake_case serde representation.
+        let det = serde_json::to_value(NodeKind::Deterministic).expect("serialize");
+        let agt = serde_json::to_value(NodeKind::Agentic).expect("serialize");
+        assert_eq!(det.as_str(), Some(NodeKind::Deterministic.as_str()));
+        assert_eq!(agt.as_str(), Some(NodeKind::Agentic.as_str()));
+    }
 }

--- a/src-tauri/src/workflow/dag_sync.rs
+++ b/src-tauri/src/workflow/dag_sync.rs
@@ -274,6 +274,8 @@ pub async fn export_workflow_as_yaml(
         cancel_reason: None,
         inputs: None,
         extract: None,
+        kind: None,
+        tool_policy: None,
     };
 
     let mut nodes = HashMap::new();
@@ -289,6 +291,7 @@ pub async fn export_workflow_as_yaml(
             max_iterations: Some(max_iterations as u32),
             ..WorkflowSettings::default()
         },
+        blueprint_defaults: None,
     };
 
     // 4. Serialise to YAML


### PR DESCRIPTION
## Runner Blueprints — Typed Deterministic/Agentic Node Model

Implements plan `2026-05-31-runner-blueprint-typed-nodes-plan` (Phases 1–4; Phase 5 meta-optimizer deferred to a separate PR). Opt-in and fully backward compatible — workflows with no blueprint annotations behave exactly as before.

### What's in it
- **Phase 1 — Schema + inference** (`workflow/dag_schema.rs`): `NodeKind { Deterministic, Agentic }`, `ToolPolicy { allow, deny, on_violation }`, `ViolationAction { RejectCall(default), FailNode }`, `DenyEntry` + `classified_denies()`, `DagNodeDef.{kind,tool_policy}`, `DagNodeDef::effective_kind()`, `DagWorkflowDef.blueprint_defaults`. Pure, exhaustively unit-tested inference table.
- **Phase 2 — Deterministic guarantee** (`step_executor`): `ExecutionStepConfig` carries the resolved `node_kind`; `execute_single_step` makes the "no AI session at the deterministic dispatch boundary" invariant explicit (debug-assert + log).
- **Phase 3 — Tool-policy enforcement** (`claude_session`, `unified_ai_session`): `ToolPolicy` threads through `AiSessionConfig` to the CLI spawn. Tool-name denies → `--disallowedTools`; allow-list → `--allowedTools`; command-arg-scoped denies (e.g. `Bash:git push --force`) → a `permissions.deny` rule `Bash(<prefix>:*)` in an ephemeral `--settings` file. `FailNode` is a post-hoc detector over the observed tool stream; `RejectCall` is the CLI's native behavior. A generated prompt preamble declares the policy. Malformed deny tokens fail DAG validation (no silent no-op). A per-node effective `ActionPolicy` overlay builder mirrors arg-scoped denies for runner-executed command steps.
- **Phase 4 — Telemetry** (`unified_workflow_executor`, `step_executor`): step events carry `node_id` + `node_kind`; `IterationResult`/`LoopResult` gain per-node rollups (`tools_used`, `tools_rejected`, `tokens`) for the future meta-optimizer.

### Phase-3b CLI spike (verified against claude 2.1.167)
Under `--permission-mode bypassPermissions` (the mode every runner session uses):
- whole-tool `--disallowedTools Bash` → **honored** ✓
- bare arg-scoped `--disallowedTools "Bash(...)"` → **ignored** ✗
- `--settings '{"permissions":{"deny":["Bash(<prefix>:*)"]}}'` → **honored** ✓ (`git status --short` blocked, `git --version` ran)

The implementation uses the verified `--settings` carrier and keeps `bypassPermissions` unchanged (plan non-goal). Because that carrier can always be constructed, an arg-scoped deny never silently evaporates; validation only rejects malformed deny tokens.

### Verification
- `cargo clippy --bin qontinui-runner --features custom-protocol --tests -- -D warnings` → clean.
- `cargo clippy --all-targets -- -D warnings` (prepush gate, default features) → clean.
- 216 tests across the affected modules pass (0 failures). Backend/library only — no UI changes, so no manual-test/spec steps.

Plan: 2026-05-31-runner-blueprint-typed-nodes-plan
