### PR TITLE
fix(restore): verify resume landed + poll grace for restoring tabs + summary-picker answer (#548 Phase 3)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -863,8 +863,47 @@ pub fn terminal_session_record_open(
         close_reason: None,
         // `None` (origin-unaware callers) preserves any existing origin.
         bind_origin,
+        restore_pending_at: None,
     };
     store.record_open(record);
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: None,
+    })
+}
+
+/// Mark a session restore-pending in the lifecycle registry: the boot-restore
+/// drain is about to type `claude --resume` into a freshly-created plain shell
+/// and the handshake is not yet verified. While the marker is set the
+/// backend liveness poll never flips the record `poll-dead` (a failed restore
+/// must leave the durable `open` record intact for the next attempt). The
+/// marker is backend-owned + durable so a frontend crash mid-restore can't
+/// lose it. No-op (still succeeds) if the session is absent.
+#[tauri::command]
+pub fn terminal_session_mark_restore_pending(
+    store: tauri::State<'_, Arc<SessionLifecycleStore>>,
+    claude_session_id: String,
+) -> Result<CommandResponse, String> {
+    store.mark_restore_pending(&claude_session_id);
+    Ok(CommandResponse {
+        success: true,
+        message: None,
+        data: None,
+    })
+}
+
+/// Clear a session's restore-pending marker: the restore drain verified the
+/// Claude UI handshake (the resume actually landed), so normal liveness
+/// classification resumes. No-op (still succeeds) if the session is absent or
+/// the marker is already clear. The backend poll also self-heals a stale
+/// marker when it observes the session confidently alive.
+#[tauri::command]
+pub fn terminal_session_clear_restore_pending(
+    store: tauri::State<'_, Arc<SessionLifecycleStore>>,
+    claude_session_id: String,
+) -> Result<CommandResponse, String> {
+    store.clear_restore_pending(&claude_session_id);
     Ok(CommandResponse {
         success: true,
         message: None,
@@ -1241,6 +1280,7 @@ async fn poll_and_record_session<F>(
                 close_reason: None,
                 // Freshest-transcript mtime guess — may be a foreign session.
                 bind_origin: Some("guessed".to_string()),
+                restore_pending_at: None,
             };
             store.record_open(record);
             info!(
@@ -1289,6 +1329,7 @@ pub(crate) fn record_pinned_session_open(
         closed_at: None,
         close_reason: None,
         bind_origin: Some("pinned".to_string()),
+        restore_pending_at: None,
     });
     info!(
         terminal_id = %terminal_id,
@@ -1358,6 +1399,8 @@ pub fn plugin() -> TauriPlugin<tauri::Wry> {
             terminal_session_record_open,
             terminal_session_record_close,
             terminal_session_list_open,
+            terminal_session_mark_restore_pending,
+            terminal_session_clear_restore_pending,
         ])
         .build()
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1719,7 +1719,9 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::terminal::terminal_list,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_save_scrollback,
+            commands::terminal::terminal_session_clear_restore_pending,
             commands::terminal::terminal_session_list_open,
+            commands::terminal::terminal_session_mark_restore_pending,
             commands::terminal::terminal_session_record_close,
             commands::terminal::terminal_session_record_open,
             commands::terminal::terminal_set_title,
@@ -2283,11 +2285,30 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                 .get(&rec.claude_session_id)
                                 .copied()
                                 .unwrap_or(0);
-                            let action =
-                                classify(live_is_alive, descendant_count, prior, snapshot_ok);
+                            // Restore-pending records (a boot-restore typed
+                            // `claude --resume` whose handshake isn't verified
+                            // yet — or whose restore FAILED and awaits a retry)
+                            // must never flip `poll-dead`: classify Skips them
+                            // unless the session is confidently alive.
+                            let restore_pending = rec.restore_pending_at.is_some();
+                            let action = classify(
+                                live_is_alive,
+                                descendant_count,
+                                prior,
+                                snapshot_ok,
+                                restore_pending,
+                            );
 
                             match action {
                                 PollAction::KeepAlive => {
+                                    // Confidently alive — self-heal a stale
+                                    // restore-pending marker (the frontend's
+                                    // verified-handshake clear may have been
+                                    // lost with a crash).
+                                    if restore_pending {
+                                        poll_lifecycle_store
+                                            .clear_restore_pending(&rec.claude_session_id);
+                                    }
                                     poll_lifecycle_store.touch(&rec.claude_session_id);
                                     consecutive_dead.remove(&rec.claude_session_id);
                                 }

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -101,6 +101,18 @@ pub struct TerminalSessionRecord {
     /// Records predating the field deserialize as `None` = guessed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bind_origin: Option<String>,
+    /// Unix millis when a boot-restore began re-typing this session's
+    /// `claude --resume` (set via [`SessionLifecycleStore::mark_restore_pending`],
+    /// cleared via [`SessionLifecycleStore::clear_restore_pending`] once the
+    /// resume handshake is verified). While set, the liveness poll must NEVER
+    /// flip the record `poll-dead` — a restore whose resume command silently
+    /// failed to land needs its durable `open` state intact for the next
+    /// attempt (operator retry or next boot), not destroyed mid-restore. The
+    /// marker is backend-owned and durable so a frontend crash mid-restore
+    /// can't lose it. Self-heals: the poll clears a stale marker the moment it
+    /// observes the session confidently alive (KeepAlive).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub restore_pending_at: Option<i64>,
 }
 
 /// Durable map of `claude_session_id -> TerminalSessionRecord`. Cheap to
@@ -209,6 +221,51 @@ impl SessionLifecycleStore {
             match m.get_mut(claude_session_id) {
                 Some(rec) => rec.last_seen_at = now,
                 None => return,
+            }
+            m.clone()
+        };
+        self.persist(&snapshot);
+    }
+
+    /// Mark a present session as restore-pending (a boot-restore is about to
+    /// type / has typed `claude --resume` and the handshake is not yet
+    /// verified). While the marker is set the liveness poll skips the record
+    /// entirely except for a confident-alive observation — see [`classify`].
+    /// No-op (no write) if the session is absent.
+    pub fn mark_restore_pending(&self, claude_session_id: &str) {
+        let now = Utc::now().timestamp_millis();
+        let snapshot = {
+            let mut m = match self.map.lock() {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(error = %e, "session_lifecycle_store: lock poisoned on mark_restore_pending");
+                    return;
+                }
+            };
+            match m.get_mut(claude_session_id) {
+                Some(rec) => rec.restore_pending_at = Some(now),
+                None => return,
+            }
+            m.clone()
+        };
+        self.persist(&snapshot);
+    }
+
+    /// Clear a session's restore-pending marker (resume handshake verified —
+    /// the session is live again). No-op (no write) if the session is absent
+    /// or the marker is already clear.
+    pub fn clear_restore_pending(&self, claude_session_id: &str) {
+        let snapshot = {
+            let mut m = match self.map.lock() {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(error = %e, "session_lifecycle_store: lock poisoned on clear_restore_pending");
+                    return;
+                }
+            };
+            match m.get_mut(claude_session_id) {
+                Some(rec) if rec.restore_pending_at.is_some() => rec.restore_pending_at = None,
+                _ => return, // absent or already clear — nothing to flush
             }
             m.clone()
         };
@@ -380,16 +437,26 @@ pub enum PollAction {
 /// - `descendant_count`: number of descendant processes of the shell pid.
 /// - `consecutive_dead`: count of prior consecutive zero-descendant ticks.
 /// - `snapshot_ok`: whether the system-wide process snapshot succeeded.
+/// - `restore_pending`: whether the record carries a restore-pending marker
+///   (a boot-restore typed/queued `claude --resume` whose handshake has not
+///   been verified yet — or the restore FAILED and awaits an operator retry).
+///   A mid-restore record is uncertainty by definition: the restored pane may
+///   be a plain shell whose resume never landed, and flipping it `poll-dead`
+///   would destroy the durable `open` state the next attempt needs. So while
+///   pending, only a confident "alive and busy" (KeepAlive) observation
+///   passes through — which also lets the caller self-heal a stale marker —
+///   and every other outcome becomes Skip.
 pub fn classify(
     live_is_alive: Option<bool>,
     descendant_count: usize,
     consecutive_dead: u32,
     snapshot_ok: bool,
+    restore_pending: bool,
 ) -> PollAction {
     if !snapshot_ok {
         return PollAction::Skip;
     }
-    match live_is_alive {
+    let base = match live_is_alive {
         None => PollAction::Skip,
         Some(false) => PollAction::Close,
         Some(true) => {
@@ -405,7 +472,14 @@ pub fn classify(
                 PollAction::Close
             }
         }
+    };
+    // Restore-pending guard arm (never-close-on-uncertainty): a record mid-
+    // restore (or whose restore failed) must keep its `open` state intact —
+    // never Close, and don't even accumulate NeedsConfirm ticks against it.
+    if restore_pending && base != PollAction::KeepAlive {
+        return PollAction::Skip;
     }
+    base
 }
 
 #[cfg(test)]
@@ -429,6 +503,7 @@ mod tests {
             closed_at: None,
             close_reason: None,
             bind_origin: None,
+            restore_pending_at: None,
         }
     }
 
@@ -691,27 +766,33 @@ mod tests {
     #[test]
     fn classify_skip_on_snapshot_failure() {
         // snapshot_ok=false dominates every other input.
-        assert_eq!(classify(Some(false), 0, 5, false), PollAction::Skip);
-        assert_eq!(classify(Some(true), 3, 0, false), PollAction::Skip);
-        assert_eq!(classify(None, 0, 0, false), PollAction::Skip);
+        assert_eq!(classify(Some(false), 0, 5, false, false), PollAction::Skip);
+        assert_eq!(classify(Some(true), 3, 0, false, false), PollAction::Skip);
+        assert_eq!(classify(None, 0, 0, false, false), PollAction::Skip);
     }
 
     #[test]
     fn classify_skip_on_no_matching_pty() {
-        assert_eq!(classify(None, 0, 0, true), PollAction::Skip);
-        assert_eq!(classify(None, 9, 9, true), PollAction::Skip);
+        assert_eq!(classify(None, 0, 0, true, false), PollAction::Skip);
+        assert_eq!(classify(None, 9, 9, true, false), PollAction::Skip);
     }
 
     #[test]
     fn classify_close_on_dead_shell() {
-        assert_eq!(classify(Some(false), 0, 0, true), PollAction::Close);
-        assert_eq!(classify(Some(false), 5, 0, true), PollAction::Close);
+        assert_eq!(classify(Some(false), 0, 0, true, false), PollAction::Close);
+        assert_eq!(classify(Some(false), 5, 0, true, false), PollAction::Close);
     }
 
     #[test]
     fn classify_keepalive_when_alive_with_descendants() {
-        assert_eq!(classify(Some(true), 1, 0, true), PollAction::KeepAlive);
-        assert_eq!(classify(Some(true), 7, 9, true), PollAction::KeepAlive);
+        assert_eq!(
+            classify(Some(true), 1, 0, true, false),
+            PollAction::KeepAlive
+        );
+        assert_eq!(
+            classify(Some(true), 7, 9, true, false),
+            PollAction::KeepAlive
+        );
     }
 
     #[test]
@@ -721,13 +802,16 @@ mod tests {
         // brief idle lull (the poll-dead race this fix closes).
         for prior in 0..LIVE_SHELL_DEAD_TICKS {
             assert_eq!(
-                classify(Some(true), 0, prior, true),
+                classify(Some(true), 0, prior, true, false),
                 PollAction::NeedsConfirm,
                 "live shell, 0 descendants, {prior} prior ticks must NeedsConfirm"
             );
         }
         // Specifically: the second tick (prior == 1) no longer closes.
-        assert_eq!(classify(Some(true), 0, 1, true), PollAction::NeedsConfirm);
+        assert_eq!(
+            classify(Some(true), 0, 1, true, false),
+            PollAction::NeedsConfirm
+        );
     }
 
     #[test]
@@ -735,12 +819,96 @@ mod tests {
         // Only once we've accumulated LIVE_SHELL_DEAD_TICKS consecutive
         // zero-descendant ticks does a live shell finally close.
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, true),
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, true, false),
             PollAction::Close
         );
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, true),
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, true, false),
             PollAction::Close
