### PR TITLE
feat(federation): surface skip reason to the UI instead of silent warn

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -36,6 +36,91 @@ use qontinui_runner_lib::observable_bridge::{ReconcileReport, SessionContext};
 /// M pulled, K failed" banner described in plan Phase 5.
 pub const RECONCILE_EVENT: &str = "memory-federation:reconcile";
 
+/// Tauri event channel for federation-skipped broadcasts. Mirrors
+/// [`RECONCILE_EVENT`]: when federation is skipped for a session the
+/// spawn site emits a one-line `{ session_id, reason, detail }` payload
+/// here so the React frontend can surface a "federation: skipped
+/// (<reason>)" notice instead of the old silent warn-only behavior.
+pub const SKIP_EVENT: &str = "memory-federation:skipped";
+
+/// Why memory federation was skipped for a session. Returned by
+/// [`build_federation_ctx`] (as the `Err` arm) so the spawn site can
+/// surface the reason to the UI via [`SKIP_EVENT`] instead of silently
+/// dropping a bare `None`. The `disabled` (kill-switch) case is not part
+/// of this enum because it short-circuits before `build_federation_ctx`
+/// is ever called — the call site emits `reason = "disabled"` directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FederationSkipReason {
+    /// No `paired_user.json::tenant_id` and no claim in the cached
+    /// device-token JWT — the runner isn't paired to a tenant.
+    TenantUnresolved,
+    /// `~/.qontinui/machine.json` is missing or unparseable.
+    DeviceIdMissing,
+    /// No effective Claude config dir could be resolved.
+    NoConfigDir,
+}
+
+impl FederationSkipReason {
+    /// Stable machine-readable reason token, mirrored by the frontend
+    /// skip-notice copy. Kept in sync with `MemoryFederationBanner.tsx`.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            FederationSkipReason::TenantUnresolved => "tenant-unresolved",
+            FederationSkipReason::DeviceIdMissing => "device-id-missing",
+            FederationSkipReason::NoConfigDir => "no-config-dir",
+        }
+    }
+
+    /// Short human-readable explanation for the UI skip notice. Kept
+    /// concise (one short clause) since the frontend renders it inline.
+    pub fn detail(&self) -> &'static str {
+        match self {
+            FederationSkipReason::TenantUnresolved => "Runner not paired to a tenant.",
+            FederationSkipReason::DeviceIdMissing => {
+                "Device identity (~/.qontinui/machine.json) is missing."
+            }
+            FederationSkipReason::NoConfigDir => "No effective Claude config directory.",
+        }
+    }
+}
+
+impl std::fmt::Display for FederationSkipReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Tauri event payload for [`SKIP_EVENT`]. `reason` is a stable token
+/// (see [`FederationSkipReason::as_str`] plus the `"disabled"`
+/// kill-switch case); `detail` is a short human-readable explanation.
+#[derive(Debug, Clone, Serialize)]
+pub struct SkipPayload {
+    pub session_id: String,
+    pub reason: String,
+    pub detail: String,
+}
+
+/// Emit a [`SKIP_EVENT`] for `session_id` with the given reason token and
+/// detail. Best-effort: an emit failure is logged at `debug` and never
+/// propagated, mirroring [`emit_federation_report`]'s emit handling. The
+/// caller is responsible for the accompanying `warn!` (preserved at each
+/// skip site).
+pub fn emit_federation_skip(
+    app_handle: &tauri::AppHandle,
+    session_id: &str,
+    reason: &str,
+    detail: &str,
+) {
+    let payload = SkipPayload {
+        session_id: session_id.to_string(),
+        reason: reason.to_string(),
+        detail: detail.to_string(),
+    };
+    if let Err(e) = app_handle.emit(SKIP_EVENT, &payload) {
+        debug!("claude_session::federation: emit {SKIP_EVENT} failed: {e} (non-fatal)");
+    }
+}
+
 /// Cross-account memory federation kill switch — reads from
 /// `AiSettings::memory_federation_enabled`. Default ON; the field is
 /// `#[serde(default = "default_memory_federation_enabled")]` so the
