### PR TITLE
feat(federation): settings toggle for the memory_federation_enabled kill switch

### DIFF
--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -111,10 +111,11 @@ pub fn save_ai_settings(
     max_tokens: u32,
     auto_refine_video_after_iterations: Option<u32>,
     interactive_sessions_enabled: Option<bool>,
+    memory_federation_enabled: Option<bool>,
 ) -> Result<CommandResponse, String> {
     info!(
-        "Saving AI settings: provider={}, execution_mode={}, timeout={}s, config_dir={:?}, account_selection={:?}, video_after_iterations={:?}, interactive={:?}",
-        provider, execution_mode, timeout_seconds, config_dir, account_selection_mode, auto_refine_video_after_iterations, interactive_sessions_enabled
+        "Saving AI settings: provider={}, execution_mode={}, timeout={}s, config_dir={:?}, account_selection={:?}, video_after_iterations={:?}, interactive={:?}, memory_federation={:?}",
+        provider, execution_mode, timeout_seconds, config_dir, account_selection_mode, auto_refine_video_after_iterations, interactive_sessions_enabled, memory_federation_enabled
     );
 
     let ai_provider = match provider.as_str() {
@@ -167,7 +168,8 @@ pub fn save_ai_settings(
         interactive_sessions_enabled: interactive_sessions_enabled
             .unwrap_or(existing_settings.interactive_sessions_enabled),
         ai_path_prediction_enabled: existing_settings.ai_path_prediction_enabled,
-        memory_federation_enabled: existing_settings.memory_federation_enabled,
+        memory_federation_enabled: memory_federation_enabled
+            .unwrap_or(existing_settings.memory_federation_enabled),
     };
 
     settings::save_ai_settings(ai_settings).map_err(|e| {

--- a/src/components/settings/AiSettings.tsx
+++ b/src/components/settings/AiSettings.tsx
@@ -145,6 +145,9 @@ export function AiSettings({ onLog }: AiSettingsProps) {
           interactive_sessions_enabled:
             result.data.interactive_sessions_enabled ??
             DEFAULT_AI_SETTINGS.interactive_sessions_enabled,
+          memory_federation_enabled:
+            result.data.memory_federation_enabled ??
+            DEFAULT_AI_SETTINGS.memory_federation_enabled,
         });
         onLog("debug", "AI settings loaded");
       }
@@ -225,6 +228,7 @@ export function AiSettings({ onLog }: AiSettingsProps) {
         maxTokens: settings.claude_api.max_tokens,
         autoRefineVideoAfterIterations: settings.auto_refine_video_after_iterations,
         interactiveSessionsEnabled: settings.interactive_sessions_enabled,
+        memoryFederationEnabled: settings.memory_federation_enabled,
       });
 
       if (!result || !result.success) {
@@ -602,6 +606,36 @@ export function AiSettings({ onLog }: AiSettingsProps) {
               <span
                 className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
                   settings.interactive_sessions_enabled ? "translate-x-4" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </label>
+
+          <label
+            htmlFor="memory-federation-toggle"
+            className="flex items-center justify-between cursor-pointer p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+          >
+            <div className="space-y-1">
+              <div className="text-sm font-medium">Memory Federation</div>
+              <div className="text-xs text-muted-foreground">
+                Sync Claude memories across this account&apos;s machines via coord. Default on.
+              </div>
+            </div>
+            <button
+              id="memory-federation-toggle"
+              onClick={() =>
+                setSettings((prev) => ({
+                  ...prev,
+                  memory_federation_enabled: !prev.memory_federation_enabled,
+                }))
+              }
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors shrink-0 ml-4 ${
+                settings.memory_federation_enabled ? "bg-primary" : "bg-muted"
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                  settings.memory_federation_enabled ? "translate-x-4" : "translate-x-1"
                 }`}
               />
             </button>

--- a/src/components/settings/ai-settings/types.ts
+++ b/src/components/settings/ai-settings/types.ts
@@ -117,6 +117,7 @@ export const DEFAULT_AI_SETTINGS: AiSettings = {
   },
   auto_refine_video_after_iterations: 3,
   interactive_sessions_enabled: true,
+  memory_federation_enabled: true,
 };
 
 export const PROVIDER_OPTIONS: {

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -176,6 +176,9 @@ export interface AiSettings {
    * When true, sessions use multi-turn interactive mode with message queuing.
    * When false, sessions use one-shot inline mode. */
   interactive_sessions_enabled: boolean;
+  /** Kill switch for memory federation. When true, Claude memories are synced
+   * across this account's machines via coord. Default on. */
+  memory_federation_enabled: boolean;
 }
 
 export interface AiConnectionTestResult {


### PR DESCRIPTION
## What
Phase 4 of `2026-06-07-memory-federation-multi-user-auth-redesign`. Surfaces a UI toggle for the `memory_federation_enabled` kill switch (default ON), which existed in `AiSettings` but had no way to be changed from the frontend.

## Change
- `save_ai_settings` gains `memory_federation_enabled: Option<bool>` (mirrors `interactive_sessions_enabled`), applied as `.unwrap_or(existing_settings.memory_federation_enabled)`. Other provider-specific save commands are untouched (still preserve the value).
- Frontend: field added to the `AiSettings` type + default `true`; a labeled "Memory Federation" toggle in the AI settings panel; the value threads into the `save_ai_settings` invoke and is re-loaded on mount.

## Safety
Defensive both ways: Rust `Option<bool>.unwrap_or(existing)` never force-resets on an omitted value, and the frontend always re-sends the loaded value — so toggling other settings can't reset federation.

## Verification
`cargo clippy --tests` clean (6m45s); `pnpm exec tsc --noEmit` clean.

(Phase 4's coord-URL provisioning + tenant/device population are already handled by the existing pairing/profile flow; this toggle is the remaining onboarding piece.)