+        );
+    }
+
+    #[test]
+    fn classify_restore_pending_never_closes() {
+        // The incident shape: a restored pane whose resume silently failed.
+        // Dead pty (the restore shell died / was never matched) → Skip, NOT
+        // Close — the durable `open` record must survive for the next attempt.
+        assert_eq!(classify(Some(false), 0, 0, true, true), PollAction::Skip);
+        // Plain shell idling with zero descendants, even past the debounce
+        // ticks (the exact poll-dead flip the incident hit) → Skip.
+        assert_eq!(
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, true, true),
+            PollAction::Skip
+        );
+        assert_eq!(
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, true, true),
+            PollAction::Skip
+        );
+        // Below the debounce it must not even accumulate NeedsConfirm ticks.
+        assert_eq!(classify(Some(true), 0, 0, true, true), PollAction::Skip);
+        // No matching pty → Skip (unchanged).
+        assert_eq!(classify(None, 0, 0, true, true), PollAction::Skip);
+    }
+
+    #[test]
+    fn classify_restore_pending_passes_through_confident_alive() {
+        // A confidently-alive session (descendants running) classifies
+        // KeepAlive even while restore-pending — the caller uses this to
+        // self-heal a stale marker.
+        assert_eq!(
+            classify(Some(true), 2, 0, true, true),
+            PollAction::KeepAlive
+        );
+    }
+
+    #[test]
+    fn mark_and_clear_restore_pending_round_trip_and_persist() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        store.record_open(rec("sess-1"));
+        assert!(store.open_records()[0].restore_pending_at.is_none());
+
+        store.mark_restore_pending("sess-1");
+        assert!(store.open_records()[0].restore_pending_at.is_some());
+
+        // Durable across a "restart" — the marker must survive a frontend /
+        // process crash mid-restore.
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        assert!(store.open_records()[0].restore_pending_at.is_some());
+
+        store.clear_restore_pending("sess-1");
+        assert!(store.open_records()[0].restore_pending_at.is_none());
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        assert!(store.open_records()[0].restore_pending_at.is_none());
+
+        // Absent ids are no-ops (no panic).
+        store.mark_restore_pending("ghost");
+        store.clear_restore_pending("ghost");
+        // Double-clear is a no-op.
+        store.clear_restore_pending("sess-1");
+    }
+
+    #[test]
+    fn record_open_preserves_restore_pending_marker() {
+        // The restore path re-asserts the open record under the fresh terminal
+        // id AFTER marking restore-pending — the re-assert must not wipe the
+        // marker (only a verified handshake / confident-alive poll clears it).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        store.record_open(rec("sess-1"));
+        store.mark_restore_pending("sess-1");
+
+        let mut r2 = rec("sess-1");
+        r2.terminal_id = "term-new".to_string();
+        store.record_open(r2);
+
+        let open = store.open_records();
+        assert_eq!(open[0].terminal_id, "term-new", "re-assert refreshed");
+        assert!(
+            open[0].restore_pending_at.is_some(),
+            "record_open must preserve the restore-pending marker"
         );
     }
 

