### PR TITLE
runner: manual-test-loop iter 1 — resume verification + binding quarantine + zone restore fixes

### DIFF
--- a/src/components/terminal/ResumeFailedBanner.test.ts
+++ b/src/components/terminal/ResumeFailedBanner.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for the `ResumeFailedBanner` pure tab filters: which tabs surface in
+ * the "resume failed — retry" list vs the item-5 quarantine ("binding
+ * unverified — confirm resume") list. vitest runs `environment: "node"` with
+ * no React Testing Library, so we exercise the exported filters directly
+ * (same precedent as `useTerminalInitialization.test.ts`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { failedResumeTabs, quarantinedResumeTabs } from "./ResumeFailedBanner";
+import type { TerminalTab } from "./useTerminalManager";
+
+const tab = (id: string, overrides: Partial<TerminalTab> = {}): TerminalTab => ({
+  id,
+  title: id,
+  pid: 1234,
+  isAlive: true,
+  exitCode: null,
+  ...overrides,
+});
+
+describe("failedResumeTabs / quarantinedResumeTabs", () => {
+  it("a quarantined (guessed-binding) tab surfaces in the confirm list, not the failed list", () => {
+    const tabs = [tab("t-1", { resumeQuarantined: true, claudeSessionId: "sess-guessed" })];
+    expect(quarantinedResumeTabs(tabs).map((t) => t.id)).toEqual(["t-1"]);
+    expect(failedResumeTabs(tabs)).toEqual([]);
+  });
+
+  it("a failed tab surfaces in the failed list only", () => {
+    const tabs = [tab("t-1", { resumeFailed: true })];
+    expect(failedResumeTabs(tabs).map((t) => t.id)).toEqual(["t-1"]);
+    expect(quarantinedResumeTabs(tabs)).toEqual([]);
+  });
+
+  it("a confirmed-then-failed tab moves to the failed list — never listed twice", () => {
+    // Operator confirmed the quarantined resume; verification then failed.
+    // (`handleRetryResume` clears the quarantine flag, but even if a stale
+    // flag survived, failed wins.)
+    const tabs = [tab("t-1", { resumeQuarantined: true, resumeFailed: true })];
+    expect(failedResumeTabs(tabs).map((t) => t.id)).toEqual(["t-1"]);
+    expect(quarantinedResumeTabs(tabs)).toEqual([]);
+  });
+
+  it("dead tabs are dropped from both lists", () => {
+    const tabs = [
+      tab("t-1", { resumeQuarantined: true, isAlive: false }),
+      tab("t-2", { resumeFailed: true, isAlive: false }),
+    ];
+    expect(quarantinedResumeTabs(tabs)).toEqual([]);
+    expect(failedResumeTabs(tabs)).toEqual([]);
+  });
+
+  it("ordinary tabs (auto-resumed pinned restores, plain shells) surface in neither", () => {
+    const tabs = [tab("t-1"), tab("t-2", { claudeSessionId: "sess-pinned" })];
+    expect(quarantinedResumeTabs(tabs)).toEqual([]);
+    expect(failedResumeTabs(tabs)).toEqual([]);
+  });
+});

--- a/src/components/terminal/ResumeFailedBanner.tsx
+++ b/src/components/terminal/ResumeFailedBanner.tsx
@@ -11,67 +11,125 @@
  * time, so the backend liveness poll cannot flip it `poll-dead` while the
  * operator decides.
  *
- * Renders nothing when no tab is in the failed state. Visual language
- * follows {@link SessionRecoveryBanner} / {@link CoordWarningBanner}
- * (top-right advisory column).
+ * Boot-restore remediation item 5 adds a second list: QUARANTINED tabs —
+ * restored registry rows whose `bindOrigin` is not `"pinned"` (mtime-guessed
+ * binding that can name a foreign VS Code session). No resume was typed for
+ * them; the operator confirms with one click, which runs the exact same
+ * type-and-verify path as a retry.
+ *
+ * Renders nothing when no tab is in either state. Visual language follows
+ * {@link SessionRecoveryBanner} / {@link CoordWarningBanner} (top-right
+ * advisory column).
  */
 
-import { AlertTriangle, RotateCcw } from "lucide-react";
+import { AlertTriangle, HelpCircle, Play, RotateCcw } from "lucide-react";
 import type { TerminalTab } from "./useTerminalManager";
 
 export interface ResumeFailedBannerProps {
   tabs: TerminalTab[];
-  /** Re-run the type-and-verify resume for one failed tab. */
+  /** Re-run (or confirm-and-run) the type-and-verify resume for one tab. */
   onRetryResume: (tabId: string) => void;
 }
 
-/** The tabs this banner surfaces — exported for unit tests. */
+/** The failed-resume tabs this banner surfaces — exported for unit tests. */
 export function failedResumeTabs(tabs: TerminalTab[]): TerminalTab[] {
   return tabs.filter((t) => t.resumeFailed && t.isAlive !== false);
 }
 
+/**
+ * The quarantined (guessed-binding, awaiting operator confirm) tabs this
+ * banner surfaces — exported for unit tests. A tab that later FAILS its
+ * confirmed resume moves to the failed list, never both.
+ */
+export function quarantinedResumeTabs(tabs: TerminalTab[]): TerminalTab[] {
+  return tabs.filter((t) => t.resumeQuarantined && !t.resumeFailed && t.isAlive !== false);
+}
+
 export function ResumeFailedBanner({ tabs, onRetryResume }: ResumeFailedBannerProps) {
   const failed = failedResumeTabs(tabs);
-  if (failed.length === 0) return null;
+  const quarantined = quarantinedResumeTabs(tabs);
+  if (failed.length === 0 && quarantined.length === 0) return null;
 
   return (
     <div
       data-ui-bridge-id="terminal.resume-failed-banner"
       className="absolute top-2 right-2 z-30 w-[360px] rounded border shadow-lg p-2.5 bg-[#f7768e]/10 border-[#f7768e]/40"
     >
-      <div className="flex items-start gap-2">
-        <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5 text-[#f7768e]" />
-        <div className="flex-1 min-w-0">
-          <div className="text-[12px] font-semibold text-[#c0caf5] leading-snug">
-            {failed.length === 1
-              ? "Session resume failed"
-              : `${failed.length} session resumes failed`}
-          </div>
-          <ul className="mt-1.5 space-y-1">
-            {failed.map((t) => (
-              <li
-                key={t.id}
-                data-ui-bridge-id="terminal.resume-failed-banner-item"
-                data-terminal-id={t.id}
-                className="flex items-center gap-2 text-[11px] leading-snug"
-              >
-                <span className="text-[#c0caf5] font-medium truncate flex-1">{t.title}</span>
-                <button
-                  type="button"
-                  data-ui-bridge-id="terminal.resume-failed-retry"
+      {failed.length > 0 && (
+        <div className="flex items-start gap-2">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5 text-[#f7768e]" />
+          <div className="flex-1 min-w-0">
+            <div className="text-[12px] font-semibold text-[#c0caf5] leading-snug">
+              {failed.length === 1
+                ? "Session resume failed"
+                : `${failed.length} session resumes failed`}
+            </div>
+            <ul className="mt-1.5 space-y-1">
+              {failed.map((t) => (
+                <li
+                  key={t.id}
+                  data-ui-bridge-id="terminal.resume-failed-banner-item"
                   data-terminal-id={t.id}
-                  onClick={() => onRetryResume(t.id)}
-                  className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-[#f7768e]/40 text-[#f7768e] hover:bg-[#f7768e]/15 text-[10px]"
-                  title="Retype the resume command and re-verify the Claude UI handshake"
+                  className="flex items-center gap-2 text-[11px] leading-snug"
                 >
-                  <RotateCcw className="w-2.5 h-2.5" />
-                  Retry resume
-                </button>
-              </li>
-            ))}
-          </ul>
+                  <span className="text-[#c0caf5] font-medium truncate flex-1">{t.title}</span>
+                  <button
+                    type="button"
+                    data-ui-bridge-id="terminal.resume-failed-retry"
+                    data-terminal-id={t.id}
+                    onClick={() => onRetryResume(t.id)}
+                    className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-[#f7768e]/40 text-[#f7768e] hover:bg-[#f7768e]/15 text-[10px]"
+                    title="Retype the resume command and re-verify the Claude UI handshake"
+                  >
+                    <RotateCcw className="w-2.5 h-2.5" />
+                    Retry resume
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
-      </div>
+      )}
+
+      {quarantined.length > 0 && (
+        <div className={`flex items-start gap-2 ${failed.length > 0 ? "mt-2" : ""}`}>
+          <HelpCircle className="w-3.5 h-3.5 shrink-0 mt-0.5 text-[#e0af68]" />
+          <div className="flex-1 min-w-0">
+            <div className="text-[12px] font-semibold text-[#c0caf5] leading-snug">
+              {quarantined.length === 1
+                ? "Session binding unverified — confirm resume"
+                : `${quarantined.length} session bindings unverified — confirm resumes`}
+            </div>
+            <div className="text-[10px] text-[#a9b1d6] leading-snug mt-0.5">
+              These session ids were guessed from transcript timing and may belong to another
+              tool's session. Nothing was resumed automatically.
+            </div>
+            <ul className="mt-1.5 space-y-1">
+              {quarantined.map((t) => (
+                <li
+                  key={t.id}
+                  data-ui-bridge-id="terminal.resume-quarantined-banner-item"
+                  data-terminal-id={t.id}
+                  className="flex items-center gap-2 text-[11px] leading-snug"
+                >
+                  <span className="text-[#c0caf5] font-medium truncate flex-1">{t.title}</span>
+                  <button
+                    type="button"
+                    data-ui-bridge-id="terminal.resume-quarantined-confirm"
+                    data-terminal-id={t.id}
+                    onClick={() => onRetryResume(t.id)}
+                    className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-[#e0af68]/40 text-[#e0af68] hover:bg-[#e0af68]/15 text-[10px]"
+                    title="Type the resume command for this session and verify the Claude UI handshake"
+                  >
+                    <Play className="w-2.5 h-2.5" />
+                    Resume
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -720,24 +720,38 @@ function TerminalPageInner({
   });
 
   // Operator-clickable retry for a restored tab whose resume verification
-  // failed (Phase 3, #548): re-run the same type-and-verify path. The durable
-  // restore-pending marker is still set from the failed attempt, so the
-  // liveness poll keeps protecting the open record while this runs.
+  // failed (Phase 3, #548) AND the one-click confirm for quarantined
+  // guessed-binding tabs (boot-restore item 5): re-run the same
+  // type-and-verify path. The durable restore-pending marker is still set
+  // from the restore, so the liveness poll keeps protecting the open record
+  // while this runs. On VERIFIED handshake the OPEN record is re-asserted
+  // under this live terminal id (item 3 — the restore no longer re-asserts
+  // before verification, so the verified branch owns it).
   const handleRetryResume = useCallback(
     (tabId: string) => {
       const tab = tabsRef.current.find((t) => t.id === tabId);
       if (!tab?.claudeSessionId) return;
-      updateTab(tabId, { resumeFailed: false, isReconnecting: true });
+      updateTab(tabId, { resumeFailed: false, resumeQuarantined: false, isReconnecting: true });
       void runVerifiedResume({
         terminalRefs: terminalRefs.current,
         tabId,
         claudeSessionId: tab.claudeSessionId,
         configDir: tab.claudeConfigDir,
         updateTab,
+        // Re-assert payload for the verified branch — no bindOrigin, so the
+        // backend preserves the record's existing origin.
+        recordOpen: buildSessionOpenArgs({
+          assignments: assignmentsRef.current,
+          tabs: tabsRef.current,
+          tabId,
+          claudeSessionId: tab.claudeSessionId,
+          configDir: tab.claudeConfigDir,
+          pageId,
+        }),
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [updateTab],
+    [updateTab, pageId],
   );
 
   const handleExit = useCallback(

--- a/src/components/terminal/resumeVerification.test.ts
+++ b/src/components/terminal/resumeVerification.test.ts
@@ -18,6 +18,7 @@ vi.mock("@tauri-apps/api/core", () => ({
 import {
   stripAnsi,
   detectClaudeHandshake,
+  detectResumeFailure,
   detectResumePicker,
   buildPickerAnswer,
   waitForClaudeHandshake,
@@ -27,6 +28,15 @@ import {
 const CLAUDE_UI =
   "╭──────────────────────────────╮\n│ > │\n╰──────────────────────────────╯\n  ? for shortcuts";
 const PLAIN_SHELL = "PS C:\\repo> claude --resume abc-123\r\nPS C:\\repo>";
+// A bogus `--resume` that fell through: the CLI's unknown-session error is
+// rendered INSIDE Claude-UI frames, so the positive handshake patterns match
+// the same tail (the item-4 false-positive being fixed).
+const BOGUS_RESUME_ERROR =
+  "╭──────────────────────────────╮\n" +
+  "│ No conversation found with session ID: fixture-ghost-0004 │\n" +
+  "╰──────────────────────────────╯\n  ? for shortcuts";
+const SESSION_PICKER =
+  "Select a session to resume\n  1. fix the tests (2h ago)\n  2. refactor zone grid (1d ago)";
 
 describe("stripAnsi", () => {
   it("removes CSI sequences so patterns match rendered text", () => {
@@ -62,6 +72,36 @@ describe("detectClaudeHandshake", () => {
       "╭──────────────────────────────╮\n" +
       "  Resume from summary (recommended)\n  Resume full session as-is\n  Don't ask me again";
     expect(detectClaudeHandshake(picker)).toBe(true);
+  });
+});
+
+// Item 4 (boot-restore remediation): "the Claude TUI appeared" is not "the
+// requested session resumed" — definitive failure frames must be recognized
+// and must WIN over the positive handshake patterns.
+describe("detectResumeFailure", () => {
+  it.each([
+    ["unknown-session error inside TUI frames", BOGUS_RESUME_ERROR],
+    ["bare unknown-session error", "No conversation found with session ID: abc-123"],
+    ["empty-history variant", "No conversations found"],
+    ["interactive session picker", SESSION_PICKER],
+    ["ANSI-wrapped error", `\x1b[31mNo conversation found\x1b[0m`],
+  ])("recognizes a definitive resume failure: %s", (_name, text) => {
+    expect(detectResumeFailure(text)).toBe(true);
+  });
+
+  it.each([
+    ["healthy Claude UI", CLAUDE_UI],
+    ["plain shell", PLAIN_SHELL],
+    ["resume-size picker (a LANDED resume)", "  Resume from summary (recommended)"],
+    ["empty buffer", ""],
+  ])("does NOT flag non-failure output: %s", (_name, text) => {
+    expect(detectResumeFailure(text)).toBe(false);
+  });
+
+  it("the bogus-resume tail ALSO matches the positive handshake (why negative-first matters)", () => {
+    // Documents the false positive: without the negative check, this tail
+    // verifies. The wait loop must therefore evaluate failure first.
+    expect(detectClaudeHandshake(BOGUS_RESUME_ERROR)).toBe(true);
   });
 });
 
@@ -117,6 +157,26 @@ describe("waitForClaudeHandshake", () => {
       readTail,
     });
     expect(out).toBe("timeout");
+  });
+
+  it("returns 'failed' when failure frames show — even though TUI frames are in the same tail", async () => {
+    const readTail = vi.fn(async () => BOGUS_RESUME_ERROR);
+    const out = await waitForClaudeHandshake("tab-1", {
+      timeoutMs: 500,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("failed");
+  });
+
+  it("returns 'failed' on the interactive session picker (resume fell through)", async () => {
+    const readTail = vi.fn(async () => SESSION_PICKER);
+    const out = await waitForClaudeHandshake("tab-1", {
+      timeoutMs: 500,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("failed");
   });
 });
 
@@ -188,6 +248,24 @@ describe("typeResumeAndVerify (retry-once state machine)", () => {
       readTail: async () => CLAUDE_UI,
     });
     expect(writes).not.toContain("2\r");
+  });
+
+  it("a bogus --resume (definitive failure frames) fails FAST — no pointless retype", async () => {
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    const out = await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 50,
+      intervalMs: 1,
+      readTail: async () => BOGUS_RESUME_ERROR,
+    });
+    // The pane shows Claude UI frames, but the negative patterns win: the
+    // requested session did NOT resume.
+    expect(out).toBe("failed");
+    // Definitive CLI answer ⇒ exactly ONE typed attempt (the retry exists
+    // for lost keystrokes, not for a CLI that answered).
+    expect(writes.filter((w) => w === CMD)).toHaveLength(1);
   });
 
   it("fails after the retry is exhausted and never falsely verifies", async () => {

--- a/src/components/terminal/resumeVerification.ts
+++ b/src/components/terminal/resumeVerification.ts
@@ -101,6 +101,37 @@ const CLAUDE_HANDSHAKE_PATTERNS: RegExp[] = [
   /[╭╰]─{3,}/, // rounded input-box / dialog frame
 ];
 
+/**
+ * Definitive evidence that the REQUESTED session did NOT resume — evaluated
+ * BEFORE the handshake patterns on every probe. "The Claude TUI appeared" is
+ * not the same claim as "the requested session resumed": a
+ * `claude --resume <bogus-id>` can fall through to an error dialog, a fresh
+ * session, or the interactive session picker, all of which still render
+ * Claude-UI frames and previously read as a VERIFIED restore (boot-restore
+ * remediation item 4). Matching any of these parks the tab `resumeFailed`
+ * with the durable restore-pending marker kept.
+ *
+ * Wording sourced from the Claude Code CLI's unknown-session error and the
+ * `--resume` session-picker frames; extend from real scrollback if a real
+ * failed resume ever verifies (same maintenance rule as the picker patterns
+ * above).
+ */
+const RESUME_FAILURE_PATTERNS: RegExp[] = [
+  /No conversation found/i, // `--resume <unknown-id>` error
+  /No conversations? (?:found|to resume)/i, // empty-history variants
+  /Select a (?:session|conversation) to resume/i, // interactive session picker frame
+];
+
+/**
+ * True when the pane's recent output shows a definitive resume FAILURE
+ * (unknown session id / fell through to the session picker). Checked before
+ * {@link detectClaudeHandshake} — failure frames are themselves Claude UI.
+ */
+export function detectResumeFailure(text: string): boolean {
+  const stripped = stripAnsi(text);
+  return RESUME_FAILURE_PATTERNS.some((p) => p.test(stripped));
+}
+
 /** True when the pane's recent output shows the Claude Code UI. */
 export function detectClaudeHandshake(text: string): boolean {
   const stripped = stripAnsi(text);
@@ -145,19 +176,25 @@ export interface HandshakeWaitOptions {
 }
 
 /**
- * Poll the pane's scrollback until the Claude UI handshake appears or the
- * timeout elapses. Resolves `"verified"` or `"timeout"`; never throws.
+ * Poll the pane's scrollback until the Claude UI handshake appears, a
+ * definitive resume failure shows, or the timeout elapses. Resolves
+ * `"verified"`, `"failed"` (negative patterns — checked FIRST, since failure
+ * frames are themselves Claude UI), or `"timeout"`; never throws.
  */
 export async function waitForClaudeHandshake(
   tabId: string,
   options: HandshakeWaitOptions = {},
-): Promise<"verified" | "timeout"> {
+): Promise<"verified" | "failed" | "timeout"> {
   const { timeoutMs = 15_000, intervalMs = 1_000, readTail = readScrollbackTail, onProbe } = options;
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const tail = await readTail(tabId);
     if (tail !== null) {
       onProbe?.(tail);
+      // Negative evidence wins over positive: an error dialog / session
+      // picker renders TUI frames too, so the handshake check alone would
+      // false-positive exactly the wrong-content case being fixed.
+      if (detectResumeFailure(tail)) return "failed";
       if (detectClaudeHandshake(tail)) return "verified";
     }
     if (Date.now() >= deadline) return "timeout";
@@ -230,6 +267,16 @@ export async function typeResumeAndVerify(
     await new Promise((r) => setTimeout(r, settleMs));
     const outcome = await waitForClaudeHandshake(tabId, { ...waitOpts, onProbe: probe });
     if (outcome === "verified") return "verified";
+    if (outcome === "failed") {
+      // Definitive negative evidence (unknown session id / session picker):
+      // retyping the same command can only reproduce it, and the failure
+      // frames persist in the scrollback tail anyway — fail fast. The retry
+      // exists for LOST keystrokes (timeout), not for a CLI that answered.
+      console.warn(
+        `[resumeVerification] resume FAILURE frames observed for ${tabId} (attempt ${attempt}/${attempts})`,
+      );
+      return "failed";
+    }
     console.warn(
       `[resumeVerification] handshake not observed for ${tabId} (attempt ${attempt}/${attempts})`,
     );

--- a/src/components/terminal/types.ts
+++ b/src/components/terminal/types.ts
@@ -42,6 +42,13 @@ export interface TerminalSessionRecord {
   /** Why the session closed. */
   closeReason?: string;
   /**
+   * How `claudeSessionId` was bound: `"pinned"` (`--session-id` / `--resume`
+   * — exact) or `"guessed"` (freshest-transcript mtime guess). Absent on
+   * records predating the field — read as guessed. Restore quarantines
+   * non-pinned rows behind an operator confirm instead of auto-resuming.
+   */
+  bindOrigin?: string;
+  /**
    * Epoch ms a boot-restore began re-typing this session's resume command
    * (backend-owned; while set the liveness poll never flips the record
    * `poll-dead`). Cleared once the resume handshake is verified.

--- a/src/components/terminal/useTabSessionIdCapture.test.ts
+++ b/src/components/terminal/useTabSessionIdCapture.test.ts
@@ -31,6 +31,8 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+import { effectiveCaptureDir, projectPathMatches } from "./useTabSessionIdCapture";
+
 interface TranscriptSessionPayload {
   session_id: string;
   config_dir: string;
@@ -236,6 +238,67 @@ describe("invoke contract", () => {
  * accept" is unchanged — what matters is that the backend now returns
  * the right payload because the wrong-account ones are filtered out.
  */
+/**
+ * Item 6 (boot-restore remediation) — the freshest-mtime guess must never
+ * probe with the broad workspace-root fallback, and a payload answered from
+ * a different project is rejected. "Prefer timeout-unbound over mis-bound":
+ * a record left absent is recoverable; a foreign (VS Code) session id bound
+ * into the durable registry resurrects on every restart.
+ */
+describe("capture narrowing — effectiveCaptureDir / projectPathMatches (item 6)", () => {
+  it("prefers the tab's LIVE cwd over the dir snapshotted at startCapture", () => {
+    expect(effectiveCaptureDir("D:/repo/sub", "D:/repo")).toBe("D:/repo/sub");
+  });
+
+  it("falls back to the startCapture dir when the cwd event hasn't fired yet", () => {
+    expect(effectiveCaptureDir(undefined, "D:/repo")).toBe("D:/repo");
+    expect(effectiveCaptureDir("", "D:/repo")).toBe("D:/repo");
+  });
+
+  it("returns '' when no cwd is known — the tick must SKIP the probe (timeout-unbound)", () => {
+    expect(effectiveCaptureDir(undefined, "")).toBe("");
+    expect(effectiveCaptureDir("", undefined)).toBe("");
+  });
+
+  it("accepts a payload whose project_path matches the probed dir (separator/case tolerant)", () => {
+    expect(projectPathMatches("D:/repo", "D:/repo")).toBe(true);
+    expect(projectPathMatches("D:\\Repo\\", "d:/repo")).toBe(true);
+  });
+
+  it("rejects a foreign-dir payload (workspace-root fallback answered broadly)", () => {
+    expect(projectPathMatches("D:/other-project", "D:/repo")).toBe(false);
+    expect(projectPathMatches("", "D:/repo")).toBe(false);
+  });
+
+  it("mtime race: a fresher FOREIGN-dir session never binds; only the matching-cwd id does", () => {
+    const claimed = new Set<string>();
+    const paneDir = "D:/repo";
+
+    // A concurrent VS Code session in another project has the freshest
+    // mtime; a broad backend answer would surface it first.
+    const foreign: TranscriptSessionPayload = {
+      session_id: "session-vscode-foreign",
+      config_dir: "C:/claude/.claude-default",
+      project_path: "D:/other-project",
+      last_modified: new Date(Date.now() + 1000).toISOString(),
+    };
+    // The narrowing gate rejects it BEFORE decideClaim ever runs.
+    expect(projectPathMatches(foreign.project_path, paneDir)).toBe(false);
+
+    // The pane's own session (older mtime, matching dir) is the only
+    // payload that passes the gate and binds.
+    const own: TranscriptSessionPayload = {
+      session_id: "session-pane",
+      config_dir: "C:/claude/.claude-default",
+      project_path: "D:/repo",
+      last_modified: new Date().toISOString(),
+    };
+    expect(projectPathMatches(own.project_path, paneDir)).toBe(true);
+    const claim = decideClaim(tab("tab-1", paneDir), own, claimed);
+    expect(claim?.claudeSessionId).toBe("session-pane");
+  });
+});
+
 describe("decideClaim — cross-config-dir scope (P0 fix)", () => {
   it("accepts a session whose config_dir matches the launching account", () => {
     // Backend was called with configDir filter, so it returns ONLY

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -64,6 +64,44 @@ const POLL_INTERVAL_MS = 500;
 // is bound, so a longer ceiling costs nothing in the common (fast) case.
 const POLL_TIMEOUT_MS = 45_000;
 
+/**
+ * The working directory a capture tick may probe with (boot-restore
+ * remediation item 6). Prefers the tab's LIVE cwd (the shell-integration
+ * `cwd` event often fires after capture start) over the dir snapshotted at
+ * `startCapture` time. Returns `""` when neither is known — the tick must
+ * then SKIP the probe entirely rather than let the backend fall back to the
+ * broad workspace root, where a concurrent foreign-dir session (e.g. VS
+ * Code) can win the freshest-mtime race. Timing out unbound is strictly
+ * better than binding a foreign session id into the registry.
+ *
+ * Pure + exported for unit tests.
+ */
+export function effectiveCaptureDir(
+  tabWorkingDir: string | undefined,
+  startDir: string | undefined,
+): string {
+  return tabWorkingDir || startDir || "";
+}
+
+/** Normalize a path for equality: separators, trailing slash, Windows case. */
+function normalizePath(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "").toLowerCase();
+}
+
+/**
+ * True when a transcript payload's `project_path` matches the directory the
+ * probe asked for. Defense-in-depth behind the projectPath request filter:
+ * if the backend ever answers from a broader scope (fallback path), a
+ * foreign-dir session is rejected here and the poll keeps ticking — worst
+ * case the capture times out unbound (preferred over a mis-bind).
+ *
+ * Pure + exported for unit tests.
+ */
+export function projectPathMatches(payloadProjectPath: string, workingDir: string): boolean {
+  if (!payloadProjectPath || !workingDir) return false;
+  return normalizePath(payloadProjectPath) === normalizePath(workingDir);
+}
+
 interface CaptureParams {
   updateTab: (
     id: string,
@@ -220,15 +258,33 @@ export function useTabSessionIdCapture({
           return;
         }
 
+        // Item 6 (boot-restore remediation): NEVER probe with the broad
+        // workspace-root fallback. Without a known cwd the backend's
+        // freshest-mtime answer can name a concurrent foreign-dir session
+        // (VS Code in another project) and the wrong id poisons the durable
+        // registry. Prefer the tab's live cwd (shell-integration event may
+        // fire after capture start); if no cwd is known yet, skip this tick
+        // and keep polling — timing out unbound beats binding a mis-guess.
+        const captureDir = effectiveCaptureDir(tab.workingDir, workingDir);
+        if (!captureDir) {
+          if (debug()) logger.debug("[tabSidCapture] no-cwd-yet", { tabId });
+          setTimeout(() => {
+            void tick();
+          }, POLL_INTERVAL_MS);
+          return;
+        }
+
         try {
-          // Pass workingDir + configDir when known, plus sinceMs so the
-          // backend can drop pre-spawn JSONLs before answering. Both
-          // workingDir/configDir fall back server-side: empty workingDir
-          // → workspace project path; missing configDir → scan all known
-          // config dirs (the bug path that motivated adding configDir —
-          // see hook docstring).
-          const args: Record<string, string | number> = { sinceMs: spawnTimestamp };
-          if (workingDir) args.projectPath = workingDir;
+          // Pass workingDir + configDir, plus sinceMs so the backend can
+          // drop pre-spawn JSONLs before answering. configDir falls back
+          // server-side: missing configDir → scan all known config dirs
+          // (the bug path that motivated adding configDir — see hook
+          // docstring). projectPath is now ALWAYS sent (see captureDir gate
+          // above).
+          const args: Record<string, string | number> = {
+            sinceMs: spawnTimestamp,
+            projectPath: captureDir,
+          };
           if (configDir) args.configDir = configDir;
           const resp = await invoke<CommandResponse>("transcript_get_latest", args);
           if (handle.cancelled) return;
@@ -236,6 +292,16 @@ export function useTabSessionIdCapture({
           const data = resp.success ? (resp.data as TranscriptSessionPayload | null) : null;
           if (!data) {
             if (debug()) logger.debug("[tabSidCapture] probe-null", { tabId });
+          } else if (!projectPathMatches(data.project_path, captureDir)) {
+            // Backend answered from a different project (fallback/broad
+            // scope) — reject and keep polling (item 6 narrowing).
+            if (debug()) {
+              logger.debug("[tabSidCapture] project-mismatch", {
+                tabId,
+                payloadProjectPath: data.project_path,
+                captureDir,
+              });
+            }
           } else if (claimedSessionIds.current.has(data.session_id)) {
             if (debug()) {
               logger.debug("[tabSidCapture] already-claimed", {

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -19,8 +19,10 @@ import {
   claimInitForPage,
   buildResumeCmd,
   runVerifiedResume,
+  classifyRestoreAction,
 } from "./useTerminalInitialization";
 import type { TerminalSessionRecord } from "./types";
+import type { SessionOpenArgs } from "./sessionRecordArgs";
 
 const rec = (overrides: Partial<TerminalSessionRecord>): TerminalSessionRecord => ({
   claudeSessionId: "sid",
@@ -235,6 +237,122 @@ describe("runVerifiedResume", () => {
       "terminal_session_clear_restore_pending",
       expect.anything(),
     );
+  });
+
+  // Item 3 (boot-restore remediation): the registry re-assert moved from
+  // tab-creation time into the VERIFIED branch. A failed resume must leave
+  // the original row untouched (original lastSeenAt ⇒ ages out normally).
+  const RECORD_OPEN: SessionOpenArgs = {
+    claudeSessionId: "sess-1",
+    configDir: "C:/claude/.claude-hotmail",
+    workingDir: "D:/repo",
+    pageId: "default",
+    zoneIndex: 3,
+    title: "Claude 1",
+    terminalId: "tab-1",
+  };
+
+  it("verified handshake → re-asserts the OPEN record under the new terminal id (recordOpen)", async () => {
+    const writes: string[] = [];
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle(writes),
+      tabId: "tab-1",
+      claudeSessionId: "sess-1",
+      updateTab,
+      recordOpen: RECORD_OPEN,
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 50,
+        intervalMs: 1,
+        readTail: async () => CLAUDE_UI,
+      },
+    });
+    expect(out).toBe("verified");
+    expect(mockInvoke).toHaveBeenCalledWith("terminal_session_record_open", RECORD_OPEN);
+  });
+
+  it("failed verification → NEVER re-asserts (ghost row keeps its original lastSeenAt)", async () => {
+    const writes: string[] = [];
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle(writes),
+      tabId: "tab-1",
+      claudeSessionId: "sess-1",
+      updateTab,
+      recordOpen: RECORD_OPEN,
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 5,
+        intervalMs: 1,
+        readTail: async () => PLAIN_SHELL,
+      },
+    });
+    expect(out).toBe("failed");
+    // No record_open ⇒ the registry row's lastSeenAt is untouched and the
+    // prune clock / recency cap keep running — ghosts are no longer immortal.
+    expect(mockInvoke).not.toHaveBeenCalledWith("terminal_session_record_open", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "terminal_session_clear_restore_pending",
+      expect.anything(),
+    );
+  });
+
+  it("bogus session id (failure frames inside Claude UI) → failed, marker kept, no re-assert (item 4)", async () => {
+    const BOGUS =
+      "╭──────────────╮\n│ No conversation found with session ID: sess-1 │\n╰──────────────╯\n  ? for shortcuts";
+    const writes: string[] = [];
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle(writes),
+      tabId: "tab-1",
+      claudeSessionId: "sess-1",
+      updateTab,
+      recordOpen: RECORD_OPEN,
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 50,
+        intervalMs: 1,
+        readTail: async () => BOGUS,
+      },
+    });
+    expect(out).toBe("failed");
+    expect(updateTab).toHaveBeenCalledWith("tab-1", {
+      isReconnecting: false,
+      resumeFailed: true,
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("terminal_session_record_open", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "terminal_session_clear_restore_pending",
+      expect.anything(),
+    );
+  });
+});
+
+// Item 5 (boot-restore remediation): restore must consult `bindOrigin`. Only
+// pinned bindings auto-resume; guessed/absent rows are quarantined behind a
+// one-click operator confirm (no resume typed).
+describe("classifyRestoreAction (bindOrigin quarantine gate)", () => {
+  it("pinned binding with a valid id auto-resumes", () => {
+    expect(classifyRestoreAction({ claudeSessionId: "sess-1", bindOrigin: "pinned" })).toBe(
+      "auto-resume",
+    );
+  });
+
+  it("guessed binding is quarantined (mtime guess can name a foreign VS Code session)", () => {
+    expect(classifyRestoreAction({ claudeSessionId: "sess-1", bindOrigin: "guessed" })).toBe(
+      "quarantine",
+    );
+  });
+
+  it("absent bindOrigin (pre-field record) reads as guessed ⇒ quarantined", () => {
+    expect(classifyRestoreAction({ claudeSessionId: "sess-1" })).toBe("quarantine");
+  });
+
+  it("shell-unsafe session ids are skipped outright, never typed or quarantined", () => {
+    expect(
+      classifyRestoreAction({ claudeSessionId: "bad; rm -rf /", bindOrigin: "pinned" }),
+    ).toBe("skip-invalid");
   });
 });
 

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -14,6 +14,7 @@ import type { TerminalTab } from "./useTerminalManager";
 import type { TerminalInstanceHandle } from "./TerminalInstance";
 import type { CommandResponse, TerminalSessionRecord } from "./types";
 import type { SaveSessionLayoutParams } from "./useSessionPersistence";
+import type { SessionOpenArgs } from "./sessionRecordArgs";
 import { rememberSessionId } from "./lastKnownSessionIds";
 
 /**
@@ -117,9 +118,21 @@ export async function runVerifiedResume(params: {
     id: string,
     updates: Partial<{ isReconnecting?: boolean; resumeFailed?: boolean }>,
   ) => void;
+  /**
+   * Registry re-assert payload for the VERIFIED branch (boot-restore item 3):
+   * the OPEN record is re-recorded under the freshly created terminal id
+   * ONLY after the resume handshake verified. Re-asserting at tab-creation
+   * time refreshed `lastSeenAt` on rows whose resume then failed — resetting
+   * both the prune clock and the recency cap, making ghost rows immortal. On
+   * `failed` the original row is left untouched (restore-pending already
+   * protects it from the liveness poll). Omitted = no re-assert (operator
+   * retry without zone context, tests).
+   */
+  recordOpen?: SessionOpenArgs;
   verifyOptions?: TypeAndVerifyOptions;
 }): Promise<"verified" | "failed"> {
-  const { terminalRefs, tabId, claudeSessionId, configDir, updateTab, verifyOptions } = params;
+  const { terminalRefs, tabId, claudeSessionId, configDir, updateTab, recordOpen, verifyOptions } =
+    params;
   const policy = getResumeSummaryPolicy();
   const resumeCmd = buildResumeCmd(claudeSessionId, configDir, policy);
   const outcome = await typeResumeAndVerify(terminalRefs, tabId, resumeCmd, {
@@ -131,8 +144,18 @@ export async function runVerifiedResume(params: {
   });
   if (outcome === "verified") {
     updateTab(tabId, { isReconnecting: false, resumeFailed: false });
-    // Verified handshake — release the liveness-poll restore guard so normal
-    // classification resumes for this session.
+    // Verified handshake — NOW re-assert the OPEN record under the live
+    // terminal id so the registry tracks this tab (the next restart
+    // reconnect-matches on it). Deliberately after verification, never
+    // before: see `recordOpen` docs. No `bindOrigin` is sent, so the
+    // backend preserves the existing origin (unasserted re-record).
+    if (recordOpen) {
+      invoke("terminal_session_record_open", { ...recordOpen }).catch((err) => {
+        console.warn(`[TerminalPage] re-record open failed for ${claudeSessionId}:`, err);
+      });
+    }
+    // Release the liveness-poll restore guard so normal classification
+    // resumes for this session.
     invoke("terminal_session_clear_restore_pending", { claudeSessionId }).catch((err) => {
       // Best-effort: the poll self-heals a stale marker on the next
       // confident-alive tick.
@@ -174,6 +197,32 @@ function isValidSessionId(id: string): boolean {
   return SESSION_ID_RE.test(id);
 }
 
+/**
+ * What the cold-restore path does with a registry record (boot-restore
+ * remediation item 5):
+ *
+ * - `"auto-resume"`: `bindOrigin === "pinned"` — the id came from
+ *   `--session-id` / `--resume` (exact), safe to type `claude --resume`
+ *   unattended.
+ * - `"quarantine"`: any other origin (`"guessed"`, or absent on rows
+ *   predating the field — both mean a freshest-transcript mtime GUESS that
+ *   can name a foreign VS Code session). The tab is still created so the
+ *   screen layout is preserved, but no resume is typed; the operator
+ *   confirms via a one-click `ResumeFailedBanner` affordance.
+ * - `"skip-invalid"`: the recorded id fails shell-safety validation — never
+ *   typed, never quarantined (nothing actionable).
+ *
+ * Pure + exported so the quarantine gate is unit-testable without React.
+ */
+export type RestoreAction = "auto-resume" | "quarantine" | "skip-invalid";
+
+export function classifyRestoreAction(
+  rec: Pick<TerminalSessionRecord, "claudeSessionId" | "bindOrigin">,
+): RestoreAction {
+  if (!isValidSessionId(rec.claudeSessionId)) return "skip-invalid";
+  return rec.bindOrigin === "pinned" ? "auto-resume" : "quarantine";
+}
+
 /** Validate config dir paths — reject shell metacharacters. */
 const SAFE_PATH_RE = /^[a-zA-Z0-9_\-./\\: ]+$/;
 function sanitizeConfigDir(dir: string | undefined): string | undefined {
@@ -197,6 +246,7 @@ interface UseTerminalInitializationParams {
       claudeConfigDir?: string;
       isReconnecting?: boolean;
       resumeFailed?: boolean;
+      resumeQuarantined?: boolean;
     }>,
   ) => void;
   zoneLayout: {
@@ -316,6 +366,8 @@ export function useTerminalInitialization({
       isClaudeSession?: boolean;
       claudeSessionId?: string;
       claudeConfigDir?: string;
+      /** Deferred registry re-assert — applied only on VERIFIED resume. */
+      recordOpen?: SessionOpenArgs;
     }> = [];
 
     (async () => {
@@ -382,7 +434,7 @@ export function useTerminalInitialization({
         //    zones still empty after this loop runs).
         for (const rec of openRecords) {
           const safeConfigDir = sanitizeConfigDir(rec.configDir);
-          const validSessionId = isValidSessionId(rec.claudeSessionId);
+          const restoreAction = classifyRestoreAction(rec);
 
           // a) A live reconnected PTY is already running this session (React
           //    remount): match by the record's stable terminalId. Just rebind
@@ -402,9 +454,11 @@ export function useTerminalInitialization({
           }
 
           // b) Cold restart (no live pty): recreate the tab, bind its recorded
-          //    zone, attach the session id, and queue a `claude --resume` via
-          //    the existing drain loop. Re-assert the OPEN record under the new
-          //    ephemeral terminal id so the registry tracks the live tab.
+          //    zone, attach the session id, and (for pinned bindings) queue a
+          //    `claude --resume` via the existing drain loop. The OPEN record
+          //    is re-asserted under the new ephemeral terminal id ONLY after
+          //    the resume handshake VERIFIES (item 3 — re-asserting here
+          //    refreshed `lastSeenAt` on ghost rows, making them immortal).
           const tabId = await createTerminal(rec.title, rec.workingDir);
           if (!tabId) continue;
           if (rec.zoneIndex >= 0) {
@@ -416,25 +470,22 @@ export function useTerminalInitialization({
             claudeConfigDir: safeConfigDir,
             // Show a "resuming" affordance until `claude --resume` lands;
             // cleared in the drain loop after the resume command is written.
-            isReconnecting: true,
+            // Quarantined rows are NOT auto-resumed (item 5): a non-pinned
+            // bindOrigin is an mtime guess that can name a foreign VS Code
+            // session — surface a one-click confirm instead.
+            isReconnecting: restoreAction === "auto-resume",
+            resumeQuarantined: restoreAction === "quarantine",
           });
           rememberSessionId(tabId, rec.claudeSessionId, safeConfigDir);
 
-          if (validSessionId) {
-            pendingRestores.push({
-              tabId,
-              scrollbackPath:
-                rec.zoneIndex >= 0 ? cosmeticsByZone.get(rec.zoneIndex)?.scrollbackPath : undefined,
-              isClaudeSession: true,
-              claudeSessionId: rec.claudeSessionId,
-              claudeConfigDir: safeConfigDir,
-            });
+          if (restoreAction !== "skip-invalid") {
             // Durable, backend-owned restore-pending marker (Phase 3, #548):
             // from here until the resume handshake is VERIFIED the liveness
-            // poll must never flip this record `poll-dead` — a failed restore
-            // leaves the `open` record intact for the next attempt. Cleared in
-            // `runVerifiedResume` on verified handshake (and self-healed by
-            // the poll once it sees the session confidently alive).
+            // poll must never flip this record `poll-dead` — a failed (or
+            // quarantined-awaiting-confirm) restore leaves the `open` record
+            // intact for the next attempt. Cleared in `runVerifiedResume` on
+            // verified handshake (and self-healed by the poll once it sees
+            // the session confidently alive).
             invoke("terminal_session_mark_restore_pending", {
               claudeSessionId: rec.claudeSessionId,
             }).catch((err) => {
@@ -445,20 +496,34 @@ export function useTerminalInitialization({
             });
           }
 
-          // Re-assert the OPEN record under the freshly created terminal id so
-          // the registry's `terminalId` tracks the live tab (the next restart
-          // reconnect-matches on this id).
-          invoke("terminal_session_record_open", {
-            claudeSessionId: rec.claudeSessionId,
-            configDir: rec.configDir,
-            workingDir: rec.workingDir,
-            pageId,
-            zoneIndex: rec.zoneIndex,
-            title: rec.title,
-            terminalId: tabId,
-          }).catch((err) => {
-            console.warn(`[TerminalPage] re-record open failed for ${rec.claudeSessionId}:`, err);
-          });
+          if (restoreAction !== "skip-invalid") {
+            // Both auto-resume and quarantined tabs get their saved scrollback
+            // replayed by the drain; ONLY auto-resume entries type a resume
+            // (`isClaudeSession` gates the typing in the drain loop).
+            pendingRestores.push({
+              tabId,
+              scrollbackPath:
+                rec.zoneIndex >= 0 ? cosmeticsByZone.get(rec.zoneIndex)?.scrollbackPath : undefined,
+              isClaudeSession: restoreAction === "auto-resume",
+              claudeSessionId: rec.claudeSessionId,
+              claudeConfigDir: safeConfigDir,
+              // Deferred re-assert payload: applied by `runVerifiedResume`
+              // on VERIFIED handshake only. No `bindOrigin` — the backend
+              // preserves the existing (pinned) origin on unasserted writes.
+              recordOpen:
+                restoreAction === "auto-resume"
+                  ? {
+                      claudeSessionId: rec.claudeSessionId,
+                      configDir: rec.configDir,
+                      workingDir: rec.workingDir,
+                      pageId,
+                      zoneIndex: rec.zoneIndex,
+                      title: rec.title,
+                      terminalId: tabId,
+                    }
+                  : undefined,
+            });
+          }
         }
 
         // 4) Plan tabs are cosmetic-only state held in the snapshot (no PTY, no
@@ -533,6 +598,7 @@ export function useTerminalInitialization({
                     claudeSessionId: restore.claudeSessionId,
                     configDir: restore.claudeConfigDir,
                     updateTab,
+                    recordOpen: restore.recordOpen,
                   });
                 }
               }

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -30,6 +30,16 @@ export interface TerminalTab {
    * restore-pending marker so the liveness poll can't flip it `poll-dead`.
    */
   resumeFailed?: boolean;
+  /**
+   * True when a boot-restore re-created this tab for a registry record whose
+   * `bindOrigin` is NOT `"pinned"` (mtime-guessed or pre-bindOrigin row). The
+   * resume command is deliberately NOT auto-typed — a guessed binding can be
+   * a foreign (e.g. VS Code) session, and auto-resuming it resurrects the
+   * mis-bind. Surfaced as a one-click operator confirm (`ResumeFailedBanner`);
+   * cleared when the operator confirms (which runs the normal verified
+   * resume). The durable record keeps its restore-pending marker meanwhile.
+   */
+  resumeQuarantined?: boolean;
   /** Claude Code session ID running in this tab (set on resume). */
   claudeSessionId?: string;
   /** Claude config dir for the session (set on resume). */
@@ -552,6 +562,7 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
           | "claudeConfigDir"
           | "isReconnecting"
           | "resumeFailed"
+          | "resumeQuarantined"
         >
       >,
     ) => {

--- a/src/components/terminal/useZoneLayout.restore.test.ts
+++ b/src/components/terminal/useZoneLayout.restore.test.ts
@@ -18,6 +18,7 @@
 import { describe, it, expect } from "vitest";
 import {
   reconcileAssignments,
+  applyLayoutAssignments,
   pickLayout,
   computeAutoGrowLayoutId,
   LAYOUT_PRESETS,
@@ -76,6 +77,70 @@ describe("reconcileAssignments — registry zones win over creation-order shells
     const next = reconcileAssignments({ 0: "claudeA" }, ["claudeA", "shell-1"], 6, new Set());
     expect(next[0]).toBe("claudeA");
     expect(next[1]).toBe("shell-1");
+  });
+});
+
+/**
+ * Item 10 (boot-restore remediation) — restored zone bindings must survive
+ * layout application even when an excluded row leaves a gap. The drift
+ * ("record z3 rendered z2") came from `applyLayout`'s old inline reducer
+ * dropping any assignment whose tab was missing from its (possibly STALE)
+ * `tabIds` closure during the async restore drain; the auto-fill then
+ * re-placed the tab into the first empty zone. The extracted
+ * `applyLayoutAssignments` preserves every in-range assignment exactly and
+ * compacts ONLY assignments whose zone exceeds the layout's zone count.
+ */
+describe("applyLayoutAssignments — recorded zones survive restore gaps (item 10)", () => {
+  it("fixture rows at z0/z3 restore to z0/z3 — the z2 gap is NOT compacted away", () => {
+    // Registry rows at zones 0 and 3 (the zone-2 row was excluded). Quad
+    // layout (4 zones): both recorded zones fit and must be preserved.
+    const prev = { 0: "claudeA", 3: "claudeB" };
+    const next = applyLayoutAssignments(prev, ["claudeA", "claudeB"], zoneCount("quad"));
+    expect(next[0]).toBe("claudeA");
+    expect(next[3]).toBe("claudeB");
+    expect(next[2]).toBeUndefined();
+  });
+
+  it("preserves recorded zones even when tabIds is STALE/empty (the restore-drain race)", () => {
+    // The old reducer required `tabIds.includes(tabId)` — a stale closure
+    // dropped the z3 binding and the auto-fill later re-placed the tab at
+    // z2. The fix never drops an in-range assignment.
+    const prev = { 0: "claudeA", 3: "claudeB" };
+    const next = applyLayoutAssignments(prev, [], zoneCount("quad"));
+    expect(next).toEqual({ 0: "claudeA", 3: "claudeB" });
+  });
+
+  it("compacts ONLY when the recorded zone exceeds the layout's zone count", () => {
+    // z5 doesn't exist in quad (4 zones) — that tab compacts into the
+    // lowest empty zone; the in-range z0 binding is untouched.
+    const prev = { 0: "claudeA", 5: "claudeB" };
+    const next = applyLayoutAssignments(prev, ["claudeA", "claudeB"], zoneCount("quad"));
+    expect(next[0]).toBe("claudeA");
+    expect(next[1]).toBe("claudeB");
+  });
+
+  it("still fills remaining empty zones with unassigned tabs in creation order", () => {
+    const prev = { 3: "claudeB" };
+    const next = applyLayoutAssignments(prev, ["shell-1", "claudeB", "shell-2"], zoneCount("quad"));
+    expect(next[3]).toBe("claudeB");
+    expect(next[0]).toBe("shell-1");
+    expect(next[1]).toBe("shell-2");
+  });
+
+  it("grow path keeps gapped bindings: split → quad after a third tab lands", () => {
+    // Auto-grow applies a bigger layout while records own z0/z3; growing
+    // must not reshuffle them.
+    expect(computeAutoGrowLayoutId("split", 3)).toBe("quad");
+    const prev = { 0: "claudeA", 3: "claudeB" };
+    const next = applyLayoutAssignments(
+      prev,
+      ["claudeA", "claudeB", "shell-1"],
+      zoneCount("quad"),
+    );
+    expect(next[0]).toBe("claudeA");
+    expect(next[3]).toBe("claudeB");
+    // The plain shell fills a remaining empty zone — never a recorded one.
+    expect([next[1], next[2]]).toContain("shell-1");
   });
 });
 

--- a/src/components/terminal/useZoneLayout.ts
+++ b/src/components/terminal/useZoneLayout.ts
@@ -287,6 +287,70 @@ export function reconcileAssignments(
   return next;
 }
 
+/**
+ * Pure reducer behind `applyLayout` (layout switch / auto-grow). Boot-restore
+ * remediation item 10: a restored session's RECORDED zone must survive layout
+ * application — compaction is allowed ONLY for assignments whose zone index
+ * exceeds the new layout's zone count.
+ *
+ * The previous inline version kept an assignment only when
+ * `tabIds.includes(prev[z])` — but `applyLayout` closes over `tabIds`, and
+ * during the async restore drain that closure can be STALE (the tab exists
+ * but isn't in the captured list yet). The assignment was silently dropped
+ * and the creation-order auto-fill later re-placed the tab into the first
+ * empty zone — the "record z3 rendered z2" drift. Dead-tab cleanup is NOT
+ * this reducer's job: `reconcileAssignments` runs right after every layout
+ * change with fresh `tabIds` and owns dropping dead assignments.
+ *
+ * Rules:
+ *   - in-range assignments (`zone < zoneCount`) are preserved EXACTLY;
+ *   - out-of-range assignments are compacted into the lowest empty zones
+ *     (they had recorded zones, so they outrank plain unassigned tabs);
+ *   - remaining empty zones are filled with unassigned tabs in creation
+ *     order (same behavior as before).
+ *
+ * Exported so the restore regression test can assert the binding without
+ * booting React (`useZoneLayout.restore.test.ts`).
+ */
+export function applyLayoutAssignments(
+  prev: ZoneAssignments,
+  tabIds: string[],
+  zoneCount: number,
+): ZoneAssignments {
+  const next: ZoneAssignments = {};
+  const overflow: string[] = [];
+  const usedTabs = new Set<string>();
+
+  for (const [z, tabId] of Object.entries(prev)) {
+    const zone = Number(z);
+    if (zone < zoneCount) {
+      next[zone] = tabId;
+      usedTabs.add(tabId);
+    } else {
+      overflow.push(tabId);
+    }
+  }
+
+  // Compact ONLY the out-of-range tabs into the lowest empty zones.
+  for (let z = 0; z < zoneCount && overflow.length > 0; z++) {
+    if (!(z in next)) {
+      const tabId = overflow.shift()!;
+      next[z] = tabId;
+      usedTabs.add(tabId);
+    }
+  }
+
+  // Fill remaining zones with unassigned tabs (creation order).
+  const unassigned = tabIds.filter((id) => !usedTabs.has(id));
+  for (let z = 0; z < zoneCount && unassigned.length > 0; z++) {
+    if (!(z in next)) {
+      next[z] = unassigned.shift()!;
+    }
+  }
+
+  return next;
+}
+
 // ── Hook ───────────────────────────────────────────────────────────────────
 
 export function useZoneLayout(
@@ -342,29 +406,12 @@ export function useZoneLayout(
       setLayoutIdState(id);
       setMaximizedZone(null);
 
-      // Reassign: keep existing assignments where zones exist, redistribute
-      setAssignments((prev) => {
-        const next: ZoneAssignments = {};
-        const usedTabs = new Set<string>();
-
-        // Keep assignments that fit in the new layout
-        for (let z = 0; z < newLayout.zones.length; z++) {
-          if (prev[z] && tabIds.includes(prev[z])) {
-            next[z] = prev[z];
-            usedTabs.add(prev[z]);
-          }
-        }
-
-        // Fill remaining zones with unassigned tabs
-        const unassigned = tabIds.filter((id) => !usedTabs.has(id));
-        for (let z = 0; z < newLayout.zones.length && unassigned.length > 0; z++) {
-          if (!(z in next)) {
-            next[z] = unassigned.shift()!;
-          }
-        }
-
-        return next;
-      });
+      // Reassign: preserve every in-range assignment exactly; compact only
+      // out-of-range ones; fill remaining zones with unassigned tabs. See
+      // `applyLayoutAssignments` (item 10 — recorded zones must survive
+      // layout application; dead-tab cleanup belongs to
+      // `reconcileAssignments`, which runs with fresh tabIds).
+      setAssignments((prev) => applyLayoutAssignments(prev, tabIds, newLayout.zones.length));
 
       // Clamp focused zone
       setFocusedZone((prev) => (prev >= newLayout.zones.length ? 0 : prev));

--- a/src/components/terminal/zone-grid/ZoneLabel.test.ts
+++ b/src/components/terminal/zone-grid/ZoneLabel.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for the zone-header UI Bridge registration spec (boot-restore
+ * remediation item 8): session/zone identity must be discoverable via
+ * `ai/find` — the registered element's label carries the session title and a
+ * stable per-zone id. The `useUIElement` call itself needs a DOM; the spec
+ * builder is pure, so we assert the contract here (vitest `node` env, same
+ * precedent as the sibling restore tests).
+ */
+
+import { describe, it, expect } from "vitest";
+import { zoneHeaderElementSpec } from "./ZoneLabel";
+
+describe("zoneHeaderElementSpec", () => {
+  it("labels the element with the session title so ai/find by title resolves", () => {
+    const spec = zoneHeaderElementSpec(0, "FIXTURE-ONSCREEN-1");
+    expect(spec.label).toContain("FIXTURE-ONSCREEN-1");
+  });
+
+  it("uses a stable per-zone element id (1-based zone numbering in the label)", () => {
+    expect(zoneHeaderElementSpec(3, "Claude 4")).toEqual({
+      id: "terminal-zone-header-3",
+      label: "Zone 4: Claude 4",
+    });
+  });
+
+  it("ids are unique per zone — two zones never collide in the registry", () => {
+    expect(zoneHeaderElementSpec(0, "same title").id).not.toBe(
+      zoneHeaderElementSpec(1, "same title").id,
+    );
+  });
+});

--- a/src/components/terminal/zone-grid/ZoneLabel.tsx
+++ b/src/components/terminal/zone-grid/ZoneLabel.tsx
@@ -1,10 +1,32 @@
 import { useState, useRef, useEffect } from "react";
 import { ChevronDown, Pin, Filter, ArrowDownToLine, Zap } from "lucide-react";
+import { useUIElement } from "@qontinui/ui-bridge";
 import type { TerminalTab } from "../useTerminalManager";
 import type { ZoneAssignments, SessionState } from "../useZoneLayout";
 import { STATE_BORDER_COLORS } from "./constants";
 import { isNonDurablePty, NON_DURABLE_TOOLTIP, NON_DURABLE_LABEL } from "../sessionDurability";
 import { useTerminalWindowActions } from "../useTerminalWindowActions";
+
+/**
+ * UI Bridge registration spec for a zone header (boot-restore remediation
+ * item 8): session/zone identity was previously only observable through a
+ * debug DOM text node — `ai/find "<session title>"` resolved nothing. The
+ * header element registers with the session title as its label and carries
+ * the binding as data attributes (`data-claude-session-id`,
+ * `data-zone-index`, `data-resume-failed`) so UI Bridge clients can verify
+ * session↔zone placement without scraping internals.
+ *
+ * Pure + exported for unit tests (the hook call itself needs a DOM).
+ */
+export function zoneHeaderElementSpec(
+  zoneIndex: number,
+  title: string,
+): { id: string; label: string } {
+  return {
+    id: `terminal-zone-header-${zoneIndex}`,
+    label: `Zone ${zoneIndex + 1}: ${title}`,
+  };
+}
 
 export function ZoneLabel({
   tab,
@@ -47,6 +69,16 @@ export function ZoneLabel({
   const selectorRef = useRef<HTMLDivElement>(null);
   const { popOutTab } = useTerminalWindowActions();
 
+  // Item 8: expose session/zone identity to UI Bridge clients. The label is
+  // the session title so `ai/find` by title resolves to this header; the
+  // session binding rides as data attributes on the registered node.
+  const headerSpec = zoneHeaderElementSpec(zoneIndex, tab.title);
+  const { ref: headerRef } = useUIElement({
+    id: headerSpec.id,
+    type: "generic",
+    label: headerSpec.label,
+  });
+
   useEffect(() => {
     if (!showSelector) return;
     const handleClick = (e: MouseEvent) => {
@@ -60,6 +92,10 @@ export function ZoneLabel({
 
   return (
     <div
+      ref={headerRef}
+      data-claude-session-id={tab.claudeSessionId ?? undefined}
+      data-zone-index={zoneIndex}
+      data-resume-failed={tab.resumeFailed ? "true" : undefined}
       className="absolute top-0 left-0 right-0 flex items-center gap-1.5 px-2 py-0.5 bg-[#13141f]/80 backdrop-blur-sm z-10 cursor-grab active:cursor-grabbing"
       draggable
       onDragStart={(e) => {


### PR DESCRIPTION
- pre-verification record_open re-assert made ghosts immortal → re-assert only in verified branch (useTerminalInitialization.ts)
- handshake verified TUI-appeared not session-resumed → negative failure patterns first (resumeVerification.ts)
- guessed bindOrigin rows auto-resumed blindly → quarantine behind one-click confirm in ResumeFailedBanner
- freshest-mtime transcript guess could bind foreign sessions → never probe without cwd + reject foreign-project payloads (useTabSessionIdCapture.ts)
- zone drift on restore gap → preserve in-range recorded zoneIndex (useZoneLayout.ts)
- zone headers registered as UI Bridge elements (ZoneLabel.tsx)

Part of manual-test-loop iteration 1 (boot-restore wrong-sessions remediation, plan 2026-06-13-boot-restore-wrong-sessions-remediation).