### PR TITLE
feat(session): pre-pin --session-id at every runner-initiated spawn (#548 Phase 1)

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1767,6 +1767,26 @@ fn pick_continuation_page(
     mint()
 }
 
+/// Build the gate-continuation `claude` spawn argv. Pure for unit-testing:
+/// every flag — including the pre-pinned `--session-id` — MUST precede the
+/// trailing positional prompt arg, or the CLI eats it as prompt text.
+fn build_continuation_claude_command(
+    claude_bin: String,
+    pinned_session_id: &str,
+    add_dir_args: Vec<String>,
+    prompt: String,
+) -> Vec<String> {
+    let mut command_vec = vec![
+        claude_bin,
+        "--dangerously-skip-permissions".to_string(),
+        "--session-id".to_string(),
+        pinned_session_id.to_string(),
+    ];
+    command_vec.extend(add_dir_args);
+    command_vec.push(prompt);
+    command_vec
+}
+
 /// Run a gate continuation as a VISIBLE terminal session (Decision 1/2/3).
 ///
 /// Opens a pop-out terminal window and creates a terminal session whose PTY
@@ -1857,10 +1877,16 @@ async fn run_continuation_terminal(
         .as_ref()
         .map(|c| c.claude_add_dir_args())
         .unwrap_or_default();
-    let mut command_vec = vec![claude_bin, "--dangerously-skip-permissions".to_string()];
-    command_vec.extend(add_dir_args);
-    command_vec.push(payload.initial_prompt.clone());
-    let command = Some(command_vec);
+    // Pre-pin the Claude session id (#548 Phase 1): the registry records
+    // synchronously at spawn instead of mtime-guessing from transcripts.
+    // Fresh uuid per spawn attempt — never reused (CLI fails loudly on reuse).
+    let pinned_session_id = uuid::Uuid::new_v4().to_string();
+    let command = Some(build_continuation_claude_command(
+        claude_bin,
+        &pinned_session_id,
+        add_dir_args,
+        payload.initial_prompt.clone(),
+    ));
 
     // First repo (if any) is the session's intent_repo for coord attribution.
     let intent_repo = payload.repos.first().cloned();
@@ -1927,6 +1953,8 @@ async fn run_continuation_terminal(
         working_dir: workdir.to_string(),
         title: title.clone(),
         page_id: Some(target_page.clone()),
+        // Matches the `--session-id` in the spawn argv → synchronous record.
+        claude_session_id: Some(pinned_session_id),
     });
 
     // Provision `.mcp.json` so this continuation can reach coord coordination
@@ -2805,6 +2833,24 @@ mod tests {
         assert_eq!(
             pick_continuation_page(&counts, 9, || MINTED.to_string()),
             "default"
+        );
+    }
+
+    /// The pinned `--session-id <uuid>` pair sits among the flags, BEFORE the
+    /// trailing positional prompt (the CLI treats everything after the flags
+    /// as prompt text), with `--add-dir` siblings preserved in between.
+    #[test]
+    fn continuation_command_pins_session_id_before_positional_prompt() {
+        let cmd = build_continuation_claude_command(
+            "claude".to_string(),
+            "abc-123",
+            vec!["--add-dir".to_string(), "D:/wt/sibling".to_string()],
+            "do the thing".to_string(),
+        );
+        assert_eq!(
+            cmd.join("|"),
+            "claude|--dangerously-skip-permissions|--session-id|abc-123|\
+             --add-dir|D:/wt/sibling|do the thing"
         );
     }
 

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -845,6 +845,7 @@ pub fn terminal_session_record_open(
     zone_index: i32,
     title: Option<String>,
     terminal_id: String,
+    bind_origin: Option<String>,
 ) -> Result<CommandResponse, String> {
     let record = TerminalSessionRecord {
         claude_session_id,
@@ -860,6 +861,8 @@ pub fn terminal_session_record_open(
         state: "open".to_string(),
         closed_at: None,
         close_reason: None,
+        // `None` (origin-unaware callers) preserves any existing origin.
+        bind_origin,
     };
     store.record_open(record);
     Ok(CommandResponse {
@@ -926,6 +929,10 @@ pub(crate) struct SessionCaptureHint {
     /// Page the session should land on (and be durably recorded against) so a
     /// restart re-lands the continuation on its page. `None` → `"default"`.
     pub page_id: Option<String>,
+    /// Pre-pinned Claude session id (`--session-id <uuid>` in the spawn
+    /// argv): `Some(..)` records the OPEN synchronously (origin `"pinned"`)
+    /// and demotes the transcript poller to a verification arm.
+    pub claude_session_id: Option<String>,
 }
 
 /// Backend-task entry point for creating a terminal session + coord row from a
@@ -1097,24 +1104,62 @@ pub(crate) fn create_terminal_session_backend(
                 working_dir,
                 title,
                 page_id: hint_page_id,
+                claude_session_id: pinned_session_id,
             } = hint;
             // Single source of truth for the recorded page: the hint's page_id
             // (set by the caller to the picked page), defaulting to "default".
             let record_page_id = hint_page_id.unwrap_or_else(|| "default".to_string());
-            let since = chrono::Utc::now();
-            let resolver_dir = working_dir.clone();
-            let resolver = move || resolve_latest_claude_session_id(&resolver_dir, since);
-            tokio::spawn(poll_and_record_session(
-                store,
-                resolver,
-                terminal_id,
-                config_dir,
-                working_dir,
-                title,
-                record_page_id,
-                SESSION_CAPTURE_POLL_INTERVAL,
-                SESSION_CAPTURE_TIMEOUT,
-            ));
+            if let Some(pinned) = pinned_session_id {
+                // Pre-pinned id: record synchronously, then verify async that
+                // the transcript appears. NEVER rebinds from transcripts.
+                record_pinned_session_open(
+                    &store,
+                    pinned.clone(),
+                    terminal_id.clone(),
+                    config_dir.clone(),
+                    working_dir.clone(),
+                    title,
+                    record_page_id,
+                );
+                let verify_dirs: Vec<std::path::PathBuf> = config_dir
+                    .iter()
+                    .map(std::path::PathBuf::from)
+                    .chain(crate::terminal::transcript::find_claude_config_dirs())
+                    .collect();
+                let verify_pinned = pinned.clone();
+                let verify = move || {
+                    verify_dirs.iter().any(|dir| {
+                        crate::terminal::transcript::session_transcript_path(
+                            dir,
+                            &working_dir,
+                            &verify_pinned,
+                        )
+                        .exists()
+                    })
+                };
+                tokio::spawn(poll_and_verify_pinned_session(
+                    verify,
+                    terminal_id,
+                    pinned,
+                    SESSION_CAPTURE_POLL_INTERVAL,
+                    SESSION_CAPTURE_TIMEOUT,
+                ));
+            } else {
+                let since = chrono::Utc::now();
+                let resolver_dir = working_dir.clone();
+                let resolver = move || resolve_latest_claude_session_id(&resolver_dir, since);
+                tokio::spawn(poll_and_record_session(
+                    store,
+                    resolver,
+                    terminal_id,
+                    config_dir,
+                    working_dir,
+                    title,
+                    record_page_id,
+                    SESSION_CAPTURE_POLL_INTERVAL,
+                    SESSION_CAPTURE_TIMEOUT,
+                ));
+            }
         } else {
             warn!(
                 terminal_id = %info.id,
@@ -1194,6 +1239,8 @@ async fn poll_and_record_session<F>(
                 state: "open".to_string(),
                 closed_at: None,
                 close_reason: None,
+                // Freshest-transcript mtime guess — may be a foreign session.
+                bind_origin: Some("guessed".to_string()),
             };
             store.record_open(record);
             info!(
@@ -1209,6 +1256,77 @@ async fn poll_and_record_session<F>(
                 working_dir = %working_dir,
                 "create_terminal_session_backend: timed out resolving Claude session id — \
                  continuation session not durably recorded"
+            );
+            return;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Durably record a PRE-PINNED session (`--session-id <id>` in the spawn
+/// argv) the instant the PTY exists — no transcript mtime race to lose.
+pub(crate) fn record_pinned_session_open(
+    store: &SessionLifecycleStore,
+    claude_session_id: String,
+    terminal_id: String,
+    config_dir: Option<String>,
+    working_dir: String,
+    title: String,
+    page_id: String,
+) {
+    store.record_open(TerminalSessionRecord {
+        claude_session_id: claude_session_id.clone(),
+        config_dir,
+        working_dir: Some(working_dir),
+        page_id,
+        zone_index: 0,
+        title: Some(title),
+        terminal_id: terminal_id.clone(),
+        // record_open seeds these from `now`; values here are placeholders.
+        opened_at: 0,
+        last_seen_at: 0,
+        state: "open".to_string(),
+        closed_at: None,
+        close_reason: None,
+        bind_origin: Some("pinned".to_string()),
+    });
+    info!(
+        terminal_id = %terminal_id,
+        claude_session = %claude_session_id,
+        "create_terminal_session_backend: pinned session durably recorded at spawn"
+    );
+}
+
+/// Verification arm for a pre-pinned session: poll `verify` (pinned
+/// transcript exists on disk?) until confirmed or `timeout`. Pure
+/// observability — NEVER touches the registry binding; timeout warns loudly.
+async fn poll_and_verify_pinned_session<F>(
+    verify: F,
+    terminal_id: String,
+    claude_session_id: String,
+    interval: std::time::Duration,
+    timeout: std::time::Duration,
+) where
+    F: Fn() -> bool,
+{
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if verify() {
+            info!(
+                terminal_id = %terminal_id,
+                claude_session = %claude_session_id,
+                "pinned session verified: transcript present on disk"
+            );
+            return;
+        }
+        if std::time::Instant::now() >= deadline {
+            warn!(
+                terminal_id = %terminal_id,
+                claude_session = %claude_session_id,
+                "PINNED SESSION MISMATCH: transcript for the pinned --session-id never \
+                 appeared — claude likely failed to start (session-id collision fails \
+                 loudly in the pane) or wrote to an unexpected config dir. Registry \
+                 binding left as-is; NOT rebinding from transcripts."
             );
             return;
         }
@@ -1366,5 +1484,59 @@ mod tests {
         // Hint absent → poll_and_record_session is never spawned (see
         // create_terminal_session_backend). The store therefore has no rows.
         assert!(store.open_records().is_empty());
+    }
+
+    /// Regression for the 2026-06-12 mis-bind incident: two transcripts in
+    /// the project dir, the FRESHER one foreign. The mtime guess binds the
+    /// foreign id; the pinned path must take NOTHING from transcripts.
+    #[tokio::test]
+    async fn pinned_path_ignores_fresher_foreign_transcript() {
+        use crate::terminal::transcript::{get_latest_session_id, session_transcript_path};
+        let cfg = tempfile::tempdir().unwrap();
+        let project_path = "C:/work/repo";
+        let pinned_id = "11111111-1111-4111-8111-111111111111";
+        let foreign_id = "99999999-9999-4999-8999-999999999999";
+
+        // Lay both transcripts down, the foreign one FRESHER (later mtime).
+        let pinned_path = session_transcript_path(cfg.path(), project_path, pinned_id);
+        std::fs::create_dir_all(pinned_path.parent().unwrap()).unwrap();
+        std::fs::write(&pinned_path, "{\"type\":\"user\"}\n").unwrap();
+        std::thread::sleep(Duration::from_millis(30));
+        let foreign_path = session_transcript_path(cfg.path(), project_path, foreign_id);
+        std::fs::write(&foreign_path, "{\"type\":\"user\"}\n").unwrap();
+
+        // Sanity: the incident's guess mechanism really picks the foreign id.
+        let guessed = get_latest_session_id(cfg.path(), project_path, None)
+            .expect("fixture must yield a freshest session");
+        assert_eq!(guessed.session_id, foreign_id, "foreign must be freshest");
+
+        // Pinned path: synchronous record + verification arm.
+        let dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(
+            SessionLifecycleStore::open(dir.path().join("terminal-sessions.json")).unwrap(),
+        );
+        record_pinned_session_open(
+            &store,
+            pinned_id.to_string(),
+            "term-pin".to_string(),
+            Some(cfg.path().to_string_lossy().to_string()),
+            project_path.to_string(),
+            "Pinned".to_string(),
+            "default".to_string(),
+        );
+        let verify_cfg = cfg.path().to_path_buf();
+        poll_and_verify_pinned_session(
+            move || session_transcript_path(&verify_cfg, project_path, pinned_id).exists(),
+            "term-pin".to_string(),
+            pinned_id.to_string(),
+            Duration::from_millis(1),
+            Duration::from_millis(50),
+        )
+        .await;
+
+        let open = store.open_records();
+        assert_eq!(open.len(), 1, "exactly one record — nothing guessed in");
+        assert_eq!(open[0].claude_session_id, pinned_id);
+        assert_eq!(open[0].bind_origin.as_deref(), Some("pinned"));
     }
 }

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -96,6 +96,11 @@ pub struct TerminalSessionRecord {
     pub closed_at: Option<i64>,
     /// Why the session was closed (e.g. `"poll-dead"`, an explicit reason).
     pub close_reason: Option<String>,
+    /// How `claude_session_id` was bound: `"pinned"` (`--session-id` /
+    /// `--resume` — exact) or `"guessed"` (freshest-transcript mtime guess).
+    /// Records predating the field deserialize as `None` = guessed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bind_origin: Option<String>,
 }
 
 /// Durable map of `claude_session_id -> TerminalSessionRecord`. Cheap to
@@ -151,6 +156,11 @@ impl SessionLifecycleStore {
             entry.zone_index = rec.zone_index;
             entry.title = rec.title;
             entry.terminal_id = rec.terminal_id;
+            // Unasserted origin (zone-move backstop / boot re-assert) must
+            // not degrade a pinned binding to guessed — preserve on None.
+            if rec.bind_origin.is_some() {
+                entry.bind_origin = rec.bind_origin;
+            }
             entry.state = "open".to_string();
             entry.closed_at = None;
             entry.close_reason = None;
@@ -418,7 +428,41 @@ mod tests {
             state: "open".to_string(),
             closed_at: None,
             close_reason: None,
+            bind_origin: None,
         }
+    }
+
+    /// Records predating `bindOrigin` must deserialize and read as guessed.
+    #[test]
+    fn pre_bind_origin_record_deserializes_as_guessed() {
+        let json = r#"{"claudeSessionId":"old-sess","configDir":null,"workingDir":"C:/repo",
+            "pageId":"default","zoneIndex":1,"title":"Old","terminalId":"term-old",
+            "openedAt":1,"lastSeenAt":2,"state":"open","closedAt":null,"closeReason":null}"#;
+        let rec: TerminalSessionRecord = serde_json::from_str(json).unwrap();
+        // `None` IS the guessed reading — consumers default absent to "guessed".
+        assert_eq!(rec.bind_origin.as_deref().unwrap_or("guessed"), "guessed");
+    }
+
+    /// Pinned origin survives an unasserted re-record; asserted updates.
+    #[test]
+    fn record_open_preserves_bind_origin_when_unasserted() {
+        let dir = tempdir().unwrap();
+        let store = SessionLifecycleStore::open(dir.path().join("s.json")).unwrap();
+        let mut pinned = rec("sess-1");
+        pinned.bind_origin = Some("pinned".to_string());
+        store.record_open(pinned);
+        store.record_open(rec("sess-1")); // unasserted (None)
+        assert_eq!(
+            store.open_records()[0].bind_origin.as_deref(),
+            Some("pinned")
+        );
+        let mut guessed = rec("sess-1");
+        guessed.bind_origin = Some("guessed".to_string());
+        store.record_open(guessed);
+        assert_eq!(
+            store.open_records()[0].bind_origin.as_deref(),
+            Some("guessed")
+        );
     }
 
     #[test]

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -41,7 +41,9 @@ import { setTerminalSessions, type TerminalSessionEntry } from "@/lib/terminal-s
 import { UIBridgeComponentScope } from "@qontinui/ui-bridge";
 import { useCommitState } from "./useCommitState";
 import { useTabSessionIdCapture } from "./useTabSessionIdCapture";
-import { buildSessionOpenArgs } from "./sessionRecordArgs";
+import { buildSessionOpenArgs, type SessionBindOrigin } from "./sessionRecordArgs";
+import { buildAiLaunchCommand } from "./aiLaunchCommand";
+import { rememberSessionId } from "./lastKnownSessionIds";
 import { useRegistryAwareness } from "./useRegistryAwareness";
 import { useMidSessionProbe, useMidSessionProbeEnabled } from "./useMidSessionProbe";
 import { MidSessionToast } from "./MidSessionToast";
@@ -515,7 +517,14 @@ function TerminalPageInner({
    * restore hint, the live session is unaffected.
    */
   const recordSessionOpen = useCallback(
-    (tabId: string, claudeSessionId: string, configDir?: string) => {
+    // Default origin "guessed": the only caller that omits it is the
+    // transcript-capture hook, whose id IS a freshest-mtime guess.
+    (
+      tabId: string,
+      claudeSessionId: string,
+      configDir?: string,
+      bindOrigin: SessionBindOrigin = "guessed",
+    ) => {
       const args = buildSessionOpenArgs({
         assignments: assignmentsRef.current,
         tabs: tabsRef.current,
@@ -523,6 +532,7 @@ function TerminalPageInner({
         claudeSessionId,
         configDir,
         pageId,
+        bindOrigin,
       });
       invoke("terminal_session_record_open", { ...args }).catch((err) => {
         logger.warn(`terminal_session_record_open failed for ${claudeSessionId}: ${err}`);
@@ -819,16 +829,6 @@ function TerminalPageInner({
 
     const isWindows = navigator.platform.startsWith("Win");
     const customCmd = sessionManager.launchCommands?.[configDir];
-    // Default to autonomous mode (`--permission-mode bypassPermissions`),
-    // matching the operator's `clg`/`clh`/`clp` wrappers — runner-spawned
-    // AI sessions are for autonomous development and must not stall on a
-    // permission prompt. An explicit per-account launch command (if
-    // configured in settings) still overrides.
-    const cmd = customCmd
-      ? customCmd
-      : isWindows
-        ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; claude --permission-mode bypassPermissions`
-        : `CLAUDE_CONFIG_DIR="${configDir}" claude --permission-mode bypassPermissions`;
     const dirName = configDir.replace(/\\/g, "/").replace(/\/$/, "").split("/").pop() ?? "";
     const label = customCmd ?? dirName.match(/^\.claude-(.+)$/)?.[1] ?? "claude";
     const createdTabIds: string[] = [];
@@ -839,9 +839,24 @@ function TerminalPageInner({
     if (createdTabIds.length > 0) {
       const spawnAt = Date.now();
       for (const tabId of createdTabIds) {
-        writeWhenReady(tabId, `${cmd}\r`);
-        const tab = tabs.find((t) => t.id === tabId);
-        startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt, configDir);
+        // Fresh uuid per tab/retype (a reused --session-id fails loudly) —
+        // the registry records synchronously, no transcript mtime guess.
+        const { command, pinnedSessionId } = buildAiLaunchCommand({
+          configDir,
+          isWindows,
+          customCmd,
+          newSessionId: () => crypto.randomUUID(),
+        });
+        writeWhenReady(tabId, `${command}\r`);
+        if (pinnedSessionId) {
+          updateTab(tabId, { claudeSessionId: pinnedSessionId, claudeConfigDir: configDir });
+          rememberSessionId(tabId, pinnedSessionId, configDir);
+          recordSessionOpen(tabId, pinnedSessionId, configDir, "pinned");
+        } else {
+          // Custom launch command — id unknown; capture poll is the fallback.
+          const tab = tabs.find((t) => t.id === tabId);
+          startSessionIdCapture(tabId, tab?.workingDir ?? "", spawnAt, configDir);
+        }
       }
       if (context) {
         const safeContext = context.replace(/\n/g, " ");
@@ -911,11 +926,7 @@ function TerminalPageInner({
             Visually hidden; not interactive. Lists ALL sessions regardless
             of which zones are currently mounted, so verification never
             depends on the active layout preset. */}
-        <span
-          data-page-element="terminal-session-roster"
-          style={{ display: "none" }}
-          aria-hidden
-        >
+        <span data-page-element="terminal-session-roster" style={{ display: "none" }} aria-hidden>
           {terminalSessionRoster}
         </span>
         {/* Phase 2 — honesty backstop for sessions past the zone ceiling.

--- a/src/components/terminal/aiLaunchCommand.test.ts
+++ b/src/components/terminal/aiLaunchCommand.test.ts
@@ -1,0 +1,53 @@
+/** Launch-menu AI-session command builder (#548 Phase 1: pre-pin --session-id). */
+
+import { describe, it, expect } from "vitest";
+import { buildAiLaunchCommand } from "./aiLaunchCommand";
+
+const CFG = "C:\\claude\\.claude-hotmail";
+
+describe("buildAiLaunchCommand", () => {
+  it("appends --session-id <fresh uuid> to the default Windows command", () => {
+    const { command, pinnedSessionId } = buildAiLaunchCommand({
+      configDir: CFG,
+      isWindows: true,
+      newSessionId: () => "11111111-1111-4111-8111-111111111111",
+    });
+    expect(pinnedSessionId).toBe("11111111-1111-4111-8111-111111111111");
+    expect(command).toBe(
+      `$env:CLAUDE_CONFIG_DIR="${CFG}"; claude --permission-mode bypassPermissions ` +
+        `--session-id 11111111-1111-4111-8111-111111111111`,
+    );
+  });
+
+  it("appends --session-id to the default POSIX command", () => {
+    const { command } = buildAiLaunchCommand({
+      configDir: "/h/.claude-x",
+      isWindows: false,
+      newSessionId: () => "abc",
+    });
+    expect(command).toBe(
+      'CLAUDE_CONFIG_DIR="/h/.claude-x" claude --permission-mode bypassPermissions --session-id abc',
+    );
+  });
+
+  it("never touches an operator-configured custom command (capture fallback)", () => {
+    const { command, pinnedSessionId } = buildAiLaunchCommand({
+      configDir: CFG,
+      isWindows: true,
+      customCmd: "clh",
+      newSessionId: () => {
+        throw new Error("must not mint an id for a custom command");
+      },
+    });
+    expect(command).toBe("clh");
+    expect(pinnedSessionId).toBeNull();
+  });
+
+  it("mints a FRESH id per call — ids are never reused across tabs/retries", () => {
+    let n = 0;
+    const opts = { configDir: CFG, isWindows: true, newSessionId: () => `uuid-${n++}` };
+    expect(buildAiLaunchCommand(opts).pinnedSessionId).not.toBe(
+      buildAiLaunchCommand(opts).pinnedSessionId,
+    );
+  });
+});

--- a/src/components/terminal/aiLaunchCommand.ts
+++ b/src/components/terminal/aiLaunchCommand.ts
@@ -1,0 +1,37 @@
+/**
+ * Launch-menu "new AI session" command builder (#548 Phase 1): the default
+ * command gets a fresh UUIDv4 as `--session-id <uuid>` so the tab knows its
+ * id BEFORE the process exists — no transcript mtime guess a concurrent
+ * same-cwd session can win. The CLI fails LOUDLY on a reused id (verified
+ * 2026-06-12), so call once per typed command — fresh uuid per tab/retry. A
+ * custom launch command (possibly an alias that drops extra args) is left
+ * untouched and keeps the capture fallback ("guessed").
+ */
+
+export interface AiLaunchCommand {
+  /** Full command to type into the PTY (no trailing newline). */
+  command: string;
+  /** Pre-pinned Claude session id; null = capture fallback. */
+  pinnedSessionId: string | null;
+}
+
+export function buildAiLaunchCommand(params: {
+  configDir: string;
+  isWindows: boolean;
+  customCmd?: string;
+  /** Fresh-UUIDv4 source; injected for testability. */
+  newSessionId: () => string;
+}): AiLaunchCommand {
+  const { configDir, isWindows, customCmd, newSessionId } = params;
+  if (customCmd) {
+    return { command: customCmd, pinnedSessionId: null };
+  }
+  const pinnedSessionId = newSessionId();
+  // Autonomous mode (matches the operator's clg/clh/clp wrappers) —
+  // runner-spawned AI sessions must not stall on a permission prompt.
+  const base = `claude --permission-mode bypassPermissions --session-id ${pinnedSessionId}`;
+  const command = isWindows
+    ? `$env:CLAUDE_CONFIG_DIR="${configDir}"; ${base}`
+    : `CLAUDE_CONFIG_DIR="${configDir}" ${base}`;
+  return { command, pinnedSessionId };
+}

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -329,6 +329,19 @@ const PageSessionScope = memo(function PageSessionScope({
           claudeSessionId: s.claudeSessionId,
           claudeConfigDir: s.claudeConfigDir,
         });
+        // Durable-registry OPEN at type time (#548 Phase 1): `--resume` names
+        // the exact id in the typed command — no transcript guess.
+        const resumedTab = tabs.find((t) => t.id === tabId);
+        invoke("terminal_session_record_open", {
+          claudeSessionId: s.claudeSessionId,
+          configDir: s.claudeConfigDir,
+          workingDir: resumedTab?.workingDir,
+          pageId,
+          zoneIndex: s.zoneIndex,
+          title: resumedTab?.title,
+          terminalId: tabId,
+          bindOrigin: "pinned",
+        }).catch((err) => console.warn(`[TerminalSession] profile resume record failed:`, err));
         writeWhenReady(
           terminalRefs.current,
           tabId,
@@ -345,7 +358,7 @@ const PageSessionScope = memo(function PageSessionScope({
       }
     }
     pendingProfileSessionsRef.current = remaining.length > 0 ? remaining : null;
-  }, [zoneLayout.assignments, updateTab]);
+  }, [zoneLayout.assignments, updateTab, tabs, pageId]);
 
   // Transcripts are read up here (rather than in the AiFeatures block below)
   // because the debug-gated synthetic-tab seam derives synthetic tabs from
@@ -446,6 +459,7 @@ const PageSessionScope = memo(function PageSessionScope({
     terminalRefs,
     setRightPanelMode: (v) => rightPanelModeSetterRef.current(v as never),
     setSelectedTranscriptSessionId: (v) => selectedSessionSetterRef.current(v as never),
+    pageId,
   });
 
   const getScrollback = useCallback(

--- a/src/components/terminal/sessionRecordArgs.test.ts
+++ b/src/components/terminal/sessionRecordArgs.test.ts
@@ -62,6 +62,20 @@ describe("buildSessionOpenArgs — onSessionIdBound zone resolution", () => {
     });
   });
 
+  // Omitted bindOrigin → key ABSENT so the backend preserves any existing origin.
+  it("includes bindOrigin only when the caller asserts one", () => {
+    const base = {
+      assignments: {},
+      tabs: [],
+      tabId: "t",
+      claudeSessionId: "sid",
+      configDir: undefined,
+      pageId: "default",
+    };
+    expect("bindOrigin" in buildSessionOpenArgs(base)).toBe(false);
+    expect(buildSessionOpenArgs({ ...base, bindOrigin: "pinned" }).bindOrigin).toBe("pinned");
+  });
+
   it("records zoneIndex -1 when the bound tab is unassigned", () => {
     const args = buildSessionOpenArgs({
       assignments: { 0: "other" },

--- a/src/components/terminal/sessionRecordArgs.ts
+++ b/src/components/terminal/sessionRecordArgs.ts
@@ -18,6 +18,13 @@ export interface OpenRecordTab {
   workingDir?: string;
 }
 
+/**
+ * How a tab learned its `claudeSessionId`: `"pinned"` (`--session-id` /
+ * `--resume` — exact) vs `"guessed"` (freshest-transcript mtime guess).
+ * Omitted = unknown; the backend then preserves any existing origin.
+ */
+export type SessionBindOrigin = "pinned" | "guessed";
+
 /** Args for the `terminal_session_record_open` Tauri command. */
 export interface SessionOpenArgs {
   claudeSessionId: string;
@@ -27,6 +34,7 @@ export interface SessionOpenArgs {
   zoneIndex: number;
   title?: string;
   terminalId: string;
+  bindOrigin?: SessionBindOrigin;
 }
 
 /**
@@ -34,10 +42,7 @@ export interface SessionOpenArgs {
  * `zoneIndex → tabId` assignments. Returns -1 (unassigned/hidden) when the tab
  * is in no zone — the same sentinel the backend record uses.
  */
-export function resolveZoneIndex(
-  assignments: Record<number, string>,
-  tabId: string,
-): number {
+export function resolveZoneIndex(assignments: Record<number, string>, tabId: string): number {
   return Number(Object.entries(assignments).find(([, id]) => id === tabId)?.[0] ?? -1);
 }
 
@@ -53,8 +58,9 @@ export function buildSessionOpenArgs(params: {
   claudeSessionId: string;
   configDir: string | undefined;
   pageId: string;
+  bindOrigin?: SessionBindOrigin;
 }): SessionOpenArgs {
-  const { assignments, tabs, tabId, claudeSessionId, configDir, pageId } = params;
+  const { assignments, tabs, tabId, claudeSessionId, configDir, pageId, bindOrigin } = params;
   const tab = tabs.find((t) => t.id === tabId);
   return {
     claudeSessionId,
@@ -64,5 +70,6 @@ export function buildSessionOpenArgs(params: {
     zoneIndex: resolveZoneIndex(assignments, tabId),
     title: tab?.title,
     terminalId: tabId,
+    ...(bindOrigin ? { bindOrigin } : {}),
   };
 }

--- a/src/components/terminal/useShellIntegration.ts
+++ b/src/components/terminal/useShellIntegration.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import type { ShellIntegrationEvent } from "./TerminalInstance";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { TranscriptSession } from "./useTranscriptSessions";
@@ -38,6 +39,8 @@ interface UseShellIntegrationParams {
     >
   >;
   setSelectedTranscriptSessionId: React.Dispatch<React.SetStateAction<string | null>>;
+  /** Page the resumed tab lands on — recorded in the durable registry. */
+  pageId: string;
 }
 
 interface UseShellIntegrationResult {
@@ -57,6 +60,7 @@ export function useShellIntegration({
   terminalRefs,
   setRightPanelMode,
   setSelectedTranscriptSessionId,
+  pageId,
 }: UseShellIntegrationParams): UseShellIntegrationResult {
   // Shell integration: structured command history per tab
   const [commandHistories, setCommandHistories] = useState<Record<string, CommandHistoryEntry[]>>(
@@ -145,6 +149,18 @@ export function useShellIntegration({
       // Persist durably so the tab stays resumable across a close→reopen even
       // if the live tab object later loses the id.
       rememberSessionId(tabId, session.session_id, session.config_dir);
+      // Durable-registry OPEN at type time (#548 Phase 1): `--resume` names
+      // the exact id. Zone unknown (-1); the zone-move backstop refreshes it.
+      invoke("terminal_session_record_open", {
+        claudeSessionId: session.session_id,
+        configDir: session.config_dir,
+        workingDir: session.project_path,
+        pageId,
+        zoneIndex: -1,
+        title: tabTitle,
+        terminalId: tabId,
+        bindOrigin: "pinned",
+      }).catch((err) => console.warn(`[ShellIntegration] resume record failed:`, err));
 
       // Close the transcript panel so the terminal is visible
       setRightPanelMode(null);
@@ -177,7 +193,14 @@ export function useShellIntegration({
         ref?.current?.writeToTerminal(`${pending.resumeCmd}\r`);
       }, 1500);
     },
-    [createTerminal, updateTab, terminalRefs, setRightPanelMode, setSelectedTranscriptSessionId],
+    [
+      createTerminal,
+      updateTab,
+      terminalRefs,
+      setRightPanelMode,
+      setSelectedTranscriptSessionId,
+      pageId,
+    ],
   );
 
   // ── Auto-naming from first input ──────────────────────────────────────────

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -2,6 +2,10 @@
  * Post-spawn polling hook that fills in `tab.claudeSessionId` for
  * PTY-launched AI tabs (the `onLaunchAiSession` path in TerminalPage).
  *
+ * FALLBACK ONLY since #548 Phase 1: runner launches pre-pin the id via
+ * `--session-id` and never start a capture; this poll covers only un-pinned
+ * tabs (custom launch commands, hand-typed `claude`), binds origin "guessed".
+ *
  * Today, `useShellIntegration.ts:135` only sets `claudeSessionId` on
  * the resume path (`handleResumeSession`). For initial spawns, the
  * field is never set — which means `useCommitState`'s per-tab probe has


### PR DESCRIPTION
Phase 1 of `2026-06-12-runner-session-registry-and-restore-hardening` (#548).

Runner tabs previously learned their Claude session id by polling for the freshest transcript in the project dir (`useTabSessionIdCapture` → `transcript_get_latest`). Concurrent same-account/same-cwd sessions (VS Code) win the mtime race, so foreign sessions got registered against runner tabs while the tab's real session stayed unregistered and was lost on crash (the 2026-06-12 incident). The CLI accepts `--session-id <uuid>` for new sessions, so every runner-initiated surface can know the id BEFORE the process exists and register synchronously.

## Changes

- **1a. Launch-menu new session** — `buildAiLaunchCommand` (new pure builder) appends `--session-id <fresh UUIDv4>` to the default typed command; the tab binds the id and fires `terminal_session_record_open` (origin `pinned`) at type time, skipping the transcript-capture poll. Operator-configured custom launch commands (possibly arg-dropping aliases) are left untouched and keep the capture fallback.
- **1b. Gate-continuation spawn** — `build_continuation_claude_command` puts `--session-id <uuid>` in the spawn argv (before the positional prompt); `create_terminal_session_backend` records the OPEN synchronously (`record_pinned_session_open`) and demotes the transcript poller to a verification arm (`poll_and_verify_pinned_session`): confirms the pinned transcript appears, loud WARN on timeout, NEVER rebinds from transcripts.
- **1c. Resume surfaces** — zone-profile restore (`TerminalSessionContext`) and transcript-panel resume (`useShellIntegration`) now fire `terminal_session_record_open` at type time with origin `pinned` (the exact id is in the `--resume` command being typed).
- **1d. Provenance + capture demotion** — `TerminalSessionRecord` gains additive optional `bindOrigin: "pinned" | "guessed"` (absent = guessed for pre-existing records; `record_open` preserves an existing origin when the caller doesn't assert one, so zone-move/boot re-asserts can't degrade a pinned binding). Capture-bound ids are recorded as `guessed`; the capture hook runs only for tabs with no pinned id.

## Collision spike

`claude --session-id <uuid> -p ...` run twice with the same uuid: the second invocation fails loudly (`Error: Session ID <uuid> is already in use.`, exit 1) — no silent fresh-session fork. All pin sites mint a fresh uuid per typed command / per spawn attempt, so an id is never reused.

## Tests

- Rust: `pinned_path_ignores_fresher_foreign_transcript` reproduces the incident (two transcripts, fresher one foreign; `get_latest_session_id` provably picks the foreign one) and proves the pinned path binds nothing from transcripts; `pre_bind_origin_record_deserializes_as_guessed`; `record_open_preserves_bind_origin_when_unasserted`; `continuation_command_pins_session_id_before_positional_prompt`.
- Frontend: `aiLaunchCommand.test.ts` (default Windows/POSIX append, custom-command passthrough, fresh-uuid-per-call) + `sessionRecordArgs.test.ts` bindOrigin presence/omission.
- `cargo check` clean; targeted `cargo test` (lifecycle store / commands::terminal / agent_runtime) green; `npx tsc --noEmit` clean; `npx vitest run src/components/terminal` 43 files / 529 tests passed; eslint + prettier clean on touched files.

Closes nothing on its own; tracks #548 Phase 1. Boot-restore re-assert already names its id and is untouched (its unasserted re-record now preserves origin).
