### PR TITLE
runner: manual-test-loop iter 1 — boot-restore ghost exclusion + no-terminal poll close

### DIFF
--- a/UI-BRIDGE-AUTOMATION.md
+++ b/UI-BRIDGE-AUTOMATION.md
@@ -197,6 +197,50 @@ internal sub-tab state whenever that prop changes.
 
 ---
 
+## Reading terminal pane content: `GET /terminals/{id}/buffer?format=text`
+
+xterm renders terminal panes to a **canvas** — UI Bridge
+`snapshot`/`read-value`/DOM walks return empty text for them. To verify
+what a pane actually shows, do NOT scrape the DOM; read the live
+scrollback ring over the runner API instead (same port as the routes
+above; this is a runner API route, not a `/ui-bridge/*` one):
+
+```bash
+# 1. Find the terminal id (and its page/title/workingDir).
+curl http://localhost:9876/terminals
+
+# 2. Read the pane's scrollback as plain text (UTF-8, ANSI/OSC stripped).
+curl "http://localhost:9876/terminals/<id>/buffer?format=text"
+```
+
+Response shape with `format=text`:
+
+```json
+{
+  "success": true,
+  "data": {
+    "data": { "text": "...full scrollback text..." },
+    "start_offset": 0,
+    "total_bytes_produced": 12345
+  }
+}
+```
+
+Query forms (all on the same handler; `GET /terminals/{id}/output` is an
+alias for `/buffer`):
+
+| Query              | Returns                                                                         |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `?format=text`     | Canonical: UTF-8 lossy decode + ANSI/OSC stripped, nested `{ data: { text } }`   |
+| `?decoded=true`    | UTF-8 lossy decode, ANSI escape codes left intact (top-level string `data`)      |
+| `?strip_ansi=true` | Implies `decoded=true`; strips CSI/OSC + control bytes (top-level string `data`) |
+| _(none)_           | Base64-encoded raw PTY bytes — byte-fidelity for replays / WS scrollback         |
+
+Source: `src-tauri/src/mcp/terminals.rs` (`BufferQuery`,
+`get_buffer_handler`, route registration in `routes()`).
+
+---
+
 ## Behind the scenes
 
 ### Invoke proxy wire flow

