### PR TITLE
feat(lineage): report session commits to coord via outbox

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -251,10 +251,7 @@ impl AiCoordRegistrar {
         if !crate::terminal::commit_report::report_enabled() {
             return;
         }
-        let shas: Vec<String> = shas
-            .into_iter()
-            .filter(|s| !s.trim().is_empty())
-            .collect();
+        let shas: Vec<String> = shas.into_iter().filter(|s| !s.trim().is_empty()).collect();
         if shas.is_empty() {
             return;
         }

--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -231,6 +231,65 @@ impl AiCoordRegistrar {
         Some(session_id)
     }
 
+    /// Commit ↔ session lineage push-report (plan
+    /// `2026-06-07-coord-commit-session-lineage.md`, Population path 2). Enqueue
+    /// a `commit_report` outbox row carrying `{repo, branch, shas}`. The drain
+    /// loop POSTs it to `POST /coord/commits/report`; coord resolves the
+    /// session server-side from `(repo, branch)`, so the body carries NO session
+    /// id.
+    ///
+    /// The outbox keys its monotonic `seq` on `(machine_id, session_id)`, but
+    /// commit reports have no real session — we mint a **deterministic** UUIDv5
+    /// from `(repo, branch)` so all reports for one branch share a seq lane
+    /// (stable ordering, idempotent replay) without colliding across branches.
+    /// Coord never reads this id.
+    ///
+    /// Best-effort and gated on `QONTINUI_COMMIT_LINEAGE_REPORT` (default ON);
+    /// a disabled gate, empty `shas`, or an outbox write error is a silent
+    /// no-op that never disturbs the live session.
+    pub fn report_commits(&self, repo: &str, branch: &str, shas: Vec<String>) {
+        if !crate::terminal::commit_report::report_enabled() {
+            return;
+        }
+        let shas: Vec<String> = shas
+            .into_iter()
+            .filter(|s| !s.trim().is_empty())
+            .collect();
+        if shas.is_empty() {
+            return;
+        }
+
+        // Deterministic per-(repo, branch) synthetic session id for the outbox
+        // seq lane. URL namespace + "repo/branch" key.
+        let session_id = Uuid::new_v5(
+            &Uuid::NAMESPACE_URL,
+            format!("commit-report:{repo}:{branch}").as_bytes(),
+        );
+        let payload = json!({
+            "repo": repo,
+            "branch": branch,
+            "shas": shas,
+        });
+
+        match self.inner.outbox.record(
+            self.inner.machine_id,
+            session_id,
+            SessionEventKind::CommitReport,
+            payload,
+        ) {
+            Ok(_) => info!(
+                "ai_coord_register: enqueued commit report for {}@{} ({} sha(s))",
+                repo,
+                branch,
+                shas.len()
+            ),
+            Err(e) => warn!(
+                "ai_coord_register: outbox CommitReport write failed for {}@{} (best-effort): {}",
+                repo, branch, e
+            ),
+        }
+    }
+
     /// R3 — emit a coord heartbeat for the AI session backing `task_run_id`,
     /// driven by **operator interaction** (called from `send_user_message`).
     /// This is the ONLY heartbeat these sessions ever get, so an idle session
@@ -430,6 +489,66 @@ mod tests {
                 r.event_kind == SessionEventKind::Closed.as_str() && r.session_id == coord_id
             });
         assert!(closed, "a Closed outbox row must be emitted on close");
