### PR TITLE
feat(agent-worktree): Phase 5 fs_backstop — detect edits leaking into shared canonical checkouts

### DIFF
--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -262,7 +262,11 @@ fn resolve_tenant_id() -> Option<Uuid> {
 /// The parent dir under which the runner's canonical checkouts +
 /// sibling worktrees live. `QONTINUI_ROOT` env → `D:/qontinui-root`
 /// (Windows) → `$HOME/qontinui-root`. Mirrors `fleet::qontinui_root`.
-fn qontinui_root() -> Option<PathBuf> {
+///
+/// `pub(crate)` so the Phase 5 fs_backstop poller enumerates governed
+/// canonical checkouts under the SAME workspace root (env → Windows default →
+/// `$HOME`) the census walks — no second root-resolution to drift from.
+pub(crate) fn qontinui_root() -> Option<PathBuf> {
     if let Ok(s) = std::env::var("QONTINUI_ROOT") {
         let p = PathBuf::from(s);
         if p.is_dir() {
@@ -473,7 +477,7 @@ fn normalize_path_str(path: &Path) -> String {
 /// mis-treated as a repo root and re-listing a shared worktree under a phantom
 /// repo (which the coord `DISTINCT ON (device, repo, path)` read then keeps as a
 /// duplicate row).
-fn is_canonical_repo_dir(name: &str) -> bool {
+pub(crate) fn is_canonical_repo_dir(name: &str) -> bool {
     name.starts_with("qontinui-") && !name.contains("-wt-") && !name.ends_with("-wt")
 }
 
@@ -621,7 +625,7 @@ fn compute_landed_in_main(worktree: &Path) -> Option<bool> {
 /// Ξ_Worktree P7.3 — current branch of the canonical checkout
 /// (`git symbolic-ref --short HEAD`). `None` on detached HEAD (the command
 /// errors), an empty result, or any git failure.
-fn compute_canonical_branch(canonical: &Path) -> Option<String> {
+pub(crate) fn compute_canonical_branch(canonical: &Path) -> Option<String> {
     git_capture(canonical, &["symbolic-ref", "--short", "HEAD"]).filter(|s| !s.is_empty())
 }
 
@@ -630,7 +634,7 @@ fn compute_canonical_branch(canonical: &Path) -> Option<String> {
 /// uncommitted changes, `Some(false)` when clean, `None` on a git failure
 /// (fail-OPEN to `None` is fine: coord reads `None` as unsafe). This is the
 /// P1-clean precondition input for SharedBranch.
-fn compute_canonical_is_dirty(canonical: &Path) -> Option<bool> {
+pub(crate) fn compute_canonical_is_dirty(canonical: &Path) -> Option<bool> {
     git_capture(canonical, &["status", "--porcelain"]).map(|s| !s.trim().is_empty())
 }
 

--- a/src-tauri/src/agent_worktree/fs_backstop.rs
+++ b/src-tauri/src/agent_worktree/fs_backstop.rs
@@ -1,0 +1,592 @@
+//! Runner-side **fs_observer backstop** (Ξ_FS Phase 5) — a defense-in-depth
+//! DETECTOR (not a prevent mechanism) for edits that leaked OUTSIDE any
+//! session worktree.
+//!
+//! ## What it does
+//!
+//! A machine-wide periodic scanner. Each tick it enumerates the SHARED
+//! canonical checkouts (`<root>/<repo>/`, the same governed set the census
+//! walks) and, for each one that is **dirty** (uncommitted working-tree
+//! changes) AND **not covered by any live `kind=worktree` coord claim**,
+//! POSTs the drift to coord's existing `POST /coord/fs/observations` ingest
+//! tagged `source: "canonical_drift"`.
+//!
+//! "Dirty AND unclaimed" is the leak signature: Phases 1+2 register a
+//! `kind=worktree` claim for every checkout a session legitimately
+//! materializes / shared-branches in (keyed on the canonical path via
+//! [`super::worktree_resource_key`]). So a checkout that is dirty with NO
+//! holder is an edit the runner never provisioned — e.g. a VS Code
+//! native-panel agent operating directly in the canonical tree.
+//!
+//! ## Why reuse `/coord/fs/observations` (not a new endpoint)
+//!
+//! Self-contained + immediately functional: coord already accepts that body
+//! and ignores the extra `source`/`device_id`/… fields forward-compatibly.
+//! A coord-side dashboard alarm keyed on `source=canonical_drift` is a
+//! separate follow-up; the coord POST + the runner `warn!` line ARE the
+//! alarm here.
+//!
+//! ## Tier-1 only — surface/attribute, never mutate
+//!
+//! This reconcile is detection only: NO auto-stash, no working-tree
+//! mutation. It reads (`git status`, a libgit2 diff) and POSTs. Tier-2
+//! (auto-stash) is deferred.
+//!
+//! ## Suppression contract (never false-alarm)
+//!
+//! An alarm fires STRICTLY on dirty AND a `null` `by-resource` holder. Any
+//! other shape suppresses:
+//!   - a non-null holder (claimed — including a legitimate `SharedBranch`
+//!     self-claim) ⇒ suppress;
+//!   - a lookup ERROR or coord-unreachable ⇒ suppress (we can't prove the
+//!     checkout is unclaimed, so we never alarm);
+//!   - a clean checkout, or zero reportable observations ⇒ suppress.
+//!
+//! ## Gating
+//!
+//! Behind [`FS_BACKSTOP_FLAG_ENV`] (`QONTINUI_FS_BACKSTOP_ENABLED`),
+//! **default off**, best-effort, NEVER blocking. Cadence from
+//! [`FS_BACKSTOP_INTERVAL_ENV`] (default 300s, floor 30s). Runs on the
+//! non-Tauri fleet-publishers runtime (no `AppHandle`) — there is no banner.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::Serialize;
+use tracing::{debug, info, warn};
+
+use super::fs_observer::FsObservation;
+
+/// Env flag that turns the fs_observer backstop on. Default off. Accepts the
+/// usual truthy values; anything else (including unset) is false. Matches the
+/// truthy-set used by [`super::fs_observer::fs_observer_enabled`].
+pub const FS_BACKSTOP_FLAG_ENV: &str = "QONTINUI_FS_BACKSTOP_ENABLED";
+
+/// Cadence env var for the backstop poller. Default 300s, floored at 30s
+/// (mirrors the census / reclaim cadence knobs).
+pub const FS_BACKSTOP_INTERVAL_ENV: &str = "QONTINUI_FS_BACKSTOP_INTERVAL_SECS";
+
+/// Default backstop cadence in seconds — an order of magnitude slower than
+/// the heartbeat, matching the census/reclaim pollers.
+const DEFAULT_FS_BACKSTOP_INTERVAL_SECS: u64 = 300;
+
+/// Floor for the cadence — never tighter than 30s regardless of env.
+const FS_BACKSTOP_INTERVAL_FLOOR_SECS: u64 = 30;
+
+/// Returns true iff the fs_observer backstop is enabled. Default off.
+pub fn fs_backstop_enabled() -> bool {
+    matches!(
+        std::env::var(FS_BACKSTOP_FLAG_ENV).ok().as_deref(),
+        Some("1") | Some("true") | Some("TRUE") | Some("yes") | Some("YES")
+    )
+}
+
+/// Resolve the poller cadence from [`FS_BACKSTOP_INTERVAL_ENV`], defaulting to
+/// [`DEFAULT_FS_BACKSTOP_INTERVAL_SECS`] and flooring at
+/// [`FS_BACKSTOP_INTERVAL_FLOOR_SECS`]. (Copy of the census interval helper.)
+fn interval_secs() -> u64 {
+    std::env::var(FS_BACKSTOP_INTERVAL_ENV)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_FS_BACKSTOP_INTERVAL_SECS)
+        .max(FS_BACKSTOP_INTERVAL_FLOOR_SECS)
+}
+
+/// A live `kind=worktree` claim holder, as parsed from coord's
+/// `GET /coord/claims/by-resource`. Only the fields we log are captured; an
+/// object response (any holder) is enough to SUPPRESS the alarm.
+#[derive(Debug, Clone)]
+pub struct Holder {
+    pub machine_id: Option<String>,
+    pub session_id: Option<String>,
+}
+
+/// GET the live `kind=worktree` claim holder for `resource_key`.
+///
+/// Returns `Ok(None)` when coord answers `null` (no holder — the leak
+/// signature), `Ok(Some(holder))` when an object is returned (claimed —
+/// suppress), and `Err` on any transport / non-2xx / parse failure (the
+/// caller treats an `Err` as "can't prove unclaimed" and suppresses).
+///
+/// Near-verbatim from `terminal::coord_warn::check_and_warn`'s by-resource
+/// lookup, minus the peer/self disambiguation: for the backstop ANY holder
+/// (peer OR our own SharedBranch self-claim) is a legitimate cover that
+/// suppresses the alarm.
+pub async fn canonical_checkout_claim_holder(
+    coord_base: &str,
+    resource_key: &str,
+) -> Result<Option<Holder>, String> {
+    let url = format!(
+        "{}/coord/claims/by-resource?kind=worktree&key={}",
+        coord_base.trim_end_matches('/'),
+        urlencoding::encode(resource_key),
+    );
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("build client: {e}"))?;
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("GET {url}: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("GET by-resource {}", resp.status().as_u16()));
+    }
+    let body: serde_json::Value = resp.json().await.map_err(|e| format!("parse body: {e}"))?;
+    Ok(parse_by_resource_holder(&body))
+}
+
+/// Pure parse of a `by-resource` body into an optional [`Holder`]: `null`
+/// ⇒ `None`, an object ⇒ `Some`. Extracted so the null-vs-object decision is
+/// unit-testable without a live coord.
+fn parse_by_resource_holder(body: &serde_json::Value) -> Option<Holder> {
+    if body.is_null() {
+        return None;
+    }
+    Some(Holder {
+        machine_id: body
+            .get("machine_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        session_id: body
+            .get("session_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
+}
+
+/// Body of the backstop's `POST /coord/fs/observations`. A SUPERSET of
+/// `fs_observer::FsObservationsRequest` — coord deserializes the
+/// `observations` it knows and ignores the extra `source`/`device_id`/…
+/// fields forward-compatibly. `source: "canonical_drift"` is the
+/// distinguishing tag a coord-side dashboard alarm keys on (follow-up).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct CanonicalDriftRequest {
+    /// Distinguishes a backstop drift from a normal worktree observation.
+    /// Always `"canonical_drift"`.
+    pub source: &'static str,
+    pub device_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repo: Option<String>,
+    pub canonical_path: String,
+    pub head_sha: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant_id: Option<uuid::Uuid>,
+    pub observations: Vec<FsObservation>,
+}
+
+/// The `source` tag value for a backstop drift POST.
+const CANONICAL_DRIFT_SOURCE: &str = "canonical_drift";
+
+/// PURE alarm decision: alarm iff the checkout is dirty AND has reportable
+/// observations AND no holder covers it. A non-null `holder` (claimed,
+/// including a legitimate SharedBranch self-claim) suppresses; a clean
+/// checkout suppresses; zero observations suppress. Callers map a lookup
+/// ERROR / coord-unreachable to "can't prove unclaimed" by NOT calling this
+/// (they suppress directly), so this function only ever sees a proven holder
+/// state.
+pub fn should_alarm(is_dirty: bool, holder: Option<&Holder>, obs_len: usize) -> bool {
+    is_dirty && holder.is_none() && obs_len > 0
+}
+
+/// Enumerate the governed canonical checkouts under `root`: every top-level
+/// `qontinui-*` dir that is a CANONICAL repo root (not a `-wt-`/`-wt` worktree
+/// dir) and has a `.git`. Reuses the census enumeration predicate
+/// [`super::census::is_canonical_repo_dir`] so the backstop governs exactly
+/// the set the census reports — they never drift.
+///
+/// Returns `(repo_name, canonical_path)` pairs.
+fn governed_canonical_checkouts(root: &Path) -> Vec<(String, PathBuf)> {
+    let mut out: Vec<(String, PathBuf)> = Vec::new();
+    let entries = match std::fs::read_dir(root) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        if !super::census::is_canonical_repo_dir(&name) {
+            continue;
+        }
+        if path.join(".git").exists() {
+            out.push((name, path));
+        }
+    }
+    out
+}
+
+/// Read `active_tenant_id` from `~/.qontinui/machine.json` (advisory — coord
+/// DB-resolves the real tenant). `None` for single-tenant operators, which is
+/// fine. Mirrors `census::resolve_tenant_id` (which is private; the read is
+/// trivial and tenant attribution is best-effort).
+fn resolve_tenant_id() -> Option<uuid::Uuid> {
+    let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
+    let bytes = std::fs::read(path).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let raw = value.get("active_tenant_id").and_then(|v| v.as_str())?;
+    uuid::Uuid::parse_str(raw.trim()).ok()
+}
+
+/// One scanned checkout's drift, assembled on the blocking pool: the dirty
+/// gate already passed and observations were collected. The async tick then
+/// performs the (async) claim lookup + POST per item.
+struct ScannedDrift {
+    repo: String,
+    canonical_path: PathBuf,
+    resource_key: String,
+    head_sha: String,
+    current_branch: Option<String>,
+    observations: Vec<FsObservation>,
+}
+
+/// Synchronous disk-walk + git half of a tick: enumerate governed checkouts,
+/// apply the cheap dirty gate, and for each dirty checkout collect its
+/// uncommitted observations + branch + HEAD. Returns the candidates that are
+/// dirty with ≥1 reportable observation (the async half does the claim
+/// lookup + POST). Runs under `spawn_blocking`.
+fn scan_drift_candidates(root: &Path) -> Vec<ScannedDrift> {
+    let mut out: Vec<ScannedDrift> = Vec::new();
+    for (repo, canonical) in governed_canonical_checkouts(root) {
+        // Cheap dirty gate first — reuse the census `git status --porcelain`
+        // probe. `None` (git failure) ⇒ treat as not-dirty (degrade honestly,
+        // never alarm on a checkout we can't read).
+        let is_dirty = super::census::compute_canonical_is_dirty(&canonical).unwrap_or(false);
+        if !is_dirty {
+            continue;
+        }
+        // Resolve the uncommitted observations against the checkout's own HEAD
+        // (reuses the gitignore/denylist/blob-sha/hunk/cap logic).
+        let observations = match super::fs_observer::collect_uncommitted_observations(&canonical) {
+            Ok(o) => o,
+            Err(e) => {
+                debug!(
+                    repo = %repo,
+                    path = %canonical.display(),
+                    error = %e,
+                    "fs_backstop: collect failed — skipping checkout"
+                );
+                continue;
+            }
+        };
+        if observations.is_empty() {
+            // Dirty only in denylisted/ignored noise — nothing reportable.
+            continue;
+        }
+        // HEAD sha + current branch for the request (best-effort; HEAD must
+        // resolve since collect_uncommitted_observations already opened it).
+        let head_sha = match resolve_head_sha(&canonical) {
+            Some(sha) => sha,
+            None => {
+                debug!(
+                    repo = %repo,
+                    path = %canonical.display(),
+                    "fs_backstop: HEAD unresolved — skipping checkout"
+                );
+                continue;
+            }
+        };
+        let current_branch = super::census::compute_canonical_branch(&canonical);
+        let resource_key = super::worktree_resource_key(&canonical);
+        out.push(ScannedDrift {
+            repo,
+            canonical_path: canonical,
+            resource_key,
+            head_sha,
+            current_branch,
+            observations,
+        });
+    }
+    out
+}
+
+/// Resolve a checkout's current HEAD sha via libgit2 (same pattern as
+/// `edit_effect_loop::worktree_head_sha`). `None` on any error.
+fn resolve_head_sha(checkout: &Path) -> Option<String> {
+    let repo = git2::Repository::open(checkout).ok()?;
+    let head = repo.head().ok()?;
+    Some(head.target()?.to_string())
+}
+
+/// POST a built [`CanonicalDriftRequest`] to coord's existing fs-observations
+/// ingest. Best-effort: any transport error / non-2xx logs and returns — the
+/// backstop never surfaces a coord failure.
+async fn post_canonical_drift(coord_base: &str, body: &CanonicalDriftRequest) {
+    let url = format!("{}/coord/fs/observations", coord_base.trim_end_matches('/'));
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("fs_backstop: build http client failed: {e}");
+            return;
+        }
+    };
+    // Attach the device-JWT bearer when available (same write-path attach the
+    // fs_observer producer uses; collapses to an anonymous send when unpaired).
+    let req = crate::auth::attach_device_auth(client.post(&url));
+    match req.json(body).send().await {
+        Ok(resp) => {
+            let status = resp.status();
+            if status.is_success() {
+                info!(
+                    repo = %body.repo.as_deref().unwrap_or("?"),
+                    path = %body.canonical_path,
+                    n = body.observations.len(),
+                    "fs_backstop: ALARM — canonical checkout dirty + unclaimed, posted canonical_drift"
+                );
+            } else {
+                let txt = resp.text().await.unwrap_or_default();
+                warn!(
+                    url = %url,
+                    status = status.as_u16(),
+                    body = %txt,
+                    "fs_backstop: coord returned non-2xx (soft failure)"
+                );
+            }
+        }
+        Err(e) => {
+            debug!(url = %url, error = %e, "fs_backstop: post failed (coord unreachable)");
+        }
+    }
+}
+
+/// One backstop cycle: scan governed canonical checkouts, and for each that is
+/// dirty + unclaimed with reportable observations, POST a `canonical_drift`
+/// alarm. Gated on [`fs_backstop_enabled`] — a no-op (returns `Ok`) when off.
+///
+/// Returns `Ok(())` on a clean skip OR after best-effort POSTs (a coord
+/// failure is swallowed inside [`post_canonical_drift`], never surfaced). The
+/// disk-walk + git runs under `spawn_blocking`; the claim lookups + POSTs run
+/// async.
+pub async fn tick_once() -> Result<(), String> {
+    if !fs_backstop_enabled() {
+        return Ok(());
+    }
+    let device_id = match super::census::load_device_id_pub() {
+        Some(id) => id.to_string(),
+        None => {
+            debug!("fs_backstop: no device_id — skipping");
+            return Ok(());
+        }
+    };
+    let coord_base = match super::census::coord_http_base_pub() {
+        Some(b) => b,
+        None => {
+            debug!("fs_backstop: no coord_url configured — skipping");
+            return Ok(());
+        }
+    };
+    let root = match super::census::qontinui_root() {
+        Some(r) => r,
+        None => {
+            debug!("fs_backstop: no qontinui-root dir resolved — skipping");
+            return Ok(());
+        }
+    };
+
+    // Disk-walk + git (status probe + libgit2 diff per dirty checkout) is a
+    // synchronous multi-second walk — run it off the async worker, matching
+    // the census/reclaim pattern.
+    let candidates = tokio::task::spawn_blocking(move || scan_drift_candidates(&root))
+        .await
+        .map_err(|e| format!("fs_backstop scan panicked: {e}"))?;
+
+    let tenant_id = resolve_tenant_id();
+
+    for c in candidates {
+        // Claim lookup — an ERROR / coord-unreachable SUPPRESSES (can't prove
+        // unclaimed). Only a proven `null` holder lets the alarm through.
+        let holder = match canonical_checkout_claim_holder(&coord_base, &c.resource_key).await {
+            Ok(h) => h,
+            Err(e) => {
+                debug!(
+                    repo = %c.repo,
+                    key = %c.resource_key,
+                    error = %e,
+                    "fs_backstop: claim lookup failed — suppressing (can't prove unclaimed)"
+                );
+                continue;
+            }
+        };
+        if !should_alarm(true, holder.as_ref(), c.observations.len()) {
+            debug!(
+                repo = %c.repo,
+                key = %c.resource_key,
+                claimed = holder.is_some(),
+                "fs_backstop: suppressed (covered by a live worktree claim)"
+            );
+            continue;
+        }
+        let body = CanonicalDriftRequest {
+            source: CANONICAL_DRIFT_SOURCE,
+            device_id: device_id.clone(),
+            repo: Some(c.repo.clone()),
+            canonical_path: super::worktree_resource_key(&c.canonical_path),
+            head_sha: c.head_sha,
+            current_branch: c.current_branch,
+            tenant_id,
+            observations: c.observations,
+        };
+        post_canonical_drift(&coord_base, &body).await;
+    }
+    Ok(())
+}
+
+/// Spawn the periodic backstop poller on the ambient tokio runtime. Interval
+/// from [`FS_BACKSTOP_INTERVAL_ENV`] (default 300s, floor 30s).
+/// `MissedTickBehavior::Skip` + warn-and-retry, like
+/// [`super::census::spawn_census`] / [`super::reclaim::spawn_reclaim`]. The
+/// loop never panics; the gate is re-checked every tick inside
+/// [`tick_once`] so flipping the flag at runtime takes effect.
+pub fn spawn_backstop() {
+    let secs = interval_secs();
+    info!(
+        "fs_backstop: starting periodic backstop poller, interval={}s (flag {} gates each tick)",
+        secs, FS_BACKSTOP_FLAG_ENV
+    );
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = tick_once().await {
+                warn!("fs_backstop: {e}");
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent_worktree::canonical_paths::default_canonical_path;
+    use crate::agent_worktree::worktree_resource_key;
+
+    #[test]
+    fn enabled_is_false_by_default() {
+        // Holds as long as no concurrent test set the flag (env is global).
+        if std::env::var(FS_BACKSTOP_FLAG_ENV).is_err() {
+            assert!(!fs_backstop_enabled());
+        }
+    }
+
+    #[test]
+    fn interval_defaults_and_floors() {
+        // With the env unset, the default applies.
+        if std::env::var(FS_BACKSTOP_INTERVAL_ENV).is_err() {
+            assert_eq!(interval_secs(), DEFAULT_FS_BACKSTOP_INTERVAL_SECS);
+        }
+        // Floor is below the default — sanity on the constants (const block so
+        // clippy doesn't flag the constant-value assertion).
+        const { assert!(FS_BACKSTOP_INTERVAL_FLOOR_SECS <= DEFAULT_FS_BACKSTOP_INTERVAL_SECS) };
+    }
+
+    #[test]
+    fn parse_holder_null_is_none() {
+        assert!(parse_by_resource_holder(&serde_json::Value::Null).is_none());
+    }
+
+    #[test]
+    fn parse_holder_object_is_some() {
+        let v = serde_json::json!({
+            "machine_id": "11111111-1111-1111-1111-111111111111",
+            "session_id": "22222222-2222-2222-2222-222222222222",
+        });
+        let h = parse_by_resource_holder(&v).expect("object => Some");
+        assert_eq!(
+            h.machine_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        assert_eq!(
+            h.session_id.as_deref(),
+            Some("22222222-2222-2222-2222-222222222222")
+        );
+    }
+
+    #[test]
+    fn parse_holder_object_missing_fields_still_some() {
+        // Any object => a holder => SUPPRESS, even if it omits ids.
+        let v = serde_json::json!({});
+        let h = parse_by_resource_holder(&v);
+        assert!(h.is_some(), "an empty object is still a holder");
+        let h = h.unwrap();
+        assert!(h.machine_id.is_none());
+        assert!(h.session_id.is_none());
+    }
+
+    #[test]
+    fn should_alarm_truth_table() {
+        let holder = Holder {
+            machine_id: Some("m".into()),
+            session_id: None,
+        };
+        // dirty + null holder + obs > 0 => ALARM.
+        assert!(should_alarm(true, None, 1));
+        // dirty + a holder (claimed, incl. SharedBranch self-claim) => suppress.
+        assert!(!should_alarm(true, Some(&holder), 1));
+        // clean => suppress regardless of holder/obs.
+        assert!(!should_alarm(false, None, 1));
+        assert!(!should_alarm(false, Some(&holder), 1));
+        // dirty + null holder but zero observations => suppress.
+        assert!(!should_alarm(true, None, 0));
+    }
+
+    #[test]
+    fn request_serializes_to_coord_contract() {
+        // Build the canonical path portably (no hardcoded d:/qontinui-root
+        // literal) so the test runs on every platform.
+        let canonical = default_canonical_path("qontinui-runner").unwrap();
+        let key = worktree_resource_key(&canonical);
+        let req = CanonicalDriftRequest {
+            source: CANONICAL_DRIFT_SOURCE,
+            device_id: "dev-1".into(),
+            repo: Some("qontinui-runner".into()),
+            canonical_path: key.clone(),
+            head_sha: "abc123".into(),
+            current_branch: Some("main".into()),
+            tenant_id: None,
+            observations: vec![FsObservation {
+                path: "src/leaked.rs".into(),
+                pre_sha: Some("aaa".into()),
+                post_sha: "bbb".into(),
+                hunks: serde_json::json!([]),
+            }],
+        };
+        let v = serde_json::to_value(&req).expect("serialize");
+        // The distinguishing tag coord (eventually) alarms on.
+        assert_eq!(v["source"], "canonical_drift");
+        assert_eq!(v["device_id"], "dev-1");
+        assert_eq!(v["repo"], "qontinui-runner");
+        assert_eq!(v["canonical_path"], key);
+        assert_eq!(v["head_sha"], "abc123");
+        assert_eq!(v["current_branch"], "main");
+        // tenant_id omitted (skip-if-none) — absent, not null.
+        assert!(v.get("tenant_id").is_none());
+        // observations reuse the fs_observer FsObservation shape.
+        let obs = v["observations"].as_array().unwrap();
+        assert_eq!(obs.len(), 1);
+        assert_eq!(obs[0]["path"], "src/leaked.rs");
+        assert_eq!(obs[0]["pre_sha"], "aaa");
+        assert_eq!(obs[0]["post_sha"], "bbb");
+    }
+
+    #[tokio::test]
+    async fn tick_once_is_ok_noop_when_flag_off() {
+        // With the flag off (default), tick_once short-circuits to Ok without
+        // touching disk / coord. Only assert when the flag isn't set by a
+        // concurrent test (env is global).
+        if std::env::var(FS_BACKSTOP_FLAG_ENV).is_err() {
+            assert!(tick_once().await.is_ok());
+        }
+    }
+}

--- a/src-tauri/src/agent_worktree/fs_observer.rs
+++ b/src-tauri/src/agent_worktree/fs_observer.rs
@@ -339,6 +339,38 @@ pub fn collect_observations(
     Ok(out)
 }
 
+/// Phase 5 (fs_observer backstop) — collect the uncommitted edits of an
+/// arbitrary checkout against its OWN current `HEAD`.
+///
+/// Unlike [`collect_observations`], whose `parent_sha` is the base commit an
+/// agent worktree branched from, this resolves the checkout's `HEAD` via
+/// libgit2 (the same `repo.head()?.target()` pattern the verify side uses in
+/// `edit_effect_loop::worktree_head_sha`) and delegates to
+/// [`collect_observations`] so it reuses ALL of the gitignore / denylist /
+/// blob-sha / hunk / cap logic — there is no second diff implementation.
+///
+/// The fs_backstop poller uses this to surface the working-tree drift of a
+/// SHARED canonical checkout that is dirty AND not covered by any live
+/// `kind=worktree` claim (an edit that leaked outside a session worktree).
+///
+/// Errors (not a git repo, unborn/detached HEAD we can't resolve, libgit2
+/// failure) are returned as `Err` so the caller degrades honestly — it never
+/// alarms on a checkout it couldn't read.
+pub fn collect_uncommitted_observations(
+    checkout_path: &Path,
+) -> Result<Vec<FsObservation>, String> {
+    let repo = git2::Repository::open(checkout_path)
+        .map_err(|e| format!("open checkout {}: {e}", checkout_path.display()))?;
+    let head = repo
+        .head()
+        .map_err(|e| format!("resolve HEAD of {}: {e}", checkout_path.display()))?;
+    let head_sha = head
+        .target()
+        .ok_or_else(|| format!("HEAD of {} has no target oid", checkout_path.display()))?
+        .to_string();
+    collect_observations(checkout_path, &head_sha)
+}
+
 /// Derive a repo basename from a worktree path or coord repo slug. Coord
 /// stores `repo` as an optional basename; we send the leaf dir name of the
 /// canonical repo (e.g. `owner/qontinui-runner` ⇒ `qontinui-runner`).
@@ -710,5 +742,41 @@ mod tests {
         let (_dir, repo, parent_sha) = init_repo();
         let obs = collect_observations(&repo, &parent_sha).expect("collect");
         assert!(obs.is_empty(), "clean worktree yields no observations");
+    }
+
+    // ---- Phase 5: collect_uncommitted_observations (HEAD-relative) --------
+
+    #[test]
+    fn collect_uncommitted_reports_modified_and_new_skips_ignored() {
+        let (_dir, repo, _head) = init_repo();
+        // Modify a tracked file + add an untracked one.
+        std::fs::write(repo.join("kept.rs"), "// v2 modified\n").unwrap();
+        std::fs::write(repo.join("added.rs"), "// brand new\n").unwrap();
+        // gitignored file must NOT appear.
+        std::fs::write(repo.join("ignored.txt"), "scratch\n").unwrap();
+
+        let obs = collect_uncommitted_observations(&repo).expect("collect uncommitted");
+        let paths: HashSet<&str> = obs.iter().map(|o| o.path.as_str()).collect();
+        assert!(paths.contains("kept.rs"), "modified tracked file reported");
+        assert!(paths.contains("added.rs"), "new file reported");
+        assert!(
+            !paths.contains("ignored.txt"),
+            "gitignored file must be dropped: {:?}",
+            paths
+        );
+
+        // Resolves HEAD itself — pre_sha of a modified file is the HEAD blob.
+        let kept = obs.iter().find(|o| o.path == "kept.rs").unwrap();
+        assert_eq!(
+            kept.pre_sha.as_deref(),
+            Some(blob_sha_for_bytes(b"// v1\n").unwrap().as_str())
+        );
+    }
+
+    #[test]
+    fn collect_uncommitted_empty_when_clean() {
+        let (_dir, repo, _head) = init_repo();
+        let obs = collect_uncommitted_observations(&repo).expect("collect uncommitted");
+        assert!(obs.is_empty(), "clean checkout yields no observations");
     }
 }

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -60,6 +60,7 @@ use crate::worktree::run_git_command;
 pub mod canonical_paths;
 pub mod census;
 pub mod edit_effect_loop;
+pub mod fs_backstop;
 pub mod fs_observer;
 pub mod isolated_edit;
 pub mod reclaim;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -565,6 +565,16 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS). Same machine-
                 // wide, anonymous, device-keyed posture as the census.
                 agent_worktree::reclaim::spawn_reclaim();
+                // Ξ_FS backstop (Phase 5) — a defense-in-depth DETECTOR for
+                // edits that leaked OUTSIDE any session worktree. Periodically
+                // scans the SHARED canonical checkouts; alarms (POST
+                // /coord/fs/observations with source=canonical_drift) on a
+                // checkout that is dirty AND not covered by any live
+                // kind=worktree claim. Tier-1 surface/attribute only — never
+                // mutates the working tree. Gated OFF by default
+                // (QONTINUI_FS_BACKSTOP_ENABLED); best-effort, never blocking.
+                // Default 300s cadence (QONTINUI_FS_BACKSTOP_INTERVAL_SECS).
+                agent_worktree::fs_backstop::spawn_backstop();
                 // Phase 4 — coord-driven Claude Code subprocess runtime.
                 // Subscribes to `events.agent.spawn_requested.<device_id>`
                 // on coord WS and supervises the resulting `claude` CLI


### PR DESCRIPTION
## Phase 5 — fs_observer backstop (session-scoped multi-repo workspace coordination)

Follows #447 (Phase 1) + #477 (Phase 2). A defense-in-depth **detector** — load-bearing per P0b-i (PreToolUse hooks don't fire in the VS Code native panel, so an unprovisioned session can edit a shared checkout undetected).

### What it does
A machine-wide periodic scanner (`fs_backstop.rs`, alongside census/reclaim) alarms when a canonical checkout (`D:/qontinui-root/<repo>`) is **dirty AND covered by no live `kind=worktree` claim** — an edit that leaked outside any session worktree.

- `collect_uncommitted_observations()` reuses `fs_observer`'s diff machinery against the checkout's own HEAD (gitignore/denylist/blob-sha/hunk/cap for free).
- `should_alarm(dirty && unclaimed && obs>0)` — pure, unit-tested. A non-null holder (incl. legit SharedBranch self-claim) suppresses; a claim-lookup error / coord-unreachable suppresses (never false-alarm).
- Reuses the live `POST /coord/fs/observations` with `source:"canonical_drift"` — **no coord-side dependency**; a coord dashboard alarm on that source is a follow-up.
- **Tier-1 surface only** — no working-tree mutation (auto-stash deferred). Flag `QONTINUI_FS_BACKSTOP_ENABLED` (default OFF), cadence `QONTINUI_FS_BACKSTOP_INTERVAL_SECS` (300, floor 30).

### Verification
20 tests pass (9 fs_backstop incl. the should_alarm truth table + serialization contract, 2 new fs_observer); clippy `-D warnings` + `cargo fmt` clean. (census helpers widened to `pub(crate)`, no logic change.)
