### PR TITLE
refactor(ui-bridge): promote runner-windows out of runner_only_baseline (Phase 2)

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/mod.rs
+++ b/src-tauri/src/mcp/ui_bridge/mod.rs
@@ -738,11 +738,12 @@ mod manifest_drift_tests {
             // Pairs with `terminal-launch-menu` component actions.
             ("GET", "/ui-bridge/control/terminal-sessions"),
             ("GET", "/ui-bridge/control/terminal-sessions/{}"),
-            // Runner-owned webview windows — runner-only (enumerates THIS
-            // process's own Tauri windows; the SDK contract and the OS-window
-            // enumerator at /control/windows don't cover them). Phase 0 of the
-            // pop-out terminal-windows plan (2026-06-03).
-            ("GET", "/ui-bridge/control/runner-windows"),
+            // NOTE: /ui-bridge/control/runner-windows was here (runner-only
+            // allow-list) until the SDK declared it in UI_BRIDGE_ROUTES as the
+            // `listWindows` discovery method (plan 2026-06-07-multi-window-sdk-
+            // automation, Phase 2). Now that both sides declare it, it must NOT
+            // be allow-listed — leave it in the bidirectional diff so SDK and
+            // runner stay in lockstep.
             // /control/ai/* aliases mirroring SDK /ai/* (runner-side dual mount)
             ("DELETE", "/ui-bridge/control/ai/bookmark/{}"),
             ("DELETE", "/ui-bridge/control/ai/bookmarks/{}"),


### PR DESCRIPTION
## What

Phase 2 of plan `2026-06-07-multi-window-sdk-automation` — the **runner half** of a cross-repo **ATOMIC** change.

`GET /ui-bridge/control/runner-windows` already exists and is registered (`capabilities.rs` `routes()` + `route_entries()`); it was allow-listed in `runner_only_baseline` so the bidirectional `sdk_manifest_routes_are_exposed_by_runner` diff ignored it. Now that `@qontinui/ui-bridge` declares it in `UI_BRIDGE_ROUTES` as the typed `listWindows()` discovery method, this removes the baseline entry so the SDK and runner stay in lockstep.

With the route in both `UI_BRIDGE_ROUTES` and `route_manifest()` (and absent from both baselines), it lands in both filtered sets → the diff stays empty. **No handler change** — pure baseline-allowlist edit.

## ⚠️ Cross-repo atomic — pairs with ui-bridge PR #98

The `sdk_manifest_routes_are_exposed_by_runner` diff is **bidirectional** and **skips when `ui-bridge` isn't checked out beside the runner** — so this repo's CI does NOT catch the half-landed state. Pairs with **ui-bridge PR #98** (declares the route). Verified together in a **co-located worktree pair** (`cargo test --bin qontinui-runner manifest` with PR #98's branch as the sibling `ui-bridge`).

Land both in a tight window: until #98 merges, a co-located dev / spawn-test tree sees `runner-windows` in `runner_extra_vs_sdk` (runner exposes it, SDK main doesn't yet declare it).

## Verification

- Co-located runner manifest tests pass with the paired ui-bridge branch as sibling.