--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -929,20 +929,31 @@ pub fn terminal_session_record_close(
 /// The grid hydrates its session tiles from this on boot instead of
 /// `localStorage`.
 ///
-/// Returns the restorable superset (see `restorable_records`): all `open`
-/// records (hard-crash case) PLUS `closed`/`pty-exit` records still within the
-/// grace window (graceful-restart case, where `handleExit` flipped every live
-/// PTY to `closed`). User-closed and stale records are excluded so the restore
-/// path resurrects exactly the sessions that died with the runner.
+/// Returns the restorable set (see `restorable_records`): `open` records
+/// whose `last_seen_at` is recent relative to the registry's ANCHOR (its last
+/// moment of life — max of every row's timestamps plus the prior shutdown
+/// marker's `at`), PLUS `closed`/`pty-exit` and `closed`/`poll-dead` records
+/// still within their grace windows (graceful-restart case, where
+/// `handleExit` flipped every live PTY to `closed`). User-closed, orphan
+/// (`no-terminal`) and stale-ghost records are excluded so the restore path
+/// resurrects exactly the sessions that died with the runner.
 #[tauri::command]
 pub fn terminal_session_list_open(
     store: tauri::State<'_, Arc<SessionLifecycleStore>>,
 ) -> Result<CommandResponse, String> {
     let now = chrono::Utc::now().timestamp_millis();
+    // The prior shutdown marker's `at` is one input to the anchor. It is
+    // captured ONCE at boot (main.rs setup, before this command can run) —
+    // the on-disk marker itself already says `clean:false` for the NOW-
+    // running process and must never be re-read for restore decisions.
+    let prior_marker_at =
+        crate::session::shutdown_marker::boot_classification().and_then(|c| c.prior_marker_at);
     Ok(CommandResponse {
         success: true,
         message: None,
-        data: Some(serde_json::json!({ "sessions": store.restorable_records(now) })),
+        data: Some(
+            serde_json::json!({ "sessions": store.restorable_records(now, prior_marker_at) }),
+        ),
     })
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1883,6 +1883,30 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
         .setup(|app| {
             info!("Tauri application setup starting");
 
+            // Boot-restore remediation item 1 — classify THIS boot (crash
+            // recovery vs planned restart) exactly once, synchronously,
+            // BEFORE the API server / frontend restore can race it.
+            // `classify_boot` reads the PRIOR shutdown marker, stashes the
+            // classification in a process-wide OnceLock, and immediately
+            // re-marks the marker `clean:false` for the now-running process.
+            // Consumers (`resume_ai_sessions` via mcp_api.rs, the terminal
+            // restore path via `terminal_session_list_open`) read the stash —
+            // a command-time file read would ALWAYS see `clean:false` after
+            // this point and permanently classify "crash".
+            {
+                let marker_path = session::shutdown_marker::marker_path(
+                    crate::mcp::types::get_mcp_api_port(),
+                );
+                let boot = session::shutdown_marker::classify_boot(&marker_path);
+                if boot.crash_recovery {
+                    warn!(
+                        "boot classification: previous shutdown was NOT clean — crash recovery"
+                    );
+                } else {
+                    info!("boot classification: previous shutdown was clean — planned restart");
+                }
+            }
+
             // Plan 2026-05-18-agent-spawn-coordination Phase 3 — stash a
             // global AppHandle so background tokio tasks (e.g. claim
             // heartbeats from `agent_claims`) can emit Tauri events
@@ -2230,6 +2254,13 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     // claudeSessionId -> consecutive zero-descendant ticks,
                     // carried across ticks to debounce `NeedsConfirm`.
                     let mut consecutive_dead: StdHashMap<String, u32> = StdHashMap::new();
+                    // claudeSessionId -> consecutive NO-MATCHING-TERMINAL
+                    // ticks, carried across ticks to debounce the orphan
+                    // close (`CloseNoTerminal`): a record matching nothing
+                    // in this instance for ~4 ticks is an orphan, not
+                    // uncertainty — without this it stays `open` for up to
+                    // 7 days and re-qualifies for restore at every boot.
+                    let mut consecutive_no_match: StdHashMap<String, u32> = StdHashMap::new();
 
                     loop {
                         tokio::time::sleep(Duration::from_secs(45)).await;
@@ -2238,6 +2269,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         if open.is_empty() {
                             // Forget any stale counters and prune, then idle.
                             consecutive_dead.clear();
+                            consecutive_no_match.clear();
                             poll_lifecycle_store
                                 .prune(chrono::Utc::now().timestamp_millis());
                             continue;
@@ -2286,16 +2318,24 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                 .get(&rec.claude_session_id)
                                 .copied()
                                 .unwrap_or(0);
+                            let prior_no_match = consecutive_no_match
+                                .get(&rec.claude_session_id)
+                                .copied()
+                                .unwrap_or(0);
                             // Restore-pending records (a boot-restore typed
                             // `claude --resume` whose handshake isn't verified
                             // yet — or whose restore FAILED and awaits a retry)
-                            // must never flip `poll-dead`: classify Skips them
-                            // unless the session is confidently alive.
+                            // must never flip `poll-dead` / `no-terminal`:
+                            // classify Skips them (and accumulates no ticks)
+                            // unless the session is confidently alive. A mid-
+                            // restore record keeps its OLD terminal_id until
+                            // the re-assert, so it naturally matches nothing.
                             let restore_pending = rec.restore_pending_at.is_some();
                             let action = classify(
                                 live_is_alive,
                                 descendant_count,
                                 prior,
+                                prior_no_match,
                                 snapshot_ok,
                                 restore_pending,
                             );
@@ -2312,10 +2352,14 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                     poll_lifecycle_store.touch(&rec.claude_session_id);
                                     consecutive_dead.remove(&rec.claude_session_id);
+                                    consecutive_no_match.remove(&rec.claude_session_id);
                                 }
                                 PollAction::NeedsConfirm => {
                                     consecutive_dead
                                         .insert(rec.claude_session_id.clone(), prior + 1);
+                                    // A terminal matched this tick — any
+                                    // no-match streak is broken.
+                                    consecutive_no_match.remove(&rec.claude_session_id);
                                     tracing::debug!(
                                         claude_session = %rec.claude_session_id,
                                         "session lifecycle poll: zero descendants — confirming before close"
@@ -2325,13 +2369,46 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                     poll_lifecycle_store
                                         .record_close(&rec.claude_session_id, "poll-dead");
                                     consecutive_dead.remove(&rec.claude_session_id);
+                                    consecutive_no_match.remove(&rec.claude_session_id);
                                     tracing::info!(
                                         claude_session = %rec.claude_session_id,
                                         "session lifecycle poll: closing dead session"
                                     );
                                 }
+                                PollAction::NoMatchWait => {
+                                    consecutive_no_match
+                                        .insert(rec.claude_session_id.clone(), prior_no_match + 1);
+                                    // A no-match tick breaks any zero-
+                                    // descendant streak (the streaks are
+                                    // mutually exclusive — a stale dead
+                                    // counter must not survive terminal
+                                    // churn and trigger an early poll-dead
+                                    // close when the terminal re-matches).
+                                    consecutive_dead.remove(&rec.claude_session_id);
+                                    tracing::debug!(
+                                        claude_session = %rec.claude_session_id,
+                                        terminal = %rec.terminal_id,
+                                        ticks = prior_no_match + 1,
+                                        "session lifecycle poll: no matching terminal — debouncing before orphan close"
+                                    );
+                                }
+                                PollAction::CloseNoTerminal => {
+                                    // No matching terminal for several
+                                    // consecutive ticks — an orphan row (e.g.
+                                    // a ghost inherited from a prior process).
+                                    // `"no-terminal"` is non-restorable.
+                                    poll_lifecycle_store
+                                        .record_close(&rec.claude_session_id, "no-terminal");
+                                    consecutive_dead.remove(&rec.claude_session_id);
+                                    consecutive_no_match.remove(&rec.claude_session_id);
+                                    tracing::info!(
+                                        claude_session = %rec.claude_session_id,
+                                        terminal = %rec.terminal_id,
+                                        "session lifecycle poll: closing orphan session (no matching terminal)"
+                                    );
+                                }
                                 PollAction::Skip => {
-                                    // Uncertain — do NOT touch the counter.
+                                    // Uncertain — do NOT touch the counters.
                                 }
                             }
                         }

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1388,18 +1388,19 @@ pub fn create_router(
             // Wait a bit longer than unified workflows to let the server fully start
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
-            // Phase 4 — classify this boot as crash recovery vs a planned
-            // restart from the on-disk shutdown marker, BEFORE we overwrite
-            // it. A missing / `clean:false` / corrupt marker ⇒ the previous
-            // shutdown was NOT clean ⇒ crash recovery. We then immediately
-            // (re)write the marker `clean:false` for the NOW-running process
-            // so that if THIS process crashes the next boot detects it. The
-            // clean drain / exit seam flips it back to `clean:true`.
+            // Phase 4 — crash recovery vs planned restart. The classification
+            // is captured EXACTLY ONCE per process by `classify_boot` (which
+            // reads the prior marker, stashes the result, and re-marks the
+            // marker `clean:false` for the NOW-running process so a crash of
+            // THIS process is detected next boot; the clean drain / exit seam
+            // flips it back to `clean:true`). `main.rs` setup performs the
+            // classification synchronously at boot; this call is idempotent
+            // and simply reads the stash (OnceLock) — re-reading the marker
+            // file here would ALWAYS classify "crash" post-`mark_running`.
             let marker_path =
                 crate::session::shutdown_marker::marker_path(crate::mcp::types::get_mcp_api_port());
             let crash_recovery =
-                crate::session::shutdown_marker::was_unclean_shutdown(&marker_path);
-            crate::session::shutdown_marker::mark_running(&marker_path);
+                crate::session::shutdown_marker::classify_boot(&marker_path).crash_recovery;
             if crash_recovery {
                 warn!("Startup recovery: previous shutdown was NOT clean — this is crash recovery");
             }

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -54,6 +54,18 @@ const RESTORABLE_PTY_EXIT_MS: i64 = 600_000;
 /// NOT restorable (a genuinely abandoned session should not resurrect days
 /// later). 10 minutes in millis.
 const RESTORABLE_POLL_DEAD_MS: i64 = 600_000;
+/// Anchored-recency grace for `state == "open"` rows in
+/// [`SessionLifecycleStore::restorable_records`]. An open row is restorable
+/// iff `anchor - last_seen_at <= grace`, where `anchor` is the registry's
+/// LAST MOMENT OF LIFE (max of every row's `last_seen_at` / `closed_at`,
+/// plus the prior shutdown marker's `at`). Recency relative to the anchor —
+/// not wall-clock now — survives arbitrary downtime: a crash followed by an
+/// hours-later boot still restores the rows that were fresh when the
+/// previous process died, while a multi-day ghost row stays excluded on
+/// EVERY boot kind. 10 minutes in millis (matches the close-grace windows;
+/// live sessions are touched every ~45s by the poll, so anything on screen
+/// at shutdown sits well inside it).
+const RESTORABLE_OPEN_ANCHOR_GRACE_MS: i64 = 600_000;
 /// Number of consecutive zero-descendant ticks a *live* shell (`Some(true)`)
 /// must accumulate before the poll closes it `poll-dead`. A live Claude
 /// session routinely idles with zero descendants between tool calls / while
@@ -64,6 +76,17 @@ const RESTORABLE_POLL_DEAD_MS: i64 = 600_000;
 /// shell still closes immediately — that path is unambiguous and bypasses
 /// this debounce entirely.
 const LIVE_SHELL_DEAD_TICKS: u32 = 3;
+/// Number of consecutive NO-MATCHING-TERMINAL ticks an open record must
+/// accumulate before the poll closes it `"no-terminal"`. A record whose
+/// terminal id (and fallback triple) matches nothing in THIS instance for
+/// many consecutive ticks is not "uncertainty" — it is an orphan (e.g. a
+/// stale ghost row inherited from a previous process) that would otherwise
+/// stay `open` for up to 7 days and re-qualify for restore at every boot.
+/// The close fires on tick N+1 (≈ 4 ticks × 45s ≈ 3 min), debounced so a
+/// just-created record whose terminal is still registering never closes.
+/// `"no-terminal"` is automatically NON-restorable: the restore grace match
+/// only covers `"pty-exit"` / `"poll-dead"`.
+const NO_TERMINAL_ORPHAN_TICKS: u32 = 3;
 
 /// One persisted terminal-session lifecycle record, keyed by
 /// `claude_session_id`. Timestamps are unix epoch millis.
@@ -284,9 +307,13 @@ impl SessionLifecycleStore {
     }
 
     /// Clone of every record that should be RESTORED on boot. This is the
-    /// superset of [`Self::open_records`] used by the restore path:
+    /// subset of records the restore path resurrects:
     ///
-    /// - every `state == "open"` record (a hard crash leaves records open), PLUS
+    /// - every `state == "open"` record that is RECENT relative to the
+    ///   registry's anchor (see below) — a hard crash AND a clean shutdown
+    ///   whose `pty-exit` close never flushed both leave fresh open rows,
+    ///   while a stale ghost row (terminal long gone) carries an old
+    ///   `last_seen_at` and is excluded on every boot kind, PLUS
     /// - every `state == "closed"` record whose `close_reason == "pty-exit"`
     ///   (its PTY died — the case a GRACEFUL restart produces by firing
     ///   `handleExit` on every live PTY) that closed within the
@@ -297,35 +324,69 @@ impl SessionLifecycleStore {
     ///   uncertain (the shell pty was still alive), so an immediate restart
     ///   should bring the session back rather than silently drop it.
     ///
-    /// Records closed for any other reason (explicit user close), or `pty-exit`
-    /// / `poll-dead` closes older than their grace windows, are excluded — a
-    /// user who closes a tab does not want it resurrected, and a long-dead
-    /// close is stale.
-    pub fn restorable_records(&self, now_ms: i64) -> Vec<TerminalSessionRecord> {
+    /// Records closed for any other reason (explicit user close, the poll's
+    /// `"no-terminal"` orphan close), or `pty-exit` / `poll-dead` closes older
+    /// than their grace windows, are excluded — a user who closes a tab does
+    /// not want it resurrected, and a long-dead close is stale.
+    ///
+    /// ## Anchored recency (open rows)
+    ///
+    /// An open row is admitted iff
+    /// `anchor - last_seen_at <= RESTORABLE_OPEN_ANCHOR_GRACE_MS`, where
+    /// `anchor = max(every last_seen_at, every closed_at, prior_marker_at)` —
+    /// the registry's last moment of life, NOT wall-clock now. A wall-clock
+    /// rule (`now - last_seen <= grace`) would restore NOTHING after any
+    /// downtime longer than the grace (crash, hours-later boot), while a
+    /// clean-boot hard exclusion would silently lose a real on-screen session
+    /// whose `pty-exit` close never flushed. `prior_marker_at` is the prior
+    /// shutdown marker's `at` (shutdown instant on a clean exit, the crashed
+    /// process's boot instant on a crash), captured ONCE at boot — see
+    /// [`crate::session::shutdown_marker::boot_classification`].
+    pub fn restorable_records(
+        &self,
+        now_ms: i64,
+        prior_marker_at: Option<i64>,
+    ) -> Vec<TerminalSessionRecord> {
         match self.map.lock() {
-            Ok(m) => m
-                .values()
-                .filter(|r| {
-                    if r.state == "open" {
-                        return true;
-                    }
-                    if r.state == "closed" {
-                        let grace = match r.close_reason.as_deref() {
-                            Some("pty-exit") => Some(RESTORABLE_PTY_EXIT_MS),
-                            Some("poll-dead") => Some(RESTORABLE_POLL_DEAD_MS),
-                            _ => None,
-                        };
-                        if let Some(grace_ms) = grace {
-                            return match r.closed_at {
-                                Some(closed_at) => now_ms - closed_at <= grace_ms,
-                                None => false,
+            Ok(m) => {
+                // The registry's last moment of life across every row, plus
+                // the prior shutdown marker.
+                let anchor = m
+                    .values()
+                    .flat_map(|r| [Some(r.last_seen_at), r.closed_at])
+                    .chain(std::iter::once(prior_marker_at))
+                    .flatten()
+                    .max();
+                m.values()
+                    .filter(|r| {
+                        if r.state == "open" {
+                            return match anchor {
+                                Some(anchor) => {
+                                    anchor - r.last_seen_at <= RESTORABLE_OPEN_ANCHOR_GRACE_MS
+                                }
+                                // Unreachable: an open row's own last_seen_at
+                                // feeds the anchor. Admit defensively.
+                                None => true,
                             };
                         }
-                    }
-                    false
-                })
-                .cloned()
-                .collect(),
+                        if r.state == "closed" {
+                            let grace = match r.close_reason.as_deref() {
+                                Some("pty-exit") => Some(RESTORABLE_PTY_EXIT_MS),
+                                Some("poll-dead") => Some(RESTORABLE_POLL_DEAD_MS),
+                                _ => None,
+                            };
+                            if let Some(grace_ms) = grace {
+                                return match r.closed_at {
+                                    Some(closed_at) => now_ms - closed_at <= grace_ms,
+                                    None => false,
+                                };
+                            }
+                        }
+                        false
+                    })
+                    .cloned()
+                    .collect()
+            }
             Err(e) => {
                 warn!(error = %e, "session_lifecycle_store: lock poisoned on restorable_records");
                 Vec::new()
@@ -422,34 +483,52 @@ pub enum PollAction {
     /// reached [`LIVE_SHELL_DEAD_TICKS`] consecutive zero-descendant ticks —
     /// wait more ticks before closing (debounce idle lulls between tool calls).
     NeedsConfirm,
-    /// The session is dead — flip it to `closed`.
+    /// The session is dead — flip it to `closed` (reason `"poll-dead"`).
     Close,
+    /// No live terminal matched this record this tick, and it has not yet
+    /// reached [`NO_TERMINAL_ORPHAN_TICKS`] consecutive no-match ticks —
+    /// increment the no-match counter and wait (debounce registration races).
+    NoMatchWait,
+    /// No live terminal matched for > [`NO_TERMINAL_ORPHAN_TICKS`]
+    /// consecutive ticks — the record is an orphan; close it with reason
+    /// `"no-terminal"` (non-restorable).
+    CloseNoTerminal,
     /// Uncertain — do nothing (NEVER close on uncertainty).
     Skip,
 }
 
 /// Pure liveness-classification core. Asymmetric by design: we only ever
-/// `Close` on a *confident* dead signal, and `Skip` (never close) on any
-/// uncertainty (snapshot failure or no matching pty).
+/// close on a *confident* dead signal (a dead pty, or a no-match streak long
+/// enough to be an orphan rather than a race), and `Skip` (never close) on
+/// genuine uncertainty (snapshot failure, mid-restore records).
 ///
 /// - `live_is_alive`: `Some(true)` shell pty alive, `Some(false)` dead,
 ///   `None` no matching pty for this session.
 /// - `descendant_count`: number of descendant processes of the shell pid.
 /// - `consecutive_dead`: count of prior consecutive zero-descendant ticks.
+/// - `consecutive_no_match`: count of prior consecutive ticks where NO live
+///   terminal matched this record. "No matching terminal in THIS instance
+///   for many consecutive ticks" is not uncertainty — it is an orphan that
+///   would otherwise stay `open` for up to 7 days and re-qualify for restore
+///   at every boot. Debounced via [`NO_TERMINAL_ORPHAN_TICKS`].
 /// - `snapshot_ok`: whether the system-wide process snapshot succeeded.
 /// - `restore_pending`: whether the record carries a restore-pending marker
 ///   (a boot-restore typed/queued `claude --resume` whose handshake has not
 ///   been verified yet — or the restore FAILED and awaits an operator retry).
 ///   A mid-restore record is uncertainty by definition: the restored pane may
-///   be a plain shell whose resume never landed, and flipping it `poll-dead`
+///   be a plain shell whose resume never landed, and flipping it closed
 ///   would destroy the durable `open` state the next attempt needs. So while
 ///   pending, only a confident "alive and busy" (KeepAlive) observation
 ///   passes through — which also lets the caller self-heal a stale marker —
-///   and every other outcome becomes Skip.
+///   and every other outcome becomes Skip. In particular a mid-restore row
+///   (which keeps its OLD `terminal_id` until the deferred re-assert) must
+///   never accumulate no-match ticks: `None` + pending ⇒ Skip, not
+///   `NoMatchWait`.
 pub fn classify(
     live_is_alive: Option<bool>,
     descendant_count: usize,
     consecutive_dead: u32,
+    consecutive_no_match: u32,
     snapshot_ok: bool,
     restore_pending: bool,
 ) -> PollAction {
@@ -457,7 +536,13 @@ pub fn classify(
         return PollAction::Skip;
     }
     let base = match live_is_alive {
-        None => PollAction::Skip,
+        None => {
+            if consecutive_no_match < NO_TERMINAL_ORPHAN_TICKS {
+                PollAction::NoMatchWait
+            } else {
+                PollAction::CloseNoTerminal
+            }
+        }
         Some(false) => PollAction::Close,
         Some(true) => {
             if descendant_count > 0 {
@@ -475,7 +560,8 @@ pub fn classify(
     };
     // Restore-pending guard arm (never-close-on-uncertainty): a record mid-
     // restore (or whose restore failed) must keep its `open` state intact —
-    // never Close, and don't even accumulate NeedsConfirm ticks against it.
+    // never Close, and don't even accumulate NeedsConfirm or no-match ticks
+    // against it.
     if restore_pending && base != PollAction::KeepAlive {
         return PollAction::Skip;
     }
@@ -657,7 +743,7 @@ mod tests {
         let store = SessionLifecycleStore::open(&path).unwrap();
 
         let mut ids: Vec<String> = store
-            .restorable_records(now)
+            .restorable_records(now, None)
             .into_iter()
             .map(|r| r.claude_session_id)
             .collect();
@@ -766,31 +852,77 @@ mod tests {
     #[test]
     fn classify_skip_on_snapshot_failure() {
         // snapshot_ok=false dominates every other input.
-        assert_eq!(classify(Some(false), 0, 5, false, false), PollAction::Skip);
-        assert_eq!(classify(Some(true), 3, 0, false, false), PollAction::Skip);
-        assert_eq!(classify(None, 0, 0, false, false), PollAction::Skip);
+        assert_eq!(
+            classify(Some(false), 0, 5, 0, false, false),
+            PollAction::Skip
+        );
+        assert_eq!(
+            classify(Some(true), 3, 0, 0, false, false),
+            PollAction::Skip
+        );
+        assert_eq!(classify(None, 0, 0, 0, false, false), PollAction::Skip);
+        // Even a no-match streak past the orphan threshold must Skip (not
+        // CloseNoTerminal) when the snapshot failed.
+        assert_eq!(
+            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS + 5, false, false),
+            PollAction::Skip
+        );
     }
 
     #[test]
-    fn classify_skip_on_no_matching_pty() {
-        assert_eq!(classify(None, 0, 0, true, false), PollAction::Skip);
-        assert_eq!(classify(None, 9, 9, true, false), PollAction::Skip);
+    fn classify_no_match_waits_below_orphan_ticks() {
+        // A record matching no live terminal accumulates NoMatchWait ticks
+        // for every tick strictly below NO_TERMINAL_ORPHAN_TICKS — it must
+        // NOT close on a brief registration race.
+        for prior in 0..NO_TERMINAL_ORPHAN_TICKS {
+            assert_eq!(
+                classify(None, 0, 0, prior, true, false),
+                PollAction::NoMatchWait,
+                "no match, {prior} prior no-match ticks must NoMatchWait"
+            );
+        }
+        // descendant/dead-tick inputs are irrelevant to the no-match arm.
+        assert_eq!(
+            classify(None, 9, 9, 0, true, false),
+            PollAction::NoMatchWait
+        );
+    }
+
+    #[test]
+    fn classify_no_match_closes_no_terminal_after_orphan_ticks() {
+        // Once the no-match streak reaches the threshold the record is an
+        // orphan — close it with the (non-restorable) "no-terminal" reason.
+        // With a 45s poll the close lands on the 4th consecutive tick ≈ 3min.
+        assert_eq!(
+            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS, true, false),
+            PollAction::CloseNoTerminal
+        );
+        assert_eq!(
+            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS + 5, true, false),
+            PollAction::CloseNoTerminal
+        );
     }
 
     #[test]
     fn classify_close_on_dead_shell() {
-        assert_eq!(classify(Some(false), 0, 0, true, false), PollAction::Close);
-        assert_eq!(classify(Some(false), 5, 0, true, false), PollAction::Close);
+        assert_eq!(
+            classify(Some(false), 0, 0, 0, true, false),
+            PollAction::Close
+        );
+        assert_eq!(
+            classify(Some(false), 5, 0, 0, true, false),
+            PollAction::Close
+        );
     }
 
     #[test]
     fn classify_keepalive_when_alive_with_descendants() {
         assert_eq!(
-            classify(Some(true), 1, 0, true, false),
+            classify(Some(true), 1, 0, 0, true, false),
             PollAction::KeepAlive
         );
         assert_eq!(
-            classify(Some(true), 7, 9, true, false),
+            classify(Some(true), 7, 9, 0, true, false),
             PollAction::KeepAlive
         );
     }
@@ -802,14 +934,14 @@ mod tests {
         // brief idle lull (the poll-dead race this fix closes).
         for prior in 0..LIVE_SHELL_DEAD_TICKS {
             assert_eq!(
-                classify(Some(true), 0, prior, true, false),
+                classify(Some(true), 0, prior, 0, true, false),
                 PollAction::NeedsConfirm,
                 "live shell, 0 descendants, {prior} prior ticks must NeedsConfirm"
             );
         }
         // Specifically: the second tick (prior == 1) no longer closes.
         assert_eq!(
-            classify(Some(true), 0, 1, true, false),
+            classify(Some(true), 0, 1, 0, true, false),
             PollAction::NeedsConfirm
         );
     }
@@ -819,11 +951,11 @@ mod tests {
         // Only once we've accumulated LIVE_SHELL_DEAD_TICKS consecutive
         // zero-descendant ticks does a live shell finally close.
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, true, false),
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, 0, true, false),
             PollAction::Close
         );
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, true, false),
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, 0, true, false),
             PollAction::Close
         );
     }
@@ -833,21 +965,29 @@ mod tests {
         // The incident shape: a restored pane whose resume silently failed.
         // Dead pty (the restore shell died / was never matched) → Skip, NOT
         // Close — the durable `open` record must survive for the next attempt.
-        assert_eq!(classify(Some(false), 0, 0, true, true), PollAction::Skip);
+        assert_eq!(classify(Some(false), 0, 0, 0, true, true), PollAction::Skip);
         // Plain shell idling with zero descendants, even past the debounce
         // ticks (the exact poll-dead flip the incident hit) → Skip.
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, true, true),
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, 0, true, true),
             PollAction::Skip
         );
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, true, true),
+            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, 0, true, true),
             PollAction::Skip
         );
         // Below the debounce it must not even accumulate NeedsConfirm ticks.
-        assert_eq!(classify(Some(true), 0, 0, true, true), PollAction::Skip);
-        // No matching pty → Skip (unchanged).
-        assert_eq!(classify(None, 0, 0, true, true), PollAction::Skip);
+        assert_eq!(classify(Some(true), 0, 0, 0, true, true), PollAction::Skip);
+        // No matching pty → Skip, NOT NoMatchWait: a mid-restore row keeps
+        // its OLD terminal_id until the re-assert and must never accumulate
+        // no-match ticks toward an orphan close.
+        assert_eq!(classify(None, 0, 0, 0, true, true), PollAction::Skip);
+        // Even a streak past the orphan threshold must not close while the
+        // restore-pending marker is set.
+        assert_eq!(
+            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS + 1, true, true),
+            PollAction::Skip
+        );
     }
 
     #[test]
@@ -856,8 +996,25 @@ mod tests {
         // KeepAlive even while restore-pending — the caller uses this to
         // self-heal a stale marker.
         assert_eq!(
-            classify(Some(true), 2, 0, true, true),
+            classify(Some(true), 2, 0, 0, true, true),
             PollAction::KeepAlive
+        );
+    }
+
+    #[test]
+    fn no_terminal_close_is_not_restorable() {
+        // The poll's orphan close ("no-terminal") must NOT re-qualify for
+        // restore — only "pty-exit"/"poll-dead" closes get a grace window.
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        store.record_open(rec("orphan-sess"));
+        store.record_close("orphan-sess", "no-terminal");
+
+        let now = Utc::now().timestamp_millis();
+        assert!(
+            store.restorable_records(now, None).is_empty(),
+            "a no-terminal close (even seconds old) must not be restorable"
         );
     }
 
@@ -912,6 +1069,203 @@ mod tests {
         );
     }
 
+    /// Build a fully-specified fixture record (explicit timestamps, unlike
+    /// `rec` whose timestamps `record_open` overwrites).
+    fn fixture_rec(
+        id: &str,
+        state: &str,
+        last_seen_at: i64,
+        closed_at: Option<i64>,
+        close_reason: Option<&str>,
+    ) -> TerminalSessionRecord {
+        TerminalSessionRecord {
+            claude_session_id: id.to_string(),
+            config_dir: None,
+            working_dir: Some("C:/repo".to_string()),
+            page_id: "default".to_string(),
+            zone_index: 0,
+            title: Some(id.to_string()),
+            terminal_id: format!("term-{id}"),
+            opened_at: last_seen_at - 1_000,
+            last_seen_at,
+            state: state.to_string(),
+            closed_at,
+            close_reason: close_reason.map(str::to_string),
+            bind_origin: None,
+            restore_pending_at: None,
+        }
+    }
+
+    /// Write a registry fixture file directly (bypassing `record_open`'s
+    /// now-stamping) so tests control every timestamp.
+    fn write_fixture(path: &Path, recs: Vec<TerminalSessionRecord>) {
+        let m: HashMap<String, TerminalSessionRecord> = recs
+            .into_iter()
+            .map(|r| (r.claude_session_id.clone(), r))
+            .collect();
+        std::fs::write(path, serde_json::to_vec_pretty(&m).unwrap()).unwrap();
+    }
+
+    fn restorable_ids(
+        store: &SessionLifecycleStore,
+        now: i64,
+        prior_marker_at: Option<i64>,
+    ) -> Vec<String> {
+        let mut ids: Vec<String> = store
+            .restorable_records(now, prior_marker_at)
+            .into_iter()
+            .map(|r| r.claude_session_id)
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    /// Item-1 verification fixture (the on-page repro): two in-grace
+    /// pty-exit rows (exactly what a graceful shutdown writes for on-screen
+    /// panes), one explicit close, and one stale `open` ghost whose terminal
+    /// died 72h before shutdown. After a clean restart only the two pty-exit
+    /// rows may restore — the ghost spawns no pane.
+    #[test]
+    fn restorable_records_exclude_stale_open_ghost_after_clean_restart() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let shutdown = 1_700_000_000_000_i64; // registry's last moment of life
+        let now = shutdown + 60_000; // restart one minute later
+        write_fixture(
+            &path,
+            vec![
+                fixture_rec(
+                    "fixture-onscreen-0001",
+                    "closed",
+                    shutdown,
+                    Some(shutdown),
+                    Some("pty-exit"),
+                ),
+                fixture_rec(
+                    "fixture-onscreen-0002",
+                    "closed",
+                    shutdown,
+                    Some(shutdown),
+                    Some("pty-exit"),
+                ),
+                fixture_rec(
+                    "fixture-explicit-0003",
+                    "closed",
+                    shutdown,
+                    Some(shutdown),
+                    Some("explicit"),
+                ),
+                fixture_rec(
+                    "fixture-ghost-0004",
+                    "open",
+                    shutdown - 72 * 3_600_000,
+                    None,
+                    None,
+                ),
+            ],
+        );
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        let expected = vec![
+            "fixture-onscreen-0001".to_string(),
+            "fixture-onscreen-0002".to_string(),
+        ];
+        // With the clean-shutdown marker anchoring the registry…
+        assert_eq!(restorable_ids(&store, now, Some(shutdown)), expected);
+        // …and even without it: the pty-exit closes already anchor the
+        // registry at the shutdown instant, so the 72h ghost stays out.
+        assert_eq!(restorable_ids(&store, now, None), expected);
+    }
+
+    /// Anchored recency is downtime-proof: open rows fresh AT THE CRASH
+    /// restore even when the next boot happens hours later (a wall-clock
+    /// `now - last_seen <= grace` rule would restore nothing), while the
+    /// stale ghost stays excluded.
+    #[test]
+    fn restorable_records_open_rows_survive_long_downtime_anchor_relative() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let crash = 1_700_000_000_000_i64;
+        let now = crash + 6 * 3_600_000; // booted 6 hours later
+        write_fixture(
+            &path,
+            vec![
+                fixture_rec("fresh-a", "open", crash, None, None),
+                fixture_rec("fresh-b", "open", crash - 30_000, None, None),
+                fixture_rec("ghost", "open", crash - 72 * 3_600_000, None, None),
+            ],
+        );
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        // The crashed process's marker (`clean:false`, stamped at ITS boot,
+        // a day earlier) must not shrink the anchor below the fresh rows.
+        let prior_marker_at = Some(crash - 86_400_000);
+        assert_eq!(
+            restorable_ids(&store, now, prior_marker_at),
+            vec!["fresh-a".to_string(), "fresh-b".to_string()],
+            "fresh-at-crash open rows restore after multi-hour downtime; ghost excluded"
+        );
+    }
+
+    /// A real on-screen session whose `pty-exit` close never flushed during
+    /// a clean shutdown (the webview died before `handleExit` wrote) leaves
+    /// an `open` row with a fresh-relative-to-anchor `last_seen_at` — it
+    /// must restore on the clean boot (no silent session loss).
+    #[test]
+    fn restorable_records_admit_unflushed_close_open_row_on_clean_boot() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let shutdown = 1_700_000_000_000_i64;
+        let now = shutdown + 60_000;
+        write_fixture(
+            &path,
+            vec![
+                fixture_rec(
+                    "flushed",
+                    "closed",
+                    shutdown,
+                    Some(shutdown),
+                    Some("pty-exit"),
+                ),
+                // Last touched by the 45s poll shortly before shutdown; its
+                // pty-exit close never flushed.
+                fixture_rec("unflushed", "open", shutdown - 90_000, None, None),
+            ],
+        );
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        assert_eq!(
+            restorable_ids(&store, now, Some(shutdown)),
+            vec!["flushed".to_string(), "unflushed".to_string()],
+            "an open row within grace of the anchor restores even on a clean boot"
+        );
+    }
+
+    /// A registry whose ONLY row is a stale open ghost self-anchors (its own
+    /// `last_seen_at` is the max) — the prior shutdown marker supplies the
+    /// honest "last moment of life" and excludes it.
+    #[test]
+    fn restorable_records_marker_anchor_excludes_lone_ghost() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let shutdown = 1_700_000_000_000_i64;
+        let now = shutdown + 60_000;
+        let ghost_seen = shutdown - 72 * 3_600_000;
+        write_fixture(
+            &path,
+            vec![fixture_rec("ghost", "open", ghost_seen, None, None)],
+        );
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        assert!(
+            restorable_ids(&store, now, Some(shutdown)).is_empty(),
+            "the marker anchor must exclude a lone stale ghost"
+        );
+        // Documented fallback: with no marker and no sibling rows the ghost
+        // self-anchors and is admitted (defensive — better than losing a
+        // real lone session on a registry with no other signal).
+        assert_eq!(restorable_ids(&store, now, None), vec!["ghost".to_string()]);
+    }
+
     #[test]
     fn restorable_records_includes_in_grace_poll_dead() {
         let dir = tempdir().unwrap();
@@ -944,7 +1298,7 @@ mod tests {
         let store = SessionLifecycleStore::open(&path).unwrap();
 
         let ids: Vec<String> = store
-            .restorable_records(now)
+            .restorable_records(now, None)
             .into_iter()
             .map(|r| r.claude_session_id)
             .collect();

--- a/src-tauri/src/session/shutdown_marker.rs
+++ b/src-tauri/src/session/shutdown_marker.rs
@@ -30,6 +30,7 @@
 //! rather over-report a crash banner than silently hide a real crash).
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -61,6 +62,30 @@ pub fn marker_path(api_port: u16) -> PathBuf {
         .join(file_name)
 }
 
+/// Read the prior marker from disk. `None` when absent, unreadable, or
+/// corrupt (a corrupt marker is logged).
+fn read_marker(path: &Path) -> Option<ShutdownMarker> {
+    match std::fs::read(path) {
+        Ok(bytes) => match serde_json::from_slice::<ShutdownMarker>(&bytes) {
+            Ok(m) => Some(m),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "shutdown_marker: corrupt marker — treating as unclean (crash recovery)"
+                );
+                None
+            }
+        },
+        // Absent (first ever boot, or the file was never written) — treat as
+        // unclean is the SAFE default, but the very first boot legitimately
+        // has no marker. We still report crash-recovery=true; the recovery
+        // summary only surfaces a banner when there are sessions to resume,
+        // so a clean first boot with zero sessions shows nothing.
+        Err(_) => None,
+    }
+}
+
 /// Read the prior marker and decide whether this boot is crash recovery.
 ///
 /// Returns `true` (crash recovery) when the marker is absent, unreadable,
