### PR TITLE
fix(ui-bridge): exactly-once IPC request handling — dedupe listeners + request_id guard

### DIFF
--- a/src/hooks/ui-bridge-events/request-dedupe.test.ts
+++ b/src/hooks/ui-bridge-events/request-dedupe.test.ts
@@ -1,0 +1,77 @@
+/**
+ * RequestDedupe tests — exactly-once request_id claiming + bounded memory.
+ */
+
+import { describe, it, expect } from "vitest";
+import { RequestDedupe, MAX_TRACKED } from "./request-dedupe";
+
+describe("RequestDedupe", () => {
+  it("claims a fresh request_id exactly once", () => {
+    const d = new RequestDedupe();
+    expect(d.claim("req-1")).toBe(true);
+    expect(d.claim("req-1")).toBe(false);
+    expect(d.claim("req-1")).toBe(false);
+  });
+
+  it("treats distinct ids independently", () => {
+    const d = new RequestDedupe();
+    expect(d.claim("a")).toBe(true);
+    expect(d.claim("b")).toBe(true);
+    expect(d.claim("a")).toBe(false);
+    expect(d.claim("b")).toBe(false);
+  });
+
+  it("never claims empty or non-string ids", () => {
+    const d = new RequestDedupe();
+    expect(d.claim("")).toBe(false);
+    // @ts-expect-error testing runtime guard against bad input
+    expect(d.claim(undefined)).toBe(false);
+    // @ts-expect-error testing runtime guard against bad input
+    expect(d.claim(null)).toBe(false);
+    expect(d.size()).toBe(0);
+  });
+
+  it("models N accumulated listeners → one execution", () => {
+    // Each "listener" calls claim() for the same event. Only the first wins.
+    const d = new RequestDedupe();
+    const N = 4; // the observed fan-out on a fresh single-window instance
+    const wins = Array.from({ length: N }, () => d.claim("storm-id")).filter(Boolean);
+    expect(wins).toHaveLength(1);
+  });
+
+  it("is bounded: evicts oldest beyond the cap", () => {
+    const d = new RequestDedupe(3);
+    expect(d.claim("1")).toBe(true);
+    expect(d.claim("2")).toBe(true);
+    expect(d.claim("3")).toBe(true);
+    expect(d.size()).toBe(3);
+    // "2" and "3" are still tracked at this point.
+    expect(d.claim("2")).toBe(false);
+    expect(d.claim("3")).toBe(false);
+    // 4th distinct id evicts "1" (oldest). Set is now {2,3,4}.
+    expect(d.claim("4")).toBe(true);
+    expect(d.size()).toBe(3);
+    // "1" was evicted, so it is claimable again (definitionally stale).
+    expect(d.claim("1")).toBe(true);
+    // That claim evicted "2" (now oldest), so "2" is claimable again too;
+    // "3" and "4" remain tracked.
+    expect(d.claim("3")).toBe(false);
+    expect(d.claim("4")).toBe(false);
+  });
+
+  it("default cap matches MAX_TRACKED", () => {
+    const d = new RequestDedupe();
+    for (let i = 0; i < MAX_TRACKED + 50; i++) {
+      d.claim(`id-${i}`);
+    }
+    expect(d.size()).toBe(MAX_TRACKED);
+  });
+
+  it("reset clears tracked ids", () => {
+    const d = new RequestDedupe();
+    d.claim("x");
+    d.reset();
+    expect(d.size()).toBe(0);
+    expect(d.claim("x")).toBe(true);
+  });
+});

