### PR TITLE
fix(runner): make pop-out terminal windows answer the UI Bridge (capabilities + port)

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Capability for the main window",
-  "windows": ["main"],
+  "description": "Capability for the main window and pop-out terminal windows (term-N)",
+  "windows": ["main", "term-*"],
   "permissions": [
     "core:default",
     "core:window:allow-minimize",

--- a/src/lib/runner-api.ts
+++ b/src/lib/runner-api.ts
@@ -13,9 +13,35 @@
  */
 import { useEffect, useState } from "react";
 
-let _apiPort: number = 9876;
-let _apiBase: string = "http://localhost:9876";
-let _wsBase: string = "ws://localhost:9876";
+/**
+ * Synchronous port-resolution fast-path. Every webview (the main window AND
+ * each pop-out terminal window) is launched with an init script that sets
+ * `window.__QONTINUI_PORT__` to the runner's bound API port *before* this
+ * bundle evaluates (`main.rs` for main, `commands/terminal_windows.rs` for
+ * pop-outs). Seeding `_apiPort` from it here means every realm addresses the
+ * correct port from its very first call.
+ *
+ * Why this matters: each webview is a separate JS realm with its own
+ * `_apiPort`. The main window also self-corrects via the `api-ready` Tauri
+ * event (it exists when that one-shot event fires at startup), but a pop-out
+ * window opened *later* misses that event — so without this seed it stayed on
+ * the `9876` default and sent its UI Bridge responses/pongs to the wrong
+ * runner (e.g. the primary on 9876 instead of a temp runner on 9877),
+ * silently breaking per-window targeting on any non-9876 runner.
+ * `useApiReady`/`get_api_port` still override this asynchronously.
+ */
+function injectedApiPort(): number {
+  if (typeof window !== "undefined") {
+    const injected = (window as unknown as Record<string, unknown>).__QONTINUI_PORT__;
+    const n = Number(injected);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 9876;
+}
+
+let _apiPort: number = injectedApiPort();
+let _apiBase: string = `http://localhost:${_apiPort}`;
+let _wsBase: string = `ws://localhost:${_apiPort}`;
 
 const portChangeListeners = new Set<() => void>();
 


### PR DESCRIPTION
## Summary
Pop-out terminal windows (Phase 1–4 of `plans/2026-06-03-runner-popout-terminal-windows.md`) never completed a UI Bridge round-trip — every `GET /ui-bridge/control/elements?windowLabel=term-N` timed out, even though the Phase-4 dispatcher (#444) routed correctly. Found during live temp-runner verification of #444. Two distinct, compounding bugs:

### 1. Tauri capabilities didn't cover pop-out windows (primary fix — all runners)
The sole Tauri v2 capability (`capabilities/default.json`) was scoped to `"windows": ["main"]`, so pop-out windows (`term-N`) were granted **no** permissions — including `core:event:allow-listen`. The pop-out's `useUIBridgeEventHandler` calls `listen("ui-bridge-request")`, which the ACL **rejected** (`event.listen not allowed on window "term-N"`). The listener never registered, so the pop-out received no requests and never replied.

**Fix:** extend the window glob to `["main", "term-*"]` so pop-outs get the same permissions as main.

### 2. Pop-out replies went to the wrong port on non-9876 runners (secondary fix)
Each webview is a separate JS realm with its own module-global `_apiPort` (`lib/runner-api.ts`), defaulting to 9876. The main window self-corrects via the one-shot `api-ready` Tauri event, but a pop-out opened *later* misses it, so `httpSendResponse`/`httpSendPong` addressed `localhost:9876` — the primary runner — instead of the runner hosting the pop-out. Both webviews already inject `window.__QONTINUI_PORT__` before the bundle loads (the "synchronous port-resolution fast-path"), but `_apiPort` never read it.

**Fix:** seed `_apiPort`/`_apiBase`/`_wsBase` from `window.__QONTINUI_PORT__` at module init. `useApiReady`/`get_api_port` still override asynchronously; the main window is unaffected.

## Why both
- The capabilities fix is required on **every** runner (including the primary on 9876) — without it the pop-out's listener never registers.
- The port-seed fix is required additionally on **non-9876** runners (every temp/named runner), where the pop-out would otherwise reply to 9876.

## Verification (live, temp runner)
- Before: `?windowLabel=term-N` timed out; pop-out's `event.listen` → "not allowed"; zero pop-out traffic on the runner's port.
- After: `event.listen` allowed in the pop-out; `?windowLabel=term-N` → **success, 52 elements** returned from that window. Phase-4 per-window targeting now works end-to-end.

(`gen/schemas/capabilities.json` is gitignored and regenerated from `capabilities/default.json` on a clean build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)