### PR TITLE
fix(runner): startup resilience + async-observe + coord capability gate (§8/§6/§5)

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -222,10 +222,19 @@ fn agent_log_path(agent_id: uuid::Uuid) -> Option<PathBuf> {
     agent_logs_root().map(|d| d.join(format!("{agent_id}.log")))
 }
 
-/// Resolve the coord HTTP base from the active profile (mirrors the
-/// resolver in `fleet.rs`). Returns `None` when no profile or no
-/// coord_url is configured — runtime no-ops in that case.
+/// Resolve the coord HTTP base. Honors the `COORD_HTTP_URL` env var FIRST
+/// (mirrors `mcp::agent_worktrees::coord_http_base`'s env check — every other
+/// resolver honors it, this one used to ignore it), then falls back to the
+/// active profile's `coord_url` (mirrors the resolver in `fleet.rs`). Returns
+/// `None` when neither is set — runtime no-ops in that case (no localhost
+/// fallback, unchanged).
 fn coord_http_base() -> Option<String> {
+    // env override first — the source-of-truth chain every other resolver uses.
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
     let coord_url = qontinui_runner_lib::profiles::load_strict()
         .ok()?
         .coord_url?;

--- a/src-tauri/src/install_effects_producer/mod.rs
+++ b/src-tauri/src/install_effects_producer/mod.rs
@@ -381,11 +381,209 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
         );
     }
 