--- a/src/hooks/ui-bridge-events/request-dedupe.ts
+++ b/src/hooks/ui-bridge-events/request-dedupe.ts
@@ -1,0 +1,100 @@
+/**
+ * request-dedupe — exactly-once execution guard for tagged UI Bridge
+ * request/response flows (`ui-bridge:invoke-request` /
+ * `ui-bridge:evaluate-request`).
+ *
+ * Background (round-2, PR #473 falsification):
+ * Even after the Rust side switched from a global `app_handle.emit(...)`
+ * broadcast to `emit_to(main_window, ...)`, a single
+ * `POST /ui-bridge/control/page/evaluate` was observed executing the
+ * inner command 4× on a FRESH single-window headless instance. The cause
+ * is NOT multiple windows — it is multiple Tauri listeners accumulated
+ * INSIDE the one main webview (async `listen()` + synchronous cleanup
+ * race, amplified by React StrictMode's mount→unmount→remount). N
+ * listeners on the one window each fire once per emitted event → N
+ * executions of the same `request_id`.
+ *
+ * The structural fix is a singleton subscription (see
+ * `singleton-listener.ts`), but listener accumulation is a recurring
+ * footgun, so this module adds a cheap defense-in-depth layer: a
+ * per-webview, module-level, bounded record of `request_id`s that have
+ * already been claimed. The FIRST listener to see a `request_id` claims
+ * it and proceeds; every subsequent listener (or duplicate event)
+ * observes the claim and drops the call. Net result: one execution and
+ * one response per `request_id` regardless of how many listeners exist.
+ *
+ * Bounded: we keep at most {@link MAX_TRACKED} ids (insertion-ordered via
+ * a Set) and evict the oldest when the cap is exceeded, so a long-lived
+ * webview never leaks memory. The cap is generous relative to the number
+ * of in-flight requests, so an evicted id is one whose response has long
+ * since been delivered — a re-fire that old would be a non-issue anyway.
+ */
+
+/**
+ * Maximum number of recently-seen request_ids retained per channel.
+ * Far exceeds realistic concurrent in-flight requests; sized so an
+ * evicted id is definitionally stale.
+ */
+export const MAX_TRACKED = 200;
+
+/**
+ * A bounded, insertion-ordered set of claimed request_ids. One instance
+ * per logical channel (invoke vs evaluate) so the two flows never
+ * cross-contaminate each other's ids.
+ */
+export class RequestDedupe {
+  private readonly seen = new Set<string>();
+  private readonly max: number;
+
+  constructor(max: number = MAX_TRACKED) {
+    this.max = max;
+  }
+
+  /**
+   * Attempt to claim a request_id for execution.
+   *
+   * @returns `true` if THIS caller won the claim (first to see the id —
+   *   proceed with execution). `false` if the id was already claimed by a
+   *   prior listener/event (drop the call — someone else is handling it).
+   *
+   * Empty / non-string ids are never claimed and always return `false`;
+   * the caller is responsible for its own missing-id handling (it can't
+   * route a response without one anyway).
+   */
+  claim(requestId: string): boolean {
+    if (typeof requestId !== "string" || requestId.length === 0) {
+      return false;
+    }
+    if (this.seen.has(requestId)) {
+      return false;
+    }
+    this.seen.add(requestId);
+    // Evict oldest entries once over the cap. Set preserves insertion
+    // order, so the first key is the oldest.
+    while (this.seen.size > this.max) {
+      const oldest = this.seen.values().next().value;
+      if (oldest === undefined) break;
+      this.seen.delete(oldest);
+    }
+    return true;
+  }
+
+  /** Test-only: current number of tracked ids. */
+  size(): number {
+    return this.seen.size;
+  }
+
+  /** Test-only: drop all tracked ids. */
+  reset(): void {
+    this.seen.clear();
+  }
+}
+
+/**
+ * Module-level singletons — one per channel. Shared across every mount of
+ * the corresponding handler hook within this webview, which is exactly
+ * what makes the guard effective against accumulated listeners (they all
+ * consult the same Set).
+ */
+export const invokeRequestDedupe = new RequestDedupe();
+export const evaluateRequestDedupe = new RequestDedupe();

