### PR TITLE
fix(account-selection): exhaustion-aware Terminal launcher + spend-limit rotation

### DIFF
--- a/src-tauri/src/ai_provider/retry.rs
+++ b/src-tauri/src/ai_provider/retry.rs
@@ -26,6 +26,12 @@ pub fn is_rate_limit_error(error_msg: &str) -> bool {
         || lower.contains("overloaded")
         || lower.contains("token limit")
         || lower.contains("usage limit")
+        // The Claude CLI prints "You've hit your monthly spend limit ..." on a
+        // capacity-exhausted account. Treat it as a rate-limit so a mid-request
+        // hit rotates to another account instead of failing the call. (The
+        // weekly-usage snapshot already de-prefers such accounts at selection
+        // time; this covers an account that tips over mid-flight.)
+        || lower.contains("spend limit")
 }
 
 /// Determine whether an AI error response represents a transient/retryable failure.
@@ -43,6 +49,16 @@ pub fn is_rate_limit_error(error_msg: &str) -> bool {
 /// - Missing API key configuration
 /// - Client construction failures
 pub(super) fn is_retryable_error(error_msg: &str) -> bool {
+    // Every rate-limit / capacity-exhaustion error is retryable — it triggers
+    // account rotation upstream (the rotation branch is gated behind this
+    // function returning true). Keeping this as the first check makes
+    // `is_rate_limit_error` a true subset, so signals it matches but the
+    // explicit list below omits (e.g. "token limit", "usage limit", "spend
+    // limit") still reach the rotation path.
+    if is_rate_limit_error(error_msg) {
+        return true;
+    }
+
     let lower = error_msg.to_lowercase();
 
     // HTTP status code checks (from API error messages like "API error (429): ...")
@@ -392,6 +408,16 @@ mod tests {
         ));
         assert!(is_retryable_error("Too Many Requests"));
         assert!(is_retryable_error("rate limit reached, please slow down"));
+    }
+
+    #[test]
+    fn test_spend_limit_is_rate_limit() {
+        // The Claude CLI's monthly-spend-limit message must count as a
+        // rate-limit so a mid-request hit triggers account rotation.
+        let msg = "Claude CLI failed (exit 1): stdout: You've hit your monthly \
+                   spend limit . raise it at claude.ai/settings/usage";
+        assert!(is_rate_limit_error(msg));
+        assert!(is_retryable_error(msg));
     }
 
     #[test]

--- a/src/components/settings/compareByUsageHeadroom.test.ts
+++ b/src/components/settings/compareByUsageHeadroom.test.ts
@@ -5,12 +5,17 @@
  * one with the lowest raw utilization.
  */
 import { describe, expect, it } from "vitest";
-import { compareByUsageHeadroom } from "./types";
+import { compareByUsageHeadroom, isAccountExhausted } from "./types";
 
-type A = { utilization: number; usage_delta?: number | null; label?: string };
+type A = {
+  utilization: number;
+  usage_delta?: number | null;
+  status?: string | null;
+  error?: string | null;
+  label?: string;
+};
 
