### PR TITLE
feat(terminal): window lifecycle — orphan sweep, close-on-clean-exit, anchor_key dedup, continuation cap

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -783,6 +783,151 @@ fn claim_gate_dispatch(gate_id: uuid::Uuid) -> bool {
     dispatched_gate_ids().lock().unwrap().insert(gate_id)
 }
 
+// =============================================================================
+// Continuation-session registry (P3 anchor_key dedup + P4 concurrency cap)
+// =============================================================================
+
+/// Default cap on concurrently-live *continuation-spawned* terminal sessions.
+/// Overridable via `QONTINUI_CONTINUATION_SESSION_CAP`. Operator-opened
+/// sessions are never counted (they are never registered here).
+const DEFAULT_CONTINUATION_SESSION_CAP: usize = 4;
+
+/// One registered continuation-spawned session.
+#[derive(Debug, Clone)]
+struct ContinuationSession {
+    /// The runner-local terminal id (`TerminalManager` key) — used to test
+    /// liveness against the manager.
+    terminal_id: String,
+    /// The gate `anchor_key` this continuation was spawned for, if any. The
+    /// dedup key: a second continuation with the same live `anchor_key` is a
+    /// re-cleared gate / duplicate and must not double-spawn.
+    anchor_key: Option<String>,
+}
+
+/// Process-wide registry of continuation-spawned terminal sessions, keyed by
+/// `terminal_id`. Distinct from [`dispatched_gate_ids`] (which dedupes a single
+/// `gate_id` delivered twice): this tracks LIVE sessions so a re-cleared gate
+/// (new `gate_id`, same `anchor_key`) is deduped (P3) and the live count is
+/// capped (P4).
+fn continuation_sessions(
+) -> &'static std::sync::Mutex<std::collections::HashMap<String, ContinuationSession>> {
+    static SESSIONS: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<String, ContinuationSession>>,
+    > = std::sync::OnceLock::new();
+    SESSIONS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// The configured continuation-session cap (env override, else the default).
+/// A non-numeric / empty env value falls back to the default.
+fn continuation_session_cap() -> usize {
+    std::env::var("QONTINUI_CONTINUATION_SESSION_CAP")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CONTINUATION_SESSION_CAP)
+}
+
+/// Drop registry entries whose terminal is no longer live, using `is_live`
+/// (`terminal_id -> bool`). Called under the registry lock by the guard below
+/// so the count and the anchor_key scan only ever see currently-running
+/// sessions. Returns the retained entries' count.
+fn prune_dead_continuations(
+    map: &mut std::collections::HashMap<String, ContinuationSession>,
+    is_live: &dyn Fn(&str) -> bool,
+) {
+    map.retain(|tid, _| is_live(tid));
+}
+
+/// Outcome of the pre-spawn continuation guard (P3 + P4).
+#[derive(Debug, PartialEq, Eq)]
+enum ContinuationGuard {
+    /// Clear to spawn — no live duplicate, under cap.
+    Proceed,
+    /// A live continuation already exists for this `anchor_key` (P3): skip the
+    /// spawn (re-cleared gate / duplicate). Carries the existing terminal_id.
+    DuplicateAnchor(String),
+    /// At the concurrency cap (P4): skip the spawn. Carries the cap for the log.
+    AtCap(usize),
+}
+
+/// Pre-spawn guard: prune dead sessions, then enforce P3 (anchor_key dedup) and
+/// P4 (concurrency cap). Pure over (`anchor_key`, `is_live`, env cap) so it is
+/// unit-testable without a live `TerminalManager`.
+///
+/// Order matters: dedup is checked BEFORE the cap so a duplicate of an
+/// already-running anchor is reported as a dedup (the honest reason) rather than
+/// "capped". Operator sessions never enter the registry, so they never count.
+fn evaluate_continuation_guard(
+    anchor_key: Option<&str>,
+    is_live: &dyn Fn(&str) -> bool,
+) -> ContinuationGuard {
+    let mut map = continuation_sessions().lock().unwrap();
+    prune_dead_continuations(&mut map, is_live);
+
+    // P3: a LIVE session already exists for this anchor_key → dedup.
+    if let Some(anchor) = anchor_key {
+        if let Some(existing) = map
+            .values()
+            .find(|s| s.anchor_key.as_deref() == Some(anchor))
+        {
+            return ContinuationGuard::DuplicateAnchor(existing.terminal_id.clone());
+        }
+    }
+
+    // P4: at the cap → refuse.
+    let cap = continuation_session_cap();
+    if map.len() >= cap {
+        return ContinuationGuard::AtCap(cap);
+    }
+
+    ContinuationGuard::Proceed
+}
+
+/// Register a freshly-spawned continuation session in the live registry (after
+/// `create_terminal_session_backend` succeeds). The entry is reaped lazily by
+/// [`prune_dead_continuations`] the next time the guard runs.
+fn register_continuation_session(terminal_id: String, anchor_key: Option<String>) {
+    continuation_sessions().lock().unwrap().insert(
+        terminal_id.clone(),
+        ContinuationSession {
+            terminal_id,
+            anchor_key,
+        },
+    );
+}
+
+/// Liveness predicate for the continuation guard, backed by the process-global
+/// `TerminalManager`. Returns `terminal_id -> still running?`. When there is no
+/// Tauri runtime / no managed `TerminalManager` (headless or unit-test context)
+/// every terminal id reads as NOT live — the registry is empty there anyway, so
+/// the guard is a no-op.
+fn live_terminal_predicate() -> impl Fn(&str) -> bool {
+    use std::sync::Arc;
+    let manager: Option<Arc<crate::terminal::TerminalManager>> = crate::tauri_app_handle::current()
+        .and_then(|app| {
+            tauri::Manager::try_state::<Arc<crate::terminal::TerminalManager>>(&app)
+                .map(|s| s.inner().clone())
+        });
+    move |terminal_id: &str| {
+        manager
+            .as_ref()
+            .and_then(|m| m.get(terminal_id))
+            .map(|sess| sess.is_alive())
+            .unwrap_or(false)
+    }
+}
+
+/// Log the existing live continuation tab a duplicate-anchor dispatch was
+/// folded onto (P3). There is no runner-wired "focus this tab" event today
+/// (the tab strip listens to none), so this is a deliberate no-op-plus-log:
+/// the operator already has the live continuation docked in `main`, and the
+/// duplicate is dropped rather than opening a second identical session.
+fn focus_existing_continuation(terminal_id: &str) {
+    debug!(
+        "agent_runtime: duplicate continuation folded onto existing live \
+         terminal_id={terminal_id} (already docked in main)"
+    );
+}
+
 /// Shared dispatch seam for BOTH the WS fast-path and the poll backstop.
 ///
 /// 1. If the payload carries a `gate_id`, dedupe against [`dispatched_gate_ids`]:
@@ -975,6 +1120,45 @@ async fn run_gate_continuation(
         return Ok(());
     }
 
+    // P3 (anchor_key dedup) + P4 (concurrency cap): before acquiring any
+    // device-local resources, check the live continuation-session registry.
+    // `gate_id` dedup (#450, the `dispatched_gate_ids` set) already collapses a
+    // SAME gate delivered twice; this catches the residual cases it can't — a
+    // re-cleared gate (new `gate_id`, same `anchor_key`) and the cap — both
+    // evaluated against sessions that are STILL running. Liveness is tested
+    // against the `TerminalManager` (continuation TERMINAL sessions register
+    // there); with no Tauri runtime the registry is empty so the guard is a
+    // no-op (the unit-test / headless-only context).
+    match evaluate_continuation_guard(payload.anchor_key.as_deref(), &live_terminal_predicate()) {
+        ContinuationGuard::Proceed => {}
+        ContinuationGuard::DuplicateAnchor(existing_terminal_id) => {
+            info!(
+                "agent_runtime: gate-continuation deduped by anchor_key={:?} — a live \
+                 continuation session (terminal_id={existing_terminal_id}) already exists; \
+                 skipping double-spawn",
+                payload.anchor_key
+            );
+            // Best-effort: bring the existing docked tab to focus so the
+            // operator sees the live continuation rather than nothing happening.
+            focus_existing_continuation(&existing_terminal_id);
+            return Ok(());
+        }
+        ContinuationGuard::AtCap(cap) => {
+            let reason =
+                format!("continuation cap ({cap}) reached — operator must resume manually");
+            warn!(
+                "agent_runtime: gate-continuation refused: {reason} (anchor_key={:?})",
+                payload.anchor_key
+            );
+            // No coord "operator must resume" alert path is runner-wirable
+            // (`/coord/alerts` is read-only); `spawn-failed` is the honest,
+            // already-wired fallback. A fresh correlation id (no worktree/agent
+            // was acquired) carries the lifecycle post.
+            report_spawn_failed(uuid::Uuid::now_v7(), &reason, None, 0).await;
+            return Ok(());
+        }
+    }
+
     // Step 1: acquire a device-local worktree (+ claim heartbeat). The `ctx`
     // owns the claim heartbeat task. For the HEADLESS path it stays bound here
     // so its heartbeat runs for the whole subprocess and the claim releases on