--- a/src/hooks/ui-bridge-events/singleton-listener.test.ts
+++ b/src/hooks/ui-bridge-events/singleton-listener.test.ts
@@ -1,0 +1,137 @@
+/**
+ * singleton-listener tests — exactly one Tauri listen() per webview
+ * regardless of mount count / async-cleanup races (the PR #473 round-2
+ * accumulation bug).
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// --- Mock Tauri event API -------------------------------------------------
+// `listen` resolves asynchronously to an unlisten fn — exactly the shape
+// that makes the naive useEffect cleanup race. We record each call so we
+// can assert how many real listeners were installed.
+const listenCalls: Array<{ event: string; cb: (e: unknown) => void }> = [];
+const unlistenSpies: Array<ReturnType<typeof vi.fn>> = [];
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (event: string, cb: (e: unknown) => void) => {
+    listenCalls.push({ event, cb });
+    const unlisten = vi.fn();
+    unlistenSpies.push(unlisten);
+    // Resolve on a microtask to mimic the real async race window.
+    await Promise.resolve();
+    return unlisten;
+  }),
+}));
+
+import {
+  acquireSingletonListener,
+  _activeSubscriptionCount,
+  _resetSingletonRegistry,
+} from "./singleton-listener";
+
+const EVT = "ui-bridge:test-request";
+
+beforeEach(() => {
+  listenCalls.length = 0;
+  unlistenSpies.length = 0;
+  _resetSingletonRegistry();
+});
+
+describe("acquireSingletonListener", () => {
+  it("installs exactly one real listener for N concurrent mounts", async () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    const h3 = vi.fn();
+    const r1 = acquireSingletonListener(EVT, h1);
+    const r2 = acquireSingletonListener(EVT, h2);
+    const r3 = acquireSingletonListener(EVT, h3);
+
+    // Let listen() promises settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(listenCalls).toHaveLength(1);
+    expect(_activeSubscriptionCount()).toBe(1);
+
+    // Cleanup all consumers.
+    r1();
+    r2();
+    r3();
+  });
+
+  it("dispatches to the LATEST handler without re-subscribing", async () => {
+    const first = vi.fn();
+    const release1 = acquireSingletonListener(EVT, first);
+    await Promise.resolve();
+
+    const latest = vi.fn();
+    const release2 = acquireSingletonListener(EVT, latest); // adopts latest handler
+    await Promise.resolve();
+
+    // Still one underlying listener.
+    expect(listenCalls).toHaveLength(1);
+
+    // Fire the registered trampoline.
+    const evt = { payload: { request_id: "x" } };
+    listenCalls[0].cb(evt);
+
+    expect(first).not.toHaveBeenCalled();
+    expect(latest).toHaveBeenCalledWith(evt);
+
+    release1();
+    release2();
+  });
+
+  it("simulates the StrictMode mount→unmount→remount race without leaking", async () => {
+    // Mount #1 (acquire) then immediately unmount (release) BEFORE the
+    // listen() promise resolves — this is the exact race that leaked a
+    // listener in the old code.
+    const release1 = acquireSingletonListener(EVT, vi.fn());
+    release1(); // refCount 1 -> 0 while listenPromise still pending
+
+    // Remount #2 (StrictMode's second mount).
+    const release2 = acquireSingletonListener(EVT, vi.fn());
+
+    // Drain microtasks: first listen() resolves; its teardown must NOT
+    // unlisten the listener the remount now relies on.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The first subscription's teardown deletes the registry entry, so the
+    // remount creates a fresh one — at most a single live subscription.
+    expect(_activeSubscriptionCount()).toBe(1);
+
+    release2();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(_activeSubscriptionCount()).toBe(0);
+  });
+
+  it("tears down only when the last consumer releases", async () => {
+    const a = acquireSingletonListener(EVT, vi.fn());
+    const b = acquireSingletonListener(EVT, vi.fn());
+    await Promise.resolve();
+    await Promise.resolve();
+
+    a();
+    expect(_activeSubscriptionCount()).toBe(1); // b still holds it
+
+    b();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(_activeSubscriptionCount()).toBe(0);
+    // The single unlisten was eventually invoked.
+    expect(unlistenSpies[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it("release is idempotent", async () => {
+    const release = acquireSingletonListener(EVT, vi.fn());
+    await Promise.resolve();
+    release();
+    release(); // no-op, must not throw or double-decrement
+    await Promise.resolve();
+    expect(_activeSubscriptionCount()).toBe(0);
+  });
+});

--- a/src/hooks/ui-bridge-events/singleton-listener.ts
+++ b/src/hooks/ui-bridge-events/singleton-listener.ts
@@ -1,0 +1,127 @@
+/**
+ * singleton-listener — install a Tauri event listener exactly once per
+ * webview, no matter how many React components mount the corresponding
+ * hook (or how many times StrictMode re-runs the effect).
+ *
+ * Why this exists:
+ * The naive pattern
+ *
+ * ```ts
+ * useEffect(() => {
+ *   let unlisten: UnlistenFn | null = null;
+ *   listen(evt, cb).then((fn) => { unlisten = fn; });
+ *   return () => { if (unlisten) unlisten(); };
+ * }, []);
+ * ```
+ *
+ * has a race: `listen()` is async, so when React StrictMode mounts →
+ * unmounts → remounts (which it does even in PRODUCTION builds, because
+ * <React.StrictMode> is in the tree — only its dev console warnings are
+ * stripped), the cleanup from the first mount runs while `unlisten` is
+ * still `null`. The first listen() promise then resolves AFTER cleanup
+ * and is never torn down. The remount installs a second listener. Net:
+ * two (or more) live listeners on a single webview, each firing once per
+ * emitted event → duplicate command execution. (Observed 4× on a fresh
+ * single-window headless instance — PR #473 round-2 falsification.)
+ *
+ * The fix: track the subscription at MODULE scope, keyed by event name,
+ * with a mount ref-count. The first mounter triggers the single
+ * `listen()`; later mounters just bump the count. Cleanup decrements; the
+ * underlying listener is torn down only when the count returns to zero,
+ * and the teardown awaits the in-flight `listen()` promise so a cleanup
+ * that races the initial subscribe still unlistens correctly.
+ *
+ * The HANDLER is read through a ref-like getter so the latest callback is
+ * used without re-subscribing (deps-stable). This means a changing
+ * handler identity never churns the subscription.
+ */
+
+import { listen, type UnlistenFn, type Event } from "@tauri-apps/api/event";
+
+type Handler<T> = (event: Event<T>) => void | Promise<void>;
+
+interface Subscription<T> {
+  /** Count of currently-mounted consumers. */
+  refCount: number;
+  /** In-flight or resolved listen() promise (for race-safe teardown). */
+  listenPromise: Promise<UnlistenFn> | null;
+  /** Latest handler — invoked via a stable trampoline so the live
+   *  listener always calls the most recent callback without re-subscribing. */
+  handler: Handler<T>;
+}
+
+// Keyed by event name. `unknown` payloads; each acquire() narrows.
+const subscriptions = new Map<string, Subscription<unknown>>();
+
+/**
+ * Acquire the singleton listener for `eventName`, installing it on first
+ * use. Returns a release function to call on unmount.
+ *
+ * @param eventName Tauri event channel (e.g. "ui-bridge:invoke-request").
+ * @param handler   Current handler. Updated in place on every acquire so
+ *                   the live listener always dispatches to the latest
+ *                   closure (no re-subscribe needed).
+ */
+export function acquireSingletonListener<T>(eventName: string, handler: Handler<T>): () => void {
+  let sub = subscriptions.get(eventName) as Subscription<T> | undefined;
+
+  if (!sub) {
+    const created: Subscription<T> = {
+      refCount: 0,
+      listenPromise: null,
+      handler,
+    };
+    // Stable trampoline: closed over `created`, so it always reads the
+    // current `created.handler`. The Tauri listener is registered with
+    // THIS function once and never re-registered.
+    const trampoline: Handler<T> = (event) => created.handler(event);
+    created.listenPromise = listen<T>(eventName, (event) => trampoline(event));
+    sub = created;
+    subscriptions.set(eventName, created as Subscription<unknown>);
+  } else {
+    // Already subscribed in this webview — just adopt the latest handler.
+    sub.handler = handler;
+  }
+
+  sub.refCount += 1;
+  const acquired = sub;
+
+  let released = false;
+  return function release() {
+    if (released) return;
+    released = true;
+    acquired.refCount -= 1;
+    if (acquired.refCount > 0) return;
+
+    // Last consumer left — tear down. Await the (possibly still in-flight)
+    // listen() promise so a cleanup that races the initial subscribe still
+    // unlistens correctly, then drop the registry entry so a future mount
+    // re-subscribes cleanly.
+    const promise = acquired.listenPromise;
+    subscriptions.delete(eventName);
+    if (promise) {
+      void promise
+        .then((unlisten) => {
+          // Guard against a remount that re-acquired between our refCount
+          // hitting 0 and this microtask: only unlisten if no new
+          // subscription took over this event name.
+          if (!subscriptions.has(eventName)) {
+            unlisten();
+          }
+        })
+        .catch(() => {
+          /* listen() rejected — nothing to unlisten. */
+        });
+    }
+  };
+}
+
+/** Test-only: number of live singleton subscriptions. */
+export function _activeSubscriptionCount(): number {
+  return subscriptions.size;
+}
+
+/** Test-only: clear the registry (does not unlisten — tests use mocks). */
+export function _resetSingletonRegistry(): void {
+  subscriptions.clear();
+}

