### PR TITLE
fix(runner): scope page/evaluate to a single window (windowLabel)

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/page.rs
+++ b/src-tauri/src/mcp/ui_bridge/page.rs
@@ -11,12 +11,12 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::Json,
 };
 use serde::{Deserialize, Serialize};
-use tauri::Emitter;
+use tauri::{Emitter, EventTarget};
 use tracing::{debug, error, info};
 
 use super::types::UiBridgeError;
@@ -24,7 +24,10 @@ use crate::mcp::envelope::{RequestHints, UiBridgeJson};
 use crate::mcp::types::{api_error, api_error_detailed, ApiResponse, ApiState};
 
 use super::helpers::{direct_webview_evaluate_with_result, evaluate_js_expression, safe_evaluate};
-use super::request::{ui_bridge_request_sync, wrap_ipc_result};
+use super::request::{
+    multi_window_dispatch_enabled, ui_bridge_request_sync, wrap_ipc_result, MAIN_WINDOW_LABEL,
+    TARGET_WINDOW_FIELD,
+};
 use super::{ipc_handler_get, ipc_handler_post};
 
 // Macro-generated IPC forwarders for SDK-relayed page-control routes.
@@ -168,6 +171,26 @@ pub struct PageEvaluateRequest {
     /// directly. Structural code-injection blocks stay in force regardless.
     #[serde(default)]
     pub allow_network_requests: Option<bool>,
+    /// Optional target pop-out window (`{ "windowLabel": "term-1" }`),
+    /// mirroring `execute_action` / `get_elements`. Absent / empty → the main
+    /// window. A `?windowLabel=` query param takes precedence over this body
+    /// field (see [`EvaluateQueryParams`]). Without this, `page/evaluate`
+    /// broadcasts the expression to every open runner window.
+    #[serde(default)]
+    pub window_label: Option<String>,
+}
+
+/// Optional query parameters for `page/evaluate`.
+///
+/// `?windowLabel=term-1` targets a pop-out terminal window (discoverable via
+/// `GET /ui-bridge/control/runner-windows`). Omitted → the main window. Mirrors
+/// [`super::elements::ActionQueryParams`] so the routing convention is identical
+/// across control routes. A query param takes precedence over the body's
+/// `windowLabel` so a caller can address a window without rewriting the body.
+#[derive(Debug, Deserialize, Default)]
+pub struct EvaluateQueryParams {
+    #[serde(default, rename = "windowLabel")]
+    pub window_label: Option<String>,
 }
 
 impl RequestHints for PageEvaluateRequest {
@@ -708,6 +731,17 @@ const DEFAULT_PAGE_EVALUATE_TIMEOUT_MS: u64 = 10_000;
 /// Dispatch a page/evaluate request over the tagged
 /// `ui-bridge:evaluate-request` / `ui-bridge:evaluate-response` event pair,
 /// correlating the response through [`EvaluateRequestStore`].
+///
+/// `window_label` is the resolved target window ([`MAIN_WINDOW_LABEL`] for the
+/// single-window default). The request is registered under
+/// `(window_label, request_id)` and the emit is scoped to that window only via
+/// `emit_to(EventTarget::labeled(window_label), …)` (so a `page/evaluate` no
+/// longer fires the expression in every open window). Delivery is authoritative
+/// on the Rust side: unlike the bare `Emitter::emit`, which broadcasts to ALL
+/// targets, `emit_to` is filtered down to the listener registered under that
+/// label. The emitted payload still carries `windowLabel` so the frontend
+/// evaluate listener can additionally ignore any event not addressed to its own
+/// `getCurrentWindow().label` (defense-in-depth, no longer load-bearing).
 async fn tagged_page_evaluate(
     state: &Arc<ApiState>,
     expression: &str,
@@ -715,17 +749,33 @@ async fn tagged_page_evaluate(
     timeout_ms: Option<u64>,
     unwrap: bool,
     allow_network_requests: bool,
+    window_label: &str,
 ) -> Result<serde_json::Value, String> {
     let timeout_ms = timeout_ms.unwrap_or(DEFAULT_PAGE_EVALUATE_TIMEOUT_MS);
     let request_id = uuid::Uuid::new_v4().to_string();
 
+    // Fail fast for a non-existent target window — mirrors the guard in
+    // `request::ui_bridge_request_inner`. Without it, the emit lands on a window
+    // every listener filters out by label, so the caller waits the full timeout
+    // for a request nothing can answer. The main window always exists, so the
+    // default path skips the lookup.
+    if window_label != MAIN_WINDOW_LABEL {
+        use tauri::Manager;
+        if state.app_handle.get_webview_window(window_label).is_none() {
+            return Err(format!(
+                "No runner window labeled '{window_label}'. Discover live windows via \
+                 GET /ui-bridge/control/runner-windows."
+            ));
+        }
+    }
+
     let (sender, receiver) = tokio::sync::oneshot::channel();
     state
         .ui_bridge_evaluate_store
-        .register(request_id.clone(), sender)
+        .register(window_label, &request_id, sender)
         .await;
 
-    let payload = serde_json::json!({
+    let mut payload = serde_json::json!({
         "request_id": request_id,
         "expression": expression,
         "await_promise": await_promise,
@@ -740,19 +790,55 @@ async fn tagged_page_evaluate(
         // convention (await_promise / timeout_ms / request_id).
         "allow_network_requests": allow_network_requests,
     });
+    // The frontend evaluate listener filters on `windowLabel` against its own
+    // `getCurrentWindow().label`; it also echoes it back on the
+    // `ui-bridge:evaluate-response` so the store delivers under the same
+    // `(window_label, request_id)` key it was registered with. Use the shared
+    // `TARGET_WINDOW_FIELD` constant (camelCase `windowLabel`) so the routing
+    // field name can't drift from the other control routes.
+    if let Some(obj) = payload.as_object_mut() {
+        obj.insert(
+            TARGET_WINDOW_FIELD.to_string(),
+            serde_json::Value::String(window_label.to_string()),
+        );
+    }
 
-    // Target the canonical MAIN window only. `AppHandle::emit` is a GLOBAL
-    // broadcast that reaches every webview (main + pop-out `term-N`
-    // terminals); each window's `useUIBridgeEvaluateHandler` would then run
-    // the expression independently, fanning out a single-consumer request to
-    // N windows (duplicate side-effecting invokes). `emit_to(<main label>)`
-    // routes it to exactly one deterministic consumer.
-    if let Err(e) = state.app_handle.emit_to(
-        qontinui_runner_lib::get_main_window_label(),
-        "ui-bridge:evaluate-request",
-        &payload,
-    ) {
-        state.ui_bridge_evaluate_store.cancel(&request_id).await;
+    // Route the emit to the target window ONLY (Phase 1 multi-window dispatch),
+    // honoring the same `QONTINUI_UI_BRIDGE_MULTI_WINDOW` flag as the main IPC
+    // path.
+    //
+    // ROOT-CAUSE NOTE: `WebviewWindow::emit` / `AppHandle::emit` (the `Emitter`
+    // trait's default `emit`) deliver to ALL targets — they are NOT scoped to
+    // the receiver. The previous `get_webview_window(label).emit(...)` therefore
+    // broadcast the expression to every open window, and single-window behavior
+    // depended entirely on each window's frontend own-label filter. That filter
+    // is kept as defense-in-depth, but it is no longer load-bearing: scope the
+    // delivery on the Rust side with `emit_to(EventTarget::labeled(label), …)`,
+    // which the runtime filters down to the listener registered under that label
+    // (a webview `listen()` registers as `WebviewWindow { label }`, matched by
+    // `AnyLabel`). Now an eval that clicks a button fires in ONE window only,
+    // even if a pop-out's frontend filter were ever wrong.
+    //
+    // When the flag is off we fall back to the legacy process-global broadcast
+    // (the frontend own-label filter is then the only scoping), preserving the
+    // documented escape hatch.
+    let emit_result = if multi_window_dispatch_enabled() {
+        state.app_handle.emit_to(
+            EventTarget::labeled(window_label),
+            "ui-bridge:evaluate-request",
+            &payload,
+        )
+    } else {
+        state
+            .app_handle
+            .emit("ui-bridge:evaluate-request", &payload)
+    };
+
+    if let Err(e) = emit_result {
+        state
+            .ui_bridge_evaluate_store
+            .cancel(window_label, &request_id)
+            .await;
         return Err(format!("Failed to emit ui-bridge:evaluate-request: {}", e));
     }
 
@@ -784,14 +870,20 @@ async fn tagged_page_evaluate(
             }
         }
         Ok(Err(_)) => {
-            state.ui_bridge_evaluate_store.cancel(&request_id).await;
+            state
+                .ui_bridge_evaluate_store
+                .cancel(window_label, &request_id)
+                .await;
             Err(format!(
                 "page/evaluate: response channel closed before delivery (request_id={})",
                 request_id
             ))
         }
         Err(_) => {
-            state.ui_bridge_evaluate_store.cancel(&request_id).await;
+            state
+                .ui_bridge_evaluate_store
+                .cancel(window_label, &request_id)
+                .await;
             Err(format!(
                 "UI Bridge page_evaluate timed out after {}ms",
                 timeout_ms
@@ -807,9 +899,13 @@ async fn page_evaluate_inner(
     await_promise: bool,
     unwrap: bool,
     allow_network_requests: bool,
+    window_label: &str,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     let preview: String = expression.chars().take(80).collect();
-    info!("UI Bridge API: Page evaluate ({}...)", preview);
+    info!(
+        "UI Bridge API: Page evaluate (window={}, {}...)",
+        window_label, preview
+    );
 
     let ipc_result = tagged_page_evaluate(
         &state,
@@ -818,6 +914,7 @@ async fn page_evaluate_inner(
         timeout_ms,
         unwrap,
         allow_network_requests,
+        window_label,
     )
     .await;
     match ipc_result {
@@ -844,8 +941,32 @@ async fn page_evaluate_inner(
             Ok(Json(ApiResponse::success(data)))
         }
         Err(ipc_err) => {
+            // The `direct_webview_evaluate_with_result` fallback below targets
+            // the MAIN window only (see helpers.rs). Falling back to it for a
+            // request addressed to a *non-main* window is wrong on two counts:
+            //
+            //  1. An unknown-window fail-fast (e.g. `?windowLabel=ghost`, which
+            //     `tagged_page_evaluate` rejects before emitting) would be
+            //     silently "recovered" by running the expression in main —
+            //     turning a should-have-failed call into a false success. This
+            //     is exactly the `ghost → {success:true}` bug.
+            //  2. Even a genuine IPC/transport failure for a *real* pop-out
+            //     window must NOT be retried against main — that would run the
+            //     caller's expression in the wrong window.
+            //
+            // So the main-only fallback is permitted ONLY when the caller
+            // actually addressed the main window. Any error while addressing a
+            // non-main window propagates verbatim.
+            if window_label != MAIN_WINDOW_LABEL {
+                error!(
+                    "UI Bridge API: evaluate failed for window '{}' (no main-window fallback for a non-main target): {}",
+                    window_label, ipc_err
+                );
+                return Err((StatusCode::BAD_REQUEST, Json(api_error(ipc_err))));
+            }
+
             debug!(
-                "UI Bridge: IPC evaluate failed ({}), trying direct WebView eval",
+                "UI Bridge: IPC evaluate failed for main window ({}), trying direct WebView eval",
                 ipc_err
             );
 
@@ -991,14 +1112,77 @@ mod static_guard_hint_tests {
     }
 }
 
+/// Resolve the effective target window for an evaluate request.
+///
+/// Precedence: `?windowLabel=` query param → body `windowLabel` → the main
+/// window. Empty strings are treated as "not provided" (so `?windowLabel=`
+/// falls through to the body, and an empty body field falls through to main),
+/// matching how [`super::request::split_target_window`] normalizes the field.
+fn resolve_evaluate_window(query: Option<&str>, body: Option<&str>) -> String {
+    query
+        .filter(|s| !s.is_empty())
+        .or_else(|| body.filter(|s| !s.is_empty()))
+        .unwrap_or(MAIN_WINDOW_LABEL)
+        .to_string()
+}
+
+#[cfg(test)]
+mod resolve_evaluate_window_tests {
+    use super::{resolve_evaluate_window, MAIN_WINDOW_LABEL};
+
+    /// Goal behavior 1: with NO `windowLabel` anywhere, an evaluate targets the
+    /// MAIN window — so the dispatcher's `emit_to(EventTarget::labeled("main"))`
+    /// runs the expression in the main window only.
+    #[test]
+    fn no_label_anywhere_resolves_to_main() {
+        assert_eq!(resolve_evaluate_window(None, None), MAIN_WINDOW_LABEL);
+    }
+
+    /// Empty strings are "not provided" — `?windowLabel=` (and an empty body
+    /// field) fall through to main, matching `split_target_window`.
+    #[test]
+    fn empty_strings_fall_through_to_main() {
+        assert_eq!(resolve_evaluate_window(Some(""), None), MAIN_WINDOW_LABEL);
+        assert_eq!(
+            resolve_evaluate_window(Some(""), Some("")),
+            MAIN_WINDOW_LABEL
+        );
+        assert_eq!(resolve_evaluate_window(None, Some("")), MAIN_WINDOW_LABEL);
+    }
+
+    /// Goal behavior 2: `?windowLabel=term-1` targets `term-1` only. The query
+    /// param wins over the body.
+    #[test]
+    fn query_label_wins_and_is_used_verbatim() {
+        assert_eq!(resolve_evaluate_window(Some("term-1"), None), "term-1");
+        assert_eq!(
+            resolve_evaluate_window(Some("term-1"), Some("term-2")),
+            "term-1",
+            "query param must win over the body field"
+        );
+    }
+
+    /// Body `windowLabel` is the fallback when the query param is absent/empty.
+    #[test]
+    fn body_label_is_the_fallback() {
+        assert_eq!(resolve_evaluate_window(None, Some("term-3")), "term-3");
+        assert_eq!(resolve_evaluate_window(Some(""), Some("term-3")), "term-3");
+    }
+}
+
 /// Evaluate a JavaScript expression in the webview.
 pub async fn ui_bridge_page_evaluate_handler(
     State(state): State<Arc<ApiState>>,
+    Query(query): Query<EvaluateQueryParams>,
     UiBridgeJson(request): UiBridgeJson<PageEvaluateRequest>,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     let timeout = request.timeout_ms.map(|ms| ms.clamp(1000, 600_000));
     let unwrap = request.unwrap.unwrap_or(false);
     let allow_network_requests = request.allow_network_requests.unwrap_or(false);
+    let window_label = resolve_evaluate_window(
+        query.window_label.as_deref(),
+        request.window_label.as_deref(),
+    );
     page_evaluate_inner(
         state,
         request.expression,
@@ -1006,13 +1190,19 @@ pub async fn ui_bridge_page_evaluate_handler(
         request.await_promise,
         unwrap,
         allow_network_requests,
+        &window_label,
     )
     .await
 }
 
 /// `POST /ui-bridge/control/page/evaluate-raw`
+///
+/// The whole body is the JS expression, so the only way to address a pop-out
+/// window here is the `?windowLabel=` query param (the body can't carry a
+/// routing field). Absent / empty → the main window.
 pub async fn ui_bridge_page_evaluate_raw_handler(
     State(state): State<Arc<ApiState>>,
+    Query(query): Query<EvaluateQueryParams>,
     body: String,
 ) -> Result<Json<ApiResponse<serde_json::Value>>, (StatusCode, Json<ApiResponse<()>>)> {
     if body.trim().is_empty() {
@@ -1021,7 +1211,8 @@ pub async fn ui_bridge_page_evaluate_raw_handler(
             Json(api_error("page/evaluate-raw: body is empty".to_string())),
         ));
     }
-    page_evaluate_inner(state, body, None, false, false, false).await
+    let window_label = resolve_evaluate_window(query.window_label.as_deref(), None);
+    page_evaluate_inner(state, body, None, false, false, false, &window_label).await
 }
 
 /// POST /ui-bridge/control/page/evaluate-safe
@@ -1900,12 +2091,12 @@ mod page_evaluate_tagging_tests {
         // Caller A: evaluates `document.title` → "Runner".
         let request_id_a = "evaluate-call-a".to_string();
         let (tx_a, rx_a) = oneshot::channel::<EvaluateResponse>();
-        store.register(request_id_a.clone(), tx_a).await;
+        store.register("main", &request_id_a, tx_a).await;
 
         // Caller B: evaluates `window.location.pathname` → "/dashboard".
         let request_id_b = "evaluate-call-b".to_string();
         let (tx_b, rx_b) = oneshot::channel::<EvaluateResponse>();
-        store.register(request_id_b.clone(), tx_b).await;
+        store.register("main", &request_id_b, tx_b).await;
 
         // Run both HTTP-handler-equivalent awaits concurrently. Each
         // simulates `tagged_page_evaluate`'s `tokio::time::timeout(..., rx)`.
@@ -1930,6 +2121,7 @@ mod page_evaluate_tagging_tests {
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             store_for_b
                 .deliver(
+                    "main",
                     "evaluate-call-b",
                     EvaluateResponse {
                         ok: true,
@@ -1947,6 +2139,7 @@ mod page_evaluate_tagging_tests {
             tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             store_for_a
                 .deliver(
+                    "main",
                     "evaluate-call-a",
                     EvaluateResponse {
                         ok: true,
@@ -2000,23 +2193,24 @@ mod page_evaluate_tagging_tests {
 
         let request_id_a = "evaluate-timeout".to_string();
         let (tx_a, rx_a) = oneshot::channel::<EvaluateResponse>();
-        store.register(request_id_a.clone(), tx_a).await;
+        store.register("main", &request_id_a, tx_a).await;
 
         let request_id_b = "evaluate-sibling".to_string();
         let (tx_b, rx_b) = oneshot::channel::<EvaluateResponse>();
-        store.register(request_id_b.clone(), tx_b).await;
+        store.register("main", &request_id_b, tx_b).await;
 
         // Caller A times out while waiting (mirrors the Elapsed branch of
         // tagged_page_evaluate). The handler cancels its slot.
         let wait_a = tokio::time::timeout(std::time::Duration::from_millis(50), rx_a).await;
         assert!(wait_a.is_err(), "caller A must time out");
-        store.cancel(&request_id_a).await;
+        store.cancel("main", &request_id_a).await;
 
         // Caller B still gets a clean delivery afterwards.
         let store_for_b = store.clone();
         tokio::spawn(async move {
             store_for_b
                 .deliver(
+                    "main",
                     "evaluate-sibling",
                     EvaluateResponse {
                         ok: true,

--- a/src-tauri/src/mcp/ui_bridge/request.rs
+++ b/src-tauri/src/mcp/ui_bridge/request.rs
@@ -110,7 +110,11 @@ pub(crate) fn pending_key(window_label: &str, request_id: &str) -> String {
 /// broadcast, minus the cross-window noise. Set `QONTINUI_UI_BRIDGE_MULTI_WINDOW=0`
 /// (or `false`/`off`) to revert to unconditional broadcast. Read per-call so it can
 /// be toggled without a restart.
-fn multi_window_dispatch_enabled() -> bool {
+///
+/// `pub(crate)` so the tagged `page/evaluate` dispatcher (which owns its own
+/// event pair and store rather than funneling through `ui_bridge_request_inner`)
+/// can honor the same flag.
+pub(crate) fn multi_window_dispatch_enabled() -> bool {
     std::env::var("QONTINUI_UI_BRIDGE_MULTI_WINDOW")
         .map(|v| !(v == "0" || v.eq_ignore_ascii_case("false") || v.eq_ignore_ascii_case("off")))
         .unwrap_or(true)

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -772,6 +772,17 @@ pub fn create_router(
                 return;
             };
 
+            // The responding window echoes its own label (camelCase, mirroring
+            // the request envelope). Absent → "main": both the single-window
+            // default and any pre-window-aware frontend register/deliver under
+            // "main", so the key matches what the dispatcher stored.
+            let window_label = parsed
+                .get("windowLabel")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or("main")
+                .to_string();
+
             let ok = parsed.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
             let result = parsed.get("result").cloned();
             let error = parsed
@@ -784,7 +795,7 @@ pub fn create_router(
             let store = evaluate_store.clone();
             if let Ok(rt) = tokio::runtime::Handle::try_current() {
                 rt.spawn(async move {
-                    let delivered = store.deliver(&request_id, response).await;
+                    let delivered = store.deliver(&window_label, &request_id, response).await;
                     if !delivered {
                         tracing::debug!(
                             "UI Bridge evaluate: response for unknown request_id {} (likely timed out)",

--- a/src-tauri/src/ui_bridge_evaluate.rs
+++ b/src-tauri/src/ui_bridge_evaluate.rs
@@ -70,11 +70,29 @@ pub struct EvaluateResponse {
     pub error: Option<String>,
 }
 
+/// Build the evaluate-store map key.
+///
+/// Keying by `(window_label, request_id)` rather than `request_id` alone makes a
+/// `ui-bridge:evaluate-response` from a window the request was NOT addressed to a
+/// no-op (its computed key can't match the stored one). This is what stops the
+/// process-global `ui-bridge:evaluate-request` broadcast race once multiple
+/// runner windows (main + `term-N` pop-outs) mount the SDK — without it, the
+/// first window to answer resolves the oneshot and every other window still runs
+/// the expression (so an evaluate that clicks a button fires N times).
+///
+/// `request_id` is a UUID, so the U+001F delimiter can never collide with a
+/// (simple `main` / `term-N`) window label. Mirrors
+/// [`crate::mcp::ui_bridge::request::pending_key`] so the two pending stores
+/// share one key shape.
+pub fn evaluate_pending_key(window_label: &str, request_id: &str) -> String {
+    format!("{window_label}\u{1f}{request_id}")
+}
+
 /// Keyed store of pending oneshot senders — one per in-flight evaluate.
 ///
-/// Multiple evaluates can be in-flight at once; the HashMap is keyed by a
-/// fresh uuid-v4 `request_id` so concurrent callers never observe each
-/// other's responses.
+/// Multiple evaluates can be in-flight at once; the HashMap is keyed by
+/// `(window_label, request_id)` (see [`evaluate_pending_key`]) so concurrent
+/// callers — and concurrent windows — never observe each other's responses.
 pub struct EvaluateRequestStore {
     pending: Arc<Mutex<HashMap<String, oneshot::Sender<EvaluateResponse>>>>,
 }
@@ -92,28 +110,40 @@ impl EvaluateRequestStore {
         }
     }
 
-    /// Register a new pending evaluate.
+    /// Register a new pending evaluate, scoped to a target window.
     ///
     /// Takes ownership of the oneshot sender and stashes it under
-    /// `request_id`. If an entry for that id already exists (shouldn't
-    /// happen with uuid v4, but defensive), it is silently replaced —
-    /// the prior waiter will observe a dropped-sender error via
-    /// `Receiver::await`.
-    pub async fn register(&self, request_id: String, sender: oneshot::Sender<EvaluateResponse>) {
+    /// `(window_label, request_id)` (see [`evaluate_pending_key`]). If an entry
+    /// for that key already exists (shouldn't happen with uuid v4, but
+    /// defensive), it is silently replaced — the prior waiter will observe a
+    /// dropped-sender error via `Receiver::await`.
+    pub async fn register(
+        &self,
+        window_label: &str,
+        request_id: &str,
+        sender: oneshot::Sender<EvaluateResponse>,
+    ) {
         let mut guard = self.pending.lock().await;
-        guard.insert(request_id, sender);
+        guard.insert(evaluate_pending_key(window_label, request_id), sender);
     }
 
-    /// Deliver a response to a pending evaluate by id.
+    /// Deliver a response to a pending evaluate by `(window_label, request_id)`.
     ///
     /// Removes the entry from the map and sends the response through the
-    /// oneshot. If the receiver has already been dropped (e.g. the HTTP
-    /// handler timed out and bailed), the response is silently discarded —
-    /// this mirrors the "best effort" semantics of oneshot channels.
-    /// Returns `true` if a pending entry existed for this id.
-    pub async fn deliver(&self, request_id: &str, response: EvaluateResponse) -> bool {
+    /// oneshot. A response from a window the request was NOT addressed to
+    /// computes a key that isn't present, so it's a no-op — exactly what kills
+    /// the broadcast race. If the receiver has already been dropped (e.g. the
+    /// HTTP handler timed out and bailed), the response is silently discarded —
+    /// this mirrors the "best effort" semantics of oneshot channels. Returns
+    /// `true` if a pending entry existed for this key.
+    pub async fn deliver(
+        &self,
+        window_label: &str,
+        request_id: &str,
+        response: EvaluateResponse,
+    ) -> bool {
         let mut guard = self.pending.lock().await;
-        if let Some(sender) = guard.remove(request_id) {
+        if let Some(sender) = guard.remove(&evaluate_pending_key(window_label, request_id)) {
             let _ = sender.send(response);
             true
         } else {
@@ -125,9 +155,9 @@ impl EvaluateRequestStore {
     ///
     /// Called by the HTTP handler on timeout / emit failure so a subsequent
     /// late response doesn't linger in the map.
-    pub async fn cancel(&self, request_id: &str) {
+    pub async fn cancel(&self, window_label: &str, request_id: &str) {
         let mut guard = self.pending.lock().await;
-        guard.remove(request_id);
+        guard.remove(&evaluate_pending_key(window_label, request_id));
     }
 
     /// Snapshot of the pending entry count — useful for tests and for
@@ -143,18 +173,38 @@ impl EvaluateRequestStore {
 mod tests {
     use super::*;
 
+    // Default window label used by the single-window evaluate path. Kept
+    // local to the test module so the test file doesn't reach across crates
+    // for the `MAIN_WINDOW_LABEL` constant.
+    const MAIN: &str = "main";
+
+    #[test]
+    fn evaluate_pending_key_is_distinct_per_window_for_same_request_id() {
+        let id = "11111111-2222-3333-4444-555555555555";
+        // Same request id in two windows must NOT collide on the store.
+        assert_ne!(
+            evaluate_pending_key("main", id),
+            evaluate_pending_key("term-1", id)
+        );
+        // Same (window, id) is stable so register and deliver agree.
+        assert_eq!(
+            evaluate_pending_key("main", id),
+            evaluate_pending_key("main", id)
+        );
+    }
+
     #[tokio::test]
     async fn register_and_deliver_round_trip() {
         let store = EvaluateRequestStore::new();
         let (tx, rx) = oneshot::channel();
-        store.register("req-1".to_string(), tx).await;
+        store.register(MAIN, "req-1", tx).await;
 
         let response = EvaluateResponse {
             ok: true,
             result: Some(serde_json::json!({ "result": { "value": 42 } })),
             error: None,
         };
-        assert!(store.deliver("req-1", response.clone()).await);
+        assert!(store.deliver(MAIN, "req-1", response.clone()).await);
 
         let received = rx.await.expect("receiver should observe sent value");
         assert!(received.ok);
@@ -167,6 +217,7 @@ mod tests {
         let store = EvaluateRequestStore::new();
         let delivered = store
             .deliver(
+                MAIN,
                 "does-not-exist",
                 EvaluateResponse {
                     ok: true,
@@ -179,17 +230,117 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn deliver_to_wrong_window_is_noop_and_leaves_entry_pending() {
+        // The central multi-window regression: window A registers a request,
+        // and a response that echoes a DIFFERENT window label must NOT resolve
+        // it (that's the broadcast race — every window runs the same eval and
+        // the first reply wins). Only the addressed window's response resolves.
+        let store = EvaluateRequestStore::new();
+        let (tx, _rx) = oneshot::channel();
+        store.register("term-1", "req-w", tx).await;
+        assert_eq!(store.pending_len().await, 1);
+
+        // A reply tagged with the wrong window label must be a no-op...
+        let wrong = store
+            .deliver(
+                "main",
+                "req-w",
+                EvaluateResponse {
+                    ok: true,
+                    result: Some(serde_json::json!("from-main")),
+                    error: None,
+                },
+            )
+            .await;
+        assert!(!wrong, "wrong-window reply must not resolve the request");
+        assert_eq!(
+            store.pending_len().await,
+            1,
+            "entry must still be pending after a wrong-window reply"
+        );
+
+        // ...but the addressed window's reply resolves it.
+        let right = store
+            .deliver(
+                "term-1",
+                "req-w",
+                EvaluateResponse {
+                    ok: true,
+                    result: Some(serde_json::json!("from-term-1")),
+                    error: None,
+                },
+            )
+            .await;
+        assert!(right, "addressed-window reply must resolve the request");
+        assert_eq!(store.pending_len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn same_request_id_in_two_windows_is_independent() {
+        // Two windows can legitimately mint the same request id (the broadcast
+        // emit hands every window the same envelope). The composite key keeps
+        // their oneshots independent — each window's reply resolves only its own.
+        let store = EvaluateRequestStore::new();
+        let (tx_main, rx_main) = oneshot::channel();
+        let (tx_term, rx_term) = oneshot::channel();
+        store.register("main", "shared-id", tx_main).await;
+        store.register("term-1", "shared-id", tx_term).await;
+        assert_eq!(store.pending_len().await, 2);
+
+        assert!(
+            store
+                .deliver(
+                    "term-1",
+                    "shared-id",
+                    EvaluateResponse {
+                        ok: true,
+                        result: Some(serde_json::json!("term")),
+                        error: None,
+                    },
+                )
+                .await
+        );
+
+        // term-1's receiver resolved; main is still pending.
+        assert_eq!(
+            rx_term.await.expect("term receiver resolves").result,
+            Some(serde_json::json!("term"))
+        );
+        assert_eq!(store.pending_len().await, 1);
+
+        assert!(
+            store
+                .deliver(
+                    "main",
+                    "shared-id",
+                    EvaluateResponse {
+                        ok: true,
+                        result: Some(serde_json::json!("main")),
+                        error: None,
+                    },
+                )
+                .await
+        );
+        assert_eq!(
+            rx_main.await.expect("main receiver resolves").result,
+            Some(serde_json::json!("main"))
+        );
+        assert_eq!(store.pending_len().await, 0);
+    }
+
+    #[tokio::test]
     async fn cancel_removes_entry_so_late_deliver_is_noop() {
         let store = EvaluateRequestStore::new();
         let (tx, _rx) = oneshot::channel();
-        store.register("req-2".to_string(), tx).await;
+        store.register(MAIN, "req-2", tx).await;
         assert_eq!(store.pending_len().await, 1);
 
-        store.cancel("req-2").await;
+        store.cancel(MAIN, "req-2").await;
         assert_eq!(store.pending_len().await, 0);
 
         let delivered = store
             .deliver(
+                MAIN,
                 "req-2",
                 EvaluateResponse {
                     ok: false,
@@ -205,14 +356,14 @@ mod tests {
     async fn error_response_round_trip() {
         let store = EvaluateRequestStore::new();
         let (tx, rx) = oneshot::channel();
-        store.register("req-3".to_string(), tx).await;
+        store.register(MAIN, "req-3", tx).await;
 
         let response = EvaluateResponse {
             ok: false,
             result: None,
             error: Some("SyntaxError: Unexpected token".to_string()),
         };
-        assert!(store.deliver("req-3", response.clone()).await);
+        assert!(store.deliver(MAIN, "req-3", response.clone()).await);
         let received = rx.await.expect("receiver should observe error value");
         assert!(!received.ok);
         assert_eq!(received.error, response.error);
@@ -230,8 +381,8 @@ mod tests {
 
         let (tx_a, rx_a) = oneshot::channel();
         let (tx_b, rx_b) = oneshot::channel();
-        store.register("req-a".to_string(), tx_a).await;
-        store.register("req-b".to_string(), tx_b).await;
+        store.register(MAIN, "req-a", tx_a).await;
+        store.register(MAIN, "req-b", tx_b).await;
         assert_eq!(store.pending_len().await, 2);
 
         // Deliver B first, then A — exercises that arrival order doesn't
@@ -240,6 +391,7 @@ mod tests {
         let deliver_b = tokio::spawn(async move {
             store_b
                 .deliver(
+                    MAIN,
                     "req-b",
                     EvaluateResponse {
                         ok: true,
@@ -254,6 +406,7 @@ mod tests {
         let deliver_a = tokio::spawn(async move {
             store_a
                 .deliver(
+                    MAIN,
                     "req-a",
                     EvaluateResponse {
                         ok: true,

--- a/src/hooks/useUIBridgeEvaluateHandler.ts
+++ b/src/hooks/useUIBridgeEvaluateHandler.ts
@@ -41,6 +41,7 @@
 
 import { useEffect } from "react";
 import { emit, type Event } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { createLogger } from "@/lib/logger";
 import { getErrorMessage } from "@/lib/utils";
 import { awaitWithTimeout, PAGE_EVALUATE_PROMISE_TIMEOUT_MS } from "./ui-bridge-events/utils";
@@ -68,6 +69,17 @@ interface EvaluateRequestPayload {
    * branch in usePageEvents.ts::page_evaluate.
    */
   allow_network_requests?: boolean;
+  /**
+   * Multi-window addressing — the target window's Tauri label. The Rust
+   * `tagged_page_evaluate` dispatcher stamps it on every request so a
+   * `page/evaluate` runs the expression in ONE window only (it used to
+   * broadcast to every window, firing the eval N times). A window ignores
+   * any request whose `windowLabel` differs from its own
+   * `getCurrentWindow().label`. Absent / "main" → the primary window
+   * processes it (single-window default, behavior unchanged). Mirrors the
+   * own-label filter in `useUIBridgeEventHandler.ts`.
+   */
+  windowLabel?: string;
 }
 
 interface EvaluateResponsePayload {
@@ -75,6 +87,13 @@ interface EvaluateResponsePayload {
   ok: boolean;
   result?: unknown;
   error?: string;
+  /**
+   * This window's own label, echoed so the Rust `EvaluateRequestStore`
+   * delivers the response under the same `(windowLabel, requestId)` key the
+   * request was registered with. Defaulting an omitted label to "main" on
+   * the Rust side keeps single-window callers backward-compatible.
+   */
+  windowLabel?: string;
 }
 
 /**
@@ -177,6 +196,22 @@ export async function handleEvaluateRequest(
 ): Promise<boolean> {
   const { request_id, expression, unwrap, allow_network_requests } = payload;
 
+  // Multi-window addressing — the load-bearing scoping mechanism. The Rust
+  // dispatcher targets a window via `emit_to(EventTarget::labeled(target), …)`,
+  // BUT the frontend subscribes through the process-global `listen()`
+  // (`EventTarget::Any`), which receives `emit_to`-targeted events in EVERY
+  // window. So without this own-label filter a single-consumer `page/evaluate`
+  // fans out — the expression runs once per open window. Ignore any request not
+  // addressed to THIS window. Checked BEFORE the dedupe claim so a non-target
+  // window doesn't consume the per-window dedupe slot. Absent label (legacy /
+  // single-window) → every window processes it, preserving old behavior.
+  // Short-circuit so `getCurrentWindow()` (Tauri runtime only) is invoked
+  // ONLY when a target label is present — keeps `handleEvaluateRequest` unit-
+  // testable in jsdom (the single-window default path never touches Tauri).
+  if (payload.windowLabel && payload.windowLabel !== getCurrentWindow().label) {
+    return false;
+  }
+
   if (!request_id) {
     // Without a request_id we can't route the response back. Drop the call
     // entirely — the Rust side will observe a timeout.
@@ -246,6 +281,16 @@ export async function handleEvaluateRequest(
       log.debug(`evaluate(${request_id}) threw:`, message);
       response = { request_id, ok: false, error: message };
     }
+  }
+
+  // When the request was addressed to a specific window, echo that label so the
+  // Rust dispatcher delivers the response under the same (windowLabel, requestId)
+  // key the request was registered with. The own-label filter above guarantees
+  // `payload.windowLabel` is THIS window's label, so echoing it verbatim routes
+  // the reply correctly. The single-window default (no label) leaves the response
+  // shape untouched — the Rust side defaults the key's window to "main".
+  if (payload.windowLabel) {
+    response = { ...response, windowLabel: payload.windowLabel };
   }
 
   try {


### PR DESCRIPTION
## Scope `page/evaluate` to a single window (emit_to + windowLabel)

From a /manual-test run (plan `2026-06-07-popout-ui-bridge-testability-and-spawn-build-remediation`). `POST /ui-bridge/control/page/evaluate` fired the expression in **every** open runner window — with N windows, an eval that clicks a button opened N windows.

**Root cause:** in Tauri v2, `WebviewWindow::emit` / `AppHandle::emit` **broadcast to all windows**; only `emit_to(target, …)` scopes delivery. The sibling routes only *appeared* single-window because their target element exists in one window's DOM (an accident of element placement) — a generic JS eval runs everywhere. So the fix makes the Rust side authoritative.

### Change
- `mcp/ui_bridge/page.rs`: parse `windowLabel` (query → body → `"main"`); fail-fast on unknown window; emit via `app_handle.emit_to(EventTarget::labeled(window_label), …)` (broadcast retained only for the `QONTINUI_UI_BRIDGE_MULTI_WINDOW=0` escape hatch). `page_evaluate_inner` now **propagates** a non-main window-addressing error instead of swallowing it via the main-only `direct_webview_evaluate` fallback.
- `ui_bridge_evaluate.rs`: re-key `EvaluateRequestStore` on `(window_label, request_id)`. +3 store + 4 resolver tests.
- `request.rs`: `multi_window_dispatch_enabled()` → `pub(crate)`. `mcp_api.rs`: response listener delivers under the composite key.
- `useUIBridgeEvaluateHandler.ts`: own-label filter (defense-in-depth backstop) via `getCurrentWindow().label`.

`execute_action` already behaves single-window for element actions — unchanged.

### Verification (temp runner, ≥2 windows)
- no `windowLabel` → **+1** (main only).
- `?windowLabel=term-1` → **+1** (addressed window, not N).
- `?windowLabel=ghost` → **400 fail-fast** `"No runner window labeled 'ghost'"`.
- `cargo check` + `clippy --bin qontinui-runner --features custom-protocol -- -D warnings` clean; **196 ui_bridge tests** pass; `tsc --noEmit` clean.
