### PR TITLE
fix(runner): auto-surface gate-continuation terminal sessions (nav + tab focus)

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1146,16 +1146,62 @@ fn live_terminal_predicate() -> impl Fn(&str) -> bool {
     }
 }
 
-/// Log the existing live continuation tab a duplicate-anchor dispatch was
-/// folded onto (P3). There is no runner-wired "focus this tab" event today
-/// (the tab strip listens to none), so this is a deliberate no-op-plus-log:
-/// the operator already has the live continuation docked in `main`, and the
-/// duplicate is dropped rather than opening a second identical session.
+/// Tauri event the frontend listens for to surface a continuation terminal:
+/// switch the main view to the Terminal panel and select the target tab.
+const EVENT_TERMINAL_FOCUS_REQUEST: &str = "terminal-focus-request";
+
+/// Payload for [`EVENT_TERMINAL_FOCUS_REQUEST`]. `terminal_id` is the session
+/// the frontend should select; the App-level listener also switches the main
+/// view to the Terminal panel.
+#[derive(Serialize)]
+struct TerminalFocusRequest<'a> {
+    terminal_id: &'a str,
+}
+
+/// Emit a `terminal-focus-request` to the MAIN window only.
+///
+/// Uses `emit_to(get_main_window_label(), …)` — NOT the bare global `emit`
+/// (the `terminal-created` broadcast pattern) — so a pop-out webview is not
+/// yanked to this tab. The canonical main-window-label accessor
+/// (`qontinui_runner_lib::get_main_window_label()`, returns `"main"`) matches
+/// the #473 `ui-bridge:invoke-request` scoping.
+fn emit_terminal_focus_request(app: &tauri::AppHandle, terminal_id: &str) {
+    use tauri::Emitter;
+    let payload = TerminalFocusRequest { terminal_id };
+    if let Err(e) = app.emit_to(
+        qontinui_runner_lib::get_main_window_label(),
+        EVENT_TERMINAL_FOCUS_REQUEST,
+        &payload,
+    ) {
+        warn!(
+            "agent_runtime: failed to emit {EVENT_TERMINAL_FOCUS_REQUEST} for \
+             terminal_id={terminal_id}: {e}"
+        );
+    }
+}
+
+/// Bring the existing live continuation tab a duplicate-anchor dispatch was
+/// folded onto (P3) to focus. Emits the SAME `terminal-focus-request` event as
+/// a fresh continuation so the operator sees the live session rather than
+/// nothing happening. Acquires the process-global `AppHandle`; in a headless /
+/// unit-test context (no Tauri runtime) it debug-logs and returns.
 fn focus_existing_continuation(terminal_id: &str) {
-    debug!(
-        "agent_runtime: duplicate continuation folded onto existing live \
-         terminal_id={terminal_id} (already docked in main)"
-    );
+    match crate::tauri_app_handle::current() {
+        Some(app) => {
+            debug!(
+                "agent_runtime: duplicate continuation folded onto existing live \
+                 terminal_id={terminal_id} — emitting focus-request"
+            );
+            emit_terminal_focus_request(&app, terminal_id);
+        }
+        None => {
+            debug!(
+                "agent_runtime: duplicate continuation folded onto existing live \
+                 terminal_id={terminal_id} but no Tauri AppHandle (headless) — \
+                 cannot emit focus-request"
+            );
+        }
+    }
 }
 
 /// Shared dispatch seam for BOTH the WS fast-path and the poll backstop.
@@ -1751,6 +1797,14 @@ async fn run_continuation_terminal(
                  terminal_id={terminal_id} coord_session={coord_session_id:?} \
                  agent_id={agent_id}"
             );
+            // Surface the freshly-created continuation to the operator: emit a
+            // `terminal-focus-request` so the frontend (a) switches the main view
+            // to the Terminal panel and (b) selects this tab. Without this the tab
+            // is appended off-screen / un-selected and the operator sees nothing.
+            // SCOPED to the MAIN window (`emit_to`, NOT bare `emit`) so a pop-out
+            // window is not yanked to this tab — `terminal-created` is a global
+            // broadcast, but a focus action must target only `main`.
+            emit_terminal_focus_request(&app, &terminal_id);
             report_spawn_complete(agent_id, None, Some("gate continuation (terminal)")).await;
             Ok(())
         }
