### PR TITLE
feat(runner): per-terminal "send to window" menu + drag-tab-out

### DIFF
--- a/src/components/terminal/ZoneHoverActions.tsx
+++ b/src/components/terminal/ZoneHoverActions.tsx
@@ -31,6 +31,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
+  AppWindow,
   Download,
   Maximize2,
   Minimize2,
@@ -40,6 +41,8 @@ import {
 } from "lucide-react";
 
 import { useTerminalSession, useTransitionEffects, useZoneMetadata } from "./contexts";
+import { useWindowAssignments } from "./contexts/WindowAssignmentsContext";
+import { useTerminalWindowActions, type RunnerWindowRecord } from "./useTerminalWindowActions";
 
 interface ZoneHoverActionsProps {
   zoneIdx: number;
@@ -57,6 +60,8 @@ export function ZoneHoverActions({ zoneIdx, onExportZone }: ZoneHoverActionsProp
   const { zoneLayout, closeTerminal, sessionStates } = session;
   const transitionEffects = useTransitionEffects();
   const { labelsAndTags } = useZoneMetadata();
+  const { ownerOf } = useWindowAssignments();
+  const { popOutTab, moveTabToWindow, listWindows } = useTerminalWindowActions();
 
   const tabId = zoneLayout.assignments[zoneIdx];
   const isMaximized = zoneLayout.maximizedZone === zoneIdx;
@@ -67,14 +72,17 @@ export function ZoneHoverActions({ zoneIdx, onExportZone }: ZoneHoverActionsProp
   const [showExportMenu, setShowExportMenu] = useState(false);
   const [showLabelInput, setShowLabelInput] = useState(false);
   const [labelDraft, setLabelDraft] = useState("");
+  const [showWindowMenu, setShowWindowMenu] = useState(false);
+  const [windowList, setWindowList] = useState<RunnerWindowRecord[]>([]);
 
   const exportRef = useRef<HTMLDivElement>(null);
   const labelPopoverRef = useRef<HTMLDivElement>(null);
   const labelInputRef = useRef<HTMLInputElement>(null);
+  const windowMenuRef = useRef<HTMLDivElement>(null);
 
   // Outside-click close for both popovers.
   useEffect(() => {
-    if (!showExportMenu && !showLabelInput) return;
+    if (!showExportMenu && !showLabelInput && !showWindowMenu) return;
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;
       if (showExportMenu && exportRef.current && !exportRef.current.contains(target)) {
@@ -86,10 +94,13 @@ export function ZoneHoverActions({ zoneIdx, onExportZone }: ZoneHoverActionsProp
         labelsAndTags.setZoneLabel(zoneIdx, labelDraft.trim());
         setShowLabelInput(false);
       }
+      if (showWindowMenu && windowMenuRef.current && !windowMenuRef.current.contains(target)) {
+        setShowWindowMenu(false);
+      }
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [showExportMenu, showLabelInput, labelDraft, labelsAndTags, zoneIdx]);
+  }, [showExportMenu, showLabelInput, showWindowMenu, labelDraft, labelsAndTags, zoneIdx]);
 
   useEffect(() => {
     if (showLabelInput) {
@@ -156,6 +167,50 @@ export function ZoneHoverActions({ zoneIdx, onExportZone }: ZoneHoverActionsProp
       closeTerminal(tabId);
     },
     [tabId, closeTerminal],
+  );
+
+  const openWindowMenu = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!tabId) return;
+      setShowExportMenu(false);
+      setShowLabelInput(false);
+      setShowWindowMenu((prev) => {
+        const next = !prev;
+        if (next) {
+          // Refresh the target list each open — pop-outs may have come/gone.
+          listWindows()
+            .then(setWindowList)
+            .catch((err) => console.error("list_runner_windows failed:", err));
+        }
+        return next;
+      });
+    },
+    [tabId, listWindows],
+  );
+
+  const handlePopOutNew = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (!tabId) return;
+      setShowWindowMenu(false);
+      void popOutTab(tabId).catch((err) =>
+        console.error("Failed to pop out terminal to a new window:", err),
+      );
+    },
+    [tabId, popOutTab],
+  );
+
+  const handleMoveTo = useCallback(
+    (e: React.MouseEvent, target: string) => {
+      e.stopPropagation();
+      if (!tabId) return;
+      setShowWindowMenu(false);
+      void moveTabToWindow(tabId, target).catch((err) =>
+        console.error(`Failed to move terminal to ${target}:`, err),
+      );
+    },
+    [tabId, moveTabToWindow],
   );
 
   return (
@@ -249,6 +304,48 @@ export function ZoneHoverActions({ zoneIdx, onExportZone }: ZoneHoverActionsProp
                   {format}
                 </button>
               ))}
