### PR TITLE
fix(ai-provider): exhaustion tier + single-account pinning in account selection

### DIFF
--- a/src-tauri/src/ai_provider/account_usage.rs
+++ b/src-tauri/src/ai_provider/account_usage.rs
@@ -2,20 +2,24 @@
 //!
 //! [`pick_best_account`] picks an effective Claude config dir from the
 //! configured `claude_config_dirs`. Among accounts that are **not** in a
-//! rate-limit cooldown, it prefers the one with the most weekly-usage
-//! *headroom* — the lowest [`super::config::usage_headroom_key`] (actual
+//! rate-limit cooldown, it ranks by [`super::config::usage_rank`] —
+//! `(exhausted, headroom)`. `headroom` is the weekly-usage signal (actual
 //! 7-day utilization minus the expected linear utilization at this point in
-//! the billing window; negative = under projected pace). This mirrors the
+//! the billing window; negative = under projected pace), mirroring the
 //! Terminal "best account" picker (`compareByUsageHeadroom` in
-//! `src/components/settings/types.ts`), so the co-pilot — which relays its
-//! planning prompt through this picker — chooses the same account a human
-//! would when opening a new session.
+//! `src/components/settings/types.ts`). `exhausted` is the dominating tier: an
+//! out-of-tokens / rejected account is deprioritized no matter how favourable
+//! its headroom (a fully-used account that is "under projection" still has no
+//! tokens left). The co-pilot relays its planning prompt through this picker,
+//! so it chooses the same account a human would when opening a new session.
 //!
 //! Selection order:
-//! 1. Among non-cooled accounts with a fresh usage sample, the one with the
-//!    most headroom (lowest `usage_delta`, else lowest raw utilization).
+//! 1. Among non-cooled accounts with a fresh usage sample, the best by
+//!    `(exhausted, headroom)` ascending: a usable account beats an exhausted
+//!    one, then most-under-projection wins within a tier.
 //! 2. If no non-cooled account has a fresh sample, the first non-cooled
-//!    account (legacy cooldown-only behaviour — preserved for cold start).
+//!    account (legacy cooldown-only behaviour — preserved for cold start and
+//!    for the single-account case, where the one account is simply pinned).
 //! 3. If every account is cooled, the one with the **shortest remaining
 //!    cooldown** (closest to expiry).
 //!
@@ -35,7 +39,7 @@
 //! the default 5-minute cooldown (no header source on stdout).
 //!
 //! [`pick_best_account`] is a no-op when `account_selection_mode != LeastUsage`
-//! or fewer than two accounts are configured.
+//! or no accounts are configured.
 
 use crate::settings::{self, AccountSelectionMode};
 use std::path::Path;
@@ -49,11 +53,14 @@ use tracing::info;
 ///
 /// No-op when:
 ///   - account selection mode is `Manual`
-///   - fewer than two accounts are configured
+///   - no accounts are configured
 ///
