### PR TITLE
fix(runner): instance-scoped session outbox + targeted ui-bridge IPC emits

### DIFF
--- a/src-tauri/src/instance.rs
+++ b/src-tauri/src/instance.rs
@@ -175,11 +175,63 @@ fn sanitize(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// `QONTINUI_INSTANCE_NAME` is process-global mutable state; tests that
+    /// set/remove it race when the harness runs them on parallel threads
+    /// (one test's `remove_var` lands between another's `set_var` and its
+    /// assert — flakes on windows-latest). Every env-touching test holds this
+    /// lock for its full body. Poisoning is harmless — each test resets the
+    /// var on entry — so recover with `into_inner`. Mirrors the ENV_GUARD
+    /// pattern in `claude_session/coord_register.rs`.
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_GUARD.lock().unwrap_or_else(|p| p.into_inner())
+    }
 
     #[test]
     fn sanitize_keeps_safe_chars() {
         assert_eq!(sanitize("test-runner_1"), "test-runner_1");
         assert_eq!(sanitize("abc/def"), "abc_def");
         assert_eq!(sanitize("weird name!"), "weird_name_");
+    }
+
+    /// The outbox base dir (`~/.qontinui/runner`) must scope per-instance for
+    /// secondaries so spawn-test runners never race the primary on a single
+    /// shared `session-outbox.jsonl`. This asserts the exact `scope_path`
+    /// contract relied on by the outbox + pane-store wiring in `main.rs`.
+    #[test]
+    fn scope_path_isolates_outbox_dir_for_secondary() {
+        let _env = env_lock();
+        let base = Path::new(".qontinui").join("runner");
+
+        // Secondary: appends `instance-<sanitized-name>`.
+        std::env::set_var("QONTINUI_INSTANCE_NAME", "test-runner 7!");
+        let scoped = scope_path(&base);
+        assert_eq!(
+            scoped,
+            base.join("instance-test-runner_7_"),
+            "secondary outbox dir must be instance-scoped"
+        );
+        let outbox = scoped.join("session-outbox.jsonl");
+        assert!(outbox.to_string_lossy().contains("instance-test-runner_7_"));
+
+        std::env::remove_var("QONTINUI_INSTANCE_NAME");
+    }
+
+    /// The PRIMARY runner (no `QONTINUI_INSTANCE_NAME`) must keep resolving to
+    /// the UNSCOPED legacy path so its pre-existing pending outbox rows are
+    /// never orphaned by this change.
+    #[test]
+    fn scope_path_is_noop_for_primary() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_INSTANCE_NAME");
+        let base = Path::new(".qontinui").join("runner");
+        assert_eq!(
+            scope_path(&base),
+            base,
+            "primary must keep the legacy unscoped outbox path"
+        );
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1870,11 +1870,26 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 let term_state: tauri::State<'_, std::sync::Arc<terminal::TerminalManager>> =
                     app.state();
                 let term_for_session = term_state.inner().clone();
