### PR TITLE
chore(federation): drop the vestigial X-Qontinui-Tenant-Id header from memory_client

### DIFF
--- a/src-tauri/src/claude_session/federation.rs
+++ b/src-tauri/src/claude_session/federation.rs
@@ -377,11 +377,8 @@ fn post_report_to_coord(ctx: &SessionContext, report: &ReconcileReport) {
         }
     };
 
-    let tenant_id = ctx.tenant_id;
     spawn_detached_best_effort(async move {
-        if let Err(e) =
-            memory_client::post_federation_report(&http, &base, &token, tenant_id, &body).await
-        {
+        if let Err(e) = memory_client::post_federation_report(&http, &base, &token, &body).await {
             debug!("federation report: coord POST failed: {e} (non-fatal)");
         }
     });

--- a/src-tauri/src/observable_bridge/memory.rs
+++ b/src-tauri/src/observable_bridge/memory.rs
@@ -126,18 +126,12 @@ impl MemoryBridge {
                     written_by_agent: Some(session_ctx.session_id.to_string()),
                     written_by_device: Some(session_ctx.device_id.to_string()),
                 };
-                if let Err(e) =
-                    memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req)
-                        .await
-                {
+                if let Err(e) = memory_client::upsert(&self.http, &base, &token, &req).await {
                     warn!("observable_bridge::memory::push upsert {name} failed: {e}");
                 }
             }
             ObservableChange::Deleted { name } => {
-                if let Err(e) =
-                    memory_client::delete(&self.http, &base, &token, session_ctx.tenant_id, &name)
-                        .await
-                {
+                if let Err(e) = memory_client::delete(&self.http, &base, &token, &name).await {
                     warn!("observable_bridge::memory::push delete {name} failed: {e}");
                 }
             }
@@ -369,18 +363,17 @@ impl RunnerObservableBridge for MemoryBridge {
         };
 
         // Step 1: list coord's tenant pool.
-        let listing =
-            match memory_client::list(&self.http, &base, &token, session_ctx.tenant_id).await {
-                Ok(l) => l,
-                Err(e) => {
-                    warn!(
-                        "observable_bridge::memory::pull: list failed ({e}); \
+        let listing = match memory_client::list(&self.http, &base, &token).await {
+            Ok(l) => l,
+            Err(e) => {
+                warn!(
+                    "observable_bridge::memory::pull: list failed ({e}); \
                      leaving memory_dir untouched, snapshot = local"
-                    );
-                    session_ctx.post_pull_snapshot = Some(local_pre);
-                    return Ok(());
-                }
-            };
+                );
+                session_ctx.post_pull_snapshot = Some(local_pre);
+                return Ok(());
+            }
+        };
 
         // Step 2: for each coord entry, GET full payload (the list
         // response omits content + hash to keep the metadata call
