### PR TITLE
feat(ui-bridge): control-API discoverability — /control/* redirect + page/summary bodyText

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/CONTRACT.md
+++ b/src-tauri/src/mcp/ui_bridge/CONTRACT.md
@@ -225,6 +225,54 @@ The gating IDs do NOT have to share the gating button's naming convention,
 and a `reveals` glob authored to look like the gate's own id will silently
 match nothing.
 
+## Discoverability & ergonomics (driving the control API by hand)
+
+Friction captured while an agent drove the control API to verify a rendered
+page (plan `2026-06-06-ui-bridge-control-discoverability-friction`). Read this
+before reaching for a hand-rolled workaround — the affordance you want probably
+already exists.
+
+### Base path: `/control/*` redirects to `/ui-bridge/control/*`
+The control surface is mounted under the `/ui-bridge` prefix. A bare
+`/control/tabs` used to 404 with nothing naming the right prefix. It now
+**308-redirects** to `/ui-bridge/control/tabs` (`mod.rs::control_prefix_redirect`,
+registered as `.route("/control/{*path}", any(...))`). 308 preserves method +
+body, so `POST /control/page/evaluate` works through the redirect. The redirect
+route is deliberately NOT in `route_manifest()` — its path isn't under
+`/ui-bridge/`, so the drift-test regex never sees it; adding it would make the
+test flag an unregistered manifest entry.
+
+### `page/evaluate` 422 already names the expected field
+The body field is `expression`. Sending `script` / `code` / `js` deserializes
+to a `JsonDataError` (missing required `expression`) → **422 whose
+`suggestions` array literally names the field**: `"Required field: \`expression\`
+(JavaScript string). …"`. Read the `suggestions` array, not just `error`. This
+is wired via `PageEvaluateRequest`'s `RequestHints::shape_error_suggestions`
+(`page.rs:173`) surfaced by `envelope.rs::envelope_422_with_hints`. There is
+intentionally no `script` alias — the hint already closes the discoverability
+gap, and an alias would add a permanent special case to a typed request.
+
+### Reading visible page text (esp. unregistered plain-JSX)
+`GET /ui-bridge/control/snapshot` returns only **registered** UI Bridge
+components (`useUIComponent`), so a panel rendered as plain JSX shows nothing
+there. To answer "did my panel render?":
+- **`POST /ui-bridge/control/page/summary`** now returns a `bodyText` field —
+  the whole page's `document.body.innerText`, trimmed and capped at 8000 chars
+  (`page.rs::ui_bridge_page_summary_handler`) — alongside the structured
+  headings/buttons/inputs/links digest. One call, no hand-rolled evaluate.
+- **`POST /ui-bridge/control/page/read-value`** (`elements.rs:3336`) reads one
+  selector's `textContent`/`value`.
+- **`find-by-text`** (`elements.rs:3158`) locates elements by visible text.
+
+### `page/evaluate` result envelope: pass `unwrap: true` for a stable shape
+By default the result shape varies by type (scalars get wrapped as
+`{success, result:{value}}`; objects pass through bare), which breaks naive
+`data.result.value` parsing. Pass **`unwrap: true`** and the frontend returns a
+consistent discriminated `{value, type}` shape for every result type
+(`page.rs:159` field, applied at `page.rs:752`). The varying `unwrap:false`
+shape is the legacy default kept for back-compat — prefer `unwrap:true` for
+parse-without-try/except.
+
 ## Contract test surface
 
 - **Internal manifest drift** — `cargo test manifest_matches_route_calls`

--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -380,8 +380,34 @@ fn local_route_entries() -> &'static [(&'static str, &'static str)] {
     ]
 }
 
+/// Redirect bare `/control/*` requests to the canonical
+/// `/ui-bridge/control/*` surface.
+///
+/// The control API is mounted under the `/ui-bridge` prefix, but an agent
+/// reaching for "control" routinely guesses `/control/tabs` first and gets an
+/// opaque 404 with nothing pointing at the right prefix. A **308 Permanent
+/// Redirect** preserves the method AND body, so `POST /control/page/evaluate`
+/// transparently lands on the real handler instead of forcing a retry.
+/// Nothing is mounted at top-level `/control/*`, so there is no collision.
+///
+/// NOTE: this route's path does NOT start with `/ui-bridge/`, so it is
+/// intentionally invisible to the `manifest_matches_route_calls` drift test
+/// (whose regex only scans `/ui-bridge/*` literals) — it must NOT be added to
+/// `route_manifest()`, which would otherwise flag it as an unregistered
+/// manifest entry.
+async fn control_prefix_redirect(uri: axum::http::Uri) -> axum::response::Redirect {
+    // `uri.path()` is e.g. `/control/tabs`; prefixing `/ui-bridge` yields the
+    // canonical `/ui-bridge/control/tabs`. `path_and_query()` preserves any
+    // query string (e.g. `/control/snapshot?visibleOnly=1`).
+    let tail = uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or_else(|| uri.path());
+    axum::response::Redirect::permanent(&format!("/ui-bridge{tail}"))
+}
+
 pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
-    use axum::routing::{get, post};
+    use axum::routing::{any, get, post};
     // Each `pub mod` listed at the top of this file owns a thematic slice of
     // the UI Bridge HTTP surface and exposes `routes()` + `route_entries()`.
     // Composition here is purely structural — every handler lives in a
@@ -426,6 +452,10 @@ pub fn routes() -> axum::Router<std::sync::Arc<crate::mcp::types::ApiState>> {
             "/ui-bridge/invoke/{command_name}",
             post(crate::mcp::ui_bridge_invoke_handlers::ui_bridge_invoke_handler),
         )
+        // Discoverability: 308-redirect bare `/control/*` → `/ui-bridge/control/*`
+        // so the control surface is reachable from the obvious path. See
+        // `control_prefix_redirect` for why this is NOT in `route_manifest()`.
+        .route("/control/{*path}", any(control_prefix_redirect))
 }
 
 #[cfg(test)]

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -1365,6 +1365,12 @@ pub async fn ui_bridge_page_summary_handler(
         return JSON.stringify({
             title: document.title,
             url: document.URL,
+            // Whole-page visible text (capped at 8000 chars). Lets a caller
+            // answer "did my plain-JSX panel render?" in one call without a
+            // hand-rolled page/evaluate `document.body.innerText` — the
+            // get_snapshot affordance surfaces only *registered* UI Bridge
+            // components, so unregistered JSX is invisible there.
+            bodyText: (document.body ? document.body.innerText : '').trim().slice(0, 8000),
             headings: vis('h1, h2, h3').map(function(el) { return { tag: el.tagName, text: el.textContent.trim().slice(0, 100) }; }).slice(0, 10),
             buttons: vis('button').filter(function(el) { return el.textContent.trim().length > 0; }).map(function(el) { return el.textContent.trim().slice(0, 40); }).filter(function(t) { return t.length < 30; }).slice(0, 20),
             inputs: vis('input, textarea, select').map(function(el) { return { tag: el.tagName, type: el.type || null, placeholder: (el.placeholder || '').slice(0, 40) || null, hasValue: (el.value || '').length > 0 }; }).slice(0, 15),


### PR DESCRIPTION
Implements plan `2026-06-06-ui-bridge-control-discoverability-friction` (VETTED).

Reduces trial-and-error friction when driving the UI Bridge control API by hand.

## Changes
- **308-redirect `/control/*` → `/ui-bridge/control/*`** (`mod.rs::control_prefix_redirect`). Method+body preserved, so `POST /control/page/evaluate` works through the redirect. Intentionally NOT in `route_manifest()` (its path isn't under `/ui-bridge/`, so the drift-test regex never sees it — adding it would flag an unregistered manifest entry).
- **`page/summary` now returns `bodyText`** — whole-page `document.body.innerText`, trimmed, capped 8000 chars. One-call "did my plain-JSX panel render?" check without a hand-rolled `page/evaluate`.
- **CONTRACT.md** documents the redirect, that `page/evaluate` 422s already name `expression` in `suggestions`, the visible-text read affordances, and `unwrap:true` for a stable evaluate envelope.

Two of the four friction points the plan captured were already shipped (the `unwrap:true` envelope and the 422 field hint) — those reduced to docs.

## Verification
- `cargo check` clean; `cargo test manifest_matches_route_calls` passes (redirect correctly invisible to the drift check).
- Pre-push clippy (`--all-targets -D warnings`) passed.
- Live on a temp runner built from this branch SHA `085827187cca`:
  - `GET /control/tabs` → 308 `location: /ui-bridge/control/tabs`; followed → real tabs JSON.
  - `POST /control/page/evaluate {expression:"1+1"}` via `/control/*` → 308, followed → `{result:{value:2}}`.
  - `POST /ui-bridge/control/page/summary` → `bodyText` present (712 chars).
  - `POST .../page/evaluate {script:...}` → 422 with `suggestions:["Required field: \`expression\` …"]`.

Plan: 2026-06-06-ui-bridge-control-discoverability-friction