### PR TITLE
fix(runner): credential-aware account selection — no silent 401 zombies

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1882,6 +1882,25 @@ async fn run_continuation_terminal(
         crate::ai_provider::get_effective_config_dir(&ai.claude_cli)
     };
 
+    // Fail loud, not a 401 zombie: `None` here means no credential-valid account
+    // was resolved, so `CLAUDE_CONFIG_DIR` would be left unset and the PTY would
+    // inherit the ambient default. That is only safe if the ambient default
+    // itself has live credentials; otherwise the continuation would spawn a
+    // `claude` that immediately dies with `401 ... Please run /login`, leaving a
+    // dead terminal the operator can't diagnose. Abort with an actionable
+    // reason so coord/the operator sees WHY instead of a blank 401 pane.
+    if selected_config_dir.is_none()
+        && !crate::ai_provider::oauth_refresh::default_location_has_valid_credentials()
+    {
+        let instance = crate::instance::instance_name().unwrap_or_else(|| "primary".to_string());
+        let reason = format!(
+            "no authenticated Claude account on this runner — run /login (instance={instance})"
+        );
+        warn!("agent_runtime: gate-continuation terminal aborted — {reason}");
+        report_spawn_failed(agent_id, &reason, None, 0).await;
+        return Err(anyhow::anyhow!(reason));
+    }
+
     // Durable lifecycle capture: this backend path never fires the frontend
     // `terminal_session_record_open`, so without a hint a restart loses the
     // continuation. `config_dir` is now the SELECTED account dir (above): it
@@ -2592,11 +2611,29 @@ async fn spawn_claude_child(workdir: &str, initial_prompt: &str) -> anyhow::Resu
     // continuation/worker `claude` spawns under whatever account the runner
     // booted with (e.g. a quota-exhausted one) and dies instantly. The caller
     // calls `pick_best_account()` once per unit of work; here we read the
-    // resolved-or-manual effective dir. `None` → leave env unset (single-account
-    // / Manual-mode default — unchanged behavior).
+    // resolved-or-manual effective dir (already credential-validated).
+    //
+    // `None` means no credential-valid account resolved → leaving the env unset
+    // would inherit the ambient default. That is only safe if the ambient
+    // default itself has live credentials; otherwise the spawn is a 401 zombie.
+    // Fail loud with an actionable reason (the callers turn this `Err` into a
+    // `report_spawn_failed` lifecycle post) rather than starting a dead `claude`.
     let ai = crate::settings::get_ai_settings();
