### PR TITLE
fix(federation): forward bearer on reports fetch + fix gray-not-red banner

### DIFF
--- a/src-tauri/src/commands/federation.rs
+++ b/src-tauri/src/commands/federation.rs
@@ -72,15 +72,15 @@ async fn get_federation_reports_impl(
         url.push_str(&params.join("&"));
     }
 
-    let tenant_id = qontinui_runner_lib::pair::read_paired_tenant_id_from_disk()
-        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok());
+    // coord resolves the tenant from the verified bearer (FleetPrincipal,
+    // coord #440) — NOT the X-Qontinui-Tenant-Id header, which it no longer
+    // reads. Forward the device-JWT exactly like the reconcile path
+    // (`memory_client`); without it this read 403s `auth_required`.
+    let token = crate::auth::AuthManager::new()
+        .get_access_token()
+        .map_err(|e| anyhow::anyhow!("federation reports: no device token: {e}"))?;
 
-    let mut req = client.get(&url);
-    if let Some(tid) = tenant_id {
-        req = req.header("X-Qontinui-Tenant-Id", tid.to_string());
-    }
-
-    let resp = req.send().await?;
+    let resp = client.get(&url).bearer_auth(token).send().await?;
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();

--- a/src/components/MemoryFederationBanner.tsx
+++ b/src/components/MemoryFederationBanner.tsx
@@ -326,7 +326,7 @@ const bannerStyleSuccess: React.CSSProperties = {
 
 const bannerStyleFailure: React.CSSProperties = {
   ...bannerBase,
-  border: "1px solid var(--destructive, #ef4444)",
+  border: "1px solid hsl(var(--destructive, 0 84% 60%))",
 };
 
 const titleStyleSuccess: React.CSSProperties = {
@@ -340,7 +340,7 @@ const titleStyleFailure: React.CSSProperties = {
   margin: 0,
   marginBottom: 4,
   fontWeight: 600,
-  color: "var(--destructive, #ef4444)",
+  color: "hsl(var(--destructive, 0 84% 60%))",
 };
 
 const messageStyle: React.CSSProperties = {
@@ -359,7 +359,7 @@ const codeStyle: React.CSSProperties = {
 };
 
 const failedNumberStyle: React.CSSProperties = {
-  color: "var(--destructive, #ef4444)",
+  color: "hsl(var(--destructive, 0 84% 60%))",
 };
 
 const actionsColumnStyle: React.CSSProperties = {


### PR DESCRIPTION
Two memory-federation dashboard bugs surfaced after **coord #440** deployed (FleetPrincipal on the federation routes). Both found by the 5am UI verification (re-run on the hotmail account — gmail had hit its spend cap); all three federation surfaces otherwise **PASS**.

### 1. `403 auth_required` on historical reports (real regression)
The dashboard's "fetch from coord" uses the **`get_federation_reports`** Tauri command (`commands/federation.rs`), which sent only the `X-Qontinui-Tenant-Id` header and **no bearer**. #498 added bearer-forwarding to the reconcile path (`memory_client`) but missed this **read** path — so coord now `403`s on **every** runner's dashboard. Fix: forward the device-JWT (`AuthManager::get_access_token`), drop the ignored header (mirrors `memory_client` post-#508).

### 2. Reconcile-failure banner renders gray, not red (cosmetic)
`MemoryFederationBanner` used `var(--destructive, #ef4444)`, but the theme **does** define `--destructive` — as a bare HSL triplet (`0 84% 71%`), which is an invalid color outside `hsl()`, so it fell back to gray and the `#ef4444` fallback never fired. Fix: `hsl(var(--destructive, 0 84% 60%))` at the 3 sites.

> The same `--destructive` pattern exists in `StolenBanner` / `WebIntegrationAuthBanner` — left as a separate cosmetic follow-up to keep this PR federation-scoped.

### Verification
`cargo check` + `cargo fmt --check` + `cargo clippy` clean; `tsc --noEmit` clean.