-                let outbox_path = dirs::home_dir()
-                    .unwrap_or_else(|| std::path::PathBuf::from("."))
-                    .join(".qontinui")
-                    .join("runner")
-                    .join("session-outbox.jsonl");
+                // Instance-scope the outbox dir so every spawn-test / named
+                // secondary runner gets its OWN `instance-<name>/` outbox file
+                // instead of racing the primary on a single shared
+                // `session-outbox.jsonl`. `scope_path` is a no-op for the
+                // primary (no `QONTINUI_INSTANCE_NAME`), so the primary keeps
+                // resolving to the legacy unscoped path — its pending outbox
+                // rows are never orphaned. `OutboxWriter::open` create_dir_all's
+                // the parent, so the scoped dir is created automatically.
+                let outbox_dir = instance::scope_path(
+                    &dirs::home_dir()
+                        .unwrap_or_else(|| std::path::PathBuf::from("."))
+                        .join(".qontinui")
+                        .join("runner"),
+                );
+                let outbox_path = outbox_dir.join("session-outbox.jsonl");
+                tracing::info!(
+                    path = %outbox_path.display(),
+                    instance = ?instance::instance_name(),
+                    "session: resolved outbox path"
+                );
                 let outbox = match session::local_store::OutboxWriter::open(&outbox_path) {
                     Ok(o) => std::sync::Arc::new(o),
                     Err(e) => {
@@ -1957,11 +1972,16 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // store, so a restored terminal pane RESUMES its prior coord
                 // session instead of orphaning the row + minting a duplicate.
                 // Co-located with the session outbox under `.qontinui/runner`.
-                let pane_store_path = dirs::home_dir()
-                    .unwrap_or_else(|| std::path::PathBuf::from("."))
-                    .join(".qontinui")
-                    .join("runner")
-                    .join("pane-sessions.json");
+                // Co-located with — and scoped identically to — the session
+                // outbox above, so a secondary instance's pane→coord-session
+                // map never collides with the primary's.
+                let pane_store_path = instance::scope_path(
+                    &dirs::home_dir()
+                        .unwrap_or_else(|| std::path::PathBuf::from("."))
+                        .join(".qontinui")
+                        .join("runner"),
+                )
+                .join("pane-sessions.json");
                 let pane_store = std::sync::Arc::new(
                     match session::pane_store::PaneSessionStore::open(&pane_store_path) {
                         Ok(s) => s,

--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -741,10 +741,17 @@ async fn tagged_page_evaluate(
         "allow_network_requests": allow_network_requests,
     });
 
-    if let Err(e) = state
-        .app_handle
-        .emit("ui-bridge:evaluate-request", &payload)
-    {
+    // Target the canonical MAIN window only. `AppHandle::emit` is a GLOBAL
+    // broadcast that reaches every webview (main + pop-out `term-N`
+    // terminals); each window's `useUIBridgeEvaluateHandler` would then run
+    // the expression independently, fanning out a single-consumer request to
+    // N windows (duplicate side-effecting invokes). `emit_to(<main label>)`
+    // routes it to exactly one deterministic consumer.
+    if let Err(e) = state.app_handle.emit_to(
+        qontinui_runner_lib::get_main_window_label(),
+        "ui-bridge:evaluate-request",
+        &payload,
+    ) {
         state.ui_bridge_evaluate_store.cancel(&request_id).await;
         return Err(format!("Failed to emit ui-bridge:evaluate-request: {}", e));
     }

--- a/src-tauri/src/mcp/ui_bridge_invoke_handlers.rs
+++ b/src-tauri/src/mcp/ui_bridge_invoke_handlers.rs
@@ -150,7 +150,16 @@ pub async fn ui_bridge_invoke_handler(
         timeout_ms,
         "ui_bridge_invoke: emitting ui-bridge:invoke-request"
     );
-    if let Err(e) = state.app_handle.emit("ui-bridge:invoke-request", &payload) {
+    // Target the canonical MAIN window only — see the matching emit in
+    // mcp/ui_bridge/page.rs. A global broadcast reaches every webview window
+    // (main + pop-out `term-N` terminals); each runs `invoke(command, args)`
+    // and emits a duplicate `ui-bridge:invoke-response` for the same
+    // request_id, fanning out side-effecting invokes and racing the oneshot.
+    if let Err(e) = state.app_handle.emit_to(
+        qontinui_runner_lib::get_main_window_label(),
+        "ui-bridge:invoke-request",
+        &payload,
+    ) {
         state.ui_bridge_invoke_store.cancel(&request_id).await;
         return Err((
             StatusCode::INTERNAL_SERVER_ERROR,

--- a/src-tauri/src/ui_bridge_invoke_probe.rs
+++ b/src-tauri/src/ui_bridge_invoke_probe.rs
@@ -96,7 +96,16 @@ pub async fn probe_allowlist_wire_contracts(
         });
 
         // Emit; if emit itself fails we can't probe this one and move on.
-        if let Err(e) = app_handle.emit("ui-bridge:invoke-request", &payload) {
+        // Target the canonical MAIN window only (same root cause as the live
+        // invoke proxy in mcp/ui_bridge_invoke_handlers.rs): a global
+        // broadcast would have every webview answer with a duplicate response
+        // for the same request_id, racing the probe oneshot and re-running the
+        // probed command in each pop-out window.
+        if let Err(e) = app_handle.emit_to(
+            qontinui_runner_lib::get_main_window_label(),
+            "ui-bridge:invoke-request",
+            &payload,
+        ) {
             store.cancel(&request_id).await;
             results.push(ProbeResult {
                 command: cmd.name.to_string(),


### PR DESCRIPTION
## Root causes

Two defects from `plans/2026-06-07-temp-runner-coordsync-and-eval-invoke-fanout-fixes.md` that broke the standard "verify via temp runner" flow.

### 1. Session outbox not instance-scoped (Defect 1, P1)
The session outbox dir (`~/.qontinui/runner` -> `session-outbox.jsonl`) and the co-located `pane-sessions.json` were NOT wrapped in `instance::scope_path(...)`. Every runner on the machine — primary AND every spawn-test secondary — opened the SAME file. Two drain loops racing `OutboxWriter::ack` -> `rewrite_all` (write `.tmp` then `rename(tmp, path)`) produced `ack write failed (os error 2)` on every tick, and AI-session rows written on a test instance never reached coord.

**Fix:** wrap both base dirs in `instance::scope_path(...)` so each secondary gets its own `instance-<name>/` dir (the existing pattern from `context/storage.rs`, `playwright/script_storage.rs`, `prompts.rs`). `OutboxWriter::open` already `create_dir_all`s the parent, so scoped dirs appear automatically. Added a boot-time `info!` of the resolved outbox path.

**Primary-path compatibility:** `scope_path` is a no-op when `QONTINUI_INSTANCE_NAME` is unset (returns `base` unchanged — see `instance.rs:59`). The PRIMARY runner therefore keeps resolving to the UNSCOPED legacy path `~/.qontinui/runner/session-outbox.jsonl`, so its pre-existing pending outbox rows are never orphaned by this change. Asserted by the new `scope_path_is_noop_for_primary` test.

### 2. ui-bridge IPC emits broadcast to every webview (Defects 2 + 3, P1/P2 — one root cause)
`AppHandle::emit(...)` is a GLOBAL broadcast that reaches every webview window (main + pop-out `term-N` terminals). Each window's `useUIBridgeEvaluateHandler` / `useUIBridgeInvokeHandler` independently executed the expression / invoke command, fanning out a single-consumer request to N windows — duplicate side-effecting invokes (observed 2x..11x = live window count), and duplicate `invoke-response`s carrying the same `request_id` racing the consumed oneshot (the "ipc down" wedge, Defect 3).

**Fix:** replace `emit` with `emit_to(qontinui_runner_lib::get_main_window_label(), ...)` so exactly the canonical main webview consumes each request.

#### Emit-site audit (`*.emit("ui-bridge:...")`)
Three call sites found; all three fixed (same single-consumer call-site class):
- `mcp/ui_bridge/page.rs` — `ui-bridge:evaluate-request` (Defect 2)
- `mcp/ui_bridge_invoke_handlers.rs` — `ui-bridge:invoke-request`, live invoke proxy (Defect 3)
- `ui_bridge_invoke_probe.rs` — `ui-bridge:invoke-request`, boot-time allowlist contract probe. Runs before pop-outs typically exist and only probes non-destructive commands, but it is the identical single-consumer pattern (duplicate responses would race the probe oneshot and misclassify), so it was fixed too.

The frontend handlers (`useUIBridgeEvaluateHandler.ts`, `useUIBridgeInvokeHandler.ts`) are window-agnostic — they listen on the request event and emit the response globally with no window-label gating. Nothing relies on a non-main window answering, so targeting "main" is safe. The `ui-bridge:*-response` emits are not affected (they are correlated by `request_id` on the Rust side, not by window).

The main window label is `"main"` (verified: `window_assignments.rs:47` `pub const MAIN_WINDOW_LABEL: &str = "main"`; `tauri.conf.json` declares no static windows and the main window is built with label `"main"` at `main.rs`; the canonical accessor `qontinui_runner_lib::get_main_window_label()` returns it).

## Tests
Added to `src-tauri/src/instance.rs` (env-var `ENV_GUARD` mutex pattern, mirrors `claude_session/coord_register.rs`):
- `scope_path_isolates_outbox_dir_for_secondary` — `QONTINUI_INSTANCE_NAME` set -> path contains `instance-<sanitized-name>`.
- `scope_path_is_noop_for_primary` — unset -> legacy unscoped path.

`cargo test ... instance`: 5 passed, 0 failed. `cargo check --bin qontinui-runner --features custom-protocol`: clean.

## Acceptance criteria (from plan)
- Defect 1: spawn-test runner -> AI session -> coord row visible; zero `ack write failed`; primary and a concurrent spawn-test resolve to DISTINCT outbox paths (new boot `info!` line + tests).
- Defect 2: mutating invoke-via-evaluate produces exactly one `task_run_id` with pop-out windows open (single deterministic consumer by construction).
- Defect 3: after the targeted-emit fix, sequential `POST /ui-bridge/invoke/<read-only>` calls all return (no `ipc down`) with pop-outs open.
