### PR TITLE
fix(federation): wrap get_federation_reports IPC payload under `args`

### DIFF
--- a/src/components/MemoryFederationPage.tsx
+++ b/src/components/MemoryFederationPage.tsx
@@ -138,7 +138,11 @@ export function MemoryFederationPage() {
           reported_at: string;
           metadata?: Record<string, unknown>;
         }>;
-      }>("get_federation_reports", { since, limit: 200 });
+        // Tauri wraps the command's single struct parameter under its
+        // declared name (`args`); the payload must mirror that or Tauri
+        // rejects the call with "missing required key args" before any
+        // HTTP request to coord is made.
+      }>("get_federation_reports", { args: { since, limit: 200 } });
 
       const rows: FederationReportRow[] = (result?.items ?? []).map((item) => ({
         id: item.report_id,
@@ -163,6 +167,11 @@ export function MemoryFederationPage() {
           "Historical data unavailable (Tauri command not registered). " +
             "Showing live session reports only.",
         );
+      } else if (msg.includes("invalid args") || msg.includes("missing required key")) {
+        // Tauri rejected the IPC payload before any HTTP call — this is a
+        // client-side contract bug, not a coord-side failure. Don't blame
+        // coord.
+        setCoordError(`Internal error loading history (IPC contract): ${msg}`);
       } else {
         setCoordError(`Failed to fetch from coord: ${msg}`);
       }


### PR DESCRIPTION
## Problem

The **Memory Federation** page never loaded historical reports from coord. It surfaced:

> Failed to fetch from coord: invalid args `args` for command `get_federation_reports`: command get_federation_reports missing required key args

That message is misleading — **no request to coord was ever made**. It's a Tauri IPC argument-shape mismatch:

- The Rust command takes a single struct param named `args` (`src-tauri/src/commands/federation.rs`):
  ```rust
  pub async fn get_federation_reports(args: GetFederationReportsArgs) -> ...
  ```
  Tauri therefore expects the invoke payload wrapped as `{ args: { … } }`.
- The frontend invoked it **unwrapped** (`MemoryFederationPage.tsx`):
  ```ts
  invoke("get_federation_reports", { since, limit: 200 })
  ```

Tauri rejects the call before any HTTP request. The catch block then prefixed the raw Tauri error with `"Failed to fetch from coord:"`, blaming coord for a client-side bug.

## Fix

1. Wrap the payload under `args` to match the command signature.
2. Label genuine IPC-contract rejections (`invalid args` / `missing required key`) distinctly instead of attributing them to coord.

## Impact

- Historical federation reports now load on the page.
- This also restores visibility of `failed_names` in the detail rows, which is what you need to diagnose a "N failed" reconcile (the failing memory-file name is captured server-side but was never rendered because this fetch always errored).

## Test

Single-line payload-shape fix + error-branch label; verified the Rust command signature requires the `args` wrapper. CI typecheck/build covers the TS change.