### PR TITLE
feat(code-graph): Ξ_Layering advisory architecture-drift observer (Phase 4a)

### DIFF
--- a/src-tauri/src/mcp/code_semantics/arch_classify.rs
+++ b/src-tauri/src/mcp/code_semantics/arch_classify.rs
@@ -1,0 +1,213 @@
+//! Shared `{module → architectural-layer}` classify path for the stochastic-kernel
+//! observers.
+//!
+//! Extracted from `Ξ_Arch` (`arch_observer.rs`) so it has an in-process seam: both
+//! `Ξ_Arch` (which renders the labels into its own advisory envelope) and
+//! `Ξ_Layering` (which uses the labels to evaluate the layering-allowed-edge
+//! relation Φ over the resolved dependency digraph) call [`classify_layers`].
+//!
+//! This is the LLM-coupled classify step only — prompt build, the forced-CLI call,
+//! and the tolerant parse. It is observer-agnostic about envelopes: it returns the
+//! raw [`LayerAssignment`]s and lets each observer assemble its own kernel envelope.
+//! On any model failure it returns an empty vec (the honest "I couldn't read it"
+//! signal — every caller maps that to coverage 0, never a confident false answer).
+
+use serde_json::Value;
+
+use super::module_graph::{self, ModuleSummary};
+
+/// The architectural-layer taxonomy (UA's architecture-analyzer set + `unknown`).
+pub(super) const LAYERS: &[&str] = &["api", "service", "data", "ui", "utility", "unknown"];
+
+/// One module's layer assignment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct LayerAssignment {
+    pub(super) module: String,
+    pub(super) layer: String,
+    pub(super) rationale: String,
+}
+
+/// Classify each module into an architectural layer via the forced Claude-CLI path.
+///
+/// `build_prompt` → [`module_graph::run_cli_structured`] → [`parse_layers`]. Returns
+/// an empty vec on model failure (honest degrade → the caller maps that to coverage
+/// 0). The model sees only the rendered module structure, never raw source.
+pub(super) async fn classify_layers(modules: &[ModuleSummary]) -> Vec<LayerAssignment> {
+    let prompt = build_prompt(modules);
+    match module_graph::run_cli_structured(prompt).await {
+        Some(output) => parse_layers(&output),
+        None => Vec::new(),
+    }
+}
+
+// ===========================================================================
+// Prompt construction (pure)
+// ===========================================================================
+
+/// Build the classification prompt: the arch-layer instruction header + the
+/// shared module-list block. The model sees only structure (no source) and must
+/// return strict JSON.
+fn build_prompt(modules: &[ModuleSummary]) -> String {
+    let mut s = String::from(
+        "You are classifying the ARCHITECTURAL LAYER of each MODULE in a codebase.\n\
+         A module is a directory. For each module you are given its files, its exported\n\
+         symbols, the other in-repo modules it imports from, and the external packages\n\
+         it uses. You do NOT see source code — classify from this structure alone.\n\n\
+         Assign each module EXACTLY ONE layer from this taxonomy:\n\
+         - api: HTTP/RPC route handlers, controllers, transport/request-response edges.\n\
+         - service: business logic, orchestration, use-cases, domain operations.\n\
+         - data: persistence, models, repositories, DB/ORM/migrations, schema.\n\
+         - ui: user-interface components, views, widgets, frontend rendering.\n\
+         - utility: cross-cutting helpers, shared types, config, logging, pure utils.\n\
+         - unknown: the structure is insufficient to decide.\n\n\
+         Return ONLY a JSON object, no prose, no code fences:\n\
+         {\"modules\":[{\"module\":\"<exact module key>\",\"layer\":\"<taxonomy value>\",\"rationale\":\"<=12 words\"}]}\n\n\
+         Modules:\n",
+    );
+    s.push_str(&module_graph::render_modules(modules));
+    s
+}
+
+// ===========================================================================
+// Response parsing (pure, tolerant)
+// ===========================================================================
+
+/// Parse `{"modules":[{module,layer,rationale}]}` (or a bare array) out of the
+/// model's output, tolerant of surrounding prose / ```json fences. An unknown or
+/// missing layer normalizes to `"unknown"`; entries without a `module` are
+/// dropped. Returns an empty vec on any failure (the honest "I couldn't read it"
+/// signal — the caller maps that to coverage 0, never a confident false answer).
+fn parse_layers(output: &str) -> Vec<LayerAssignment> {
+    let json_str = match module_graph::extract_json(output) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let value: Value = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    // Accept either `{"modules":[...]}` or a bare `[...]`.
+    let arr = match &value {
+        Value::Object(map) => map.get("modules").and_then(|v| v.as_array()).cloned(),
+        Value::Array(a) => Some(a.clone()),
+        _ => None,
+    };
+    let arr = match arr {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for entry in arr {
+        let module = entry
+            .get("module")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string());
+        let module = match module {
+            Some(m) if !m.is_empty() => m,
+            _ => continue,
+        };
+        let layer = entry
+            .get("layer")
+            .and_then(|v| v.as_str())
+            .map(normalize_layer)
+            .unwrap_or_else(|| "unknown".to_string());
+        let rationale = entry
+            .get("rationale")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        out.push(LayerAssignment {
+            module,
+            layer,
+            rationale,
+        });
+    }
+    out
+}
+
+/// Normalize a model-supplied layer string to the taxonomy; anything off-taxonomy
+/// (or empty) becomes `"unknown"` rather than leaking an invented label.
+fn normalize_layer(raw: &str) -> String {
+    let l = raw.trim().to_lowercase();
+    if LAYERS.contains(&l.as_str()) {
+        l
+    } else {
+        "unknown".to_string()
+    }
+}
+
+// ===========================================================================
+// Tests (pure — no LLM call)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_contains_modules_taxonomy_and_json_instruction() {
+        let mods = vec![ModuleSummary {
+            module: "src/api".into(),
+            files: vec!["routes.ts".into()],
+            exports: vec!["registerRoutes".into()],
+            internal_deps: vec!["src/services".into()],
+            external_pkgs: vec!["express".into()],
+            export_count: 1,
+        }];
+        let p = build_prompt(&mods);
+        assert!(p.contains("src/api"));
+        assert!(p.contains("registerRoutes"));
+        assert!(p.contains("imports-from: src/services"));
+        assert!(p.contains("external: express"));
+        // taxonomy + strict-JSON instruction present
+        assert!(p.contains("service:"));
+        assert!(p.contains("\"modules\""));
+    }
+
+    #[test]
+    fn parse_clean_json_object() {
+        let out = r#"{"modules":[{"module":"src/api","layer":"api","rationale":"route handlers"},{"module":"src/db","layer":"data","rationale":"models"}]}"#;
+        let parsed = parse_layers(out);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].module, "src/api");
+        assert_eq!(parsed[0].layer, "api");
+        assert_eq!(parsed[1].layer, "data");
+    }
+
+    #[test]
+    fn parse_tolerates_prose_and_code_fences() {
+        let out = "Sure — here is the classification:\n```json\n{\"modules\":[{\"module\":\"src/ui\",\"layer\":\"UI\",\"rationale\":\"views\"}]}\n```\nLet me know if you need more.";
+        let parsed = parse_layers(out);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].module, "src/ui");
+        // layer is normalized to lowercase taxonomy.
+        assert_eq!(parsed[0].layer, "ui");
+    }
+
+    #[test]
+    fn parse_normalizes_offtaxonomy_layer_to_unknown() {
+        let out = r#"{"modules":[{"module":"src/x","layer":"controller","rationale":"?"}]}"#;
+        let parsed = parse_layers(out);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].layer, "unknown");
+    }
+
+    #[test]
+    fn parse_accepts_bare_array_and_drops_module_less_entries() {
+        let out = r#"[{"module":"src/a","layer":"service"},{"layer":"data"}]"#;
+        let parsed = parse_layers(out);
+        assert_eq!(parsed.len(), 1, "entry without a module is dropped");
+        assert_eq!(parsed[0].module, "src/a");
+        // missing rationale defaults to empty.
+        assert_eq!(parsed[0].rationale, "");
+    }
+
+    #[test]
+    fn parse_garbage_returns_empty() {
+        assert!(parse_layers("I cannot help with that.").is_empty());
+        assert!(parse_layers("").is_empty());
+        assert!(parse_layers("{not json").is_empty());
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/arch_observer.rs
+++ b/src-tauri/src/mcp/code_semantics/arch_observer.rs
@@ -35,12 +35,10 @@ use once_cell::sync::Lazy;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use super::arch_classify::{self, LayerAssignment, LAYERS};
 use super::module_graph::{self, ModuleSummary};
 use super::{code_graph_api, scope_project_dir, Envelope};
 use crate::mcp::types::ApiState;
-
-/// The architectural-layer taxonomy (UA's architecture-analyzer set + `unknown`).
-const LAYERS: &[&str] = &["api", "service", "data", "ui", "utility", "unknown"];
 
 /// Observer name + provenance for the kernel envelope.
 const OBSERVER: &str = "arch";
@@ -103,123 +101,14 @@ async fn arch_layers(
     // Cap to the highest-signal modules (most exports first); coverage reflects
     // anything omitted.
     let capped: Vec<ModuleSummary> = summaries.into_iter().take(max_modules).collect();
-    let prompt = build_prompt(&capped);
 
-    // The single LLM call (forced Claude-CLI, no API key); honest degrade on
-    // failure → zero classified (coverage 0), never a confident false answer.
-    let parsed = match module_graph::run_cli_structured(prompt).await {
-        Some(output) => parse_layers(&output),
-        None => Vec::new(),
-    };
+    // The single LLM call (forced Claude-CLI, no API key) lives behind the shared
+    // classify seam; honest degrade on failure → zero classified (coverage 0),
+    // never a confident false answer.
+    let parsed = arch_classify::classify_layers(&capped).await;
 
     cache_put(fingerprint, parsed.clone());
     Json(make_envelope(q, &scope.key, &parsed, total_modules, false))
-}
-
-// ===========================================================================
-// Prompt construction (pure)
-// ===========================================================================
-
-/// Build the classification prompt: the arch-layer instruction header + the
-/// shared module-list block. The model sees only structure (no source) and must
-/// return strict JSON.
-fn build_prompt(modules: &[ModuleSummary]) -> String {
-    let mut s = String::from(
-        "You are classifying the ARCHITECTURAL LAYER of each MODULE in a codebase.\n\
-         A module is a directory. For each module you are given its files, its exported\n\
-         symbols, the other in-repo modules it imports from, and the external packages\n\
-         it uses. You do NOT see source code — classify from this structure alone.\n\n\
-         Assign each module EXACTLY ONE layer from this taxonomy:\n\
-         - api: HTTP/RPC route handlers, controllers, transport/request-response edges.\n\
-         - service: business logic, orchestration, use-cases, domain operations.\n\
-         - data: persistence, models, repositories, DB/ORM/migrations, schema.\n\
-         - ui: user-interface components, views, widgets, frontend rendering.\n\
-         - utility: cross-cutting helpers, shared types, config, logging, pure utils.\n\
-         - unknown: the structure is insufficient to decide.\n\n\
-         Return ONLY a JSON object, no prose, no code fences:\n\
-         {\"modules\":[{\"module\":\"<exact module key>\",\"layer\":\"<taxonomy value>\",\"rationale\":\"<=12 words\"}]}\n\n\
-         Modules:\n",
-    );
-    s.push_str(&module_graph::render_modules(modules));
-    s
-}
-
-// ===========================================================================
-// Response parsing (pure, tolerant)
-// ===========================================================================
-
-/// One module's layer assignment.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct LayerAssignment {
-    module: String,
-    layer: String,
-    rationale: String,
-}
-
-/// Parse `{"modules":[{module,layer,rationale}]}` (or a bare array) out of the
-/// model's output, tolerant of surrounding prose / ```json fences. An unknown or
-/// missing layer normalizes to `"unknown"`; entries without a `module` are
-/// dropped. Returns an empty vec on any failure (the honest "I couldn't read it"
-/// signal — the caller maps that to coverage 0, never a confident false answer).
-fn parse_layers(output: &str) -> Vec<LayerAssignment> {
-    let json_str = match module_graph::extract_json(output) {
-        Some(s) => s,
-        None => return Vec::new(),
-    };
-    let value: Value = match serde_json::from_str(json_str) {
-        Ok(v) => v,
-        Err(_) => return Vec::new(),
-    };
-    // Accept either `{"modules":[...]}` or a bare `[...]`.
-    let arr = match &value {
-        Value::Object(map) => map.get("modules").and_then(|v| v.as_array()).cloned(),
-        Value::Array(a) => Some(a.clone()),
-        _ => None,
-    };
-    let arr = match arr {
-        Some(a) => a,
-        None => return Vec::new(),
-    };
-
-    let mut out = Vec::new();
-    for entry in arr {
-        let module = entry
-            .get("module")
-            .and_then(|v| v.as_str())
-            .map(|s| s.trim().to_string());
-        let module = match module {
-            Some(m) if !m.is_empty() => m,
-            _ => continue,
-        };
-        let layer = entry
-            .get("layer")
-            .and_then(|v| v.as_str())
-            .map(normalize_layer)
-            .unwrap_or_else(|| "unknown".to_string());
-        let rationale = entry
-            .get("rationale")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-        out.push(LayerAssignment {
-            module,
-            layer,
-            rationale,
-        });
-    }
-    out
-}
-
-/// Normalize a model-supplied layer string to the taxonomy; anything off-taxonomy
-/// (or empty) becomes `"unknown"` rather than leaking an invented label.
-fn normalize_layer(raw: &str) -> String {
-    let l = raw.trim().to_lowercase();
-    if LAYERS.contains(&l.as_str()) {
-        l
-    } else {
-        "unknown".to_string()
-    }
 }
 
 // ===========================================================================
