### PR TITLE
feat(ui-bridge): windowLabel on the read/convenience family (Phase 4a)

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/CONTRACT.md
+++ b/src-tauri/src/mcp/ui_bridge/CONTRACT.md
@@ -185,6 +185,13 @@ Two thread-through styles, mirroring the `tabId` split:
   (`ActionQueryParams.window_label`, which also scopes its pre/post detector and
   disabled-state queries so the element id resolves in the right window's
   registry). Rust callers holding a label call `ui_bridge_request_sync_in_window`.
+- **Read/convenience family** — `find-by-text`, `click-by-text`,
+  `click-by-selector`, `read-value`, `type-into` (`elements.rs`) read an optional
+  `windowLabel` **body** field and evaluate through
+  `helpers::evaluate_js_expression_in_window`, which routes the IPC `page_evaluate`
+  to that window (no main-window direct-eval fallback for pop-outs — that path is
+  main-coupled). Omitting `windowLabel` is byte-identical to the single-window
+  default. (Phase 4, plan 2026-06-07-multi-window-sdk-automation.)
 
 An unknown `windowLabel` (no such window — e.g. a pop-out that already closed)
 returns an immediate, structured error naming the missing window and the

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -38,8 +38,8 @@ use crate::mcp::types::{api_error, api_error_detailed, ApiResponse, ApiState};
 use super::diagnostics::{extract_error_code, CanonicalCode};
 use super::helpers::{
     count_elements_in_discover_payload, direct_webview_evaluate_with_result,
-    evaluate_js_expression, extract_ai_find_match, extract_get_element_match,
-    filter_element_fields, snapshot_signature,
+    evaluate_js_expression_in_window, extract_ai_find_match, extract_get_element_match,
+    filter_element_fields, read_window_label, snapshot_signature,
 };
 use super::recovery_executor::attempt_recovery;
 use super::request::{ui_bridge_request_sync, wrap_ipc_result};
@@ -3278,7 +3278,10 @@ pub async fn ui_bridge_find_by_text_handler(
         match_expr = match_expr
     );
 