+    }
+
+    #[test]
+    fn report_commits_enqueues_commit_report_row() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_COMMIT_LINEAGE_REPORT");
+        let (reg, _dir) = registrar();
+
+        reg.report_commits(
+            "qontinui/qontinui-runner",
+            "feat/x",
+            vec!["sha1".into(), "sha2".into()],
+        );
+
+        let pending = reg.inner.outbox.pending().unwrap();
+        assert_eq!(pending.len(), 1);
+        let row = &pending[0];
+        assert_eq!(row.event_kind, SessionEventKind::CommitReport.as_str());
+        assert_eq!(row.payload["repo"], json!("qontinui/qontinui-runner"));
+        assert_eq!(row.payload["branch"], json!("feat/x"));
+        assert_eq!(row.payload["shas"], json!(["sha1", "sha2"]));
+        // No session id is carried in the body — coord resolves it server-side.
+        assert!(row.payload.get("agent_session_id").is_none());
+    }
+
+    #[test]
+    fn report_commits_per_branch_seq_lane_is_deterministic() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_COMMIT_LINEAGE_REPORT");
+        let (reg, _dir) = registrar();
+
+        reg.report_commits("o/r", "main", vec!["a".into()]);
+        reg.report_commits("o/r", "main", vec!["b".into()]);
+        let pending = reg.inner.outbox.pending().unwrap();
+        // Both reports for the same (repo, branch) share one seq lane (same
+        // synthetic session id), so seqs are 1 then 2.
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].session_id, pending[1].session_id);
+        assert_eq!(pending[0].seq, 1);
+        assert_eq!(pending[1].seq, 2);
+    }
+
+    #[test]
+    fn report_commits_skips_empty_shas() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_COMMIT_LINEAGE_REPORT");
+        let (reg, _dir) = registrar();
+        reg.report_commits("o/r", "main", vec![]);
+        reg.report_commits("o/r", "main", vec!["   ".into()]);
+        assert!(reg.inner.outbox.pending().unwrap().is_empty());
+    }
+
+    #[test]
+    fn report_commits_disabled_gate_is_noop() {
+        let _env = env_lock();
+        std::env::set_var("QONTINUI_COMMIT_LINEAGE_REPORT", "0");
+        let (reg, _dir) = registrar();
+        reg.report_commits("o/r", "main", vec!["a".into()]);
+        assert!(reg.inner.outbox.pending().unwrap().is_empty());
+        std::env::remove_var("QONTINUI_COMMIT_LINEAGE_REPORT");
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2693,10 +2693,17 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                             Vec::new()
                         }
                     };
+                // Commit ↔ session lineage push-report (Population path 2): the
+                // watcher reuses the AiCoordRegistrar's outbox to enqueue
+                // `commit_report` rows on observed `git push`es.
+                let tw_registrar = app
+                    .try_state::<Arc<claude_session::coord_register::AiCoordRegistrar>>()
+                    .map(|s| s.inner().clone());
                 if let Err(e) = crate::terminal::transcript_watcher::start_transcript_watcher(
                     tw_app_handle,
                     tw_pg,
                     workspace_paths,
+                    tw_registrar,
                 ) {
                     tracing::warn!("transcript watcher failed to start: {}", e);
                 }

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -655,8 +655,7 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
             // comes from the X-Qontinui-Tenant-Id header (post_device_register
             // posture) — mirror `rebuild_create_body`'s machine.json resolve.
             let url = format!("{base}/coord/commits/report");
-            let mut rb =
-                crate::auth::attach_device_auth(inner.http.post(&url).json(&rec.payload));
+            let mut rb = crate::auth::attach_device_auth(inner.http.post(&url).json(&rec.payload));
             if let Some(tid) = crate::session::dual_write::resolve_active_tenant_id() {
                 rb = rb.header("X-Qontinui-Tenant-Id", tid.to_string());
             }

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -647,6 +647,21 @@ async fn push_record(inner: &Arc<CoordSyncInner>, rec: &OutboxRecord) -> PushOut
                 .send()
                 .await
         }
+        "commit_report" => {
+            // Commit ↔ session lineage push-report (plan
+            // 2026-06-07-coord-commit-session-lineage.md, Population path 2).
+            // Body is the payload verbatim ({repo, branch, shas}); coord
+            // resolves the session server-side from (repo, branch). Tenant
+            // comes from the X-Qontinui-Tenant-Id header (post_device_register
+            // posture) — mirror `rebuild_create_body`'s machine.json resolve.
+            let url = format!("{base}/coord/commits/report");
+            let mut rb =
+                crate::auth::attach_device_auth(inner.http.post(&url).json(&rec.payload));
+            if let Some(tid) = crate::session::dual_write::resolve_active_tenant_id() {
+                rb = rb.header("X-Qontinui-Tenant-Id", tid.to_string());
+            }
+            rb.send().await
+        }
         other => {
             // OutputChunk + HandoffRequest are Phase 7/8 — defined now
             // for wire shape, not pushed yet. Quietly ACK so the file

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -170,6 +170,12 @@ pub enum SessionEventKind {
     OutputChunk,
     /// Phase 7 — defined now, published when handoff lands.
     HandoffRequest,
+    /// Commit ↔ session lineage push-report (plan
+    /// `2026-06-07-coord-commit-session-lineage.md`, Population path 2).
+    /// Drained to `POST /coord/commits/report {repo, branch, shas[]}`; the
+    /// payload carries `{repo, branch, shas}` and NO session id (coord resolves
+    /// the session server-side from `(repo, branch)`).
+    CommitReport,
 }
 
 impl SessionEventKind {
@@ -182,6 +188,7 @@ impl SessionEventKind {
             SessionEventKind::ClaimStolen => "claim_stolen",
             SessionEventKind::OutputChunk => "output_chunk",
             SessionEventKind::HandoffRequest => "handoff_request",
+            SessionEventKind::CommitReport => "commit_report",
         }
     }
 }
