### PR TITLE
fix(git-ops): runner forwards device-JWT bearer + fix gray sibling banners

### DIFF
--- a/src-tauri/src/observable_bridge/git_ops_client.rs
+++ b/src-tauri/src/observable_bridge/git_ops_client.rs
@@ -52,8 +52,9 @@ pub fn coord_http_base() -> Option<String> {
 /// `POST /coord/git-ops/record` — append one git op to the tenant feed.
 ///
 /// Best-effort: returns `Result` so the caller can log and continue. The
-/// tenant is resolved server-side from the `X-Qontinui-Tenant-Id` header
-/// (NOT the JWT) — see [`TENANT_HEADER`].
+/// tenant is resolved server-side from the verified device-JWT bearer
+/// (coord's `FleetPrincipal`); the `X-Qontinui-Tenant-Id` header is retained
+/// transitionally but coord no longer reads it.
 pub async fn record(
     client: &reqwest::Client,
     base: &str,
@@ -61,14 +62,13 @@ pub async fn record(
     tenant_id: Uuid,
     req: &RecordGitOpRequest,
 ) -> Result<()> {
-    let _ = device_token; // retained for forward-compat; see TENANT_HEADER.
     let url = format!("{base}/coord/git-ops/record");
     let resp = client
         .post(&url)
+        // coord resolves the tenant from the verified bearer (FleetPrincipal);
+        // the header is retained transitionally (coord no longer reads it).
         .header(TENANT_HEADER, tenant_id.to_string())
-        // bearer_auth deferred: coord anonymous-pilot posture doesn't
-        // validate JWT; re-enable when SSO lands.
-        // .bearer_auth(device_token)
+        .bearer_auth(device_token)
         .json(req)
         .send()
         .await

--- a/src/components/StolenBanner.tsx
+++ b/src/components/StolenBanner.tsx
@@ -137,7 +137,7 @@ const bannerStyle: React.CSSProperties = {
   padding: "12px 14px",
   background: "var(--bg-tertiary, #242837)",
   color: "var(--text-primary, #e4e4e7)",
-  border: "1px solid var(--destructive, #ef4444)",
+  border: "1px solid hsl(var(--destructive, 0 84% 60%))",
   borderRadius: 8,
   boxShadow: "0 4px 16px rgba(0, 0, 0, 0.35)",
   fontSize: "0.875rem",
@@ -147,7 +147,7 @@ const titleStyle: React.CSSProperties = {
   margin: 0,
   marginBottom: 4,
   fontWeight: 600,
-  color: "var(--destructive, #ef4444)",
+  color: "hsl(var(--destructive, 0 84% 60%))",
 };
 
 const messageStyle: React.CSSProperties = {

--- a/src/components/WebIntegrationAuthBanner.tsx
+++ b/src/components/WebIntegrationAuthBanner.tsx
@@ -327,7 +327,7 @@ export function WebIntegrationAuthBanner() {
             {reKickError ? (
               <>
                 <br />
-                <span style={{ color: "var(--destructive, #ef4444)" }}>{reKickError}</span>
+                <span style={{ color: "hsl(var(--destructive, 0 84% 60%))" }}>{reKickError}</span>
               </>
             ) : null}
           </div>
@@ -395,7 +395,7 @@ export function WebIntegrationAuthBanner() {
           {authorizeError ? (
             <>
               <br />
-              <span style={{ color: "var(--destructive, #ef4444)" }}>{authorizeError}</span>
+              <span style={{ color: "hsl(var(--destructive, 0 84% 60%))" }}>{authorizeError}</span>
             </>
           ) : null}
         </div>


### PR DESCRIPTION
Pairs with **coord #472** (git-ops routes → FleetPrincipal). Two fixes from the federation audit:

1. **git-ops feed bearer** — `git_ops_client::record` forwarded **no** bearer (`let _ = device_token`), so the post-action git-ops federation feed was 403'd-and-swallowed (same break as memory federation). Forward `bearer_auth(device_token)`; coord (#472) resolves the tenant from the verified token. Mirrors #498.
2. **Gray banners** — `StolenBanner` + `WebIntegrationAuthBanner` rendered the destructive style gray, not red — the same `--destructive` CSS-var bug fixed for the federation banner in #514 (`var(--destructive, #ef4444)` → `hsl(var(--destructive, …))`).

`cargo check` + `fmt --check` + `clippy` clean; `tsc --noEmit` clean.