### PR TITLE
refactor(runner): centralize coord_http_base, non-silent localhost fallback

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -229,26 +229,13 @@ fn agent_log_path(agent_id: uuid::Uuid) -> Option<PathBuf> {
 /// `None` when neither is set — runtime no-ops in that case (no localhost
 /// fallback, unchanged).
 fn coord_http_base() -> Option<String> {
-    // env override first — the source-of-truth chain every other resolver uses.
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return Some(v);
-        }
+    // Delegates to the shared resolver, preserving the no-localhost-fallback
+    // posture: only an explicitly-configured base (env or profile) yields
+    // `Some`; nothing configured ⇒ `None` (runtime no-ops, unchanged).
+    match qontinui_runner_lib::profiles::resolve_coord_base() {
+        qontinui_runner_lib::profiles::CoordBase::Configured(base) => Some(base),
+        _ => None,
     }
-    let coord_url = qontinui_runner_lib::profiles::load_strict()
-        .ok()?
-        .coord_url?;
-    let trimmed = coord_url.trim_end_matches("/ws");
-    let with_http = trimmed
-        .strip_prefix("wss://")
-        .map(|rest| format!("https://{rest}"))
-        .or_else(|| {
-            trimmed
-                .strip_prefix("ws://")
-                .map(|rest| format!("http://{rest}"))
-        })
-        .unwrap_or_else(|| trimmed.to_string());
-    Some(with_http)
 }
 
 /// Resolve the coord WS URL from the active profile's `coord_url`,

