### PR TITLE
fix(fs-observer): use the bin crate's auth attach so dogfood counters aren't split

### DIFF
--- a/src-tauri/src/agent_worktree/fs_observer.rs
+++ b/src-tauri/src/agent_worktree/fs_observer.rs
@@ -376,8 +376,11 @@ async fn post_observations(coord_http_base: &str, body: &FsObservationsRequest) 
     // unpaired / empty keychain collapses to the anonymous send coord accepts
     // today). Same write-path attach the credential-helper uses, and it feeds
     // the data-plane auth-coverage metric ahead of multiuser Phase-2
-    // enforcement on `/coord/fs/observations`.
-    let req = qontinui_runner_lib::auth::attach_device_auth(client.post(&url));
+    // enforcement on `/coord/fs/observations`. Must be `crate::auth`, not
+    // `qontinui_runner_lib::auth` — this module compiles into the bin target,
+    // and the lib path would bump the lib crate's separate counter statics,
+    // invisible to the bin's `DATA_PLANE_TOTAL/AUTHED` coverage readout.
+    let req = crate::auth::attach_device_auth(client.post(&url));
     match req.json(body).send().await {
         Ok(resp) => {
             let status = resp.status();


### PR DESCRIPTION
## What

`fs_observer` compiles into the **bin** target, but its bearer attach (#438) called `qontinui_runner_lib::auth::attach_device_auth` — the lib crate's copy — so every `/coord/fs/observations` push incremented the **lib's** `DATA_PLANE_TOTAL/AUTHED` statics: a second instance invisible to the bin's auth-coverage readout.

One-line switch to `crate::auth` (same on-disk token, identical behavior; only the counter instance changes) + a comment documenting the invariant.

## Verification

- Grep-verified this was the only main-bin callsite on the lib auth path (`src/bin/*.rs` standalone binaries correctly keep `qontinui_runner_lib::` — the lib is their only option)
- `cargo clippy --all-targets -- -D warnings` clean (the pre-push hook's exact invocation) and `--bin qontinui-runner --features custom-protocol --tests` clean
- 10/10 `fs_observer` tests pass

Found during the install-effects producer work (#441), whose `coord_client` deliberately uses `crate::auth` for this reason.