### PR TITLE
fix(runner): throttle vision-cache MutationObserver (true OOM root cause)

### DIFF
--- a/src/hooks/useVisionCacheInvalidation.ts
+++ b/src/hooks/useVisionCacheInvalidation.ts
@@ -64,18 +64,43 @@ export function useVisionCacheInvalidation(opts?: { debounceMs?: number }): void
     };
 
     const schedule = () => {
-      if (timer) clearTimeout(timer);
+      // THROTTLE, not debounce-reset. The previous implementation did
+      // `clearTimeout(timer); timer = setTimeout(...)` on EVERY mutation
+      // batch, so a high-frequency mutation source churned one setTimeout
+      // per batch. Under sustained mutation (e.g. the UI Bridge
+      // auto-register scanner stamping `data-ui-bridge-id` attributes, a
+      // streaming text node, a re-render loop) that reached ~1,700
+      // setTimeout/sec — each allocating a closure — which pegged the
+      // WebView2 renderer's CPU and grew its heap ~150 MB/min until it
+      // hard-OOM-crashed ("Error code: out of memory" → reload → sign-in).
+      //
+      // Throttling arms at most one timer per `debounceMs` window
+      // regardless of mutation rate (so a 1,700/sec mutation storm yields
+      // ~4 setTimeout/sec), while still bumping the vision cache once per
+      // window during sustained mutation — which is actually a better
+      // freshness guarantee than the old trailing debounce that never
+      // fired at all while mutations kept arriving.
+      if (timer) return;
       timer = setTimeout(() => {
+        timer = null;
         void bump();
       }, debounceMs);
     };
 
     const observer = new MutationObserver(schedule);
+    // Observe structural (childList) and text (characterData) changes —
+    // what OCR actually re-reads. Deliberately NOT `attributes: true`:
+    // arbitrary attribute churn (the bridge's own `data-ui-bridge-id`
+    // stamps, `aria-*`/`data-*` live regions, class/style toggles) is a
+    // high-frequency, largely-OCR-irrelevant trigger, and watching the
+    // bridge's own attribute writes made this observer self-triggering.
+    // Control actions still bump the cache directly, and a `{force:true}`
+    // read overrides — cache freshness here is best-effort, not
+    // correctness-critical (see the hook doc above).
     observer.observe(document.body, {
       childList: true,
       subtree: true,
       characterData: true,
-      attributes: true,
     });
 
     return () => {


### PR DESCRIPTION
## The actual OOM root cause (found via live call-stack capture)

The WebView2 renderer crashes with **"Error code: out of memory" → reload → sign-in**. Diagnosed on the running runner by capturing the call stack of the hot path:

- A **MutationObserver callback was scheduling ~1,700 `setTimeout`/sec**, pegging the renderer CPU (>300% across threads) and growing memory ~150 MB/min (JS heap + ~5GB external) from a fresh 72 MB start until OOM in well under an hour.
- Source: `useVisionCacheInvalidation` observes `childList + characterData + attributes` on the whole `document.body`, and on **every** mutation batch did `clearTimeout(timer); timer = setTimeout(bump, 250)` — a debounce-**reset**. Any sustained mutation source churns one `setTimeout` per batch.
- Likely driver is self-inflicted: the UI Bridge **auto-register scanner stamps `data-ui-bridge-id` attributes**, which this `attributes: true` observer then reacts to.

## Fix
1. **Throttle, not debounce-reset.** `schedule()` now arms at most one timer per window (early-return while one is pending). A 1,700/sec mutation storm becomes ~4 `setTimeout`/sec, and the cache is still bumped once per window during sustained mutation (strictly better than the old trailing debounce, which never fired while mutations kept arriving).
2. **Drop `attributes: true`** from the observer — arbitrary attribute churn (the bridge's own id stamps, aria/data live regions, class/style toggles) is high-frequency and largely OCR-irrelevant, and watching the bridge's own writes made the observer self-triggering. `childList + characterData` (structure + text, what OCR re-reads) remain.

## Verification
- `tsc` / eslint / prettier clean.
- Post-merge I'll confirm with the method that exposed the leak: fresh-restart the primary and watch the renderer process working set — it should stay flat instead of climbing 758 MB → 8.6 GB.

## Relationship to earlier fixes this session
- **#523** (dead-pane scrollback trim) and **#528** (disable browser-capture network module) were real improvements but did **not** stop the leak — a fresh-start renderer-WS trend with both deployed still climbed to 8.6 GB, which pointed here. This is the dominant cause.

Requires merge + manual supervisor rebuild to deploy.