@@ -1121,6 +1305,10 @@ async fn run_continuation_terminal(
 
     match result {
         Ok((terminal_id, coord_session_id)) => {
+            // Register in the live continuation-session registry so P3 (dedup by
+            // anchor_key) and P4 (concurrency cap) see this session as live until
+            // its PTY exits (reaped lazily by the guard's liveness prune).
+            register_continuation_session(terminal_id.clone(), payload.anchor_key.clone());
             // The session is intentionally left on `main` (docked, visible) — no
             // pop-out window was opened, so there is nothing to reassign it to.
             info!(
@@ -2574,6 +2762,181 @@ mod tests {
             claim_gate_dispatch(other),
             "a different gate_id is unaffected"
         );
+    }
+
+    // =========================================================================
+    // P3 (anchor_key dedup) + P4 (concurrency cap): continuation guard
+    // =========================================================================
+
+    /// Reset the process-wide continuation registry between guard tests (it is a
+    /// `OnceLock`-backed singleton). Tests that touch it run under a shared mutex
+    /// (`CONT_GUARD_LOCK`) so they don't race each other's registry state.
+    fn clear_continuation_registry() {
+        continuation_sessions().lock().unwrap().clear();
+    }
+
+    static CONT_GUARD_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// REGRESSION (P3 must not regress #450): a SAME gate_id delivered twice is
+    /// still short-circuited by the `dispatched_gate_ids` set — the anchor_key
+    /// layer is additive, not a replacement. (Mirrors
+    /// `claim_gate_dispatch_is_once_per_gate_id` but named as the explicit
+    /// regression guard the plan asks for.)
+    #[test]
+    fn gate_id_dedup_still_holds_alongside_anchor_guard() {
+        let gate = uuid::Uuid::now_v7();
+        assert!(claim_gate_dispatch(gate), "first delivery of the gate wins");
+        assert!(
+            !claim_gate_dispatch(gate),
+            "second delivery of the SAME gate_id is still deduped (#450 intact)"
+        );
+    }
+
+    /// P3: a live continuation for an anchor_key dedups a second dispatch with
+    /// the SAME anchor_key (the re-cleared-gate / legacy-no-gate_id case the
+    /// gate_id set can't catch). A different anchor proceeds. The guard prunes
+    /// dead sessions first, so once the first session dies the anchor is free.
+    #[test]
+    fn anchor_key_guard_dedups_live_then_frees_on_death() {
+        let _g = CONT_GUARD_LOCK.lock().unwrap();
+        clear_continuation_registry();
+        // Raise the cap out of the way so this test isolates the dedup path.
+        std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", "100");
+
+        // No session yet → proceed, then register it as live.
+        let live_all = |_id: &str| true;
+        assert_eq!(
+            evaluate_continuation_guard(Some("plan:foo:phase:1"), &live_all),
+            ContinuationGuard::Proceed
+        );
+        register_continuation_session("term-tid-1".to_string(), Some("plan:foo:phase:1".into()));
+
+        // Same anchor, still live → DuplicateAnchor (carries the existing tid).
+        assert_eq!(
+            evaluate_continuation_guard(Some("plan:foo:phase:1"), &live_all),
+            ContinuationGuard::DuplicateAnchor("term-tid-1".to_string())
+        );
+        // A different anchor is unaffected.
+        assert_eq!(
+            evaluate_continuation_guard(Some("plan:foo:phase:2"), &live_all),
+            ContinuationGuard::Proceed
+        );
+
+        // Now the first session is dead → the guard prunes it and the anchor is
+        // free to spawn again (the legitimate re-run after completion).
+        let dead_first = |id: &str| id != "term-tid-1";
+        assert_eq!(
+            evaluate_continuation_guard(Some("plan:foo:phase:1"), &dead_first),
+            ContinuationGuard::Proceed
+        );
+        // The registry no longer holds the dead session.
+        assert!(continuation_sessions()
+            .lock()
+            .unwrap()
+            .get("term-tid-1")
+            .is_none());
+
+        std::env::remove_var("QONTINUI_CONTINUATION_SESSION_CAP");
+        clear_continuation_registry();
+    }
+
+    /// P3: a continuation with NO anchor_key (legacy frame) never dedups by
+    /// anchor — it always proceeds (the gate_id set is its only dedup).
+    #[test]
+    fn no_anchor_key_never_dedups() {
+        let _g = CONT_GUARD_LOCK.lock().unwrap();
+        clear_continuation_registry();
+        std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", "100");
+        let live_all = |_id: &str| true;
+
+        register_continuation_session("tid-a".into(), None);
+        // Another anchor-less dispatch must NOT be deduped against the existing
+        // anchor-less session (we can't correlate them).
+        assert_eq!(
+            evaluate_continuation_guard(None, &live_all),
+            ContinuationGuard::Proceed
+        );
+
+        std::env::remove_var("QONTINUI_CONTINUATION_SESSION_CAP");
+        clear_continuation_registry();
+    }
+
+    /// P4: at the configured cap, a fresh dispatch is refused (`AtCap`). Below
+    /// the cap it proceeds. Dead sessions are pruned before counting, so they
+    /// don't consume cap slots. Env override is honored.
+    #[test]
+    fn continuation_cap_refuses_at_limit() {
+        let _g = CONT_GUARD_LOCK.lock().unwrap();
+        clear_continuation_registry();
+        std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", "2");
+        let live_all = |_id: &str| true;
+
+        // 0 live, cap 2 → proceed.
+        assert_eq!(
+            evaluate_continuation_guard(Some("a1"), &live_all),
+            ContinuationGuard::Proceed
+        );
+        register_continuation_session("t1".into(), Some("a1".into()));
+        register_continuation_session("t2".into(), Some("a2".into()));
+
+        // 2 live, cap 2 → AtCap (a NEW anchor, so not a dedup).
+        assert_eq!(
+            evaluate_continuation_guard(Some("a3"), &live_all),
+            ContinuationGuard::AtCap(2)
+        );
+
+        // One session dies → pruned → back under cap → proceed.
+        let t1_dead = |id: &str| id != "t1";
+        assert_eq!(
+            evaluate_continuation_guard(Some("a3"), &t1_dead),
+            ContinuationGuard::Proceed
+        );
+
+        std::env::remove_var("QONTINUI_CONTINUATION_SESSION_CAP");
+        clear_continuation_registry();
+    }
+
+    /// P3 before P4: a duplicate of an already-LIVE anchor is reported as a
+    /// dedup even when the registry is at the cap — the honest reason is "this
+    /// is already running", not "capped".
+    #[test]
+    fn dedup_takes_precedence_over_cap() {
+        let _g = CONT_GUARD_LOCK.lock().unwrap();
+        clear_continuation_registry();
+        std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", "1");
+        let live_all = |_id: &str| true;
+
+        register_continuation_session("t1".into(), Some("anchor-dup".into()));
+        // At cap (1) AND the anchor matches a live session → dedup wins.
+        assert_eq!(
+            evaluate_continuation_guard(Some("anchor-dup"), &live_all),
+            ContinuationGuard::DuplicateAnchor("t1".to_string())
+        );
+
+        std::env::remove_var("QONTINUI_CONTINUATION_SESSION_CAP");
+        clear_continuation_registry();
+    }
+
+    /// The cap reads `QONTINUI_CONTINUATION_SESSION_CAP`, falling back to the
+    /// default for an unset / non-numeric value.
+    #[test]
+    fn continuation_session_cap_env_parsing() {
+        let _g = CONT_GUARD_LOCK.lock().unwrap();
+        let prev = std::env::var("QONTINUI_CONTINUATION_SESSION_CAP").ok();
+
+        std::env::remove_var("QONTINUI_CONTINUATION_SESSION_CAP");
+        assert_eq!(continuation_session_cap(), DEFAULT_CONTINUATION_SESSION_CAP);
+
+        std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", "7");
+        assert_eq!(continuation_session_cap(), 7);
+
+        std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", "not-a-number");
+        assert_eq!(continuation_session_cap(), DEFAULT_CONTINUATION_SESSION_CAP);
+
+        match prev {
+            Some(v) => std::env::set_var("QONTINUI_CONTINUATION_SESSION_CAP", v),
+            None => std::env::remove_var("QONTINUI_CONTINUATION_SESSION_CAP"),
+        }
     }
 
     // =========================================================================

--- a/src-tauri/src/commands/terminal_windows.rs
+++ b/src-tauri/src/commands/terminal_windows.rs
@@ -207,11 +207,15 @@ pub fn restore_pop_out_windows(
 /// affordance ([`close_empty_terminal_windows`]) so both behave identically.
 ///
 /// A pop-out is "empty" when [`WindowAssignments::has_assigned_sessions`] is
-/// false for its label — no tab renders there. Closing routes through the OS
-/// close (`window.close()`), so the central `CloseRequested` handler runs the
-/// usual reassign-to-main + `window-closed` path (a no-op reassign when empty),
-/// then we prune the now-dead records. Returns the labels closed/pruned.
-/// Never touches `"main"`.
+/// false for its label — no tab renders there. Programmatic teardown routes
+/// through `WebviewWindow::destroy()` (NOT `close()`): on Windows/WebView2 a
+/// `close()` only requests a close that the event loop may never finish
+/// destroying, leaving the OS window VISIBLE (observed live — `EnumWindows`
+/// still reports the window `[vis]` after `close()` returned `ok`). `destroy()`
+/// forces the teardown synchronously. The central `CloseRequested` handler still
+/// fires (so the usual reassign-to-main + `window-closed` path runs — a no-op
+/// reassign when empty), then we prune the now-dead records. Returns the labels
+/// closed/pruned. Never touches `"main"`.
 pub fn sweep_empty_pop_out_windows(
     app: &tauri::AppHandle,
     assignments: &Arc<WindowAssignments>,
@@ -222,12 +226,13 @@ pub fn sweep_empty_pop_out_windows(
         if assignments.has_assigned_sessions(label) {
             continue; // still hosts a tab — leave it
         }
-        // Close the live OS window if one is open (best-effort). The record is
-        // pruned below regardless, so a record with no live window is still
-        // cleaned up.
+        // Destroy (not close) the live OS window if one is open (best-effort):
+        // close() leaves WebView2 pop-outs visible; destroy() forces teardown.
+        // The record is pruned below regardless, so a record with no live
+        // window is still cleaned up.
         if let Some(win) = app.get_webview_window(label) {
-            if let Err(e) = win.close() {
-                tracing::warn!(window = %label, error = %e, "sweep_empty_pop_out_windows: close failed");
+            if let Err(e) = win.destroy() {
+                tracing::warn!(window = %label, error = %e, "sweep_empty_pop_out_windows: destroy failed");
             }
         }
         swept.push(label.clone());
@@ -299,12 +304,16 @@ pub fn auto_close_owner_window_if_empty(
         // Another live tab remains in the pop-out — leave it open.
         return;
     }
-    // The owner pop-out is now empty: close the OS window (the central
-    // CloseRequested handler emits `window-closed`) and prune the record so the
-    // boot-restore loop won't resurrect it.
+    // The owner pop-out is now empty: destroy the OS window and prune the
+    // record so the boot-restore loop won't resurrect it. We destroy() rather
+    // than close() because close() only REQUESTS a close that WebView2 may never
+    // finish, leaving the pop-out visible on screen (observed live: `EnumWindows`
+    // still reported it `[vis]` after a successful close()). destroy() forces the
+    // teardown; the central `CloseRequested` handler still fires (and emits
+    // `window-closed`) before the window is gone.
     if let Some(win) = app.get_webview_window(&owner) {
-        if let Err(e) = win.close() {
-            tracing::warn!(window = %owner, error = %e, "auto_close_owner_window_if_empty: close failed");
+        if let Err(e) = win.destroy() {
+            tracing::warn!(window = %owner, error = %e, "auto_close_owner_window_if_empty: destroy failed");
         }
     }
     let pruned = assignments.prune_empty_pop_outs();
@@ -345,8 +354,12 @@ pub fn capture_open_geometry(app: &tauri::AppHandle, assignments: &Arc<WindowAss
 
 /// Close a pop-out terminal window. The actual reassignment + events happen in
 /// the central `on_window_event` `CloseRequested` handler (so the OS close
-/// button takes the same path); here we just request the close. Closing
-/// `"main"` is rejected.
+/// button takes the same path); here we force the teardown. We use `destroy()`
+/// rather than `close()` because `close()` only requests a close that WebView2
+/// may never finish, leaving the pop-out visible on screen (observed live:
+/// `EnumWindows` still reported it `[vis]` after a successful `close()`).
+/// `destroy()` forces the teardown while still firing `CloseRequested` (so the
+/// central handler emits `window-closed`). Closing `"main"` is rejected.
 #[tauri::command]
 pub async fn close_terminal_window(app: tauri::AppHandle, label: String) -> Result<(), String> {
     if label == MAIN_WINDOW_LABEL {
@@ -354,8 +367,8 @@ pub async fn close_terminal_window(app: tauri::AppHandle, label: String) -> Resu
     }
     match app.get_webview_window(&label) {
         Some(win) => win
-            .close()
-            .map_err(|e| format!("Failed to close window {}: {}", label, e)),
+            .destroy()
+            .map_err(|e| format!("Failed to destroy window {}: {}", label, e)),
         None => Ok(()), // already gone — idempotent
     }
 }

--- a/src-tauri/src/commands/terminal_windows.rs
+++ b/src-tauri/src/commands/terminal_windows.rs
@@ -151,6 +151,25 @@ pub fn restore_pop_out_windows(
     app: &tauri::AppHandle,
     assignments: &Arc<WindowAssignments>,
 ) -> usize {
+    // P2 (orphan sweep): a persisted pop-out's PTYs never survive the process
+    // restart — terminal ids are a fresh uuid per launch and are never
+    // recreated — so EVERY persisted `session_owner` entry is stale on boot and
+    // every `term-N` record is genuinely empty (no live tab can claim it).
+    // Restoring them just produces empty, un-closable windows whose monotonic
+    // `term-N` counter keeps climbing (the observed orphan-accumulation loop,
+    // `term-19`). So FIRST clear the stale owner map, THEN prune the now-empty
+    // pop-out records, so we neither restore them nor resurrect them next boot.
+    let cleared = assignments.clear_session_owners();
+    let pruned = assignments.prune_empty_pop_outs();
+    if cleared > 0 || !pruned.is_empty() {
+        tracing::info!(
+            cleared_owners = cleared,
+            pruned = pruned.len(),
+            labels = ?pruned,
+            "restore_pop_out_windows: cleared stale owners + pruned empty pop-out records (boot orphan sweep)"
+        );
+    }
+
     let mut restored = 0usize;
     for record in assignments.pop_out_records() {
         let label = record.label.clone();
@@ -180,6 +199,121 @@ pub fn restore_pop_out_windows(
         tracing::info!(restored, "Restored pop-out terminal windows on boot");
     }
     restored
+}
+
+/// P2 (orphan sweep) — close every OPEN pop-out (`term-N`) window that owns no
+/// assigned session, and prune any session-less pop-out records. Shared by the
+/// boot path's intent and the operator-initiated "close empty terminal windows"
+/// affordance ([`close_empty_terminal_windows`]) so both behave identically.
+///
+/// A pop-out is "empty" when [`WindowAssignments::has_assigned_sessions`] is
+/// false for its label — no tab renders there. Closing routes through the OS
+/// close (`window.close()`), so the central `CloseRequested` handler runs the
+/// usual reassign-to-main + `window-closed` path (a no-op reassign when empty),
+/// then we prune the now-dead records. Returns the labels closed/pruned.
+/// Never touches `"main"`.
+pub fn sweep_empty_pop_out_windows(
+    app: &tauri::AppHandle,
+    assignments: &Arc<WindowAssignments>,
+) -> Vec<String> {
+    let mut swept: Vec<String> = Vec::new();
+    for record in assignments.pop_out_records() {
+        let label = &record.label;
+        if assignments.has_assigned_sessions(label) {
+            continue; // still hosts a tab — leave it
+        }
+        // Close the live OS window if one is open (best-effort). The record is
+        // pruned below regardless, so a record with no live window is still
+        // cleaned up.
+        if let Some(win) = app.get_webview_window(label) {
+            if let Err(e) = win.close() {
+                tracing::warn!(window = %label, error = %e, "sweep_empty_pop_out_windows: close failed");
+            }
+        }
+        swept.push(label.clone());
+    }
+    let pruned = assignments.prune_empty_pop_outs();
+    if !pruned.is_empty() {
+        tracing::info!(count = pruned.len(), labels = ?pruned, "sweep_empty_pop_out_windows: pruned empty pop-out records");
+    }
+    // Union (a record may be pruned without a live window, or closed without
+    // having been in pop_out_records by the time prune ran) — de-dup by set.
+    let mut set: std::collections::BTreeSet<String> = swept.into_iter().collect();
+    set.extend(pruned);
+    set.into_iter().collect()
+}
+
+/// Operator-initiated "close empty terminal windows" affordance (P2). Reuses
+/// [`sweep_empty_pop_out_windows`] — closes every pop-out that owns no live tab
+/// and prunes its record. Returns the labels swept (for an optional toast).
+#[tauri::command]
+pub async fn close_empty_terminal_windows(
+    app: tauri::AppHandle,
+    assignments: tauri::State<'_, Arc<WindowAssignments>>,
+) -> Result<Vec<String>, String> {
+    Ok(sweep_empty_pop_out_windows(&app, assignments.inner()))
+}
+
+/// P1 (close-on-clean-exit) — invoked from the terminal session's PTY-exit
+/// waiter the instant a session's child exits. On a CLEAN exit (`Some(0)`)
+/// only, if the session's owning window is a `term-N` pop-out that now hosts NO
+/// other live session, close that window (the predictable terminal-emulator
+/// close-on-exit behaviour) and prune its record so boot-restore won't
+/// resurrect it. A non-zero / unknown exit NEVER auto-closes (honesty: a failed
+/// session stays visible). `"main"` is never auto-closed. Multi-tab pop-outs are
+/// never closed by one tab's exit (the emptiness check sees the sibling tabs).
+///
+/// `terminal_id` is the session id used as the `window_assignments` owner key
+/// (the same id the frontend passes to `assign_session_to_window`).
+///
+/// Best-effort + cheap: a non-clean exit returns immediately; an owner of
+/// `"main"` (the common case — most sessions are docked) returns immediately.
+pub fn auto_close_owner_window_if_empty(
+    app: &tauri::AppHandle,
+    assignments: &Arc<WindowAssignments>,
+    terminal_id: &str,
+    exit_code: Option<i32>,
+) {
+    // Honesty: only a clean exit auto-closes. Non-zero / None stays open.
+    if exit_code != Some(0) {
+        return;
+    }
+    let owner = assignments.owner_of(terminal_id);
+    if owner == MAIN_WINDOW_LABEL {
+        return; // docked session, or main — never auto-close
+    }
+    // Drop this session's ownership first (its PTY just died), then test the
+    // window for remaining tabs. `assign_session(.., "main")` removes the
+    // explicit entry; emit the reassignment so any window views stay in sync.
+    if let Some(from) = assignments.assign_session(terminal_id, MAIN_WINDOW_LABEL) {
+        let payload = SessionAssignmentChanged {
+            session_id: terminal_id.to_string(),
+            from: Some(from),
+            to: MAIN_WINDOW_LABEL.to_string(),
+        };
+        if let Err(e) = app.emit("session-assignment-changed", &payload) {
+            tracing::warn!(error = %e, "auto_close_owner_window_if_empty: failed to emit reassignment");
+        }
+    }
+    if assignments.has_assigned_sessions(&owner) {
+        // Another live tab remains in the pop-out — leave it open.
+        return;
+    }
+    // The owner pop-out is now empty: close the OS window (the central
+    // CloseRequested handler emits `window-closed`) and prune the record so the
+    // boot-restore loop won't resurrect it.
+    if let Some(win) = app.get_webview_window(&owner) {
+        if let Err(e) = win.close() {
+            tracing::warn!(window = %owner, error = %e, "auto_close_owner_window_if_empty: close failed");
+        }
+    }
+    let pruned = assignments.prune_empty_pop_outs();
+    tracing::info!(
+        window = %owner,
+        terminal_id = %terminal_id,
+        pruned = ?pruned,
+        "auto-closed empty pop-out on clean session exit"
+    );
 }
 
 /// Snapshot every open pop-out window's current geometry into the registry

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1644,6 +1644,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::terminal_analysis::get_latest_plan_content,
             // Pop-out terminal windows (Phase 1)
             commands::terminal_windows::assign_session_to_window,
+            commands::terminal_windows::close_empty_terminal_windows,
             commands::terminal_windows::close_terminal_window,
             commands::terminal_windows::focus_runner_window,
             commands::terminal_windows::get_window_assignments,

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -535,6 +535,23 @@ impl TerminalSession {
                         }
                     }
                 }
+
+                // P1 (close-on-clean-exit): on a CLEAN exit only, close the
+                // owning `term-N` pop-out window iff this was its last live
+                // session. A non-zero / unknown exit stays visible (honesty).
+                // Docked sessions (owner "main") and the main window are never
+                // auto-closed. Best-effort + cheap; guarded inside the helper.
+                if let Some(assignments) = tauri::Manager::try_state::<
+                    std::sync::Arc<crate::window_assignments::WindowAssignments>,
+                >(&waiter_app)
+                {
+                    crate::commands::terminal_windows::auto_close_owner_window_if_empty(
+                        &waiter_app,
+                        assignments.inner(),
+                        &waiter_id,
+                        code,
+                    );
+                }
             })
             .map_err(|e| format!("Failed to spawn waiter thread: {}", e))?;
 

--- a/src-tauri/src/window_assignments.rs
+++ b/src-tauri/src/window_assignments.rs
@@ -326,6 +326,92 @@ impl WindowAssignments {
             .unwrap_or_default()
     }
 
+    /// Whether a window currently owns at least one assigned session. `"main"`
+    /// is the default owner for every unmapped session, so it is reported as
+    /// non-empty whenever ANY session exists (it always "could" host one) — but
+    /// callers only ever ask this about `term-N` pop-outs, where an empty answer
+    /// means "no tab renders here". Unknown labels are empty.
+    pub fn has_assigned_sessions(&self, label: &str) -> bool {
+        self.inner
+            .lock()
+            .map(|s| s.session_owner.values().any(|owner| owner == label))
+            .unwrap_or(false)
+    }
+
+    /// Clear the entire `session_owner` map (reverting every session to the
+    /// default `"main"`), persisting on change. Returns the number of entries
+    /// dropped.
+    ///
+    /// **Boot-only.** Terminal ids are a fresh `uuid_v4` per launch and do NOT
+    /// survive a process restart (`terminal::manager::create`), so EVERY
+    /// persisted owner entry references a terminal that will never reappear —
+    /// the map is entirely stale on boot. Clearing it before
+    /// [`Self::prune_empty_pop_outs`] makes every persisted pop-out correctly
+    /// register as empty (no live tab can ever claim it) so the boot orphan
+    /// sweep prunes them all, instead of a stale entry wrongly pinning a dead
+    /// pop-out open forever. Mid-session callers must NOT use this (it would
+    /// strand live tabs back on `main`).
+    pub fn clear_session_owners(&self) -> usize {
+        let (count, snapshot) = {
+            let mut s = match self.inner.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "window_assignments: lock poisoned on clear_session_owners");
+                    return 0;
+                }
+            };
+            if s.session_owner.is_empty() {
+                return 0;
+            }
+            let count = s.session_owner.len();
+            s.session_owner.clear();
+            (count, s.clone())
+        };
+        self.persist(&snapshot);
+        count
+    }
+
+    /// Prune every pop-out (`term-N`) record that currently owns NO assigned
+    /// session, removing it from the registry so the boot-restore loop stops
+    /// resurrecting it and the monotonic `term-N` counter stops climbing on
+    /// dead records. Returns the labels pruned. Never touches `"main"` or a
+    /// pop-out that still owns a session. Persists on change.
+    ///
+    /// **Why this is the boot-orphan fix:** PTYs do not survive a process
+    /// restart, so a persisted pop-out's sessions are always gone on the next
+    /// boot — `restore_pop_out_windows` would otherwise recreate an empty,
+    /// purposeless window every time. Pruning the empties on boot breaks that
+    /// loop. (A pop-out whose tabs were reassigned to `main` before shutdown is
+    /// likewise empty here and correctly pruned — its tabs render on `main`.)
+    pub fn prune_empty_pop_outs(&self) -> Vec<WindowLabel> {
+        let (pruned, snapshot) = {
+            let mut s = match self.inner.lock() {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(error = %e, "window_assignments: lock poisoned on prune_empty_pop_outs");
+                    return Vec::new();
+                }
+            };
+            let owned: std::collections::HashSet<&str> =
+                s.session_owner.values().map(|v| v.as_str()).collect();
+            let empties: Vec<WindowLabel> = s
+                .windows
+                .values()
+                .filter(|r| r.kind == WindowKind::PopOut && !owned.contains(r.label.as_str()))
+                .map(|r| r.label.clone())
+                .collect();
+            if empties.is_empty() {
+                return Vec::new();
+            }
+            for label in &empties {
+                s.windows.remove(label);
+            }
+            (empties, s.clone())
+        };
+        self.persist(&snapshot);
+        pruned
+    }
+
     /// Record a window's last-known geometry (for Phase-2 restore). Persists
     /// only when the geometry actually changed (so the periodic capture poll
     /// is a no-op while a window sits still — no disk churn). Returns `true`
@@ -583,6 +669,93 @@ mod tests {
         assert_eq!(wa.owner_of("sess-live"), "term-1"); // untouched
                                                         // Idempotent: a second pass finds nothing.
         assert!(wa.reconcile_orphans().is_empty());
+    }
+
+    #[test]
+    fn has_assigned_sessions_reflects_owner_map() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        let w = wa.create_window(None, None, 10); // term-1, no sessions yet
+        assert!(
+            !wa.has_assigned_sessions(&w.label),
+            "a freshly-created pop-out owns no sessions"
+        );
+        wa.assign_session("sess-A", &w.label);
+        assert!(wa.has_assigned_sessions(&w.label), "now owns sess-A");
+        // Moving the only session away empties it again.
+        wa.assign_session("sess-A", "main");
+        assert!(
+            !wa.has_assigned_sessions(&w.label),
+            "empty again after the tab moved to main"
+        );
+        assert!(
+            !wa.has_assigned_sessions("term-999"),
+            "unknown label is empty"
+        );
+    }
+
+    #[test]
+    fn prune_empty_pop_outs_removes_only_session_less_popouts() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        let empty1 = wa.create_window(None, None, 10); // term-1, empty
+        let live = wa.create_window(None, None, 20); // term-2, will hold a session
+        let empty2 = wa.create_window(None, None, 30); // term-3, empty
+        wa.assign_session("sess-live", &live.label);
+
+        let mut pruned = wa.prune_empty_pop_outs();
+        pruned.sort();
+        assert_eq!(pruned, vec![empty1.label.clone(), empty2.label.clone()]);
+
+        let remaining: std::collections::HashSet<String> =
+            wa.pop_out_records().into_iter().map(|r| r.label).collect();
+        assert_eq!(remaining, [live.label.clone()].into());
+        // main is never pruned.
+        assert!(wa.snapshot().windows.contains_key("main"));
+        // The live window's session is untouched.
+        assert_eq!(wa.owner_of("sess-live"), live.label);
+        // Idempotent: a second pass finds nothing new.
+        assert!(wa.prune_empty_pop_outs().is_empty());
+    }
+
+    #[test]
+    fn clear_session_owners_then_prune_removes_all_popouts_on_boot() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        let a = wa.create_window(None, None, 10);
+        let b = wa.create_window(None, None, 20);
+        // Simulate the persisted (now-stale) owner map from a prior session.
+        wa.assign_session("dead-tid-1", &a.label);
+        wa.assign_session("dead-tid-2", &b.label);
+        assert!(wa.has_assigned_sessions(&a.label));
+
+        // Boot sweep: clear stale owners → every pop-out becomes empty → pruned.
+        let cleared = wa.clear_session_owners();
+        assert_eq!(cleared, 2);
+        let pruned = wa.prune_empty_pop_outs();
+        assert_eq!(
+            pruned.len(),
+            2,
+            "both pop-outs are empty after clear → pruned"
+        );
+        assert!(wa.pop_out_records().is_empty());
+        // main survives; owner map is empty.
+        assert!(wa.snapshot().windows.contains_key("main"));
+        assert!(wa.snapshot().session_owner.is_empty());
+        // Idempotent.
+        assert_eq!(wa.clear_session_owners(), 0);
+    }
+
+    #[test]
+    fn prune_empty_pop_outs_noop_when_all_have_sessions() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        let a = wa.create_window(None, None, 10);
+        let b = wa.create_window(None, None, 20);
+        wa.assign_session("s1", &a.label);
+        wa.assign_session("s2", &b.label);
+        assert!(wa.prune_empty_pop_outs().is_empty());
+        assert_eq!(wa.pop_out_records().len(), 2);
     }
 
     #[test]

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -204,6 +204,16 @@ function TerminalPageInner({
           "Return this runner process's own windows [{ label, kind, title }] (main + pop-outs).",
         handler: async () => invoke("list_runner_windows"),
       },
+      // P2 (orphan sweep) — operator-initiated cleanup of empty pop-out windows
+      // (no live tab). Reuses the same backend sweep the boot-restore path uses.
+      // Returns the labels swept.
+      {
+        id: "close-empty-terminal-windows",
+        label: "Close Empty Terminal Windows",
+        description:
+          "Close every pop-out OS window that has no live terminal tab and prune its record. Returns the labels closed.",
+        handler: async () => invoke("close_empty_terminal_windows"),
+      },
     ],
   });
 