@@ -392,15 +385,7 @@ impl RunnerObservableBridge for MemoryBridge {
         let mut coord_names: HashSet<String> = HashSet::new();
         for summary in &listing.items {
             coord_names.insert(summary.name.clone());
-            let full = match memory_client::get(
-                &self.http,
-                &base,
-                &token,
-                session_ctx.tenant_id,
-                &summary.name,
-            )
-            .await
-            {
+            let full = match memory_client::get(&self.http, &base, &token, &summary.name).await {
                 Ok(p) => p,
                 Err(e) => {
                     warn!(
@@ -444,9 +429,7 @@ impl RunnerObservableBridge for MemoryBridge {
                 written_by_agent: Some(session_ctx.session_id.to_string()),
                 written_by_device: Some(session_ctx.device_id.to_string()),
             };
-            if let Err(e) =
-                memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req).await
-            {
+            if let Err(e) = memory_client::upsert(&self.http, &base, &token, &req).await {
                 warn!(
                     "observable_bridge::memory::pull: first-contact upsert {} failed: {e}",
                     fp.name
@@ -626,9 +609,7 @@ impl RunnerObservableBridge for MemoryBridge {
                 written_by_agent: Some(session_ctx.session_id.to_string()),
                 written_by_device: Some(session_ctx.device_id.to_string()),
             };
-            match memory_client::upsert(&self.http, &base, &token, session_ctx.tenant_id, &req)
-                .await
-            {
+            match memory_client::upsert(&self.http, &base, &token, &req).await {
                 Ok(_) => report.pushed = report.pushed.saturating_add(1),
                 Err(e) => {
                     warn!(
@@ -643,9 +624,7 @@ impl RunnerObservableBridge for MemoryBridge {
 
         // Deletes: name in pre_pull but gone now.
         for name in pre_names.difference(&post_names) {
-            match memory_client::delete(&self.http, &base, &token, session_ctx.tenant_id, name)
-                .await
-            {
+            match memory_client::delete(&self.http, &base, &token, name).await {
                 Ok(_) => report.pushed = report.pushed.saturating_add(1),
                 Err(e) => {
                     warn!(

--- a/src-tauri/src/observable_bridge/memory_client.rs
+++ b/src-tauri/src/observable_bridge/memory_client.rs
@@ -17,23 +17,12 @@ use qontinui_types::memory::{
     MemoryListResponse, MemoryUpsertRequest, MemoryUpsertResponse, MemoryWithHistory,
 };
 use std::time::Duration;
-use uuid::Uuid;
 
 /// Per-call timeout. List/get are cheap metadata reads; upsert writes
 /// one row; delete writes one tombstone — all should land well under
 /// this. Matches the 10s timeout `fleet::publish_budget` uses for
 /// similar single-row POSTs.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// Coord's tenant-scoping header. Coord's `TenantId` extractor
-/// (`qontinui-coord/src/tenant_scope.rs`) resolves the tenant **solely**
-/// from this header — it does NOT parse the Bearer JWT (device-token →
-/// tenant resolution is a deferred coord hardening pass). The bridge
-/// resolves `tenant_id` locally (paired_user.json / OAuth claim) and
-/// sends it here; the Bearer token is retained for forward-compat with
-/// that future authenticated path. Without this header every call 403s
-/// with `tenant_not_resolved`.
-const TENANT_HEADER: &str = "X-Qontinui-Tenant-Id";
 
 /// Build the long-lived reqwest client the bridge reuses across calls.
 /// Returned to the bridge once at construction; cloned cheaply (it's an
@@ -74,12 +63,10 @@ pub async fn list(
     client: &reqwest::Client,
     base: &str,
     device_token: &str,
-    tenant_id: Uuid,
 ) -> Result<MemoryListResponse> {
     let url = format!("{base}/coord/memory/list");
     let resp = client
         .get(&url)
-        .header(TENANT_HEADER, tenant_id.to_string())
         .bearer_auth(device_token)
         .send()
         .await
@@ -101,13 +88,11 @@ pub async fn get(
     client: &reqwest::Client,
     base: &str,
     device_token: &str,
-    tenant_id: Uuid,
     name: &str,
 ) -> Result<MemoryWithHistory> {
     let url = format!("{base}/coord/memory/{}", urlencoding::encode(name));
     let resp = client
         .get(&url)
-        .header(TENANT_HEADER, tenant_id.to_string())
         .bearer_auth(device_token)
         .send()
         .await
@@ -129,13 +114,11 @@ pub async fn upsert(
     client: &reqwest::Client,
     base: &str,
     device_token: &str,
-    tenant_id: Uuid,
     req: &MemoryUpsertRequest,
 ) -> Result<MemoryUpsertResponse> {
     let url = format!("{base}/coord/memory/upsert");
     let resp = client
         .post(&url)
-        .header(TENANT_HEADER, tenant_id.to_string())
         .bearer_auth(device_token)
         .json(req)
         .send()
@@ -158,13 +141,11 @@ pub async fn post_federation_report(
     client: &reqwest::Client,
     base: &str,
     device_token: &str,
-    tenant_id: Uuid,
     body: &serde_json::Value,
 ) -> Result<()> {
     let url = format!("{base}/coord/federation/reports");
     let resp = client
         .post(&url)
-        .header(TENANT_HEADER, tenant_id.to_string())
         .bearer_auth(device_token)
         .json(body)
         .send()
@@ -186,13 +167,11 @@ pub async fn delete(
     client: &reqwest::Client,
     base: &str,
     device_token: &str,
-    tenant_id: Uuid,
     name: &str,
 ) -> Result<()> {
     let url = format!("{base}/coord/memory/{}", urlencoding::encode(name));
     let resp = client
         .delete(&url)
-        .header(TENANT_HEADER, tenant_id.to_string())
         .bearer_auth(device_token)
         .send()
         .await


### PR DESCRIPTION
Cleanup completing the 1a auth end-state. coord #440 (deployed) resolves tenant from the verified bearer (`FleetPrincipal`) and **no longer reads** `X-Qontinui-Tenant-Id` — verified live (anonymous + header-only both `403 auth_required`). So the runner sending that header + threading a `tenant_id` purely to build it is dead weight.

Removes `TENANT_HEADER` + its stale doc + the `.header()` calls + the `tenant_id` param from all 5 `memory_client` fns, drops the now-unused `Uuid` import, and updates the 8 callers (`memory.rs` + `federation.rs`). `.bearer_auth(device_token)` is now the sole auth. `cargo check` + `cargo clippy --tests` clean.