### PR TITLE
feat(terminal): typed claude-resume sniff — register + bypass-mark all typed paths (#548 Phase 2)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -276,13 +276,11 @@ pub fn terminal_write(
         )))
     })?;
 
+    // Typed-input observation (L3 git-warn + typed claude resume sniff) is
+    // funneled inside `TerminalSession::write` itself, so every write
+    // surface (this command, HTTP, WS, transports) is covered without
+    // per-caller calls.
     session.write(&bytes)?;
-
-    // L3 (shared-checkout coordination gap fix) — observe typed input for
-    // branch-mutating git so a soft coord-conflict warning can surface
-    // when a peer holds the worktree claim. Best-effort + non-blocking;
-    // runs AFTER the write so it never delays keystroke delivery.
-    session.observe_input_for_warn(&bytes);
 
     Ok(CommandResponse {
         success: true,

--- a/src-tauri/src/terminal/claude_resume_sniff.rs
+++ b/src-tauri/src/terminal/claude_resume_sniff.rs
@@ -1,0 +1,337 @@
+//! Phase 2 of `plans/2026-06-12-runner-session-registry-and-restore-hardening.md`
+//! — typed `claude --resume <id>` / `claude --session-id <id>` sniff (issue #548).
+//!
+//! Every restore surface TYPES such a line into a plain shell, so a backend
+//! observer on completed typed input lines can register the session in the
+//! durable lifecycle store deterministically — no frontend hook, no
+//! transcript-mtime guessing. The same line carries the bypass-permissions
+//! form, so the typed path also emits the `terminal-bypass-permissions`
+//! event the spawn-argv sniff in `TerminalManager::create` already emits,
+//! closing the approval-phantom gap for restored tabs.
+//!
+//! Consumes the SAME completed-line stream as the L3 git-warn observer
+//! (`TerminalSession::observe_input`). Best-effort and SOFT throughout: never
+//! blocks input; all effects dispatch on a detached async task.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Emitter, Manager};
+use tracing::{debug, info, warn};
+
+use crate::session::session_lifecycle_store::{SessionLifecycleStore, TerminalSessionRecord};
+
+/// A typed input line recognized as a `claude` invocation carrying an
+/// explicit session id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypedClaudeResume {
+    /// The session id extracted from `--resume <id>` / `--session-id <id>`.
+    pub claude_session_id: String,
+    /// Whether the line also implies bypassed tool permissions (per
+    /// [`crate::terminal::manager::command_implies_bypass_permissions`]).
+    pub bypass_permissions: bool,
+}
+
+/// Parse a completed typed input line as `claude … (--resume <id> |
+/// --session-id <id>)`.
+///
+/// Heuristic, mirroring the L3 git-warn matcher's posture (soft, never a
+/// shell parser): the line is split into command segments on `;`, `&`, `|`
+/// (so `cd x && claude --resume …` and `$env:FOO="y"; claude …` both work);
+/// within a segment, leading env-assignment tokens (containing `=`) are
+/// skipped and the first real token must be the `claude` program. The id
+/// must be a strict UUID (what every restore surface types), so prose
+/// containing "claude" can't false-positive. A bare `claude --resume`
+/// (interactive picker form) has no id and does NOT match.
+pub fn parse_typed_claude_resume(line: &str) -> Option<TypedClaudeResume> {
+    for segment in line.split([';', '&', '|']) {
+        let mut tokens = segment.split_whitespace();
+        // Skip leading env-assignment prefixes (`FOO=bar`, `$env:FOO="bar"`).
+        // A segment that is ONLY assignments is skipped, not a parse failure.
+        let Some(program) = tokens.by_ref().find(|t| !t.contains('=')) else {
+            continue;
+        };
+        if !is_claude_program(program) {
+            continue;
+        }
+        let rest: Vec<&str> = tokens.collect();
+        for (i, t) in rest.iter().enumerate() {
+            let candidate = if *t == "--resume" || *t == "--session-id" {
+                rest.get(i + 1).copied()
+            } else {
+                t.strip_prefix("--resume=")
+                    .or_else(|| t.strip_prefix("--session-id="))
+            };
+            let Some(cand) = candidate else { continue };
+            let cand = cand.trim_matches(|c| c == '"' || c == '\'');
+            if is_session_uuid(cand) {
+                return Some(TypedClaudeResume {
+                    claude_session_id: cand.to_ascii_lowercase(),
+                    bypass_permissions:
+                        crate::terminal::manager::command_implies_bypass_permissions(&[
+                            line.to_string()
+                        ]),
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Whether `token` names the `claude` CLI — bare, extensioned, or
+/// path-qualified (`/usr/local/bin/claude`, `C:\…\claude.exe`).
+fn is_claude_program(token: &str) -> bool {
+    let t = token.trim_matches(|c| c == '"' || c == '\'');
+    let base = t.rsplit(['/', '\\']).next().unwrap_or(t);
+    matches!(base, "claude" | "claude.exe" | "claude.cmd" | "claude.ps1")
+}
+
+/// Strict 8-4-4-4-12 hex UUID check — the only id shape `claude --resume` /
+/// `--session-id` accepts, and the shape every restore surface types.
+fn is_session_uuid(s: &str) -> bool {
+    s.len() == 36
+        && s.bytes().enumerate().all(|(i, b)| {
+            if matches!(i, 8 | 13 | 18 | 23) {
+                b == b'-'
+            } else {
+                b.is_ascii_hexdigit()
+            }
+        })
+}
+
+/// Apply the two effects of a recognized typed resume line: (1) `record_open`
+/// the session in the lifecycle store — a NEW writer arm beside the existing
+/// frontend-command / continuation-poller writers (structural dedup by
+/// session id means a frontend re-record simply refreshes this row); (2) for
+/// the bypass form, invoke `emit_bypass` (production emits
+/// `terminal-bypass-permissions`). Split out from
+/// [`spawn_register_typed_resume`] so the pair is testable without a Tauri app.
+pub(crate) fn apply_typed_resume_effects(
+    store: Option<&SessionLifecycleStore>,
+    parsed: &TypedClaudeResume,
+    terminal_id: &str,
+    working_dir: &str,
+    page_id: &str,
+    title: &str,
+    emit_bypass: impl FnOnce(),
+) {
+    match store {
+        Some(store) => {
+            store.record_open(TerminalSessionRecord {
+                claude_session_id: parsed.claude_session_id.clone(),
+                // config_dir None → restore scans every known config dir.
+                // Zone unknown backend-side → 0 (wrong zone beats a lost
+                // session). Timestamps are placeholders record_open seeds.
+                config_dir: None,
+                working_dir: Some(working_dir.to_string()),
+                page_id: page_id.to_string(),
+                zone_index: 0,
+                title: Some(title.to_string()),
+                terminal_id: terminal_id.to_string(),
+                opened_at: 0,
+                last_seen_at: 0,
+                state: "open".to_string(),
+                closed_at: None,
+                close_reason: None,
+                // Exact id lifted from the typed `--resume`/`--session-id`
+                // flag — a pinned bind, same as the spawn-argv pre-pin path.
+                bind_origin: Some("pinned".to_string()),
+                restore_pending_at: None,
+            });
+            info!(
+                terminal_id = %terminal_id,
+                claude_session = %parsed.claude_session_id,
+                bypass = parsed.bypass_permissions,
+                "typed claude resume sniff: session durably recorded"
+            );
+        }
+        None => warn!(
+            terminal_id = %terminal_id,
+            claude_session = %parsed.claude_session_id,
+            "typed claude resume sniff: lifecycle store not managed — session not recorded"
+        ),
+    }
+    if parsed.bypass_permissions {
+        emit_bypass();
+    }
+}
+
+/// Dispatch the effects of a recognized typed resume line off the PTY write
+/// hot path. Mirrors `coord_warn::spawn_check_and_warn`: a detached async
+/// task, all failures swallowed. `tauri::async_runtime::spawn` (not bare
+/// `tokio::spawn`) so dispatch works from any caller thread —
+/// `TerminalSession::write` is reachable from bare OS threads.
+pub fn spawn_register_typed_resume(
+    app_handle: AppHandle,
+    terminal_id: String,
+    working_dir: String,
+    page_id: String,
+    title: String,
+    parsed: TypedClaudeResume,
+) {
+    tauri::async_runtime::spawn(async move {
+        let store = app_handle
+            .try_state::<Arc<SessionLifecycleStore>>()
+            .map(|s| s.inner().clone());
+        let emit_handle = app_handle.clone();
+        let emit_terminal_id = terminal_id.clone();
+        apply_typed_resume_effects(
+            store.as_deref(),
+            &parsed,
+            &terminal_id,
+            &working_dir,
+            &page_id,
+            &title,
+            move || {
+                if let Err(e) = emit_handle.emit(
+                    "terminal-bypass-permissions",
+                    serde_json::json!({ "id": emit_terminal_id }),
+                ) {
+                    debug!(
+                        terminal_id = %emit_terminal_id,
+                        error = %e,
+                        "typed claude resume sniff: bypass event emit failed"
+                    );
+                }
+            },
+        );
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+    use tempfile::tempdir;
+
+    const UUID: &str = "0d5e9a8c-1111-2222-3333-444455556666";
+
+    fn parse(line: &str) -> Option<TypedClaudeResume> {
+        parse_typed_claude_resume(line)
+    }
+
+    #[test]
+    fn parses_resume_and_session_id_forms() {
+        for line in [
+            format!("claude --resume {UUID}"),
+            format!("claude --session-id {UUID}"),
+            format!("claude --resume={UUID}"),
+            format!("claude --session-id={UUID}"),
+        ] {
+            let parsed = parse(&line).unwrap_or_else(|| panic!("must parse: {line}"));
+            assert_eq!(parsed.claude_session_id, UUID, "id from: {line}");
+            assert!(!parsed.bypass_permissions, "no bypass in: {line}");
+        }
+    }
+
+    #[test]
+    fn detects_bypass_forms() {
+        let p = parse(&format!(
+            "claude --resume {UUID} --permission-mode bypassPermissions"
+        ))
+        .expect("bypass form must parse");
+        assert_eq!(p.claude_session_id, UUID);
+        assert!(p.bypass_permissions);
+        let p = parse(&format!(
+            "claude --dangerously-skip-permissions --resume {UUID}"
+        ))
+        .expect("dangerously-skip form must parse");
+        assert!(p.bypass_permissions);
+    }
+
+    #[test]
+    fn parses_env_prefix_chain_and_path_qualified_forms() {
+        for line in [
+            format!("CLAUDE_CONFIG_DIR=C:/cfg claude --resume {UUID}"),
+            format!("$env:CLAUDE_CONFIG_DIR=\"C:/cfg\"; claude --resume {UUID}"),
+            format!("cd /d/repo && claude --resume {UUID}"),
+            format!("C:\\bin\\claude.exe --resume {UUID}"),
+        ] {
+            assert!(parse(&line).is_some(), "must parse: {line}");
+        }
+    }
+
+    #[test]
+    fn rejects_non_claude_lines_and_idless_forms() {
+        for line in [
+            "git status".to_string(),
+            "ls -la".to_string(),
+            format!("echo claude --resume {UUID}"), // "claude" not in program position
+            "claude \"do the thing\"".to_string(),  // no resume/session-id flag
+            "claude --resume".to_string(),          // bare picker form, no id
+            "claude --resume --permission-mode bypassPermissions".to_string(),
+            "claude --resume not-a-uuid".to_string(),
+            String::new(),
+        ] {
+            assert!(parse(&line).is_none(), "must NOT parse: {line:?}");
+        }
+    }
+
+    #[test]
+    fn apply_effects_records_open_and_emits_bypass() {
+        // A typed bypass resume line must produce BOTH a record_open effect
+        // and a bypass-event effect.
+        let dir = tempdir().unwrap();
+        let store = SessionLifecycleStore::open(dir.path().join("terminal-sessions.json")).unwrap();
+        let parsed = parse(&format!(
+            "claude --resume {UUID} --permission-mode bypassPermissions"
+        ))
+        .unwrap();
+
+        let bypass_emitted = Cell::new(false);
+        apply_typed_resume_effects(
+            Some(&store),
+            &parsed,
+            "term-1",
+            "C:/repo",
+            "default",
+            "Terminal 1",
+            || bypass_emitted.set(true),
+        );
+
+        let open = store.open_records();
+        assert_eq!(open.len(), 1, "record_open effect must land");
+        assert_eq!(open[0].claude_session_id, UUID);
+        assert_eq!(open[0].terminal_id, "term-1");
+        assert_eq!(open[0].working_dir.as_deref(), Some("C:/repo"));
+        assert_eq!(open[0].page_id, "default");
+        assert_eq!(open[0].state, "open");
+        assert!(bypass_emitted.get(), "bypass event effect must fire");
+    }
+
+    #[test]
+    fn apply_effects_independence_of_the_two_arms() {
+        // No bypass flag → record lands, no event.
+        let dir = tempdir().unwrap();
+        let store = SessionLifecycleStore::open(dir.path().join("terminal-sessions.json")).unwrap();
+        let parsed = parse(&format!("claude --resume {UUID}")).unwrap();
+        let bypass_emitted = Cell::new(false);
+        apply_typed_resume_effects(
+            Some(&store),
+            &parsed,
+            "term-1",
+            "C:/repo",
+            "default",
+            "Terminal 1",
+            || bypass_emitted.set(true),
+        );
+        assert_eq!(store.open_records().len(), 1);
+        assert!(!bypass_emitted.get(), "no bypass flag → no event");
+
+        // Store missing (best-effort warn + skip) → bypass mark still fires.
+        let parsed = parse(&format!(
+            "claude --resume {UUID} --dangerously-skip-permissions"
+        ))
+        .unwrap();
+        let bypass_emitted = Cell::new(false);
+        apply_typed_resume_effects(
+            None,
+            &parsed,
+            "term-1",
+            "C:/repo",
+            "default",
+            "Terminal 1",
+            || bypass_emitted.set(true),
+        );
+        assert!(bypass_emitted.get());
+    }
+}

--- a/src-tauri/src/terminal/coord_warn.rs
+++ b/src-tauri/src/terminal/coord_warn.rs
@@ -77,9 +77,13 @@ pub struct CoordWarning {
 
 /// Best-effort: resolve the session's repo, ask coord for the live
 /// `worktree` claim holder, and — if a PEER holds it — emit a soft
-/// `terminal-coord-warning` event. Spawns a detached tokio task so the
+/// `terminal-coord-warning` event. Spawns a detached async task so the
 /// caller (the PTY write hot path) never blocks. All failures are
 /// swallowed.
+///
+/// Uses `tauri::async_runtime::spawn` (not bare `tokio::spawn`) because the
+/// observer lives inside `TerminalSession::write` (the single input funnel),
+/// which is reachable from bare OS threads — `tokio::spawn` would panic there.
 ///
 /// `our_session_id` is this terminal's coord session id (if wired); it is
 /// used to distinguish a same-machine peer (different session) from
@@ -91,7 +95,7 @@ pub fn spawn_check_and_warn(
     our_session_id: Option<uuid::Uuid>,
     command: String,
 ) {
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         if let Err(e) = check_and_warn(
             &app_handle,
             &terminal_id,

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -343,7 +343,11 @@ impl TerminalManager {
 ///   embedded inside a shell wrapper string (e.g.
 ///   `CLAUDE_CONFIG_DIR=… claude --permission-mode bypassPermissions`) is still
 ///   caught.
-fn command_implies_bypass_permissions(argv: &[String]) -> bool {
+///
+/// `pub(crate)` so the typed-input resume sniff
+/// ([`super::claude_resume_sniff`], #548 Phase 2) reuses the SAME matcher —
+/// one definition of "bypass-implying command" for spawn-argv and typed paths.
+pub(crate) fn command_implies_bypass_permissions(argv: &[String]) -> bool {
     let joined = argv.join(" ");
     joined.contains("--dangerously-skip-permissions")
         || joined.contains("--permission-mode bypassPermissions")

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -4,6 +4,7 @@
 //! Each session spawns a native shell (PowerShell on Windows, $SHELL on Unix)
 //! with proper environment for running Claude CLI and other dev tools.
 
+pub mod claude_resume_sniff;
 pub mod commit_report;
 pub mod coord_warn;
 pub mod grid;

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -139,6 +139,40 @@ pub(crate) fn build_submit_payload(message: &str) -> Vec<u8> {
     out
 }
 
+/// Pure line-assembly core of the typed-input observer
+/// ([`TerminalSession::observe_input`]): walk one chunk of raw keystroke
+/// bytes, mutating the per-terminal line buffer, and return any lines this
+/// chunk completed (CR/LF-submitted, non-blank). Heuristic by design:
+/// backspace/DEL pop one char, printable ASCII accumulates, control bytes
+/// and non-ASCII are dropped. Capped at 4 KiB so a pathological no-newline
+/// stream (e.g. a huge paste) can't grow unbounded.
+fn consume_input_bytes(buf: &mut String, data: &[u8]) -> Vec<String> {
+    let mut completed: Vec<String> = Vec::new();
+    for &b in data {
+        match b {
+            // CR or LF — submit the line.
+            0x0D | 0x0A => {
+                if !buf.trim().is_empty() {
+                    completed.push(std::mem::take(buf));
+                } else {
+                    buf.clear();
+                }
+            }
+            // Backspace / DEL — approximate edit handling.
+            0x08 | 0x7F => {
+                buf.pop();
+            }
+            // Printable ASCII (incl. space).
+            0x20..=0x7E => buf.push(b as char),
+            _ => {}
+        }
+    }
+    if buf.len() > 4096 {
+        buf.clear();
+    }
+    completed
+}
+
 /// A single PTY-backed terminal session.
 pub struct TerminalSession {
     /// Unique identifier for this terminal.
@@ -222,16 +256,16 @@ pub struct TerminalSession {
     /// teardown.
     isolated_edit_ctx:
         Arc<Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>>,
-    /// App handle, retained so the input-line warn hook
-    /// ([`Self::observe_input_for_warn`]) can emit the soft
-    /// `terminal-coord-warning` Tauri event off the PTY write path.
+    /// App handle, retained so the typed-input observer
+    /// ([`Self::observe_input`]) can dispatch its effects (coord warning
+    /// event; lifecycle-store registration + bypass event of the typed
+    /// claude resume sniff) off the PTY write path.
     /// `None` only in unit-test fixtures that don't drive a real app.
     app_handle: Option<AppHandle>,
-    /// L3 (shared-checkout coordination gap fix) — accumulates printable
-    /// keystroke bytes between line submits so a completed line can be
-    /// matched against branch-mutating git. Soft heuristic: backspace is
-    /// handled approximately, control sequences are dropped. Drained on
-    /// CR/LF. Cheap to keep on the hot path (a few bytes per keystroke).
+    /// Accumulates printable keystroke bytes between line submits so
+    /// completed lines can be matched by the typed-input consumers (L3
+    /// branch-mutating-git warn; typed claude resume sniff). Drained on
+    /// CR/LF; see [`consume_input_bytes`]. Cheap on the hot path.
     input_line_buf: Arc<Mutex<String>>,
 }
 
@@ -801,72 +835,79 @@ impl TerminalSession {
     }
 
     /// Write data (keystrokes) to the PTY stdin.
+    ///
+    /// This is the SINGLE funnel for terminal input — every write surface
+    /// (Tauri `terminal_write`, HTTP `write_terminal_handler`, the WS input
+    /// loop, transports, backend relay) routes through here, so the
+    /// typed-input observer ([`Self::observe_input`]) covers every present
+    /// and future write path. Observation happens AFTER the bytes hit the
+    /// PTY and the writer lock is released — it never delays keystrokes.
     pub fn write(&self, data: &[u8]) -> Result<(), String> {
-        let mut writer = self
-            .writer
-            .lock()
-            .map_err(|e| format!("Writer lock poisoned: {}", e))?;
-        writer
-            .write_all(data)
-            .map_err(|e| format!("Failed to write to PTY: {}", e))?;
-        writer
-            .flush()
-            .map_err(|e| format!("Failed to flush PTY: {}", e))?;
+        {
+            let mut writer = self
+                .writer
+                .lock()
+                .map_err(|e| format!("Writer lock poisoned: {}", e))?;
+            writer
+                .write_all(data)
+                .map_err(|e| format!("Failed to write to PTY: {}", e))?;
+            writer
+                .flush()
+                .map_err(|e| format!("Failed to flush PTY: {}", e))?;
+        } // writer lock released before observation
+
+        self.observe_input(data);
         Ok(())
     }
 
-    /// L3 (shared-checkout coordination gap fix) — feed raw keystroke
-    /// bytes through the input-line buffer and, on a completed line
-    /// (CR/LF), evaluate it for a branch-mutating git command. If it
-    /// matches, kick off a best-effort coord lookup that emits a soft
-    /// `terminal-coord-warning` event when a PEER holds the worktree
-    /// claim on this session's repo.
+    /// Observe raw typed input bytes — feed them through the per-terminal
+    /// input-line buffer ([`consume_input_bytes`]) and dispatch each
+    /// completed (CR/LF-submitted) line to the typed-input consumers:
     ///
-    /// SOFT + CHEAP: this NEVER blocks, NEVER affects the actual PTY
-    /// write, and only does the (rare) coord lookup once a line that
-    /// matches the branch-mutating regex is submitted. Backspace handling
-    /// is approximate — this is a heuristic warn, not a parser. Called
-    /// from `terminal_write` AFTER the bytes are written to the PTY.
-    pub fn observe_input_for_warn(&self, data: &[u8]) {
+    /// 1. **L3 git-warn**: a branch-mutating git line kicks off a
+    ///    best-effort coord lookup that emits a soft
+    ///    `terminal-coord-warning` event when a PEER holds this repo's
+    ///    worktree claim.
+    /// 2. **Typed claude resume sniff** (#548 Phase 2): a
+    ///    `claude … --resume <id>` / `--session-id <id>` line registers the
+    ///    session in the durable lifecycle store and — for the bypass form —
+    ///    emits the `terminal-bypass-permissions` event, mirroring the
+    ///    spawn-argv sniff in `TerminalManager::create`.
+    ///
+    /// SOFT + CHEAP: never blocks, never affects the PTY write. Called from
+    /// [`Self::write`] AFTER the bytes are written; all effects run on
+    /// detached async tasks.
+    fn observe_input(&self, data: &[u8]) {
         // Collect any completed lines this chunk produced. We hold the
         // buffer lock only for the cheap byte-walk, then release before
-        // spawning the async lookup.
+        // spawning the async effect tasks.
         let mut completed: Vec<String> = Vec::new();
         if let Ok(mut buf) = self.input_line_buf.lock() {
-            for &b in data {
-                match b {
-                    // CR or LF — submit the line.
-                    0x0D | 0x0A => {
-                        if !buf.trim().is_empty() {
-                            completed.push(std::mem::take(&mut *buf));
-                        } else {
-                            buf.clear();
-                        }
-                    }
-                    // Backspace / DEL — approximate edit handling.
-                    0x08 | 0x7F => {
-                        buf.pop();
-                    }
-                    // Printable ASCII (incl. space). Control chars and
-                    // non-ASCII (escape sequences, arrow keys, UTF-8
-                    // multibyte) are dropped — this is a heuristic over
-                    // simple typed commands, not a full line editor.
-                    0x20..=0x7E => buf.push(b as char),
-                    _ => {}
-                }
-            }
-            // Cap the buffer so a pathological no-newline stream can't grow
-            // unbounded (e.g. a paste of a huge blob). 4 KiB is far beyond
-            // any real command line.
-            if buf.len() > 4096 {
-                buf.clear();
-            }
+            completed = consume_input_bytes(&mut buf, data);
+        }
+        if completed.is_empty() {
+            return;
         }
 
         let Some(app_handle) = self.app_handle.clone() else {
             return;
         };
         for line in completed {
+            if let Some(parsed) = super::claude_resume_sniff::parse_typed_claude_resume(&line) {
+                let title = self
+                    .title
+                    .lock()
+                    .map(|g| g.clone())
+                    .unwrap_or_else(|e| e.into_inner().clone());
+                super::claude_resume_sniff::spawn_register_typed_resume(
+                    app_handle.clone(),
+                    self.id.clone(),
+                    self.working_dir.clone(),
+                    self.page_id.clone(),
+                    title,
+                    parsed,
+                );
+            }
             if super::coord_warn::is_branch_mutating_git(&line) {
                 super::coord_warn::spawn_check_and_warn(
                     app_handle.clone(),
@@ -1417,6 +1458,56 @@ mod tests {
         // Idempotent overwrite.
         session.set_title("Worker 1".to_string());
         assert_eq!(session.info().title, "Worker 1");
+    }
+
+    // --- typed-input observer: line assembly + the write() funnel ----------
+
+    #[test]
+    fn consume_input_bytes_assembles_edits_and_caps_lines() {
+        let mut buf = String::new();
+        // Partial chunk — no completed line, buffer accumulates across calls.
+        assert!(consume_input_bytes(&mut buf, b"claude --re").is_empty());
+        assert_eq!(buf, "claude --re");
+        let done = consume_input_bytes(&mut buf, b"sume abc\r");
+        assert_eq!(done, vec!["claude --resume abc".to_string()]);
+        assert!(buf.is_empty());
+        // LF completes too; blank lines are not emitted.
+        assert!(consume_input_bytes(&mut buf, b"   \n").is_empty());
+        // 0x08 backspace and 0x7F DEL both pop the last char.
+        let done = consume_input_bytes(&mut buf, b"claude -x\x08-resume\r");
+        assert_eq!(done, vec!["claude --resume".to_string()]);
+        let done = consume_input_bytes(&mut buf, b"git statuz\x7Fs\r");
+        assert_eq!(done, vec!["git status".to_string()]);
+        // Escape sequences / non-ASCII bytes are dropped, printables kept.
+        let done = consume_input_bytes(&mut buf, b"ls\x1b\x01\xc3\xa9 -la\r");
+        assert_eq!(done, vec!["ls -la".to_string()]);
+        // > 4 KiB with no newline — buffer cleared, not unbounded growth.
+        assert!(consume_input_bytes(&mut buf, &vec![b'a'; 5000]).is_empty());
+        assert!(buf.is_empty(), "over-cap buffer must be cleared");
+        // Still usable afterwards.
+        let done = consume_input_bytes(&mut buf, b"echo hi\r");
+        assert_eq!(done, vec!["echo hi".to_string()]);
+    }
+
+    #[test]
+    fn write_funnels_input_into_the_observer() {
+        // The observation funnel lives in `TerminalSession::write` itself —
+        // ANY caller of write() feeds the input-line buffer, with no
+        // per-caller observe call (the fixture has no app_handle, so effect
+        // dispatch is skipped but line assembly still runs).
+        let buf = Arc::new(Mutex::new(Vec::<u8>::new()));
+        let session = make_test_session(buf.clone());
+        session.write(b"claude --re").expect("write failed");
+        assert_eq!(
+            session.input_line_buf.lock().unwrap().as_str(),
+            "claude --re",
+            "write() must feed the typed-input observer"
+        );
+        // Completing the line drains the buffer (the line was dispatched)...
+        session.write(b"sume\r").expect("write failed");
+        assert!(session.input_line_buf.lock().unwrap().is_empty());
+        // ...and the PTY itself still received every byte, unchanged.
+        assert_eq!(buf.lock().unwrap().as_slice(), b"claude --resume\r");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 2 of `plans/2026-06-12-runner-session-registry-and-restore-hardening.md` (issue #548).

Every restore surface TYPES a `claude --resume <id>` line into a plain shell — so a backend observer on completed typed-input lines can register the session in the durable lifecycle store deterministically, with no transcript-mtime guessing. The same line carries the bypass form, closing the restored-tab approval-phantom gap.

- **Single input funnel**: typed-input observation moves into `TerminalSession::write` itself, so every write surface (Tauri `terminal_write`, HTTP `write_terminal_handler`, the WS input loop, transports) is covered — a per-caller approach would have missed exactly the manual-HTTP-recovery surface this phase promises (the 06-12 incident recovery would now self-register). Upgrades the existing L3 git-warn to HTTP/WS coverage for free.
- **New consumer arm** beside the L3 git-warn: a completed line parsing as `claude … (--resume|--session-id) <uuid>` → `record_open` (`bind_origin: "pinned"`) + `terminal-bypass-permissions` event for the bypass form (same matcher as the spawn-argv sniff — `command_implies_bypass_permissions` now `pub(crate)`).
- `coord_warn` switches to `tauri::async_runtime::spawn` — `write()` is reachable from bare OS threads where bare `tokio::spawn` panics.
- Parser is soft/heuristic by design (mirrors the git-warn posture): segment-split on `;&|`, env-prefix skip, path-qualified `claude`, strict-UUID id gate; bare `claude --resume` (interactive picker) does NOT match.

## Testing
- 6 new parser/effects unit tests (`claude_resume_sniff`), 2 new funnel tests (`consume_input_bytes`, `write_funnels_input_into_the_observer`) — all green locally; full session test module (13) green.
- `cargo check` green after rebase onto #552 (`bind_origin` union).

🤖 Generated with [Claude Code](https://claude.com/claude-code)