### PR TITLE
fix(ai-provider): cold-start account pick skips known-exhausted accounts

### DIFF
--- a/src-tauri/src/ai_provider/account_usage.rs
+++ b/src-tauri/src/ai_provider/account_usage.rs
@@ -17,9 +17,11 @@
 //! 1. Among non-cooled accounts with a fresh usage sample, the best by
 //!    `(exhausted, headroom)` ascending: a usable account beats an exhausted
 //!    one, then most-under-projection wins within a tier.
-//! 2. If no non-cooled account has a fresh sample, the first non-cooled
-//!    account (legacy cooldown-only behaviour — preserved for cold start and
-//!    for the single-account case, where the one account is simply pinned).
+//! 2. If no non-cooled account has a fresh sample (cold start / stale
+//!    snapshot), the first non-cooled account that is not *known-exhausted*
+//!    (per the last sample, with a longer staleness tolerance); if every
+//!    available account is known-exhausted, the first non-cooled. The
+//!    single-account case resolves here — the one account is simply pinned.
 //! 3. If every account is cooled, the one with the **shortest remaining
 //!    cooldown** (closest to expiry).
 //!
@@ -76,6 +78,7 @@ pub fn pick_best_account() {
         &config_dirs,
         |d| super::config::is_account_cooled_down(d),
         |d| super::config::usage_rank(d),
+        |d| super::config::account_known_exhausted(d),
         |d| super::config::time_until_cooled_down(d),
     );
 
@@ -91,13 +94,17 @@ pub fn pick_best_account() {
 /// Pure selection core, parameterised over the cooldown/usage/expiry lookups
 /// so it can be unit-tested without the global settings + state singletons.
 ///
-/// `is_cooled` / `usage` / `remaining` mirror the `super::config` helpers.
-/// `usage` returns `(exhausted, headroom)` for accounts with a fresh sample.
-/// Returns the chosen config dir, or `None` only when `config_dirs` is empty.
+/// `is_cooled` / `usage` / `known_exhausted` / `remaining` mirror the
+/// `super::config` helpers. `usage` returns `(exhausted, headroom)` for
+/// accounts with a *fresh* sample; `known_exhausted` reports the last-seen
+/// exhaustion with a longer staleness tolerance, used only by the cold-start
+/// fallback. Returns the chosen config dir, or `None` only when `config_dirs`
+/// is empty.
 fn pick_from<'a>(
     config_dirs: &'a [String],
     is_cooled: impl Fn(&str) -> bool,
     usage: impl Fn(&str) -> Option<(bool, f64)>,
+    known_exhausted: impl Fn(&str) -> bool,
     remaining: impl Fn(&str) -> Option<Duration>,
 ) -> Option<String> {
     let available: Vec<&'a String> = config_dirs.iter().filter(|d| !is_cooled(d)).collect();
@@ -106,9 +113,7 @@ fn pick_from<'a>(
         // Among available accounts that have a fresh usage sample, pick the
         // best by `(exhausted, headroom)` ascending: a usable account always
         // beats an exhausted one (out of tokens / rejected) regardless of
-        // headroom, and within a tier the most-under-projection wins. If no
-        // available account has a fresh sample, fall back to the first
-        // available (legacy cooldown-only pick / cold start).
+        // headroom, and within a tier the most-under-projection wins.
         let best = available
             .iter()
             .filter_map(|d| usage(d).map(|rank| (*d, rank)))
@@ -121,7 +126,20 @@ fn pick_from<'a>(
                 )
             })
             .map(|(d, _)| d.clone());
-        return best.or_else(|| available.first().map(|d| (*d).clone()));
+        return best
+            // Cold start / stale snapshot (no fresh ranks): prefer the first
+            // available account NOT known-exhausted, so we don't pin a
+            // recently-maxed-out account just because it isn't in cooldown
+            // (the usage probe's 429 doesn't set an inference cooldown).
+            .or_else(|| {
+                available
+                    .iter()
+                    .find(|d| !known_exhausted(d))
+                    .map(|d| (*d).clone())
+            })
+            // Everything available is known-exhausted (or unknown): fall back
+            // to the first available so we always return something.
+            .or_else(|| available.first().map(|d| (*d).clone()));
     }
 
     // All cooled: pick the one with the shortest remaining cooldown.
@@ -259,6 +277,7 @@ mod tests {
                 "/c" => Some((false, 0.05)),
                 _ => None,
             },
+            |_| false,
             |_| None,
         );
         assert_eq!(chosen.as_deref(), Some("/b"));
