### PR TITLE
feat(fleet-policy): runner policy poller + dynamic per-install interception mode (P3+P4)

### DIFF
--- a/src-tauri/resources/intercept/shim.bash
+++ b/src-tauri/resources/intercept/shim.bash
@@ -302,6 +302,7 @@ pkgs_json="$pkgs_json]"
 correlation_id=""
 gate=""
 risk_factors=""
+resp_eff_mode=""
 PORT="${QONTINUI_INSTALL_INTERCEPT_PORT:-}"
 MODE="${QONTINUI_INSTALL_INTERCEPT_MODE:-observe}"
 OVERRIDE="${QONTINUI_INSTALL_OVERRIDE:-}"
@@ -347,6 +348,16 @@ elif command -v curl >/dev/null 2>&1; then
     if printf '%s' "$pre_resp" | grep -q '"gate"[[:space:]]*:[[:space:]]*"escalate"'; then
       gate="escalate"
     fi
+    # DYNAMIC interception mode (P4): the producer returns the device's EFFECTIVE
+    # interception level resolved from the fleet policy at pre-call time
+    # ("off" | "observe" | "gate"). When present, it OVERRIDES this shim's
+    # spawn-time MODE env so an operator flipping the policy takes effect on
+    # already-injected terminals. Parsed with the SAME grep style as gate above.
+    # ABSENT (old runner/coord) -> empty -> the eff_mode fallback below keeps the
+    # env MODE (full back-compat). An "off" effective mode short-circuits the
+    # producer (no correlation_id), so the post-call is already skipped by the
+    # existing [ -n "$correlation_id" ] guard.
+    resp_eff_mode="$(printf '%s' "$pre_resp" | grep -o '"effective_mode"[[:space:]]*:[[:space:]]*"[^"]*"' | head -n1 | sed 's/.*"\([^"]*\)"$/\1/')"
     # risk_factors is a JSON string array; the extraction is DISPLAY-ONLY
     # best-effort (not load-bearing — only the gate field is). Pull the bracketed
     # array, strip quotes/brackets, join elements with "; ".
@@ -362,12 +373,20 @@ fi
 
 # ---------------------------------------------------------------------------
 # GATE DECISION (plan §3 A4 — shell transliteration of gate::should_block).
-# BLOCK iff: MODE==gate AND gate==escalate AND OVERRIDE!=1 AND NOT lockfile_only
-# (A6) AND NOT never-gate tool (npx, NEVER_GATE==1). Every other case proceeds.
-# A block prints the A4 UX to STDERR and exits 1 WITHOUT running the real tool
-# and WITHOUT a post-call (no install happened — PreContext TTLs out).
+# BLOCK iff: eff_mode==gate AND gate==escalate AND OVERRIDE!=1 AND NOT
+# lockfile_only (A6) AND NOT never-gate tool (npx, NEVER_GATE==1). Every other
+# case proceeds. A block prints the A4 UX to STDERR and exits 1 WITHOUT running
+# the real tool and WITHOUT a post-call (no install happened — PreContext TTLs
+# out).
+#
+# eff_mode (P4): the EFFECTIVE interception mode is the producer-returned
+# effective_mode when present, else the spawn-time MODE env (back-compat with an
+# old runner/coord that omits the field). This is what makes the per-install
+# mode DYNAMIC — the fleet policy governs already-injected terminals, not just
+# the env captured when the terminal was spawned.
 # ---------------------------------------------------------------------------
-if [ "$MODE" = "gate" ] \
+eff_mode="${resp_eff_mode:-$MODE}"
+if [ "$eff_mode" = "gate" ] \
    && [ "$gate" = "escalate" ] \
    && [ "$OVERRIDE" != "1" ] \
    && [ "$lockfile_only" != "true" ] \

