### PR TITLE
feat(terminal): provision coord-mcp on operator-opened terminal tabs (#527)

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -2433,7 +2433,12 @@ fn write_coord_mcp_config(primary_wt: &str, jwt: &str) {
 ///    checkout (worktree mode off / acquire declined), which may already hold
 ///    the operator's own `.mcp.json`. Overwrite only when the file is absent or
 ///    is solely our `coord-mcp` config (see [`coord_mcp_safe_to_write`]).
-fn provision_coord_mcp_for_session(workdir: &str) {
+// `pub(crate)` so the operator-opened-tab entry point
+// (`commands::terminal::terminal_create`) reuses this exact helper — closing the
+// last dark runner-spawned session kind (plan
+// 2026-06-09-provision-coord-mcp-operator-tabs). Both modules compile into the
+// runner bin crate, so `pub(crate)` is the minimal visibility that reaches it.
+pub(crate) fn provision_coord_mcp_for_session(workdir: &str) {
     let jwt = match crate::auth::AuthManager::new().get_access_token() {
         Ok(t) if !t.trim().is_empty() => t,
         _ => {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -112,6 +112,21 @@ pub async fn terminal_create(
     )
     .await;
 
+    // Provision `.mcp.json` so this operator-opened terminal tab can reach coord
+    // coordination tools (`coord_register_gate` over /mcp) and
+    // `coord-acting-bearer.sh` for the operator-scoped write surface — the same
+    // device-JWT path #526 wired into gate continuations, now closing the last
+    // dark runner-spawned session kind (operator tabs). Targets the POST-acquire
+    // `working_dir` (the PTY cwd): worktree-mode-on → a fresh isolated dir,
+    // -off → the operator's real cwd. `working_dir` is `Option`; when `None` the
+    // PTY inherits the runner's ambient cwd, which we deliberately do NOT
+    // provision into. The helper's sub_type + non-clobber guards make this safe
+    // even when the tab opened in a checkout that already holds the operator's
+    // own `.mcp.json` (left untouched). Mirrors the continuation call site.
+    if let Some(ref wd) = working_dir {
+        crate::agent_runtime::provision_coord_mcp_for_session(wd);
+    }
+
     let repo_detect_handle = app_handle.clone();
     let repo_detect_dir = working_dir.clone();
     let cred_helper_dir = working_dir.clone();


### PR DESCRIPTION
Closes #527. Fast-follow to #526.

**Stacked on #526** (`feat/provision-coord-mcp-all-sessions`) — the device-JWT helper this PR calls lives only there, not yet on main. Base auto-retargets to main when #526 merges.

## What
`terminal_create` (the operator-opened terminal-tab path) now calls #526's `provision_coord_mcp_for_session` on the post-acquire `working_dir`, so operator tabs get a coord identity (`.mcp.json`) instead of falling back to the operator-bearer stopgap. This closes the last dark runner-spawned session kind.

## Changes
- `agent_runtime.rs`: promote `provision_coord_mcp_for_session` `fn` → `pub(crate)` (mirrors the `notify_continuation_terminal_exit` cross-module pattern). Pure visibility change.
- `commands/terminal.rs`: guarded call `if let Some(ref wd) = working_dir { provision_coord_mcp_for_session(wd) }` right after `acquire_for_terminal`. `None` (tab with no dir → runner's ambient cwd) is deliberately not provisioned.

## Safety
The helper's existing `sub_type` (device/agent JWT only) + non-clobber (`coord_mcp_safe_to_write`) guards make this safe even when the tab opened in a checkout holding the operator's own `.mcp.json` — left untouched. Covered by the existing `coord_mcp_safe_to_write_guards_user_config` test (all 5 cases).

## Verify
Compile + CI; manual smoke on a temp runner / next primary rebuild: clean dir → `.mcp.json` with `sub_type=device` bearer appears; dir with foreign `.mcp.json` → untouched.

Plan: `2026-06-09-provision-coord-mcp-operator-tabs`.