### PR TITLE
fix(runner): pop-out polish — clear unknown-window error + default per-window dispatch ON

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -878,8 +878,29 @@ pub async fn ui_bridge_execute_action_handler(
     // Target pop-out window (`?windowLabel=term-1`); scopes the action AND its
     // detector/validation queries below so the element id resolves in the right
     // window's registry. Owned so it survives the awaits without borrowing query.
+    // Empty string is treated as "no target" (main).
     let window_label = query.window_label.clone();
-    let window_label = window_label.as_deref();
+    let window_label = window_label.as_deref().filter(|s| !s.is_empty());
+
+    // ── Unknown-window gate ─────────────────────────────────────────────
+    // Fail fast with a clear error if a non-existent target window was named.
+    // Without this, the pre-flight element probes below (is-input / supported-
+    // actions `get_element`) hit the missing window, swallow the "no window"
+    // error as an empty supported-actions list, and the action is rejected with
+    // a misleading "action not supported ... advertises []" instead of naming
+    // the real problem. Mirrors the guard in `request::ui_bridge_request_inner`.
+    if let Some(target) = window_label {
+        use tauri::Manager;
+        if state.app_handle.get_webview_window(target).is_none() {
+            return Err((
+                StatusCode::NOT_FOUND,
+                Json(api_error(format!(
+                    "No runner window labeled '{target}'. Discover live windows via \
+                     GET /ui-bridge/control/runner-windows."
+                ))),
+            ));
+        }
+    }
 
     // ── Invalid-action gate ─────────────────────────────────────────────
     // Reject unknown action names BEFORE the registry lookup, the

--- a/src-tauri/src/mcp/ui_bridge/request.rs
+++ b/src-tauri/src/mcp/ui_bridge/request.rs
@@ -102,15 +102,18 @@ pub(crate) fn pending_key(window_label: &str, request_id: &str) -> String {
 
 /// Whether targeted per-window `ui-bridge-request` emit is enabled.
 ///
-/// Default OFF — the shipping single-window behavior broadcasts the event to all
-/// windows exactly as before (`app_handle.emit`), so Phase 0 is byte-identical to
-/// pre-window-aware behavior. Phase 1 flips this on (env `QONTINUI_UI_BRIDGE_MULTI_WINDOW=1`)
-/// once pop-out windows mount the SDK, so each request reaches only its target
-/// window. Read per-call so it can be toggled without a restart during rollout.
+/// Default ON now that pop-out windows answer the bridge (capabilities + per-realm
+/// port seed shipped). Each request is emitted only to its target window
+/// (`app.get_webview_window(label).emit(...)`), falling back to broadcast if the
+/// webview can't be resolved (mid-teardown) so a request is never dropped. For the
+/// single-window case this targets "main" only — functionally identical to the old
+/// broadcast, minus the cross-window noise. Set `QONTINUI_UI_BRIDGE_MULTI_WINDOW=0`
+/// (or `false`/`off`) to revert to unconditional broadcast. Read per-call so it can
+/// be toggled without a restart.
 fn multi_window_dispatch_enabled() -> bool {
     std::env::var("QONTINUI_UI_BRIDGE_MULTI_WINDOW")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+        .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off")))
+        .unwrap_or(true)
 }
 
 /// Gather structured readiness diagnostics when the frontend readiness gate


### PR DESCRIPTION
Two small follow-ups to the pop-out terminal window work (#444/#452), both verified live on a temp runner.

## 1. Clear error when `execute_action` targets a non-existent window
`POST /ui-bridge/control/element/:id/action?windowLabel=<bad>` returned a misleading *"Action '<x>' is not supported by element … advertises []"* — the pre-flight is-input / supported-actions `get_element` probes hit the missing window, swallowed the "no window" error as an empty supported-actions list, and rejected the action on that empty list. Adds an explicit unknown-window gate at the top of the handler (mirrors the guard in `request::ui_bridge_request_inner`); also treats an empty `?windowLabel=` as no target.

**Verified:** `?windowLabel=ghost-window` → HTTP 404 *"No runner window labeled 'ghost-window'. Discover live windows via GET /ui-bridge/control/runner-windows."*

## 2. Default per-window UI Bridge dispatch ON
Now that pop-out windows answer the bridge (#452), flip `multi_window_dispatch_enabled` to default ON so each `ui-bridge-request` is emitted only to its target window instead of broadcast to all (falls back to broadcast if the webview can't be resolved). Single-window case targets "main" only — functionally identical, minus cross-window noise. Set `QONTINUI_UI_BRIDGE_MULTI_WINDOW=0`/`false`/`off` to revert.

**Verified:** with no flag env (new default), pop-out targeting returns 53 elements and `?windowLabel=main` returns 63 — targeted emit works for both.

(The third optional item — a multi-window UX entry point — is already shipped: `TerminalPageTabBar` has a wired "pop out" button at `App.tsx`. No change needed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)