@@ -70,25 +95,57 @@ pub fn marker_path(api_port: u16) -> PathBuf {
 /// This must be called BEFORE [`mark_running`] overwrites the marker for the
 /// current process.
 pub fn was_unclean_shutdown(path: &Path) -> bool {
-    match std::fs::read(path) {
-        Ok(bytes) => match serde_json::from_slice::<ShutdownMarker>(&bytes) {
-            Ok(m) => !m.clean,
-            Err(e) => {
-                warn!(
-                    error = %e,
-                    path = %path.display(),
-                    "shutdown_marker: corrupt marker — treating as unclean (crash recovery)"
-                );
-                true
-            }
-        },
-        // Absent (first ever boot, or the file was never written) — treat as
-        // unclean is the SAFE default, but the very first boot legitimately
-        // has no marker. We still report crash-recovery=true; the recovery
-        // summary only surfaces a banner when there are sessions to resume,
-        // so a clean first boot with zero sessions shows nothing.
-        Err(_) => true,
+    classify_prior_marker(read_marker(path).as_ref()).crash_recovery
+}
+
+/// The one-shot classification of THIS boot, derived from the PRIOR
+/// process's shutdown marker. Captured exactly once per process by
+/// [`classify_boot`] — a later marker file read is USELESS for
+/// classification because [`mark_running`] immediately rewrites the marker
+/// `clean:false` for the now-running process (any command-time read would
+/// permanently classify "crash").
+#[derive(Debug, Clone, Copy)]
+pub struct BootClassification {
+    /// `true` iff the previous shutdown was NOT clean (marker absent,
+    /// corrupt, or `clean:false`) ⇒ this boot is crash recovery.
+    pub crash_recovery: bool,
+    /// `at` of the PRIOR marker, if one was readable. On a clean shutdown
+    /// this is the shutdown instant; on a crash it is the crashed process's
+    /// boot instant. Used as one input to the restore path's anchored
+    /// recency rule (the registry's "last moment of life").
+    pub prior_marker_at: Option<i64>,
+}
+
+/// Pure classification core for [`classify_boot`] (testable without the
+/// process-wide [`OnceLock`]).
+fn classify_prior_marker(prior: Option<&ShutdownMarker>) -> BootClassification {
+    BootClassification {
+        crash_recovery: prior.map(|m| !m.clean).unwrap_or(true),
+        prior_marker_at: prior.map(|m| m.at),
     }
+}
+
+static BOOT_CLASSIFICATION: OnceLock<BootClassification> = OnceLock::new();
+
+/// Classify this boot EXACTLY ONCE: read the prior marker, stash the
+/// classification process-wide, and immediately (re)write the marker
+/// `clean:false` for the now-running process. Idempotent — every call after
+/// the first returns the stashed classification without touching disk, so
+/// call-site ordering (synchronous boot in `main.rs` setup vs the delayed
+/// AI-session resume spawn) cannot double-classify or double-overwrite.
+pub fn classify_boot(path: &Path) -> BootClassification {
+    *BOOT_CLASSIFICATION.get_or_init(|| {
+        let classification = classify_prior_marker(read_marker(path).as_ref());
+        mark_running(path);
+        classification
+    })
+}
+
+/// The stashed boot classification, if [`classify_boot`] has run. Consumers
+/// that must never trigger a marker write (e.g. `terminal_session_list_open`)
+/// read this instead of calling [`classify_boot`].
+pub fn boot_classification() -> Option<BootClassification> {
+    BOOT_CLASSIFICATION.get().copied()
 }
 
 /// Write the marker for the NOW-running process as `clean:false`. Call once,
@@ -203,6 +260,31 @@ mod tests {
 
         // Boot 3: prior marker is still clean:false → crash recovery.
         assert!(was_unclean_shutdown(&path));
+    }
+
+    #[test]
+    fn classify_prior_marker_covers_all_marker_shapes() {
+        // Absent marker → crash recovery, no anchor.
+        let absent = classify_prior_marker(None);
+        assert!(absent.crash_recovery);
+        assert!(absent.prior_marker_at.is_none());
+
+        // Clean marker → planned restart, anchor = shutdown instant.
+        let clean = classify_prior_marker(Some(&ShutdownMarker {
+            clean: true,
+            at: 1_000,
+        }));
+        assert!(!clean.crash_recovery);
+        assert_eq!(clean.prior_marker_at, Some(1_000));
+
+        // Running (clean:false) marker left by a crash → crash recovery, but
+        // the prior `at` (the crashed process's boot instant) still anchors.
+        let crashed = classify_prior_marker(Some(&ShutdownMarker {
+            clean: false,
+            at: 2_000,
+        }));
+        assert!(crashed.crash_recovery);
+        assert_eq!(crashed.prior_marker_at, Some(2_000));
     }
 
     #[test]


### PR DESCRIPTION
- stale open ghost rows restored though not on screen at shutdown → anchored-recency admit rule + OnceLock boot-time shutdown classification (session_lifecycle_store.rs, shutdown_marker.rs, main.rs, mcp_api.rs, commands/terminal.rs)
- liveness poll never closed no-match records → debounced "no-terminal" close after 4 ticks, restore_pending guard honored; NoMatchWait clears consecutive_dead
- documented GET /terminals/{id}/buffer?format=text in UI-BRIDGE-AUTOMATION.md

Part of manual-test-loop iteration 1 (boot-restore wrong-sessions remediation, plan 2026-06-13-boot-restore-wrong-sessions-remediation).