--- a/src/components/terminal/ResumeFailedBanner.tsx
+++ b/src/components/terminal/ResumeFailedBanner.tsx
@@ -1,0 +1,77 @@
+/**
+ * "Resume failed — retry" affordance for restored tabs whose typed
+ * `claude --resume` never produced the Claude UI handshake (Phase 3 of
+ * `2026-06-12-runner-session-registry-and-restore-hardening`, issue #548).
+ *
+ * The boot-restore drain verifies each resume and retries once; a tab that
+ * still shows no handshake is parked with `resumeFailed: true` instead of
+ * being silently presented as resumed. This banner lists those tabs with an
+ * operator-clickable retry (which re-runs the same type-and-verify path).
+ * The durable registry record keeps its restore-pending marker the whole
+ * time, so the backend liveness poll cannot flip it `poll-dead` while the
+ * operator decides.
+ *
+ * Renders nothing when no tab is in the failed state. Visual language
+ * follows {@link SessionRecoveryBanner} / {@link CoordWarningBanner}
+ * (top-right advisory column).
+ */
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+import type { TerminalTab } from "./useTerminalManager";
+
+export interface ResumeFailedBannerProps {
+  tabs: TerminalTab[];
+  /** Re-run the type-and-verify resume for one failed tab. */
+  onRetryResume: (tabId: string) => void;
+}
+
+/** The tabs this banner surfaces — exported for unit tests. */
+export function failedResumeTabs(tabs: TerminalTab[]): TerminalTab[] {
+  return tabs.filter((t) => t.resumeFailed && t.isAlive !== false);
+}
+
+export function ResumeFailedBanner({ tabs, onRetryResume }: ResumeFailedBannerProps) {
+  const failed = failedResumeTabs(tabs);
+  if (failed.length === 0) return null;
+
+  return (
+    <div
+      data-ui-bridge-id="terminal.resume-failed-banner"
+      className="absolute top-2 right-2 z-30 w-[360px] rounded border shadow-lg p-2.5 bg-[#f7768e]/10 border-[#f7768e]/40"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5 text-[#f7768e]" />
+        <div className="flex-1 min-w-0">
+          <div className="text-[12px] font-semibold text-[#c0caf5] leading-snug">
+            {failed.length === 1
+              ? "Session resume failed"
+              : `${failed.length} session resumes failed`}
+          </div>
+          <ul className="mt-1.5 space-y-1">
+            {failed.map((t) => (
+              <li
+                key={t.id}
+                data-ui-bridge-id="terminal.resume-failed-banner-item"
+                data-terminal-id={t.id}
+                className="flex items-center gap-2 text-[11px] leading-snug"
+              >
+                <span className="text-[#c0caf5] font-medium truncate flex-1">{t.title}</span>
+                <button
+                  type="button"
+                  data-ui-bridge-id="terminal.resume-failed-retry"
+                  data-terminal-id={t.id}
+                  onClick={() => onRetryResume(t.id)}
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-[#f7768e]/40 text-[#f7768e] hover:bg-[#f7768e]/15 text-[10px]"
+                  title="Retype the resume command and re-verify the Claude UI handshake"
+                >
+                  <RotateCcw className="w-2.5 h-2.5" />
+                  Retry resume
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -34,7 +34,8 @@ import { ResultCardProvider, ResultCardMount, useResultCard } from "./result-car
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { callRegistry, useTerminalCommands } from "./commands";
-import { useTerminalInitialization } from "./useTerminalInitialization";
+import { useTerminalInitialization, runVerifiedResume } from "./useTerminalInitialization";
+import { ResumeFailedBanner } from "./ResumeFailedBanner";
 import { useZoneActions } from "./useZoneActions";
 import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
 import { setTerminalSessions, type TerminalSessionEntry } from "@/lib/terminal-sessions-registry";
@@ -718,6 +719,27 @@ function TerminalPageInner({
     },
   });
 
+  // Operator-clickable retry for a restored tab whose resume verification
+  // failed (Phase 3, #548): re-run the same type-and-verify path. The durable
+  // restore-pending marker is still set from the failed attempt, so the
+  // liveness poll keeps protecting the open record while this runs.
+  const handleRetryResume = useCallback(
+    (tabId: string) => {
+      const tab = tabsRef.current.find((t) => t.id === tabId);
+      if (!tab?.claudeSessionId) return;
+      updateTab(tabId, { resumeFailed: false, isReconnecting: true });
+      void runVerifiedResume({
+        terminalRefs: terminalRefs.current,
+        tabId,
+        claudeSessionId: tab.claudeSessionId,
+        configDir: tab.claudeConfigDir,
+        updateTab,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [updateTab],
+  );
+
   const handleExit = useCallback(
     (terminalId: string, exitCode: number | null) => {
       // Record the durable session CLOSE when a pty backing a Claude session
@@ -1137,6 +1159,12 @@ function TerminalPageInner({
                 `terminalId={zoneTab.id}`). Soft + dismissible; never
                 blocks input. */}
             <CoordWarningBanner activeTerminalId={activeId ?? undefined} />
+
+            {/* Phase 3 (#548) — restored tabs whose `claude --resume` never
+                produced the Claude UI handshake (after one auto-retry) park
+                here with an explicit operator retry instead of silently
+                posing as resumed. Same top-right advisory column. */}
+            <ResumeFailedBanner tabs={tabs} onRetryResume={handleRetryResume} />
           </div>
 
           {/* Phase 2 — `isMultiZone` gate dropped so the Unassigned (N) list

--- a/src/components/terminal/resumeVerification.test.ts
+++ b/src/components/terminal/resumeVerification.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the resume-landed verification loop (Phase 3 of
+ * `2026-06-12-runner-session-registry-and-restore-hardening`, issue #548):
+ * handshake detection over decoded PTY output, the poll-until-deadline wait,
+ * and the type → verify → retry-once state machine.
+ *
+ * vitest runs `environment: "node"` with no React Testing Library; the
+ * scrollback probe and writer are injectable so no IPC is exercised (same
+ * precedent as `useTerminalInitialization.test.ts`).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import {
+  stripAnsi,
+  detectClaudeHandshake,
+  waitForClaudeHandshake,
+  typeResumeAndVerify,
+} from "./resumeVerification";
+
+const CLAUDE_UI =
+  "╭──────────────────────────────╮\n│ > │\n╰──────────────────────────────╯\n  ? for shortcuts";
+const PLAIN_SHELL = "PS C:\\repo> claude --resume abc-123\r\nPS C:\\repo>";
+
+describe("stripAnsi", () => {
+  it("removes CSI sequences so patterns match rendered text", () => {
+    expect(stripAnsi("\x1b[38;5;205m? for shortcuts\x1b[0m")).toBe("? for shortcuts");
+  });
+});
+
+describe("detectClaudeHandshake", () => {
+  it.each([
+    ["status-line shortcuts hint", "  ? for shortcuts"],
+    ["working indicator", "✻ Pondering… (esc to interrupt)"],
+    ["bypass-permissions status line", "  bypass permissions on"],
+    ["welcome banner", "Welcome back to Claude Code!"],
+    ["rounded input-box frame", CLAUDE_UI],
+    ["ANSI-wrapped UI", `\x1b[2m${CLAUDE_UI}\x1b[0m`],
+  ])("recognizes the Claude UI: %s", (_name, text) => {
+    expect(detectClaudeHandshake(text)).toBe(true);
+  });
+
+  it.each([
+    ["bare shell prompt + command echo", PLAIN_SHELL],
+    ["command-not-found error", "claude : The term 'claude' is not recognized"],
+    ["unrelated shell output", "Directory: D:\\repo\r\nMode  LastWriteTime  Name"],
+    ["empty buffer", ""],
+  ])("does NOT count non-Claude output: %s", (_name, text) => {
+    // The verification must never pass on a pane that is still a bare shell —
+    // that false positive is exactly the silent failure mode being fixed.
+    expect(detectClaudeHandshake(text)).toBe(false);
+  });
+
+  it("counts the resume-size picker as a landed resume (it IS Claude UI)", () => {
+    const picker =
+      "╭──────────────────────────────╮\n" +
+      "  Resume from summary (recommended)\n  Resume full session as-is\n  Don't ask me again";
+    expect(detectClaudeHandshake(picker)).toBe(true);
+  });
+});
+
+describe("waitForClaudeHandshake", () => {
+  it("verifies as soon as a probe shows the Claude UI", async () => {
+    const tails = [PLAIN_SHELL, PLAIN_SHELL, CLAUDE_UI];
+    const readTail = vi.fn(async () => tails.shift() ?? CLAUDE_UI);
+    const out = await waitForClaudeHandshake("tab-1", {
+      timeoutMs: 500,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("verified");
+    expect(readTail).toHaveBeenCalledTimes(3);
+  });
+
+  it("times out when the pane never shows the Claude UI", async () => {
+    const readTail = vi.fn(async () => PLAIN_SHELL);
+    const out = await waitForClaudeHandshake("tab-1", {
+      timeoutMs: 10,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("timeout");
+  });
+
+  it("treats an unreadable scrollback (null) as no-evidence, not success", async () => {
+    const readTail = vi.fn(async () => null);
+    const out = await waitForClaudeHandshake("tab-1", {
+      timeoutMs: 10,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("timeout");
+  });
+});
+
+describe("typeResumeAndVerify (retry-once state machine)", () => {
+  const CMD = "claude --resume abc-123\r";
+
+  it("types once and verifies when the handshake appears", async () => {
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    const out = await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 50,
+      intervalMs: 1,
+      readTail: async () => CLAUDE_UI,
+    });
+    expect(out).toBe("verified");
+    expect(writes).toEqual([CMD]);
+  });
+
+  it("retries ONCE (clear-line then retype the same command) when the first attempt never lands", async () => {
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    // First attempt: pane stays a bare shell. Second attempt (the retype):
+    // Claude UI shows — keyed off the write log so the flip is deterministic
+    // regardless of probe pacing.
+    const readTail = async () =>
+      writes.filter((w) => w === CMD).length >= 2 ? CLAUDE_UI : PLAIN_SHELL;
+    const out = await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 10,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("verified");
+    // attempt 1: CMD; attempt 2: ESC (clear any half-typed line) + CMD.
+    expect(writes).toEqual([CMD, "\x1b", CMD]);
+  });
+
+  it("fails after the retry is exhausted and never falsely verifies", async () => {
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    const out = await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 5,
+      intervalMs: 1,
+      readTail: async () => PLAIN_SHELL,
+    });
+    expect(out).toBe("failed");
+    // Exactly two typed attempts — the spec is retry ONCE, not retry forever.
+    expect(writes.filter((w) => w === CMD)).toHaveLength(2);
+  });
+});

--- a/src/components/terminal/resumeVerification.ts
+++ b/src/components/terminal/resumeVerification.ts
@@ -1,0 +1,153 @@
+/**
+ * Resume-landed verification for the registry-driven boot restore — Phase 3 of
+ * `2026-06-12-runner-session-registry-and-restore-hardening` (issue #548).
+ *
+ * The boot restore types `claude --resume <id>` into a freshly-created plain
+ * shell and previously walked away. When the command silently never landed
+ * (lost keystrokes into a still-initializing ConPTY, a wedged prompt, …) the
+ * pane sat as a bare shell while the backend liveness poll eventually flipped
+ * the durable record `poll-dead` — destroying the very state a retry needs.
+ *
+ * This module closes the loop: after typing the resume command we poll the
+ * backend scrollback ring (`terminal_get_scrollback`, the raw PTY byte
+ * history) for the Claude UI handshake. On failure we retype the same command
+ * ONCE; on persistent failure the tab is parked in an explicit
+ * "resume failed — retry" state (see `runVerifiedResume` in
+ * `useTerminalInitialization.ts`) instead of pretending the resume worked.
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import type { CommandResponse } from "./types";
+import { writeWhenReady, type TerminalRefsMap } from "./writeWhenReady";
+
+/** Strip ANSI escape sequences so patterns match rendered text. */
+export function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;?]*[a-zA-Z]/g, "").replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "");
+}
+
+/**
+ * Markers that the Claude Code TUI actually rendered in this pane — i.e. the
+ * resume command landed and the CLI took over the terminal. Deliberately
+ * Claude-UI-shaped (rounded input box, status-line hints) rather than "any
+ * output grew": a shell prompt echo or an error message must NOT count.
+ *
+ * The interactive resume-size picker ("Resume from summary?") is itself
+ * Claude UI — a pane wedged on it still counts as HANDSHAKE OK here (the
+ * resume landed; answering the picker is a separate concern).
+ */
+const CLAUDE_HANDSHAKE_PATTERNS: RegExp[] = [
+  /\? for shortcuts/, // persistent status-line hint under the input box
+  /esc to interrupt/i, // shown while Claude is actively working
+  /bypass permissions/i, // permission-mode indicator in the status line
+  /Welcome (?:back )?to Claude/i, // launch banner
+  /[╭╰]─{3,}/, // rounded input-box / dialog frame
+];
+
+/** True when the pane's recent output shows the Claude Code UI. */
+export function detectClaudeHandshake(text: string): boolean {
+  const stripped = stripAnsi(text);
+  return CLAUDE_HANDSHAKE_PATTERNS.some((p) => p.test(stripped));
+}
+
+/** How many trailing characters of the (decoded) ring to scan per probe. */
+const TAIL_SCAN_CHARS = 16_000;
+
+/**
+ * Read the tail of a terminal's live scrollback ring as decoded text.
+ * Returns `null` when the ring can't be read (terminal gone / IPC failure) —
+ * callers treat that as "no evidence yet", never as success.
+ */
+export async function readScrollbackTail(tabId: string): Promise<string | null> {
+  try {
+    const resp = await invoke<CommandResponse>("terminal_get_scrollback", {
+      terminalId: tabId,
+    });
+    const encoded = (resp?.data as { data?: string } | undefined)?.data;
+    if (typeof encoded !== "string") return null;
+    const raw = atob(encoded);
+    const decoded = new TextDecoder().decode(Uint8Array.from(raw, (c) => c.charCodeAt(0)));
+    return decoded.slice(-TAIL_SCAN_CHARS);
+  } catch {
+    return null;
+  }
+}
+
+export interface HandshakeWaitOptions {
+  /** Total time to wait for the handshake before giving up. */
+  timeoutMs?: number;
+  /** Poll interval between scrollback probes. */
+  intervalMs?: number;
+  /** Injectable probe (tests); defaults to {@link readScrollbackTail}. */
+  readTail?: (tabId: string) => Promise<string | null>;
+  /**
+   * Called once per probe with the decoded tail — hook for picker detection
+   * (the "Resume from summary?" answerer) without coupling it in here.
+   */
+  onProbe?: (tail: string) => void;
+}
+
+/**
+ * Poll the pane's scrollback until the Claude UI handshake appears or the
+ * timeout elapses. Resolves `"verified"` or `"timeout"`; never throws.
+ */
+export async function waitForClaudeHandshake(
+  tabId: string,
+  options: HandshakeWaitOptions = {},
+): Promise<"verified" | "timeout"> {
+  const { timeoutMs = 15_000, intervalMs = 1_000, readTail = readScrollbackTail, onProbe } = options;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const tail = await readTail(tabId);
+    if (tail !== null) {
+      onProbe?.(tail);
+      if (detectClaudeHandshake(tail)) return "verified";
+    }
+    if (Date.now() >= deadline) return "timeout";
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+/**
+ * ESC clears any partially-typed line in PSReadLine / readline before a
+ * retry retype, so a half-landed first attempt can't corrupt the second.
+ */
+const CLEAR_LINE = "\x1b";
+
+export interface TypeAndVerifyOptions extends HandshakeWaitOptions {
+  /** Total attempts (initial type + retries). Spec: retry ONCE → 2. */
+  attempts?: number;
+  /** Delay between typing and the first probe, and before a retry retype. */
+  settleMs?: number;
+  /** Injectable writer (tests); defaults to {@link writeWhenReady}. */
+  write?: (refs: TerminalRefsMap, tabId: string, text: string) => void;
+}
+
+/**
+ * Type `resumeCmd` into the tab and verify the Claude UI handshake within the
+ * timeout; on failure retype the SAME command once and verify again. Resolves
+ * `"verified"` on handshake, `"failed"` after all attempts are exhausted.
+ */
+export async function typeResumeAndVerify(
+  terminalRefs: TerminalRefsMap,
+  tabId: string,
+  resumeCmd: string,
+  options: TypeAndVerifyOptions = {},
+): Promise<"verified" | "failed"> {
+  const { attempts = 2, settleMs = 500, write = writeWhenReady, ...waitOpts } = options;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    if (attempt > 1) {
+      // Clear any half-typed line from the failed attempt, then retype.
+      write(terminalRefs, tabId, CLEAR_LINE);
+      await new Promise((r) => setTimeout(r, settleMs));
+    }
+    write(terminalRefs, tabId, resumeCmd);
+    await new Promise((r) => setTimeout(r, settleMs));
+    const outcome = await waitForClaudeHandshake(tabId, waitOpts);
+    if (outcome === "verified") return "verified";
+    console.warn(
+      `[resumeVerification] handshake not observed for ${tabId} (attempt ${attempt}/${attempts})`,
+    );
+  }
+  return "failed";
+}

--- a/src/components/terminal/types.ts
+++ b/src/components/terminal/types.ts
@@ -41,4 +41,10 @@ export interface TerminalSessionRecord {
   closedAt?: number;
   /** Why the session closed. */
   closeReason?: string;
+  /**
+   * Epoch ms a boot-restore began re-typing this session's resume command
+   * (backend-owned; while set the liveness poll never flips the record
+   * `poll-dead`). Cleared once the resume handshake is verified.
+   */
+  restorePendingAt?: number;
 }

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -14,7 +14,12 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
-import { fetchOpenRecords, claimInitForPage, buildResumeCmd } from "./useTerminalInitialization";
+import {
+  fetchOpenRecords,
+  claimInitForPage,
+  buildResumeCmd,
+  runVerifiedResume,
+} from "./useTerminalInitialization";
 import type { TerminalSessionRecord } from "./types";
 
 const rec = (overrides: Partial<TerminalSessionRecord>): TerminalSessionRecord => ({
@@ -172,5 +177,83 @@ describe("buildResumeCmd (boot-restore resume command)", () => {
     } finally {
       vi.unstubAllGlobals();
     }
+  });
+});
+
+// Phase 3 (#548) — verified-resume state machine: the restore drain (and the
+// operator retry) must only clear the durable restore-pending marker on a
+// VERIFIED Claude UI handshake; a failed resume parks the tab in an explicit
+// `resumeFailed` retry state with the marker left intact.
+describe("runVerifiedResume", () => {
+  const CLAUDE_UI = "╭──────────────╮\n│ > │\n╰──────────────╯\n  ? for shortcuts";
+  const PLAIN_SHELL = "PS C:\\repo> claude --resume sess-1\r\nPS C:\\repo>";
+
+  /** A refs map whose handle accepts writes (the default writeWhenReady path). */
+  const refsWithHandle = (writes: string[]) =>
+    new Map([
+      [
+        "tab-1",
+        { current: { writeToTerminal: (text: string) => void writes.push(text) } },
+      ],
+    ]) as never;
+
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue({ success: true, message: null, data: null });
+  });
+
+  it("verified handshake → clears isReconnecting AND the backend restore-pending marker", async () => {
+    const writes: string[] = [];
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle(writes),
+      tabId: "tab-1",
+      claudeSessionId: "sess-1",
+      updateTab,
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 50,
+        intervalMs: 1,
+        readTail: async () => CLAUDE_UI,
+      },
+    });
+    expect(out).toBe("verified");
+    expect(writes.some((w) => w.includes("--resume sess-1\r"))).toBe(true);
+    expect(updateTab).toHaveBeenCalledWith("tab-1", {
+      isReconnecting: false,
+      resumeFailed: false,
+    });
+    expect(mockInvoke).toHaveBeenCalledWith("terminal_session_clear_restore_pending", {
+      claudeSessionId: "sess-1",
+    });
+  });
+
+  it("persistent failure → parks the tab resumeFailed and does NOT clear the marker", async () => {
+    const writes: string[] = [];
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle(writes),
+      tabId: "tab-1",
+      claudeSessionId: "sess-1",
+      updateTab,
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 5,
+        intervalMs: 1,
+        readTail: async () => PLAIN_SHELL,
+      },
+    });
+    expect(out).toBe("failed");
+    // Retried once: the same command typed exactly twice.
+    expect(writes.filter((w) => w.includes("--resume sess-1\r"))).toHaveLength(2);
+    expect(updateTab).toHaveBeenCalledWith("tab-1", {
+      isReconnecting: false,
+      resumeFailed: true,
+    });
+    // The durable open record must stay poll-protected for the retry.
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "terminal_session_clear_restore_pending",
+      expect.anything(),
+    );
   });
 });

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -2,7 +2,8 @@ import { useEffect, useRef, useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LAYOUT_PRESETS } from "./useZoneLayout";
-import { writeWhenReady } from "./writeWhenReady";
+import type { TerminalRefsMap } from "./writeWhenReady";
+import { typeResumeAndVerify, type TypeAndVerifyOptions } from "./resumeVerification";
 import type { TerminalTab } from "./useTerminalManager";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { CommandResponse, TerminalSessionRecord } from "./types";