@@ -65,8 +150,9 @@ pub fn session_uuid(session_id: &str) -> Uuid {
 }
 
 /// Build a `SessionContext` for the about-to-spawn Claude subprocess.
-/// Returns `None` (with a warn log) when any required identity field is
-/// missing — that signals the spawn site to skip federation.
+/// Returns `Err(FederationSkipReason)` (with a warn log) when any required
+/// identity field is missing — that signals the spawn site to skip
+/// federation (and surface the reason to the UI via [`SKIP_EVENT`]).
 ///
 /// Resolution sources:
 ///
@@ -83,7 +169,7 @@ pub fn build_federation_ctx(
     session_id: &str,
     working_dir: &str,
     cli_settings: &ClaudeCliSettings,
-) -> Option<SessionContext> {
+) -> Result<SessionContext, FederationSkipReason> {
     let tenant_id = match resolve_tenant_id() {
         Some(t) => t,
         None => {
@@ -92,7 +178,7 @@ pub fn build_federation_ctx(
                  (no paired_user.json::tenant_id, no claim in cached device-token JWT); \
                  skipping memory federation for session {session_id}"
             );
-            return None;
+            return Err(FederationSkipReason::TenantUnresolved);
         }
     };
 
@@ -103,7 +189,7 @@ pub fn build_federation_ctx(
                 "claude_session::federation: ~/.qontinui/machine.json missing or unparseable; \
                  skipping memory federation for session {session_id}"
             );
-            return None;
+            return Err(FederationSkipReason::DeviceIdMissing);
         }
     };
 
@@ -115,14 +201,14 @@ pub fn build_federation_ctx(
                 "claude_session::federation: no effective claude config_dir; \
                  skipping memory federation for session {session_id}"
             );
-            return None;
+            return Err(FederationSkipReason::NoConfigDir);
         }
     };
 
     let memory_dir = derive_memory_dir(&config_dir_str, working_dir);
     let account_name = derive_account_name(&config_dir_str);
 
