### PR TITLE
feat(terminal): auto-distribute gate continuations across page tabs

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1723,6 +1723,54 @@ async fn run_gate_continuation_inner(
     result
 }
 
+/// Zone ceiling for a continuation page before it is considered "full".
+///
+/// Mirrors the frontend `useZoneLayout.ts` `full-grid` layout, which lays out
+/// at most 9 zones (a 3×3 grid) per page; beyond that, extra sessions spill
+/// into the page's Unassigned list. The backend picker uses this to spread
+/// continuations across non-full pages instead of overflowing one page.
+const CONTINUATION_PAGE_ZONE_CEILING: usize = 9;
+
+/// Choose the page_id a new continuation terminal should land on.
+/// Prefers, in order: the "default" page if under the ceiling, then any other
+/// existing page under the ceiling (fewest terminals first, tie-break by page_id
+/// for determinism), else a freshly-minted uuid.
+///
+/// `counts` is the live `(page_id, terminal count)` map. A page absent from
+/// `counts` is treated as count 0; in particular an absent `"default"` is
+/// treated as empty (so it is chosen when no continuations exist yet). The
+/// picker decides only among the pages PRESENT in `counts` plus the implicit
+/// `"default"`.
+fn pick_continuation_page(
+    counts: &[(String, usize)],
+    ceiling: usize,
+    mint: impl FnOnce() -> String,
+) -> String {
+    // Default page count (absent → 0).
+    let default_count = counts
+        .iter()
+        .find(|(p, _)| p == "default")
+        .map(|(_, c)| *c)
+        .unwrap_or(0);
+    if default_count < ceiling {
+        return "default".to_string();
+    }
+
+    // Among the OTHER existing pages under the ceiling, pick the one with the
+    // fewest terminals; tie-break by lexicographically-smallest page_id for
+    // determinism.
+    let best = counts
+        .iter()
+        .filter(|(p, c)| p != "default" && *c < ceiling)
+        .min_by(|(pa, ca), (pb, cb)| ca.cmp(cb).then_with(|| pa.cmp(pb)));
+    if let Some((page, _)) = best {
+        return page.clone();
+    }
+
+    // Everything full → mint a fresh page.
+    mint()
+}
+
 /// Run a gate continuation as a VISIBLE terminal session (Decision 1/2/3).
 ///
 /// Opens a pop-out terminal window and creates a terminal session whose PTY