@@ -65,6 +66,53 @@ export function buildResumeCmd(sessionId: string, configDir: string | undefined)
 }
 
 /**
+ * Type the resume command for a restored tab and VERIFY the Claude UI
+ * handshake actually appeared (Phase 3, issue #548): on first failure the
+ * same command is retyped once; on persistent failure the tab is parked in an
+ * explicit `resumeFailed` state (operator-clickable retry via
+ * `ResumeFailedBanner`) and the durable restore-pending marker is left SET so
+ * the backend liveness poll keeps protecting the `open` record. Only a
+ * verified handshake clears the marker and the reconnecting affordance.
+ *
+ * Used by the boot-restore drain below AND by the operator retry path in
+ * `TerminalPage`. Exported (with injectable verify options) so the
+ * verified/failed state machine is unit-testable without booting React.
+ */
+export async function runVerifiedResume(params: {
+  terminalRefs: TerminalRefsMap;
+  tabId: string;
+  claudeSessionId: string;
+  configDir?: string;
+  updateTab: (
+    id: string,
+    updates: Partial<{ isReconnecting?: boolean; resumeFailed?: boolean }>,
+  ) => void;
+  verifyOptions?: TypeAndVerifyOptions;
+}): Promise<"verified" | "failed"> {
+  const { terminalRefs, tabId, claudeSessionId, configDir, updateTab, verifyOptions } = params;
+  const resumeCmd = buildResumeCmd(claudeSessionId, configDir);
+  const outcome = await typeResumeAndVerify(terminalRefs, tabId, resumeCmd, verifyOptions);
+  if (outcome === "verified") {
+    updateTab(tabId, { isReconnecting: false, resumeFailed: false });
+    // Verified handshake — release the liveness-poll restore guard so normal
+    // classification resumes for this session.
+    invoke("terminal_session_clear_restore_pending", { claudeSessionId }).catch((err) => {
+      // Best-effort: the poll self-heals a stale marker on the next
+      // confident-alive tick.
+      console.warn(`[TerminalPage] clear restore-pending failed for ${claudeSessionId}:`, err);
+    });
+  } else {
+    // Resume never landed. Surface an explicit retry affordance and KEEP the
+    // restore-pending marker — the open record must survive for the retry.
+    console.warn(
+      `[TerminalPage] resume verification failed for ${tabId} (session ${claudeSessionId})`,
+    );
+    updateTab(tabId, { isReconnecting: false, resumeFailed: true });
+  }
+  return outcome;
+}
+
+/**
  * Pure guard for the once-per-pageId init backstop (Phase 3 mount-hydration
  * lift). With the session provider lifted above the page, the single
  * `useTerminalInitialization` instance persists across terminal-page switches,
@@ -111,6 +159,7 @@ interface UseTerminalInitializationParams {
       claudeSessionId?: string;
       claudeConfigDir?: string;
       isReconnecting?: boolean;
+      resumeFailed?: boolean;
     }>,
   ) => void;
   zoneLayout: {
@@ -343,6 +392,20 @@ export function useTerminalInitialization({
               claudeSessionId: rec.claudeSessionId,
               claudeConfigDir: safeConfigDir,
             });
+            // Durable, backend-owned restore-pending marker (Phase 3, #548):
+            // from here until the resume handshake is VERIFIED the liveness
+            // poll must never flip this record `poll-dead` — a failed restore
+            // leaves the `open` record intact for the next attempt. Cleared in
+            // `runVerifiedResume` on verified handshake (and self-healed by
+            // the poll once it sees the session confidently alive).
+            invoke("terminal_session_mark_restore_pending", {
+              claudeSessionId: rec.claudeSessionId,
+            }).catch((err) => {
+              console.warn(
+                `[TerminalPage] mark restore-pending failed for ${rec.claudeSessionId}:`,
+                err,
+              );
+            });
           }
 
           // Re-assert the OPEN record under the freshly created terminal id so
@@ -421,28 +484,19 @@ export function useTerminalInitialization({
                   restore.claudeSessionId &&
                   isValidSessionId(restore.claudeSessionId)
                 ) {
-                  try {
-                    const resumeCmd = buildResumeCmd(
-                      restore.claudeSessionId,
-                      restore.claudeConfigDir,
-                    );
-                    await new Promise((r) => setTimeout(r, 500));
-                    writeWhenReady(terminalRefs.current, restore.tabId, resumeCmd, {
-                      onTimeout: (id) =>
-                        console.warn(
-                          `[TerminalPage] resume: terminal ref for ${id} never became ready`,
-                        ),
-                    });
-                  } catch (err) {
-                    console.warn(
-                      `[TerminalPage] Failed to resume Claude session for ${restore.tabId}:`,
-                      err,
-                    );
-                  } finally {
-                    // Resume command issued (or best-effort failed) — drop the
-                    // "resuming" affordance so the live `claude` UI shows.
-                    updateTab(restore.tabId, { isReconnecting: false });
-                  }
+                  await new Promise((r) => setTimeout(r, 500));
+                  // Type the resume and VERIFY the handshake (retry once on
+                  // failure). Fire-and-forget per tab so one slow/failed
+                  // verification (up to ~30s) doesn't serialize the drain;
+                  // `runVerifiedResume` owns clearing `isReconnecting` /
+                  // setting `resumeFailed` and never throws.
+                  void runVerifiedResume({
+                    terminalRefs: terminalRefs.current,
+                    tabId: restore.tabId,
+                    claudeSessionId: restore.claudeSessionId,
+                    configDir: restore.claudeConfigDir,
+                    updateTab,
+                  });
                 }
               }
 

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -21,6 +21,15 @@ export interface TerminalTab {
   planFilePath?: string;
   /** True while the frontend is replaying the scrollback buffer from Rust. */
   isReconnecting?: boolean;
