### PR TITLE
feat(agent-worktree): Phase 2 launch-provisioning — configurable intent_repo + multi-repo sibling rooting

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1114,11 +1114,18 @@ async fn run_continuation_terminal(
     // permission prompts — an unattended gate continuation has no operator to
     // answer them.
     let claude_bin = claude_bin_path();
-    let command = Some(vec![
-        claude_bin,
-        "--dangerously-skip-permissions".to_string(),
-        payload.initial_prompt.clone(),
-    ]);
+    // Phase 2c — `--add-dir <sibling>` for each non-cwd worktree of this
+    // continuation's context so the launched `claude` can edit sibling repos
+    // that materialized on disk but aren't the process cwd. Flags MUST precede
+    // the trailing positional prompt arg. Empty for single-repo continuations.
+    let add_dir_args = ctx
+        .as_ref()
+        .map(|c| c.claude_add_dir_args())
+        .unwrap_or_default();
+    let mut command_vec = vec![claude_bin, "--dangerously-skip-permissions".to_string()];
+    command_vec.extend(add_dir_args);
+    command_vec.push(payload.initial_prompt.clone());
+    let command = Some(command_vec);
 
     // First repo (if any) is the session's intent_repo for coord attribution.
     let intent_repo = payload.repos.first().cloned();
@@ -1572,6 +1579,15 @@ fn local_repo_name(repo: &str) -> &str {
 /// runner owns this layout; coord's emitted `worktree_path` (computed for its
 /// own host) is ignored. Scheme:
 /// `<QONTINUI_ROOT>/.agent-worktrees/<agent_id>/<repo-name>`.
+///
+/// Phase 2b note (launch-provisioning): the per-spawn `<agent_id>` directory
+/// is already per-session-unique — each spawn mints a fresh `agent_id` — so
+/// this layout satisfies the §3.6 `.agent-worktrees/<session>/<repo>` model
+/// without re-keying. Cross-restart STABLE reuse (a worktree the same logical
+/// session reattaches to after a runner restart) is intentionally deferred to
+/// the restart-resilience plan; do NOT re-key this dir on a stable
+/// session id here — doing so would orphan the per-spawn worktrees the live
+/// claim bookkeeping already tracks under `<agent_id>`.
 fn local_worktree_path(root: &Path, agent_id: uuid::Uuid, repo: &str) -> PathBuf {
     root.join(".agent-worktrees")
         .join(agent_id.to_string())

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -510,13 +510,78 @@ fn spawn_claim_heartbeat(
     )
 }
 
-/// Convenience helper for the three runner terminal-spawn entry points
+/// Environment-variable name carrying the full set of materialized
+/// per-repo worktrees onto a launched agent process (Phase 2c). The value
+/// is a `;`-separated list of `<repo>=<abs_worktree_path>` pairs covering
+/// EVERY worktree in the launch's `IsolatedEditContext` (including the
+/// first / cwd repo), so an agent-agnostic launch can locate sibling
+/// repos that materialized on disk but aren't the process cwd.
+pub const SESSION_WORKTREES_ENV: &str = "QONTINUI_SESSION_WORKTREES";
+
+/// Build the [`SESSION_WORKTREES_ENV`] value for a set of materialized
+/// worktrees: `"<repo>=<abs_path>;<repo2>=<abs_path2>;…"` over ALL
+/// worktrees in order (the first entry is the session cwd repo). Returns
+/// `None` when there are no worktrees (worktree mode off / no allocate) so
+/// the caller can skip setting an empty env var.
+///
+/// Paths are emitted via `Path::display()` so they stay platform-native
+/// (`D:\…` on Windows, `/home/…` on POSIX). `repo` slugs never contain
+/// `=` or `;`, so the delimiter set is unambiguous.
+pub fn session_worktrees_env_value(worktrees: &[MaterializedWorktree]) -> Option<String> {
+    if worktrees.is_empty() {
+        return None;
+    }
+    let joined = worktrees
+        .iter()
+        .map(|w| format!("{}={}", w.repo, w.worktree_path.display()))
+        .collect::<Vec<_>>()
+        .join(";");
+    Some(joined)
+}
+
+/// Build the `--add-dir <path>` argument pairs for the SIBLING worktrees of
+/// a launch — every worktree except the first (the first is the process
+/// cwd, which `claude` already roots at, so it needs no `--add-dir`). Used
+/// to append to a `claude` command so a multi-repo session can edit the
+/// non-cwd repos too. Returns an empty vec for single-repo (or empty)
+/// launches.
+///
+/// Order matches `worktrees[1..]` so the resulting args are deterministic.
+pub fn claude_add_dir_args(worktrees: &[MaterializedWorktree]) -> Vec<String> {
+    worktrees
+        .iter()
+        .skip(1)
+        .flat_map(|w| {
+            [
+                "--add-dir".to_string(),
+                w.worktree_path.display().to_string(),
+            ]
+        })
+        .collect()
+}
+
+impl IsolatedEditContext {
+    /// [`session_worktrees_env_value`] over this context's worktrees — the
+    /// [`SESSION_WORKTREES_ENV`] value to export onto the launched process.
+    pub fn session_worktrees_env_value(&self) -> Option<String> {
+        session_worktrees_env_value(&self.worktrees)
+    }
+
+    /// [`claude_add_dir_args`] over this context's worktrees — the
+    /// `--add-dir <sibling>` args to append to a `claude` launch command.
+    pub fn claude_add_dir_args(&self) -> Vec<String> {
+        claude_add_dir_args(&self.worktrees)
+    }
+}
+
+/// Convenience helper for the runner terminal-spawn entry points
 /// (`commands/terminal.rs::terminal_create`, `commands/productivity.rs::
-/// spawn_worker_session`, `mcp/tauri_proxy.rs::"terminal_create"`,
-/// `mcp/backend_relay.rs::handle_terminal_create`). Given the caller's
-/// `intent_repo` + `purpose` + original `working_dir`, returns the
-/// effective working dir for the PTY plus an `IsolatedEditContext` to
-/// park on the resulting `TerminalSession`.
+/// spawn_worker_session` + `launch_coordinator_session`,
+/// `mcp/terminals.rs::handle_terminal_create`, `mcp/tauri_proxy.rs::
+/// "terminal_create"`, `mcp/backend_relay.rs::handle_terminal_create`).
+/// Given the caller's `intent_repo` + `purpose` + original `working_dir`,
+/// returns the effective working dir for the PTY plus an
+/// `IsolatedEditContext` to park on the resulting `TerminalSession`.
 ///
 /// Behavior:
 /// - `intent_repo == None` → returns `(working_dir, None)`. Observation
@@ -843,5 +908,109 @@ mod tests {
             .expect("flag-off should return Ok(None), not Err");
             assert!(ctx.is_none(), "flag-off must return None");
         }
+    }
+
+    // ---- Phase 2c: QONTINUI_SESSION_WORKTREES env + --add-dir args ----
+
+    /// Expected `<repo>=<path>` segment for a `repo_fixture`-built worktree —
+    /// its `worktree_path` is the repo's `default_canonical_path`, so we
+    /// derive both sides from the same helpers (platform-portable; never a
+    /// hardcoded `d:/qontinui-root/...` literal).
+    fn expected_env_segment(repo: &str) -> String {
+        let canonical = super::super::canonical_paths::default_canonical_path(repo).unwrap();
+        format!("{}={}", repo, canonical.display())
+    }
+
+    #[test]
+    fn session_worktrees_env_value_covers_all_repos_in_order() {
+        // The env string lists EVERY materialized worktree (incl. repo[0]) as
+        // `<repo>=<abs_path>` joined by `;`, in worktree order.
+        let (wa, _ca) = repo_fixture("qontinui-runner");
+        let (wb, _cb) = repo_fixture("qontinui-coord");
+        let worktrees = vec![wa, wb];
+
+        let value = session_worktrees_env_value(&worktrees)
+            .expect("multi-repo context yields an env value");
+
+        let expected = format!(
+            "{};{}",
+            expected_env_segment("qontinui-runner"),
+            expected_env_segment("qontinui-coord"),
+        );
+        assert_eq!(value, expected);
+
+        // Every repo is represented, with its canonical path.
+        for repo in ["qontinui-runner", "qontinui-coord"] {
+            assert!(
+                value.contains(&expected_env_segment(repo)),
+                "env value missing segment for {repo}"
+            );
+        }
+        // Exactly one delimiter for two repos.
+        assert_eq!(value.matches(';').count(), 1, "one ';' between two repos");
+    }
+
+    #[test]
+    fn session_worktrees_env_value_is_none_for_empty() {
+        assert!(
+            session_worktrees_env_value(&[]).is_none(),
+            "no worktrees → no env var"
+        );
+    }
+
+    #[test]
+    fn claude_add_dir_args_skips_the_first_worktree() {
+        // `--add-dir` is appended once per SIBLING (worktrees[1..]); the first
+        // worktree is the process cwd and needs no `--add-dir`.
+        let (wa, _ca) = repo_fixture("qontinui-runner");
+        let (wb, _cb) = repo_fixture("qontinui-coord");
+        let worktrees = vec![wa, wb];
+
+        let args = claude_add_dir_args(&worktrees);
+
+        let coord_path = super::super::canonical_paths::default_canonical_path("qontinui-coord")
+            .unwrap()
+            .display()
+            .to_string();
+        assert_eq!(
+            args,
+            vec!["--add-dir".to_string(), coord_path],
+            "exactly one --add-dir pair, for the sibling (non-cwd) repo"
+        );
+    }
+
+    #[test]
+    fn claude_add_dir_args_empty_for_single_repo() {
+        let (wa, _ca) = repo_fixture("qontinui-runner");
+        assert!(
+            claude_add_dir_args(&[wa]).is_empty(),
+            "single-repo launch has no sibling --add-dir args"
+        );
+        assert!(
+            claude_add_dir_args(&[]).is_empty(),
+            "empty launch has no --add-dir args"
+        );
+    }
+
+    #[test]
+    fn context_accessors_match_freestanding_helpers() {
+        // The `IsolatedEditContext` convenience accessors must agree with the
+        // freestanding helpers over the same worktrees.
+        let (wa, ca) = repo_fixture("qontinui-runner");
+        let (wb, cb) = repo_fixture("qontinui-coord");
+        let mut ctx = IsolatedEditContext::for_test(vec![wa, wb], vec![ca, cb]);
+
+        assert_eq!(
+            ctx.session_worktrees_env_value(),
+            session_worktrees_env_value(&ctx.worktrees)
+        );
+        assert_eq!(
+            ctx.claude_add_dir_args(),
+            claude_add_dir_args(&ctx.worktrees)
+        );
+
+        // Non-async test: drain before drop.
+        ctx.active_claims.clear();
+        ctx.worktrees.clear();
     }
 }

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -781,6 +781,14 @@ fn resolve_runner_repo_path() -> Option<String> {
 /// one short line that PowerShell parses cleanly, and `cd` is unneeded
 /// because `TerminalManager::create` already starts the pty in
 /// `working_dir = Some(repo_path)`.
+/// Phase 2a — resolve the edit-intent repo slug for a worker / coordinator
+/// launch: the caller's explicit `intent_repo` when present, else the
+/// historical `"qontinui-runner"` default. Shared by `spawn_worker_session`
+/// and `launch_coordinator_session` so both default identically.
+fn resolve_intent_repo(intent_repo: Option<String>) -> String {
+    intent_repo.unwrap_or_else(|| "qontinui-runner".to_string())
+}
+
 fn build_coordinator_initial_command(
     runner_port: u16,
     plan_path: Option<&str>,
@@ -841,6 +849,50 @@ fn next_worker_title(manager: &TerminalManager) -> String {
     format!("Worker {}", max_n + 1)
 }
 
+/// Phase 2c — splice `--add-dir <sibling>` flags into a `claude` command
+/// line built for the interactive shell (the worker/coordinator launch
+/// strings). The flags MUST land BEFORE any trailing positional prompt arg
+/// (claude treats the last positional as the prompt), so they are inserted
+/// immediately after the `--dangerously-skip-permissions` flag that both
+/// builders emit. When that anchor is absent (defensive) or there are no
+/// sibling dirs, the command is returned unchanged.
+///
+/// Each path is single-quoted PowerShell-style (with `'` doubled) so paths
+/// with spaces survive the shell — matching the coordinator builder's own
+/// quoting of the prompt-file path.
+fn append_claude_add_dir(command: String, add_dir_args: &[String]) -> String {
+    if add_dir_args.is_empty() {
+        return command;
+    }
+    // `add_dir_args` is a flat [--add-dir, <path>, --add-dir, <path>, …]
+    // vec (from `claude_add_dir_args`). Re-quote each path value.
+    let mut rendered = String::new();
+    let mut it = add_dir_args.iter();
+    while let (Some(flag), Some(path)) = (it.next(), it.next()) {
+        let quoted = path.replace('\'', "''");
+        rendered.push(' ');
+        rendered.push_str(flag);
+        rendered.push_str(" '");
+        rendered.push_str(&quoted);
+        rendered.push('\'');
+    }
+
+    const ANCHOR: &str = "--dangerously-skip-permissions";
+    match command.find(ANCHOR) {
+        Some(idx) => {
+            let insert_at = idx + ANCHOR.len();
+            let mut out = String::with_capacity(command.len() + rendered.len());
+            out.push_str(&command[..insert_at]);
+            out.push_str(&rendered);
+            out.push_str(&command[insert_at..]);
+            out
+        }
+        // No known flag anchor — append at the end (the worker builder has no
+        // trailing positional, so this is still correct for that shape).
+        None => format!("{}{}", command, rendered),
+    }
+}
+
 /// Spawn the post-init shell-line write that `terminal_create` doesn't
 /// do for us when invoked via Tauri (the HTTP path at
 /// `mcp/terminals.rs:115-126` does this; we replicate it here so the
@@ -893,9 +945,15 @@ pub async fn launch_coordinator_session(
     mode: Option<String>,
     plan_path: Option<String>,
     title_hint: Option<String>,
+    // Phase 2a — which repo the coordinator session intends to edit. Tauri/
+    // serde pass a missing arg as `None`; defaulted to "qontinui-runner"
+    // below to preserve the historical hardcode. Lets a caller root the
+    // coordinator in a different repo's worktree without a code change.
+    intent_repo: Option<String>,
 ) -> Result<LaunchResult, String> {
     let app_state = require_app_state(&app_handle)?;
     let mode = mode.unwrap_or_else(|| "rust".to_string());
+    let intent_repo = resolve_intent_repo(intent_repo);
 
     // Reject unknown modes early — keeps the surface small and surfaces
     // typos in callers/tests immediately.
@@ -957,13 +1015,13 @@ pub async fn launch_coordinator_session(
         .inner()
         .clone();
 
-    // Phase 2 round 2 — Coordinator sessions always edit qontinui-runner
-    // (same class as `spawn_worker_session`). Route through the shared
-    // facade so flag-on lands in a worktree, flag-off keeps the primary
-    // checkout.
+    // Phase 2 round 2 — Coordinator sessions default to editing
+    // qontinui-runner (same class as `spawn_worker_session`) but honor an
+    // explicit `intent_repo` (Phase 2a). Route through the shared facade so
+    // flag-on lands in a worktree, flag-off keeps the primary checkout.
     let (effective_repo_path, isolated_ctx) =
         crate::agent_worktree::isolated_edit::acquire_for_terminal(
-            Some("qontinui-runner"),
+            Some(&intent_repo),
             "Coordinator session",
             Some(primary_repo_path.clone()),
             // No stable per-session id exists yet at spawn time — the new
@@ -975,6 +1033,25 @@ pub async fn launch_coordinator_session(
         .await;
     let repo_path = effective_repo_path.unwrap_or(primary_repo_path);
 
+    // Phase 2c — `QONTINUI_SESSION_WORKTREES` (agent-agnostic, all sibling
+    // worktrees) onto the PTY + `--add-dir <sibling>` appended to the claude
+    // command (convenience for claude). Derived from the live context before
+    // it is parked on the session. Single-repo coordinator → no siblings, so
+    // both are no-ops (env carries just the cwd repo, no `--add-dir`).
+    let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+        ctx.session_worktrees_env_value().map(|v| {
+            vec![(
+                crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                v,
+            )]
+        })
+    });
+    let add_dir_args = isolated_ctx
+        .as_ref()
+        .map(|ctx| ctx.claude_add_dir_args())
+        .unwrap_or_default();
+    let initial_command = append_claude_add_dir(initial_command, &add_dir_args);
+
     let info = terminal_manager.create(
         Some(title),
         Some(repo_path),
@@ -983,6 +1060,7 @@ pub async fn launch_coordinator_session(
         None,
         app_handle.clone(),
         None,
+        extra_env,
     )?;
 
     if let Some(ctx) = isolated_ctx {
@@ -1038,6 +1116,11 @@ pub async fn stop_coordinator_session(app_handle: tauri::AppHandle) -> Result<bo
 pub async fn spawn_worker_session(
     app_handle: tauri::AppHandle,
     title_hint: Option<String>,
+    // Phase 2a — which repo the worker intends to edit. Tauri/serde pass a
+    // missing arg as `None`; defaulted to "qontinui-runner" below to
+    // preserve the historical hardcode. Lets a coordinator dispatch a
+    // worker rooted in a different repo's worktree without a code change.
+    intent_repo: Option<String>,
 ) -> Result<LaunchResult, String> {
     let app_state = require_app_state(&app_handle)?;
 
@@ -1052,11 +1135,12 @@ pub async fn spawn_worker_session(
     // distinct claim holders.
     let task_run_id = Uuid::new_v4().to_string();
 
-    // Phase 2 — worker sessions always intend to edit qontinui-runner
-    // (the Coordinator's `assign-task` dispatch targets runner code).
-    // Route through `acquire_for_terminal` so this path stays in
-    // lockstep with the other three terminal-spawn entry points.
-    let intent_repo = "qontinui-runner".to_string();
+    // Phase 2 — worker sessions default to editing qontinui-runner (the
+    // Coordinator's `assign-task` dispatch targets runner code) but honor an
+    // explicit `intent_repo` (Phase 2a). Route through `acquire_for_terminal`
+    // so this path stays in lockstep with the other terminal-spawn entry
+    // points.
+    let intent_repo = resolve_intent_repo(intent_repo);
     let (effective_repo_path, isolated_ctx) =
         crate::agent_worktree::isolated_edit::acquire_for_terminal(
             Some(&intent_repo),
@@ -1101,6 +1185,25 @@ pub async fn spawn_worker_session(
     // Coordinator's flag for the same reason).
     let initial_command = "claude --dangerously-skip-permissions".to_string();
 
+    // Phase 2c — `QONTINUI_SESSION_WORKTREES` (agent-agnostic, all sibling
+    // worktrees) onto the PTY + `--add-dir <sibling>` appended to the claude
+    // command (convenience for claude). Derived from the live context before
+    // it is parked on the session. Single-repo worker → no siblings, so both
+    // are no-ops (env carries just the cwd repo, no `--add-dir`).
+    let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+        ctx.session_worktrees_env_value().map(|v| {
+            vec![(
+                crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                v,
+            )]
+        })
+    });
+    let add_dir_args = isolated_ctx
+        .as_ref()
+        .map(|ctx| ctx.claude_add_dir_args())
+        .unwrap_or_default();
+    let initial_command = append_claude_add_dir(initial_command, &add_dir_args);
+
     // Phase 4: pre-size the worker PTY to match the dominant existing
     // zone so worker briefs land on a grid the same size the user will
     // eventually see (rather than the 120×30 default, which produces
@@ -1119,6 +1222,7 @@ pub async fn spawn_worker_session(
         Some(dom_rows),
         app_handle.clone(),
         None,
+        extra_env,
     )?;
 
     // Phase 2 — park the isolated edit context on the TerminalSession
@@ -2086,5 +2190,82 @@ mod overlap_tests {
     fn disjoint_empty() {
         let r = compute_overlap(&["a/b.rs".to_string()], &["x/y.rs".to_string()]);
         assert!(r.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod launch_intent_tests {
+    use super::*;
+
+    // ---- Phase 2a: intent_repo defaulting ----
+
+    #[test]
+    fn intent_repo_defaults_to_runner_when_none() {
+        // Tauri/serde pass a missing arg as `None`; both launch commands must
+        // preserve the historical hardcode.
+        assert_eq!(resolve_intent_repo(None), "qontinui-runner");
+    }
+
+    #[test]
+    fn intent_repo_honors_explicit_slug() {
+        assert_eq!(
+            resolve_intent_repo(Some("qontinui-coord".to_string())),
+            "qontinui-coord"
+        );
+        // An empty string is honored verbatim (not coerced to the default) —
+        // callers pass `None`, not `Some("")`, to request the default.
+        assert_eq!(resolve_intent_repo(Some(String::new())), "");
+    }
+
+    // ---- Phase 2c: --add-dir splicing into the claude launch line ----
+
+    #[test]
+    fn append_add_dir_inserts_after_skip_permissions_flag() {
+        // Coordinator-shape command: a trailing positional prompt arg
+        // (`(Get-Content ...)`) must stay LAST — the --add-dir flags land
+        // immediately after `--dangerously-skip-permissions`.
+        let cmd =
+            "claude --dangerously-skip-permissions (Get-Content -Raw 'C:\\tmp\\p.md')".to_string();
+        let args = vec!["--add-dir".to_string(), "/abs/qontinui-coord".to_string()];
+        let out = append_claude_add_dir(cmd, &args);
+        assert_eq!(
+            out,
+            "claude --dangerously-skip-permissions --add-dir '/abs/qontinui-coord' \
+             (Get-Content -Raw 'C:\\tmp\\p.md')"
+        );
+    }
+
+    #[test]
+    fn append_add_dir_handles_multiple_siblings() {
+        let cmd = "claude --dangerously-skip-permissions".to_string();
+        let args = vec![
+            "--add-dir".to_string(),
+            "/abs/repo-a".to_string(),
+            "--add-dir".to_string(),
+            "/abs/repo-b".to_string(),
+        ];
+        let out = append_claude_add_dir(cmd, &args);
+        assert_eq!(
+            out,
+            "claude --dangerously-skip-permissions --add-dir '/abs/repo-a' --add-dir '/abs/repo-b'"
+        );
+    }
+
+    #[test]
+    fn append_add_dir_quotes_paths_with_spaces_and_quotes() {
+        let cmd = "claude --dangerously-skip-permissions".to_string();
+        let args = vec!["--add-dir".to_string(), "/has space/o'brien".to_string()];
+        let out = append_claude_add_dir(cmd, &args);
+        // Single-quoted, with the embedded `'` doubled (PowerShell escape).
+        assert_eq!(
+            out,
+            "claude --dangerously-skip-permissions --add-dir '/has space/o''brien'"
+        );
+    }
+
+    #[test]
+    fn append_add_dir_no_args_returns_command_unchanged() {
+        let cmd = "claude --dangerously-skip-permissions".to_string();
+        assert_eq!(append_claude_add_dir(cmd.clone(), &[]), cmd);
     }
 }

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -115,6 +115,19 @@ pub async fn terminal_create(
     let repo_detect_handle = app_handle.clone();
     let repo_detect_dir = working_dir.clone();
     let cred_helper_dir = working_dir.clone();
+    // Phase 2c — export `QONTINUI_SESSION_WORKTREES` (all materialized
+    // sibling worktrees) onto the PTY so an agent-agnostic launch can find
+    // repos that materialized on disk but aren't the process cwd. Derived
+    // from the live isolated edit context before it is parked on the
+    // session. `None` (no ctx / single-or-zero worktree) → no env var.
+    let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+        ctx.session_worktrees_env_value().map(|v| {
+            vec![(
+                crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                v,
+            )]
+        })
+    });
     let info = terminal_manager.create(
         title.clone(),
         working_dir.clone(),
@@ -123,6 +136,7 @@ pub async fn terminal_create(
         rows,
         app_handle,
         command,
+        extra_env,
     )?;
 
     // Park the isolated edit context on the terminal session so its
@@ -880,6 +894,20 @@ pub(crate) fn create_terminal_session_backend(
     command: Option<Vec<String>>,
     isolated_ctx: Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
 ) -> Result<(String, Option<uuid::Uuid>), String> {
+    // Phase 2c — derive the `QONTINUI_SESSION_WORKTREES` env from the
+    // pre-acquired context (all materialized sibling worktrees) before it is
+    // parked on the session. `None` (no ctx / single-or-zero worktree) → no
+    // env var. The `--add-dir <sibling>` convenience for `claude` launches is
+    // appended into `command` by the caller (gate-continuation in
+    // `agent_runtime.rs`), since only the caller knows the launch is `claude`.
+    let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+        ctx.session_worktrees_env_value().map(|v| {
+            vec![(
+                crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                v,
+            )]
+        })
+    });
     let info = terminal_manager.create(
         Some(title.clone()),
         Some(working_dir.clone()),
@@ -888,6 +916,7 @@ pub(crate) fn create_terminal_session_backend(
         None,
         app_handle,
         command,
+        extra_env,
     )?;
 
     // Park the pre-acquired isolated edit context on the session so its

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -2338,6 +2338,17 @@ async fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Opti
             )
             .await;
 
+        // Phase 2c — carry `QONTINUI_SESSION_WORKTREES` (all materialized
+        // sibling worktrees) onto the PTY, derived before the ctx is parked.
+        let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+            ctx.session_worktrees_env_value().map(|v| {
+                vec![(
+                    crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                    v,
+                )]
+            })
+        });
+
         match tm.create(
             title,
             working_dir,
@@ -2346,6 +2357,7 @@ async fn handle_terminal_create(api_state: &Arc<ApiState>, data: &Value) -> Opti
             rows,
             api_state.app_handle.clone(),
             None,
+            extra_env,
         ) {
             Ok(info) => {
                 if let Some(ctx) = isolated_ctx {

--- a/src-tauri/src/mcp/tauri_proxy.rs
+++ b/src-tauri/src/mcp/tauri_proxy.rs
@@ -223,6 +223,17 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 )
                 .await;
 
+            // Phase 2c — carry `QONTINUI_SESSION_WORKTREES` (all materialized
+            // sibling worktrees) onto the PTY, derived before the ctx is parked.
+            let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+                ctx.session_worktrees_env_value().map(|v| {
+                    vec![(
+                        crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                        v,
+                    )]
+                })
+            });
+
             match tm.create(
                 a.title,
                 working_dir,
@@ -231,6 +242,7 @@ async fn dispatch(state: Arc<ApiState>, req: TauriInvokeRequest) -> TauriInvokeR
                 a.rows,
                 state.app_handle.clone(),
                 None,
+                extra_env,
             ) {
                 Ok(info) => {
                     if let Some(ctx) = isolated_ctx {

--- a/src-tauri/src/mcp/terminals.rs
+++ b/src-tauri/src/mcp/terminals.rs
@@ -161,6 +161,18 @@ pub async fn create_terminal_handler(
     )
     .await;
 
+    // Phase 2c — carry `QONTINUI_SESSION_WORKTREES` (all materialized sibling
+    // worktrees) onto the PTY, derived from the live context before it is
+    // parked on the session. `None` (no ctx / single-or-zero worktree) → no env.
+    let extra_env = isolated_ctx.as_ref().and_then(|ctx| {
+        ctx.session_worktrees_env_value().map(|v| {
+            vec![(
+                crate::agent_worktree::isolated_edit::SESSION_WORKTREES_ENV.to_string(),
+                v,
+            )]
+        })
+    });
+
     match terminal_manager.create(
         request.title,
         working_dir,
@@ -169,6 +181,7 @@ pub async fn create_terminal_handler(
         request.rows,
         app_handle,
         None,
+        extra_env,
     ) {
         Ok(info) => {
             if let Some(ctx) = isolated_ctx {

--- a/src-tauri/src/session/transport/claude_cli.rs
+++ b/src-tauri/src/session/transport/claude_cli.rs
@@ -79,6 +79,7 @@ impl Transport for ClaudeCliTransport {
                         None,
                         self.app_handle.clone(),
                         None,
+                        None,
                     )
                     .map_err(TransportError::Runtime)?;
 

--- a/src-tauri/src/session/transport/pty.rs
+++ b/src-tauri/src/session/transport/pty.rs
@@ -79,6 +79,7 @@ impl Transport for PtyTransport {
                 None,
                 self.app_handle.clone(),
                 None,
+                None,
             )
             .map_err(TransportError::Runtime)?;
 

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -35,6 +35,11 @@ impl TerminalManager {
     /// the PTY child (the gate-continuation terminal branch launches `claude`
     /// this way); `None` keeps the interactive-shell behavior every
     /// operator-opened terminal uses.
+    ///
+    /// `extra_env` (Phase 2c) is an optional set of `(key, value)` env vars
+    /// exported onto the PTY child in addition to the built-in runner vars —
+    /// the launch surfaces use it to carry `QONTINUI_SESSION_WORKTREES` (the
+    /// agent-agnostic pointer to every materialized sibling worktree).
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         &self,
@@ -45,6 +50,7 @@ impl TerminalManager {
         rows: Option<u16>,
         app_handle: AppHandle,
         command: Option<Vec<String>>,
+        extra_env: Option<Vec<(String, String)>>,
     ) -> Result<TerminalInfo, String> {
         let id = uuid::Uuid::new_v4().to_string();
         let title = title.unwrap_or_else(|| format!("Terminal {}", self.count() + 1));
@@ -70,6 +76,7 @@ impl TerminalManager {
             app_handle,
             self.interceptor.clone(),
             command,
+            extra_env,
         )?;
 
         let info = session.info();

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -224,6 +224,7 @@ impl TerminalSession {
         app_handle: AppHandle,
         interceptor: Arc<OutputInterceptor>,
         command: Option<Vec<String>>,
+        extra_env: Option<Vec<(String, String)>>,
     ) -> Result<Self, String> {
         let pty_system = native_pty_system();
 
@@ -266,6 +267,16 @@ impl TerminalSession {
             "QONTINUI_RUNNER_API_PORT",
             crate::mcp::types::get_mcp_api_port().to_string(),
         );
+
+        // Phase 2c — caller-supplied launch env (e.g.
+        // `QONTINUI_SESSION_WORKTREES`, the agent-agnostic pointer to every
+        // materialized sibling worktree of this session). Set after the
+        // built-in runner vars so a caller can intentionally override them.
+        if let Some(env) = extra_env {
+            for (k, v) in env {
+                cmd.env(k, v);
+            }
+        }
 
         // Set CLAUDE_CONFIG_DIR so Claude Code uses the resolved account
         // (multi-account support with auto-rotation on rate-limit).


### PR DESCRIPTION
## Phase 2 — Launch-provisioning (session-scoped multi-repo workspace coordination)

Follows #447 (Phase 1: per-repo `kind=worktree` claims + multi-claim context). Plan: `qontinui-dev-notes/plans/2026-06-06-session-scoped-multi-repo-workspace-coordination.md` (§3.6 delivery decisions).

**Key finding during decomposition:** the runner already roots launched sessions in their per-session worktree (`acquire_for_terminal` → `cmd.cwd`) across all 5 spawn surfaces, so Phase 2 is a *completion*, not a rewrite.

### What's here
- **2a** — `spawn_worker_session` + `launch_coordinator_session` take an optional `intent_repo` (defaults to `qontinui-runner`); drops the hardcode so any repo can be the session's claimed workspace.
- **2c** — multi-repo sibling rooting: export `QONTINUI_SESSION_WORKTREES` (`<repo>=<path>;…` over all materialized worktrees) onto every launched process (**agent-agnostic** — works for any AI CLI), plus `--add-dir <sibling>` for `claude` launches.
- **2b** — doc: per-spawn `<agent_id>` worktree dir already satisfies the per-session model.
- **2d** — audited all 5 launch surfaces provision in-process via `acquire_for_terminal`.
- **2g** — platform-portable unit tests (env value, `--add-dir`, intent_repo default).

### Design decisions
- **In-process `acquire`, NOT re-adding `/agents/allocate-local`** (removed in #443 with zero callers). Resolved on clean-code/robustness. An HTTP face is only justified by a genuine cross-process caller, which is the deferred Phase 3 hook.
- **2e (VS-Code-via-runner) deferred** — its detached-process claim lifecycle belongs to the sibling restart-resilience plan.

### Verification
Local: `cargo fmt` + `cargo clippy --all-targets --features custom-protocol -- -D warnings` clean; `cargo test` 138 passed (affected modules). Agent-agnostic live proof (launch a non-Claude session via the runner → worktree claim appears with no hook) to be confirmed on a temp runner.