--- a/src-tauri/src/bin/qontinui_shim.rs
+++ b/src-tauri/src/bin/qontinui_shim.rs
@@ -143,6 +143,12 @@ fn run(tool: ShimTool, args: &[String]) -> Option<i32> {
     let mut correlation_id: Option<String> = None;
     let mut escalate = false;
     let mut risk_factors = String::new();
+    // DYNAMIC interception mode (P4): start from the spawn-time env MODE and
+    // OVERRIDE it with the producer-returned `effective_mode` when present, so
+    // the fleet policy governs this already-injected stub. Absent (old
+    // runner/coord) ⇒ keep the env-derived mode (full back-compat). Parity with
+    // the bash shim's `eff_mode="${resp_eff_mode:-$MODE}"`.
+    let mut eff_mode = mode;
     if let Some(port) = port {
         let body = pre_call_body(tool.wire_pm().as_str(), &packages, dev, override_on);
         match http_post(port, "/install-effects/run", &body) {
@@ -151,6 +157,9 @@ fn run(tool: ShimTool, args: &[String]) -> Option<i32> {
                 escalate = resp.contains("\"gate\":\"escalate\"")
                     || resp.contains("\"gate\": \"escalate\"");
                 risk_factors = extract_risk_factors(&resp);
+                if let Some(em) = extract_effective_mode(&resp) {
+                    eff_mode = InterceptMode::parse(&em);
+                }
             }
             Err(_) => {
                 log_unavailable_once();
@@ -164,8 +173,9 @@ fn run(tool: ShimTool, args: &[String]) -> Option<i32> {
     }
 
     // ---- gate decision (lib-crate truth table) ---------------------------
+    // Uses `eff_mode` (effective_mode-over-env), NOT the raw spawn-time `mode`.
     if should_block(
-        mode,
+        eff_mode,
         escalate,
         override_on,
         lockfile_sync,
@@ -257,6 +267,27 @@ fn extract_correlation_id(resp: &str) -> Option<String> {
     let after_q1 = &after[q1 + 1..];
     let q2 = after_q1.find('"')?;
     Some(after_q1[..q2].to_string())
+}
+
+/// Best-effort grab of `"effective_mode":"…"` from the pre-call response
+/// (P4 — the dynamic per-install interception mode). `None` when absent (an
+/// old runner/coord that omits the field) so the caller keeps the spawn-time
+/// env mode. Mirrors `extract_correlation_id` + the bash shim's grep.
+fn extract_effective_mode(resp: &str) -> Option<String> {
+    let key = "\"effective_mode\"";
+    let i = resp.find(key)? + key.len();
+    let rest = &resp[i..];
+    let colon = rest.find(':')?;
+    let after = &rest[colon + 1..];
+    let q1 = after.find('"')?;
+    let after_q1 = &after[q1 + 1..];
+    let q2 = after_q1.find('"')?;
+    let val = after_q1[..q2].to_string();
+    if val.trim().is_empty() {
+        None
+    } else {
+        Some(val)
+    }
 }
 
 /// Best-effort display-only join of the `risk_factors` string array. Not
@@ -531,6 +562,28 @@ mod tests {
             Some("11111111-2222-3333-4444-555555555555")
         );
         assert_eq!(extract_correlation_id("{}"), None);
+    }
+
+    #[test]
+    fn extract_effective_mode_reads_field_or_falls_back() {
+        // Present + non-empty ⇒ Some(value), driving the dynamic override.
+        let resp = r#"{"gate":"escalate","effective_mode":"gate"}"#;
+        assert_eq!(extract_effective_mode(resp).as_deref(), Some("gate"));
+        assert_eq!(
+            extract_effective_mode(r#"{"effective_mode":"observe"}"#).as_deref(),
+            Some("observe")
+        );
+        // Absent (old runner/coord) ⇒ None ⇒ caller keeps the env mode.
+        assert_eq!(extract_effective_mode(r#"{"gate":"proceed"}"#), None);
+        assert_eq!(extract_effective_mode("{}"), None);
+        // Empty string ⇒ None (treated as absent, not a parseable mode).
+        assert_eq!(extract_effective_mode(r#"{"effective_mode":""}"#), None);
+        // Back-compat: an unrecognized value still parses (InterceptMode::parse
+        // fails open to Observe), but the extractor surfaces it verbatim.
+        assert_eq!(
+            extract_effective_mode(r#"{"effective_mode":"bogus"}"#).as_deref(),
+            Some("bogus")
+        );
     }
 
     #[test]

--- a/src-tauri/src/install_effects_producer/mod.rs
+++ b/src-tauri/src/install_effects_producer/mod.rs
@@ -333,6 +333,41 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
     let correlation_id = Uuid::new_v4();
     let repo = repo_basename(&req.repo_path);
 
+    // ---- DYNAMIC interception mode (P4) -------------------------------------
+    // Read the device's EFFECTIVE install-interception level from the
+    // process-global fleet-policy cache (refreshed every ~45s by
+    // `mcp::fleet_policy_poller`). `run_with_base` has no app state, so the
+    // accessor is a synchronous lock read of the cache directly. Defaults to
+    // `"off"` until the poller's first success (fail-safe — never gate).
+    let effective_mode = crate::mcp::fleet_policy_poller::effective_install_intercept_mode();
+
+    // OFF short-circuit (D6): when the effective mode is `off`, an interception
+    // pre-call must SKIP declare/predict entirely, return NO `correlation_id`
+    // (so the shim's `[ -n "$correlation_id" ]` guard skips the post-call), and
+    // hand back `effective_mode:"off"` immediately — the real tool still runs
+    // in the agent's shell (the shim runs it; we just don't observe). The
+    // explicit `Full` route is UNAFFECTED (it never short-circuits on the fleet
+    // policy — it's the operator-driven `/install-effects/run` path).
+    if req.mode == RunMode::Intercept && effective_mode == "off" {
+        info!(
+            "install-effects: INTERCEPT pre-call but fleet policy = OFF (repo={repo}) \
+             — short-circuiting (no declare/predict, no correlation_id; tool runs uninstrumented)"
+        );
+        return Ok(ApiResponse::success(RunResponse {
+            correlation_id: Uuid::nil(),
+            repo,
+            package_manager: pm.as_str().to_string(),
+            gate: GateOutcome::Proceed,
+            risk_factors: Vec::new(),
+            escalation_overridden: false,
+            install: None,
+            dry_run_only: false,
+            resolution: serde_json::Value::Null,
+            verify: None,
+            effective_mode: "off".to_string(),
+        }));
+    }
+
     // ---- Phase 4: resolve private-registry auth env (NEVER logged/sent) ------
     // Injected into the dry-run / install / audit subprocesses ONLY. Custom
     // `CARGO_REGISTRIES_<NAME>_TOKEN` names the caller declares ride in
@@ -469,7 +504,8 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
         );
         info!(
             "install-effects: INTERCEPT pre-call (corr={correlation_id}, repo={repo}, pm={}) \
-             — declared+gated, install deferred to the agent shell; gate={gate:?}",
+             — declared+gated, install deferred to the agent shell; gate={gate:?}, \
+             effective_mode={effective_mode}",
             pm.as_str()
         );
         return Ok(ApiResponse::success(RunResponse {
@@ -483,6 +519,8 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
             dry_run_only: false,
             resolution: pac.resolution,
             verify: None,
+            // `observe` or `gate` here — `off` was short-circuited before declare.
+            effective_mode: effective_mode.clone(),
         }));
     }
 
@@ -505,6 +543,7 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
             dry_run_only: req.dry_run_only,
             resolution: pac.resolution,
             verify: None,
+            effective_mode: effective_mode.clone(),
         }));
     }
 
@@ -547,6 +586,7 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
         dry_run_only: false,
         resolution: pac.resolution,
         verify: Some(verify),
+        effective_mode,
     }))
 }
 