+            </div>
+          )}
+        </div>
+
+        {/* Send to window (pop out to a new window / move to an existing one) */}
+        <div className="relative" ref={windowMenuRef}>
+          <button
+            type="button"
+            onClick={openWindowMenu}
+            disabled={!hasTab}
+            className={`p-1 rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              showWindowMenu
+                ? "text-[#7aa2f7] bg-[#7aa2f7]/10"
+                : "text-[#565f89] hover:text-[#7aa2f7] hover:bg-[#7aa2f7]/10"
+            }`}
+            title="Send this terminal to a window (or drag its header out)"
+            aria-label="Send terminal to a window"
+            aria-expanded={showWindowMenu}
+          >
+            <AppWindow className="w-3 h-3" />
+          </button>
+          {showWindowMenu && (
+            <div className="absolute top-full right-0 mt-1 w-40 bg-[#1a1b26] border border-[#2a2d3d] rounded shadow-xl z-50 overflow-hidden">
+              <button
+                type="button"
+                onClick={handlePopOutNew}
+                className="block w-full text-left px-2 py-1 text-[10px] text-[#a9b1d6] hover:bg-[#2a2d3d] hover:text-[#c0caf5] transition-colors"
+              >
+                New window
+              </button>
+              {windowList
+                .filter((w) => w.label !== ownerOf(tabId ?? ""))
+                .map((w) => (
+                  <button
+                    key={w.label}
+                    type="button"
+                    onClick={(e) => handleMoveTo(e, w.label)}
+                    className="block w-full text-left px-2 py-1 text-[10px] text-[#a9b1d6] hover:bg-[#2a2d3d] hover:text-[#c0caf5] transition-colors"
+                  >
+                    {w.label === "main" ? "Main window" : w.label}
+                  </button>
+                ))}
             </div>
           )}
         </div>

--- a/src/components/terminal/useTerminalWindowActions.ts
+++ b/src/components/terminal/useTerminalWindowActions.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * A runner-owned OS window (the main window or a `term-N` pop-out), as
+ * returned by the `list_runner_windows` Tauri command. Mirrors the Rust
+ * `WindowRecord` — only the fields the terminal UI needs are typed here.
+ */
+export interface RunnerWindowRecord {
+  label: string;
+  kind: "main" | "pop_out";
+}
+
+/**
+ * Per-terminal window operations shared by the zone hover toolbar
+ * ("Send to window" menu) and the drag-tab-out gesture. Thin wrappers over
+ * the same Tauri commands the `useUIComponent` actions in `TerminalPage`
+ * already use, so the human-facing and agent-facing surfaces stay in lockstep.
+ */
+export function useTerminalWindowActions() {
+  /** Open a fresh pop-out window and move `tabId` into it. Returns the new
+   *  window's label (e.g. `"term-2"`). */
+  const popOutTab = useCallback(async (tabId: string): Promise<string> => {
+    const rec = await invoke<{ label: string }>("open_terminal_window", { placement: null });
+    await invoke("assign_session_to_window", { sessionId: tabId, windowLabel: rec.label });
+    return rec.label;
+  }, []);
+
+  /** Move `tabId` to an existing window (`"main"` or `"term-N"`). */
+  const moveTabToWindow = useCallback(
+    async (tabId: string, windowLabel: string): Promise<void> => {
+      await invoke("assign_session_to_window", { sessionId: tabId, windowLabel });
+    },
+    [],
+  );
+
+  /** Enumerate the runner's own windows (main + pop-outs). */
+  const listWindows = useCallback(async (): Promise<RunnerWindowRecord[]> => {
+    return await invoke<RunnerWindowRecord[]>("list_runner_windows");
+  }, []);
+
+  return { popOutTab, moveTabToWindow, listWindows };
+}

