### PR TITLE
feat(federation): surface reconcile-level errors + adaptive cross-device copy

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -43,6 +43,15 @@ pub const RECONCILE_EVENT: &str = "memory-federation:reconcile";
 /// (<reason>)" notice instead of the old silent warn-only behavior.
 pub const SKIP_EVENT: &str = "memory-federation:skipped";
 
+/// Tauri event channel for reconcile-LEVEL failure broadcasts. Distinct
+/// from per-file `failed_names` (which ride on [`RECONCILE_EVENT`]): this
+/// fires when the whole reconcile returns `Err` and no `ReconcileReport`
+/// is produced at all. Mirrors [`SKIP_EVENT`]: the spawn site emits a
+/// one-line `{ session_id, account, error }` payload here so the React
+/// frontend can surface a sticky "reconcile failed" notice instead of the
+/// old silent warn-only behavior.
+pub const ERROR_EVENT: &str = "memory-federation:error";
+
 /// Why memory federation was skipped for a session. Returned by
 /// [`build_federation_ctx`] (as the `Err` arm) so the spawn site can
 /// surface the reason to the UI via [`SKIP_EVENT`] instead of silently
@@ -118,6 +127,36 @@ pub fn emit_federation_skip(
     };
     if let Err(e) = app_handle.emit(SKIP_EVENT, &payload) {
         debug!("claude_session::federation: emit {SKIP_EVENT} failed: {e} (non-fatal)");
+    }
+}
+
+/// Tauri event payload for [`ERROR_EVENT`]. `error` is the
+/// `Display`-formatted reconcile-level error string.
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorPayload {
+    pub session_id: String,
+    pub account: String,
+    pub error: String,
+}
+
+/// Emit an [`ERROR_EVENT`] for `session_id` carrying the reconcile-level
+/// failure. Best-effort: an emit failure is logged at `debug` and never
+/// propagated, mirroring [`emit_federation_skip`]'s emit handling. The
+/// caller is responsible for the accompanying `warn!` (preserved at the
+/// failure site).
+pub fn emit_federation_error(
+    app_handle: &tauri::AppHandle,
+    session_id: &str,
+    account: &str,
+    error: &str,
+) {
+    let payload = ErrorPayload {
+        session_id: session_id.to_string(),
+        account: account.to_string(),
+        error: error.to_string(),
+    };
+    if let Err(e) = app_handle.emit(ERROR_EVENT, &payload) {
+        debug!("claude_session::federation: emit {ERROR_EVENT} failed: {e} (non-fatal)");
     }
 }
 
@@ -270,6 +309,16 @@ pub fn emit_federation_report(
                 account = %ctx.account_name,
                 error = %e,
                 "memory federation reconcile failed"
+            );
+            // Surface the reconcile-LEVEL failure on the dashboard. Unlike
+            // per-file `failed_names` (which ride on RECONCILE_EVENT), a
+            // whole-reconcile `Err` produces no report at all, so without
+            // this the dashboard would show nothing.
+            emit_federation_error(
+                app_handle,
+                &ctx.session_id.to_string(),
+                &ctx.account_name,
+                &e.to_string(),
             );
         }
     }

--- a/src/components/MemoryFederationBanner.tsx
+++ b/src/components/MemoryFederationBanner.tsx
@@ -20,6 +20,12 @@
  * is skipped for a session — missing identity or the settings
  * kill-switch). These render a single-line informational notice that
  * auto-dismisses, so the previously-silent skip becomes visible.
+ *
+ * Finally listens for `memory-federation:error` (emitted from
+ * `claude_session::federation::emit_federation_error` when the WHOLE
+ * reconcile fails — distinct from per-file `failed_names`). A
+ * reconcile-level failure is not transient, so these render a
+ * destructive, sticky (no auto-dismiss) one-line notice.
  */
 
 import { useEffect, useState } from "react";
@@ -44,9 +50,18 @@ interface SkipEvent {
   detail: string;
 }
 
+/** Payload for `memory-federation:error`. Hand-written to mirror the Rust
+ *  `ErrorPayload` struct — these federation events are NOT codegen'd. */
+interface ErrorEvent {
+  session_id: string;
+  account: string;
+  error: string;
+}
+
 type ActiveNotice =
   | ({ kind: "reconcile"; id: number; receivedAt: number } & ReconcileEvent)
-  | ({ kind: "skip"; id: number; receivedAt: number } & SkipEvent);
+  | ({ kind: "skip"; id: number; receivedAt: number } & SkipEvent)
+  | ({ kind: "error"; id: number; receivedAt: number } & ErrorEvent);
 
 const SUCCESS_TTL_MS = 6000;
 const SKIP_TTL_MS = 8000;
@@ -104,6 +119,18 @@ export function MemoryFederationBanner() {
             setNotices((prev) => [...prev, notice]);
           }),
         );
+        unlisteners.push(
+          await listen<ErrorEvent>("memory-federation:error", (event) => {
+            counter += 1;
+            const notice: ActiveNotice = {
+              kind: "error",
+              ...event.payload,
+              id: counter,
+              receivedAt: Date.now(),
+            };
+            setNotices((prev) => [...prev, notice]);
+          }),
+        );
       } catch (e) {
         console.error("MemoryFederationBanner: listen failed", e);
       }