-const best = (accounts: A[]): string =>
-  [...accounts].sort(compareByUsageHeadroom)[0]?.label ?? "";
+const best = (accounts: A[]): string => [...accounts].sort(compareByUsageHeadroom)[0]?.label ?? "";
 
 describe("compareByUsageHeadroom", () => {
   it("prefers the account furthest UNDER its projection, not lowest utilization", () => {
@@ -39,5 +44,61 @@ describe("compareByUsageHeadroom", () => {
       { label: "low", utilization: 0.2 },
     ];
     expect(best(accounts)).toBe("low");
+  });
+
+  it("a usable account beats an exhausted one with better headroom", () => {
+    // 'full' is out of tokens (100% used) but its delta (+0.05) looks better
+    // than 'usable' (80% used / 60% expected = +0.20). 'usable' must win — the
+    // exhausted account won't serve a request.
+    const accounts: A[] = [
+      { label: "full", utilization: 1.0, usage_delta: 0.05 },
+      { label: "usable", utilization: 0.8, usage_delta: 0.2 },
+    ];
+    expect(best(accounts)).toBe("usable");
+  });
+
+  it("when all exhausted, picks the least-bad headroom among them", () => {
+    const accounts: A[] = [
+      { label: "a", utilization: 1.0, usage_delta: 0.3 },
+      { label: "b", utilization: 1.0, usage_delta: 0.1 },
+    ];
+    expect(best(accounts)).toBe("b");
+  });
+
+  it("treats a rejected status or probe error as exhausted", () => {
+    const rejected: A[] = [
+      { label: "rejected", utilization: 0.5, status: "rejected", usage_delta: -0.4 },
+      { label: "ok", utilization: 0.7, usage_delta: 0.1 },
+    ];
+    expect(best(rejected)).toBe("ok");
+
+    const errored: A[] = [
+      {
+        label: "errored",
+        utilization: 0.1,
+        error: "API error (429): rate limit",
+        usage_delta: -0.5,
+      },
+      { label: "ok", utilization: 0.7, usage_delta: 0.1 },
+    ];
+    expect(best(errored)).toBe("ok");
+  });
+});
+
+describe("isAccountExhausted", () => {
+  it("is false for a usable, allowed account", () => {
+    expect(isAccountExhausted({ utilization: 0.8, status: "allowed" })).toBe(false);
+    expect(isAccountExhausted({ utilization: 0.98, status: "allowed_warning" })).toBe(false);
+  });
+
+  it("is true at/over the weekly cap", () => {
+    expect(isAccountExhausted({ utilization: 0.99 })).toBe(true);
+    expect(isAccountExhausted({ utilization: 1.0 })).toBe(true);
+  });
+
+  it("is true on probe error or rejected/blocked status", () => {
+    expect(isAccountExhausted({ utilization: 0.1, error: "boom" })).toBe(true);
+    expect(isAccountExhausted({ utilization: 0.5, status: "rejected" })).toBe(true);
+    expect(isAccountExhausted({ utilization: 0.5, status: "BLOCKED" })).toBe(true);
   });
 });

--- a/src/components/settings/types.ts
+++ b/src/components/settings/types.ts
@@ -125,21 +125,61 @@ export interface AccountUsageInfo {
   period_remaining_days: number | null;
 }
 
+/** Weekly utilization at/above which an account is treated as "out of
+ * tokens" for selection. Mirrors `EXHAUSTION_UTILIZATION` in the runner
+ * (`src-tauri/src/commands/ai_settings.rs`). */
+const EXHAUSTION_UTILIZATION = 0.99;
+
 /**
- * Comparator for "best account" selection. Prefers the account furthest
- * UNDER its projected usage — i.e. the most-negative `usage_delta`
- * (actual minus expected), which is "least usage relative to its
- * projected usage". Falls back to raw `utilization` when `usage_delta`
- * is unavailable (e.g. `expected_utilization` is null). Ascending: the
- * best (most headroom) account sorts first.
+ * Whether an account **won't serve a request right now** — at/over its weekly
+ * cap, server-reported rejected/blocked/exceeded, or its usage probe errored
+ * (the probe hits the same per-account quota the CLI uses, so this also catches
+ * a spend-limited account whose weekly *token* utilization still reads low).
+ * Mirrors the runner's `probe_result_exhausted`.
+ */
+export function isAccountExhausted(a: {
+  utilization: number;
+  status?: string | null;
+  error?: string | null;
+}): boolean {
+  if (a.error != null || a.utilization >= EXHAUSTION_UTILIZATION) return true;
+  const s = (a.status ?? "").toLowerCase();
+  return s.includes("reject") || s.includes("block") || s.includes("exceed");
+}
+
+/**
+ * Comparator for "best account" selection. Two-level key `(exhausted,
+ * headroom)`, ascending — the best account sorts first.
  *
+ * 1. Exhausted accounts (out of tokens / rejected; see {@link
+ *    isAccountExhausted}) always sort AFTER usable ones, no matter how
+ *    favourable their headroom — a fully-used account that is "under
+ *    projection" still has no tokens left.
+ * 2. Within a tier, the account furthest UNDER its projected usage wins —
+ *    the most-negative `usage_delta` (actual minus expected), falling back to
+ *    raw `utilization` when `usage_delta` is unavailable.
+ *
+ * Mirrors the runner's `pick_from` ranking (`ai_provider/account_usage.rs`).
  * Structurally typed so both `AccountUsageInfo` shapes (settings + the
  * terminal subset in `useSessionManager`) can use the one comparator.
  */
 export function compareByUsageHeadroom(
-  a: { utilization: number; usage_delta?: number | null },
-  b: { utilization: number; usage_delta?: number | null },
+  a: {
+    utilization: number;
+    usage_delta?: number | null;
+    status?: string | null;
+    error?: string | null;
+  },
+  b: {
+    utilization: number;
+    usage_delta?: number | null;
+    status?: string | null;
+    error?: string | null;
+  },
 ): number {
+  const ea = isAccountExhausted(a) ? 1 : 0;
+  const eb = isAccountExhausted(b) ? 1 : 0;
+  if (ea !== eb) return ea - eb;
   const ka = a.usage_delta ?? a.utilization ?? 0;
   const kb = b.usage_delta ?? b.utilization ?? 0;
   return ka - kb;


### PR DESCRIPTION
Two follow-ups to the runner's weekly-usage account selection (#509 / #510), requested by Joshua.

## 1. Frontend parity — Terminal launcher had the same exhaustion bug
#510 added an exhaustion tier to the **backend** picker, but the human-facing Terminal "best account" launcher (`compareByUsageHeadroom`) still ranked purely by `usage_delta` — so it could point you at a **100%-used account that "looks under projection."**

- `compareByUsageHeadroom` now sorts by `(exhausted, headroom)` — a usable account always beats an out-of-tokens one; headroom only breaks ties within a tier.
- New `isAccountExhausted()` mirrors the runner's `probe_result_exhausted`: weekly utilization ≥ 99%, server `status` reject/block/exceed, or a probe `error`.
- `LaunchMenu`, `useTerminalCommands` (`account="best"`), and `ClaudeCliSection` all inherit it (no signature break — the comparator's param only gained optional fields).

## 2. Spend-limit triggers rotation
`retry.rs::is_rate_limit_error` now matches `"spend limit"`, so a mid-request **"You've hit your monthly spend limit"** rotates to another account instead of failing.

Critically, the rotation branch is gated behind `is_retryable_error` returning true *first* — and that function did **not** cover the rate-limit list (it even missed the existing `"token limit"` / `"usage limit"` signals, a latent bug where those never reached rotation). It now **defers to `is_rate_limit_error` as its first check**, making rate-limit a true subset of retryable and fixing that gap in one stroke.

*Note:* the spend-limit cooldown is the default 5 min (a monthly cap really wants longer), but the 10-min usage-probe + exhaustion tier already de-prefer such accounts at selection — this change is purely "rotate on a mid-flight hit." For a **single-account** user a spend-limit now incurs a few bounded retries before failing (same as any rate-limit) rather than failing instantly; acceptable since rotation is a no-op there anyway.

## Verification
- `cargo check --lib --tests` ✅ (worktree, 12m48s)
- pre-push `cargo fmt + clippy` ✅
- `prettier --check` ✅ on both TS files (printWidth 100)
- New tests: 7 `compareByUsageHeadroom`/`isAccountExhausted` cases (usable-beats-exhausted, all-exhausted-least-bad, rejected/error → exhausted, classifier truth table); `test_spend_limit_is_rate_limit` (recognized as both rate-limit and retryable). Frontend vitest runs in CI; local `cargo test` blocked by the worktree-incompatible cargo-guard → CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)