@@ -1583,7 +1623,13 @@ mod tests {
     // ===================================================================
 
     /// Build an intercept-mode pre-call request for a real `repo_path`.
+    ///
+    /// Pins the process-global fleet-policy cache to `observe` as a side effect
+    /// so the P4 `off` short-circuit (which fires when the cache is `off`, the
+    /// fail-safe default before any live poll) does NOT trigger — these tests
+    /// exercise the full declare→gate→stash intercept pre-call path.
     fn intercept_req(repo_path: &str, packages: Vec<&str>) -> RunRequest {
+        crate::mcp::fleet_policy_poller::set_mode_for_test("observe");
         RunRequest {
             repo_path: repo_path.to_string(),
             package_manager: Some("npm".to_string()),

--- a/src-tauri/src/install_effects_producer/types.rs
+++ b/src-tauri/src/install_effects_producer/types.rs
@@ -126,6 +126,13 @@ impl From<&PackageSpecInput> for PackageSpec {
 pub struct RunResponse {
     /// The uuid minted for this run; echoed into every coord call so declare /
     /// predict-and-check / (Phase 3) verify correlate.
+    ///
+    /// OMITTED from the JSON when nil (`Uuid::nil()`): the P4 `off`
+    /// short-circuit returns a nil id so the shim's existing
+    /// `[ -n "$correlation_id" ]` guard skips the post-call WITHOUT any shim
+    /// change for the off path. A real run always mints a v4 (never nil), so
+    /// this only ever fires on the off short-circuit.
+    #[serde(skip_serializing_if = "Uuid::is_nil")]
     pub correlation_id: Uuid,
     /// The resolved repo slug (basename of `repo_path`).
     pub repo: String,
@@ -152,6 +159,17 @@ pub struct RunResponse {
     /// `None` when no verify ran (`dry_run_only` / blocked escalation).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verify: Option<VerifyOutcome>,
+    /// The EFFECTIVE per-install interception mode this device resolved from
+    /// the fleet policy at pre-call time (`off` | `observe` | `gate`), P4 of
+    /// the fleet-policy channel redesign. The shim obeys THIS over its
+    /// spawn-time `QONTINUI_INSTALL_INTERCEPT_MODE` env so an operator flipping
+    /// the policy takes effect on already-injected terminals.
+    ///
+    /// Additive + serde-default: an old runner/coord that omits the field
+    /// deserializes as `""`, and the shim's `eff_mode="${resp_eff_mode:-$MODE}"`
+    /// fallback then keeps using the spawn-time env (full back-compat).
+    #[serde(default)]
+    pub effective_mode: String,
 }
 
 /// The slice of coord's `InstallVerification` the route surfaces to the caller

--- a/src-tauri/src/mcp/fleet_policy_poller.rs
+++ b/src-tauri/src/mcp/fleet_policy_poller.rs
@@ -1,0 +1,423 @@
+//! Device-scoped poller for the fleet-policy `install_interception` domain
+//! (P3 + P4 of `2026-06-08-fleet-policy-channel-redesign.md`).
+//!
+//! Coord exposes `GET /coord/fleet-policy?domain=install_interception`
+//! (FleetPrincipal / device-JWT gated) which returns the EFFECTIVE
+//! interception level resolved for THIS device's tenant/fleet:
+//!
+//! ```json
+//! {"domain":"install_interception","effective_level":"off|observe|gate",
+//!  "master_enabled":true,"resolved_scope":"..."}
+//! ```
+//!
+//! This module owns a process-global cache of that `effective_level` and a
+//! supervised background loop that refreshes it every [`POLL_INTERVAL`]. The
+//! cache is read SYNCHRONOUSLY (no app state, no async) by
+//! `install_effects_producer::run_with_base` via
+//! [`effective_install_intercept_mode`] so the interception pre-call can make
+//! the per-install mode DYNAMIC (P4) rather than trusting the shim's
+//! spawn-time `QONTINUI_INSTALL_INTERCEPT_MODE` env.
+//!
+//! ## Lifecycle parallel to `device_jwt_refresher`
+//!
+//! Mirrors `mcp::device_jwt_refresher`'s shape so the call sites read
+//! consistently:
+//!
+//! - [`PollerState`] holds the `watch` shutdown channel + join handle.
+//! - [`start_poller`] spawns the loop via `task_supervisor::spawn_supervised`
+//!   so a panic self-heals (a dead poller would silently freeze the cached
+//!   mode — see the refresher's supervisor rationale).
+//! - [`commands::auto_start_fleet_policy_poller`] is the idempotent boot entry
+//!   wired beside `auto_start_device_jwt_refresher` in `mcp_api`.
+//!
+//! ## Fail-safe contract (D7)
+//!
+//! - Before the FIRST successful poll, the cache reads **`off`** (NEVER gate).
+//! - A poll ERROR (network / decode / non-2xx) keeps the LAST-GOOD value.
+//! - A coord **404 / 401 / auth-required** resets the cache to **`off`** (the
+//!   policy is absent or this device isn't authorized — never gate).
+//! - If there is no device JWT yet (unpaired) the poll is SKIPPED quietly —
+//!   no log spam — like the other daemons that no-op without a token.
+//! - Degradation is logged ONCE (a level transition), not every tick.
+
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::RwLock;
+use std::time::Duration;
+
+use tokio::sync::{watch, Mutex};
+use tracing::{info, warn};
+
+use crate::mcp::types::ApiState;
+
+/// How often the loop refreshes the cached effective level. 45s sits in the
+/// 30–60s window the plan specifies — long enough to not hammer coord, short
+/// enough that an operator flipping the fleet policy sees it take effect on
+/// already-injected terminals within a minute.
+const POLL_INTERVAL: Duration = Duration::from_secs(45);
+
+/// The fleet-policy domain this poller tracks.
+const DOMAIN: &str = "install_interception";
+
+/// The fail-safe default: every read before the first success, and every
+/// reset on a 404/401/auth-required, collapses to this. NEVER `gate`.
+const DEFAULT_MODE: &str = "off";
+
+// ===========================================================================
+// Process-global cache
+// ===========================================================================
+
+/// The cached effective interception mode (`off` | `observe` | `gate`).
+/// `RwLock<String>` behind a `OnceLock` — `once_cell` is already a dep, but
+/// `std::sync::OnceLock` is in std since 1.70 and is the same idiom the
+/// `device_jwt_refresher::commands` holder uses, so we stay consistent.
+static EFFECTIVE_MODE: OnceLock<RwLock<String>> = OnceLock::new();
+
+fn cache() -> &'static RwLock<String> {
+    EFFECTIVE_MODE.get_or_init(|| RwLock::new(DEFAULT_MODE.to_string()))
+}
+
+/// Read the current effective install-interception mode. Returns `"off"`
+/// until the first successful poll (and after any auth/absent reset).
+///
+/// SYNCHRONOUS + lock-only — safe to call from `run_with_base` (which has no
+/// app state and is not the place to do async I/O). A poisoned lock degrades
+/// fail-safe to `"off"`.
+pub fn effective_install_intercept_mode() -> String {
+    cache()
+        .read()
+        .map(|g| g.clone())
+        .unwrap_or_else(|_| DEFAULT_MODE.to_string())
+}
+
+/// Overwrite the cached mode. Internal — only the poll loop calls this.
+fn set_mode(mode: &str) {
+    if let Ok(mut g) = cache().write() {
+        *g = mode.to_string();
+    }
+}
+
+/// Test-only cache setter so other modules' tests (e.g.
+/// `install_effects_producer`'s intercept-mode tests, which need a non-`off`
+/// effective mode for the pre-call to proceed past the P4 short-circuit) can
+/// pin the process-global cache. NEVER compiled into a release binary.
+#[cfg(test)]
+pub(crate) fn set_mode_for_test(mode: &str) {
+    set_mode(mode);
+}
+
+// ===========================================================================
+// Wire type (coord response subset)
+// ===========================================================================
+
+/// Subset of coord's `GET /coord/fleet-policy` response we read. `master_enabled`
+/// + `resolved_scope` are pulled through for observability but only
+/// `effective_level` drives the cache. Every field defaults so a coord that
+/// trims/renames a sibling field doesn't break the decode.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct FleetPolicyResponse {
+    #[serde(default)]
+    effective_level: Option<String>,
+}
+
+// ===========================================================================
+// Poller state + supervised loop
+// ===========================================================================
+
+/// State for the fleet-policy poller task. Owns the shutdown channel + join
+/// handle so the boot entry can stop / restart it. (No kick channel: unlike
+/// the refresher there's no event that needs to wake it early — the policy is
+/// pull-only on a fixed cadence.)
+pub struct PollerState {
+    shutdown_tx: watch::Sender<bool>,
+    task_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl PollerState {
+    /// Stop the poller task, giving it up to 3 seconds to shut down cleanly.
+    pub async fn stop(&self) {
+        let _ = self.shutdown_tx.send(true);
+        if let Some(handle) = self.task_handle.lock().await.take() {
+            match tokio::time::timeout(Duration::from_secs(3), handle).await {
+                Ok(_) => info!("Fleet-policy poller stopped gracefully"),
+                Err(_) => {
+                    warn!("Fleet-policy poller did not stop in 3s; shutdown signal sent, moving on")
+                }
+            }
+        }
+    }
+}
+
+/// Spawn the poller task. Returns the state handle so the caller can stop it.
+pub fn start_poller(api_state: Arc<ApiState>) -> Arc<PollerState> {
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    // SUPERVISOR. Same rationale as `device_jwt_refresher::start_refresher`:
+    // `poller_loop` is long-lived and should only RETURN on shutdown. A bare
+    // panic would PERMANENTLY freeze the cached mode at its last value (which,
+    // worse, could be a stale `gate` after the operator turned the policy off
+    // — leaving every terminal blocking installs). Supervise it so a
+    // panic/wedge self-heals instead of requiring a runner restart.
+    let shutdown_rx_loop = shutdown_rx.clone();
+    let task_handle = crate::mcp::task_supervisor::spawn_supervised(
+        "Fleet-policy poller",
+        shutdown_rx,
+        move || poller_loop(api_state.clone(), shutdown_rx_loop.clone()),
+    );
+
+    Arc::new(PollerState {
+        shutdown_tx,
+        task_handle: Mutex::new(Some(task_handle)),
+    })
+}
+
+/// Outcome of a single poll attempt. Factored out so the loop's logging stays
+/// edge-triggered (log only on a transition, never every tick).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum PollOutcome {
+    /// Coord returned 2xx with a level — cache updated to this value.
+    Updated(String),
+    /// No device JWT yet (unpaired) — poll skipped, cache untouched.
+    SkippedNoJwt,
+    /// Coord said 401 / 404 / auth-required — cache RESET to `off` (fail-safe).
+    ResetOff(u16),
+    /// Network / decode / other non-2xx error — LAST-GOOD value kept.
+    Kept(String),
+}
+
+async fn poller_loop(_api_state: Arc<ApiState>, mut shutdown_rx: watch::Receiver<bool>) {
+    info!(
+        "Fleet-policy poller started (domain={DOMAIN}, interval={}s, fail-safe default={DEFAULT_MODE})",
+        POLL_INTERVAL.as_secs()
+    );
+
+    // Edge-trigger degradation logs: remember the LAST outcome class we logged
+    // so a steady-state (e.g. repeated SkippedNoJwt while unpaired, or repeated
+    // network errors) emits exactly one line, not one per tick.
+    let mut last_logged: Option<PollOutcome> = None;
+
+    loop {
+        if *shutdown_rx.borrow() {
+            info!("Fleet-policy poller shutting down");
+            return;
+        }
+
+        let outcome = poll_once().await;
+
+        // Apply the cache effect.
+        match &outcome {
+            PollOutcome::Updated(level) => set_mode(level),
+            PollOutcome::ResetOff(_) => set_mode(DEFAULT_MODE),
+            // Skipped / Kept leave the cache as-is (last-good or default).
+            PollOutcome::SkippedNoJwt | PollOutcome::Kept(_) => {}
+        }
+
+        // Log only on a class change so we don't spam every 45s.
+        let changed = last_logged.as_ref() != Some(&outcome);
+        if changed {
+            match &outcome {
+                PollOutcome::Updated(level) => {
+                    info!("fleet_policy_poller: effective install-interception level = {level}");
+                }
+                PollOutcome::SkippedNoJwt => {
+                    info!(
+                        "fleet_policy_poller: no device JWT yet (unpaired) — skipping poll, \
+                         interception mode stays {DEFAULT_MODE}"
+                    );
+                }
+                PollOutcome::ResetOff(status) => {
+                    warn!(
+                        "fleet_policy_poller: coord returned {status} (auth/absent) — \
+                         resetting interception mode to {DEFAULT_MODE} (fail-safe, never gate)"
+                    );
+                }
+                PollOutcome::Kept(err) => {
+                    warn!(
+                        "fleet_policy_poller: poll failed ({err}) — keeping last-good \
+                         interception mode ({})",
+                        effective_install_intercept_mode()
+                    );
+                }
+            }
+            last_logged = Some(outcome);
+        }
+
+        // Sleep until the next tick, waking early on shutdown.
+        tokio::select! {
+            _ = shutdown_rx.changed() => {
+                info!("Fleet-policy poller shutting down");
+                return;
+            }
+            _ = tokio::time::sleep(POLL_INTERVAL) => {}
+        }
+    }
+}
+
+/// One poll against coord. Resolves the coord base the SAME way the
+/// install-effects producer does (`agent_worktrees::coord_http_base()`) and
+/// presents the device JWT from `AuthManager::get_access_token()` as the
+/// `Authorization: Bearer` — the exact accessor `backend_relay` uses
+/// (`backend_relay.rs:452`) to authenticate the device WS.
+///
+/// NET-NEW coord client (D4): the existing `device_jwt_refresher` talks to the
+/// WEB-BACKEND proxy, not coord, so we issue our own GET here.
+async fn poll_once() -> PollOutcome {
+    // Device JWT — same slot the relay reads as its Bearer (REPLACE-not-REVOKE
+    // lifecycle owned by the refresher). Empty ⇒ unpaired ⇒ skip quietly.
+    let device_jwt = match crate::auth::AuthManager::new().get_access_token() {
+        Ok(t) if !t.trim().is_empty() => t.trim().to_string(),
+        _ => return PollOutcome::SkippedNoJwt,
+    };
+
+    // coord base — identical source-of-truth chain to the producer's
+    // `coord_base()` (env COORD_HTTP_URL → profile coord_url → default).
+    let base = match crate::mcp::agent_worktrees::coord_http_base() {
+        Ok(b) => b,
+        Err(e) => return PollOutcome::Kept(format!("coord base unresolved: {e}")),
+    };
+    let url = format!(
+        "{}/coord/fleet-policy?domain={DOMAIN}",
+        base.trim_end_matches('/')
+    );
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return PollOutcome::Kept(format!("client build: {e}")),
+    };
+
+    let resp = match client.get(&url).bearer_auth(&device_jwt).send().await {
+        Ok(r) => r,
+        Err(e) => return PollOutcome::Kept(format!("request: {e}")),
+    };
+
+    let status = resp.status();
+    // Auth / absent ⇒ fail-safe reset to off (NEVER gate on a 401/404).
+    if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::NOT_FOUND {
+        return PollOutcome::ResetOff(status.as_u16());
+    }
+    if !status.is_success() {
+        return PollOutcome::Kept(format!("coord status {}", status.as_u16()));
+    }
+
+    let body: FleetPolicyResponse = match resp.json().await {
+        Ok(b) => b,
+        Err(e) => return PollOutcome::Kept(format!("decode: {e}")),
+    };
+
+    // `effective_level` absent / null ⇒ coord's documented "off when absent"
+    // contract — treat as off (cache update, not an error).
+    let level = body
+        .effective_level
+        .map(|s| s.trim().to_ascii_lowercase())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| DEFAULT_MODE.to_string());
+
+    // Normalize anything unexpected to off (fail-safe: never honor a level we
+    // don't recognize as a gate trigger).
+    let level = match level.as_str() {
+        "off" | "observe" | "gate" => level,
+        _ => DEFAULT_MODE.to_string(),
+    };
+
+    PollOutcome::Updated(level)
+}
+
+// ===========================================================================
+// Boot entry — mirrors device_jwt_refresher::commands
+// ===========================================================================
+
+/// Global state holder + public boot surface. Same shape as
+/// `device_jwt_refresher::commands` so the `mcp_api` call sites read alike.
+pub mod commands {
+    use super::*;
+
+    static POLLER_STATE: OnceLock<tokio::sync::Mutex<Option<Arc<PollerState>>>> = OnceLock::new();
+
+    fn get_holder() -> &'static tokio::sync::Mutex<Option<Arc<PollerState>>> {
+        POLLER_STATE.get_or_init(|| tokio::sync::Mutex::new(None))
+    }
+
+    /// Idempotent start. If a live task already exists, no-op (the poller has
+    /// no kick — it's a fixed-cadence pull). If the prior task ended, restart.
+    /// Wired beside `auto_start_device_jwt_refresher` in `mcp_api::start_server`
+    /// — runs ONCE per runner (device-scoped), supervised, regardless of agents.
+    pub async fn auto_start_fleet_policy_poller(api_state: Arc<ApiState>) {
+        let mut guard = get_holder().lock().await;
+
+        if let Some(ref existing) = *guard {
+            let handle_guard = existing.task_handle.lock().await;
+            let is_alive = handle_guard.as_ref().is_some_and(|h| !h.is_finished());
+            drop(handle_guard);
+            if is_alive {
+                info!("Fleet-policy poller already running; leaving it");
+                return;
+            }
+            info!("Fleet-policy poller task has ended, restarting...");
+            existing.stop().await;
+            *guard = None;
+        }
+
+        info!("Starting fleet-policy poller");
+        let state = start_poller(api_state);
+        *guard = Some(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_mode_constant_is_off() {
+        // The fail-safe contract pin: the cache's resting/initial value is `off`
+        // (NEVER gate before a successful poll). We assert the CONSTANT only —
+        // NOT a live read of the shared process-global cache, which other
+        // modules' tests legitimately mutate via `set_mode_for_test` and which
+        // would race under cargo's parallel test threads.
+        assert_eq!(DEFAULT_MODE, "off");
+    }
+
+    #[test]
+    fn fresh_oncelock_initializes_to_off() {
+        // Exercise the OnceLock init closure directly (a private throwaway lock,
+        // not the shared global) so this is race-free: the cache MUST initialize
+        // to the fail-safe default.
+        let fresh = RwLock::new(DEFAULT_MODE.to_string());
+        assert_eq!(*fresh.read().unwrap(), "off");
+    }
+
+    #[test]
+    fn poll_interval_is_in_30_to_60s_window() {
+        // Pin the cadence to the plan's window so a future "tune" has to update
+        // this test and justify it in review.
+        let s = POLL_INTERVAL.as_secs();
+        assert!(
+            (30..=60).contains(&s),
+            "poll interval {s}s out of 30-60s window"
+        );
+    }
+
+    #[test]
+    fn unknown_level_is_normalized_off_via_response_shape() {
+        // The decode + normalize path collapses an unrecognized level to off.
+        // We exercise the pure normalization the loop relies on.
+        let normalize = |raw: Option<&str>| -> String {
+            let level = raw
+                .map(|s| s.trim().to_ascii_lowercase())
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| DEFAULT_MODE.to_string());
+            match level.as_str() {
+                "off" | "observe" | "gate" => level,
+                _ => DEFAULT_MODE.to_string(),
+            }
+        };
+        assert_eq!(normalize(Some("GATE")), "gate");
+        assert_eq!(normalize(Some(" observe ")), "observe");
+        assert_eq!(normalize(Some("bogus")), DEFAULT_MODE);
+        assert_eq!(normalize(None), DEFAULT_MODE);
+        assert_eq!(normalize(Some("")), DEFAULT_MODE);
+    }
+}

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -64,6 +64,7 @@ pub mod extraction;
 pub mod file_browser;
 pub mod file_registry;
 pub mod findings_api;
+pub mod fleet_policy_poller;
 pub mod generation_rules_api;
 pub mod generator_eval;
 pub mod git_supervision_api;

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1117,6 +1117,23 @@ pub fn create_router(
         });
     }
 
