### PR TITLE
fix(fmt): reformat agent_worktree/mod.rs to satisfy CI rustfmt

### DIFF
--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -412,9 +412,7 @@ enum CanonicalLeasePlan {
 /// `Err` stops the walk and yields a [`CanonicalLeasePlan::Bail`] carrying the
 /// successes-so-far (to release) and the error. All-`Ok` yields
 /// [`CanonicalLeasePlan::Proceed`].
-fn plan_canonical_leases(
-    outcomes: Vec<Result<ActiveClaim, AllocateError>>,
-) -> CanonicalLeasePlan {
+fn plan_canonical_leases(outcomes: Vec<Result<ActiveClaim, AllocateError>>) -> CanonicalLeasePlan {
     let mut acquired: Vec<ActiveClaim> = Vec::with_capacity(outcomes.len());
     for outcome in outcomes {
         match outcome {
@@ -1703,9 +1701,7 @@ mod tests {
                 assert_eq!(acquired[0].resource_key, "repo:qontinui-coord");
                 assert_eq!(acquired[1].resource_key, "repo:qontinui-web");
                 // The same vec the session-end release path drains.
-                assert!(acquired
-                    .iter()
-                    .all(|c| c.agent_session_id == Some(session)));
+                assert!(acquired.iter().all(|c| c.agent_session_id == Some(session)));
             }
             CanonicalLeasePlan::Bail { .. } => panic!("expected Proceed on all-Ok outcomes"),
         }
@@ -1732,10 +1728,8 @@ mod tests {
             intent: None,
         };
         // First repo acquires; second is Held by a peer.
-        let outcomes: Vec<Result<ActiveClaim, AllocateError>> = vec![
-            Ok(first),
-            Err(AllocateError::ClaimConflict(conflict)),
-        ];
+        let outcomes: Vec<Result<ActiveClaim, AllocateError>> =
+            vec![Ok(first), Err(AllocateError::ClaimConflict(conflict))];
 
         match plan_canonical_leases(outcomes) {
             CanonicalLeasePlan::Bail { to_release, error } => {


### PR DESCRIPTION
## Problem — runner `main` is fmt-broken, blocking every PR

The PR `test` job's **Format Rust code check** step fails on `src-tauri/src/agent_worktree/mod.rs` (`plan_canonical_leases` + its tests are in the pre-rustfmt *expanded* form). This is **not** introduced by any PR — it's on `main`:

- Introduced by `44eb25cc feat(agent-worktree): Ξ_Worktree P7.5b…` — a **direct-to-main commit with no PR number**, i.e. it bypassed the PR fmt gate.
- The **main-push workflow does not run the fmt check** (only PRs do), so `main` shows green while being fmt-dirty.
- Net: every PR that reaches the fmt step fails on this drift (e.g. #474).

## Fix

`cargo fmt` applied to the **single flagged file only** (4 insertions / 10 deletions — collapsing the expanded `vec!`/fn-signature forms to the rustfmt-canonical shape). No other files touched. Local `cargo clippy --tests` is clean.

## Follow-up (not in this PR)

The main-push workflow should also run `cargo fmt --check` (or block direct-to-main pushes), otherwise the next gate-bypassing commit silently re-breaks all PRs. Flagging for a separate CI change.