@@ -317,71 +206,6 @@ fn cache_put(fp: u64, assignments: Vec<LayerAssignment>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn prompt_contains_modules_taxonomy_and_json_instruction() {
-        let mods = vec![ModuleSummary {
-            module: "src/api".into(),
-            files: vec!["routes.ts".into()],
-            exports: vec!["registerRoutes".into()],
-            internal_deps: vec!["src/services".into()],
-            external_pkgs: vec!["express".into()],
-            export_count: 1,
-        }];
-        let p = build_prompt(&mods);
-        assert!(p.contains("src/api"));
-        assert!(p.contains("registerRoutes"));
-        assert!(p.contains("imports-from: src/services"));
-        assert!(p.contains("external: express"));
-        // taxonomy + strict-JSON instruction present
-        assert!(p.contains("service:"));
-        assert!(p.contains("\"modules\""));
-    }
-
-    #[test]
-    fn parse_clean_json_object() {
-        let out = r#"{"modules":[{"module":"src/api","layer":"api","rationale":"route handlers"},{"module":"src/db","layer":"data","rationale":"models"}]}"#;
-        let parsed = parse_layers(out);
-        assert_eq!(parsed.len(), 2);
-        assert_eq!(parsed[0].module, "src/api");
-        assert_eq!(parsed[0].layer, "api");
-        assert_eq!(parsed[1].layer, "data");
-    }
-
-    #[test]
-    fn parse_tolerates_prose_and_code_fences() {
-        let out = "Sure — here is the classification:\n```json\n{\"modules\":[{\"module\":\"src/ui\",\"layer\":\"UI\",\"rationale\":\"views\"}]}\n```\nLet me know if you need more.";
-        let parsed = parse_layers(out);
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].module, "src/ui");
-        // layer is normalized to lowercase taxonomy.
-        assert_eq!(parsed[0].layer, "ui");
-    }
-
-    #[test]
-    fn parse_normalizes_offtaxonomy_layer_to_unknown() {
-        let out = r#"{"modules":[{"module":"src/x","layer":"controller","rationale":"?"}]}"#;
-        let parsed = parse_layers(out);
-        assert_eq!(parsed.len(), 1);
-        assert_eq!(parsed[0].layer, "unknown");
-    }
-
-    #[test]
-    fn parse_accepts_bare_array_and_drops_module_less_entries() {
-        let out = r#"[{"module":"src/a","layer":"service"},{"layer":"data"}]"#;
-        let parsed = parse_layers(out);
-        assert_eq!(parsed.len(), 1, "entry without a module is dropped");
-        assert_eq!(parsed[0].module, "src/a");
-        // missing rationale defaults to empty.
-        assert_eq!(parsed[0].rationale, "");
-    }
-
-    #[test]
-    fn parse_garbage_returns_empty() {
-        assert!(parse_layers("I cannot help with that.").is_empty());
-        assert!(parse_layers("").is_empty());
-        assert!(parse_layers("{not json").is_empty());
-    }
 
     #[test]
     fn assemble_coverage_and_kernel_discipline() {

--- a/src-tauri/src/mcp/code_semantics/layer_observer.rs
+++ b/src-tauri/src/mcp/code_semantics/layer_observer.rs
@@ -1,0 +1,760 @@
+//! `Ξ_Layering` — architecture-drift advisory observer (Phase 4a / Pillar 3 of the
+//! twin-ast plan).
+//!
+//! Where `Ξ_Arch` *labels* each module with an architectural layer, `Ξ_Layering`
+//! takes those labels and evaluates the **layering-allowed-edge relation Φ** over
+//! the repo's resolved cross-module dependency digraph: it flags **layer breaches**
+//! (an edge that violates the allowed direction, e.g. `ui → data` skipping the
+//! service layer) and **layer cycles** (a strongly-connected component spanning ≥2
+//! distinct layers). The module labels come from the shared
+//! [`super::arch_classify::classify_layers`] seam (the same forced Claude-CLI path
+//! as `Ξ_Arch`); the edge set comes from the deterministic resolver
+//! ([`super::module_graph::cross_module_edges`], UNCAPPED — it must NOT use the
+//! prompt-budget-capped `internal_deps`).
+//!
+//! **Advisory, never gate-worthy** — like its siblings the envelope is always
+//! `kernel:true`, `posterior<1`, `credibility=(causal:medium, authorial:low,
+//! boundary:low)`. There is NO permit/deny/decision/gate code path in this file:
+//! the labels are a model hint, so a "breach" is a drift *signal*, never a verdict.
+//! coord receives the kernel envelope and a top-level `drift_class` wire token
+//! (`none` / `in_place` / `divergent` / `unknown`) and decides what (if anything)
+//! to do with it.
+//!
+//! **Coverage is honest about unknowns.** An edge whose endpoint has no label (the
+//! module wasn't classified / was capped out) or a label of `"unknown"` is *carved
+//! out* — never counted as a breach, but it lowers coverage. A `"utility"` endpoint
+//! (import-by-anyone) is also carved (clean, and counts as judged). `coverage` =
+//! judged edges / total edges; `posterior` is the uncalibrated kernel hint, or 0
+//! when nothing was judged.
+//!
+//! Route: `POST /code-graph/layer-drift` — `{scope?, max_modules?}`.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::sync::{Arc, Mutex};
+
+use axum::{extract::State, routing::post, Json, Router};
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::module_graph::{self, ModuleSummary};
+use super::{arch_classify, code_graph_api, scope_project_dir, Envelope};
+use crate::mcp::types::ApiState;
+
+/// Observer name + provenance for the kernel envelope.
+const OBSERVER: &str = "layer";
+const PROVENANCE: &str = super::PROV_KERNEL_LAYER;
+
+/// The structural layers Φ reasons over. `utility` and `unknown` are deliberately
+/// NOT here — they're handled by the carve-out, not the allowed-edge relation.
+const STRUCTURAL_LAYERS: &[&str] = &["ui", "api", "service", "data"];
+
+// ===========================================================================
+// Request / route
+// ===========================================================================
+
+#[derive(Debug, Deserialize, Default)]
+pub struct LayerDriftReq {
+    /// Optional `(repo,language)` scope selector — a repo name/slug (cross-repo
+    /// `Ξ_AST`), a project dir, or a tsconfig path.
+    pub scope: Option<String>,
+    /// Cap on modules classified for layer labels in one pass (default
+    /// [`module_graph::DEFAULT_MAX_MODULES`], clamped to 1..=200). The Φ edge set is
+    /// always the UNCAPPED digraph; the cap only bounds the label prompt.
+    pub max_modules: Option<usize>,
+}
+
+/// Routes contributed alongside the `/code-graph/*` surface.
+pub fn routes() -> Router<Arc<ApiState>> {
+    Router::new().route("/code-graph/layer-drift", post(layer_drift))
+}
+
+/// POST /code-graph/layer-drift → kernel envelope of layer-drift findings.
+async fn layer_drift(
+    State(_state): State<Arc<ApiState>>,
+    Json(req): Json<LayerDriftReq>,
+) -> Json<Envelope> {
+    let q = "layer_drift";
+
+    let scope = match code_graph_api::resolve_project_scope(req.scope.as_deref(), None) {
+        Some(s) => s,
+        None => return Json(cold_envelope(q, "", "no resolvable scope (cold)")),
+    };
+    let project_dir = scope_project_dir(&scope);
+    let max_modules = req
+        .max_modules
+        .unwrap_or(module_graph::DEFAULT_MAX_MODULES)
+        .clamp(1, 200);
+
+    // Build the resolved graph ONCE → summaries (for labels), total, fingerprint,
+    // and the UNCAPPED cross-module edge set (for Φ + cycles).
+    let (summaries, total_modules, fingerprint, edges) =
+        match module_graph::build_layer_inputs(project_dir).await {
+            Some(t) => t,
+            None => return Json(cold_envelope(q, &scope.key, "graph build failed")),
+        };
+
+    // A cold graph (no modules or no cross-module edges) → honest "unknown", never a
+    // false "no breaches" assertion.
+    if total_modules == 0 || edges.is_empty() {
+        return Json(cold_envelope(
+            q,
+            &scope.key,
+            "empty / cold graph (no cross-module edges)",
+        ));
+    }
+
+    // Fingerprint cache: a prior identical graph already evaluated → free.
+    if let Some(cached) = cache_get(fingerprint) {
+        return Json(make_envelope(q, &scope.key, &edges, &cached, true));
+    }
+
+    // Cap to the highest-signal modules for the LABEL prompt only; the Φ edge set
+    // above stays uncapped. Get module→layer labels via the shared classify seam.
+    let capped: Vec<ModuleSummary> = summaries.into_iter().take(max_modules).collect();
+    let assignments = arch_classify::classify_layers(&capped).await;
+    let layer_of: HashMap<String, String> = assignments
+        .iter()
+        .map(|a| (a.module.clone(), a.layer.clone()))
+        .collect();
+
+    cache_put(fingerprint, layer_of.clone());
+    Json(make_envelope(q, &scope.key, &edges, &layer_of, false))
+}
+
+// ===========================================================================
+// Φ — the layering-allowed-edge relation (pure)
+// ===========================================================================
+
+/// The allowed-edge relation over the STRUCTURAL layers (`ui/api/service/data`).
+///
+/// An edge `a → b` is allowed iff it is intra-layer (`a == b`) or a sanctioned
+/// downward dependency. `utility`/`unknown` endpoints are NOT decided here — the
+/// caller's carve-out handles them before Φ is consulted.
+fn is_allowed(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    const ALLOWED_CORE: &[(&str, &str)] = &[
+        ("ui", "api"),
+        ("ui", "service"),
+        ("api", "service"),
+        ("service", "data"),
+    ];
+    ALLOWED_CORE.contains(&(a, b))
+}
+
+/// Is this a structural layer Φ reasons over (`ui/api/service/data`)?
+fn is_structural(layer: &str) -> bool {
+    STRUCTURAL_LAYERS.contains(&layer)
+}
+
+/// Classification of a single edge under Φ + the carve-out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EdgeVerdict {
+    /// Both endpoints structural + allowed (intra-layer or sanctioned downward).
+    Clean,
+    /// An endpoint is `utility` (import-by-anyone) — judged, clean, never a breach.
+    CarvedUtility,
+    /// An endpoint is unlabelled or `"unknown"` — NOT judged (lowers coverage).
+    CarvedUnknown,
+    /// Both endpoints structural, edge violates Φ — a layer breach.
+    Breach {
+        from_layer: String,
+        to_layer: String,
+    },
+}
+
+/// Evaluate one edge `(from, to)` under Φ + the carve-out, given the labels.
+fn classify_edge(from: &str, to: &str, layer_of: &HashMap<String, String>) -> EdgeVerdict {
+    let la = layer_of.get(from).map(|s| s.as_str());
+    let lb = layer_of.get(to).map(|s| s.as_str());
+
+    // Unlabelled or explicit "unknown" → carved as unknown (lowers coverage,
+    // never a breach).
+    let la = match la {
+        Some(l) if l != "unknown" => l,
+        _ => return EdgeVerdict::CarvedUnknown,
+    };
+    let lb = match lb {
+        Some(l) if l != "unknown" => l,
+        _ => return EdgeVerdict::CarvedUnknown,
+    };
+
+    // Utility (import-by-anyone) → carved clean, counts as judged.
+    if la == "utility" || lb == "utility" {
+        return EdgeVerdict::CarvedUtility;
+    }
+
+    // Both structural → apply Φ.
+    if is_allowed(la, lb) {
+        EdgeVerdict::Clean
+    } else {
+        EdgeVerdict::Breach {
+            from_layer: la.to_string(),
+            to_layer: lb.to_string(),
+        }
+    }
+}
+
+/// A layer breach: a single dependency edge that violates Φ.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Breach {
+    from: String,
+    to: String,
+    from_layer: String,
+    to_layer: String,
+}
+
+/// The outcome of running Φ over every edge: the breaches, the count of judged
+/// edges (both endpoints structural-or-utility, i.e. not carved-unknown), and the
+/// count of utility/unknown carve-outs.
+struct PhiResult {
+    breaches: Vec<Breach>,
+    judged_edges: usize,
+    carved_utility_or_unknown: usize,
+}
+
+/// Run Φ over the full (uncapped) edge set. Pure — feed it a fixture edge set + a
+/// stub `layer_of` and it is fully testable without the model.
+fn evaluate_phi(
+    edges: &BTreeSet<(String, String)>,
+    layer_of: &HashMap<String, String>,
+) -> PhiResult {
+    let mut breaches = Vec::new();
+    let mut judged = 0usize;
+    let mut carved = 0usize;
+    for (from, to) in edges {
+        match classify_edge(from, to, layer_of) {
+            EdgeVerdict::Clean => judged += 1,
+            EdgeVerdict::CarvedUtility => {
+                judged += 1;
+                carved += 1;
+            }
+            EdgeVerdict::CarvedUnknown => carved += 1,
+            EdgeVerdict::Breach {
+                from_layer,
+                to_layer,
+            } => {
+                judged += 1;
+                breaches.push(Breach {
+                    from: from.clone(),
+                    to: to.clone(),
+                    from_layer,
+                    to_layer,
+                });
+            }
+        }
+    }
+    breaches.sort_by(|x, y| x.from.cmp(&y.from).then_with(|| x.to.cmp(&y.to)));
+    PhiResult {
+        breaches,
+        judged_edges: judged,
+        carved_utility_or_unknown: carved,
+    }
+}
+
+// ===========================================================================
+// Cycle detection — Tarjan SCC over the full digraph (pure)
+// ===========================================================================
+
+/// A cross-layer dependency cycle: a strongly-connected component (>1 member) that
+/// spans ≥2 distinct STRUCTURAL layers (per the labels, ignoring utility/unknown
+/// members). A same-layer or utility/unknown-only SCC is informational, not a
+/// breach, so it is excluded here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LayerCycle {
+    members: Vec<String>,
+}
+
+/// Tarjan SCC state over an integer-indexed adjacency list. Bundling the working
+/// state in a struct keeps the recursive `strongconnect` a 1-arg method (no
+/// `clippy::too_many_arguments`) and the borrows local.
+struct Tarjan<'a> {
+    adj: &'a [Vec<usize>],
+    index: Vec<Option<usize>>,
+    lowlink: Vec<usize>,
+    on_stack: Vec<bool>,
+    stack: Vec<usize>,
+    next_index: usize,
+    sccs: Vec<Vec<usize>>,
+}
+
+impl<'a> Tarjan<'a> {
+    fn new(adj: &'a [Vec<usize>]) -> Self {
+        let n = adj.len();
+        Tarjan {
+            adj,
+            index: vec![None; n],
+            lowlink: vec![0; n],
+            on_stack: vec![false; n],
+            stack: Vec::new(),
+            next_index: 0,
+            sccs: Vec::new(),
+        }
+    }
+
+    /// Compute all SCCs and consume the state.
+    fn run(mut self) -> Vec<Vec<usize>> {
+        for v in 0..self.adj.len() {
+            if self.index[v].is_none() {
+                self.strongconnect(v);
+            }
+        }
+        self.sccs
+    }
+
+    fn strongconnect(&mut self, v: usize) {
+        self.index[v] = Some(self.next_index);
+        self.lowlink[v] = self.next_index;
+        self.next_index += 1;
+        self.stack.push(v);
+        self.on_stack[v] = true;
+
+        for i in 0..self.adj[v].len() {
+            let w = self.adj[v][i];
+            match self.index[w] {
+                None => {
+                    self.strongconnect(w);
+                    self.lowlink[v] = self.lowlink[v].min(self.lowlink[w]);
+                }
+                Some(w_idx) => {
+                    if self.on_stack[w] {
+                        self.lowlink[v] = self.lowlink[v].min(w_idx);
+                    }
+                }
+            }
+        }
+
+        if self.index[v] == Some(self.lowlink[v]) {
+            let mut component = Vec::new();
+            loop {
+                let w = self.stack.pop().unwrap();
+                self.on_stack[w] = false;
+                component.push(w);
+                if w == v {
+                    break;
+                }
+            }
+            self.sccs.push(component);
+        }
+    }
+}
+
+/// Find cross-layer cycles via Tarjan's SCC over the full edge digraph. Recursion is
+/// bounded by the module count (well within stack limits for any real repo). Pure —
+/// testable from a fixture edge set + stub labels.
+fn find_layer_cycles(
+    edges: &BTreeSet<(String, String)>,
+    layer_of: &HashMap<String, String>,
+) -> Vec<LayerCycle> {
+    // Stable, deterministic node indexing (BTreeSet → sorted node order).
+    let mut node_set: BTreeSet<&str> = BTreeSet::new();
+    for (from, to) in edges {
+        node_set.insert(from.as_str());
+        node_set.insert(to.as_str());
+    }
+    let nodes: Vec<&str> = node_set.into_iter().collect();
+    let index_of: HashMap<&str, usize> = nodes.iter().enumerate().map(|(i, n)| (*n, i)).collect();
+
+    // Integer-indexed adjacency list.
+    let mut adj: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
+    for (from, to) in edges {
+        adj[index_of[from.as_str()]].push(index_of[to.as_str()]);
+    }
+
+    let sccs = Tarjan::new(&adj).run();
+
+    // Keep only multi-member SCCs that span ≥2 distinct structural layers.
+    let mut cycles = Vec::new();
+    for comp in sccs {
+        if comp.len() < 2 {
+            continue;
+        }
+        let mut members: Vec<String> = comp.iter().map(|&i| nodes[i].to_string()).collect();
+        let distinct_structural: BTreeSet<&str> = members
+            .iter()
+            .filter_map(|m| layer_of.get(m).map(|s| s.as_str()))
+            .filter(|&l| is_structural(l))
+            .collect();
+        if distinct_structural.len() >= 2 {
+            members.sort();
+            cycles.push(LayerCycle { members });
+        }
+    }
+    cycles.sort_by(|a, b| a.members.cmp(&b.members));
+    cycles
+}
+
+// ===========================================================================
+// Envelope assembly (pure)
+// ===========================================================================
+
+/// The coord wire token for the top-level `drift_class`, by precedence: any cycle
+/// → `divergent`; else any breach → `in_place`; else any unjudged edge → `unknown`;
+/// else → `none`.
+fn drift_class(
+    breaches: usize,
+    cycles: usize,
+    judged_edges: usize,
+    total_edges: usize,
+) -> &'static str {
+    if cycles > 0 {
+        "divergent"
+    } else if breaches > 0 {
+        "in_place"
+    } else if judged_edges < total_edges {
+        "unknown"
+    } else {
+        "none"
+    }
+}
+
+/// Build the result body + coverage/posterior from the (uncapped) edge set + labels.
+/// Pure — the tests drive this directly with fixture edges + a stub `layer_of`.
+fn assemble(
+    scope_key: &str,
+    edges: &BTreeSet<(String, String)>,
+    layer_of: &HashMap<String, String>,
+    cached: bool,
+) -> (Value, f64, f64) {
+    let total_edges = edges.len();
+    let phi = evaluate_phi(edges, layer_of);
+    let cycles = find_layer_cycles(edges, layer_of);
+    let judged_edges = phi.judged_edges;
+
+    let coverage = if total_edges == 0 {
+        0.0
+    } else {
+        (judged_edges as f64 / total_edges as f64).min(1.0)
+    };
+    let posterior = if judged_edges == 0 {
+        0.0
+    } else {
+        module_graph::KERNEL_POSTERIOR
+    };
+
+    let breaches_json: Vec<Value> = phi
+        .breaches
+        .iter()
+        .map(|b| {
+            json!({
+                "from": b.from,
+                "to": b.to,
+                "from_layer": b.from_layer,
+                "to_layer": b.to_layer,
+                "class": "arch:layer_breach",
+            })
+        })
+        .collect();
+    let cycles_json: Vec<Value> = cycles
+        .iter()
+        .map(|c| json!({ "members": c.members, "class": "arch:layer_cycle" }))
+        .collect();
+
+    // The layer map only carries known (label-present) modules touched by the graph.
+    let layer_map: BTreeMap<&str, &str> = layer_of
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+
+    let cls = drift_class(phi.breaches.len(), cycles.len(), judged_edges, total_edges);
+
+    let result = json!({
+        "scope": scope_key,
+        "drift_class": cls,
+        "breaches": breaches_json,
+        "cycles": cycles_json,
+        "layer_map": layer_map,
+        "carve_out": {
+            "utility_or_unknown_edges": phi.carved_utility_or_unknown,
+            "note": "edges with a utility endpoint (import-by-anyone) or an unlabelled/unknown endpoint are carved out — never a breach; unknown-endpoint edges lower coverage",
+        },
+        "total_edges": total_edges,
+        "judged_edges": judged_edges,
+        "cached": cached,
+    });
+    (result, posterior, coverage)
+}
+
+fn make_envelope(
+    query: &str,
+    scope_key: &str,
+    edges: &BTreeSet<(String, String)>,
+    layer_of: &HashMap<String, String>,
+    cached: bool,
+) -> Envelope {
+    let (result, posterior, coverage) = assemble(scope_key, edges, layer_of, cached);
+    Envelope::kernel(query, OBSERVER, PROVENANCE, result, posterior, coverage)
+}
+
+/// An honest cold/degraded envelope: kernel, coverage 0, posterior 0, never a false
+/// "no breaches" assertion. A cold graph is `drift_class:"unknown"`, NOT `"none"`.
+fn cold_envelope(query: &str, scope_key: &str, reason: &str) -> Envelope {
+    Envelope::kernel(
+        query,
+        OBSERVER,
+        PROVENANCE,
+        json!({
+            "scope": scope_key,
+            "drift_class": "unknown",
+            "breaches": [],
+            "cycles": [],
+            "layer_map": {},
+            "carve_out": { "utility_or_unknown_edges": 0, "note": "cold graph — no edges judged" },
+            "total_edges": 0,
+            "judged_edges": 0,
+            "reason": reason,
+        }),
+        0.0,
+        0.0,
+    )
+}
+
+// ===========================================================================
+// Process-local fingerprint cache
+// ===========================================================================
+
+static CACHE: Lazy<Mutex<BTreeMap<u64, HashMap<String, String>>>> =
+    Lazy::new(|| Mutex::new(BTreeMap::new()));
+
+fn cache_get(fp: u64) -> Option<HashMap<String, String>> {
+    CACHE.lock().ok().and_then(|m| m.get(&fp).cloned())
+}
+
+fn cache_put(fp: u64, layer_of: HashMap<String, String>) {
+    // Don't cache an empty (failed) classification — let the next call retry.
+    if layer_of.is_empty() {
+        return;
+    }
+    if let Ok(mut m) = CACHE.lock() {
+        m.insert(fp, layer_of);
+    }
+}
+
+// ===========================================================================
+// Tests (pure — no LLM call; fixture edges + stub layer_of maps)
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn edges(pairs: &[(&str, &str)]) -> BTreeSet<(String, String)> {
+        pairs
+            .iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect()
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(m, l)| (m.to_string(), l.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn is_allowed_relation() {
+        // intra-layer always allowed.
+        assert!(is_allowed("service", "service"));
+        // sanctioned downward.
+        assert!(is_allowed("ui", "api"));
+        assert!(is_allowed("ui", "service"));
+        assert!(is_allowed("api", "service"));
+        assert!(is_allowed("service", "data"));
+        // skipping / upward NOT allowed.
+        assert!(!is_allowed("ui", "data"));
+        assert!(!is_allowed("data", "service"));
+        assert!(!is_allowed("api", "ui"));
+    }
+
+    // 1. ui→data (skip) = breach / in_place; ui→api→service→data chain = clean / none.
+    #[test]
+    fn skip_layer_is_breach_and_downward_chain_is_clean() {
+        let layer_of = labels(&[
+            ("m_ui", "ui"),
+            ("m_api", "api"),
+            ("m_svc", "service"),
+            ("m_data", "data"),
+        ]);
+
+        let breach_edges = edges(&[("m_ui", "m_data")]);
+        let (result, _p, _c) = assemble("s", &breach_edges, &layer_of, false);
+        assert_eq!(result["drift_class"], json!("in_place"));
+        assert_eq!(result["breaches"].as_array().unwrap().len(), 1);
+        assert_eq!(result["breaches"][0]["class"], json!("arch:layer_breach"));
+        assert_eq!(result["breaches"][0]["from_layer"], json!("ui"));
+        assert_eq!(result["breaches"][0]["to_layer"], json!("data"));
+
+        let chain = edges(&[("m_ui", "m_api"), ("m_api", "m_svc"), ("m_svc", "m_data")]);
+        let (result, _p, coverage) = assemble("s", &chain, &layer_of, false);
+        assert_eq!(result["drift_class"], json!("none"));
+        assert!(result["breaches"].as_array().unwrap().is_empty());
+        assert_eq!(result["judged_edges"], json!(3));
+        assert!(
+            (coverage - 1.0).abs() < 1e-9,
+            "all edges judged → coverage 1"
+        );
+    }
+
+    // 2. data→service (upward) = breach; service→data (downward) = clean.
+    #[test]
+    fn upward_is_breach_downward_is_clean() {
+        let layer_of = labels(&[("m_svc", "service"), ("m_data", "data")]);
+
+        let up = edges(&[("m_data", "m_svc")]);
+        let (result, _p, _c) = assemble("s", &up, &layer_of, false);
+        assert_eq!(result["drift_class"], json!("in_place"));
+        assert_eq!(result["breaches"].as_array().unwrap().len(), 1);
+
+        let down = edges(&[("m_svc", "m_data")]);
+        let (result, _p, _c) = assemble("s", &down, &layer_of, false);
+        assert_eq!(result["drift_class"], json!("none"));
+        assert!(result["breaches"].as_array().unwrap().is_empty());
+    }
+
+    // 3. any → utility, and utility → anything = carved, never a breach.
+    #[test]
+    fn utility_endpoints_are_carved_never_a_breach() {
+        let layer_of = labels(&[("m_ui", "ui"), ("m_util", "utility"), ("m_data", "data")]);
+        // ui→utility and utility→data: both carved (utility = import-by-anyone),
+        // judged + clean → no breach, drift_class none, coverage 1.
+        let e = edges(&[("m_ui", "m_util"), ("m_util", "m_data")]);
+        let (result, posterior, coverage) = assemble("s", &e, &layer_of, false);
+        assert!(result["breaches"].as_array().unwrap().is_empty());
+        assert_eq!(result["drift_class"], json!("none"));
+        assert_eq!(result["judged_edges"], json!(2));
+        assert_eq!(result["carve_out"]["utility_or_unknown_edges"], json!(2));
+        assert!((coverage - 1.0).abs() < 1e-9);
+        assert!((posterior - module_graph::KERNEL_POSTERIOR).abs() < 1e-9);
+    }
+
+    // 4. edge touching an unknown/unlabelled module = arch:unknown_edge (carved),
+    //    lowers coverage, drift_class unknown, never a false breach.
+    #[test]
+    fn unknown_endpoint_lowers_coverage_and_is_not_a_breach() {
+        // m_x has no label; m_data is data. m_svc→m_data is judged + clean.
+        let layer_of = labels(&[("m_svc", "service"), ("m_data", "data")]);
+        let e = edges(&[("m_x", "m_data"), ("m_svc", "m_data")]);
+        let (result, _p, coverage) = assemble("s", &e, &layer_of, false);
+        assert!(
+            result["breaches"].as_array().unwrap().is_empty(),
+            "an unknown-endpoint edge is never a breach"
+        );
+        assert_eq!(result["total_edges"], json!(2));
+        assert_eq!(result["judged_edges"], json!(1));
+        assert_eq!(result["drift_class"], json!("unknown"));
+        assert!(coverage < 1.0, "unknown-endpoint edge lowers coverage");
+        assert!((coverage - 0.5).abs() < 1e-9);
+
+        // explicit "unknown" label is treated the same as unlabelled.
+        let layer_of2 = labels(&[("m_x", "unknown"), ("m_data", "data")]);
+        let e2 = edges(&[("m_x", "m_data")]);
+        let (result2, _p2, c2) = assemble("s", &e2, &layer_of2, false);
+        assert!(result2["breaches"].as_array().unwrap().is_empty());
+        assert_eq!(result2["judged_edges"], json!(0));
+        assert_eq!(c2, 0.0);
+    }
+
+    // 5. cross-layer cycle (api↔data) = layer_cycle / divergent with full SCC;
+    //    same-layer 2-cycle = NOT a breach.
+    #[test]
+    fn cross_layer_cycle_is_divergent_same_layer_cycle_is_not() {
+        let layer_of = labels(&[("m_api", "api"), ("m_data", "data")]);
+        let e = edges(&[("m_api", "m_data"), ("m_data", "m_api")]);
+        let (result, _p, _c) = assemble("s", &e, &layer_of, false);
+        assert_eq!(result["drift_class"], json!("divergent"));
+        let cycles = result["cycles"].as_array().unwrap();
+        assert_eq!(cycles.len(), 1);
+        assert_eq!(cycles[0]["class"], json!("arch:layer_cycle"));
+        let members = cycles[0]["members"].as_array().unwrap();
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0], json!("m_api"));
+        assert_eq!(members[1], json!("m_data"));
+
+        // same-layer 2-cycle: both service → SCC spans only 1 structural layer → NOT
+        // a cycle finding (informational).
+        let layer_same = labels(&[("m_a", "service"), ("m_b", "service")]);
+        let e2 = edges(&[("m_a", "m_b"), ("m_b", "m_a")]);
+        let (result2, _p2, _c2) = assemble("s", &e2, &layer_same, false);
+        assert!(
+            result2["cycles"].as_array().unwrap().is_empty(),
+            "a same-layer cycle is informational, not a breach"
+        );
+        // ...but note service→service edges are clean, so drift_class is none.
+        assert_eq!(result2["drift_class"], json!("none"));
+    }
+
+    // 6. D2 regression: a module with 9+ resolved cross-layer edges — the 9th breach
+    //    is still flagged (Φ uses the uncapped edge set, not capped internal_deps).
+    #[test]
+    fn ninth_cross_layer_breach_is_still_flagged() {
+        // m_ui (ui) → 9 distinct data modules. ui→data is a breach (skips api/service).
+        let mut layer_pairs = vec![("m_ui", "ui")];
+        let mut edge_pairs = Vec::new();
+        let data_mods: Vec<String> = (0..9).map(|i| format!("m_data{i}")).collect();
+        for d in &data_mods {
+            layer_pairs.push((d.as_str(), "data"));
+            edge_pairs.push(("m_ui", d.as_str()));
+        }
+        let layer_of = labels(&layer_pairs);
+        let e = edges(&edge_pairs);
+        let (result, _p, _c) = assemble("s", &e, &layer_of, false);
+        let breaches = result["breaches"].as_array().unwrap();
+        assert_eq!(
+            breaches.len(),
+            9,
+            "all 9 cross-layer breaches flagged — proves uncapped edge set"
+        );
+        assert_eq!(result["drift_class"], json!("in_place"));
+        // The 9th breach edge (to m_data8) is present.
+        assert!(breaches
+            .iter()
+            .any(|b| b["to"] == json!("m_data8") && b["class"] == json!("arch:layer_breach")));
+    }
+
+    // 7. envelope discipline: kernel:true, posterior<1, credibility (medium,low,low);
+    //    cold graph → coverage 0, no false "no breaches".
+    #[test]
+    fn envelope_is_advisory_kernel_and_cold_is_honest() {
+        let layer_of = labels(&[("m_ui", "ui"), ("m_api", "api")]);
+        let e = edges(&[("m_ui", "m_api")]);
+        let env = make_envelope("layer_drift", "scope-key", &e, &layer_of, false);
+        assert!(env.kernel, "Ξ_Layering envelope MUST be kernel:true");
+        assert!(env.posterior < 1.0, "kernel posterior must be < 1");
+        assert_eq!(env.observer, OBSERVER);
+        assert_eq!(env.provenance, PROVENANCE);
+        assert_eq!(env.credibility.causal, "medium");
+        assert_eq!(env.credibility.authorial, "low");
+        assert_eq!(env.credibility.boundary, "low");
+        assert_eq!(env.result["scope"], json!("scope-key"));
+
+        // Cold graph → coverage 0, drift_class unknown, breaches empty but with a
+        // reason — never a false "no breaches" assertion.
+        let cold = cold_envelope(
+            "layer_drift",
+            "scope-key",
+            "empty / cold graph (no cross-module edges)",
+        );
+        assert!(cold.kernel);
+        assert_eq!(cold.coverage, 0.0);
+        assert_eq!(cold.posterior, 0.0);
+        assert_eq!(cold.result["drift_class"], json!("unknown"));
+        assert!(cold.result["breaches"].as_array().unwrap().is_empty());
+        assert!(cold.result.get("reason").is_some());
+    }
+
+    #[test]
+    fn cache_skips_empty_and_roundtrips_nonempty() {
+        let fp = 0x1A2B_3C4D_5E6F_7788u64;
+        cache_put(fp, HashMap::new());
+        assert!(
+            cache_get(fp).is_none(),
+            "empty classification is not cached"
+        );
+        let layer_of = labels(&[("m_a", "api")]);
+        cache_put(fp, layer_of.clone());
+        assert_eq!(cache_get(fp), Some(layer_of));
+    }
+}