--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -217,26 +217,16 @@ pub(crate) fn load_device_id_pub() -> Option<Uuid> {
 /// tick cleanly skips) when nothing is configured, matching
 /// `fleet::coord_http_base`.
 fn coord_http_base() -> Option<String> {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        let t = v.trim();
-        if !t.is_empty() {
-            return Some(t.trim_end_matches('/').to_string());
+    // Delegates to the shared resolver, preserving `None` (the tick cleanly
+    // skips) when nothing is configured. The shared resolver already trims the
+    // trailing slash on both the env and ws→http paths; the extra trim here is
+    // a belt-and-suspenders no-op kept for byte-identical behavior.
+    match qontinui_runner_lib::profiles::resolve_coord_base() {
+        qontinui_runner_lib::profiles::CoordBase::Configured(base) => {
+            Some(base.trim_end_matches('/').to_string())
         }
+        _ => None,
     }
-    let coord_url = qontinui_runner_lib::profiles::load_strict()
-        .ok()?
-        .coord_url?;
-    let trimmed = coord_url.trim_end_matches('/').trim_end_matches("/ws");
-    let with_http = trimmed
-        .strip_prefix("wss://")
-        .map(|rest| format!("https://{rest}"))
-        .or_else(|| {
-            trimmed
-                .strip_prefix("ws://")
-                .map(|rest| format!("http://{rest}"))
-        })
-        .unwrap_or_else(|| trimmed.to_string());
-    Some(with_http.trim_end_matches('/').to_string())
 }
 
 /// Crate-visible alias of [`coord_http_base`] so the Phase 4 reclaim

--- a/src-tauri/src/agent_worktree/mod.rs
+++ b/src-tauri/src/agent_worktree/mod.rs
@@ -1459,15 +1459,13 @@ fn checkout_shared_branch(
 /// get appended onto the WS upgrade path (which JWT-rejects with 401).
 /// Mirrors the supervisor's resolver at
 /// `qontinui-supervisor/src/fleet.rs::coord_http_base`.
+///
+/// Thin re-export of the unified normalizer in
+/// [`qontinui_runner_lib::profiles::coord_ws_to_http`] — kept under this name
+/// so its existing ~6 call sites (and the doc-comment cross-refs) don't churn.
+/// The unified fn is the byte-identical superset of this fn's prior body.
 pub fn coord_ws_to_http(coord_url: &str) -> String {
-    let trimmed = coord_url.trim_end_matches('/').trim_end_matches("/ws");
-    if let Some(rest) = trimmed.strip_prefix("ws://") {
-        format!("http://{}", rest)
-    } else if let Some(rest) = trimmed.strip_prefix("wss://") {
-        format!("https://{}", rest)
-    } else {
-        trimmed.to_string()
-    }
+    qontinui_runner_lib::profiles::coord_ws_to_http(coord_url)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/claims.rs
+++ b/src-tauri/src/commands/claims.rs
@@ -100,15 +100,10 @@ pub type StealResultDto = serde_json::Value;
 /// dependency that lives behind axum (Tauri commands don't have
 /// access to it without significantly more plumbing).
 fn coord_http_base() -> String {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
-        return crate::agent_worktree::coord_ws_to_http(ws);
-    }
-    "http://localhost:9870".to_string()
+    // Delegates to the shared resolver; the dev-localhost guess is now logged
+    // once per process via `coord_base_or_dev_localhost`.
+    qontinui_runner_lib::profiles::coord_base_or_dev_localhost()
+        .unwrap_or_else(|| "http://localhost:9870".to_string())
 }
 
 fn http_client() -> Result<reqwest::Client, String> {

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1908,18 +1908,10 @@ pub async fn add_task_dependency(
 /// profile `coord_url` (ws→http via `coord_ws_to_http`) → default
 /// `http://localhost:9870`.
 fn coord_http_base_for_fleet() -> String {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    // `qontinui_runner_lib::profiles` (not `crate::profiles`) — same
-    // proven path as mcp::agent_worktrees::coord_http_base; `crate::`
-    // doesn't resolve `profiles` from this lib compilation unit.
-    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
-        return crate::agent_worktree::coord_ws_to_http(ws);
-    }
-    "http://localhost:9870".to_string()
+    // Delegates to the shared resolver; the dev-localhost guess is now logged
+    // once per process via `coord_base_or_dev_localhost`.
+    qontinui_runner_lib::profiles::coord_base_or_dev_localhost()
+        .unwrap_or_else(|| "http://localhost:9870".to_string())
 }
 
 /// `get_coord_http_base` — expose the runner's resolved coord HTTP base

--- a/src-tauri/src/coord_mcp.rs
+++ b/src-tauri/src/coord_mcp.rs
@@ -16,25 +16,13 @@ use tracing::{info, warn};
 /// Inline copy of `agent_runtime::coord_http_base` — kept local so this leaf
 /// module does NOT depend on `agent_runtime` (which depends back on us).
 fn coord_http_base() -> Option<String> {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return Some(v);
-        }
+    // Delegates to the shared resolver. `None` when nothing is configured; the
+    // localhost fallback for the `.mcp.json` write is applied by the caller
+    // (`write_coord_mcp_config`), unchanged.
+    match qontinui_runner_lib::profiles::resolve_coord_base() {
+        qontinui_runner_lib::profiles::CoordBase::Configured(base) => Some(base),
+        _ => None,
     }
-    let coord_url = qontinui_runner_lib::profiles::load_strict()
-        .ok()?
-        .coord_url?;
-    let trimmed = coord_url.trim_end_matches("/ws");
-    let with_http = trimmed
-        .strip_prefix("wss://")
-        .map(|rest| format!("https://{rest}"))
-        .or_else(|| {
-            trimmed
-                .strip_prefix("ws://")
-                .map(|rest| format!("http://{rest}"))
-        })
-        .unwrap_or_else(|| trimmed.to_string());
-    Some(with_http)
 }
 
 /// The coord-native `/mcp` endpoint is live (coord PR #277 Phase-2 cutover),

--- a/src-tauri/src/credential_helper.rs
+++ b/src-tauri/src/credential_helper.rs
@@ -25,15 +25,10 @@ fn config_file_path(session_id: &str) -> PathBuf {
 }
 
 fn coord_http_base() -> String {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
-        return crate::agent_worktree::coord_ws_to_http(ws);
-    }
-    "http://localhost:9870".to_string()
+    // Delegates to the shared resolver; the dev-localhost guess is now logged
+    // once per process via `coord_base_or_dev_localhost`.
+    qontinui_runner_lib::profiles::coord_base_or_dev_localhost()
+        .unwrap_or_else(|| "http://localhost:9870".to_string())
 }
 
 async fn fetch_push_token(coord_base: &str, session_id: &str) -> Result<String, String> {

--- a/src-tauri/src/fleet.rs
+++ b/src-tauri/src/fleet.rs
@@ -309,25 +309,13 @@ fn error_chain(e: &(dyn std::error::Error + 'static)) -> String {
 /// defaulting to `http://localhost:9870`) when nothing is configured, so the
 /// heartbeat cleanly skips instead of spamming connection errors every tick.
 fn coord_http_base() -> Option<String> {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return Some(v);
-        }
+    // Delegates to the shared resolver, preserving the deliberate `None`
+    // (rather than localhost) when nothing is configured, so the heartbeat
+    // cleanly skips instead of spamming connection errors every tick.
+    match qontinui_runner_lib::profiles::resolve_coord_base() {
+        qontinui_runner_lib::profiles::CoordBase::Configured(base) => Some(base),
+        _ => None,
     }
-    let coord_url = qontinui_runner_lib::profiles::load_strict()
-        .ok()?
-        .coord_url?;
-    let trimmed = coord_url.trim_end_matches("/ws");
-    let with_http = trimmed
-        .strip_prefix("wss://")
-        .map(|rest| format!("https://{rest}"))
-        .or_else(|| {
-            trimmed
-                .strip_prefix("ws://")
-                .map(|rest| format!("http://{rest}"))
-        })
-        .unwrap_or_else(|| trimmed.to_string());
-    Some(with_http)
 }
 
 /// POST the budget payload with exponential backoff (2s, 4s, 8s, 16s, 32s, 60s).

--- a/src-tauri/src/mcp/agent_worktrees.rs
+++ b/src-tauri/src/mcp/agent_worktrees.rs
@@ -14,19 +14,12 @@
 //! superseded it — so it was removed along with the unused no-claim
 //! `allocate_and_materialize` wrapper.
 
-use crate::agent_worktree::coord_ws_to_http;
-
 pub(crate) fn coord_http_base() -> Result<String, String> {
     // Source-of-truth chain: env `COORD_HTTP_URL` → profile `coord_url`
-    // (ws→http) → default `http://localhost:9870`.
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return Ok(v);
-        }
-    }
-    let profile = qontinui_runner_lib::profiles::load();
-    if let Some(ws) = profile.coord_url.as_deref() {
-        return Ok(coord_ws_to_http(ws));
-    }
-    Ok("http://localhost:9870".to_string())
+    // (ws→http) → default `http://localhost:9870`. Delegates to the shared
+    // resolver; the dev-localhost guess is now logged once per process. This
+    // resolver never errored before (it always fell back to localhost-Ok), so
+    // the `Result` contract is preserved by always returning Ok.
+    Ok(qontinui_runner_lib::profiles::coord_base_or_dev_localhost()
+        .unwrap_or_else(|| "http://localhost:9870".to_string()))
 }

--- a/src-tauri/src/observable_bridge/memory_client.rs
+++ b/src-tauri/src/observable_bridge/memory_client.rs
@@ -36,24 +36,18 @@ pub fn build_client() -> Result<reqwest::Client> {
         .context("observable_bridge::memory_client: reqwest client build")
 }
 
-/// Resolve the coord HTTP base from the active profile's `coord_url`.
+/// Resolve the coord HTTP base. Delegates to the shared resolver in
+/// `crate::profiles` (this is a lib module, so `crate::profiles` resolves).
 ///
-/// Duplicated from `fleet.rs::coord_http_base` (private there) rather
-/// than re-exporting to keep the bridge self-contained. Five lines, no
-/// drift risk.
+/// Preserves `None` when nothing is configured (Option-family contract).
+/// NOTE: previously this was env-LESS (profile `coord_url` only); routing
+/// through the shared resolver now also honors `COORD_HTTP_URL`, which is the
+/// desirable behavior every other resolver already had.
 pub fn coord_http_base() -> Option<String> {
-    let coord_url = crate::profiles::load_strict().ok()?.coord_url?;
-    let trimmed = coord_url.trim_end_matches("/ws");
-    let with_http = trimmed
-        .strip_prefix("wss://")
-        .map(|rest| format!("https://{rest}"))
-        .or_else(|| {
-            trimmed
-                .strip_prefix("ws://")
-                .map(|rest| format!("http://{rest}"))
-        })
-        .unwrap_or_else(|| trimmed.to_string());
-    Some(with_http)
+    match crate::profiles::resolve_coord_base() {
+        crate::profiles::CoordBase::Configured(base) => Some(base),
+        _ => None,
+    }
 }
 
 /// `GET /coord/memory/list` — metadata-only catalog of every live

--- a/src-tauri/src/pair.rs
+++ b/src-tauri/src/pair.rs
@@ -366,17 +366,17 @@ pub fn coord_http_base() -> Result<String, String> {
 /// Pure conversion: `ws[s]://host[:port][/ws]` → `http[s]://host[:port]`.
 /// Mirrors `qontinui-supervisor/src/fleet.rs::coord_http_base` so the
 /// register and pair paths agree on the recipe.
+///
+/// Thin re-export of the unified normalizer in
+/// [`crate::profiles::coord_ws_to_http`] (which is the superset
+/// of this fn's prior body — it additionally strips a bare trailing `/`, a
+/// no-op on every input this fn's callers / tests exercise). Kept under this
+/// name so the register/pair call site and the `coord_http_base_from_url`
+/// tests don't churn. `coord_http_base()` below stays ENV-LESS (profile-or-Err)
+/// — it deliberately does NOT route through the env-reading
+/// `profiles::resolve_coord_base`.
 pub fn coord_http_base_from_url(coord_url: &str) -> String {
-    let trimmed = coord_url.trim_end_matches("/ws");
-    trimmed
-        .strip_prefix("wss://")
-        .map(|rest| format!("https://{rest}"))
-        .or_else(|| {
-            trimmed
-                .strip_prefix("ws://")
-                .map(|rest| format!("http://{rest}"))
-        })
-        .unwrap_or_else(|| trimmed.to_string())
+    crate::profiles::coord_ws_to_http(coord_url)
 }
 
 /// Derive a `https://` web base from the coord HTTP base, assuming web

--- a/src-tauri/src/profiles.rs
+++ b/src-tauri/src/profiles.rs
@@ -219,6 +219,122 @@ fn legacy_env_fallback() -> ResolvedProfile {
     }
 }
 
+// ============================================================================
+// Shared coord HTTP base resolver
+// ============================================================================
+//
+// Historically ~12 call sites each re-implemented the same chain
+// (env `COORD_HTTP_URL` → profile `coord_url` ws→http → `http://localhost:9870`)
+// with subtly different trimming and, worse, a SILENT localhost fallback. The
+// operator's stance is "log loudly, don't silently write to a phantom coord":
+// localhost is the legitimate local-dev coord, so we keep the fallback but emit
+// exactly one process-global WARN the first time we guess it.
+
+/// Outcome of resolving the coord HTTP base, before any dev-localhost policy
+/// is applied. Lets each caller family pick its own fallback posture:
+/// - String family: `coord_base_or_dev_localhost().unwrap_or_else(localhost)`
+/// - Option family: `Configured ⇒ Some`, otherwise `None` (no-op when unconfigured)
+/// - Result family: map as appropriate, preserving the call site's contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CoordBase {
+    /// A coord base was explicitly configured (env `COORD_HTTP_URL` or the
+    /// active profile's `coord_url`). The string is already ws→http normalized.
+    Configured(String),
+    /// Nothing was configured; this is the dev-localhost guess
+    /// (`http://localhost:9870`). Treated as "configured enough" for the
+    /// String family but as "unconfigured" (None) for the Option family.
+    DevLocalhost(String),
+    /// Nothing configured AND the caller did not want a localhost guess.
+    Unset,
+}
+
+/// Pure conversion: `ws[s]://host[:port][/ws][/]` → `http[s]://host[:port]`.
+///
+/// This is the single source of truth that the two historical normalizers
+/// (`pair::coord_http_base_from_url` and `agent_worktree::coord_ws_to_http`)
+/// now both delegate to. It is the SUPERSET of both old behaviors:
+/// - strips a trailing `/` *and* a trailing `/ws` (the `agent_worktree`
+///   variant did both; the `pair` variant only stripped `/ws`),
+/// - flips `ws://`→`http://`, `wss://`→`https://`,
+/// - passes through anything already `http(s)://` (or scheme-less) unchanged.
+///
+/// Stripping the bare trailing `/` is a strict superset: every input the `pair`
+/// tests exercise (`ws://h:9870/ws`, `ws://h:9870`, `http://h:9870`) maps
+/// identically under both old fns and this one. See the `unified_ws_to_http_*`
+/// tests for the equivalence proof against both old suites.
+pub fn coord_ws_to_http(coord_url: &str) -> String {
+    let trimmed = coord_url.trim_end_matches('/').trim_end_matches("/ws");
+    if let Some(rest) = trimmed.strip_prefix("ws://") {
+        format!("http://{}", rest)
+    } else if let Some(rest) = trimmed.strip_prefix("wss://") {
+        format!("https://{}", rest)
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// The dev-localhost coord base used when nothing is configured.
+pub const DEV_LOCALHOST_COORD_BASE: &str = "http://localhost:9870";
+
+/// Resolve the coord HTTP base WITHOUT applying any dev-localhost policy.
+///
+/// Chain: env `COORD_HTTP_URL` (non-empty, trimmed) → active profile's
+/// `coord_url` (ws→http via [`coord_ws_to_http`]) → [`CoordBase::Unset`].
+///
+/// "Pure-ish": reads the process env and `~/.qontinui/profiles.json`, but does
+/// no logging and no fallback — callers decide the localhost posture.
+pub fn resolve_coord_base() -> CoordBase {
+    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return CoordBase::Configured(t.trim_end_matches('/').to_string());
+        }
+    }
+    // `load_strict` (not `load`) so a missing/invalid profiles.json yields
+    // Unset rather than a legacy-env best-effort with no coord_url — matches
+    // the prior Option-family resolvers, which all used `load_strict`.
+    if let Ok(p) = load_strict() {
+        if let Some(ws) = p.coord_url.as_deref() {
+            return CoordBase::Configured(coord_ws_to_http(ws));
+        }
+    }
+    CoordBase::Unset
+}
+
+/// Process-global one-shot WARN guard for the dev-localhost fallback.
+static DEV_LOCALHOST_WARN_ONCE: std::sync::Once = std::sync::Once::new();
+
+/// Resolve the coord HTTP base, applying the dev-localhost policy.
+///
+/// - `Configured(base)` ⇒ `Some(base)`.
+/// - Nothing configured ⇒ `Some("http://localhost:9870")`, emitting exactly
+///   ONE process-global `tracing::warn!` (across all call sites, for the life
+///   of the process) the first time the localhost guess is used.
+///
+/// Returns `None` only... never, actually — the localhost guess always applies
+/// here. Callers that must stay no-op when unconfigured should call
+/// [`resolve_coord_base`] directly and map `Configured ⇒ Some`, else `None`.
+/// (The `Option` return type is kept so String-family sites can write
+/// `coord_base_or_dev_localhost().unwrap_or_else(|| DEV_LOCALHOST.into())`
+/// without changing should the policy ever grow an opt-out.)
+pub fn coord_base_or_dev_localhost() -> Option<String> {
+    match resolve_coord_base() {
+        CoordBase::Configured(base) => Some(base),
+        CoordBase::DevLocalhost(base) => Some(base),
+        CoordBase::Unset => {
+            DEV_LOCALHOST_WARN_ONCE.call_once(|| {
+                warn!(
+                    coord_base = DEV_LOCALHOST_COORD_BASE,
+                    "no coord configured (COORD_HTTP_URL unset, profile has no coord_url) — \
+                     falling back to dev-localhost coord; set COORD_HTTP_URL or profiles.json \
+                     coord_url to point at the real coordinator"
+                );
+            });
+            Some(DEV_LOCALHOST_COORD_BASE.to_string())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -297,5 +413,161 @@ mod tests {
         assert_eq!(p.source, "legacy-env");
         assert!(p.database_url.contains("qontinui_user"));
         // `_restore` drops here, including the panic path above.
+    }
+
+    // ------------------------------------------------------------------
+    // Unified ws→http equivalence: the new `coord_ws_to_http` must match
+    // BOTH historical normalizers on every case their own tests exercised.
+    // ------------------------------------------------------------------
+
+    /// Reference impl of the OLD `pair::coord_http_base_from_url` — kept
+    /// here so the equivalence assertion is self-contained and survives
+    /// the real fn being folded into a re-export.
+    fn old_pair_from_url(coord_url: &str) -> String {
+        let trimmed = coord_url.trim_end_matches("/ws");
+        trimmed
+            .strip_prefix("wss://")
+            .map(|rest| format!("https://{rest}"))
+            .or_else(|| {
+                trimmed
+                    .strip_prefix("ws://")
+                    .map(|rest| format!("http://{rest}"))
+            })
+            .unwrap_or_else(|| trimmed.to_string())
+    }
+
+    /// Reference impl of the OLD `agent_worktree::coord_ws_to_http`.
+    fn old_worktree_ws_to_http(coord_url: &str) -> String {
+        let trimmed = coord_url.trim_end_matches('/').trim_end_matches("/ws");
+        if let Some(rest) = trimmed.strip_prefix("ws://") {
+            format!("http://{}", rest)
+        } else if let Some(rest) = trimmed.strip_prefix("wss://") {
+            format!("https://{}", rest)
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    #[test]
+    fn unified_ws_to_http_matches_old_pair_test_cases() {
+        // Exactly the inputs pair.rs:923-956 asserts on.
+        for input in [
+            "ws://localhost:9870/ws",
+            "wss://coord.qontinui.io:9870/ws",
+            "ws://host:9870/ws",
+            "ws://host:9870",
+            "http://host:9870",
+        ] {
+            assert_eq!(
+                coord_ws_to_http(input),
+                old_pair_from_url(input),
+                "unified disagrees with old pair fn on {input:?}"
+            );
+        }
+        // Spot-check the concrete expected values too.
+        assert_eq!(
+            coord_ws_to_http("ws://localhost:9870/ws"),
+            "http://localhost:9870"
+        );
+        assert_eq!(
+            coord_ws_to_http("wss://coord.qontinui.io:9870/ws"),
+            "https://coord.qontinui.io:9870"
+        );
+    }
+
+    #[test]
+    fn unified_ws_to_http_matches_old_worktree_test_cases() {
+        // Exactly the inputs agent_worktree/mod.rs:1491-1512 asserts on.
+        for input in [
+            "ws://h:9870",
+            "wss://h:9870",
+            "http://h:9870",
+            "https://h:9870",
+            "ws://h:9870/ws",
+            "wss://h:9870/ws",
+            "http://h:9870/ws",
+            "ws://h:9870/ws/",
+            "ws://h:9870/",
+        ] {
+            assert_eq!(
+                coord_ws_to_http(input),
+                old_worktree_ws_to_http(input),
+                "unified disagrees with old worktree fn on {input:?}"
+            );
+        }
+        // The cases that distinguish the two old fns (trailing-slash handling).
+        assert_eq!(coord_ws_to_http("ws://h:9870/ws/"), "http://h:9870");
+        assert_eq!(coord_ws_to_http("ws://h:9870/"), "http://h:9870");
+    }
+
+    // ------------------------------------------------------------------
+    // resolve_coord_base — env wins; profile ws→http; unset ⇒ Unset.
+    // These mutate process-wide env, so serialize via a module mutex (the
+    // runner test harness mutates env globally — memory
+    // `feedback_env_var_tests_serialize`).
+    // ------------------------------------------------------------------
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct CoordEnvRestore {
+        prev: Option<String>,
+    }
+    impl Drop for CoordEnvRestore {
+        fn drop(&mut self) {
+            match self.prev.take() {
+                Some(v) => std::env::set_var("COORD_HTTP_URL", v),
+                None => std::env::remove_var("COORD_HTTP_URL"),
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_coord_base_env_wins() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _restore = CoordEnvRestore {
+            prev: std::env::var("COORD_HTTP_URL").ok(),
+        };
+        std::env::set_var("COORD_HTTP_URL", "http://env-coord:9999/");
+        // Env wins regardless of any profiles.json on the test machine, and
+        // the trailing slash is trimmed.
+        assert_eq!(
+            resolve_coord_base(),
+            CoordBase::Configured("http://env-coord:9999".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_coord_base_empty_env_is_ignored() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _restore = CoordEnvRestore {
+            prev: std::env::var("COORD_HTTP_URL").ok(),
+        };
+        // Whitespace-only env is treated as unset; falls through to profile
+        // (which, absent a configured coord_url in the test env, is Unset).
+        std::env::set_var("COORD_HTTP_URL", "   ");
+        // We can't assert the profile branch deterministically (the dev box
+        // may have a profiles.json), but we CAN assert the empty env did not
+        // win: the result is never `Configured("   ")`.
+        assert_ne!(resolve_coord_base(), CoordBase::Configured("".to_string()));
+        assert_ne!(
+            resolve_coord_base(),
+            CoordBase::Configured("   ".to_string())
+        );
+    }
+
+    #[test]
+    fn coord_base_or_dev_localhost_never_none() {
+        // The String-family contract: this always yields Some(...). When the
+        // env path is taken it's the configured base; otherwise it's the
+        // localhost guess (Unset) or a profile value.
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _restore = CoordEnvRestore {
+            prev: std::env::var("COORD_HTTP_URL").ok(),
+        };
+        std::env::set_var("COORD_HTTP_URL", "http://configured:1234");
+        assert_eq!(
+            coord_base_or_dev_localhost().as_deref(),
+            Some("http://configured:1234")
+        );
     }
 }

--- a/src-tauri/src/repo_detection.rs
+++ b/src-tauri/src/repo_detection.rs
@@ -60,15 +60,11 @@ fn parse_repo_slug(url: &str) -> Option<String> {
 }
 
 fn coord_http_base() -> String {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        if !v.is_empty() {
-            return v;
-        }
-    }
-    if let Some(ws) = qontinui_runner_lib::profiles::load().coord_url.as_deref() {
-        return crate::agent_worktree::coord_ws_to_http(ws);
-    }
-    "http://localhost:9870".to_string()
+    // Delegates to the shared resolver; the dev-localhost guess is now logged
+    // once per process via `coord_base_or_dev_localhost` instead of silently
+    // returned here.
+    qontinui_runner_lib::profiles::coord_base_or_dev_localhost()
+        .unwrap_or_else(|| "http://localhost:9870".to_string())
 }
 
 async fn fetch_registered_repos() -> Result<HashSet<String>, String> {

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -101,29 +101,13 @@ fn env_u64(name: &str, default: u64) -> u64 {
 /// Resolve the coord HTTP base URL. Priority: `COORD_HTTP_URL` env →
 /// active profile (`profiles::load_strict().coord_url`, ws→http) →
 /// fallback `http://localhost:9870`.
+///
+/// Delegates to the shared resolver; the dev-localhost guess is now logged
+/// once per process via `coord_base_or_dev_localhost` instead of silently
+/// returned here.
 fn resolve_coord_url() -> String {
-    if let Ok(v) = std::env::var("COORD_HTTP_URL") {
-        let t = v.trim();
-        if !t.is_empty() {
-            return t.trim_end_matches('/').to_string();
-        }
-    }
-    if let Ok(profile) = qontinui_runner_lib::profiles::load_strict() {
-        if let Some(coord_url) = profile.coord_url {
-            let trimmed = coord_url.trim_end_matches("/ws");
-            let with_http = trimmed
-                .strip_prefix("wss://")
-                .map(|rest| format!("https://{rest}"))
-                .or_else(|| {
-                    trimmed
-                        .strip_prefix("ws://")
-                        .map(|rest| format!("http://{rest}"))
-                })
-                .unwrap_or_else(|| trimmed.to_string());
-            return with_http.trim_end_matches('/').to_string();
-        }
-    }
-    DEFAULT_COORD_URL.to_string()
+    qontinui_runner_lib::profiles::coord_base_or_dev_localhost()
+        .unwrap_or_else(|| DEFAULT_COORD_URL.to_string())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Deferred follow-up to §5 (parent fleet-policy/interception design): fold the ~13 duplicated `coord_http_base` resolvers into one.

## What
- New `qontinui_runner_lib::profiles::resolve_coord_base()` (env `COORD_HTTP_URL` → profile `coord_url` ws→http → `Unset`) + `coord_base_or_dev_localhost()` which applies the dev-localhost policy with a **process-global log-once WARN**. A runner that silently fell back to `http://localhost:9870` (a phantom coord on a prod box) now **logs it loudly** — without removing localhost (it's the legit local-dev coord; operator's stance: "log loudly, don't silently write to a phantom coord").
- Unified the two ws→http normalizers (`pair` + `agent_worktree`) into one pure fn with **equivalence tests** vs both old bodies; old names kept as thin re-exports (zero caller churn).
- **All 13 sites delegate, preserving public return types** (String / Option / Result). The 6 `Option` sites kept their `None`-when-unconfigured behavior; the 4 String + `agent_worktrees` Result sites now log-once on the localhost guess; **`pair` stays ENV-LESS by design** (device-pair path). Folded in a 13th offender (`session/coord_sync.rs`) the original survey missed.

## Pure refactor
Zero behavior change except (a) the added log-once WARN on the localhost guess, and (b) `memory_client`/`git_ops_client` now also honor `COORD_HTTP_URL` (desirable; no test pinned env-less).

## Verified
cargo check clean; profiles resolver + ws→http equivalence + pair/worktree tests pass (7); clippy clean; pre-push fmt+clippy passed.

(The sibling follow-up — the `intercept_classification` column — was closed WONTFIX: a vet found the precise misclassification-FP it targets is structurally unmeasurable on `coord.install_signatures` since wrongly-gated non-installs are Passthrough and never declare; the compile-time soak corpus already asserts FP=0/FN=0.)