### PR TITLE
feat(terminal): auto-grow zone layout, unzoned-count chip, app-level session provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,11 @@ import { ContextualTutorial } from "./components/tutorial";
 import { DemoVisualOverlay } from "./components/demo-video/DemoVisualOverlay";
 import { getGraphQLClient } from "./lib/graphql-client";
 
-import { UIBridgeProvider, AutoRegisterProvider, UIBridgeWindowProvider } from "@qontinui/ui-bridge";
+import {
+  UIBridgeProvider,
+  AutoRegisterProvider,
+  UIBridgeWindowProvider,
+} from "@qontinui/ui-bridge";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { setupEventHandlers, eventRouter } from "./managers";
@@ -69,6 +73,8 @@ import { TerminalPage } from "./components/terminal";
 import { TerminalPageTabBar } from "./components/terminal/TerminalPageTabBar";
 import { useTerminalPages } from "./components/terminal/useTerminalPages";
 import { TerminalPageProvider } from "./components/terminal/TerminalPageContext";
+import { TerminalSessionProvider } from "./components/terminal/contexts";
+import { WindowAssignmentsProvider } from "./components/terminal/contexts/WindowAssignmentsContext";
 import { Now1HzProvider } from "./components/terminal/useNow1Hz";
 import { ReorganizeDialog, type ReorganizePlan } from "./components/terminal/ReorganizeDialog";
 import { PerformanceOverlay, GiantSCCFixture } from "./components/dev";
@@ -334,11 +340,7 @@ function AppContent() {
     // `get_user_projects` invoke runs only after the access token is in
     // place. The retry-on-Not-authenticated inside `loadProjects` still
     // covers the rare keychain-write/read ordering blip.
-    if (
-      auth.authStatus?.authenticated &&
-      !auth.loading &&
-      !auth.devAutoLoginPending
-    ) {
+    if (auth.authStatus?.authenticated && !auth.loading && !auth.devAutoLoginPending) {
       projectSelection.loadProjects();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- loadProjects changes with selectedProjectId; including it would reload projects on every selection change
@@ -563,8 +565,8 @@ function AppContent() {
                     // own terminal tabs — the visible counterpart to the
                     // `open-terminal-window` UI Bridge action. New terminals
                     // created in that window belong to it (window_assignments).
-                    void invoke("open_terminal_window", { placement: null }).catch(
-                      (err) => console.error("Failed to open pop-out window:", err),
+                    void invoke("open_terminal_window", { placement: null }).catch((err) =>
+                      console.error("Failed to open pop-out window:", err),
                     );
                   }}
                 />
@@ -579,14 +581,39 @@ function AppContent() {
                   />
                 )}
                 <div className="flex-1 min-h-0">
-                  <TerminalPageProvider value={terminalPages.activePageId}>
-                    <TerminalPage
-                      key={terminalPages.activePageId}
+                  {/*
+                    Phase 3 (mount-hydration lift): the terminal session state
+                    provider is lifted ABOVE TerminalPage and made page-scoped
+                    INSIDE the provider (one always-mounted PageSessionScope per
+                    page) rather than remounted per page via `key`. Switching
+                    terminal pages no longer destroys any page's tab state, and
+                    every page's `terminal-created` listener stays live so an
+                    externally-created terminal (e.g. a docked gate
+                    continuation) is never dropped while the operator is on
+                    another page. WindowAssignmentsProvider sits above so
+                    tab-ownership filtering can read "which window owns which
+                    session" (a no-op in the single-window case).
+
+                    `TerminalPageProvider` still carries the ACTIVE page id to
+                    TerminalPage (== session.pageId) so the page's render logic
+                    is untouched; the `key={activePageId}` remount is gone.
+                  */}
+                  <WindowAssignmentsProvider>
+                    <TerminalSessionProvider
+                      pages={terminalPages.pages}
+                      activePageId={terminalPages.activePageId}
                       onNavigateToBuilder={() => setActiveTab("unified-workflow-builder")}
                       onNavigateToActive={() => setActiveTab("active")}
-                      onSessionCountChange={setTerminalSessionCount}
-                    />
-                  </TerminalPageProvider>
+                    >
+                      <TerminalPageProvider value={terminalPages.activePageId}>
+                        <TerminalPage
+                          onNavigateToBuilder={() => setActiveTab("unified-workflow-builder")}
+                          onNavigateToActive={() => setActiveTab("active")}
+                          onSessionCountChange={setTerminalSessionCount}
+                        />
+                      </TerminalPageProvider>
+                    </TerminalSessionProvider>
+                  </WindowAssignmentsProvider>
                 </div>
               </div>
             </main>
@@ -888,7 +915,7 @@ export default function App() {
         features={{ renderLog: true, control: true, debug: true }}
         browserCaptureConfig={{
           console: true,
-          consoleLevels: ['error', 'warn', 'debug', 'info', 'log'],
+          consoleLevels: ["error", "warn", "debug", "info", "log"],
         }}
       >
         <UIBridgeEventHandler />
@@ -923,15 +950,15 @@ export default function App() {
           identical to before; pop-out windows (Phase 1) supply "term-N".
         */}
         <UIBridgeWindowProvider windowLabel={getCurrentWindow().label}>
-        <AutoRegisterProvider
-          enabled
-          idStrategy="prefer-existing"
-          debounceMs={100}
-          excludeSelectors={["[data-no-register]"]}
-          contentDiscovery={{ enabled: true, maxContentElements: 200 }}
-        >
-          <AuthProvider>
-            {/*
+          <AutoRegisterProvider
+            enabled
+            idStrategy="prefer-existing"
+            debounceMs={100}
+            excludeSelectors={["[data-no-register]"]}
+            contentDiscovery={{ enabled: true, maxContentElements: 200 }}
+          >
+            <AuthProvider>
+              {/*
               Plan 2026-05-22-coord-native-session-coordination §D12 + §Phase 4.
               TenantProvider wraps SessionProvider per plan: the active tenant
               is the default stamp for new sessions started via SessionContext.
@@ -939,25 +966,25 @@ export default function App() {
               future auth state (paired_user.json reads happen at the Rust
               layer; placement here is for symmetry with NavigationProvider).
             */}
-            <TenantProvider>
-              <SessionProvider>
-                <NavigationProvider>
-                  <EventManagerProvider>
-                    <ExecutionProvider
-                      onLog={(_level, _message) => {
-                        // Logs are handled by LogManager through event handlers
-                      }}
-                    >
-                      <AutoContinueProvider>
-                        <AppWithTutorials />
-                      </AutoContinueProvider>
-                    </ExecutionProvider>
-                  </EventManagerProvider>
-                </NavigationProvider>
-              </SessionProvider>
-            </TenantProvider>
-          </AuthProvider>
-        </AutoRegisterProvider>
+              <TenantProvider>
+                <SessionProvider>
+                  <NavigationProvider>
+                    <EventManagerProvider>
+                      <ExecutionProvider
+                        onLog={(_level, _message) => {
+                          // Logs are handled by LogManager through event handlers
+                        }}
+                      >
+                        <AutoContinueProvider>
+                          <AppWithTutorials />
+                        </AutoContinueProvider>
+                      </ExecutionProvider>
+                    </EventManagerProvider>
+                  </NavigationProvider>
+                </SessionProvider>
+              </TenantProvider>
+            </AuthProvider>
+          </AutoRegisterProvider>
         </UIBridgeWindowProvider>
       </UIBridgeProvider>
     </ApolloProvider>

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -31,6 +31,8 @@ import { TerminalOverlays } from "./TerminalOverlays";
 import { CommandBar } from "./CommandBar";
 import { SuggestionsProvider } from "./suggestions";
 import { StatusStrip } from "./StatusStrip";
+import { UnzonedChip } from "./UnzonedChip";
+import { pickLayout } from "./useZoneLayout";
 import { ResultCardProvider, ResultCardMount, useResultCard } from "./result-card";
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
@@ -38,10 +40,7 @@ import { callRegistry, useTerminalCommands } from "./commands";
 import { useTerminalInitialization } from "./useTerminalInitialization";
 import { useZoneActions } from "./useZoneActions";
 import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
-import {
-  setTerminalSessions,
-  type TerminalSessionEntry,
-} from "@/lib/terminal-sessions-registry";
+import { setTerminalSessions, type TerminalSessionEntry } from "@/lib/terminal-sessions-registry";
 import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
 import { useCommitState } from "./useCommitState";
 import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
@@ -69,23 +68,23 @@ export function TerminalPage(props: TerminalPageProps) {
     // session provider so tab-ownership filtering + owner-gated stdin can read
     // "which window owns which session". A no-op in the single-window case.
     <WindowAssignmentsProvider>
-    <TerminalSessionProvider
-      pageId={pageId}
-      onNavigateToBuilder={props.onNavigateToBuilder}
-      onNavigateToActive={props.onNavigateToActive}
-    >
-      <ZoneMetadataProvider>
-        <TransitionEffectsProvider>
-          <UIStateProvider>
-            <SuggestionsProvider>
-              <ResultCardProvider>
-                <TerminalPageInner {...props} />
-              </ResultCardProvider>
-            </SuggestionsProvider>
-          </UIStateProvider>
-        </TransitionEffectsProvider>
-      </ZoneMetadataProvider>
-    </TerminalSessionProvider>
+      <TerminalSessionProvider
+        pageId={pageId}
+        onNavigateToBuilder={props.onNavigateToBuilder}
+        onNavigateToActive={props.onNavigateToActive}
+      >
+        <ZoneMetadataProvider>
+          <TransitionEffectsProvider>
+            <UIStateProvider>
+              <SuggestionsProvider>
+                <ResultCardProvider>
+                  <TerminalPageInner {...props} />
+                </ResultCardProvider>
+              </SuggestionsProvider>
+            </UIStateProvider>
+          </TransitionEffectsProvider>
+        </ZoneMetadataProvider>
+      </TerminalSessionProvider>
     </WindowAssignmentsProvider>
   );
 }
@@ -447,10 +446,7 @@ function TerminalPageInner({
     });
   }, [fileLockStates]);
 
-  const activeTab = useMemo(
-    () => tabs.find((t) => t.id === activeId),
-    [tabs, activeId],
-  );
+  const activeTab = useMemo(() => tabs.find((t) => t.id === activeId), [tabs, activeId]);
   const activeLockState = activeId ? fileLockStates?.[activeId] : undefined;
   // Phase 3 — pull per-tab incoming yield requests so the holding
   // banner can shift into request-mode and we can surface the request
