### PR TITLE
feat(ai-provider): rank Claude account selection by weekly-usage headroom

### DIFF
--- a/src-tauri/src/ai_provider/account_usage.rs
+++ b/src-tauri/src/ai_provider/account_usage.rs
@@ -1,26 +1,38 @@
-//! Cooldown-driven Claude account selection.
+//! Weekly-usage-aware Claude account selection.
 //!
 //! [`pick_best_account`] picks an effective Claude config dir from the
-//! configured `claude_config_dirs` based purely on local cooldown state —
-//! no HTTP calls on the hot path. The selection is:
+//! configured `claude_config_dirs`. Among accounts that are **not** in a
+//! rate-limit cooldown, it prefers the one with the most weekly-usage
+//! *headroom* — the lowest [`super::config::usage_headroom_key`] (actual
+//! 7-day utilization minus the expected linear utilization at this point in
+//! the billing window; negative = under projected pace). This mirrors the
+//! Terminal "best account" picker (`compareByUsageHeadroom` in
+//! `src/components/settings/types.ts`), so the co-pilot — which relays its
+//! planning prompt through this picker — chooses the same account a human
+//! would when opening a new session.
 //!
-//! 1. The first account that is not currently in cooldown.
-//! 2. If every account is cooled, the one with the **shortest remaining
-//!    cooldown** (closest to expiry), so the next attempt happens as soon
-//!    as possible.
+//! Selection order:
+//! 1. Among non-cooled accounts with a fresh usage sample, the one with the
+//!    most headroom (lowest `usage_delta`, else lowest raw utilization).
+//! 2. If no non-cooled account has a fresh sample, the first non-cooled
+//!    account (legacy cooldown-only behaviour — preserved for cold start).
+//! 3. If every account is cooled, the one with the **shortest remaining
+//!    cooldown** (closest to expiry).
+//!
+//! The usage signal comes from a cached snapshot, never an inline probe: the
+//! probe endpoint (`commands::ai_settings::probe_account_usage`) self-rate-
+//! limits, so probing on the hot path would give the worst signal exactly
+//! when it matters most. The snapshot is refreshed off the hot path — at
+//! startup and periodically (see `main.rs`), and opportunistically whenever
+//! the Settings/Terminal `check_accounts_usage` command or the
+//! `/analytics/account-usage` route runs — via
+//! [`super::config::record_account_usage`].
 //!
 //! Cooldown state is mutated by the inference path itself: when a 429 hits,
 //! `claude_api`/`claude_api_warm` parse the `Retry-After` header and call
 //! [`super::config::mark_account_rate_limited_with_duration`]. The CLI
 //! subprocess path uses [`super::config::mark_account_rate_limited`] with
 //! the default 5-minute cooldown (no header source on stdout).
-//!
-//! Authoritative server-side utilization (`/api/oauth/usage` and the
-//! `anthropic-ratelimit-unified-*` response headers) is a **calibration**
-//! signal, surfaced via `commands::ai_settings::probe_account_usage` for the
-//! Settings UI and the `/analytics/account-usage` HTTP route. It is never
-//! used on the selection hot path because the probe endpoint itself
-//! self-rate-limits and gives the worst signal exactly when it matters most.
 //!
 //! [`pick_best_account`] is a no-op when `account_selection_mode != LeastUsage`
 //! or fewer than two accounts are configured.
@@ -39,8 +51,9 @@ use tracing::info;
 ///   - account selection mode is `Manual`
 ///   - fewer than two accounts are configured
 ///