+    // Auto-start the fleet-policy poller (P3 of the fleet-policy channel
+    // redesign). Device-scoped: it polls coord's effective
+    // `install_interception` level every ~45s and caches it for the
+    // interception pre-call to make the per-install mode dynamic (P4). It
+    // no-ops quietly while unpaired (no device JWT) and fails safe to `off`
+    // before its first success, so spawning unconditionally is harmless.
+    {
+        let poller_api_state = api_state.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            crate::mcp::fleet_policy_poller::commands::auto_start_fleet_policy_poller(
+                poller_api_state,
+            )
+            .await;
+        });
+    }
+
     // Sync workflows from web backend on startup (background task)
     {
         let sync_pg_db = api_state.app_state.pg_db.clone();


### PR DESCRIPTION
## What (P3 + P4 of the fleet-policy channel)
Runner side of coord-served fleet policy: a device-scoped poller that caches the effective `install_interception` mode, and dynamic per-install mode so an operator's policy flip reaches **already-running** terminals.

## P3 — poller + cache
- `mcp/fleet_policy_poller.rs`: net-new coord client `GET /coord/fleet-policy?domain=install_interception` with the **device-JWT** Bearer (`AuthManager::get_access_token()`), coord base via `agent_worktrees::coord_http_base()` — the same source-of-truth the producer uses. Supervised loop beside `device_jwt_refresher` (45s), auto-started once per runner.
- Process-global cache (`OnceLock<RwLock<String>>`), sync accessor `effective_install_intercept_mode()`.
- **Fail-safe (D7):** default `off` (never gate) before first poll; last-good on error; reset `off` on 401/404; skip-quiet when unpaired; edge-triggered logs.

## P4 — dynamic mode
- `RunResponse.effective_mode` (additive, serde-default). `run_with_base` reads the cache: `mode==off` short-circuits the intercept pre-call (skip declare/predict, nil `correlation_id` ⇒ the shim's existing guard skips the post-call). `observe`/`gate` proceed and set `effective_mode`.
- `shim.bash` + `qontinui_shim.rs` parse `effective_mode` from the pre-call response and use it in the block decision, **defaulting to env `MODE` when absent** (back-compat with old coord/runner). The seam still gates *materialization* at spawn on the enabled flag; dynamic mode governs already-injected terminals → a flip reaches running sessions on their next install.

## Verified (coordinator-driven build)
`cargo check` clean (16m); **35 tests pass** (4 poller + 23 intercept incl. the off short-circuit + 8 shim-bin); clippy clean; pre-push fmt+clippy passed.

## Depends-on / follow-up
- Consumes coord `GET /coord/fleet-policy` (coord #483, merged) + `coord.fleet_runtime_policy` (web #547, merged). Ships dark (materialization still env-gated). Live E2E (flag-on temp runner → prod coord → PUT policy → confirm dynamic mode on a running terminal) to follow post-merge, like #21.

Design: `plans/2026-06-08-fleet-policy-channel-redesign.md` §4 / §0a (P3+P4).