### PR TITLE
feat(runner): flag-gated degraded no-DB boot + DB-less CI contract smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,118 +296,6 @@ jobs:
         #      `--no-bundle` — compilation + link is the sanity gate we want.
         run: pnpm run tauri build --debug --no-bundle
 
-      # The contract smoke boots the runner exe directly, and the runner's
-      # boot path HARD-PANICS at main.rs:419 if it can't reach PostgreSQL
-      # ("PostgreSQL connection required"). There is no PG-less escape hatch:
-      # `profiles::load()` always resolves a `database_url` (active profile →
-      # RUNNER_DATABASE_URL → a localhost default) and `PgDb::new` connects +
-      # self-bootstraps its schema unconditionally. windows-latest ships PG
-      # 17.10 but with the service Stopped/Disabled, and the runner additionally
-      # requires the `vector` (pgvector) extension (CREATE EXTENSION IF NOT
-      # EXISTS vector is fatal in PgDb::new) which is NOT bundled. So before the
-      # smoke we (1) compile+install pgvector into the preinstalled PG, (2) init
-      # a fresh data dir + start the server, (3) create an empty db with the
-      # `vector` extension and the `project` schema the runner's self-heal CREATE
-      # TABLEs target (the runner makes `runner`/`vector`/its tables itself, but
-      # never `CREATE SCHEMA project`). The runner self-provisions every table it
-      # needs (all web/alembic-owned tables are guarded by IF EXISTS), so a bare
-      # empty db + project schema is sufficient — no qontinui-web migrator run.
-      #
-      # Data dir lives under RUNNER_TEMP, NOT the preinstalled PGDATA
-      # (C:\PostgreSQL\17\data), which has an ACL that makes pg_ctl -D PGDATA
-      # fail "could not open data dir" on hosted Windows runners
-      # (actions/runner-images#13040). Fail-loud: every command's exit code is
-      # checked and versions are echoed.
-      - name: Start local PostgreSQL + pgvector (Windows smoke prereq)
-        if: matrix.platform == 'windows-latest'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          # PGROOT/PGBIN are preset on the image; assert and echo them loudly.
-          if (-not $env:PGROOT) { throw "PGROOT not set — preinstalled PostgreSQL missing from image" }
-          if (-not $env:PGBIN)  { throw "PGBIN not set — preinstalled PostgreSQL missing from image" }
-          Write-Host "PGROOT = $env:PGROOT"
-          Write-Host "PGBIN  = $env:PGBIN"
-          & "$env:PGBIN\postgres.exe" --version
-          if ($LASTEXITCODE -ne 0) { throw "postgres --version failed ($LASTEXITCODE)" }
-
-          # --- 1. Build + install pgvector into the preinstalled PG ---------
-          # pgvector ships no Windows binary; build from source with nmake under
-          # the VS C++ toolchain (preinstalled on windows-latest). Locate
-          # vcvars64.bat via vswhere rather than hardcoding the VS edition path.
-          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-          if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found at $vswhere" }
-          $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
-          if (-not $vsPath) { throw "Visual Studio with VC++ tools not found via vswhere" }
-          $vcvars = Join-Path $vsPath "VC\Auxiliary\Build\vcvars64.bat"
-          if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
-          Write-Host "vcvars64.bat = $vcvars"
-
-          $pgvDir = Join-Path $env:RUNNER_TEMP "pgvector"
-          git clone --branch v0.8.0 --depth 1 https://github.com/pgvector/pgvector.git $pgvDir
-          if ($LASTEXITCODE -ne 0) { throw "git clone pgvector failed ($LASTEXITCODE)" }
-
-          # nmake must run inside the vcvars64 environment. Shell out to cmd so
-          # vcvars64.bat exports the MSVC env into the same process that runs
-          # nmake. PGROOT tells the Makefile where to install the extension.
-          # Built as a string array (NOT a here-string — the closing "@ must sit
-          # at column 0, which a YAML block scalar can't contain).
-          $buildLines = @(
-            "call `"$vcvars`"",
-            "if errorlevel 1 exit /b 1",
-            "cd /d `"$pgvDir`"",
-            "set `"PGROOT=$env:PGROOT`"",
-            "nmake /NOLOGO /F Makefile.win",
-            "if errorlevel 1 exit /b 1",
-            "nmake /NOLOGO /F Makefile.win install",
-            "if errorlevel 1 exit /b 1"
-          )
-          $buildBat = Join-Path $env:RUNNER_TEMP "build-pgvector.bat"
-          Set-Content -Path $buildBat -Value $buildLines -Encoding ascii
-          cmd /c $buildBat
-          if ($LASTEXITCODE -ne 0) { throw "pgvector build/install failed ($LASTEXITCODE)" }
-          Write-Host "pgvector installed into $env:PGROOT"
-
-          # --- 2. Init a fresh data dir + start the server -----------------
-          $dataDir = Join-Path $env:RUNNER_TEMP "pgdata"
-          $pwFile  = Join-Path $env:RUNNER_TEMP "pgpw.txt"
-          Set-Content -Path $pwFile -Value "postgres" -Encoding ascii -NoNewline
-          & "$env:PGBIN\initdb.exe" -D $dataDir -U postgres -A md5 --pwfile=$pwFile -E UTF8
-          if ($LASTEXITCODE -ne 0) { throw "initdb failed ($LASTEXITCODE)" }
-
-          $logFile = Join-Path $env:RUNNER_TEMP "pg.log"
-          & "$env:PGBIN\pg_ctl.exe" -D $dataDir -l $logFile -o "-p 5432" start
-          if ($LASTEXITCODE -ne 0) {
-            Write-Host "=== pg.log ==="
-            if (Test-Path $logFile) { Get-Content $logFile }
-            throw "pg_ctl start failed ($LASTEXITCODE)"
-          }
-
-          # Wait for readiness (pg_isready), fail loud with the log on timeout.
-          $ready = $false
-          for ($i = 0; $i -lt 30; $i++) {
-            & "$env:PGBIN\pg_isready.exe" -h localhost -p 5432 -U postgres | Out-Null
-            if ($LASTEXITCODE -eq 0) { $ready = $true; break }
-            Start-Sleep -Seconds 1
-          }
-          if (-not $ready) {
-            Write-Host "=== pg.log ==="
-            if (Test-Path $logFile) { Get-Content $logFile }
-            throw "PostgreSQL did not become ready within 30s"
-          }
-          Write-Host "PostgreSQL is ready on localhost:5432"
-
-          # --- 3. Create the empty db + extension + project schema ---------
-          $env:PGPASSWORD = "postgres"
-          & "$env:PGBIN\createdb.exe" -h localhost -p 5432 -U postgres qontinui_db
-          if ($LASTEXITCODE -ne 0) { throw "createdb qontinui_db failed ($LASTEXITCODE)" }
-          # Verify pgvector loads, then create the schema the runner self-heal
-          # writes into (the runner creates `runner` + its tables itself).
-          & "$env:PGBIN\psql.exe" -h localhost -p 5432 -U postgres -d qontinui_db -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS vector; CREATE SCHEMA IF NOT EXISTS project;"
-          if ($LASTEXITCODE -ne 0) { throw "extension/schema bootstrap failed ($LASTEXITCODE)" }
-          & "$env:PGBIN\psql.exe" -h localhost -p 5432 -U postgres -d qontinui_db -c "SELECT extversion FROM pg_extension WHERE extname='vector';"
-          Write-Host "Local PostgreSQL + pgvector + project schema ready for the contract smoke."
-
       # SDK↔runner behavior-contract gate. Boots the just-built debug exe
       # supervisor-free (`-DirectExe`), walks every UI_BRIDGE_ROUTES entry from
       # the sibling ui-bridge clone, and asserts the shape contracts the offline
@@ -421,15 +309,22 @@ jobs:
       # probe: if it fails at WebView2 init, the fallback is a parallel hosted
       # windows job (per the plan), not a blocker for the script mode.
       #
-      # RUNNER_DATABASE_URL points the runner's `profiles::load()` legacy-env
-      # fallback at the local PG started above (libpq keyword DSN — the format
-      # tokio_postgres::Config parses and the same shape as profiles.rs's
-      # localhost default). No ~/.qualified profiles.json exists in CI, so the
-      # loader takes the legacy-env path and uses this DSN.
+      # DB-LESS BOOT (QONTINUI_ALLOW_NO_DB=1): the runner used to HARD-PANIC at
+      # main.rs:419 when it couldn't reach PostgreSQL, so this job previously
+      # compiled pgvector from source and stood up a local PG cluster (~highest-
+      # variance step in the gate) just to let the runner boot for a route-shape
+      # smoke that needs no DB *rows*. The runner now supports a flag-gated
+      # degraded boot: with QONTINUI_ALLOW_NO_DB=1 it builds an unverified PG
+      # pool, skips connectivity + self-provision, and serves a clean 503 on the
+      # known DB-backed routes (crate::mcp::pg_guard) while the control/vision/
+      # contract surfaces stay fully functional. The contract smoke walks those
+      # surfaces, so no database is provisioned here at all. Prod is unaffected:
+      # without the flag the runner still fail-fasts on an unreachable PG.
+      # See plans/2026-06-07-runner-degraded-no-db-boot-and-dbless-ci.md.
       - name: SDK↔runner contract smoke (direct-exe)
         if: matrix.platform == 'windows-latest'
         env:
-          RUNNER_DATABASE_URL: "host=localhost port=5432 user=postgres password=postgres dbname=qontinui_db"
+          QONTINUI_ALLOW_NO_DB: "1"
         run: powershell -File scripts/contract-smoke.ps1 -DirectExe target/debug/qontinui-runner.exe -Profile ci -SdkTypesPath ../ui-bridge/packages/ui-bridge/src/server/types.ts
         shell: bash
 

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -104,6 +104,28 @@ use tracing::{info, warn};
 /// without threading Arc<PgDb> through every call chain.
 static GLOBAL_PG_DB: OnceLock<Arc<PgDb>> = OnceLock::new();
 
+/// Whether the canonical PG was reachable at boot. `true` after a successful
+/// `PgDb::new`; `false` when the runner booted degraded (`QONTINUI_ALLOW_NO_DB`)
+/// with PG unreachable. DB-backed HTTP handlers consult `pg_available()` to
+/// return a clean `503 database unavailable` instead of hitting a dead pool.
+///
+/// Defaults to `true` so the overwhelmingly common path (PG present) needs no
+/// explicit set and any code that reads it before boot completes does not
+/// spuriously 503; the degraded-boot path explicitly flips it to `false`.
+static PG_AVAILABLE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+/// Record whether the canonical PG is available. Called once at boot:
+/// `true` on a verified connection, `false` on degraded boot.
+pub fn set_pg_available(available: bool) {
+    PG_AVAILABLE.store(available, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Returns `false` only when the runner booted degraded with PG unreachable.
+/// DB-backed handlers use this to short-circuit to a 503 in degraded mode.
+pub fn pg_available() -> bool {
+    PG_AVAILABLE.load(std::sync::atomic::Ordering::Relaxed)
+}
+
 /// PostgreSQL connection pool backed by deadpool-postgres.
 pub struct PgDb {
     pool: deadpool_postgres::Pool,
@@ -132,13 +154,13 @@ impl PgDb {
         GLOBAL_PG_DB.get().cloned()
     }
 
-    /// Connect to PostgreSQL using the given connection string.
-    ///
-    /// The connection string should NOT include search_path — it's set per-connection
-    /// via the pool's post_create hook to avoid parsing issues.
-    ///
-    /// Returns `Err` if the connection string is invalid or initial connectivity fails.
-    pub async fn new(database_url: &str) -> Result<Self, String> {
+    /// Build the deadpool connection pool WITHOUT verifying connectivity or
+    /// running the self-provision DDL. Shared by `new` (which then probes and
+    /// self-provisions) and `new_degraded` (which does neither). The builder
+    /// does no I/O and registers no timers (we deliberately avoid
+    /// `.recycle_timeout` — see the comment below), so it is safe to call from
+    /// a synchronous context outside a Tokio runtime.
+    fn build_pool(database_url: &str) -> Result<deadpool_postgres::Pool, String> {
         let pg_config: tokio_postgres::Config = database_url
             .parse()
             .map_err(|e| format!("Invalid PostgreSQL connection string: {}", e))?;
@@ -165,7 +187,7 @@ impl PgDb {
         // runs synchronously before the first `.await`, so the timer
         // registration races with runtime entry and panics.
         // See: src/main.rs:285 for the calling context.
-        let pool = deadpool_postgres::Pool::builder(mgr)
+        deadpool_postgres::Pool::builder(mgr)
             .max_size(8)
             .post_create(deadpool_postgres::Hook::async_fn(|conn, _| {
                 Box::pin(async move {
@@ -180,7 +202,30 @@ impl PgDb {
                 })
             }))
             .build()
-            .map_err(|e| format!("Failed to create PG pool: {}", e))?;
+            .map_err(|e| format!("Failed to create PG pool: {}", e))
+    }
+
+    /// Construct a DEGRADED PgDb for `QONTINUI_ALLOW_NO_DB` boot: the pool is
+    /// built (and reconnects lazily if PG later becomes reachable) but initial
+    /// connectivity is NOT verified and the self-provision DDL is skipped.
+    ///
+    /// Used only by the degraded-boot path in `main.rs` when the canonical PG
+    /// is unreachable AND degraded boot is explicitly enabled. The caller MUST
+    /// flip `set_pg_available(false)` so DB-backed handlers can return 503
+    /// instead of repeatedly hitting a pool that has no live backend.
+    pub fn new_degraded(database_url: &str) -> Result<Self, String> {
+        let pool = Self::build_pool(database_url)?;
+        Ok(Self { pool })
+    }
+
+    /// Connect to PostgreSQL using the given connection string.
+    ///
+    /// The connection string should NOT include search_path — it's set per-connection
+    /// via the pool's post_create hook to avoid parsing issues.
+    ///
+    /// Returns `Err` if the connection string is invalid or initial connectivity fails.
+    pub async fn new(database_url: &str) -> Result<Self, String> {
+        let pool = Self::build_pool(database_url)?;
 
         // Verify connectivity and schema
         let conn = pool

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -97,7 +97,7 @@ pub mod worktrees;
 pub mod wsv_disagreements;
 
 use std::sync::{Arc, OnceLock};
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Global PgDb instance, set once during app initialization.
 /// Allows sync-context code (thread spawns, closures) to access PG
@@ -226,9 +226,21 @@ impl PgDb {
     /// Returns `Err` if the connection string is invalid or initial connectivity fails.
     pub async fn new(database_url: &str) -> Result<Self, String> {
         let pool = Self::build_pool(database_url)?;
+        let db = Self { pool };
+        db.verify_and_provision().await?;
+        Ok(db)
+    }
 
+    /// Verify connectivity and run the idempotent self-provision DDL (schema +
+    /// pgvector extension + the workflow-verification self-heals). Shared by
+    /// `new` at boot and the degraded-mode reconnect probe
+    /// (`spawn_reconnect_probe`), so a runner that booted with
+    /// `QONTINUI_ALLOW_NO_DB` provisions exactly as a normal boot would once PG
+    /// becomes reachable. Idempotent — safe to re-run on every retry.
+    pub async fn verify_and_provision(&self) -> Result<(), String> {
         // Verify connectivity and schema
-        let conn = pool
+        let conn = self
+            .pool
             .get()
             .await
             .map_err(|e| format!("PostgreSQL connection failed: {}", e))?;
@@ -406,8 +418,49 @@ impl PgDb {
 
         info!("PostgreSQL connected (deadpool, max_size=8, schema=runner)");
 
-        let db = Self { pool };
-        Ok(db)
+        Ok(())
+    }
+
+    /// D3 (self-healing degraded mode): when the runner booted degraded
+    /// (`QONTINUI_ALLOW_NO_DB` + PG unreachable, so `pg_available()` is false),
+    /// spawn a background task that retries `verify_and_provision` with
+    /// exponential backoff (2s → 60s cap). On the first success it provisions
+    /// the schema/extension that degraded boot skipped, flips
+    /// `set_pg_available(true)` so `pg_guard` stops 503-ing DB-backed routes,
+    /// and exits. The deadpool pool reconnects lazily, so a transient PG outage
+    /// self-heals without a runner restart. No-op if PG is already available.
+    pub fn spawn_reconnect_probe(self: Arc<Self>) {
+        if pg_available() {
+            return;
+        }
+        tokio::spawn(async move {
+            let mut delay = std::time::Duration::from_secs(2);
+            let max_delay = std::time::Duration::from_secs(60);
+            loop {
+                tokio::time::sleep(delay).await;
+                // Another path may have already lifted the gate — stop probing.
+                if pg_available() {
+                    break;
+                }
+                match self.verify_and_provision().await {
+                    Ok(()) => {
+                        set_pg_available(true);
+                        info!(
+                            "PG reconnect probe: PostgreSQL is reachable and provisioned — \
+                             exiting degraded mode, DB-backed routes resumed"
+                        );
+                        break;
+                    }
+                    Err(e) => {
+                        debug!(
+                            "PG reconnect probe: still unavailable ({}); retrying in {:?}",
+                            e, delay
+                        );
+                        delay = (delay * 2).min(max_delay);
+                    }
+                }
+            }
+        });
     }
 
     // ========================================================================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -366,6 +366,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 info!("PostgreSQL connected successfully");
                 let pg = Arc::new(pg);
                 crate::database::pg::PgDb::set_global(pg.clone());
+                crate::database::pg::set_pg_available(true);
 
                 // Phase 5 startup sweep (productivity-coordinator-completion-reports
                 // §9 "Memory pressure audit"): clear any stale
@@ -412,11 +413,51 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 pg
             }
             Err(e) => {
-                error!(
-                    "PostgreSQL connection failed: {}. Ensure docker-compose PG is running.",
-                    e
-                );
-                panic!("PostgreSQL connection required — {}", e);
+                // Degraded boot (QONTINUI_ALLOW_NO_DB): the runner normally
+                // HARD-PANICS here so a misconfigured production runner surfaces
+                // the broken DB immediately. When degraded boot is explicitly
+                // enabled (CI contract smoke, offline demos, fast local UI
+                // iteration, or riding out a transient PG blip), construct an
+                // UNVERIFIED PgDb whose deadpool pool reconnects lazily, mark PG
+                // unavailable so DB-backed routes return a clean 503, and
+                // continue booting the Tauri/axum stack. Default (flag unset) =
+                // the current fail-fast invariant — prod is unchanged.
+                let degraded = std::env::var("QONTINUI_ALLOW_NO_DB")
+                    .map(|v| matches!(v.trim(), "1" | "true" | "TRUE" | "yes"))
+                    .unwrap_or(false);
+                if degraded {
+                    warn!(
+                        "PostgreSQL connection failed: {}. QONTINUI_ALLOW_NO_DB is set — \
+                         booting DEGRADED: DB-backed routes return 503 until PG is reachable. \
+                         DO NOT use this mode in production.",
+                        e
+                    );
+                    match crate::database::pg::PgDb::new_degraded(&pg_url) {
+                        Ok(pg) => {
+                            let pg = Arc::new(pg);
+                            crate::database::pg::PgDb::set_global(pg.clone());
+                            crate::database::pg::set_pg_available(false);
+                            pg
+                        }
+                        Err(build_err) => {
+                            // Even building the pool failed — a genuine config
+                            // error (unparseable URL), not mere unreachability.
+                            // Fail fast regardless of the degraded flag.
+                            error!(
+                                "Degraded boot requested but PG pool could not be built: {}",
+                                build_err
+                            );
+                            panic!("PostgreSQL pool construction failed — {}", build_err);
+                        }
+                    }
+                } else {
+                    error!(
+                        "PostgreSQL connection failed: {}. Ensure docker-compose PG is running \
+                         (or set QONTINUI_ALLOW_NO_DB=1 to boot DB-less in degraded mode).",
+                        e
+                    );
+                    panic!("PostgreSQL connection required — {}", e);
+                }
             }
         }
     };

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -91,6 +91,7 @@ pub mod observations_api;
 pub mod online_learning_api;
 pub mod orchestration_loop_api;
 pub mod otel_status;
+pub mod pg_guard;
 pub mod physical_device;
 pub mod physical_device_api;
 pub mod plans;

--- a/src-tauri/src/mcp/pg_guard.rs
+++ b/src-tauri/src/mcp/pg_guard.rs
@@ -1,0 +1,129 @@
+//! Degraded-boot PostgreSQL guard (D2 mechanism).
+//!
+//! When the runner boots with `QONTINUI_ALLOW_NO_DB=1` and the canonical PG is
+//! unreachable (`main.rs` degraded path), [`crate::database::pg::pg_available`]
+//! flips to `false`. This middleware then short-circuits requests to
+//! KNOWN-DB-backed route families with a clean
+//! `503 {success:false, code:"DATABASE_UNAVAILABLE"}` envelope instead of
+//! letting them reach a handler that would hit a pool with no live backend.
+//!
+//! ## Conservative by design
+//!
+//! [`route_requires_db`] returns `true` only for an explicit allowlist of route
+//! prefixes that unambiguously require PG. Every other path passes through
+//! untouched, so this guard can NEVER turn a currently-working, DB-free route
+//! into a 503. A DB-backed route that is *not yet* in the list still fails
+//! safely in degraded mode — its handler returns its own error when the pool
+//! cannot connect (connection-refused is immediate on a dead `localhost:5432`,
+//! so there is no hang); listing it here only upgrades that raw 500 to a clean
+//! 503. The list is the extension point: broaden it as the per-handler audit in
+//! `plans/2026-06-07-runner-degraded-no-db-boot-and-dbless-ci.md` (D2 follow-up)
+//! proceeds.
+//!
+//! ## Cost
+//!
+//! The fast path (PG available — the overwhelmingly common case) is a single
+//! `Relaxed` atomic load and an immediate `next.run`. No allocation, no path
+//! inspection. Zero measurable overhead in normal operation.
+
+use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response, Json};
+
+use crate::mcp::types::ApiResponse;
+
+/// Route prefixes that are KNOWN to require PostgreSQL. Matched as whole path
+/// segments (exact, or followed by `/`), so `/plans` and `/plans/decompose`
+/// match but `/plansomething` does not.
+///
+/// Extension point — see the module docs. Verified against the live route
+/// registrations in `mcp_api.rs::create_router`.
+const DB_BACKED_PREFIXES: &[&str] = &[
+    "/task-runs",
+    "/plans",
+    "/reviews",
+    "/findings",
+    "/decisions",
+    "/observations",
+    "/productivity-knowledge",
+];
+
+/// True iff `path` is at or under `prefix` on a segment boundary
+/// (`prefix` itself, or `prefix` + `/...`).
+fn path_under(path: &str, prefix: &str) -> bool {
+    match path.strip_prefix(prefix) {
+        Some(rest) => rest.is_empty() || rest.starts_with('/'),
+        None => false,
+    }
+}
+
+/// Whether a request path targets a known DB-backed route family.
+/// Conservative: defaults to `false` for anything not explicitly listed.
+pub fn route_requires_db(path: &str) -> bool {
+    DB_BACKED_PREFIXES
+        .iter()
+        .any(|prefix| path_under(path, prefix))
+}
+
+/// The canonical `503 database unavailable` JSON envelope.
+fn db_unavailable_response(path: &str) -> Response {
+    use axum::response::IntoResponse;
+
+    let body = ApiResponse::<()>::error_with_code(
+        format!(
+            "database unavailable — runner booted with QONTINUI_ALLOW_NO_DB and \
+             PostgreSQL is unreachable; route {path} requires the database"
+        ),
+        "DATABASE_UNAVAILABLE",
+    );
+    (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response()
+}
+
+/// `axum::middleware::from_fn` guard. See module docs.
+pub async fn pg_degraded_guard_middleware(req: Request, next: Next) -> Response {
+    // Fast path: PG is available — straight through, one atomic load.
+    if crate::database::pg::pg_available() {
+        return next.run(req).await;
+    }
+
+    // Degraded boot: 503 the known DB-backed families; pass everything else
+    // (health, control surface, vision capture, route manifest, ...).
+    let path = req.uri().path();
+    if route_requires_db(path) {
+        return db_unavailable_response(path);
+    }
+    next.run(req).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_backed_prefixes_match_on_segment_boundary() {
+        // Exact prefix and sub-paths match.
+        assert!(route_requires_db("/task-runs"));
+        assert!(route_requires_db("/task-runs/running"));
+        assert!(route_requires_db("/task-runs/abc-123/output"));
+        assert!(route_requires_db("/plans"));
+        assert!(route_requires_db("/plans/decompose"));
+        assert!(route_requires_db("/reviews/recent"));
+        assert!(route_requires_db("/findings/xyz"));
+        assert!(route_requires_db("/decisions/search"));
+        assert!(route_requires_db("/observations/stats"));
+        assert!(route_requires_db("/productivity-knowledge"));
+    }
+
+    #[test]
+    fn non_db_and_lookalike_paths_pass_through() {
+        // Boot-critical / DB-free surfaces the contract smoke depends on.
+        assert!(!route_requires_db("/health"));
+        assert!(!route_requires_db("/ui-bridge/health"));
+        assert!(!route_requires_db("/control/elements"));
+        assert!(!route_requires_db("/control/component/abc"));
+        assert!(!route_requires_db("/vision/capture"));
+        assert!(!route_requires_db("/ui-bridge/_routes"));
+        // Lookalikes must NOT match — segment-boundary matching, not raw prefix.
+        assert!(!route_requires_db("/plansomething"));
+        assert!(!route_requires_db("/task-runs-archive"));
+        assert!(!route_requires_db("/reviewsx"));
+    }
+}

--- a/src-tauri/src/mcp/pg_guard.rs
+++ b/src-tauri/src/mcp/pg_guard.rs
@@ -1,66 +1,247 @@
-//! Degraded-boot PostgreSQL guard (D2 mechanism).
+//! Degraded-boot PostgreSQL guard (D2).
 //!
 //! When the runner boots with `QONTINUI_ALLOW_NO_DB=1` and the canonical PG is
 //! unreachable (`main.rs` degraded path), [`crate::database::pg::pg_available`]
-//! flips to `false`. This middleware then short-circuits requests to
-//! KNOWN-DB-backed route families with a clean
-//! `503 {success:false, code:"DATABASE_UNAVAILABLE"}` envelope instead of
-//! letting them reach a handler that would hit a pool with no live backend.
+//! is `false`. This middleware then short-circuits requests to DB-backed routes
+//! with a clean `503 {success:false, code:"DATABASE_UNAVAILABLE"}` envelope
+//! instead of letting them reach a handler that would hit a pool with no live
+//! backend. Once the background reconnect probe (`PgDb::spawn_reconnect_probe`)
+//! re-establishes PG, `pg_available()` flips back to true and the guard becomes
+//! a no-op again.
 //!
-//! ## Conservative by design
+//! ## Comprehensive, but fail-safe
 //!
-//! [`route_requires_db`] returns `true` only for an explicit allowlist of route
-//! prefixes that unambiguously require PG. Every other path passes through
-//! untouched, so this guard can NEVER turn a currently-working, DB-free route
-//! into a 503. A DB-backed route that is *not yet* in the list still fails
-//! safely in degraded mode — its handler returns its own error when the pool
-//! cannot connect (connection-refused is immediate on a dead `localhost:5432`,
-//! so there is no hang); listing it here only upgrades that raw 500 to a clean
-//! 503. The list is the extension point: broaden it as the per-handler audit in
-//! `plans/2026-06-07-runner-degraded-no-db-boot-and-dbless-ci.md` (D2 follow-up)
-//! proceeds.
+//! [`route_requires_db`] classifies a path against tables derived from a full
+//! audit of every route module's `routes()` + handler bodies (which touch
+//! `pg_db`/`PgDb`/`.pool`/SQL). The matching is segment-wise so it can target
+//! individual routes in MIXED modules (e.g. `/sessions/*/touched-files` is DB
+//! but `/sessions/*/message` is not). [`DB_EXEMPT`] lists the few DB-FREE routes
+//! that live UNDER a DB prefix (e.g. `/findings/summary`) so they keep working.
+//!
+//! Errs toward NOT 503-ing: a route we fail to list still fails safely (its
+//! handler returns its own error when the pool can't connect — connection-
+//! refused is immediate on a dead `localhost:5432`, no hang), so a miss is a raw
+//! 500, never a hang or a broken DB-free route. The control surface, vision
+//! capture, health, and the route manifest are never matched.
 //!
 //! ## Cost
 //!
 //! The fast path (PG available — the overwhelmingly common case) is a single
-//! `Relaxed` atomic load and an immediate `next.run`. No allocation, no path
-//! inspection. Zero measurable overhead in normal operation.
+//! `Relaxed` atomic load and an immediate `next.run`. Path classification only
+//! runs while degraded.
 
 use axum::{extract::Request, http::StatusCode, middleware::Next, response::Response, Json};
 
 use crate::mcp::types::ApiResponse;
 
-/// Route prefixes that are KNOWN to require PostgreSQL. Matched as whole path
-/// segments (exact, or followed by `/`), so `/plans` and `/plans/decompose`
-/// match but `/plansomething` does not.
-///
-/// Extension point — see the module docs. Verified against the live route
-/// registrations in `mcp_api.rs::create_router`.
+/// Route families that are ENTIRELY DB-backed — every route at or under the
+/// prefix requires PG. Matched segment-wise (so `/plans` matches `/plans` and
+/// `/plans/decompose` but not `/plansomething`). `*` matches one segment.
+/// Verified against the live route registrations + handler bodies.
 const DB_BACKED_PREFIXES: &[&str] = &[
-    "/task-runs",
+    // Coordinator / planning / tasks
     "/plans",
-    "/reviews",
-    "/findings",
-    "/decisions",
-    "/observations",
+    "/coordinator",
+    "/workers",
+    "/tasks", // completion_reports: /tasks/{id}/report, /add-dependency
+    "/task-run",
+    "/task-runs",
+    "/current-execution",
+    "/execution-spans",
+    "/traces",
+    "/runs", // automation_runs + regression_api drift
+    "/comparison",
+    "/comparisons",
+    // Checks / verification / triggers
+    "/checks",
+    "/check-groups",
+    "/tests", // verification_tests (exempt: /tests/execute-suite)
+    "/test-results",
+    "/triggers", // (exempt: /triggers/status)
+    "/hooks",
+    // Reflection / productivity / learning
+    "/productivity", // reflection module
     "/productivity-knowledge",
+    "/reflection", // reflection_api
+    "/reflection-fixes",
+    "/development-intelligence",
+    "/meta-optimizer",
+    "/learning",
+    "/workflow-generation",
+    "/online-learning/model-routing/table",
+    "/online-learning/drift-signals",
+    "/online-learning/step-credits",
+    "/online-learning/step-scorecard",
+    "/online-learning/strategies",
+    "/online-learning/experiences",
+    "/generator-eval",
+    "/generation-rules",
+    "/generation", // unified_workflows
+    "/step-type-knowledge",
+    "/blind-spots",
+    "/prm",
+    // Memory / knowledge / decisions / observations
+    "/observations",
+    "/decisions",
+    "/concept-summaries",
+    "/memory/entity-profiles",
+    "/memory/search",
+    "/memory/consolidate",
+    "/memory/consolidation-log",
+    "/memory/mental-models",
+    "/memory/decay-preview",
+    "/memory/health",
+    "/memory/contradictions",
+    "/memory/dreamer",
+    "/mcp/memory", // (exempt: /mcp/memory/tool-descriptor)
+    // CRUD-style registries
+    "/recordings",
+    "/mcp-servers",
+    "/saved-api-requests",
+    "/shell-commands",
+    "/skills",
+    "/unified-workflows",
+    "/slash-commands",
+    "/scheduler/tasks", // (exempt: /scheduler/tasks/*/run)
+    "/state-machine/configs",
+    // Errors / analytics / security / reviews
+    "/error-monitor",
+    "/analytics", // token_analytics
+    "/security",  // security_audit (/security/audit/*)
+    "/reviews",
+    // Workflow / spec / scenarios / state-discovery
+    "/scenarios",
+    "/state-discovery",
+    "/co-occurrence",
+    "/spec-check",
+    "/apps", // spec_api (exempt: /apps/*/spec/health, /apps/*/spec/subscribe)
+    "/hitl",
+    "/restate/awakeables",
+    "/trace", // trace_api (exempt: /trace/health)
+    // UI-Bridge DB-backed sub-surfaces (NOT the control/vision surfaces)
+    "/ui-bridge/integration",
+    "/ui-bridge/analytics",
+    "/ui-bridge/history",
+    "/ui-bridge/graph",
+    // Settings backup only (rest of /settings is file/keychain-backed)
+    "/settings/backup",
+    // api_surface_diff (api_surface /api-surface/scan is DB-free)
+    "/api-surface/diff",
+    "/api-surface/snapshot",
+    "/api-surface/snapshots",
 ];
 
-/// True iff `path` is at or under `prefix` on a segment boundary
-/// (`prefix` itself, or `prefix` + `/...`).
-fn path_under(path: &str, prefix: &str) -> bool {
-    match path.strip_prefix(prefix) {
-        Some(rest) => rest.is_empty() || rest.starts_with('/'),
-        None => false,
+/// Individual DB-backed routes inside MIXED modules whose DB-free siblings share
+/// a parent (so a blanket prefix would over-match). Matched as EXACT segment
+/// patterns; `*` matches one path-param segment.
+const DB_BACKED_EXACT: &[&str] = &[
+    // sessions (MIXED with /sessions/*/message, /sessions/idle-status = DB-free)
+    "/sessions/spawn",
+    "/sessions/*/touched-files",
+    "/sessions/*/transcript",
+    "/sessions/*/promote-to-worktree",
+    "/sessions/*/commit-progress",
+    "/sessions/*/latest-review",
+    "/sessions/*/snapshots",
+    "/sessions/*/rewind",
+    // misc (mostly DB-free IPC; these specific ones hit PG)
+    "/status",
+    "/runners",
+    "/instances", // GET list only; /instances/spawn etc. are DB-free
+    "/instances/purge-stale",
+    "/load-config",
+    "/run-workflow",
+    // api_requests
+    "/api-request/import-to-library",
+    // completion_sources (ci-pipeline is a DB-free stub)
+    "/completion-sources/github-merge",
+    "/completion-sources/manual-user-fire",
+    // api_spec_verify (api-specs GET is filesystem)
+    "/ui-bridge/specs/verify-api",
+    // state_machine (runtime/bridge routes are DB-free)
+    "/state-machine/available-transitions",
+    "/state-machine/save-compiled",
+    "/state-machine/current",
+    // scheduler (tasks covered by prefix; these two are the other DB routes)
+    "/scheduler/settings",
+    "/scheduler/status",
+    // state_explorer (only cross-run-diff hits PG)
+    "/state-explorer/cross-run-diff",
+    // file_registry / file_activity (rest is in-memory / coord-proxy)
+    "/file-registry/probe-conflicts",
+    "/file-activity/heatmap",
+    // graph_api (MIXED — these branches read PG; neighborhood/paths/etc. don't)
+    "/graph/summary",
+    "/graph/search",
+    "/graph/cross-run-patterns",
+    "/graph/workflow-versions",
+    "/graph/step-provenance",
+    "/graph/rule-influence",
+    "/graph/ineffective-rules",
+    "/graph/pipeline-events",
+    "/graph/phase-stats",
+    "/graph/detect-patterns",
+    "/graph/similar-errors",
+    "/graph/ui-failure-chain",
+    "/graph/ui-fix-effectiveness",
+    "/graph/skill-metrics",
+    // ui_bridge control workflow status (the rest of /ui-bridge/control is DB-free)
+    "/ui-bridge/control/workflow/*/status",
+];
+
+/// DB-FREE routes that fall UNDER a [`DB_BACKED_PREFIXES`] entry and must keep
+/// working in degraded mode. Checked FIRST; a match here means "never 503".
+/// `*` matches one path-param segment.
+const DB_EXEMPT: &[&str] = &[
+    "/findings/summary",           // under /findings (misc; returns empty)
+    "/triggers/status",            // under /triggers
+    "/tests/execute-suite",        // under /tests
+    "/mcp/memory/tool-descriptor", // under /mcp/memory
+    "/scheduler/tasks/*/run",      // under /scheduler/tasks
+    "/trace/health",               // under /trace
+    "/apps/*/spec/health",         // under /apps
+    "/apps/*/spec/subscribe",      // under /apps
+];
+
+/// Segment-wise match. `pattern` and `path` are split on `/` (leading/trailing
+/// slashes ignored); `*` in the pattern matches exactly one path segment.
+/// `prefix = true` matches when the pattern is a segment-prefix of the path
+/// (the pattern itself or any sub-path); `prefix = false` requires equal length.
+fn seg_match(pattern: &str, path: &str, prefix: bool) -> bool {
+    let p = pattern.trim_matches('/');
+    let s = path.trim_matches('/');
+    let pseg: Vec<&str> = if p.is_empty() {
+        vec![]
+    } else {
+        p.split('/').collect()
+    };
+    let sseg: Vec<&str> = if s.is_empty() {
+        vec![]
+    } else {
+        s.split('/').collect()
+    };
+    if prefix {
+        if sseg.len() < pseg.len() {
+            return false;
+        }
+    } else if sseg.len() != pseg.len() {
+        return false;
     }
+    pseg.iter()
+        .zip(sseg.iter())
+        .all(|(pp, ss)| *pp == "*" || pp == ss)
 }
 
-/// Whether a request path targets a known DB-backed route family.
-/// Conservative: defaults to `false` for anything not explicitly listed.
+/// Whether a request path targets a DB-backed route that should 503 in degraded
+/// mode. Exempt routes (DB-free siblings under a DB prefix) always return false.
 pub fn route_requires_db(path: &str) -> bool {
-    DB_BACKED_PREFIXES
-        .iter()
-        .any(|prefix| path_under(path, prefix))
+    if DB_EXEMPT.iter().any(|e| seg_match(e, path, false)) {
+        return false;
+    }
+    if DB_BACKED_PREFIXES.iter().any(|p| seg_match(p, path, true)) {
+        return true;
+    }
+    DB_BACKED_EXACT.iter().any(|e| seg_match(e, path, false))
 }
 
 /// The canonical `503 database unavailable` JSON envelope.
@@ -84,7 +265,7 @@ pub async fn pg_degraded_guard_middleware(req: Request, next: Next) -> Response 
         return next.run(req).await;
     }
 
-    // Degraded boot: 503 the known DB-backed families; pass everything else
+    // Degraded boot: 503 the DB-backed routes; pass everything else
     // (health, control surface, vision capture, route manifest, ...).
     let path = req.uri().path();
     if route_requires_db(path) {
@@ -98,32 +279,118 @@ mod tests {
     use super::*;
 
     #[test]
-    fn db_backed_prefixes_match_on_segment_boundary() {
-        // Exact prefix and sub-paths match.
-        assert!(route_requires_db("/task-runs"));
-        assert!(route_requires_db("/task-runs/running"));
-        assert!(route_requires_db("/task-runs/abc-123/output"));
-        assert!(route_requires_db("/plans"));
-        assert!(route_requires_db("/plans/decompose"));
-        assert!(route_requires_db("/reviews/recent"));
-        assert!(route_requires_db("/findings/xyz"));
-        assert!(route_requires_db("/decisions/search"));
-        assert!(route_requires_db("/observations/stats"));
-        assert!(route_requires_db("/productivity-knowledge"));
+    fn whole_db_families_match_at_and_under_prefix() {
+        for p in [
+            "/plans",
+            "/plans/decompose",
+            "/coordinator/state",
+            "/workers",
+            "/task-runs",
+            "/task-runs/abc-123/output",
+            "/task-run/abc/events",
+            "/checks/scan-workspace",
+            "/check-groups/x/run",
+            "/observations/stats",
+            "/decisions/search",
+            "/recordings/x/actions",
+            "/reviews/recent",
+            "/hooks/x/test",
+            "/meta-optimizer/runs",
+            "/memory/entity-profiles/search",
+            "/security/audit/events",
+            "/analytics/token-usage/daily",
+            "/spec-check/batch",
+            "/apps/myapp/spec/get",
+            "/ui-bridge/integration/analyze",
+            "/ui-bridge/analytics/health-score",
+            "/settings/backup/export",
+            "/api-surface/diff",
+        ] {
+            assert!(route_requires_db(p), "expected DB: {p}");
+        }
     }
 
     #[test]
-    fn non_db_and_lookalike_paths_pass_through() {
-        // Boot-critical / DB-free surfaces the contract smoke depends on.
-        assert!(!route_requires_db("/health"));
-        assert!(!route_requires_db("/ui-bridge/health"));
-        assert!(!route_requires_db("/control/elements"));
-        assert!(!route_requires_db("/control/component/abc"));
-        assert!(!route_requires_db("/vision/capture"));
-        assert!(!route_requires_db("/ui-bridge/_routes"));
-        // Lookalikes must NOT match — segment-boundary matching, not raw prefix.
-        assert!(!route_requires_db("/plansomething"));
-        assert!(!route_requires_db("/task-runs-archive"));
-        assert!(!route_requires_db("/reviewsx"));
+    fn mixed_module_db_routes_match_exactly() {
+        for p in [
+            "/sessions/spawn",
+            "/sessions/abc/touched-files",
+            "/sessions/abc/latest-review",
+            "/status",
+            "/instances",
+            "/instances/purge-stale",
+            "/api-request/import-to-library",
+            "/completion-sources/github-merge",
+            "/ui-bridge/specs/verify-api",
+            "/state-machine/configs/import",
+            "/state-machine/current",
+            "/scheduler/settings",
+            "/state-explorer/cross-run-diff",
+            "/file-registry/probe-conflicts",
+            "/file-activity/heatmap",
+            "/graph/summary",
+            "/online-learning/strategies",
+            "/ui-bridge/control/workflow/run-7/status",
+        ] {
+            assert!(route_requires_db(p), "expected DB: {p}");
+        }
+    }
+
+    #[test]
+    fn exempt_and_db_free_routes_pass_through() {
+        for p in [
+            // Boot-critical / smoke-walked DB-free surfaces.
+            "/health",
+            "/ui-bridge/health",
+            "/ui-bridge/status",
+            "/control/elements",
+            "/control/component/abc",
+            "/control/element/x/expect",
+            "/vision/capture",
+            "/ui-bridge/_routes",
+            "/ui-bridge/capabilities",
+            "/awas/discover",
+            // DB-free siblings of DB routes (mixed modules).
+            "/sessions/abc/message",
+            "/sessions/idle-status",
+            "/instances/spawn",
+            "/instances/abc/heartbeat",
+            "/api-request/test",
+            "/completion-sources/ci-pipeline",
+            "/api-surface/scan",
+            "/memory/invalidate-graph-cache",
+            "/graph/neighborhood",
+            "/online-learning/model-routing",
+            "/scheduler/reconcile-now",
+            "/state-machine/execute-transition",
+            // Explicit exemptions under a DB prefix.
+            "/findings/summary",
+            "/triggers/status",
+            "/tests/execute-suite",
+            "/mcp/memory/tool-descriptor",
+            "/scheduler/tasks/abc/run",
+            "/trace/health",
+            "/apps/myapp/spec/health",
+            "/apps/myapp/spec/subscribe",
+            // Segment-boundary lookalikes must NOT match.
+            "/plansomething",
+            "/task-runs-archive",
+            "/reviewsx",
+        ] {
+            assert!(!route_requires_db(p), "expected DB-free: {p}");
+        }
+    }
+
+    #[test]
+    fn segment_boundary_not_substring() {
+        // /productivity must not catch /productivity-knowledge (different segment).
+        assert!(route_requires_db("/productivity/reflection/p1"));
+        assert!(route_requires_db("/productivity-knowledge/search")); // its own prefix
+                                                                      // A lookalike that is neither prefix:
+        assert!(!route_requires_db("/productivityx"));
+        // /trace vs /traces (distinct segments).
+        assert!(route_requires_db("/traces/abc")); // task_runs /traces prefix
+        assert!(route_requires_db("/trace/list")); // trace_api /trace prefix
+        assert!(!route_requires_db("/trace/health")); // exempt
     }
 }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1831,6 +1831,12 @@ pub fn create_router(
     //   2. In debug builds only, add the audit layer via a rebind.
     //   3. Add the outermost CatchPanicLayer + state unconditionally.
     let router_with_inner_layers = base_router
+        // Degraded-boot guard (D2): when PG is unavailable (QONTINUI_ALLOW_NO_DB),
+        // short-circuit KNOWN DB-backed routes to a clean 503. No-op (one atomic
+        // load) on the normal PG-available path. See crate::mcp::pg_guard.
+        .layer(axum::middleware::from_fn(
+            crate::mcp::pg_guard::pg_degraded_guard_middleware,
+        ))
         .layer(axum::middleware::from_fn(
             crate::middleware::trace_propagation_middleware,
         ))

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1965,6 +1965,19 @@ pub async fn start_server(
     let router = create_router(app_state, rag_state, app_handle, instance_manager);
     info!("MCP API server: create_router returned, entering bind loop");
 
+    // D3 (self-healing degraded mode): if the runner booted degraded (PG
+    // unreachable + QONTINUI_ALLOW_NO_DB), start a background probe that
+    // reconnects + provisions and lifts the pg_guard 503 gate when PG returns —
+    // no restart needed for a transient outage. No-op on a normal boot.
+    if !crate::database::pg::pg_available() {
+        if let Some(pg) = crate::database::pg::PgDb::try_global() {
+            tracing::warn!(
+                "Runner booted DEGRADED (no PG); starting background PG reconnect probe"
+            );
+            pg.spawn_reconnect_probe();
+        }
+    }
+
     // Try the requested port first, then fallback ports if zombie connections are blocking
     // This can happen on Windows when previous process crashes leave orphaned sockets
     let ports_to_try = [port, port + 1, port + 2];


### PR DESCRIPTION
Implements **D1 + D4 + the D2 mechanism** from `plans/2026-06-07-runner-degraded-no-db-boot-and-dbless-ci.md` (VETTED). Builds on #479 (CI contract gate, merged `be1e1e5f`).

## Why
The runner hard-`panic!`s at `main.rs:419` when PostgreSQL is unreachable. That meant (a) a brief PG blip crashes a user's runner where a degraded "database unavailable, retrying" surface would keep the UI alive, and (b) every windows PR compiled pgvector from source + stood up a PG cluster just to let the runner boot for a route-shape smoke that needs no DB *rows* — the gate's highest-variance step.

## What

**D1 — Flag-gated degraded boot.** `QONTINUI_ALLOW_NO_DB=1` turns the `main.rs:419` panic into a degraded path: build an unverified pool via the new `PgDb::new_degraded` (connectivity probe + self-provision skipped, deadpool reconnects lazily), flip the global `pg_available()` flag to `false`, and continue booting Tauri/axum. **Default (flag unset) keeps the current fail-fast invariant — production is unchanged.** `AppState.pg_db` stays a non-optional `Arc<PgDb>`, so the ~1480 `.pg_db` call sites are untouched.

**D2 (mechanism, not full audit — operator-approved scope).** There is no single error-mapping chokepoint (~111 handler files map errors individually), so comprehensive per-route 503-gating is a ~100-file audit. This PR ships the *mechanism*: a tower middleware `crate::mcp::pg_guard::pg_degraded_guard_middleware` that returns a clean `503 {code: DATABASE_UNAVAILABLE}` for a conservative, **verified** allowlist of DB-backed route prefixes when degraded, and passes everything else through (**never regresses a working route**). Fast path is one atomic load. The allowlist (`/task-runs`, `/plans`, `/reviews`, `/findings`, `/decisions`, `/observations`, `/productivity-knowledge`) is the documented extension point.

> **Follow-up:** broaden `DB_BACKED_PREFIXES` to the full DB-route set (separate PR).

**D4 — DB-less CI.** Deletes the pgvector-from-source + local-PG provisioning step; the windows contract smoke now runs with `QONTINUI_ALLOW_NO_DB=1` and no `RUNNER_DATABASE_URL`.

## Verification
- `cargo clippy --tests --features custom-protocol -- -D warnings` ✅ (incl. `pg_guard` unit tests for segment-boundary matching)
- `cargo fmt --check` ✅
- **Make-or-break (this PR's CI):** the windows contract smoke now boots the runner with **zero database** and walks the contract surface. DB-free routes 200, listed DB routes 503, unlisted DB routes fast-500 (connection-refused) — all PASS-reachable in the route walk; the 4 shape probes (`/control/*`, `/vision/capture`) are DB-free.
- Prod invariant: without the flag, an unreachable PG still panics at `main.rs:419`.

Depends-On: #479 (merged).