### PR DESCRIPTION
Implements **all four phases** of `plans/2026-06-07-continuation-terminal-window-lifecycle.md` (vetted against runner `origin/main` @ `01a6c25d`, which is this branch's base). Recommended plan order followed: P2 → P1 → P3 → P4.

## P2 — orphan sweep at startup + manual affordance *(primary payoff)*
Kills the boot-restore orphan loop that climbed `term-N` to `term-19`. **Key finding:** terminal ids are a fresh `uuid_v4` per launch (`terminal::manager::create`) and never survive a restart, so every persisted `session_owner` entry is stale on boot and every `term-N` record is genuinely empty.
- `WindowAssignments::clear_session_owners()` + `prune_empty_pop_outs()` + `has_assigned_sessions()` (new).
- `restore_pop_out_windows` now clears the stale owner map, then prunes session-less pop-out records, **before** restoring — so empty pop-outs are neither restored nor resurrected next boot.
- Operator affordance: `close_empty_terminal_windows` command + "Close Empty Terminal Windows" terminal palette entry, reusing `sweep_empty_pop_out_windows`.

## P1 — close-on-clean-exit + keep-on-error
- The PTY-exit waiter (`terminal/session.rs`) now calls `auto_close_owner_window_if_empty` on a **clean** exit only (`exit_code == Some(0)`): if the session's owner is a `term-N` pop-out with no other live tab, it closes the window via the existing OS-close path (reassign→`main` + `window-closed`) and prunes the record.
- Non-zero / unknown exit **never** auto-closes (failures stay visible). Multi-tab pop-outs are never closed by one tab's exit. `main` is never auto-closed. No confirm dialog (per the plan's predictability tie-break).