-    match evaluate_js_expression(&state, &js).await {
+    // Optional `windowLabel` scopes the read to a pop-out window (Phase 4 of
+    // plan 2026-06-07-multi-window-sdk-automation); omit -> main window.
+    let window_label = read_window_label(&body);
+    match evaluate_js_expression_in_window(&state, &js, window_label).await {
         Ok(result) => {
             let parsed: serde_json::Value =
                 serde_json::from_str(&result).unwrap_or(serde_json::Value::Array(vec![]));
@@ -3347,7 +3350,10 @@ pub async fn ui_bridge_click_by_text_handler(
         index = index
     );
 
-    match evaluate_js_expression(&state, &js).await {
+    // Optional `windowLabel` scopes the read to a pop-out window (Phase 4 of
+    // plan 2026-06-07-multi-window-sdk-automation); omit -> main window.
+    let window_label = read_window_label(&body);
+    match evaluate_js_expression_in_window(&state, &js, window_label).await {
         Ok(result) => {
             let parsed: serde_json::Value = serde_json::from_str(&result)
                 .unwrap_or(serde_json::json!({"clicked": false, "error": "Parse error"}));
@@ -3401,7 +3407,10 @@ pub async fn ui_bridge_click_by_selector_handler(
         index = index
     );
 
-    match evaluate_js_expression(&state, &js).await {
+    // Optional `windowLabel` scopes the read to a pop-out window (Phase 4 of
+    // plan 2026-06-07-multi-window-sdk-automation); omit -> main window.
+    let window_label = read_window_label(&body);
+    match evaluate_js_expression_in_window(&state, &js, window_label).await {
         Ok(result) => {
             let parsed: serde_json::Value = serde_json::from_str(&result)
                 .unwrap_or(serde_json::json!({"clicked": false, "error": "Parse error"}));
@@ -3454,7 +3463,10 @@ pub async fn ui_bridge_read_value_handler(
         index = index
     );
 
-    match evaluate_js_expression(&state, &js).await {
+    // Optional `windowLabel` scopes the read to a pop-out window (Phase 4 of
+    // plan 2026-06-07-multi-window-sdk-automation); omit -> main window.
+    let window_label = read_window_label(&body);
+    match evaluate_js_expression_in_window(&state, &js, window_label).await {
         Ok(result) => {
             let parsed: serde_json::Value = serde_json::from_str(&result)
                 .unwrap_or(serde_json::json!({"found": false, "error": "Parse error"}));
@@ -3549,7 +3561,10 @@ pub async fn ui_bridge_type_into_handler(
         text_literal = text_js_literal
     );
 
-    match evaluate_js_expression(&state, &js).await {
+    // Optional `windowLabel` scopes the read to a pop-out window (Phase 4 of
+    // plan 2026-06-07-multi-window-sdk-automation); omit -> main window.
+    let window_label = read_window_label(&body);
+    match evaluate_js_expression_in_window(&state, &js, window_label).await {
         Ok(result) => {
             let parsed: serde_json::Value = serde_json::from_str(&result)
                 .unwrap_or(serde_json::json!({"typed": false, "error": "Parse error"}));

--- a/src-tauri/src/mcp/ui_bridge/helpers.rs
+++ b/src-tauri/src/mcp/ui_bridge/helpers.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use crate::mcp::types::ApiState;
 
-use super::request::ui_bridge_request_sync;
+use super::request::{ui_bridge_request_sync, ui_bridge_request_sync_in_window, MAIN_WINDOW_LABEL};
 
 /// Allowed top-level field names for the `?fields=` filter on
 /// `GET /control/element/{id}`. Unknown names are silently dropped to keep
@@ -565,6 +565,71 @@ pub(super) async fn evaluate_js_expression(
     }
 }
 
+/// Like [`evaluate_js_expression`] but targets a specific runner window.
+///
+/// For the main window (empty label or [`MAIN_WINDOW_LABEL`]) this is identical
+/// to [`evaluate_js_expression`] — the IPC fast-path with a direct-WebView
+/// fallback. For a pop-out window it routes the IPC request to that window via
+/// [`ui_bridge_request_sync_in_window`]. There is intentionally NO direct-eval
+/// fallback for non-main windows: [`direct_webview_evaluate_with_result`] is
+/// main-coupled (it resolves `get_main_window_label()` and its injected JS posts
+/// the result back under the `(main, id)` key), so falling back would silently
+/// run the expression in the WRONG window. An unknown label yields the same
+/// structured error as `page/evaluate` (`page.rs`), pointing at the discovery
+/// route.
+pub(super) async fn evaluate_js_expression_in_window(
+    state: &Arc<ApiState>,
+    expression: &str,
+    window_label: &str,
+) -> Result<String, String> {
+    if window_label.is_empty() || window_label == MAIN_WINDOW_LABEL {
+        return evaluate_js_expression(state, expression).await;
+    }
+
+    // Fail fast on an unknown label rather than hanging on an IPC request
+    // nothing can answer — same contract as `page/evaluate`.
+    {
+        use tauri::Manager;
+        if state.app_handle.get_webview_window(window_label).is_none() {
+            return Err(format!(
+                "No runner window labeled '{window_label}'. Discover live windows via \
+                 GET /ui-bridge/control/runner-windows."
+            ));
+        }
+    }
+
+    let payload = serde_json::json!({ "expression": expression });
+    let data =
+        ui_bridge_request_sync_in_window(state, "page_evaluate", payload, window_label).await?;
+
+    // Surface an inner evaluation error rather than masking it with a main-window
+    // fallback (which would be the wrong window).
+    if data.get("success") == Some(&serde_json::Value::Bool(false)) || data.get("error").is_some() {
+        let msg = data
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("evaluation failed in target window");
+        return Err(msg.to_string());
+    }
+    if let Some(result) = data.get("result").and_then(|r| r.get("value")) {
+        match result {
+            serde_json::Value::String(s) => Ok(s.clone()),
+            other => Ok(other.to_string()),
+        }
+    } else {
+        Ok(data.to_string())
+    }
+}
+
+/// Read the optional `windowLabel` body field used by the read/convenience
+/// family (`read-value`, `type-into`, `click-by-text`, …) to scope a read to a
+/// pop-out window. Absent, non-string, or empty → `""` (the main window).
+pub(super) fn read_window_label(body: &serde_json::Value) -> &str {
+    body.get("windowLabel")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+}
+
 /// Match a path string against a glob pattern. `*` matches a single path
 /// segment (no `/`); `**` matches any sequence of characters including `/`.
 /// All other characters match literally.
@@ -745,4 +810,33 @@ where
     }
 
     deserializer.deserialize_option(TimestampVisitor)
+}
+
+#[cfg(test)]
+mod read_window_label_tests {
+    use super::read_window_label;
+    use serde_json::json;
+
+    #[test]
+    fn absent_window_label_is_main() {
+        assert_eq!(read_window_label(&json!({ "selector": "input" })), "");
+    }
+
+    #[test]
+    fn empty_window_label_is_main() {
+        assert_eq!(read_window_label(&json!({ "windowLabel": "" })), "");
+    }
+
+    #[test]
+    fn non_string_window_label_is_main() {
+        assert_eq!(read_window_label(&json!({ "windowLabel": 42 })), "");
+    }
+
+    #[test]
+    fn present_window_label_is_returned() {
+        assert_eq!(
+            read_window_label(&json!({ "windowLabel": "term-2" })),
+            "term-2"
+        );
+    }
 }


### PR DESCRIPTION
## What

Phase 4a of plan `2026-06-07-multi-window-sdk-automation` — runner prerequisite for window-scoped reads. The read/convenience family (`find-by-text`, `click-by-text`, `click-by-selector`, `read-value`, `type-into`) was hardcoded to the main window: each builds a JS string and called `evaluate_js_expression`, whose direct-WebView fallback resolves `get_main_window_label()`.

- **`helpers.rs`** — `evaluate_js_expression_in_window(state, expr, window_label)`. Main/empty label → identical to `evaluate_js_expression`. Pop-out label → route the IPC `page_evaluate` to that window via `ui_bridge_request_sync_in_window`, with a fail-fast unknown-label error (same wording as `page/evaluate`) and **no direct-eval fallback** for non-main windows — `direct_webview_evaluate_with_result` is main-coupled (it resolves `get_main_window_label()` and its injected JS posts back under the `(main, id)` key), so a fallback would silently run in the **wrong** window.
- **`helpers.rs`** — `read_window_label(body)` reads the optional `windowLabel` body field (absent/empty/non-string → `""` = main). Unit-tested.
- **`elements.rs`** — the 5 read-family handlers thread `read_window_label(&body)` into `evaluate_js_expression_in_window`. Omitting `windowLabel` is byte-identical to the single-window default.
- **`CONTRACT.md`** — documents the read-family as `windowLabel`-wired (body field).

## Pairs with ui-bridge Phase 4b (#100)

No route change → the manifest diff tests are unaffected (verified locally: `manifest_matches_route_calls` + `sdk_manifest_routes_are_exposed_by_runner` still pass). The SDK side (#100) adds the typed option + facade methods; merge this first so the SDK type is honest. The behavioral routing/unknown-label paths are Tauri-webview-coupled → verified by Phase 5 E2E; `read_window_label` is pure-unit-tested.

## Verification

- Compiles clean; `read_window_label` unit tests pass; manifest tests pass (no regression).