--- a/src/hooks/useUIBridgeEvaluateHandler.test.ts
+++ b/src/hooks/useUIBridgeEvaluateHandler.test.ts
@@ -1,0 +1,88 @@
+/**
+ * useUIBridgeEvaluateHandler tests — exactly-once evaluate dispatch.
+ *
+ * The expression is executed for SIDE EFFECTS (it can call
+ * `window.__TAURI__.core.invoke(...)`), so duplicate execution is the bug
+ * the PR #473 round-2 falsification surfaced (one /page/evaluate ran a
+ * command 4×). These tests assert the `request_id` dedupe backstop caps
+ * execution at one even when N listeners deliver the same event.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/event", () => ({ emit: vi.fn(), listen: vi.fn() }));
+
+import { handleEvaluateRequest, type EvaluateHandlerDeps } from "./useUIBridgeEvaluateHandler";
+import { evaluateRequestDedupe } from "./ui-bridge-events/request-dedupe";
+
+function makeDeps(): EvaluateHandlerDeps & { emit: ReturnType<typeof vi.fn> } {
+  return { emit: vi.fn().mockResolvedValue(undefined) };
+}
+
+beforeEach(() => {
+  evaluateRequestDedupe.reset();
+});
+
+describe("handleEvaluateRequest", () => {
+  it("evaluates an expression and emits a success response", async () => {
+    const deps = makeDeps();
+    const handled = await handleEvaluateRequest({ request_id: "r1", expression: "1 + 2" }, deps);
+    expect(handled).toBe(true);
+    expect(deps.emit).toHaveBeenCalledWith("ui-bridge:evaluate-response", {
+      request_id: "r1",
+      ok: true,
+      result: { success: true, result: { value: 3 } },
+    });
+  });
+
+  it("executes the expression EXACTLY ONCE across N deliveries", async () => {
+    const deps = makeDeps();
+    // Side-effecting expression: each execution bumps a global counter.
+    (globalThis as Record<string, unknown>).__evalCount = 0;
+    const expr = "(globalThis.__evalCount = (globalThis.__evalCount || 0) + 1)";
+
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        handleEvaluateRequest({ request_id: "storm", expression: expr }, deps),
+      ),
+    );
+
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect((globalThis as Record<string, unknown>).__evalCount).toBe(1);
+    expect(deps.emit).toHaveBeenCalledTimes(1);
+    delete (globalThis as Record<string, unknown>).__evalCount;
+  });
+
+  it("drops a request with no request_id", async () => {
+    const deps = makeDeps();
+    const handled = await handleEvaluateRequest(
+      // @ts-expect-error intentionally missing request_id
+      { expression: "1" },
+      deps,
+    );
+    expect(handled).toBe(false);
+    expect(deps.emit).not.toHaveBeenCalled();
+  });
+
+  it("rejects a dangerous expression with an error response", async () => {
+    const deps = makeDeps();
+    const handled = await handleEvaluateRequest(
+      { request_id: "danger", expression: "eval('x')" },
+      deps,
+    );
+    expect(handled).toBe(true);
+    const [, payload] = deps.emit.mock.calls[0];
+    expect(payload).toMatchObject({ request_id: "danger", ok: false });
+    expect((payload as { error: string }).error).toMatch(/prohibited pattern/);
+  });
+
+  it("emits the discriminated {value,type} shape when unwrap=true", async () => {
+    const deps = makeDeps();
+    await handleEvaluateRequest({ request_id: "u1", expression: "42", unwrap: true }, deps);
+    expect(deps.emit).toHaveBeenCalledWith("ui-bridge:evaluate-response", {
+      request_id: "u1",
+      ok: true,
+      result: { value: 42, type: "scalar" },
+    });
+  });
+});

--- a/src/hooks/useUIBridgeEvaluateHandler.ts
+++ b/src/hooks/useUIBridgeEvaluateHandler.ts
@@ -40,13 +40,12 @@
  */
 
 import { useEffect } from "react";
-import { listen, emit, type UnlistenFn } from "@tauri-apps/api/event";
+import { emit, type Event } from "@tauri-apps/api/event";
 import { createLogger } from "@/lib/logger";
 import { getErrorMessage } from "@/lib/utils";
-import {
-  awaitWithTimeout,
-  PAGE_EVALUATE_PROMISE_TIMEOUT_MS,
-} from "./ui-bridge-events/utils";
+import { awaitWithTimeout, PAGE_EVALUATE_PROMISE_TIMEOUT_MS } from "./ui-bridge-events/utils";
+import { acquireSingletonListener } from "./ui-bridge-events/singleton-listener";
+import { evaluateRequestDedupe } from "./ui-bridge-events/request-dedupe";
 
 const log = createLogger("UIBridgeEvaluateHandler");
 