-    Some(SessionContext {
+    Ok(SessionContext {
         tenant_id,
         device_id,
         account_name,

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -480,16 +480,35 @@ fn run_claude_session_inline(
     // bridge — federation is best-effort and never blocks the spawn.
     let federation_ctx_opt = if crate::claude_session::federation::federation_enabled() {
         let ai_settings = crate::settings::get_ai_settings();
-        crate::claude_session::federation::build_federation_ctx(
+        match crate::claude_session::federation::build_federation_ctx(
             session_id,
             working_dir,
             &ai_settings.claude_cli,
-        )
+        ) {
+            Ok(ctx) => Some(ctx),
+            Err(reason) => {
+                // Surface the skip reason to the UI (warn! already logged
+                // inside build_federation_ctx); proceed locally.
+                crate::claude_session::federation::emit_federation_skip(
+                    app_handle,
+                    session_id,
+                    reason.as_str(),
+                    reason.detail(),
+                );
+                None
+            }
+        }
     } else {
         debug!(
             "memory federation disabled via settings (memory_federation_enabled=false); \
              skipping pull/watch for session {}",
             session_id
+        );
+        crate::claude_session::federation::emit_federation_skip(
+            app_handle,
+            session_id,
+            "disabled",
+            "Memory federation disabled via settings kill-switch.",
         );
         None
     };

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -263,15 +263,34 @@ impl ClaudeSession {
         // identity / toggle short-circuits return `None` so federation
         // never blocks the spawn.
         let federation_ctx = if crate::claude_session::federation::federation_enabled() {
-            super::federation::build_federation_ctx(
+            match super::federation::build_federation_ctx(
                 session_id,
                 working_dir,
                 &ai_settings.claude_cli,
-            )
+            ) {
+                Ok(ctx) => Some(ctx),
+                Err(reason) => {
+                    // Surface the skip reason to the UI (warn! already
+                    // logged inside build_federation_ctx); proceed locally.
+                    super::federation::emit_federation_skip(
+                        app_handle,
+                        session_id,
+                        reason.as_str(),
+                        reason.detail(),
+                    );
+                    None
+                }
+            }
         } else {
             debug!(
                 "memory federation disabled via settings; skipping pull/watch for session {}",
                 session_id
+            );
+            super::federation::emit_federation_skip(
+                app_handle,
+                session_id,
+                "disabled",
+                "Memory federation disabled via settings kill-switch.",
             );
             None
         };

--- a/src/components/MemoryFederationBanner.tsx
+++ b/src/components/MemoryFederationBanner.tsx
@@ -14,6 +14,12 @@
  * across many short sessions. Reports with `report.failed > 0` are
  * persistent and styled with a destructive border so the operator
  * notices.
+ *
+ * Also listens for `memory-federation:skipped` (emitted from
+ * `claude_session::federation::emit_federation_skip` whenever federation
+ * is skipped for a session — missing identity or the settings
+ * kill-switch). These render a single-line informational notice that
+ * auto-dismisses, so the previously-silent skip becomes visible.
  */
 
 import { useEffect, useState } from "react";
@@ -32,50 +38,97 @@ interface ReconcileEvent {
   report: ReconcileReport;
 }
 
-interface ActiveNotice extends ReconcileEvent {
-  id: number;
-  receivedAt: number;
+interface SkipEvent {
+  session_id: string;
+  reason: string;
+  detail: string;
 }
 
+type ActiveNotice =
+  | ({ kind: "reconcile"; id: number; receivedAt: number } & ReconcileEvent)
+  | ({ kind: "skip"; id: number; receivedAt: number } & SkipEvent);
+
 const SUCCESS_TTL_MS = 6000;
+const SKIP_TTL_MS = 8000;
+
+/** Map a stable skip-reason token to a concise human label. Kept in sync
+ *  with `FederationSkipReason::as_str` (Rust) plus the `"disabled"`
+ *  kill-switch case. */
+function skipReasonLabel(reason: string): string {
+  switch (reason) {
+    case "tenant-unresolved":
+      return "not paired (no tenant id)";
+    case "device-id-missing":
+      return "no device identity";
+    case "no-config-dir":
+      return "no Claude config dir";
+    case "disabled":
+      return "disabled in settings";
+    default:
+      return reason;
+  }
+}
 
 export function MemoryFederationBanner() {
   const [notices, setNotices] = useState<ActiveNotice[]>([]);
 
   useEffect(() => {
-    let unlisten: UnlistenFn | undefined;
+    const unlisteners: UnlistenFn[] = [];
     let counter = 0;
     (async () => {
       try {
-        unlisten = await listen<ReconcileEvent>(
-          "memory-federation:reconcile",
-          (event) => {
+        unlisteners.push(
+          await listen<ReconcileEvent>(
+            "memory-federation:reconcile",
+            (event) => {
+              counter += 1;
+              const notice: ActiveNotice = {
+                kind: "reconcile",
+                ...event.payload,
+                id: counter,
+                receivedAt: Date.now(),
+              };
+              setNotices((prev) => [...prev, notice]);
+            },
+          ),
+        );
+        unlisteners.push(
+          await listen<SkipEvent>("memory-federation:skipped", (event) => {
             counter += 1;
             const notice: ActiveNotice = {
+              kind: "skip",
               ...event.payload,
               id: counter,
               receivedAt: Date.now(),
             };
             setNotices((prev) => [...prev, notice]);
-          },
+          }),
         );
       } catch (e) {
         console.error("MemoryFederationBanner: listen failed", e);
       }
     })();
     return () => {
-      if (unlisten) unlisten();
+      for (const unlisten of unlisteners) unlisten();
     };
   }, []);
 
   useEffect(() => {
     if (notices.length === 0) return;
-    const earliestSuccess = notices.find((n) => n.report.failed === 0);
-    if (!earliestSuccess) return;
-    const elapsed = Date.now() - earliestSuccess.receivedAt;
-    const remaining = Math.max(0, SUCCESS_TTL_MS - elapsed);
+    // Auto-dismiss the earliest transient notice: reconcile successes
+    // (no failures) and all skip notices are informational and shouldn't
+    // accumulate. Reconcile reports with failures stay until dismissed.
+    const earliestTransient = notices.find(
+      (n) =>
+        n.kind === "skip" || (n.kind === "reconcile" && n.report.failed === 0),
+    );
+    if (!earliestTransient) return;
+    const ttl =
+      earliestTransient.kind === "skip" ? SKIP_TTL_MS : SUCCESS_TTL_MS;
+    const elapsed = Date.now() - earliestTransient.receivedAt;
+    const remaining = Math.max(0, ttl - elapsed);
     const timeout = window.setTimeout(() => {
-      setNotices((prev) => prev.filter((n) => n.id !== earliestSuccess.id));
+      setNotices((prev) => prev.filter((n) => n.id !== earliestTransient.id));
     }, remaining);
     return () => window.clearTimeout(timeout);
   }, [notices]);
@@ -93,6 +146,35 @@ export function MemoryFederationBanner() {
       style={containerStyle}
     >
       {notices.map((n) => {
+        if (n.kind === "skip") {
+          return (
+            <div
+              key={n.id}
+              role="status"
+              aria-live="polite"
+              style={bannerStyleSuccess}
+            >
+              <div style={{ flex: 1 }}>
+                <p style={titleStyleSuccess}>Memory federation</p>
+                <p style={messageStyle}>
+                  skipped — {skipReasonLabel(n.reason)}
+                  {" — session "}
+                  <code style={codeStyle}>{n.session_id.slice(0, 8)}</code>
+                </p>
+              </div>
+              <div style={actionsColumnStyle}>
+                <button
+                  type="button"
+                  onClick={() => dismiss(n.id)}
+                  style={dismissBtn}
+                  aria-label="Dismiss"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          );
+        }
         const hasFailures = n.report.failed > 0;
         return (
           <div


### PR DESCRIPTION
## What

Phase 3 of the memory-federation multi-user redesign (`plans/2026-06-07-memory-federation-multi-user-auth-redesign.md`).

When memory federation is **skipped** for a session it previously left only a stderr `warn!` — invisible to the operator. The most common skip is exactly the multi-user breakage the redesign needs surfaced: the runner not being paired (no tenant id) → it forwards no bearer → its coord round-trips are 403'd-and-swallowed (corrected Gap A in the plan).

## Change

- `build_federation_ctx` now returns `Result<SessionContext, FederationSkipReason>` (was `Option`), so the spawn site knows **why** it was skipped: `TenantUnresolved` / `DeviceIdMissing` / `NoConfigDir`.
- New Tauri event `memory-federation:skipped` carrying `{ session_id, reason, detail }`, emitted from both spawn sites (`run_claude_session_inline`, `ClaudeSession::spawn`), including a `"disabled"` reason for the settings kill-switch path. Best-effort emit, mirrors the existing `memory-federation:reconcile` event.
- `MemoryFederationBanner` renders a one-line, auto-dismissing skip notice (reason→label map kept in sync with the Rust enum).

## Scope / safety

- Existing `warn!` logs and the proceed-locally behavior are **unchanged** — this only adds the emission + UI surface.
- Deliberately **not** on `MemoryFederationPage.tsx`, to avoid colliding with the in-flight IPC fix (#474). The notice lives on the already-mounted `MemoryFederationBanner`.
- No event-bindings codegen needed — the reconcile event is hand-written too; mirrored that.

## Test

- Frontend `tsc --noEmit` clean; `vite build` clean.
- `cargo check` clean (full crate, with `dist/` present so `generate_context!` resolves).
- Pre-push `cargo fmt + clippy -D warnings` Passed.

## Related

- Pairs with coord PR qontinui-coord#417 (server-side `tenant_not_resolved` telemetry) — together they make a non-author user's silent federation failure visible from both ends.