### PR TITLE
fix(fs-observer): info-level push log + commit-forwarder device auth

### DIFF
--- a/src-tauri/src/agent_worktree/fs_observer.rs
+++ b/src-tauri/src/agent_worktree/fs_observer.rs
@@ -52,7 +52,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use serde::Serialize;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 /// Env flag that turns the Ξ_FS observer producer on. Default off. Accepts
 /// the usual truthy values; anything else (including unset) is false. Matches
@@ -385,7 +385,7 @@ async fn post_observations(coord_http_base: &str, body: &FsObservationsRequest) 
         Ok(resp) => {
             let status = resp.status();
             if status.is_success() {
-                debug!(
+                info!(
                     url = %url,
                     n = body.observations.len(),
                     status = status.as_u16(),

--- a/src-tauri/src/git_supervision/commit_forwarder.rs
+++ b/src-tauri/src/git_supervision/commit_forwarder.rs
@@ -165,7 +165,15 @@ async fn post_commit_observation(coord_http_base: &str, body: &CommitObservation
             return;
         }
     };
-    match client.post(&url).json(body).send().await {
+    // Attach the device-JWT bearer when one is available (never fatal —
+    // unpaired / empty keychain collapses to the anonymous send coord accepts
+    // today). Same write-path attach the Ξ_FS observer uses on its push, and it
+    // feeds the data-plane auth-coverage metric. Must be `crate::auth`, not
+    // `qontinui_runner_lib::auth` — this module compiles into the bin target,
+    // and the lib path would bump the lib crate's separate counter statics,
+    // invisible to the bin's `DATA_PLANE_TOTAL/AUTHED` coverage readout.
+    let req = crate::auth::attach_device_auth(client.post(&url));
+    match req.json(body).send().await {
         Ok(resp) => {
             let status = resp.status();
             if status.is_success() {


### PR DESCRIPTION
Phase 2 of the Ξ_FS observer instrumentation plan (`qontinui-dev-notes/plans/2026-06-07-fs-observer-instrumentation-and-attribution.md`).

## Changes
- **fs_observer** (`agent_worktree/fs_observer.rs`): raise the push-success log from `debug!` to `info!`. The producer has no metrics counter, so this log is the only passive activation signal — at the default `info` level it's now visible (previously filtered).
- **commit_forwarder** (`git_supervision/commit_forwarder.rs`): attach the device-JWT bearer on the `/coord/commits/observations` POST via `crate::auth::attach_device_auth` — matching the fs_observer sibling. Uses `crate::auth` (the bin path), NOT `qontinui_runner_lib::auth`, so the data-plane auth-coverage counter isn't split. Brings the commit forwarder to auth parity ahead of the multiuser Phase-2 enforcement on the observation endpoints.

## Deferred (re-scoped)
`agent_id` attribution (plan #3) is **not** here. The commit_forwarder fires from `git_watcher` over arbitrary watched repos with no session/worktree context (its `GitSupervisionEvent` payload carries only git metadata), so a real `agent_id` can't be resolved runner-side. Re-scoped to a coord-side correlation follow-up (observed `agent/*` branch → `coord.agent_worktrees.agent_id`).

Verified: `cargo clippy --bin qontinui-runner --features custom-protocol -- -D warnings` clean; commit_forwarder unit tests pass.