### PR TITLE
fix(runner): drive hoverClick E2E (pin ^0.17.0 + per-element action gate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@qontinui/design-tokens": "^1.0.0",
     "@qontinui/navigation": "^0.1.0",
     "@qontinui/shared-types": "^0.6.0",
-    "@qontinui/ui-bridge": "^0.15.0",
+    "@qontinui/ui-bridge": "^0.17.0",
     "@qontinui/ui-bridge-auto": "^0.1.7",
     "@qontinui/workflow-ui": "^0.1.0",
     "@qontinui/workflow-utils": "^0.1.0",
@@ -120,7 +120,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "graphql:codegen": "graphql-codegen",
-    "graphql:check": "graphql-codegen && git diff --exit-code src/generated/graphql.ts || (echo 'GraphQL codegen output is stale — run npm run graphql:codegen' && exit 1)",
+    "graphql:check": "graphql-codegen && git diff --exit-code src/generated/graphql.ts || (echo 'GraphQL codegen output is stale \u00e2\u20ac\u201d run npm run graphql:codegen' && exit 1)",
     "graphql:schema": "cd src-tauri && cargo test --bin qontinui-runner schema_exports_valid_sdl -- --nocapture",
     "typecheck": "tsc --noEmit"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,13 +26,13 @@ importers:
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
         specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.15.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
+        version: 0.1.1(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.6.0
         version: 0.6.0
       '@qontinui/ui-bridge':
-        specifier: ^0.15.0
-        version: 0.15.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
+        specifier: ^0.17.0
+        version: 0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
       '@qontinui/ui-bridge-auto':
         specifier: ^0.1.7
         version: 0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
@@ -1150,8 +1150,8 @@ packages:
     peerDependencies:
       eslint: ^8.0.0 || ^9.0.0 || ^10.0.0
 
-  '@qontinui/ui-bridge@0.15.0':
-    resolution: {integrity: sha512-LS6ozdAn2x4fEqT7IBUNJbmXsc03DkzmDZAogJ8h8y7RfdjDODOrjd6UPf+COX+XcY8QpzohfZxAT1SFi3/gGg==}
+  '@qontinui/ui-bridge@0.17.0':
+    resolution: {integrity: sha512-yG2niZz6o9Yg+IjTk/gUbPi1u+QRCsvBZBrYYSaIgmOVe9dPCWKVhDK6jbhqTX7uUtxA0//IWmeWUnClkAieiQ==}
     hasBin: true
     peerDependencies:
       '@qontinui/ui-bridge-auto': '>=0.1.0'
@@ -6128,9 +6128,9 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.15.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
     optionalDependencies:
-      '@qontinui/ui-bridge': 0.15.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
+      '@qontinui/ui-bridge': 0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
       react: 19.2.5
 
   '@qontinui/shared-types@0.6.0': {}
@@ -6157,7 +6157,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@qontinui/ui-bridge@0.15.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)':
+  '@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)':
     dependencies:
       dom-accessibility-api: 0.5.16
       react: 19.2.5

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -625,6 +625,10 @@ pub async fn ui_bridge_batch_actions_handler(
 /// `scroll_into_view`, see `recovery_executor::execute_recovery_command`).
 const SUPPORTED_ACTION_NAMES: &[&str] = &[
     "click",
+    // Reveal a hover-gated control (`pointer-events:none` until `:hover`/
+    // `group-hover`) then click it, in one dispatch. Handled SDK-side by
+    // `@qontinui/ui-bridge` >= 0.16.0; the runner just forwards it.
+    "hoverClick",
     "doubleClick",
     "double_click",
     "double",
@@ -719,7 +723,16 @@ pub(crate) fn extract_supported_actions(elem_data: &serde_json::Value) -> Option
 /// distortion not a feature.
 pub(crate) fn is_action_advertised(action: &str, supported: &Option<Vec<String>>) -> bool {
     match supported {
-        Some(list) => list.iter().any(|s| s == action),
+        Some(list) => {
+            list.iter().any(|s| s == action)
+                // `hoverClick` is a click-variant — it reveals a hover-gated
+                // control then clicks it. Any element that advertises `click`
+                // can be hover-clicked, even when the SDK's inferActions didn't
+                // enumerate `hoverClick` explicitly on this element. Without
+                // this, hover-revealed toolbar buttons (which advertise `click`
+                // but not `hoverClick`) would be rejected here pre-IPC.
+                || (action == "hoverClick" && list.iter().any(|s| s == "click"))
+        }
         // Unknown supported list (fetch failed or element didn't advertise
         // any) — assume yes, so we don't manufacture false ACTION_NOT_SUPPORTED.
         None => true,

--- a/src/hooks/ui-bridge-events/useControlEvents.ts
+++ b/src/hooks/ui-bridge-events/useControlEvents.ts
@@ -3,7 +3,12 @@ import { getApiPort } from "@/lib/runner-api";
 import type { MainTabId } from "@/components/app/tab-types";
 import { migrateTabId } from "@/components/app/tab-types";
 import type { UIBridgeRequestPayload, UIBridgeEventContext } from "./types";
-import { closestElementIds, serializeElement, serializeComponent } from "./utils";
+import {
+  closestElementIds,
+  serializeElement,
+  serializeComponent,
+  isElementActionAllowed,
+} from "./utils";
 
 /**
  * Handles: get_elements, get_element, execute_action, get_components, get_component,
@@ -143,7 +148,10 @@ export function useControlEvents(
               ? Object.keys(targetElement.customActions)
               : [];
             const allowedActions = [...builtinActions, ...customActions];
-            if (allowedActions.length > 0 && !allowedActions.includes(actionObj.action)) {
+            // `isElementActionAllowed` exempts `hoverClick` (a click-variant)
+            // wherever `click` is advertised, mirroring the runner-side Rust
+            // `is_action_advertised` gate so the two layers can't disagree.
+            if (!isElementActionAllowed(allowedActions, actionObj.action)) {
               await sendResponse({
                 requestId,
                 type,

--- a/src/hooks/ui-bridge-events/utils.test.ts
+++ b/src/hooks/ui-bridge-events/utils.test.ts
@@ -16,7 +16,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { awaitWithTimeout, isThenable, PAGE_EVALUATE_PROMISE_TIMEOUT_MS } from "./utils";
+import {
+  awaitWithTimeout,
+  isThenable,
+  isElementActionAllowed,
+  PAGE_EVALUATE_PROMISE_TIMEOUT_MS,
+} from "./utils";
 
 describe("isThenable", () => {
   it("accepts native Promise instances", () => {
@@ -134,4 +139,34 @@ beforeEach(() => {
 });
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe("isElementActionAllowed — execute_action per-element gate", () => {
+  it("permits any action when the element declares no action set", () => {
+    expect(isElementActionAllowed([], "hoverClick")).toBe(true);
+    expect(isElementActionAllowed([], "type")).toBe(true);
+  });
+
+  it("permits an action that is explicitly advertised", () => {
+    expect(isElementActionAllowed(["click", "focus"], "click")).toBe(true);
+  });
+
+  it("rejects an action not in a non-empty declared set", () => {
+    expect(isElementActionAllowed(["click", "focus"], "type")).toBe(false);
+    expect(isElementActionAllowed(["focus", "blur"], "click")).toBe(false);
+  });
+
+  it("exempts hoverClick wherever click is advertised (click-variant) — the regression", () => {
+    // A hover-gated toolbar button (e.g. ZoneHoverActions "Send to window")
+    // advertises click but not hoverClick; hoverClick must still be allowed so
+    // it reaches actionExecutor.performHoverClick instead of being rejected
+    // pre-dispatch (mirrors the runner Rust is_action_advertised exemption).
+    expect(isElementActionAllowed(["focus", "blur", "click", "hover", "middleClick"], "hoverClick")).toBe(
+      true,
+    );
+  });
+
+  it("does NOT exempt hoverClick when click is absent", () => {
+    expect(isElementActionAllowed(["focus", "blur", "hover"], "hoverClick")).toBe(false);
+  });
 });

--- a/src/hooks/ui-bridge-events/utils.ts
+++ b/src/hooks/ui-bridge-events/utils.ts
@@ -265,3 +265,26 @@ export function closestElementIds(target: string, candidates: readonly string[])
   scored.sort((a, b) => a.distance - b.distance || a.id.localeCompare(b.id));
   return scored.slice(0, 5).map((s) => s.id);
 }
+
+/**
+ * Per-element action-allow gate for the `execute_action` IPC handler.
+ *
+ * Returns `true` when `action` may be dispatched to the element. An element
+ * with NO declared action set (`allowedActions` empty) is permissive (the SDK's
+ * global supported-action validation still applies downstream). When a declared
+ * set is present, the action must be in it — EXCEPT `hoverClick`, a click-variant
+ * (reveal a `pointer-events:none`-until-`:hover`/`group-hover` control, then
+ * click) that is allowed wherever `click` is. This mirrors the runner-side Rust
+ * `is_action_advertised` click-variant exemption so the two advertised-action
+ * gates (Rust pre-IPC + this frontend pre-check) can't disagree and silently
+ * reject a hover-gated toolbar button registered with an explicit `actions=` prop.
+ */
+export function isElementActionAllowed(
+  allowedActions: readonly string[],
+  action: string,
+): boolean {
+  if (allowedActions.length === 0) return true;
+  if (allowedActions.includes(action)) return true;
+  if (action === "hoverClick" && allowedActions.includes("click")) return true;
+  return false;
+}


### PR DESCRIPTION
## Make the runner drive `hoverClick` end-to-end

Implements `plans/2026-06-07-hoverclick-unify-sdk-action-dispatch.md` (vet-corrected). The SDK side of `hoverClick` was already complete (`@qontinui/ui-bridge` 0.17.0: `actionExecutor` + `inferActions`); the runner couldn't exercise it because (a) its pin was still `^0.15.0` and (b) a runner **frontend** per-element gate rejected the action. There was **no SDK dispatch gap** — the runner already routes `execute_action` straight to `actionExecutor.executeAction`.

### Changes
- **Pin bump** `@qontinui/ui-bridge` `^0.15.0 → ^0.17.0` + a runner **Rust** gate (`is_action_advertised` treats `hoverClick` as a click-variant) — the previously-pushed groundwork (`ece73357`), rebased in.
- **Frontend gate** (`useControlEvents.ts` `execute_action` pre-check): a hover-gated toolbar button (the `ZoneHoverActions` "Send to window" button) advertises an explicit `actions` list with `click` but not `hoverClick`, so the pre-check rejected it *before dispatch* (surfaced as `ACTION_NOT_SUPPORTED`). Now uses `isElementActionAllowed`, which exempts `hoverClick` wherever `click` is advertised — mirroring the Rust exemption so the two gates can't disagree.
- **`utils.ts`** `isElementActionAllowed(allowedActions, action)` + **5 regression tests** in `utils.test.ts`.

### Verification
**E2E on a temp runner** (built on SDK 0.17.0 + this branch): `POST /ui-bridge/control/element/button-send-terminal-to-a-window/action {"action":"hoverClick"}` → `success: true`, the **Send-to-window dropdown opens** ("New window" + windows), with **no `page/evaluate` workaround**. `tsc` + `eslint` clean; 18 `utils` tests pass (5 new); cargo build clean.
