### PR TITLE
feat(ai-settings): default account selection to least-usage, not manual

### DIFF
--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -139,9 +139,13 @@ pub fn save_ai_settings(
     // Get existing settings to preserve Gemini configuration when saving Claude settings
     let existing_settings = settings::get_ai_settings();
 
+    // Default to least-usage; only an explicit "manual" pins to a single
+    // account. (None / unknown / "least_usage" all resolve to LeastUsage so a
+    // multi-account runner auto-balances by default — matching the
+    // AccountSelectionMode::LeastUsage default in settings.rs.)
     let selection_mode = match account_selection_mode.as_deref() {
-        Some("least_usage") => AccountSelectionMode::LeastUsage,
-        _ => AccountSelectionMode::Manual,
+        Some("manual") => AccountSelectionMode::Manual,
+        _ => AccountSelectionMode::LeastUsage,
     };
 
     let ai_settings = AiSettings {

--- a/src/components/settings/AiSettings.tsx
+++ b/src/components/settings/AiSettings.tsx
@@ -223,7 +223,7 @@ export function AiSettings({ onLog }: AiSettingsProps) {
         customPath: settings.claude_cli.custom_path || null,
         timeoutSeconds: settings.claude_cli.timeout_seconds,
         configDir: settings.claude_cli.config_dir || null,
-        accountSelectionMode: settings.claude_cli.account_selection_mode || "manual",
+        accountSelectionMode: settings.claude_cli.account_selection_mode || "least_usage",
         model: settings.claude_api.model,
         maxTokens: settings.claude_api.max_tokens,
         autoRefineVideoAfterIterations: settings.auto_refine_video_after_iterations,

--- a/src/components/settings/ai-settings/types.ts
+++ b/src/components/settings/ai-settings/types.ts
@@ -98,7 +98,11 @@ export const DEFAULT_AI_SETTINGS: AiSettings = {
     execution_mode: "auto",
     timeout_seconds: 600,
     config_dir: undefined,
-    account_selection_mode: "manual",
+    // Default to least-usage so a multi-account runner auto-balances across
+    // accounts (and never pins to a single, possibly-exhausted one). No-op
+    // with fewer than two config dirs, so safe as the default. Matches the
+    // Rust default (settings.rs AccountSelectionMode::LeastUsage).
+    account_selection_mode: "least_usage",
   },
   claude_api: {
     model: "claude-sonnet-4-20250514",


### PR DESCRIPTION
Follow-up from activating #509/#510/#513: verifying on the live runner revealed it was pinned to `account_selection_mode: "manual"` on the **exhausted** `.claude-gmail` account — so the weekly-usage picker never engaged, even with three accounts configured. Root cause: the Rust struct default is `LeastUsage`, but three spots forced `"manual"`.

## Changes
- **`ai-settings/types.ts`** — `DEFAULT_AI_SETTINGS.claude_cli.account_selection_mode`: `"manual"` → `"least_usage"`.
- **`AiSettings.tsx`** — save payload fallback `|| "manual"` → `|| "least_usage"`.
- **`ai_settings.rs`** — the save command matched only `"least_usage"` and defaulted *everything else (including `None`)* to `Manual`. Now an **explicit** `"manual"` still pins to a single account, but `None` / unknown / `"least_usage"` all resolve to `LeastUsage`.

least-usage is a no-op with fewer than two config dirs, so it's safe as the default (matches the existing `AccountSelectionMode::LeastUsage` default in `settings.rs`).

## Scope note
Existing runners keep their **persisted** value — this only changes the default for fresh/unset config. (Joshua already flipped the primary to least-usage in the UI; verified live — the picker now resolves `.claude-hotmail` instead of the exhausted `.claude-gmail`.)

## Verification
- rustfmt + prettier clean on touched files; minimal 3-file diff.
- CI runs the Rust `test` jobs + frontend vitest. (Pure default-value change; honoring-explicit-manual behavior is the only logic change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)