### PR TITLE
fix(ui-bridge): execute_action honors windowLabel from the body (Phase 4 follow-up)

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -841,7 +841,7 @@ pub async fn ui_bridge_execute_action_handler(
     //      `serde_json::Error::InvalidUnicodeCodePoint`. Manual parsing
     //      lets us fall back to `String::from_utf8_lossy` and retry so a
     //      stray byte doesn't break the whole "type" action.
-    let request: UIBridgeActionRequest = match serde_json::from_slice(&body_bytes) {
+    let mut request: UIBridgeActionRequest = match serde_json::from_slice(&body_bytes) {
         Ok(req) => req,
         Err(first_err) => {
             // First retry: bytes may be valid JSON whose string contents
@@ -892,7 +892,19 @@ pub async fn ui_bridge_execute_action_handler(
     // detector/validation queries below so the element id resolves in the right
     // window's registry. Owned so it survives the awaits without borrowing query.
     // Empty string is treated as "no target" (main).
-    let window_label = query.window_label.clone();
+    //
+    // The `?windowLabel=` query wins; otherwise fall back to a `windowLabel`
+    // body field. The SDK's `ControlActionRequest` and the `windowScope` facade
+    // send the label in the body (like `page_evaluate` and the read/convenience
+    // family), so without this fallback a body-only label would silently run in
+    // the main window. Removed from `extra` so it never leaks into the merged
+    // action params.
+    let window_label = query.window_label.clone().or_else(|| {
+        request
+            .extra
+            .remove("windowLabel")
+            .and_then(|v| v.as_str().map(String::from))
+    });
     let window_label = window_label.as_deref().filter(|s| !s.is_empty());
 
     // ── Unknown-window gate ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Phase 4 follow-up (plan `2026-06-07-multi-window-sdk-automation`) — closes an honesty gap in window targeting.

`ui_bridge_execute_action_handler` resolved the target window from the `?windowLabel=` **query only** (`ActionQueryParams.window_label`). But the SDK's `ControlActionRequest` and the Phase-3 `windowScope` facade send the label in the request **body** (like `page_evaluate` and the read/convenience family). So `windowScope(h, 'term-2').executeAction(id, { action: 'click' })` silently ran in the **main** window — a dishonest facade method.

## Fix

`UIBridgeActionRequest` already flattens unknown top-level fields into `extra`, so the body `windowLabel` is captured. Fall back to it when the query is absent (the `?windowLabel=` query still wins), and `remove()` it from `extra` so it never leaks into the merged action params.

```rust
let window_label = query.window_label.clone().or_else(|| {
    request.extra.remove("windowLabel").and_then(|v| v.as_str().map(String::from))
});
```

## Why

Every other window-targetable route honors a body `windowLabel` (`page_evaluate` reads body+query; the read family reads body, runner PR #511). This makes `execute_action` — and therefore the SDK `executeAction` per-call option + the `windowScope` facade — honest end-to-end via the body.

## Verification

- No route change → manifest tests unaffected (verified: `manifest_matches_route_calls` + `sdk_manifest_routes_are_exposed_by_runner` pass).
- Compiles clean. Behavioral window-routing is Tauri-webview-coupled → covered by Phase 5 E2E.