@@ -151,138 +150,146 @@ async function evaluateExpression(expression: string): Promise<unknown> {
 }
 
 /**
+ * Dependencies for {@link handleEvaluateRequest}, injected so the
+ * evaluation logic is unit-testable without a live Tauri runtime.
+ */
+export interface EvaluateHandlerDeps {
+  emit: (event: string, payload: unknown) => Promise<void>;
+}
+
+/**
+ * Pure(-ish) handler for one `ui-bridge:evaluate-request` event.
+ *
+ * Defense-in-depth EXACTLY-ONCE guard: the FIRST listener to see a given
+ * `request_id` claims it via {@link evaluateRequestDedupe} and proceeds;
+ * any later listener (e.g. an accumulated duplicate) observes the claim
+ * and drops the call. This caps execution at one per request_id even if
+ * the singleton subscription guard is somehow bypassed — critical here
+ * because the expression is executed for side effects (it can call
+ * `window.__TAURI__.core.invoke(...)`).
+ *
+ * Returns `true` if this call executed the expression (won the claim),
+ * `false` if it was deduped/ignored — exposed for tests.
+ */
+export async function handleEvaluateRequest(
+  payload: EvaluateRequestPayload,
+  deps: EvaluateHandlerDeps,
+): Promise<boolean> {
+  const { request_id, expression, unwrap, allow_network_requests } = payload;
+
+  if (!request_id) {
+    // Without a request_id we can't route the response back. Drop the call
+    // entirely — the Rust side will observe a timeout.
+    console.warn("[UIBridgeEvaluateHandler] evaluate-request missing request_id; ignoring");
+    return false;
+  }
+
+  if (!evaluateRequestDedupe.claim(request_id)) {
+    log.debug(`evaluate(${request_id}) already handled; ignoring duplicate`);
+    return false;
+  }
+
+  log.debug(`Received evaluate request`, request_id);
+
+  let response: EvaluateResponsePayload;
+
+  if (typeof expression !== "string" || expression.length === 0) {
+    response = { request_id, ok: false, error: "expression is required" };
+  } else {
+    try {
+      rejectIfDangerous(expression, allow_network_requests === true);
+      const resolved = await evaluateExpression(expression);
+      if (unwrap === true) {
+        // Opt-in consistent shape: always `{ value, type }`. Mirrors the
+        // sibling unwrap branch in usePageEvents.ts::page_evaluate. Rust
+        // passes this shape through verbatim when unwrap=true so the HTTP
+        // caller sees `{success: true, data: {value, type}}`.
+        let valueType: "scalar" | "object" | "undefined" | "function" | "null";
+        let normalizedValue: unknown;
+        if (resolved === null) {
+          valueType = "null";
+          normalizedValue = null;
+        } else if (resolved === undefined) {
+          valueType = "undefined";
+          normalizedValue = undefined;
+        } else if (typeof resolved === "function") {
+          valueType = "function";
+          // Functions aren't structured-clone-safe. Surface the name (or
+          // `<anonymous>`) so the caller gets something useful.
+          normalizedValue = (resolved as { name?: string }).name || "<anonymous>";
+        } else if (typeof resolved === "object") {
+          valueType = "object";
+          normalizedValue = resolved;
+        } else {
+          valueType = "scalar";
+          normalizedValue = resolved;
+        }
+        response = {
+          request_id,
+          ok: true,
+          result: { value: normalizedValue, type: valueType },
+        };
+      } else {
+        // Match the legacy IPC page_evaluate shape so the Rust
+        // `tagged_page_evaluate` helper can pass the `data` field through
+        // unchanged: `{ result: object | { value: primitive } }`.
+        const resultField =
+          typeof resolved === "object" && resolved !== null ? resolved : { value: resolved };
+        response = {
+          request_id,
+          ok: true,
+          result: { success: true, result: resultField },
+        };
+      }
+    } catch (err) {
+      const message = getErrorMessage(err);
+      log.debug(`evaluate(${request_id}) threw:`, message);
+      response = { request_id, ok: false, error: message };
+    }
+  }
+
+  try {
+    await deps.emit("ui-bridge:evaluate-response", response);
+  } catch (emitErr) {
+    // If emit itself fails, the Rust side will hit its timeout.
+    console.error("[UIBridgeEvaluateHandler] Failed to emit evaluate-response:", emitErr);
+  }
+  return true;
+}
+
+const evaluateDeps: EvaluateHandlerDeps = {
+  emit: (event, payload) => emit(event, payload),
+};
+
+/**
  * Install a Tauri listener on `ui-bridge:evaluate-request` that runs the
  * caller's expression (after security gating) and emits the result back
  * over `ui-bridge:evaluate-response`. Every request carries a `request_id`
  * which we echo verbatim so the Rust `EvaluateRequestStore` can correlate
  * concurrent callers.
  *
+ * The subscription is a SINGLETON per webview (see
+ * `ui-bridge-events/singleton-listener.ts`): no matter how many times this
+ * hook mounts — including React StrictMode's mount→unmount→remount, which
+ * runs in production too — exactly one underlying Tauri listener exists.
+ * That is the structural fix for the duplicate-execution bug; the
+ * `request_id` dedupe in {@link handleEvaluateRequest} is the
+ * defense-in-depth backstop.
+ *
  * Safe to mount once at app root alongside `UIBridgeInvokeHandler`.
  */
 export function useUIBridgeEvaluateHandler(): void {
   useEffect(() => {
-    let unlisten: UnlistenFn | null = null;
-    let isMounted = true;
-
-    const setupListener = async () => {
-      try {
-        log.debug("Setting up ui-bridge:evaluate-request listener");
-
-        unlisten = await listen<EvaluateRequestPayload>(
-          "ui-bridge:evaluate-request",
-          async (event) => {
-            if (!isMounted) {
-              log.debug("Component unmounted, ignoring evaluate request");
-              return;
-            }
-
-            const { request_id, expression, unwrap, allow_network_requests } = event.payload;
-            log.debug(`Received evaluate request`, request_id);
-
-            let response: EvaluateResponsePayload;
-
-            if (!request_id) {
-              // Without a request_id we can't route the response back. Drop
-              // the call entirely — the Rust side will observe a timeout.
-              console.warn(
-                "[UIBridgeEvaluateHandler] evaluate-request missing request_id; ignoring",
-              );
-              return;
-            }
-
-            if (typeof expression !== "string" || expression.length === 0) {
-              response = {
-                request_id,
-                ok: false,
-                error: "expression is required",
-              };
-            } else {
-              try {
-                rejectIfDangerous(expression, allow_network_requests === true);
-                const resolved = await evaluateExpression(expression);
-                if (unwrap === true) {
-                  // Opt-in consistent shape: always `{ value, type }`.
-                  // Mirrors the sibling unwrap branch in
-                  // usePageEvents.ts::page_evaluate. Rust passes this
-                  // shape through verbatim when unwrap=true so the HTTP
-                  // caller sees `{success: true, data: {value, type}}`.
-                  let valueType: "scalar" | "object" | "undefined" | "function" | "null";
-                  let normalizedValue: unknown;
-                  if (resolved === null) {
-                    valueType = "null";
-                    normalizedValue = null;
-                  } else if (resolved === undefined) {
-                    valueType = "undefined";
-                    normalizedValue = undefined;
-                  } else if (typeof resolved === "function") {
-                    valueType = "function";
-                    // Functions aren't structured-clone-safe. Surface the
-                    // name (or `<anonymous>`) so the caller gets something
-                    // useful.
-                    normalizedValue = (resolved as { name?: string }).name || "<anonymous>";
-                  } else if (typeof resolved === "object") {
-                    valueType = "object";
-                    normalizedValue = resolved;
-                  } else {
-                    valueType = "scalar";
-                    normalizedValue = resolved;
-                  }
-                  response = {
-                    request_id,
-                    ok: true,
-                    result: { value: normalizedValue, type: valueType },
-                  };
-                } else {
-                  // Match the legacy IPC page_evaluate shape so the Rust
-                  // `tagged_page_evaluate` helper can pass the `data` field
-                  // through unchanged: `{ result: object | { value: primitive } }`.
-                  const resultField =
-                    typeof resolved === "object" && resolved !== null
-                      ? resolved
-                      : { value: resolved };
-                  response = {
-                    request_id,
-                    ok: true,
-                    result: { success: true, result: resultField },
-                  };
-                }
-              } catch (err) {
-                const message = getErrorMessage(err);
-                log.debug(`evaluate(${request_id}) threw:`, message);
-                response = {
-                  request_id,
-                  ok: false,
-                  error: message,
-                };
-              }
-            }
-
-            try {
-              await emit("ui-bridge:evaluate-response", response);
-            } catch (emitErr) {
-              // If emit itself fails, the Rust side will hit its timeout.
-              console.error("[UIBridgeEvaluateHandler] Failed to emit evaluate-response:", emitErr);
-            }
-          },
-        );
-
-        log.debug("evaluate-request listener set up successfully");
-      } catch (error) {
-        console.error(
-          "[UIBridgeEvaluateHandler] Failed to set up evaluate-request listener:",
-          error,
-        );
-      }
-    };
-
-    setupListener();
-
+    log.debug("Acquiring singleton ui-bridge:evaluate-request listener");
+    const release = acquireSingletonListener<EvaluateRequestPayload>(
+      "ui-bridge:evaluate-request",
+      (event: Event<EvaluateRequestPayload>) => {
+        void handleEvaluateRequest(event.payload, evaluateDeps);
+      },
+    );
     return () => {
-      log.debug("Cleaning up evaluate-request listener");
-      isMounted = false;
-      if (unlisten) {
-        unlisten();
-      }
+      log.debug("Releasing singleton ui-bridge:evaluate-request listener");
+      release();
     };
   }, []);
 }

