### PR TITLE
fix(worktree): census building uses held-cargo-lock-only probe (twin saturation)

### DIFF
--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -694,9 +694,12 @@ fn capture_worktree(repo: &str, worktree: &Path) -> WorktreeCensus {
     // None when undeterminable (no origin/main, git failure).
     let landed_in_main = compute_landed_in_main(worktree);
 
-    // G6 shadow-mode: the same build probe the reclaim executor uses,
-    // reported every tick regardless of arming (the passive prove-out feed).
-    let building = Some(super::reclaim::probe_building(worktree));
+    // G6 shadow-mode: held-cargo-lock-only build probe for the FLEET census
+    // (NOT the reclaim executor's `probe_building`, which also counts recent
+    // file activity — editor saves / git ops are not builds and over-reported
+    // coord's build-concurrency gauge). Phase 2 of
+    // `plans/2026-06-08-coord-build-slot-budget-saturation-fix.md`.
+    let building = Some(super::reclaim::probe_building_for_census(worktree));
 
     // Ξ_Worktree P7.3 — canonical-checkout state (per-REPO, not per-worktree;
     // it's fine that every worktree row of a repo carries the same values —

--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -1056,9 +1056,12 @@ mod tests {
         // No git repo → no origin/main ref → landed_in_main is the honest
         // unknown `None` (which coord's gate reads as not-landed).
         assert!(row.landed_in_main.is_none());
-        // G6 shadow probe always reports: a freshly-created tempdir has a
-        // root mtime inside the activity window → Some(true).
-        assert_eq!(row.building, Some(true));
+        // The census `building` probe is now held-cargo-lock-only
+        // (`probe_building_for_census`): a freshly-created tempdir has no
+        // `target/*/.cargo-lock` held by a live cargo, so it is NOT building.
+        // (The dropped root-mtime-recency heuristic is what over-reported the
+        // fleet `count_building` gauge — see this plan's Phase 2.)
+        assert_eq!(row.building, Some(false));
     }
 
     #[test]

--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -534,6 +534,21 @@ pub(super) fn probe_building(worktree: &Path) -> bool {
     worktree_is_building(worktree, Duration::from_secs(activity_window_secs()))
 }
 
+/// Census-only build signal: a genuinely-held cargo build lock under
+/// `<worktree>/target/`, and NOTHING else. Unlike [`probe_building`] (used by
+/// the reclaim executor, which legitimately also skips a recently-touched
+/// worktree) this DROPS the recent-activity heuristic — an editor save,
+/// `git status`, or any write to the worktree root bumps mtime WITHOUT a build
+/// in flight. Reporting that as `building` in the FLEET census over-reported
+/// coord's build-concurrency gauge (`count_building` climbed across idle/edited
+/// dev worktrees with no real builds), pinning `decide_isolation` in rule 3c so
+/// every allocate `Wait`-ed and sessions fell back to the shared root. Phase 2
+/// of `plans/2026-06-08-coord-build-slot-budget-saturation-fix.md`; coord's
+/// building-freshness TTL is the backstop for any flag that still goes stale.
+pub(super) fn probe_building_for_census(worktree: &Path) -> bool {
+    cargo_lock_held(&worktree.join("target"))
+}
+
 /// G6: is this worktree currently being built? Either signal → skip.
 /// Injectable (takes the worktree root) so tests drive it with tempdirs.
 ///


### PR DESCRIPTION
## What

The fleet worktree census reported `building=true` via `probe_building`, which ORs a held cargo lock **with a recent-activity mtime window** (target/node_modules/worktree-root touched within 600s). Editor saves and `git` ops therefore flagged idle dev worktrees as "building".

## Why

coord's `decide_isolation` gates dedicated worktree allocation on `count_building < max_concurrent_builds()` and charges the INV-W3 disk projection per in-flight build. With the census over-reporting, `count_building` climbed across idle/edited dev worktrees (observed live: **active_builds=28 and rising, no cargo/rustc running**), pinning every `/agents/allocate` in rule 3c → `Wait{build_slot}`. Runner sessions then fell back to the **shared root** instead of an isolated per-session worktree — the hazard the worktree-coordination layer exists to prevent.

## Change

- Add `probe_building_for_census` — a **held-cargo-lock-only** signal (no recency heuristic; the real in-flight-build indicator).
- The census producer (`census.rs`) now uses it for the posted `building` flag.
- `probe_building` (lock **OR** recency) is unchanged and still used by the reclaim-skip guard, where erring toward "active" is correct.

Pairs with the coord-side `count_building` freshness TTL (qontinui-coord#486). Verified `cargo check` green in an isolated worktree off origin/main; fmt/clippy/tests gated by CI here.

Plan: `2026-06-08-coord-build-slot-budget-saturation-fix.md`