### PR TITLE
runner: manual-test-loop iter 1 — heartbeat lan_reachable honesty (advertise loopback-only bind)

### DIFF
--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -354,6 +354,17 @@ pub struct AppState {
     /// Actual port the HTTP API server bound to.
     /// Set by `mcp_api::start_server` after successful bind.
     pub api_port: AtomicU16,
+    /// Whether the HTTP API server's actual bound address is LAN-reachable
+    /// (i.e. it bound a non-loopback interface). Set by
+    /// `mcp_api::start_server` from the listener's real local address at
+    /// bind time — currently always `false` because `try_bind_port`
+    /// intentionally binds `127.0.0.1` only — but DERIVED rather than
+    /// hardcoded so a future non-loopback bind flips it automatically.
+    /// Forwarded on backend heartbeats as `lan_reachable` so the fleet
+    /// registry stops handing mobile clients an advertised LAN `ip:port`
+    /// the runner does not actually serve (plan
+    /// 2026-06-12-mobile-account-usage-error-recovery, runner P1).
+    pub api_lan_bound: AtomicBool,
     /// Shared PID tracker for spawned AI (Claude CLI) processes.
     /// Shared between AppState (for shutdown cleanup) and ApiState (for stop endpoints).
     pub ai_pid_tracker: Arc<Mutex<Vec<u32>>>,

--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -18,6 +18,18 @@ struct HeartbeatPayload {
     hostname: String,
     ip: String,
     port: u16,
+    /// Reachability honesty (plan
+    /// 2026-06-12-mobile-account-usage-error-recovery, runner P1): whether
+    /// the advertised `ip:port` is actually served on a LAN-reachable
+    /// (non-loopback) interface. Derived at bind time from the API
+    /// listener's REAL local address (`AppState.api_lan_bound`, set in
+    /// `mcp_api::start_server`) — currently always `false` because the
+    /// runner API intentionally binds `127.0.0.1` only
+    /// (`mcp_api::try_bind_port`) while `ip` reports the machine's LAN IP.
+    /// Consumers (backend fleet registry → mobile) should treat `false` as
+    /// "do not dial `ip:port` directly; use a loopback path (adb reverse)
+    /// or a proxy". Additive field — backends that don't know it ignore it.
+    lan_reachable: bool,
     instance_name: Option<String>,
     os: String,
     os_version: Option<String>,
@@ -182,6 +194,7 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
                     hostname: hostname.clone(),
                     ip,
                     port,
+                    lan_reachable: app_state.api_lan_bound.load(Ordering::Relaxed),
                     instance_name: instance_name.clone(),
                     os: os.clone(),
                     os_version: None,
@@ -272,4 +285,66 @@ fn get_local_ip() -> Option<String> {
 /// Fallback when PG query fails — returns empty.
 fn get_running_tasks_fallback() -> (u32, Vec<String>) {
     (0, vec![])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Loopback bind ⇒ heartbeat advertises `lan_reachable: false`, with the
+    /// flag DERIVED from a listener's real bound address through the same
+    /// seam `mcp_api::start_server` uses (`lan_reachable_for_bound_addr`),
+    /// not hardcoded. Also asserts the payload stays backward compatible:
+    /// the pre-existing keys are still emitted alongside the new field.
+    #[test]
+    fn payload_serializes_lan_reachable_false_when_bound_to_loopback() {
+        // Bind exactly like the runner API does today: loopback only.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local_addr");
+        let lan_reachable = crate::mcp_api::lan_reachable_for_bound_addr(&addr);
+
+        let payload = HeartbeatPayload {
+            hostname: "test-host".to_string(),
+            // The advertised LAN IP — the half that made the old payload
+            // dishonest when paired with a loopback-only bind.
+            ip: "192.168.8.192".to_string(),
+            port: addr.port(),
+            lan_reachable,
+            instance_name: None,
+            os: "windows".to_string(),
+            os_version: None,
+            running_task_count: 0,
+            running_task_ids: vec![],
+            derived_status: "healthy".to_string(),
+            ui_error: None,
+            recent_crash: None,
+        };
+
+        let json = serde_json::to_value(&payload).expect("payload serializes");
+        assert_eq!(json["lan_reachable"], serde_json::Value::Bool(false));
+        // Backward compatibility: existing wire keys unchanged.
+        assert_eq!(json["ip"], "192.168.8.192");
+        assert_eq!(json["port"], addr.port());
+        assert_eq!(json["hostname"], "test-host");
+        assert_eq!(json["derived_status"], "healthy");
+        assert!(json.as_object().unwrap().contains_key("ui_error"));
+    }
+
+    /// The derivation must flip to `true` for a non-loopback bind (all-
+    /// interfaces or a concrete LAN address) so a future bind-strategy
+    /// change is advertised honestly without touching the heartbeat.
+    #[test]
+    fn lan_reachable_derivation_flips_true_for_non_loopback_bind() {
+        let unspecified: std::net::SocketAddr = "0.0.0.0:9876".parse().unwrap();
+        assert!(crate::mcp_api::lan_reachable_for_bound_addr(&unspecified));
+
+        let lan: std::net::SocketAddr = "192.168.8.192:9876".parse().unwrap();
+        assert!(crate::mcp_api::lan_reachable_for_bound_addr(&lan));
+
+        let loopback: std::net::SocketAddr = "127.0.0.1:9876".parse().unwrap();
+        assert!(!crate::mcp_api::lan_reachable_for_bound_addr(&loopback));
+
+        let v6_loopback: std::net::SocketAddr = "[::1]:9876".parse().unwrap();
+        assert!(!crate::mcp_api::lan_reachable_for_bound_addr(&v6_loopback));
+    }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -790,6 +790,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         api_ready: AtomicBool::new(false),              // Set when MCP API server binds
         frontend_ready: AtomicBool::new(false), // Set on first successful UI Bridge IPC response
         api_port: AtomicU16::new(crate::mcp::types::get_mcp_api_port()), // Updated when server binds
+        api_lan_bound: AtomicBool::new(false), // Derived from the actual bound address when server binds
         ai_pid_tracker: Arc::new(std::sync::Mutex::new(Vec::new())),
         canvas_state: Arc::new(tokio::sync::RwLock::new(
             crate::mcp::canvas::CanvasState::new(),

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -2361,6 +2361,19 @@ fn runner_panic_handler(err: Box<dyn std::any::Any + Send + 'static>) -> axum::r
         .into_response()
 }
 
+/// Whether a bound socket address is reachable from the LAN: any
+/// non-loopback IP counts (including the unspecified address `0.0.0.0`,
+/// which listens on all interfaces); `127.0.0.1`/`::1` does not.
+///
+/// Used at bind time to populate `AppState.api_lan_bound`, which the
+/// backend heartbeat advertises as `lan_reachable` (plan
+/// 2026-06-12-mobile-account-usage-error-recovery, runner P1). Derived
+/// from the listener's REAL local address so a future non-loopback bind
+/// flips the advertisement without further changes.
+pub(crate) fn lan_reachable_for_bound_addr(addr: &std::net::SocketAddr) -> bool {
+    !addr.ip().is_loopback()
+}
+
 /// Try to bind to a port with SO_REUSEADDR
 fn try_bind_port(port: u16) -> Result<std::net::TcpListener, std::io::Error> {
     // Create socket with SO_REUSEADDR to allow binding even if there are zombie connections
@@ -2418,6 +2431,19 @@ pub async fn start_server(
         info!("MCP API server: try_bind_port({})...", try_port);
         match try_bind_port(try_port) {
             Ok(std_listener) => {
+                // Record whether the ACTUAL bound address is LAN-reachable
+                // (non-loopback). Read from the listener rather than assumed,
+                // so the heartbeat's `lan_reachable` advertisement stays
+                // honest if the bind strategy ever changes. Currently always
+                // false: `try_bind_port` binds 127.0.0.1 only (intentional —
+                // see the comment there).
+                let lan_bound = std_listener
+                    .local_addr()
+                    .map(|addr| lan_reachable_for_bound_addr(&addr))
+                    .unwrap_or(false);
+                api_ready_flag
+                    .api_lan_bound
+                    .store(lan_bound, Ordering::Relaxed);
                 let listener = tokio::net::TcpListener::from_std(std_listener)?;
                 if try_port != port {
                     warn!(


### PR DESCRIPTION
- Heartbeat now reports `lan_reachable` honestly: when the API server is bound loopback-only, the runner advertises `lan_reachable: false` instead of implying LAN availability.
- Adds bind-address introspection in `heartbeat.rs` feeding the heartbeat payload.
- Exposes the reachability state via commands (`commands/mod.rs`) and the MCP API (`mcp_api.rs`).
- Pairs with qontinui-web #572 (heartbeat ingest + /operations/fleet forwarding) and qontinui-mobile #23 (lanReachable mapping).

Part of manual-test-loop iteration 1 (usage).