### PR TITLE
feat(code-graph): Ξ_Domain business-domain observer + shared module_graph (Phase 3)

### DIFF
--- a/src-tauri/src/mcp/code_semantics/arch_observer.rs
+++ b/src-tauri/src/mcp/code_semantics/arch_observer.rs
@@ -18,18 +18,16 @@
 //!
 //! Route: `POST /code-graph/arch-layers` — `{scope?, max_modules?}` → a uniform
 //! kernel envelope wrapping `{modules:[{module,layer,rationale}], ...}`. The
-//! module *structure* (files, exported symbols, resolved internal deps, external
-//! packages) is built from the resolved `Ξ_AST` graph (Pillar 1) and summarized
-//! into the prompt; the model only assigns layers — it never sees raw source.
+//! module *structure* is built from the resolved `Ξ_AST` graph and summarized into
+//! the prompt by [`super::module_graph`] (shared with `Ξ_Domain`); the model only
+//! assigns layers — it never sees raw source.
 //!
-//! Per-module granularity is the vet's Q4 v1 decision (`Ξ_Domain` — business
-//! flows — is deferred behind this). A process-local fingerprint cache makes
-//! repeated calls on an unchanged graph free (the LLM pass runs once per distinct
-//! graph fingerprint per process); durable app-data persistence (§4.5) is a
-//! follow-up.
+//! Per-module granularity is the vet's Q4 v1 decision. A process-local
+//! fingerprint cache makes repeated calls on an unchanged graph free (the LLM pass
+//! runs once per distinct graph fingerprint per process); durable app-data
+//! persistence (§4.5) is a follow-up.
 
-use std::collections::{BTreeMap, BTreeSet};
-use std::hash::{Hash, Hasher};
+use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
 use axum::{extract::State, routing::post, Json, Router};
@@ -37,31 +35,12 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use super::module_graph::{self, ModuleSummary};
 use super::{code_graph_api, scope_project_dir, Envelope};
-use crate::ai_provider::{run_structured_prompt, StructuredPrompt};
-use crate::ai_router::TaskContext;
 use crate::mcp::types::ApiState;
-use crate::workflow_generation::code_graph::CodeGraph;
 
 /// The architectural-layer taxonomy (UA's architecture-analyzer set + `unknown`).
 const LAYERS: &[&str] = &["api", "service", "data", "ui", "utility", "unknown"];
-
-/// Default cap on modules classified in one pass — bounds prompt size + token
-/// cost. Modules beyond the cap (lowest export-count first) are omitted and
-/// reflected honestly in `coverage`.
-const DEFAULT_MAX_MODULES: usize = 60;
-
-/// Uncalibrated kernel posterior (vet Q5): a fixed "model hint" confidence, NOT a
-/// measured accuracy. `kernel:true` + `authorial:low` is what tells a consumer
-/// this is advisory; the posterior is here to be calibrated against acceptance
-/// data later, not trusted today.
-const KERNEL_POSTERIOR: f64 = 0.5;
-
-// Per-module summary caps (keep the prompt bounded regardless of repo size).
-const MAX_EXPORTS_PER_MODULE: usize = 12;
-const MAX_DEPS_PER_MODULE: usize = 8;
-const MAX_EXTERNAL_PER_MODULE: usize = 8;
-const MAX_FILES_PER_MODULE: usize = 10;
 
 /// Observer name + provenance for the kernel envelope.
 const OBSERVER: &str = "arch";
@@ -74,10 +53,10 @@ const PROVENANCE: &str = super::PROV_KERNEL_ARCH;
 #[derive(Debug, Deserialize, Default)]
 pub struct ArchLayersReq {
     /// Optional `(repo,language)` scope selector — a repo name/slug (cross-repo
-    /// `Ξ_AST` via [`scope::repo_dir`]), a project dir, or a tsconfig path.
+    /// `Ξ_AST`), a project dir, or a tsconfig path.
     pub scope: Option<String>,
-    /// Cap on modules classified in one pass (default [`DEFAULT_MAX_MODULES`],
-    /// clamped to 1..=200).
+    /// Cap on modules classified in one pass (default
+    /// [`module_graph::DEFAULT_MAX_MODULES`], clamped to 1..=200).
     pub max_modules: Option<usize>,
 }
 
@@ -100,22 +79,17 @@ async fn arch_layers(
         None => return Json(cold_envelope(q, "no resolvable scope (cold)")),
     };
     let project_dir = scope_project_dir(&scope);
-    let max_modules = req.max_modules.unwrap_or(DEFAULT_MAX_MODULES).clamp(1, 200);
+    let max_modules = req
+        .max_modules
+        .unwrap_or(module_graph::DEFAULT_MAX_MODULES)
+        .clamp(1, 200);
 
     // Build the resolved graph + module summaries off the async runtime.