+  /**
+   * True when a boot-restore typed `claude --resume` into this tab but the
+   * Claude UI handshake never appeared (after one retry) — the pane is most
+   * likely still a bare shell. Surfaced as an explicit operator-clickable
+   * "resume failed — retry" affordance (`ResumeFailedBanner`); cleared when a
+   * retry verifies. While set, the durable record keeps its backend
+   * restore-pending marker so the liveness poll can't flip it `poll-dead`.
+   */
+  resumeFailed?: boolean;
   /** Claude Code session ID running in this tab (set on resume). */
   claudeSessionId?: string;
   /** Claude config dir for the session (set on resume). */
@@ -542,6 +551,7 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
           | "claudeSessionId"
           | "claudeConfigDir"
           | "isReconnecting"
+          | "resumeFailed"
         >
       >,
     ) => {


### PR DESCRIPTION
## Summary

Phase 3 of `2026-06-12-runner-session-registry-and-restore-hardening` — items 1 + 2 (item 3, the "Resume from summary?" picker answer, is the stacked follow-up PR on `feat/resume-picker-answer`). Closes the boot-restore failure mode from the 2026-06-12 incident: a restored pane's typed `claude --resume` silently never landed, and the backend liveness poll then flipped the durable record `poll-dead` mid-restore — destroying the `open` state the retry needed (a `poll-dead` row is restorable only within the 10-min grace, and within it the retry races the next poll flip). Refs #548.

### Item 1 — verify the resume landed (frontend)
- `resumeVerification.ts` (new): after the restore drain types the resume command, poll the live scrollback ring (`terminal_get_scrollback`) for the Claude UI handshake (Claude-UI-shaped markers only — a shell echo or error never counts) within ~15s; on failure retype the SAME command once (ESC first, clearing any half-typed line); on persistent failure park the tab in an explicit `resumeFailed` state instead of posing as resumed.
- `ResumeFailedBanner` (new): operator-clickable "Retry resume" per failed tab (top-right advisory column, same visual language as `SessionRecoveryBanner`); retry re-runs the identical type-and-verify path (`TerminalPage.handleRetryResume`).
- The resume-size picker counts as a landed resume for verification purposes (it IS Claude UI); answering it is the follow-up PR.

### Item 2 — liveness-poll grace for restoring tabs (backend)
- `TerminalSessionRecord.restore_pending_at`: durable, **backend-owned** marker (`#[serde(default)]`, omitted when None — existing registry files load unchanged). Set when the restore drain queues a resume (`terminal_session_mark_restore_pending`), cleared on verified handshake (`terminal_session_clear_restore_pending`). Survives frontend crashes; `record_open` re-asserts preserve it.
- `classify()` gains exactly one guard arm: a restore-pending record Skips every outcome except confident-alive (KeepAlive) — never `poll-dead`, never `NeedsConfirm` tick accumulation, dead-pty close included. The poll self-heals a stale marker on the first KeepAlive observation (covers a lost frontend clear). The asymmetric never-close-on-uncertainty design and both 600000 ms grace consts are untouched.

## Test evidence
- Rust: `cargo clippy --workspace --tests -- -D warnings` clean; `cargo fmt --check` clean (also enforced at push by the pre-push hook, passed).
- `cargo test --bin qontinui-runner session_lifecycle`: **20 passed, 0 failed** (incl. new: `classify_restore_pending_never_closes`, `classify_restore_pending_passes_through_confident_alive`, `mark_and_clear_restore_pending_round_trip_and_persist`, `record_open_preserves_restore_pending_marker`); `commands::terminal::tests`: 4 passed.
- `cargo test --lib`: 237 passed, 1 failed — `auth::device_jwt_tests::needs_refresh_when_no_token`, pre-existing flaky/parallel-interference (passes in isolation at base cf918d81 and on this branch; this diff does not touch auth).
- Frontend: `npx tsc --noEmit` clean; `pnpm run lint` clean; full `npx vitest run`: **75 files / 914 tests passed** at this commit.

## Note on size
833 insertions — over the 500-line auto-merge budget, dominated by the required Rust+frontend test coverage and codebase-idiomatic doc comments. Expecting the merge gate to hold this for operator review; admin-merge is the intended path per the line-budget playbook.

Refs #548.