--- a/src/components/terminal/zone-grid/ZoneLabel.tsx
+++ b/src/components/terminal/zone-grid/ZoneLabel.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Pin, Filter, ArrowDownToLine } from "lucide-react";
 import type { TerminalTab } from "../useTerminalManager";
 import type { ZoneAssignments, SessionState } from "../useZoneLayout";
 import { STATE_BORDER_COLORS } from "./constants";
+import { useTerminalWindowActions } from "../useTerminalWindowActions";
 
 export function ZoneLabel({
   tab,
@@ -43,6 +44,7 @@ export function ZoneLabel({
   const [editingLabel, setEditingLabel] = useState(false);
   const [labelValue, setLabelValue] = useState(zoneLabel ?? "");
   const selectorRef = useRef<HTMLDivElement>(null);
+  const { popOutTab } = useTerminalWindowActions();
 
   useEffect(() => {
     if (!showSelector) return;
@@ -62,6 +64,24 @@ export function ZoneLabel({
       onDragStart={(e) => {
         e.dataTransfer.setData("text/tab-id", tab.id);
         e.dataTransfer.effectAllowed = "move";
+      }}
+      onDragEnd={(e) => {
+        // Drag-tab-out: if the header was dropped OUTSIDE this window's
+        // viewport and no in-window zone accepted it (dropEffect "none"),
+        // pop the terminal into its own new window. HTML5 DnD can't cross
+        // OS windows, so a release over another runner window also lands
+        // here as "none" with an out-of-bounds pointer — treated the same
+        // (new window). A drop onto a zone sets dropEffect "move" → skip.
+        if (e.dataTransfer.dropEffect !== "none") return;
+        const out =
+          e.clientX <= 0 ||
+          e.clientY <= 0 ||
+          e.clientX >= window.innerWidth ||
+          e.clientY >= window.innerHeight;
+        if (!out) return;
+        void popOutTab(tab.id).catch((err) =>
+          console.error("Failed to pop out terminal (drag-out):", err),
+        );
       }}
     >
       <div


### PR DESCRIPTION
## Per-terminal "send to window" menu + drag-tab-out

Completes the optional multi-window UX polish from `plans/2026-06-03-runner-popout-terminal-windows.md`, on top of the global pop-out button (#456). These surface the existing window backend to operators per-terminal, not just globally / via agents.

### Changes
- **`useTerminalWindowActions`** (new shared hook) — `popOutTab(tabId)` (open a new pop-out + move the tab in), `moveTabToWindow(tabId, label)`, `listWindows()`. Thin wrappers over the same Tauri commands the `pop-out-active-terminal` / `move-terminal-to-window` UI Bridge actions already use, so human + agent surfaces stay in lockstep.
- **`ZoneHoverActions`** — a per-terminal **"Send to window"** dropdown (`AppWindow` icon) in the zone hover toolbar. Always offers **New window**; lists every other runner window (`main` + `term-N`) as a move target, excluding the tab's current owner. Refreshes on each open; reuses the existing export-menu popover + outside-click pattern.
- **`ZoneLabel`** — **drag-tab-out**. The zone header is already `draggable` for zone-to-zone moves; `onDragEnd` now pops the terminal into a new window when released **outside this window's viewport** with no in-window drop (`dropEffect === "none"`). A successful zone drop (`dropEffect "move"`) is untouched — existing rearrange behavior preserved. (HTML5 DnD can't cross OS windows, so a release over another runner window also lands here as out-of-bounds "none" → new window; the menu is the way to target a *specific* existing window.)

### Scope
Frontend-only; **no backend change**. `tsc --noEmit` + `eslint` clean locally; CI runs typecheck + lint + vitest + Tauri build. With these, every multi-window operation has a human affordance: open a new window (tab strip button, #456), pop **this** terminal out / move it to a named window (hover menu), or drag it out (gesture).
