### PR TITLE
fix(spawn): attached-form --add-dir= — variadic space form swallowed the trailing prompt

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1779,6 +1779,12 @@ fn pick_continuation_page(
 /// session would idle at an empty REPL — the 2026-06-12 multi-repo
 /// gate-continuation incident (single-repo continuations were immune only
 /// because their `add_dir_args` is empty).
+///
+/// A `--` end-of-options terminator additionally separates the flags from
+/// the prompt (emitted unconditionally, even with no `--add-dir`): it is a
+/// second, independent cutoff for the variadic list AND keeps a prompt that
+/// happens to start with `-` from being parsed as a flag. The combined
+/// `--add-dir=<dir> -- "<prompt>"` shape is live-verified against the CLI.
 fn build_continuation_claude_command(
     claude_bin: String,
     pinned_session_id: &str,
@@ -1792,6 +1798,7 @@ fn build_continuation_claude_command(
         pinned_session_id.to_string(),
     ];
     command_vec.extend(add_dir_args);
+    command_vec.push("--".to_string());
     command_vec.push(prompt);
     command_vec
 }
@@ -2846,10 +2853,9 @@ mod tests {
         );
     }
 
-    /// The pinned `--session-id <uuid>` pair sits among the flags, BEFORE the
-    /// trailing positional prompt (the CLI treats everything after the flags
-    /// as prompt text), with attached-form `--add-dir=` siblings preserved
-    /// in between.
+    /// The pinned `--session-id <uuid>` pair sits among the flags, BEFORE
+    /// the `--` terminator and the trailing positional prompt, with
+    /// attached-form `--add-dir=` siblings preserved in between.
     #[test]
     fn continuation_command_pins_session_id_before_positional_prompt() {
         let cmd = build_continuation_claude_command(
@@ -2861,7 +2867,7 @@ mod tests {
         assert_eq!(
             cmd.join("|"),
             "claude|--dangerously-skip-permissions|--session-id|abc-123|\
-             --add-dir=D:/wt/sibling|do the thing"
+             --add-dir=D:/wt/sibling|--|do the thing"
         );
     }
 
@@ -2869,7 +2875,7 @@ mod tests {
     /// the variadic `--add-dir <directories...>` (space form) swallows the
     /// trailing positional prompt as a bogus extra directory, so the argv
     /// must carry attached-form `--add-dir=` tokens only, with the prompt
-    /// as the final element.
+    /// as the final element behind the `--` terminator.
     #[test]
     fn continuation_command_add_dir_attached_form_keeps_prompt_positional() {
         let cmd = build_continuation_claude_command(
@@ -2886,9 +2892,31 @@ mod tests {
             Some("run /implement-plan plans/x.md"),
             "prompt must be the trailing positional"
         );
+        assert_eq!(
+            cmd.get(cmd.len() - 2).map(String::as_str),
+            Some("--"),
+            "the end-of-options terminator must immediately precede the prompt"
+        );
         assert!(
             !cmd.iter().any(|a| a == "--add-dir"),
             "bare variadic --add-dir must never appear in the spawn argv: {cmd:?}"
+        );
+    }
+
+    /// No sibling worktrees → no `--add-dir=`, but the `--` stays so a
+    /// prompt starting with `-` can never be parsed as a flag.
+    #[test]
+    fn continuation_command_single_repo_still_emits_terminator() {
+        let cmd = build_continuation_claude_command(
+            "claude".to_string(),
+            "abc-123",
+            vec![],
+            "-prompt with dash".to_string(),
+        );
+        assert_eq!(
+            cmd.join("|"),
+            "claude|--dangerously-skip-permissions|--session-id|abc-123|\
+             --|-prompt with dash"
         );
     }
 

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1770,6 +1770,15 @@ fn pick_continuation_page(
 /// Build the gate-continuation `claude` spawn argv. Pure for unit-testing:
 /// every flag — including the pre-pinned `--session-id` — MUST precede the
 /// trailing positional prompt arg, or the CLI eats it as prompt text.
+///
+/// `add_dir_args` must be ATTACHED-form `--add-dir=<path>` tokens (what
+/// [`crate::agent_worktree::isolated_edit::claude_add_dir_args`] emits).
+/// The space-separated pair form is FORBIDDEN here: `--add-dir` is variadic
+/// (`<directories...>`), so in pair form the dir list would consume the
+/// trailing positional prompt as a bogus extra directory and the spawned
+/// session would idle at an empty REPL — the 2026-06-12 multi-repo
+/// gate-continuation incident (single-repo continuations were immune only
+/// because their `add_dir_args` is empty).
 fn build_continuation_claude_command(
     claude_bin: String,
     pinned_session_id: &str,
@@ -1869,7 +1878,8 @@ async fn run_continuation_terminal(
     // permission prompts — an unattended gate continuation has no operator to
     // answer them.
     let claude_bin = claude_bin_path();
-    // Phase 2c — `--add-dir <sibling>` for each non-cwd worktree of this
+    // Phase 2c — `--add-dir=<sibling>` (attached form — see the
+    // build_continuation_claude_command doc) for each non-cwd worktree of this
     // continuation's context so the launched `claude` can edit sibling repos
     // that materialized on disk but aren't the process cwd. Flags MUST precede
     // the trailing positional prompt arg. Empty for single-repo continuations.
@@ -2838,19 +2848,47 @@ mod tests {
 
     /// The pinned `--session-id <uuid>` pair sits among the flags, BEFORE the
     /// trailing positional prompt (the CLI treats everything after the flags
-    /// as prompt text), with `--add-dir` siblings preserved in between.
+    /// as prompt text), with attached-form `--add-dir=` siblings preserved
+    /// in between.
     #[test]
     fn continuation_command_pins_session_id_before_positional_prompt() {
         let cmd = build_continuation_claude_command(
             "claude".to_string(),
             "abc-123",
-            vec!["--add-dir".to_string(), "D:/wt/sibling".to_string()],
+            vec!["--add-dir=D:/wt/sibling".to_string()],
             "do the thing".to_string(),
         );
         assert_eq!(
             cmd.join("|"),
             "claude|--dangerously-skip-permissions|--session-id|abc-123|\
-             --add-dir|D:/wt/sibling|do the thing"
+             --add-dir=D:/wt/sibling|do the thing"
+        );
+    }
+
+    /// Regression for the 2026-06-12 multi-repo gate-continuation incident:
+    /// the variadic `--add-dir <directories...>` (space form) swallows the
+    /// trailing positional prompt as a bogus extra directory, so the argv
+    /// must carry attached-form `--add-dir=` tokens only, with the prompt
+    /// as the final element.
+    #[test]
+    fn continuation_command_add_dir_attached_form_keeps_prompt_positional() {
+        let cmd = build_continuation_claude_command(
+            "claude".to_string(),
+            "abc-123",
+            vec![
+                "--add-dir=D:/wt/coord".to_string(),
+                "--add-dir=D:/wt/web".to_string(),
+            ],
+            "run /implement-plan plans/x.md".to_string(),
+        );
+        assert_eq!(
+            cmd.last().map(String::as_str),
+            Some("run /implement-plan plans/x.md"),
+            "prompt must be the trailing positional"
+        );
+        assert!(
+            !cmd.iter().any(|a| a == "--add-dir"),
+            "bare variadic --add-dir must never appear in the spawn argv: {cmd:?}"
         );
     }
 

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -539,24 +539,28 @@ pub fn session_worktrees_env_value(worktrees: &[MaterializedWorktree]) -> Option
     Some(joined)
 }
 
-/// Build the `--add-dir <path>` argument pairs for the SIBLING worktrees of
+/// Build the `--add-dir=<path>` arguments for the SIBLING worktrees of
 /// a launch — every worktree except the first (the first is the process
 /// cwd, which `claude` already roots at, so it needs no `--add-dir`). Used
 /// to append to a `claude` command so a multi-repo session can edit the
 /// non-cwd repos too. Returns an empty vec for single-repo (or empty)
 /// launches.
 ///
+/// ATTACHED (`=`) form, one self-contained token per sibling — NEVER the
+/// space-separated pair. The CLI's `--add-dir <directories...>` is VARIADIC:
+/// in space form it consumes every following non-flag arg up to the next
+/// flag, including a trailing positional prompt — which it then swallows as
+/// a bogus extra "directory", leaving the spawned session idle at an empty
+/// REPL (the 2026-06-12 multi-repo gate-continuation incident). The `=` form
+/// binds exactly one value (live-verified against the CLI: the directory
+/// registers AND a trailing prompt still parses).
+///
 /// Order matches `worktrees[1..]` so the resulting args are deterministic.
 pub fn claude_add_dir_args(worktrees: &[MaterializedWorktree]) -> Vec<String> {
     worktrees
         .iter()
         .skip(1)
-        .flat_map(|w| {
-            [
-                "--add-dir".to_string(),
-                w.worktree_path.display().to_string(),
-            ]
-        })
+        .map(|w| format!("--add-dir={}", w.worktree_path.display()))
         .collect()
 }
 
@@ -979,8 +983,8 @@ mod tests {
 
     #[test]
     fn claude_add_dir_args_skips_the_first_worktree() {
-        // `--add-dir` is appended once per SIBLING (worktrees[1..]); the first
-        // worktree is the process cwd and needs no `--add-dir`.
+        // `--add-dir=` is appended once per SIBLING (worktrees[1..]); the
+        // first worktree is the process cwd and needs no `--add-dir`.
         let (wa, _ca) = repo_fixture("qontinui-runner");
         let (wb, _cb) = repo_fixture("qontinui-coord");
         let worktrees = vec![wa, wb];
@@ -993,9 +997,27 @@ mod tests {
             .to_string();
         assert_eq!(
             args,
-            vec!["--add-dir".to_string(), coord_path],
-            "exactly one --add-dir pair, for the sibling (non-cwd) repo"
+            vec![format!("--add-dir={coord_path}")],
+            "exactly one --add-dir= token, for the sibling (non-cwd) repo"
         );
+    }
+
+    #[test]
+    fn claude_add_dir_args_are_attached_form_never_variadic_pairs() {
+        // The space-separated pair form is FORBIDDEN: the CLI's variadic
+        // `--add-dir <directories...>` swallows a trailing positional prompt
+        // (2026-06-12 gate-continuation incident). Every emitted arg must be
+        // a self-contained `--add-dir=<path>` token.
+        let (wa, _ca) = repo_fixture("qontinui-runner");
+        let (wb, _cb) = repo_fixture("qontinui-coord");
+        let (wc, _cc) = repo_fixture("qontinui-web");
+
+        for arg in claude_add_dir_args(&[wa, wb, wc]) {
+            assert!(
+                arg.starts_with("--add-dir=") && arg.len() > "--add-dir=".len(),
+                "arg {arg:?} must be attached-form --add-dir=<path>"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/commands/productivity.rs
+++ b/src-tauri/src/commands/productivity.rs
@@ -849,7 +849,7 @@ fn next_worker_title(manager: &TerminalManager) -> String {
     format!("Worker {}", max_n + 1)
 }
 
-/// Phase 2c — splice `--add-dir <sibling>` flags into a `claude` command
+/// Phase 2c — splice `--add-dir=<sibling>` flags into a `claude` command
 /// line built for the interactive shell (the worker/coordinator launch
 /// strings). The flags MUST land BEFORE any trailing positional prompt arg
 /// (claude treats the last positional as the prompt), so they are inserted
@@ -857,22 +857,33 @@ fn next_worker_title(manager: &TerminalManager) -> String {
 /// builders emit. When that anchor is absent (defensive) or there are no
 /// sibling dirs, the command is returned unchanged.
 ///
+/// ATTACHED (`=`) form is load-bearing here, not cosmetic: the CLI's
+/// `--add-dir <directories...>` is variadic, so the space form would
+/// consume the coordinator builder's trailing positional prompt
+/// (`(Get-Content -Raw '…')` expands to it) as a bogus extra directory —
+/// the same swallow as the 2026-06-12 gate-continuation incident.
+///
 /// Each path is single-quoted PowerShell-style (with `'` doubled) so paths
-/// with spaces survive the shell — matching the coordinator builder's own
-/// quoting of the prompt-file path.
+/// with spaces survive the shell — PowerShell concatenates the bare
+/// `--add-dir=` prefix with the adjacent quoted segment into one argv
+/// element. Matches the coordinator builder's own quoting of the
+/// prompt-file path.
 fn append_claude_add_dir(command: String, add_dir_args: &[String]) -> String {
     if add_dir_args.is_empty() {
         return command;
     }
-    // `add_dir_args` is a flat [--add-dir, <path>, --add-dir, <path>, …]
-    // vec (from `claude_add_dir_args`). Re-quote each path value.
+    // `add_dir_args` is a flat [--add-dir=<path>, …] vec of attached-form
+    // tokens (from `claude_add_dir_args`). Re-quote each path value.
     let mut rendered = String::new();
-    let mut it = add_dir_args.iter();
-    while let (Some(flag), Some(path)) = (it.next(), it.next()) {
+    for arg in add_dir_args {
+        let Some((flag, path)) = arg.split_once('=') else {
+            // Defensive: never emit a bare variadic flag into the line.
+            continue;
+        };
         let quoted = path.replace('\'', "''");
         rendered.push(' ');
         rendered.push_str(flag);
-        rendered.push_str(" '");
+        rendered.push_str("='");
         rendered.push_str(&quoted);
         rendered.push('\'');
     }
@@ -2215,15 +2226,16 @@ mod launch_intent_tests {
     #[test]
     fn append_add_dir_inserts_after_skip_permissions_flag() {
         // Coordinator-shape command: a trailing positional prompt arg
-        // (`(Get-Content ...)`) must stay LAST — the --add-dir flags land
-        // immediately after `--dangerously-skip-permissions`.
+        // (`(Get-Content ...)`) must stay LAST — the --add-dir= flags land
+        // immediately after `--dangerously-skip-permissions`, in attached
+        // form so the variadic CLI flag cannot swallow the prompt.
         let cmd =
             "claude --dangerously-skip-permissions (Get-Content -Raw 'C:\\tmp\\p.md')".to_string();
-        let args = vec!["--add-dir".to_string(), "/abs/qontinui-coord".to_string()];
+        let args = vec!["--add-dir=/abs/qontinui-coord".to_string()];
         let out = append_claude_add_dir(cmd, &args);
         assert_eq!(
             out,
-            "claude --dangerously-skip-permissions --add-dir '/abs/qontinui-coord' \
+            "claude --dangerously-skip-permissions --add-dir='/abs/qontinui-coord' \
              (Get-Content -Raw 'C:\\tmp\\p.md')"
         );
     }
@@ -2232,28 +2244,39 @@ mod launch_intent_tests {
     fn append_add_dir_handles_multiple_siblings() {
         let cmd = "claude --dangerously-skip-permissions".to_string();
         let args = vec![
-            "--add-dir".to_string(),
-            "/abs/repo-a".to_string(),
-            "--add-dir".to_string(),
-            "/abs/repo-b".to_string(),
+            "--add-dir=/abs/repo-a".to_string(),
+            "--add-dir=/abs/repo-b".to_string(),
         ];
         let out = append_claude_add_dir(cmd, &args);
         assert_eq!(
             out,
-            "claude --dangerously-skip-permissions --add-dir '/abs/repo-a' --add-dir '/abs/repo-b'"
+            "claude --dangerously-skip-permissions --add-dir='/abs/repo-a' --add-dir='/abs/repo-b'"
         );
     }
 
     #[test]
     fn append_add_dir_quotes_paths_with_spaces_and_quotes() {
         let cmd = "claude --dangerously-skip-permissions".to_string();
-        let args = vec!["--add-dir".to_string(), "/has space/o'brien".to_string()];
+        let args = vec!["--add-dir=/has space/o'brien".to_string()];
         let out = append_claude_add_dir(cmd, &args);
         // Single-quoted, with the embedded `'` doubled (PowerShell escape).
+        // PS concatenates the bare `--add-dir=` prefix with the adjacent
+        // quoted segment into ONE argv element for the claude process.
         assert_eq!(
             out,
-            "claude --dangerously-skip-permissions --add-dir '/has space/o''brien'"
+            "claude --dangerously-skip-permissions --add-dir='/has space/o''brien'"
         );
+    }
+
+    #[test]
+    fn append_add_dir_skips_malformed_bare_flag_tokens() {
+        // Defensive: a bare variadic `--add-dir` token (the pre-fix pair
+        // form) must never be spliced into the line — it would swallow the
+        // coordinator's trailing positional prompt.
+        let cmd = "claude --dangerously-skip-permissions".to_string();
+        let args = vec!["--add-dir".to_string(), "/abs/repo-a".to_string()];
+        let out = append_claude_add_dir(cmd.clone(), &args);
+        assert_eq!(out, cmd, "pair-form tokens are dropped, command unchanged");
     }
 
     #[test]

--- a/src-tauri/src/terminal/manager.rs
+++ b/src-tauri/src/terminal/manager.rs
@@ -364,8 +364,7 @@ mod tests {
         assert!(command_implies_bypass_permissions(&argv(&[
             "claude",
             "--dangerously-skip-permissions",
-            "--add-dir",
-            "/some/worktree",
+            "--add-dir=/some/worktree",
             "run /implement-plan",
         ])));
     }


### PR DESCRIPTION
## Summary

Fixes the 2026-06-12 multi-repo gate-continuation incident: the spawned `claude` session sat idle at an empty REPL because its initial prompt was never submitted. Supersedes #553 (same incident, narrower scope — see below).

**Root cause.** The claude CLI's `--add-dir <directories...>` is **variadic** — in space-separated form it consumes every following non-flag arg up to the next flag, including the trailing positional prompt, which it swallows as a bogus extra "directory". `build_continuation_claude_command` emitted exactly that shape (`… --add-dir <sibling> "<prompt>"`), confirmed on the live wedged process's command line (`Win32_Process`). Single-repo continuations were immune only because their add-dir list is empty. The coordinator launch line has the same latent swallow: `append_claude_add_dir` splices `--add-dir '<sibling>'` directly before the PowerShell-expanded positional prompt (`(Get-Content -Raw …)`). The worker line has no trailing positional and was safe.

**Fix (two independent layers).**
1. **Attached form at the emitter:** `claude_add_dir_args` now produces self-contained `--add-dir=<path>` tokens, so *every* consumer (continuation argv + coordinator splice) inherits safety. `append_claude_add_dir` re-quotes the attached form PowerShell-style and defensively drops bare pair-form tokens.
2. **Unconditional `--` end-of-options terminator** before the continuation prompt (grafted from #553): a second cutoff for the variadic list, and keeps a prompt that starts with `-` from being parsed as a flag.

**CLI semantics verified empirically (`--print` probes):**
- `claude --print --add-dir <dir> "prompt"` → `Error: Input must be provided either through stdin or as a prompt argument` (bug reproduced)
- `claude --print --add-dir=<dir> "prompt"` → prompt parses **and** the directory registers
- `claude --print --add-dir=<dir> -- "prompt"` → `OK` (combined shape)

**Why supersede #553:** the `--` terminator alone fixes only the gate-continuation argv; the coordinator splice path keeps emitting the variadic pair form directly before its positional prompt. Fixing the emitter covers both, and this PR carries #553's terminator as defense-in-depth anyway.

**Regression tests** pin: no bare `--add-dir` token in the continuation argv, `--` immediately precedes the trailing prompt (incl. single-repo dash-prompt case), emitter output is attached-form only, pair-form input is never spliced into a launch line.

Recovery recipe for any already-wedged session (independent of this fix): `POST :9876/terminals/{id}/submit-prompt`.

After merge: **primary rebuild + restart required** (same as #554) for the live runner to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)