--- a/src-tauri/src/mcp/code_semantics/mod.rs
+++ b/src-tauri/src/mcp/code_semantics/mod.rs
@@ -25,11 +25,13 @@
 //! - Node/TS permanently unavailable → degrade (symbol-lookup → code_graph_fallback;
 //!   resolution → `engine_unavailable`, coverage 0). Never 500 on a missing engine.
 
+pub mod arch_classify;
 pub mod arch_observer;
 pub mod cargo_check;
 pub mod code_graph_api;
 pub mod domain_observer;
 pub mod lang;
+pub mod layer_observer;
 pub mod module_graph;
 pub mod mypy_check;
 pub mod node_bridge;
@@ -147,6 +149,11 @@ pub const PROV_KERNEL_ARCH: &str = "claude_cli_arch";
 /// `Ξ_Domain` LLM business-domain mapper provenance (Phase 3): a stochastic
 /// kernel run through the Claude-CLI path. Advisory, never gate-worthy.
 pub const PROV_KERNEL_DOMAIN: &str = "claude_cli_domain";
+/// `Ξ_Layering` architecture-drift observer provenance (Phase 4a): a stochastic
+/// kernel that labels modules via the Claude-CLI path (`Ξ_Arch`), then evaluates
+/// the layering-allowed-edge relation Φ over the resolved dependency digraph.
+/// Advisory, never gate-worthy.
+pub const PROV_KERNEL_LAYER: &str = "claude_cli_layer";
 /// Python `mypy` typecheck provenance (Phase A): full-fidelity, true overlay via
 /// `--shadow-file`. Boundary `high` (crosses the type checker).
 pub const PROV_MYPY: &str = "mypy";
