### PR TITLE
feat: restart-resilience — graceful drain, lossless resume, crash reattach, PTY honesty (Phases 2-5)

### DIFF
--- a/src-tauri/src/claude_session/manager.rs
+++ b/src-tauri/src/claude_session/manager.rs
@@ -305,6 +305,27 @@ impl SessionManager {
         active
     }
 
+    /// Snapshot every active `ClaudeSession` as `(task_run_id, session)`.
+    ///
+    /// Used by the graceful-drain sequence (`crate::drain`) which needs the
+    /// live `Arc<ClaudeSession>` (not just the id) to flush in-flight turns,
+    /// read each session's `worktree()`, and force-flush unpersisted output.
+    /// Excludes Workers and inline PIDs — they don't run a resumable Claude
+    /// conversation with an `output_log` replay, so there's nothing to drain.
+    pub fn active_claude_sessions(&self) -> Vec<(String, Arc<ClaudeSession>)> {
+        self.sessions
+            .lock()
+            .ok()
+            .map(|guard| {
+                guard
+                    .iter()
+                    .filter(|(_, s)| s.state().is_active())
+                    .map(|(k, s)| (k.clone(), s.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Clean up any closed sessions and workers.
     pub fn cleanup_closed(&self) {
         if let Ok(mut guard) = self.sessions.lock() {

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -2438,6 +2438,7 @@ pub fn run_claude_session_interactive(
         model_override,
         None, // worktree — promoted later via ClaudeSession::promote_to_worktree
         tool_policy,
+        None, // cli_session_ctx — non-chat spawn; CLI generates its own id
     )?;
 
     // Register with Doctor health monitoring

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -161,6 +161,7 @@ impl ClaudeSession {
         model_override: Option<&str>,
         worktree: Option<WorktreeInfo>,
         tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
+        cli_session_ctx: Option<&crate::claude_session::runner::CliSessionContext>,
     ) -> Result<Self, String> {
         info!(
             "Spawning interactive Claude session: {} in {}",
@@ -180,6 +181,32 @@ impl ClaudeSession {
             "--permission-mode".to_string(),
             "bypassPermissions".to_string(),
         ];
+
+        // ── Claude CLI session id (restart survival) ──────────────────────
+        // `--session-id <uuid>` pins the CLI session id on a NEW launch so the
+        // on-disk transcript lands at `<config_dir>/projects/<encoded(cwd)>/
+        // <id>.jsonl`; `--resume <uuid>` resumes a previously-pinned session
+        // losslessly from that transcript. The chat path passes the runner's
+        // own `session_id` (== task_run_id) as the CLI id so resume is
+        // deterministic without persisting a separate Claude-internal id.
+        // `None` preserves today's behavior (CLI generates a random id).
+        if let Some(ctx) = cli_session_ctx {
+            if ctx.is_resume {
+                cli_args.push("--resume".to_string());
+                cli_args.push(ctx.cli_session_id.clone());
+                info!(
+                    "Resuming Claude CLI session {} for interactive session {}",
+                    ctx.cli_session_id, session_id
+                );
+            } else {
+                cli_args.push("--session-id".to_string());
+                cli_args.push(ctx.cli_session_id.clone());
+                info!(
+                    "Pinning Claude CLI session id {} for interactive session {}",
+                    ctx.cli_session_id, session_id
+                );
+            }
+        }
 
         // Add model override if specified (e.g., from per-stage config)
         if let Some(model) = model_override {
@@ -1636,6 +1663,7 @@ impl ClaudeSession {
             None, // model_override
             Some(info.clone()),
             None, // tool_policy — worktree promotion preserves the original spawn's policy state
+            None, // cli_session_ctx — promotion changes cwd + does its own replay; no --resume
         )
         .map_err(|e| format!("promote_to_worktree: respawn failed: {}", e))?;
 
@@ -1734,6 +1762,7 @@ impl ClaudeSession {
             None, // model_override
             None, // worktree (rate-limit restart preserves the original cwd)
             None, // tool_policy (rate-limit restart preserves the original policy-less spawn)
+            None, // cli_session_ctx — in-process restart does its own replay; no --resume
         ) {
             Ok(new_session) => {
                 let new_session = Arc::new(new_session);

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -1382,6 +1382,37 @@ impl ClaudeSession {
         }
     }
 
+    /// Flush any unpersisted accumulated output to `output_log` WITHOUT
+    /// closing the session.
+    ///
+    /// Used by the graceful-drain sequence (`crate::drain`) to ensure an
+    /// in-flight turn's text reaches the DB before a planned restart, so the
+    /// resume replay sees it. Idempotent vs. the dispatcher's own per-turn
+    /// flush (both guard on `persisted_output_len`): a turn that already
+    /// checkpointed Processing → Ready flushes nothing extra here.
+    ///
+    /// Mirrors the flush block in [`Self::close`], but leaves stdin, the state
+    /// machine, and the persister thread alive — the session keeps running
+    /// until the seam's `close_all_sessions` tears it down.
+    pub fn flush_pending_output(&self) {
+        if let Some(ref tx) = self.turn_persist_tx {
+            if let Ok(buf) = self.accumulated_output.lock() {
+                // Reserve the persisted region atomically so a concurrent
+                // dispatcher flush for the same content can't double-send.
+                let persisted = self.persisted_output_len.swap(usize::MAX, Ordering::SeqCst);
+                if buf.len() > persisted && persisted != usize::MAX {
+                    let delta = buf[persisted..].to_string();
+                    if !delta.trim().is_empty() {
+                        let _ = tx.send(delta);
+                    }
+                }
+                // Do NOT clear the buffer — the session stays alive and may
+                // produce more output before the seam closes it (close() will
+                // flush the remainder and clear).
+            }
+        }
+    }
+
     /// Gracefully close the session.
     pub fn close(&self) -> Result<(), String> {
         info!("Closing session {}", self.session_id);

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -132,6 +132,16 @@ pub struct ClaudeSession {
     ///
     /// Plan: `2026-05-22-memories-on-coord-cross-machine.md` Phase 5.D.
     federation_ctx: Option<qontinui_runner_lib::observable_bridge::SessionContext>,
+    /// Worktree-isolation Phase 3 (restart-resilience): when a RESUMED chat
+    /// session re-acquired its `kind=worktree` coord claim on startup, this
+    /// carries the re-acquired `IsolatedEditContext`. The context's `Drop`
+    /// impl stops the heartbeat task and fires a best-effort claim release,
+    /// so the claim's lifetime tracks this session — `close()` clears the
+    /// slot first so release fires before the rest of the teardown.
+    /// Mirrors `TerminalSession::isolated_edit_ctx`. `None` for fresh
+    /// sessions and sessions that resumed into the shared checkout.
+    isolated_edit_ctx:
+        Arc<Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>>,
 }
 
 // SAFETY: ClaudeSession contains a raw Windows handle (RawHandle = *mut c_void) for the stdout
@@ -1173,6 +1183,7 @@ impl ClaudeSession {
             turn_persist_tx: turn_persist_tx_option,
             worktree,
             federation_ctx,
+            isolated_edit_ctx: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -1441,8 +1452,32 @@ impl ClaudeSession {
     }
 
     /// Gracefully close the session.
+    /// Worktree-isolation Phase 3 — park the `IsolatedEditContext` returned
+    /// by `agent_worktree::isolated_edit::acquire` (during resume re-acquire)
+    /// so its heartbeat task + coord claim live exactly as long as this
+    /// session. The slot is cleared in `close()` (and on `Drop`), which drops
+    /// the context and fires the best-effort claim release. Mirrors
+    /// `TerminalSession::set_isolated_edit_ctx`.
+    pub fn set_isolated_edit_ctx(
+        &self,
+        ctx: crate::agent_worktree::isolated_edit::IsolatedEditContext,
+    ) {
+        if let Ok(mut slot) = self.isolated_edit_ctx.lock() {
+            *slot = Some(ctx);
+        }
+    }
+
     pub fn close(&self) -> Result<(), String> {
         info!("Closing session {}", self.session_id);
+
+        // Worktree-isolation Phase 3 — drop the re-acquired isolated edit
+        // context first so the claim-release fire-and-forget posts ahead of
+        // the rest of teardown (release uses tokio::spawn; running it before
+        // we tear down stdin/threads makes ordering observable in coord audit
+        // logs). No-op for fresh / shared-checkout sessions (slot is None).
+        if let Ok(mut slot) = self.isolated_edit_ctx.lock() {
+            slot.take();
+        }
 
         // Stop heartbeat
         if let Some(ref tx) = self.stop_heartbeat {
@@ -1880,5 +1915,56 @@ impl std::fmt::Debug for ClaudeSession {
             .field("pid", &self.child_pid)
             .field("user_interacted", &self.has_user_interacted())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// The `isolated_edit_ctx` slot on `ClaudeSession` is the worktree-isolation
+    /// Phase 3 (restart-resilience) fix for the `mem::forget` claim leak: a
+    /// resumed session OWNS its re-acquired `IsolatedEditContext` in this slot,
+    /// and `close()` (and `Drop`, since the field lives on the struct) clears
+    /// the slot so the context's own `Drop` runs — which stops the heartbeat
+    /// and releases the coord claim. This test pins the load-bearing mechanism:
+    /// taking the value out of the `Arc<Mutex<Option<_>>>` slot (exactly what
+    /// `close()` does via `slot.take()`) DROPS the held value. A real
+    /// `IsolatedEditContext` can't be exercised without a tokio runtime for its
+    /// fire-and-forget Drop tasks, so we stand in a drop-flagging sentinel held
+    /// in the same slot shape.
+    #[test]
+    fn clearing_isolated_edit_ctx_slot_drops_the_held_value() {
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let dropped = Arc::new(AtomicBool::new(false));
+        // Same slot shape as `ClaudeSession::isolated_edit_ctx`.
+        let slot: Arc<Mutex<Option<DropFlag>>> = Arc::new(Mutex::new(None));
+
+        // Park the value (mirrors `set_isolated_edit_ctx` after resume).
+        slot.lock()
+            .unwrap()
+            .replace(DropFlag(dropped.clone()));
+        assert!(
+            !dropped.load(Ordering::SeqCst),
+            "held value must stay alive while parked on the session"
+        );
+
+        // Close path: `close()` does `slot.take()` to drop the context first
+        // so the claim release fires ahead of the rest of teardown.
+        let taken = slot.lock().unwrap().take();
+        assert!(taken.is_some(), "slot held a value before close");
+        drop(taken);
+        assert!(
+            dropped.load(Ordering::SeqCst),
+            "clearing the slot must drop the held context (releasing the claim) — \
+             NOT leak it the way mem::forget did"
+        );
     }
 }

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -1948,9 +1948,7 @@ mod tests {
         let slot: Arc<Mutex<Option<DropFlag>>> = Arc::new(Mutex::new(None));
 
         // Park the value (mirrors `set_isolated_edit_ctx` after resume).
-        slot.lock()
-            .unwrap()
-            .replace(DropFlag(dropped.clone()));
+        slot.lock().unwrap().replace(DropFlag(dropped.clone()));
         assert!(
             !dropped.load(Ordering::SeqCst),
             "held value must stay alive while parked on the session"

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -136,6 +136,15 @@ pub async fn send_user_message(
         message.len()
     );
 
+    // Graceful-drain gate (Phase 2): once a planned restart begins draining,
+    // refuse new AI turns so we don't start work that the imminent kill would
+    // tear in half. The drain flushes in-flight turns; new ones are rejected.
+    if crate::drain::is_draining() {
+        return Err(
+            "runner is draining for a planned restart — new messages are refused".to_string(),
+        );
+    }
+
     // Session-automation Phase 0 (R3) — operator interaction is the ONLY signal
     // that refreshes this session's coord heartbeat. Driving the heartbeat off
     // `send_user_message` (rather than the unconditional registry heartbeat

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -40,6 +40,104 @@ pub struct SessionStateEvent {
     pub resumed: bool,
 }
 
+/// How a session's conversation was reconstructed on resume (Phase 4
+/// honesty gate). Serialized lowercase-kebab for the frontend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ResumeFidelity {
+    /// Resumed losslessly via the on-disk `--resume` transcript.
+    Lossless,
+    /// Reconstructed from the lossy `output_log` summary — earlier context
+    /// may be missing. `turnsCovered` carries the count.
+    Summary,
+}
+
+/// What happened to the session's isolated-worktree coord claim on resume
+/// (Phase 4 honesty gate). Serialized lowercase-kebab for the frontend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ClaimStatus {
+    /// No isolated worktree was involved (shared checkout / worktree mode
+    /// off) — nothing session-scoped to re-acquire.
+    None,
+    /// The worktree claim was cleanly re-acquired under the original owner.
+    Reacquired,
+    /// A peer now holds the claim under a different owner — degraded to the
+    /// shared checkout in read-mostly mode (NOT clobbered).
+    PeerConflict,
+    /// Re-acquire failed for another reason — degraded to the shared
+    /// checkout without a claim.
+    Degraded,
+}
+
+/// What happened to the session's drained WIP ref on resume (Phase 4 honesty
+/// gate). Serialized lowercase-kebab for the frontend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum WipStatus {
+    /// No WIP ref was captured at drain time (clean tree / no worktree).
+    None,
+    /// The drained WIP applied cleanly back into the worktree.
+    Restored,
+    /// The WIP could not be applied cleanly — kept at `refs/wip/*` for the
+    /// operator to recover manually.
+    KeptForManual,
+}
+
+/// Per-session recovery outcome, assembled as `resume_ai_sessions` resumes
+/// each session (Phase 4). Threaded out of the resume loop and into the
+/// `session-recovery-summary` event so the frontend can surface an HONEST
+/// per-session status (lossy / degraded / peer-conflict are never hidden).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRecoveryOutcome {
+    /// The resumed session's task run id (stable identity across restarts).
+    pub task_run_id: String,
+    /// Human-readable title shown in the banner.
+    pub title: String,
+    /// Lossless `--resume` vs lossy summary fallback.
+    pub fidelity: ResumeFidelity,
+    /// On a `summary` fidelity, the number of conversation turns the lossy
+    /// summary covers (mirrors the honest-label marker). `0` for lossless.
+    pub turns_covered: usize,
+    /// Worktree-claim re-acquire outcome.
+    pub claim_status: ClaimStatus,
+    /// Drained-WIP restore outcome.
+    pub wip_status: WipStatus,
+}
+
+/// Structured startup-recovery summary emitted ONCE after `resume_ai_sessions`
+/// runs at boot (Phase 4). Carries the crash-vs-planned classification (from
+/// the on-disk shutdown marker) plus a per-session honesty breakdown.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRecoverySummary {
+    /// `true` when the previous shutdown was NOT clean (the runner crashed /
+    /// was hard-killed). Drives the prominent vs quiet banner on the
+    /// frontend.
+    pub crash_recovery: bool,
+    /// Number of sessions successfully resumed.
+    pub resumed_count: u32,
+    /// Per-session honest outcomes (one entry per successfully resumed
+    /// session).
+    pub sessions: Vec<SessionRecoveryOutcome>,
+}
+
+/// Tauri event name for the one-shot startup recovery summary (Phase 4).
+pub const SESSION_RECOVERY_SUMMARY_EVENT: &str = "session-recovery-summary";
+
+/// Emit the startup recovery summary to the frontend, once, after resume
+/// completes. A banner subscribes and renders crash-vs-planned + per-session
+/// fidelity/claim/WIP honesty. No-op-safe: an emit failure is logged only.
+pub fn emit_session_recovery_summary(
+    app_handle: &tauri::AppHandle,
+    summary: &SessionRecoverySummary,
+) {
+    if let Err(e) = app_handle.emit(SESSION_RECOVERY_SUMMARY_EVENT, summary) {
+        warn!("Failed to emit {} event: {}", SESSION_RECOVERY_SUMMARY_EVENT, e);
+    }
+}
+
 /// Emit a session state change event to the frontend.
 pub fn emit_session_state(
     app_handle: &tauri::AppHandle,
@@ -1294,6 +1392,8 @@ async fn reacquire_and_restore_session_worktree(
     Option<String>,
     Vec<String>,
     Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
+    ClaimStatus,
+    WipStatus,
 ) {
     use crate::agent_worktree::isolated_edit::{acquire, AcquireRequest};
 
@@ -1310,11 +1410,11 @@ async fn reacquire_and_restore_session_worktree(
                 "AI session resume: worktree lookup failed for {} ({}); shared-checkout fallback",
                 task_run_id, e
             );
-            return (None, notes, None);
+            return (None, notes, None, ClaimStatus::None, WipStatus::None);
         }
     };
     if worktree_rows.is_empty() {
-        return (None, notes, None);
+        return (None, notes, None, ClaimStatus::None, WipStatus::None);
     }
 
     // 2. Map each worktree's `repo_path` (the source checkout) back to a bare
@@ -1336,7 +1436,7 @@ async fn reacquire_and_restore_session_worktree(
         }
     }
     if repos.is_empty() {
-        return (None, notes, None);
+        return (None, notes, None, ClaimStatus::None, WipStatus::None);
     }
 
     // 3. Re-acquire under the SAME stable agent_session_id the drain used, so
@@ -1367,9 +1467,16 @@ async fn reacquire_and_restore_session_worktree(
 
             // 4. Restore the drained WIP ref into each re-acquired worktree
             //    (Phase 2 wrote `refs/wip/<agent_session_id>` per worktree).
+            //    `wip_status` is the WORST outcome across worktrees: a single
+            //    not-clean apply degrades the whole session to KeptForManual
+            //    (the honest banner state).
+            let mut wip_status = WipStatus::None;
             for w in &ctx.worktrees {
                 match crate::drain::restore_wip_ref(&w.worktree_path, &agent_session_id) {
                     Ok(outcome) if outcome.ref_existed && outcome.applied_clean => {
+                        if wip_status == WipStatus::None {
+                            wip_status = WipStatus::Restored;
+                        }
                         info!(
                             "AI session resume: restored WIP {} into {} (ref deleted={})",
                             outcome.ref_name,
@@ -1379,6 +1486,7 @@ async fn reacquire_and_restore_session_worktree(
                     }
                     Ok(outcome) if outcome.ref_existed => {
                         // Apply was not clean — ref kept; surface for manual apply.
+                        wip_status = WipStatus::KeptForManual;
                         notes.push(format!(
                             "[SYSTEM_NOTE] Uncommitted work from before the restart could not be \
                              applied cleanly in {}. It is preserved at `{}` — run \
@@ -1413,16 +1521,21 @@ async fn reacquire_and_restore_session_worktree(
             // would keep the heartbeat alive until process exit and never
             // release the claim, blocking a peer from re-acquiring the
             // worktree after this session dies.
-            (workdir, notes, Some(ctx))
+            (workdir, notes, Some(ctx), ClaimStatus::Reacquired, wip_status)
         }
         Ok(None) => {
             // Worktree mode off — shared-checkout fallback, no claim.
-            (None, notes, None)
+            (None, notes, None, ClaimStatus::None, WipStatus::None)
         }
         Err(e) => {
             // A `ClaimConflict` (peer holds it under a different owner) or any
             // other allocate error → DO NOT clobber. Surface + degrade to the
-            // shared checkout in read-mostly mode.
+            // shared checkout in read-mostly mode. A genuine peer-conflict is
+            // classified distinctly (PeerConflict) so the banner can be HONEST
+            // that another agent now holds the worktree, vs a generic transport
+            // failure (Degraded).
+            let is_peer_conflict =
+                matches!(e, crate::agent_worktree::AllocateError::ClaimConflict(_));
             let msg = e.to_string();
             warn!(
                 "AI session resume: worktree re-acquire for {} failed ({}); \
@@ -1434,7 +1547,12 @@ async fn reacquire_and_restore_session_worktree(
                  the restart ({msg}). Another agent may now hold it — resuming in shared, \
                  read-mostly mode. Re-check ownership before making edits."
             ));
-            (None, notes, None)
+            let claim_status = if is_peer_conflict {
+                ClaimStatus::PeerConflict
+            } else {
+                ClaimStatus::Degraded
+            };
+            (None, notes, None, claim_status, WipStatus::None)
         }
     }
 }
@@ -1454,13 +1572,31 @@ async fn reacquire_and_restore_session_worktree(
 /// marked failed in PG with a `resume_failed:` error message so the sidebar
 /// reflects reality rather than showing a phantom "running" state.
 ///
-/// Returns the number of sessions successfully resumed.
+/// `crash_recovery` is the boot classification from the on-disk shutdown
+/// marker (see `session::shutdown_marker`): `true` when the previous shutdown
+/// was NOT clean. It is threaded onto the returned [`SessionRecoverySummary`]
+/// so the caller can emit a single `session-recovery-summary` event and the
+/// frontend can choose a prominent (crash) vs quiet (planned) banner.
+///
+/// Returns a [`SessionRecoverySummary`] carrying the resumed count, the
+/// crash-vs-planned flag, and a per-session honesty breakdown (resume
+/// fidelity + claim status + WIP status).
 pub async fn resume_ai_sessions(
     session_manager: Arc<SessionManager>,
     app_handle: tauri::AppHandle,
-) -> u32 {
+    crash_recovery: bool,
+) -> SessionRecoverySummary {
     use crate::claude_session::resume::{build_replay_prompt, parse_conversation};
     use crate::claude_session::ClaudeSession;
+
+    // An empty summary carries only the boot classification — used for every
+    // early exit (no sessions / not-yet-ready) so the caller still learns
+    // whether this was a crash boot.
+    let empty_summary = || SessionRecoverySummary {
+        crash_recovery,
+        resumed_count: 0,
+        sessions: Vec::new(),
+    };
 
     // Grab AppState from Tauri's managed state — same pattern other resume
     // paths use. If unavailable we're being invoked before setup completes;
@@ -1469,7 +1605,7 @@ pub async fn resume_ai_sessions(
         Some(s) => s.inner().clone(),
         None => {
             warn!("AI session resume: AppState not yet available; skipping");
-            return 0;
+            return empty_summary();
         }
     };
 
@@ -1486,7 +1622,7 @@ pub async fn resume_ai_sessions(
         .load(std::sync::atomic::Ordering::Relaxed);
     if my_port == 0 {
         warn!("AI session resume: api_port not set yet; skipping");
-        return 0;
+        return empty_summary();
     }
 
     let pg = app_state.pg_db.clone();
@@ -1495,13 +1631,13 @@ pub async fn resume_ai_sessions(
         Ok(rows) => rows,
         Err(e) => {
             error!("AI session resume: failed to query resumable chats: {}", e);
-            return 0;
+            return empty_summary();
         }
     };
 
     if rows.is_empty() {
         info!("AI session resume: no resumable chat sessions found");
-        return 0;
+        return empty_summary();
     }
 
     info!(
@@ -1517,6 +1653,7 @@ pub async fn resume_ai_sessions(
     };
 
     let mut resumed: u32 = 0;
+    let mut outcomes: Vec<SessionRecoveryOutcome> = Vec::new();
 
     for (task_run_id, task_name, auto_continue) in rows {
         if !auto_continue {
@@ -1578,7 +1715,7 @@ pub async fn resume_ai_sessions(
         // Returns the worktree path to re-spawn into (when re-acquire
         // succeeded) plus any operator-facing notes (peer-conflict / manual
         // WIP recovery). Graceful-degrades to the shared cwd on any failure.
-        let (workdir_override, system_notes, reacquired_ctx) =
+        let (workdir_override, system_notes, reacquired_ctx, claim_status, wip_status) =
             reacquire_and_restore_session_worktree(&task_run_id, &pg).await;
 
         // Effective working dir: the re-acquired worktree, else the shared cwd
@@ -1641,6 +1778,18 @@ pub async fn resume_ai_sessions(
                 build_honest_summary_prompt(&replay_prompt, turns.len())
             ))
         };
+
+        // Capture the per-session honesty signals BEFORE the spawn closure
+        // moves/consumes the locals. `fidelity` is lossless iff we resumed from
+        // an on-disk transcript; otherwise it's the lossy summary, and
+        // `turns_covered` records how many turns that summary spans.
+        let fidelity = if can_full_resume {
+            ResumeFidelity::Lossless
+        } else {
+            ResumeFidelity::Summary
+        };
+        let turns_covered = if can_full_resume { 0 } else { turns.len() };
+        let outcome_title = task_name.clone();
 
         // Spawn the Claude CLI session on a blocking thread — ClaudeSession::spawn
         // blocks waiting for the init handshake. This mirrors create_ai_session.
@@ -1745,8 +1894,19 @@ pub async fn resume_ai_sessions(
 
         match spawn_result {
             Ok(Ok(())) => {
-                info!("AI session resume: resumed {}", task_run_id);
+                info!(
+                    "AI session resume: resumed {} (fidelity={:?} claim={:?} wip={:?})",
+                    task_run_id, fidelity, claim_status, wip_status
+                );
                 resumed += 1;
+                outcomes.push(SessionRecoveryOutcome {
+                    task_run_id: task_run_id.clone(),
+                    title: outcome_title,
+                    fidelity,
+                    turns_covered,
+                    claim_status,
+                    wip_status,
+                });
             }
             Ok(Err(e)) => {
                 warn!("AI session resume: {} failed: {}", task_run_id, e);
@@ -1767,7 +1927,11 @@ pub async fn resume_ai_sessions(
         }
     }
 
-    resumed
+    SessionRecoverySummary {
+        crash_recovery,
+        resumed_count: resumed,
+        sessions: outcomes,
+    }
 }
 
 /// Tries both the cached external app specs and the runner's own specs.
@@ -2057,5 +2221,109 @@ mod resume_tests {
         // marker string only originates from honest_summary_marker, which the
         // full-resume branch does not call.
         assert!(!notes_only.contains(&honest_summary_marker(1)));
+    }
+
+    // ── Phase 4 — recovery-summary assembly + serde honesty contract ────────
+
+    fn outcome(
+        id: &str,
+        fidelity: ResumeFidelity,
+        turns: usize,
+        claim: ClaimStatus,
+        wip: WipStatus,
+    ) -> SessionRecoveryOutcome {
+        SessionRecoveryOutcome {
+            task_run_id: id.to_string(),
+            title: format!("title-{id}"),
+            fidelity,
+            turns_covered: turns,
+            claim_status: claim,
+            wip_status: wip,
+        }
+    }
+
+    #[test]
+    fn summary_assembles_count_and_crash_flag() {
+        let summary = SessionRecoverySummary {
+            crash_recovery: true,
+            resumed_count: 2,
+            sessions: vec![
+                outcome(
+                    "a",
+                    ResumeFidelity::Lossless,
+                    0,
+                    ClaimStatus::Reacquired,
+                    WipStatus::Restored,
+                ),
+                outcome(
+                    "b",
+                    ResumeFidelity::Summary,
+                    5,
+                    ClaimStatus::PeerConflict,
+                    WipStatus::KeptForManual,
+                ),
+            ],
+        };
+        assert!(summary.crash_recovery);
+        assert_eq!(summary.resumed_count, 2);
+        assert_eq!(summary.sessions.len(), 2);
+    }
+
+    #[test]
+    fn summary_serializes_camelcase_with_honest_kebab_statuses() {
+        // The frontend banner type mirrors this exact wire shape; pin it so a
+        // rename can't silently break the honesty surfacing.
+        let summary = SessionRecoverySummary {
+            crash_recovery: true,
+            resumed_count: 1,
+            sessions: vec![outcome(
+                "task-1",
+                ResumeFidelity::Summary,
+                3,
+                ClaimStatus::PeerConflict,
+                WipStatus::KeptForManual,
+            )],
+        };
+        let v = serde_json::to_value(&summary).expect("serialize");
+
+        assert_eq!(v["crashRecovery"], serde_json::json!(true));
+        assert_eq!(v["resumedCount"], serde_json::json!(1));
+
+        let s = &v["sessions"][0];
+        assert_eq!(s["taskRunId"], serde_json::json!("task-1"));
+        assert_eq!(s["title"], serde_json::json!("title-task-1"));
+        // Honesty contract: lossy / degraded / peer-conflict states are
+        // surfaced verbatim as kebab-case enum tags.
+        assert_eq!(s["fidelity"], serde_json::json!("summary"));
+        assert_eq!(s["turnsCovered"], serde_json::json!(3));
+        assert_eq!(s["claimStatus"], serde_json::json!("peer-conflict"));
+        assert_eq!(s["wipStatus"], serde_json::json!("kept-for-manual"));
+    }
+
+    #[test]
+    fn lossless_clean_session_serializes_honestly() {
+        let summary = SessionRecoverySummary {
+            crash_recovery: false,
+            resumed_count: 1,
+            sessions: vec![outcome(
+                "task-2",
+                ResumeFidelity::Lossless,
+                0,
+                ClaimStatus::Reacquired,
+                WipStatus::None,
+            )],
+        };
+        let v = serde_json::to_value(&summary).expect("serialize");
+        assert_eq!(v["crashRecovery"], serde_json::json!(false));
+        let s = &v["sessions"][0];
+        assert_eq!(s["fidelity"], serde_json::json!("lossless"));
+        assert_eq!(s["claimStatus"], serde_json::json!("reacquired"));
+        assert_eq!(s["wipStatus"], serde_json::json!("none"));
+    }
+
+    #[test]
+    fn recovery_event_name_is_stable() {
+        // The frontend `useSessionRecovery` hook listens on this exact name.
+        assert_eq!(SESSION_RECOVERY_SUMMARY_EVENT, "session-recovery-summary");
     }
 }

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -375,6 +375,17 @@ pub async fn create_ai_session(
         // and the frontend would be unable to filter them.
         let session_ctx = AiSessionContext::setup(&trid, &name_for_ctx);
 
+        // Pin the Claude CLI session id to the task_run_id on this fresh launch
+        // (Phase 3, restart resilience). This makes the on-disk transcript land
+        // at a DETERMINISTIC path (`<config_dir>/projects/<encoded(cwd)>/
+        // <task_run_id>.jsonl`), so a later restart can resume LOSSLESSLY via
+        // `--resume <task_run_id>` instead of replaying a lossy output_log
+        // summary. `is_resume:false` → `--session-id` (new), not `--resume`.
+        let cli_session_ctx = crate::claude_session::runner::CliSessionContext {
+            cli_session_id: trid.clone(),
+            is_resume: false,
+        };
+
         match crate::claude_session::ClaudeSession::spawn(
             &working_dir,
             &trid,
@@ -386,6 +397,7 @@ pub async fn create_ai_session(
             None,              // model_override
             None,              // worktree
             None,              // tool_policy
+            Some(&cli_session_ctx),
         ) {
             Ok(session) => {
                 let session = Arc::new(session);
@@ -1200,6 +1212,220 @@ pub async fn recent_session_touched_files(
         .collect())
 }
 
+/// Honest-label marker prepended to a SUMMARY-fallback replay so the
+/// operator/agent knows the resume is LOSSY (the full on-disk transcript was
+/// unavailable). The `{n}` is the actual number of conversation turns the
+/// summary covers — see [`build_honest_summary_prompt`].
+///
+/// This is the UX honesty gate (Phase 3, plan
+/// `2026-06-06-runner-dev-loop-and-restart-resilience`): we never silently
+/// present a reconstructed-from-output_log summary as a complete resume.
+fn honest_summary_marker(turns_covered: usize) -> String {
+    format!(
+        "[SYSTEM_NOTE] Resumed from the last {turns_covered} turns \
+         (full transcript unavailable — earlier context may be missing).\n\n"
+    )
+}
+
+/// Prepend [`honest_summary_marker`] to a `build_replay_prompt` summary so the
+/// lossy nature of the resume is labelled. `turns_covered` is the count of
+/// parsed turns the summary was built from.
+fn build_honest_summary_prompt(replay_prompt: &str, turns_covered: usize) -> String {
+    format!("{}{}", honest_summary_marker(turns_covered), replay_prompt)
+}
+
+/// Does an on-disk Claude transcript exist for `(working_dir, cli_session_id)`?
+///
+/// The chat path pins the CLI session id to the `task_run_id` (see
+/// `create_ai_session`), so the transcript lands at
+/// `<config_dir>/projects/<encoded(working_dir)>/<cli_session_id>.jsonl`. When
+/// it exists we can resume LOSSLESSLY via `--resume <cli_session_id>` and skip
+/// the lossy output_log summary entirely. We probe every discovered Claude
+/// config dir (multi-account installs) and the resolved effective dir.
+fn transcript_exists_for(working_dir: &str, cli_session_id: &str) -> bool {
+    use crate::terminal::transcript;
+
+    // The effective config dir for the active account, plus all discovered
+    // config dirs (multi-account). Any hit means the transcript is resumable.
+    let mut config_dirs: Vec<std::path::PathBuf> = transcript::find_claude_config_dirs();
+    if let Some(eff) =
+        crate::ai_provider::get_effective_config_dir(&crate::settings::get_ai_settings().claude_cli)
+    {
+        let p = std::path::PathBuf::from(eff);
+        if !config_dirs.iter().any(|d| d == &p) {
+            config_dirs.push(p);
+        }
+    }
+
+    config_dirs
+        .iter()
+        .any(|cfg| transcript::session_transcript_path(cfg, working_dir, cli_session_id).exists())
+}
+
+/// Re-acquire the coord `kind=worktree` claim(s) for a resumed chat session and
+/// restore its drained WIP state, BEFORE re-spawning the CLI.
+///
+/// Closes the P0c gap: the legacy resume path never re-`acquire`d the worktree
+/// claim, orphaning it for the TTL (a peer could steal it). We derive the same
+/// stable `agent_session_id` Phase 2's drain used
+/// (`drain::stable_ai_session_id(task_run_id)`), so the re-acquire idempotently
+/// RENEWS the original claim if still within TTL, or cleanly re-takes it if the
+/// TTL expired.
+///
+/// Returns the effective working dir for the re-spawn (the worktree path when
+/// re-acquire succeeded, else `None` → caller keeps the shared cwd) plus any
+/// `[SYSTEM_NOTE]` strings to surface (peer-conflict / manual-WIP-recovery).
+///
+/// Graceful degrade (mirrors the launch path): worktree mode off / no persisted
+/// worktree / acquire fails → returns `(None, notes)` and resume continues in
+/// the shared checkout with no claim. A peer holding the claim under a
+/// DIFFERENT owner is surfaced (note) and NOT clobbered — resume goes
+/// read-mostly/shared.
+async fn reacquire_and_restore_session_worktree(
+    task_run_id: &str,
+    pg: &Arc<crate::database::pg::PgDb>,
+) -> (Option<String>, Vec<String>) {
+    use crate::agent_worktree::isolated_edit::{acquire, AcquireRequest};
+
+    let mut notes: Vec<String> = Vec::new();
+
+    // 1. Which repo(s)/worktree(s) was this session editing? Sourced from the
+    //    persisted `coord.worktrees` rows keyed by task_run_id (written by
+    //    `promote_to_worktree`). No row → the session ran in the shared cwd;
+    //    nothing session-scoped to re-acquire.
+    let worktree_rows = match pg.get_worktrees_for_task_run(task_run_id).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(
+                "AI session resume: worktree lookup failed for {} ({}); shared-checkout fallback",
+                task_run_id, e
+            );
+            return (None, notes);
+        }
+    };
+    if worktree_rows.is_empty() {
+        return (None, notes);
+    }
+
+    // 2. Map each worktree's `repo_path` (the source checkout) back to a bare
+    //    repo slug for the acquire facade. A slug we can't resolve is skipped
+    //    (best-effort) rather than failing the whole resume.
+    let mut repos: Vec<String> = Vec::new();
+    for row in &worktree_rows {
+        if let Some(slug) = crate::agent_worktree::canonical_paths::repo_slug_for_path(
+            std::path::Path::new(&row.repo_path),
+        ) {
+            if !repos.contains(&slug) {
+                repos.push(slug);
+            }
+        } else {
+            warn!(
+                "AI session resume: could not resolve repo slug for {} (worktree {}); skipping",
+                row.repo_path, row.id
+            );
+        }
+    }
+    if repos.is_empty() {
+        return (None, notes);
+    }
+
+    // 3. Re-acquire under the SAME stable agent_session_id the drain used, so
+    //    the owner token (`<machine_id>:<agent_session_id>`) matches the
+    //    original claim → idempotent renew within TTL / clean re-take after.
+    let agent_session_id = crate::drain::stable_ai_session_id(task_run_id);
+    let intent = format!("resume chat session {task_run_id}");
+
+    match acquire(AcquireRequest {
+        repos: &repos,
+        intent: Some(&intent),
+        declared_overlap_paths: None,
+        plan_id: None,
+        phase: None,
+        agent_session_id: Some(agent_session_id),
+    })
+    .await
+    {
+        Ok(Some(ctx)) => {
+            let workdir = ctx
+                .worktrees
+                .first()
+                .map(|w| w.worktree_path.to_string_lossy().to_string());
+            info!(
+                "AI session resume: re-acquired worktree claim(s) for {} (repos={:?}, agent_session_id={})",
+                task_run_id, repos, agent_session_id
+            );
+
+            // 4. Restore the drained WIP ref into each re-acquired worktree
+            //    (Phase 2 wrote `refs/wip/<agent_session_id>` per worktree).
+            for w in &ctx.worktrees {
+                match crate::drain::restore_wip_ref(&w.worktree_path, &agent_session_id) {
+                    Ok(outcome) if outcome.ref_existed && outcome.applied_clean => {
+                        info!(
+                            "AI session resume: restored WIP {} into {} (ref deleted={})",
+                            outcome.ref_name,
+                            w.worktree_path.display(),
+                            outcome.ref_deleted
+                        );
+                    }
+                    Ok(outcome) if outcome.ref_existed => {
+                        // Apply was not clean — ref kept; surface for manual apply.
+                        notes.push(format!(
+                            "[SYSTEM_NOTE] Uncommitted work from before the restart could not be \
+                             applied cleanly in {}. It is preserved at `{}` — run \
+                             `git -C {} stash apply {}` to recover it manually.",
+                            w.repo,
+                            outcome.ref_name,
+                            w.worktree_path.display(),
+                            outcome.ref_name
+                        ));
+                        warn!(
+                            "AI session resume: WIP {} did not apply cleanly into {}; kept for manual recovery",
+                            outcome.ref_name,
+                            w.worktree_path.display()
+                        );
+                    }
+                    Ok(_) => { /* no ref captured — clean drain or clean tree */ }
+                    Err(e) => {
+                        warn!(
+                            "AI session resume: WIP restore probe failed in {}: {}",
+                            w.worktree_path.display(),
+                            e
+                        );
+                    }
+                }
+            }
+
+            // The IsolatedEditContext owns the claim heartbeats; leak it so the
+            // claim stays live for the resumed session's lifetime (the CLI
+            // outlives this function). Dropping it here would tear down the
+            // heartbeat we just re-established.
+            std::mem::forget(ctx);
+            (workdir, notes)
+        }
+        Ok(None) => {
+            // Worktree mode off — shared-checkout fallback, no claim.
+            (None, notes)
+        }
+        Err(e) => {
+            // A `ClaimConflict` (peer holds it under a different owner) or any
+            // other allocate error → DO NOT clobber. Surface + degrade to the
+            // shared checkout in read-mostly mode.
+            let msg = e.to_string();
+            warn!(
+                "AI session resume: worktree re-acquire for {} failed ({}); \
+                 resuming in shared/read-mostly mode without a claim",
+                task_run_id, msg
+            );
+            notes.push(format!(
+                "[SYSTEM_NOTE] Could not re-acquire the isolated worktree for this session after \
+                 the restart ({msg}). Another agent may now hold it — resuming in shared, \
+                 read-mostly mode. Re-check ownership before making edits."
+            ));
+            (None, notes)
+        }
+    }
+}
+
 /// Resume interrupted AI sessions on startup.
 ///
 /// Queries for task runs with status='running' and workflow_type='chat'
@@ -1334,16 +1560,74 @@ pub async fn resume_ai_sessions(
             continue;
         }
 
-        let replay_prompt = build_replay_prompt(&turns, None);
-        if replay_prompt.is_empty() {
-            mark_failed(
-                task_run_id.clone(),
-                "empty replay prompt".to_string(),
-                pg.clone(),
-            )
-            .await;
-            continue;
-        }
+        // ── (A) Re-acquire the worktree claim + (C) restore drained WIP ────
+        // Closes the P0c gap. Runs in the async context (PG + coord I/O).
+        // Returns the worktree path to re-spawn into (when re-acquire
+        // succeeded) plus any operator-facing notes (peer-conflict / manual
+        // WIP recovery). Graceful-degrades to the shared cwd on any failure.
+        let (workdir_override, system_notes) =
+            reacquire_and_restore_session_worktree(&task_run_id, &pg).await;
+
+        // Effective working dir: the re-acquired worktree, else the shared cwd
+        // the session originally ran in.
+        let working_dir = workdir_override.clone().unwrap_or_else(|| {
+            std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| ".".to_string())
+        });
+
+        // ── (B) Prefer lossless `--resume`; honestly label the summary ─────
+        // The chat path pins the CLI session id to the task_run_id, so an
+        // on-disk transcript at `<cfg>/projects/<encoded(cwd)>/<id>.jsonl`
+        // means we can resume losslessly via `--resume` and SKIP the lossy
+        // output_log summary entirely. Only when no transcript exists do we
+        // fall back to `build_replay_prompt` — and we LABEL it honestly so the
+        // operator/agent knows earlier context may be missing.
+        let can_full_resume = transcript_exists_for(&working_dir, &task_run_id);
+
+        // The replay prompt is only used on the summary fallback. When we have
+        // a full transcript we send NO initial prompt (the --resume restores
+        // the real conversation; injecting a summary would be redundant +
+        // lossy). `notes_prefix` carries any worktree SYSTEM_NOTEs onto
+        // whichever initial turn we DO send.
+        let notes_prefix = if system_notes.is_empty() {
+            String::new()
+        } else {
+            format!("{}\n\n", system_notes.join("\n\n"))
+        };
+
+        let initial_prompt: Option<String> = if can_full_resume {
+            info!(
+                "AI session resume: {} has an on-disk transcript — resuming losslessly via --resume",
+                task_run_id
+            );
+            // Even on a lossless resume, surface worktree notes (if any) as a
+            // standalone initial turn so the operator sees the conflict/WIP
+            // status. No notes → no initial prompt at all.
+            if notes_prefix.is_empty() {
+                None
+            } else {
+                Some(notes_prefix.trim_end().to_string())
+            }
+        } else {
+            let replay_prompt = build_replay_prompt(&turns, None);
+            if replay_prompt.is_empty() {
+                mark_failed(
+                    task_run_id.clone(),
+                    "empty replay prompt".to_string(),
+                    pg.clone(),
+                )
+                .await;
+                continue;
+            }
+            // Honesty gate: label the lossy summary with the turn count it
+            // covers, prefixed by any worktree notes.
+            Some(format!(
+                "{}{}",
+                notes_prefix,
+                build_honest_summary_prompt(&replay_prompt, turns.len())
+            ))
+        };
 
         // Spawn the Claude CLI session on a blocking thread — ClaudeSession::spawn
         // blocks waiting for the init handshake. This mirrors create_ai_session.
@@ -1351,17 +1635,24 @@ pub async fn resume_ai_sessions(
         let handle = app_handle.clone();
         let trid = task_run_id.clone();
         let name_for_ctx = task_name.clone();
-        let replay_for_spawn = replay_prompt;
+        let initial_for_spawn = initial_prompt;
+        let working_dir_for_spawn = working_dir;
+        let resume_from_transcript = can_full_resume;
 
         let spawn_result = tokio::task::spawn_blocking(move || -> Result<(), String> {
-            let working_dir = std::env::current_dir()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_else(|_| ".".to_string());
-
             let session_ctx = AiSessionContext::setup(&trid, &name_for_ctx);
 
+            // Pin/resume the CLI session id to the task_run_id. `is_resume` is
+            // true ONLY when an on-disk transcript exists (→ `--resume`); else
+            // we still `--session-id`-pin so a SUBSEQUENT restart can resume
+            // losslessly from the transcript this launch creates.
+            let cli_session_ctx = crate::claude_session::runner::CliSessionContext {
+                cli_session_id: trid.clone(),
+                is_resume: resume_from_transcript,
+            };
+
             let session = ClaudeSession::spawn(
-                &working_dir,
+                &working_dir_for_spawn,
                 &trid,
                 &handle,
                 Some(session_ctx),
@@ -1371,6 +1662,7 @@ pub async fn resume_ai_sessions(
                 None, // model_override
                 None, // worktree
                 None, // tool_policy
+                Some(&cli_session_ctx),
             )
             .map_err(|e| format!("spawn failed: {}", e))?;
 
@@ -1379,17 +1671,20 @@ pub async fn resume_ai_sessions(
             sm.register(&trid, session.clone())
                 .map_err(|e| format!("register failed: {}", e))?;
 
-            // Send the replay prompt as the initial turn. `send_initial_prompt`
-            // is exactly the right entrypoint: it requires Ready state (which
-            // spawn just established), writes to stdin, transitions to
-            // Processing, and crucially does NOT set `user_has_interacted` —
-            // so the next real user message still triggers the
-            // first-interaction context-switch note in send_user_message.
-            // It also does not append anything to output_log, so the next
-            // restart's replay won't double-count.
-            session
-                .send_initial_prompt(&replay_for_spawn)
-                .map_err(|e| format!("send_initial_prompt failed: {}", e))?;
+            // Send an initial turn ONLY when we have something to say:
+            //   - summary fallback → the honest-labelled replay summary, or
+            //   - lossless resume  → just the worktree SYSTEM_NOTEs (if any).
+            // `send_initial_prompt` requires Ready state (spawn just
+            // established it), writes to stdin, transitions to Processing, and
+            // crucially does NOT set `user_has_interacted` — so the next real
+            // user message still triggers the first-interaction context-switch
+            // note. It does not append to output_log, so the next restart's
+            // replay won't double-count.
+            if let Some(prompt) = initial_for_spawn.as_deref() {
+                session
+                    .send_initial_prompt(prompt)
+                    .map_err(|e| format!("send_initial_prompt failed: {}", e))?;
+            }
 
             // Emit the state event with resumed=true so the frontend can
             // surface a one-time "resumed" badge/toast.
@@ -1682,4 +1977,58 @@ pub fn plugin() -> TauriPlugin<tauri::Wry> {
             recent_session_touched_files,
         ])
         .build()
+}
+
+#[cfg(test)]
+mod resume_tests {
+    use super::*;
+
+    #[test]
+    fn honest_marker_reports_actual_turn_count() {
+        let marker = honest_summary_marker(7);
+        assert!(marker.starts_with("[SYSTEM_NOTE]"));
+        assert!(
+            marker.contains("last 7 turns"),
+            "marker must state the actual N turns it covers: {marker}"
+        );
+        assert!(
+            marker.contains("full transcript unavailable"),
+            "marker must flag the resume as lossy: {marker}"
+        );
+    }
+
+    #[test]
+    fn summary_fallback_is_labelled_with_n() {
+        // The summary path (no on-disk transcript) prepends the honest marker
+        // to the replay prompt, with N = number of turns covered.
+        let replay = "<conversation_history>...</conversation_history>";
+        let n = 3usize;
+        let labelled = build_honest_summary_prompt(replay, n);
+        assert!(
+            labelled.starts_with("[SYSTEM_NOTE]"),
+            "summary fallback must be honestly labelled"
+        );
+        assert!(labelled.contains("last 3 turns"));
+        assert!(
+            labelled.ends_with(replay),
+            "the original replay prompt must follow the marker verbatim"
+        );
+    }
+
+    #[test]
+    fn full_resume_path_has_no_honesty_marker() {
+        // On the lossless `--resume` path we send NO summary, so the honesty
+        // marker MUST be absent. We model the decision: when can_full_resume is
+        // true and there are no worktree notes, the initial prompt is None;
+        // with notes it is just the notes (never the lossy marker).
+        let notes_only = "[SYSTEM_NOTE] Could not re-acquire the isolated worktree.";
+        assert!(
+            !notes_only.contains("full transcript unavailable"),
+            "the lossless-resume initial turn must never carry the lossy summary marker"
+        );
+        // And the summary builder is simply never invoked on this path — the
+        // marker string only originates from honest_summary_marker, which the
+        // full-resume branch does not call.
+        assert!(!notes_only.contains(&honest_summary_marker(1)));
+    }
 }

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -1273,18 +1273,28 @@ fn transcript_exists_for(working_dir: &str, cli_session_id: &str) -> bool {
 /// TTL expired.
 ///
 /// Returns the effective working dir for the re-spawn (the worktree path when
-/// re-acquire succeeded, else `None` → caller keeps the shared cwd) plus any
-/// `[SYSTEM_NOTE]` strings to surface (peer-conflict / manual-WIP-recovery).
+/// re-acquire succeeded, else `None` → caller keeps the shared cwd); any
+/// `[SYSTEM_NOTE]` strings to surface (peer-conflict / manual-WIP-recovery);
+/// and the re-acquired `IsolatedEditContext` (`Some` only when re-acquire
+/// succeeded). The caller MUST hand the context to the resumed
+/// `ClaudeSession` (via `set_isolated_edit_ctx`) so the claim heartbeat lives
+/// for the session's lifetime and the claim RELEASES (via the context's Drop)
+/// when the session ends — NOT `mem::forget` it (that orphans the claim past
+/// session end and blocks a peer from re-acquiring the worktree).
 ///
 /// Graceful degrade (mirrors the launch path): worktree mode off / no persisted
-/// worktree / acquire fails → returns `(None, notes)` and resume continues in
-/// the shared checkout with no claim. A peer holding the claim under a
+/// worktree / acquire fails → returns `(None, notes, None)` and resume continues
+/// in the shared checkout with no claim. A peer holding the claim under a
 /// DIFFERENT owner is surfaced (note) and NOT clobbered — resume goes
 /// read-mostly/shared.
 async fn reacquire_and_restore_session_worktree(
     task_run_id: &str,
     pg: &Arc<crate::database::pg::PgDb>,
-) -> (Option<String>, Vec<String>) {
+) -> (
+    Option<String>,
+    Vec<String>,
+    Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
+) {
     use crate::agent_worktree::isolated_edit::{acquire, AcquireRequest};
 
     let mut notes: Vec<String> = Vec::new();
@@ -1300,11 +1310,11 @@ async fn reacquire_and_restore_session_worktree(
                 "AI session resume: worktree lookup failed for {} ({}); shared-checkout fallback",
                 task_run_id, e
             );
-            return (None, notes);
+            return (None, notes, None);
         }
     };
     if worktree_rows.is_empty() {
-        return (None, notes);
+        return (None, notes, None);
     }
 
     // 2. Map each worktree's `repo_path` (the source checkout) back to a bare
@@ -1326,7 +1336,7 @@ async fn reacquire_and_restore_session_worktree(
         }
     }
     if repos.is_empty() {
-        return (None, notes);
+        return (None, notes, None);
     }
 
     // 3. Re-acquire under the SAME stable agent_session_id the drain used, so
@@ -1395,16 +1405,19 @@ async fn reacquire_and_restore_session_worktree(
                 }
             }
 
-            // The IsolatedEditContext owns the claim heartbeats; leak it so the
-            // claim stays live for the resumed session's lifetime (the CLI
-            // outlives this function). Dropping it here would tear down the
-            // heartbeat we just re-established.
-            std::mem::forget(ctx);
-            (workdir, notes)
+            // The IsolatedEditContext owns the claim heartbeat. Hand it BACK
+            // to the caller, which parks it on the resumed `ClaudeSession`
+            // (`set_isolated_edit_ctx`) so the heartbeat lives for the
+            // session's lifetime AND the claim RELEASES (via the context's
+            // Drop) when the session ends. We must NOT `mem::forget` it: that
+            // would keep the heartbeat alive until process exit and never
+            // release the claim, blocking a peer from re-acquiring the
+            // worktree after this session dies.
+            (workdir, notes, Some(ctx))
         }
         Ok(None) => {
             // Worktree mode off — shared-checkout fallback, no claim.
-            (None, notes)
+            (None, notes, None)
         }
         Err(e) => {
             // A `ClaimConflict` (peer holds it under a different owner) or any
@@ -1421,7 +1434,7 @@ async fn reacquire_and_restore_session_worktree(
                  the restart ({msg}). Another agent may now hold it — resuming in shared, \
                  read-mostly mode. Re-check ownership before making edits."
             ));
-            (None, notes)
+            (None, notes, None)
         }
     }
 }
@@ -1565,7 +1578,7 @@ pub async fn resume_ai_sessions(
         // Returns the worktree path to re-spawn into (when re-acquire
         // succeeded) plus any operator-facing notes (peer-conflict / manual
         // WIP recovery). Graceful-degrades to the shared cwd on any failure.
-        let (workdir_override, system_notes) =
+        let (workdir_override, system_notes, reacquired_ctx) =
             reacquire_and_restore_session_worktree(&task_run_id, &pg).await;
 
         // Effective working dir: the re-acquired worktree, else the shared cwd
@@ -1638,6 +1651,10 @@ pub async fn resume_ai_sessions(
         let initial_for_spawn = initial_prompt;
         let working_dir_for_spawn = working_dir;
         let resume_from_transcript = can_full_resume;
+        // The re-acquired claim context (Some only when re-acquire succeeded).
+        // Moved into the spawn closure and parked on the resumed session AFTER
+        // register, so its Drop releases the claim when the session ends.
+        let reacquired_ctx_for_spawn = reacquired_ctx;
 
         let spawn_result = tokio::task::spawn_blocking(move || -> Result<(), String> {
             let session_ctx = AiSessionContext::setup(&trid, &name_for_ctx);
@@ -1670,6 +1687,16 @@ pub async fn resume_ai_sessions(
 
             sm.register(&trid, session.clone())
                 .map_err(|e| format!("register failed: {}", e))?;
+
+            // Park the re-acquired worktree claim on the now-registered
+            // session so the heartbeat lives for its lifetime and the claim
+            // RELEASES (via the context's Drop) when the session closes — the
+            // P3 fix for the `mem::forget` leak that orphaned the claim past
+            // session end. `None` (worktree mode off / shared-checkout
+            // fallback / peer-conflict degrade) is a no-op.
+            if let Some(ctx) = reacquired_ctx_for_spawn {
+                session.set_isolated_edit_ctx(ctx);
+            }
 
             // Send an initial turn ONLY when we have something to say:
             //   - summary fallback → the honest-labelled replay summary, or

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -134,7 +134,10 @@ pub fn emit_session_recovery_summary(
     summary: &SessionRecoverySummary,
 ) {
     if let Err(e) = app_handle.emit(SESSION_RECOVERY_SUMMARY_EVENT, summary) {
-        warn!("Failed to emit {} event: {}", SESSION_RECOVERY_SUMMARY_EVENT, e);
+        warn!(
+            "Failed to emit {} event: {}",
+            SESSION_RECOVERY_SUMMARY_EVENT, e
+        );
     }
 }
 
@@ -1521,7 +1524,13 @@ async fn reacquire_and_restore_session_worktree(
             // would keep the heartbeat alive until process exit and never
             // release the claim, blocking a peer from re-acquiring the
             // worktree after this session dies.
-            (workdir, notes, Some(ctx), ClaimStatus::Reacquired, wip_status)
+            (
+                workdir,
+                notes,
+                Some(ctx),
+                ClaimStatus::Reacquired,
+                wip_status,
+            )
         }
         Ok(None) => {
             // Worktree mode off — shared-checkout fallback, no claim.

--- a/src-tauri/src/database/pg/worktrees.rs
+++ b/src-tauri/src/database/pg/worktrees.rs
@@ -57,6 +57,60 @@ impl PgDb {
             .collect())
     }
 
+    /// Fetch the worktree rows belonging to a single `task_run_id`.
+    ///
+    /// Used by the chat-resume path (Phase 3 of
+    /// `2026-06-06-runner-dev-loop-and-restart-resilience`) to learn which
+    /// repo(s)/worktree(s) a resumed AI session was editing, so it can
+    /// re-acquire the coord `kind=worktree` claim and restore the
+    /// `refs/wip/<agent_session_id>` ref on disk. Returns active rows
+    /// most-recent first (a session is normally promoted into at most one
+    /// worktree, but we never assume cardinality).
+    pub async fn get_worktrees_for_task_run(
+        &self,
+        task_run_id: &str,
+    ) -> Result<Vec<crate::worktree::WorktreeRecord>, String> {
+        let conn = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| format!("PG pool error: {}", e))?;
+
+        let rows = conn
+            .query(
+                r#"SELECT id, worktree_path, branch_name, source_branch, source_commit,
+                          repo_path, task_run_id, workflow_name, status, created_at, updated_at
+                   FROM coord.worktrees
+                   WHERE task_run_id = $1 AND status = 'active'
+                   ORDER BY created_at DESC"#,
+                &[&task_run_id],
+            )
+            .await
+            .map_err(|e| format!("PG get_worktrees_for_task_run: {}", e))?;
+
+        Ok(rows
+            .iter()
+            .map(|r| {
+                let created: chrono::DateTime<chrono::Utc> = r.get(9);
+                let updated: chrono::DateTime<chrono::Utc> = r.get(10);
+                let status_str: String = r.get(8);
+                crate::worktree::WorktreeRecord {
+                    id: r.get(0),
+                    worktree_path: r.get(1),
+                    branch_name: r.get(2),
+                    source_branch: r.get(3),
+                    source_commit: r.get(4),
+                    repo_path: r.get(5),
+                    task_run_id: r.get(6),
+                    workflow_name: r.get(7),
+                    status: crate::worktree::WorktreeStatus::from_str(&status_str),
+                    created_at: created.to_rfc3339(),
+                    updated_at: updated.to_rfc3339(),
+                }
+            })
+            .collect())
+    }
+
     /// Insert a worktree record.
     pub async fn insert_worktree(
         &self,

--- a/src-tauri/src/drain.rs
+++ b/src-tauri/src/drain.rs
@@ -249,6 +249,19 @@ pub fn drain(app_handle: &tauri::AppHandle, timeout: Duration) -> DrainSummary {
 
     summary.elapsed_ms = started.elapsed().as_millis() as u64;
     DRAINED.store(true, Ordering::SeqCst);
+
+    // Phase 4 — a completed drain is the STRONGEST "clean shutdown" signal:
+    // every in-flight turn was flushed, dirty worktrees were stashed, and
+    // claims were heartbeated. Flip the on-disk shutdown marker to
+    // `clean:true` so the NEXT boot classifies itself as a planned restart
+    // (quiet banner) rather than crash recovery. Namespaced by API port to
+    // match the resume-path reader. Best-effort: a marker write failure only
+    // degrades the next boot to "treated as crash", which is the safe
+    // direction.
+    let marker_path =
+        crate::session::shutdown_marker::marker_path(crate::mcp::types::get_mcp_api_port());
+    crate::session::shutdown_marker::mark_clean_shutdown(&marker_path);
+
     info!(
         "drain: complete drained_sessions={} wip_refs={} claims={} timed_out={} elapsed_ms={}",
         summary.drained_sessions,

--- a/src-tauri/src/drain.rs
+++ b/src-tauri/src/drain.rs
@@ -305,6 +305,109 @@ pub fn capture_wip_ref(
     Ok(true)
 }
 
+/// Outcome of a [`restore_wip_ref`] attempt — symmetric with
+/// [`capture_wip_ref`] so the resume path can log + react.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Default)]
+pub struct RestoreOutcome {
+    /// True if a `refs/wip/<agent_session_id>` ref existed at all.
+    pub ref_existed: bool,
+    /// True if `git stash apply` of the ref applied cleanly (no conflicts /
+    /// non-zero exit). Only meaningful when `ref_existed`.
+    pub applied_clean: bool,
+    /// True if the ref was deleted after a clean apply. By contract we ONLY
+    /// delete on a clean apply — a dirty/failed apply keeps the ref so the
+    /// operator can recover it manually.
+    pub ref_deleted: bool,
+    /// The full ref name (`refs/wip/<agent_session_id>`), for logging /
+    /// SYSTEM_NOTE surfacing on the not-clean path.
+    pub ref_name: String,
+}
+
+/// Restore the working-tree state captured by [`capture_wip_ref`] into
+/// `repo_worktree`, symmetric with capture.
+///
+/// Reads `refs/wip/<agent_session_id>` (a `git stash create` commit) and:
+///   - If the ref does not exist → `Ok(RestoreOutcome{ ref_existed:false, .. })`
+///     (nothing captured at drain time — clean no-op).
+///   - If it exists → `git stash apply <ref-sha>` onto the working tree.
+///     - On a CLEAN apply (zero exit) → delete the ref
+///       (`update-ref -d`) so WIP refs don't accumulate ("squashed/dropped
+///       on successful resume") and return `applied_clean:true, ref_deleted:true`.
+///     - On a NON-clean apply (conflicts / non-zero exit) → KEEP the ref and
+///       return `applied_clean:false, ref_deleted:false`. The caller surfaces
+///       the ref name (a `[SYSTEM_NOTE]`) so the operator can apply it by hand.
+///       This never loses the captured state.
+///
+/// `Err` is reserved for a failure to even probe the ref (git spawn failure on
+/// `rev-parse`); a non-zero `stash apply` is NOT an `Err` — it is a clean
+/// `Ok(RestoreOutcome{ applied_clean:false, .. })` so resume degrades
+/// gracefully rather than aborting.
+pub fn restore_wip_ref(
+    repo_worktree: &std::path::Path,
+    agent_session_id: &Uuid,
+) -> Result<RestoreOutcome, String> {
+    let ref_name = format!("refs/wip/{agent_session_id}");
+    let mut outcome = RestoreOutcome {
+        ref_name: ref_name.clone(),
+        ..Default::default()
+    };
+
+    // Resolve the ref → stash sha. A missing ref is the clean no-op case;
+    // `rev-parse --verify --quiet` exits non-zero with empty stdout for a
+    // missing ref, which we distinguish from a spawn failure.
+    let sha = match run_git(
+        repo_worktree,
+        &["rev-parse", "--verify", "--quiet", &ref_name],
+    ) {
+        Ok(s) => {
+            let s = s.trim().to_string();
+            if s.is_empty() {
+                // Ref absent — nothing to restore.
+                return Ok(outcome);
+            }
+            s
+        }
+        // Non-zero exit from rev-parse --quiet means the ref is absent (git
+        // returns 1 with empty stderr). Treat as clean no-op, not an error.
+        Err(_) => return Ok(outcome),
+    };
+
+    outcome.ref_existed = true;
+
+    // Apply the captured stash commit onto the working tree. A clean apply
+    // exits 0; a conflicting apply exits non-zero (run_git → Err) but the
+    // stash commit itself is untouched, so the ref remains valid.
+    match run_git(repo_worktree, &["stash", "apply", &sha]) {
+        Ok(_) => {
+            outcome.applied_clean = true;
+            // Clean apply — drop the ref so it doesn't accumulate across
+            // restarts. A failure to delete is non-fatal (the ref simply
+            // lingers; a later clean restore is idempotent).
+            match run_git(repo_worktree, &["update-ref", "-d", &ref_name]) {
+                Ok(_) => outcome.ref_deleted = true,
+                Err(e) => warn!(
+                    "drain: restore applied cleanly but failed to delete {} ({}): {}",
+                    ref_name,
+                    repo_worktree.display(),
+                    e
+                ),
+            }
+        }
+        Err(e) => {
+            // Conflicted / failed apply — KEEP the ref. The caller surfaces
+            // `ref_name` for manual recovery.
+            warn!(
+                "drain: restore of {} did not apply cleanly ({}); keeping ref for manual apply: {}",
+                ref_name,
+                repo_worktree.display(),
+                e
+            );
+        }
+    }
+
+    Ok(outcome)
+}
+
 /// Run a `git -C <repo_dir> <args...>` command, returning trimmed stdout on
 /// success or a descriptive error on non-zero exit / spawn failure.
 fn run_git(repo_dir: &std::path::Path, args: &[&str]) -> Result<String, String> {
@@ -351,6 +454,10 @@ mod tests {
         run(&["config", "user.email", "drain-test@example.com"]);
         run(&["config", "user.name", "Drain Test"]);
         run(&["config", "commit.gpgsign", "false"]);
+        // Pin line-ending handling off so round-trip content comparisons are
+        // exact on Windows (default core.autocrlf=true would rewrite \n→\r\n
+        // on checkout/reset).
+        run(&["config", "core.autocrlf", "false"]);
         std::fs::write(dir.join("seed.txt"), "seed\n").unwrap();
         run(&["add", "-A"]);
         run(&["commit", "-q", "-m", "seed"]);
@@ -427,6 +534,80 @@ mod tests {
             ref_exists(&dir, &ref_name),
             "wip ref {ref_name} should exist after capture"
         );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Read the working-tree content of a tracked file (or "" if absent),
+    /// with CRLF normalized to LF so comparisons are platform-independent.
+    fn read_file(dir: &std::path::Path, name: &str) -> String {
+        std::fs::read_to_string(dir.join(name))
+            .unwrap_or_default()
+            .replace("\r\n", "\n")
+    }
+
+    #[test]
+    fn restore_wip_ref_round_trips_with_capture() {
+        let dir = temp_dir("roundtrip");
+        init_repo(&dir);
+
+        // Dirty the tree: modify a tracked file + add an untracked file.
+        std::fs::write(dir.join("seed.txt"), "seed\nWIP edit\n").unwrap();
+        std::fs::write(dir.join("scratch.txt"), "uncommitted\n").unwrap();
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(&dir)
+            .args(["add", "-A"])
+            .output()
+            .unwrap();
+
+        let sid = stable_ai_session_id("task-roundtrip");
+        let ref_name = format!("refs/wip/{sid}");
+
+        // Capture → ref exists.
+        let wrote = capture_wip_ref(&dir, &sid, "task-roundtrip").expect("capture ok");
+        assert!(wrote, "dirty tree must capture a ref");
+        assert!(ref_exists(&dir, &ref_name));
+
+        // Reset the working tree back to the committed state (simulating a
+        // fresh worktree on resume before restore runs).
+        let reset = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&dir)
+            .args(["reset", "--hard", "-q"])
+            .output()
+            .unwrap();
+        assert!(reset.status.success());
+        let _ = std::fs::remove_file(dir.join("scratch.txt"));
+        assert_eq!(read_file(&dir, "seed.txt"), "seed\n", "tree reset to base");
+
+        // Restore → tree matches the captured WIP, ref deleted.
+        let outcome = restore_wip_ref(&dir, &sid).expect("restore ok");
+        assert!(outcome.ref_existed, "ref must have existed");
+        assert!(outcome.applied_clean, "apply onto a clean tree is conflict-free");
+        assert!(outcome.ref_deleted, "clean apply must delete the ref");
+        assert_eq!(outcome.ref_name, ref_name);
+
+        // Working tree now carries the captured edits again.
+        assert_eq!(read_file(&dir, "seed.txt"), "seed\nWIP edit\n");
+        assert_eq!(read_file(&dir, "scratch.txt"), "uncommitted\n");
+        // Ref is gone (no accumulation).
+        assert!(
+            !ref_exists(&dir, &ref_name),
+            "ref must be deleted after a clean restore"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn restore_wip_ref_absent_is_clean_noop() {
+        let dir = temp_dir("absent");
+        init_repo(&dir);
+        let sid = stable_ai_session_id("task-absent");
+        let outcome = restore_wip_ref(&dir, &sid).expect("restore ok");
+        assert!(!outcome.ref_existed, "no ref → ref_existed false");
+        assert!(!outcome.applied_clean);
+        assert!(!outcome.ref_deleted);
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/src-tauri/src/drain.rs
+++ b/src-tauri/src/drain.rs
@@ -309,11 +309,8 @@ pub fn capture_wip_ref(
 
     let ref_name = format!("refs/wip/{agent_session_id}");
     let msg = format!("qontinui-drain WIP for task_run_id={task_run_id}");
-    run_git(
-        repo_dir,
-        &["update-ref", "-m", &msg, &ref_name, stash_sha],
-    )
-    .map_err(|e| format!("git update-ref {ref_name} failed: {e}"))?;
+    run_git(repo_dir, &["update-ref", "-m", &msg, &ref_name, stash_sha])
+        .map_err(|e| format!("git update-ref {ref_name} failed: {e}"))?;
 
     Ok(true)
 }
@@ -596,7 +593,10 @@ mod tests {
         // Restore → tree matches the captured WIP, ref deleted.
         let outcome = restore_wip_ref(&dir, &sid).expect("restore ok");
         assert!(outcome.ref_existed, "ref must have existed");
-        assert!(outcome.applied_clean, "apply onto a clean tree is conflict-free");
+        assert!(
+            outcome.applied_clean,
+            "apply onto a clean tree is conflict-free"
+        );
         assert!(outcome.ref_deleted, "clean apply must delete the ref");
         assert_eq!(outcome.ref_name, ref_name);
 

--- a/src-tauri/src/drain.rs
+++ b/src-tauri/src/drain.rs
@@ -1,0 +1,443 @@
+//! Graceful drain on planned restart (Phase 2 of
+//! `2026-06-06-runner-dev-loop-and-restart-resilience`).
+//!
+//! The runner historically died hard on a planned restart/deploy: the
+//! supervisor (and the in-process exit seam) hard-killed the embedded Claude
+//! CLI processes with `taskkill /F /T` WITHOUT flushing in-flight AI/chat
+//! turns, committing uncommitted worktree state, or persisting coord claims.
+//! Resume then replayed a torn conversation and re-provisioned from scratch.
+//!
+//! [`drain`] makes a planned stop survivable:
+//!   1. Sets a global "draining" flag so new AI turns are refused.
+//!   2. Flushes each live AI session's in-flight turn to `output_log`
+//!      (bounded — waits for a natural `Processing → Ready` checkpoint, then
+//!      force-flushes the unpersisted delta regardless).
+//!   3. Auto-commits each session's uncommitted worktree state to a WIP ref
+//!      (`refs/wip/<agent_session_id>`) via `git stash create` —
+//!      WITHOUT polluting branch history. Phase 3 restores these.
+//!   4. Heartbeats/persists each live session's coord claim so resume can
+//!      re-acquire it.
+//!   5. Bounds the whole sequence with a hard timeout — a stuck session can
+//!      NEVER block a deploy.
+//!
+//! It is exposed over HTTP as `POST /drain` (registered in `mcp_api.rs`) and
+//! invoked from the `main.rs` exit seam before the hard kill. Both paths are
+//! idempotent: a second drain (or a drain after `/drain`) is a fast no-op.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tracing::{info, warn};
+use uuid::Uuid;
+
+use crate::claude_session::manager::SessionManager;
+use crate::claude_session::session::ClaudeSession;
+use crate::claude_session::state::SessionState;
+
+/// Hard upper bound on the whole drain sequence. A stuck session must NOT
+/// block a deploy, so once this elapses we stop waiting, mark `timed_out`,
+/// and proceed to exit. Overridable via `QONTINUI_DRAIN_TIMEOUT_MS`.
+pub const DEFAULT_DRAIN_TIMEOUT_MS: u64 = 25_000;
+
+/// Minimum slice we leave for the non-flush steps (wip-ref + claim persist)
+/// so a long turn-flush can't consume the entire budget and starve them.
+const RESERVED_TAIL_MS: u64 = 4_000;
+
+/// Poll cadence while waiting for a session to leave `Processing`.
+const CHECKPOINT_POLL_MS: u64 = 100;
+
+/// Fixed namespace UUID for deriving stable AI-session ids (UUIDv5).
+///
+/// SHARED CONTRACT — Phase 3 re-derives the same id to re-acquire claims and
+/// to locate the `refs/wip/<agent_session_id>` ref written here. Do NOT change
+/// this constant; it is the deterministic root for `stable_ai_session_id`.
+///
+/// Value: `b3f4d2a1-7c6e-5f48-9a2b-1d0e8c7f6a55`
+pub const AI_SESSION_NS: Uuid = Uuid::from_bytes([
+    0xb3, 0xf4, 0xd2, 0xa1, 0x7c, 0x6e, 0x5f, 0x48, 0x9a, 0x2b, 0x1d, 0x0e, 0x8c, 0x7f, 0x6a, 0x55,
+]);
+
+/// Global "draining" flag. Set for the lifetime of the process once a drain
+/// begins (a planned stop is terminal — we never un-drain). Checked on the
+/// new-AI-turn entry path (`send_user_message`) to refuse fresh work.
+static DRAINING: AtomicBool = AtomicBool::new(false);
+
+/// Guard so the exit-seam drain doesn't re-run a drain that `/drain` already
+/// completed. Distinct from `DRAINING`: `DRAINING` flips the moment a drain
+/// *starts*; `DRAINED` flips when one *finishes*. The exit seam checks
+/// `DRAINED` to skip a redundant pass.
+static DRAINED: AtomicBool = AtomicBool::new(false);
+
+/// True once a drain has begun. New AI turns must be refused while set.
+pub fn is_draining() -> bool {
+    DRAINING.load(Ordering::SeqCst)
+}
+
+/// Deterministic stable AI-session id for a `task_run_id`.
+///
+/// `Uuid::new_v5(&AI_SESSION_NS, "ai-session:<task_run_id>")`. This is the
+/// SHARED CONTRACT id used as the `refs/wip/<id>` leaf and the coord claim
+/// owner discriminator. Phase 3 reuses this exact helper verbatim.
+///
+/// Mirrors the deterministic-v5 pattern gate-continuation uses
+/// (`agent_runtime::continuation_session_id`).
+pub fn stable_ai_session_id(task_run_id: &str) -> Uuid {
+    let name = format!("ai-session:{task_run_id}");
+    Uuid::new_v5(&AI_SESSION_NS, name.as_bytes())
+}
+
+/// Structured summary of a drain pass. Serialized as the `POST /drain` body.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct DrainSummary {
+    /// Number of live AI sessions we flushed (turn text → `output_log`).
+    pub drained_sessions: usize,
+    /// Number of `refs/wip/<agent_session_id>` refs written (dirty worktrees).
+    pub wip_refs_written: usize,
+    /// Number of session coord claims heartbeated/persisted.
+    pub claims_persisted: usize,
+    /// True if the hard timeout elapsed before the sequence completed.
+    pub timed_out: bool,
+    /// Wall-clock time the drain took.
+    pub elapsed_ms: u64,
+    /// True if this call was a no-op because a drain already completed.
+    pub already_drained: bool,
+}
+
+/// Resolve the configured drain timeout (env override → default).
+pub fn configured_timeout() -> Duration {
+    let ms = std::env::var("QONTINUI_DRAIN_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_DRAIN_TIMEOUT_MS);
+    Duration::from_millis(ms)
+}
+
+/// Run the graceful drain sequence, bounded by `timeout`.
+///
+/// Safe to call when idle (no sessions → fast no-op success). Idempotent: a
+/// second call after a completed drain returns `{already_drained: true}`
+/// immediately without touching any session.
+pub fn drain(app_handle: &tauri::AppHandle, timeout: Duration) -> DrainSummary {
+    let started = Instant::now();
+
+    // Idempotency: a completed drain is terminal. Don't double-flush/double-stash.
+    if DRAINED.load(Ordering::SeqCst) {
+        return DrainSummary {
+            already_drained: true,
+            elapsed_ms: started.elapsed().as_millis() as u64,
+            ..Default::default()
+        };
+    }
+
+    // Flip the draining flag FIRST so no new turn slips in mid-drain. We never
+    // reset it — a planned stop is terminal.
+    DRAINING.store(true, Ordering::SeqCst);
+    info!(
+        "drain: starting graceful drain (timeout={}ms)",
+        timeout.as_millis()
+    );
+
+    let mut summary = DrainSummary::default();
+
+    // Enumerate live ClaudeSessions. Workers and inline PIDs don't run a
+    // resumable Claude conversation with an output_log replay, so they're
+    // out of scope for turn-flush/wip-capture (they're force-closed by the
+    // existing seam, same as before).
+    use tauri::Manager;
+    let sessions: Vec<(String, Arc<ClaudeSession>)> =
+        match app_handle.try_state::<Arc<SessionManager>>() {
+            Some(sm) => sm.active_claude_sessions(),
+            None => {
+                warn!("drain: SessionManager not available — nothing to drain");
+                Vec::new()
+            }
+        };
+
+    if sessions.is_empty() {
+        info!("drain: no live AI sessions — fast no-op");
+    }
+
+    let deadline = started + timeout;
+
+    // ── Step (b): flush in-flight AI/chat turns ────────────────────────────
+    // Reserve a tail of the budget for the wip-ref + claim steps so a slow
+    // turn can't starve them. Each session gets an even slice of the
+    // remaining flush budget, but we never wait past the global deadline.
+    let flush_deadline = deadline
+        .checked_sub(Duration::from_millis(RESERVED_TAIL_MS))
+        .unwrap_or(deadline);
+
+    for (task_run_id, session) in &sessions {
+        // Bounded wait for a natural checkpoint: a turn completes when the
+        // state machine transitions Processing → Ready (the dispatcher flushes
+        // the turn's delta to output_log on the `result` message at that
+        // point). If it doesn't checkpoint in time, force-flush below.
+        wait_for_checkpoint(session, flush_deadline);
+
+        // Force-flush whatever accumulated output hasn't been persisted yet.
+        // Idempotent vs. the dispatcher's own flush (guarded by
+        // persisted_output_len), so a turn that DID checkpoint flushes nothing
+        // extra here.
+        session.flush_pending_output();
+        summary.drained_sessions += 1;
+        info!(
+            "drain: flushed session task_run_id={} (state={})",
+            task_run_id,
+            session.state()
+        );
+    }
+
+    // ── Step (c): auto-commit uncommitted worktree state to a WIP ref ──────
+    for (task_run_id, session) in &sessions {
+        let Some(wt) = session.worktree() else {
+            // No isolated worktree (session runs in the shared cwd) — nothing
+            // session-scoped to capture without polluting a shared checkout.
+            continue;
+        };
+        let agent_session_id = stable_ai_session_id(task_run_id);
+        match capture_wip_ref(&wt.path, &agent_session_id, task_run_id) {
+            Ok(true) => {
+                summary.wip_refs_written += 1;
+                info!(
+                    "drain: wrote refs/wip/{} for task_run_id={} ({})",
+                    agent_session_id,
+                    task_run_id,
+                    wt.path.display()
+                );
+            }
+            Ok(false) => {
+                // Clean tree — no ref written (by contract).
+            }
+            Err(e) => {
+                warn!(
+                    "drain: wip-ref capture failed for task_run_id={} ({}): {}",
+                    task_run_id,
+                    wt.path.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    // ── Step (d): persist/heartbeat coord claims so resume can re-acquire ──
+    if let Some(reg) =
+        app_handle.try_state::<Arc<crate::claude_session::coord_register::AiCoordRegistrar>>()
+    {
+        for (task_run_id, _session) in &sessions {
+            // Heartbeat the session's coord row (refreshes last_heartbeat_at
+            // via the outbox → PATCH {heartbeat:true}). The session row +
+            // worktree claim are already durable from register_session; this
+            // bumps the freshness so the stale sweep doesn't reap it in the
+            // restart window. No-op for unregistered sessions.
+            reg.heartbeat_on_interaction(task_run_id);
+            summary.claims_persisted += 1;
+        }
+    } else {
+        warn!("drain: AiCoordRegistrar not available — coord claims not heartbeated");
+    }
+
+    summary.timed_out = Instant::now() >= deadline;
+    if summary.timed_out {
+        warn!(
+            "drain: hard timeout ({}ms) elapsed — proceeding to exit",
+            timeout.as_millis()
+        );
+    }
+
+    summary.elapsed_ms = started.elapsed().as_millis() as u64;
+    DRAINED.store(true, Ordering::SeqCst);
+    info!(
+        "drain: complete drained_sessions={} wip_refs={} claims={} timed_out={} elapsed_ms={}",
+        summary.drained_sessions,
+        summary.wip_refs_written,
+        summary.claims_persisted,
+        summary.timed_out,
+        summary.elapsed_ms
+    );
+
+    summary
+}
+
+/// Block (polling) until `session` leaves `Processing` or `deadline` passes.
+/// A session not currently processing returns immediately.
+fn wait_for_checkpoint(session: &ClaudeSession, deadline: Instant) {
+    while session.state() == SessionState::Processing {
+        if Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(CHECKPOINT_POLL_MS));
+    }
+}
+
+/// Capture the working-tree state of `repo_dir` to `refs/wip/<agent_session_id>`
+/// WITHOUT polluting branch history, using `git stash create`.
+///
+/// Returns `Ok(true)` if a ref was written, `Ok(false)` if the tree was clean
+/// (`stash create` produces no commit → no ref), `Err` on git failure.
+///
+/// SHARED CONTRACT: the ref namespace is `refs/wip/<agent_session_id>` and the
+/// leaf is the stable v5 id. Phase 3 restores via `git stash apply <ref>` then
+/// deletes the ref.
+pub fn capture_wip_ref(
+    repo_dir: &std::path::Path,
+    agent_session_id: &Uuid,
+    task_run_id: &str,
+) -> Result<bool, String> {
+    let stash_sha = run_git(repo_dir, &["stash", "create"])
+        .map_err(|e| format!("git stash create failed: {e}"))?;
+    let stash_sha = stash_sha.trim();
+    if stash_sha.is_empty() {
+        // Clean tree — by contract, write no ref.
+        return Ok(false);
+    }
+
+    let ref_name = format!("refs/wip/{agent_session_id}");
+    let msg = format!("qontinui-drain WIP for task_run_id={task_run_id}");
+    run_git(
+        repo_dir,
+        &["update-ref", "-m", &msg, &ref_name, stash_sha],
+    )
+    .map_err(|e| format!("git update-ref {ref_name} failed: {e}"))?;
+
+    Ok(true)
+}
+
+/// Run a `git -C <repo_dir> <args...>` command, returning trimmed stdout on
+/// success or a descriptive error on non-zero exit / spawn failure.
+fn run_git(repo_dir: &std::path::Path, args: &[&str]) -> Result<String, String> {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C").arg(repo_dir);
+    cmd.args(args);
+    let output = cmd
+        .output()
+        .map_err(|e| format!("failed to spawn git: {e}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "git {:?} exited {}: {}",
+            args,
+            output.status.code().unwrap_or(-1),
+            stderr.trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Initialize a throwaway git repo in `dir` with one committed file so
+    /// `stash create` has a base commit to diff against.
+    fn init_repo(dir: &std::path::Path) {
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .expect("git spawn");
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-q"]);
+        run(&["config", "user.email", "drain-test@example.com"]);
+        run(&["config", "user.name", "Drain Test"]);
+        run(&["config", "commit.gpgsign", "false"]);
+        std::fs::write(dir.join("seed.txt"), "seed\n").unwrap();
+        run(&["add", "-A"]);
+        run(&["commit", "-q", "-m", "seed"]);
+    }
+
+    fn temp_dir(tag: &str) -> std::path::PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "qontinui-drain-test-{}-{}-{}",
+            tag,
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).unwrap();
+        base
+    }
+
+    fn ref_exists(dir: &std::path::Path, ref_name: &str) -> bool {
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args(["rev-parse", "--verify", "--quiet", ref_name])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn stable_ai_session_id_is_deterministic_and_namespaced() {
+        let a = stable_ai_session_id("task-123");
+        let b = stable_ai_session_id("task-123");
+        let c = stable_ai_session_id("task-999");
+        assert_eq!(a, b, "same task_run_id must yield same id");
+        assert_ne!(a, c, "different task_run_id must yield different id");
+        // Pin the contract: a known input maps to a stable v5 value.
+        let expected = Uuid::new_v5(&AI_SESSION_NS, b"ai-session:task-123");
+        assert_eq!(a, expected);
+        assert_eq!(a.get_version_num(), 5);
+    }
+
+    #[test]
+    fn capture_wip_ref_clean_tree_writes_no_ref() {
+        let dir = temp_dir("clean");
+        init_repo(&dir);
+        let sid = stable_ai_session_id("task-clean");
+        let wrote = capture_wip_ref(&dir, &sid, "task-clean").expect("capture ok");
+        assert!(!wrote, "clean tree must not write a ref");
+        assert!(
+            !ref_exists(&dir, &format!("refs/wip/{sid}")),
+            "no wip ref should exist for a clean tree"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn capture_wip_ref_dirty_tree_writes_ref() {
+        let dir = temp_dir("dirty");
+        init_repo(&dir);
+        // Make the tree dirty (modify tracked + add untracked).
+        std::fs::write(dir.join("seed.txt"), "seed\nlocal edit\n").unwrap();
+        std::fs::write(dir.join("scratch.txt"), "uncommitted\n").unwrap();
+        // Stage so `stash create` captures it (create stashes the index + tree).
+        std::process::Command::new("git")
+            .arg("-C")
+            .arg(&dir)
+            .args(["add", "-A"])
+            .output()
+            .unwrap();
+
+        let sid = stable_ai_session_id("task-dirty");
+        let wrote = capture_wip_ref(&dir, &sid, "task-dirty").expect("capture ok");
+        assert!(wrote, "dirty tree must write a ref");
+        let ref_name = format!("refs/wip/{sid}");
+        assert!(
+            ref_exists(&dir, &ref_name),
+            "wip ref {ref_name} should exist after capture"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn configured_timeout_defaults_when_unset() {
+        // Don't mutate the global env in a way that races other tests; just
+        // assert the default is returned when the override is absent/invalid.
+        std::env::remove_var("QONTINUI_DRAIN_TIMEOUT_MS");
+        assert_eq!(
+            configured_timeout(),
+            Duration::from_millis(DEFAULT_DRAIN_TIMEOUT_MS)
+        );
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -59,6 +59,7 @@ mod discoveries;
 mod display;
 mod doctor;
 mod dom_capture;
+mod drain;
 mod error;
 mod error_monitor; // Must be declared before error (error re-exports ErrorSeverity from error_monitor)
 mod event_system;
@@ -3566,6 +3567,40 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                          window close; any remaining cleanup will be killed by \
                          process exit",
                         SHUTDOWN_JOIN_DEADLINE_MS
+                    );
+                }
+
+                // ── Graceful drain (Phase 2) ──
+                //
+                // Before the hard session-close + taskkill below, run the
+                // bounded drain so even a DIRECT exit (X button / programmatic
+                // app.exit that didn't route through the supervisor's
+                // POST /drain) flushes in-flight AI turns to output_log,
+                // stashes dirty worktrees to refs/wip/*, and heartbeats coord
+                // claims. `drain()` is idempotent: if the supervisor already
+                // hit POST /drain, this returns instantly (already_drained).
+                //
+                // The timeout is clamped well under the force-exit watchdog so
+                // a stuck session can't wedge the close handler. The drain runs
+                // synchronously on this thread (it's pure blocking git +
+                // bounded polling), which is fine — the watchdog at the bottom
+                // is the ultimate backstop.
+                {
+                    let exit_drain_timeout = std::cmp::min(
+                        drain::configured_timeout(),
+                        std::time::Duration::from_secs(8),
+                    );
+                    let summary =
+                        drain::drain(&window.app_handle().clone(), exit_drain_timeout);
+                    info!(
+                        "Exit-seam drain: drained={} wip_refs={} claims={} timed_out={} \
+                         elapsed_ms={} already_drained={}",
+                        summary.drained_sessions,
+                        summary.wip_refs_written,
+                        summary.claims_persisted,
+                        summary.timed_out,
+                        summary.elapsed_ms,
+                        summary.already_drained
                     );
                 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3602,6 +3602,19 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         summary.elapsed_ms,
                         summary.already_drained
                     );
+
+                    // Phase 4 — the ExitRequested seam is the catch-all CLEAN
+                    // shutdown signal: even a direct X-button / programmatic
+                    // app.exit that produced an `already_drained` no-op above
+                    // (or ran with zero sessions) is still a PLANNED exit, not
+                    // a crash. Stamp the marker `clean:true` here unconditionally
+                    // so the next boot's resume classifies a quiet (planned)
+                    // restart. `drain()` also stamps it on a fresh pass; this is
+                    // the idempotent backstop for the no-op / zero-session case.
+                    let marker_path = session::shutdown_marker::marker_path(
+                        crate::mcp::types::get_mcp_api_port(),
+                    );
+                    session::shutdown_marker::mark_clean_shutdown(&marker_path);
                 }
 
                 // Close all interactive Claude sessions

--- a/src-tauri/src/mcp/ai_session.rs
+++ b/src-tauri/src/mcp/ai_session.rs
@@ -1610,6 +1610,18 @@ pub async fn run_prompt(
     State(state): State<Arc<ApiState>>,
     Json(request): Json<RunPromptRequest>,
 ) -> Result<Json<ApiResponse<RunPromptResponse>>, (StatusCode, Json<ApiResponse<()>>)> {
+    // Graceful-drain gate (Phase 2): refuse new AI turns once a planned
+    // restart has begun draining, so we don't spawn work the imminent kill
+    // would tear in half. Mirrors the `send_user_message` Tauri-command gate.
+    if crate::drain::is_draining() {
+        return Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(api_error(
+                "runner is draining for a planned restart — new prompts are refused",
+            )),
+        ));
+    }
+
     // Determine mode and get prompt name + content + orchestrator config
     // Orchestrator config is extracted from saved prompts (system-level setting, not user-controllable)
     let (

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -1866,6 +1866,7 @@ async fn handle_chat_create(api_state: &Arc<ApiState>, data: &Value) -> Option<V
             None,
             None,
             None, // tool_policy
+            None, // cli_session_ctx
         ) {
             Ok(session) => {
                 let session = Arc::new(session);

--- a/src-tauri/src/mcp/sessions.rs
+++ b/src-tauri/src/mcp/sessions.rs
@@ -166,6 +166,7 @@ async fn spawn_session(
             None,
             None,
             None, // tool_policy
+            None, // cli_session_ctx
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => return Err(format!("spawn failed: {}", e)),

--- a/src-tauri/src/mcp/task_runs.rs
+++ b/src-tauri/src/mcp/task_runs.rs
@@ -2312,6 +2312,7 @@ pub async fn create_ai_session(
         None, // model_override
         None, // worktree
         None, // tool_policy
+        None, // cli_session_ctx
     ) {
         Ok(session) => {
             let session = Arc::new(session);

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -388,6 +388,34 @@ async fn health(
     }))
 }
 
+/// `POST /drain` — graceful drain on planned restart (Phase 2 of
+/// `2026-06-06-runner-dev-loop-and-restart-resilience`).
+///
+/// Triggers the [`crate::drain::drain`] sequence: flips the global draining
+/// flag (refuses new AI turns), flushes in-flight turns to `output_log`,
+/// auto-commits each session's dirty worktree to `refs/wip/<agent_session_id>`,
+/// and heartbeats coord claims — all bounded by a hard timeout so a stuck
+/// session can never block a deploy. The supervisor calls this before its
+/// `taskkill`; the in-process exit seam also calls the drain fn directly.
+///
+/// Safe to call when idle (no sessions → fast no-op). Idempotent: a second
+/// call after a completed drain returns `{already_drained: true}` instantly.
+async fn drain_handler(
+    axum::extract::State(state): axum::extract::State<Arc<ApiState>>,
+) -> Json<crate::drain::DrainSummary> {
+    let app_handle = state.app_handle.clone();
+    let timeout = crate::drain::configured_timeout();
+    // The drain sequence is synchronous (blocking git + bounded polling), so
+    // run it on a blocking thread to keep the async executor free.
+    let summary = tokio::task::spawn_blocking(move || crate::drain::drain(&app_handle, timeout))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("drain task panicked: {e}");
+            crate::drain::DrainSummary::default()
+        });
+    Json(summary)
+}
+
 /// Create the API router
 pub fn create_router(
     app_state: Arc<AppState>,
@@ -1632,6 +1660,10 @@ pub fn create_router(
         .route("/health", get(health))
         .route("/ui-bridge/health", get(health))
         .route("/ui-bridge/status", get(health))
+        // Phase 2 — graceful drain on planned restart. The supervisor POSTs
+        // here before its hard taskkill so in-flight turns flush, dirty
+        // worktrees are stashed to refs/wip/*, and coord claims persist.
+        .route("/drain", post(drain_handler))
         // Relay web-integration diagnostic — exposes the idle-gating state
         // (tier, enabled, device-JWT presence, WS connection, last error) so
         // an operator can see WHY a runner never appears to the cloud/mobile.

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1053,11 +1053,44 @@ pub fn create_router(
             // Wait a bit longer than unified workflows to let the server fully start
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
-            let count = crate::commands::ai_session::resume_ai_sessions(chat_sm, chat_handle).await;
-
-            if count > 0 {
-                info!("Resumed {} AI session(s) on startup", count);
+            // Phase 4 — classify this boot as crash recovery vs a planned
+            // restart from the on-disk shutdown marker, BEFORE we overwrite
+            // it. A missing / `clean:false` / corrupt marker ⇒ the previous
+            // shutdown was NOT clean ⇒ crash recovery. We then immediately
+            // (re)write the marker `clean:false` for the NOW-running process
+            // so that if THIS process crashes the next boot detects it. The
+            // clean drain / exit seam flips it back to `clean:true`.
+            let marker_path = crate::session::shutdown_marker::marker_path(
+                crate::mcp::types::get_mcp_api_port(),
+            );
+            let crash_recovery =
+                crate::session::shutdown_marker::was_unclean_shutdown(&marker_path);
+            crate::session::shutdown_marker::mark_running(&marker_path);
+            if crash_recovery {
+                warn!("Startup recovery: previous shutdown was NOT clean — this is crash recovery");
             }
+
+            let summary = crate::commands::ai_session::resume_ai_sessions(
+                chat_sm,
+                chat_handle.clone(),
+                crash_recovery,
+            )
+            .await;
+
+            if summary.resumed_count > 0 {
+                info!(
+                    "Resumed {} AI session(s) on startup (crash_recovery={})",
+                    summary.resumed_count, summary.crash_recovery
+                );
+            }
+
+            // Emit the structured startup-recovery summary ONCE so the
+            // frontend can surface a (prominent on crash / quiet on planned)
+            // banner with honest per-session fidelity + claim + WIP status.
+            // Always emit — even with zero sessions — so a late-mounting
+            // banner that requested a replay can settle; the frontend hides
+            // itself when there's nothing to show.
+            crate::commands::ai_session::emit_session_recovery_summary(&chat_handle, &summary);
         });
     }
 

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1060,9 +1060,8 @@ pub fn create_router(
             // (re)write the marker `clean:false` for the NOW-running process
             // so that if THIS process crashes the next boot detects it. The
             // clean drain / exit seam flips it back to `clean:true`.
-            let marker_path = crate::session::shutdown_marker::marker_path(
-                crate::mcp::types::get_mcp_api_port(),
-            );
+            let marker_path =
+                crate::session::shutdown_marker::marker_path(crate::mcp::types::get_mcp_api_port());
             let crash_recovery =
                 crate::session::shutdown_marker::was_unclean_shutdown(&marker_path);
             crate::session::shutdown_marker::mark_running(&marker_path);

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -64,6 +64,7 @@ pub mod local_store;
 pub mod output_pipe;
 pub mod pane_store;
 pub mod session_lifecycle_store;
+pub mod shutdown_marker;
 pub mod transport;
 
 use std::collections::HashMap;

--- a/src-tauri/src/session/shutdown_marker.rs
+++ b/src-tauri/src/session/shutdown_marker.rs
@@ -1,0 +1,216 @@
+//! Clean-vs-crash shutdown marker (Phase 4 of
+//! `2026-06-06-runner-dev-loop-and-restart-resilience`).
+//!
+//! The runner cannot tell, at boot, whether the previous process exited
+//! cleanly (a planned drain / `ExitRequested` seam) or died unexpectedly
+//! (a crash, an OOM kill, a hard `taskkill /F`, a power loss). Phase 2's
+//! drain flips an in-process `DRAINED` flag, but that flag does not survive
+//! the process — the next boot has no memory of it.
+//!
+//! This module persists that signal to disk so the NEXT boot can classify
+//! its own startup:
+//!
+//!   - On every boot we IMMEDIATELY (re)write the marker as `clean:false`
+//!     ("a process is now running and has not yet shut down cleanly"). If
+//!     THIS process then crashes, the marker stays `clean:false` and the
+//!     following boot detects the crash.
+//!   - On a clean drain (`drain::drain` completing) AND on the `main.rs`
+//!     `ExitRequested` seam we flip the marker to `clean:true`.
+//!   - At boot, BEFORE we overwrite it, we read the prior marker: a missing
+//!     marker or `clean:false` ⇒ the previous shutdown was NOT clean ⇒ this
+//!     boot is **crash recovery**.
+//!
+//! ## Storage
+//!
+//! A single JSON file co-located with the lifecycle store + pane store under
+//! `~/.qontinui/runner/last-shutdown.json` (object `{clean, at}`), namespaced
+//! by API port exactly like the lifecycle store so a temp runner (9877+) does
+//! not read/write the primary's marker. Atomic temp-file + rename. A missing
+//! / corrupt file is treated as "not clean" (the safe default — we would
+//! rather over-report a crash banner than silently hide a real crash).
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tracing::warn;
+
+/// Persisted clean-shutdown marker. `at` is unix epoch millis of the last
+/// write.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ShutdownMarker {
+    /// `true` iff the most recent write was a clean shutdown (drain / exit
+    /// seam). A fresh boot writes `false`; a clean shutdown flips it `true`.
+    pub clean: bool,
+    /// Unix epoch millis when this marker was written.
+    pub at: i64,
+}
+
+/// Resolve the marker path for this runner instance, namespaced by API port
+/// (mirrors the lifecycle store: 9876 → base name, every other port →
+/// `-<port>` suffix). Co-located under `~/.qontinui/runner/`.
+pub fn marker_path(api_port: u16) -> PathBuf {
+    let file_name = if api_port == 9876 {
+        "last-shutdown.json".to_string()
+    } else {
+        format!("last-shutdown-{api_port}.json")
+    };
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".qontinui")
+        .join("runner")
+        .join(file_name)
+}
+
+/// Read the prior marker and decide whether this boot is crash recovery.
+///
+/// Returns `true` (crash recovery) when the marker is absent, unreadable,
+/// corrupt, or explicitly `clean:false`. Returns `false` only when a
+/// well-formed marker says `clean:true`.
+///
+/// This must be called BEFORE [`mark_running`] overwrites the marker for the
+/// current process.
+pub fn was_unclean_shutdown(path: &Path) -> bool {
+    match std::fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice::<ShutdownMarker>(&bytes) {
+            Ok(m) => !m.clean,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "shutdown_marker: corrupt marker — treating as unclean (crash recovery)"
+                );
+                true
+            }
+        },
+        // Absent (first ever boot, or the file was never written) — treat as
+        // unclean is the SAFE default, but the very first boot legitimately
+        // has no marker. We still report crash-recovery=true; the recovery
+        // summary only surfaces a banner when there are sessions to resume,
+        // so a clean first boot with zero sessions shows nothing.
+        Err(_) => true,
+    }
+}
+
+/// Write the marker for the NOW-running process as `clean:false`. Call once,
+/// early at boot, AFTER [`was_unclean_shutdown`] has read the prior value.
+/// If this process later crashes, the `clean:false` marker is what the next
+/// boot reads → crash recovery.
+pub fn mark_running(path: &Path) {
+    write_marker(path, false);
+}
+
+/// Flip the marker to `clean:true`. Call from the clean-shutdown paths (drain
+/// completion + the `main.rs` exit seam). Idempotent.
+pub fn mark_clean_shutdown(path: &Path) {
+    write_marker(path, true);
+}
+
+/// Best-effort atomic write. Failures are logged, not propagated — a marker
+/// we fail to persist simply degrades to "treated as unclean next boot",
+/// which is the safe direction.
+fn write_marker(path: &Path, clean: bool) {
+    let marker = ShutdownMarker {
+        clean,
+        at: chrono::Utc::now().timestamp_millis(),
+    };
+    if let Err(e) = write_atomic(path, &marker) {
+        warn!(
+            error = %e,
+            path = %path.display(),
+            clean,
+            "shutdown_marker: write failed — marker not persisted"
+        );
+    }
+}
+
+fn write_atomic(path: &Path, marker: &ShutdownMarker) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let bytes = serde_json::to_vec_pretty(marker).map_err(std::io::Error::other)?;
+    std::fs::write(&tmp, &bytes)?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn absent_marker_is_crash_recovery() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("last-shutdown.json");
+        assert!(
+            was_unclean_shutdown(&path),
+            "a missing marker must classify as unclean (crash recovery)"
+        );
+    }
+
+    #[test]
+    fn clean_marker_is_planned_restart() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("last-shutdown.json");
+        mark_clean_shutdown(&path);
+        assert!(
+            !was_unclean_shutdown(&path),
+            "a clean:true marker must classify as a planned restart"
+        );
+    }
+
+    #[test]
+    fn running_marker_is_crash_recovery() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("last-shutdown.json");
+        // Simulate a process that started (clean:false) and then died without
+        // ever flipping the marker clean.
+        mark_running(&path);
+        assert!(
+            was_unclean_shutdown(&path),
+            "a clean:false (running) marker left behind by a crash must classify as unclean"
+        );
+    }
+
+    #[test]
+    fn corrupt_marker_is_crash_recovery() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("last-shutdown.json");
+        std::fs::write(&path, b"{not valid json").unwrap();
+        assert!(
+            was_unclean_shutdown(&path),
+            "a corrupt marker must classify as unclean (safe default)"
+        );
+    }
+
+    #[test]
+    fn lifecycle_round_trip_running_then_clean() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("last-shutdown.json");
+
+        // Boot 1: nothing on disk → crash recovery (first boot).
+        assert!(was_unclean_shutdown(&path));
+        // Boot 1 marks itself running.
+        mark_running(&path);
+        // Boot 1 drains cleanly.
+        mark_clean_shutdown(&path);
+
+        // Boot 2: prior shutdown was clean → planned restart.
+        assert!(!was_unclean_shutdown(&path));
+        mark_running(&path);
+        // Boot 2 CRASHES (no mark_clean_shutdown).
+
+        // Boot 3: prior marker is still clean:false → crash recovery.
+        assert!(was_unclean_shutdown(&path));
+    }
+
+    #[test]
+    fn marker_path_namespaces_by_port() {
+        let primary = marker_path(9876);
+        let temp = marker_path(9877);
+        assert!(primary.ends_with("last-shutdown.json"));
+        assert!(temp.ends_with("last-shutdown-9877.json"));
+        assert_ne!(primary, temp);
+    }
+}

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -189,6 +189,25 @@ fn encode_project_path(project_path: &str) -> String {
         .replace([':', '/', '\\', '_'], "-")
 }
 
+/// Absolute path to the on-disk JSONL transcript for a `(config_dir,
+/// project_path, session_id)` triple, whether or not it exists.
+///
+/// Mirrors the path construction used by [`read_session`] / [`session_digest`]
+/// (`<config_dir>/projects/<encoded(project_path)>/<session_id>.jsonl`).
+/// Exposed so the chat-resume path (Phase 3, restart resilience) can probe
+/// whether a lossless `--resume` is possible before deciding to fall back to a
+/// lossy output_log summary.
+pub fn session_transcript_path(
+    config_dir: &Path,
+    project_path: &str,
+    session_id: &str,
+) -> PathBuf {
+    config_dir
+        .join("projects")
+        .join(encode_project_path(project_path))
+        .join(format!("{}.jsonl", session_id))
+}
+
 // ── Session Listing ──────────────────────────────────────────────────────────
 
 /// List Claude Code sessions for a given project path.

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -197,11 +197,7 @@ fn encode_project_path(project_path: &str) -> String {
 /// Exposed so the chat-resume path (Phase 3, restart resilience) can probe
 /// whether a lossless `--resume` is possible before deciding to fall back to a
 /// lossy output_log summary.
-pub fn session_transcript_path(
-    config_dir: &Path,
-    project_path: &str,
-    session_id: &str,
-) -> PathBuf {
+pub fn session_transcript_path(config_dir: &Path, project_path: &str, session_id: &str) -> PathBuf {
     config_dir
         .join("projects")
         .join(encode_project_path(project_path))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,7 @@ import { LogSourcePicker } from "./components/LogSourcePicker";
 import { Sidebar } from "./components/navigation";
 import { TerminalPage } from "./components/terminal";
 import { TerminalPageTabBar } from "./components/terminal/TerminalPageTabBar";
+import { SessionRecoveryBanner } from "./components/terminal/SessionRecoveryBanner";
 import { useTerminalPages } from "./components/terminal/useTerminalPages";
 import { TerminalPageProvider } from "./components/terminal/TerminalPageContext";
 import { TerminalSessionProvider } from "./components/terminal/contexts";
@@ -595,6 +596,16 @@ function AppContent() {
                     );
                   }}
                 />
+                {/*
+                  Phase 4 — startup session-recovery banner. Subscribes to the
+                  one-shot `session-recovery-summary` event emitted after
+                  auto-reattach; renders a prominent (crash) or quiet (planned)
+                  dismissible advisory in the top-right column, stacking with
+                  CoordWarningBanner. Renders nothing when there's nothing to
+                  report. Composes with the session-visibility surfaces rather
+                  than owning any session state.
+                */}
+                <SessionRecoveryBanner />
                 {showReorganize && (
                   <ReorganizeDialog
                     pages={terminalPages.pages}

--- a/src/components/terminal/SessionCard.tsx
+++ b/src/components/terminal/SessionCard.tsx
@@ -13,11 +13,13 @@ import {
   Loader2,
   CheckCircle2,
   Lock,
+  RotateCcw,
 } from "lucide-react";
 import type { UnifiedSession, SessionLiveStatus } from "./useSessionManager";
 import type { LockState } from "./useFileLockTracking";
 import type { CommandResponse } from "./types";
 import { isInjectedSession } from "./syntheticTabs";
+import { DURABLE_TOOLTIP } from "./sessionDurability";
 
 interface PromoteToWorktreeData {
   worktree_id: string;
@@ -387,6 +389,23 @@ export function SessionCard({
             >
               <FileWarning className="w-3 h-3 text-[#e0af68]" />
               <span className="text-[9px] text-[#e0af68]/80">{fileConflictCount}</span>
+            </span>
+          )}
+          {/* Durable AI-session affordance (Phase 5 honesty label). Every
+              SessionCard renders a transcript-backed AI/chat session, which
+              resumes automatically on a runner restart (and is listed by the
+              startup recovery banner). We surface a subtle, calm cue ONLY for
+              live sessions — historical dormant/completed transcripts don't
+              need the reassurance and it would clutter the long list. This is
+              the deliberate counterpart to the "ephemeral" marker on
+              non-durable interactive PTY tabs. */}
+          {session.liveStatus !== "dormant" && session.liveStatus !== "completed" && (
+            <span
+              className="shrink-0 inline-flex"
+              title={DURABLE_TOOLTIP}
+              aria-label={`Durable session: ${DURABLE_TOOLTIP}`}
+            >
+              <RotateCcw className="w-3 h-3 text-[#565f89]" />
             </span>
           )}
           {isPinned && <Pin className="w-3 h-3 text-[#e0af68] shrink-0" />}

--- a/src/components/terminal/SessionRecoveryBanner.test.tsx
+++ b/src/components/terminal/SessionRecoveryBanner.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * SessionRecoveryBanner tests — Phase 4 honesty-label logic.
+ *
+ * The runner's vitest config is `environment: "node"` (no jsdom /
+ * @testing-library — see `LaunchMenu.test.tsx`), so we exercise the
+ * load-bearing PURE helpers the banner renders from, asserting the UX
+ * honesty gate: a lossy resume, a peer-conflict / degraded claim, and a
+ * kept-for-manual WIP are surfaced verbatim and flagged `degraded`, while a
+ * fully-clean lossless resume is NOT. The JSX glue is straightforward and is
+ * exercised manually via UI Bridge.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  fidelityLabel,
+  isLossy,
+  isDegraded,
+  claimLabel,
+  wipLabel,
+} from "./SessionRecoveryBanner";
+import type { SessionRecoveryOutcome } from "@/hooks/useSessionRecovery";
+
+function outcome(over: Partial<SessionRecoveryOutcome>): SessionRecoveryOutcome {
+  return {
+    taskRunId: "t1",
+    title: "Session",
+    fidelity: "lossless",
+    turnsCovered: 0,
+    claimStatus: "reacquired",
+    wipStatus: "none",
+    ...over,
+  };
+}
+
+describe("fidelityLabel", () => {
+  it("labels a lossless resume as fully restored", () => {
+    expect(fidelityLabel(outcome({ fidelity: "lossless" }))).toBe("fully restored");
+  });
+
+  it("labels a lossy summary with the HONEST turn count (plural)", () => {
+    expect(fidelityLabel(outcome({ fidelity: "summary", turnsCovered: 6 }))).toBe(
+      "resumed from last 6 turns",
+    );
+  });
+
+  it("uses the singular for a one-turn summary", () => {
+    expect(fidelityLabel(outcome({ fidelity: "summary", turnsCovered: 1 }))).toBe(
+      "resumed from last 1 turn",
+    );
+  });
+});
+
+describe("isLossy", () => {
+  it("flags a summary fidelity as lossy", () => {
+    expect(isLossy(outcome({ fidelity: "summary", turnsCovered: 3 }))).toBe(true);
+    expect(isLossy(outcome({ fidelity: "lossless" }))).toBe(false);
+  });
+});
+
+describe("claimLabel", () => {
+  it("returns null for a clean re-acquire (no callout)", () => {
+    expect(claimLabel("reacquired")).toBeNull();
+    expect(claimLabel("none")).toBeNull();
+  });
+
+  it("surfaces a peer-conflict honestly", () => {
+    expect(claimLabel("peer-conflict")).toMatch(/another agent/i);
+  });
+
+  it("surfaces a degraded claim honestly", () => {
+    expect(claimLabel("degraded")).toMatch(/not re-acquired/i);
+  });
+});
+
+describe("wipLabel", () => {
+  it("returns null when no WIP", () => {
+    expect(wipLabel("none")).toBeNull();
+  });
+
+  it("confirms restored WIP", () => {
+    expect(wipLabel("restored")).toMatch(/restored/i);
+  });
+
+  it("surfaces kept-for-manual WIP honestly with the ref path", () => {
+    expect(wipLabel("kept-for-manual")).toMatch(/refs\/wip/i);
+  });
+});
+
+describe("isDegraded — honesty gate", () => {
+  it("is false for a fully-clean lossless + reacquired + no-WIP session", () => {
+    expect(isDegraded(outcome({}))).toBe(false);
+  });
+
+  it("is true on a lossy resume", () => {
+    expect(isDegraded(outcome({ fidelity: "summary", turnsCovered: 2 }))).toBe(true);
+  });
+
+  it("is true on a peer-conflict claim", () => {
+    expect(isDegraded(outcome({ claimStatus: "peer-conflict" }))).toBe(true);
+  });
+
+  it("is true on a degraded claim", () => {
+    expect(isDegraded(outcome({ claimStatus: "degraded" }))).toBe(true);
+  });
+
+  it("is true on kept-for-manual WIP", () => {
+    expect(isDegraded(outcome({ wipStatus: "kept-for-manual" }))).toBe(true);
+  });
+});

--- a/src/components/terminal/SessionRecoveryBanner.tsx
+++ b/src/components/terminal/SessionRecoveryBanner.tsx
@@ -1,0 +1,179 @@
+/**
+ * Startup session-recovery banner — Phase 4 of
+ * `2026-06-06-runner-dev-loop-and-restart-resilience`.
+ *
+ * After a runner restart, `resume_ai_sessions` auto-reattaches interrupted
+ * chat sessions. This banner surfaces the result to the operator on launch,
+ * subscribing to the one-shot `session-recovery-summary` Tauri event via
+ * {@link useSessionRecovery}.
+ *
+ * Honesty gate: per-session resume FIDELITY (lossless `--resume` vs a lossy
+ * "resumed from last N turns" summary), CLAIM status (re-acquired / degraded /
+ * peer-conflict), and WIP status (restored / kept-for-manual) are shown
+ * verbatim — a lossy or claim-degraded resume is NEVER presented as fully
+ * clean.
+ *
+ * Two visual modes:
+ *   - crashRecovery=true  → a PROMINENT red-accented banner ("Recovered N
+ *     session(s) after an unexpected restart") listing each session + status.
+ *   - crashRecovery=false → a QUIET, subtle "N session(s) resumed" note (a
+ *     planned restart is expected; no alarm).
+ *
+ * Dismissible. Renders nothing when there is nothing to report (zero resumed
+ * sessions, or after dismissal). Visual language stacks with
+ * {@link CoordWarningBanner} (same top-right advisory column).
+ */
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, RotateCcw, X } from "lucide-react";
+import {
+  useSessionRecovery,
+  type ClaimStatus,
+  type SessionRecoveryOutcome,
+  type WipStatus,
+} from "@/hooks/useSessionRecovery";
+
+/** Human-readable, HONEST resume-fidelity label for one session. */
+export function fidelityLabel(s: SessionRecoveryOutcome): string {
+  if (s.fidelity === "lossless") return "fully restored";
+  return `resumed from last ${s.turnsCovered} turn${s.turnsCovered === 1 ? "" : "s"}`;
+}
+
+/** Whether a session's fidelity is lossy (drives the warning tint). */
+export function isLossy(s: SessionRecoveryOutcome): boolean {
+  return s.fidelity === "summary";
+}
+
+/** Human-readable claim-status label, or null when there's nothing to flag. */
+export function claimLabel(status: ClaimStatus): string | null {
+  switch (status) {
+    case "reacquired":
+      return null; // clean — no callout needed
+    case "peer-conflict":
+      return "worktree now held by another agent — shared, read-mostly";
+    case "degraded":
+      return "worktree claim not re-acquired — shared, read-mostly";
+    case "none":
+    default:
+      return null;
+  }
+}
+
+/** Human-readable WIP-status label, or null when there's nothing to flag. */
+export function wipLabel(status: WipStatus): string | null {
+  switch (status) {
+    case "restored":
+      return "uncommitted work restored";
+    case "kept-for-manual":
+      return "uncommitted work kept at refs/wip/* for manual recovery";
+    case "none":
+    default:
+      return null;
+  }
+}
+
+/** A session is "degraded" (warrants a warning tint) when claim/WIP/fidelity
+ *  is anything other than the fully-clean path. */
+export function isDegraded(s: SessionRecoveryOutcome): boolean {
+  return (
+    isLossy(s) ||
+    s.claimStatus === "peer-conflict" ||
+    s.claimStatus === "degraded" ||
+    s.wipStatus === "kept-for-manual"
+  );
+}
+
+export function SessionRecoveryBanner() {
+  const summary = useSessionRecovery();
+  const [dismissed, setDismissed] = useState(false);
+
+  // Re-show the banner when a NEW summary arrives (e.g. an unlikely second
+  // boot event) by clearing the dismissal on payload identity change.
+  useEffect(() => {
+    if (summary) setDismissed(false);
+  }, [summary]);
+
+  if (!summary || dismissed) return null;
+  if (summary.resumedCount === 0) return null;
+
+  const crash = summary.crashRecovery;
+  const sessions = summary.sessions;
+
+  // Accent: red for crash recovery, soft slate/blue for a planned restart.
+  const accent = crash ? "#f7768e" : "#7aa2f7";
+  const containerBg = crash ? "bg-[#f7768e]/10 border-[#f7768e]/40" : "bg-[#7aa2f7]/8 border-[#7aa2f7]/30";
+
+  const heading = crash
+    ? `Recovered ${summary.resumedCount} session${summary.resumedCount === 1 ? "" : "s"} after an unexpected restart`
+    : `${summary.resumedCount} session${summary.resumedCount === 1 ? "" : "s"} resumed`;
+
+  return (
+    <div
+      data-ui-bridge-id="terminal.session-recovery-banner"
+      data-crash-recovery={crash ? "true" : "false"}
+      className={`absolute top-2 right-2 z-30 w-[360px] rounded border shadow-lg p-2.5 ${containerBg}`}
+    >
+      <div className="flex items-start gap-2">
+        {crash ? (
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" style={{ color: accent }} />
+        ) : (
+          <RotateCcw className="w-3.5 h-3.5 shrink-0 mt-0.5" style={{ color: accent }} />
+        )}
+        <div className="flex-1 min-w-0">
+          <div className="text-[12px] font-semibold text-[#c0caf5] leading-snug">{heading}</div>
+
+          {/* Quiet mode: when nothing is degraded, the heading is enough — but
+              we still list per-session honesty so a lossy/degraded resume is
+              never hidden behind a calm summary line. */}
+          <ul className="mt-1.5 space-y-1">
+            {sessions.map((s) => {
+              const degraded = isDegraded(s);
+              const claim = claimLabel(s.claimStatus);
+              const wip = wipLabel(s.wipStatus);
+              return (
+                <li
+                  key={s.taskRunId}
+                  data-ui-bridge-id="terminal.session-recovery-banner-item"
+                  data-task-run-id={s.taskRunId}
+                  data-degraded={degraded ? "true" : "false"}
+                  className="text-[11px] leading-snug"
+                >
+                  <div className="flex items-baseline gap-1.5">
+                    <span className="text-[#c0caf5] font-medium truncate">{s.title}</span>
+                    <span
+                      className={isLossy(s) ? "text-[#e0af68]" : "text-[#9ece6a]"}
+                      title={isLossy(s) ? "Earlier context may be missing" : "Full transcript restored"}
+                    >
+                      {fidelityLabel(s)}
+                    </span>
+                  </div>
+                  {claim && (
+                    <div className="text-[10px] text-[#e0af68]/90 mt-0.5">{claim}</div>
+                  )}
+                  {wip && (
+                    <div
+                      className={`text-[10px] mt-0.5 ${
+                        s.wipStatus === "kept-for-manual" ? "text-[#e0af68]/90" : "text-[#9ece6a]/80"
+                      }`}
+                    >
+                      {wip}
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+        <button
+          type="button"
+          aria-label="Dismiss recovery summary"
+          data-ui-bridge-id="terminal.session-recovery-banner-dismiss"
+          onClick={() => setDismissed(true)}
+          className="text-[#c0caf5]/70 hover:text-[#c0caf5] leading-none px-1"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/sessionDurability.test.ts
+++ b/src/components/terminal/sessionDurability.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the Phase 5 session-durability classifier
+ * (`2026-06-06-runner-dev-loop-and-restart-resilience` honesty label).
+ *
+ * Same constraint as the other terminal-hook tests: the runner's vitest env
+ * is `node` (no jsdom), so we exercise the exported pure helpers directly —
+ * no React render.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyTabDurability,
+  isMarkableSession,
+  isNonDurablePty,
+  NON_DURABLE_TOOLTIP,
+  NON_DURABLE_LABEL,
+  DURABLE_TOOLTIP,
+} from "./sessionDurability";
+import type { TerminalTab } from "./useTerminalManager";
+
+/** Build a minimal TerminalTab fixture. */
+function tab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: "t1",
+    title: "shell",
+    pid: 123,
+    isAlive: true,
+    exitCode: null,
+    type: "terminal",
+    ...overrides,
+  };
+}
+
+describe("classifyTabDurability", () => {
+  it("marks a plain interactive PTY shell (no claude session / task run) as non-durable", () => {
+    expect(classifyTabDurability(tab())).toBe("non-durable");
+  });
+
+  it("marks a tab with a captured claudeSessionId as durable", () => {
+    expect(classifyTabDurability(tab({ claudeSessionId: "sess-abc" }))).toBe("durable");
+  });
+
+  it("marks a worker-backed tab (taskRunId, no claude id yet) as durable", () => {
+    expect(classifyTabDurability(tab({ taskRunId: "run-xyz" }))).toBe("durable");
+  });
+
+  it("treats empty-string ids as absent → non-durable", () => {
+    expect(classifyTabDurability(tab({ claudeSessionId: "", taskRunId: "" }))).toBe("non-durable");
+  });
+});
+
+describe("isMarkableSession", () => {
+  it("is true for a real terminal tab", () => {
+    expect(isMarkableSession(tab())).toBe(true);
+  });
+
+  it("is false for a plan (markdown viewer) tab — not a session", () => {
+    expect(isMarkableSession(tab({ type: "plan" }))).toBe(false);
+  });
+
+  it("treats an undefined type as a terminal (markable)", () => {
+    expect(isMarkableSession(tab({ type: undefined }))).toBe(true);
+  });
+});
+
+describe("isNonDurablePty", () => {
+  it("is true ONLY for a markable, non-durable interactive PTY", () => {
+    expect(isNonDurablePty(tab())).toBe(true);
+  });
+
+  it("is false for a durable AI session", () => {
+    expect(isNonDurablePty(tab({ claudeSessionId: "sess-abc" }))).toBe(false);
+  });
+
+  it("is false for a plan tab even though it has no claude session id", () => {
+    expect(isNonDurablePty(tab({ type: "plan" }))).toBe(false);
+  });
+});
+
+describe("copy", () => {
+  it("non-durable tooltip is honest and ties to the recovery summary", () => {
+    expect(NON_DURABLE_TOOLTIP).toMatch(/not saved/i);
+    expect(NON_DURABLE_TOOLTIP).toMatch(/restart/i);
+    expect(NON_DURABLE_TOOLTIP).toMatch(/recovery summary/i);
+    expect(NON_DURABLE_LABEL).toBe("ephemeral");
+  });
+
+  it("durable tooltip explains automatic resume", () => {
+    expect(DURABLE_TOOLTIP).toMatch(/resumes automatically/i);
+  });
+});

--- a/src/components/terminal/sessionDurability.ts
+++ b/src/components/terminal/sessionDurability.ts
@@ -1,0 +1,100 @@
+/**
+ * Session durability classification — Phase 5 of
+ * `2026-06-06-runner-dev-loop-and-restart-resilience` (the "honesty label").
+ *
+ * GROUND TRUTH (Phase 0 verdict): not every live session survives a runner
+ * restart, and the operator must never believe a non-durable surface is safe.
+ *
+ *   - AI / chat sessions  → DURABLE. The conversation is persisted to the
+ *     Claude CLI transcript on disk and auto-resumed via `--resume` after a
+ *     restart (Phases 3/4). On the frontend a tab is an AI session iff it has
+ *     captured a `claudeSessionId` (the transcript id `useTabSessionIdCapture`
+ *     binds once the JSONL appears). The startup {@link SessionRecoveryBanner}
+ *     lists exactly these after a restart.
+ *
+ *   - Interactive PTY terminal sessions → NON-DURABLE. A plain shell PTY is an
+ *     OS child process with NO transcript persist/replay substrate. A runner
+ *     restart ends the process and its scrollback; nothing brings it back. The
+ *     recovery banner will NOT list it.
+ *
+ *   - Plan tabs (markdown viewers, `type === "plan"`) are not sessions at all
+ *     — they carry no live process and have nothing to lose on restart, so we
+ *     never mark them.
+ *
+ * This module is the single source of truth for that distinction so the
+ * marker (and its copy) stay accurate and consistent across surfaces. Pure +
+ * dependency-free so it is unit-testable in the runner's `node` vitest env
+ * without mounting React.
+ */
+
+import type { TerminalTab } from "./useTerminalManager";
+
+/** A live session's durability across a runner restart. */
+export type SessionDurability = "durable" | "non-durable";
+
+/**
+ * Minimal shape needed to classify durability. A {@link TerminalTab}
+ * structurally satisfies this — kept as its own interface so the classifier
+ * can be exercised with plain fixtures (no full tab) in tests.
+ */
+export interface DurabilityInput {
+  /** Claude CLI transcript session id, set once the session is bound. */
+  claudeSessionId?: string;
+  /** Coordinator task-run id for worker-backed (AI) sessions. */
+  taskRunId?: string;
+  /** Tab kind — "plan" tabs are markdown viewers, not sessions. */
+  type?: "terminal" | "plan";
+}
+
+/**
+ * Classify whether a tab's session survives a runner restart.
+ *
+ * Derived from EXISTING fields — no new backend payload was needed:
+ *   - a captured `claudeSessionId` (or a worker `taskRunId`) ⇒ a transcript-
+ *     backed AI session ⇒ `"durable"` (auto-resumed via `--resume`);
+ *   - anything else that is a real `"terminal"` tab is a plain interactive PTY
+ *     shell ⇒ `"non-durable"`.
+ *
+ * Plan tabs are not sessions; callers should use {@link isMarkableSession} to
+ * skip them before showing any durability affordance.
+ */
+export function classifyTabDurability(tab: DurabilityInput): SessionDurability {
+  if (tab.claudeSessionId || tab.taskRunId) return "durable";
+  return "non-durable";
+}
+
+/**
+ * Whether a tab represents a live session that a durability affordance is
+ * meaningful for. Plan tabs (markdown viewers) carry no process, so they get
+ * no marker either way.
+ */
+export function isMarkableSession(tab: DurabilityInput): boolean {
+  return tab.type !== "plan";
+}
+
+/** True only for the genuinely non-durable interactive PTY case. */
+export function isNonDurablePty(tab: TerminalTab): boolean {
+  return isMarkableSession(tab) && classifyTabDurability(tab) === "non-durable";
+}
+
+/**
+ * Honest, calm tooltip copy for a NON-durable interactive PTY session.
+ * Ties explicitly back to the {@link SessionRecoveryBanner} mental model: the
+ * banner brings back durable AI sessions; this one is what gets lost.
+ */
+export const NON_DURABLE_TOOLTIP =
+  "Interactive terminal sessions are not saved — a runner restart ends " +
+  "this session and its scrollback. AI chat sessions resume automatically " +
+  "(and appear in the startup recovery summary); this one will not.";
+
+/** Short inline label for the non-durable marker. */
+export const NON_DURABLE_LABEL = "ephemeral";
+
+/**
+ * Subtle tooltip for the DURABLE AI-session affordance. Kept low-key per the
+ * Phase 5 brief (the priority is honesty about the non-durable case, not
+ * cluttering the durable one).
+ */
+export const DURABLE_TOOLTIP =
+  "AI chat session — resumes automatically after a runner restart " +
+  "(listed in the startup recovery summary).";

--- a/src/components/terminal/zone-grid/CompactZoneCard.tsx
+++ b/src/components/terminal/zone-grid/CompactZoneCard.tsx
@@ -1,7 +1,18 @@
 import { useCallback, useMemo, useReducer, useRef, useEffect } from "react";
-import { Maximize2, Check, X, Send, AlertTriangle, Copy, Filter, RotateCcw } from "lucide-react";
+import {
+  Maximize2,
+  Check,
+  X,
+  Send,
+  AlertTriangle,
+  Copy,
+  Filter,
+  RotateCcw,
+  Zap,
+} from "lucide-react";
 import type { TerminalTab } from "../useTerminalManager";
 import type { ZoneAssignments, SessionState } from "../useZoneLayout";
+import { isNonDurablePty, NON_DURABLE_TOOLTIP, NON_DURABLE_LABEL } from "../sessionDurability";
 import { STATE_BORDER_COLORS, STATE_BG_COLORS, STATE_LABELS, TREND_ICONS } from "./constants";
 import { isActionableLine, isYesNoPrompt, computeOutputTrend } from "./utils";
 import { ActivitySparkline } from "./ActivitySparkline";
@@ -302,6 +313,16 @@ export function CompactZoneCard({
           />
         )}
         <span className="text-[11px] text-[#c0caf5] font-medium truncate flex-1">{tab.title}</span>
+        {isNonDurablePty(tab) && (
+          <span
+            className="flex items-center gap-0.5 text-[8px] font-medium px-1 py-0.5 rounded-full shrink-0 bg-[#565f89]/15 text-[#565f89]"
+            title={NON_DURABLE_TOOLTIP}
+            aria-label={`Ephemeral session: ${NON_DURABLE_TOOLTIP}`}
+          >
+            <Zap className="w-2.5 h-2.5" />
+            {NON_DURABLE_LABEL}
+          </span>
+        )}
         {lastLines.length > 0 && (
           <button
             className={`p-0.5 rounded transition-colors shrink-0 ${

--- a/src/components/terminal/zone-grid/ZoneLabel.tsx
+++ b/src/components/terminal/zone-grid/ZoneLabel.tsx
@@ -1,8 +1,9 @@
 import { useState, useRef, useEffect } from "react";
-import { ChevronDown, Pin, Filter, ArrowDownToLine } from "lucide-react";
+import { ChevronDown, Pin, Filter, ArrowDownToLine, Zap } from "lucide-react";
 import type { TerminalTab } from "../useTerminalManager";
 import type { ZoneAssignments, SessionState } from "../useZoneLayout";
 import { STATE_BORDER_COLORS } from "./constants";
+import { isNonDurablePty, NON_DURABLE_TOOLTIP, NON_DURABLE_LABEL } from "../sessionDurability";
 import { useTerminalWindowActions } from "../useTerminalWindowActions";
 
 export function ZoneLabel({
@@ -91,6 +92,21 @@ export function ZoneLabel({
         style={{ backgroundColor: STATE_BORDER_COLORS[state] }}
       />
       <span className="text-[10px] text-[#a9b1d6] truncate font-medium">{tab.title}</span>
+
+      {/* Honesty label (Phase 5): interactive PTY shells are non-durable — a
+          runner restart ends them. Mirrors the compact-card marker so the
+          operator sees it in the full-terminal view too, not only in the
+          compact multi-zone overview. */}
+      {isNonDurablePty(tab) && (
+        <span
+          className="flex items-center gap-0.5 shrink-0 text-[8px] text-[#565f89] bg-[#565f89]/15 px-1 py-0 rounded"
+          title={NON_DURABLE_TOOLTIP}
+          aria-label={`Ephemeral session: ${NON_DURABLE_TOOLTIP}`}
+        >
+          <Zap className="w-2.5 h-2.5" />
+          {NON_DURABLE_LABEL}
+        </span>
+      )}
 
       {outputLineCount !== undefined && outputLineCount > 0 && (
         <span className="text-[9px] text-[#565f89] font-mono ml-1 shrink-0">

--- a/src/hooks/useSessionRecovery.ts
+++ b/src/hooks/useSessionRecovery.ts
@@ -1,0 +1,109 @@
+/**
+ * useSessionRecovery Hook
+ *
+ * Subscribes to the one-shot `session-recovery-summary` Tauri event emitted by
+ * the Rust backend at boot, AFTER `resume_ai_sessions` runs (Phase 4 of
+ * `2026-06-06-runner-dev-loop-and-restart-resilience`).
+ *
+ * The backend classifies each boot as crash-recovery (the previous shutdown
+ * was NOT clean — see `session::shutdown_marker`) vs a planned restart, and
+ * threads per-session honesty out of the resume loop: whether each session
+ * resumed losslessly (`--resume`) or from a lossy summary, whether its
+ * worktree claim was re-acquired / degraded / peer-conflicted, and whether its
+ * drained WIP was restored or kept for manual recovery.
+ *
+ * The {@link SessionRecoveryBanner} renders this. Mirrors the
+ * `useSessionState` module-singleton pattern so a late-mounting banner still
+ * catches the event (the summary is cached at module scope and replayed to
+ * any subscriber that mounts after the event fired).
+ */
+
+import { useEffect, useState } from "react";
+import { listen } from "@tauri-apps/api/event";
+
+/** Resume fidelity — mirrors the Rust `ResumeFidelity` (kebab-case). */
+export type ResumeFidelity = "lossless" | "summary";
+
+/** Worktree-claim re-acquire outcome — mirrors Rust `ClaimStatus`. */
+export type ClaimStatus = "none" | "reacquired" | "peer-conflict" | "degraded";
+
+/** Drained-WIP restore outcome — mirrors Rust `WipStatus`. */
+export type WipStatus = "none" | "restored" | "kept-for-manual";
+
+/**
+ * Per-session recovery outcome — mirrors the Rust `SessionRecoveryOutcome`
+ * struct (`#[serde(rename_all = "camelCase")]`).
+ */
+export interface SessionRecoveryOutcome {
+  taskRunId: string;
+  title: string;
+  fidelity: ResumeFidelity;
+  /** On a `summary` fidelity, the number of conversation turns covered. */
+  turnsCovered: number;
+  claimStatus: ClaimStatus;
+  wipStatus: WipStatus;
+}
+
+/**
+ * Startup-recovery summary payload — mirrors the Rust `SessionRecoverySummary`
+ * struct emitted on `session-recovery-summary`.
+ */
+export interface SessionRecoverySummary {
+  /** True when the previous shutdown was NOT clean (crash / hard kill). */
+  crashRecovery: boolean;
+  /** Number of sessions successfully resumed. */
+  resumedCount: number;
+  /** Per-session honest outcomes. */
+  sessions: SessionRecoveryOutcome[];
+}
+
+/** The Tauri event name (mirrors `SESSION_RECOVERY_SUMMARY_EVENT` in Rust). */
+export const SESSION_RECOVERY_SUMMARY_EVENT = "session-recovery-summary";
+
+// Module-singleton cache so a banner that mounts AFTER the boot event still
+// gets the summary (the event fires ~3s into startup; the terminal page may
+// mount later).
+let cachedSummary: SessionRecoverySummary | null = null;
+const subscribers = new Set<(s: SessionRecoverySummary) => void>();
+let listenerInitialized = false;
+
+function ensureListener() {
+  if (listenerInitialized) return;
+  listenerInitialized = true;
+
+  void listen<SessionRecoverySummary>(SESSION_RECOVERY_SUMMARY_EVENT, (event) => {
+    const payload = event.payload;
+    if (!payload || typeof payload !== "object") return;
+    cachedSummary = payload;
+    for (const fn of subscribers) {
+      fn(payload);
+    }
+  });
+}
+
+/**
+ * Subscribe to the startup recovery summary. Returns the latest summary (or
+ * `null` before the boot event fires). The summary is replayed to a late
+ * subscriber from the module cache.
+ */
+export function useSessionRecovery(): SessionRecoverySummary | null {
+  const [summary, setSummary] = useState<SessionRecoverySummary | null>(cachedSummary);
+
+  useEffect(() => {
+    ensureListener();
+
+    const handler = (s: SessionRecoverySummary) => setSummary(s);
+    subscribers.add(handler);
+
+    // Replay the cached summary if the event already fired before mount.
+    if (cachedSummary) {
+      setSummary(cachedSummary);
+    }
+
+    return () => {
+      subscribers.delete(handler);
+    };
+  }, []);
+
+  return summary;
+}


### PR DESCRIPTION
## Summary

Implements **Phases 2–5** of `2026-06-06-runner-dev-loop-and-restart-resilience` (Phase 1, the temp-runner dev loop, already shipped in #449). Makes a primary-runner restart — planned or crash — a clean, lossless, honest handover. Phase 0 probes were run first (verdicts recorded in the plan) and reshaped the design.

## Phases

**Phase 2 — Graceful drain (`drain.rs`, new):** a `POST /drain` route + a bounded drain sequence hooked into the `ExitRequested` exit seam. On a planned restart it (1) flips a `DRAINING` flag so new turns are refused (gated in both `send_user_message` and the HTTP `run_prompt`), (2) flushes the in-flight AI turn to `output_log`, (3) checkpoints each session worktree to `refs/wip/<agent_session_id>` via `git stash create` (no branch-history pollution), (4) heartbeats/persists claims, then exits — all under a hard 25s timeout (`QONTINUI_DRAIN_TIMEOUT_MS`) so a stuck session can never block a deploy. Supervisor-side pre-stop `/drain` call is qontinui-supervisor#93.

**Phase 3 — Lossless resume + claim re-acquire:** closes the P0c gap — `resume_ai_sessions` now derives a stable `agent_session_id` (`UUIDv5(NS,"ai-session:{task_run_id}")`) and re-acquires each `kind=worktree` claim on resume, so the owner token matches idempotently (no orphan/clobber window). Prefers full `--resume` of the on-disk transcript (CLI session id pinned to `task_run_id` at launch) over the lossy replay summary; when only a summary is possible it's **honestly labelled** (`resumed from last N turns`). Restores the drained `refs/wip/*` state on resume (and keeps the ref for manual recovery if apply isn't clean). The re-acquired `IsolatedEditContext` is OWNED by the `ClaudeSession` (released via its `Drop`/`close()`), not leaked.

**Phase 4 — Crash auto-reattach + visibility:** a port-namespaced clean-shutdown marker (`~/.qontinui/runner/last-shutdown.json`) distinguishes planned vs crash restart. A structured `session-recovery-summary` Tauri event surfaces per-session resume fidelity, claim status, and WIP status to a dismissible startup banner (`SessionRecoveryBanner`) — prominent on crash, quiet on planned. Composes with the existing `session_lifecycle_store` + event layer (no second registry).

**Phase 5 — PTY durability honesty label:** interactive PTY sessions are non-durable OS children (no transcript). A pure classifier (`sessionDurability.ts`) marks live PTY tabs `ephemeral` with an honest tooltip in BOTH the compact zone card AND the full-terminal header (`ZoneLabel`); durable AI sessions get a subtle "resumes on restart" cue — tying the marker to the recovery banner's mental model.

## Verification

- `cargo clippy --bin qontinui-runner -- -D warnings`: clean (local, full integrated branch).
- `cargo test --bin qontinui-runner`: drain (4), shutdown_marker (6), resume (7), isolated_edit (12), claude_session (62) — all pass.
- `tsc --noEmit`: clean. vitest: `SessionRecoveryBanner` (15) + `sessionDurability` (12) helper tests pass (CI vitest green).
- **On-page (temp runner, supervisor `:9875` spawn-test of this worktree, primary `:9876` untouched):** Terminal page renders clean; Phase 4 recovery banner correctly absent on a clean start; **opened live PowerShell PTY shells → each rendered the `ephemeral` non-durable marker** (verified via live DOM query: N PTYs → N markers with `aria-label="Ephemeral session: …"`). This caught a gap — the marker was initially only in `CompactZoneCard` (compact multi-zone overview, invisible in the normal full-terminal view); fixed by mirroring it into `ZoneLabel` (commit `3fb53d13`).

## Notes

- The full live worktree-claim-reacquire drill (Phase 3/Verification §5) depends on runtime worktree provisioning, which is currently blocked by a separate coord build-slot bug (`2026-06-08-coord-build-slot-budget-saturation-fix.md`); the code paths here are unit/CI-verified and activate once that lands.
