### PR TITLE
feat(terminal): auto-migrate token-exhausted Claude sessions to a fresh account

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -305,7 +305,7 @@ fn load_local_device_id() -> Option<uuid::Uuid> {
 /// Path to the `claude` binary. Default: `claude` (PATH-resolved).
 /// Override with `QONTINUI_CLAUDE_BIN` for testing (e.g. the
 /// `mock_claude_cli` fixture in `bin/`).
-fn claude_bin_path() -> String {
+pub(crate) fn claude_bin_path() -> String {
     std::env::var("QONTINUI_CLAUDE_BIN").unwrap_or_else(|_| "claude".to_string())
 }
 
@@ -1972,6 +1972,7 @@ async fn run_continuation_terminal(
         page_id: Some(target_page.clone()),
         // Matches the `--session-id` in the spawn argv → synchronous record.
         claude_session_id: Some(pinned_session_id),
+        zone_index: None,
     });
 
     // Provision `.mcp.json` so this continuation can reach coord coordination

--- a/src-tauri/src/ai_provider/account_usage.rs
+++ b/src-tauri/src/ai_provider/account_usage.rs
@@ -168,6 +168,73 @@ fn pick_from<'a>(
         .map(|d| (*d).clone())
 }
 
+/// Pick the account a token-exhausted session should MIGRATE to: the best
+/// `(exhausted, headroom)`-ranked account among the configured dirs,
+/// excluding the exhausted source dir.
+///
+/// Unlike [`pick_best_account`] (spawn-time selection, which must always pin
+/// *something*), migration is optional work — moving a session onto another
+/// exhausted or cooldown'd account gains nothing, so this returns `None`
+/// instead of a least-bad fallback. Does NOT touch the global resolved dir;
+/// the caller pins the choice per-spawn via `CLAUDE_CONFIG_DIR`.
+///
+/// Also unlike [`pick_best_account`], this is NOT gated on
+/// `account_selection_mode == LeastUsage`: the migration feature has its own
+/// settings switch (`claude_cli.auto_migrate_on_token_exhaustion`), and a
+/// Manual-mode operator who triggers a manual migration still wants a target.
+pub fn pick_migration_target(exclude_dir: &str) -> Option<String> {
+    let config_dirs: Vec<String> = settings::get_claude_config_dirs()
+        .into_iter()
+        .filter(|d| d != exclude_dir)
+        .collect();
+
+    pick_target_from(
+        &config_dirs,
+        |d| super::oauth_refresh::has_valid_credentials(d),
+        |d| super::config::is_account_cooled_down(d),
+        |d| super::config::usage_rank(d),
+        |d| super::config::account_known_exhausted(d),
+    )
+}
+
+/// Pure core of [`pick_migration_target`], parameterised like [`pick_from`]
+/// so it can be unit-tested without the settings/state singletons. Requires
+/// the chosen dir to have live credentials, be out of cooldown, and not be
+/// known-exhausted; ranks the survivors with a fresh usage sample by
+/// headroom ascending (lowest used-vs-expected delta wins), excluding
+/// fresh-sample-exhausted dirs the staleness-tolerant `known_exhausted`
+/// filter missed.
+fn pick_target_from<'a>(
+    config_dirs: &'a [String],
+    has_valid_creds: impl Fn(&str) -> bool,
+    is_cooled: impl Fn(&str) -> bool,
+    usage: impl Fn(&str) -> Option<(bool, f64)>,
+    known_exhausted: impl Fn(&str) -> bool,
+) -> Option<String> {
+    let candidates: Vec<&'a String> = config_dirs
+        .iter()
+        .filter(|d| has_valid_creds(d) && !is_cooled(d) && !known_exhausted(d))
+        .collect();
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // Best fresh-sample rank wins; with no fresh samples (cold start), take
+    // the first surviving candidate — it passed the credential / cooldown /
+    // known-exhaustion filters, which is the strongest signal available.
+    candidates
+        .iter()
+        .filter_map(|d| usage(d).map(|rank| (*d, rank)))
+        .filter(|(_, (exhausted, _))| !exhausted)
+        .min_by(|a, b| {
+            a.1 .1
+                .partial_cmp(&b.1 .1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|(d, _)| d.clone())
+        .or_else(|| candidates.first().map(|d| (*d).clone()))
+}
+
 fn short_label(config_dir: &str) -> &str {
     Path::new(config_dir)
         .file_name()
@@ -536,5 +603,86 @@ mod tests {
             },
         );
         assert_eq!(chosen.as_deref(), Some("/authed-cooled"));
+    }
+
+    // --- pick_target_from: migration-target selection ------------------------
+    //
+    // Migration differs from spawn-time selection in one key way: it may
+    // return `None`. Moving a session onto another dead account is pure
+    // churn, so exhausted/cooled/credential-less dirs are filtered out
+    // entirely instead of falling back to "least bad".
+
+    #[test]
+    fn migration_target_best_headroom_wins() {
+        let d = dirs(&["/gmail", "/paktis"]);
+        let chosen = pick_target_from(
+            &d,
+            |_| true,
+            |_| false,
+            |x| match x {
+                "/gmail" => Some((false, 0.15)),
+                "/paktis" => Some((false, -0.20)), // furthest under projection
+                _ => None,
+            },
+            |_| false,
+        );
+        assert_eq!(chosen.as_deref(), Some("/paktis"));
+    }
+
+    #[test]
+    fn migration_target_none_when_all_exhausted() {
+        let d = dirs(&["/gmail", "/paktis"]);
+        let chosen = pick_target_from(
+            &d,
+            |_| true,
+            |_| false,
+            |_| Some((true, 0.0)),
+            |_| true, // every candidate known-exhausted
+        );
+        assert_eq!(
+            chosen, None,
+            "migrating onto another exhausted account gains nothing"
+        );
+    }
+
+    #[test]
+    fn migration_target_none_when_all_cooled_or_credentialless() {
+        let d = dirs(&["/no-creds", "/cooled"]);
+        let chosen = pick_target_from(
+            &d,
+            |x| x == "/cooled", // only /cooled is authenticated…
+            |x| x == "/cooled", // …but it's in cooldown
+            |_| None,
+            |_| false,
+        );
+        assert_eq!(chosen, None);
+    }
+
+    #[test]
+    fn migration_target_fresh_exhausted_sample_filtered() {
+        // `known_exhausted` (long TTL) says fine, but the FRESH sample says
+        // exhausted — the fresh signal must win and the dir be skipped.
+        let d = dirs(&["/stale-ok-fresh-dead", "/usable"]);
+        let chosen = pick_target_from(
+            &d,
+            |_| true,
+            |_| false,
+            |x| match x {
+                "/stale-ok-fresh-dead" => Some((true, -0.50)),
+                "/usable" => Some((false, 0.30)),
+                _ => None,
+            },
+            |_| false,
+        );
+        assert_eq!(chosen.as_deref(), Some("/usable"));
+    }
+
+    #[test]
+    fn migration_target_cold_start_takes_first_surviving() {
+        // No fresh usage samples at all: the filters are the only signal —
+        // first survivor wins rather than returning None.
+        let d = dirs(&["/cooled", "/a", "/b"]);
+        let chosen = pick_target_from(&d, |_| true, |x| x == "/cooled", |_| None, |_| false);
+        assert_eq!(chosen.as_deref(), Some("/a"));
     }
 }

--- a/src-tauri/src/ai_provider/mod.rs
+++ b/src-tauri/src/ai_provider/mod.rs
@@ -31,10 +31,11 @@ pub(crate) mod routing;
 mod types;
 
 // Re-export public API
-pub use account_usage::pick_best_account;
+pub use account_usage::{pick_best_account, pick_migration_target};
 pub use cache_aware_builder::StructuredPrompt;
 pub use config::{
-    get_account_statuses, get_effective_config_dir, get_resolved_config_dir, record_account_usage,
+    account_known_exhausted, get_account_statuses, get_effective_config_dir,
+    get_resolved_config_dir, mark_account_rate_limited_with_duration, record_account_usage,
     rotate_account_on_rate_limit, set_resolved_config_dir, switch_to_account,
 };
 pub use multimodal::{ContentBlock, ImageSource, MultimodalPrompt};

--- a/src-tauri/src/commands/ai_settings.rs
+++ b/src-tauri/src/commands/ai_settings.rs
@@ -156,6 +156,11 @@ pub fn save_ai_settings(
             timeout_seconds,
             config_dir,
             account_selection_mode: selection_mode,
+            // This command's surface doesn't expose the auto-migration
+            // switch; preserve whatever is currently configured.
+            auto_migrate_on_token_exhaustion: existing_settings
+                .claude_cli
+                .auto_migrate_on_token_exhaustion,
         },
         claude_api: ClaudeApiSettings { model, max_tokens },
         // Preserve existing Gemini settings

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -989,15 +989,15 @@ pub async fn terminal_migrate_session_account(
             }
             d
         }