--- a/src/hooks/useUIBridgeInvokeHandler.test.ts
+++ b/src/hooks/useUIBridgeInvokeHandler.test.ts
@@ -1,0 +1,86 @@
+/**
+ * useUIBridgeInvokeHandler tests — exactly-once invoke dispatch.
+ *
+ * Focus: the `request_id` dedupe backstop guarantees one invoke() + one
+ * response even when N listeners deliver the same event (the PR #473
+ * round-2 fan-out). The Tauri `listen`/`invoke`/`emit` plumbing is mocked
+ * away; we test the extracted `handleInvokeRequest` with injected deps.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The hook imports @tauri-apps/api/{event,core} at module load. Stub them
+// so importing the module under test doesn't touch a real Tauri runtime.
+vi.mock("@tauri-apps/api/event", () => ({ emit: vi.fn(), listen: vi.fn() }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: vi.fn() }));
+
+import { handleInvokeRequest, type InvokeHandlerDeps } from "./useUIBridgeInvokeHandler";
+import { invokeRequestDedupe } from "./ui-bridge-events/request-dedupe";
+
+function makeDeps(): InvokeHandlerDeps & {
+  invoke: ReturnType<typeof vi.fn>;
+  emit: ReturnType<typeof vi.fn>;
+} {
+  return {
+    invoke: vi.fn().mockResolvedValue({ ok: 1 }),
+    emit: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+beforeEach(() => {
+  invokeRequestDedupe.reset();
+});
+
+describe("handleInvokeRequest", () => {
+  it("invokes the command and emits a success response", async () => {
+    const deps = makeDeps();
+    const handled = await handleInvokeRequest(
+      { request_id: "r1", command: "create_ai_session", args: { a: 1 } },
+      deps,
+    );
+    expect(handled).toBe(true);
+    expect(deps.invoke).toHaveBeenCalledWith("create_ai_session", { a: 1 });
+    expect(deps.emit).toHaveBeenCalledWith("ui-bridge:invoke-response", {
+      request_id: "r1",
+      ok: true,
+      result: { ok: 1 },
+    });
+  });
+
+  it("dedupes N deliveries of one request_id → one invoke + one response", async () => {
+    const deps = makeDeps();
+    // Simulate 4 accumulated listeners all delivering the same event.
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        handleInvokeRequest({ request_id: "storm", command: "create_ai_session", args: {} }, deps),
+      ),
+    );
+    expect(results.filter(Boolean)).toHaveLength(1);
+    expect(deps.invoke).toHaveBeenCalledTimes(1);
+    expect(deps.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops a request with no request_id (cannot route response)", async () => {
+    const deps = makeDeps();
+    const handled = await handleInvokeRequest(
+      // @ts-expect-error intentionally missing request_id
+      { command: "noop", args: {} },
+      deps,
+    );
+    expect(handled).toBe(false);
+    expect(deps.invoke).not.toHaveBeenCalled();
+    expect(deps.emit).not.toHaveBeenCalled();
+  });
+
+  it("forwards a serialized error response on invoke rejection", async () => {
+    const deps = makeDeps();
+    deps.invoke.mockRejectedValueOnce({ kind: "Boom", message: "kaboom" });
+    const handled = await handleInvokeRequest({ request_id: "e1", command: "bad", args: {} }, deps);
+    expect(handled).toBe(true);
+    expect(deps.emit).toHaveBeenCalledWith("ui-bridge:invoke-response", {
+      request_id: "e1",
+      ok: false,
+      error: JSON.stringify({ kind: "Boom", message: "kaboom" }),
+    });
+  });
+});

--- a/src/hooks/useUIBridgeInvokeHandler.ts
+++ b/src/hooks/useUIBridgeInvokeHandler.ts
@@ -32,10 +32,12 @@
  */
 
 import { useEffect } from "react";