@@ -725,15 +721,15 @@ function TerminalPageInner({
     (terminalId: string, exitCode: number | null) => {
       // Record the durable session CLOSE when a pty backing a Claude session
       // exits. Read the latest tab from the ref so this stays identity-stable.
-      const claudeSessionId = tabsRef.current.find(
-        (t) => t.id === terminalId,
-      )?.claudeSessionId;
+      const claudeSessionId = tabsRef.current.find((t) => t.id === terminalId)?.claudeSessionId;
       if (claudeSessionId) {
         invoke("terminal_session_record_close", {
           claudeSessionId,
           reason: "pty-exit",
         }).catch((err) => {
-          logger.warn(`terminal_session_record_close (pty-exit) failed for ${claudeSessionId}: ${err}`);
+          logger.warn(
+            `terminal_session_record_close (pty-exit) failed for ${claudeSessionId}: ${err}`,
+          );
         });
       }
       updateTab(terminalId, { isAlive: false, exitCode });
@@ -790,15 +786,6 @@ function TerminalPageInner({
       resumeSession: sessionManager.resumeSession,
     },
   });
-
-  /** Pick the smallest layout preset that fits `totalTabs` tabs. */
-  const pickLayout = (totalTabs: number): string => {
-    if (totalTabs >= 7) return "full-grid";
-    if (totalTabs >= 5) return "six-pack";
-    if (totalTabs >= 3) return "quad";
-    if (totalTabs >= 2) return "split";
-    return "single";
-  };
 
   const writeWhenReady = (tabId: string, text: string, maxWaitMs = 5000) =>
     writeWhenReadyHelper(terminalRefs.current, tabId, text, {
@@ -940,6 +927,14 @@ function TerminalPageInner({
         >
           {terminalSessionRoster}
         </span>
+        {/* Phase 2 — honesty backstop for sessions past the zone ceiling.
+            Renders nothing when every tab is visible; otherwise a "N more"
+            chip that opens the ZoneControlPanel's Unassigned (N) list. */}
+        <UnzonedChip
+          unassignedCount={zoneLayout.unassignedTabIds.length}
+          onOpen={() => dispatch({ type: "SET_SHOW_CONTROL_PANEL", payload: true })}
+        />
+
         {showDocFinder && (
           <DocFinderModal
             onSelect={(filePath) => {
@@ -1106,11 +1101,8 @@ function TerminalPageInner({
                     // first-arrived entry, but for the banner copy any
                     // matching entry is acceptable since a new signal
                     // for the same pair replaces in place.
-                    const signals =
-                      (activeId && pendingLongWaitSignals?.[activeId]) || [];
-                    const match = signals.find(
-                      (s) => s.filePath === activeLockState.filePath,
-                    );
+                    const signals = (activeId && pendingLongWaitSignals?.[activeId]) || [];
+                    const match = signals.find((s) => s.filePath === activeLockState.filePath);
                     if (!match) return undefined;
                     return {
                       holderName: match.holderName,
@@ -1145,7 +1137,11 @@ function TerminalPageInner({
             <CoordWarningBanner activeTerminalId={activeId ?? undefined} />
           </div>
 
-          {uiState.showControlPanel && zoneLayout.isMultiZone && (
+          {/* Phase 2 — `isMultiZone` gate dropped so the Unassigned (N) list
+              shows in `single` layout too. Past the 9-zone `full-grid` ceiling
+              the only honest surface for hidden sessions is this panel's
+              Unassigned list; the UnzonedChip near the StatusStrip opens it. */}
+          {uiState.showControlPanel && (
             <ZoneControlPanel onCreateTerminal={() => createAndAssignTerminal()} />
           )}
 
@@ -1175,7 +1171,9 @@ function TerminalPageInner({
         <div style={{ display: "none" }} aria-hidden>
           <ZoneLayoutPicker
             currentLayoutId={zoneLayout.layoutId}
-            onSelectLayout={zoneLayout.setLayoutId}
+            // Picking a layout from the picker UI is an explicit operator
+            // choice — pin it so auto-grow stops overriding it.
+            onSelectLayout={(id) => zoneLayout.setLayoutId(id, { pinned: true })}
             tabCount={tabs.length}
           />
           <ZoneProfilePicker
@@ -1189,7 +1187,9 @@ function TerminalPageInner({
             tabs={tabs}
             initialized={initialized}
             onLoadProfile={async (profile) => {
-              zoneLayout.setLayoutId(profile.layoutId);
+              // Loading a saved profile is a deliberate operator layout choice —
+              // pin it so auto-grow doesn't override the restored arrangement.
+              zoneLayout.setLayoutId(profile.layoutId, { pinned: true });
               labelsAndTags.setZoneLabels(profile.labels);
               labelsAndTags.setZoneNotes(profile.notes);
               labelsAndTags.setPinnedZones(new Set(profile.pins));

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -11,10 +11,7 @@ import { DocFinderModal } from "./DocFinderModal";
 import { BatchOperationsBar } from "./BatchOperationsBar";
 import { ZoneMinimap } from "./ZoneMinimap";
 import { ZoneProfilePicker } from "./ZoneProfilePicker";
-import { useTerminalPageId } from "./TerminalPageContext";
-import { WindowAssignmentsProvider } from "./contexts/WindowAssignmentsContext";
 import {
-  TerminalSessionProvider,
   useTerminalSession,
   ZoneMetadataProvider,
   useZoneMetadata,
@@ -62,30 +59,24 @@ interface TerminalPageProps {
 }
 
 export function TerminalPage(props: TerminalPageProps) {
-  const pageId = useTerminalPageId();
   return (
-    // Phase 1 (pop-out windows): WindowAssignmentsProvider sits above the
-    // session provider so tab-ownership filtering + owner-gated stdin can read
-    // "which window owns which session". A no-op in the single-window case.
-    <WindowAssignmentsProvider>
-      <TerminalSessionProvider
-        pageId={pageId}
-        onNavigateToBuilder={props.onNavigateToBuilder}
-        onNavigateToActive={props.onNavigateToActive}
-      >
-        <ZoneMetadataProvider>
-          <TransitionEffectsProvider>
-            <UIStateProvider>
-              <SuggestionsProvider>
-                <ResultCardProvider>
-                  <TerminalPageInner {...props} />
-                </ResultCardProvider>
-              </SuggestionsProvider>
-            </UIStateProvider>
-          </TransitionEffectsProvider>
-        </ZoneMetadataProvider>
-      </TerminalSessionProvider>
-    </WindowAssignmentsProvider>
+    // Phase 3 (mount-hydration lift): WindowAssignmentsProvider +
+    // TerminalSessionProvider were lifted to App.tsx so terminal session state
+    // survives page switches and the `terminal-created` listener stays live for
+    // every page. The remaining orthogonal UI providers stay here, scoped to
+    // the (single, active-page) page tree and reading the active page's slice
+    // off the lifted `useTerminalSession()`.
+    <ZoneMetadataProvider>
+      <TransitionEffectsProvider>
+        <UIStateProvider>
+          <SuggestionsProvider>
+            <ResultCardProvider>
+              <TerminalPageInner {...props} />
+            </ResultCardProvider>
+          </SuggestionsProvider>
+        </UIStateProvider>
+      </TransitionEffectsProvider>
+    </ZoneMetadataProvider>
   );
 }
 

--- a/src/components/terminal/UnzonedChip.test.ts
+++ b/src/components/terminal/UnzonedChip.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Phase 2 — UnzonedChip label/visibility contract.
+ *
+ * vitest runs `environment: "node"` (no jsdom), so per repo precedent
+ * (`CommitTrafficLight.test.tsx`, `useZoneLayout.restore.test.ts`) we test the
+ * exported pure helper `unzonedChipLabel` rather than rendering JSX. The chip's
+ * visual shell is verified by UI Bridge / manual tests once the spec updates.
+ */
+
+import { describe, it, expect } from "vitest";
+import { unzonedChipLabel } from "./UnzonedChip";
+
+describe("unzonedChipLabel — chip renders only when sessions are hidden", () => {
+  it("returns null when nothing is unassigned (chip must not render)", () => {
+    expect(unzonedChipLabel(0)).toBeNull();
+  });
+
+  it("returns null for negative counts (defensive)", () => {
+    expect(unzonedChipLabel(-1)).toBeNull();
+  });
+
+  it("singular phrasing for exactly one hidden session", () => {
+    const label = unzonedChipLabel(1);
+    expect(label).not.toBeNull();
+    expect(label!.text).toBe("1 more");
+    expect(label!.title).toContain("1 session is not visible");
+  });
+
+  it("plural phrasing for multiple hidden sessions", () => {
+    const label = unzonedChipLabel(4);
+    expect(label).not.toBeNull();
+    expect(label!.text).toBe("4 more");
+    expect(label!.title).toContain("4 sessions are not visible");
+  });
+});

--- a/src/components/terminal/UnzonedChip.tsx
+++ b/src/components/terminal/UnzonedChip.tsx
@@ -1,0 +1,70 @@
+/**
+ * Phase 2 — Unzoned-count chip (honesty backstop past the 9-zone ceiling).
+ *
+ * The default zone layout is `single` (1 zone), and auto-grow (Phase 1) caps at
+ * `full-grid` (9 zones). Any live tab beyond the current layout's zone capacity
+ * renders as an offscreen `HiddenTerminal` (`<div className="hidden">`) with ZERO
+ * affordance — this is exactly how 4 live gate-continuation sessions went
+ * invisible to the operator. This chip is the visible backstop: whenever ANY
+ * tab is unassigned it surfaces a compact "N more" pill near the StatusStrip;
+ * clicking it opens the `ZoneControlPanel` whose Unassigned (N) list lets the
+ * operator see and assign the hidden sessions.
+ *
+ * Renders NOTHING when nothing is hidden (`unassignedCount === 0`), matching the
+ * StatusStrip's self-hide posture so it never adds chrome when the layout
+ * already shows every session.
+ *
+ * Styling mirrors StatusStrip's `Pill` button idiom (10px, rounded, tokyo-night
+ * palette) so the chip reads as part of the same status row.
+ */
+
+import { EyeOff } from "lucide-react";
+
+/**
+ * Pure label/visibility helper — exported so the unit test can lock the
+ * count→label contract without rendering (the runner's vitest config is
+ * `environment: "node"`, no jsdom; component JSX is verified by UI Bridge /
+ * manual tests).
+ *
+ * Returns `null` when there is nothing hidden (chip must not render), otherwise
+ * the chip's short label + its `title` tooltip.
+ */
+export function unzonedChipLabel(unassignedCount: number): { text: string; title: string } | null {
+  if (unassignedCount <= 0) return null;
+  return {
+    text: `${unassignedCount} more`,
+    title: `${unassignedCount} session${
+      unassignedCount === 1 ? " is" : "s are"
+    } not visible in any zone — click to open the zone control panel and assign them`,
+  };
+}
+
+interface UnzonedChipProps {
+  /** Count of live tabs not assigned to any visible zone. */
+  unassignedCount: number;
+  /** Opens the ZoneControlPanel (where the Unassigned (N) list lives). */
+  onOpen: () => void;
+}
+
+export function UnzonedChip({ unassignedCount, onOpen }: UnzonedChipProps) {
+  const label = unzonedChipLabel(unassignedCount);
+  if (!label) return null;
+
+  return (
+    <div
+      data-page-element="unzoned-chip"
+      className="flex items-center px-2 py-1 bg-[#13141f]/40 backdrop-blur-sm border-b border-[#2a2d3d]/20 shrink-0"
+    >
+      <button
+        type="button"
+        onClick={onOpen}
+        className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium leading-none whitespace-nowrap hover:bg-white/5 transition-colors"
+        style={{ color: "#e0af68" }}
+        title={label.title}
+      >
+        <EyeOff className="w-2.5 h-2.5" aria-hidden />
+        <span>{label.text}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/components/terminal/ZoneControlPanel.tsx
+++ b/src/components/terminal/ZoneControlPanel.tsx
@@ -738,7 +738,9 @@ export const ZoneControlPanel = React.memo(function ZoneControlPanel({
   const onLoadWorkspace = useCallback(
     async (workspace: SavedWorkspace) => {
       if (workspace.layoutId !== zoneLayout.layoutId) {
-        zoneLayout.setLayoutId(workspace.layoutId);
+        // Loading a saved workspace is a deliberate operator layout choice —
+        // pin it so auto-grow doesn't override the restored arrangement.
+        zoneLayout.setLayoutId(workspace.layoutId, { pinned: true });
       }
       for (const session of workspace.sessions) {
         if (session.zoneIndex < 0) {

--- a/src/components/terminal/commands/useTerminalCommands.ts
+++ b/src/components/terminal/commands/useTerminalCommands.ts
@@ -36,7 +36,12 @@
 
 import { instanceStorage } from "@/lib/instance-storage";
 
-import { useTerminalSession, useTransitionEffects, useUIStateCx, useZoneMetadata } from "../contexts";
+import {
+  useTerminalSession,
+  useTransitionEffects,
+  useUIStateCx,
+  useZoneMetadata,
+} from "../contexts";
 import type { AccountUsageInfo } from "../useSessionManager";
 import { compareByUsageHeadroom } from "../../settings/types";
 import type { ResultCardSpec } from "../result-card";
@@ -65,11 +70,7 @@ export interface TerminalCommandsContext {
    * closure at `TerminalPage.tsx:559` (passed down as `onLaunchAiSession`
    * to `TerminalTabBar`).
    */
-  spawnAi: (
-    count: number,
-    configDir: string,
-    context?: string,
-  ) => Promise<string[] | void>;
+  spawnAi: (count: number, configDir: string, context?: string) => Promise<string[] | void>;
   /**
    * Snapshot of the available Claude Code accounts, in the original
    * `useSessionManager` shape (NOT sorted). Handlers sort locally when
@@ -120,7 +121,7 @@ const SCHEMA = {
     count: "number (>= 1, defaults to 1)",
     account:
       'string — either a Claude account label (e.g. "gmail", "hotmail") or the literal "best" to pick the lowest-utilization account',
-    context: 'string (optional initial prompt auto-typed after `claude` starts)',
+    context: "string (optional initial prompt auto-typed after `claude` starts)",
   },
   spawnWith: {
     count: "number (>= 1, defaults to 1)",
@@ -152,10 +153,7 @@ function fail(code: string, message?: string): CommandResult<never> {
  * number or the words `next` / `prev` / `needs-input`. Returns `null` when
  * the args don't carry a usable target.
  */
-function readZoneArg(
-  args: Record<string, unknown>,
-  field: string = "zone",
-): number | null {
+function readZoneArg(args: Record<string, unknown>, field: string = "zone"): number | null {
   const v = args[field];
   if (typeof v === "number" && Number.isFinite(v)) return Math.floor(v);
   if (typeof v === "string") {
@@ -295,7 +293,7 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
     aliases: ["/spawn-best"],
     label: "Spawn AI session",
     description:
-      "Spawn N Claude CLI sessions in a specific account. account=\"best\" picks the " +
+      'Spawn N Claude CLI sessions in a specific account. account="best" picks the ' +
       "lowest-utilization account. context (optional) is typed after `claude` starts.",
     paramSchema: SCHEMA.spawnAi,
     // Tier-2 patterns:
@@ -372,10 +370,7 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
       "Toggle maximize for the given zone (1-based), or the currently focused zone " +
       "when no argument is provided. Calling on the already-maximized zone restores.",
     paramSchema: SCHEMA.maximize,
-    patterns: [
-      /^maximize(?:\s+(?<zone>\d+))?$/i,
-      /^fullscreen(?:\s+(?<zone>\d+))?$/i,
-    ],
+    patterns: [/^maximize(?:\s+(?<zone>\d+))?$/i, /^fullscreen(?:\s+(?<zone>\d+))?$/i],
     handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
       const idx = resolveZoneIdx(args);
       if (idx === null) return fail("out-of-range");
@@ -433,11 +428,11 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
     handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
       const preset = typeof args.preset === "string" ? args.preset.toLowerCase() : "";
       // Normalize "six-pack" / "sixpack" → "six-pack"; same for full-grid.
-      const normalized = preset
-        .replace(/sixpack/, "six-pack")
-        .replace(/fullgrid/, "full-grid");
+      const normalized = preset.replace(/sixpack/, "six-pack").replace(/fullgrid/, "full-grid");
       if (!normalized) return fail("invalid-preset");
-      zoneLayout.setLayoutId(normalized);
+      // `/layout <preset>` is an explicit operator choice — pin it so auto-grow
+      // stops overriding it.
+      zoneLayout.setLayoutId(normalized, { pinned: true });
       return ok();
     },
   });
@@ -462,7 +457,7 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
       const idx = resolveZoneIdx(args);
       if (idx === null) return fail("out-of-range");
       const tabId = zoneLayout.assignments[idx];
-      const state = tabId ? sessionStates[tabId] ?? "idle" : "idle";
+      const state = tabId ? (sessionStates[tabId] ?? "idle") : "idle";
       if (state !== "completed" && state !== "error") {
         return fail("not-restartable", `session state is ${state}`);
       }
@@ -817,9 +812,7 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
     paramSchema: {
       state: 'string — one of "idle", "working", "needs-input", "completed", "error"',
     },
-    patterns: [
-      /^select(?:-by-state)?\s+(?<state>idle|working|needs[-_ ]?input|completed|error)$/i,
-    ],
+    patterns: [/^select(?:-by-state)?\s+(?<state>idle|working|needs[-_ ]?input|completed|error)$/i],
     handler: async (args: Record<string, unknown>): Promise<CommandResult> => {
       const raw = typeof args.state === "string" ? args.state.toLowerCase() : "";
       const state = /^needs[-_ ]?input$/.test(raw) ? "needs-input" : raw;

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -29,17 +29,23 @@
  * coord-unrelated UI state like zone layout, AI workflow generation,
  * findings, transcripts).
  *
- * Provider order in TerminalPage.tsx:
+ * Provider order (Phase 3 mount-hydration lift):
  *
- *   <TerminalSessionProvider pageId={pageId}>
- *     <ZoneMetadataProvider>
- *       <TransitionEffectsProvider>
- *         <UIStateProvider>
- *           {children}
- *         </UIStateProvider>
- *       </TransitionEffectsProvider>
- *     </ZoneMetadataProvider>
- *   </TerminalSessionProvider>
+ *   App.tsx:
+ *     <WindowAssignmentsProvider>
+ *       <TerminalSessionProvider pages={…} activePageId={…}>  // always mounted
+ *         <TerminalPage>  // single instance, reads the active page's slice
+ *           <ZoneMetadataProvider>
+ *             <TransitionEffectsProvider>
+ *               <UIStateProvider>{children}</UIStateProvider>
+ *             …
+ *
+ * `TerminalSessionProvider` renders one always-mounted `PageSessionScope` per
+ * terminal page (each owning its page's tab + zone + AI state and its own live
+ * `terminal-created` listener) and surfaces the ACTIVE page's value through
+ * `TerminalSessionContext`. Switching terminal pages no longer destroys any
+ * page's state, and a `terminal-created` event is never dropped by a page
+ * switch.
  *
  * The previously-circular dependencies (TransitionEffects + ZoneMetadata
  * read from TerminalCore + SessionState) collapse to a single
@@ -88,6 +94,7 @@ import { useFindingsActions } from "../useFindingsActions";
 import { useTranscriptSessions } from "../useTranscriptSessions";
 import { useSessionManager } from "../useSessionManager";
 import { deriveSyntheticTabs } from "../syntheticTabs";
+import { useZoneLabelsAndTags } from "../useZoneLabelsAndTags";
 
 import { instanceStorage } from "@/lib/instance-storage";
 
@@ -108,6 +115,7 @@ type FindingsActionsReturn = ReturnType<typeof useFindingsActions>;
 type SessionManagerReturn = ReturnType<typeof useSessionManager>;
 type FileConflictsReturn = ReturnType<typeof useFileConflicts>;
 type SessionPersistenceReturn = ReturnType<typeof useSessionPersistence>;
+type LabelsAndTagsReturn = ReturnType<typeof useZoneLabelsAndTags>;
 
 /**
  * Flat value-object exposed by `useTerminalSession()`. The shape is the
@@ -121,14 +129,19 @@ type SessionPersistenceReturn = ReturnType<typeof useSessionPersistence>;
  * matches the prior consumers, which previously destructured these
  * fields off `useTerminalCore()` / `useSessionState()` directly.
  */
-export interface TerminalSessionContextValue
-  extends TerminalManagerReturn,
-    StateTrackingReturn {
+export interface TerminalSessionContextValue extends TerminalManagerReturn, StateTrackingReturn {
   // — TerminalCore extras —
   pageId: string;
   zoneLayout: ZoneLayoutReturn;
   terminalRefs: React.MutableRefObject<Map<string, RefObject<TerminalInstanceHandle | null>>>;
   pendingProfileSessionsRef: React.MutableRefObject<ZoneSessionInfo[] | null>;
+  /**
+   * Per-page zone labels / notes / pins / tags. Owned by the per-page
+   * `PageSessionScope` (namespaced by `pageId` in `instanceStorage`) so the
+   * cold-start init backstop can run inside the scope; `ZoneMetadataProvider`
+   * re-exposes this exact reference to the wider page tree.
+   */
+  labelsAndTags: LabelsAndTagsReturn;
 
   // — SessionState extras —
   unreadZones: ReturnType<typeof useUnreadTracking>["unreadZones"];
@@ -159,35 +172,45 @@ export interface TerminalSessionContextValue
   loadMessages: ReturnType<typeof useTranscriptSessions>["loadMessages"];
   sessionSummary: string | null;
   sessionSummaryLoading: boolean;
-  handleSummarizeSession: (
-    messages: Array<{ msg_type: string; text: string }>,
-  ) => Promise<void>;
+  handleSummarizeSession: (messages: Array<{ msg_type: string; text: string }>) => Promise<void>;
   getScrollback: (tabId: string, maxLines?: number) => string;
   getActiveSelection: () => string;
 }
 
-export const TerminalSessionContext =
-  createContext<TerminalSessionContextValue | null>(null);
+export const TerminalSessionContext = createContext<TerminalSessionContextValue | null>(null);
 
-interface TerminalSessionProviderProps {
+interface PageSessionScopeProps {
   pageId: string;
+  /**
+   * Publish (or, with `null`, retract) this page's computed session value to
+   * the lifted `TerminalSessionProvider`. The provider keeps a Map keyed by
+   * pageId and surfaces the ACTIVE page's value through context.
+   */
+  register: (pageId: string, value: TerminalSessionContextValue | null) => void;
   onNavigateToBuilder?: () => void;
   onNavigateToActive?: () => void;
-  children: ReactNode;
 }
 
 /**
- * The collapsed provider. Owns every piece of state previously split
- * across TerminalCore + SessionState + ShellInfra + AiFeatures. Wire
- * order matches the prior provider nesting precisely so the underlying
- * hooks see the same input timing.
+ * Per-page state scope. Owns every piece of terminal-page state previously
+ * split across TerminalCore + SessionState + ShellInfra + AiFeatures (plus the
+ * page-namespaced `labelsAndTags`). Wire order matches the prior provider
+ * nesting precisely so the underlying hooks see the same input timing.
+ *
+ * Phase 3 (mount-hydration lift): one of these is mounted PER terminal page,
+ * all simultaneously, regardless of which page the operator is viewing. That
+ * keeps every page's `terminal-created` listener live (no dropped events on a
+ * page switch) and preserves every page's tab state across switches. The
+ * component renders nothing — it only computes its page's value and publishes
+ * it via `register`; the lifted provider routes the active page's value into
+ * the `TerminalSessionContext` the page tree consumes.
  */
-export function TerminalSessionProvider({
+function PageSessionScope({
   pageId,
+  register,
   onNavigateToBuilder,
   onNavigateToActive,
-  children,
-}: TerminalSessionProviderProps) {
+}: PageSessionScopeProps) {
   // Phase 1 (pop-out windows): render only the tabs THIS window owns. With a
   // single ("main") window and no assignments every tab is owned by "main", so
   // `tabs === allTabs` and every downstream consumer behaves byte-identically.
@@ -197,8 +220,14 @@ export function TerminalSessionProvider({
 
   // ---- TerminalCore ----
   const terminalManager = useTerminalManager(pageId, myWindowLabel);
-  const { tabs: allTabs, activeId, setActiveId, updateTab, renameTab, createTerminal } =
-    terminalManager;
+  const {
+    tabs: allTabs,
+    activeId,
+    setActiveId,
+    updateTab,
+    renameTab,
+    createTerminal,
+  } = terminalManager;
   const tabs = useMemo(() => allTabs.filter((t) => isOwned(t.id)), [allTabs, isOwned]);
 
   // A terminal created in a pop-out window must belong to THAT window, not the
@@ -225,6 +254,14 @@ export function TerminalSessionProvider({
   const tabIds = useMemo(() => tabs.map((t) => t.id), [tabs]);
   const zoneLayout = useZoneLayout(tabIds, pageId, myWindowLabel);
 
+  // Page-namespaced zone labels / notes / pins / tags. Moved into the scope
+  // (from ZoneMetadataProvider) so each page owns its own labels regardless of
+  // which page is active, and the cold-start restore path (init backstop) can
+  // apply saved cosmetics to the right page. `ZoneMetadataProvider` re-exposes
+  // this exact reference to the page tree, so downstream consumers are
+  // unchanged.
+  const labelsAndTags = useZoneLabelsAndTags(zoneLayout.layoutId, zoneLayout.assignments, pageId);
+
   // Sync focused zone → active tab.
   useEffect(() => {
     if (
@@ -237,9 +274,7 @@ export function TerminalSessionProvider({
   }, [zoneLayout.focusedTabId, activeId, setActiveId, tabs]);
 
   // Terminal refs map — create refs for new tabs, clean up stale ones.
-  const terminalRefs = useRef<Map<string, RefObject<TerminalInstanceHandle | null>>>(
-    new Map(),
-  );
+  const terminalRefs = useRef<Map<string, RefObject<TerminalInstanceHandle | null>>>(new Map());
 
   useEffect(() => {
     const map = terminalRefs.current;
@@ -336,9 +371,7 @@ export function TerminalSessionProvider({
   );
 
   // ---- SessionState ----
-  const processOutputRef = useRef<((tabId: string, text: string) => void) | undefined>(
-    undefined,
-  );
+  const processOutputRef = useRef<((tabId: string, text: string) => void) | undefined>(undefined);
 
   const stateTracking = useSessionStateTracking({
     tabs: tabsWithSynthetic,
@@ -363,9 +396,7 @@ export function TerminalSessionProvider({
 
   const snapshots = useOutputSnapshots(stateTracking.lastOutputLines);
 
-  const { processOutput, activeFindings, allFindings } = useTerminalFindings(
-    activeId ?? null,
-  );
+  const { processOutput, activeFindings, allFindings } = useTerminalFindings(activeId ?? null);
 
   // Wire findings processOutput into stateTracking's processOutputRef.
   useEffect(() => {
@@ -388,18 +419,13 @@ export function TerminalSessionProvider({
   const rightPanelModeSetterRef = useRef<
     React.Dispatch<
       React.SetStateAction<
-        | "transcript"
-        | "workflow"
-        | "analysis"
-        | "findings"
-        | "file-ownership"
-        | null
+        "transcript" | "workflow" | "analysis" | "findings" | "file-ownership" | null
       >
     >
   >(() => {});
-  const selectedSessionSetterRef = useRef<
-    React.Dispatch<React.SetStateAction<string | null>>
-  >(() => {});
+  const selectedSessionSetterRef = useRef<React.Dispatch<React.SetStateAction<string | null>>>(
+    () => {},
+  );
 
   const shellIntegration = useShellIntegration({
     tabs,
@@ -409,8 +435,7 @@ export function TerminalSessionProvider({
     setSessionStates: stateTracking.setSessionStates,
     terminalRefs,
     setRightPanelMode: (v) => rightPanelModeSetterRef.current(v as never),
-    setSelectedTranscriptSessionId: (v) =>
-      selectedSessionSetterRef.current(v as never),
+    setSelectedTranscriptSessionId: (v) => selectedSessionSetterRef.current(v as never),
   });
 
   const getScrollback = useCallback(
@@ -496,9 +521,7 @@ export function TerminalSessionProvider({
       setSessionSummary(null);
       try {
         const text = messages
-          .map(
-            (m) => `${m.msg_type === "user" ? "User" : "Assistant"}: ${m.text}`,
-          )
+          .map((m) => `${m.msg_type === "user" ? "User" : "Assistant"}: ${m.text}`)
           .join("\n\n");
         const result = await invoke<{
           success: boolean;
@@ -512,17 +535,13 @@ export function TerminalSessionProvider({
           let summaryContent: string | null = null;
 
           if (Array.isArray(data)) {
-            const markdownPanel = data.find(
-              (p) => p.type === "markdown" || p.content,
-            );
+            const markdownPanel = data.find((p) => p.type === "markdown" || p.content);
             summaryContent = markdownPanel?.content ?? null;
           } else if (data && "panels" in data && Array.isArray(data.panels)) {
             summaryContent = data.panels[0]?.content ?? null;
           }
 
-          setSessionSummary(
-            summaryContent || "Summary generated but no content available.",
-          );
+          setSessionSummary(summaryContent || "Summary generated but no content available.");
         } else {
           setSessionSummary(result.message || "Unable to generate summary.");
         }
@@ -555,6 +574,7 @@ export function TerminalSessionProvider({
       zoneLayout,
       terminalRefs,
       pendingProfileSessionsRef,
+      labelsAndTags,
       // SessionState (spread)
       ...stateTracking,
       unreadZones,
@@ -590,6 +610,7 @@ export function TerminalSessionProvider({
       createTerminalForWindow,
       pageId,
       zoneLayout,
+      labelsAndTags,
       stateTracking,
       unreadZones,
       snapshots,
@@ -617,10 +638,107 @@ export function TerminalSessionProvider({
     ],
   );
 
+  // Publish this page's value to the lifted provider whenever it changes, and
+  // retract it on unmount (page removed). Done in an effect — never during
+  // render — so a child never sets parent state mid-render.
+  useEffect(() => {
+    register(pageId, value);
+    return () => register(pageId, null);
+  }, [register, pageId, value]);
+
+  // Renders nothing: the lifted provider routes the active page's value into
+  // context and renders the (single) page tree.
+  return null;
+}
+
+interface TerminalSessionProviderProps {
+  /** Every terminal page that should keep live state (all stay mounted). */
+  pages: Array<{ id: string }>;
+  /** The page the operator is currently viewing — its value is surfaced. */
+  activePageId: string;
+  onNavigateToBuilder?: () => void;
+  onNavigateToActive?: () => void;
+  children: ReactNode;
+}
+
+/**
+ * Lifted, always-mounted terminal session provider (Phase 3 mount-hydration).
+ *
+ * Mounts ABOVE `TerminalPage` (in `App.tsx`) so it survives both app-tab
+ * switches and terminal-PAGE switches. It renders one always-mounted
+ * `PageSessionScope` per terminal page; each scope keeps its page's tab state
+ * and runs its own live `terminal-created` listener. The provider surfaces the
+ * ACTIVE page's value through `TerminalSessionContext`, so the single
+ * `TerminalPage` consuming `useTerminalSession()` sees only its page's slice —
+ * exactly as before — while page switches no longer destroy any page's state
+ * and a `terminal-created` event is never dropped.
+ *
+ * Invariant: alive PTY ⇒ tab survives navigation; `terminal-created` never
+ * dropped.
+ */
+export function TerminalSessionProvider({
+  pages,
+  activePageId,
+  onNavigateToBuilder,
+  onNavigateToActive,
+  children,
+}: TerminalSessionProviderProps) {
+  const [values, setValues] = useState<Record<string, TerminalSessionContextValue | null>>({});
+
+  const register = useCallback((pageId: string, value: TerminalSessionContextValue | null) => {
+    setValues((prev) => {
+      if (value === null) {
+        if (!(pageId in prev)) return prev;
+        const next = { ...prev };
+        delete next[pageId];
+        return next;
+      }
+      if (prev[pageId] === value) return prev;
+      return { ...prev, [pageId]: value };
+    });
+  }, []);
+
+  // Always mount the active page even if it isn't yet in `pages` (e.g. a page
+  // removed from the list while still selected, mid-transition) so the page
+  // tree always has a value to read once its scope publishes.
+  const scopedPageIds = useMemo(() => {
+    const ids = pages.map((p) => p.id);
+    if (!ids.includes(activePageId)) ids.push(activePageId);
+    return ids;
+  }, [pages, activePageId]);
+
+  const activeValue = values[activePageId] ?? null;
+
   return (
-    <TerminalSessionContext.Provider value={value}>
-      {children}
-    </TerminalSessionContext.Provider>
+    <>
+      {scopedPageIds.map((id) => (
+        <PageSessionScope
+          key={id}
+          pageId={id}
+          register={register}
+          onNavigateToBuilder={onNavigateToBuilder}
+          onNavigateToActive={onNavigateToActive}
+        />
+      ))}
+      {/* Gate the page tree on the active page's value. A freshly-mounted
+          scope publishes its value in an effect (post-paint), so for the very
+          first frame after an app boot or a switch to a brand-new page,
+          `activeValue` is momentarily null. Rendering `children` then would
+          throw in `useTerminalSession()`. The window is sub-frame; show the
+          same spinner TerminalPage uses while not `initialized`. */}
+      {activeValue ? (
+        <TerminalSessionContext.Provider value={activeValue}>
+          {children}
+        </TerminalSessionContext.Provider>
+      ) : (
+        <div className="h-full flex items-center justify-center bg-[#1a1b26]">
+          <div className="flex flex-col items-center gap-3">
+            <div className="w-8 h-8 border-2 border-[#7aa2f7] border-t-transparent rounded-full animate-spin" />
+            <span className="text-[12px] text-[#565f89]">Loading terminals...</span>
+          </div>
+        </div>
+      )}
+    </>
   );
 }
 
@@ -637,9 +755,7 @@ export function TerminalSessionProvider({
 export function useTerminalSession(): TerminalSessionContextValue {
   const ctx = useContext(TerminalSessionContext);
   if (!ctx) {
-    throw new Error(
-      "useTerminalSession must be used within a TerminalSessionProvider",
-    );
+    throw new Error("useTerminalSession must be used within a TerminalSessionProvider");
   }
   return ctx;
 }

--- a/src/components/terminal/contexts/ZoneMetadataContext.tsx
+++ b/src/components/terminal/contexts/ZoneMetadataContext.tsx
@@ -8,7 +8,7 @@
 
 import { createContext, useMemo, type ReactNode } from "react";
 import { useTerminalSession } from "./TerminalSessionContext";
-import { useZoneLabelsAndTags } from "../useZoneLabelsAndTags";
+import type { useZoneLabelsAndTags } from "../useZoneLabelsAndTags";
 import { useEventHistory } from "../useEventHistory";
 import { useFocusHistory } from "../useFocusHistory";
 
@@ -32,10 +32,12 @@ interface ZoneMetadataProviderProps {
 }
 
 export function ZoneMetadataProvider({ children }: ZoneMetadataProviderProps) {
-  const { pageId, zoneLayout } = useTerminalSession();
+  const { zoneLayout, labelsAndTags } = useTerminalSession();
 
-  const labelsAndTags = useZoneLabelsAndTags(zoneLayout.layoutId, zoneLayout.assignments, pageId);
-
+  // `labelsAndTags` now lives in the per-page `PageSessionScope` (so each page
+  // owns its own page-namespaced labels and the cold-start init backstop can
+  // apply restored cosmetics to the right page). Re-expose the exact reference
+  // here so every downstream `useZoneMetadata()` consumer is unchanged.
   const { eventHistory, addHistoryEvent, metrics, incrementMetric } = useEventHistory();
 
   const focusHistory = useFocusHistory(zoneLayout.focusedZone, zoneLayout.setFocusedZone);

--- a/src/components/terminal/pickLayout.test.ts
+++ b/src/components/terminal/pickLayout.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Phase 1 — `pickLayout` count→preset mapping.
+ *
+ * `pickLayout` was extracted from an inline copy in `TerminalPage.tsx` into an
+ * exported pure function in `useZoneLayout.ts` so the quick-launch path, the
+ * in-hook auto-grow effect, and this test all share ONE mapping. These tests
+ * lock the exact mapping down (a drifted boundary silently re-hides sessions).
+ *
+ * vitest runs `environment: "node"` here — pure-function tests only (repo
+ * precedent: `reconcileAssignments` in `useZoneLayout.restore.test.ts`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { pickLayout, computeAutoGrowLayoutId, LAYOUT_PRESETS } from "./useZoneLayout";
+
+describe("pickLayout — smallest uniform preset that fits N tabs (cap full-grid/9)", () => {
+  it("0 and 1 tabs → single", () => {
+    expect(pickLayout(0)).toBe("single");
+    expect(pickLayout(1)).toBe("single");
+  });
+
+  it("2 tabs → split", () => {
+    expect(pickLayout(2)).toBe("split");
+  });
+
+  it("3 and 4 tabs → quad", () => {
+    expect(pickLayout(3)).toBe("quad");
+    expect(pickLayout(4)).toBe("quad");
+  });
+
+  it("5 and 6 tabs → six-pack", () => {
+    expect(pickLayout(5)).toBe("six-pack");
+    expect(pickLayout(6)).toBe("six-pack");
+  });
+
+  it("7, 9, and 20 tabs → full-grid (capped at the largest preset)", () => {
+    expect(pickLayout(7)).toBe("full-grid");
+    expect(pickLayout(9)).toBe("full-grid");
+    expect(pickLayout(20)).toBe("full-grid");
+  });
+
+  it("every returned id is a real preset", () => {
+    for (let n = 0; n <= 20; n++) {
+      const id = pickLayout(n);
+      expect(LAYOUT_PRESETS.some((l) => l.id === id)).toBe(true);
+    }
+  });
+
+  it("the chosen preset has enough zones to fit N (up to the 9 ceiling)", () => {
+    for (let n = 1; n <= 9; n++) {
+      const preset = LAYOUT_PRESETS.find((l) => l.id === pickLayout(n))!;
+      expect(preset.zones.length).toBeGreaterThanOrEqual(n);
+    }
+  });
+});
+
+describe("computeAutoGrowLayoutId — grow-only, pin-aware, capacity-gated", () => {
+  it("grows single → split when a 2nd tab arrives", () => {
+    expect(computeAutoGrowLayoutId("single", 2, false)).toBe("split");
+  });
+
+  it("grows single → full-grid when 9 tabs arrive at once (reconnect ingest)", () => {
+    expect(computeAutoGrowLayoutId("single", 9, false)).toBe("full-grid");
+  });
+
+  it("returns null when the current layout already fits (no thrash)", () => {
+    expect(computeAutoGrowLayoutId("quad", 4, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("quad", 3, false)).toBeNull();
+  });
+
+  it("NEVER shrinks: more zones than tabs → null", () => {
+    expect(computeAutoGrowLayoutId("full-grid", 2, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("six-pack", 1, false)).toBeNull();
+  });
+
+  it("stays put at full-grid even past the 9 ceiling (10+ tabs → null)", () => {
+    expect(computeAutoGrowLayoutId("full-grid", 10, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("full-grid", 50, false)).toBeNull();
+  });
+
+  it("operator-pinned layout is NEVER auto-grown", () => {
+    expect(computeAutoGrowLayoutId("single", 9, true)).toBeNull();
+    expect(computeAutoGrowLayoutId("split", 6, true)).toBeNull();
+  });
+
+  it("only grows to a STRICTLY larger preset (asymmetric presets never shrink zones)", () => {
+    // From a hypothetical larger-but-named-smaller current id, ensure the
+    // target never has fewer/equal zones than current.
+    const cases: Array<[string, number]> = [
+      ["single", 3],
+      ["split", 5],
+      ["quad", 7],
+      ["six-pack", 9],
+    ];
+    for (const [current, count] of cases) {
+      const target = computeAutoGrowLayoutId(current, count, false);
+      expect(target).not.toBeNull();
+      const cur = LAYOUT_PRESETS.find((l) => l.id === current)!;
+      const tgt = LAYOUT_PRESETS.find((l) => l.id === target!)!;
+      expect(tgt.zones.length).toBeGreaterThan(cur.zones.length);
+    }
+  });
+});

--- a/src/components/terminal/useKeyboardShortcuts.ts
+++ b/src/components/terminal/useKeyboardShortcuts.ts
@@ -26,7 +26,7 @@ interface UseKeyboardShortcutsParams {
     focusNextNeedsInput: (states: Record<string, SessionState>) => void;
     toggleMaximize: (idx: number) => void;
     setMaximizedZone: (idx: number | null) => void;
-    setLayoutId: (id: string) => void;
+    setLayoutId: (id: string, opts?: { pinned?: boolean }) => void;
     assignTabToZone: (idx: number, tabId: string) => void;
   };
   sessionStates: Record<string, SessionState>;
@@ -53,7 +53,9 @@ interface UseKeyboardShortcutsParams {
     showSidebar: boolean;
     setShowSidebar: React.Dispatch<React.SetStateAction<boolean>>;
     setRightPanelMode: React.Dispatch<
-      React.SetStateAction<"transcript" | "workflow" | "analysis" | "findings" | "file-ownership" | null>
+      React.SetStateAction<
+        "transcript" | "workflow" | "analysis" | "findings" | "file-ownership" | null
+      >
     >;
     setSelectedTranscriptSessionId: React.Dispatch<React.SetStateAction<string | null>>;
   };
@@ -155,7 +157,8 @@ export function useKeyboardShortcuts({
         const num = parseInt(e.key, 10);
         const preset = LAYOUT_PRESETS.find((l) => l.shortcutKey === num);
         if (preset) {
-          zoneLayout.setLayoutId(preset.id);
+          // Keyboard shortcut is an explicit operator choice — pin it.
+          zoneLayout.setLayoutId(preset.id, { pinned: true });
         }
         return;
       }
@@ -208,7 +211,8 @@ export function useKeyboardShortcuts({
         e.preventDefault();
         const currentIdx = LAYOUT_PRESETS.findIndex((l) => l.id === zoneLayout.layoutId);
         const nextIdx = (currentIdx + 1) % LAYOUT_PRESETS.length;
-        zoneLayout.setLayoutId(LAYOUT_PRESETS[nextIdx].id);
+        // Cycle-layout shortcut is an explicit operator choice — pin it.
+        zoneLayout.setLayoutId(LAYOUT_PRESETS[nextIdx].id, { pinned: true });
         return;
       }
       if (e.ctrlKey && e.shiftKey && e.key === "K") {

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -14,7 +14,7 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
-import { fetchOpenRecords } from "./useTerminalInitialization";
+import { fetchOpenRecords, claimInitForPage } from "./useTerminalInitialization";
 import type { TerminalSessionRecord } from "./types";
 
 const rec = (overrides: Partial<TerminalSessionRecord>): TerminalSessionRecord => ({
@@ -87,9 +87,7 @@ describe("fetchOpenRecords", () => {
       success: true,
       message: null,
       data: {
-        sessions: [
-          { ...rec({ claudeSessionId: "A" }), pageId: undefined as unknown as string },
-        ],
+        sessions: [{ ...rec({ claudeSessionId: "A" }), pageId: undefined as unknown as string }],
       },
     });
     const out = await fetchOpenRecords("default");
@@ -124,5 +122,35 @@ describe("fetchOpenRecords", () => {
   it("returns [] when the payload has no sessions array", async () => {
     mockInvoke.mockResolvedValueOnce({ success: true, message: null, data: {} });
     expect(await fetchOpenRecords("default")).toEqual([]);
+  });
+});
+
+// Phase 3 (mount-hydration lift): the convergence backstop must run once PER
+// PAGEID, not once per mount. The single TerminalPage instance now persists
+// across terminal-page switches (the session provider was lifted above it), so
+// the guard is keyed by pageId.
+describe("claimInitForPage (once-per-pageId guard)", () => {
+  it("runs init the first time a page is seen", () => {
+    const seen = new Set<string>();
+    expect(claimInitForPage(seen, "default")).toBe(true);
+  });
+
+  it("does NOT re-run init for a page already initialized", () => {
+    const seen = new Set<string>();
+    expect(claimInitForPage(seen, "default")).toBe(true);
+    expect(claimInitForPage(seen, "default")).toBe(false);
+    expect(claimInitForPage(seen, "default")).toBe(false);
+  });
+
+  it("runs init independently for each pageId (page switch ⇒ new page inits once)", () => {
+    const seen = new Set<string>();
+    // First visit to page A initializes it.
+    expect(claimInitForPage(seen, "page-a")).toBe(true);
+    // Switch to page B (no remount) — B initializes once.
+    expect(claimInitForPage(seen, "page-b")).toBe(true);
+    // Switching back to A does NOT re-init (state survived the switch).
+    expect(claimInitForPage(seen, "page-a")).toBe(false);
+    // ...and B is likewise already converged.
+    expect(claimInitForPage(seen, "page-b")).toBe(false);
   });
 });

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -55,6 +55,25 @@ function buildResumeCmd(sessionId: string, configDir: string | undefined): strin
     : `CLAUDE_CONFIG_DIR="${configDir}" ${base}\r`;
 }
 
+/**
+ * Pure guard for the once-per-pageId init backstop (Phase 3 mount-hydration
+ * lift). With the session provider lifted above the page, the single
+ * `useTerminalInitialization` instance persists across terminal-page switches,
+ * so the convergence backstop (reconnect + durable-record restore + resume
+ * drain) must run exactly ONCE per pageId — not once per mount. Returns `true`
+ * (and records `pageId` as seen) the FIRST time a page is initialized;
+ * `false` on every subsequent call for that page.
+ *
+ * Mutating the passed Set keeps the call-site a one-liner and lets the hook
+ * hold the Set in a ref. Exported so the per-pageId semantics can be unit-
+ * tested without booting React (vitest `environment: "node"`).
+ */
+export function claimInitForPage(seen: Set<string>, pageId: string): boolean {
+  if (seen.has(pageId)) return false;
+  seen.add(pageId);
+  return true;
+}
+
 /** Validate session IDs before interpolating into shell commands. */
 const SESSION_ID_RE = /^[a-zA-Z0-9_-]+$/;
 function isValidSessionId(id: string): boolean {
@@ -148,33 +167,31 @@ export function useTerminalInitialization({
   sessionPersistence,
   layoutState,
 }: UseTerminalInitializationParams) {
+  // Phase 3 (mount-hydration lift): with the session provider lifted above the
+  // page and per-page scopes always mounted, a terminal-PAGE switch no longer
+  // unmounts/remounts this hook — so the old "REMOUNTED … tabs were lost" /
+  // "UNMOUNTED … will be destroyed" warnings (which fired on every page
+  // switch) are gone. A genuine unmount of the whole tree (auth change) is
+  // still surfaced once.
   const mountCountRef = useRef(0);
   useEffect(() => {
     mountCountRef.current += 1;
     const mountNum = mountCountRef.current;
     if (mountNum > 1) {
       console.warn(
-        `[TerminalPage] REMOUNTED (mount #${mountNum}) — all terminal tabs were lost. ` +
-          `This usually means the parent component tree unmounted (e.g., auth state change).`,
+        `[TerminalPage] REMOUNTED (mount #${mountNum}) — the terminal page tree remounted. ` +
+          `Page state is preserved by the lifted session provider; this usually means the ` +
+          `parent app tree unmounted (e.g., auth state change).`,
       );
     }
-    return () => {
-      console.warn(
-        `[TerminalPage] UNMOUNTED (was mount #${mountNum}), ${tabs.length} tab(s) will be destroyed`,
-      );
-    };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
-  const didInit = useRef(false);
-  const pendingRestoresRef = useRef<
-    Array<{
-      tabId: string;
-      scrollbackPath?: string;
-      isClaudeSession?: boolean;
-      claudeSessionId?: string;
-      claudeConfigDir?: string;
-    }>
-  >([]);
+  // Init / restore guards are keyed by pageId, NOT per hook mount. The single
+  // TerminalPage instance now persists across terminal-page switches (no
+  // remount), so the convergence backstop (reconnect + durable-record restore
+  // + resume-drain) must run exactly ONCE per pageId — the first time each page
+  // becomes active — rather than once per mount.
+  const didInitPages = useRef<Set<string>>(new Set());
 
   // Gate for the debounced auto-save effect. The restore path recreates
   // plain shells and only *asynchronously* types `claude --resume <id>` /
@@ -186,17 +203,31 @@ export function useTerminalInitialization({
   // then open the gate exactly once. The flag is opened in a `finally` so
   // it ALWAYS flips — even when there were no saved sessions or restore
   // threw — so brand-new sessions still persist normally.
-  const restoreCompleteRef = useRef(false);
+  //
+  // Keyed per pageId (Phase 3): each page's restore drains independently, and
+  // auto-save runs in the single page instance for whichever page is active.
+  const restoreCompletePages = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    if (didInit.current) return;
-    didInit.current = true;
+    if (!claimInitForPage(didInitPages.current, pageId)) return;
+    const initPageId = pageId;
+
+    // Per-page restore queue (Phase 3): local to this page's init run so a
+    // second page initializing before this one's drain timer fires can't see
+    // (or clear) the other page's pending restores.
+    const pendingRestores: Array<{
+      tabId: string;
+      scrollbackPath?: string;
+      isClaudeSession?: boolean;
+      claudeSessionId?: string;
+      claudeConfigDir?: string;
+    }> = [];
 
     (async () => {
       // True once a deferred resume/scrollback drain timer is scheduled. When
-      // set, that timer owns flipping `restoreCompleteRef` (after it issues the
-      // resume commands); the `finally` below only opens the gate when NO drain
-      // was scheduled, so the flag always flips exactly once.
+      // set, that timer owns flipping the per-page restore-complete gate (after
+      // it issues the resume commands); the `finally` below only opens the gate
+      // when NO drain was scheduled, so the flag always flips exactly once.
       let drainScheduled = false;
       try {
         // 1) Reconnect to live PTYs that survived a React remount. These tabs
@@ -295,7 +326,7 @@ export function useTerminalInitialization({
           rememberSessionId(tabId, rec.claudeSessionId, safeConfigDir);
 
           if (validSessionId) {
-            pendingRestoresRef.current.push({
+            pendingRestores.push({
               tabId,
               scrollbackPath:
                 rec.zoneIndex >= 0 ? cosmeticsByZone.get(rec.zoneIndex)?.scrollbackPath : undefined,
@@ -344,12 +375,12 @@ export function useTerminalInitialization({
 
         // 6) Drain: restore scrollback then issue `claude --resume` for every
         //    cold-created Claude tab. Identical mechanism to the prior restore;
-        //    the gate (`restoreCompleteRef`) flips in the drain's finally.
-        if (pendingRestoresRef.current.length > 0) {
+        //    the per-page gate flips in the drain's finally.
+        if (pendingRestores.length > 0) {
           drainScheduled = true;
           setTimeout(async () => {
             try {
-              for (const restore of pendingRestoresRef.current) {
+              for (const restore of pendingRestores) {
                 const ref = terminalRefs.current.get(restore.tabId);
                 const handle = ref?.current;
 
@@ -412,11 +443,11 @@ export function useTerminalInitialization({
                 console.warn("[TerminalPage] Failed to cleanup scrollback files:", err);
               }
 
-              pendingRestoresRef.current = [];
+              pendingRestores.length = 0;
             } finally {
               // Restored tabs now carry their claudeSessionId / scrollback —
-              // safe to let the debounced auto-save persist the layout.
-              restoreCompleteRef.current = true;
+              // safe to let the debounced auto-save persist this page's layout.
+              restoreCompletePages.current.add(initPageId);
             }
           }, 1500);
         }
@@ -435,7 +466,7 @@ export function useTerminalInitialization({
         // so brand-new sessions still persist. Never leave it permanently
         // closed (that would silently disable persistence).
         if (!drainScheduled) {
-          restoreCompleteRef.current = true;
+          restoreCompletePages.current.add(initPageId);
         }
       }
     })();
@@ -455,12 +486,13 @@ export function useTerminalInitialization({
   // Auto-save session layout for persistence across app restarts
   useEffect(() => {
     if (tabs.length === 0) return;
-    // Suppress auto-save until restore has fully completed. Otherwise the
-    // debounced save can fire while the restore path still holds plain shells
-    // (no claudeSessionId yet) and clobber the good saved Claude layout. Once
-    // the gate opens, the `updateTab` calls that attach claudeSessionId mutate
-    // `tabs`, re-running this effect — so no save is permanently lost.
-    if (!restoreCompleteRef.current) return;
+    // Suppress auto-save until THIS page's restore has fully completed.
+    // Otherwise the debounced save can fire while the restore path still holds
+    // plain shells (no claudeSessionId yet) and clobber the good saved Claude
+    // layout. Once the gate opens, the `updateTab` calls that attach
+    // claudeSessionId mutate `tabs`, re-running this effect — so no save is
+    // permanently lost.
+    if (!restoreCompletePages.current.has(pageId)) return;
     sessionPersistence.saveSessionLayout({
       layoutId: layoutState.layoutId,
       tabs,
@@ -471,6 +503,7 @@ export function useTerminalInitialization({
       focusedZone: layoutState.focusedZone,
     });
   }, [
+    pageId,
     tabs,
     zoneLayout.assignments,
     layoutState.layoutId,

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -87,7 +87,7 @@ interface UseTerminalInitializationParams {
   ) => void;
   zoneLayout: {
     layoutId: string;
-    setLayoutId: (id: string) => void;
+    setLayoutId: (id: string, opts?: { pinned?: boolean }) => void;
     assignTabToZone: (zoneIdx: number, tabId: string) => void;
     setFocusedZone: (zoneIdx: number) => void;
     assignments: Record<number, string>;
@@ -243,9 +243,11 @@ export function useTerminalInitialization({
         };
 
         // Restore the layout preset from the cosmetic snapshot if it differs.
+        // A saved snapshot is the operator's deliberate arrangement, so pin it
+        // — auto-grow must not override a restored layout.
         if (saved && saved.layoutId !== zoneLayout.layoutId) {
           const preset = LAYOUT_PRESETS.find((p) => p.id === saved.layoutId);
-          if (preset) zoneLayout.setLayoutId(preset.id);
+          if (preset) zoneLayout.setLayoutId(preset.id, { pinned: true });
         }
 
         // 3) Bind every open Claude record to its RECORDED zone — Claude zones
@@ -295,7 +297,8 @@ export function useTerminalInitialization({
           if (validSessionId) {
             pendingRestoresRef.current.push({
               tabId,
-              scrollbackPath: rec.zoneIndex >= 0 ? cosmeticsByZone.get(rec.zoneIndex)?.scrollbackPath : undefined,
+              scrollbackPath:
+                rec.zoneIndex >= 0 ? cosmeticsByZone.get(rec.zoneIndex)?.scrollbackPath : undefined,
               isClaudeSession: true,
               claudeSessionId: rec.claudeSessionId,
               claudeConfigDir: safeConfigDir,
@@ -314,10 +317,7 @@ export function useTerminalInitialization({
             title: rec.title,
             terminalId: tabId,
           }).catch((err) => {
-            console.warn(
-              `[TerminalPage] re-record open failed for ${rec.claudeSessionId}:`,
-              err,
-            );
+            console.warn(`[TerminalPage] re-record open failed for ${rec.claudeSessionId}:`, err);
           });
         }
 
@@ -355,12 +355,9 @@ export function useTerminalInitialization({
 
                 if (restore.scrollbackPath && handle) {
                   try {
-                    const result = await invoke<CommandResponse>(
-                      "terminal_get_saved_scrollback",
-                      {
-                        filePath: restore.scrollbackPath,
-                      },
-                    );
+                    const result = await invoke<CommandResponse>("terminal_get_saved_scrollback", {
+                      filePath: restore.scrollbackPath,
+                    });
                     if (result.success && result.data) {
                       const encoded = (result.data as { data: string }).data;
                       if (encoded) {

--- a/src/components/terminal/useTerminalManager.test.ts
+++ b/src/components/terminal/useTerminalManager.test.ts
@@ -14,7 +14,13 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { applyWorkerMark, type TerminalTab } from "./useTerminalManager";
+import type { TerminalInfo } from "@qontinui/shared-types/tauri-events";
+import {
+  applyWorkerMark,
+  reduceCreatedTerminal,
+  shouldIngestCreatedTerminal,
+  type TerminalTab,
+} from "./useTerminalManager";
 
 const tab = (id: string, overrides: Partial<TerminalTab> = {}): TerminalTab => ({
   id,
@@ -22,6 +28,27 @@ const tab = (id: string, overrides: Partial<TerminalTab> = {}): TerminalTab => (
   pid: 1,
   isAlive: true,
   exitCode: null,
+  ...overrides,
+});
+
+// Minimal `terminal-created` payload. Only the fields the ingest path reads
+// matter; the rest satisfy the generated `TerminalInfo` shape.
+const createdEvent = (
+  id: string,
+  pageId: string,
+  overrides: Partial<TerminalInfo> = {},
+): TerminalInfo => ({
+  id,
+  title: id,
+  pid: 100,
+  isAlive: true,
+  exitCode: null,
+  workingDir: "/repo",
+  createdAt: 1_700_000_000_000,
+  pageId,
+  cols: 80,
+  rows: 24,
+  totalBytesProduced: 0,
   ...overrides,
 });
 
@@ -60,5 +87,79 @@ describe("applyWorkerMark", () => {
     const result = applyWorkerMark(tabs, "worker-tab", "task-new");
     expect(result.buffered).toBe(false);
     expect(result.tabs[0].taskRunId).toBe("task-new");
+  });
+});
+
+// Phase 3 (mount-hydration lift): the session provider is lifted above the
+// page and every page's `useTerminalManager` runs simultaneously. Each page's
+// `terminal-created` listener must claim ONLY the terminals tagged with its own
+// pageId, and dedup by id — so a `terminal-created` event arriving while the
+// operator is on another page lands in the right page's slice and is never
+// dropped.
+describe("shouldIngestCreatedTerminal (page routing)", () => {
+  it("claims an event whose pageId matches this manager's page", () => {
+    expect(shouldIngestCreatedTerminal("page-a", "page-a")).toBe(true);
+  });
+
+  it("ignores an event destined for a different page", () => {
+    expect(shouldIngestCreatedTerminal("page-b", "page-a")).toBe(false);
+  });
+
+  it("treats a missing/empty pageId as the default page", () => {
+    expect(shouldIngestCreatedTerminal(undefined, "default")).toBe(true);
+    expect(shouldIngestCreatedTerminal(null, "default")).toBe(true);
+    expect(shouldIngestCreatedTerminal("", "default")).toBe(true);
+    expect(shouldIngestCreatedTerminal(undefined, "page-a")).toBe(false);
+  });
+});
+
+describe("reduceCreatedTerminal (ingest + dedup)", () => {
+  it("captures a terminal-created payload into the page slice", () => {
+    const next = reduceCreatedTerminal([], createdEvent("t1", "page-a"), undefined);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toMatchObject({ id: "t1", title: "t1", isAlive: true, workingDir: "/repo" });
+  });
+
+  it("appends without clearing the existing page state", () => {
+    const existing = [tab("t1")];
+    const next = reduceCreatedTerminal(existing, createdEvent("t2", "page-a"), undefined);
+    expect(next).toHaveLength(2);
+    expect(next.map((t) => t.id)).toEqual(["t1", "t2"]);
+    // Original array is not mutated (the t1 tab object survives untouched).
+    expect(next[0]).toBe(existing[0]);
+  });
+
+  it("dedups by id: a re-delivered event returns the same array identity", () => {
+    const existing = [tab("t1")];
+    const next = reduceCreatedTerminal(existing, createdEvent("t1", "page-a"), undefined);
+    expect(next).toBe(existing);
+  });
+
+  it("stamps the drained worker mark onto the new tab", () => {
+    const next = reduceCreatedTerminal([], createdEvent("w1", "page-a"), "task-42");
+    expect(next[0].taskRunId).toBe("task-42");
+  });
+
+  it("end-to-end: an event for page B while page A is active lands in B's slice only", () => {
+    // Two independent page slices (provider lifted ⇒ both mounted at once).
+    let pageA: TerminalTab[] = [tab("a1")];
+    let pageB: TerminalTab[] = [];
+
+    const deliver = (info: TerminalInfo) => {
+      // page A's listener
+      if (shouldIngestCreatedTerminal(info.pageId, "page-a")) {
+        pageA = reduceCreatedTerminal(pageA, info, undefined);
+      }
+      // page B's listener
+      if (shouldIngestCreatedTerminal(info.pageId, "page-b")) {
+        pageB = reduceCreatedTerminal(pageB, info, undefined);
+      }
+    };
+
+    // An externally-created terminal for page B arrives while page A is active.
+    deliver(createdEvent("b1", "page-b"));
+
+    expect(pageB.map((t) => t.id)).toEqual(["b1"]); // captured in B
+    expect(pageA.map((t) => t.id)).toEqual(["a1"]); // A unchanged, not cleared
   });
 });

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -68,6 +68,57 @@ export function buildSessionCloseRecord(
 }
 
 /**
+ * Pure helper: decide whether a `terminal-created` event belongs to the page
+ * this manager instance is scoped to. With the session provider lifted above
+ * the page (so every page's manager is mounted simultaneously), each page's
+ * `terminal-created` listener must claim ONLY the terminals created for its own
+ * page — otherwise a terminal created for page B would be ingested into every
+ * page's tab slice.
+ *
+ * Older wire forms that omit `pageId` hydrate to `"default"` on the Rust side
+ * (`TerminalInfo`), so an undefined/empty value here is treated as "default".
+ *
+ * Exported so `useTerminalManager.test.ts` can drive the page-routing contract
+ * without booting React.
+ */
+export function shouldIngestCreatedTerminal(
+  eventPageId: string | undefined | null,
+  pageId: string,
+): boolean {
+  return (eventPageId || "default") === pageId;
+}
+
+/**
+ * Pure helper: fold a `terminal-created` payload into the existing tab list.
+ * Returns the next tabs array — the SAME identity when the terminal already
+ * exists (dedup), otherwise a new array with the tab appended. `pendingTaskRunId`
+ * is the worker mark drained from the race buffer by the caller (or `undefined`).
+ *
+ * Exported so `useTerminalManager.test.ts` can drive the ingest + dedup contract
+ * without booting React.
+ */
+export function reduceCreatedTerminal(
+  tabs: TerminalTab[],
+  info: TerminalInfo,
+  pendingTaskRunId: string | undefined,
+): TerminalTab[] {
+  if (tabs.some((t) => t.id === info.id)) return tabs;
+  return [
+    ...tabs,
+    {
+      id: info.id,
+      title: info.title,
+      pid: info.pid ?? null,
+      isAlive: info.isAlive,
+      exitCode: info.exitCode ?? null,
+      workingDir: info.workingDir || undefined,
+      createdAt: info.createdAt,
+      taskRunId: pendingTaskRunId,
+    },
+  ];
+}
+
+/**
  * Pure helper: decide whether `tabs` should be replaced when applying a
  * worker mark for `terminalId`. Returns the next tabs array (same identity
  * if no change), and a `buffered` flag the caller uses to record the mark
@@ -120,12 +171,21 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
     });
   }, []);
 
-  // Listen for terminals created externally (e.g. via HTTP API) and add them as tabs.
-  // Deduplicates by checking if the terminal ID already exists in state.
+  // Listen for terminals created externally (e.g. via HTTP API) and add them as
+  // tabs. This is the ONLY live-ingest path for externally-created terminals
+  // (e.g. a docked gate continuation). With the session provider lifted above
+  // TerminalPage (so every page's manager is mounted at once), the listener
+  // ALWAYS runs regardless of which page the operator is viewing — a
+  // `terminal-created` event is therefore never dropped by a page switch. Each
+  // page's listener claims ONLY the terminals tagged with its own `pageId`
+  // (`shouldIngestCreatedTerminal`), and dedups by id (`reduceCreatedTerminal`).
   useEffect(() => {
     let unlisten: (() => void) | null = null;
     listen<TerminalInfo>("terminal-created", (event) => {
       const info = event.payload;
+      // Route the event to the page it belongs to. A terminal created for
+      // another page is ignored here — its own page's manager will claim it.
+      if (!shouldIngestCreatedTerminal(info.pageId, pageId)) return;
       // Drain the race buffer OUTSIDE the reducer so the `setTabs` updater
       // stays pure (React StrictMode double-invokes updaters in dev; a
       // delete-inside-reducer would miss on the second pass).
@@ -134,21 +194,11 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
         pendingWorkerMarks.current.delete(info.id);
       }
       setTabs((prev) => {
-        if (prev.some((t) => t.id === info.id)) return prev;
-        logger.info(`External terminal created: ${info.id} (${info.title})`);
-        return [
-          ...prev,
-          {
-            id: info.id,
-            title: info.title,
-            pid: info.pid ?? null,
-            isAlive: info.isAlive,
-            exitCode: info.exitCode ?? null,
-            workingDir: info.workingDir || undefined,
-            createdAt: info.createdAt,
-            taskRunId: pendingTaskRunId,
-          },
-        ];
+        const next = reduceCreatedTerminal(prev, info, pendingTaskRunId);
+        if (next !== prev) {
+          logger.info(`External terminal created: ${info.id} (${info.title}) [page ${pageId}]`);
+        }
+        return next;
       });
     }).then((fn) => {
       unlisten = fn;
@@ -156,7 +206,7 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
     return () => {
       unlisten?.();
     };
-  }, []);
+  }, [pageId]);
 
   // Mirror the Phase 1 backend worker gate on the frontend. The Rust side
   // emits `worker-registered` right after `SessionManager::register_worker`

--- a/src/components/terminal/useZoneLayout.restore.test.ts
+++ b/src/components/terminal/useZoneLayout.restore.test.ts
@@ -16,7 +16,23 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { reconcileAssignments } from "./useZoneLayout";
+import {
+  reconcileAssignments,
+  pickLayout,
+  computeAutoGrowLayoutId,
+  LAYOUT_PRESETS,
+} from "./useZoneLayout";
+
+/** Mirror of the hook's derived `unassignedTabIds` over a pure assignment map. */
+function unassignedCount(assignments: Record<number, string>, tabIds: string[]): number {
+  const assigned = new Set(Object.values(assignments));
+  return tabIds.filter((id) => !assigned.has(id)).length;
+}
+
+/** Zone capacity for a layout id. */
+function zoneCount(layoutId: string): number {
+  return (LAYOUT_PRESETS.find((l) => l.id === layoutId) ?? LAYOUT_PRESETS[0]).zones.length;
+}
 
 describe("reconcileAssignments — registry zones win over creation-order shells", () => {
   it("binds records {0: claudeA, 3: claudeB} to zones 0 and 3 even though shells were created first", () => {
@@ -60,5 +76,60 @@ describe("reconcileAssignments — registry zones win over creation-order shells
     const next = reconcileAssignments({ 0: "claudeA" }, ["claudeA", "shell-1"], 6, new Set());
     expect(next[0]).toBe("claudeA");
     expect(next[1]).toBe("shell-1");
+  });
+});
+
+describe("Phase 1 auto-grow — layout grows to fit live tabs across ALL ingest paths", () => {
+  it("N tabs at default `single` auto-grows to a preset that fits (grow simulation)", () => {
+    // Model the in-hook effect: starting at `single`, repeatedly apply
+    // `computeAutoGrowLayoutId` until it stabilizes (the effect re-runs as
+    // `layoutId` changes). Six tabs land at once (a reconnect ingest).
+    let layoutId = "single";
+    const tabIds = ["t1", "t2", "t3", "t4", "t5", "t6"];
+    // Fixed-point iteration (the effect re-keys on layoutId; <= presets.length
+    // iterations is plenty and guards against any loop bug).
+    for (let i = 0; i < LAYOUT_PRESETS.length; i++) {
+      const next = computeAutoGrowLayoutId(layoutId, tabIds.length, false);
+      if (!next) break;
+      layoutId = next;
+    }
+    expect(layoutId).toBe("six-pack");
+    expect(zoneCount(layoutId)).toBeGreaterThanOrEqual(tabIds.length);
+  });
+
+  it("converges in ONE step (grow-only target = pickLayout, no ping-pong)", () => {
+    // The grow target is always `pickLayout(N)` directly, so the first
+    // application already reaches the fixed point — a SECOND call returns null.
+    const first = computeAutoGrowLayoutId("single", 9, false);
+    expect(first).toBe("full-grid");
+    const second = computeAutoGrowLayoutId(first!, 9, false);
+    expect(second).toBeNull();
+  });
+
+  it("at full-grid, unassignedTabIds.length === max(0, N-9)", () => {
+    const fullGridZones = zoneCount("full-grid");
+    expect(fullGridZones).toBe(9);
+    for (const n of [5, 9, 12, 20]) {
+      const tabIds = Array.from({ length: n }, (_, i) => `t${i}`);
+      // After growing for N tabs (capped at full-grid) and reconciling:
+      const layoutId = pickLayout(n);
+      const assignments = reconcileAssignments({}, tabIds, zoneCount(layoutId));
+      expect(unassignedCount(assignments, tabIds)).toBe(Math.max(0, n - 9));
+    }
+  });
+
+  it("operator-pinned layout is NOT overridden even when tabs overflow", () => {
+    // Operator pinned `split` (2 zones) but 6 tabs are live — auto-grow must
+    // stay null, leaving 4 tabs in the Unassigned list (the chip's job).
+    expect(computeAutoGrowLayoutId("split", 6, true)).toBeNull();
+    const tabIds = ["a", "b", "c", "d", "e", "f"];
+    const assignments = reconcileAssignments({}, tabIds, zoneCount("split"));
+    expect(unassignedCount(assignments, tabIds)).toBe(4);
+  });
+
+  it("never shrinks: closing tabs below capacity does NOT reduce the layout", () => {
+    // Grew to full-grid for 9 tabs; now only 2 remain. Auto-grow returns null
+    // (shrinking is out of scope — grow only).
+    expect(computeAutoGrowLayoutId("full-grid", 2, false)).toBeNull();
   });
 });

--- a/src/components/terminal/useZoneLayout.ts
+++ b/src/components/terminal/useZoneLayout.ts
@@ -132,6 +132,61 @@ export const LAYOUT_PRESETS: LayoutPreset[] = [
   },
 ];
 
+/** Largest preset by zone count — the auto-grow ceiling. `full-grid` (9). */
+export const MAX_LAYOUT_ID = "full-grid";
+
+/**
+ * Pick the smallest layout preset whose zone count fits `totalTabs` live tabs,
+ * capped at the largest preset (`full-grid`, 9 zones). Pure — exported so the
+ * `+ new terminal` quick-launch path, the in-hook auto-grow effect, and the
+ * unit test can all share ONE mapping (the prior copy lived inline in
+ * `TerminalPage.tsx`).
+ *
+ * Mapping: 1→single, 2→split, 3-4→quad, 5-6→six-pack, ≥7→full-grid. Skips the
+ * asymmetric presets (triptych / 1-plus-4 / command-center) deliberately — the
+ * grow path wants the smallest *uniform* grid that fits, matching the legacy
+ * inline behavior this extracted.
+ */
+export function pickLayout(totalTabs: number): string {
+  if (totalTabs >= 7) return "full-grid";
+  if (totalTabs >= 5) return "six-pack";
+  if (totalTabs >= 3) return "quad";
+  if (totalTabs >= 2) return "split";
+  return "single";
+}
+
+/**
+ * Decide whether the layout must GROW to fit `tabCount` live tabs, returning the
+ * target layout id or `null` when no change is needed. Pure reducer behind the
+ * in-hook auto-grow effect.
+ *
+ * Rules (all enforced here so the effect stays a thin wrapper, and the test can
+ * assert them without React):
+ *   - **operator-pinned wins**: when `pinned`, never auto-grow (return null).
+ *   - **grow only, never shrink**: only returns a target whose zone count is
+ *     STRICTLY GREATER than the current layout's; fewer tabs → null.
+ *   - **capacity-driven**: only grows when `tabCount` exceeds the current
+ *     layout's zone capacity.
+ *   - **capped at `full-grid`** (via `pickLayout`); at 9+ tabs the target is
+ *     already `full-grid`, so once there it returns null (no thrash).
+ */
+export function computeAutoGrowLayoutId(
+  currentLayoutId: string,
+  tabCount: number,
+  pinned: boolean,
+): string | null {
+  if (pinned) return null;
+  const current = LAYOUT_PRESETS.find((l) => l.id === currentLayoutId) ?? LAYOUT_PRESETS[0];
+  // Only act when live tabs overflow the current capacity.
+  if (tabCount <= current.zones.length) return null;
+  const targetId = pickLayout(tabCount);
+  const target = LAYOUT_PRESETS.find((l) => l.id === targetId);
+  if (!target) return null;
+  // Grow only — never pick a target with fewer/equal zones than current.
+  if (target.zones.length <= current.zones.length) return null;
+  return targetId;
+}
+
 // ── Zone Assignment ────────────────────────────────────────────────────────
 
 /** Maps zone index → tab ID */
@@ -147,6 +202,15 @@ interface PersistedState {
   layoutId: string;
   assignments: ZoneAssignments;
   focusedZone: number;
+  /**
+   * Operator-pinned latch (Phase 1 auto-grow). True once the operator picks a
+   * layout explicitly (picker UI / keyboard shortcut / `/layout` command /
+   * profile or workspace load). While pinned, the auto-grow effect leaves the
+   * layout alone — the operator's deliberate choice always wins over the
+   * fit-to-tabs heuristic. Programmatic grows (`+ new terminal`, restore
+   * auto-fill) never set it. Persisted so the latch survives a remount/reload.
+   */
+  pinned?: boolean;
 }
 
 // Phase 1 (pop-out windows): pop-out windows share the main window's
@@ -159,10 +223,7 @@ function storageKey(pageId: string, windowLabel: string = "main"): string {
 }
 
 function loadPersistedState(pageId: string, windowLabel?: string): PersistedState | null {
-  return instanceStorage.getJSON<PersistedState | null>(
-    storageKey(pageId, windowLabel),
-    null,
-  );
+  return instanceStorage.getJSON<PersistedState | null>(storageKey(pageId, windowLabel), null);
 }
 
 function persistState(pageId: string, windowLabel: string | undefined, state: PersistedState) {
@@ -256,11 +317,23 @@ export function useZoneLayout(
   // async restore window; the reservation is cleared once the zone is filled.
   const reservedZonesRef = useRef<Set<number>>(new Set());
 
+  // Operator-pinned latch (Phase 1 auto-grow). Seeded from persisted state so a
+  // pin survives remount/reload. A ref (not state) because nothing renders off
+  // it — only the auto-grow effect reads it, and it must reflect the latest
+  // operator action synchronously within the same commit that calls
+  // `setLayoutId({ pinned: true })`.
+  const userPinnedLayoutRef = useRef<boolean>(persistedState?.pinned ?? false);
+
   const layout = LAYOUT_PRESETS.find((l) => l.id === layoutId) ?? LAYOUT_PRESETS[0];
 
-  // Persist on changes
+  // Persist on changes (including the pinned latch).
   useEffect(() => {
-    persistState(pageId, windowLabel, { layoutId, assignments, focusedZone });
+    persistState(pageId, windowLabel, {
+      layoutId,
+      assignments,
+      focusedZone,
+      pinned: userPinnedLayoutRef.current,
+    });
   }, [pageId, windowLabel, layoutId, assignments, focusedZone]);
 
   // Auto-assign tabs to empty zones when tabs change
@@ -270,7 +343,12 @@ export function useZoneLayout(
     );
   }, [tabIds, layout.zones.length]);
 
-  const setLayoutId = useCallback(
+  // Shared layout-application logic: switch the preset and redistribute
+  // assignments. Used by BOTH the operator-facing `setLayoutId` and the
+  // programmatic auto-grow effect — the ONLY difference between them is whether
+  // they set the operator-pinned latch (auto-grow never does, `setLayoutId`'s
+  // `{ pinned: true }` opt does).
+  const applyLayout = useCallback(
     (id: string) => {
       const newLayout = LAYOUT_PRESETS.find((l) => l.id === id);
       if (!newLayout) return;
@@ -306,6 +384,42 @@ export function useZoneLayout(
       setFocusedZone((prev) => (prev >= newLayout.zones.length ? 0 : prev));
     },
     [tabIds],
+  );
+
+  // ── Phase 1: auto-grow layout to fit live tabs ───────────────────────────
+  // When the live tab count overflows the current layout's zone capacity, grow
+  // the layout to the smallest preset that fits (capped at `full-grid`/9). Lives
+  // HERE (in the hook, keyed on the live `tabIds.length` the hook already owns)
+  // so it fires for EVERY ingest path — first mount/reconnect, `terminal-created`
+  // events, gate-continuation ingest, and profile restore — not just the
+  // `+ new terminal` button that grew the layout before.
+  //
+  // No render loop: `computeAutoGrowLayoutId` is GROW-ONLY and capacity-gated.
+  // After it grows, `layout.zones.length >= tabIds.length`, so the next run of
+  // this effect (re-keyed by the new `layoutId`) computes `null` and is inert.
+  // It also bails immediately when the operator has pinned a layout.
+  useEffect(() => {
+    const target = computeAutoGrowLayoutId(layoutId, tabIds.length, userPinnedLayoutRef.current);
+    if (target) {
+      // Programmatic grow — do NOT touch the pinned latch.
+      applyLayout(target);
+    }
+  }, [layoutId, tabIds.length, applyLayout]);
+
+  /**
+   * Operator-facing layout switch. `opts.pinned === true` (passed from the
+   * picker UI / keyboard shortcut / `/layout` command / profile + workspace
+   * load) latches the layout so auto-grow stops overriding the operator's
+   * deliberate choice. Programmatic callers (`+ new terminal`) omit the opt and
+   * leave the latch alone.
+   */
+  const setLayoutId = useCallback(
+    (id: string, opts?: { pinned?: boolean }) => {
+      if (!LAYOUT_PRESETS.some((l) => l.id === id)) return;
+      if (opts?.pinned) userPinnedLayoutRef.current = true;
+      applyLayout(id);
+    },
+    [applyLayout],
   );
 
   const assignTabToZone = useCallback((zoneIndex: number, tabId: string) => {


### PR DESCRIPTION
## Summary
Implements `2026-06-07-terminal-page-mount-hydration-and-zone-overflow` (VETTED). Fixes the operator-reported defect where 4 live sessions were invisible until '+ new terminal' was clicked — root-caused to zone-overflow: mount reconnect ingests all alive PTYs, but the default `single` (1-zone) layout rendered the rest as offscreen `HiddenTerminal`s with zero affordance.

## Phase 1+2 — `1704da1e` (Defect B)
- **Auto-grow**: layout grows to fit the live tab count for ALL ingest paths (reconnect, terminal-created, continuations), reusing the extracted `pickLayout` mapping; grow-only, capped at full-grid (9), converges in one step.
- **Operator-pinned latch**: explicit layout choices (picker, Ctrl+Shift+1-8, `/layout`, profile/workspace load) pin the layout; auto-grow never overrides. Persisted (`pinned` field in the existing zone-layout blob).
- **UnzonedChip**: 'N more' chip (renders nothing at 0) when tabs exceed zones; click opens ZoneControlPanel (its `isMultiZone` gate dropped so Unassigned shows in `single` too).

## Phase 3 — `c8e9532a` (Defect A)
- `TerminalSessionProvider` lifted to `App.tsx` with one always-mounted `PageSessionScope` per terminal page; `key={activePageId}` remount removed. Page switches no longer destroy tab state; each page's `terminal-created` listener stays live so a docked gate continuation arriving while the operator is elsewhere is ingested, not dropped. Init guards converted to once-per-pageId.

## Verification
- vitest: **798/798** green (+24 new tests: `pickLayout`, auto-grow rules, `UnzonedChip`, terminal-created routing/dedup, once-per-page init). `tsc --noEmit` clean; ESLint/prettier clean on touched files.
- **On-page E2E (temp runner :9877, built from this branch)**: 5 backend-created terminals → auto-grew to six-pack, all visible (OCR-confirmed); 6th created while on another app page → present+visible on return, zero `UNMOUNTED` warnings; pinned `single` honored after 7th create, chip 5→6 more, panel opens with Unassigned(6).

Follow-up friction (separate draft plan): exited-session tombstones still count in chip/panel; action param `{params:{}}` wrapper schema mismatch.