-/// Selection is cooldown-driven: prefers an account with no active cooldown,
-/// otherwise picks the one whose cooldown will expire soonest.
+/// Selection prefers the non-cooled account with the most weekly-usage
+/// headroom; falls back to first-non-cooled (cold start), then to the
+/// soonest-to-expire cooldown when every account is rate-limited.
 pub fn pick_best_account() {
     let ai_settings = settings::get_ai_settings();
     if ai_settings.claude_cli.account_selection_mode != AccountSelectionMode::LeastUsage {
@@ -52,28 +65,52 @@ pub fn pick_best_account() {
         return;
     }
 
-    let chosen = config_dirs
-        .iter()
-        .find(|d| !super::config::is_account_cooled_down(d))
-        .cloned()
-        .or_else(|| {
-            // All cooled: pick the one with the shortest remaining cooldown.
-            config_dirs
-                .iter()
-                .min_by_key(|d| super::config::time_until_cooled_down(d).unwrap_or(Duration::ZERO))
-                .cloned()
-        });
+    let chosen = pick_from(
+        &config_dirs,
+        |d| super::config::is_account_cooled_down(d),
+        |d| super::config::usage_headroom_key(d),
+        |d| super::config::time_until_cooled_down(d),
+    );
 
     if let Some(dir) = chosen {
         let current = super::config::get_resolved_config_dir();
         if current.as_deref() != Some(dir.as_str()) {
-            info!(
-                "pick_best_account: selecting '{}' (cooldown-driven)",
-                short_label(&dir)
-            );
+            info!("pick_best_account: selecting '{}'", short_label(&dir));
             super::config::set_resolved_config_dir(Some(dir));
         }
     }
+}
+
+/// Pure selection core, parameterised over the cooldown/usage/expiry lookups
+/// so it can be unit-tested without the global settings + state singletons.
+///
+/// `is_cooled` / `headroom` / `remaining` mirror the `super::config` helpers.
+/// Returns the chosen config dir, or `None` only when `config_dirs` is empty.
+fn pick_from<'a>(
+    config_dirs: &'a [String],
+    is_cooled: impl Fn(&str) -> bool,
+    headroom: impl Fn(&str) -> Option<f64>,
+    remaining: impl Fn(&str) -> Option<Duration>,
+) -> Option<String> {
+    let available: Vec<&'a String> = config_dirs.iter().filter(|d| !is_cooled(d)).collect();
+
+    if !available.is_empty() {
+        // Prefer the available account with the most usage headroom (lowest
+        // key). Only ranks accounts that have a fresh usage sample; if none
+        // do, fall back to the first available (legacy cooldown-only pick).
+        let best_by_headroom = available
+            .iter()
+            .filter_map(|d| headroom(d).map(|k| (*d, k)))
+            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .map(|(d, _)| d.clone());
+        return best_by_headroom.or_else(|| available.first().map(|d| (*d).clone()));
+    }
+
+    // All cooled: pick the one with the shortest remaining cooldown.
+    config_dirs
+        .iter()
+        .min_by_key(|d| remaining(d).unwrap_or(Duration::ZERO))
+        .cloned()
 }
 
 fn short_label(config_dir: &str) -> &str {
@@ -175,5 +212,98 @@ mod tests {
         assert_eq!(short_label("relative/path/.claude"), ".claude");
         // No separators → returns the whole string.
         assert_eq!(short_label("name-only"), "name-only");
+    }
+
+    // --- pick_from: the pure selection core ---------------------------------
+    //
+    // `pick_from` is parameterised over the cooldown/usage/expiry lookups, so
+    // these tests inject closures and assert the ranking directly — no global
+    // settings/state needed. Mirrors the frontend `compareByUsageHeadroom`
+    // semantics: lowest `usage_delta` (else utilization) wins among available.
+
+    fn dirs(names: &[&str]) -> Vec<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn headroom_wins_among_available() {
+        let d = dirs(&["/a", "/b", "/c"]);
+        // /b is furthest under projected pace (most-negative delta) → chosen,
+        // even though /a sorts first by position.
+        let chosen = pick_from(
+            &d,
+            |_| false, // none cooled
+            |x| match x {
+                "/a" => Some(0.10),
+                "/b" => Some(-0.30),
+                "/c" => Some(0.05),
+                _ => None,
+            },
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn cooled_account_excluded_even_with_best_headroom() {
+        let d = dirs(&["/a", "/b"]);
+        // /a has the best headroom but is cooled → must not be picked.
+        let chosen = pick_from(
+            &d,
+            |x| x == "/a",
+            |x| match x {
+                "/a" => Some(-0.90),
+                "/b" => Some(0.20),
+                _ => None,
+            },
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn falls_back_to_first_available_when_no_usage_data() {
+        let d = dirs(&["/a", "/b", "/c"]);
+        // No fresh samples → legacy "first non-cooled" behaviour. /a is cooled,
+        // so /b (first available) wins.
+        let chosen = pick_from(&d, |x| x == "/a", |_| None, |_| None);
+        assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn ranks_only_accounts_with_samples_then_keeps_them() {
+        let d = dirs(&["/a", "/b"]);
+        // Only /b has a sample → it is selected (a known-headroom account is
+        // preferred over an unprobed one).
+        let chosen = pick_from(
+            &d,
+            |_| false,
+            |x| if x == "/b" { Some(0.40) } else { None },
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn all_cooled_picks_soonest_to_expire() {
+        let d = dirs(&["/a", "/b"]);
+        let chosen = pick_from(
+            &d,
+            |_| true, // all cooled
+            |_| None,
+            |x| match x {
+                "/a" => Some(Duration::from_secs(600)),
+                "/b" => Some(Duration::from_secs(30)),
+                _ => None,
+            },
+        );
+        assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn empty_config_dirs_returns_none() {
+        let d: Vec<String> = Vec::new();
+        let chosen = pick_from(&d, |_| false, |_| None, |_| None);
+        assert_eq!(chosen, None);
     }
 }

--- a/src-tauri/src/ai_provider/config.rs
+++ b/src-tauri/src/ai_provider/config.rs
@@ -20,6 +20,35 @@ static ACCOUNT_COOLDOWNS: Mutex<Option<HashMap<String, (Instant, Duration)>>> = 
 /// on stdout without a header). Five minutes.
 const RATE_LIMIT_COOLDOWN_SECS: u64 = 300;
 
+/// One account's weekly-usage sample, captured by the usage probe
+/// (`commands::ai_settings::probe_account_usage`). `usage_delta` is the
+/// account's actual 7-day utilization minus its *expected* linear utilization
+/// at this point in the billing window (negative = under projected pace);
+/// `None` when the probe couldn't compute it (e.g. the 7d-reset header was
+/// absent). `utilization` is the raw 0.0–1.0 weekly fraction, used as the
+/// fallback selection key when `usage_delta` is unavailable — mirroring the
+/// frontend `compareByUsageHeadroom` (`src/components/settings/types.ts`).
+#[derive(Clone, Copy, Debug)]
+struct UsageSample {
+    captured_at: Instant,
+    usage_delta: Option<f64>,
+    utilization: f64,
+}
+
+/// Latest weekly-usage snapshot per account, keyed by config dir. Populated
+/// off the selection hot path by the usage-probe callers (the periodic
+/// startup refresh, the Settings/Terminal `check_accounts_usage` command, and
+/// the `/analytics/account-usage` route) so [`usage_headroom_key`] can rank
+/// accounts by headroom without making its own HTTP calls. The probe
+/// endpoint self-rate-limits, so the hot path must never probe inline — it
+/// reads this cache instead.
+static USAGE_SNAPSHOT: Mutex<Option<HashMap<String, UsageSample>>> = Mutex::new(None);
+
+/// Maximum age of a usage sample before [`usage_headroom_key`] treats it as
+/// stale and returns `None` (so selection falls back to cooldown ordering).
+/// Fifteen minutes — comfortably longer than the startup refresh cadence.
+const USAGE_SNAPSHOT_TTL: Duration = Duration::from_secs(15 * 60);
+
 /// Set the resolved config directory (called after usage check).
 pub fn set_resolved_config_dir(dir: Option<String>) {
     if let Ok(mut cached) = RESOLVED_CONFIG_DIR.lock() {
@@ -111,6 +140,47 @@ pub fn time_until_cooled_down(config_dir: &str) -> Option<Duration> {
     } else {
         Some(remaining)
     }
+}
+
+/// Record weekly-usage samples from a probe into the selection snapshot.
+///
+/// Called by the usage-probe paths (startup periodic refresh, the
+/// `check_accounts_usage` command, the `/analytics/account-usage` route) so
+/// the selection hot path has fresh headroom data without issuing its own
+/// HTTP calls. Each tuple is `(config_dir, utilization, usage_delta)`.
+pub fn record_account_usage(samples: &[(String, f64, Option<f64>)]) {
+    if let Ok(mut snap) = USAGE_SNAPSHOT.lock() {
+        let map = snap.get_or_insert_with(HashMap::new);
+        let now = Instant::now();
+        for (dir, utilization, usage_delta) in samples {
+            map.insert(
+                dir.clone(),
+                UsageSample {
+                    captured_at: now,
+                    usage_delta: *usage_delta,
+                    utilization: *utilization,
+                },
+            );
+        }
+    }
+}
+
+/// Weekly-usage headroom key for an account from the latest snapshot, if a
+/// fresh sample exists. Returns `usage_delta` when available (most-negative =
+/// furthest under projected weekly pace = best), else the raw `utilization`
+/// — mirroring the frontend `compareByUsageHeadroom`. Returns `None` when
+/// there is no sample or it is older than [`USAGE_SNAPSHOT_TTL`], so callers
+/// fall back to cooldown-only ordering.
+///
+/// Lower is better (ascending = most headroom first).
+pub fn usage_headroom_key(config_dir: &str) -> Option<f64> {
+    let snap = USAGE_SNAPSHOT.lock().ok()?;
+    let map = snap.as_ref()?;
+    let sample = map.get(config_dir)?;
+    if sample.captured_at.elapsed() > USAGE_SNAPSHOT_TTL {
+        return None;
+    }
+    Some(sample.usage_delta.unwrap_or(sample.utilization))
 }
 
 /// Rotate to the next available account after a rate-limit hit.
@@ -414,6 +484,23 @@ mod tests {
             "expired cooldown should report None"
         );
         clear_dir(dir);
+    }
+
+    #[test]
+    fn usage_headroom_prefers_delta_then_falls_back_to_utilization() {
+        let dir_delta = "/test/config/headroom_delta";
+        let dir_util = "/test/config/headroom_util";
+        // Fresh sample with a delta → key is the delta.
+        record_account_usage(&[(dir_delta.to_string(), 0.80, Some(-0.25))]);
+        assert_eq!(usage_headroom_key(dir_delta), Some(-0.25));
+        // Fresh sample without a delta → key falls back to raw utilization.
+        record_account_usage(&[(dir_util.to_string(), 0.42, None)]);
+        assert_eq!(usage_headroom_key(dir_util), Some(0.42));
+    }
+
+    #[test]
+    fn usage_headroom_none_when_unrecorded() {
+        assert_eq!(usage_headroom_key("/test/config/headroom_never"), None);
     }
 
     #[test]

--- a/src-tauri/src/ai_provider/mod.rs
+++ b/src-tauri/src/ai_provider/mod.rs
@@ -34,7 +34,7 @@ mod types;
 pub use account_usage::pick_best_account;
 pub use cache_aware_builder::StructuredPrompt;
 pub use config::{
-    get_account_statuses, get_effective_config_dir, get_resolved_config_dir,
+    get_account_statuses, get_effective_config_dir, get_resolved_config_dir, record_account_usage,
     rotate_account_on_rate_limit, set_resolved_config_dir, switch_to_account,
 };
 pub use multimodal::{ContentBlock, ImageSource, MultimodalPrompt};

--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -1266,6 +1266,11 @@ pub async fn check_accounts_usage(config_dirs: Vec<String>) -> Result<CommandRes
 
     let results = futures::future::join_all(futures).await;
 
+    // Feed the selection hot path's usage snapshot for free, so
+    // `pick_best_account` can rank by weekly-usage headroom without probing
+    // inline (see `ai_provider::account_usage`).
+    record_usage_snapshot(&results);
+
     Ok(CommandResponse {
         success: true,
         message: Some(format!("Checked {} accounts", results.len())),
@@ -1273,6 +1278,39 @@ pub async fn check_accounts_usage(config_dirs: Vec<String>) -> Result<CommandRes
             serde_json::to_value(&results).map_err(|e| String::from(AppError::JsonError(e)))?,
         ),
     })
+}
+
+/// Record probe results into the account-selection usage snapshot.
+///
+/// Shared by every usage-probe caller so the hot-path picker
+/// (`ai_provider::pick_best_account`) always reads from a cache rather than
+/// issuing its own (self-rate-limiting) probe.
+pub fn record_usage_snapshot(results: &[AccountUsageInfo]) {
+    let samples: Vec<(String, f64, Option<f64>)> = results
+        .iter()
+        .map(|r| (r.config_dir.clone(), r.utilization, r.usage_delta))
+        .collect();
+    crate::ai_provider::record_account_usage(&samples);
+}
+
+/// Probe every configured account and refresh the selection usage snapshot.
+///
+/// Called off the hot path — at startup and on a periodic timer (see
+/// `main.rs`) — so a runner whose Settings/Terminal UI is never opened (e.g. a
+/// headless or co-pilot-only runner) still has fresh weekly-usage headroom
+/// data for `pick_best_account`. No-op when fewer than two accounts are
+/// configured (single-account runners have nothing to choose between).
+pub async fn refresh_account_usage_snapshot() {
+    let config_dirs = crate::settings::get_claude_config_dirs();
+    if config_dirs.len() < 2 {
+        return;
+    }
+    let futures: Vec<_> = config_dirs
+        .into_iter()
+        .map(|dir| async move { probe_account_usage(dir).await })
+        .collect();
+    let results = futures::future::join_all(futures).await;
+    record_usage_snapshot(&results);
 }
 
 // ============================================================================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3170,15 +3170,34 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     );
                 }
 
-                // Cooldown-driven account selection. `pick_best_account`
+                // Weekly-usage-aware account selection. `pick_best_account`
                 // internally checks `account_selection_mode == LeastUsage`
                 // and returns immediately otherwise — no need to gate the
-                // call here. Runs on a blocking pool because the picker
-                // reads global settings/state synchronously.
-                info!("Running cooldown-driven account selection at startup...");
+                // call here. Refresh the usage snapshot FIRST so the initial
+                // pick can rank accounts by weekly-usage headroom rather than
+                // falling back to cooldown-only ordering.
+                info!("Refreshing Claude account usage snapshot at startup...");
+                commands::ai_settings::refresh_account_usage_snapshot().await;
+                info!("Running account selection at startup...");
                 tokio::task::spawn_blocking(ai_provider::pick_best_account)
                     .await
                     .ok();
+
+                // Keep the usage snapshot fresh for headless / co-pilot-only
+                // runners whose Settings/Terminal UI never polls usage. This
+                // loop ONLY refreshes the cache — re-picking is deferred to
+                // the next unit of AI work (so warm-provider prompt-cache
+                // locality within a unit is preserved). `refresh_*` is a
+                // no-op unless ≥2 accounts are configured.
+                tauri::async_runtime::spawn(async {
+                    let mut tick =
+                        tokio::time::interval(tokio::time::Duration::from_secs(10 * 60));
+                    tick.tick().await; // consume the immediate first tick (just refreshed)
+                    loop {
+                        tick.tick().await;
+                        commands::ai_settings::refresh_account_usage_snapshot().await;
+                    }
+                });
             });
 
             // Bootstrap World State Verifier live config from persisted

--- a/src-tauri/src/mcp/token_analytics.rs
+++ b/src-tauri/src/mcp/token_analytics.rs
@@ -303,6 +303,9 @@ pub async fn get_account_usage(
     let results = futures::future::join_all(futures).await;
     let count = results.len();
 
+    // Keep the account-selection usage snapshot warm off the hot path.
+    crate::commands::ai_settings::record_usage_snapshot(&results);
+
     Ok(Json(serde_json::json!({
         "success": true,
         "data": results,


### PR DESCRIPTION
## Problem

The co-pilot page failed with **"You've hit your monthly spend limit."** Tracing it:

- qontinui-web has **no Claude invocation of its own** — the co-pilot relays its plan request (`planClient.ts` → `runner-proxy/prompt-home/plan`) over WS to the paired runner, which runs `prompt_home.rs:477 pick_best_account()` and then invokes the Claude CLI.
- `pick_best_account()` was **cooldown-only**. It never consulted the weekly-usage signal that the Terminal "best account" launcher already uses (`compareByUsageHeadroom` in `src/components/settings/types.ts`).
- Result: the picker could hand the co-pilot an account that was **over its weekly budget but not in a rate-limit cooldown** → spend-limit failure.

## Fix

Make the runner's picker rank by the same metric a human gets in the Terminal launcher: among **non-cooled** accounts, prefer the one furthest **under** its projected weekly pace (lowest `usage_delta`, else lowest raw `utilization`). The co-pilot inherits this automatically through the relay — **no qontinui-web change needed**.

### Changes
- **`config.rs`** — cached per-account usage snapshot (`record_account_usage` / `usage_headroom_key`, 15-min TTL). The hot path reads this cache and **never probes inline** (the probe endpoint self-rate-limits, so an inline probe gives the worst signal exactly when it matters).
- **`account_usage.rs`** — extract a pure, unit-tested `pick_from()` core. Selection: headroom among non-cooled → first-non-cooled (cold start) → soonest-to-expire (all cooled).
- **`ai_settings.rs`** — `record_usage_snapshot()` + `refresh_account_usage_snapshot()`; `check_accounts_usage` feeds the snapshot for free.
- **`token_analytics.rs`** — `/analytics/account-usage` feeds the snapshot too.
- **`main.rs`** — refresh the snapshot at startup (before the first pick) and on a 10-min timer, so **headless / co-pilot-only runners** (Terminal UI never opened) still have fresh data. The timer only refreshes the cache; re-picking stays deferred to each unit of AI work to preserve warm-provider prompt-cache locality.

## Verification
- `cargo check --lib` ✅ (worktree)
- pre-push `cargo fmt + clippy` ✅ (ran against this worktree)
- `rustfmt --check` ✅ on all touched files
- Added 8 unit tests (6 `pick_from` + 2 snapshot) mirroring `compareByUsageHeadroom.test.ts` semantics. Local `cargo test` execution was blocked by the worktree-incompatible cargo-guard (it can only build the primary checkout) — CI runs them.

## Note / possible follow-up
Adjacent gap: `retry.rs is_rate_limit_error()` does not match `"spend limit"`, so a spend-limit message still won't trigger cooldown-based rotation. With headroom selection an over-budget account is already de-preferred, so this is lower priority — happy to add it in a follow-up if you want defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)