@@ -1198,6 +1205,7 @@ mod tests {
             SessionEventKind::ClaimStolen,
             SessionEventKind::OutputChunk,
             SessionEventKind::HandoffRequest,
+            SessionEventKind::CommitReport,
         ];
         for k in kinds {
             let json = serde_json::to_string(&k).unwrap();

--- a/src-tauri/src/terminal/commit_report.rs
+++ b/src-tauri/src/terminal/commit_report.rs
@@ -47,7 +47,10 @@ use tracing::debug;
 /// (including unset) leaves it ON.
 pub fn report_enabled() -> bool {
     match std::env::var("QONTINUI_COMMIT_LINEAGE_REPORT") {
-        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off"),
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "false" | "off"
+        ),
         Err(_) => true,
     }
 }
@@ -262,7 +265,11 @@ pub fn parse_repo_full_name(remote_url: &str) -> Option<String> {
 
 /// Run a git subcommand in `dir`, returning trimmed stdout on success.
 fn git(dir: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git").current_dir(dir).args(args).output().ok()?;
+    let output = Command::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .ok()?;
     if !output.status.success() {
         return None;
     }
@@ -299,11 +306,7 @@ pub fn resolve_push(working_dir: &str) -> Option<ResolvedPush> {
         return None;
     }
 
-    Some(ResolvedPush {
-        repo,
-        branch,
-        shas,
-    })
+    Some(ResolvedPush { repo, branch, shas })
 }
 
 /// Dedup gate: returns `true` (report) only if the branch's HEAD SHA has moved
@@ -324,7 +327,10 @@ pub fn should_report(repo: &str, branch: &str, head_sha: &str) -> bool {
 /// Test-only: clear the dedup cache so tests don't bleed into each other.
 #[cfg(test)]
 pub fn reset_dedup_for_test() {
-    LAST_REPORTED.lock().unwrap_or_else(|e| e.into_inner()).clear();
+    LAST_REPORTED
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clear();
 }
 
 /// Full pipeline for one push observation: resolve git facts, apply dedup, and
@@ -451,10 +457,9 @@ mod tests {
     #[test]
     fn parse_line_ignores_user_and_malformed() {
         assert!(parse_line_for_pushes("not json").is_empty());
-        assert!(parse_line_for_pushes(
-            r#"{"type":"user","message":{"content":"git push"}}"#
-        )
-        .is_empty());
+        assert!(
+            parse_line_for_pushes(r#"{"type":"user","message":{"content":"git push"}}"#).is_empty()
+        );
         assert!(parse_line_for_pushes("").is_empty());
     }
 
@@ -473,7 +478,10 @@ mod tests {
             Some("qontinui/qontinui-web")
         );
         assert_eq!(parse_repo_full_name("not-a-url").as_deref(), None);
-        assert_eq!(parse_repo_full_name("https://host/onlyone").as_deref(), None);
+        assert_eq!(
+            parse_repo_full_name("https://host/onlyone").as_deref(),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/terminal/commit_report.rs
+++ b/src-tauri/src/terminal/commit_report.rs
@@ -1,0 +1,494 @@
+//! Commit ↔ session lineage push-report trigger (Population path 2 of plan
+//! `2026-06-07-coord-commit-session-lineage.md`).
+//!
+//! ## Trigger
+//!
+//! The most robust runner-observed signal that a session produced commits is a
+//! **successful `git push`** in the session's working directory. A push means
+//! SHAs left the machine — exactly the lineage event coord wants to record. We
+//! piggyback on the existing [`super::transcript_watcher`] tail loop, which
+//! already parses every new JSONL line of each interactive Claude session for
+//! `tool_use` blocks. Here we parse `Bash` `tool_use` blocks instead of
+//! Edit/Write/MultiEdit, detect `git push` invocations, and (best-effort)
+//! enumerate the pushed SHAs to enqueue a coord outbox report.
+//!
+//! Why a push and not a commit: a commit can be amended/rebased/dropped before
+//! it ever reaches a remote, so committing is a noisier, less durable signal. A
+//! push is the point at which a SHA becomes a shared, attributable fact — which
+//! is precisely what `coord.commit_lineage` records.
+//!
+//! ## Wire path
+//!
+//! Detection enqueues a `commit_report` row on the shared
+//! [`crate::session::local_store::OutboxWriter`] (via
+//! [`crate::claude_session::coord_register::AiCoordRegistrar::report_commits`]).
+//! The existing `CoordSync` drain loop POSTs it to
+//! `POST /coord/commits/report {repo, branch, shas[]}`. Coord resolves the
+//! session **server-side** from `(repo, branch)`; the body carries NO session
+//! id (plan §Population path 2).
+//!
+//! ## Dedup
+//!
+//! Re-reporting the same SHAs is harmless (coord is `ON CONFLICT DO NOTHING`),
+//! but we still suppress no-op work: a process-global cache remembers the last
+//! HEAD SHA reported per `(repo, branch)`. A subsequent push that hasn't moved
+//! HEAD enqueues nothing.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+
+use once_cell::sync::Lazy;
+use tracing::debug;
+
+/// Default-ON env gate (mirrors `coord_register::registration_enabled`). Any of
+/// `0` / `false` / `off` (case-insensitive) disables push-report; anything else
+/// (including unset) leaves it ON.
+pub fn report_enabled() -> bool {
+    match std::env::var("QONTINUI_COMMIT_LINEAGE_REPORT") {
+        Ok(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "off"),
+        Err(_) => true,
+    }
+}
+
+/// How many recent SHAs to enumerate + report per push. Coord dedups, so an
+/// upper bound here just caps the body size; the branch's most recent commits
+/// are the ones a push most likely just delivered.
+const SHA_WINDOW: usize = 25;
+
+/// A detected `git push` observation extracted from a single Bash `tool_use`
+/// block. Pure parse output — no git has been run yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushObservation {
+    /// Working directory to run git in. Resolution order: a `cd "<dir>" &&`
+    /// prefix in the command (overrides), else the transcript record's
+    /// top-level `cwd`.
+    pub working_dir: String,
+}
+
+/// Process-global dedup cache: `(repo, branch)` → last reported HEAD SHA.
+static LAST_REPORTED: Lazy<Mutex<HashMap<(String, String), String>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+// ── Pure parsing ─────────────────────────────────────────────────────────────
+
+/// Return true if a shell command string contains a `git push` invocation.
+///
+/// Tolerant of the common shapes the agent emits: `git push`,
+/// `git push -u origin x`, `cd "<dir>" && git push …`, `git -C <dir> push`,
+/// piped/redirected (`… | tail`, `2>&1`). Conservative: requires the literal
+/// token sequence `git … push` so `git pushd`-style false positives and
+/// `git log` don't match. Does NOT match `--dry-run` pushes.
+pub fn command_is_git_push(command: &str) -> bool {
+    // Split on shell separators so each sub-command is checked independently
+    // (`cd x && git push` → ["cd x", "git push"]).
+    for segment in command.split(['&', ';', '|', '\n']) {
+        let toks: Vec<&str> = segment.split_whitespace().collect();
+        // `git` must be the FIRST token of the segment — otherwise `echo git
+        // push` or `git push` mentioned as an argument would match. A leading
+        // env-assignment (`FOO=bar git push`) is tolerated by skipping tokens
+        // that contain `=` and no `/` before they could be a path.
+        let mut start = 0;
+        while start < toks.len() && toks[start].contains('=') {
+            start += 1;
+        }
+        if toks.get(start) != Some(&"git") {
+            continue;
+        }
+        let git_idx = start;
+        // Find the first non-flag, non-`-C <path>` token after `git`.
+        let mut i = git_idx + 1;
+        while i < toks.len() {
+            let t = toks[i];
+            if t == "-C" {
+                i += 2; // skip `-C <path>`
+                continue;
+            }
+            if t.starts_with('-') {
+                i += 1;
+                continue;
+            }
+            // First subcommand token.
+            if t == "push" {
+                // Exclude dry-runs — they push nothing.
+                if segment.contains("--dry-run") {
+                    return false;
+                }
+                return true;
+            }
+            break;
+        }
+    }
+    false
+}
+
+/// Extract the working directory from a shell command, preferring a leading
+/// `cd "<dir>" &&` (or `cd <dir> &&`) prefix, else `git -C <dir>`, else falling
+/// back to the supplied transcript `cwd`. Strips surrounding quotes.
+pub fn resolve_working_dir(command: &str, transcript_cwd: &str) -> String {
+    // 1. `cd <dir> &&` prefix.
+    for segment in command.split("&&") {
+        let seg = segment.trim();
+        if let Some(rest) = seg.strip_prefix("cd ") {
+            let dir = unquote(rest.trim());
+            if !dir.is_empty() {
+                return dir;
+            }
+        }
+    }
+    // 2. `git -C <dir>`.
+    let toks: Vec<&str> = command.split_whitespace().collect();
+    if let Some(idx) = toks.iter().position(|t| *t == "-C") {
+        if let Some(dir) = toks.get(idx + 1) {
+            let d = unquote(dir);
+            if !d.is_empty() {
+                return d;
+            }
+        }
+    }
+    // 3. Transcript cwd fallback.
+    transcript_cwd.to_string()
+}
+
+/// Strip one layer of matching single/double quotes.
+fn unquote(s: &str) -> String {
+    let s = s.trim();
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2
+        && ((bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"')
+            || (bytes[0] == b'\'' && bytes[bytes.len() - 1] == b'\''))
+    {
+        return s[1..s.len() - 1].to_string();
+    }
+    s.to_string()
+}
+
+/// Walk a parsed `{type:"assistant"}` JSONL record and emit a [`PushObservation`]
+/// for each Bash `tool_use` block whose command is a `git push`. Pure (no I/O).
+/// Uses the record's top-level `cwd` as the working-dir fallback.
+pub fn extract_push_observations(record: &serde_json::Value) -> Vec<PushObservation> {
+    let transcript_cwd = record.get("cwd").and_then(|c| c.as_str()).unwrap_or("");
+
+    let Some(content) = record
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for block in content {
+        if block.get("type").and_then(|t| t.as_str()) != Some("tool_use") {
+            continue;
+        }
+        if block.get("name").and_then(|n| n.as_str()) != Some("Bash") {
+            continue;
+        }
+        let Some(command) = block
+            .get("input")
+            .and_then(|i| i.get("command"))
+            .and_then(|c| c.as_str())
+        else {
+            continue;
+        };
+        if command_is_git_push(command) {
+            out.push(PushObservation {
+                working_dir: resolve_working_dir(command, transcript_cwd),
+            });
+        }
+    }
+    out
+}
+
+/// Convenience: parse one JSONL line and return push observations (empty for
+/// non-assistant records / malformed JSON — never panics).
+pub fn parse_line_for_pushes(line: &str) -> Vec<PushObservation> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    let Ok(record) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+        return Vec::new();
+    };
+    if record.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+        return Vec::new();
+    }
+    extract_push_observations(&record)
+}
+
+// ── Git enumeration (impure) ──────────────────────────────────────────────────
+
+/// Resolved facts about a pushed branch, ready to hand to the coord report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPush {
+    /// `owner/repo` derived from `git remote get-url origin`.
+    pub repo: String,
+    /// Current branch name.
+    pub branch: String,
+    /// Recent SHAs on the branch (newest first), capped at [`SHA_WINDOW`].
+    pub shas: Vec<String>,
+}
+
+/// Normalize a `git remote get-url origin` value to `owner/repo`. Handles both
+/// SSH (`git@github.com:owner/repo.git`) and HTTPS
+/// (`https://github.com/owner/repo.git`) forms; strips a trailing `.git`.
+/// Returns `None` for shapes we don't recognise.
+pub fn parse_repo_full_name(remote_url: &str) -> Option<String> {
+    let url = remote_url.trim();
+    let tail = if let Some(idx) = url.find('@') {
+        // SSH: git@github.com:owner/repo.git
+        let after_at = &url[idx + 1..];
+        after_at.split_once(':').map(|(_, p)| p)?
+    } else if let Some(pos) = url.find("://") {
+        // HTTPS: https://github.com/owner/repo.git
+        let after_scheme = &url[pos + 3..];
+        let path = after_scheme.split_once('/').map(|(_, p)| p)?;
+        path
+    } else {
+        // scp-like without scheme, or bare path: host:owner/repo
+        url.split_once(':').map(|(_, p)| p).unwrap_or(url)
+    };
+    let cleaned = tail.trim_end_matches('/').trim_end_matches(".git");
+    // Require at least `owner/repo`.
+    let parts: Vec<&str> = cleaned.split('/').filter(|s| !s.is_empty()).collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let n = parts.len();
+    Some(format!("{}/{}", parts[n - 2], parts[n - 1]))
+}
+
+/// Run a git subcommand in `dir`, returning trimmed stdout on success.
+fn git(dir: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git").current_dir(dir).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Resolve repo full_name, branch, and the recent-SHA window for a working dir.
+/// Returns `None` if the dir isn't a git repo, has no origin remote, or is in a
+/// detached-HEAD / unparseable state.
+pub fn resolve_push(working_dir: &str) -> Option<ResolvedPush> {
+    let dir = PathBuf::from(working_dir);
+    if working_dir.trim().is_empty() {
+        return None;
+    }
+    let remote = git(&dir, &["remote", "get-url", "origin"])?;
+    let repo = parse_repo_full_name(&remote)?;
+
+    let branch = git(&dir, &["rev-parse", "--abbrev-ref", "HEAD"])?;
+    if branch.is_empty() || branch == "HEAD" {
+        // Detached HEAD — no branch to attribute against. Skip.
+        return None;
+    }
+
+    let log = git(
+        &dir,
+        &["log", "--format=%H", &format!("-n{SHA_WINDOW}"), &branch],
+    )?;
+    let shas: Vec<String> = log
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+    if shas.is_empty() {
+        return None;
+    }
+
+    Some(ResolvedPush {
+        repo,
+        branch,
+        shas,
+    })
+}
+
+/// Dedup gate: returns `true` (report) only if the branch's HEAD SHA has moved
+/// since the last report for this `(repo, branch)`. Records the new HEAD on a
+/// `true` so the next identical push is a no-op.
+pub fn should_report(repo: &str, branch: &str, head_sha: &str) -> bool {
+    let mut cache = LAST_REPORTED.lock().unwrap_or_else(|e| e.into_inner());
+    let key = (repo.to_string(), branch.to_string());
+    match cache.get(&key) {
+        Some(prev) if prev == head_sha => false,
+        _ => {
+            cache.insert(key, head_sha.to_string());
+            true
+        }
+    }
+}
+
+/// Test-only: clear the dedup cache so tests don't bleed into each other.
+#[cfg(test)]
+pub fn reset_dedup_for_test() {
+    LAST_REPORTED.lock().unwrap_or_else(|e| e.into_inner()).clear();
+}
+
+/// Full pipeline for one push observation: resolve git facts, apply dedup, and
+/// (when warranted) report via the registrar. Best-effort — logs and returns on
+/// any miss. Synchronous git calls are cheap and run on the tail task's thread.
+pub fn handle_push_observation(
+    obs: &PushObservation,
+    registrar: &crate::claude_session::coord_register::AiCoordRegistrar,
+) {
+    if !report_enabled() {
+        return;
+    }
+    let Some(resolved) = resolve_push(&obs.working_dir) else {
+        debug!(
+            "commit_report: could not resolve git push in {} — skipping",
+            obs.working_dir
+        );
+        return;
+    };
+    let head = &resolved.shas[0];
+    if !should_report(&resolved.repo, &resolved.branch, head) {
+        debug!(
+            "commit_report: {}@{} HEAD {} already reported — no-op",
+            resolved.repo, resolved.branch, head
+        );
+        return;
+    }
+    registrar.report_commits(&resolved.repo, &resolved.branch, resolved.shas);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn detects_plain_git_push() {
+        assert!(command_is_git_push("git push"));
+        assert!(command_is_git_push("git push -u origin feat/x"));
+        assert!(command_is_git_push(
+            "cd \"C:/repo\" && git push -u origin feat/x 2>&1 | tail -10"
+        ));
+        assert!(command_is_git_push("git -C /some/dir push origin main"));
+    }
+
+    #[test]
+    fn ignores_non_push_git() {
+        assert!(!command_is_git_push("git log --oneline"));
+        assert!(!command_is_git_push("git commit -m 'x'"));
+        assert!(!command_is_git_push("git status && echo done"));
+        // pushd is not push
+        assert!(!command_is_git_push("pushd /tmp"));
+        // dry-run pushes nothing
+        assert!(!command_is_git_push("git push --dry-run origin main"));
+    }
+
+    #[test]
+    fn ignores_non_git_commands() {
+        assert!(!command_is_git_push("npm run build"));
+        assert!(!command_is_git_push("echo git push"));
+    }
+
+    #[test]
+    fn resolve_dir_prefers_cd_prefix() {
+        assert_eq!(
+            resolve_working_dir("cd \"C:/repo/x\" && git push", "C:/fallback"),
+            "C:/repo/x"
+        );
+        assert_eq!(
+            resolve_working_dir("cd /home/u/proj && git push", "/fallback"),
+            "/home/u/proj"
+        );
+    }
+
+    #[test]
+    fn resolve_dir_uses_dash_c() {
+        assert_eq!(
+            resolve_working_dir("git -C /repo/y push origin main", "/fallback"),
+            "/repo/y"
+        );
+    }
+
+    #[test]
+    fn resolve_dir_falls_back_to_cwd() {
+        assert_eq!(resolve_working_dir("git push", "C:/the/cwd"), "C:/the/cwd");
+    }
+
+    #[test]
+    fn extract_pushes_from_assistant_record() {
+        let record = json!({
+            "type": "assistant",
+            "cwd": "C:/Users/x/repo",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "pushing now"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "git push -u origin feat/y"}},
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "/x"}},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "git status"}}
+                ]
+            }
+        });
+        let pushes = extract_push_observations(&record);
+        assert_eq!(pushes.len(), 1);
+        assert_eq!(pushes[0].working_dir, "C:/Users/x/repo");
+    }
+
+    #[test]
+    fn extract_pushes_honors_cd_prefix_over_cwd() {
+        let record = json!({
+            "type": "assistant",
+            "cwd": "C:/wrong",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Bash",
+                     "input": {"command": "cd \"C:/right/repo\" && git push 2>&1 | tail -5"}}
+                ]
+            }
+        });
+        let pushes = extract_push_observations(&record);
+        assert_eq!(pushes.len(), 1);
+        assert_eq!(pushes[0].working_dir, "C:/right/repo");
+    }
+
+    #[test]
+    fn parse_line_ignores_user_and_malformed() {
+        assert!(parse_line_for_pushes("not json").is_empty());
+        assert!(parse_line_for_pushes(
+            r#"{"type":"user","message":{"content":"git push"}}"#
+        )
+        .is_empty());
+        assert!(parse_line_for_pushes("").is_empty());
+    }
+
+    #[test]
+    fn parse_repo_full_name_ssh_and_https() {
+        assert_eq!(
+            parse_repo_full_name("git@github.com:qontinui/qontinui-runner.git").as_deref(),
+            Some("qontinui/qontinui-runner")
+        );
+        assert_eq!(
+            parse_repo_full_name("https://github.com/qontinui/qontinui-coord.git").as_deref(),
+            Some("qontinui/qontinui-coord")
+        );
+        assert_eq!(
+            parse_repo_full_name("https://github.com/qontinui/qontinui-web").as_deref(),
+            Some("qontinui/qontinui-web")
+        );
+        assert_eq!(parse_repo_full_name("not-a-url").as_deref(), None);
+        assert_eq!(parse_repo_full_name("https://host/onlyone").as_deref(), None);
+    }
+
+    #[test]
+    fn dedup_suppresses_repeat_same_head() {
+        reset_dedup_for_test();
+        assert!(should_report("o/r", "main", "sha1"), "first report fires");
+        assert!(
+            !should_report("o/r", "main", "sha1"),
+            "same HEAD is a no-op"
+        );
+        assert!(
+            should_report("o/r", "main", "sha2"),
+            "moved HEAD reports again"
+        );
+        // Different branch is independent.
+        assert!(should_report("o/r", "feat/x", "sha2"));
+    }
+}

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -4,6 +4,7 @@
 //! Each session spawns a native shell (PowerShell on Windows, $SHELL on Unix)
 //! with proper environment for running Claude CLI and other dev tools.
 