@@ -278,6 +297,7 @@ mod tests {
                 "/usable" => Some((false, 0.20)), // usable, worse headroom
                 _ => None,
             },
+            |_| false,
             |_| None,
         );
         assert_eq!(chosen.as_deref(), Some("/usable"));
@@ -295,6 +315,7 @@ mod tests {
                 "/b" => Some((true, 0.10)),
                 _ => None,
             },
+            |_| false,
             |_| None,
         );
         assert_eq!(chosen.as_deref(), Some("/b"));
@@ -312,6 +333,7 @@ mod tests {
                 "/b" => Some((false, 0.20)),
                 _ => None,
             },
+            |_| false,
             |_| None,
         );
         assert_eq!(chosen.as_deref(), Some("/b"));
@@ -322,8 +344,34 @@ mod tests {
         let d = dirs(&["/a", "/b", "/c"]);
         // No fresh samples → legacy "first non-cooled" behaviour. /a is cooled,
         // so /b (first available) wins.
-        let chosen = pick_from(&d, |x| x == "/a", |_| None, |_| None);
+        let chosen = pick_from(&d, |x| x == "/a", |_| None, |_| false, |_| None);
         assert_eq!(chosen.as_deref(), Some("/b"));
+    }
+
+    #[test]
+    fn stale_fallback_skips_known_exhausted() {
+        let d = dirs(&["/gmail", "/hotmail", "/paktis"]);
+        // Stale snapshot: no fresh ranks. /gmail is known-exhausted and NOT
+        // cooled (the usage probe's 429 doesn't set an inference cooldown), so
+        // the cold-start fallback must skip it and take the first non-exhausted
+        // available account.
+        let chosen = pick_from(
+            &d,
+            |_| false,         // none cooled
+            |_| None,          // no fresh usage sample (stale)
+            |x| x == "/gmail", // gmail last seen exhausted
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/hotmail"));
+    }
+
+    #[test]
+    fn stale_fallback_all_known_exhausted_returns_first() {
+        let d = dirs(&["/a", "/b"]);
+        // Stale snapshot and every available account known-exhausted → still
+        // return something (first available) rather than nothing.
+        let chosen = pick_from(&d, |_| false, |_| None, |_| true, |_| None);
+        assert_eq!(chosen.as_deref(), Some("/a"));
     }
 
     #[test]
@@ -335,6 +383,7 @@ mod tests {
             &d,
             |_| false,
             |x| if x == "/b" { Some((false, 0.40)) } else { None },
+            |_| false,
             |_| None,
         );
         assert_eq!(chosen.as_deref(), Some("/b"));
@@ -345,7 +394,7 @@ mod tests {
         // One configured account, no usage sample, not cooled → it is selected
         // (the single-account case must resolve, not no-op).
         let d = dirs(&["/only"]);
-        let chosen = pick_from(&d, |_| false, |_| None, |_| None);
+        let chosen = pick_from(&d, |_| false, |_| None, |_| false, |_| None);
         assert_eq!(chosen.as_deref(), Some("/only"));
     }
 
@@ -353,7 +402,7 @@ mod tests {
     fn single_exhausted_account_still_pinned() {
         // One account, exhausted → still the only option, so still selected.
         let d = dirs(&["/only"]);
-        let chosen = pick_from(&d, |_| false, |_| Some((true, 1.0)), |_| None);
+        let chosen = pick_from(&d, |_| false, |_| Some((true, 1.0)), |_| true, |_| None);
         assert_eq!(chosen.as_deref(), Some("/only"));
     }
 
@@ -364,6 +413,7 @@ mod tests {
             &d,
             |_| true, // all cooled
             |_| None,
+            |_| false,
             |x| match x {
                 "/a" => Some(Duration::from_secs(600)),
                 "/b" => Some(Duration::from_secs(30)),
@@ -376,7 +426,7 @@ mod tests {
     #[test]
     fn empty_config_dirs_returns_none() {
         let d: Vec<String> = Vec::new();
-        let chosen = pick_from(&d, |_| false, |_| None, |_| None);
+        let chosen = pick_from(&d, |_| false, |_| None, |_| false, |_| None);
         assert_eq!(chosen, None);
     }
 }

--- a/src-tauri/src/ai_provider/config.rs
+++ b/src-tauri/src/ai_provider/config.rs
@@ -60,6 +60,13 @@ static USAGE_SNAPSHOT: Mutex<Option<HashMap<String, UsageSample>>> = Mutex::new(
 /// minutes — comfortably longer than the startup refresh cadence.
 const USAGE_SNAPSHOT_TTL: Duration = Duration::from_secs(15 * 60);
 
+/// Maximum age at which a sample's `exhausted` flag is still trusted by
+/// [`account_known_exhausted`]. Longer than [`USAGE_SNAPSHOT_TTL`] because
+/// exhaustion is a slow-changing signal — a weekly cap doesn't clear in
+/// minutes — so the cold-start/stale fallback can still avoid an account we
+/// saw maxed out a little while ago, without acting on hours-old data.
+const EXHAUSTION_STALE_TTL: Duration = Duration::from_secs(60 * 60);
+
 /// Set the resolved config directory (called after usage check).
 pub fn set_resolved_config_dir(dir: Option<String>) {
     if let Ok(mut cached) = RESOLVED_CONFIG_DIR.lock() {
@@ -201,6 +208,24 @@ pub fn usage_rank(config_dir: &str) -> Option<(bool, f64)> {
         sample.exhausted,
         sample.usage_delta.unwrap_or(sample.utilization),
     ))
+}
+
+/// Whether an account was last seen **exhausted** (out of tokens / rejected),
+/// tolerating a longer staleness than [`usage_rank`] (see
+/// [`EXHAUSTION_STALE_TTL`]). Used only by the cold-start / stale-snapshot
+/// fallback in `pick_best_account` to skip an account we recently saw maxed
+/// out but that isn't in a rate-limit cooldown (the usage probe's 429 doesn't
+/// set an inference cooldown). Returns `false` when there is no sample, the
+/// sample is older than the exhaustion staleness window, or it was usable.
+pub fn account_known_exhausted(config_dir: &str) -> bool {
+    if let Ok(snap) = USAGE_SNAPSHOT.lock() {
+        if let Some(map) = snap.as_ref() {
+            if let Some(sample) = map.get(config_dir) {
+                return sample.exhausted && sample.captured_at.elapsed() <= EXHAUSTION_STALE_TTL;
+            }
+        }
+    }
+    false
 }
 
 /// Rotate to the next available account after a rate-limit hit.
@@ -529,6 +554,18 @@ mod tests {
     #[test]
     fn usage_rank_none_when_unrecorded() {
         assert_eq!(usage_rank("/test/config/headroom_never"), None);
+    }
+
+    #[test]
+    fn account_known_exhausted_reflects_last_sample() {
+        let dir_ex = "/test/config/known_exhausted";
+        let dir_ok = "/test/config/known_usable";
+        record_account_usage(&[(dir_ex.to_string(), 1.0, Some(0.1), true)]);
+        record_account_usage(&[(dir_ok.to_string(), 0.5, Some(-0.1), false)]);
+        assert!(account_known_exhausted(dir_ex), "exhausted sample → true");
+        assert!(!account_known_exhausted(dir_ok), "usable sample → false");
+        // Unrecorded account is treated as not-known-exhausted (eligible).
+        assert!(!account_known_exhausted("/test/config/known_never"));
     }
 
     #[test]


### PR DESCRIPTION
Closes the cold-start gap spotted while verifying #520 live: after flipping the runner to least-usage, the picker briefly resolved the **exhausted** `.claude-gmail` (~3s) before settling on a usable account.

## Cause
`pick_from`'s stale-snapshot / cold-start fallback chose "first available" = first **non-cooled** config dir. But the usage probe's 429 doesn't set an inference *cooldown*, so a maxed-out account (100% / rejected) that happens to be first in the list isn't excluded — it gets pinned until the next 10-min snapshot refresh.

## Fix
Give the fallback a **stale-tolerant exhaustion** signal (exhaustion is slow-changing — a weekly cap doesn't clear in minutes, unlike the precise headroom delta):
- **`config.rs`** — `account_known_exhausted(dir)`: returns the last sample's `exhausted` flag if it's within `EXHAUSTION_STALE_TTL` (1h, vs the 15-min `USAGE_SNAPSHOT_TTL`); hours-old data is ignored.
- **`account_usage.rs`** — `pick_from` gains a `known_exhausted` closure. Fallback chain is now:
  1. best by fresh `(exhausted, headroom)` rank, else
  2. first available **not** known-exhausted (cold start / stale), else
  3. first available (all known-exhausted → still return something).

## Tests
- `stale_fallback_skips_known_exhausted` — stale snapshot, gmail known-exhausted-not-cooled → picks the next usable account.
- `stale_fallback_all_known_exhausted_returns_first` — all exhausted → still returns first available.
- `account_known_exhausted_reflects_last_sample`.
- All 10 existing `pick_from` call sites updated for the new closure.

## Verification
- `cargo check --lib --tests` ✅ (worktree); rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)