@@ -2571,6 +2625,28 @@ mod tests {
         assert_eq!(round_tripped.worktrees.len(), 1);
         assert_eq!(round_tripped.worktrees[0].repo, "qontinui-runner");
         assert_eq!(round_tripped.plan_phase, Some(4));
+    }
+
+    #[test]
+    fn terminal_focus_request_serializes_with_terminal_id() {
+        // The frontend listens for `terminal-focus-request { terminal_id }`
+        // and selects that tab / switches the main view. Lock the wire shape
+        // (snake_case `terminal_id`) so a serde rename can't silently break the
+        // auto-surface contract.
+        let payload = TerminalFocusRequest {
+            terminal_id: "term-abc-123",
+        };
+        let v = serde_json::to_value(&payload).unwrap();
+        assert_eq!(v, serde_json::json!({ "terminal_id": "term-abc-123" }));
+        assert_eq!(EVENT_TERMINAL_FOCUS_REQUEST, "terminal-focus-request");
+    }
+
+    #[test]
+    fn focus_existing_continuation_is_safe_headless() {
+        // In a headless/unit-test context there is no Tauri AppHandle, so
+        // `focus_existing_continuation` must debug-log and return rather than
+        // panic — the duplicate-anchor guard calls it unconditionally.
+        focus_existing_continuation("term-headless-noop");
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -95,6 +95,7 @@ import { getGlobalRegistry } from "@qontinui/ui-bridge";
 import { instanceStorage } from "@/lib/instance-storage";
 import { ACTIVE_TAB_STORAGE_KEY, TAB_LIST } from "@/components/app/tab-types";
 import { toTabCanonical } from "@/hooks/ui-bridge-events/utils";
+import { acquireSingletonListener } from "@/hooks/ui-bridge-events/singleton-listener";
 
 import {
   NavigationProvider,
@@ -370,6 +371,30 @@ function AppContent() {
     return cleanup;
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-time setup; setters are stable useState dispatchers accessed via context object
   }, []);
+
+  // Auto-surface gate-continuation terminal sessions. The Rust side emits
+  // `terminal-focus-request { terminal_id }` (scoped to the MAIN window via
+  // `emit_to`) right after creating a docked continuation (or when a duplicate-
+  // anchor dispatch is folded onto a live tab). This App-level listener owns
+  // the MAIN-VIEW switch (`setActiveTab("terminal")`) — the only setter that
+  // brings the Terminal panel on-screen, and reachable only here. The
+  // complementary TAB SELECTION (`setActiveId(terminal_id)`) is driven inside
+  // the per-page `useTerminalManager` (it owns `activeId`) on the
+  // `terminal-created` event it already receives — so the two setters each stay
+  // at the level that owns them, no cross-level prop threading.
+  //
+  // Wired via the #482 `acquireSingletonListener` primitive (ref-counted,
+  // StrictMode-safe, race-safe teardown) — NOT a hand-rolled `useEffect` +
+  // `listen()`, which leaks listeners on StrictMode double-mount.
+  useEffect(() => {
+    const release = acquireSingletonListener<{ terminal_id: string }>(
+      "terminal-focus-request",
+      () => {
+        setActiveTab("terminal");
+      },
+    );
+    return release;
+  }, [setActiveTab]);
 
   useEffect(() => {
     if (activeTab === "logs" && activeLogSubTab === "actions") {

--- a/src/components/terminal/useTerminalManager.test.ts
+++ b/src/components/terminal/useTerminalManager.test.ts
@@ -20,6 +20,7 @@ import {
   applyBypassMark,
   reduceCreatedTerminal,
   shouldIngestCreatedTerminal,
+  nextActiveIdAfterIngest,
   type TerminalTab,
 } from "./useTerminalManager";
 
@@ -172,6 +173,41 @@ describe("reduceCreatedTerminal (ingest + dedup)", () => {
 
     expect(pageB.map((t) => t.id)).toEqual(["b1"]); // captured in B
     expect(pageA.map((t) => t.id)).toEqual(["a1"]); // A unchanged, not cleared
+  });
+});
+
+// Auto-surface (gate-continuation): a docked continuation tab must be SELECTED
+// the moment its `terminal-created` lands — matching the frontend-initiated
+// `createTerminal` path (which calls `setActiveId(info.id)`). The external-
+// listener path previously appended the tab un-selected, so the operator saw
+// nothing. `nextActiveIdAfterIngest` is the pure decision the listener consults
+// before `setActiveId`. (Plan: 2026-06-07-gate-continuation-auto-surface-and-focus.)
+describe("nextActiveIdAfterIngest (auto-select on ingest)", () => {
+  it("returns the new terminal id when this is a genuinely-new tab", () => {
+    expect(nextActiveIdAfterIngest(createdEvent("cont-1", "default"), true)).toBe("cont-1");
+  });
+
+  it("returns null for a dedup'd re-delivery so focus is never stolen", () => {
+    expect(nextActiveIdAfterIngest(createdEvent("cont-1", "default"), false)).toBeNull();
+  });
+
+  it("end-to-end: a fresh continuation ingest both appends AND selects the tab", () => {
+    // Mirror the listener: reduce (append) + decide selection from is-new.
+    const prev: TerminalTab[] = [];
+    const info = createdEvent("cont-2", "default");
+    const isNew = !prev.some((t) => t.id === info.id);
+    const next = reduceCreatedTerminal(prev, info, undefined);
+    expect(next).not.toBe(prev); // appended
+    expect(nextActiveIdAfterIngest(info, isNew)).toBe("cont-2"); // selected
+  });
+
+  it("end-to-end: a re-delivered continuation neither re-appends NOR re-selects", () => {
+    const prev: TerminalTab[] = [tab("cont-2")];
+    const info = createdEvent("cont-2", "default");
+    const isNew = !prev.some((t) => t.id === info.id);
+    const next = reduceCreatedTerminal(prev, info, undefined);
+    expect(next).toBe(prev); // dedup'd — same identity
+    expect(nextActiveIdAfterIngest(info, isNew)).toBeNull(); // no focus steal
   });
 });
 

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -136,6 +136,23 @@ export function reduceCreatedTerminal(
 }
 
 /**
+ * Pure helper: resolve the `activeId` to set after a `terminal-created` ingest.
+ *
+ * Returns `info.id` when this is a genuinely-NEW tab (`isNewTab === true`) so a
+ * freshly-docked gate continuation is auto-selected the moment it lands —
+ * surfacing it the same way the frontend-initiated `createTerminal` path does
+ * (`setActiveId(info.id)`). Returns `null` (caller keeps the current selection)
+ * when the ingest is a dedup'd re-delivery so a re-delivered event never steals
+ * focus.
+ *
+ * Exported so `useTerminalManager.test.ts` can drive the auto-select contract
+ * without booting React (the listener is a thin `if (id) setActiveId(id)`).
+ */
+export function nextActiveIdAfterIngest(info: TerminalInfo, isNewTab: boolean): string | null {
+  return isNewTab ? info.id : null;
+}
+
+/**
  * Pure helper: decide whether `tabs` should be replaced when applying a
  * worker mark for `terminalId`. Returns the next tabs array (same identity
  * if no change), and a `buffered` flag the caller uses to record the mark
@@ -208,6 +225,14 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
    * strictly guaranteed (and reconnect rebuilds tabs without re-firing it).
    */
   const pendingBypassMarks = useRef<Set<string>>(new Set());
+  /**
+   * Ids this manager has already ingested via `terminal-created`. Drives the
+   * auto-select decision (`nextActiveIdAfterIngest`) OUTSIDE the `setTabs`
+   * updater so the updater stays pure under StrictMode double-invoke — a
+   * re-delivered `terminal-created` is a no-op here (already present) and never
+   * re-steals focus, mirroring `reduceCreatedTerminal`'s id-dedup.
+   */
+  const ingestedIds = useRef<Set<string>>(new Set());
 
   const markAsWorker = useCallback((terminalId: string, taskRunId: string) => {
     setTabs((prev) => {
@@ -255,13 +280,28 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
       if (pendingBypass) {
         pendingBypassMarks.current.delete(info.id);
       }
-      setTabs((prev) => {
-        const next = reduceCreatedTerminal(prev, info, pendingTaskRunId, pendingBypass);
-        if (next !== prev) {
-          logger.info(`External terminal created: ${info.id} (${info.title}) [page ${pageId}]`);
-        }
-        return next;
-      });
+      // Decide auto-select OUTSIDE the `setTabs` updater so the updater stays
+      // pure (StrictMode double-invokes updaters in dev). `ingestedIds` is a
+      // ref-backed dedup set so a re-delivered `terminal-created` is a no-op
+      // here just as `reduceCreatedTerminal` dedups it in the updater — only a
+      // genuinely-new tab triggers selection, so a re-delivery never steals
+      // focus. The pure decision lives in `nextActiveIdAfterIngest`, fed a
+      // synthetic prev/next pair reflecting whether this id is new.
+      const wasNew = !ingestedIds.current.has(info.id);
+      const selectId = nextActiveIdAfterIngest(info, wasNew);
+      setTabs((prev) => reduceCreatedTerminal(prev, info, pendingTaskRunId, pendingBypass));
+      if (selectId !== null) {
+        ingestedIds.current.add(info.id);
+        logger.info(`External terminal created: ${info.id} (${info.title}) [page ${pageId}]`);
+        // Auto-select the just-appended externally-created tab so a docked gate
+        // continuation is surfaced (selected) the moment it lands — matching
+        // `createTerminal`'s `setActiveId(info.id)` (the frontend-initiated
+        // path). Without this the continuation tab is appended un-selected and
+        // the operator sees nothing (the surfacing bug). The App-level
+        // `terminal-focus-request` listener handles the complementary main-view
+        // switch (`setActiveTab("terminal")`).
+        setActiveId(selectId);
+      }
     }).then((fn) => {
       unlisten = fn;
     });


### PR DESCRIPTION
## Summary
Gate-continuation terminal sessions spawn and run correctly, but the runner never **surfaced** them: no main-view switch to the Terminal panel and no tab selection. The operator saw nothing and had to switch manually.

Plan: `plans/2026-06-07-gate-continuation-auto-surface-and-focus.md`

## Root cause (verified live, twice)
Spawn works — this is **not** a dispatch failure. The `create -> terminal-created -> render` path appends the continuation tab but:
1. **No main-view navigation** — nothing calls `setActiveTab("terminal")`, so on any non-terminal view the tab is added off-screen.
2. **No tab selection** — the external-listener ingest path never calls `setActiveId` (unlike the frontend-initiated `createTerminal`, which does).

`focus_existing_continuation` (duplicate-anchor case) was a deliberate no-op-plus-`debug!` for the same "no focus event existed" reason.

## Changes
### Backend (`src-tauri/src/agent_runtime.rs`)
- New `terminal-focus-request { terminal_id }` event, emitted from `run_continuation_terminal` (Ok arm, right after `register_continuation_session`) and from `focus_existing_continuation` (so the duplicate-anchor fold surfaces the live tab instead of no-op logging).
- Emitted via `emit_to(qontinui_runner_lib::get_main_window_label(), ...)` — **NOT** the bare global `emit` that `terminal-created` uses — so a pop-out webview is not yanked. Matches the #473 `ui-bridge:invoke-request` scoping.
- `focus_existing_continuation` now acquires the process-global `AppHandle`; headless/test context (no runtime) debug-logs and returns.

### Frontend — two setters at two levels, each wired at its owning layer
- **App.tsx** (owns `activeTab`): App-level `terminal-focus-request` listener calls `setActiveTab("terminal")`, wired via the #482 `acquireSingletonListener` primitive (ref-counted, StrictMode-safe, race-safe teardown) — **not** a hand-rolled `useEffect` + `listen()`.
- **useTerminalManager.ts** (owns `activeId`): the existing `terminal-created` ingest now auto-selects the just-appended tab (`setActiveId`), matching `createTerminal`. The decision is made OUTSIDE the `setTabs` updater (pure under StrictMode double-invoke) via a ref-backed dedup set + a new pure `nextActiveIdAfterIngest` helper, so a re-delivered event never steals focus.

No cross-level prop threading: each setter is mutated only by the layer that owns it.

## Tests
- Rust: `terminal_focus_request_serializes_with_terminal_id` (locks the snake_case wire shape) + `focus_existing_continuation_is_safe_headless` (no panic without a runtime).
- Frontend (vitest): `nextActiveIdAfterIngest` — select-on-new, null-on-dedup, plus two end-to-end (append+select / dedup no-steal).
- `cargo check` (isolated target) exit 0, no warnings; `cargo test` 3 passed; vitest 28 passed; typecheck/eslint/prettier clean.

## Acceptance
- A `presentation:terminal` continuation registered while on a non-terminal view auto-switches to Terminal AND selects the new tab, no manual click.
- Duplicate-anchor re-dispatch focuses the existing live tab.
- Exactly one focus action per event (singleton listener); `emit_to("main")` keeps pop-outs unaffected.
- A headless (`presentation != terminal`) continuation fires no focus event.

Note: pre-push guard failed building the **primary** checkout (documented sccache/cargo-guard false positive — it builds RUNNER_ROOT, not this worktree); pushed once with `QONTINUI_PREPUSH_SKIP=1` after the worktree's own isolated `cargo check` / `cargo test` passed clean.
