### PR TITLE
feat(runner): visible pop-out button in the terminal tab strip

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -558,6 +558,15 @@ function AppContent() {
                   onRemovePage={terminalPages.removePage}
                   onRenamePage={terminalPages.renamePage}
                   onReorganize={() => setShowReorganize(true)}
+                  onPopOut={() => {
+                    // Open a new pop-out OS window (same process) that hosts its
+                    // own terminal tabs — the visible counterpart to the
+                    // `open-terminal-window` UI Bridge action. New terminals
+                    // created in that window belong to it (window_assignments).
+                    void invoke("open_terminal_window", { placement: null }).catch(
+                      (err) => console.error("Failed to open pop-out window:", err),
+                    );
+                  }}
                 />
                 {showReorganize && (
                   <ReorganizeDialog

--- a/src/components/terminal/TerminalPageTabBar.tsx
+++ b/src/components/terminal/TerminalPageTabBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { Plus, X, Shuffle } from "lucide-react";
+import { Plus, X, Shuffle, SquareArrowOutUpRight } from "lucide-react";
 import type { TerminalPageConfig } from "./useTerminalPages";
 
 interface TerminalPageTabBarProps {
@@ -10,6 +10,8 @@ interface TerminalPageTabBarProps {
   onRemovePage: (id: string) => void;
   onRenamePage: (id: string, name: string) => void;
   onReorganize?: () => void;
+  /** Open a new pop-out OS window (same process) hosting its own terminals. */
+  onPopOut?: () => void;
 }
 
 export function TerminalPageTabBar({
@@ -20,6 +22,7 @@ export function TerminalPageTabBar({
   onRemovePage,
   onRenamePage,
   onReorganize,
+  onPopOut,
 }: TerminalPageTabBarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
@@ -135,6 +138,16 @@ export function TerminalPageTabBar({
           title="Reorganize pages by topic (AI)"
         >
           <Shuffle className="w-3 h-3" />
+        </button>
+      )}
+      {onPopOut && (
+        <button
+          onClick={onPopOut}
+          aria-label="Open terminal in a new window"
+          className="flex items-center gap-0.5 px-1.5 py-1 rounded text-[10px] text-[#565f89] hover:text-[#7aa2f7] hover:bg-[#7aa2f7]/10 transition-colors"
+          title="Open a new pop-out terminal window"
+        >
+          <SquareArrowOutUpRight className="w-3 h-3" />
         </button>
       )}
     </div>


### PR DESCRIPTION
## Visible pop-out button in the terminal tab strip

Surfaces the existing pop-out window capability to operators. Until now, opening a pop-out terminal window was only reachable via the `open-terminal-window` UI Bridge action (agent/automation) or the raw Tauri command — there was no human-clickable control. This adds the missing UX entry point flagged as the last optional item in `plans/2026-06-03-runner-popout-terminal-windows.md`.

### Change
- **`TerminalPageTabBar`** gains an optional `onPopOut` prop that renders a `SquareArrowOutUpRight` icon button next to Add (`+`) and Reorganize, titled *"Open a new pop-out terminal window"*. Hidden when the prop is absent, so the presentational component stays decoupled.
- **`App.tsx`** wires `onPopOut` to `invoke("open_terminal_window", { placement: null })` — the same command the existing UI Bridge action already uses. Terminals created in the new window belong to it (`window_assignments`); geometry persistence + boot restore are already shipped (Phase 2, #440).

### Scope
Frontend-only; **no backend change**. The button appears in the main window's terminal view (pop-out windows render the terminal-only view). `tsc --noEmit` clean; CI runs the full typecheck + lint + vitest + Tauri build.

### Not in scope (future)
Per-tab "pop out this terminal" / "move to window N" context menu and drag-tab-out — this PR is the single lowest-effort, highest-discoverability affordance (a global "new window" button).
