### PR TITLE
fix(agent_worktree): stale-census husk guard — never create paths during reclaim

### DIFF
--- a/src-tauri/src/agent_worktree/census.rs
+++ b/src-tauri/src/agent_worktree/census.rs
@@ -64,6 +64,54 @@ use super::canonical_paths::default_canonical_path;
 /// 30s fleet heartbeat. Override via `QONTINUI_WORKTREE_CENSUS_INTERVAL_SECS`.
 const DEFAULT_CENSUS_INTERVAL_SECS: u64 = 300;
 
+// ---------------------------------------------------------------------------
+// Census-before-reclaim boot ordering (the stale-census husk-guard, R3).
+//
+// The boot-time reclaim pull must not race ahead of the boot-time census:
+// coord's view between the two is whatever the LAST census of the previous
+// boot reported, so any worktree deleted while the runner was down generates
+// stale instructions for the whole window. The reclaim poller therefore
+// gates its FIRST pull of each boot on this signal (with a one-interval
+// timeout fallback so a census-disabled config never deadlocks reclaim).
+// ---------------------------------------------------------------------------
+
+/// Set once the first census POST of this boot has succeeded (2xx).
+static FIRST_CENSUS_POSTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Wakes reclaim's boot-ordering wait the moment the flag flips.
+static FIRST_CENSUS_NOTIFY: std::sync::OnceLock<tokio::sync::Notify> = std::sync::OnceLock::new();
+
+fn first_census_notify() -> &'static tokio::sync::Notify {
+    FIRST_CENSUS_NOTIFY.get_or_init(tokio::sync::Notify::new)
+}
+
+/// Record that a census POST landed (called from [`tick_once`] on 2xx).
+fn mark_first_census_posted() {
+    FIRST_CENSUS_POSTED.store(true, std::sync::atomic::Ordering::Release);
+    first_census_notify().notify_waiters();
+}
+
+/// Wait up to `timeout` for the first successful census POST of this boot.
+/// Returns `true` when a census has been posted (possibly before the call),
+/// `false` on timeout (census disabled, no coord configured, or slow walk —
+/// the caller proceeds and relies on coord's staleness degrade).
+pub(super) async fn wait_first_census_posted(timeout: Duration) -> bool {
+    // Register the waiter BEFORE the flag check so a mark between the check
+    // and the await can't be missed (Notify::notified buffers a permit only
+    // for already-registered waiters via notify_waiters).
+    let notified = first_census_notify().notified();
+    if FIRST_CENSUS_POSTED.load(std::sync::atomic::Ordering::Acquire) {
+        return true;
+    }
+    tokio::select! {
+        _ = notified => true,
+        _ = tokio::time::sleep(timeout) => {
+            FIRST_CENSUS_POSTED.load(std::sync::atomic::Ordering::Acquire)
+        }
+    }
+}
+
 /// Windows reparse-point attribute bit (`FILE_ATTRIBUTE_REPARSE_POINT`).
 /// A junction (and a symlink) sets this in the file attributes returned
 /// by `symlink_metadata`. Defined locally so the check needs no winapi
@@ -870,6 +918,9 @@ pub async fn tick_once() -> Result<(), String> {
         let excerpt: String = body.chars().take(200).collect();
         return Err(format!("coord returned {status} for POST {url}: {excerpt}"));
     }
