### PR TITLE
fix(terminal): trim dead-pane scrollback to release WebView2 memory

### DIFF
--- a/OOM_STRESS_TEST.md
+++ b/OOM_STRESS_TEST.md
@@ -134,6 +134,23 @@ FROM generate_series(1, 5000) AS i;
    - No "Out of Memory" crash
    - All pages remain responsive
 
+### Test 8: Dead-pane scrollback trim (the always-on leak)
+This guards the regression behind the most common "Error code: out of memory"
+crash during normal multi-session use: finished terminal panes stay mounted
+(only an explicit close disposes the backend) and each retains ~20MB of xterm
+cell storage at the live `scrollback: 10000` cap, so they accumulate until the
+renderer dies. On process exit `TerminalInstance` now trims the pane to
+`DEAD_TERMINAL_SCROLLBACK` (2000 lines).
+1. Open a terminal, run a command that emits >10K lines (e.g. `seq 1 200000`),
+   let it fill the scrollback, then let the shell process exit (`exit`).
+2. Take a heap snapshot before and after the exit message appears.
+3. **PASS criteria:**
+   - After exit, the pane's retained buffer drops to ~2000 lines worth of cells
+     (DevTools → Memory shows the large xterm buffer arrays shrink).
+   - The tail of the output is still scrollable/readable in the dead pane.
+   - Spawning + exiting many panes over a long session does NOT monotonically
+     grow WebView2 memory the way it did pre-fix.
+
 ## Failure Diagnosis
 
 If OOM occurs:

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -128,6 +128,21 @@ const TERMINAL_OPTIONS = {
   },
 };
 
+/**
+ * Scrollback cap applied once a terminal's process has exited.
+ *
+ * A dead pane never produces more output, but it stays mounted (often
+ * indefinitely — see `useTerminalManager.closeTerminal`, the only path that
+ * disposes the backend) so the operator can still read its result. At the live
+ * `scrollback: 10000` cap each xterm buffer retains ~20MB of cell storage, and
+ * under a heavy multi-session workload these finished panes accumulate until
+ * the WebView2 renderer hits its memory ceiling and crashes with
+ * "Error code: out of memory". Trimming the buffer to its tail on exit releases
+ * the bulk of that storage while keeping the recent output readable (the full
+ * scrollback is persisted Rust-side for session restore regardless).
+ */
+const DEAD_TERMINAL_SCROLLBACK = 2000;
+
 export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInstanceProps>(
   function TerminalInstanceInner(
     {
@@ -894,6 +909,11 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
           backend.write(
             `\r\n\x1b[90m[Process exited with code ${event.payload.exitCode ?? "unknown"}]\x1b[0m\r\n`,
           );
+          // Release the memory held by this now-dead pane. It will never emit
+          // more output, so trim its scrollback to the tail — this is the
+          // accumulator behind the WebView2 "out of memory" crash when many
+          // finished sessions stay mounted. See DEAD_TERMINAL_SCROLLBACK.
+          backend.setScrollback(DEAD_TERMINAL_SCROLLBACK);
           onExitRef.current?.(event.payload.exitCode ?? null);
         });
         if (disposed) return;

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -108,6 +108,12 @@ export class GhosttyBackend implements ITerminalBackend {
     return this.term.buffer.active.length;
   }
 
+  setScrollback(lines: number): void {
+    // GhosttyBackend wraps an xterm Terminal too, so the same in-place trim
+    // applies (see XtermBackend.setScrollback).
+    this.term.options.scrollback = lines;
+  }
+
   fit(): void {
     this.fitAddon.fit();
   }

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -153,6 +153,12 @@ export class XtermBackend implements ITerminalBackend {
     return this.term.buffer.active.length;
   }
 
+  setScrollback(lines: number): void {
+    // xterm trims the active buffer to the new cap on assignment when it is
+    // lowered, so this frees the dead pane's retained cell storage in place.
+    this.term.options.scrollback = lines;
+  }
+
   fit(): void {
     this.fitAddon.fit();
   }

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -145,6 +145,14 @@ export interface ITerminalBackend {
   getBufferLine(line: number): string | null;
   /** Total number of lines in the active buffer (scrollback + viewport). */
   getBufferLength(): number;
+  /**
+   * Set the maximum scrollback line count, trimming the existing buffer down
+   * to the new cap immediately when it is lowered. Used to release memory held
+   * by a terminal whose process has exited — a dead pane never produces more
+   * output, so only its tail is worth keeping resident. Backends without
+   * runtime scrollback control may no-op.
+   */
+  setScrollback(lines: number): void;
 
   // -- Layout ---------------------------------------------------------------
   /** Fit the terminal to its container. */


### PR DESCRIPTION
## Symptom
The runner shows the Chromium **"Error code: out of memory"** page during normal multi-session use; clicking its **Reload** button reboots the web app cold, and since the auth session lived in the crashed renderer's memory, you land on the **sign-in screen**. The OOM → reload → sign-in chain is one bug (a WebView2 renderer crash), not three.

## Root cause
Earlier work paginated the large data viewers, and most frontend buffers are capped. The remaining always-on accumulator is **finished terminal panes**:

- Terminal tabs (incl. hidden ones) stay mounted; the only thing that disposes a backend is an **explicit user close** (`useTerminalManager.closeTerminal`).
- A process **exit** only flags the tab `isAlive:false` (`TerminalPage.tsx`) — the pane stays mounted so its output is still readable.
- At the live `scrollback: 10000` cap, each xterm buffer retains **~20MB** of cell storage.

Under a heavy workload (many concurrent sessions + gate-continuation panes spawned throughout the day), these dead-but-mounted panes accumulate until the renderer hits its memory ceiling and crashes. That's why it feels frequent/random rather than tied to one action.

## Fix
A dead pane never produces more output, so on `terminal-exit` we trim its scrollback to `DEAD_TERMINAL_SCROLLBACK` (2000 lines). xterm trims the buffer **in place** when the cap is lowered, releasing the bulk of the retained storage while keeping the tail readable.

- Live panes keep the full 10000-line history (no UX regression for active work).
- The durable Rust-side scrollback used for session restore is unaffected.

### Changes
- `backends/types.ts`: add `ITerminalBackend.setScrollback(lines)`.
- `XtermBackend` / `GhosttyBackend`: implement it (`term.options.scrollback = lines`).
- `TerminalInstance.tsx`: call `setScrollback(DEAD_TERMINAL_SCROLLBACK)` in the exit handler.
- `OOM_STRESS_TEST.md`: add Test 8 to guard the regression.

## Verification
- `tsc --noEmit` clean
- eslint + prettier clean on changed files
- `vitest run src/components/terminal` → **507 passed**

Manual heap-snapshot verification (Test 8 in `OOM_STRESS_TEST.md`) requires a runner rebuild + supervisor restart.