-    let dir = project_dir.clone();
-    let (summaries, total_modules, fingerprint) = match tokio::task::spawn_blocking(move || {
-        let graph = CodeGraph::build(&dir);
-        let mods = summarize_modules(&graph);
-        let total = mods.len();
-        let fp = fingerprint_modules(&mods);
-        (mods, total, fp)
-    })
-    .await
-    {
-        Ok(t) => t,
-        Err(_) => return Json(cold_envelope(q, "graph build failed")),
-    };
+    let (summaries, total_modules, fingerprint) =
+        match module_graph::build_module_graph(project_dir).await {
+            Some(t) => t,
+            None => return Json(cold_envelope(q, "graph build failed")),
+        };
 
     if total_modules == 0 {
         return Json(cold_envelope(q, "empty / cold graph (no modules)"));
@@ -131,39 +105,11 @@ async fn arch_layers(
     let capped: Vec<ModuleSummary> = summaries.into_iter().take(max_modules).collect();
     let prompt = build_prompt(&capped);
 
-    // The single LLM call — forced through the Claude-CLI provider so this
-    // observer NEVER makes a keyed API call (the operator constraint). Synchronous
-    // (spawns the CLI subprocess), so run it off the runtime.
-    let response = match tokio::task::spawn_blocking(move || {
-        let context = TaskContext::from_prompt(&prompt);
-        let structured = StructuredPrompt::uncached(prompt);
-        run_structured_prompt(
-            &structured,
-            &context,
-            None,
-            None,
-            Some("claude_cli"), // provider_override — force CLI, no API key
-            Some(0.0),          // temperature_override — deterministic classification
-            None,
-            None,
-            None,
-        )
-    })
-    .await
-    {
-        Ok(r) => r,
-        Err(_) => {
-            // The classification task panicked — degrade honestly, never 500.
-            return Json(make_envelope(q, &scope.key, &[], total_modules, false));
-        }
-    };
-
-    // Parse the model's assignments; an unavailable model / unparseable output
-    // degrades to zero classified (coverage 0), never a confident false answer.
-    let parsed = if response.success {
-        parse_layers(&response.output)
-    } else {
-        Vec::new()
+    // The single LLM call (forced Claude-CLI, no API key); honest degrade on
+    // failure → zero classified (coverage 0), never a confident false answer.
+    let parsed = match module_graph::run_cli_structured(prompt).await {
+        Some(output) => parse_layers(&output),
+        None => Vec::new(),
     };
 
     cache_put(fingerprint, parsed.clone());
@@ -171,158 +117,14 @@ async fn arch_layers(
 }
 
 // ===========================================================================
-// Module summarization (pure — built from the resolved Ξ_AST graph)
-// ===========================================================================
-
-/// A module = a directory of files, summarized for the classifier. The model
-/// sees only this structure, never source.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ModuleSummary {
-    /// Module key — the directory path (repo-relative, forward slashes; `"."` for
-    /// repo-root files).
-    module: String,
-    /// File basenames in the module (sorted, capped).
-    files: Vec<String>,
-    /// Exported symbol names declared in the module (sorted, capped).
-    exports: Vec<String>,
-    /// Other in-repo module dirs this module imports from, via *resolved* edges
-    /// (sorted, capped).
-    internal_deps: Vec<String>,
-    /// External package specifiers the module imports (sorted, capped).
-    external_pkgs: Vec<String>,
-    /// Total exports before the cap — the ranking + tie-break signal.
-    export_count: usize,
-}
-
-/// The directory component of a repo-relative path (forward slashes). Files at
-/// the repo root map to `"."`.
-fn module_dir(path: &str) -> String {
-    match path.rsplit_once('/') {
-        Some((dir, _)) if !dir.is_empty() => dir.to_string(),
-        _ => ".".to_string(),
-    }
-}
-
-/// The basename of a repo-relative path.
-fn basename(path: &str) -> &str {
-    path.rsplit_once('/').map(|(_, b)| b).unwrap_or(path)
-}
-
-/// Group the resolved graph's files into per-directory module summaries, sorted
-/// by export count (desc), then module name (asc) for a stable, high-signal-first
-/// ordering. Internal vectors are sorted + de-duplicated so the output (and its
-/// fingerprint) is deterministic.
-fn summarize_modules(graph: &CodeGraph) -> Vec<ModuleSummary> {
-    // Accumulate per-module sets.
-    struct Acc {
-        files: BTreeSet<String>,
-        exports: BTreeSet<String>,
-        deps: BTreeSet<String>,
-        external: BTreeSet<String>,
-    }
-    let mut acc: BTreeMap<String, Acc> = BTreeMap::new();
-    let ensure = |acc: &mut BTreeMap<String, Acc>, m: String| {
-        acc.entry(m).or_insert_with(|| Acc {
-            files: BTreeSet::new(),
-            exports: BTreeSet::new(),
-            deps: BTreeSet::new(),
-            external: BTreeSet::new(),
-        });
-    };
-
-    for f in &graph.files {
-        let m = module_dir(&f.path);
-        ensure(&mut acc, m.clone());
-        acc.get_mut(&m)
-            .unwrap()
-            .files
-            .insert(basename(&f.path).to_string());
-    }
-    for e in &graph.exports {
-        let m = module_dir(&e.file_path);
-        ensure(&mut acc, m.clone());
-        acc.get_mut(&m).unwrap().exports.insert(e.name.clone());
-    }
-    for imp in &graph.imports {
-        let m = module_dir(&imp.from_file);
-        ensure(&mut acc, m.clone());
-        match &imp.resolved_target {
-            Some(target) => {
-                let target_mod = module_dir(target);
-                if target_mod != m {
-                    acc.get_mut(&m).unwrap().deps.insert(target_mod);
-                }
-            }
-            None => {
-                use crate::workflow_generation::code_graph::ResolutionKind;
-                // Only count honestly-external specifiers as external packages;
-                // an `Unresolved` internal-looking edge is a coverage hole, not a
-                // package signal, so it is deliberately dropped here.
-                if matches!(imp.resolution, ResolutionKind::External) {
-                    acc.get_mut(&m)
-                        .unwrap()
-                        .external
-                        .insert(imp.to_module.clone());
-                }
-            }
-        }
-    }
-
-    let mut out: Vec<ModuleSummary> = acc
-        .into_iter()
-        .map(|(module, a)| {
-            let export_count = a.exports.len();
-            ModuleSummary {
-                module,
-                files: cap(a.files, MAX_FILES_PER_MODULE),
-                exports: cap(a.exports, MAX_EXPORTS_PER_MODULE),
-                internal_deps: cap(a.deps, MAX_DEPS_PER_MODULE),
-                external_pkgs: cap(a.external, MAX_EXTERNAL_PER_MODULE),
-                export_count,
-            }
-        })
-        .collect();
-
-    out.sort_by(|a, b| {
-        b.export_count
-            .cmp(&a.export_count)
-            .then_with(|| a.module.cmp(&b.module))
-    });
-    out
-}
-
-/// Take the first `n` of a sorted set into a `Vec` (the set is already ordered).
-fn cap(set: BTreeSet<String>, n: usize) -> Vec<String> {
-    set.into_iter().take(n).collect()
-}
-
-/// A stable fingerprint of the module structure — same structure → same value, so
-/// the LLM pass runs once per distinct graph per process. Hashes a name-ordered
-/// view of every module's (files, exports, internal deps); ignores the cap-driven
-/// `export_count` ordering so only *content* changes invalidate the cache.
-fn fingerprint_modules(mods: &[ModuleSummary]) -> u64 {
-    let mut ordered: Vec<&ModuleSummary> = mods.iter().collect();
-    ordered.sort_by(|a, b| a.module.cmp(&b.module));
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for m in ordered {
-        m.module.hash(&mut hasher);
-        m.files.hash(&mut hasher);
-        m.exports.hash(&mut hasher);
-        m.internal_deps.hash(&mut hasher);
-    }
-    hasher.finish()
-}
-
-// ===========================================================================
 // Prompt construction (pure)
 // ===========================================================================
 
-/// Build the classification prompt from the module summaries. The model sees only
-/// structure (no source) and must return strict JSON. Kept deterministic (modules
-/// in the given order, internal lists pre-sorted) so the cache + tests are stable.
+/// Build the classification prompt: the arch-layer instruction header + the
+/// shared module-list block. The model sees only structure (no source) and must
+/// return strict JSON.
 fn build_prompt(modules: &[ModuleSummary]) -> String {
-    let mut s = String::new();
-    s.push_str(
+    let mut s = String::from(
         "You are classifying the ARCHITECTURAL LAYER of each MODULE in a codebase.\n\
          A module is a directory. For each module you are given its files, its exported\n\
          symbols, the other in-repo modules it imports from, and the external packages\n\
@@ -338,24 +140,7 @@ fn build_prompt(modules: &[ModuleSummary]) -> String {
          {\"modules\":[{\"module\":\"<exact module key>\",\"layer\":\"<taxonomy value>\",\"rationale\":\"<=12 words\"}]}\n\n\
          Modules:\n",
     );
-    for (i, m) in modules.iter().enumerate() {
-        s.push_str(&format!("{}. module: {}\n", i + 1, m.module));
-        if !m.files.is_empty() {
-            s.push_str(&format!("   files: {}\n", m.files.join(", ")));
-        }
-        if !m.exports.is_empty() {
-            s.push_str(&format!("   exports: {}\n", m.exports.join(", ")));
-        }
-        if !m.internal_deps.is_empty() {
-            s.push_str(&format!(
-                "   imports-from: {}\n",
-                m.internal_deps.join(", ")
-            ));
-        }
-        if !m.external_pkgs.is_empty() {
-            s.push_str(&format!("   external: {}\n", m.external_pkgs.join(", ")));
-        }
-    }
+    s.push_str(&module_graph::render_modules(modules));
     s
 }
 
@@ -377,7 +162,7 @@ struct LayerAssignment {
 /// dropped. Returns an empty vec on any failure (the honest "I couldn't read it"
 /// signal — the caller maps that to coverage 0, never a confident false answer).
 fn parse_layers(output: &str) -> Vec<LayerAssignment> {
-    let json_str = match extract_json(output) {
+    let json_str = match module_graph::extract_json(output) {
         Some(s) => s,
         None => return Vec::new(),
     };
@@ -437,43 +222,6 @@ fn normalize_layer(raw: &str) -> String {
     }
 }
 
-/// Extract the first balanced JSON object/array from a string, ignoring prose and
-/// ```json code fences and respecting string literals (so a `}` inside a string
-/// doesn't close the scan early).
-fn extract_json(s: &str) -> Option<&str> {
-    let bytes = s.as_bytes();
-    let start = bytes.iter().position(|&b| b == b'{' || b == b'[')?;
-    let open = bytes[start];
-    let close = if open == b'{' { b'}' } else { b']' };
-    let mut depth = 0i32;
-    let mut in_str = false;
-    let mut escaped = false;
-    for (i, &b) in bytes.iter().enumerate().skip(start) {
-        if in_str {
-            if escaped {
-                escaped = false;
-            } else if b == b'\\' {
-                escaped = true;
-            } else if b == b'"' {
-                in_str = false;
-            }
-            continue;
-        }
-        match b {
-            b'"' => in_str = true,
-            x if x == open => depth += 1,
-            x if x == close => {
-                depth -= 1;
-                if depth == 0 {
-                    return Some(&s[start..=i]);
-                }
-            }
-            _ => {}
-        }
-    }
-    None
-}
-
 // ===========================================================================
 // Envelope assembly
 // ===========================================================================
@@ -492,7 +240,7 @@ fn assemble(parsed: &[LayerAssignment], total_modules: usize, cached: bool) -> (
     let posterior = if classified == 0 {
         0.0
     } else {
-        KERNEL_POSTERIOR
+        module_graph::KERNEL_POSTERIOR
     };
     let modules: Vec<Value> = parsed
         .iter()
@@ -569,122 +317,6 @@ fn cache_put(fp: u64, assignments: Vec<LayerAssignment>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workflow_generation::code_graph::{
-        ExportNode, FileNode, ImportEdge, ResolutionKind,
-    };
-
-    fn file(path: &str) -> FileNode {
-        FileNode {
-            path: path.into(),
-            language: "typescript".into(),
-            line_count: 10,
-        }
-    }
-    fn export(name: &str, file: &str) -> ExportNode {
-        ExportNode {
-            name: name.into(),
-            file_path: file.into(),
-            kind: "function".into(),
-            line: 1,
-        }
-    }
-    fn import(
-        from: &str,
-        to_module: &str,
-        target: Option<&str>,
-        kind: ResolutionKind,
-    ) -> ImportEdge {
-        ImportEdge {
-            from_file: from.into(),
-            to_module: to_module.into(),
-            imported_names: vec![],
-            line: 1,
-            resolved_target: target.map(|s| s.into()),
-            resolution: kind,
-        }
-    }
-
-    #[test]
-    fn module_dir_and_basename() {
-        assert_eq!(module_dir("src/api/auth.ts"), "src/api");
-        assert_eq!(module_dir("main.rs"), ".");
-        assert_eq!(basename("src/api/auth.ts"), "auth.ts");
-        assert_eq!(basename("main.rs"), "main.rs");
-    }
-
-    #[test]
-    fn summarize_groups_files_exports_deps_and_external() {
-        let graph = CodeGraph {
-            files: vec![
-                file("src/api/routes.ts"),
-                file("src/api/handlers.ts"),
-                file("src/services/auth.ts"),
-            ],
-            functions: vec![],
-            classes: vec![],
-            imports: vec![
-                // api → services (resolved internal dep)
-                import(
-                    "src/api/routes.ts",
-                    "../services/auth",
-                    Some("src/services/auth.ts"),
-                    ResolutionKind::Relative,
-                ),
-                // api → external package
-                import(
-                    "src/api/routes.ts",
-                    "express",
-                    None,
-                    ResolutionKind::External,
-                ),
-                // an unresolved internal-looking edge must NOT become an external pkg
-                import(
-                    "src/api/routes.ts",
-                    "./missing",
-                    None,
-                    ResolutionKind::Unresolved,
-                ),
-            ],
-            exports: vec![
-                export("registerRoutes", "src/api/routes.ts"),
-                export("handle", "src/api/handlers.ts"),
-                export("authenticate", "src/services/auth.ts"),
-            ],
-            build_duration_ms: 0,
-        };
-        let mods = summarize_modules(&graph);
-        // Two modules: src/api (2 exports) ranks before src/services (1 export).
-        assert_eq!(mods.len(), 2);
-        assert_eq!(mods[0].module, "src/api");
-        assert_eq!(mods[0].export_count, 2);
-        assert!(mods[0].files.contains(&"routes.ts".to_string()));
-        assert!(mods[0].internal_deps.contains(&"src/services".to_string()));
-        assert!(mods[0].external_pkgs.contains(&"express".to_string()));
-        // The Unresolved edge is dropped from external packages (coverage hole, not a pkg).
-        assert!(!mods[0].external_pkgs.contains(&"./missing".to_string()));
-        assert_eq!(mods[1].module, "src/services");
-    }
-
-    #[test]
-    fn fingerprint_is_stable_and_content_sensitive() {
-        let g1 = CodeGraph {
-            files: vec![file("src/a/x.ts")],
-            functions: vec![],
-            classes: vec![],
-            imports: vec![],
-            exports: vec![export("foo", "src/a/x.ts")],
-            build_duration_ms: 0,
-        };
-        let g2 = g1.clone();
-        let fp1 = fingerprint_modules(&summarize_modules(&g1));
-        let fp2 = fingerprint_modules(&summarize_modules(&g2));
-        assert_eq!(fp1, fp2, "identical structure → identical fingerprint");
-
-        let mut g3 = g1.clone();
-        g3.exports.push(export("bar", "src/a/x.ts"));
-        let fp3 = fingerprint_modules(&summarize_modules(&g3));
-        assert_ne!(fp1, fp3, "an added export must change the fingerprint");
-    }
 
     #[test]
     fn prompt_contains_modules_taxonomy_and_json_instruction() {
@@ -752,13 +384,6 @@ mod tests {
     }
 
     #[test]
-    fn extract_json_respects_string_literals() {
-        // A `}` inside a string must not close the object early.
-        let s = "prefix {\"k\":\"a}b\",\"n\":1} suffix";
-        assert_eq!(extract_json(s), Some("{\"k\":\"a}b\",\"n\":1}"));
-    }
-
-    #[test]
     fn assemble_coverage_and_kernel_discipline() {
         let parsed = vec![
             LayerAssignment {
@@ -775,7 +400,7 @@ mod tests {
         // 2 classified of 4 total → coverage 0.5, posterior = kernel hint.
         let (result, posterior, coverage) = assemble(&parsed, 4, false);
         assert!((coverage - 0.5).abs() < 1e-9);
-        assert!((posterior - KERNEL_POSTERIOR).abs() < 1e-9);
+        assert!((posterior - module_graph::KERNEL_POSTERIOR).abs() < 1e-9);
         assert_eq!(result["classified_modules"], json!(2));
         assert_eq!(result["total_modules"], json!(4));
 

--- a/src-tauri/src/mcp/code_semantics/domain_observer.rs
+++ b/src-tauri/src/mcp/code_semantics/domain_observer.rs
@@ -1,0 +1,493 @@
+//! `Ξ_Domain` — business-domain / flow mapping observer (Phase 3 / Pillar 3 of the
+//! twin-ast plan; the fuzzier sibling sequenced behind `Ξ_Arch` per vet Q4).
+//!
+//! A **stochastic-kernel** twin observer that maps a repo's modules onto the
+//! business/functional **domains** (and the flows) they implement — UA's
+//! domain-analyzer (`/understand-domain`). Where `Ξ_Arch` answers "what *layer* is
+//! this module" against a fixed taxonomy, `Ξ_Domain` *discovers* an open-ended set
+//! of domains (Authentication, Billing, Notifications, …) and groups modules under
+//! them. It runs through the same Claude-CLI path — **no API key** — and shares
+//! the module-graph summarization, JSON extraction, and forced-CLI call with
+//! `Ξ_Arch` via [`super::module_graph`].
+//!
+//! Same kernel discipline as `Ξ_Arch`: **advisory, never gate-worthy** —
+//! `kernel:true`, `posterior<1`, `credibility=(causal:medium, authorial:low,
+//! boundary:low)`. The model sees only module structure, never source.
+//!
+//! Route: `POST /code-graph/domains` — `{scope?, max_modules?}` → a uniform kernel
+//! envelope wrapping `{domains:[{name,summary,modules,flows}], ...}`.
+//!
+//! **Coverage is honest about hallucination.** Each domain's `modules` is
+//! validated against the real module-key set; a module the model invents (renamed
+//! / nonexistent) is dropped from the output and does NOT count toward coverage.
+//! `coverage` = distinct *real* modules assigned to some domain / total modules
+//! (so cap-omitted, unassigned, and hallucinated modules all lower it honestly).
+//!
+//! v1 ships the pure observer only; the `Ξ_Domain`-vs-resolved-dependency-graph
+//! declared-vs-actual / Φ layering-breach drift pair is Phase 4 (needs the
+//! declared-vs-actual construct doc + a declared-side source).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex};
+
+use axum::{extract::State, routing::post, Json, Router};
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::module_graph::{self, ModuleSummary};
+use super::{code_graph_api, scope_project_dir, Envelope};
+use crate::mcp::types::ApiState;
+
+/// Observer name + provenance for the kernel envelope.
+const OBSERVER: &str = "domain";
+const PROVENANCE: &str = super::PROV_KERNEL_DOMAIN;
+
+// ===========================================================================
+// Request / route
+// ===========================================================================
+
+#[derive(Debug, Deserialize, Default)]
+pub struct DomainsReq {
+    /// Optional `(repo,language)` scope selector — a repo name/slug (cross-repo
+    /// `Ξ_AST`), a project dir, or a tsconfig path.
+    pub scope: Option<String>,
+    /// Cap on modules sent to the model in one pass (default
+    /// [`module_graph::DEFAULT_MAX_MODULES`], clamped to 1..=200).
+    pub max_modules: Option<usize>,
+}
+
+/// Routes contributed alongside the `/code-graph/*` surface.
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new().route("/code-graph/domains", post(domains))
+}
+
+/// POST /code-graph/domains → kernel envelope of discovered business domains.
+async fn domains(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<DomainsReq>,
+) -> Json<Envelope> {
+    let q = "domains";
+
+    let scope = match code_graph_api::resolve_project_scope(req.scope.as_deref(), None) {
+        Some(s) => s,
+        None => return Json(cold_envelope(q, "no resolvable scope (cold)")),
+    };
+    let project_dir = scope_project_dir(&scope);
+    let max_modules = req
+        .max_modules
+        .unwrap_or(module_graph::DEFAULT_MAX_MODULES)
+        .clamp(1, 200);
+
+    let (summaries, total_modules, fingerprint) =
+        match module_graph::build_module_graph(project_dir).await {
+            Some(t) => t,
+            None => return Json(cold_envelope(q, "graph build failed")),
+        };
+
+    if total_modules == 0 {
+        return Json(cold_envelope(q, "empty / cold graph (no modules)"));
+    }
+
+    // The real module-key set — used to validate the model's groupings (drop
+    // hallucinated module paths, compute honest coverage). Built from ALL modules,
+    // not just the capped subset sent to the model.
+    let module_keys: BTreeSet<String> = summaries.iter().map(|m| m.module.clone()).collect();
+
+    if let Some(cached) = cache_get(fingerprint) {
+        return Json(make_envelope(
+            q,
+            &scope.key,
+            &cached,
+            total_modules,
+            &module_keys,
+            true,
+        ));
+    }
+
+    let capped: Vec<ModuleSummary> = summaries.into_iter().take(max_modules).collect();
+    let prompt = build_prompt(&capped);
+
+    let parsed = match module_graph::run_cli_structured(prompt).await {
+        Some(output) => parse_domains(&output),
+        None => Vec::new(),
+    };
+
+    cache_put(fingerprint, parsed.clone());
+    Json(make_envelope(
+        q,
+        &scope.key,
+        &parsed,
+        total_modules,
+        &module_keys,
+        false,
+    ))
+}
+
+// ===========================================================================
+// Prompt construction (pure)
+// ===========================================================================
+
+/// Build the domain-mapping prompt: the instruction header + the shared
+/// module-list block. The model sees only structure (no source) and must return
+/// strict JSON.
+fn build_prompt(modules: &[ModuleSummary]) -> String {
+    let mut s = String::from(
+        "You are mapping a codebase to its BUSINESS DOMAINS and flows.\n\
+         A module is a directory. For each module you are given its files, its exported\n\
+         symbols, the other in-repo modules it imports from, and the external packages\n\
+         it uses. You do NOT see source code — infer domains from names + structure alone.\n\n\
+         Identify the distinct business/functional domains the code implements (e.g.\n\
+         Authentication, Billing, Notifications, Search, Reporting) and assign the modules\n\
+         that implement each. Use the EXACT module keys given below. A module belongs to\n\
+         at most one domain; OMIT generic infrastructure/utility modules that aren't\n\
+         domain-specific (do not invent a catch-all domain for them).\n\n\
+         Return ONLY a JSON object, no prose, no code fences:\n\
+         {\"domains\":[{\"name\":\"<domain>\",\"summary\":\"<=15 words\",\"modules\":[\"<exact module key>\"],\"flows\":[\"<short flow name>\"]}]}\n\n\
+         Modules:\n",
+    );
+    s.push_str(&module_graph::render_modules(modules));
+    s
+}
+
+// ===========================================================================
+// Response parsing (pure, tolerant)
+// ===========================================================================
+
+/// One discovered business domain and the modules/flows the model assigned it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DomainAssignment {
+    name: String,
+    summary: String,
+    /// Module keys as the model returned them — validated against real keys at
+    /// assembly time (hallucinated paths are dropped there, not here).
+    modules: Vec<String>,
+    flows: Vec<String>,
+}
+
+/// Parse `{"domains":[{name,summary,modules,flows}]}` (or a bare array) out of the
+/// model's output, tolerant of surrounding prose / ```json fences. Entries without
+/// a non-empty `name` are dropped. Returns an empty vec on any failure (the honest
+/// "I couldn't read it" signal — the caller maps that to coverage 0).
+fn parse_domains(output: &str) -> Vec<DomainAssignment> {
+    let json_str = match module_graph::extract_json(output) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let value: Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let arr = match &value {
+        Value::Object(map) => map.get("domains").and_then(|v| v.as_array()).cloned(),
+        Value::Array(a) => Some(a.clone()),
+        _ => None,
+    };
+    let arr = match arr {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for entry in arr {
+        let name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string());
+        let name = match name {
+            Some(n) if !n.is_empty() => n,
+            _ => continue,
+        };
+        let summary = entry
+            .get("summary")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        out.push(DomainAssignment {
+            name,
+            summary,
+            modules: string_array(entry.get("modules")),
+            flows: string_array(entry.get("flows")),
+        });
+    }
+    out
+}
+
+/// Collect a JSON array of strings into a `Vec<String>`, trimming and dropping
+/// empties. Non-arrays / absent → empty.
+fn string_array(v: Option<&Value>) -> Vec<String> {
+    v.and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|x| x.as_str())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+// ===========================================================================
+// Envelope assembly
+// ===========================================================================
+
+/// Build the result body + coverage/posterior. Each domain's `modules` is filtered
+/// to keys that actually exist in the graph (hallucinated paths dropped);
+/// `coverage` = distinct real modules covered / `total_modules`; `posterior` is the
+/// kernel hint, or 0 when nothing real was covered.
+fn assemble(
+    parsed: &[DomainAssignment],
+    total_modules: usize,
+    module_keys: &BTreeSet<String>,
+    cached: bool,
+) -> (Value, f64, f64) {
+    let mut covered: BTreeSet<&str> = BTreeSet::new();
+    let domains_json: Vec<Value> = parsed
+        .iter()
+        .map(|d| {
+            let real_modules: Vec<&str> = d
+                .modules
+                .iter()
+                .filter(|m| module_keys.contains(m.as_str()))
+                .map(|m| m.as_str())
+                .collect();
+            for m in &real_modules {
+                covered.insert(m);
+            }
+            json!({
+                "name": d.name,
+                "summary": d.summary,
+                "modules": real_modules,
+                "flows": d.flows,
+            })
+        })
+        .collect();
+
+    let covered_count = covered.len();
+    let coverage = if total_modules == 0 {
+        0.0
+    } else {
+        (covered_count as f64 / total_modules as f64).min(1.0)
+    };
+    let posterior = if covered_count == 0 {
+        0.0
+    } else {
+        module_graph::KERNEL_POSTERIOR
+    };
+    let result = json!({
+        "domains": domains_json,
+        "total_modules": total_modules,
+        "covered_modules": covered_count,
+        "domain_count": parsed.len(),
+        "cached": cached,
+    });
+    (result, posterior, coverage)
+}
+
+fn make_envelope(
+    query: &str,
+    scope_key: &str,
+    parsed: &[DomainAssignment],
+    total_modules: usize,
+    module_keys: &BTreeSet<String>,
+    cached: bool,
+) -> Envelope {
+    let (mut result, posterior, coverage) = assemble(parsed, total_modules, module_keys, cached);
+    if let Value::Object(map) = &mut result {
+        map.insert("scope".to_string(), json!(scope_key));
+    }
+    Envelope::kernel(query, OBSERVER, PROVENANCE, result, posterior, coverage)
+}
+
+/// An honest cold/degraded envelope: kernel, coverage 0, posterior 0, never an
+/// assertion that the repo "has no domains".
+fn cold_envelope(query: &str, reason: &str) -> Envelope {
+    Envelope::kernel(
+        query,
+        OBSERVER,
+        PROVENANCE,
+        json!({
+            "domains": [],
+            "total_modules": 0,
+            "covered_modules": 0,
+            "domain_count": 0,
+            "reason": reason,
+        }),
+        0.0,
+        0.0,
+    )
+}
+
+// ===========================================================================
+// Process-local fingerprint cache
+// ===========================================================================
+
+static CACHE: Lazy<Mutex<BTreeMap<u64, Vec<DomainAssignment>>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+fn cache_get(fp: u64) -> Option<Vec<DomainAssignment>> {
+    CACHE.lock().ok().and_then(|m| m.get(&fp).cloned())
+}
+
+fn cache_put(fp: u64, domains: Vec<DomainAssignment>) {
+    // Don't cache an empty (failed) mapping — let the next call retry.
+    if domains.is_empty() {
+        return;
+    }
+    if let Ok(mut m) = CACHE.lock() {
+        m.insert(fp, domains);
+    }
+}
+
+// ===========================================================================
+// Tests (pure — no LLM call)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys(items: &[&str]) -> BTreeSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn prompt_contains_modules_and_domain_json_instruction() {
+        let mods = vec![ModuleSummary {
+            module: "src/auth".into(),
+            files: vec!["login.ts".into()],
+            exports: vec!["authenticate".into()],
+            internal_deps: vec![],
+            external_pkgs: vec!["jsonwebtoken".into()],
+            export_count: 1,
+        }];
+        let p = build_prompt(&mods);
+        assert!(p.contains("src/auth"));
+        assert!(p.contains("authenticate"));
+        assert!(p.contains("BUSINESS DOMAINS"));
+        assert!(p.contains("\"domains\""));
+    }
+
+    #[test]
+    fn parse_clean_domains_object() {
+        let out = r#"{"domains":[
+            {"name":"Authentication","summary":"login + tokens","modules":["src/auth","src/services/login"],"flows":["user login","token refresh"]},
+            {"name":"Billing","summary":"invoices","modules":["src/billing"],"flows":["charge"]}
+        ]}"#;
+        let parsed = parse_domains(out);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "Authentication");
+        assert_eq!(parsed[0].modules, vec!["src/auth", "src/services/login"]);
+        assert_eq!(parsed[0].flows, vec!["user login", "token refresh"]);
+        assert_eq!(parsed[1].name, "Billing");
+    }
+
+    #[test]
+    fn parse_tolerates_prose_and_fences_and_drops_nameless() {
+        let out = "Here you go:\n```json\n{\"domains\":[{\"name\":\"Search\",\"modules\":[\"src/search\"]},{\"summary\":\"no name\"}]}\n```";
+        let parsed = parse_domains(out);
+        assert_eq!(parsed.len(), 1, "the name-less entry is dropped");
+        assert_eq!(parsed[0].name, "Search");
+        // missing summary/flows default to empty.
+        assert_eq!(parsed[0].summary, "");
+        assert!(parsed[0].flows.is_empty());
+    }
+
+    #[test]
+    fn parse_garbage_returns_empty() {
+        assert!(parse_domains("I can't do that").is_empty());
+        assert!(parse_domains("").is_empty());
+        assert!(parse_domains("{nope").is_empty());
+    }
+
+    #[test]
+    fn assemble_drops_hallucinated_modules_and_counts_real_coverage() {
+        let parsed = vec![
+            DomainAssignment {
+                name: "Auth".into(),
+                summary: "s".into(),
+                modules: vec!["src/auth".into(), "src/ghost".into()], // ghost is hallucinated
+                flows: vec!["login".into()],
+            },
+            DomainAssignment {
+                name: "Billing".into(),
+                summary: "s".into(),
+                modules: vec!["src/billing".into()],
+                flows: vec![],
+            },
+        ];
+        let real = keys(&["src/auth", "src/billing", "src/util", "src/api"]);
+        // 2 real covered (src/auth, src/billing) of 4 total → coverage 0.5.
+        let (result, posterior, coverage) = assemble(&parsed, 4, &real, false);
+        assert!((coverage - 0.5).abs() < 1e-9);
+        assert!((posterior - module_graph::KERNEL_POSTERIOR).abs() < 1e-9);
+        assert_eq!(result["covered_modules"], json!(2));
+        assert_eq!(result["domain_count"], json!(2));
+        // The hallucinated module is dropped from the Auth domain's output.
+        let auth_modules = result["domains"][0]["modules"].as_array().unwrap();
+        assert_eq!(auth_modules.len(), 1);
+        assert_eq!(auth_modules[0], json!("src/auth"));
+    }
+
+    #[test]
+    fn assemble_all_hallucinated_is_zero_coverage_and_posterior() {
+        let parsed = vec![DomainAssignment {
+            name: "Ghosts".into(),
+            summary: "s".into(),
+            modules: vec!["src/nope".into()],
+            flows: vec![],
+        }];
+        let real = keys(&["src/auth"]);
+        let (_r, posterior, coverage) = assemble(&parsed, 1, &real, false);
+        assert_eq!(coverage, 0.0, "no real module covered → coverage 0");
+        assert_eq!(posterior, 0.0, "nothing real covered → posterior 0");
+    }
+
+    #[test]
+    fn envelope_is_advisory_kernel_low_authorial() {
+        let parsed = vec![DomainAssignment {
+            name: "Auth".into(),
+            summary: "s".into(),
+            modules: vec!["src/auth".into()],
+            flows: vec![],
+        }];
+        let real = keys(&["src/auth", "src/billing"]);
+        let env = make_envelope("domains", "scope-key", &parsed, 2, &real, false);
+        assert!(env.kernel, "Ξ_Domain envelope MUST be kernel:true");
+        assert!(env.posterior < 1.0, "kernel posterior must be < 1");
+        assert_eq!(env.observer, OBSERVER);
+        assert_eq!(env.provenance, PROVENANCE);
+        assert_eq!(env.credibility.authorial, "low");
+        assert_eq!(env.credibility.boundary, "low");
+        assert_eq!(env.credibility.causal, "medium");
+        assert_eq!(env.result["scope"], json!("scope-key"));
+        // 1 real of 2 total → coverage 0.5.
+        assert!((env.coverage - 0.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn cold_envelope_does_not_assert_absence() {
+        let env = cold_envelope("domains", "empty / cold graph (no modules)");
+        assert!(env.kernel);
+        assert_eq!(env.coverage, 0.0);
+        assert_eq!(env.posterior, 0.0);
+        assert_eq!(env.result["domain_count"], json!(0));
+        assert!(env.result.get("reason").is_some());
+    }
+
+    #[test]
+    fn cache_skips_empty_and_roundtrips_nonempty() {
+        let fp = 0xDADA_BEEF_1234_5678u64;
+        cache_put(fp, Vec::new());
+        assert!(cache_get(fp).is_none(), "empty mapping is not cached");
+        let domains = vec![DomainAssignment {
+            name: "Auth".into(),
+            summary: "s".into(),
+            modules: vec!["src/auth".into()],
+            flows: vec![],
+        }];
+        cache_put(fp, domains.clone());
+        assert_eq!(cache_get(fp), Some(domains));
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/mod.rs
+++ b/src-tauri/src/mcp/code_semantics/mod.rs
@@ -28,7 +28,9 @@
 pub mod arch_observer;
 pub mod cargo_check;
 pub mod code_graph_api;
+pub mod domain_observer;
 pub mod lang;
+pub mod module_graph;
 pub mod mypy_check;
 pub mod node_bridge;
 pub mod scope;
@@ -142,6 +144,9 @@ pub const PROV_RESOLVED: &str = "code_graph_resolved";
 /// `Ξ_Arch` LLM layer-classifier provenance (Phase 3): a stochastic kernel run
 /// through the Claude-CLI path. Advisory, never gate-worthy.
 pub const PROV_KERNEL_ARCH: &str = "claude_cli_arch";
+/// `Ξ_Domain` LLM business-domain mapper provenance (Phase 3): a stochastic
+/// kernel run through the Claude-CLI path. Advisory, never gate-worthy.
+pub const PROV_KERNEL_DOMAIN: &str = "claude_cli_domain";
 /// Python `mypy` typecheck provenance (Phase A): full-fidelity, true overlay via
 /// `--shadow-file`. Boundary `high` (crosses the type checker).
 pub const PROV_MYPY: &str = "mypy";
@@ -446,8 +451,9 @@ pub struct TypecheckReq {
 
 /// Routes contributed to the runner's main router from `mcp_api.rs`. Includes
 /// the LSP `Ξ_Type` `/code-semantics/*` surface, the resolved-import `Ξ_AST`
-/// `/code-graph/*` diff blast-radius surface (Pillar 2), and the `Ξ_Arch`
-/// `/code-graph/arch-layers` stochastic-kernel layer classifier (Phase 3).
+/// `/code-graph/*` diff blast-radius surface (Pillar 2), and the Phase-3
+/// stochastic-kernel observers `Ξ_Arch` (`/code-graph/arch-layers`) and
+/// `Ξ_Domain` (`/code-graph/domains`).
 pub fn routes() -> Router<Arc<ApiState>> {
     Router::new()
         .route("/code-semantics/health", get(health))
@@ -457,6 +463,7 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .route("/code-semantics/typecheck", post(typecheck))
         .merge(code_graph_api::routes())
         .merge(arch_observer::routes())
+        .merge(domain_observer::routes())
 }
 
 /// GET /code-semantics/health — per CONTRACT §B.

--- a/src-tauri/src/mcp/code_semantics/module_graph.rs
+++ b/src-tauri/src/mcp/code_semantics/module_graph.rs
@@ -1,0 +1,447 @@
+//! Shared substrate for the CLI-backed **stochastic-kernel** twin observers
+//! (`Ξ_Arch` arch-layers, `Ξ_Domain` domains — Phase 3 / Pillar 3 of the twin-ast
+//! plan).
+//!
+//! Both observers do the same three observer-agnostic things and differ only in
+//! their prompt + response shape:
+//!   1. summarize the resolved `Ξ_AST` graph into per-directory **module**
+//!      structure ([`ModuleSummary`] via [`summarize_modules`] /
+//!      [`build_module_graph`]),
+//!   2. run one structure-only classification prompt through the Claude-CLI
+//!      provider — *forced*, so there is **no API key, no `@anthropic-ai/sdk`**
+//!      ([`run_cli_structured`]),
+//!   3. tolerantly extract the JSON answer from possibly-prose model output
+//!      ([`extract_json`]).
+//!
+//! The kernel envelope itself (`kernel:true`, `posterior<1`, credibility
+//! `(causal:medium, authorial:low, boundary:low)`) lives on
+//! [`super::Envelope::kernel`]. The model only ever sees this derived structure —
+//! never raw source.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+
+use crate::ai_provider::{run_structured_prompt, StructuredPrompt};
+use crate::ai_router::TaskContext;
+use crate::workflow_generation::code_graph::CodeGraph;
+
+/// Default cap on modules sent to the model in one pass — bounds prompt size +
+/// token cost. Modules beyond the cap (lowest export-count first) are omitted and
+/// reflected honestly in each observer's `coverage`.
+pub(super) const DEFAULT_MAX_MODULES: usize = 60;
+
+/// Uncalibrated kernel posterior (vet Q5): a fixed "model hint" confidence, NOT a
+/// measured accuracy. `kernel:true` + `authorial:low` is what tells a consumer
+/// the answer is advisory; the posterior is here to be calibrated against
+/// acceptance data later, not trusted today.
+pub(super) const KERNEL_POSTERIOR: f64 = 0.5;
+
+// Per-module summary caps (keep the prompt bounded regardless of repo size).
+const MAX_EXPORTS_PER_MODULE: usize = 12;
+const MAX_DEPS_PER_MODULE: usize = 8;
+const MAX_EXTERNAL_PER_MODULE: usize = 8;
+const MAX_FILES_PER_MODULE: usize = 10;
+
+/// A module = a directory of files, summarized for a classifier. The model sees
+/// only this structure, never source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ModuleSummary {
+    /// Module key — the directory path (repo-relative, forward slashes; `"."` for
+    /// repo-root files).
+    pub(super) module: String,
+    /// File basenames in the module (sorted, capped).
+    pub(super) files: Vec<String>,
+    /// Exported symbol names declared in the module (sorted, capped).
+    pub(super) exports: Vec<String>,
+    /// Other in-repo module dirs this module imports from, via *resolved* edges
+    /// (sorted, capped).
+    pub(super) internal_deps: Vec<String>,
+    /// External package specifiers the module imports (sorted, capped).
+    pub(super) external_pkgs: Vec<String>,
+    /// Total exports before the cap — the ranking + tie-break signal.
+    pub(super) export_count: usize,
+}
+
+/// The directory component of a repo-relative path (forward slashes). Files at
+/// the repo root map to `"."`.
+pub(super) fn module_dir(path: &str) -> String {
+    match path.rsplit_once('/') {
+        Some((dir, _)) if !dir.is_empty() => dir.to_string(),
+        _ => ".".to_string(),
+    }
+}
+
+/// The basename of a repo-relative path.
+fn basename(path: &str) -> &str {
+    path.rsplit_once('/').map(|(_, b)| b).unwrap_or(path)
+}
+
+/// Group the resolved graph's files into per-directory module summaries, sorted
+/// by export count (desc), then module name (asc) for a stable, high-signal-first
+/// ordering. Internal vectors are sorted + de-duplicated so the output (and its
+/// fingerprint) is deterministic.
+pub(super) fn summarize_modules(graph: &CodeGraph) -> Vec<ModuleSummary> {
+    // Accumulate per-module sets.
+    struct Acc {
+        files: BTreeSet<String>,
+        exports: BTreeSet<String>,
+        deps: BTreeSet<String>,
+        external: BTreeSet<String>,
+    }
+    let mut acc: BTreeMap<String, Acc> = BTreeMap::new();
+    let ensure = |acc: &mut BTreeMap<String, Acc>, m: String| {
+        acc.entry(m).or_insert_with(|| Acc {
+            files: BTreeSet::new(),
+            exports: BTreeSet::new(),
+            deps: BTreeSet::new(),
+            external: BTreeSet::new(),
+        });
+    };
+
+    for f in &graph.files {
+        let m = module_dir(&f.path);
+        ensure(&mut acc, m.clone());
+        acc.get_mut(&m)
+            .unwrap()
+            .files
+            .insert(basename(&f.path).to_string());
+    }
+    for e in &graph.exports {
+        let m = module_dir(&e.file_path);
+        ensure(&mut acc, m.clone());
+        acc.get_mut(&m).unwrap().exports.insert(e.name.clone());
+    }
+    for imp in &graph.imports {
+        let m = module_dir(&imp.from_file);
+        ensure(&mut acc, m.clone());
+        match &imp.resolved_target {
+            Some(target) => {
+                let target_mod = module_dir(target);
+                if target_mod != m {
+                    acc.get_mut(&m).unwrap().deps.insert(target_mod);
+                }
+            }
+            None => {
+                use crate::workflow_generation::code_graph::ResolutionKind;
+                // Only count honestly-external specifiers as external packages;
+                // an `Unresolved` internal-looking edge is a coverage hole, not a
+                // package signal, so it is deliberately dropped here.
+                if matches!(imp.resolution, ResolutionKind::External) {
+                    acc.get_mut(&m)
+                        .unwrap()
+                        .external
+                        .insert(imp.to_module.clone());
+                }
+            }
+        }
+    }
+
+    let mut out: Vec<ModuleSummary> = acc
+        .into_iter()
+        .map(|(module, a)| {
+            let export_count = a.exports.len();
+            ModuleSummary {
+                module,
+                files: cap(a.files, MAX_FILES_PER_MODULE),
+                exports: cap(a.exports, MAX_EXPORTS_PER_MODULE),
+                internal_deps: cap(a.deps, MAX_DEPS_PER_MODULE),
+                external_pkgs: cap(a.external, MAX_EXTERNAL_PER_MODULE),
+                export_count,
+            }
+        })
+        .collect();
+
+    out.sort_by(|a, b| {
+        b.export_count
+            .cmp(&a.export_count)
+            .then_with(|| a.module.cmp(&b.module))
+    });
+    out
+}
+
+/// Take the first `n` of a sorted set into a `Vec` (the set is already ordered).
+fn cap(set: BTreeSet<String>, n: usize) -> Vec<String> {
+    set.into_iter().take(n).collect()
+}
+
+/// A stable fingerprint of the module structure — same structure → same value, so
+/// each observer's LLM pass runs once per distinct graph per process. Hashes a
+/// name-ordered view of every module's (files, exports, internal deps); ignores
+/// the cap-driven `export_count` ordering so only *content* changes invalidate the
+/// cache.
+pub(super) fn fingerprint_modules(mods: &[ModuleSummary]) -> u64 {
+    let mut ordered: Vec<&ModuleSummary> = mods.iter().collect();
+    ordered.sort_by(|a, b| a.module.cmp(&b.module));
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for m in ordered {
+        m.module.hash(&mut hasher);
+        m.files.hash(&mut hasher);
+        m.exports.hash(&mut hasher);
+        m.internal_deps.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Build the resolved `Ξ_AST` graph + module summaries off the async runtime.
+/// Returns `(summaries, total_module_count, fingerprint)`, or `None` if the
+/// blocking build task panicked (the caller degrades to a cold envelope).
+pub(super) async fn build_module_graph(dir: PathBuf) -> Option<(Vec<ModuleSummary>, usize, u64)> {
+    tokio::task::spawn_blocking(move || {
+        let graph = CodeGraph::build(&dir);
+        let mods = summarize_modules(&graph);
+        let total = mods.len();
+        let fp = fingerprint_modules(&mods);
+        (mods, total, fp)
+    })
+    .await
+    .ok()
+}
+
+/// Render the numbered module-list block shared by both observers' prompts.
+/// Deterministic (modules in the given order, internal lists pre-sorted) so the
+/// prompt + tests are stable.
+pub(super) fn render_modules(modules: &[ModuleSummary]) -> String {
+    let mut s = String::new();
+    for (i, m) in modules.iter().enumerate() {
+        s.push_str(&format!("{}. module: {}\n", i + 1, m.module));
+        if !m.files.is_empty() {
+            s.push_str(&format!("   files: {}\n", m.files.join(", ")));
+        }
+        if !m.exports.is_empty() {
+            s.push_str(&format!("   exports: {}\n", m.exports.join(", ")));
+        }
+        if !m.internal_deps.is_empty() {
+            s.push_str(&format!(
+                "   imports-from: {}\n",
+                m.internal_deps.join(", ")
+            ));
+        }
+        if !m.external_pkgs.is_empty() {
+            s.push_str(&format!("   external: {}\n", m.external_pkgs.join(", ")));
+        }
+    }
+    s
+}
+
+/// Run a structure-only classification prompt through the Claude-CLI provider,
+/// off the async runtime. The provider is **forced** to `claude_cli` so the
+/// observer NEVER makes a keyed API call (the operator constraint), and
+/// temperature is pinned to 0 for deterministic classification. Returns the raw
+/// model output on success; `None` on task panic OR provider failure (the caller
+/// degrades honestly to coverage 0 — never a confident false answer).
+pub(super) async fn run_cli_structured(prompt: String) -> Option<String> {
+    match tokio::task::spawn_blocking(move || {
+        let context = TaskContext::from_prompt(&prompt);
+        let structured = StructuredPrompt::uncached(prompt);
+        run_structured_prompt(
+            &structured,
+            &context,
+            None,
+            None,
+            Some("claude_cli"), // provider_override — force CLI, no API key
+            Some(0.0),          // temperature_override — deterministic
+            None,
+            None,
+            None,
+        )
+    })
+    .await
+    {
+        Ok(resp) if resp.success => Some(resp.output),
+        _ => None,
+    }
+}
+
+/// Extract the first balanced JSON object/array from a string, ignoring prose and
+/// ```json code fences and respecting string literals (so a `}` inside a string
+/// doesn't close the scan early).
+pub(super) fn extract_json(s: &str) -> Option<&str> {
+    let bytes = s.as_bytes();
+    let start = bytes.iter().position(|&b| b == b'{' || b == b'[')?;
+    let open = bytes[start];
+    let close = if open == b'{' { b'}' } else { b']' };
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut escaped = false;
+    for (i, &b) in bytes.iter().enumerate().skip(start) {
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == b'"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match b {
+            b'"' => in_str = true,
+            x if x == open => depth += 1,
+            x if x == close => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&s[start..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+// ===========================================================================
+// Tests (pure — no LLM call)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workflow_generation::code_graph::{
+        ExportNode, FileNode, ImportEdge, ResolutionKind,
+    };
+
+    fn file(path: &str) -> FileNode {
+        FileNode {
+            path: path.into(),
+            language: "typescript".into(),
+            line_count: 10,
+        }
+    }
+    fn export(name: &str, file: &str) -> ExportNode {
+        ExportNode {
+            name: name.into(),
+            file_path: file.into(),
+            kind: "function".into(),
+            line: 1,
+        }
+    }
+    fn import(
+        from: &str,
+        to_module: &str,
+        target: Option<&str>,
+        kind: ResolutionKind,
+    ) -> ImportEdge {
+        ImportEdge {
+            from_file: from.into(),
+            to_module: to_module.into(),
+            imported_names: vec![],
+            line: 1,
+            resolved_target: target.map(|s| s.into()),
+            resolution: kind,
+        }
+    }
+
+    #[test]
+    fn module_dir_and_basename() {
+        assert_eq!(module_dir("src/api/auth.ts"), "src/api");
+        assert_eq!(module_dir("main.rs"), ".");
+        assert_eq!(basename("src/api/auth.ts"), "auth.ts");
+        assert_eq!(basename("main.rs"), "main.rs");
+    }
+
+    #[test]
+    fn summarize_groups_files_exports_deps_and_external() {
+        let graph = CodeGraph {
+            files: vec![
+                file("src/api/routes.ts"),
+                file("src/api/handlers.ts"),
+                file("src/services/auth.ts"),
+            ],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![
+                // api → services (resolved internal dep)
+                import(
+                    "src/api/routes.ts",
+                    "../services/auth",
+                    Some("src/services/auth.ts"),
+                    ResolutionKind::Relative,
+                ),
+                // api → external package
+                import(
+                    "src/api/routes.ts",
+                    "express",
+                    None,
+                    ResolutionKind::External,
+                ),
+                // an unresolved internal-looking edge must NOT become an external pkg
+                import(
+                    "src/api/routes.ts",
+                    "./missing",
+                    None,
+                    ResolutionKind::Unresolved,
+                ),
+            ],
+            exports: vec![
+                export("registerRoutes", "src/api/routes.ts"),
+                export("handle", "src/api/handlers.ts"),
+                export("authenticate", "src/services/auth.ts"),
+            ],
+            build_duration_ms: 0,
+        };
+        let mods = summarize_modules(&graph);
+        // Two modules: src/api (2 exports) ranks before src/services (1 export).
+        assert_eq!(mods.len(), 2);
+        assert_eq!(mods[0].module, "src/api");
+        assert_eq!(mods[0].export_count, 2);
+        assert!(mods[0].files.contains(&"routes.ts".to_string()));
+        assert!(mods[0].internal_deps.contains(&"src/services".to_string()));
+        assert!(mods[0].external_pkgs.contains(&"express".to_string()));
+        // The Unresolved edge is dropped from external packages (coverage hole, not a pkg).
+        assert!(!mods[0].external_pkgs.contains(&"./missing".to_string()));
+        assert_eq!(mods[1].module, "src/services");
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_content_sensitive() {
+        let g1 = CodeGraph {
+            files: vec![file("src/a/x.ts")],
+            functions: vec![],
+            classes: vec![],
+            imports: vec![],
+            exports: vec![export("foo", "src/a/x.ts")],
+            build_duration_ms: 0,
+        };
+        let g2 = g1.clone();
+        let fp1 = fingerprint_modules(&summarize_modules(&g1));
+        let fp2 = fingerprint_modules(&summarize_modules(&g2));
+        assert_eq!(fp1, fp2, "identical structure → identical fingerprint");
+
+        let mut g3 = g1.clone();
+        g3.exports.push(export("bar", "src/a/x.ts"));
+        let fp3 = fingerprint_modules(&summarize_modules(&g3));
+        assert_ne!(fp1, fp3, "an added export must change the fingerprint");
+    }
+
+    #[test]
+    fn render_modules_lists_structure() {
+        let mods = vec![ModuleSummary {
+            module: "src/api".into(),
+            files: vec!["routes.ts".into()],
+            exports: vec!["registerRoutes".into()],
+            internal_deps: vec!["src/services".into()],
+            external_pkgs: vec!["express".into()],
+            export_count: 1,
+        }];
+        let r = render_modules(&mods);
+        assert!(r.contains("1. module: src/api"));
+        assert!(r.contains("files: routes.ts"));
+        assert!(r.contains("exports: registerRoutes"));
+        assert!(r.contains("imports-from: src/services"));
+        assert!(r.contains("external: express"));
+    }
+
+    #[test]
+    fn extract_json_respects_string_literals() {
+        // A `}` inside a string must not close the object early.
+        let s = "prefix {\"k\":\"a}b\",\"n\":1} suffix";
+        assert_eq!(extract_json(s), Some("{\"k\":\"a}b\",\"n\":1}"));
+    }
+
+    #[test]
+    fn extract_json_none_on_garbage() {
+        assert!(extract_json("no json here").is_none());
+        assert!(extract_json("").is_none());
+    }
+}


### PR DESCRIPTION
## Phase 3 — `Ξ_Domain` business-domain observer (+ shared `module_graph`)

The second CLI-backed semantic twin observer, completing the Phase 3 pair from `plans/2026-06-02-twin-ast-import-resolution-and-semantic-observers.md`. Sequenced behind `Ξ_Arch` (#448) per vet Q4.

### What it does
`POST /code-graph/domains` — `{scope?, max_modules?}`. Maps a repo's modules onto the **business/functional domains** (and flows) they implement — UA's domain-analyzer. Where `Ξ_Arch` classifies each module into a *fixed* layer taxonomy, `Ξ_Domain` **discovers an open-ended set of domains** (Authentication, Billing, Notifications, …) and groups modules under each. The model sees only module structure, never source.

### Shared substrate (the DRY half)
Extracts the observer-agnostic pieces both observers need into **`module_graph.rs`**:
- module-graph summarization — `ModuleSummary`, `summarize_modules`, `build_module_graph`, `fingerprint_modules`
- tolerant `extract_json` (prose / ```json-fence / string-literal-safe)
- the forced-`claude_cli` `run_cli_structured` call (**no API key**)
- shared `render_modules` + the `DEFAULT_MAX_MODULES` / `KERNEL_POSTERIOR` constants

`arch_observer.rs` is refactored onto it — **behavior unchanged** (its arch-specific prompt/parse/envelope/cache stay); it just sheds the now-shared code (~412 lines).

### Kernel discipline (same as `Ξ_Arch`)
`kernel:true`, `posterior<1`, `credibility=(causal:medium, authorial:low, boundary:low)`, provenance `claude_cli_domain` — **advisory, never gate-worthy**.

### Honest about hallucination
Each domain's `modules` is validated against the **real module-key set**: a module the model invents (renamed / nonexistent) is **dropped from the output and does not count toward coverage**. `coverage` = distinct *real* modules assigned to a domain / total modules — so cap-omitted, unassigned, and hallucinated modules all lower it honestly. Cold/unparseable → coverage 0, never a false "no domains".

### Scope
v1 ships the pure observer only. The `Ξ_Domain`-vs-resolved-dependency-graph **declared-vs-actual / Φ layering-breach** drift pair is Phase 4 (needs the declared-vs-actual construct doc + a declared-side source).

### Tests
94 `code_semantics` tests green (the new `module_graph` + `domain_observer` suites + the refactored `arch` + siblings — no regression). Highlights: `assemble_drops_hallucinated_modules_and_counts_real_coverage`, `assemble_all_hallucinated_is_zero_coverage_and_posterior`, tolerant-parse (prose/fences/nameless-dropped/garbage), kernel-envelope assertions. `cargo clippy --all-targets -- -D warnings` clean; rustfmt clean.