+    // R3 boot ordering: the first successful POST of this boot releases the
+    // reclaim poller's census-before-reclaim gate.
+    mark_first_census_posted();
     debug!(
         "worktree_census: posted device_id={} worktrees={} volumes={}",
         req.device_id,

--- a/src-tauri/src/agent_worktree/reclaim.rs
+++ b/src-tauri/src/agent_worktree/reclaim.rs
@@ -188,8 +188,9 @@ pub enum ReclaimStep {
 /// filesystem mutation, no junction *verification* (that happens at
 /// execution time, where we have the real disk). This is the function the
 /// unit tests pin: it guarantees junction-unlinks come before the
-/// worktree removal, that a dirty instruction yields only a `Skip`, and
-/// that an UNARMED action yields only `Skip`s.
+/// worktree removal, that a dirty instruction yields only a `Skip`, that
+/// an UNARMED action yields only `Skip`s, and that an instruction whose
+/// worktree root is ABSENT on disk yields only a `Skip`.
 ///
 /// Arming is per-action (Q1): a `Remove` is destructive only when
 /// `remove_armed`; a `Rejunction` creates junctions only when
@@ -199,12 +200,31 @@ pub enum ReclaimStep {
 /// `canonical_path` is the repo's canonical checkout — the junction target
 /// root for a `rejunction`. `None` when the runner couldn't resolve it
 /// (then a rejunction degrades to a `Skip`).
+///
+/// `root_exists` is the caller's dispatch-time `worktree_path` existence
+/// probe. `false` means coord's instruction is built on a stale census (the
+/// worktree was deleted out-of-band): executing a `Rejunction` against it
+/// would re-materialize the root as an empty husk (the 2026-06-12 incident),
+/// so the ENTIRE instruction is skipped — for `Remove` too, uniformly. The
+/// invariant this pins: a reclaim execution must never create a filesystem
+/// path, except junction reparse points inside an already-existing worktree
+/// root.
 pub fn plan_reclaim(
     instr: &ReclaimInstruction,
     rejunction_armed: bool,
     remove_armed: bool,
     canonical_path: Option<&Path>,
+    root_exists: bool,
 ) -> Vec<ReclaimStep> {
+    // Absent-root guard — a stale instruction for a worktree that no longer
+    // exists must do NOTHING (the next census is the ack that clears it).
+    if !root_exists {
+        return vec![ReclaimStep::Skip(format!(
+            "skipping {} — absent on disk (stale instruction; next census is the ack)",
+            instr.worktree_path
+        ))];
+    }
+
     // Defense in depth #1 — NEVER act on a dirty worktree.
     if instr.is_dirty {
         return vec![ReclaimStep::Skip(format!(
@@ -388,10 +408,17 @@ fn create_junction(link: &Path, target: &Path) -> Result<(), String> {
             link.display()
         ));
     }
+    // A missing parent means the worktree root itself is gone (for the sink
+    // links `<wt>/node_modules` / `<wt>/target`, `link.parent()` IS the
+    // worktree root). The only legitimate parents are created by
+    // `git worktree add`, never by reclaim — creating them here would
+    // re-materialize a deleted worktree as an empty husk.
     if let Some(parent) = link.parent() {
         if !parent.exists() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("rejunction: mkdir {} : {e}", parent.display()))?;
+            return Err(format!(
+                "rejunction: link parent {} missing — refusing to create directories",
+                parent.display()
+            ));
         }
     }
     // `cmd /C mklink /J <link> <target>` — /J = directory junction.
@@ -582,6 +609,19 @@ fn execute_pull(pull: &ReclaimPull) {
     for instr in &pull.instructions {
         let wt = PathBuf::from(&instr.worktree_path);
 
+        // Absent-root probe — once per instruction, at dispatch time. A
+        // worktree deleted out-of-band (operator cleanup, another machine)
+        // leaves coord serving stale instructions until the next census
+        // tick; executing one would re-create the root as an empty husk.
+        let root_exists = wt.exists();
+        if !root_exists {
+            warn!(
+                "worktree_reclaim: skipping {} — absent on disk (stale instruction; \
+                 next census is the ack)",
+                instr.worktree_path
+            );
+        }
+
         // Whether THIS instruction's action is armed (would actually do
         // something destructive/mutating this tick). Skip the execution-time
         // guards entirely for an unarmed (advisory) instruction so the
@@ -633,6 +673,7 @@ fn execute_pull(pull: &ReclaimPull) {
             pull.rejunction_armed,
             pull.remove_armed,
             canonical.as_deref(),
+            root_exists,
         );
         for step in &steps {
             if let Err(e) = execute_step(step) {
@@ -714,6 +755,14 @@ pub async fn tick_once() -> Result<(), String> {
 /// `QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS` (default 300s, floored 30s).
 /// `MissedTickBehavior::Skip` + warn-and-retry, like
 /// [`super::census::spawn_census`].
+///
+/// Census-before-reclaim boot ordering (R3, the stale-census husk-guard):
+/// the FIRST pull of each boot waits for the census publisher to land ≥1
+/// successful POST, so coord decides from this boot's disk truth rather
+/// than the previous boot's last census (the window where a worktree
+/// deleted while the runner was down draws husk-creating instructions).
+/// Bounded by one reclaim interval so a census-disabled config never
+/// deadlocks the poller.
 pub fn spawn_reclaim() {
     let secs: u64 = std::env::var("QONTINUI_WORKTREE_RECLAIM_INTERVAL_SECS")
         .ok()
@@ -727,6 +776,15 @@ pub fn spawn_reclaim() {
     );
 
     tokio::spawn(async move {
+        if super::census::wait_first_census_posted(Duration::from_secs(secs)).await {
+            debug!("worktree_reclaim: census posted this boot — reclaim pulls may begin");
+        } else {
+            warn!(
+                "worktree_reclaim: no census POST within {secs}s — proceeding without the \
+                 boot-ordering gate (census disabled or slow; coord's staleness degrade is \
+                 the backstop)"
+            );
+        }
         let mut tick = tokio::time::interval(Duration::from_secs(secs));
         tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
@@ -761,7 +819,7 @@ mod tests {
     fn remove_unlinks_every_junction_before_removing_worktree() {
         let i = instr(ReclaimAction::Remove, &["target", "node_modules"], false);
         // remove_armed=true.
-        let steps = plan_reclaim(&i, false, true, None);
+        let steps = plan_reclaim(&i, false, true, None, true);
 
         // Exactly: UnlinkJunction(target), UnlinkJunction(node_modules),
         // RemoveWorktree(path) — junctions first, in order.
@@ -790,7 +848,7 @@ mod tests {
             &["a", "b", "c", "node_modules", "target"],
             false,
         );
-        let steps = plan_reclaim(&i, false, true, None);
+        let steps = plan_reclaim(&i, false, true, None, true);
         let remove_idx = steps
             .iter()
             .position(|s| matches!(s, ReclaimStep::RemoveWorktree(_)))
@@ -810,7 +868,7 @@ mod tests {
     #[test]
     fn remove_with_no_junctions_is_just_a_removal() {
         let i = instr(ReclaimAction::Remove, &[], false);
-        let steps = plan_reclaim(&i, false, true, None);
+        let steps = plan_reclaim(&i, false, true, None, true);
         assert_eq!(
             steps,
             vec![ReclaimStep::RemoveWorktree(PathBuf::from(
@@ -823,7 +881,7 @@ mod tests {
     fn dirty_instruction_yields_no_destructive_steps() {
         let i = instr(ReclaimAction::Remove, &["target", "node_modules"], true);
         // Even fully armed, a dirty worktree yields only a Skip.
-        let steps = plan_reclaim(&i, true, true, None);
+        let steps = plan_reclaim(&i, true, true, None, true);
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));
         // No unlink / remove / create anywhere.
@@ -840,7 +898,7 @@ mod tests {
         // remove_armed=false → advisory-only Skip even though it's clean.
         let i = instr(ReclaimAction::Remove, &["target", "node_modules"], false);
         let steps = plan_reclaim(
-            &i, /* rejunction */ false, /* remove */ false, None,
+            &i, /* rejunction */ false, /* remove */ false, None, true,
         );
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));
@@ -857,7 +915,7 @@ mod tests {
         // rejunction_armed=false → advisory-only Skip.
         let i = instr(ReclaimAction::Rejunction, &["target"], false);
         let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
-        let steps = plan_reclaim(&i, false, false, Some(&canonical));
+        let steps = plan_reclaim(&i, false, false, Some(&canonical), true);
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));
     }
@@ -868,7 +926,7 @@ mod tests {
         // A Remove instruction is advisory-only...
         let rm = instr(ReclaimAction::Remove, &["target"], false);
         let steps = plan_reclaim(
-            &rm, /* rejunction */ true, /* remove */ false, None,
+            &rm, /* rejunction */ true, /* remove */ false, None, true,
         );
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));
@@ -880,7 +938,7 @@ mod tests {
         // ...while a Rejunction in the SAME tick actually executes.
         let rj = instr(ReclaimAction::Rejunction, &["target"], false);
         let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
-        let rj_steps = plan_reclaim(&rj, true, false, Some(&canonical));
+        let rj_steps = plan_reclaim(&rj, true, false, Some(&canonical), true);
         assert_eq!(
             rj_steps,
             vec![ReclaimStep::CreateJunction {
@@ -897,7 +955,7 @@ mod tests {
         for action in [ReclaimAction::Remove, ReclaimAction::Rejunction] {
             let i = instr(action, &["target", "node_modules"], false);
             let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
-            let steps = plan_reclaim(&i, false, false, Some(&canonical));
+            let steps = plan_reclaim(&i, false, false, Some(&canonical), true);
             assert_eq!(steps.len(), 1);
             assert!(matches!(steps[0], ReclaimStep::Skip(_)));
             assert!(!steps.iter().any(|s| matches!(
@@ -918,7 +976,7 @@ mod tests {
         );
         let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
         // rejunction_armed=true.
-        let steps = plan_reclaim(&i, true, false, Some(&canonical));
+        let steps = plan_reclaim(&i, true, false, Some(&canonical), true);
         assert_eq!(
             steps,
             vec![
@@ -938,7 +996,7 @@ mod tests {
     fn rejunction_without_canonical_path_skips() {
         let i = instr(ReclaimAction::Rejunction, &["target"], false);
         // Armed, but no canonical path → degrades to Skip.
-        let steps = plan_reclaim(&i, true, false, None);
+        let steps = plan_reclaim(&i, true, false, None, true);
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));
     }
@@ -951,9 +1009,57 @@ mod tests {
             false,
         );
         // Even with both flags armed, an unknown action is a no-op Skip.
-        let steps = plan_reclaim(&i, true, true, None);
+        let steps = plan_reclaim(&i, true, true, None, true);
         assert_eq!(steps.len(), 1);
         assert!(matches!(steps[0], ReclaimStep::Skip(_)));
+    }
+
+    #[test]
+    fn absent_root_skips_entire_instruction_for_both_actions() {
+        // The stale-census husk-guard (R1): a worktree missing on disk must
+        // yield ONLY a Skip — for both actions, armed and unarmed — never a
+        // step that could create a filesystem path.
+        let canonical = PathBuf::from("D:/qontinui-root/qontinui-runner");
+        for action in [ReclaimAction::Remove, ReclaimAction::Rejunction] {
+            for (rj_armed, rm_armed) in [(false, false), (true, true)] {
+                let i = instr(action.clone(), &["target", "node_modules"], false);
+                let steps = plan_reclaim(
+                    &i,
+                    rj_armed,
+                    rm_armed,
+                    Some(&canonical),
+                    /* root */ false,
+                );
+                assert_eq!(steps.len(), 1, "{action:?} armed=({rj_armed},{rm_armed})");
+                assert!(
+                    matches!(&steps[0], ReclaimStep::Skip(r) if r.contains("absent on disk")),
+                    "absent root must be a Skip carrying the absent-on-disk reason"
+                );
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn create_junction_refuses_to_create_missing_parent() {
+        // R2: a rejunction whose link parent (the worktree root) is missing
+        // must Err and create NOTHING — never re-materialize a husk.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("canonical-node_modules");
+        std::fs::create_dir(&target).unwrap();
+        let missing_parent = dir.path().join("gone-wt");
+        let link = missing_parent.join("node_modules");
+
+        let res = create_junction(&link, &target);
+        assert!(res.is_err(), "missing parent must be an error");
+        assert!(
+            res.unwrap_err().contains("refusing to create directories"),
+            "error must name the refusal"
+        );
+        assert!(
+            !missing_parent.exists(),
+            "the missing parent must NOT be created"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Runner half of the stale-census husk guard (plan `2026-06-12-worktree-reclaim-stale-census-husk-guard`, VETTED). Pins the invariant: **a reclaim execution must never create a filesystem path, except junction reparse points inside an already-existing worktree root.**

Incident (2026-06-12): a boot-time reclaim pull raced ahead of the boot-time census, so coord decided from the previous boot's disk truth and served `Rejunction` instructions for four worktrees deleted during a cleanup — `create_junction` then `create_dir_all`'d the missing roots back as empty husks.

- **R1 — absent-root skip at the pure seam.** `plan_reclaim` gains a `root_exists` parameter (probed once per instruction at dispatch time in `execute_pull`) and yields only the existing `ReclaimStep::Skip` when the worktree root is gone — both actions, armed and unarmed, same shape as the `is_dirty` and unarmed guards. The next census is the ack that clears the stale instruction.
- **R2 — `create_junction` refuses to mkdir.** A missing link parent (for sink links the parent IS the worktree root) is now an `Err` instead of `create_dir_all`. The only legitimate parents are created by `git worktree add`, never by reclaim. Defense in depth behind R1.
- **R3 — census-before-reclaim boot ordering.** The reclaim poller's first pull of each boot waits for the census publisher's first successful POST (`AtomicBool` + `Notify` pair in `census.rs`), bounded by one reclaim interval so census-disabled configs never deadlock. This alone would have prevented the incident.
- **R4 — tests.** Absent root yields only `Skip` (both actions, armed/unarmed); `create_junction` with a missing parent errs and creates nothing (tempdir); all existing INV-W4 ordering tests stay green with the new parameter threaded.

Independent of (but defense-in-depth with) sibling coord PR qontinui/qontinui-coord#584, which fixes the serving side (census snapshot read semantics + whole-census staleness degrade). Either alone stops husk creation.

After merge: **primary rebuild + restart required** for the fix to take effect on the live runner.

## Verification

- `cargo test agent_worktree::reclaim` in the worktree (via cargo-guard `--manifest-path`): 24 passed, 0 failed — including the two new tests by name.
- `cargo clippy --bin qontinui-runner --tests`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)