### PR TITLE
fix(runner): disable continuous browser-capture modules (OOM root cause)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -950,8 +950,36 @@ export default function App() {
       <UIBridgeProvider
         features={{ renderLog: true, control: true, debug: true }}
         browserCaptureConfig={{
+          // Capture errors/warnings only. The runner's error-monitor consumes
+          // console errors, resource errors, WS disconnects, and React error
+          // overlays — all event-driven and rare.
+          //
+          // CRITICAL: the continuous performance/telemetry capture modules
+          // (`network`, `navigation`, `longTasks`, `longAnimationFrames`,
+          // `webVitals`, `memory`, `domMetrics`) default to ON in the SDK's
+          // DEFAULT_CAPTURE_CONFIG, so this object — which previously only set
+          // `console` — silently enabled all of them. `network` monkey-patches
+          // `fetch`/XHR and tracks every request; on the runner that includes
+          // the long-lived SSE stream and the 3s/10s background polls, whose
+          // response data accumulates unboundedly → the WebView2 renderer grew
+          // ~84MB/min while idle and crashed with "Out of memory" in under an
+          // hour (verified via live A/B: capture ON → +84MB/min, OFF → flat).
+          // Disable every continuous module explicitly; keep only the rare,
+          // event-driven error captures the error-monitor actually needs.
           console: true,
-          consoleLevels: ["error", "warn", "debug", "info", "log"],
+          consoleLevels: ["error", "warn"],
+          network: false,
+          navigation: false,
+          longTasks: false,
+          longAnimationFrames: false,
+          webVitals: false,
+          memory: false,
+          domMetrics: false,
+          freezeDetector: false,
+          hmr: false,
+          resourceErrors: true,
+          wsDisconnections: true,
+          frameworkOverlays: true,
         }}
       >
         <UIBridgeEventHandler />


### PR DESCRIPTION
## Symptom
The runner's WebView2 renderer crashes with **"Error code: out of memory"** during normal use, then reloads to the **sign-in screen** (the renderer crash wipes the in-memory auth session).

## Root cause — confirmed via live A/B on the running runner
With the UI Bridge **browser-capture** layer installed, the renderer's memory climbs **~84MB/min while completely idle** (zero terminals, zero user interaction). With it uninstalled, memory is **flat**:

| Condition | Renderer working set |
|---|---|
| capture **OFF** + idle | flat ~4700MB (even declining) |
| capture **ON** + idle | climbing ~84MB/min (4225 → 4562MB over 4 min) |

At ~84MB/min it exhausts the renderer in under an hour — matching the observed crash cadence. ~4GB of the crashed renderer's footprint was **non-JS-heap** (ArrayBuffers/Blobs), consistent with buffered HTTP/stream response bodies, not React objects.

### Mechanism
`App.tsx`'s `browserCaptureConfig` only set `console`, but the SDK's `DEFAULT_CAPTURE_CONFIG` defaults `network`, `navigation`, `longTasks`, `longAnimationFrames` (and more) to **ON**, so the config merge silently enabled all of them. `network` monkey-patches `fetch`/XHR and tracks every request — including the **long-lived SSE stream** and the **3s/10s background polls** — whose response data accumulates unboundedly.

## Fix
Explicitly disable every continuous performance/telemetry capture module; keep only the rare, **event-driven** error captures the runner's error-monitor needs (`console` error/warn, `resourceErrors`, `wsDisconnections`, `frameworkOverlays`). None of the retained modules fire continuously, so none can leak.

## Verification
- `tsc --noEmit` clean; eslint + prettier clean.
- Live A/B (above) proves capture is the driver and disabling it flattens memory.

## Notes
- This is the **dominant** cause. The earlier dead-pane scrollback trim (#523) addressed a separate, secondary terminal-scrollback accumulator.
- **Follow-up (separate, upstream):** the SDK network tracker buffering an infinite SSE response body looks like a real bug — worth fixing in `@qontinui/ui-bridge` so the heavy modules don't leak when a consumer genuinely wants them.

Requires merge + manual supervisor rebuild to deploy.