-/// Selection prefers the non-cooled account with the most weekly-usage
-/// headroom; falls back to first-non-cooled (cold start), then to the
-/// soonest-to-expire cooldown when every account is rate-limited.
+/// With a single configured account it simply pins that account (so the
+/// effective config dir resolves even for users who never set a manual
+/// `config_dir`). With several, selection prefers the non-cooled, non-
+/// exhausted account with the most weekly-usage headroom; falls back to
+/// first-non-cooled (cold start), then to the soonest-to-expire cooldown when
+/// every account is rate-limited.
 pub fn pick_best_account() {
     let ai_settings = settings::get_ai_settings();
     if ai_settings.claude_cli.account_selection_mode != AccountSelectionMode::LeastUsage {
@@ -61,14 +68,14 @@ pub fn pick_best_account() {
     }
 
     let config_dirs = settings::get_claude_config_dirs();
-    if config_dirs.len() < 2 {
+    if config_dirs.is_empty() {
         return;
     }
 
     let chosen = pick_from(
         &config_dirs,
         |d| super::config::is_account_cooled_down(d),
-        |d| super::config::usage_headroom_key(d),
+        |d| super::config::usage_rank(d),
         |d| super::config::time_until_cooled_down(d),
     );
 
@@ -84,26 +91,37 @@ pub fn pick_best_account() {
 /// Pure selection core, parameterised over the cooldown/usage/expiry lookups
 /// so it can be unit-tested without the global settings + state singletons.
 ///
-/// `is_cooled` / `headroom` / `remaining` mirror the `super::config` helpers.
+/// `is_cooled` / `usage` / `remaining` mirror the `super::config` helpers.
+/// `usage` returns `(exhausted, headroom)` for accounts with a fresh sample.
 /// Returns the chosen config dir, or `None` only when `config_dirs` is empty.
 fn pick_from<'a>(
     config_dirs: &'a [String],
     is_cooled: impl Fn(&str) -> bool,
-    headroom: impl Fn(&str) -> Option<f64>,
+    usage: impl Fn(&str) -> Option<(bool, f64)>,
     remaining: impl Fn(&str) -> Option<Duration>,
 ) -> Option<String> {
     let available: Vec<&'a String> = config_dirs.iter().filter(|d| !is_cooled(d)).collect();
 
     if !available.is_empty() {
-        // Prefer the available account with the most usage headroom (lowest
-        // key). Only ranks accounts that have a fresh usage sample; if none
-        // do, fall back to the first available (legacy cooldown-only pick).
-        let best_by_headroom = available
+        // Among available accounts that have a fresh usage sample, pick the
+        // best by `(exhausted, headroom)` ascending: a usable account always
+        // beats an exhausted one (out of tokens / rejected) regardless of
+        // headroom, and within a tier the most-under-projection wins. If no
+        // available account has a fresh sample, fall back to the first
+        // available (legacy cooldown-only pick / cold start).
+        let best = available
             .iter()
-            .filter_map(|d| headroom(d).map(|k| (*d, k)))
-            .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+            .filter_map(|d| usage(d).map(|rank| (*d, rank)))
+            .min_by(|a, b| {
+                // (exhausted, headroom) — false < true, then headroom ascending.
+                a.1 .0.cmp(&b.1 .0).then(
+                    a.1 .1
+                        .partial_cmp(&b.1 .1)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                )
+            })
             .map(|(d, _)| d.clone());
-        return best_by_headroom.or_else(|| available.first().map(|d| (*d).clone()));
+        return best.or_else(|| available.first().map(|d| (*d).clone()));
     }
 
     // All cooled: pick the one with the shortest remaining cooldown.
@@ -218,8 +236,10 @@ mod tests {
     //
     // `pick_from` is parameterised over the cooldown/usage/expiry lookups, so
     // these tests inject closures and assert the ranking directly — no global
-    // settings/state needed. Mirrors the frontend `compareByUsageHeadroom`
-    // semantics: lowest `usage_delta` (else utilization) wins among available.
+    // settings/state needed. `usage` returns `(exhausted, headroom)`: a usable
+    // account beats an exhausted one regardless of headroom, and within a tier
+    // the lowest `usage_delta` (else utilization) wins — mirroring the frontend
+    // `compareByUsageHeadroom` plus the out-of-tokens guard.
 
     fn dirs(names: &[&str]) -> Vec<String> {
         names.iter().map(|s| s.to_string()).collect()
@@ -229,14 +249,50 @@ mod tests {
     fn headroom_wins_among_available() {
         let d = dirs(&["/a", "/b", "/c"]);
         // /b is furthest under projected pace (most-negative delta) → chosen,
-        // even though /a sorts first by position.
+        // even though /a sorts first by position. None exhausted.
         let chosen = pick_from(
             &d,
             |_| false, // none cooled
             |x| match x {
-                "/a" => Some(0.10),
-                "/b" => Some(-0.30),
-                "/c" => Some(0.05),
+                "/a" => Some((false, 0.10)),
+                "/b" => Some((false, -0.30)),
+                "/c" => Some((false, 0.05)),
+                _ => None,
+            },
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn usable_account_beats_exhausted_with_better_headroom() {
+        let d = dirs(&["/full", "/usable"]);
+        // /full is fully used (100%) when 95% expected → favourable delta
+        // (-... no, +0.05) BUT exhausted. /usable is 80% used / 60% expected
+        // (+0.20, worse delta) but has tokens left → must win.
+        let chosen = pick_from(
+            &d,
+            |_| false,
+            |x| match x {
+                "/full" => Some((true, 0.05)),    // exhausted, better headroom
+                "/usable" => Some((false, 0.20)), // usable, worse headroom
+                _ => None,
+            },
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/usable"));
+    }
+
+    #[test]
+    fn all_exhausted_picks_best_headroom_among_them() {
+        let d = dirs(&["/a", "/b"]);
+        // Both exhausted → least-bad (lowest headroom) is the fallback choice.
+        let chosen = pick_from(
+            &d,
+            |_| false,
+            |x| match x {
+                "/a" => Some((true, 0.30)),
+                "/b" => Some((true, 0.10)),
                 _ => None,
             },
             |_| None,
@@ -252,8 +308,8 @@ mod tests {
             &d,
             |x| x == "/a",
             |x| match x {
-                "/a" => Some(-0.90),
-                "/b" => Some(0.20),
+                "/a" => Some((false, -0.90)),
+                "/b" => Some((false, 0.20)),
                 _ => None,
             },
             |_| None,
@@ -273,15 +329,32 @@ mod tests {
     #[test]
     fn ranks_only_accounts_with_samples_then_keeps_them() {
         let d = dirs(&["/a", "/b"]);
-        // Only /b has a sample → it is selected (a known-headroom account is
+        // Only /b has a sample → it is selected (a known-rank account is
         // preferred over an unprobed one).
         let chosen = pick_from(
             &d,
             |_| false,
-            |x| if x == "/b" { Some(0.40) } else { None },
+            |x| if x == "/b" { Some((false, 0.40)) } else { None },
             |_| None,
         );
         assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn single_account_is_pinned() {
+        // One configured account, no usage sample, not cooled → it is selected
+        // (the single-account case must resolve, not no-op).
+        let d = dirs(&["/only"]);
+        let chosen = pick_from(&d, |_| false, |_| None, |_| None);
+        assert_eq!(chosen.as_deref(), Some("/only"));
+    }
+
+    #[test]
+    fn single_exhausted_account_still_pinned() {
+        // One account, exhausted → still the only option, so still selected.
+        let d = dirs(&["/only"]);
+        let chosen = pick_from(&d, |_| false, |_| Some((true, 1.0)), |_| None);
+        assert_eq!(chosen.as_deref(), Some("/only"));
     }
 
     #[test]

--- a/src-tauri/src/ai_provider/config.rs
+++ b/src-tauri/src/ai_provider/config.rs
@@ -26,27 +26,38 @@ const RATE_LIMIT_COOLDOWN_SECS: u64 = 300;
 /// at this point in the billing window (negative = under projected pace);
 /// `None` when the probe couldn't compute it (e.g. the 7d-reset header was
 /// absent). `utilization` is the raw 0.0–1.0 weekly fraction, used as the
-/// fallback selection key when `usage_delta` is unavailable — mirroring the
+/// fallback ranking key when `usage_delta` is unavailable — mirroring the
 /// frontend `compareByUsageHeadroom` (`src/components/settings/types.ts`).
+///
+/// `exhausted` marks an account that **won't serve a request right now** — at
+/// or over its weekly cap, server-reported rejected, or the probe call itself
+/// failed (the probe hits the same per-account quota the CLI uses, so this
+/// also catches a spend-limited account whose weekly token utilization still
+/// looks low). Exhausted accounts are deprioritized in selection regardless of
+/// how favourable their `usage_delta` is: a fully-used account that is "under
+/// projection" still has no tokens left, so a less-favourable but *usable*
+/// account must win. Computed at probe time by
+/// `commands::ai_settings::record_usage_snapshot`.
 #[derive(Clone, Copy, Debug)]
 struct UsageSample {
     captured_at: Instant,
     usage_delta: Option<f64>,
     utilization: f64,
+    exhausted: bool,
 }
 
 /// Latest weekly-usage snapshot per account, keyed by config dir. Populated
 /// off the selection hot path by the usage-probe callers (the periodic
 /// startup refresh, the Settings/Terminal `check_accounts_usage` command, and
-/// the `/analytics/account-usage` route) so [`usage_headroom_key`] can rank
-/// accounts by headroom without making its own HTTP calls. The probe
-/// endpoint self-rate-limits, so the hot path must never probe inline — it
-/// reads this cache instead.
+/// the `/analytics/account-usage` route) so [`usage_rank`] can rank
+/// accounts without making its own HTTP calls. The probe endpoint
+/// self-rate-limits, so the hot path must never probe inline — it reads this
+/// cache instead.
 static USAGE_SNAPSHOT: Mutex<Option<HashMap<String, UsageSample>>> = Mutex::new(None);
 
-/// Maximum age of a usage sample before [`usage_headroom_key`] treats it as
-/// stale and returns `None` (so selection falls back to cooldown ordering).
-/// Fifteen minutes — comfortably longer than the startup refresh cadence.
+/// Maximum age of a usage sample before [`usage_rank`] treats it as stale and
+/// returns `None` (so selection falls back to cooldown ordering). Fifteen
+/// minutes — comfortably longer than the startup refresh cadence.
 const USAGE_SNAPSHOT_TTL: Duration = Duration::from_secs(15 * 60);
 
 /// Set the resolved config directory (called after usage check).
@@ -147,40 +158,49 @@ pub fn time_until_cooled_down(config_dir: &str) -> Option<Duration> {
 /// Called by the usage-probe paths (startup periodic refresh, the
 /// `check_accounts_usage` command, the `/analytics/account-usage` route) so
 /// the selection hot path has fresh headroom data without issuing its own
-/// HTTP calls. Each tuple is `(config_dir, utilization, usage_delta)`.
-pub fn record_account_usage(samples: &[(String, f64, Option<f64>)]) {
+/// HTTP calls. Each tuple is `(config_dir, utilization, usage_delta,
+/// exhausted)`.
+pub fn record_account_usage(samples: &[(String, f64, Option<f64>, bool)]) {
     if let Ok(mut snap) = USAGE_SNAPSHOT.lock() {
         let map = snap.get_or_insert_with(HashMap::new);
         let now = Instant::now();
-        for (dir, utilization, usage_delta) in samples {
+        for (dir, utilization, usage_delta, exhausted) in samples {
             map.insert(
                 dir.clone(),
                 UsageSample {
                     captured_at: now,
                     usage_delta: *usage_delta,
                     utilization: *utilization,
+                    exhausted: *exhausted,
                 },
             );
         }
     }
 }
 
-/// Weekly-usage headroom key for an account from the latest snapshot, if a
-/// fresh sample exists. Returns `usage_delta` when available (most-negative =
-/// furthest under projected weekly pace = best), else the raw `utilization`
-/// — mirroring the frontend `compareByUsageHeadroom`. Returns `None` when
-/// there is no sample or it is older than [`USAGE_SNAPSHOT_TTL`], so callers
-/// fall back to cooldown-only ordering.
+/// Selection rank for an account from the latest snapshot, if a fresh sample
+/// exists: `(exhausted, headroom)`.
 ///
-/// Lower is better (ascending = most headroom first).
-pub fn usage_headroom_key(config_dir: &str) -> Option<f64> {
+/// `exhausted` is the primary tier — an exhausted account (out of tokens /
+/// rejected) always sorts after a usable one, no matter how favourable its
+/// headroom. `headroom` is the tie-breaker within a tier: `usage_delta` when
+/// available (most-negative = furthest under projected weekly pace = best),
+/// else the raw `utilization` — mirroring the frontend
+/// `compareByUsageHeadroom`. Both keys are ascending (lower is better).
+///
+/// Returns `None` when there is no sample or it is older than
+/// [`USAGE_SNAPSHOT_TTL`], so callers fall back to cooldown-only ordering.
+pub fn usage_rank(config_dir: &str) -> Option<(bool, f64)> {
     let snap = USAGE_SNAPSHOT.lock().ok()?;
     let map = snap.as_ref()?;
     let sample = map.get(config_dir)?;
     if sample.captured_at.elapsed() > USAGE_SNAPSHOT_TTL {
         return None;
     }
-    Some(sample.usage_delta.unwrap_or(sample.utilization))
+    Some((
+        sample.exhausted,
+        sample.usage_delta.unwrap_or(sample.utilization),
+    ))
 }
 
 /// Rotate to the next available account after a rate-limit hit.
@@ -487,20 +507,28 @@ mod tests {
     }
 
     #[test]
-    fn usage_headroom_prefers_delta_then_falls_back_to_utilization() {
+    fn usage_rank_prefers_delta_then_falls_back_to_utilization() {
         let dir_delta = "/test/config/headroom_delta";
         let dir_util = "/test/config/headroom_util";
-        // Fresh sample with a delta → key is the delta.
-        record_account_usage(&[(dir_delta.to_string(), 0.80, Some(-0.25))]);
-        assert_eq!(usage_headroom_key(dir_delta), Some(-0.25));
-        // Fresh sample without a delta → key falls back to raw utilization.
-        record_account_usage(&[(dir_util.to_string(), 0.42, None)]);
-        assert_eq!(usage_headroom_key(dir_util), Some(0.42));
+        // Fresh sample with a delta → headroom key is the delta, not exhausted.
+        record_account_usage(&[(dir_delta.to_string(), 0.80, Some(-0.25), false)]);
+        assert_eq!(usage_rank(dir_delta), Some((false, -0.25)));
+        // Fresh sample without a delta → headroom falls back to utilization.
+        record_account_usage(&[(dir_util.to_string(), 0.42, None, false)]);
+        assert_eq!(usage_rank(dir_util), Some((false, 0.42)));
     }
 
     #[test]
-    fn usage_headroom_none_when_unrecorded() {
-        assert_eq!(usage_headroom_key("/test/config/headroom_never"), None);
+    fn usage_rank_carries_exhausted_flag() {
+        let dir = "/test/config/headroom_exhausted";
+        // Exhausted even though the delta looks favourable (under projection).
+        record_account_usage(&[(dir.to_string(), 1.0, Some(-0.05), true)]);
+        assert_eq!(usage_rank(dir), Some((true, -0.05)));
+    }
+
+    #[test]
+    fn usage_rank_none_when_unrecorded() {
+        assert_eq!(usage_rank("/test/config/headroom_never"), None);
     }
 
     #[test]

--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -1280,15 +1280,46 @@ pub async fn check_accounts_usage(config_dirs: Vec<String>) -> Result<CommandRes
     })
 }
 
+/// Weekly utilization at/above which an account is treated as "out of tokens"
+/// for selection — close enough to the cap that it won't reliably serve a
+/// request. A backstop alongside the server `status` / probe-error signals in
+/// [`probe_result_exhausted`].
+const EXHAUSTION_UTILIZATION: f64 = 0.99;
+
+/// Whether a probe result means the account **won't serve a request right
+/// now**. True when the probe call itself failed (the probe hits the same
+/// per-account quota the CLI uses — so a 429/403/spend-limit rejection shows
+/// up here even if weekly *token* utilization still looks low), when the
+/// server reports the account rejected/blocked/exceeded, or when weekly
+/// utilization is at/over [`EXHAUSTION_UTILIZATION`].
+fn probe_result_exhausted(info: &AccountUsageInfo) -> bool {
+    if info.error.is_some() || info.utilization >= EXHAUSTION_UTILIZATION {
+        return true;
+    }
+    info.status.as_deref().is_some_and(|s| {
+        let s = s.to_ascii_lowercase();
+        s.contains("reject") || s.contains("block") || s.contains("exceed")
+    })
+}
+
 /// Record probe results into the account-selection usage snapshot.
 ///
 /// Shared by every usage-probe caller so the hot-path picker
 /// (`ai_provider::pick_best_account`) always reads from a cache rather than
-/// issuing its own (self-rate-limiting) probe.
+/// issuing its own (self-rate-limiting) probe. Computes the per-account
+/// `exhausted` flag here, where the full probe result (status + error) is
+/// available.
 pub fn record_usage_snapshot(results: &[AccountUsageInfo]) {
-    let samples: Vec<(String, f64, Option<f64>)> = results
+    let samples: Vec<(String, f64, Option<f64>, bool)> = results
         .iter()
-        .map(|r| (r.config_dir.clone(), r.utilization, r.usage_delta))
+        .map(|r| {
+            (
+                r.config_dir.clone(),
+                r.utilization,
+                r.usage_delta,
+                probe_result_exhausted(r),
+            )
+        })
         .collect();
     crate::ai_provider::record_account_usage(&samples);
 }
@@ -1894,4 +1925,59 @@ pub fn plugin<R: Runtime>() -> TauriPlugin<R> {
             reset_provider_circuit,
         ])
         .build()
+}
+
+#[cfg(test)]
+mod exhaustion_tests {
+    use super::*;
+
+    fn usage(utilization: f64, status: Option<&str>, error: Option<&str>) -> AccountUsageInfo {
+        AccountUsageInfo {
+            config_dir: "/test/acct".to_string(),
+            label: "acct".to_string(),
+            utilization,
+            rate_limit_type: Some("seven_day".to_string()),
+            resets_at: None,
+            status: status.map(|s| s.to_string()),
+            error: error.map(|s| s.to_string()),
+            expected_utilization: None,
+            usage_delta: None,
+            period_elapsed_fraction: None,
+            period_remaining_days: None,
+        }
+    }
+
+    #[test]
+    fn under_cap_and_allowed_is_not_exhausted() {
+        assert!(!probe_result_exhausted(&usage(0.80, Some("allowed"), None)));
+        // Even fully under projection but high (98%) — still usable.
+        assert!(!probe_result_exhausted(&usage(
+            0.98,
+            Some("allowed_warning"),
+            None
+        )));
+    }
+
+    #[test]
+    fn at_or_over_cap_is_exhausted() {
+        assert!(probe_result_exhausted(&usage(0.99, Some("allowed"), None)));
+        assert!(probe_result_exhausted(&usage(1.0, None, None)));
+    }
+
+    #[test]
+    fn probe_error_is_exhausted() {
+        // Probe rejected (429/403/spend-limit) → won't serve a request, even if
+        // the weekly token utilization header still reads low.
+        assert!(probe_result_exhausted(&usage(
+            0.10,
+            None,
+            Some("API error (429): rate limit")
+        )));
+    }
+
+    #[test]
+    fn rejected_status_is_exhausted() {
+        assert!(probe_result_exhausted(&usage(0.50, Some("rejected"), None)));
+        assert!(probe_result_exhausted(&usage(0.50, Some("BLOCKED"), None)));
+    }
 }


### PR DESCRIPTION
Follow-up to #509, fixing two correctness gaps Joshua flagged after restarting the supervisor.

## 1. Out-of-tokens accounts could still be selected
The headroom picker ranked only by `usage_delta`, so an account at **100% used / 95% expected** (delta +0.05) beat one at **80% used / 60% expected** (delta +0.20) — but the "winner" is out of tokens and won't serve a request.

Selection now ranks by a two-level key **`(exhausted, headroom)`**:
- `exhausted` dominates — a usable account always beats an out-of-tokens one, regardless of headroom.
- `headroom` (the `usage_delta` metric) only breaks ties **within** a tier.

`exhausted` is computed at probe time (`probe_result_exhausted`) from:
- weekly utilization ≥ 99%, **or**
- server `status` of rejected/blocked/exceeded, **or**
- the probe call itself failing — which also catches the original **monthly spend-limit** case, since the probe hits the same per-account quota the CLI uses even when weekly *token* utilization reads low.

## 2. Single-account users were a no-op
The picker required ≥2 accounts, so a lone configured account never got pinned as the effective config dir (the CLI could fall back to a default/unset account). Guard lowered to ≥1 — with one account it's simply pinned. (`refresh_account_usage_snapshot` stays ≥2: a single account needs no probe; `pick_from` pins it via the cold-start fallback.)

## Changes
- **config.rs**: `UsageSample` gains `exhausted`; `usage_headroom_key` → `usage_rank` returning `(exhausted, headroom)`; `record_account_usage` carries the flag.
- **account_usage.rs**: `pick_from` ranks by `(exhausted, headroom)`; guard `is_empty()`; module doc updated.
- **ai_settings.rs**: `probe_result_exhausted()` classifier; `record_usage_snapshot` computes it.

## Verification
- `cargo check --lib --tests` ✅ (worktree, 8m14s)
- pre-push `cargo fmt + clippy` ✅ (worktree)
- New tests: `usable_account_beats_exhausted_with_better_headroom`, `all_exhausted_picks_best_headroom_among_them`, `single_account_is_pinned`, `single_exhausted_account_still_pinned`, `usage_rank_carries_exhausted_flag`, + 4 `probe_result_exhausted` cases. Local `cargo test` blocked by the worktree-incompatible cargo-guard → CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)