### PR TITLE
feat(nav): terminal-centric sidebar IA (@qontinui/navigation 0.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@dagrejs/dagre": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@qontinui/design-tokens": "^1.0.0",
-    "@qontinui/navigation": "^0.1.0",
+    "@qontinui/navigation": "^0.1.2",
     "@qontinui/shared-types": "^0.6.0",
     "@qontinui/ui-bridge": "^0.17.0",
     "@qontinui/ui-bridge-auto": "^0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
-        specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
+        specifier: ^0.1.2
+        version: 0.1.2(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1121,8 +1121,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@qontinui/navigation@0.1.1':
-    resolution: {integrity: sha512-X8MZfhzrTFvMO2VRLTiSeCldfZHcbxwX+au7mw6QibuQq9CnriGUVrSx9eubgJ/ZfNvH/hNVJ93tLFeE3KPhoQ==}
+  '@qontinui/navigation@0.1.2':
+    resolution: {integrity: sha512-+zh9r9GSJzhw6FwLdT9Y0TquGxk8VX8pG2XmI8rCYNidiVqSPMXa2q8Z0s/gMddqWem7kUlzTwQKdbnvpgSAUA==}
     peerDependencies:
       '@qontinui/ui-bridge': '>=0.3.0'
       react: ^18.0.0 || ^19.0.0
@@ -6128,7 +6128,7 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.2(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
     optionalDependencies:
       '@qontinui/ui-bridge': 0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
       react: 19.2.5

--- a/src/components/app/RunnerPageContext.tsx
+++ b/src/components/app/RunnerPageContext.tsx
@@ -1,143 +1,36 @@
 import { useMemo } from "react";
 import { usePageContext } from "@qontinui/ui-bridge";
-import type { MainTabId } from "./tab-types";
+import { deriveSection, TAB_LABELS, type MainTabId, type TabSection } from "./tab-types";
 
+/**
+ * Human label for each IA section — matches the sidebar group headers in
+ * `@qontinui/navigation` `groups.ts`. Used as the first breadcrumb segment.
+ */
+const SECTION_LABELS: Record<TabSection, string> = {
+  workspace: "Workspace",
+  review: "Review",
+  spend: "Spend",
+  automate: "Automate",
+  build: "Build",
+  insights: "Insights",
+  configure: "Configure",
+  dev: "Dev",
+  system: "System",
+};
+
+/**
+ * Publishes the active tab's page context to the UI Bridge.
+ *
+ * Name, section, and breadcrumb are all derived from the single source of
+ * truth in `tab-types.ts` (`TAB_LABELS` + `deriveSection`) rather than a
+ * hand-maintained per-tab map. This keeps the page context, the
+ * `GET /control/tabs` catalog, and the sidebar IA from ever drifting apart.
+ */
 export function RunnerPageContext({ activeTab }: { activeTab: MainTabId }) {
   const context = useMemo(() => {
-    if (activeTab.startsWith("settings")) {
-      return { name: "Settings", section: "configure", breadcrumb: ["Configure", "Settings"] };
-    }
-
-    const map: Record<string, { name: string; section: string; breadcrumb: string[] }> = {
-      "prompt-home": { name: "Home", section: "run", breadcrumb: ["Home"] },
-      "gui-automation": { name: "Execute", section: "run", breadcrumb: ["Run", "Execute"] },
-      active: { name: "Active Dashboard", section: "run", breadcrumb: ["Run", "Active Dashboard"] },
-      history: { name: "History", section: "run", breadcrumb: ["Run", "History"] },
-      runs: { name: "Runs", section: "run", breadcrumb: ["Run", "Runs"] },
-      "workflow-queue": {
-        name: "Workflow Queue",
-        section: "run",
-        breadcrumb: ["Run", "Workflow Queue"],
-      },
-      "run-recap": { name: "Run Recap", section: "observe", breadcrumb: ["Observe", "Run Recap"] },
-      "run-actions": {
-        name: "Run Actions",
-        section: "observe",
-        breadcrumb: ["Observe", "Run Actions"],
-      },
-      "run-image": {
-        name: "Image Recognition",
-        section: "observe",
-        breadcrumb: ["Observe", "Image Recognition"],
-      },
-      "run-findings": { name: "Findings", section: "observe", breadcrumb: ["Observe", "Findings"] },
-      "run-state-explorer": {
-        name: "State Explorer",
-        section: "observe",
-        breadcrumb: ["Observe", "State Explorer"],
-      },
-      "run-tests": {
-        name: "Test Results",
-        section: "observe",
-        breadcrumb: ["Observe", "Test Results"],
-      },
-      "run-ai-output": {
-        name: "AI Output",
-        section: "observe",
-        breadcrumb: ["Observe", "AI Output"],
-      },
-      "run-ai-data": {
-        name: "AI Data Viewer",
-        section: "observe",
-        breadcrumb: ["Observe", "AI Data Viewer"],
-      },
-      "run-statistics": {
-        name: "Statistics",
-        section: "observe",
-        breadcrumb: ["Observe", "Statistics"],
-      },
-      "run-traces": { name: "Traces", section: "observe", breadcrumb: ["Observe", "Traces"] },
-      "unified-workflow-builder": {
-        name: "Workflow Builder",
-        section: "build",
-        breadcrumb: ["Build", "Workflow Builder"],
-      },
-      "dag-workflow-editor": {
-        name: "DAG Workflow Editor",
-        section: "build",
-        breadcrumb: ["Build", "DAG Workflow Editor"],
-      },
-      library: { name: "Library", section: "build", breadcrumb: ["Build", "Library"] },
-      "step-builders": { name: "Library", section: "build", breadcrumb: ["Build", "Library"] },
-      capture: { name: "Capture", section: "build", breadcrumb: ["Build", "Capture"] },
-      triggers: { name: "Triggers", section: "configure", breadcrumb: ["Configure", "Triggers"] },
-      tasks: { name: "Scheduler", section: "configure", breadcrumb: ["Configure", "Scheduler"] },
-      "config-log-sources": {
-        name: "Log Sources",
-        section: "configure",
-        breadcrumb: ["Configure", "Log Sources"],
-      },
-      "config-findings": {
-        name: "Findings Config",
-        section: "configure",
-        breadcrumb: ["Configure", "Findings"],
-      },
-      "config-hooks": { name: "Hooks", section: "configure", breadcrumb: ["Configure", "Hooks"] },
-      "config-ui-bridge": {
-        name: "UI Bridge",
-        section: "tools",
-        breadcrumb: ["Tools", "UI Bridge"],
-      },
-      terminal: { name: "Terminal", section: "tools", breadcrumb: ["Tools", "Terminal"] },
-      specs: { name: "Specs", section: "tools", breadcrumb: ["Tools", "Specs"] },
-      "state-machine": {
-        name: "UI Bridge State Machine",
-        section: "tools",
-        breadcrumb: ["Tools", "UI Bridge State Machine"],
-      },
-      "generator-eval": {
-        name: "Generator Eval",
-        section: "tools",
-        breadcrumb: ["Tools", "Generator Eval"],
-      },
-      "meta-optimizer": {
-        name: "Meta-Optimizer",
-        section: "observe",
-        breadcrumb: ["Observe", "Meta-Optimizer"],
-      },
-      "orchestration-loop": {
-        name: "Orchestration Loop",
-        section: "tools",
-        breadcrumb: ["Tools", "Orchestration Loop"],
-      },
-      "image-quality-tests": {
-        name: "Image Quality Tests",
-        section: "tools",
-        breadcrumb: ["Tools", "Image Quality Tests"],
-      },
-      "error-monitor": {
-        name: "Error Monitor",
-        section: "system",
-        breadcrumb: ["System", "Error Monitor"],
-      },
-      processes: {
-        name: "Process Manager",
-        section: "system",
-        breadcrumb: ["System", "Process Manager"],
-      },
-      reflection: { name: "Reflection", section: "system", breadcrumb: ["System", "Reflection"] },
-      architecture: {
-        name: "Architecture",
-        section: "system",
-        breadcrumb: ["System", "Architecture"],
-      },
-      logs: { name: "Logs", section: "system", breadcrumb: ["System", "Logs"] },
-      help: { name: "Help", section: "system", breadcrumb: ["Help"] },
-      ai: { name: "AI Output", section: "observe", breadcrumb: ["Observe", "AI Output"] },
-      wrappers: { name: "Wrappers", section: "wrappers", breadcrumb: ["Wrappers"] },
-    };
-
-    return map[activeTab] ?? { name: activeTab, section: "other", breadcrumb: [activeTab] };
+    const section = deriveSection(activeTab);
+    const name = TAB_LABELS[activeTab] ?? activeTab;
+    return { name, section, breadcrumb: [SECTION_LABELS[section], name] };
   }, [activeTab]);
 
   usePageContext(context);

--- a/src/components/app/tab-types.ts
+++ b/src/components/app/tab-types.ts
@@ -335,46 +335,72 @@ export const TAB_LABELS: Record<MainTabId, string> = {
 
 /**
  * Logical section a tab belongs to — surfaces in `GET /control/tabs` so
- * agents can navigate the 90+ tab catalog by grouping:
- *   - "nav":      sidebar top-level navigation tabs
- *   - "run":      run-detail sub-tabs (opened from a specific run)
- *   - "monitor":  live-monitor sub-tabs
- *   - "settings": settings panel sub-tabs
- *   - "build":    workflow / spec / state-machine builders
- *   - "config":   configuration tabs (log sources, findings, hooks, triggers, tasks)
- *   - "system":   everything else (help, skills, analytics, debugging views, …)
+ * agents can navigate the 100+ tab catalog by grouping. The vocabulary
+ * mirrors the terminal-centric sidebar IA (see `@qontinui/navigation`
+ * `groups.ts`) so the agent-facing catalog and the human sidebar agree:
+ *   - "workspace": daily entry points (Terminal, Home, Active, Productivity, …)
+ *   - "review":    runs, run-detail sub-tabs, memory, knowledge
+ *   - "spend":     token cost (LLM analytics, cost control)
+ *   - "automate":  scheduled / reactive agents (triggers, tasks, watchers)
+ *   - "build":     workflow / spec / state-machine builders + library
+ *   - "insights":  live monitoring + accumulated analysis (errors, monitor-* …)
+ *   - "configure": configuration tabs (config-*, event history)
+ *   - "dev":       dev-only tooling (generator eval, meta-optimizer, skills, …)
+ *   - "system":    settings panel + help + anything unclassified
  */
-export type TabSection = "nav" | "run" | "monitor" | "settings" | "build" | "config" | "system";
+export type TabSection =
+  | "workspace"
+  | "review"
+  | "spend"
+  | "automate"
+  | "build"
+  | "insights"
+  | "configure"
+  | "dev"
+  | "system";
 
-/**
- * Sidebar top-level navigation tabs. Explicit override — these don't share a
- * common prefix with each other, so we hand-list them rather than try to
- * infer them. Everything not in this set falls through to the prefix rule.
- */
-const NAV_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
+/** WORKSPACE — daily entry points. */
+const WORKSPACE_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
   "prompt-home",
   "gui-automation",
   "workflow-queue",
   "active",
-  "runs",
-  "history",
-  "error-monitor",
-  "processes",
   "terminal",
-  "wrappers",
   "productivity",
-  "regression",
 ]);
 
 /**
- * Workflow / spec / state-machine building tabs. Explicit — these have
- * mixed prefixes (state-*, spec*, capture, library, *-builder, …).
+ * REVIEW — runs and the intelligence reviewed afterwards. The `run-*`
+ * detail sub-tabs are covered by the prefix rule below.
+ */
+const REVIEW_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
+  "runs",
+  "history",
+  "ai",
+  "memory-search",
+  "knowledge-explorer",
+]);
+
+/** SPEND — token cost surfaces. */
+const SPEND_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
+  "llm-analytics",
+  "cost-control",
+]);
+
+/** AUTOMATE — scheduled / reactive agents. */
+const AUTOMATE_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
+  "triggers",
+  "tasks",
+  "watchers",
+]);
+
+/**
+ * BUILD — workflow / spec / state-machine builders and assets. Mixed
+ * prefixes (state-*, spec*, capture, library, *-builder, …), so explicit.
  */
 const BUILD_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
