### PR TITLE
feat(session): carry continuation page_id into coord session registration

### DIFF
--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -1292,6 +1292,7 @@ pub async fn spawn_worker_session(
                 branch: None,
                 plan_slug: None,
                 correlation_topic: None,
+                page_id: None,
                 declared_paths: vec![],
                 share_output: true,
                 redact_secrets: None,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -49,6 +49,9 @@ impl From<StartSessionArgs> for Intent {
             branch: a.branch,
             plan_slug: a.plan_slug,
             correlation_topic: a.correlation_topic,
+            // Not exposed on `session_start` — page placement is only
+            // meaningful on the gate-continuation terminal create path.
+            page_id: None,
             declared_paths: a.declared_paths,
             share_output: a.share_output,
             redact_secrets: a.redact_secrets,

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -162,6 +162,9 @@ pub async fn terminal_create(
         branch: None,
         plan_slug,
         correlation_topic,
+        // Deliberately None on the interactive create path — a PRESENT
+        // `page_id` is the coord-side "this is a gate continuation" marker.
+        page_id: None,
         declared_paths: working_dir
             .map(std::path::PathBuf::from)
             .into_iter()
@@ -985,6 +988,9 @@ pub(crate) fn create_terminal_session_backend(
         branch: None,
         plan_slug,
         correlation_topic,
+        // Gate-continuation create path — carry the chosen page tab into
+        // `coord.sessions.intent` so coord learns the placement.
+        page_id: page_id.clone(),
         declared_paths: vec![std::path::PathBuf::from(&working_dir)],
         share_output: true,
         redact_secrets: None,

--- a/src-tauri/src/session/coord_sync.rs
+++ b/src-tauri/src/session/coord_sync.rs
@@ -1055,6 +1055,7 @@ mod tests {
             branch: Some("feat/coord-sync".into()),
             plan_slug: None,
             correlation_topic: None,
+            page_id: None,
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,

--- a/src-tauri/src/session/handoff.rs
+++ b/src-tauri/src/session/handoff.rs
@@ -643,6 +643,7 @@ fn build_child_intent(state: &HandoffState) -> Result<Intent, HandoffError> {
         branch: state.branch.clone(),
         plan_slug,
         correlation_topic,
+        page_id: None,
         declared_paths,
         share_output,
         redact_secrets,

--- a/src-tauri/src/session/intent.rs
+++ b/src-tauri/src/session/intent.rs
@@ -54,6 +54,11 @@ pub struct Intent {
     /// rendezvous. Forwarded into `coord.sessions.intent`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub correlation_topic: Option<String>,
+    /// Optional page tab id the terminal pane was placed on. Set ONLY on
+    /// the gate-continuation create path; a present `page_id` is the
+    /// coord-side marker that the session is a gate continuation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub page_id: Option<String>,
     /// Paths the session intends to touch. The plan calls this out as the
     /// hook for fine-grained claim narrowing in later phases; for now the
     /// list is persisted verbatim in the intent JSON.
@@ -135,6 +140,7 @@ mod tests {
             branch: None,
             plan_slug: None,
             correlation_topic: None,
+            page_id: None,
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,
@@ -213,6 +219,7 @@ mod tests {
             branch: Some("main".into()),
             plan_slug: Some("2026-05-22-coord-native-session-coordination".into()),
             correlation_topic: Some("by-correlation-topic/demo".into()),
+            page_id: Some("page-2".into()),
             declared_paths: vec![PathBuf::from("/repo/path")],
             share_output: true,
             redact_secrets: Some(false),
@@ -220,5 +227,21 @@ mod tests {
         let serialized = serde_json::to_string(&i).unwrap();
         let back: Intent = serde_json::from_str(&serialized).unwrap();
         assert_eq!(back, i);
+    }
+
+    #[test]
+    fn page_id_none_omits_key_and_some_round_trips() {
+        // `None` must serialize WITHOUT the key (skip_serializing_if) so
+        // existing coord rows / consumers see no shape change.
+        let serialized = serde_json::to_string(&good_intent()).unwrap();
+        assert!(!serialized.contains("page_id"));
+
+        // A JSON intent carrying `"page_id":"page-2"` round-trips.
+        let mut with_page = good_intent();
+        with_page.page_id = Some("page-2".into());
+        let json = serde_json::to_string(&with_page).unwrap();
+        assert!(json.contains("\"page_id\":\"page-2\""));
+        let back: Intent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, with_page);
     }
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1057,6 +1057,7 @@ mod tests {
             branch: None,
             plan_slug: None,
             correlation_topic: None,
+            page_id: None,
             declared_paths: vec![],
             share_output: false,
             redact_secrets: None,


### PR DESCRIPTION
## What

Phase 1 of plan `2026-06-10-continuation-page-placement-observability-gate`:

- Add optional `page_id` to the runner `Intent` (`session/intent.rs`) with `#[serde(default, skip_serializing_if = "Option::is_none")]` — `None` produces no wire/shape change, older consumers unaffected.
- `create_terminal_session_backend` (`commands/terminal.rs`) sets `page_id: page_id.clone()` from the page the gate continuation was placed on. Its sole caller is the continuation path (`run_continuation_terminal`), so a present `page_id` IS the continuation marker.
- The interactive `terminal_create` path deliberately keeps `page_id: None` — setting it there would break the coord-side continuation predicate (see plan, Out of scope).
- All other `Intent` construction sites gain a mechanical `page_id: None`.

No drainer change: the outbox `Started` payload embeds the intent and `rebuild_create_body` forwards it verbatim; coord persists it into the `coord.sessions.intent` JSONB automatically.

## Why

`2026-06-09-continuation-overflow-auto-page-distribution` shipped the page-spread/mint path with no coord-side signal that it ever fires in production. This carries the placement into coord so the `continuation_sessions_on_non_default_page` named query (companion coord PR qontinui/qontinui-coord#525) can count it and the "spread-in-the-wild" gate can watch it.

## Tests

- New `page_id_none_omits_key_and_some_round_trips` — None omits the key entirely; Some round-trips.
- Existing intent JSON round-trip extended with `Some("page-2")`.
- `cargo fmt --check` + `cargo clippy -D warnings` clean locally.

Independent of the coord PR — neither blocks the other; the Phase 3 gate just needs both deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)