### PR TITLE
fix(runner): stop PageSessionScope infinite render loop (renderer OOM root)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -397,6 +397,16 @@ function AppContent() {
     return release;
   }, [setActiveTab]);
 
+  // Stable nav handlers — passed into TerminalSessionProvider/PageSessionScope,
+  // which is React.memo'd. Inline arrows here would change identity every
+  // AppContent render, defeating the memo and (via the scope's register →
+  // setValues → provider re-render feedback) driving an infinite render loop.
+  const navigateToBuilder = useCallback(
+    () => setActiveTab("unified-workflow-builder"),
+    [setActiveTab],
+  );
+  const navigateToActive = useCallback(() => setActiveTab("active"), [setActiveTab]);
+
   useEffect(() => {
     if (activeTab === "logs" && activeLogSubTab === "actions") {
       refreshActionLog();
@@ -638,13 +648,13 @@ function AppContent() {
                     <TerminalSessionProvider
                       pages={terminalPages.pages}
                       activePageId={terminalPages.activePageId}
-                      onNavigateToBuilder={() => setActiveTab("unified-workflow-builder")}
-                      onNavigateToActive={() => setActiveTab("active")}
+                      onNavigateToBuilder={navigateToBuilder}
+                      onNavigateToActive={navigateToActive}
                     >
                       <TerminalPageProvider value={terminalPages.activePageId}>
                         <TerminalPage
-                          onNavigateToBuilder={() => setActiveTab("unified-workflow-builder")}
-                          onNavigateToActive={() => setActiveTab("active")}
+                          onNavigateToBuilder={navigateToBuilder}
+                          onNavigateToActive={navigateToActive}
                           onSessionCountChange={setTerminalSessionCount}
                         />
                       </TerminalPageProvider>

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -61,6 +61,7 @@ import {
   useMemo,
   createRef,
   useContext,
+  memo,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -205,7 +206,16 @@ interface PageSessionScopeProps {
  * it via `register`; the lifted provider routes the active page's value into
  * the `TerminalSessionContext` the page tree consumes.
  */
-function PageSessionScope({
+// React.memo so a re-render of the lifted provider (driven by its own
+// `setValues` when ANY page publishes a new value) does NOT cascade back into
+// every scope. Without this, each scope re-renders on every provider render,
+// recomputes its (ref-unstable) `value`, re-`register`s it → `setValues` →
+// provider re-renders → … a self-sustaining infinite render loop (introduced
+// when #476 lifted the provider + added the register feedback path). Props are
+// stable (pageId, the useCallback `register`, and App's memoized nav handlers),
+// so memo short-circuits the cascade; the scope still re-renders normally when
+// its OWN session hooks change.
+const PageSessionScope = memo(function PageSessionScope({
   pageId,
   register,
   onNavigateToBuilder,
@@ -649,7 +659,7 @@ function PageSessionScope({
   // Renders nothing: the lifted provider routes the active page's value into
   // context and renders the (single) page tree.
   return null;
-}
+});
 
 interface TerminalSessionProviderProps {
   /** Every terminal page that should keep live state (all stay mounted). */


### PR DESCRIPTION
## The OOM root cause (found via a live instrumented build)

The WebView2 renderer crashes with **"Error code: out of memory" → reload → sign-in**. A render-counter built into a temp build showed **`PageSessionScope` re-rendering ~2,985×/sec** (29,849 renders in 10s), pegging renderer CPU (117–323%) and growing memory ~150–365 MB/min until OOM.

### Mechanism
`#476` lifted `TerminalSessionProvider` above `TerminalPage` and had each per-page `PageSessionScope` publish its context `value` into the provider's `useState` via an effect (`register` → `setValues`). That `value` is a `useMemo` whose deps include **~12 hook returns that are a fresh ref every render** (`terminalManager`, `zoneLayout`, `stateTracking`, `workflowGen`, …). So:

> scope renders → `value` is a new ref → register effect fires → `setValues` → provider re-renders → re-renders the scope (it's a child) → `value` new again → … **self-sustaining loop**

Pre-#476 the same ref-instability was benign (no register→provider-state feedback). The looping commits set the controlled CommandBar input's `name` ~2,985×/sec — the high-frequency DOM mutation the separate vision-cache observer amplified into a setTimeout storm (#532).

## Fix (break the feedback, not chase 12 unstable hooks)
- **`React.memo(PageSessionScope)`** so a provider re-render no longer cascades back into every scope. The scope still re-renders when its OWN session hooks change — it just stops bouncing off the provider's `setValues`.
- For memo to short-circuit, props must be stable: `pageId` (stable), `register` (useCallback), and the nav handlers — which `AppContent` passed as **inline arrows**. Memoized `onNavigateToBuilder`/`onNavigateToActive` with `useCallback`.

## Verification (live, instrumented temp build)
| | broken | fixed |
|---|---|---|
| `PageSessionScope` renders | 29,849 / 10s | **36 total (idle)** |
| renderer CPU | 117–323% | **0–2%** |
| JS heap | → 8.6 GB | **38 MB** |
| renderer WS | climbing to 8.6 GB | **flat ~148 MB** |

`tsc` / eslint / prettier clean. The diagnostic render-counter was removed before this commit.

## Relationship to the other OOM PRs
- **This is the source.** #532 (vision-cache observer throttle) fixed the *amplifier*; #528 (browser-capture) and #523 (dead-pane scrollback) were earlier partial/incorrect fixes. All four are independent files; this one is the root.

Requires merge + manual supervisor rebuild to deploy (the live primary already runs it via a `from_working_tree` build).