-  "state-machine",
-  "specs",
-  "capture",
-  "library",
+  "unified-workflow-builder",
+  "dag-workflow-editor",
   "step-builders",
   "check-builder",
   "check-group-builder",
@@ -382,30 +408,71 @@ const BUILD_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
   "task-builder",
   "context-builder",
   "playwright-test-builder",
-  "unified-workflow-builder",
-  "dag-workflow-editor",
+  "library",
+  "state-machine",
+  "specs",
+  "capture",
+  "regression",
+  "demo-video",
+  "product-tours",
+  "orchestration-loop",
+  "wrappers",
 ]);
 
 /**
- * Non-prefix-matching config tabs. The `config-*` family is picked up by
- * the prefix rule below; these are misc config-ish tabs without the prefix.
+ * INSIGHTS — live monitoring + accumulated analysis. The `monitor-*`
+ * family is covered by the prefix rule below.
  */
-const CONFIG_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>(["triggers", "tasks"]);
+const INSIGHTS_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
+  "error-monitor",
+  "processes",
+  "automation-health",
+  "activity-timeline",
+  "reflection",
+  "observations",
+  "architecture",
+  "api-surface",
+  "development-intelligence",
+  "project-explainer",
+  "decision-trail",
+  "session-recap",
+  "logs",
+  "evaluation",
+  "memory-federation",
+]);
+
+/** DEV — dev-only tooling (mostly `hiddenInProd` in the sidebar). */
+const DEV_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>([
+  "generator-eval",
+  "meta-optimizer",
+  "online-learning",
+  "skills",
+  "image-quality-tests",
+  "accessibility-explorer",
+]);
+
+/** CONFIGURE — misc config tabs without the `config-` prefix. */
+const CONFIGURE_TAB_IDS: ReadonlySet<MainTabId> = new Set<MainTabId>(["event-history"]);
 
 /**
- * Derive the section for a tab id. Prefix rule covers the large families
- * (run-*, monitor-*, settings-*, config-*); the explicit overrides above
- * capture sidebar nav and build/config tabs that don't share a prefix.
+ * Derive the section for a tab id. Explicit sets mirror the sidebar IA
+ * groups; prefix rules cover the large sub-tab families (run-* → review,
+ * monitor-* → insights, settings-* → system, config-* → configure).
  * Unknown ids fall back to "system".
  */
 export function deriveSection(id: MainTabId): TabSection {
-  if (NAV_TAB_IDS.has(id)) return "nav";
+  if (WORKSPACE_TAB_IDS.has(id)) return "workspace";
+  if (REVIEW_TAB_IDS.has(id)) return "review";
+  if (SPEND_TAB_IDS.has(id)) return "spend";
+  if (AUTOMATE_TAB_IDS.has(id)) return "automate";
   if (BUILD_TAB_IDS.has(id)) return "build";
-  if (CONFIG_TAB_IDS.has(id)) return "config";
-  if (id.startsWith("run-")) return "run";
-  if (id.startsWith("monitor-")) return "monitor";
-  if (id.startsWith("settings-") || id === "settings") return "settings";
-  if (id.startsWith("config-")) return "config";
+  if (INSIGHTS_TAB_IDS.has(id)) return "insights";
+  if (DEV_TAB_IDS.has(id)) return "dev";
+  if (CONFIGURE_TAB_IDS.has(id)) return "configure";
+  if (id.startsWith("run-")) return "review";
+  if (id.startsWith("monitor-")) return "insights";
+  if (id.startsWith("config-")) return "configure";
+  if (id.startsWith("settings-") || id === "settings") return "system";
   return "system";
 }
 

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -823,7 +823,7 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapsedChange }
         if (parsed) {
           return {
             activeItemId: activeTab,
-            expandedGroups: parsed.expandedGroups ?? new Set(["run", "system"]),
+            expandedGroups: parsed.expandedGroups ?? new Set(["workspace", "review", "system"]),
             expandedItems: parsed.expandedItems ?? new Set(),
             secondarySidebar: { isOpen: false, parentId: null, items: [] },
             isCollapsed: collapsed,

--- a/src/lib/ui-bridge/UIBridgeHooks.tsx
+++ b/src/lib/ui-bridge/UIBridgeHooks.tsx
@@ -21,6 +21,7 @@ import {
 } from "@qontinui/ui-bridge";
 
 import { useVisionCacheInvalidation } from "../../hooks/useVisionCacheInvalidation";
+import { deriveSection, type MainTabId } from "../../components/app/tab-types";
 
 // ---------------------------------------------------------------------------
 // Props — the host component (AppContent) passes live state so hooks can
@@ -40,76 +41,25 @@ export interface UIBridgeHooksProps {
 }
 
 // -------------------------------------------------------------------------
-// Main navigation tab groups — aligned with RunnerPageContext sections.
+// Navigation sections — derived from the shared IA (`deriveSection` in
+// tab-types.ts) so the UI Bridge route-awareness and section states stay in
+// lockstep with the sidebar and the GET /control/tabs catalog, rather than a
+// hand-maintained group map that drifts.
 // -------------------------------------------------------------------------
-const TAB_GROUPS = {
-  run: ["gui-automation", "workflow-queue", "active"],
-  observe: [
-    "runs",
-    "history",
-    "run-recap",
-    "run-actions",
-    "run-image",
-    "run-findings",
-    "run-state-explorer",
-    "run-tests",
-    "run-ai-output",
-    "run-statistics",
-    "run-ai-data",
-    "run-traces",
-  ],
-  build: [
-    "unified-workflow-builder",
-    "step-builders",
-    "library",
-    "capture",
-    "check-builder",
-    "check-group-builder",
-    "shell-command-builder",
-    "task-builder",
-    "context-builder",
-    "playwright-test-builder",
-  ],
-  configure: ["config-findings", "config-hooks", "config-log-sources", "triggers", "tasks"],
-  tools: ["terminal", "specs", "state-machine", "generator-eval", "config-ui-bridge"],
-  system: [
-    "settings",
-    "settings-account",
-    "settings-dev-loop",
-    "settings-ai",
-    "settings-agentic",
-    "settings-self-healing",
-    "settings-world-state-verifier",
-    "settings-playwright",
-    "settings-mobile",
-    "settings-discovery",
-    "settings-backend-connection",
-    "settings-mcp",
-    "settings-log-sources",
-    "settings-execution-variables",
-    "settings-general",
-    "settings-storage",
-    "settings-backup",
-    "settings-instances",
-    "settings-debug",
-    "settings-updates",
-    "help",
-    "error-monitor",
-    "processes",
-    "reflection",
-    "architecture",
-  ],
-} satisfies Record<string, readonly string[]>;
+const NAV_SECTIONS = [
+  "workspace",
+  "review",
+  "spend",
+  "automate",
+  "build",
+  "insights",
+  "configure",
+  "dev",
+  "system",
+] as const;
 
 /** All section state IDs — used as fromStates for cross-section transitions. */
-const ANY_SECTION = [
-  "section-run",
-  "section-observe",
-  "section-build",
-  "section-configure",
-  "section-tools",
-  "section-system",
-] as const;
+const ANY_SECTION = NAV_SECTIONS.map((s) => `section-${s}`);
 
 export function UIBridgeHooks({
   activeTab,
@@ -130,20 +80,12 @@ export function UIBridgeHooks({
   useVisionCacheInvalidation();
 
   const routeInfo = useMemo(() => {
-    // Derive section from TAB_GROUPS
-    let section: string | undefined;
-    for (const [group, tabs] of Object.entries(TAB_GROUPS)) {
-      if (tabs.includes(activeTab) || (group === "system" && activeTab.startsWith("settings"))) {
-        section = group;
-        break;
-      }
-    }
-
+    const section = deriveSection(activeTab as MainTabId);
     return {
       pattern: `/${activeTab}`,
       params: {} as Record<string, string>,
       queryParams: {} as Record<string, string>,
-      routeStack: section ? [`/${section}`, `/${activeTab}`] : [`/${activeTab}`],
+      routeStack: [`/${section}`, `/${activeTab}`],
     };
   }, [activeTab]);
 
@@ -242,59 +184,78 @@ export function UIBridgeHooks({
   // Section states — one for each navigation section
   // -------------------------------------------------------------------------
 
+  // One UI state per IA section. activeWhen compares against deriveSection so
+  // membership never drifts from the sidebar / tab catalog. (Hooks can't be
+  // looped, so the nine sections are registered explicitly.)
+  const currentSection = deriveSection(activeTab as MainTabId);
+
   useUIState({
-    id: "section-run",
-    name: "Run Section Active",
-    activeWhen: () => TAB_GROUPS.run.includes(activeTab),
+    id: "section-workspace",
+    name: "Workspace Section Active",
+    activeWhen: () => currentSection === "workspace",
     group: "nav-section",
   });
 
   useUIState({
-    id: "section-observe",
-    name: "Observe Section Active",
-    activeWhen: () => TAB_GROUPS.observe.includes(activeTab),
+    id: "section-review",
+    name: "Review Section Active",
+    activeWhen: () => currentSection === "review",
+    group: "nav-section",
+  });
+
+  useUIState({
+    id: "section-spend",
+    name: "Spend Section Active",
+    activeWhen: () => currentSection === "spend",
+    group: "nav-section",
+  });
+
+  useUIState({
+    id: "section-automate",
+    name: "Automate Section Active",
+    activeWhen: () => currentSection === "automate",
     group: "nav-section",
   });
 
   useUIState({
     id: "section-build",
     name: "Build Section Active",
-    activeWhen: () => TAB_GROUPS.build.includes(activeTab),
+    activeWhen: () => currentSection === "build",
+    group: "nav-section",
+  });
+
+  useUIState({
+    id: "section-insights",
+    name: "Insights Section Active",
+    activeWhen: () => currentSection === "insights",
     group: "nav-section",
   });
 
   useUIState({
     id: "section-configure",
     name: "Configure Section Active",
-    activeWhen: () => TAB_GROUPS.configure.includes(activeTab),
+    activeWhen: () => currentSection === "configure",
     group: "nav-section",
   });
 
   useUIState({
-    id: "section-tools",
-    name: "Tools Section Active",
-    activeWhen: () => TAB_GROUPS.tools.includes(activeTab),
+    id: "section-dev",
+    name: "Dev Section Active",
+    activeWhen: () => currentSection === "dev",
     group: "nav-section",
   });
 
   useUIState({
     id: "section-system",
     name: "System Section Active",
-    activeWhen: () => TAB_GROUPS.system.includes(activeTab) || activeTab.startsWith("settings"),
+    activeWhen: () => currentSection === "system",
     group: "nav-section",
   });
 
   useUIStateGroup({
     id: "nav-section",
     name: "Navigation Sections",
-    states: [
-      "section-run",
-      "section-observe",
-      "section-build",
-      "section-configure",
-      "section-tools",
-      "section-system",
-    ],
+    states: ANY_SECTION,
   });
 
   // -------------------------------------------------------------------------
@@ -442,7 +403,7 @@ export function UIBridgeHooks({
   useUITransition({
     id: "open-action-modal",
     name: "Open Action Detail Modal",
-    fromStates: ["section-observe"],
+    fromStates: ["section-review"],
     activateStates: ["action-detail-modal"],
     exitStates: [],
   });
@@ -458,7 +419,7 @@ export function UIBridgeHooks({
   useUITransition({
     id: "open-image-modal",
     name: "Open Image Detail Modal",
-    fromStates: ["section-observe"],
+    fromStates: ["section-review"],
     activateStates: ["image-detail-modal"],
     exitStates: [],
   });


### PR DESCRIPTION
Adopts the new terminal-centric sidebar information architecture from `@qontinui/navigation@0.1.2`.

## What changes
- Bump `@qontinui/navigation` `^0.1.0` → `^0.1.2` (lockfile refreshed to 0.1.2).
- The shared sidebar regroups into **WORKSPACE / REVIEW / SPEND / AUTOMATE / BUILD / INSIGHTS / CONFIGURE / DEV / SYSTEM** with progressive disclosure: the daily set (Terminal, Home, Active, Productivity; Runs, Memory, Knowledge) stays expanded; the legacy workflow-builder + monitoring + accumulated-intelligence long tail collapses out of the default view. Terminal leads; token cost is promoted to its own SPEND group.
- `Sidebar.tsx`: update the first-load expanded-groups fallback to the new group ids (`workspace`/`review`/`system`).

Every route and tab id is preserved — deep-links and tab-activation are unaffected; long-tail items just move into collapsed groups.

## Verification
Built + ran an ephemeral temp runner via the supervisor: all 8 new group headers render, the 5 old headers (RUN/OBSERVE/LEARN/WRAPPERS/SCHEDULE) are gone, and every relocated item (Wrappers, Scheduled Tasks, Workflows, Orchestration, Watchers) remains reachable. Primary runner untouched.