### PR TITLE
fix(restore): answer/suppress the 'Resume from summary?' picker on unattended resumes (#548 Phase 3, item 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -2121,7 +2121,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2443,7 +2443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3889,7 +3889,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4809,7 +4809,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6046,9 +6046,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56df96f5394370d1b20e49de146f9e6c25aa9ae750f449c9d665eafecb3ccae6"
+checksum = "4d9d9089bb0ce62f4b5d52a0be0f4acfb35738b979380670d3dea85fe38d6ddd"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6058,9 +6058,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -6077,9 +6077,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -6645,7 +6645,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7329,7 +7329,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7388,7 +7388,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8974,7 +8974,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9175,9 +9175,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -10510,7 +10510,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src/components/settings/AdvancedSettings.tsx
+++ b/src/components/settings/AdvancedSettings.tsx
@@ -47,6 +47,13 @@ export function AdvancedSettings({ onLog, onDebugModeChange }: AdvancedSettingsP
     () => (instanceStorage.getItem("terminal-backend") as "xterm" | "ghostty" | null) || "xterm",
   );
 
+  // Unattended session-restore policy for the Claude CLI's "Resume from
+  // summary?" picker (#548 item 3). Default "full": context loss is silent
+  // and unrecoverable; token cost is visible and /compact-able.
+  const [resumePolicy, setResumePolicy] = useState<"full" | "summary">(() =>
+    instanceStorage.getItem("resume-summary-policy") === "summary" ? "summary" : "full",
+  );
+
   // Device info state
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null);
   const [deviceInfoLoading, setDeviceInfoLoading] = useState(true);
