### PR TITLE
fix(db): surface real PG error chain from create_emergent_task

### DIFF
--- a/src-tauri/src/database/pg/tasks.rs
+++ b/src-tauri/src/database/pg/tasks.rs
@@ -218,7 +218,20 @@ impl PgDb {
                 &[&assigned_session_id, &status, &origin, &description],
             )
             .await
-            .map_err(|e| format!("Failed to create emergent task: {}", e))?;
+            .map_err(|e| {
+                // `tokio_postgres::Error`'s Display prints only "db error" for
+                // server-side failures (it ignores the alternate `{:#}` flag);
+                // the real SQLSTATE + message live in the db-error cause. Surface
+                // them so a failure like 42P10 is diagnosable instead of opaque.
+                match e.as_db_error() {
+                    Some(db) => format!(
+                        "Failed to create emergent task: [{}] {}",
+                        db.code().code(),
+                        db
+                    ),
+                    None => format!("Failed to create emergent task: {e}"),
+                }
+            })?;
 
         Ok(row.map(|r| r.get(0)))
     }


### PR DESCRIPTION
## Problem

`create_emergent_task`'s `map_err` formatted `tokio_postgres::Error` with `{}`. For server-side (`Kind::Db`) failures that Display prints only the string `"db error"` — and it **ignores the alternate `{:#}` flag** (verified in tokio-postgres 0.7.16 `error/mod.rs`). The real SQLSTATE + message live in the db-error cause, so failures logged as an opaque `"db error"` with no actionable detail.

This is exactly why the missing-emergent-index **42P10** surfaced for so long as a bare "db error" (fixed schema-side in qontinui-web — companion PR).

## Fix

Extract the cause via `as_db_error()` and log `[<sqlstate>] <severity>: <message>`, e.g.:

```
Failed to create emergent task: [42P10] ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

Falls back to the generic `Display` when there is no db-error cause (connection/IO errors).

Method signatures verified against tokio-postgres 0.7.16: `Error::as_db_error() -> Option<&DbError>`, `DbError: Display`, `DbError::code() -> &SqlState`, `SqlState::code() -> &str`.

Plan: `2026-06-08-coord-tasks-emergent-onconflict-index-missing`