## P3 — continuation idempotency by anchor_key *(net-new guard)*
- Process-wide live continuation-session registry (keyed by `terminal_id`, carrying `anchor_key`) in `agent_runtime.rs`. `evaluate_continuation_guard` prunes dead sessions (liveness via `TerminalManager::is_alive`) then refuses a live-`anchor_key` duplicate **before** any worktree is acquired — catching the residual case #450's `gate_id` set can't (re-cleared gate = new `gate_id`, same `anchor_key`; legacy no-`gate_id` frame).
- **#450's `gate_id` dedup is unchanged** — regression test `gate_id_dedup_still_holds_alongside_anchor_guard` added.

## P4 — continuation concurrency cap *(smallest honest version)*
- Caps concurrently-live continuation-spawned sessions (default 4, env `QONTINUI_CONTINUATION_SESSION_CAP`). "Continuation-spawned" = sessions registered in the P3 registry on successful terminal create; operator sessions are never counted.
- At cap: log + `report_spawn_failed(..., "continuation cap (N) reached — operator must resume manually", ...)`. No runner-wirable coord alert path exists (`/coord/alerts` is read-only); `spawn-failed` is the honest, already-wired fallback (per the plan's correction).

## Tests / gates
- `window_assignments`: **14/14** (4 new: `has_assigned_sessions_*`, `prune_empty_pop_outs_*`, `clear_session_owners_then_prune_removes_all_popouts_on_boot`).
- `agent_runtime`: **32/32** (6 new: the gate_id regression guard + anchor-dedup/free-on-death + no-anchor + cap-at-limit + dedup-precedence-over-cap + env-parsing).
- `cargo check` + `cargo clippy --tests -- -D warnings`: clean.
- Frontend `tsc --noEmit` (project-local TS 6): clean.

## For the temp-runner E2E (per the plan's verification tier)
- **P2:** leave an empty `term-N`, restart the runner → it is **not** resurrected (swept). Verify via `GET /ui-bridge/control/runner-windows`.
- **P1:** open a pop-out, run a tab to a **clean** exit → pop-out closes; run a tab to a **non-zero** exit → pop-out stays with `[Process exited with code 1]` visible.
- **P3:** two continuations with the same `anchor_key` → **one** docked tab in `main` (continuations are docked since #459, not windowed).
- **P4:** with `QONTINUI_CONTINUATION_SESSION_CAP=1`, a second concurrent continuation is refused (spawn-failed, capped reason).