-        None => crate::ai_provider::pick_migration_target(&src)
-            .ok_or("no usable target account (every other account exhausted/cooled/unauthenticated)")?,
+        None => crate::ai_provider::pick_migration_target(&src).ok_or(
+            "no usable target account (every other account exhausted/cooled/unauthenticated)",
+        )?,
     };
     if dst == src {
         return Err("target account equals the session's current account".to_string());
     }
 
-    let outcome =
-        crate::terminal::account_migration::migrate_session(&app, &record, &src, &dst)?;
+    let outcome = crate::terminal::account_migration::migrate_session(&app, &record, &src, &dst)?;
     Ok(CommandResponse {
         success: true,
         message: Some(format!(

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -957,6 +957,61 @@ pub fn terminal_session_list_open(
     })
 }
 
+/// Manually migrate a Claude terminal session to a different configured
+/// account: copy its transcript into the target account's project dir, close
+/// the old pane, and respawn `claude --resume` under the target account (see
+/// `terminal::account_migration` — this is the operator-clicked form of the
+/// automatic token-exhaustion migration; the click IS the confirmation, so
+/// no usage probe gates it).
+///
+/// `target_config_dir: None` auto-picks the configured account with the most
+/// weekly-usage headroom, excluding the session's current account.
+#[tauri::command]
+pub async fn terminal_migrate_session_account(
+    app: tauri::AppHandle,
+    store: tauri::State<'_, Arc<SessionLifecycleStore>>,
+    claude_session_id: String,
+    target_config_dir: Option<String>,
+) -> Result<CommandResponse, String> {
+    let record = store
+        .get(&claude_session_id)
+        .ok_or_else(|| format!("unknown session: {claude_session_id}"))?;
+    let src = record
+        .config_dir
+        .clone()
+        .or_else(crate::ai_provider::get_resolved_config_dir)
+        .ok_or("the session's current account is unknown — cannot migrate")?;
+
+    let dst = match target_config_dir {
+        Some(d) => {
+            if !crate::settings::get_claude_config_dirs().contains(&d) {
+                return Err(format!("'{d}' is not a configured claude_config_dir"));
+            }
+            d
+        }
+        None => crate::ai_provider::pick_migration_target(&src)
+            .ok_or("no usable target account (every other account exhausted/cooled/unauthenticated)")?,
+    };
+    if dst == src {
+        return Err("target account equals the session's current account".to_string());
+    }
+
+    let outcome =
+        crate::terminal::account_migration::migrate_session(&app, &record, &src, &dst)?;
+    Ok(CommandResponse {
+        success: true,
+        message: Some(format!(
+            "migrated session {claude_session_id} to {}",
+            outcome.to_config_dir
+        )),
+        data: Some(serde_json::json!({
+            "newTerminalId": outcome.new_terminal_id,
+            "fromConfigDir": outcome.from_config_dir,
+            "toConfigDir": outcome.to_config_dir,
+        })),
+    })
+}
+
 /// Optional hint asking [`create_terminal_session_backend`] to durably record
 /// the new session in the lifecycle store once its Claude session id can be
 /// resolved from the on-disk transcript. Backend-spawned continuation
@@ -978,9 +1033,14 @@ pub(crate) struct SessionCaptureHint {
     /// restart re-lands the continuation on its page. `None` → `"default"`.
     pub page_id: Option<String>,
     /// Pre-pinned Claude session id (`--session-id <uuid>` in the spawn
-    /// argv): `Some(..)` records the OPEN synchronously (origin `"pinned"`)
-    /// and demotes the transcript poller to a verification arm.
+    /// argv, or `--resume <uuid>` for an account-migration respawn — both
+    /// name the exact id): `Some(..)` records the OPEN synchronously (origin
+    /// `"pinned"`) and demotes the transcript poller to a verification arm.
     pub claude_session_id: Option<String>,
+    /// Grid zone to durably record (account-migration respawns preserve the
+    /// migrated session's tile placement). `None` → zone 0 (the historical
+    /// continuation behavior — wrong zone beats a lost session).
+    pub zone_index: Option<i32>,
 }
 
 /// Backend-task entry point for creating a terminal session + coord row from a
@@ -1153,10 +1213,12 @@ pub(crate) fn create_terminal_session_backend(
                 title,
                 page_id: hint_page_id,
                 claude_session_id: pinned_session_id,
+                zone_index: hint_zone_index,
             } = hint;
             // Single source of truth for the recorded page: the hint's page_id
             // (set by the caller to the picked page), defaulting to "default".
             let record_page_id = hint_page_id.unwrap_or_else(|| "default".to_string());
+            let record_zone_index = hint_zone_index.unwrap_or(0);
             if let Some(pinned) = pinned_session_id {
                 // Pre-pinned id: record synchronously, then verify async that
                 // the transcript appears. NEVER rebinds from transcripts.
@@ -1168,6 +1230,7 @@ pub(crate) fn create_terminal_session_backend(
                     working_dir.clone(),
                     title,
                     record_page_id,
+                    record_zone_index,
                 );
                 let verify_dirs: Vec<std::path::PathBuf> = config_dir
                     .iter()
@@ -1204,6 +1267,7 @@ pub(crate) fn create_terminal_session_backend(
                     working_dir,
                     title,
                     record_page_id,
+                    record_zone_index,
                     SESSION_CAPTURE_POLL_INTERVAL,
                     SESSION_CAPTURE_TIMEOUT,
                 ));
@@ -1253,8 +1317,9 @@ fn resolve_latest_claude_session_id(
 ///
 /// The resolver is injected so this loop is unit-testable without a real
 /// on-disk transcript. On the first resolve it builds a [`TerminalSessionRecord`]
-/// (restored into zone 0 / the default page — wrong zone beats a lost session)
-/// and records it; on timeout it `warn!`s and gives up without recording.
+/// (restored into `zone_index` / the hint page — callers without a meaningful
+/// zone pass 0; wrong zone beats a lost session) and records it; on timeout
+/// it `warn!`s and gives up without recording.
 #[allow(clippy::too_many_arguments)]
 async fn poll_and_record_session<F>(
     store: Arc<SessionLifecycleStore>,
@@ -1264,6 +1329,7 @@ async fn poll_and_record_session<F>(
     working_dir: String,
     title: String,
     page_id: String,
+    zone_index: i32,
     interval: std::time::Duration,
     timeout: std::time::Duration,
 ) where
@@ -1277,7 +1343,7 @@ async fn poll_and_record_session<F>(
                 config_dir: config_dir.clone(),
                 working_dir: Some(working_dir.clone()),
                 page_id: page_id.clone(),
-                zone_index: 0,
+                zone_index,
                 title: Some(title.clone()),
                 terminal_id: terminal_id.clone(),
                 // record_open seeds these from `now`; values here are placeholders
@@ -1312,8 +1378,10 @@ async fn poll_and_record_session<F>(
     }
 }
 
-/// Durably record a PRE-PINNED session (`--session-id <id>` in the spawn
-/// argv) the instant the PTY exists — no transcript mtime race to lose.
+/// Durably record a PRE-PINNED session (`--session-id <id>` /
+/// account-migration `--resume <id>` in the spawn argv) the instant the PTY
+/// exists — no transcript mtime race to lose.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn record_pinned_session_open(
     store: &SessionLifecycleStore,
     claude_session_id: String,
@@ -1322,13 +1390,14 @@ pub(crate) fn record_pinned_session_open(
     working_dir: String,
     title: String,
     page_id: String,
+    zone_index: i32,
 ) {
     store.record_open(TerminalSessionRecord {
         claude_session_id: claude_session_id.clone(),
         config_dir,
         working_dir: Some(working_dir),
         page_id,
-        zone_index: 0,
+        zone_index,
         title: Some(title),
         terminal_id: terminal_id.clone(),
         // record_open seeds these from `now`; values here are placeholders.
@@ -1438,6 +1507,7 @@ mod tests {
             "/work/dir".to_string(),
             "My Continuation".to_string(),
             "default".to_string(),
+            0,
             Duration::from_millis(1),
             Duration::from_secs(5),
         )
@@ -1474,6 +1544,7 @@ mod tests {
             "/work/dir".to_string(),
             "Overflow Continuation".to_string(),
             "page-7".to_string(),
+            4,
             Duration::from_millis(1),
             Duration::from_secs(5),
         )
@@ -1482,6 +1553,10 @@ mod tests {
         let open = store.open_records();
         assert_eq!(open.len(), 1);
         assert_eq!(open[0].page_id, "page-7");
+        assert_eq!(
+            open[0].zone_index, 4,
+            "caller-supplied zone (account-migration respawn) is durably recorded"
+        );
     }
 
     /// When the resolver never yields an id, the poller gives up after the
@@ -1507,6 +1582,7 @@ mod tests {
             "/work/dir".to_string(),
             "Never Resolves".to_string(),
             "default".to_string(),
+            0,
             Duration::from_millis(1),
             Duration::from_millis(20),
         )
@@ -1575,6 +1651,7 @@ mod tests {
             project_path.to_string(),
             "Pinned".to_string(),
             "default".to_string(),
+            0,
         );
         let verify_cfg = cfg.path().to_path_buf();
         poll_and_verify_pinned_session(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1718,6 +1718,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::terminal::terminal_grid_search,
             commands::terminal::terminal_grid_text,
             commands::terminal::terminal_list,
+            commands::terminal::terminal_migrate_session_account,
             commands::terminal::terminal_resize,
             commands::terminal::terminal_save_scrollback,
             commands::terminal::terminal_session_clear_restore_pending,
@@ -2236,6 +2237,26 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 let poll_lifecycle_store = lifecycle_store.clone();
                 app.manage(lifecycle_store);
+
+                // Usage-limit watcher: every terminal PTY's output flows
+                // through the interceptor pipeline; this hook spots the
+                // Claude CLI's token-exhaustion messages and hands the
+                // (debounced) hint to the account-migration handler, which
+                // probe-confirms real exhaustion before moving the session to
+                // the account with the most weekly-usage headroom. See
+                // `terminal::account_migration` for the full flow + guards.
+                term_for_session.interceptor().add_hook(Box::new(
+                    terminal::usage_limit::UsageLimitWatchHook::new(Box::new(
+                        |terminal_id, pattern| {
+                            tauri::async_runtime::spawn(
+                                terminal::account_migration::handle_usage_limit_hint(
+                                    terminal_id,
+                                    pattern,
+                                ),
+                            );
+                        },
+                    )),
+                ));
 
                 // Infrequent liveness poll for lazy close-detection. Every
                 // 45s it snapshots open lifecycle records against the live

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -295,6 +295,33 @@ impl SessionLifecycleStore {
         self.persist(&snapshot);
     }
 
+    /// Clone of the open record currently hosted by `terminal_id`, if any.
+    /// Terminal ids are fresh per PTY spawn, so at most one OPEN record can
+    /// reference a given terminal at a time.
+    pub fn find_open_by_terminal(&self, terminal_id: &str) -> Option<TerminalSessionRecord> {
+        match self.map.lock() {
+            Ok(m) => m
+                .values()
+                .find(|r| r.state == "open" && r.terminal_id == terminal_id)
+                .cloned(),
+            Err(e) => {
+                warn!(error = %e, "session_lifecycle_store: lock poisoned on find_open_by_terminal");
+                None
+            }
+        }
+    }
+
+    /// Clone of the record for `claude_session_id`, open or closed.
+    pub fn get(&self, claude_session_id: &str) -> Option<TerminalSessionRecord> {
+        match self.map.lock() {
+            Ok(m) => m.get(claude_session_id).cloned(),
+            Err(e) => {
+                warn!(error = %e, "session_lifecycle_store: lock poisoned on get");
+                None
+            }
+        }
+    }
+
     /// Clone of every record whose `state == "open"`.
     pub fn open_records(&self) -> Vec<TerminalSessionRecord> {
         match self.map.lock() {

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -80,6 +80,18 @@ pub struct ClaudeCliSettings {
     /// How to select which account to use when multiple config dirs exist
     #[serde(default)]
     pub account_selection_mode: AccountSelectionMode,
+    /// Automatically migrate a terminal Claude session to another configured
+    /// account when its account runs out of tokens: a usage-limit message in
+    /// the PTY output, confirmed by a fresh usage probe, triggers a
+    /// transcript copy + `claude --resume` respawn under the account with the
+    /// most weekly-usage headroom (see `terminal::account_migration`).
+    /// No-op when fewer than two accounts are configured.
+    #[serde(default = "default_auto_migrate_on_token_exhaustion")]
+    pub auto_migrate_on_token_exhaustion: bool,
+}
+
+fn default_auto_migrate_on_token_exhaustion() -> bool {
+    true
 }
 
 impl Default for ClaudeCliSettings {
@@ -90,6 +102,7 @@ impl Default for ClaudeCliSettings {
             timeout_seconds: 600,
             config_dir: None,
             account_selection_mode: AccountSelectionMode::LeastUsage,
+            auto_migrate_on_token_exhaustion: default_auto_migrate_on_token_exhaustion(),
         }
     }
 }

--- a/src-tauri/src/terminal/account_migration.rs
+++ b/src-tauri/src/terminal/account_migration.rs
@@ -243,13 +243,8 @@ fn copy_transcript(
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("create {} failed: {e}", parent.display()))?;
     }
-    std::fs::copy(&src, &dst).map_err(|e| {
-        format!(
-            "copy {} -> {} failed: {e}",
-            src.display(),
-            dst.display()
-        )
-    })?;
+    std::fs::copy(&src, &dst)
+        .map_err(|e| format!("copy {} -> {} failed: {e}", src.display(), dst.display()))?;
     Ok(dst)
 }
 
@@ -268,10 +263,9 @@ pub fn migrate_session(
 ) -> Result<MigrationOutcome, String> {
     use tauri::Manager;
 
-    let working_dir = record
-        .working_dir
-        .clone()
-        .ok_or_else(|| "session record has no working_dir — cannot locate transcript".to_string())?;
+    let working_dir = record.working_dir.clone().ok_or_else(|| {
+        "session record has no working_dir — cannot locate transcript".to_string()
+    })?;
 
     let terminal_manager = app
         .try_state::<std::sync::Arc<crate::terminal::TerminalManager>>()
@@ -315,10 +309,12 @@ pub fn migrate_session(
     // 3. Respawn under the target account. Same resume form the boot-restore
     // path uses (post-#547): bypassPermissions so the resumed session doesn't
     // wedge on its first tool-approval prompt with nobody watching.
-    let title = record
-        .title
-        .clone()
-        .unwrap_or_else(|| format!("Resumed {}", &record.claude_session_id[..8.min(record.claude_session_id.len())]));
+    let title = record.title.clone().unwrap_or_else(|| {
+        format!(
+            "Resumed {}",
+            &record.claude_session_id[..8.min(record.claude_session_id.len())]
+        )
+    });
     let command = vec![
         crate::agent_runtime::claude_bin_path(),
         "--permission-mode".to_string(),
@@ -376,12 +372,7 @@ pub fn migrate_session(
     Ok(outcome)
 }
 
-fn emit_skipped(
-    app: &tauri::AppHandle,
-    record: &TerminalSessionRecord,
-    src: &str,
-    reason: &str,
-) {
+fn emit_skipped(app: &tauri::AppHandle, record: &TerminalSessionRecord, src: &str, reason: &str) {
     if let Err(e) = app.emit(
         "session-account-migration-skipped",
         json!({
@@ -410,7 +401,10 @@ mod tests {
             "4th migration within the window must be blocked"
         );
         // Outside the 24h window the old entries age out.
-        assert!(migration_cap_permits(sid, base + MIGRATION_CAP_WINDOW_MS + 4000));
+        assert!(migration_cap_permits(
+            sid,
+            base + MIGRATION_CAP_WINDOW_MS + 4000
+        ));
     }
 
     #[test]
@@ -428,21 +422,16 @@ mod tests {
 
     #[test]
     fn copy_transcript_copies_and_is_idempotent() {
-        let tmp = std::env::temp_dir().join(format!(
-            "qontinui-acctmig-test-{}",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("qontinui-acctmig-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         let src_cfg = tmp.join(".claude-hotmail");
         let dst_cfg = tmp.join(".claude-gmail");
         let working_dir = "D:\\qontinui-root";
         let sid = "11111111-2222-3333-4444-555555555555";
 
-        let src_path = crate::terminal::transcript::session_transcript_path(
-            &src_cfg,
-            working_dir,
-            sid,
-        );
+        let src_path =
+            crate::terminal::transcript::session_transcript_path(&src_cfg, working_dir, sid);
         std::fs::create_dir_all(src_path.parent().unwrap()).unwrap();
         std::fs::write(&src_path, b"{\"type\":\"user\"}\n").unwrap();
 
@@ -454,7 +443,10 @@ mod tests {
         )
         .expect("copy should succeed");
         assert!(dst.exists());
-        assert_eq!(std::fs::read(&dst).unwrap(), std::fs::read(&src_path).unwrap());
+        assert_eq!(
+            std::fs::read(&dst).unwrap(),
+            std::fs::read(&src_path).unwrap()
+        );
         // Source untouched.
         assert!(src_path.exists());
 
@@ -473,10 +465,8 @@ mod tests {
 
     #[test]
     fn copy_transcript_missing_source_errors() {
-        let tmp = std::env::temp_dir().join(format!(
-            "qontinui-acctmig-missing-{}",
-            std::process::id()
-        ));
+        let tmp =
+            std::env::temp_dir().join(format!("qontinui-acctmig-missing-{}", std::process::id()));
         let err = copy_transcript(
             tmp.join("nope-src").to_str().unwrap(),
             tmp.join("nope-dst").to_str().unwrap(),

--- a/src-tauri/src/terminal/account_migration.rs
+++ b/src-tauri/src/terminal/account_migration.rs
@@ -1,0 +1,489 @@
+//! Automatic cross-account migration of token-exhausted Claude terminal
+//! sessions.
+//!
+//! ## Problem
+//!
+//! A long-running interactive Claude session pins the account it was launched
+//! under (`CLAUDE_CONFIG_DIR`). When that account runs out of tokens the CLI
+//! prints a usage-limit message and the session is stranded — the operator
+//! has to manually re-open it under another account (the `/resume-foreign`
+//! slash-command flow) even when a sibling account has plenty of headroom.
+//!
+//! ## Flow
+//!
+//! 1. **Hint** — [`super::usage_limit::UsageLimitWatchHook`] sees a
+//!    usage-limit message in the PTY stream and calls
+//!    [`handle_usage_limit_hint`] (debounced per terminal).
+//! 2. **Confirm** — re-probe every configured account
+//!    (`refresh_account_usage_snapshot`) and require the *probe* to agree the
+//!    session's account is exhausted. Conversation text that merely quotes a
+//!    limit message never migrates anything.
+//! 3. **Pick target** — the non-exhausted, credential-valid, non-cooled
+//!    account with the best weekly-usage headroom
+//!    (`pick_migration_target` — same `(exhausted, headroom)` ranking the
+//!    spawn-time picker uses, i.e. lowest used-vs-expected ratio wins).
+//! 4. **Migrate** — copy the session transcript
+//!    (`<src>/projects/<slug>/<sid>.jsonl` → same slug under the target dir;
+//!    the source file is never touched), close the old pane
+//!    (`close_reason: "account-migrated"`), and respawn
+//!    `claude --permission-mode bypassPermissions --resume <sid>` in a fresh
+//!    PTY pinned to the target account, on the same grid page/zone.
+//!
+//! Guards: per-session migration cap (no ping-pong when every account is
+//! dry), settings kill-switch
+//! (`claude_cli.auto_migrate_on_token_exhaustion`), and a no-op with fewer
+//! than two configured accounts. The manual Tauri command
+//! (`terminal_migrate_session_account`) reuses step 4 directly — an operator
+//! click is its own confirmation.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
+
+use serde_json::json;
+use tauri::Emitter;
+use tracing::{info, warn};
+
+use crate::session::session_lifecycle_store::TerminalSessionRecord;
+
+/// Close reason recorded on the old pane's lifecycle row. Deliberately NOT
+/// `pty-exit`/`poll-dead`: the boot-restore path must not resurrect the old
+/// pane — its replacement is already running under the new account.
+pub const CLOSE_REASON_MIGRATED: &str = "account-migrated";
+
+/// Max migrations per Claude session within [`MIGRATION_CAP_WINDOW_MS`].
+/// A second hop is legitimate (the target can run dry too); an unbounded
+/// chain means every account is exhausted and migrating is pure churn.
+const MIGRATION_CAP: usize = 3;
+const MIGRATION_CAP_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// Cooldown stamped on the exhausted source account so spawn-time selection
+/// (`pick_best_account` / `rotate_account_on_rate_limit`) stays off it. One
+/// hour — matches `EXHAUSTION_STALE_TTL`'s trust window for the probe's
+/// `exhausted` flag; a weekly/5-hour cap doesn't clear in minutes.
+const EXHAUSTED_ACCOUNT_COOLDOWN: std::time::Duration = std::time::Duration::from_secs(3600);
+
+/// Per-session migration timestamps (unix millis), for the cap.
+static MIGRATION_HISTORY: Mutex<Option<HashMap<String, Vec<i64>>>> = Mutex::new(None);
+
+/// Record-and-check the migration cap for a session. Returns `false` when
+/// the cap is exhausted (caller must not migrate).
+fn migration_cap_permits(claude_session_id: &str, now_ms: i64) -> bool {
+    let Ok(mut hist) = MIGRATION_HISTORY.lock() else {
+        return false;
+    };
+    let map = hist.get_or_insert_with(HashMap::new);
+    let entry = map.entry(claude_session_id.to_string()).or_default();
+    entry.retain(|t| now_ms - *t <= MIGRATION_CAP_WINDOW_MS);
+    if entry.len() >= MIGRATION_CAP {
+        return false;
+    }
+    entry.push(now_ms);
+    true
+}
+
+/// Outcome payload emitted on `session-account-migrated`.
+#[derive(Debug)]
+pub struct MigrationOutcome {
+    pub new_terminal_id: String,
+    pub from_config_dir: String,
+    pub to_config_dir: String,
+}
+
+/// Entry point for a PTY usage-limit hint (spawned async off the reader
+/// thread). Resolves everything it needs from the global app handle, mirrors
+/// `agent_runtime`'s state-access pattern.
+pub async fn handle_usage_limit_hint(terminal_id: String, matched_pattern: &'static str) {
+    use tauri::Manager;
+
+    let Some(app) = crate::tauri_app_handle::current() else {
+        return;
+    };
+    let Some(store) = app.try_state::<std::sync::Arc<crate::session::session_lifecycle_store::SessionLifecycleStore>>() else {
+        return;
+    };
+
+    // Only sessions the lifecycle registry knows about can migrate — a plain
+    // shell pane (or an unregistered session) has no transcript binding.
+    let Some(record) = store.find_open_by_terminal(&terminal_id) else {
+        info!(
+            terminal_id,
+            matched_pattern,
+            "usage-limit hint on a terminal with no registered Claude session — ignoring"
+        );
+        return;
+    };
+
+    // Source account: the dir the session launched under, else the runner's
+    // currently-resolved global dir (pre-existing sessions registered before
+    // config_dir capture).
+    let Some(src) = record
+        .config_dir
+        .clone()
+        .or_else(crate::ai_provider::get_resolved_config_dir)
+    else {
+        warn!(
+            terminal_id,
+            session = %record.claude_session_id,
+            "usage-limit hint but the session's account is unknown — cannot migrate"
+        );
+        return;
+    };
+
+    let ai_settings = crate::settings::get_ai_settings();
+    if !ai_settings.claude_cli.auto_migrate_on_token_exhaustion {
+        info!(
+            session = %record.claude_session_id,
+            "usage-limit confirmed-candidate but auto-migration is disabled in settings"
+        );
+        return;
+    }
+    if crate::settings::get_claude_config_dirs().len() < 2 {
+        return; // nothing to migrate to
+    }
+
+    // CONFIRM: a usage-limit *message* is only a hint (conversation text can
+    // quote one; a resume repaint can re-render a historical one). Re-probe
+    // and require the account to actually be exhausted before acting.
+    crate::commands::ai_settings::refresh_account_usage_snapshot().await;
+    if !crate::ai_provider::account_known_exhausted(&src) {
+        info!(
+            terminal_id,
+            session = %record.claude_session_id,
+            account = %src,
+            matched_pattern,
+            "usage-limit message NOT confirmed by probe — skipping (likely echoed text)"
+        );
+        return;
+    }
+
+    // Keep spawn-time selection off the dead account, and repoint the global
+    // resolved dir so unrelated new sessions stop landing on it.
+    crate::ai_provider::mark_account_rate_limited_with_duration(&src, EXHAUSTED_ACCOUNT_COOLDOWN);
+    crate::ai_provider::pick_best_account();
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    if !migration_cap_permits(&record.claude_session_id, now_ms) {
+        warn!(
+            session = %record.claude_session_id,
+            cap = MIGRATION_CAP,
+            "migration cap reached for this session — not migrating again"
+        );
+        emit_skipped(&app, &record, &src, "migration-cap-reached");
+        return;
+    }
+
+    let Some(dst) = crate::ai_provider::pick_migration_target(&src) else {
+        warn!(
+            session = %record.claude_session_id,
+            from = %src,
+            "no usable migration target (every other account exhausted/cooled/unauthenticated)"
+        );
+        emit_skipped(&app, &record, &src, "no-usable-target");
+        return;
+    };
+
+    info!(
+        session = %record.claude_session_id,
+        from = %src,
+        to = %dst,
+        matched_pattern,
+        "token exhaustion confirmed — migrating session to a fresh account"
+    );
+
+    match migrate_session(&app, &record, &src, &dst) {
+        Ok(outcome) => {
+            info!(
+                session = %record.claude_session_id,
+                new_terminal = %outcome.new_terminal_id,
+                from = %outcome.from_config_dir,
+                to = %outcome.to_config_dir,
+                "session migrated"
+            );
+        }
+        Err(e) => {
+            warn!(
+                session = %record.claude_session_id,
+                error = %e,
+                "session migration failed"
+            );
+            emit_skipped(&app, &record, &src, &format!("migration-failed: {e}"));
+        }
+    }
+}
+
+/// Copy the session transcript from the source account's project dir into
+/// the target account's matching project dir. The source file is never
+/// modified or removed. Skips the copy when the destination already exists
+/// and is at least as large (idempotent retry).
+fn copy_transcript(
+    src_config_dir: &str,
+    dst_config_dir: &str,
+    working_dir: &str,
+    claude_session_id: &str,
+) -> Result<std::path::PathBuf, String> {
+    let src = super::transcript::session_transcript_path(
+        Path::new(src_config_dir),
+        working_dir,
+        claude_session_id,
+    );
+    let dst = super::transcript::session_transcript_path(
+        Path::new(dst_config_dir),
+        working_dir,
+        claude_session_id,
+    );
+    let src_meta = std::fs::metadata(&src)
+        .map_err(|e| format!("source transcript missing at {}: {e}", src.display()))?;
+    if let Ok(dst_meta) = std::fs::metadata(&dst) {
+        if dst_meta.len() >= src_meta.len() {
+            return Ok(dst); // already migrated (retry / repeated hint)
+        }
+    }
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {} failed: {e}", parent.display()))?;
+    }
+    std::fs::copy(&src, &dst).map_err(|e| {
+        format!(
+            "copy {} -> {} failed: {e}",
+            src.display(),
+            dst.display()
+        )
+    })?;
+    Ok(dst)
+}
+
+/// Perform the migration mechanics: transcript copy → close old pane →
+/// respawn under the target account → re-record lifecycle row → emit event.
+///
+/// Shared by the automatic path ([`handle_usage_limit_hint`], which has
+/// already confirmed exhaustion) and the manual Tauri command
+/// (`terminal_migrate_session_account`, where the operator's click is the
+/// confirmation).
+pub fn migrate_session(
+    app: &tauri::AppHandle,
+    record: &TerminalSessionRecord,
+    src_config_dir: &str,
+    dst_config_dir: &str,
+) -> Result<MigrationOutcome, String> {
+    use tauri::Manager;
+
+    let working_dir = record
+        .working_dir
+        .clone()
+        .ok_or_else(|| "session record has no working_dir — cannot locate transcript".to_string())?;
+
+    let terminal_manager = app
+        .try_state::<std::sync::Arc<crate::terminal::TerminalManager>>()
+        .ok_or("TerminalManager not managed")?
+        .inner()
+        .clone();
+    let session_registry = app
+        .try_state::<std::sync::Arc<crate::session::SessionRegistry>>()
+        .ok_or("SessionRegistry not managed")?
+        .inner()
+        .clone();
+    let store = app
+        .try_state::<std::sync::Arc<crate::session::session_lifecycle_store::SessionLifecycleStore>>()
+        .ok_or("SessionLifecycleStore not managed")?
+        .inner()
+        .clone();
+
+    // 1. Transcript first — if this fails the old pane is left untouched.
+    copy_transcript(
+        src_config_dir,
+        dst_config_dir,
+        &working_dir,
+        &record.claude_session_id,
+    )?;
+
+    // 2. Close the old pane. Record the migration close-reason BEFORE the
+    // PTY teardown so the exit hook's later `pty-exit` close is a no-op
+    // (record_close ignores already-closed rows) and boot-restore never
+    // resurrects the stranded pane.
+    store.record_close(&record.claude_session_id, CLOSE_REASON_MIGRATED);
+    if let Err(e) = terminal_manager.close(&record.terminal_id) {
+        // Old pane may already be gone (user closed it after exhaustion) —
+        // not fatal, the respawn is what matters.
+        info!(
+            terminal_id = %record.terminal_id,
+            error = %e,
+            "old terminal close failed (continuing with respawn)"
+        );
+    }
+
+    // 3. Respawn under the target account. Same resume form the boot-restore
+    // path uses (post-#547): bypassPermissions so the resumed session doesn't
+    // wedge on its first tool-approval prompt with nobody watching.
+    let title = record
+        .title
+        .clone()
+        .unwrap_or_else(|| format!("Resumed {}", &record.claude_session_id[..8.min(record.claude_session_id.len())]));
+    let command = vec![
+        crate::agent_runtime::claude_bin_path(),
+        "--permission-mode".to_string(),
+        "bypassPermissions".to_string(),
+        "--resume".to_string(),
+        record.claude_session_id.clone(),
+    ];
+    let capture_hint = crate::commands::terminal::SessionCaptureHint {
+        config_dir: Some(dst_config_dir.to_string()),
+        working_dir: working_dir.clone(),
+        title: title.clone(),
+        page_id: Some(record.page_id.clone()),
+        // `--resume <id>` names the exact session id → synchronous pinned
+        // record (same row, new terminal/account/zone) + verification arm.
+        claude_session_id: Some(record.claude_session_id.clone()),
+        zone_index: Some(record.zone_index),
+    };
+    let (new_terminal_id, _coord_id) = crate::commands::terminal::create_terminal_session_backend(
+        &terminal_manager,
+        &session_registry,
+        app.clone(),
+        title.clone(),
+        working_dir.clone(),
+        None,
+        None,
+        None,
+        Some(command),
+        None,
+        Some(capture_hint),
+        Some(record.page_id.clone()),
+    )?;
+
+    // The lifecycle row was re-opened synchronously by the pinned-id capture
+    // hint inside `create_terminal_session_backend` (`--resume <id>` keys the
+    // SAME row: new terminal/account, preserved page/zone, origin "pinned").
+
+    let outcome = MigrationOutcome {
+        new_terminal_id: new_terminal_id.clone(),
+        from_config_dir: src_config_dir.to_string(),
+        to_config_dir: dst_config_dir.to_string(),
+    };
+    if let Err(e) = app.emit(
+        "session-account-migrated",
+        json!({
+            "claudeSessionId": record.claude_session_id,
+            "fromConfigDir": outcome.from_config_dir,
+            "toConfigDir": outcome.to_config_dir,
+            "newTerminalId": outcome.new_terminal_id,
+            "pageId": record.page_id,
+            "zoneIndex": record.zone_index,
+        }),
+    ) {
+        warn!(error = %e, "failed to emit session-account-migrated");
+    }
+    Ok(outcome)
+}
+
+fn emit_skipped(
+    app: &tauri::AppHandle,
+    record: &TerminalSessionRecord,
+    src: &str,
+    reason: &str,
+) {
+    if let Err(e) = app.emit(
+        "session-account-migration-skipped",
+        json!({
+            "claudeSessionId": record.claude_session_id,
+            "fromConfigDir": src,
+            "reason": reason,
+        }),
+    ) {
+        warn!(error = %e, "failed to emit session-account-migration-skipped");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn migration_cap_allows_then_blocks() {
+        let sid = "test/account_migration/cap-session";
+        let base = 1_750_000_000_000i64;
+        assert!(migration_cap_permits(sid, base));
+        assert!(migration_cap_permits(sid, base + 1000));
+        assert!(migration_cap_permits(sid, base + 2000));
+        assert!(
+            !migration_cap_permits(sid, base + 3000),
+            "4th migration within the window must be blocked"
+        );
+        // Outside the 24h window the old entries age out.
+        assert!(migration_cap_permits(sid, base + MIGRATION_CAP_WINDOW_MS + 4000));
+    }
+
+    #[test]
+    fn migration_cap_is_per_session() {
+        let base = 1_750_000_000_000i64;
+        for i in 0..MIGRATION_CAP {
+            assert!(migration_cap_permits("test/cap/a", base + i as i64));
+        }
+        assert!(!migration_cap_permits("test/cap/a", base + 10));
+        assert!(
+            migration_cap_permits("test/cap/b", base + 10),
+            "an unrelated session is not capped"
+        );
+    }
+
+    #[test]
+    fn copy_transcript_copies_and_is_idempotent() {
+        let tmp = std::env::temp_dir().join(format!(
+            "qontinui-acctmig-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let src_cfg = tmp.join(".claude-hotmail");
+        let dst_cfg = tmp.join(".claude-gmail");
+        let working_dir = "D:\\qontinui-root";
+        let sid = "11111111-2222-3333-4444-555555555555";
+
+        let src_path = crate::terminal::transcript::session_transcript_path(
+            &src_cfg,
+            working_dir,
+            sid,
+        );
+        std::fs::create_dir_all(src_path.parent().unwrap()).unwrap();
+        std::fs::write(&src_path, b"{\"type\":\"user\"}\n").unwrap();
+
+        let dst = copy_transcript(
+            src_cfg.to_str().unwrap(),
+            dst_cfg.to_str().unwrap(),
+            working_dir,
+            sid,
+        )
+        .expect("copy should succeed");
+        assert!(dst.exists());
+        assert_eq!(std::fs::read(&dst).unwrap(), std::fs::read(&src_path).unwrap());
+        // Source untouched.
+        assert!(src_path.exists());
+
+        // Second call (repeated hint / retry) is a no-op success.
+        let dst2 = copy_transcript(
+            src_cfg.to_str().unwrap(),
+            dst_cfg.to_str().unwrap(),
+            working_dir,
+            sid,
+        )
+        .expect("idempotent retry should succeed");
+        assert_eq!(dst, dst2);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn copy_transcript_missing_source_errors() {
+        let tmp = std::env::temp_dir().join(format!(
+            "qontinui-acctmig-missing-{}",
+            std::process::id()
+        ));
+        let err = copy_transcript(
+            tmp.join("nope-src").to_str().unwrap(),
+            tmp.join("nope-dst").to_str().unwrap(),
+            "D:\\qontinui-root",
+            "00000000-0000-0000-0000-000000000000",
+        )
+        .unwrap_err();
+        assert!(err.contains("source transcript missing"), "got: {err}");
+    }
+}

--- a/src-tauri/src/terminal/interceptor.rs
+++ b/src-tauri/src/terminal/interceptor.rs
@@ -38,7 +38,6 @@ impl OutputInterceptor {
     }
 
     /// Add a hook to the end of the pipeline.
-    #[allow(dead_code)]
     pub fn add_hook(&self, hook: Box<dyn OutputHook>) {
         if let Ok(mut hooks) = self.hooks.lock() {
             hooks.push(hook);

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -323,7 +323,6 @@ impl TerminalManager {
     }
 
     /// Get a reference to the output interceptor (for adding hooks).
-    #[allow(dead_code)]
     pub fn interceptor(&self) -> &Arc<OutputInterceptor> {
         &self.interceptor
     }

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -4,6 +4,7 @@
 //! Each session spawns a native shell (PowerShell on Windows, $SHELL on Unix)
 //! with proper environment for running Claude CLI and other dev tools.
 
+pub mod account_migration;
 pub mod claude_resume_sniff;
 pub mod commit_report;
 pub mod coord_warn;
@@ -14,6 +15,7 @@ pub mod session;
 pub mod transcript;
 pub mod transcript_watcher;
 pub mod types;
+pub mod usage_limit;
 
 pub use manager::TerminalManager;
 

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -339,6 +339,9 @@ impl TerminalSession {
         // `QONTINUI_SESSION_WORKTREES`, the agent-agnostic pointer to every
         // materialized sibling worktree of this session). Set after the
         // built-in runner vars so a caller can intentionally override them.
+        let caller_pinned_config_dir = extra_env
+            .as_ref()
+            .is_some_and(|env| env.iter().any(|(k, _)| k == "CLAUDE_CONFIG_DIR"));
         if let Some(env) = extra_env {
             for (k, v) in env {
                 cmd.env(k, v);
@@ -358,12 +361,19 @@ impl TerminalSession {
         Self::apply_install_intercept_env(&mut cmd, &id);
 
         // Set CLAUDE_CONFIG_DIR so Claude Code uses the resolved account
-        // (multi-account support with auto-rotation on rate-limit).
-        let ai_settings = crate::settings::get_ai_settings();
-        if let Some(config_dir) =
-            crate::ai_provider::get_effective_config_dir(&ai_settings.claude_cli)
-        {
-            cmd.env("CLAUDE_CONFIG_DIR", &config_dir);
+        // (multi-account support with auto-rotation on rate-limit) — UNLESS
+        // the caller already pinned an account via `extra_env`. A caller pin
+        // (backend continuation spawns, account-migration respawns) is a
+        // deliberate per-session choice and must not be clobbered by the
+        // process-global resolved dir, which may point at a different (or
+        // freshly-exhausted) account.
+        if !caller_pinned_config_dir {
+            let ai_settings = crate::settings::get_ai_settings();
+            if let Some(config_dir) =
+                crate::ai_provider::get_effective_config_dir(&ai_settings.claude_cli)
+            {
+                cmd.env("CLAUDE_CONFIG_DIR", &config_dir);
+            }
         }
 
         // Spawn the child process

--- a/src-tauri/src/terminal/usage_limit.rs
+++ b/src-tauri/src/terminal/usage_limit.rs
@@ -275,7 +275,9 @@ mod tests {
     #[test]
     fn plain_limit_message_matches() {
         assert_eq!(
-            window_indicates_usage_limit("Claude usage limit reached. Your limit will reset at 3am."),
+            window_indicates_usage_limit(
+                "Claude usage limit reached. Your limit will reset at 3am."
+            ),
             Some("usage limit reached")
         );
         assert_eq!(
@@ -298,8 +300,14 @@ mod tests {
 
     #[test]
     fn ordinary_output_does_not_match() {
-        assert_eq!(window_indicates_usage_limit("cargo build finished in 12s"), None);
-        assert_eq!(window_indicates_usage_limit("approaching usage limit"), None);
+        assert_eq!(
+            window_indicates_usage_limit("cargo build finished in 12s"),
+            None
+        );
+        assert_eq!(
+            window_indicates_usage_limit("approaching usage limit"),
+            None
+        );
     }
 
     #[test]
@@ -323,7 +331,10 @@ mod tests {
         // CSI starts at the end of chunk 1 and finishes at the start of
         // chunk 2 — the fragment must not pollute the text window.
         assert_eq!(h.scan("t1", b"usage \x1b[38;5;"), None);
-        assert_eq!(h.scan("t1", b"196mlimit reached"), Some("usage limit reached"));
+        assert_eq!(
+            h.scan("t1", b"196mlimit reached"),
+            Some("usage limit reached")
+        );
     }
 
     #[test]
@@ -336,7 +347,10 @@ mod tests {
     #[test]
     fn debounce_suppresses_repeat_within_window() {
         let h = hook();
-        assert_eq!(h.scan("t1", b"usage limit reached"), Some("usage limit reached"));
+        assert_eq!(
+            h.scan("t1", b"usage limit reached"),
+            Some("usage limit reached")
+        );
         // Re-rendered message (e.g. TUI repaint) within the debounce window.
         assert_eq!(h.scan("t1", b"usage limit reached"), None);
     }
@@ -344,8 +358,14 @@ mod tests {
     #[test]
     fn debounce_is_per_terminal() {
         let h = hook();
-        assert_eq!(h.scan("t1", b"usage limit reached"), Some("usage limit reached"));
-        assert_eq!(h.scan("t2", b"usage limit reached"), Some("usage limit reached"));
+        assert_eq!(
+            h.scan("t1", b"usage limit reached"),
+            Some("usage limit reached")
+        );
+        assert_eq!(
+            h.scan("t2", b"usage limit reached"),
+            Some("usage limit reached")
+        );
     }
 
     #[test]
@@ -361,7 +381,10 @@ mod tests {
             let st = states.get("t1").unwrap();
             assert!(st.window.len() <= WINDOW_KEEP + 1024);
         }
-        assert_eq!(h.scan("t1", b" weekly limit reached"), Some("weekly limit reached"));
+        assert_eq!(
+            h.scan("t1", b" weekly limit reached"),
+            Some("weekly limit reached")
+        );
     }
 
     #[test]

--- a/src-tauri/src/terminal/usage_limit.rs
+++ b/src-tauri/src/terminal/usage_limit.rs
@@ -1,0 +1,374 @@
+//! Usage-limit detection over raw terminal PTY output.
+//!
+//! [`UsageLimitWatchHook`] is an [`OutputHook`] installed on the terminal
+//! manager's interceptor pipeline. It watches every PTY's output stream for
+//! the Claude CLI's token-exhaustion messages ("Claude usage limit reached",
+//! "5-hour limit reached ∙ resets …", …) and fires a callback hint when one
+//! appears.
+//!
+//! The hint is deliberately a HINT, not a verdict: conversation text can echo
+//! these phrases (a diff of this very file, a quoted error in a log review…),
+//! and a TUI repaint after `claude --resume` can re-render a *historical*
+//! limit message. The downstream handler
+//! (`terminal::account_migration::handle_usage_limit_hint`) therefore
+//! re-probes the account's real usage and only acts when the probe confirms
+//! exhaustion. This module only has to be cheap, tolerant, and debounced.
+//!
+//! Hot-path discipline: `process` runs on the PTY reader thread for every
+//! chunk. Work per chunk is one pass of a byte-level ANSI-strip state machine
+//! plus a bounded substring scan over a small rolling window — no regex, no
+//! allocation growth, no locks held across the callback (the callback is
+//! invoked after the state lock is released).
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use tracing::{debug, info};
+
+use super::interceptor::OutputHook;
+
+/// Lowercased substrings that indicate the Claude CLI hit a usage limit.
+///
+/// Matched against an ANSI-stripped, lowercased, whitespace-collapsed rolling
+/// window of recent output. Generous on purpose — a false hint costs one
+/// (rate-limited) usage probe downstream, while a missed hint strands a
+/// session on a dead account.
+const USAGE_LIMIT_PATTERNS: &[&str] = &[
+    "usage limit reached",
+    "5-hour limit reached",
+    "weekly limit reached",
+    "hit your usage limit",
+    "out of extra usage",
+    "session limit reached",
+];
+
+/// Minimum gap between two hint firings for the same terminal. A limit
+/// message that keeps re-rendering (TUI repaints on resize/scroll) must not
+/// hammer the probe path.
+const HINT_DEBOUNCE: Duration = Duration::from_secs(300);
+
+/// Stripped-text rolling window kept per terminal. Must comfortably exceed
+/// the longest pattern so a phrase split across two PTY chunks still matches
+/// after the second chunk arrives.
+const WINDOW_KEEP: usize = 256;
+
+// ── ANSI stripping ──────────────────────────────────────────────────────────
+
+/// Byte-level escape-sequence stripper, stateful so sequences split across
+/// PTY read chunks are still consumed (a split CSI must not leak fragments
+/// into the text window between two words of a limit message).
+#[derive(Default)]
+struct AnsiStripper {
+    state: StripState,
+}
+
+#[derive(Default, Clone, Copy, PartialEq)]
+enum StripState {
+    #[default]
+    Ground,
+    /// Saw ESC, awaiting the introducer byte.
+    Escape,
+    /// Inside `ESC [ … <final>` — consume until a final byte `0x40..=0x7E`.
+    Csi,
+    /// Inside `ESC ] … (BEL | ESC \)` — consume until the terminator.
+    Osc,
+    /// Inside an OSC, saw ESC — next `\` ends the OSC.
+    OscEscape,
+}
+
+impl AnsiStripper {
+    /// Feed raw PTY bytes; append printable text (with control bytes mapped
+    /// to single spaces) onto `out`.
+    fn feed(&mut self, data: &[u8], out: &mut String) {
+        for &b in data {
+            match self.state {
+                StripState::Ground => match b {
+                    0x1b => self.state = StripState::Escape,
+                    b'\r' | b'\n' | b'\t' => out.push(' '),
+                    0x00..=0x1f | 0x7f => {} // other control bytes — drop
+                    _ => out.push(b as char), // lossy-ASCII: multibyte UTF-8
+                                              // bytes land as garbage chars,
+                                              // which never match the ASCII
+                                              // patterns and are trimmed away
+                                              // by the rolling window.
+                },
+                StripState::Escape => match b {
+                    b'[' => self.state = StripState::Csi,
+                    b']' => self.state = StripState::Osc,
+                    // Two-byte sequences (ESC + one char) and anything
+                    // unrecognized: swallow and return to ground.
+                    _ => self.state = StripState::Ground,
+                },
+                StripState::Csi => {
+                    if (0x40..=0x7e).contains(&b) {
+                        self.state = StripState::Ground;
+                    }
+                }
+                StripState::Osc => match b {
+                    0x07 => self.state = StripState::Ground,
+                    0x1b => self.state = StripState::OscEscape,
+                    _ => {}
+                },
+                StripState::OscEscape => {
+                    self.state = if b == b'\\' {
+                        StripState::Ground
+                    } else {
+                        StripState::Osc
+                    };
+                }
+            }
+        }
+    }
+}
+
+// ── Pattern matching ────────────────────────────────────────────────────────
+
+/// Lowercase + collapse whitespace runs to single spaces, so TUI padding /
+/// line wraps inside a message don't break the substring match.
+fn normalize(window: &str) -> String {
+    let mut out = String::with_capacity(window.len());
+    let mut last_space = false;
+    for c in window.chars() {
+        if c.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+            }
+            last_space = true;
+        } else {
+            for lc in c.to_lowercase() {
+                out.push(lc);
+            }
+            last_space = false;
+        }
+    }
+    out
+}
+
+/// First matching usage-limit pattern in the (raw, un-normalized) window,
+/// if any.
+pub fn window_indicates_usage_limit(window: &str) -> Option<&'static str> {
+    let normalized = normalize(window);
+    USAGE_LIMIT_PATTERNS
+        .iter()
+        .find(|p| normalized.contains(*p))
+        .copied()
+}
+
+// ── The hook ────────────────────────────────────────────────────────────────
+
+struct TermWatchState {
+    stripper: AnsiStripper,
+    window: String,
+    last_fired: Option<Instant>,
+}
+
+impl Default for TermWatchState {
+    fn default() -> Self {
+        Self {
+            stripper: AnsiStripper::default(),
+            window: String::with_capacity(WINDOW_KEEP * 2),
+            last_fired: None,
+        }
+    }
+}
+
+/// Callback type: `(terminal_id, matched_pattern)`.
+pub type UsageLimitHintFn = Box<dyn Fn(String, &'static str) + Send + Sync>;
+
+/// Output hook that fires `on_hint` (debounced per terminal) whenever a
+/// usage-limit message appears in a PTY's output. Pass-through for the data
+/// itself — it never modifies the stream.
+pub struct UsageLimitWatchHook {
+    states: Mutex<HashMap<String, TermWatchState>>,
+    on_hint: UsageLimitHintFn,
+    debounce: Duration,
+}
+
+impl UsageLimitWatchHook {
+    pub fn new(on_hint: UsageLimitHintFn) -> Self {
+        Self::with_debounce(on_hint, HINT_DEBOUNCE)
+    }
+
+    fn with_debounce(on_hint: UsageLimitHintFn, debounce: Duration) -> Self {
+        Self {
+            states: Mutex::new(HashMap::new()),
+            on_hint,
+            debounce,
+        }
+    }
+
+    /// Feed a chunk for `terminal_id`; returns the matched pattern when a
+    /// (debounce-permitted) hint should fire. Split out from
+    /// [`OutputHook::process`] so tests can drive chunking/debounce without a
+    /// callback.
+    fn scan(&self, terminal_id: &str, data: &[u8]) -> Option<&'static str> {
+        let mut states = self.states.lock().ok()?;
+        let st = states.entry(terminal_id.to_string()).or_default();
+
+        st.stripper.feed(data, &mut st.window);
+
+        let matched = window_indicates_usage_limit(&st.window);
+
+        // Trim the rolling window AFTER matching. On a match, clear it
+        // entirely so the same rendered message doesn't re-match on the next
+        // chunk (the debounce also guards this, but a cleared window keeps
+        // the state machine honest).
+        if matched.is_some() {
+            st.window.clear();
+        } else if st.window.len() > WINDOW_KEEP {
+            let cut = st.window.len() - WINDOW_KEEP;
+            // Avoid splitting a UTF-8 char (window may hold lossy bytes but
+            // `normalize` already tolerates garbage; keep it valid anyway).
+            let cut = (cut..st.window.len())
+                .find(|i| st.window.is_char_boundary(*i))
+                .unwrap_or(0);
+            st.window.drain(..cut);
+        }
+
+        let pattern = matched?;
+        let now = Instant::now();
+        if let Some(prev) = st.last_fired {
+            if now.duration_since(prev) < self.debounce {
+                debug!(
+                    terminal_id,
+                    pattern, "usage-limit message re-seen within debounce — suppressed"
+                );
+                return None;
+            }
+        }
+        st.last_fired = Some(now);
+        Some(pattern)
+    }
+
+    /// Drop per-terminal state for a closed terminal (best-effort hygiene;
+    /// stale entries are bounded by terminal count anyway).
+    #[allow(dead_code)]
+    pub fn forget(&self, terminal_id: &str) {
+        if let Ok(mut states) = self.states.lock() {
+            states.remove(terminal_id);
+        }
+    }
+}
+
+impl OutputHook for UsageLimitWatchHook {
+    fn process(&self, terminal_id: &str, data: &[u8]) -> Vec<u8> {
+        if let Some(pattern) = self.scan(terminal_id, data) {
+            info!(
+                terminal_id,
+                pattern, "usage-limit message detected in terminal output"
+            );
+            (self.on_hint)(terminal_id.to_string(), pattern);
+        }
+        data.to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hook() -> UsageLimitWatchHook {
+        UsageLimitWatchHook::with_debounce(Box::new(|_, _| {}), Duration::from_secs(300))
+    }
+
+    #[test]
+    fn plain_limit_message_matches() {
+        assert_eq!(
+            window_indicates_usage_limit("Claude usage limit reached. Your limit will reset at 3am."),
+            Some("usage limit reached")
+        );
+        assert_eq!(
+            window_indicates_usage_limit("5-hour limit reached ∙ resets 3am"),
+            Some("5-hour limit reached")
+        );
+        assert_eq!(
+            window_indicates_usage_limit("Weekly limit reached — resets Thursday"),
+            Some("weekly limit reached")
+        );
+    }
+
+    #[test]
+    fn case_and_whitespace_tolerant() {
+        assert_eq!(
+            window_indicates_usage_limit("USAGE   LIMIT\n REACHED"),
+            Some("usage limit reached")
+        );
+    }
+
+    #[test]
+    fn ordinary_output_does_not_match() {
+        assert_eq!(window_indicates_usage_limit("cargo build finished in 12s"), None);
+        assert_eq!(window_indicates_usage_limit("approaching usage limit"), None);
+    }
+
+    #[test]
+    fn ansi_codes_inside_message_are_stripped() {
+        let h = hook();
+        // Color change mid-phrase must not break the match.
+        let chunk = b"\x1b[31musage \x1b[1mlimit\x1b[0m reached\x1b[0m";
+        assert_eq!(h.scan("t1", chunk), Some("usage limit reached"));
+    }
+
+    #[test]
+    fn message_split_across_chunks_matches_on_second_chunk() {
+        let h = hook();
+        assert_eq!(h.scan("t1", b"Claude usage li"), None);
+        assert_eq!(h.scan("t1", b"mit reached."), Some("usage limit reached"));
+    }
+
+    #[test]
+    fn escape_sequence_split_across_chunks_is_consumed() {
+        let h = hook();
+        // CSI starts at the end of chunk 1 and finishes at the start of
+        // chunk 2 — the fragment must not pollute the text window.
+        assert_eq!(h.scan("t1", b"usage \x1b[38;5;"), None);
+        assert_eq!(h.scan("t1", b"196mlimit reached"), Some("usage limit reached"));
+    }
+
+    #[test]
+    fn osc_title_sequence_is_stripped() {
+        let h = hook();
+        let chunk = b"\x1b]0;my terminal title\x07usage limit reached";
+        assert_eq!(h.scan("t1", chunk), Some("usage limit reached"));
+    }
+
+    #[test]
+    fn debounce_suppresses_repeat_within_window() {
+        let h = hook();
+        assert_eq!(h.scan("t1", b"usage limit reached"), Some("usage limit reached"));
+        // Re-rendered message (e.g. TUI repaint) within the debounce window.
+        assert_eq!(h.scan("t1", b"usage limit reached"), None);
+    }
+
+    #[test]
+    fn debounce_is_per_terminal() {
+        let h = hook();
+        assert_eq!(h.scan("t1", b"usage limit reached"), Some("usage limit reached"));
+        assert_eq!(h.scan("t2", b"usage limit reached"), Some("usage limit reached"));
+    }
+
+    #[test]
+    fn window_is_bounded() {
+        let h = hook();
+        // Feed lots of non-matching output; window must stay bounded and a
+        // later message must still match.
+        for _ in 0..100 {
+            assert_eq!(h.scan("t1", &[b'x'; 1024]), None);
+        }
+        {
+            let states = h.states.lock().unwrap();
+            let st = states.get("t1").unwrap();
+            assert!(st.window.len() <= WINDOW_KEEP + 1024);
+        }
+        assert_eq!(h.scan("t1", b" weekly limit reached"), Some("weekly limit reached"));
+    }
+
+    #[test]
+    fn passthrough_returns_data_unchanged() {
+        let h = UsageLimitWatchHook::new(Box::new(|_, _| {}));
+        let data = b"\x1b[31musage limit reached\x1b[0m".to_vec();
+        let out = OutputHook::process(&h, "t1", &data);
+        assert_eq!(out, data);
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,7 @@ import { useGraphDataRefresh } from "./hooks/useGraphDataRefresh";
 import { useObservationServices } from "./hooks/useObservationServices";
 import { useToast } from "./hooks/useToast";
 import { useErrorNotifications } from "./hooks/useErrorNotifications";
+import { useAccountMigrationNotifications } from "./hooks/useAccountMigrationNotifications";
 import { useStateMachineRegistration } from "./hooks/useStateMachineRegistration";
 
 import { ToastContainer } from "./components/ToastContainer";
@@ -286,6 +287,7 @@ function AppContent() {
   const { alerts: canaryAlerts, dismissAlert: dismissCanaryAlert } = useCanaryAlerts();
   const { toasts, showToast, dismissToast } = useToast();
   useErrorNotifications(showToast);
+  useAccountMigrationNotifications(showToast);
 
   // Legacy dev email/password auto-login (and its `test-auto-login-failed`
   // toast) was removed in the Cognito-legacy-auth teardown — sign-in is now

--- a/src/hooks/useAccountMigrationNotifications.ts
+++ b/src/hooks/useAccountMigrationNotifications.ts
@@ -1,0 +1,67 @@
+/**
+ * useAccountMigrationNotifications — toasts for automatic session account
+ * migration (backend `terminal::account_migration`).
+ *
+ * The runner backend emits:
+ * - `session-account-migrated` when a token-exhausted Claude session was
+ *   respawned under a fresh account (the new pane appears via the normal
+ *   `terminal-created` flow — this toast explains WHY a pane just cycled).
+ * - `session-account-migration-skipped` when exhaustion was confirmed but no
+ *   migration happened (no usable target / cap reached / mechanics failed) —
+ *   surfaced as an error so the operator knows the session is stranded.
+ *
+ * Mount once at App level, next to `useErrorNotifications`.
+ */
+
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { ShowToastFn } from "./useToast";
+
+interface MigratedPayload {
+  claudeSessionId?: string;
+  fromConfigDir?: string;
+  toConfigDir?: string;
+}
+
+interface SkippedPayload {
+  claudeSessionId?: string;
+  fromConfigDir?: string;
+  reason?: string;
+}
+
+/** Last path segment of a config dir (`C:\claude\.claude-gmail` → `.claude-gmail`). */
+function accountLabel(dir: string | undefined): string {
+  if (!dir) return "unknown";
+  const parts = dir.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? dir;
+}
+
+export function useAccountMigrationNotifications(showToast: ShowToastFn) {
+  useEffect(() => {
+    const unlistenMigrated = listen<MigratedPayload>("session-account-migrated", (event) => {
+      const p = event.payload ?? {};
+      showToast(
+        `Session ${(p.claudeSessionId ?? "").slice(0, 8)} migrated: ${accountLabel(
+          p.fromConfigDir,
+        )} ran out of tokens → resumed on ${accountLabel(p.toConfigDir)}`,
+        "success",
+      );
+    });
+    const unlistenSkipped = listen<SkippedPayload>(
+      "session-account-migration-skipped",
+      (event) => {
+        const p = event.payload ?? {};
+        showToast(
+          `Session ${(p.claudeSessionId ?? "").slice(0, 8)} is out of tokens on ${accountLabel(
+            p.fromConfigDir,
+          )} but was NOT migrated: ${p.reason ?? "unknown reason"}`,
+          "error",
+        );
+      },
+    );
+    return () => {
+      unlistenMigrated.then((fn) => fn());
+      unlistenSkipped.then((fn) => fn());
+    };
+  }, [showToast]);
+}


### PR DESCRIPTION
## Problem

When a terminal session's Claude account runs out of tokens, the session is stranded: the CLI prints a usage-limit message and the operator has to manually re-open the work under another account (the `/resume-foreign` flow) — even when a sibling account has plenty of headroom. Today there are multiple hotmail-account sessions sitting dead in the runner for exactly this reason.

## What this adds

Automatic detect → confirm → migrate, entirely runner-side:

1. **Detect** — `terminal/usage_limit.rs` (new): `UsageLimitWatchHook` on the PTY output interceptor pipeline (the pipeline existed but had zero hooks). Stateful ANSI-strip + rolling-window scan spots the CLI's usage-limit messages; split-chunk safe (a CSI or a phrase split across two PTY reads still matches), debounced per terminal.
2. **Confirm** — the match is only a *hint*: conversation text can echo these phrases, and a resume repaint can re-render a historical one. `terminal/account_migration.rs` (new) re-probes every account (`refresh_account_usage_snapshot`) and only acts when the probe confirms the session's account is exhausted. Then it cools the dead account (60 min) and repoints the global resolved dir so new spawns avoid it too.
3. **Pick target** — `ai_provider::pick_migration_target` (new): same `(exhausted, headroom)` ranking as spawn-time selection — lowest used-vs-expected weekly delta wins — but excludes the source dir and returns `None` instead of a least-bad fallback (migrating onto another dead account is churn).
4. **Migrate** — copy the transcript `<src>/projects/<slug>/<sid>.jsonl` → same slug under the target dir (source never touched), close the old pane (`close_reason: "account-migrated"`, deliberately not restorable), respawn `claude --permission-mode bypassPermissions --resume <sid>` pinned to the target account on the same grid page/zone.

## Guards

- Per-session migration cap (3/24 h) — no ping-pong when every account is dry.
- Settings kill-switch `claude_cli.auto_migrate_on_token_exhaustion` (default **on**); no-op with <2 configured accounts.
- Probe-failure on the *target* side counts as exhausted (conservative).

## Also in this PR

- **Fix**: `terminal/session.rs` applied the process-global resolved `CLAUDE_CONFIG_DIR` *after* caller `extra_env`, silently clobbering a caller-pinned account. Caller pins now win (gate continuations relied on the two coinciding; migration respawns genuinely differ).
- `SessionCaptureHint` gains `zone_index` (continuation spawns pass `None` → zone 0, unchanged) and migration respawns reuse #552's pinned-id path: synchronous `record_pinned_session_open` (extended with `zone_index`) + verification arm, `bind_origin: "pinned"`.
- New Tauri command `terminal_migrate_session_account(claude_session_id, target_config_dir?)` — manual one-click form; the operator's click is the confirmation (no probe gate).
- Frontend: `useAccountMigrationNotifications` toasts on `session-account-migrated` / `session-account-migration-skipped` (the new pane itself appears via the existing `terminal-created` ingest).

## Integration with #552 / #548

Rebased on and integrated with #552 (pre-pinned session ids): a migration respawn names the exact id via `--resume`, so it records synchronously as **pinned** — no mtime-guess registration involved.

## Testing

- 23 new unit tests (ANSI-strip/chunking/debounce matrix, target-selection ranking incl. all-exhausted → `None`, migration cap, transcript copy idempotency, zone threading through both capture arms) + #552's pinned tests still green — 29 passing in the touched areas.
- `cargo check`, `clippy --workspace --tests -D warnings`, `tsc --noEmit`, ESLint: all clean.
- Not yet live-verified end-to-end (needs a runner rebuild + a genuinely exhausted account); the detection→migration path logs at each gate (`usage-limit message detected`, `NOT confirmed by probe`, `token exhaustion confirmed — migrating`) for observability on first contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)