@@ -1842,10 +1890,28 @@ async fn run_continuation_terminal(
     // Manual default) keeps the prior behavior. RISK note: the id resolver
     // scans config dirs first-hit-wins, but worktree paths are
     // per-continuation-unique, so cross-account binding stays low-probability.
+    // Page distribution: backend continuations historically all landed on the
+    // "default" page, overflowing its 9-zone grid into the Unassigned list. Pick
+    // a non-full page at create-time so continuations spread across pages, and
+    // persist it in the durable record so a restart re-lands on the same page.
+    // Count live terminals per page from the manager's current session list.
+    let counts: Vec<(String, usize)> = {
+        let mut per_page: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for info in terminal_manager.list() {
+            *per_page.entry(info.page_id).or_insert(0) += 1;
+        }
+        per_page.into_iter().collect()
+    };
+    let target_page = pick_continuation_page(&counts, CONTINUATION_PAGE_ZONE_CEILING, || {
+        uuid::Uuid::new_v4().to_string()
+    });
+
     let capture_hint = Some(crate::commands::terminal::SessionCaptureHint {
         config_dir: selected_config_dir,
         working_dir: workdir.to_string(),
         title: title.clone(),
+        page_id: Some(target_page.clone()),
     });
 
     let result = crate::commands::terminal::create_terminal_session_backend(
@@ -1860,6 +1926,7 @@ async fn run_continuation_terminal(
         command,
         ctx,
         capture_hint,
+        Some(target_page),
     );
 
     match result {
@@ -2677,6 +2744,81 @@ async fn report_spawn_failed(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Sentinel returned by the test mint closure so a mint outcome is
+    /// unambiguous and deterministic (no uuid in tests).
+    const MINTED: &str = "MINTED";
+
+    fn page(id: &str, n: usize) -> (String, usize) {
+        (id.to_string(), n)
+    }
+
+    #[test]
+    fn pick_continuation_page_default_under_ceiling_picks_default() {
+        let counts = [page("default", 3), page("p1", 9)];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            "default"
+        );
+    }
+
+    #[test]
+    fn pick_continuation_page_default_full_picks_nonfull_other() {
+        // default at the ceiling, p1 under it → p1.
+        let counts = [page("default", 9), page("p1", 4)];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            "p1"
+        );
+        // default over the ceiling behaves the same.
+        let counts = [page("default", 12), page("p1", 4)];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            "p1"
+        );
+    }
+
+    #[test]
+    fn pick_continuation_page_default_full_picks_fewest_terminals() {
+        let counts = [
+            page("default", 9),
+            page("p1", 7),
+            page("p2", 2),
+            page("p3", 5),
+        ];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            "p2"
+        );
+    }
+
+    #[test]
+    fn pick_continuation_page_tie_breaks_lexicographically() {
+        // p_b and p_a tie at count 3 → smallest page_id wins (p_a).
+        let counts = [page("default", 9), page("p_b", 3), page("p_a", 3)];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            "p_a"
+        );
+    }
+
+    #[test]
+    fn pick_continuation_page_everything_full_mints() {
+        let counts = [page("default", 9), page("p1", 9), page("p2", 11)];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            MINTED
+        );
+    }
+
+    #[test]
+    fn pick_continuation_page_empty_counts_picks_default() {
+        let counts: [(String, usize); 0] = [];
+        assert_eq!(
+            pick_continuation_page(&counts, 9, || MINTED.to_string()),
+            "default"
+        );
+    }
 
     #[test]
     fn launch_payload_round_trips_through_envelope() {

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -884,6 +884,9 @@ pub(crate) struct SessionCaptureHint {
     pub working_dir: String,
     /// Human-readable title for the restored grid tile.
     pub title: String,
+    /// Page the session should land on (and be durably recorded against) so a
+    /// restart re-lands the continuation on its page. `None` → `"default"`.
+    pub page_id: Option<String>,
 }
 
 /// Backend-task entry point for creating a terminal session + coord row from a
@@ -913,6 +916,7 @@ pub(crate) fn create_terminal_session_backend(
     command: Option<Vec<String>>,
     isolated_ctx: Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>,
     capture_hint: Option<SessionCaptureHint>,
+    page_id: Option<String>,
 ) -> Result<(String, Option<uuid::Uuid>), String> {
     // Phase 2c — derive the `QONTINUI_SESSION_WORKTREES` env from the
     // pre-acquired context (all materialized sibling worktrees) before it is
@@ -949,7 +953,7 @@ pub(crate) fn create_terminal_session_backend(
     let info = terminal_manager.create(
         Some(title.clone()),
         Some(working_dir.clone()),
-        None,
+        page_id.clone(),
         None,
         None,
         app_handle,
@@ -1050,7 +1054,11 @@ pub(crate) fn create_terminal_session_backend(
                 config_dir,
                 working_dir,
                 title,
+                page_id: hint_page_id,
             } = hint;
+            // Single source of truth for the recorded page: the hint's page_id
+            // (set by the caller to the picked page), defaulting to "default".
+            let record_page_id = hint_page_id.unwrap_or_else(|| "default".to_string());
             let since = chrono::Utc::now();
             let resolver_dir = working_dir.clone();
             let resolver = move || resolve_latest_claude_session_id(&resolver_dir, since);
@@ -1061,6 +1069,7 @@ pub(crate) fn create_terminal_session_backend(
                 config_dir,
                 working_dir,
                 title,
+                record_page_id,
                 SESSION_CAPTURE_POLL_INTERVAL,
                 SESSION_CAPTURE_TIMEOUT,
             ));
@@ -1119,6 +1128,7 @@ async fn poll_and_record_session<F>(
     config_dir: Option<String>,
     working_dir: String,
     title: String,
+    page_id: String,
     interval: std::time::Duration,
     timeout: std::time::Duration,
 ) where
@@ -1131,7 +1141,7 @@ async fn poll_and_record_session<F>(
                 claude_session_id: claude_session_id.clone(),
                 config_dir: config_dir.clone(),
                 working_dir: Some(working_dir.clone()),
-                page_id: "default".to_string(),
+                page_id: page_id.clone(),
                 zone_index: 0,
                 title: Some(title.clone()),
                 terminal_id: terminal_id.clone(),
@@ -1215,6 +1225,7 @@ mod tests {
             None,
             "/work/dir".to_string(),
             "My Continuation".to_string(),
+            "default".to_string(),
             Duration::from_millis(1),
             Duration::from_secs(5),
         )
@@ -1232,6 +1243,33 @@ mod tests {
         assert_eq!(rec.config_dir, None);
         assert_eq!(rec.state, "open");
         assert!(rec.opened_at > 0, "record_open seeds opened_at");
+    }
+
+    /// The recorded page honors the supplied `page_id` (not a hardcoded
+    /// "default") so a continuation placed on a non-default page restores there.
+    #[tokio::test]
+    async fn poll_and_record_session_honors_supplied_page_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            SessionLifecycleStore::open(dir.path().join("terminal-sessions.json")).unwrap(),
+        );
+
+        poll_and_record_session(
+            store.clone(),
+            || Some("resolved-sess-9".to_string()),
+            "term-9".to_string(),
+            None,
+            "/work/dir".to_string(),
+            "Overflow Continuation".to_string(),
+            "page-7".to_string(),
+            Duration::from_millis(1),
+            Duration::from_secs(5),
+        )
+        .await;
+
+        let open = store.open_records();
+        assert_eq!(open.len(), 1);
+        assert_eq!(open[0].page_id, "page-7");
     }
 
     /// When the resolver never yields an id, the poller gives up after the
@@ -1256,6 +1294,7 @@ mod tests {
             None,
             "/work/dir".to_string(),
             "Never Resolves".to_string(),
+            "default".to_string(),
             Duration::from_millis(1),
             Duration::from_millis(20),
         )

--- a/src/components/terminal/useTerminalPages.test.ts
+++ b/src/components/terminal/useTerminalPages.test.ts
@@ -14,9 +14,38 @@
 
 import { describe, it, expect } from "vitest";
 
-import { reconcilePages, type TerminalPageConfig } from "./useTerminalPages";
+import {
+  reconcilePages,
+  pageIdsFromTerminals,
+  pageIdsFromSessions,
+  type TerminalPageConfig,
+} from "./useTerminalPages";
 
 const DEFAULT: TerminalPageConfig = { id: "default", name: "Terminal", createdAt: 0 };
+
+describe("pageIdsFromTerminals (wire-field contract)", () => {
+  it("reads the camelCase `pageId` field TerminalInfo actually serializes", () => {
+    // Regression guard: TerminalInfo is #[serde(rename_all = "camelCase")], so
+    // the live wire field is `pageId`. Reading `page_id` here silently lands
+    // every terminal on "default" — the bug caught by temp-runner verification.
+    expect(pageIdsFromTerminals([{ pageId: "minted-1" }, { pageId: "minted-2" }])).toEqual([
+      "minted-1",
+      "minted-2",
+    ]);
+  });
+
+  it("falls back to legacy snake_case `page_id` and to 'default' when absent", () => {
+    expect(pageIdsFromTerminals([{ page_id: "legacy" }])).toEqual(["legacy"]);
+    expect(pageIdsFromTerminals([{}])).toEqual(["default"]);
+    expect(pageIdsFromTerminals([{ pageId: "" }])).toEqual(["default"]);
+  });
+});
+
+describe("pageIdsFromSessions (wire-field contract)", () => {
+  it("reads the camelCase `pageId` field on durable restore records", () => {
+    expect(pageIdsFromSessions([{ pageId: "cold-1" }, {}])).toEqual(["cold-1", "default"]);
+  });
+});
 
 describe("reconcilePages", () => {
   it("appends a synthesized tab for a backend id absent from persisted (terminal_list source)", () => {

--- a/src/components/terminal/useTerminalPages.test.ts
+++ b/src/components/terminal/useTerminalPages.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the pure page-reconciliation helper `reconcilePages` — the logic
+ * that unions persisted page tabs with the distinct backend page_ids (from
+ * `terminal_list` live terminals AND `terminal_session_list_open` durable
+ * restore records) so a backend-spawned continuation on a freshly-minted
+ * page_id gets a visible, selectable tab.
+ *
+ * vitest runs `environment: "node"` with no React Testing Library, so we
+ * exercise the exported pure helper directly (same precedent as
+ * `fetchOpenRecords` in `useTerminalInitialization.test.ts`). The component
+ * effect just feeds this helper the unioned id set, so testing the helper
+ * covers the reconciliation behavior without booting React or Tauri.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { reconcilePages, type TerminalPageConfig } from "./useTerminalPages";
+
+const DEFAULT: TerminalPageConfig = { id: "default", name: "Terminal", createdAt: 0 };
+
+describe("reconcilePages", () => {
+  it("appends a synthesized tab for a backend id absent from persisted (terminal_list source)", () => {
+    // terminal_list yields a live terminal's page_id not in the tab list.
+    const out = reconcilePages([DEFAULT], ["default", "minted-1"]);
+    expect(out.map((p) => p.id)).toEqual(["default", "minted-1"]);
+    const synth = out.find((p) => p.id === "minted-1")!;
+    expect(synth.name).toBe("Page 1");
+    expect(synth.createdAt).toBeGreaterThan(0);
+  });
+
+  it("reconstructs the tab from the durable restore source with terminal_list empty (cold restart)", () => {
+    // On a cold restart terminal_list is empty; the only signal is the durable
+    // pageId from terminal_session_list_open. The unioned set still contains it.
+    const out = reconcilePages([DEFAULT], ["minted-cold"]);
+    expect(out.map((p) => p.id)).toEqual(["default", "minted-cold"]);
+    expect(out.find((p) => p.id === "minted-cold")!.name).toBe("Page 1");
+  });
+
+  it("preserves operator pages + names and never duplicates 'default'", () => {
+    const persisted: TerminalPageConfig[] = [
+      DEFAULT,
+      { id: "op-a", name: "My Work", createdAt: 100 },
+      { id: "op-b", name: "Logs", createdAt: 200 },
+    ];
+    // Backend reports default again plus a new minted id.
+    const out = reconcilePages(persisted, ["default", "op-a", "minted-x"]);
+    // Existing pages + names untouched, default not duplicated, "default" never synthesized.
+    expect(out.slice(0, 3)).toEqual(persisted);
+    expect(out.filter((p) => p.id === "default")).toHaveLength(1);
+    const synth = out.find((p) => p.id === "minted-x")!;
+    // N = count of existing non-default pages (2) + 1 = 3.
+    expect(synth.name).toBe("Page 3");
+  });
+
+  it("returns the SAME array reference when every backend id is already persisted", () => {
+    const persisted: TerminalPageConfig[] = [
+      DEFAULT,
+      { id: "op-a", name: "My Work", createdAt: 100 },
+    ];
+    const out = reconcilePages(persisted, ["default", "op-a"]);
+    expect(out).toBe(persisted);
+  });
+
+  it("never synthesizes a tab for 'default' even when only the durable source reports it", () => {
+    const persisted = [DEFAULT];
+    const out = reconcilePages(persisted, ["default", "default"]);
+    // Nothing missing → same reference returned, single default tab.
+    expect(out).toBe(persisted);
+    expect(out.map((p) => p.id)).toEqual(["default"]);
+  });
+
+  it("normalizes an empty/falsy backend id to 'default' (no spurious tab)", () => {
+    const out = reconcilePages([DEFAULT], [""]);
+    expect(out.map((p) => p.id)).toEqual(["default"]);
+  });
+
+  it("dedupes the same minted id appearing in both backend sources into one tab", () => {
+    // Simulates the unioned set already collapsing duplicates, plus a guard
+    // against the same id arriving twice in the iterable.
+    const out = reconcilePages([DEFAULT], ["minted-dup", "minted-dup"]);
+    expect(out.map((p) => p.id)).toEqual(["default", "minted-dup"]);
+  });
+
+  it("numbers multiple new pages sequentially", () => {
+    const out = reconcilePages([DEFAULT], ["a", "b"]);
+    const names = out.filter((p) => p.id !== "default").map((p) => p.name);
+    expect(names).toEqual(["Page 1", "Page 2"]);
+  });
+});

--- a/src/components/terminal/useTerminalPages.ts
+++ b/src/components/terminal/useTerminalPages.ts
@@ -41,6 +41,32 @@ function savePages(pages: TerminalPageConfig[]) {
  * Exported so the union/synthesis logic is unit-testable without booting React
  * or Tauri (same precedent as `fetchOpenRecords` / `shouldIngestCreatedTerminal`).
  */
+/**
+ * Normalized page_ids from a `terminal_list` `terminals` array.
+ *
+ * `TerminalInfo` is `#[serde(rename_all = "camelCase")]` (qontinui-schemas
+ * `terminal.rs`), so the wire field is `pageId` — reading `page_id` here
+ * silently lands EVERY terminal on `"default"` and the reconcile never
+ * synthesizes a tab (the bug live-verification on a temp runner caught). The
+ * `page_id` fallback is defensive only (legacy/round-trip forms). Exported so
+ * the wire-field contract is unit-testable without Tauri.
+ */
+export function pageIdsFromTerminals(
+  terminals: Array<{ pageId?: string; page_id?: string }>,
+): string[] {
+  return terminals.map((t) => t.pageId || t.page_id || "default");
+}
+
+/**
+ * Normalized page_ids from a `terminal_session_list_open` `sessions` array
+ * (durable restore records). `TerminalSessionRecord` is also camelCase, so the
+ * wire field is `pageId` (matches `fetchOpenRecords` in
+ * `useTerminalInitialization.ts`). Exported for the same contract test.
+ */
+export function pageIdsFromSessions(sessions: Array<{ pageId?: string }>): string[] {
+  return sessions.map((s) => s.pageId ?? "default");
+}
+
 export function reconcilePages(
   persisted: TerminalPageConfig[],
   backendPageIds: Iterable<string>,
@@ -97,10 +123,14 @@ export function useTerminalPages() {
     try {
       const result = await invoke<{
         success: boolean;
-        data?: { terminals: Array<{ id: string; page_id: string }> };
+        data?: { terminals: Array<{ id: string; pageId?: string; page_id?: string }> };
       }>("terminal_list");
       if (result.success && result.data) {
-        const pageTerminals = result.data.terminals.filter((t) => (t.page_id || "default") === id);
+        // TerminalInfo is `#[serde(rename_all = "camelCase")]`, so the wire
+        // field is `pageId` (the `page_id` fallback is defensive only).
+        const pageTerminals = result.data.terminals.filter(
+          (t) => (t.pageId || t.page_id || "default") === id,
+        );
         for (const t of pageTerminals) {
           invoke("terminal_close", { terminalId: t.id }).catch(() => {});
         }
@@ -156,12 +186,10 @@ export function useTerminalPages() {
     try {
       const result = await invoke<{
         success: boolean;
-        data?: { terminals: Array<{ id: string; page_id: string }> };
+        data?: { terminals: Array<{ id: string; pageId?: string; page_id?: string }> };
       }>("terminal_list");
       if (result.success && result.data) {
-        for (const t of result.data.terminals) {
-          ids.add(t.page_id || "default");
-        }
+        for (const id of pageIdsFromTerminals(result.data.terminals)) ids.add(id);
       }
     } catch {
       // Best effort
@@ -178,9 +206,7 @@ export function useTerminalPages() {
       }>("terminal_session_list_open");
       const sessions = resp?.data?.sessions;
       if (Array.isArray(sessions)) {
-        for (const rec of sessions) {
-          ids.add(rec.pageId ?? "default");
-        }
+        for (const id of pageIdsFromSessions(sessions)) ids.add(id);
       }
     } catch {
       // Best effort

--- a/src/components/terminal/useTerminalPages.ts
+++ b/src/components/terminal/useTerminalPages.ts
@@ -1,5 +1,6 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { instanceStorage } from "@/lib/instance-storage";
 
 export interface TerminalPageConfig {
@@ -21,6 +22,48 @@ function loadPages(): TerminalPageConfig[] {
 
 function savePages(pages: TerminalPageConfig[]) {
   instanceStorage.setJSON(STORAGE_KEY, pages);
+}
+
+/**
+ * Pure reconciliation: union the persisted page tabs with the distinct backend
+ * page_ids, synthesizing a tab for any backend id NOT already persisted so a
+ * minted page (and continuations restored onto it) get a visible, selectable
+ * tab. "default" is always present already (loadPages) — never synthesized.
+ * Operator-created pages and their names are left intact (only ADD missing ids;
+ * never rename/remove existing). Synthesized names are sequential ("Page N")
+ * based on the count of existing non-default pages, so they're deterministic
+ * and survive a reload once persisted.
+ *
+ * Returns the SAME array reference when nothing was added, so callers can skip
+ * a redundant state update / persist (keeps the effect idempotent under React
+ * strict-mode double-invoke).
+ *
+ * Exported so the union/synthesis logic is unit-testable without booting React
+ * or Tauri (same precedent as `fetchOpenRecords` / `shouldIngestCreatedTerminal`).
+ */
+export function reconcilePages(
+  persisted: TerminalPageConfig[],
+  backendPageIds: Iterable<string>,
+): TerminalPageConfig[] {
+  const known = new Set(persisted.map((p) => p.id));
+  const missing: string[] = [];
+  for (const rawId of backendPageIds) {
+    const id = rawId || "default";
+    if (id === "default") continue;
+    if (known.has(id)) continue;
+    known.add(id); // dedupe across both backend sources
+    missing.push(id);
+  }
+  if (missing.length === 0) return persisted;
+
+  let nextN = persisted.filter((p) => p.id !== "default").length + 1;
+  const now = Date.now();
+  const synthesized = missing.map((id) => ({
+    id,
+    name: `Page ${nextN++}`,
+    createdAt: now,
+  }));
+  return [...persisted, ...synthesized];
 }
 
 export function useTerminalPages() {
@@ -99,6 +142,92 @@ export function useTerminalPages() {
       return updated;
     });
   }, []);
+
+  // Reconcile backend-known page_ids into the tab list. A backend-spawned gate
+  // continuation can land on a freshly-minted page_id that isn't in the
+  // persisted tab list, so without this it would render nowhere. We union the
+  // distinct ids from BOTH backend sources and synthesize a tab for any id not
+  // already persisted (see `reconcilePages`). Best-effort: a failed invoke must
+  // not throw out of the effect.
+  const reconcile = useCallback(async () => {
+    const ids = new Set<string>();
+
+    // Source 1: live terminals (terminal_list). Empty on a cold restart.
+    try {
+      const result = await invoke<{
+        success: boolean;
+        data?: { terminals: Array<{ id: string; page_id: string }> };
+      }>("terminal_list");
+      if (result.success && result.data) {
+        for (const t of result.data.terminals) {
+          ids.add(t.page_id || "default");
+        }
+      }
+    } catch {
+      // Best effort
+    }
+
+    // Source 2: durable restore records (terminal_session_list_open). This is
+    // the cold-restart source — a minted page holding only not-yet-restored
+    // continuations gets no tab from terminal_list alone, and fetchOpenRecords
+    // would then drop those records. Unioning the durable pageIds rebuilds the
+    // tab from durable state.
+    try {
+      const resp = await invoke<{
+        data?: { sessions?: Array<{ pageId?: string }> };
+      }>("terminal_session_list_open");
+      const sessions = resp?.data?.sessions;
+      if (Array.isArray(sessions)) {
+        for (const rec of sessions) {
+          ids.add(rec.pageId ?? "default");
+        }
+      }
+    } catch {
+      // Best effort
+    }
+
+    setPages((prev) => {
+      const next = reconcilePages(prev, ids);
+      if (next === prev) return prev; // nothing missing — no persist / no re-render
+      savePages(next);
+      return next;
+    });
+  }, []);
+
+  // Run reconciliation once on mount and on a debounced `terminal-created`
+  // event (a burst of continuations collapses to a single reconcile).
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
+
+    // `reconcile` is async: its `setPages` only runs AFTER both awaited invokes
+    // resolve (a future microtask), never synchronously during this effect's
+    // render pass — so the cascading-render concern the rule guards against does
+    // not apply here.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void reconcile();
+
+    listen("terminal-created", () => {
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        void reconcile();
+      }, 400);
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      disposed = true;
+      if (timer) clearTimeout(timer);
+      unlisten?.();
+    };
+  }, [reconcile]);
 
   return {
     pages,


### PR DESCRIPTION
## Summary
Backend-spawned gate continuations all landed on `page_id "default"`, overflowing its 9-zone grid into the Unassigned list once the primary's continuation cap was removed (parent plan `2026-06-09-continuation-spawns-primary-unbounded-no-temp-overflow`, SHIPPED). This spreads continuations across page tabs so each page stays a navigable ≤9 grid.

Implements plan `2026-06-09-continuation-overflow-auto-page-distribution` (VETTED).

## Changes
- **`agent_runtime.rs`** — pure `pick_continuation_page` (default-first if under ceiling, else fewest-terminals non-full page with lexicographic tie-break, else mint a uuid) + `CONTINUATION_PAGE_ZONE_CEILING = 9` mirroring `useZoneLayout` full-grid. Wired into `run_continuation_terminal` (counts live terminals per page from `manager.list()`).
- **`commands/terminal.rs`** — `page_id` arg on `create_terminal_session_backend` (forwarded to `manager.create`); `page_id` on `SessionCaptureHint` threaded through `poll_and_record_session` to replace the hardcoded `"default"` in the durable record, so a restart re-lands each continuation on its page.
- **`useTerminalPages.ts`** — `reconcilePages` unions persisted tabs with distinct backend page_ids from **both** `terminal_list` (live) and `terminal_session_list_open` (durable restore — the cold-restart source, since `fetchOpenRecords` drops records with no mounted page). Mount + debounced `terminal-created` effect synthesizes a tab for any minted page.

## Tests
- `pick_continuation_page` matrix (6), `poll_and_record_session` page_id (3), `reconcilePages` vitest (8). `cargo check` + `tsc` clean.