### PR TITLE
fix(sccache): pin SCCACHE_SERVER_PORT=4230 (off Docker-hijacked 4226)

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -27,6 +27,11 @@
 SCCACHE_BUCKET = { value = "qontinui-sccache-shared", force = false }
 SCCACHE_REGION = { value = "us-east-1", force = false }
 SCCACHE_S3_KEY_PREFIX = { value = "sccache", force = false }
+# Ξ_sccache: Docker/WSL hold sccache's default port 4226 on the build hosts;
+# clients that land there wedge ("version mismatch") + respawn. Pin off 4226 so
+# every cargo-spawned sccache client agrees on the port regardless of OS-env
+# inheritance (the User-env value was not inherited by all contexts).
+SCCACHE_SERVER_PORT = { value = "4230", force = false }
 # SCCACHE_S3_USE_SSL omitted — defaults on for real AWS S3.
 # SCCACHE_ENDPOINT / SCCACHE_MINIO_HOST omitted — real S3 uses the
 # default regional endpoint; in-stack MinIO env stays in docker-compose.


### PR DESCRIPTION
Pins sccache's server port off Docker's default-4226 hijack — the real cause of the recurring 'version mismatch' wedge that silently failed builds (broke 2 runner deploys this session). Adds `SCCACHE_SERVER_PORT = { value = "4230", force = false }` to .cargo/config.toml [env]. Creds were verified working (not the cause). Config-only; no deploy. See memory reference_sccache_stale_daemon.