@@ -386,6 +393,44 @@ export function AdvancedSettings({ onLog, onDebugModeChange }: AdvancedSettingsP
           <div className="text-xs text-muted-foreground">
             <strong className="text-foreground">Tip:</strong> Include your Device ID when reporting
             issues to help identify your runner in the system.
+          </div>
+        </div>
+      </div>
+
+      {/* Session Restore Section */}
+      <div className="space-y-4 rounded-lg bg-card/50 p-4">
+        <h4 className="font-medium text-sm flex items-center gap-2">
+          <RefreshCw className="w-4 h-4 text-primary" />
+          Session Restore
+        </h4>
+
+        <div className="space-y-2 p-3 rounded-lg bg-muted/30">
+          <div className="text-sm font-medium">Large-session resume behavior</div>
+          <div className="text-xs text-muted-foreground mb-2">
+            When the runner auto-resumes a large Claude session after a restart, the CLI can offer
+            to resume from a compacted summary. <strong>Full</strong> (default) resumes the
+            complete conversation as-is — context loss is silent and unrecoverable, while token
+            cost is visible and can be /compact-ed later. <strong>Summary</strong> opts in to the
+            compacted resume for cost-sensitive setups.
+          </div>
+          <div className="flex gap-2">
+            {(["full", "summary"] as const).map((policy) => (
+              <button
+                key={policy}
+                onClick={() => {
+                  setResumePolicy(policy);
+                  instanceStorage.setItem("resume-summary-policy", policy);
+                  onLog("info", `Unattended resume policy set to ${policy}.`);
+                }}
+                className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                  resumePolicy === policy
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+                }`}
+              >
+                {policy === "full" ? "Resume full (default)" : "Resume from summary"}
+              </button>
+            ))}
           </div>
         </div>
       </div>

--- a/src/components/terminal/resumeVerification.test.ts
+++ b/src/components/terminal/resumeVerification.test.ts
@@ -18,6 +18,8 @@ vi.mock("@tauri-apps/api/core", () => ({
 import {
   stripAnsi,
   detectClaudeHandshake,
+  detectResumePicker,
+  buildPickerAnswer,
   waitForClaudeHandshake,
   typeResumeAndVerify,
 } from "./resumeVerification";
@@ -60,6 +62,27 @@ describe("detectClaudeHandshake", () => {
       "╭──────────────────────────────╮\n" +
       "  Resume from summary (recommended)\n  Resume full session as-is\n  Don't ask me again";
     expect(detectClaudeHandshake(picker)).toBe(true);
+  });
+});
+
+describe("detectResumePicker / buildPickerAnswer", () => {
+  const PICKER =
+    "  Resume from summary (recommended)\n  Resume full session as-is\n  Don't ask me again";
+
+  it("recognizes the CLI's resume-size picker (ANSI-wrapped too)", () => {
+    expect(detectResumePicker(PICKER)).toBe(true);
+    expect(detectResumePicker(`\x1b[36m${PICKER}\x1b[0m`)).toBe(true);
+  });
+
+  it("does NOT match ordinary Claude UI or shell output", () => {
+    expect(detectResumePicker(CLAUDE_UI)).toBe(false);
+    expect(detectResumePicker(PLAIN_SHELL)).toBe(false);
+    expect(detectResumePicker("")).toBe(false);
+  });
+
+  it("answers option 2 (full as-is) for the default policy and 1 for summary", () => {
+    expect(buildPickerAnswer("full")).toBe("2\r");
+    expect(buildPickerAnswer("summary")).toBe("1\r");
   });
 });
 
@@ -132,6 +155,39 @@ describe("typeResumeAndVerify (retry-once state machine)", () => {
     expect(out).toBe("verified");
     // attempt 1: CMD; attempt 2: ESC (clear any half-typed line) + CMD.
     expect(writes).toEqual([CMD, "\x1b", CMD]);
+  });
+
+  it("answers the resume-size picker at most ONCE when pickerAnswer is set", async () => {
+    const PICKER =
+      "╭──────────────╮\n  ❯ Resume from summary (recommended)\n    Resume full session as-is\n    Don't ask me again";
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    const out = await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 50,
+      intervalMs: 1,
+      pickerAnswer: "2\r",
+      readTail: async () => PICKER,
+    });
+    // The picker IS Claude UI — the resume landed, so this verifies...
+    expect(out).toBe("verified");
+    // ...and the configured answer was typed exactly once.
+    expect(writes.filter((w) => w === "2\r")).toHaveLength(1);
+  });
+
+  it("never types a picker answer when the picker is absent", async () => {
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 50,
+      intervalMs: 1,
+      pickerAnswer: "2\r",
+      readTail: async () => CLAUDE_UI,
+    });
+    expect(writes).not.toContain("2\r");
   });
 
   it("fails after the retry is exhausted and never falsely verifies", async () => {

--- a/src/components/terminal/resumeVerification.ts
+++ b/src/components/terminal/resumeVerification.ts
@@ -17,8 +17,65 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
+import { instanceStorage } from "@/lib/instance-storage";
 import type { CommandResponse } from "./types";
 import { writeWhenReady, type TerminalRefsMap } from "./writeWhenReady";
+
+// ---------------------------------------------------------------------------
+// "Resume from summary?" picker policy (#548 item 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * What an unattended resume should do when the Claude CLI offers the
+ * resume-size picker for a large session:
+ *
+ * - `"full"` (DEFAULT): resume the full conversation as-is. Context loss is
+ *   silent and unrecoverable; token cost is visible and the operator can
+ *   `/compact` afterwards. NEVER default to "summary".
+ * - `"summary"`: opt-in for cost-sensitive setups — accept the CLI's
+ *   "Resume from summary (recommended)" option.
+ *
+ * Stored under the instance-scoped `resume-summary-policy` key (Settings →
+ * Advanced). Any value other than the literal `"summary"` resolves to
+ * `"full"`.
+ */
+export type ResumeSummaryPolicy = "full" | "summary";
+
+export function getResumeSummaryPolicy(): ResumeSummaryPolicy {
+  try {
+    return instanceStorage.getItem("resume-summary-policy") === "summary" ? "summary" : "full";
+  } catch {
+    return "full";
+  }
+}
+
+/**
+ * Picker frames from Claude Code's resume-size prompt (verified against the
+ * v2.1.175 CLI bundle: options are "Resume from summary (recommended)",
+ * "Resume full session as-is", "Don't ask me again"). Matched against
+ * ANSI-stripped text.
+ */
+const RESUME_PICKER_PATTERNS: RegExp[] = [
+  /Resume from summary/i,
+  /Resume full session as-is/i,
+];
+
+/** True when the pane is showing the CLI's resume-size picker. */
+export function detectResumePicker(text: string): boolean {
+  const stripped = stripAnsi(text);
+  return RESUME_PICKER_PATTERNS.some((p) => p.test(stripped));
+}
+
+/**
+ * Keystrokes that answer the picker for a policy. The CLI's select lists
+ * accept number-key selection; option order in v2.1.175 is
+ * 1) summary (recommended), 2) full as-is, 3) don't ask again. The trailing
+ * Enter is harmless if the digit already submitted (it lands on the now-open
+ * Claude input as an empty submit).
+ */
+export function buildPickerAnswer(policy: ResumeSummaryPolicy): string {
+  return policy === "summary" ? "1\r" : "2\r";
+}
 
 /** Strip ANSI escape sequences so patterns match rendered text. */
 export function stripAnsi(text: string): string {
@@ -121,12 +178,25 @@ export interface TypeAndVerifyOptions extends HandshakeWaitOptions {
   settleMs?: number;
   /** Injectable writer (tests); defaults to {@link writeWhenReady}. */
   write?: (refs: TerminalRefsMap, tabId: string, text: string) => void;
+  /**
+   * Keystrokes to type (at most ONCE per call) when a probe shows the CLI's
+   * "Resume from summary?" picker — see {@link buildPickerAnswer}. This is
+   * the FALLBACK answerer: the typed resume command already suppresses the
+   * picker via env thresholds under the default full-resume policy (see
+   * `buildResumeCmd`), so this only fires on CLI version drift or under the
+   * opt-in "summary" policy. Omit to disable.
+   */
+  pickerAnswer?: string;
 }
 
 /**
  * Type `resumeCmd` into the tab and verify the Claude UI handshake within the
  * timeout; on failure retype the SAME command once and verify again. Resolves
  * `"verified"` on handshake, `"failed"` after all attempts are exhausted.
+ *
+ * When `pickerAnswer` is set and a probe shows the resume-size picker, the
+ * answer is typed once so an unattended resume can't wedge on it. The picker
+ * is itself Claude UI, so the same probe also verifies the handshake.
  */
 export async function typeResumeAndVerify(
   terminalRefs: TerminalRefsMap,
@@ -134,7 +204,22 @@ export async function typeResumeAndVerify(
   resumeCmd: string,
   options: TypeAndVerifyOptions = {},
 ): Promise<"verified" | "failed"> {
-  const { attempts = 2, settleMs = 500, write = writeWhenReady, ...waitOpts } = options;
+  const {
+    attempts = 2,
+    settleMs = 500,
+    write = writeWhenReady,
+    pickerAnswer,
+    onProbe,
+    ...waitOpts
+  } = options;
+  let pickerAnswered = false;
+  const probe = (tail: string) => {
+    onProbe?.(tail);
+    if (pickerAnswer && !pickerAnswered && detectResumePicker(tail)) {
+      pickerAnswered = true;
+      write(terminalRefs, tabId, pickerAnswer);
+    }
+  };
   for (let attempt = 1; attempt <= attempts; attempt++) {
     if (attempt > 1) {
       // Clear any half-typed line from the failed attempt, then retype.
@@ -143,7 +228,7 @@ export async function typeResumeAndVerify(
     }
     write(terminalRefs, tabId, resumeCmd);
     await new Promise((r) => setTimeout(r, settleMs));
-    const outcome = await waitForClaudeHandshake(tabId, waitOpts);
+    const outcome = await waitForClaudeHandshake(tabId, { ...waitOpts, onProbe: probe });
     if (outcome === "verified") return "verified";
     console.warn(
       `[resumeVerification] handshake not observed for ${tabId} (attempt ${attempt}/${attempts})`,

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -19,7 +19,6 @@ import {
   claimInitForPage,
   buildResumeCmd,
   runVerifiedResume,
-  buildResumeCmd,
 } from "./useTerminalInitialization";
 import type { TerminalSessionRecord } from "./types";
 

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -268,19 +268,27 @@ describe("buildResumeCmd (resume-size picker policy)", () => {
     const cmd = buildResumeCmd("sess-1", undefined, "full");
     expect(cmd).toContain('CLAUDE_CODE_RESUME_TOKEN_THRESHOLD="999999999"');
     expect(cmd).toContain('CLAUDE_CODE_RESUME_THRESHOLD_MINUTES="999999999"');
-    expect(cmd).toContain("claude --resume sess-1\r");
+    expect(cmd).toContain("--resume sess-1\r");
   });
 
   it("'summary' policy leaves the thresholds alone (picker shows; the loop answers it)", () => {
     const cmd = buildResumeCmd("sess-1", undefined, "summary");
     expect(cmd).not.toContain("CLAUDE_CODE_RESUME_TOKEN_THRESHOLD");
-    expect(cmd).toBe("claude --resume sess-1\r");
+    expect(cmd).toBe("claude --permission-mode bypassPermissions --resume sess-1\r");
   });
 
   it("keeps the CLAUDE_CONFIG_DIR prefix alongside the threshold vars", () => {
     const cmd = buildResumeCmd("sess-1", "C:/claude/.claude-hotmail", "full");
     expect(cmd).toContain('CLAUDE_CONFIG_DIR="C:/claude/.claude-hotmail"');
     expect(cmd).toContain("CLAUDE_CODE_RESUME_TOKEN_THRESHOLD");
-    expect(cmd).toContain("claude --resume sess-1\r");
+    expect(cmd).toContain("--resume sess-1\r");
+  });
+
+  it("resumes autonomously — bypassPermissions so an unattended restore never stalls on a permission prompt (#547 union)", () => {
+    for (const policy of ["full", "summary"] as const) {
+      expect(buildResumeCmd("abc-123", undefined, policy)).toContain(
+        "claude --permission-mode bypassPermissions --resume abc-123",
+      );
+    }
   });
 });

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -19,6 +19,7 @@ import {
   claimInitForPage,
   buildResumeCmd,
   runVerifiedResume,
+  buildResumeCmd,
 } from "./useTerminalInitialization";
 import type { TerminalSessionRecord } from "./types";
 
@@ -255,5 +256,31 @@ describe("runVerifiedResume", () => {
       "terminal_session_clear_restore_pending",
       expect.anything(),
     );
+  });
+});
+
+// #548 item 3 — the typed resume must suppress the CLI's "Resume from
+// summary?" picker under the default full-resume policy (env thresholds; no
+// CLI flag / settings key short of the global "Don't ask again" exists), and
+// must leave it answerable under the opt-in summary policy.
+describe("buildResumeCmd (resume-size picker policy)", () => {
+  it("default 'full' policy raises both resume thresholds so the picker never shows", () => {
+    const cmd = buildResumeCmd("sess-1", undefined, "full");
+    expect(cmd).toContain('CLAUDE_CODE_RESUME_TOKEN_THRESHOLD="999999999"');
+    expect(cmd).toContain('CLAUDE_CODE_RESUME_THRESHOLD_MINUTES="999999999"');
+    expect(cmd).toContain("claude --resume sess-1\r");
+  });
+
+  it("'summary' policy leaves the thresholds alone (picker shows; the loop answers it)", () => {
+    const cmd = buildResumeCmd("sess-1", undefined, "summary");
+    expect(cmd).not.toContain("CLAUDE_CODE_RESUME_TOKEN_THRESHOLD");
+    expect(cmd).toBe("claude --resume sess-1\r");
+  });
+
+  it("keeps the CLAUDE_CONFIG_DIR prefix alongside the threshold vars", () => {
+    const cmd = buildResumeCmd("sess-1", "C:/claude/.claude-hotmail", "full");
+    expect(cmd).toContain('CLAUDE_CONFIG_DIR="C:/claude/.claude-hotmail"');
+    expect(cmd).toContain("CLAUDE_CODE_RESUME_TOKEN_THRESHOLD");
+    expect(cmd).toContain("claude --resume sess-1\r");
   });
 });

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -160,26 +160,6 @@ describe("claimInitForPage (once-per-pageId guard)", () => {
   });
 });
 
-describe("buildResumeCmd (boot-restore resume command)", () => {
-  it("resumes autonomously — bypassPermissions so an unattended restore never stalls on a permission prompt", () => {
-    const cmd = buildResumeCmd("abc-123", undefined);
-    expect(cmd).toBe("claude --permission-mode bypassPermissions --resume abc-123\r");
-  });
-
-  it("prefixes CLAUDE_CONFIG_DIR while keeping the bypass form", () => {
-    vi.stubGlobal("navigator", { platform: "Win32" });
-    try {
-      const cmd = buildResumeCmd("abc-123", "C:\\claude\\.claude-hotmail");
-      expect(cmd).toBe(
-        '$env:CLAUDE_CONFIG_DIR="C:\\claude\\.claude-hotmail"; ' +
-          "claude --permission-mode bypassPermissions --resume abc-123\r",
-      );
-    } finally {
-      vi.unstubAllGlobals();
-    }
-  });
-});
-
 // Phase 3 (#548) — verified-resume state machine: the restore drain (and the
 // operator retry) must only clear the durable restore-pending marker on a
 // VERIFIED Claude UI handshake; a failed resume parks the tab in an explicit

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -3,7 +3,13 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LAYOUT_PRESETS } from "./useZoneLayout";
 import type { TerminalRefsMap } from "./writeWhenReady";
-import { typeResumeAndVerify, type TypeAndVerifyOptions } from "./resumeVerification";
+import {
+  typeResumeAndVerify,
+  getResumeSummaryPolicy,
+  buildPickerAnswer,
+  type ResumeSummaryPolicy,
+  type TypeAndVerifyOptions,
+} from "./resumeVerification";
 import type { TerminalTab } from "./useTerminalManager";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { CommandResponse, TerminalSessionRecord } from "./types";
@@ -48,21 +54,39 @@ export async function fetchOpenRecords(pageId: string): Promise<TerminalSessionR
 
 /**
  * Build a `claude --resume <id>` command, optionally prefixed with
- * CLAUDE_CONFIG_DIR. Autonomous resume (`--permission-mode bypassPermissions`,
- * matching the zone-profile + shell-integration resume builders and the
- * backend `is_bypass_resume` detector) — a boot-restored session is unattended,
- * so a bare `claude --resume` would stall forever on its first permission
- * prompt.
+ * CLAUDE_CONFIG_DIR and (under the default full-resume policy) with the CLI's
+ * resume-size thresholds raised so the interactive "Resume from summary?"
+ * picker never shows — an unattended restore can't answer it, and a wedged
+ * picker reads as a failed resume (#548 item 3). No suppression flag exists;
+ * the CLI consults `CLAUDE_CODE_RESUME_TOKEN_THRESHOLD` (default 100000
+ * estimated tokens) and `CLAUDE_CODE_RESUME_THRESHOLD_MINUTES` (default 70)
+ * before showing it, and skipping it resumes the full session as-is. Scoped
+ * to the typed command (per-process) deliberately: seeding the CLI's global
+ * "Don't ask again" key (`resumeReturnDismissed` in `.claude.json`) would
+ * also kill the picker for the operator's own interactive resumes.
  *
- * Exported for unit tests (vitest `environment: "node"`).
+ * Under the opt-in `"summary"` policy the thresholds are left alone so the
+ * picker appears and the verification loop answers it
+ * (`buildPickerAnswer`). Exported for unit tests.
  */
-export function buildResumeCmd(sessionId: string, configDir: string | undefined): string {
-  const base = `claude --permission-mode bypassPermissions --resume ${sessionId}`;
-  if (!configDir) return `${base}\r`;
-  const isWindows = navigator.platform.startsWith("Win");
+export function buildResumeCmd(
+  sessionId: string,
+  configDir: string | undefined,
+  policy: ResumeSummaryPolicy = getResumeSummaryPolicy(),
+): string {
+  const base = `claude --resume ${sessionId}`;
+  const env: Array<[string, string]> = [];
+  if (configDir) env.push(["CLAUDE_CONFIG_DIR", configDir]);
+  if (policy === "full") {
+    env.push(["CLAUDE_CODE_RESUME_TOKEN_THRESHOLD", "999999999"]);
+    env.push(["CLAUDE_CODE_RESUME_THRESHOLD_MINUTES", "999999999"]);
+  }
+  if (env.length === 0) return `${base}\r`;
+  const isWindows =
+    typeof navigator !== "undefined" && (navigator.platform ?? "").startsWith("Win");
   return isWindows
-    ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; ${base}\r`
-    : `CLAUDE_CONFIG_DIR="${configDir}" ${base}\r`;
+    ? `${env.map(([k, v]) => `$env:${k}="${v}"; `).join("")}${base}\r`
+    : `${env.map(([k, v]) => `${k}="${v}" `).join("")}${base}\r`;
 }
 
 /**
@@ -90,8 +114,15 @@ export async function runVerifiedResume(params: {
   verifyOptions?: TypeAndVerifyOptions;
 }): Promise<"verified" | "failed"> {
   const { terminalRefs, tabId, claudeSessionId, configDir, updateTab, verifyOptions } = params;
-  const resumeCmd = buildResumeCmd(claudeSessionId, configDir);
-  const outcome = await typeResumeAndVerify(terminalRefs, tabId, resumeCmd, verifyOptions);
+  const policy = getResumeSummaryPolicy();
+  const resumeCmd = buildResumeCmd(claudeSessionId, configDir, policy);
+  const outcome = await typeResumeAndVerify(terminalRefs, tabId, resumeCmd, {
+    // Fallback picker answerer (#548 item 3): under the default "full" policy
+    // the env thresholds in `buildResumeCmd` already suppress the picker;
+    // this catches CLI version drift and the opt-in "summary" policy.
+    pickerAnswer: buildPickerAnswer(policy),
+    ...verifyOptions,
+  });
   if (outcome === "verified") {
     updateTab(tabId, { isReconnecting: false, resumeFailed: false });
     // Verified handshake — release the liveness-poll restore guard so normal

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -68,13 +68,19 @@ export async function fetchOpenRecords(pageId: string): Promise<TerminalSessionR
  * Under the opt-in `"summary"` policy the thresholds are left alone so the
  * picker appears and the verification loop answers it
  * (`buildPickerAnswer`). Exported for unit tests.
+ *
+ * Autonomous resume (`--permission-mode bypassPermissions`, matching the
+ * zone-profile + shell-integration resume builders): a boot-restored session
+ * is unattended, so a bare `claude --resume` would stall forever on its first
+ * permission prompt. Aligned with PR #547 — whichever lands second resolves
+ * the textual conflict by keeping this union form.
  */
 export function buildResumeCmd(
   sessionId: string,
   configDir: string | undefined,
   policy: ResumeSummaryPolicy = getResumeSummaryPolicy(),
 ): string {
-  const base = `claude --resume ${sessionId}`;
+  const base = `claude --permission-mode bypassPermissions --resume ${sessionId}`;
   const env: Array<[string, string]> = [];
   if (configDir) env.push(["CLAUDE_CONFIG_DIR", configDir]);
   if (policy === "full") {


### PR DESCRIPTION
## Summary

Item 3 of Phase 3, `2026-06-12-runner-session-registry-and-restore-hardening` — **stacked on #550** (`feat/restore-drain-verify`; this branch contains its commits, base retargets to main when #550 lands). Large-session resumes wedge unattended boot restores on the CLI's interactive "Resume from summary?" picker (observed live 2026-06-12 on a 326.6k-token session). Refs #548.

### Research findings (Claude Code v2.1.175 bundle + docs + GitHub issues)
- **No CLI flag exists.** The picker is gated by: statsig gate `tengu_gleaming_fair` (server-controlled), the global `.claude.json` key `resumeReturnDismissed` (what "Don't ask me again" writes), and two env thresholds — `CLAUDE_CODE_RESUME_TOKEN_THRESHOLD` (default 100000 est. tokens) and `CLAUDE_CODE_RESUME_THRESHOLD_MINUTES` (default 70). Suppressing the picker resumes the full session as-is. Picker options in order: 1) "Resume from summary (recommended)" (runs `/compact`), 2) "Resume full session as-is", 3) "Don't ask me again".

### Changes
- `buildResumeCmd`: under the default **full** policy, prefix the typed resume with both thresholds raised (`999999999`) so the picker never shows for runner-restored panes. Deliberately per-process env rather than seeding the global `resumeReturnDismissed` key — that would also kill the picker for the operator's own interactive resumes.
- **Fallback answerer** in the #550 verification loop: if a probe still shows the picker (CLI version drift, or the opt-in `summary` policy which leaves thresholds alone), type the configured answer once — `2` (full as-is, DEFAULT) or `1` (summary).
- **Policy knob**: Settings → Advanced → Session Restore; instance-scoped `resume-summary-policy` key. Default policy is **resume full as-is** (context loss is silent and unrecoverable; token cost is visible and `/compact`-able). Never defaults to summary.
- `buildResumeCmd` also emits `--permission-mode bypassPermissions`, the union with #547's autonomous-resume fix: whichever of #547/this lands second resolves the textual conflict in `buildResumeCmd` + its tests by keeping this union form.

## Test evidence
- `npx vitest run` (full suite at this head): 75 files / 922+ tests passed; touched suites: 39 passed (picker-pattern parser, answer keystrokes per policy, answer-at-most-once loop behavior, threshold-prefix command shapes, bypass union form).
- `npx tsc --noEmit` clean; eslint clean. No Rust changes in this PR.

## Merge-order note
Contains #550's commits (stacked). Known textual conflict with open #547 in `buildResumeCmd` (semantics already unioned here — resolution: keep this version).

Refs #548.
