### PR TITLE
feat(federation): runner forwards its device-JWT bearer on coord memory calls

### DIFF
--- a/src-tauri/src/observable_bridge/memory_client.rs
+++ b/src-tauri/src/observable_bridge/memory_client.rs
@@ -80,9 +80,7 @@ pub async fn list(
     let resp = client
         .get(&url)
         .header(TENANT_HEADER, tenant_id.to_string())
-        // bearer_auth deferred: coord anonymous-pilot posture doesn't
-        // validate JWT; re-enable when Phase 7 SSO lands.
-        // .bearer_auth(device_token)
+        .bearer_auth(device_token)
         .send()
         .await
         .with_context(|| format!("GET {url}"))?;
@@ -110,9 +108,7 @@ pub async fn get(
     let resp = client
         .get(&url)
         .header(TENANT_HEADER, tenant_id.to_string())
-        // bearer_auth deferred: coord anonymous-pilot posture doesn't
-        // validate JWT; re-enable when Phase 7 SSO lands.
-        // .bearer_auth(device_token)
+        .bearer_auth(device_token)
         .send()
         .await
         .with_context(|| format!("GET {url}"))?;
@@ -140,9 +136,7 @@ pub async fn upsert(
     let resp = client
         .post(&url)
         .header(TENANT_HEADER, tenant_id.to_string())
-        // bearer_auth deferred: coord anonymous-pilot posture doesn't
-        // validate JWT; re-enable when Phase 7 SSO lands.
-        // .bearer_auth(device_token)
+        .bearer_auth(device_token)
         .json(req)
         .send()
         .await
@@ -171,9 +165,7 @@ pub async fn post_federation_report(
     let resp = client
         .post(&url)
         .header(TENANT_HEADER, tenant_id.to_string())
-        // bearer_auth deferred: coord anonymous-pilot posture doesn't
-        // validate JWT; re-enable when Phase 7 SSO lands.
-        // .bearer_auth(device_token)
+        .bearer_auth(device_token)
         .json(body)
         .send()
         .await
@@ -201,9 +193,7 @@ pub async fn delete(
     let resp = client
         .delete(&url)
         .header(TENANT_HEADER, tenant_id.to_string())
-        // bearer_auth deferred: coord anonymous-pilot posture doesn't
-        // validate JWT; re-enable when Phase 7 SSO lands.
-        // .bearer_auth(device_token)
+        .bearer_auth(device_token)
         .send()
         .await
         .with_context(|| format!("DELETE {url}"))?;


### PR DESCRIPTION
## What
Phase 2 (runner side) of `2026-06-07-memory-federation-multi-user-auth-redesign`. Un-comments `bearer_auth(device_token)` at all 5 `memory_client` call sites (list/get/upsert/post_federation_report/delete) so the runner actually authenticates its federation calls.

## Why
coord #440 made `/coord/memory/*` + `/coord/federation/*` accept a device-JWT via `FleetPrincipal`. Until now the runner left the bearer commented out, so every federation call was **403'd-and-swallowed** — silently breaking memory federation for any non-operator user (the whole works-for-users gap this plan closes).

## Risk retired
The forwarded token (`AuthManager::get_access_token` = the coord-issued device-JWT) **carries a `tenant_id` claim** — minted by `pair-complete` via `issue_device(.., Some(tenant_id), ..)` (`routes_phase3.rs`), which `FleetPrincipal`'s device branch resolves the tenant from. So this authenticates rather than fail-closing. The `X-Qontinui-Tenant-Id` header is left transitionally (coord no longer reads it).

## Test
Local `cargo clippy --tests` clean (8m). End-to-end: once a runner rebuilds, a session-end reconcile will POST with the bearer → coord resolves the tenant → 200 (the #417 `tenant_not_resolved` telemetry stops firing for this runner).