### PR TITLE
chore: gitignore target-fixcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ target-check/
 target-fix-test/
 target-validate/
 target-run/
+target-fixcheck/
 .build-state/
 target-rebuild/
 target-types-task/


### PR DESCRIPTION
Adds `/target-fixcheck` to `.gitignore` (an isolated `CARGO_TARGET_DIR` used while diagnosing the vision-core compile break).

The actual compile fix lives in **qontinui-schemas** (`fix/vision-core-add-capturebackend`) — the runner consumers (PR #436) were already correct; they just needed the canonical `CaptureBackend` type added there. **Downstream of the schemas PR**: the runner won't compile until that lands. This PR is optional/trivial.