+pub mod commit_report;
 pub mod coord_warn;
 pub mod grid;
 pub mod interceptor;

--- a/src-tauri/src/terminal/transcript_watcher.rs
+++ b/src-tauri/src/terminal/transcript_watcher.rs
@@ -38,6 +38,7 @@ use super::transcript::{
     find_claude_config_dirs, is_workflow_session_marker, list_sessions,
     parse_line_for_touched_files,
 };
+use crate::claude_session::coord_register::AiCoordRegistrar;
 
 /// Ceiling for "recent enough to schedule a tail task on startup". Older
 /// JSONLs are skipped — they belong to closed sessions whose tabs the user
@@ -83,6 +84,7 @@ pub fn start_transcript_watcher(
     app_handle: tauri::AppHandle,
     pg: Arc<crate::database::pg::PgDb>,
     workspace_paths: Vec<String>,
+    registrar: Option<Arc<AiCoordRegistrar>>,
 ) -> Result<(), String> {
     if WATCHER.get().is_some() {
         return Err("transcript watcher already started".to_string());
@@ -96,7 +98,7 @@ pub fn start_transcript_watcher(
     // Spawn the orchestrator on the tokio runtime. It owns the channel, the
     // watcher, and the per-session task map.
     tauri::async_runtime::spawn(async move {
-        if let Err(e) = run_orchestrator(app_handle, pg, workspace_paths).await {
+        if let Err(e) = run_orchestrator(app_handle, pg, workspace_paths, registrar).await {
             warn!("transcript_watcher: orchestrator exited with error: {}", e);
         }
     });
@@ -111,6 +113,7 @@ async fn run_orchestrator(
     app_handle: tauri::AppHandle,
     pg: Arc<crate::database::pg::PgDb>,
     workspace_paths: Vec<String>,
+    registrar: Option<Arc<AiCoordRegistrar>>,
 ) -> Result<(), String> {
     let config_dirs = find_claude_config_dirs();
     if config_dirs.is_empty() {
@@ -162,6 +165,7 @@ async fn run_orchestrator(
                     jsonl,
                     pg.clone(),
                     app_handle.clone(),
+                    registrar.clone(),
                     /* start_at_eof */ true,
                 )
                 .await;
@@ -243,6 +247,7 @@ async fn run_orchestrator(
                         path.clone(),
                         pg.clone(),
                         app_handle.clone(),
+                        registrar.clone(),
                         /* start_at_eof */ false,
                     )
                     .await;
@@ -264,6 +269,7 @@ async fn run_orchestrator(
                             path.clone(),
                             pg.clone(),
                             app_handle.clone(),
+                            registrar.clone(),
                             /* start_at_eof */ true,
                         )
                         .await;
@@ -322,6 +328,7 @@ async fn schedule_tail(
     path: PathBuf,
     pg: Arc<crate::database::pg::PgDb>,
     app_handle: tauri::AppHandle,
+    registrar: Option<Arc<AiCoordRegistrar>>,
     start_at_eof: bool,
 ) {
     let mut map = tasks.lock().await;
@@ -349,6 +356,7 @@ async fn schedule_tail(
             path,
             pg,
             app_handle,
+            registrar,
             wake,
             cancel,
             start_at_eof,
@@ -374,6 +382,7 @@ async fn tail_session(
     path: PathBuf,
     pg: Arc<crate::database::pg::PgDb>,
     app_handle: tauri::AppHandle,
+    registrar: Option<Arc<AiCoordRegistrar>>,
     wake: Arc<Notify>,
     cancel: Arc<Notify>,
     start_at_eof: bool,
@@ -487,6 +496,23 @@ async fn tail_session(
                         "transcript_watcher: malformed JSON line in {}: {}",
                         session_id, e
                     );
+                }
+            }
+
+            // ── Commit ↔ session lineage push-report (Population path 2) ──
+            //
+            // Detect `git push` Bash tool_use blocks on this line and, for
+            // each, resolve repo/branch/SHAs and enqueue a coord outbox
+            // report. Best-effort; the git enumeration runs on a blocking
+            // pool so it never stalls the tail loop. Skipped entirely when no
+            // registrar (outbox) is wired.
+            if let Some(reg) = registrar.as_ref() {
+                let pushes = super::commit_report::parse_line_for_pushes(&line);
+                for obs in pushes {
+                    let reg = reg.clone();
+                    tauri::async_runtime::spawn_blocking(move || {
+                        super::commit_report::handle_push_observation(&obs, &reg);
+                    });
                 }
             }
         }


### PR DESCRIPTION
Implements Population path 2 of plan `2026-06-07-coord-commit-session-lineage.md` — the runner-side push-report emitter for commit↔session lineage.

## Trigger
On a transcript-observed successful **`git push`** in a Claude session's working directory, the runner enumerates the pushed branch's recent SHAs and enqueues a coord outbox report (`POST /coord/commits/report {repo, branch, shas[]}`). Coord resolves the session server-side from `(repo, branch)`; the body carries no session id.

A push (not a commit) is the robust signal: a SHA only becomes a shared, attributable fact once it reaches a remote. Commits can be amended/rebased/dropped before push.

## How
- Piggybacks on the existing `terminal::transcript_watcher` tail loop (already parses each session's JSONL `tool_use` blocks). New `terminal::commit_report` module parses `Bash` `tool_use` blocks for `git push`, resolves the working dir (`cd "<dir>" &&` prefix → `git -C <dir>` → transcript `cwd`), then runs `git remote get-url origin` + `git rev-parse --abbrev-ref HEAD` + `git log --format=%H -n25 <branch>` on a blocking pool.
- Reuses the existing coord **outbox** (`OutboxWriter` → `session/coord_sync.rs` drain), NOT a new HTTP client. New `SessionEventKind::CommitReport` ("commit_report") + drain arm POSTing with device auth + `X-Qontinui-Tenant-Id` header. The emit lives on `AiCoordRegistrar::report_commits` (same handle/conventions as Phase-0 session registration).
- **Dedup:** process-global `(repo, branch) → last HEAD SHA` cache suppresses no-op re-reports (coord is also `ON CONFLICT DO NOTHING`). Outbox seq lane is a deterministic UUIDv5 per `(repo, branch)` (coord ignores the id).
- **Gate:** `QONTINUI_COMMIT_LINEAGE_REPORT`, default ON (mirrors `QONTINUI_SESSION_AUTOMATION_REGISTER`). Always best-effort — never fails a session.

## Non-goals (honored)
No git hooks, no commit-message conventions, no client setup.

## Tests
16 unit tests pass (`cargo-guard test`): push detection (incl. `echo git push` / `git log` / `--dry-run` negatives), working-dir resolution, `parse_repo_full_name` (SSH+HTTPS), `(repo,branch)` dedup, and outbox round-trip for `report_commits` (payload shape, per-branch seq lane, empty-shas + disabled-gate no-ops). `cargo-guard check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)