### PR TITLE
fix(terminal): replay the Rust scrollback ring into every (re)mounted xterm

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -569,6 +569,42 @@ pub fn terminal_ack(
     })
 }
 
+/// Get the LIVE scrollback ring buffer for a terminal session.
+///
+/// Returns the raw PTY byte history (base64) plus its absolute offset range
+/// `[startOffset, endOffset)` in the session's output stream. The frontend
+/// replays this into a freshly-(re)mounted xterm so scrollback survives the
+/// TerminalInstance remounts that zone-layout changes and page reloads cause
+/// (`terminal_get_grid` only restores the visible rows×cols screen), then
+/// uses `endOffset` to dedup against offset-stamped live `terminal-output`
+/// chunks.
+#[tauri::command]
+pub fn terminal_get_scrollback(
+    terminal_manager: tauri::State<'_, Arc<TerminalManager>>,
+    terminal_id: String,
+) -> Result<CommandResponse, String> {
+    let session = terminal_manager
+        .get(&terminal_id)
+        .ok_or_else(|| format!("Terminal not found: {}", terminal_id))?;
+
+    let (data, start_offset) = session.get_scrollback_buffer();
+    let end_offset = start_offset + data.len() as u64;
+    // Reconnecting frontends fetch the full ring; reset backpressure the same
+    // way the WS/HTTP buffer path does so the reader thread doesn't stall.
+    session.reset_flow_control();
+    let encoded = STANDARD.encode(&data);
+
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: Some(serde_json::json!({
+            "data": encoded,
+            "startOffset": start_offset,
+            "endOffset": end_offset,
+        })),
+    })
+}
+
 /// Save the scrollback buffer for a terminal session to disk.
 ///
 /// Persists the current scrollback buffer to `{app_data}/terminal-scrollback/{terminal_id}.bin`

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1712,6 +1712,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::terminal::terminal_create,
             commands::terminal::terminal_get_grid,
             commands::terminal::terminal_get_saved_scrollback,
+            commands::terminal::terminal_get_scrollback,
             commands::terminal::terminal_grid_diff,
             commands::terminal::terminal_grid_search,
             commands::terminal::terminal_grid_text,

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info, warn};
 
 use super::grid::{Grid, GridPerformer};
 use super::interceptor::OutputInterceptor;
-use super::types::{TerminalExitEvent, TerminalId, TerminalInfo, TerminalOutputEvent};
+use super::types::{TerminalExitEvent, TerminalId, TerminalInfo};
 
 /// Shell integration scripts embedded at compile time.
 #[cfg(target_os = "windows")]
@@ -47,11 +47,22 @@ const SCROLLBACK_CAPACITY: usize = 1_048_576;
 /// the per-session isolation that [`TerminalSession::get_scrollback_buffer`]
 /// reads back depends on each session holding distinct instances, which is
 /// what the distinct-buffers regression test locks in.
+///
+/// Returns the chunk's absolute START offset in the session's output stream
+/// (the counter value before this chunk) — the reader thread stamps it onto
+/// the `terminal-output` event so the frontend can dedup a scrollback-ring
+/// replay against concurrently-delivered live chunks by byte offset.
+///
+/// The counter bump happens INSIDE the ring lock so that a reader of
+/// `(ring contents, total)` under the same lock sees a mutually consistent
+/// pair — [`TerminalSession::get_scrollback_buffer`] relies on this to
+/// compute an exact `end_offset` (off-by-one-chunk here would make the
+/// frontend double-write or drop a chunk at the replay boundary).
 fn tee_into_scrollback(
     scrollback: &Arc<Mutex<VecDeque<u8>>>,
     total_produced: &Arc<AtomicU64>,
     data: &[u8],
-) {
+) -> u64 {
     if let Ok(mut sb) = scrollback.lock() {
         for &byte in data {
             if sb.len() >= SCROLLBACK_CAPACITY {
@@ -59,8 +70,30 @@ fn tee_into_scrollback(
             }
             sb.push_back(byte);
         }
+        total_produced.fetch_add(data.len() as u64, Ordering::Relaxed)
+    } else {
+        // Poisoned ring lock: the chunk was still produced — keep the
+        // monotonic counter truthful even though buffering failed.
+        total_produced.fetch_add(data.len() as u64, Ordering::Relaxed)
     }
-    total_produced.fetch_add(data.len() as u64, Ordering::Relaxed);
+}
+
+/// Tauri `terminal-output` wire shape: the shared `TerminalOutputEvent`
+/// (qontinui-types) is `deny_unknown_fields`, so the extra `offset` rides on
+/// this runner-local struct instead of forcing a schemas version bump. Only
+/// the runner frontend consumes the Tauri event; the backend-relay broadcast
+/// keeps its own offset-free payload.
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TerminalOutputWire<'a> {
+    terminal_id: &'a str,
+    data: &'a str,
+    /// Absolute byte offset of this chunk's first byte in the session's
+    /// output stream (the value of `total_bytes_produced` before this chunk
+    /// was teed). Lets the frontend dedup a scrollback-ring replay against
+    /// live chunks — see `terminal_get_scrollback` and the frontend's
+    /// `scrollbackReplay.ts`.
+    offset: u64,
 }
 
 /// ANSI bracketed-paste begin marker.
