### PR TITLE
fix(terminal): boot-restore resumes with --permission-mode bypassPermissions

### DIFF
--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -14,7 +14,7 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
-import { fetchOpenRecords, claimInitForPage } from "./useTerminalInitialization";
+import { fetchOpenRecords, claimInitForPage, buildResumeCmd } from "./useTerminalInitialization";
 import type { TerminalSessionRecord } from "./types";
 
 const rec = (overrides: Partial<TerminalSessionRecord>): TerminalSessionRecord => ({
@@ -152,5 +152,25 @@ describe("claimInitForPage (once-per-pageId guard)", () => {
     expect(claimInitForPage(seen, "page-a")).toBe(false);
     // ...and B is likewise already converged.
     expect(claimInitForPage(seen, "page-b")).toBe(false);
+  });
+});
+
+describe("buildResumeCmd (boot-restore resume command)", () => {
+  it("resumes autonomously — bypassPermissions so an unattended restore never stalls on a permission prompt", () => {
+    const cmd = buildResumeCmd("abc-123", undefined);
+    expect(cmd).toBe("claude --permission-mode bypassPermissions --resume abc-123\r");
+  });
+
+  it("prefixes CLAUDE_CONFIG_DIR while keeping the bypass form", () => {
+    vi.stubGlobal("navigator", { platform: "Win32" });
+    try {
+      const cmd = buildResumeCmd("abc-123", "C:\\claude\\.claude-hotmail");
+      expect(cmd).toBe(
+        '$env:CLAUDE_CONFIG_DIR="C:\\claude\\.claude-hotmail"; ' +
+          "claude --permission-mode bypassPermissions --resume abc-123\r",
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -45,9 +45,18 @@ export async function fetchOpenRecords(pageId: string): Promise<TerminalSessionR
   return [...byId.values()];
 }
 
-/** Build a `claude --resume <id>` command, optionally prefixed with CLAUDE_CONFIG_DIR. */
-function buildResumeCmd(sessionId: string, configDir: string | undefined): string {
-  const base = `claude --resume ${sessionId}`;
+/**
+ * Build a `claude --resume <id>` command, optionally prefixed with
+ * CLAUDE_CONFIG_DIR. Autonomous resume (`--permission-mode bypassPermissions`,
+ * matching the zone-profile + shell-integration resume builders and the
+ * backend `is_bypass_resume` detector) — a boot-restored session is unattended,
+ * so a bare `claude --resume` would stall forever on its first permission
+ * prompt.
+ *
+ * Exported for unit tests (vitest `environment: "node"`).
+ */
+export function buildResumeCmd(sessionId: string, configDir: string | undefined): string {
+  const base = `claude --permission-mode bypassPermissions --resume ${sessionId}`;
   if (!configDir) return `${base}\r`;
   const isWindows = navigator.platform.startsWith("Win");
   return isWindows


### PR DESCRIPTION
## Problem

After a runner crash/restart, the registry-driven boot restore (`useTerminalInitialization.ts`) typed a **bare** `claude --resume <id>` into each restored pane. Restored sessions therefore came back in default permission mode and stalled at their first tool-permission prompt — unattended, since boot restore by definition runs with nobody watching the pane. Observed live on the 2026-06-12 12:11 unclean restart: all four resumed sessions came back permission-gated.

## Fix

Align `buildResumeCmd` with the canonical autonomous-resume form already used by **every other resume surface**:

- zone-profile restore (`TerminalSessionContext.tsx`): `claude --permission-mode bypassPermissions --resume <id>`
- shell integration (`useShellIntegration.ts`): same form
- gate-continuation spawn: `--dangerously-skip-permissions`
- backend `is_bypass_resume` detector (`terminal/manager.rs`) explicitly recognises both forms

Helper exported for vitest node-env tests (same precedent as `fetchOpenRecords`/`claimInitForPage`); two tests pin the bypass form incl. the `CLAUDE_CONFIG_DIR` prefix variant.

## Verification

- `vitest run useTerminalInitialization.test.ts` — 12/12 pass
- `tsc --noEmit` clean, eslint + prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)