-import { listen, emit, type UnlistenFn } from "@tauri-apps/api/event";
+import { emit, type Event } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { createLogger } from "@/lib/logger";
 import { getErrorMessage } from "@/lib/utils";
+import { acquireSingletonListener } from "./ui-bridge-events/singleton-listener";
+import { invokeRequestDedupe } from "./ui-bridge-events/request-dedupe";
 
 /**
  * Serialize an invoke() rejection into a string the Rust side can forward.
@@ -75,74 +77,100 @@ interface InvokeResponsePayload {
 }
 
 /**
+ * Dependencies for {@link handleInvokeRequest}, injected so the dispatch
+ * logic is unit-testable without a live Tauri runtime.
+ */
+export interface InvokeHandlerDeps {
+  invoke: (command: string, args: Record<string, unknown>) => Promise<unknown>;
+  emit: (event: string, payload: unknown) => Promise<void>;
+}
+
+/**
+ * Pure(-ish) handler for one `ui-bridge:invoke-request` event.
+ *
+ * Defense-in-depth EXACTLY-ONCE guard: the FIRST listener to see a given
+ * `request_id` claims it via {@link invokeRequestDedupe} and proceeds;
+ * any later listener (e.g. an accumulated duplicate) observes the claim
+ * and drops the call. This caps execution at one per request_id even if
+ * the singleton subscription guard is somehow bypassed.
+ *
+ * Returns `true` if this call executed the command (won the claim),
+ * `false` if it was deduped/ignored — exposed for tests.
+ */
+export async function handleInvokeRequest(
+  payload: InvokeRequestPayload,
+  deps: InvokeHandlerDeps,
+): Promise<boolean> {
+  const { request_id, command, args } = payload;
+
+  if (!request_id) {
+    // Without a request_id we can't route the response back. Drop it.
+    console.warn("[UIBridgeInvokeHandler] invoke-request missing request_id; ignoring");
+    return false;
+  }
+
+  if (!invokeRequestDedupe.claim(request_id)) {
+    log.debug(`invoke(${request_id}) already handled; ignoring duplicate`);
+    return false;
+  }
+
+  log.debug(`Received invoke request: ${command}`, request_id);
+
+  let response: InvokeResponsePayload;
+  try {
+    // Forward args verbatim. Tauri's IPC renames top-level camelCase keys
+    // to snake_case for the Rust command signature.
+    const result = await deps.invoke(command, args ?? {});
+    response = { request_id, ok: true, result: result as unknown };
+  } catch (err) {
+    const message = serializeInvokeError(err);
+    log.debug(`invoke(${command}) threw:`, message);
+    response = { request_id, ok: false, error: message };
+  }
+
+  try {
+    await deps.emit("ui-bridge:invoke-response", response);
+  } catch (emitErr) {
+    // If emit itself fails, the Rust side will hit its timeout. There's no
+    // better fallback here — we log and move on.
+    console.error("[UIBridgeInvokeHandler] Failed to emit invoke-response:", emitErr);
+  }
+  return true;
+}
+
+const invokeDeps: InvokeHandlerDeps = {
+  invoke: (command, args) => invoke(command, args),
+  emit: (event, payload) => emit(event, payload),
+};
+
+/**
  * Install a Tauri listener on `ui-bridge:invoke-request` that dispatches to
  * `invoke(command, args)` and emits the result back over
  * `ui-bridge:invoke-response`.
+ *
+ * The subscription is a SINGLETON per webview (see
+ * `ui-bridge-events/singleton-listener.ts`): no matter how many times this
+ * hook mounts — including React StrictMode's mount→unmount→remount, which
+ * runs in production too — exactly one underlying Tauri listener exists.
+ * That is the structural fix for the duplicate-execution bug; the
+ * `request_id` dedupe in {@link handleInvokeRequest} is the
+ * defense-in-depth backstop.
  *
  * Safe to mount once at app root alongside `UIBridgeEventHandler`. Multiple
  * concurrent invokes are supported (each carries its own `request_id`).
  */
 export function useUIBridgeInvokeHandler(): void {
   useEffect(() => {
-    let unlisten: UnlistenFn | null = null;
-    let isMounted = true;
-
-    const setupListener = async () => {
-      try {
-        log.debug("Setting up ui-bridge:invoke-request listener");
-
-        unlisten = await listen<InvokeRequestPayload>("ui-bridge:invoke-request", async (event) => {
-          if (!isMounted) {
-            log.debug("Component unmounted, ignoring invoke request");
-            return;
-          }
-
-          const { request_id, command, args } = event.payload;
-          log.debug(`Received invoke request: ${command}`, request_id);
-
-          let response: InvokeResponsePayload;
-          try {
-            // Forward args verbatim. Tauri's IPC renames top-level
-            // camelCase keys to snake_case for the Rust command signature.
-            const result = await invoke(command, args ?? {});
-            response = {
-              request_id,
-              ok: true,
-              result: result as unknown,
-            };
-          } catch (err) {
-            const message = serializeInvokeError(err);
-            log.debug(`invoke(${command}) threw:`, message);
-            response = {
-              request_id,
-              ok: false,
-              error: message,
-            };
-          }
-
-          try {
-            await emit("ui-bridge:invoke-response", response);
-          } catch (emitErr) {
-            // If emit itself fails, the Rust side will hit its timeout.
-            // There's no better fallback here — we log and move on.
-            console.error("[UIBridgeInvokeHandler] Failed to emit invoke-response:", emitErr);
-          }
-        });
-
-        log.debug("invoke-request listener set up successfully");
-      } catch (error) {
-        console.error("[UIBridgeInvokeHandler] Failed to set up invoke-request listener:", error);
-      }
-    };
-
-    setupListener();
-
+    log.debug("Acquiring singleton ui-bridge:invoke-request listener");
+    const release = acquireSingletonListener<InvokeRequestPayload>(
+      "ui-bridge:invoke-request",
+      (event: Event<InvokeRequestPayload>) => {
+        void handleInvokeRequest(event.payload, invokeDeps);
+      },
+    );
     return () => {
-      log.debug("Cleaning up invoke-request listener");
-      isMounted = false;
-      if (unlisten) {
-        unlisten();
-      }
+      log.debug("Releasing singleton ui-bridge:invoke-request listener");
+      release();
     };
   }, []);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -48,15 +48,28 @@ if (!rootElement) {
   console.error("Root element not found!");
   document.body.innerHTML = '<div style="color: red; padding: 20px;">Root element not found!</div>';
 } else {
+  const tree = (
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary>
+        <ProductModeProvider>
+          <App />
+        </ProductModeProvider>
+      </ErrorBoundary>
+    </QueryClientProvider>
+  );
+
+  // StrictMode is intentionally DEV-only. In React 18, <React.StrictMode>
+  // double-invokes effects (mount → unmount → remount) — and that double
+  // invocation is NOT stripped from production builds, only its dev console
+  // warnings are. With the prior unconditional StrictMode, the
+  // mount→unmount→remount churn raced the async `listen()` in the UI Bridge
+  // handlers and accumulated duplicate Tauri listeners in the shipped
+  // headless build (PR #473 round-2 falsification: one /page/evaluate ran a
+  // command 4× on a fresh single-window instance). The handlers are now
+  // individually hardened (singleton subscription + request_id dedupe), but
+  // we also keep StrictMode's intentional double-mount out of production so
+  // shipped builds don't pay for — or get surprised by — dev-only behavior.
   ReactDOM.createRoot(rootElement).render(
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary>
-          <ProductModeProvider>
-            <App />
-          </ProductModeProvider>
-        </ErrorBoundary>
-      </QueryClientProvider>
-    </React.StrictMode>,
+    import.meta.env.DEV ? <React.StrictMode>{tree}</React.StrictMode> : tree,
   );
 }


### PR DESCRIPTION
@-