### PR TITLE
fix(terminal): bypass-aware needs-input detection — no phantom approval prompts

### DIFF
--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -65,6 +65,25 @@ impl TerminalManager {
         let cols = cols.unwrap_or(120);
         let rows = rows.unwrap_or(30);
 
+        // Bypass-aware needs-input detection (plan
+        // `2026-06-07-runner-continuation-defer-and-phantom-needs-input.md`,
+        // Defect B): command-sniff whether this PTY child is a Claude session
+        // launched with permissions bypassed. The runner-spawned gate
+        // continuation injects `--dangerously-skip-permissions`
+        // (`agent_runtime.rs:1309`); operator resumes use
+        // `--permission-mode bypassPermissions`. A bypass session can never
+        // await *tool* approval, so the frontend must skip approval-shaped
+        // patterns for it (the 12-min `rm -rf` phantom, 2026-06-07). We carry
+        // this as a dedicated `terminal-bypass-permissions` Tauri event keyed
+        // by terminal id rather than a new `TerminalInfo` field, because
+        // `TerminalInfo` is the cross-repo wire schema
+        // (`qontinui-schemas`, `#[schemars(deny_unknown_fields)]`, published
+        // `@qontinui/shared-types`) and a runner-local UI hint does not belong
+        // on the wire contract.
+        let bypass_permissions = command
+            .as_deref()
+            .is_some_and(command_implies_bypass_permissions);
+
         let emitter = app_handle.clone();
         let session = TerminalSession::spawn(
             id.clone(),
@@ -91,6 +110,20 @@ impl TerminalManager {
         // Notify frontend so externally-created terminals get a UI tab
         if let Err(e) = emitter.emit("terminal-created", &info) {
             error!("Failed to emit terminal-created: {}", e);
+        }
+
+        // Bypass-aware needs-input hint — emitted only when the spawn command
+        // implies bypassed permissions. Emitted AFTER `terminal-created`; the
+        // frontend listener buffers a bypass mark whose tab record hasn't
+        // landed yet (mirrors the existing worker-registered race buffer), so
+        // either delivery order is safe.
+        if bypass_permissions {
+            if let Err(e) = emitter.emit(
+                "terminal-bypass-permissions",
+                serde_json::json!({ "id": info.id }),
+            ) {
+                error!("Failed to emit terminal-bypass-permissions: {}", e);
+            }
         }
 
         Ok(info)
@@ -293,5 +326,95 @@ impl TerminalManager {
     #[allow(dead_code)]
     pub fn interceptor(&self) -> &Arc<OutputInterceptor> {
         &self.interceptor
+    }
+}
+
+/// Whether a spawn command line implies a Claude session running with tool
+/// permissions bypassed — i.e. one that can never legitimately stall on a
+/// tool-approval prompt.
+///
+/// True iff the argv contains either:
+/// - `--dangerously-skip-permissions` (the runner-spawned gate-continuation
+///   form, `agent_runtime.rs`), or
+/// - `--permission-mode bypassPermissions` (the operator-resume form). The two
+///   tokens may be a single joined arg (`--permission-mode=bypassPermissions`)
+///   or two adjacent args (`--permission-mode`, `bypassPermissions`); both are
+///   handled. The whole command is joined and substring-matched so a flag
+///   embedded inside a shell wrapper string (e.g.
+///   `CLAUDE_CONFIG_DIR=… claude --permission-mode bypassPermissions`) is still
+///   caught.
+fn command_implies_bypass_permissions(argv: &[String]) -> bool {
+    let joined = argv.join(" ");
+    joined.contains("--dangerously-skip-permissions")
+        || joined.contains("--permission-mode bypassPermissions")
+        || joined.contains("--permission-mode=bypassPermissions")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_implies_bypass_permissions;
+
+    fn argv(s: &[&str]) -> Vec<String> {
+        s.iter().map(|x| x.to_string()).collect()
+    }
+
+    #[test]
+    fn dangerously_skip_permissions_implies_bypass() {
+        // Runner-spawned gate continuation (agent_runtime.rs:1309).
+        assert!(command_implies_bypass_permissions(&argv(&[
+            "claude",
+            "--dangerously-skip-permissions",
+            "--add-dir",
+            "/some/worktree",
+            "run /implement-plan",
+        ])));
+    }
+
+    #[test]
+    fn permission_mode_bypass_two_args_implies_bypass() {
+        // Operator resume — two adjacent args.
+        assert!(command_implies_bypass_permissions(&argv(&[
+            "claude",
+            "--permission-mode",
+            "bypassPermissions",
+            "--resume",
+            "abc123",
+        ])));
+    }
+
+    #[test]
+    fn permission_mode_bypass_joined_arg_implies_bypass() {
+        // Operator resume threaded through a shell-string command (the form
+        // the frontend injects: `CLAUDE_CONFIG_DIR=… claude --permission-mode
+        // bypassPermissions …`) lands as one arg.
+        assert!(command_implies_bypass_permissions(&argv(&[
+            "CLAUDE_CONFIG_DIR=/cfg claude --permission-mode bypassPermissions --resume abc",
+        ])));
+        // …and the `=`-joined variant.
+        assert!(command_implies_bypass_permissions(&argv(&[
+            "claude",
+            "--permission-mode=bypassPermissions",
+        ])));
+    }
+
+    #[test]
+    fn plain_shell_or_default_claude_is_not_bypass() {
+        // Interactive shell — no flag.
+        assert!(!command_implies_bypass_permissions(&argv(&["bash", "-l"])));
+        // A Claude resume WITHOUT bypass (e.g. default/ask mode) must not be
+        // treated as bypass — approval prompts there are real.
+        assert!(!command_implies_bypass_permissions(&argv(&[
+            "claude",
+            "--permission-mode",
+            "default",
+            "--resume",
+            "abc",
+        ])));
+        // The substring "bypassPermissions" alone (without the flag) does not
+        // count — guards against a worktree path or prompt mentioning it.
+        assert!(!command_implies_bypass_permissions(&argv(&[
+            "claude",
+            "echo bypassPermissions is a mode",
+        ])));
     }
 }

--- a/src/components/terminal/sessionStateDetector.test.ts
+++ b/src/components/terminal/sessionStateDetector.test.ts
@@ -43,6 +43,50 @@ describe("detectSessionState — genuine Claude prompts DO flag needs-input", ()
   }
 });
 
+describe("detectSessionState — bypass-aware approval suppression", () => {
+  // PHANTOM EVIDENCE (2026-06-07): a `--dangerously-skip-permissions`
+  // continuation latched needs-input off Bash approval-shaped scrollback during
+  // a 12-min `rm -rf`, despite no permission ask ever existing. A bypass
+  // session can never await tool approval — these must NOT latch.
+  const approvalShaped = [
+    "Allow Read tool? (y/n)",
+    "Proceed? (yes/no)",
+    "Do you want to proceed?",
+  ];
+
+  for (const text of approvalShaped) {
+    it(`"${text}" + bypass → does NOT flag needs-input`, () => {
+      expect(detectSessionState(text, "idle", { bypassPermissions: true })).not.toBe("needs-input");
+    });
+
+    it(`"${text}" + non-bypass → flags needs-input (no regression)`, () => {
+      expect(detectSessionState(text, "idle", { bypassPermissions: false })).toBe("needs-input");
+      // Omitting opts entirely must behave as non-bypass (default false).
+      expect(detectSessionState(text, "idle")).toBe("needs-input");
+    });
+  }
+
+  // Question-shaped prompts (AskUserQuestion / free-form) are REAL even under
+  // bypass — bypass suppresses only tool approvals, not questions.
+  const questionShaped = [
+    "Please provide the file path",
+    "waiting for your input",
+    "What would you like me to do?",
+  ];
+
+  for (const text of questionShaped) {
+    it(`"${text}" + bypass → still flags needs-input`, () => {
+      expect(detectSessionState(text, "idle", { bypassPermissions: true })).toBe("needs-input");
+    });
+  }
+
+  it("resumed-pattern still breaks the latch for a bypass session", () => {
+    expect(
+      detectSessionState("Reading src/main.rs", "needs-input", { bypassPermissions: true }),
+    ).toBe("working");
+  });
+});
+
 describe("detectSessionState — needs-input latch-breaker", () => {
   it("transitions needs-input → working when resumed Claude tool output arrives", () => {
     expect(detectSessionState("Reading src/main.rs", "needs-input")).toBe("working");

--- a/src/components/terminal/sessionStateDetector.ts
+++ b/src/components/terminal/sessionStateDetector.ts
@@ -1,23 +1,42 @@
 import type { SessionState } from "./useZoneLayout";
 
 /**
- * Patterns that indicate Claude Code is waiting for user input.
- * These are checked against raw terminal output (may include ANSI sequences).
+ * Tool-approval-shaped patterns — Claude asking the operator to authorize a
+ * *tool* (Bash/Read/Write/…). These are Claude-specific framings
+ * ("Allow X? (y/n)", "Do you want to proceed?") rather than the bare
+ * `(Y/n)` / `[y/N]` tokens that ordinary shell tooling (git, apt, package
+ * managers, npm) prints in non-blocking informational output — matching
+ * those latched plain *and* Claude sessions to `needs-input` when nothing
+ * was actually awaiting input (the "N need input" phantom). See the
+ * StatusStrip session-count plan, Bug 2.
+ *
+ * PHANTOM EVIDENCE (2026-06-07): a retry-snapshot continuation session running
+ * with `--dangerously-skip-permissions` (`permission-mode: bypassPermissions`
+ * in all 11 transcript records) ran a 12-minute Bash `rm -rf`. During the
+ * stall the Terminal page latched `needs-input` off a Bash *approval-shaped*
+ * line in Claude's own tool-preview scrollback — yet the transcript proves no
+ * permission ask ever existed (no hook `ask`, no sandbox flag,
+ * `interrupted: false`, zero user-input events in the gap; the command simply
+ * finished). A bypass session can NEVER await tool approval, so for those
+ * sessions these patterns are skipped entirely (see `detectSessionState`).
  */
-const NEEDS_INPUT_PATTERNS = [
-  // Claude Code tool approval prompts. These are Claude-specific framings
-  // ("Allow X? (y/n)", "Do you want to proceed?") rather than the bare
-  // `(Y/n)` / `[y/N]` tokens that ordinary shell tooling (git, apt, package
-  // managers, npm) prints in non-blocking informational output — matching
-  // those latched plain *and* Claude sessions to `needs-input` when nothing
-  // was actually awaiting input (the "N need input" phantom). See the
-  // StatusStrip session-count plan, Bug 2.
+const APPROVAL_SHAPED_PATTERNS = [
   /\? \(y\/n\)/i,
   /\? \(yes\/no\)/i,
   /Allow .+\? \(/, // "Allow Read tool? (y/n)"
   /Do you want to proceed/i,
+];
 
-  // Claude Code interactive prompts
+/**
+ * Question-shaped patterns — Claude asking the operator a *question*
+ * (`AskUserQuestion` / `ExitPlanMode` / free-form prompt). These are real
+ * needs-input even for bypass sessions: `--dangerously-skip-permissions`
+ * suppresses tool-approval prompts but NOT `AskUserQuestion` stops (verified
+ * live: a "want me to move it?" question in the same bypass session above was
+ * genuine and needed the operator). So these are ALWAYS checked, regardless
+ * of bypass.
+ */
+const QUESTION_SHAPED_PATTERNS = [
   /\? >/, // Claude input prompt
   /waiting for your (?:input|response)/i,
   /What would you like/i,
@@ -86,14 +105,31 @@ const ERROR_PATTERNS = [
 /**
  * Analyze terminal output text and determine what session state it indicates.
  * Returns the detected state, or null if no state change is warranted.
+ *
+ * `opts.bypassPermissions` — when the session was spawned with
+ * `--dangerously-skip-permissions` / `--permission-mode bypassPermissions`,
+ * skip the approval-shaped subset entirely (a bypass session can never be
+ * awaiting tool approval — see the phantom evidence on
+ * `APPROVAL_SHAPED_PATTERNS`). Question-shaped prompts (`AskUserQuestion`,
+ * etc.) are still honored because bypass sessions legitimately stop on them.
  */
-export function detectSessionState(text: string, currentState: SessionState): SessionState | null {
+export function detectSessionState(
+  text: string,
+  currentState: SessionState,
+  opts?: { bypassPermissions?: boolean },
+): SessionState | null {
   // Strip ANSI for pattern matching but check against raw text too
   // eslint-disable-next-line no-control-regex
   const stripped = text.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
 
-  // Needs-input has highest priority — check both raw and stripped
-  if (NEEDS_INPUT_PATTERNS.some((p) => p.test(text) || p.test(stripped))) {
+  // Needs-input has highest priority — check both raw and stripped.
+  // For bypass sessions, the approval-shaped subset is suppressed (it can
+  // only ever be a phantom: tool approval is impossible under bypass);
+  // question-shaped prompts are always checked.
+  const needsInputPatterns = opts?.bypassPermissions
+    ? QUESTION_SHAPED_PATTERNS
+    : [...APPROVAL_SHAPED_PATTERNS, ...QUESTION_SHAPED_PATTERNS];
+  if (needsInputPatterns.some((p) => p.test(text) || p.test(stripped))) {
     return "needs-input";
   }
 

--- a/src/components/terminal/useSessionStateTracking.ts
+++ b/src/components/terminal/useSessionStateTracking.ts
@@ -3,7 +3,20 @@ import type { SessionState } from "./useZoneLayout";
 import { detectSessionState } from "./sessionStateDetector";
 
 export interface UseSessionStateTrackingParams {
-  tabs: Array<{ id: string; isAlive: boolean; exitCode: number | null }>;
+  tabs: Array<{
+    id: string;
+    isAlive: boolean;
+    exitCode: number | null;
+    /**
+     * True when the tab's PTY child runs Claude with tool permissions bypassed
+     * (`--dangerously-skip-permissions` / `--permission-mode bypassPermissions`).
+     * Forwarded to `detectSessionState` so approval-shaped TTY patterns are
+     * suppressed for it — a bypass session can never await tool approval, so
+     * any such match is a phantom (plan
+     * `2026-06-07-runner-continuation-defer-and-phantom-needs-input.md`).
+     */
+    bypassPermissions?: boolean;
+  }>;
   processOutput?: (tabId: string, text: string) => void;
   /** Read rendered lines from the xterm buffer (handles cursor movements correctly). */
   getBufferLines?: (tabId: string, maxLines: number) => string[];
@@ -235,10 +248,15 @@ export function useSessionStateTracking(
       if (buf.length === 0) buf.push(0);
       buf[buf.length - 1] += text.length;
 
-      // Use the session state detector for pattern matching
+      // Use the session state detector for pattern matching. Look up the
+      // tab's bypass flag (via the stable `tabsRef`, so this callback need not
+      // re-create when tabs change) so the detector can suppress approval-
+      // shaped patterns for bypass sessions.
+      const bypassPermissions =
+        tabsRef.current.find((t) => t.id === tabId)?.bypassPermissions === true;
       setSessionStates((prev) => {
         const current = prev[tabId] ?? "idle";
-        const detected = detectSessionState(text, current);
+        const detected = detectSessionState(text, current, { bypassPermissions });
         if (detected && detected !== current) {
           return { ...prev, [tabId]: detected };
         }

--- a/src/components/terminal/useTerminalManager.test.ts
+++ b/src/components/terminal/useTerminalManager.test.ts
@@ -17,6 +17,7 @@ import { describe, it, expect } from "vitest";
 import type { TerminalInfo } from "@qontinui/shared-types/tauri-events";
 import {
   applyWorkerMark,
+  applyBypassMark,
   reduceCreatedTerminal,
   shouldIngestCreatedTerminal,
   type TerminalTab,
@@ -140,6 +141,16 @@ describe("reduceCreatedTerminal (ingest + dedup)", () => {
     expect(next[0].taskRunId).toBe("task-42");
   });
 
+  it("stamps the drained bypass mark onto the new tab", () => {
+    const next = reduceCreatedTerminal([], createdEvent("b1", "page-a"), undefined, true);
+    expect(next[0].bypassPermissions).toBe(true);
+  });
+
+  it("leaves bypassPermissions undefined when no bypass mark was drained", () => {
+    const next = reduceCreatedTerminal([], createdEvent("p1", "page-a"), undefined);
+    expect(next[0].bypassPermissions).toBeUndefined();
+  });
+
   it("end-to-end: an event for page B while page A is active lands in B's slice only", () => {
     // Two independent page slices (provider lifted ⇒ both mounted at once).
     let pageA: TerminalTab[] = [tab("a1")];
@@ -161,5 +172,36 @@ describe("reduceCreatedTerminal (ingest + dedup)", () => {
 
     expect(pageB.map((t) => t.id)).toEqual(["b1"]); // captured in B
     expect(pageA.map((t) => t.id)).toEqual(["a1"]); // A unchanged, not cleared
+  });
+});
+
+describe("applyBypassMark", () => {
+  it("buffers the mark when the tab record hasn't arrived yet", () => {
+    const tabs = [tab("a"), tab("b")];
+    const result = applyBypassMark(tabs, "ghost");
+    expect(result.buffered).toBe(true);
+    expect(result.tabs).toBe(tabs);
+  });
+
+  it("stamps bypassPermissions onto the matching tab and returns a fresh array", () => {
+    const tabs = [tab("a"), tab("bypass-tab")];
+    const result = applyBypassMark(tabs, "bypass-tab");
+    expect(result.buffered).toBe(false);
+    expect(result.tabs).not.toBe(tabs);
+    expect(result.tabs[1].bypassPermissions).toBe(true);
+    expect(result.tabs[0].bypassPermissions).toBeUndefined();
+  });
+
+  it("is idempotent: re-marking an already-bypass tab returns the same array identity", () => {
+    const tabs = [tab("bypass-tab", { bypassPermissions: true })];
+    const result = applyBypassMark(tabs, "bypass-tab");
+    expect(result.buffered).toBe(false);
+    expect(result.tabs).toBe(tabs);
+  });
+
+  it("does not mutate the input array", () => {
+    const tabs = [tab("bypass-tab")];
+    applyBypassMark(tabs, "bypass-tab");
+    expect(tabs[0].bypassPermissions).toBeUndefined();
   });
 });

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -34,6 +34,19 @@ export interface TerminalTab {
    */
   taskRunId?: string;
   /**
+   * True when the PTY child runs Claude with tool permissions bypassed
+   * (`--dangerously-skip-permissions` or `--permission-mode bypassPermissions`).
+   * Set from the Rust `terminal-bypass-permissions` event, which the runner
+   * emits (after `terminal-created`) when it command-sniffs a bypass flag on
+   * the spawn command. Threaded into `useSessionStateTracking` →
+   * `detectSessionState` so approval-shaped TTY patterns are suppressed for
+   * these sessions — a bypass session can never await tool approval, so any
+   * approval-shaped match is a phantom (the 12-min `rm -rf` misread,
+   * 2026-06-07; see `sessionStateDetector.ts`). Absent/false on every
+   * non-bypass tab.
+   */
+  bypassPermissions?: boolean;
+  /**
    * Marks a tab synthesized from a debug-gated test-fixtures `injected_tab`
    * spec (`syntheticTabs.ts`). Synthetic tabs are fed ONLY to
    * `useSessionStateTracking` + `useSessionManager` for StatusStrip
@@ -92,7 +105,9 @@ export function shouldIngestCreatedTerminal(
  * Pure helper: fold a `terminal-created` payload into the existing tab list.
  * Returns the next tabs array — the SAME identity when the terminal already
  * exists (dedup), otherwise a new array with the tab appended. `pendingTaskRunId`
- * is the worker mark drained from the race buffer by the caller (or `undefined`).
+ * is the worker mark drained from the race buffer by the caller (or `undefined`);
+ * `pendingBypass` is the bypass-permissions mark drained the same way (a
+ * `terminal-bypass-permissions` event that arrived before this `terminal-created`).
  *
  * Exported so `useTerminalManager.test.ts` can drive the ingest + dedup contract
  * without booting React.
@@ -101,6 +116,7 @@ export function reduceCreatedTerminal(
   tabs: TerminalTab[],
   info: TerminalInfo,
   pendingTaskRunId: string | undefined,
+  pendingBypass = false,
 ): TerminalTab[] {
   if (tabs.some((t) => t.id === info.id)) return tabs;
   return [
@@ -114,6 +130,7 @@ export function reduceCreatedTerminal(
       workingDir: info.workingDir || undefined,
       createdAt: info.createdAt,
       taskRunId: pendingTaskRunId,
+      bypassPermissions: pendingBypass || undefined,
     },
   ];
 }
@@ -140,6 +157,29 @@ export function applyWorkerMark(
   return { tabs: next, buffered: false };
 }
 
+/**
+ * Pure helper: decide whether `tabs` should be replaced when applying a
+ * bypass-permissions mark for `terminalId`. Returns the next tabs array (same
+ * identity if no change), and a `buffered` flag the caller uses to record the
+ * mark in `pendingBypassMarks` when the tab record hasn't arrived yet.
+ *
+ * Mirrors `applyWorkerMark` — the `terminal-bypass-permissions` event can
+ * arrive before OR after `terminal-created` lands the tab in React state.
+ * Exported so `useTerminalManager.test.ts` can drive the race-safety +
+ * idempotency contract without booting React.
+ */
+export function applyBypassMark(
+  tabs: TerminalTab[],
+  terminalId: string,
+): { tabs: TerminalTab[]; buffered: boolean } {
+  const idx = tabs.findIndex((t) => t.id === terminalId);
+  if (idx < 0) return { tabs, buffered: true };
+  if (tabs[idx].bypassPermissions === true) return { tabs, buffered: false };
+  const next = tabs.slice();
+  next[idx] = { ...tabs[idx], bypassPermissions: true };
+  return { tabs: next, buffered: false };
+}
+
 // `TerminalInfo` is imported from `@qontinui/shared-types/tauri-events` —
 // generated from the canonical Rust struct in
 // `qontinui-schemas/rust/src/terminal.rs`. Field names are camelCase via
@@ -160,12 +200,30 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
    * buffer is the simplest race-safe shape.
    */
   const pendingWorkerMarks = useRef<Map<string, string>>(new Map());
+  /**
+   * Bypass-permissions marks (`terminalId`) received from the Rust
+   * `terminal-bypass-permissions` event before their tab record exists in
+   * React state. Same race shape as `pendingWorkerMarks`: the event is emitted
+   * right after `terminal-created`, but arrival order at the webview is not
+   * strictly guaranteed (and reconnect rebuilds tabs without re-firing it).
+   */
+  const pendingBypassMarks = useRef<Set<string>>(new Set());
 
   const markAsWorker = useCallback((terminalId: string, taskRunId: string) => {
     setTabs((prev) => {
       const result = applyWorkerMark(prev, terminalId, taskRunId);
       if (result.buffered) {
         pendingWorkerMarks.current.set(terminalId, taskRunId);
+      }
+      return result.tabs;
+    });
+  }, []);
+
+  const markAsBypass = useCallback((terminalId: string) => {
+    setTabs((prev) => {
+      const result = applyBypassMark(prev, terminalId);
+      if (result.buffered) {
+        pendingBypassMarks.current.add(terminalId);
       }
       return result.tabs;
     });
@@ -193,8 +251,12 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
       if (pendingTaskRunId !== undefined) {
         pendingWorkerMarks.current.delete(info.id);
       }
+      const pendingBypass = pendingBypassMarks.current.has(info.id);
+      if (pendingBypass) {
+        pendingBypassMarks.current.delete(info.id);
+      }
       setTabs((prev) => {
-        const next = reduceCreatedTerminal(prev, info, pendingTaskRunId);
+        const next = reduceCreatedTerminal(prev, info, pendingTaskRunId, pendingBypass);
         if (next !== prev) {
           logger.info(`External terminal created: ${info.id} (${info.title}) [page ${pageId}]`);
         }
@@ -226,6 +288,27 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
       unlisten?.();
     };
   }, [markAsWorker]);
+
+  // Bypass-aware needs-input detection (plan
+  // `2026-06-07-runner-continuation-defer-and-phantom-needs-input.md`).
+  // The Rust `TerminalManager::create` emits `terminal-bypass-permissions`
+  // (after `terminal-created`) when the spawn command implies bypassed tool
+  // permissions; marking the tab here lets `useSessionStateTracking` skip
+  // approval-shaped TTY patterns for it (those can only ever be phantoms on a
+  // bypass session).
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    listen<{ id: string }>("terminal-bypass-permissions", (event) => {
+      const { id } = event.payload;
+      if (!id) return;
+      markAsBypass(id);
+    }).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      unlisten?.();
+    };
+  }, [markAsBypass]);
 
   /**
    * Reconnect to existing Rust PTY sessions that survived a React remount.
@@ -441,5 +524,6 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
     reconnectToExistingSessions,
     markReconnected,
     markAsWorker,
+    markAsBypass,
   };
 }


### PR DESCRIPTION
## What

Defect B of plan `D:\qontinui-root\plans\2026-06-07-runner-continuation-defer-and-phantom-needs-input.md` (Phase 2).

A bypass Claude session — spawned with `--dangerously-skip-permissions` (runner gate-continuations) or `--permission-mode bypassPermissions` (operator resumes) — can **never** stall on a tool-approval prompt. But the StatusStrip needs-input detector regex-matched approval-shaped lines from Claude's own tool-preview scrollback during a long-running tool, latching the tab to `needs-input` for the whole stall.

### Evidence (2026-06-07 phantom)

A retry-snapshot continuation session (`--dangerously-skip-permissions`) ran a **12-minute Bash delete** (huge worktree `node_modules` + a locked file). During the stall the Terminal page presented a Bash *permission request*; the operator answered it. The transcript (`30445580...`) proves no permission ask ever existed: `permission-mode: bypassPermissions` in all 11 records, no hook `ask`, no sandbox flag, `interrupted: false`, zero user-input events in the gap — the command simply finished on its own. The operator's "approval" keystroke went into the PTY and changed nothing.

## How

- **Rust (`terminal/manager.rs`)** command-sniffs whether the PTY child runs Claude with permissions bypassed (covers BOTH spawn surfaces: the runner-injected `--dangerously-skip-permissions` and the operator-resume `--permission-mode bypassPermissions`, two-arg / `=`-joined / shell-string forms) and emits a dedicated `terminal-bypass-permissions` Tauri event keyed by terminal id. Deliberately **not** a new `TerminalInfo` field: that struct is the cross-repo wire schema (`qontinui-schemas`, `#[schemars(deny_unknown_fields)]`, published `@qontinui/shared-types`) and a runner-local UI hint does not belong on the wire contract.
- **Frontend** buffers the bypass mark race-safely (mirrors the existing worker-mark buffer — the event can land before or after `terminal-created`), threads `bypassPermissions` through `useSessionStateTracking` into `detectSessionState`.
- **`sessionStateDetector.ts`** splits `NEEDS_INPUT_PATTERNS` into an **approval-shaped** subset (skipped under bypass) vs a **question-shaped** subset (always kept — bypass sessions legitimately stop on `AskUserQuestion`). Sticky latch + `RESUMED_PATTERNS` breaker unchanged.

## Tests

- Rust: 4 command-sniff cases (skip-permissions; `--permission-mode bypassPermissions` two-arg + joined; non-bypass negatives).
- Detector: approval+bypass -> no latch; approval+non-bypass -> latch (no regression); question+bypass -> still latch; resumed-pattern breaks the latch under bypass.
- `applyBypassMark` race/idempotency.

Verified: vitest 31 passed, tsc clean, `cargo clippy --workspace --tests -- -D warnings` clean, the 4 Rust tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