-    if let Some(dir) = crate::ai_provider::get_effective_config_dir(&ai.claude_cli) {
-        cmd.env("CLAUDE_CONFIG_DIR", dir);
+    match crate::ai_provider::get_effective_config_dir(&ai.claude_cli) {
+        Some(dir) => {
+            cmd.env("CLAUDE_CONFIG_DIR", dir);
+        }
+        None => {
+            if !crate::ai_provider::oauth_refresh::default_location_has_valid_credentials() {
+                let instance =
+                    crate::instance::instance_name().unwrap_or_else(|| "primary".to_string());
+                return Err(anyhow::anyhow!(
+                    "no authenticated Claude account on this runner — run /login (instance={instance})"
+                ));
+            }
+            // None + ambient default has live creds → inherit it (single-account
+            // / unset-CLAUDE_CONFIG_DIR default — unchanged behavior).
+        }
     }
     // `-p` / `--print` means "single-shot prompt mode" for Claude Code
     // CLI; not all versions support stdin-as-prompt cleanly, so we send

--- a/src-tauri/src/ai_provider/account_usage.rs
+++ b/src-tauri/src/ai_provider/account_usage.rs
@@ -76,6 +76,7 @@ pub fn pick_best_account() {
 
     let chosen = pick_from(
         &config_dirs,
+        |d| super::oauth_refresh::has_valid_credentials(d),
         |d| super::config::is_account_cooled_down(d),
         |d| super::config::usage_rank(d),
         |d| super::config::account_known_exhausted(d),
@@ -94,20 +95,34 @@ pub fn pick_best_account() {
 /// Pure selection core, parameterised over the cooldown/usage/expiry lookups
 /// so it can be unit-tested without the global settings + state singletons.
 ///
-/// `is_cooled` / `usage` / `known_exhausted` / `remaining` mirror the
-/// `super::config` helpers. `usage` returns `(exhausted, headroom)` for
-/// accounts with a *fresh* sample; `known_exhausted` reports the last-seen
+/// `has_valid_creds` / `is_cooled` / `usage` / `known_exhausted` / `remaining`
+/// mirror the `super::oauth_refresh` + `super::config` helpers.
+/// `has_valid_creds` is the highest-precedence filter — an account without
+/// live credentials is never selectable (it would 401 the moment a `claude`
+/// subprocess spawns under it), so it is excluded from BOTH the non-cooled
+/// ranking and the all-cooled fallback. `usage` returns `(exhausted, headroom)`
+/// for accounts with a *fresh* sample; `known_exhausted` reports the last-seen
 /// exhaustion with a longer staleness tolerance, used only by the cold-start
-/// fallback. Returns the chosen config dir, or `None` only when `config_dirs`
-/// is empty.
+/// fallback. Returns the chosen config dir, or `None` when `config_dirs` is
+/// empty OR no dir has valid credentials.
 fn pick_from<'a>(
     config_dirs: &'a [String],
+    has_valid_creds: impl Fn(&str) -> bool,
     is_cooled: impl Fn(&str) -> bool,
     usage: impl Fn(&str) -> Option<(bool, f64)>,
     known_exhausted: impl Fn(&str) -> bool,
     remaining: impl Fn(&str) -> Option<Duration>,
 ) -> Option<String> {
-    let available: Vec<&'a String> = config_dirs.iter().filter(|d| !is_cooled(d)).collect();
+    // Validity filter ABOVE cooldown: never select an account without live
+    // credentials. With none valid, return `None` — the caller leaves the
+    // resolved dir unchanged and the spawn path fails loud (see
+    // `agent_runtime::run_continuation_terminal` / `spawn_claude_child`).
+    let valid: Vec<&'a String> = config_dirs.iter().filter(|d| has_valid_creds(d)).collect();
+    if valid.is_empty() {
+        return None;
+    }
+
+    let available: Vec<&'a String> = valid.iter().filter(|d| !is_cooled(d)).copied().collect();
 
     if !available.is_empty() {
         // Among available accounts that have a fresh usage sample, pick the
@@ -142,11 +157,15 @@ fn pick_from<'a>(
             .or_else(|| available.first().map(|d| (*d).clone()));
     }
 
-    // All cooled: pick the one with the shortest remaining cooldown.
-    config_dirs
+    // All (credential-valid) accounts cooled: pick the valid one with the
+    // shortest remaining cooldown. Restricting to `valid` matters — a
+    // credential-less dir has no cooldown entry (`remaining` → `None` →
+    // `Duration::ZERO`) and would otherwise win the `min` precisely when every
+    // authenticated account is rate-limited.
+    valid
         .iter()
         .min_by_key(|d| remaining(d).unwrap_or(Duration::ZERO))
-        .cloned()
+        .map(|d| (*d).clone())
 }
 
 fn short_label(config_dir: &str) -> &str {
@@ -263,6 +282,11 @@ mod tests {
         names.iter().map(|s| s.to_string()).collect()
     }
 
+    // Every legacy test injects `|_| true` for the credential-validity filter
+    // (all candidates authenticated) so its assertion isolates the ranking it
+    // targets. The credential-filter behaviour itself is exercised by the
+    // `credential_*` tests at the end of this module.
+
     #[test]
     fn headroom_wins_among_available() {
         let d = dirs(&["/a", "/b", "/c"]);
@@ -270,6 +294,7 @@ mod tests {
         // even though /a sorts first by position. None exhausted.
         let chosen = pick_from(
             &d,
+            |_| true,  // all valid
             |_| false, // none cooled
             |x| match x {
                 "/a" => Some((false, 0.10)),
@@ -291,6 +316,7 @@ mod tests {
         // (+0.20, worse delta) but has tokens left → must win.
         let chosen = pick_from(
             &d,
+            |_| true,
             |_| false,
             |x| match x {
                 "/full" => Some((true, 0.05)),    // exhausted, better headroom
@@ -309,6 +335,7 @@ mod tests {
         // Both exhausted → least-bad (lowest headroom) is the fallback choice.
         let chosen = pick_from(
             &d,
+            |_| true,
             |_| false,
             |x| match x {
                 "/a" => Some((true, 0.30)),
@@ -327,6 +354,7 @@ mod tests {
         // /a has the best headroom but is cooled → must not be picked.
         let chosen = pick_from(
             &d,
+            |_| true,
             |x| x == "/a",
             |x| match x {
                 "/a" => Some((false, -0.90)),
@@ -344,7 +372,7 @@ mod tests {
         let d = dirs(&["/a", "/b", "/c"]);
         // No fresh samples → legacy "first non-cooled" behaviour. /a is cooled,
         // so /b (first available) wins.
-        let chosen = pick_from(&d, |x| x == "/a", |_| None, |_| false, |_| None);
+        let chosen = pick_from(&d, |_| true, |x| x == "/a", |_| None, |_| false, |_| None);
         assert_eq!(chosen.as_deref(), Some("/b"));
     }
 
@@ -357,6 +385,7 @@ mod tests {
         // available account.
         let chosen = pick_from(
             &d,
+            |_| true,
             |_| false,         // none cooled
             |_| None,          // no fresh usage sample (stale)
             |x| x == "/gmail", // gmail last seen exhausted
@@ -370,7 +399,7 @@ mod tests {
         let d = dirs(&["/a", "/b"]);
         // Stale snapshot and every available account known-exhausted → still
         // return something (first available) rather than nothing.
-        let chosen = pick_from(&d, |_| false, |_| None, |_| true, |_| None);
+        let chosen = pick_from(&d, |_| true, |_| false, |_| None, |_| true, |_| None);
         assert_eq!(chosen.as_deref(), Some("/a"));
     }
 
@@ -381,6 +410,7 @@ mod tests {
         // preferred over an unprobed one).
         let chosen = pick_from(
             &d,
+            |_| true,
             |_| false,
             |x| if x == "/b" { Some((false, 0.40)) } else { None },
             |_| false,
@@ -394,7 +424,7 @@ mod tests {
         // One configured account, no usage sample, not cooled → it is selected
         // (the single-account case must resolve, not no-op).
         let d = dirs(&["/only"]);
-        let chosen = pick_from(&d, |_| false, |_| None, |_| false, |_| None);
+        let chosen = pick_from(&d, |_| true, |_| false, |_| None, |_| false, |_| None);
         assert_eq!(chosen.as_deref(), Some("/only"));
     }
 
@@ -402,7 +432,14 @@ mod tests {
     fn single_exhausted_account_still_pinned() {
         // One account, exhausted → still the only option, so still selected.
         let d = dirs(&["/only"]);
-        let chosen = pick_from(&d, |_| false, |_| Some((true, 1.0)), |_| true, |_| None);
+        let chosen = pick_from(
+            &d,
+            |_| true,
+            |_| false,
+            |_| Some((true, 1.0)),
+            |_| true,
+            |_| None,
+        );
         assert_eq!(chosen.as_deref(), Some("/only"));
     }
 
@@ -411,6 +448,7 @@ mod tests {
         let d = dirs(&["/a", "/b"]);
         let chosen = pick_from(
             &d,
+            |_| true,
             |_| true, // all cooled
             |_| None,
             |_| false,
@@ -426,7 +464,77 @@ mod tests {
     #[test]
     fn empty_config_dirs_returns_none() {
         let d: Vec<String> = Vec::new();
-        let chosen = pick_from(&d, |_| false, |_| None, |_| false, |_| None);
+        let chosen = pick_from(&d, |_| true, |_| false, |_| None, |_| false, |_| None);
         assert_eq!(chosen, None);
+    }
+
+    // --- credential-validity filter (highest precedence) --------------------
+
+    #[test]
+    fn credential_invalid_dir_never_selected() {
+        let d = dirs(&["/no-creds", "/authed"]);
+        // /no-creds has the best headroom but no live credentials → must be
+        // excluded entirely; /authed wins despite worse headroom.
+        let chosen = pick_from(
+            &d,
+            |x| x == "/authed",
+            |_| false,
+            |x| match x {
+                "/no-creds" => Some((false, -0.90)),
+                "/authed" => Some((false, 0.20)),
+                _ => None,
+            },
+            |_| false,
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/authed"));
+    }
+
+    #[test]
+    fn expired_refreshable_account_is_selectable() {
+        let d = dirs(&["/refreshable"]);
+        // `has_valid_credentials` returns true for an expired-but-refreshed dir;
+        // model that with the injected validity closure → it stays selectable.
+        let chosen = pick_from(
+            &d,
+            |x| x == "/refreshable",
+            |_| false,
+            |_| None,
+            |_| false,
+            |_| None,
+        );
+        assert_eq!(chosen.as_deref(), Some("/refreshable"));
+    }
+
+    #[test]
+    fn no_valid_account_returns_none() {
+        let d = dirs(&["/a", "/b"]);
+        // Every candidate lacks live credentials → no spawnable account. `None`
+        // is the signal the spawn path uses to fail loud instead of 401-zombie.
+        let chosen = pick_from(&d, |_| false, |_| false, |_| None, |_| false, |_| None);
+        assert_eq!(chosen, None);
+    }
+
+    #[test]
+    fn all_valid_cooled_never_picks_credentialless_dir() {
+        let d = dirs(&["/no-creds", "/authed-cooled"]);
+        // Every credential-valid account is cooled; a credential-LESS dir has no
+        // cooldown (remaining → None → ZERO) and would win the min if the
+        // all-cooled fallback didn't restrict to valid dirs. It must not.
+        let chosen = pick_from(
+            &d,
+            |x| x == "/authed-cooled",
+            |x| x == "/authed-cooled", // the only valid account is cooled
+            |_| None,
+            |_| false,
+            |x| {
+                if x == "/authed-cooled" {
+                    Some(Duration::from_secs(300))
+                } else {
+                    None
+                }
+            },
+        );
+        assert_eq!(chosen.as_deref(), Some("/authed-cooled"));
     }
 }

--- a/src-tauri/src/ai_provider/config.rs
+++ b/src-tauri/src/ai_provider/config.rs
@@ -84,18 +84,30 @@ pub fn get_resolved_config_dir() -> Option<String> {
 }
 
 /// Get the effective config directory, considering account selection mode.
+///
+/// Returns a config dir ONLY when it has live credentials (a `.credentials.json`
+/// that is unexpired or refreshable — see
+/// [`super::oauth_refresh::has_valid_credentials`]). A credential-less or
+/// unrefreshable candidate yields `None` so the spawn path fails loud
+/// (`agent_runtime::run_continuation_terminal` / `spawn_claude_child`) instead
+/// of pinning `CLAUDE_CONFIG_DIR` to a dead account and 401-zombie-ing the
+/// subprocess. In `LeastUsage` mode the resolved dir
+/// ([`pick_best_account`](super::account_usage::pick_best_account)) is already
+/// credential-filtered; the recheck here also covers `Manual` mode, whose
+/// `config_dir` is never run through the picker.
 pub fn get_effective_config_dir(cli_settings: &settings::ClaudeCliSettings) -> Option<String> {
-    match cli_settings.account_selection_mode {
+    let candidate = match cli_settings.account_selection_mode {
         AccountSelectionMode::LeastUsage => {
-            if let Ok(cached) = RESOLVED_CONFIG_DIR.lock() {
-                if cached.is_some() {
-                    return cached.clone();
-                }
-            }
-            // Fallback to manual config_dir if no resolved dir
-            cli_settings.config_dir.clone()
+            // The resolved dir (set by the credential-aware picker) wins; else
+            // fall back to the manual config_dir.
+            get_resolved_config_dir().or_else(|| cli_settings.config_dir.clone())
         }
         AccountSelectionMode::Manual => cli_settings.config_dir.clone(),
+    };
+
+    match candidate {
+        Some(dir) if super::oauth_refresh::has_valid_credentials(&dir) => Some(dir),
+        _ => None,
     }
 }
 

--- a/src-tauri/src/ai_provider/oauth_refresh.rs
+++ b/src-tauri/src/ai_provider/oauth_refresh.rs
@@ -187,6 +187,51 @@ pub(crate) fn try_ensure_valid_credentials(config_dir: Option<&str>) {
     }
 }
 
+/// Whether `config_dir` has live, usable Claude OAuth credentials: a
+/// `.credentials.json` exists *in that exact dir* AND the token is either
+/// unexpired or successfully refreshed in place.
+///
+/// This is the highest-precedence account-selection filter (see
+/// [`super::account_usage::pick_best_account`]): selection must never pin a
+/// config dir that would 401 the moment a `claude` subprocess spawns under it.
+///
+/// IMPORTANT — checks `config_dir` **directly**, NOT via [`find_creds_path`].
+/// `find_creds_path` falls back to `$CLAUDE_CONFIG_DIR` then `~/.claude` when
+/// `dir` lacks creds; used as a per-candidate selection filter that fallback
+/// would collapse every credential-less candidate onto the same shared file
+/// and report them all identically — silently defeating the per-account
+/// distinction this predicate exists to make.
+pub(crate) fn has_valid_credentials(config_dir: &str) -> bool {
+    let creds_path = PathBuf::from(config_dir).join(".credentials.json");
+    creds_path_is_valid(&creds_path)
+}
+
+/// Whether the **ambient default** credential location has live, usable
+/// credentials. This is the location a `claude` subprocess inherits when
+/// `CLAUDE_CONFIG_DIR` is left unset — i.e. when account selection resolves no
+/// explicit dir to pin. Resolution order matches [`find_creds_path`] with no
+/// override: `$CLAUDE_CONFIG_DIR` then `~/.claude/.credentials.json`.
+///
+/// Spawn paths use this to decide whether an unset-`CLAUDE_CONFIG_DIR` spawn
+/// would land on a real login or 401-zombie under a dead default.
+pub(crate) fn default_location_has_valid_credentials() -> bool {
+    match find_creds_path(None) {
+        Some(path) => creds_path_is_valid(&path),
+        None => false,
+    }
+}
+
+/// Shared validity core: an existing creds file that is unexpired, or expired
+/// but refreshed in place. `try_refresh_credentials` returns `None` with no
+/// network call when there is no `refreshToken`, so an expired, unrefreshable
+/// account deterministically reports invalid.
+fn creds_path_is_valid(creds_path: &Path) -> bool {
+    if !creds_path.exists() {
+        return false;
+    }
+    !is_expired(creds_path) || try_refresh_credentials(creds_path).is_some()
+}
+
 fn find_creds_path(config_dir: Option<&str>) -> Option<PathBuf> {
     if let Some(dir) = config_dir {
         let p = PathBuf::from(dir).join(".credentials.json");
@@ -230,4 +275,80 @@ fn is_expired(creds_path: &Path) -> bool {
         .unwrap_or_default()
         .as_millis() as i64;
     now_ms >= expires_at_ms
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Write a `.credentials.json` into a fresh temp dir and return
+    /// `(tempdir_guard, dir_path_string)`. The guard must be kept alive for
+    /// the duration of the test (drop removes the dir).
+    fn dir_with_creds(expires_at_ms: i64, refresh_token: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let body = serde_json::json!({
+            "claudeAiOauth": {
+                "accessToken": "sk-oauth-test",
+                "refreshToken": refresh_token,
+                "expiresAt": expires_at_ms,
+                "scopes": ["user:inference"],
+            }
+        });
+        let mut f = std::fs::File::create(dir.path().join(".credentials.json")).expect("create");
+        write!(f, "{body}").expect("write");
+        let path = dir.path().to_string_lossy().to_string();
+        (dir, path)
+    }
+
+    fn future_ms() -> i64 {
+        (SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64)
+            + 3_600_000
+    }
+
+    fn past_ms() -> i64 {
+        (SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64)
+            - 60_000
+    }
+
+    #[test]
+    fn has_valid_credentials_false_when_dir_has_no_creds_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_string_lossy().to_string();
+        assert!(!has_valid_credentials(&path));
+    }
+
+    #[test]
+    fn has_valid_credentials_true_when_unexpired() {
+        let (_guard, path) = dir_with_creds(future_ms(), "rt-present");
+        assert!(has_valid_credentials(&path));
+    }
+
+    #[test]
+    fn has_valid_credentials_false_when_expired_and_no_refresh_token() {
+        // Empty refreshToken → `try_refresh_credentials` returns `None` with no
+        // network call, so an expired, unrefreshable account is rejected
+        // deterministically (no live HTTP in this unit test).
+        let (_guard, path) = dir_with_creds(past_ms(), "");
+        assert!(!has_valid_credentials(&path));
+    }
+
+    #[test]
+    fn has_valid_credentials_checks_the_exact_dir_not_a_fallback() {
+        // A dir that contains NO `.credentials.json` must report invalid even
+        // when `$CLAUDE_CONFIG_DIR`/`~/.claude` happen to have one — this is the
+        // distinction `find_creds_path`'s fallback chain would erase.
+        let empty = tempfile::tempdir().expect("tempdir");
+        let path = empty.path().to_string_lossy().to_string();
+        assert!(
+            !has_valid_credentials(&path),
+            "credential-less dir must be invalid regardless of fallback locations"
+        );
+    }
 }


### PR DESCRIPTION
## Problem
Account selection (`pick_best_account` → `get_effective_config_dir` → spawn) was usage/cooldown-aware but **not credential-aware**. The picker could pin a `CLAUDE_CONFIG_DIR` with no `.credentials.json` (or an expired-unrefreshable token), so a spawned `claude` died instantly with a silent **401 zombie**. Latent on any worktree/secondary/temp-runner spawn.

## Fix
- **`oauth_refresh`**: `has_valid_credentials(&str)` — a **direct** per-dir `.credentials.json` check + `is_expired`/refresh. Deliberately **not** `find_creds_path` (its `$CLAUDE_CONFIG_DIR`/`~/.claude` fallback would collapse every credential-less candidate onto the same shared file and defeat the per-account filter). Plus `default_location_has_valid_credentials()` for the ambient-default case.
- **`account_usage::pick_from`**: `has_valid_creds` threaded as the highest-precedence filter, applied to **both** the non-cooled ranking and the all-cooled fallback (a credential-less dir has no cooldown → `Duration::ZERO` would otherwise win the `min`); returns `None` when no dir is credential-valid.
- **`config::get_effective_config_dir`**: returns only a credential-valid dir, else `None`.
- **`agent_runtime`**: `run_continuation_terminal` + `spawn_claude_child` **fail loud** (`report_spawn_failed` / `Err` with `"run /login (instance=…)"`) when the spawn would land on no authenticated account — instead of a 401 zombie.

The fail-loud gate keys on the account the spawn would actually use: a pinned valid dir → fine; `None` + ambient default valid → inherit ambient (unchanged single-account behavior); `None` + ambient invalid → fail loud.

## Tests
- `oauth_refresh`: `has_valid_credentials` matrix (no-file, unexpired→true, expired+no-refresh→false, exact-dir-not-fallback).
- `account_usage`: credential-invalid never selected, expired-refreshable selectable, all-invalid→None, all-cooled never picks a credential-less dir.
- `cargo check` + `cargo clippy -D warnings` clean; 19 account_usage + 4 oauth_refresh tests pass.

Plan: `2026-06-09-worktree-runner-account-credential-validation`.