### PR TITLE
build(runner): re-run build.rs when a Tauri capability changes

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -3,6 +3,10 @@ fn main() {
     // the dist directory changes.  Without this, incremental builds silently
     // serve a stale frontend bundle from the compile-time cache.
     println!("cargo:rerun-if-changed=../dist");
+    // Re-run when a Tauri capability changes so incremental builds re-embed the
+    // updated ACL (e.g. adding a window label); otherwise gen/ stays stale and
+    // the new permission silently never takes effect until a clean build.
+    println!("cargo:rerun-if-changed=capabilities");
     // Force a re-run on every cargo build so RUNNER_BUILD_ID's millisecond
     // suffix actually changes between invocations. Without this, cargo will
     // cache the build-script output and re-stamp identical values into the


### PR DESCRIPTION
One-line follow-up to #452.

`src-tauri/build.rs` declared `cargo:rerun-if-changed` for `../dist`, the build-id, and git refs — but **not** the `capabilities/` directory. So an incremental build after editing `capabilities/default.json` kept a stale `gen/` ACL and the new permission silently never took effect (this cost a manual `touch build.rs` while root-causing the pop-out `event:allow-listen` fix in #452).

Adds `println!("cargo:rerun-if-changed=capabilities");`. Clean/CI builds were always fine (they regenerate `gen/` from source); this only fixes the local incremental-build papercut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)