+    // ---- ASYNC-OBSERVE fast-path (§6) ---------------------------------------
+    // In OBSERVE mode the shim NEVER blocks on the gate verdict — it always
+    // proceeds and runs the real install regardless of what we'd return. The
+    // expensive pre-call work (the ~13s npm `--dry-run`, the importer/sibling
+    // scans, and the two coord round-trips for `declare` + `predict-and-check`)
+    // therefore has no business sitting on the request the agent's shell is
+    // blocked on. So for `mode:intercept` + `effective_mode == "observe"` we:
+    //
+    //   1. capture pre-shas SYNCHRONOUSLY and FIRST (the pre-install
+    //      manifest/lockfile blob shas are NOT re-derivable once the install
+    //      mutates the lockfile — a cheap git blob-sha read, the one thing that
+    //      MUST happen before we hand control back to the shim),
+    //   2. stash a PreContext (pre-shas present; the predicted-pins / CVEs /
+    //      affected-files fields are filled in later by the deferred task),
+    //   3. RETURN the intercept response IMMEDIATELY (gate:proceed,
+    //      correlation_id present, effective_mode:"observe"), and
+    //   4. `tokio::spawn` the deferred work (dry-run + scans + declare +
+    //      predict-and-check) to BACKFILL/UPDATE the stashed PreContext.
+    //
+    // BEHAVIOR CHANGE (explicit §6 intent — "observe never blocks"): in observe
+    // mode `declare` is now BEST-EFFORT. On the synchronous gate path below it
+    // is `?`-load-bearing (a declare failure fails the pre-call); here a
+    // coord-down observe install instead PROCEEDS and records best-effort
+    // (declare/predict errors are logged, not surfaced). The matching post-call
+    // (`observe-verify`) already tolerates a missing/partial PreContext
+    // (mod.rs:210-231 degrades to an honest Partial), so the brief window where
+    // the spawned task hasn't yet re-`put` the enriched context is safe.
+    //
+    // GATE mode is UNCHANGED — it falls through to the synchronous path below
+    // because the shim blocks on the `gate` verdict (intercept/mod.rs), so
+    // dry-run + predict MUST complete before we return. OFF was already
+    // short-circuited above.
+    if req.mode == RunMode::Intercept && effective_mode == "observe" {
+        // (1) pre-shas — synchronous, FIRST, before any install can mutate the
+        // worktree. This is the only pre-call step that is irreversibly
+        // time-sensitive.
+        let pre_shas = observe::capture_pre_shas(pm, repo_path);
+
+        // (2) stash a PreContext now. predicted_pinned / predicted_cves /
+        // affected_files start EMPTY (honest) and are enriched by the deferred
+        // task's re-`put` below once declare-time data is available.
+        precontext::put(
+            correlation_id,
+            PreContext {
+                repo: repo.clone(),
+                repo_path: req.repo_path.clone(),
+                package_manager: pm,
+                escalation_overridden: false,
+                affected_files: Vec::new(),
+                predicted_pinned: std::collections::BTreeMap::new(),
+                predicted_cves: Vec::new(),
+                pre_shas: pre_shas.clone(),
+            },
+        );
+
+        // (4) spawn the deferred declare/predict work. It backfills the stashed
+        // PreContext (re-`put` under the SAME correlation_id, preserving the
+        // already-captured pre-shas) so a post-call that arrives after this
+        // completes sees the enriched signature; a post-call that races ahead
+        // still gets an honest Partial. Owned captures only — `cred_store` is a
+        // borrow, so registry env is resolved SYNCHRONOUSLY above and the owned
+        // `RegistryEnv` is moved in.
+        {
+            let repo_path_buf = repo_path.to_path_buf();
+            let repo_path_str = req.repo_path.clone();
+            let packages = req.packages.clone();
+            let dev = req.dev;
+            let repo_owned = repo.clone();
+            let coord_base_owned = coord_base.to_string();
+            let registry_env_owned = registry_env.clone();
+            let req_for_declare = req.clone();
+            tokio::spawn(async move {
+                let ground_truth = {
+                    let rp = repo_path_buf.clone();
+                    let pkgs = packages.clone();
+                    let env = registry_env_owned.clone();
+                    tokio::task::spawn_blocking(move || {
+                        dry_run_invoke::produce_ground_truth(pm, &rp, &pkgs, dev, &env)
+                    })
+                    .await
+                    .unwrap_or_default()
+                };
+                let importer_scan = {
+                    let rp = repo_path_buf.clone();
+                    let pkgs = packages.clone();
+                    tokio::task::spawn_blocking(move || {
+                        importer_scan::scan_importers(pm, &rp, &pkgs)
+                    })
+                    .await
+                    .unwrap_or_default()
+                };
+                let sibling_manifests = {
+                    let rp = repo_path_buf.clone();
+                    tokio::task::spawn_blocking(move || {
+                        sibling_manifests::collect_sibling_manifests(pm, &rp)
+                    })
+                    .await
+                    .unwrap_or_default()
+                };
+
+                let predicted_pinned = ground_truth
+                    .dry_run
+                    .as_ref()
+                    .map(|d| d.predicted_pinned.clone())
+                    .unwrap_or_default();
+                let predicted_cves = ground_truth
+                    .dry_run
+                    .as_ref()
+                    .map(|d| d.predicted_cves.clone())
+                    .unwrap_or_default();
+
+                let declare_req = build_declare(
+                    pm,
+                    &req_for_declare,
+                    &repo_owned,
+                    correlation_id,
+                    ground_truth,
+                    importer_scan.inventory.clone(),
+                    sibling_manifests,
+                );
+
+                // BEST-EFFORT (the §6 change): declare/predict errors are LOGGED
+                // here, never surfaced — a coord-down observe install must still
+                // proceed and record best-effort.
+                let client = match CoordInstallClient::new(coord_base_owned) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        warn!(
+                            "install-effects: OBSERVE deferred declare skipped \
+                             (corr={correlation_id}, repo={repo_owned}) — coord client \
+                             build failed (best-effort): {e}"
+                        );
+                        return;
+                    }
+                };
+                if let Err(e) = client.declare(&declare_req).await {
+                    warn!(
+                        "install-effects: OBSERVE deferred declare failed \
+                         (corr={correlation_id}, repo={repo_owned}) — proceeding \
+                         best-effort, PreContext keeps pre-shas only: {e}"
+                    );
+                    return;
+                }
+                // predict-and-check is advisory in observe mode (the shim never
+                // blocks on it) — a failure just means no enrichment.
+                if let Err(e) = client.predict_and_check(&declare_req).await {
+                    warn!(
+                        "install-effects: OBSERVE deferred predict-and-check failed \
+                         (corr={correlation_id}, repo={repo_owned}) — best-effort: {e}"
+                    );
+                }
+
+                // Re-stash the ENRICHED PreContext under the same id, preserving
+                // the original pre-shas (un-mutated worktree state captured on
+                // the request thread). A post-call that already consumed the
+                // partial context is fine — it degraded to an honest Partial.
+                precontext::put(
+                    correlation_id,
+                    PreContext {
+                        repo: repo_owned,
+                        repo_path: repo_path_str,
+                        package_manager: pm,
+                        escalation_overridden: false,
+                        affected_files: importer_scan.affected_files,
+                        predicted_pinned,
+                        predicted_cves,
+                        pre_shas,
+                    },
+                );
+            });
+        }
+
+        info!(
+            "install-effects: INTERCEPT/OBSERVE pre-call (corr={correlation_id}, repo={repo}, \
+             pm={}) — pre-shas captured + returning immediately; declare/predict deferred \
+             (best-effort), install proceeds in the agent shell",
+            pm.as_str()
+        );
+        // (3) return immediately — gate ALWAYS proceeds in observe mode.
+        return Ok(ApiResponse::success(RunResponse {
+            correlation_id,
+            repo,
+            package_manager: pm.as_str().to_string(),
+            gate: GateOutcome::Proceed,
+            risk_factors: Vec::new(),
+            escalation_overridden: false,
+            install: None,
+            dry_run_only: false,
+            resolution: serde_json::Value::Null,
+            verify: None,
+            effective_mode: "observe".to_string(),
+        }));
+    }
+
     // ---- Phase 2: read-only dry-run + native-audit probes --------------------
     // Shell out the package manager's own `--dry-run` (+ `audit`) on a blocking
     // thread and feed the captured output to the pure parsers. Best-effort: a
     // missing tool / unparseable output ⇒ honest `None`/`false` (coord degrades
     // to `Unknown`), never a fabricated plan, never a blocked install.