@@ -395,8 +428,11 @@ impl TerminalSession {
                             // Tee processed output into the per-session
                             // scrollback ring buffer + byte counter. Shared
                             // with the distinct-buffers regression test so
-                            // both drive the identical teeing path.
-                            tee_into_scrollback(&reader_scrollback, &reader_total_bytes, &data);
+                            // both drive the identical teeing path. The
+                            // returned start offset is stamped onto the
+                            // event below for replay dedup.
+                            let chunk_offset =
+                                tee_into_scrollback(&reader_scrollback, &reader_total_bytes, &data);
 
                             // Tee through the VT parser into the per-session cell grid.
                             // Detect the first OSC 0/2 title transition by
@@ -439,9 +475,10 @@ impl TerminalSession {
                             let encoded = STANDARD.encode(&data);
                             // Broadcast to HTTP/SSE subscribers (ignore if no receivers)
                             let _ = reader_output_tx.send(encoded.clone());
-                            let event = TerminalOutputEvent {
-                                terminal_id: reader_id.clone(),
-                                data: encoded,
+                            let event = TerminalOutputWire {
+                                terminal_id: &reader_id,
+                                data: &encoded,
+                                offset: chunk_offset,
                             };
                             if let Err(e) = reader_app.emit("terminal-output", &event) {
                                 warn!(
@@ -992,11 +1029,22 @@ impl TerminalSession {
 
     /// Get the scrollback buffer contents and the byte offset where the data starts.
     /// Returns `(data, start_offset)` where `start_offset = total_bytes_produced - data.len()`.
+    ///
+    /// `total` is read while HOLDING the ring lock: `tee_into_scrollback`
+    /// bumps the counter inside the same lock, so the pair is mutually
+    /// consistent — `start_offset + data.len()` is an exact replay boundary
+    /// for offset-stamped `terminal-output` chunks (no chunk is ever half
+    /// inside the snapshot).
     pub fn get_scrollback_buffer(&self) -> (Vec<u8>, u64) {
-        let total = self.total_bytes_produced.load(Ordering::Relaxed);
-        let data = match self.scrollback_buffer.lock() {
-            Ok(sb) => sb.iter().copied().collect::<Vec<u8>>(),
-            Err(_) => Vec::new(),
+        let (data, total) = match self.scrollback_buffer.lock() {
+            Ok(sb) => (
+                sb.iter().copied().collect::<Vec<u8>>(),
+                self.total_bytes_produced.load(Ordering::Relaxed),
+            ),
+            Err(_) => (
+                Vec::new(),
+                self.total_bytes_produced.load(Ordering::Relaxed),
+            ),
         };
         let start_offset = total.saturating_sub(data.len() as u64);
         (data, start_offset)
@@ -1440,7 +1488,9 @@ mod tests {
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) | Err(_) => break,
-                    Ok(n) => tee_into_scrollback(&scrollback, &total, &buf[..n]),
+                    Ok(n) => {
+                        tee_into_scrollback(&scrollback, &total, &buf[..n]);
+                    }
                 }
             }
         });

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -12,7 +12,18 @@ import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
 import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
 import { matchScrollShortcut } from "./scrollKeys";
+import { trimReplayedChunk, type OffsetChunk } from "./scrollbackReplay";
 import { useWindowAssignments } from "./contexts/WindowAssignmentsContext";
+
+/**
+ * The runner's reader thread stamps each `terminal-output` event with the
+ * chunk's absolute byte offset in the session's output stream (a runner-local
+ * extension — the shared `TerminalOutputEvent` schema is deny_unknown_fields,
+ * so the field rides outside it). Used to dedup the scrollback-ring replay
+ * against live chunks; `undefined` (older runner build) degrades to the
+ * pre-replay write-everything behavior.
+ */
+type TerminalOutputPayload = TerminalOutputEvent & { offset?: number };
 
 export interface TerminalInstanceHandle {
   getSelection: () => string;
@@ -358,9 +369,16 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       // (WASM load + open + key handlers + UI Bridge registration) takes
       // ~200ms; without this buffer we'd silently drop everything Claude
       // emits in that window and xterm would freeze on whatever the grid
-      // contained at bootstrap snapshot time.
-      let pendingBytes: Uint8Array[] = [];
+      // contained at bootstrap snapshot time. Chunks keep their absolute
+      // stream offset so the drain can dedup against the scrollback-ring
+      // replay (see scrollbackReplay.ts).
+      let pendingBytes: OffsetChunk[] = [];
       let backendReady = false;
+      // End offset (exclusive) of the scrollback-ring replay written into
+      // this xterm instance during init. Live/pending chunks below this
+      // boundary are already in the buffer via the ring and must not be
+      // written again.
+      let replayedThrough = 0;
       // Assigned once the backend exists (see Bug A note above). Until then
       // the listener buffers bytes; we can't schedule a repaint that needs
       // the backend.
@@ -384,7 +402,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       };
 
       const buildOutputListener = () =>
-        listen<TerminalOutputEvent>("terminal-output", (event) => {
+        listen<TerminalOutputPayload>("terminal-output", (event) => {
           if (event.payload.terminalId !== terminalId) return;
           const raw = atob(event.payload.data);
           const bytes = new Uint8Array(raw.length);
@@ -395,16 +413,28 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
           if (!backendReady) {
             // Backend not yet created — buffer the bytes; they'll be drained
             // (and the idle timer primed) once the backend init completes.
-            pendingBytes.push(bytes);
+            pendingBytes.push({ bytes, offset: event.payload.offset });
             return;
           }
 
           const b = backendRef.current;
           if (!b) return;
-          try {
-            b.write(bytes);
-          } catch (e) {
-            console.error(`[Terminal ${terminalId}] write error:`, e);
+          // A chunk emitted before the ring snapshot can still be DELIVERED
+          // after the replay (event delivery and invoke responses are not
+          // mutually ordered) — trim it to its unreplayed suffix so the
+          // boundary bytes aren't written twice. onOutput/ack bookkeeping
+          // below stays on the full chunk: the content reached the terminal
+          // either way (via the ring), only the duplicate write is skipped.
+          const unreplayed = trimReplayedChunk(
+            { bytes, offset: event.payload.offset },
+            replayedThrough,
+          );
+          if (unreplayed) {
+            try {
+              b.write(unreplayed);
+            } catch (e) {
+              console.error(`[Terminal ${terminalId}] write error:`, e);
+            }
           }
           if (onOutputRef.current) {
             try {
@@ -763,13 +793,49 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         //      fetch the GridSnapshot and paintGrid. paintGrid uses
         //      absolute CUP per row inside a DECAWM-off bracket — safe to
         //      write concurrently with live bytes.
-        for (const buffered of pendingBytes) {
-          try {
-            backend.write(buffered);
-          } catch (e) {
-            console.error(`[Terminal ${terminalId}] drain write error:`, e);
+        // Replay the Rust-side scrollback ring BEFORE any live/pending bytes
+        // land. TerminalInstance remounts whenever the zone layout reshapes
+        // (maximize / single-view toggle, layout switch, hidden↔assigned
+        // reclassification) and on page reload — each remount discards the
+        // previous xterm buffer, and the grid bootstrap below restores only
+        // the visible rows×cols screen. Without this replay a remounted pane
+        // has an EMPTY scrollback (wheel / Shift+PgUp scroll nothing) until
+        // fresh output accumulates. The ring is written at the backend's
+        // default size; the bootstrap fit below reflows it to the real
+        // viewport, same as the disk-based session-restore path.
+        try {
+          const ring = await invoke<{
+            success: boolean;
+            data: { data: string; startOffset: number; endOffset: number } | null;
+          }>("terminal_get_scrollback", { terminalId });
+          if (disposed) return;
+          if (ring.success && ring.data && ring.data.data) {
+            const rawRing = atob(ring.data.data);
+            const ringBytes = new Uint8Array(rawRing.length);
+            for (let i = 0; i < rawRing.length; i++) {
+              ringBytes[i] = rawRing.charCodeAt(i);
+            }
+            backend.write(ringBytes);
+            replayedThrough = ring.data.endOffset;
           }
-          bytesReceivedRef.current += buffered.length;
+        } catch (e) {
+          // Best-effort: a failed replay degrades to the pre-fix behavior
+          // (screen-only bootstrap), never blocks the live stream.
+          console.warn(`[Terminal ${terminalId}] scrollback replay failed:`, e);
+        }
+
+        for (const buffered of pendingBytes) {
+          // Drop/trim the part of each buffered chunk the ring replay above
+          // already wrote (ack bookkeeping stays on the full chunk).
+          const slice = trimReplayedChunk(buffered, replayedThrough);
+          if (slice) {
+            try {
+              backend.write(slice);
+            } catch (e) {
+              console.error(`[Terminal ${terminalId}] drain write error:`, e);
+            }
+          }
+          bytesReceivedRef.current += buffered.bytes.length;
         }
         pendingBytes = [];
         backendReady = true;

--- a/src/components/terminal/scrollbackReplay.test.ts
+++ b/src/components/terminal/scrollbackReplay.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { trimReplayedChunk } from "./scrollbackReplay";
+
+const bytes = (...vals: number[]) => new Uint8Array(vals);
+
+describe("trimReplayedChunk", () => {
+  it("returns the chunk whole when it carries no offset (pre-offset runner build)", () => {
+    const b = bytes(1, 2, 3);
+    expect(trimReplayedChunk({ bytes: b }, 100)).toBe(b);
+  });
+
+  it("returns the chunk whole when nothing was replayed", () => {
+    const b = bytes(1, 2, 3);
+    expect(trimReplayedChunk({ bytes: b, offset: 0 }, 0)).toBe(b);
+  });
+
+  it("drops a chunk entirely covered by the replay", () => {
+    expect(trimReplayedChunk({ bytes: bytes(1, 2, 3), offset: 10 }, 13)).toBeNull();
+    expect(trimReplayedChunk({ bytes: bytes(1, 2, 3), offset: 10 }, 50)).toBeNull();
+  });
+
+  it("returns the chunk whole when it starts at or after the boundary", () => {
+    const b = bytes(1, 2, 3);
+    expect(trimReplayedChunk({ bytes: b, offset: 13 }, 13)).toBe(b);
+    expect(trimReplayedChunk({ bytes: b, offset: 20 }, 13)).toBe(b);
+  });
+
+  it("trims a straddling chunk to its unreplayed suffix", () => {
+    // Chunk covers [10, 15); replay covers [_, 12) → keep bytes at 12, 13, 14.
+    const out = trimReplayedChunk({ bytes: bytes(10, 11, 12, 13, 14), offset: 10 }, 12);
+    expect(out).not.toBeNull();
+    expect(Array.from(out!)).toEqual([12, 13, 14]);
+  });
+
+  it("treats an exact-boundary chunk end as fully covered (half-open ranges)", () => {
+    // Chunk [10, 13), replay through 13 → covered; through 12 → 1 byte survives.
+    expect(trimReplayedChunk({ bytes: bytes(1, 2, 3), offset: 10 }, 13)).toBeNull();
+    const out = trimReplayedChunk({ bytes: bytes(1, 2, 3), offset: 10 }, 12);
+    expect(Array.from(out!)).toEqual([3]);
+  });
+});

--- a/src/components/terminal/scrollbackReplay.ts
+++ b/src/components/terminal/scrollbackReplay.ts
@@ -1,0 +1,50 @@
+/**
+ * scrollbackReplay — pure helper for deduping live `terminal-output` chunks
+ * against a scrollback-ring replay.
+ *
+ * Why this exists: `TerminalInstance` remounts whenever the zone layout
+ * reshapes (maximize / single-view toggle, layout switch, hidden↔assigned
+ * reclassification) and on page reload. Each remount discards the xterm
+ * buffer, and the grid bootstrap (`terminal_get_grid` + `paintGrid`) restores
+ * only the visible rows×cols screen — so a remounted pane had an EMPTY
+ * scrollback until new output accumulated. The fix replays the Rust-side
+ * 1 MB scrollback ring (`terminal_get_scrollback`) into the fresh xterm
+ * before any live bytes land.
+ *
+ * The ring snapshot covers absolute stream offsets `[startOffset, endOffset)`.
+ * Live `terminal-output` events are stamped with their chunk's absolute start
+ * `offset` (see the reader thread in `src-tauri/src/terminal/session.rs`), so
+ * any byte below `endOffset` is already in the buffer via the replay. This
+ * helper trims a chunk to its not-yet-replayed suffix — exact, no heuristics.
+ *
+ * Leaf module (no xterm / Tauri imports) so vitest can exercise the boundary
+ * math without loading the backends — same rationale as `wheelScroll.ts`.
+ */
+
+/** A live or buffered output chunk plus its absolute stream offset. */
+export interface OffsetChunk {
+  bytes: Uint8Array;
+  /**
+   * Absolute byte offset of `bytes[0]` in the session's output stream.
+   * `undefined` for events from a runner build that predates offset
+   * stamping — those are written unconditionally (pre-fix behavior).
+   */
+  offset?: number;
+}
+
+/**
+ * Return the portion of `chunk` NOT yet covered by a ring replay that ends at
+ * `replayedThrough`, or `null` if the chunk is entirely covered.
+ *
+ * - No `offset` on the chunk → no provenance → return it whole.
+ * - Entirely below the boundary → `null` (already written via the ring).
+ * - Straddling the boundary → the unreplayed suffix.
+ */
+export function trimReplayedChunk(chunk: OffsetChunk, replayedThrough: number): Uint8Array | null {
+  const { bytes, offset } = chunk;
+  if (offset === undefined || replayedThrough <= 0) return bytes;
+  const end = offset + bytes.length;
+  if (end <= replayedThrough) return null;
+  if (offset >= replayedThrough) return bytes;
+  return bytes.subarray(replayedThrough - offset);
+}


### PR DESCRIPTION
## Problem

Operator report: terminal panes on the Terminal page sometimes can't be scrolled to see earlier content — intermittently.

Live forensics on the running primary (React-fiber walk via `page/evaluate` to read real `term.buffer.active` state — xterm 6's virtualized viewport makes DOM scroll metrics meaningless) showed visible panes holding **5–89 buffer lines despite 200–900KB of PTY output**, with no app-side cause (`?1049` alt-screen: 0 toggles, `ESC[3J`: 0, no mouse capture).

Root cause: **every zone-layout change (maximize / single-view toggle, layout switch, hidden↔assigned reclassification) and every page reload remounts `TerminalInstance`**, destroying the xterm buffer. The bootstrap restores only the visible rows×cols screen (`terminal_get_grid` + `paintGrid`) — never the history — and Claude Code's TUI repaints in place afterward, so almost nothing re-accumulates. A pane scrolls fine only if it sat undisturbed since creation; rearrange it and there is literally nothing to scroll. (The #377 Shift+wheel gesture and #408 keyboard scrolling are unaffected and orthogonal — they scroll a buffer that, post-remount, was empty.)

## Fix

Replay the existing per-session 1MB Rust scrollback ring into the fresh xterm on every (re)mount, before any live bytes land, with exact offset-based dedup:

- **`session.rs`** — `tee_into_scrollback` now returns the chunk's absolute start offset and bumps `total_bytes_produced` *inside* the ring lock, so `(ring, total)` snapshots are mutually consistent (an off-by-one-chunk boundary would double-write or drop bytes). The reader thread stamps the offset onto each `terminal-output` event via a runner-local `TerminalOutputWire` (the shared `TerminalOutputEvent` is `deny_unknown_fields`; the relay/WS/SSE payloads are unchanged).
- **`commands/terminal.rs`** — new `terminal_get_scrollback` command: ring as base64 + its `[startOffset, endOffset)` range; resets flow control like the WS/HTTP buffer paths.
- **`TerminalInstance.tsx`** — during init: replay the ring, then drain buffered live chunks trimmed to their unreplayed suffix; post-init live chunks are trimmed the same way (event delivery and invoke responses are not mutually ordered). `onOutput`/ack bookkeeping stays on full chunks. A failed replay logs and degrades to the previous screen-only bootstrap.
- **`scrollbackReplay.ts`** — pure leaf helper for the boundary math (same pattern as `wheelScroll.ts`), with vitest coverage.

Also fixes the page-reload reconnect path, which had the same screen-only restore gap.

## Verification

- `cargo check` + `cargo clippy -- -D warnings` + `cargo fmt --check` clean
- `tsc --noEmit`, eslint, prettier clean
- vitest: 524 passed in `src/components/terminal` (incl. 6 new `trimReplayedChunk` boundary tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)