@@ -146,6 +173,35 @@ export function MemoryFederationBanner() {
       style={containerStyle}
     >
       {notices.map((n) => {
+        if (n.kind === "error") {
+          return (
+            <div
+              key={n.id}
+              role="alert"
+              aria-live="assertive"
+              style={bannerStyleFailure}
+            >
+              <div style={{ flex: 1 }}>
+                <p style={titleStyleFailure}>Memory federation</p>
+                <p style={messageStyle}>
+                  reconcile failed: {n.error}
+                  {" — session "}
+                  <code style={codeStyle}>{n.session_id.slice(0, 8)}</code>
+                </p>
+              </div>
+              <div style={actionsColumnStyle}>
+                <button
+                  type="button"
+                  onClick={() => dismiss(n.id)}
+                  style={dismissBtn}
+                  aria-label="Dismiss"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          );
+        }
         if (n.kind === "skip") {
           return (
             <div

--- a/src/components/MemoryFederationPage.tsx
+++ b/src/components/MemoryFederationPage.tsx
@@ -233,6 +233,37 @@ export function MemoryFederationPage() {
   );
 
   // -----------------------------------------------------------------------
+  // Install shape — single-account (cross-device sync) vs multi-account
+  // (cross-account federation). Derived purely from the data already
+  // present: count DISTINCT account_name values across the merged reports.
+  // The literal "default" account is a single-account install (no per-
+  // account .claude-<name> dir), so it does not count toward distinctness.
+  // -----------------------------------------------------------------------
+  const mode = useMemo<"cross-device" | "cross-account">(() => {
+    const distinctAccounts = new Set<string>();
+    for (const r of allReports) {
+      if (r.account_name && r.account_name !== "default") {
+        distinctAccounts.add(r.account_name);
+      }
+    }
+    return distinctAccounts.size >= 2 ? "cross-account" : "cross-device";
+  }, [allReports]);
+
+  const copy =
+    mode === "cross-account"
+      ? {
+          subtitle:
+            "Cross-account federation — memories merged across this tenant's Claude accounts.",
+          empty:
+            "No cross-account federation reports in the selected time range.",
+        }
+      : {
+          subtitle:
+            "Cross-device sync — memories synced across this account's machines.",
+          empty: "No cross-device sync reports in the selected time range.",
+        };
+
+  // -----------------------------------------------------------------------
   // Summary
   // -----------------------------------------------------------------------
   const summary = useMemo(() => {
@@ -256,7 +287,10 @@ export function MemoryFederationPage() {
     <div style={pageStyle}>
       {/* Header */}
       <div style={headerStyle}>
-        <h2 style={titleStyle}>Memory Federation</h2>
+        <div>
+          <h2 style={titleStyle}>Memory Federation</h2>
+          <p style={subtitleStyle}>{copy.subtitle}</p>
+        </div>
         <div style={headerActionsStyle}>
           {/* Time range selector */}
           <div style={timeRangeSelectorStyle}>
@@ -307,9 +341,7 @@ export function MemoryFederationPage() {
       <div style={tableContainerStyle}>
         {sortedReports.length === 0 ? (
           <div style={emptyStyle}>
-            {coordLoading
-              ? "Loading reports..."
-              : "No federation reports in the selected time range."}
+            {coordLoading ? "Loading reports..." : copy.empty}
           </div>
         ) : (
           <table style={tableStyle}>
@@ -522,6 +554,12 @@ const titleStyle: React.CSSProperties = {
   fontSize: "1.25rem",
   fontWeight: 600,
   color: "var(--text-primary, #e4e4e7)",
+};
+
+const subtitleStyle: React.CSSProperties = {
+  margin: "4px 0 0 0",
+  fontSize: "0.8125rem",
+  color: "var(--text-secondary, #a1a1aa)",
 };
 
 const headerActionsStyle: React.CSSProperties = {


### PR DESCRIPTION
## What
Phase 3 tail + Phase 5 of `2026-06-07-memory-federation-multi-user-auth-redesign`.

**Phase 3 tail** — a whole-reconcile `Err` (distinct from per-file `failed_names`, which already ride `RECONCILE_EVENT`) was warn-only and invisible on the dashboard. Adds `ERROR_EVENT` (`memory-federation:error`) emitted from `emit_federation_report`'s `Err` arm; renders a **sticky destructive** notice in `MemoryFederationBanner`. (The no-AppHandle `log_federation_report` path stays warn-only.)

**Phase 5** — the dashboard framed federation as "cross-account," misleading for a single-account install. Derives install shape from distinct (non-`default`) `account_name`s — single → **"cross-device sync"**, ≥2 → **"cross-account federation"** — and adapts the subtitle + empty-state copy. Matches the plan's decision: cross-device is the baseline, cross-account the advanced multi-dir case.

## Verification
`pnpm exec tsc --noEmit` clean; `cargo clippy --tests` clean (mirrors the existing skip-event machinery, no codegen/drift-guarded files touched).