+    //
+    // Reached by GATE-mode intercept (which blocks on the verdict) and the
+    // explicit `Full` `/install-effects/run` route — NOT by observe-intercept,
+    // which took the async fast-path above.
     let ground_truth = {
         let repo_path = repo_path.to_path_buf();
         let packages = req.packages.clone();
@@ -477,16 +675,21 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
         );
     }
 
-    // ---- INTERCEPT mode (plan §3 A2/A3) -------------------------------------
+    // ---- INTERCEPT/GATE mode (plan §3 A2/A3) --------------------------------
+    // Reached ONLY by GATE-mode intercept now: observe-mode intercept took the
+    // async fast-path above (§6) and `off` was short-circuited earlier, so
+    // `effective_mode` here is always `"gate"`. GATE mode MUST stay synchronous
+    // — the shim blocks on the returned `gate` verdict (intercept/mod.rs), so
+    // declare + predict-and-check had to complete on the request path above.
+    //
     // The shim's pre-call: declare + predict-and-check already ran above. We do
     // NOT run the install (the agent's own shell does). Capture pre-shas now
     // (worktree still un-mutated), stash the PreContext under the correlation_id
     // for the matching `/install-effects/observe-verify` post-call, and return
-    // the gate verdict so the shim can branch (observe mode always proceeds;
-    // gate mode — Phase 3 — honors Escalate). This branch is BEFORE the
-    // dry_run_only/blocked early-return so an intercept run ALWAYS hands back a
-    // correlation_id regardless of the gate (the shim, not the producer, owns
-    // the block decision).
+    // the gate verdict so the shim can branch (gate mode — Phase 3 — honors
+    // Escalate). This branch is BEFORE the dry_run_only/blocked early-return so
+    // an intercept run ALWAYS hands back a correlation_id regardless of the gate
+    // (the shim, not the producer, owns the block decision).
     if req.mode == RunMode::Intercept {
         let pre_shas = observe::capture_pre_shas(pm, repo_path);
         precontext::put(
@@ -519,7 +722,8 @@ async fn run_with_base<L: RegistryTokenLookup + ?Sized>(
             dry_run_only: false,
             resolution: pac.resolution,
             verify: None,
-            // `observe` or `gate` here — `off` was short-circuited before declare.
+            // Always `gate` here — `observe` took the async fast-path above and
+            // `off` was short-circuited before declare.
             effective_mode: effective_mode.clone(),
         }));
     }
