### PR TITLE
fix(runner): skip default ~/.claude when per-account dirs exist

### DIFF
--- a/src-tauri/src/commands/setup_wizard.rs
+++ b/src-tauri/src/commands/setup_wizard.rs
@@ -257,6 +257,7 @@ pub fn discover_claude_config_dirs() -> Result<Vec<Value>, String> {
     }
 
     // 2. Scan C:\claude\.claude-*\ (multi-account setups on Windows)
+    let mut found_per_account = false;
     let claude_root = std::path::Path::new("C:\\claude");
     if claude_root.is_dir() {
         if let Ok(entries) = std::fs::read_dir(claude_root) {
@@ -267,6 +268,7 @@ pub fn discover_claude_config_dirs() -> Result<Vec<Value>, String> {
                         if name.starts_with(".claude-") {
                             let label = name.to_string();
                             add(path, &label, "auto-detected");
+                            found_per_account = true;
                         }
                     }
                 }
@@ -275,9 +277,13 @@ pub fn discover_claude_config_dirs() -> Result<Vec<Value>, String> {
     }
 
     // 3. %USERPROFILE%\.claude (standard location)
-    if let Ok(home) = std::env::var("USERPROFILE") {
-        let home_claude = std::path::PathBuf::from(&home).join(".claude");
-        add(home_claude, ".claude", "home directory");
+    // Skip the default dir when per-account dirs exist — it always shares
+    // credentials with one of them and would show as a duplicate.
+    if !found_per_account {
+        if let Ok(home) = std::env::var("USERPROFILE") {
+            let home_claude = std::path::PathBuf::from(&home).join(".claude");
+            add(home_claude, ".claude", "home directory");
+        }
     }
 
     // 4. %LOCALAPPDATA%\claude (alternate install location)


### PR DESCRIPTION
## What

Rescues a stranded fix. `discover_claude_config_dirs` (setup wizard) currently lists **both** the per-account dirs under `C:\claude\.claude-*` **and** the default `%USERPROFILE%\.claude`. On multi-account setups the default dir shares credentials with one of the per-account dirs, so it shows up as a **duplicate row** in the account-usage display.

This adds a `found_per_account` flag and skips the default `~/.claude` add when any `.claude-*` per-account dir was found.

## Provenance

Cherry-picked from `ba7557fb` (Joshua Spinak, 2026-05-27). That commit was **stranded**: its branch `chore/staging-to-production-domains` had an earlier part merged via PR #306, but this later commit was never carried by any PR. A 2026-06-10 fleet-wide unmerged-branch audit surfaced it as the only genuinely un-landed change across 34 repos. Applies cleanly to current `main` (auto-merged despite the file shifting since May); verified the result reads coherently.

## Risk
Windows-only path (`C:\claude`), display-dedup only — no behavior change on single-account setups (`found_per_account` stays false → default dir still added).