@@ -451,9 +458,10 @@ pub struct TypecheckReq {
 
 /// Routes contributed to the runner's main router from `mcp_api.rs`. Includes
 /// the LSP `Ξ_Type` `/code-semantics/*` surface, the resolved-import `Ξ_AST`
-/// `/code-graph/*` diff blast-radius surface (Pillar 2), and the Phase-3
+/// `/code-graph/*` diff blast-radius surface (Pillar 2), the Phase-3
 /// stochastic-kernel observers `Ξ_Arch` (`/code-graph/arch-layers`) and
-/// `Ξ_Domain` (`/code-graph/domains`).
+/// `Ξ_Domain` (`/code-graph/domains`), and the Phase-4a `Ξ_Layering`
+/// architecture-drift advisory observer (`/code-graph/layer-drift`).
 pub fn routes() -> Router<Arc<ApiState>> {
     Router::new()
         .route("/code-semantics/health", get(health))
@@ -464,6 +472,7 @@ pub fn routes() -> Router<Arc<ApiState>> {
         .merge(code_graph_api::routes())
         .merge(arch_observer::routes())
         .merge(domain_observer::routes())
+        .merge(layer_observer::routes())
 }
 
 /// GET /code-semantics/health — per CONTRACT §B.

--- a/src-tauri/src/mcp/code_semantics/module_graph.rs
+++ b/src-tauri/src/mcp/code_semantics/module_graph.rs
@@ -198,6 +198,62 @@ pub(super) async fn build_module_graph(dir: PathBuf) -> Option<(Vec<ModuleSummar
     .ok()
 }
 
+/// The UNCAPPED cross-module (directory→directory) dependency digraph edges.
+///
+/// For every import that the resolver bound to an in-repo file (`resolved_target`
+/// set, `resolution` neither `External` nor `Unresolved`), map both endpoints to
+/// their module dir; keep the edge only when it crosses a module boundary
+/// (`from != to`). Unlike [`ModuleSummary::internal_deps`] (capped at
+/// `MAX_DEPS_PER_MODULE` for the prompt budget), this is the FULL edge set — the
+/// layering Φ predicate (`Ξ_Layering`) MUST use this, never the capped summaries,
+/// or a 9th cross-layer breach edge would be silently dropped. The `BTreeSet`
+/// de-duplicates + orders the edges deterministically.
+pub(super) fn cross_module_edges(graph: &CodeGraph) -> BTreeSet<(String, String)> {
+    use crate::workflow_generation::code_graph::ResolutionKind;
+    let mut edges: BTreeSet<(String, String)> = BTreeSet::new();
+    for imp in &graph.imports {
+        let target = match &imp.resolved_target {
+            Some(t) => t,
+            None => continue,
+        };
+        // Only honestly-resolved in-repo edges; External/Unresolved are not
+        // cross-module dependency edges.
+        if matches!(
+            imp.resolution,
+            ResolutionKind::External | ResolutionKind::Unresolved
+        ) {
+            continue;
+        }
+        let from = module_dir(&imp.from_file);
+        let to = module_dir(target);
+        if from != to {
+            edges.insert((from, to));
+        }
+    }
+    edges
+}
+
+/// Build the resolved `Ξ_AST` graph ONCE and derive everything `Ξ_Layering` needs
+/// off the async runtime: the per-module summaries (for the label prompt), the
+/// total module count, the structure fingerprint (cache key), and the UNCAPPED
+/// [`cross_module_edges`] digraph (for the Φ predicate + cycle detection). Returns
+/// `None` if the blocking build task panicked (the caller degrades to a cold
+/// envelope). Modeled on [`build_module_graph`]; the graph is built exactly once.
+pub(super) async fn build_layer_inputs(
+    dir: PathBuf,
+) -> Option<(Vec<ModuleSummary>, usize, u64, BTreeSet<(String, String)>)> {
+    tokio::task::spawn_blocking(move || {
+        let graph = CodeGraph::build(&dir);
+        let mods = summarize_modules(&graph);
+        let total = mods.len();
+        let fp = fingerprint_modules(&mods);
+        let edges = cross_module_edges(&graph);
+        (mods, total, fp, edges)
+    })
+    .await
+    .ok()
+}
+
 /// Render the numbered module-list block shared by both observers' prompts.
 /// Deterministic (modules in the given order, internal lists pre-sorted) so the
 /// prompt + tests are stable.
@@ -391,6 +447,55 @@ mod tests {
         // The Unresolved edge is dropped from external packages (coverage hole, not a pkg).
         assert!(!mods[0].external_pkgs.contains(&"./missing".to_string()));
         assert_eq!(mods[1].module, "src/services");
+    }
+
+    #[test]
+    fn cross_module_edges_are_uncapped_and_skip_external_unresolved() {
+        // src/api imports 9 distinct resolved targets in 9 different modules, plus an
+        // External and an Unresolved edge that must NOT become cross-module edges.
+        let mut imports = Vec::new();
+        for i in 0..9 {
+            imports.push(import(
+                "src/api/routes.ts",
+                &format!("../dep{i}/x"),
+                Some(&format!("src/dep{i}/x.ts")),
+                ResolutionKind::Relative,
+            ));
+        }
+        imports.push(import(
+            "src/api/routes.ts",
+            "express",
+            None,
+            ResolutionKind::External,
+        ));
+        imports.push(import(
+            "src/api/routes.ts",
+            "./missing",
+            None,
+            ResolutionKind::Unresolved,
+        ));
+        // An intra-module edge (same dir) must be dropped (from == to).
+        imports.push(import(
+            "src/api/routes.ts",
+            "./handlers",
+            Some("src/api/handlers.ts"),
+            ResolutionKind::Relative,
+        ));
+        let graph = CodeGraph {
+            files: vec![file("src/api/routes.ts")],
+            functions: vec![],
+            classes: vec![],
+            imports,
+            exports: vec![],
+            build_duration_ms: 0,
+        };
+        let edges = cross_module_edges(&graph);
+        // Exactly the 9 cross-module resolved edges — proves no cap at 8 (the
+        // MAX_DEPS_PER_MODULE prompt budget) and that External/Unresolved/intra are
+        // excluded.
+        assert_eq!(edges.len(), 9, "uncapped: all 9 cross-module edges kept");
+        assert!(edges.contains(&("src/api".to_string(), "src/dep8".to_string())));
+        assert!(!edges.iter().any(|(f, t)| f == "src/api" && t == "src/api"));
     }
 
     #[test]


### PR DESCRIPTION
## Phase 4a — `Ξ_Layering` advisory architecture-drift observer

Implements **Phase 4a** of `plans/2026-06-02-twin-ast-import-resolution-and-semantic-observers.md` via the vetted instance plan `plans/2026-06-07-twin-layering-architecture-drift.md`. The **architecture instance** of the declared-vs-actual construct (`theory/declared-vs-actual.md`) — and the first one whose *actual* side was already shipped.

### What it does
`POST /code-graph/layer-drift` `{scope?, max_modules?}`. The **actual** side is the resolved `Ξ_AST` import graph (already shipped, #358); **Φ** = "no import edge violates the layer order":
```
ALLOWED = {(ui,api),(ui,service),(api,service),(service,data)} ∪ self-edges
```
`ui→data` (the skip) and every upward edge are breaches; `utility`/`unknown` endpoints are carved. It reports per-edge **`arch:layer_breach`** findings and cross-layer import cycles (**`arch:layer_cycle`**, Tarjan SCC).

### Advisory by construction (the theory constraint, honored)
The declared layer map comes from the `Ξ_Arch` **kernel** — *not authored intent*. Per the construct's **credibility-gates-the-gate** rule (§9), a non-authored declared side may *surface* drift but must **never block**. So the observer emits **only** the runner-side kernel envelope (`kernel:true`, `posterior<1`, credibility `(medium,low,low)`) — there is no allow/block/decision path. It uses coord-compatible `drift_class` wire tokens (`in_place`/`divergent`/`unknown`/`none`) so Phase 4b's gate maps 1:1. **Honest coverage** = judged/total edges; unknown-endpoint edges and a cold graph lower it, never a false "no breaches".

### Two defects the vet caught, both closed
- **Φ runs over the UNCAPPED edge set** (`module_graph::cross_module_edges` / `build_layer_inputs`), not the cap-8 `internal_deps` — so a breach on a module's 9th+ edge is still caught (regression-tested: `ninth_cross_layer_breach_is_still_flagged`).
- **No in-process labeller seam existed** → extracted the `Ξ_Arch` classify path (`build_prompt`/`parse_layers`/`normalize_layer`/`LayerAssignment`/`classify_layers`) into a shared **`arch_classify.rs`** consumed by both `arch_observer` and `layer_observer`. `Ξ_Arch` behavior is byte-identical (its envelope/coverage tests retained; only the prompt/parse unit tests moved).

### Tests
104 `code_semantics` tests green (the new `layer_observer` + `arch_classify` suites + the refactored `arch` + siblings — no regression). Coverage: `is_allowed` relation, skip/upward breaches, downward-clean, utility/unknown carve-out, cross-layer-cycle vs same-layer, the 9th-edge D2 regression, and kernel/cold envelope discipline. `cargo clippy --all-targets -- -D warnings` + rustfmt clean.

### Scope
v1 advisory only. **Phase 4b** (authored `.qontinui/layers.toml` declared side → `layering_safety` gate) stays correctly blocked on the 4a false-positive data + the R-series (coord-builds-from-mirror) for prod reachability.

This PR was built by an implementer subagent and independently correctness-reviewed by a second subagent (verdict: SHIP) before the coordinator's build/clippy/fmt verification.