@@ -1622,14 +1826,26 @@ mod tests {
     // Interception — `mode:"intercept"` pre-call + `/observe-verify` post
     // ===================================================================
 
-    /// Build an intercept-mode pre-call request for a real `repo_path`.
+    /// Build an intercept-mode pre-call request for a real `repo_path`, pinned
+    /// to GATE mode.
     ///
-    /// Pins the process-global fleet-policy cache to `observe` as a side effect
-    /// so the P4 `off` short-circuit (which fires when the cache is `off`, the
-    /// fail-safe default before any live poll) does NOT trigger — these tests
-    /// exercise the full declare→gate→stash intercept pre-call path.
+    /// Pins the process-global fleet-policy cache to `gate` as a side effect so
+    /// (a) the P4 `off` short-circuit does NOT trigger and (b) the SYNCHRONOUS
+    /// declare→predict→gate→stash path runs on the request thread. GATE mode is
+    /// the deterministic path for asserting declare/predict hit counts, the gate
+    /// verdict, the override/escalation flag, and the stashed declare body — all
+    /// of which are computed BEFORE the response returns.
+    ///
+    /// (The §6 async-observe fast-path defers declare/predict to a `tokio::spawn`,
+    /// so those assertions can't be made synchronously in observe mode — observe
+    /// has its own dedicated test below.)
     fn intercept_req(repo_path: &str, packages: Vec<&str>) -> RunRequest {
-        crate::mcp::fleet_policy_poller::set_mode_for_test("observe");
+        intercept_req_mode(repo_path, packages, "gate")
+    }
+
+    /// As [`intercept_req`] but pins the effective interception mode explicitly.
+    fn intercept_req_mode(repo_path: &str, packages: Vec<&str>, mode: &str) -> RunRequest {
+        crate::mcp::fleet_policy_poller::set_mode_for_test(mode);
         RunRequest {
             repo_path: repo_path.to_string(),
             package_manager: Some("npm".to_string()),
@@ -1904,5 +2120,80 @@ mod tests {
             "bare install declares empty package_specs"
         );
         assert!(precontext::take(&data.correlation_id).is_some());
+    }
+
+    #[test]
+    fn observe_mode_returns_immediately_with_pre_shas_then_backfills() {
+        // §6 async-observe contract: the OBSERVE-mode intercept pre-call returns
+        // IMMEDIATELY (gate:proceed, correlation_id present, effective_mode
+        // "observe") with pre-shas captured SYNCHRONOUSLY — declare/predict are
+        // deferred to a spawned task that BACKFILLS the stashed PreContext. The
+        // shim never blocks on the gate verdict in observe mode, so the response
+        // is unconditional `proceed`.
+        let d = tempfile::tempdir().unwrap();
+        std::fs::write(
+            d.path().join("package.json"),
+            "{\"name\":\"x\",\"version\":\"1.0.0\"}",
+        )
+        .unwrap();
+        // Even an ESCALATE resolution from coord must NOT block / change the
+        // observe response — observe always proceeds (gate is informational).
+        let (base, _hits, _sd) = spawn_coord_mock(escalate_resolution(), vec!["major bump".into()]);
+
+        // Drive on a runtime we keep alive so the spawned backfill task can run
+        // to completion AFTER run_with_base returns (block_on returns as soon as
+        // the fast-path responds; the deferred task is still scheduled on this
+        // runtime's workers).
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .unwrap();
+        let req = intercept_req_mode(&d.path().display().to_string(), vec!["left-pad"], "observe");
+        let resp = rt
+            .block_on(run_with_base(
+                req,
+                &base,
+                DEAD_LOOPBACK,
+                &FakeCredStore::empty(),
+            ))
+            .unwrap();
+        let data = resp.data.unwrap();
+
+        // Immediate-return contract: proceed + observe + correlation_id, no install.
+        assert_eq!(
+            data.gate,
+            GateOutcome::Proceed,
+            "observe always proceeds (even on an escalate verdict)"
+        );
+        assert_eq!(data.effective_mode, "observe");
+        assert!(data.install.is_none());
+        assert!(data.verify.is_none());
+        assert!(
+            data.risk_factors.is_empty(),
+            "observe response carries no risk factors"
+        );
+        assert!(
+            !data.escalation_overridden,
+            "observe response never reports escalation_overridden"
+        );
+        let corr = data.correlation_id;
+        assert_ne!(corr, Uuid::nil(), "observe returns a real correlation_id");
+
+        // §6 core (deterministic): pre-shas are captured SYNCHRONOUSLY, so the
+        // PreContext is stashed the INSTANT the response returns — independent of
+        // the deferred declare/predict backfill. We assert the sync capture
+        // directly. (That declare/predict eventually fire is a best-effort
+        // backfill whose timing depends on a real `npm --dry-run`; that path is
+        // verified live, not in this unit test, to keep it deterministic +
+        // network-free. Pre-shas are preserved across the backfill's re-`put`,
+        // so this holds whether or not the backfill has run yet.)
+        let ctx = precontext::take(&corr).expect("PreContext stashed synchronously");
+        assert_eq!(ctx.package_manager, PackageManager::Npm);
+        assert!(
+            ctx.pre_shas.get("package.json").map(|o| o.is_some()) == Some(true),
+            "pre-sha for package.json captured synchronously: {:?}",
+            ctx.pre_shas
+        );
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -484,17 +484,20 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
     // runner-bootable-when-coord-down property. See
     // `plans/2026-05-14-fleet-topology-and-build-pool-design.md` §3.2
     // and `fleet.rs::publish_on_startup`.
-    {
-        let fleet_pg = pg_db.clone();
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to create tokio runtime for fleet publish");
-        rt.block_on(fleet::publish_on_startup(
-            &fleet_pg,
-            fleet::MachineRole::Agent,
-        ));
-    }
+    //
+    // STARTUP-RESILIENCE (§8): this call is `await`-ed NOT here on the
+    // critical boot path, but inside the dedicated "fleet-publishers" thread
+    // below (after the heartbeat block). `publish_on_startup` is already
+    // fail-open at the value level, but on a coord 503 its exponential-backoff
+    // retry ([2,4,8,16,32,60]s + 10s timeouts) blocks ~60-120s. Running it
+    // synchronously here delayed `run_app()` from reaching the MCP `/health`
+    // bind (downstream in `.setup()` → `mcp_api::start_server`), so the
+    // supervisor health-probe killed the runner before it could come up
+    // (the 2026-06 startup outage). Detaching it onto the publishers runtime
+    // keeps coord-base latency entirely OFF the `/health`-bind critical path.
+    // The clone of `pg_db` for that thread is taken here so the borrow is
+    // resolved before `pg_db` is moved into later state.
+    let fleet_publish_pg = pg_db.clone();
 
     // fleet heartbeat — see plan §5 and fleet.rs::spawn_heartbeat.
     //
@@ -557,7 +560,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
 
     std::thread::Builder::new()
         .name("fleet-publishers".to_string())
-        .spawn(|| {
+        .spawn(move || {
             let rt = match tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
                 .enable_all()
@@ -575,6 +578,21 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 }
             };
             rt.block_on(async {
+                // STARTUP-RESILIENCE (§8): the one-shot DeviceBudget publish,
+                // moved OFF the boot critical path (see the `fleet_publish_pg`
+                // comment up by the PG bootstrap). It's `await`-ed here on the
+                // publishers runtime so a coord 503 (its ~60-120s backoff
+                // ladder) can no longer delay `run_app()` reaching the MCP
+                // `/health` bind. Args are unchanged from the original
+                // synchronous call (`&fleet_pg`, `MachineRole::Agent`).
+                // Nothing downstream depends on its completion — it's a
+                // best-effort registry UPSERT; the periodic publishers /
+                // heartbeat below re-assert this device's presence regardless.
+                // It runs FIRST in this block so the initial registration
+                // still happens promptly once coord is reachable, before the
+                // periodic publishers begin their cadences.
+                fleet::publish_on_startup(&fleet_publish_pg, fleet::MachineRole::Agent).await;
+
                 // Plan 2026-05-19-coordinator-production-readiness.md
                 // Phase 1 — periodic primary-tree state publisher. These
                 // four tasks share one worker thread; they're all

--- a/src-tauri/src/mcp/fleet_policy_poller.rs
+++ b/src-tauri/src/mcp/fleet_policy_poller.rs
@@ -120,6 +120,31 @@ struct FleetPolicyResponse {
     effective_level: Option<String>,
 }
 
+/// Subset of coord's `GET /health` response we read for the capability probe.
+///
+/// Coord ships a `capabilities` object (parallel coord PR), e.g.
+/// `{"capabilities":{"install_signatures":true,"fleet_policy":true}}`. We read
+/// ONLY `fleet_policy` to decide whether this poller should run at all.
+///
+/// FAIL-SAFE DECODE (the absent-field=capable default): `capabilities` is
+/// `Option` so a coord that PREDATES the field (no `capabilities` key) decodes
+/// to `None` ⇒ we ASSUME capable and poll as normal. Within `capabilities`,
+/// `fleet_policy` is `Option<bool>` so only an EXPLICIT `false` disables the
+/// poller; an absent `fleet_policy` key (coord ships other caps but not this
+/// one yet) also assumes capable. We never break against a coord that doesn't
+/// know the field.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct HealthResponse {
+    #[serde(default)]
+    capabilities: Option<Capabilities>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct Capabilities {
+    #[serde(default)]
+    fleet_policy: Option<bool>,
+}
+
 // ===========================================================================
 // Poller state + supervised loop
 // ===========================================================================
@@ -185,7 +210,89 @@ enum PollOutcome {
     Kept(String),
 }
 
+/// Outcome of the one-shot capability probe done at poller start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum CapabilityCheck {
+    /// Coord advertises `capabilities` and `fleet_policy` is EXPLICITLY false —
+    /// the ONLY case that disables the poller.
+    Disabled,
+    /// Capable: coord said `fleet_policy:true`, OR `fleet_policy` was absent
+    /// from a present `capabilities`, OR there was no `capabilities` field at
+    /// all (older coord), OR the probe errored. Fail-safe — when in doubt, poll.
+    Capable,
+}
+
+/// One-shot `GET /health` capability probe (§5). Decides whether this poller
+/// should run at all by reading coord's `capabilities.fleet_policy`.
+///
+/// DEFENSIVE / FAIL-SAFE CONTRACT:
+/// - `fleet_policy == Some(false)` (explicitly disabled) ⇒ [`CapabilityCheck::Disabled`].
+/// - `fleet_policy == Some(true)` ⇒ Capable.
+/// - `fleet_policy` ABSENT but `capabilities` present ⇒ Capable (coord ships
+///   other caps but not this flag yet — don't disable).
+/// - NO `capabilities` field at all (coord predates it) ⇒ Capable.
+/// - ANY error (coord base unresolved / request / non-2xx / decode) ⇒ Capable.
+///   We never disable the poller because we couldn't reach `/health`.
+async fn check_fleet_policy_capability() -> CapabilityCheck {
+    let base = match crate::mcp::agent_worktrees::coord_http_base() {
+        Ok(b) => b,
+        // No coord base ⇒ assume capable; the poll loop's own per-tick base
+        // resolution + JWT gating handles an actually-unconfigured runner.
+        Err(_) => return CapabilityCheck::Capable,
+    };
+    let url = format!("{}/health", base.trim_end_matches('/'));
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+    {
+        Ok(c) => c,
+        Err(_) => return CapabilityCheck::Capable,
+    };
+
+    // `/health` is an unauthenticated liveness endpoint — no Bearer needed.
+    let resp = match client.get(&url).send().await {
+        Ok(r) => r,
+        Err(_) => return CapabilityCheck::Capable,
+    };
+    if !resp.status().is_success() {
+        return CapabilityCheck::Capable;
+    }
+    let body: HealthResponse = match resp.json().await {
+        Ok(b) => b,
+        Err(_) => return CapabilityCheck::Capable,
+    };
+
+    match body.capabilities {
+        // capabilities present + fleet_policy explicitly false ⇒ the only
+        // disable case.
+        Some(caps) if caps.fleet_policy == Some(false) => CapabilityCheck::Disabled,
+        // capabilities present, fleet_policy true or absent ⇒ capable.
+        // No capabilities field at all (older coord) ⇒ capable.
+        _ => CapabilityCheck::Capable,
+    }
+}
+
 async fn poller_loop(_api_state: Arc<ApiState>, mut shutdown_rx: watch::Receiver<bool>) {
+    // §5 capability gate (one-shot at start): if coord EXPLICITLY advertises it
+    // lacks the fleet_policy capability, stay off and don't poll. Any other
+    // outcome (capable, absent flag, no capabilities field, or any probe error)
+    // proceeds to poll as normal — defensive default never breaks against an
+    // older coord that predates the `capabilities` field.
+    //
+    // We do NOT `return` on Disabled: the task supervisor respawns any loop that
+    // returns without a shutdown signal (task_supervisor.rs:108), which would
+    // re-run this probe + re-log every backoff window. Instead we log ONCE and
+    // PARK on the shutdown channel — the cache already reads the fail-safe
+    // `off`, so a non-polling parked loop is exactly the desired "stay off".
+    if check_fleet_policy_capability().await == CapabilityCheck::Disabled {
+        info!("fleet_policy_poller: coord lacks fleet_policy capability — staying off");
+        // Park until shutdown (the cache stays at the fail-safe DEFAULT_MODE).
+        let _ = shutdown_rx.changed().await;
+        info!("Fleet-policy poller shutting down (was parked: coord lacks capability)");
+        return;
+    }
+
     info!(
         "Fleet-policy poller started (domain={DOMAIN}, interval={}s, fail-safe default={DEFAULT_MODE})",
         POLL_INTERVAL.as_secs()
@@ -419,5 +526,43 @@ mod tests {
         assert_eq!(normalize(Some("bogus")), DEFAULT_MODE);
         assert_eq!(normalize(None), DEFAULT_MODE);
         assert_eq!(normalize(Some("")), DEFAULT_MODE);
+    }
+
+    #[test]
+    fn capability_decode_disables_only_on_explicit_false() {
+        // The §5 fail-safe contract: ONLY an explicit `fleet_policy:false`
+        // disables the poller. Absent flag, no capabilities object, and a
+        // decode of an older coord's body all ⇒ Capable (never break against a
+        // coord that predates the field). We exercise the pure decision the
+        // probe makes over the decoded `HealthResponse`.
+        let decide = |json: &str| -> CapabilityCheck {
+            let body: HealthResponse = serde_json::from_str(json).expect("decode");
+            match body.capabilities {
+                Some(caps) if caps.fleet_policy == Some(false) => CapabilityCheck::Disabled,
+                _ => CapabilityCheck::Capable,
+            }
+        };
+
+        // Explicit false ⇒ the ONLY disable case.
+        assert_eq!(
+            decide(r#"{"capabilities":{"fleet_policy":false}}"#),
+            CapabilityCheck::Disabled
+        );
+        // Explicit true ⇒ capable.
+        assert_eq!(
+            decide(r#"{"capabilities":{"fleet_policy":true}}"#),
+            CapabilityCheck::Capable
+        );
+        // capabilities present, fleet_policy absent (coord ships other caps but
+        // not this flag) ⇒ capable.
+        assert_eq!(
+            decide(r#"{"capabilities":{"install_signatures":true}}"#),
+            CapabilityCheck::Capable
+        );
+        // NO capabilities field at all (older coord predating the field) ⇒
+        // capable — the defensive default that must never disable.
+        assert_eq!(decide(r#"{"status":"ok"}"#), CapabilityCheck::Capable);
+        // Empty body ⇒ capable.
+        assert_eq!(decide(r#"{}"#), CapabilityCheck::Capable);
     }
 }


### PR DESCRIPTION
Three robustness items from the fleet-policy/interception design (parent doc §5/§6/§8), all runner-side.

## §8 — startup resilience (the prod-coord-503 outage fix)
`fleet::publish_on_startup` was `block_on`'d in `run_app()` **upstream of the `/health` bind**; on a coord 503 its retry backoff (`[2,4,8,16,32,60]s` + 10s timeouts) blocked ~60-120s and the supervisor health-probe killed the runner. Detached it onto the existing fleet-publishers runtime thread → `/health` binds immediately regardless of coord. (publish was already value-level fail-open; the bug was the synchronous await.)

## §6 — async-observe latency
Observe-mode intercept pre-call now returns **immediately** (`proceed`/`observe`/`correlation_id`) with pre-shas captured **synchronously**; the dry-run + declare + predict are deferred to a spawned task that backfills the `PreContext`. Observe drops from ~13s to ~0 added latency. `declare` is best-effort in observe (documented); **gate mode stays synchronous** (the shim blocks on the verdict); the off short-circuit is unchanged.

## §5 — coord capability gate (+ targeted bug fix)
- `agent_runtime::coord_http_base` now honors `COORD_HTTP_URL` (it was the one resolver ignoring it).
- `fleet_policy_poller` does a **fail-safe** `/health` capability check (consumes coord #500): disables only on explicit `fleet_policy:false`; **assumes capable if the field is absent** (older coord) and on any error — never breaks against an old coord.
- (Full 12-site `coord_http_base` centralize + the localhost-fallback hardening deferred as a noted follow-up refactor — it carries a dev/prod-policy nuance and is the lowest-value item.)

## Verified (coordinator-driven)
`cargo check` clean (~11m); tests green — observe immediate-return + synchronous pre-sha capture, poller capability-decode (absent⇒capable / explicit-false⇒disable), 8 shim-bin; clippy clean; pre-push fmt+clippy passed.

Design: `plans/2026-06-08-fleet-policy-and-interception-rollout-design.md` §5/§6/§8.