### PR TITLE
fix(terminal): remove the pinned-zone-layout latch — auto-grow always fits live sessions

### DIFF
--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -1162,9 +1162,7 @@ function TerminalPageInner({
         <div style={{ display: "none" }} aria-hidden>
           <ZoneLayoutPicker
             currentLayoutId={zoneLayout.layoutId}
-            // Picking a layout from the picker UI is an explicit operator
-            // choice — pin it so auto-grow stops overriding it.
-            onSelectLayout={(id) => zoneLayout.setLayoutId(id, { pinned: true })}
+            onSelectLayout={(id) => zoneLayout.setLayoutId(id)}
             tabCount={tabs.length}
           />
           <ZoneProfilePicker
@@ -1178,9 +1176,7 @@ function TerminalPageInner({
             tabs={tabs}
             initialized={initialized}
             onLoadProfile={async (profile) => {
-              // Loading a saved profile is a deliberate operator layout choice —
-              // pin it so auto-grow doesn't override the restored arrangement.
-              zoneLayout.setLayoutId(profile.layoutId, { pinned: true });
+              zoneLayout.setLayoutId(profile.layoutId);
               labelsAndTags.setZoneLabels(profile.labels);
               labelsAndTags.setZoneNotes(profile.notes);
               labelsAndTags.setPinnedZones(new Set(profile.pins));

--- a/src/components/terminal/ZoneControlPanel.tsx
+++ b/src/components/terminal/ZoneControlPanel.tsx
@@ -738,9 +738,7 @@ export const ZoneControlPanel = React.memo(function ZoneControlPanel({
   const onLoadWorkspace = useCallback(
     async (workspace: SavedWorkspace) => {
       if (workspace.layoutId !== zoneLayout.layoutId) {
-        // Loading a saved workspace is a deliberate operator layout choice —
-        // pin it so auto-grow doesn't override the restored arrangement.
-        zoneLayout.setLayoutId(workspace.layoutId, { pinned: true });
+        zoneLayout.setLayoutId(workspace.layoutId);
       }
       for (const session of workspace.sessions) {
         if (session.zoneIndex < 0) {

--- a/src/components/terminal/commands/useTerminalCommands.ts
+++ b/src/components/terminal/commands/useTerminalCommands.ts
@@ -430,9 +430,7 @@ export function useTerminalCommands(ctx: TerminalCommandsContext): void {
       // Normalize "six-pack" / "sixpack" → "six-pack"; same for full-grid.
       const normalized = preset.replace(/sixpack/, "six-pack").replace(/fullgrid/, "full-grid");
       if (!normalized) return fail("invalid-preset");
-      // `/layout <preset>` is an explicit operator choice — pin it so auto-grow
-      // stops overriding it.
-      zoneLayout.setLayoutId(normalized, { pinned: true });
+      zoneLayout.setLayoutId(normalized);
       return ok();
     },
   });

--- a/src/components/terminal/pickLayout.test.ts
+++ b/src/components/terminal/pickLayout.test.ts
@@ -54,33 +54,35 @@ describe("pickLayout — smallest uniform preset that fits N tabs (cap full-grid
   });
 });
 
-describe("computeAutoGrowLayoutId — grow-only, pin-aware, capacity-gated", () => {
+describe("computeAutoGrowLayoutId — grow-only, capacity-gated", () => {
   it("grows single → split when a 2nd tab arrives", () => {
-    expect(computeAutoGrowLayoutId("single", 2, false)).toBe("split");
+    expect(computeAutoGrowLayoutId("single", 2)).toBe("split");
   });
 
   it("grows single → full-grid when 9 tabs arrive at once (reconnect ingest)", () => {
-    expect(computeAutoGrowLayoutId("single", 9, false)).toBe("full-grid");
+    expect(computeAutoGrowLayoutId("single", 9)).toBe("full-grid");
   });
 
   it("returns null when the current layout already fits (no thrash)", () => {
-    expect(computeAutoGrowLayoutId("quad", 4, false)).toBeNull();
-    expect(computeAutoGrowLayoutId("quad", 3, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("quad", 4)).toBeNull();
+    expect(computeAutoGrowLayoutId("quad", 3)).toBeNull();
   });
 
   it("NEVER shrinks: more zones than tabs → null", () => {
-    expect(computeAutoGrowLayoutId("full-grid", 2, false)).toBeNull();
-    expect(computeAutoGrowLayoutId("six-pack", 1, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("full-grid", 2)).toBeNull();
+    expect(computeAutoGrowLayoutId("six-pack", 1)).toBeNull();
   });
 
   it("stays put at full-grid even past the 9 ceiling (10+ tabs → null)", () => {
-    expect(computeAutoGrowLayoutId("full-grid", 10, false)).toBeNull();
-    expect(computeAutoGrowLayoutId("full-grid", 50, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("full-grid", 10)).toBeNull();
+    expect(computeAutoGrowLayoutId("full-grid", 50)).toBeNull();
   });
 
-  it("operator-pinned layout is NEVER auto-grown", () => {
-    expect(computeAutoGrowLayoutId("single", 9, true)).toBeNull();
-    expect(computeAutoGrowLayoutId("split", 6, true)).toBeNull();
+  it("has NO pin escape hatch: overflow always grows, even from an explicit layout", () => {
+    // The removed `pinned` latch let these return null, hiding live
+    // gate-continuation sessions behind a small layout. Overflow must grow.
+    expect(computeAutoGrowLayoutId("single", 9)).toBe("full-grid");
+    expect(computeAutoGrowLayoutId("split", 6)).toBe("six-pack");
   });
 
   it("only grows to a STRICTLY larger preset (asymmetric presets never shrink zones)", () => {
@@ -93,7 +95,7 @@ describe("computeAutoGrowLayoutId — grow-only, pin-aware, capacity-gated", () 
       ["six-pack", 9],
     ];
     for (const [current, count] of cases) {
-      const target = computeAutoGrowLayoutId(current, count, false);
+      const target = computeAutoGrowLayoutId(current, count);
       expect(target).not.toBeNull();
       const cur = LAYOUT_PRESETS.find((l) => l.id === current)!;
       const tgt = LAYOUT_PRESETS.find((l) => l.id === target!)!;

--- a/src/components/terminal/useKeyboardShortcuts.ts
+++ b/src/components/terminal/useKeyboardShortcuts.ts
@@ -26,7 +26,7 @@ interface UseKeyboardShortcutsParams {
     focusNextNeedsInput: (states: Record<string, SessionState>) => void;
     toggleMaximize: (idx: number) => void;
     setMaximizedZone: (idx: number | null) => void;
-    setLayoutId: (id: string, opts?: { pinned?: boolean }) => void;
+    setLayoutId: (id: string) => void;
     assignTabToZone: (idx: number, tabId: string) => void;
   };
   sessionStates: Record<string, SessionState>;
@@ -157,8 +157,7 @@ export function useKeyboardShortcuts({
         const num = parseInt(e.key, 10);
         const preset = LAYOUT_PRESETS.find((l) => l.shortcutKey === num);
         if (preset) {
-          // Keyboard shortcut is an explicit operator choice — pin it.
-          zoneLayout.setLayoutId(preset.id, { pinned: true });
+          zoneLayout.setLayoutId(preset.id);
         }
         return;
       }
@@ -211,8 +210,7 @@ export function useKeyboardShortcuts({
         e.preventDefault();
         const currentIdx = LAYOUT_PRESETS.findIndex((l) => l.id === zoneLayout.layoutId);
         const nextIdx = (currentIdx + 1) % LAYOUT_PRESETS.length;
-        // Cycle-layout shortcut is an explicit operator choice — pin it.
-        zoneLayout.setLayoutId(LAYOUT_PRESETS[nextIdx].id, { pinned: true });
+        zoneLayout.setLayoutId(LAYOUT_PRESETS[nextIdx].id);
         return;
       }
       if (e.ctrlKey && e.shiftKey && e.key === "K") {

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -106,7 +106,7 @@ interface UseTerminalInitializationParams {
   ) => void;
   zoneLayout: {
     layoutId: string;
-    setLayoutId: (id: string, opts?: { pinned?: boolean }) => void;
+    setLayoutId: (id: string) => void;
     assignTabToZone: (zoneIdx: number, tabId: string) => void;
     setFocusedZone: (zoneIdx: number) => void;
     assignments: Record<number, string>;
@@ -274,11 +274,11 @@ export function useTerminalInitialization({
         };
 
         // Restore the layout preset from the cosmetic snapshot if it differs.
-        // A saved snapshot is the operator's deliberate arrangement, so pin it
-        // — auto-grow must not override a restored layout.
+        // The restored layout is a starting point only — auto-grow may expand
+        // it later so every live session keeps a visible zone.
         if (saved && saved.layoutId !== zoneLayout.layoutId) {
           const preset = LAYOUT_PRESETS.find((p) => p.id === saved.layoutId);
-          if (preset) zoneLayout.setLayoutId(preset.id, { pinned: true });
+          if (preset) zoneLayout.setLayoutId(preset.id);
         }
 
         // 3) Bind every open Claude record to its RECORDED zone — Claude zones

--- a/src/components/terminal/useZoneLayout.restore.test.ts
+++ b/src/components/terminal/useZoneLayout.restore.test.ts
@@ -89,7 +89,7 @@ describe("Phase 1 auto-grow — layout grows to fit live tabs across ALL ingest 
     // Fixed-point iteration (the effect re-keys on layoutId; <= presets.length
     // iterations is plenty and guards against any loop bug).
     for (let i = 0; i < LAYOUT_PRESETS.length; i++) {
-      const next = computeAutoGrowLayoutId(layoutId, tabIds.length, false);
+      const next = computeAutoGrowLayoutId(layoutId, tabIds.length);
       if (!next) break;
       layoutId = next;
     }
@@ -100,9 +100,9 @@ describe("Phase 1 auto-grow — layout grows to fit live tabs across ALL ingest 
   it("converges in ONE step (grow-only target = pickLayout, no ping-pong)", () => {
     // The grow target is always `pickLayout(N)` directly, so the first
     // application already reaches the fixed point — a SECOND call returns null.
-    const first = computeAutoGrowLayoutId("single", 9, false);
+    const first = computeAutoGrowLayoutId("single", 9);
     expect(first).toBe("full-grid");
-    const second = computeAutoGrowLayoutId(first!, 9, false);
+    const second = computeAutoGrowLayoutId(first!, 9);
     expect(second).toBeNull();
   });
 
@@ -118,18 +118,19 @@ describe("Phase 1 auto-grow — layout grows to fit live tabs across ALL ingest 
     }
   });
 
-  it("operator-pinned layout is NOT overridden even when tabs overflow", () => {
-    // Operator pinned `split` (2 zones) but 6 tabs are live — auto-grow must
-    // stay null, leaving 4 tabs in the Unassigned list (the chip's job).
-    expect(computeAutoGrowLayoutId("split", 6, true)).toBeNull();
+  it("an explicit operator layout is grown too when tabs overflow (no pin latch)", () => {
+    // Operator chose `split` (2 zones) but 6 tabs are live — the removed
+    // `pinned` latch used to leave 4 sessions invisible here; now the layout
+    // grows so every live session gets a zone.
+    expect(computeAutoGrowLayoutId("split", 6)).toBe("six-pack");
     const tabIds = ["a", "b", "c", "d", "e", "f"];
-    const assignments = reconcileAssignments({}, tabIds, zoneCount("split"));
-    expect(unassignedCount(assignments, tabIds)).toBe(4);
+    const assignments = reconcileAssignments({}, tabIds, zoneCount("six-pack"));
+    expect(unassignedCount(assignments, tabIds)).toBe(0);
   });
 
   it("never shrinks: closing tabs below capacity does NOT reduce the layout", () => {
     // Grew to full-grid for 9 tabs; now only 2 remain. Auto-grow returns null
     // (shrinking is out of scope — grow only).
-    expect(computeAutoGrowLayoutId("full-grid", 2, false)).toBeNull();
+    expect(computeAutoGrowLayoutId("full-grid", 2)).toBeNull();
   });
 });

--- a/src/components/terminal/useZoneLayout.ts
+++ b/src/components/terminal/useZoneLayout.ts
@@ -162,20 +162,22 @@ export function pickLayout(totalTabs: number): string {
  *
  * Rules (all enforced here so the effect stays a thin wrapper, and the test can
  * assert them without React):
- *   - **operator-pinned wins**: when `pinned`, never auto-grow (return null).
  *   - **grow only, never shrink**: only returns a target whose zone count is
  *     STRICTLY GREATER than the current layout's; fewer tabs → null.
  *   - **capacity-driven**: only grows when `tabCount` exceeds the current
  *     layout's zone capacity.
  *   - **capped at `full-grid`** (via `pickLayout`); at 9+ tabs the target is
  *     already `full-grid`, so once there it returns null (no thrash).
+ *
+ * There is deliberately NO operator-pinned escape hatch: every live session
+ * must render in a zone. A pin latch used to suppress growth here, which let
+ * gate-continuation sessions dock as invisible zoneless tabs behind a small
+ * layout — operators ran blind to mid-implementation work for an hour.
  */
 export function computeAutoGrowLayoutId(
   currentLayoutId: string,
   tabCount: number,
-  pinned: boolean,
 ): string | null {
-  if (pinned) return null;
   const current = LAYOUT_PRESETS.find((l) => l.id === currentLayoutId) ?? LAYOUT_PRESETS[0];
   // Only act when live tabs overflow the current capacity.
   if (tabCount <= current.zones.length) return null;
@@ -202,15 +204,9 @@ interface PersistedState {
   layoutId: string;
   assignments: ZoneAssignments;
   focusedZone: number;
-  /**
-   * Operator-pinned latch (Phase 1 auto-grow). True once the operator picks a
-   * layout explicitly (picker UI / keyboard shortcut / `/layout` command /
-   * profile or workspace load). While pinned, the auto-grow effect leaves the
-   * layout alone — the operator's deliberate choice always wins over the
-   * fit-to-tabs heuristic. Programmatic grows (`+ new terminal`, restore
-   * auto-fill) never set it. Persisted so the latch survives a remount/reload.
-   */
-  pinned?: boolean;
+  // NOTE: older builds persisted a `pinned` latch here that suppressed
+  // auto-grow. The concept is removed (it hid live sessions as zoneless
+  // tabs); a stale `pinned` key in storage is simply ignored on load.
 }
 
 // Phase 1 (pop-out windows): pop-out windows share the main window's
@@ -317,22 +313,14 @@ export function useZoneLayout(
   // async restore window; the reservation is cleared once the zone is filled.
   const reservedZonesRef = useRef<Set<number>>(new Set());
 
-  // Operator-pinned latch (Phase 1 auto-grow). Seeded from persisted state so a
-  // pin survives remount/reload. A ref (not state) because nothing renders off
-  // it — only the auto-grow effect reads it, and it must reflect the latest
-  // operator action synchronously within the same commit that calls
-  // `setLayoutId({ pinned: true })`.
-  const userPinnedLayoutRef = useRef<boolean>(persistedState?.pinned ?? false);
-
   const layout = LAYOUT_PRESETS.find((l) => l.id === layoutId) ?? LAYOUT_PRESETS[0];
 
-  // Persist on changes (including the pinned latch).
+  // Persist on changes.
   useEffect(() => {
     persistState(pageId, windowLabel, {
       layoutId,
       assignments,
       focusedZone,
-      pinned: userPinnedLayoutRef.current,
     });
   }, [pageId, windowLabel, layoutId, assignments, focusedZone]);
 
@@ -345,9 +333,7 @@ export function useZoneLayout(
 
   // Shared layout-application logic: switch the preset and redistribute
   // assignments. Used by BOTH the operator-facing `setLayoutId` and the
-  // programmatic auto-grow effect — the ONLY difference between them is whether
-  // they set the operator-pinned latch (auto-grow never does, `setLayoutId`'s
-  // `{ pinned: true }` opt does).
+  // programmatic auto-grow effect.
   const applyLayout = useCallback(
     (id: string) => {
       const newLayout = LAYOUT_PRESETS.find((l) => l.id === id);
@@ -397,26 +383,22 @@ export function useZoneLayout(
   // No render loop: `computeAutoGrowLayoutId` is GROW-ONLY and capacity-gated.
   // After it grows, `layout.zones.length >= tabIds.length`, so the next run of
   // this effect (re-keyed by the new `layoutId`) computes `null` and is inert.
-  // It also bails immediately when the operator has pinned a layout.
   useEffect(() => {
-    const target = computeAutoGrowLayoutId(layoutId, tabIds.length, userPinnedLayoutRef.current);
+    const target = computeAutoGrowLayoutId(layoutId, tabIds.length);
     if (target) {
-      // Programmatic grow — do NOT touch the pinned latch.
       applyLayout(target);
     }
   }, [layoutId, tabIds.length, applyLayout]);
 
   /**
-   * Operator-facing layout switch. `opts.pinned === true` (passed from the
-   * picker UI / keyboard shortcut / `/layout` command / profile + workspace
-   * load) latches the layout so auto-grow stops overriding the operator's
-   * deliberate choice. Programmatic callers (`+ new terminal`) omit the opt and
-   * leave the latch alone.
+   * Operator-facing layout switch (picker UI / keyboard shortcut / `/layout`
+   * command / profile + workspace load). The choice is a STARTING POINT, not a
+   * latch: if live sessions later overflow the chosen layout's capacity,
+   * auto-grow still expands it — every live session must render in a zone.
    */
   const setLayoutId = useCallback(
-    (id: string, opts?: { pinned?: boolean }) => {
+    (id: string) => {
       if (!LAYOUT_PRESETS.some((l) => l.id === id)) return;
-      if (opts?.pinned) userPinnedLayoutRef.current = true;
       applyLayout(id);
     },
     [applyLayout],


### PR DESCRIPTION
## Problem

The operator-pinned layout latch suppressed zone-layout auto-grow forever once set. Worse, it was set **programmatically**: the cosmetic-snapshot restore in `useTerminalInitialization` pinned the layout on every runner restart, so operators who never explicitly chose a layout were still pinned.

Observed consequence (2026-06-10): three gate-continuation sessions docked as invisible zoneless tabs behind a 2-window layout — only the tiny "N more" chip showed — and ran mid-implementation unseen for 40–70 minutes until an unrelated `/spawn-ai` re-layout burst them all into view at once. Operator direction: there should be no hidden windows; fixing the window count doesn't make sense and should be removed.

## Change

Remove the pin concept outright rather than patching its triggers:

- `computeAutoGrowLayoutId` loses its `pinned` param — overflow always grows (still grow-only, capacity-gated, capped at `full-grid`/9; the `UnzonedChip` remains the honesty backstop past the ceiling)
- `setLayoutId` loses the `{ pinned }` opt — an explicit operator choice is a starting point, not a latch; if live sessions later overflow it, the layout grows
- persisted `pinned` field dropped — stale keys in existing localStorage are ignored on load, so previously-wedged layouts unpin themselves on next launch with no migration
- all six pinning call sites updated: picker UI, layout keyboard shortcuts (Ctrl+Shift+1–8, Ctrl+Shift+L), `/layout` command, profile load, workspace load, snapshot restore

Out of scope: per-zone cosmetic pins (`pinnedZones`/`togglePin`) are a different concept and untouched.

## Verification

- `tsc --noEmit` clean
- `vitest run src/components/terminal` — 41 files, 518/518 pass (pin tests replaced with grows-on-overflow assertions)
- eslint on changed files: 0 errors (3 pre-existing warnings on untouched lines/effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)