### PR TITLE
fix(restore): boot-restore restores the wrong sessions — residual #548 defects (items 1-6, 8, 10)

### DIFF
--- a/src-tauri/src/commands/terminal.rs
+++ b/src-tauri/src/commands/terminal.rs
@@ -929,20 +929,29 @@ pub fn terminal_session_record_close(
 /// The grid hydrates its session tiles from this on boot instead of
 /// `localStorage`.
 ///
-/// Returns the restorable superset (see `restorable_records`): all `open`
-/// records (hard-crash case) PLUS `closed`/`pty-exit` records still within the
+/// Returns the restorable superset (see `restorable_records`): `open` records
+/// whose `last_seen_at` is fresh relative to the registry's anchor (hard-crash
+/// and unflushed-close cases) PLUS `closed`/`pty-exit` records still within the
 /// grace window (graceful-restart case, where `handleExit` flipped every live
-/// PTY to `closed`). User-closed and stale records are excluded so the restore
-/// path resurrects exactly the sessions that died with the runner.
+/// PTY to `closed`). User-closed, orphan-closed (`no-terminal`), and stale
+/// records are excluded so the restore path resurrects exactly the sessions
+/// that were on screen when the runner died.
 #[tauri::command]
 pub fn terminal_session_list_open(
     store: tauri::State<'_, Arc<SessionLifecycleStore>>,
 ) -> Result<CommandResponse, String> {
     let now = chrono::Utc::now().timestamp_millis();
+    // The boot-time stash (single-read; main.rs setup populated it before the
+    // webview could issue this command) — the prior marker's `at` anchors the
+    // recency rule when every registry row is stale.
+    let marker_at = crate::session::shutdown_marker::classify_boot(
+        &crate::session::shutdown_marker::marker_path(crate::mcp::types::get_mcp_api_port()),
+    )
+    .prior_marker_at;
     Ok(CommandResponse {
         success: true,
         message: None,
-        data: Some(serde_json::json!({ "sessions": store.restorable_records(now) })),
+        data: Some(serde_json::json!({ "sessions": store.restorable_records(now, marker_at) })),
     })
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2180,6 +2180,26 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // runner (9877+) would read the primary's open records and
                 // try to `claude --resume` the primary's live sessions.
                 let lifecycle_api_port = crate::mcp::types::get_mcp_api_port();
+
+                // Classify this boot (crash recovery vs planned restart) from
+                // the shutdown marker SYNCHRONOUSLY, before the API server /
+                // webview exists — a frontend restore calling
+                // `terminal_session_list_open` must never race the
+                // classification. `classify_boot` is single-read by
+                // construction (OnceLock): it reads the prior marker,
+                // immediately re-marks `clean:false` for this process, and
+                // stashes the result for every later consumer (the AI-session
+                // resume in mcp_api.rs and the terminal restore path).
+                let boot = session::shutdown_marker::classify_boot(
+                    &session::shutdown_marker::marker_path(lifecycle_api_port),
+                );
+                if boot.crash_recovery {
+                    tracing::warn!(
+                        prior_marker_at = ?boot.prior_marker_at,
+                        "boot classification: previous shutdown was NOT clean — crash recovery"
+                    );
+                }
+
                 let lifecycle_file_name = if lifecycle_api_port == 9876 {
                     "terminal-sessions.json".to_string()
                 } else {
@@ -2225,11 +2245,19 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                     use std::collections::HashMap as StdHashMap;
                     use std::time::Duration;
 
-                    use session::session_lifecycle_store::{classify, PollAction};
+                    use session::session_lifecycle_store::{
+                        classify, classify_no_match, PollAction,
+                    };
 
                     // claudeSessionId -> consecutive zero-descendant ticks,
                     // carried across ticks to debounce `NeedsConfirm`.
                     let mut consecutive_dead: StdHashMap<String, u32> = StdHashMap::new();
+                    // claudeSessionId -> consecutive ticks with NO matching
+                    // live terminal in this instance. An orphaned record (its
+                    // terminal long gone) accumulates these and closes
+                    // `no-terminal` — without it the row stays `open` for up
+                    // to 7 days and re-qualifies for restore every restart.
+                    let mut no_match_ticks: StdHashMap<String, u32> = StdHashMap::new();
 
                     loop {
                         tokio::time::sleep(Duration::from_secs(45)).await;
@@ -2238,6 +2266,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         if open.is_empty() {
                             // Forget any stale counters and prune, then idle.
                             consecutive_dead.clear();
+                            no_match_ticks.clear();
                             poll_lifecycle_store
                                 .prune(chrono::Utc::now().timestamp_millis());
                             continue;
@@ -2246,6 +2275,16 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                         let live = poll_tm.list();
 
                         for rec in &open {
+                            // Restore-pending records (a boot-restore typed
+                            // `claude --resume` whose handshake isn't verified
+                            // yet — or whose restore FAILED and awaits a retry)
+                            // must never flip `poll-dead`/`no-terminal`:
+                            // classification Skips them unless the session is
+                            // confidently alive. A mid-restore record keeps
+                            // its OLD terminal_id until the verified re-assert,
+                            // so it always misses the live-terminal match.
+                            let restore_pending = rec.restore_pending_at.is_some();
+
                             // Match the live terminal: by id first, then the
                             // (page_id, title, working_dir) triple as fallback.
                             let info = live
@@ -2267,31 +2306,65 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                     })
                                 });
 
-                            let (live_is_alive, descendant_count, snapshot_ok) = match info {
-                                None => (None, 0usize, true),
-                                Some(info) => {
-                                    let pid = info.pid.unwrap_or(0);
-                                    let (descendants, parent_map) =
-                                        crate::process_capture::process_tree::discover_descendants_with_parent_map(pid)
-                                            .await;
-                                    // A totally-empty system parent_map means
-                                    // the snapshot helper failed → Skip.
-                                    let snapshot_ok = !parent_map.is_empty();
-                                    let alive = crate::process_capture::health::pid_alive(pid);
-                                    (Some(alive), descendants.len(), snapshot_ok)
+                            // No matching terminal in THIS instance: not the
+                            // same uncertainty `classify` Skips on — count
+                            // consecutive no-match ticks and close the orphan
+                            // `no-terminal` (non-restorable) once confirmed.
+                            let Some(info) = info else {
+                                consecutive_dead.remove(&rec.claude_session_id);
+                                let prior = no_match_ticks
+                                    .get(&rec.claude_session_id)
+                                    .copied()
+                                    .unwrap_or(0);
+                                match classify_no_match(prior, restore_pending) {
+                                    PollAction::Close => {
+                                        poll_lifecycle_store.record_close(
+                                            &rec.claude_session_id,
+                                            "no-terminal",
+                                        );
+                                        no_match_ticks.remove(&rec.claude_session_id);
+                                        tracing::info!(
+                                            claude_session = %rec.claude_session_id,
+                                            terminal_id = %rec.terminal_id,
+                                            "session lifecycle poll: closing orphaned record — no matching terminal"
+                                        );
+                                    }
+                                    PollAction::NeedsConfirm => {
+                                        no_match_ticks
+                                            .insert(rec.claude_session_id.clone(), prior + 1);
+                                        tracing::debug!(
+                                            claude_session = %rec.claude_session_id,
+                                            ticks = prior + 1,
+                                            "session lifecycle poll: no matching terminal — confirming before orphan close"
+                                        );
+                                    }
+                                    // Skip (restore-pending) — leave the
+                                    // counter untouched.
+                                    _ => {}
                                 }
+                                continue;
+                            };
+
+                            // Matched a live terminal — the record is not an
+                            // orphan; reset its no-match streak.
+                            no_match_ticks.remove(&rec.claude_session_id);
+
+                            let (live_is_alive, descendant_count, snapshot_ok) = {
+                                let pid = info.pid.unwrap_or(0);
+                                let (descendants, parent_map) =
+                                    crate::process_capture::process_tree::discover_descendants_with_parent_map(pid)
+                                        .await;
+                                // A totally-empty system parent_map means
+                                // the snapshot helper failed → Skip.
+                                let snapshot_ok = !parent_map.is_empty();
+                                let alive = crate::process_capture::health::pid_alive(pid);
+                                (Some(alive), descendants.len(), snapshot_ok)
                             };
 
                             let prior = consecutive_dead
                                 .get(&rec.claude_session_id)
                                 .copied()
                                 .unwrap_or(0);
-                            // Restore-pending records (a boot-restore typed
-                            // `claude --resume` whose handshake isn't verified
-                            // yet — or whose restore FAILED and awaits a retry)
-                            // must never flip `poll-dead`: classify Skips them
-                            // unless the session is confidently alive.
-                            let restore_pending = rec.restore_pending_at.is_some();
                             let action = classify(
                                 live_is_alive,
                                 descendant_count,

--- a/src-tauri/src/mcp/test_fixtures.rs
+++ b/src-tauri/src/mcp/test_fixtures.rs
@@ -352,6 +352,7 @@ pub fn project_test_session(
         first_message_preview: Some(session.name.clone()),
         has_plans: false,
         display_name: session.name.clone(),
+        cwd: None,
         injected_live_status,
         injected_tab,
     }
@@ -1165,6 +1166,7 @@ mod tests {
             first_message_preview: Some("hello".to_string()),
             has_plans: false,
             display_name: "Real one".to_string(),
+            cwd: None,
             injected_live_status: None,
             injected_tab: None,
         };

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1388,18 +1388,18 @@ pub fn create_router(
             // Wait a bit longer than unified workflows to let the server fully start
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
-            // Phase 4 — classify this boot as crash recovery vs a planned
-            // restart from the on-disk shutdown marker, BEFORE we overwrite
-            // it. A missing / `clean:false` / corrupt marker ⇒ the previous
-            // shutdown was NOT clean ⇒ crash recovery. We then immediately
-            // (re)write the marker `clean:false` for the NOW-running process
-            // so that if THIS process crashes the next boot detects it. The
-            // clean drain / exit seam flips it back to `clean:true`.
+            // Phase 4 — consume the single boot-time crash-vs-planned
+            // classification. The marker read + `mark_running` overwrite
+            // happen SYNCHRONOUSLY in `main.rs` setup (`classify_boot`,
+            // OnceLock single-read semantics) — re-reading the file here
+            // would always see the `clean:false` we wrote at boot and
+            // misclassify every boot as a crash. This call returns the
+            // boot-time stash (and is a correct self-healing fallback if the
+            // setup site were ever skipped).
             let marker_path =
                 crate::session::shutdown_marker::marker_path(crate::mcp::types::get_mcp_api_port());
             let crash_recovery =
-                crate::session::shutdown_marker::was_unclean_shutdown(&marker_path);
-            crate::session::shutdown_marker::mark_running(&marker_path);
+                crate::session::shutdown_marker::classify_boot(&marker_path).crash_recovery;
             if crash_recovery {
                 warn!("Startup recovery: previous shutdown was NOT clean — this is crash recovery");
             }

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -54,6 +54,15 @@ const RESTORABLE_PTY_EXIT_MS: i64 = 600_000;
 /// NOT restorable (a genuinely abandoned session should not resurrect days
 /// later). 10 minutes in millis.
 const RESTORABLE_POLL_DEAD_MS: i64 = 600_000;
+/// An `open` record is restorable only if its `last_seen_at` is within this
+/// window of the registry's ANCHOR — the registry's last recorded moment of
+/// life (`max(all last_seen_at, all closed_at, prior shutdown-marker at)`) —
+/// NOT of wall-clock now. Anchor-relative recency survives arbitrary downtime
+/// (a crash followed by an hours-later boot still restores the rows that were
+/// fresh at crash time) while excluding stale ghosts (an `open` row whose
+/// terminal died days before the rest of the registry last breathed) on every
+/// boot kind. 10 minutes in millis.
+const RESTORABLE_OPEN_ANCHOR_MS: i64 = 600_000;
 /// Number of consecutive zero-descendant ticks a *live* shell (`Some(true)`)
 /// must accumulate before the poll closes it `poll-dead`. A live Claude
 /// session routinely idles with zero descendants between tool calls / while
@@ -64,6 +73,17 @@ const RESTORABLE_POLL_DEAD_MS: i64 = 600_000;
 /// shell still closes immediately — that path is unambiguous and bypasses
 /// this debounce entirely.
 const LIVE_SHELL_DEAD_TICKS: u32 = 3;
+/// Number of consecutive ticks an `open` record must have NO matching live
+/// terminal in THIS instance before the poll closes it `"no-terminal"`.
+/// A single no-match tick is ambiguous (a terminal mid-create / a registry
+/// write racing the poll), but no-match for several consecutive ticks
+/// (≈ N × 45s) is not uncertainty — it is an orphan: the terminal is gone and
+/// only the registry row remains. Without this close the row stays `open` for
+/// up to 7 days ([`OPEN_STALE_MS`]) and re-qualifies for restore at every
+/// restart. `"no-terminal"` is deliberately NOT a grace-window reason in
+/// [`SessionLifecycleStore::restorable_records`], so a closed orphan never
+/// restores.
+const NO_TERMINAL_CLOSE_TICKS: u32 = 4;
 
 /// One persisted terminal-session lifecycle record, keyed by
 /// `claude_session_id`. Timestamps are unix epoch millis.
@@ -284,9 +304,17 @@ impl SessionLifecycleStore {
     }
 
     /// Clone of every record that should be RESTORED on boot. This is the
-    /// superset of [`Self::open_records`] used by the restore path:
+    /// subset of records used by the restore path:
     ///
-    /// - every `state == "open"` record (a hard crash leaves records open), PLUS
+    /// - every `state == "open"` record whose `last_seen_at` is within
+    ///   [`RESTORABLE_OPEN_ANCHOR_MS`] of the registry ANCHOR — the registry's
+    ///   last recorded moment of life,
+    ///   `max(all last_seen_at, all closed_at, marker_at)`. A hard crash
+    ///   leaves on-screen records `open` with fresh `last_seen_at` (≈ anchor),
+    ///   so they restore even after hours of downtime; a stale ghost (terminal
+    ///   long gone, `last_seen_at` days behind the anchor) is excluded on
+    ///   every boot kind. An unflushed `pty-exit` close on a clean shutdown
+    ///   also leaves a fresh `open` row — same rule restores it. PLUS
     /// - every `state == "closed"` record whose `close_reason == "pty-exit"`
     ///   (its PTY died — the case a GRACEFUL restart produces by firing
     ///   `handleExit` on every live PTY) that closed within the
@@ -297,35 +325,53 @@ impl SessionLifecycleStore {
     ///   uncertain (the shell pty was still alive), so an immediate restart
     ///   should bring the session back rather than silently drop it.
     ///
-    /// Records closed for any other reason (explicit user close), or `pty-exit`
-    /// / `poll-dead` closes older than their grace windows, are excluded — a
-    /// user who closes a tab does not want it resurrected, and a long-dead
-    /// close is stale.
-    pub fn restorable_records(&self, now_ms: i64) -> Vec<TerminalSessionRecord> {
+    /// Records closed for any other reason (explicit user close, the poll's
+    /// `no-terminal` orphan close), or `pty-exit` / `poll-dead` closes older
+    /// than their grace windows, are excluded — a user who closes a tab does
+    /// not want it resurrected, and a long-dead close is stale.
+    ///
+    /// `marker_at` is the prior shutdown-marker timestamp
+    /// ([`crate::session::shutdown_marker::BootClassification::prior_marker_at`]):
+    /// the previous process's last moment of life. It anchors a registry whose
+    /// rows are ALL stale (e.g. one lone ghost row) — without it the freshest
+    /// ghost would anchor itself in.
+    pub fn restorable_records(
+        &self,
+        now_ms: i64,
+        marker_at: Option<i64>,
+    ) -> Vec<TerminalSessionRecord> {
         match self.map.lock() {
-            Ok(m) => m
-                .values()
-                .filter(|r| {
-                    if r.state == "open" {
-                        return true;
-                    }
-                    if r.state == "closed" {
-                        let grace = match r.close_reason.as_deref() {
-                            Some("pty-exit") => Some(RESTORABLE_PTY_EXIT_MS),
-                            Some("poll-dead") => Some(RESTORABLE_POLL_DEAD_MS),
-                            _ => None,
-                        };
-                        if let Some(grace_ms) = grace {
-                            return match r.closed_at {
-                                Some(closed_at) => now_ms - closed_at <= grace_ms,
-                                None => false,
-                            };
+            Ok(m) => {
+                let anchor = m
+                    .values()
+                    .flat_map(|r| [Some(r.last_seen_at), r.closed_at])
+                    .flatten()
+                    .chain(marker_at)
+                    .max()
+                    .unwrap_or(now_ms);
+                m.values()
+                    .filter(|r| {
+                        if r.state == "open" {
+                            return anchor - r.last_seen_at <= RESTORABLE_OPEN_ANCHOR_MS;
                         }
-                    }
-                    false
-                })
-                .cloned()
-                .collect(),
+                        if r.state == "closed" {
+                            let grace = match r.close_reason.as_deref() {
+                                Some("pty-exit") => Some(RESTORABLE_PTY_EXIT_MS),
+                                Some("poll-dead") => Some(RESTORABLE_POLL_DEAD_MS),
+                                _ => None,
+                            };
+                            if let Some(grace_ms) = grace {
+                                return match r.closed_at {
+                                    Some(closed_at) => now_ms - closed_at <= grace_ms,
+                                    None => false,
+                                };
+                            }
+                        }
+                        false
+                    })
+                    .cloned()
+                    .collect()
+            }
             Err(e) => {
                 warn!(error = %e, "session_lifecycle_store: lock poisoned on restorable_records");
                 Vec::new()
@@ -480,6 +526,32 @@ pub fn classify(
         return PollAction::Skip;
     }
     base
+}
+
+/// Pure classification for an open record with NO matching live terminal in
+/// this instance ([`classify`]'s `live_is_alive: None` arm Skips by design —
+/// it cannot distinguish a transient miss from an orphan, so the caller
+/// counts consecutive no-match ticks and feeds them here).
+///
+/// - `prior_no_match`: count of prior consecutive no-match ticks.
+/// - `restore_pending`: a mid-restore record keeps its OLD `terminal_id`
+///   until the verified-resume re-assert, so it ALWAYS misses the live-
+///   terminal match — it must never accumulate no-match ticks, let alone
+///   close. The guard lives here (not in [`classify`]) because `classify`
+///   Skips a `None` match regardless and the counter is caller-owned.
+///
+/// Returns `NeedsConfirm` (caller increments its counter) until
+/// [`NO_TERMINAL_CLOSE_TICKS`] consecutive no-match ticks accumulate, then
+/// `Close` — the caller closes with reason `"no-terminal"` (non-restorable).
+pub fn classify_no_match(prior_no_match: u32, restore_pending: bool) -> PollAction {
+    if restore_pending {
+        return PollAction::Skip;
+    }
+    if prior_no_match + 1 >= NO_TERMINAL_CLOSE_TICKS {
+        PollAction::Close
+    } else {
+        PollAction::NeedsConfirm
+    }
 }
 
 #[cfg(test)]
@@ -657,7 +729,7 @@ mod tests {
         let store = SessionLifecycleStore::open(&path).unwrap();
 
         let mut ids: Vec<String> = store
-            .restorable_records(now)
+            .restorable_records(now, None)
             .into_iter()
             .map(|r| r.claude_session_id)
             .collect();
@@ -912,6 +984,146 @@ mod tests {
         );
     }
 
+    /// The on-page repro: a stale `open` ghost (terminal long gone, last_seen
+    /// 72h behind the rest of the registry) must NOT restore, while the fresh
+    /// `open` rows that were actually on screen at shutdown DO.
+    #[test]
+    fn restorable_records_excludes_stale_open_ghost_via_anchor() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        store.record_open(rec("onscreen-1"));
+        store.record_open(rec("onscreen-2"));
+        store.record_open(rec("ghost"));
+
+        let now = Utc::now().timestamp_millis();
+        // Age the ghost's last_seen 72h behind the fresh rows (the anchor).
+        {
+            let raw = std::fs::read(&path).unwrap();
+            let mut m: HashMap<String, TerminalSessionRecord> =
+                serde_json::from_slice(&raw).unwrap();
+            m.get_mut("ghost").unwrap().last_seen_at = now - 72 * 3_600_000;
+            let bytes = serde_json::to_vec_pretty(&m).unwrap();
+            std::fs::write(&path, bytes).unwrap();
+        }
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        let mut ids: Vec<String> = store
+            .restorable_records(now, None)
+            .into_iter()
+            .map(|r| r.claude_session_id)
+            .collect();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["onscreen-1".to_string(), "onscreen-2".to_string()],
+            "fresh open rows restore; the 72h ghost is excluded"
+        );
+    }
+
+    /// Anchor-relative recency must survive arbitrary downtime: a crash
+    /// followed by an hours-later boot still restores the rows that were
+    /// fresh at crash time (wall-clock `now - last_seen` would drop them).
+    #[test]
+    fn restorable_records_open_rows_survive_long_downtime() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        store.record_open(rec("crashed-fresh"));
+        store.record_open(rec("crashed-ghost"));
+
+        let crash_at = Utc::now().timestamp_millis();
+        // Simulate boot 6h after the crash; the ghost was already 72h stale
+        // AT crash time.
+        let now = crash_at + 6 * 3_600_000;
+        {
+            let raw = std::fs::read(&path).unwrap();
+            let mut m: HashMap<String, TerminalSessionRecord> =
+                serde_json::from_slice(&raw).unwrap();
+            m.get_mut("crashed-ghost").unwrap().last_seen_at = crash_at - 72 * 3_600_000;
+            let bytes = serde_json::to_vec_pretty(&m).unwrap();
+            std::fs::write(&path, bytes).unwrap();
+        }
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        let ids: Vec<String> = store
+            .restorable_records(now, None)
+            .into_iter()
+            .map(|r| r.claude_session_id)
+            .collect();
+        assert_eq!(
+            ids,
+            vec!["crashed-fresh".to_string()],
+            "rows fresh at crash time restore after multi-hour downtime; stale ghost stays out"
+        );
+    }
+
+    /// A registry whose rows are ALL stale must not let the freshest ghost
+    /// anchor itself in — the prior shutdown-marker timestamp out-anchors it.
+    #[test]
+    fn restorable_records_marker_at_anchors_lone_ghost_out() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("terminal-sessions.json");
+        let store = SessionLifecycleStore::open(&path).unwrap();
+        store.record_open(rec("lone-ghost"));
+
+        let now = Utc::now().timestamp_millis();
+        {
+            let raw = std::fs::read(&path).unwrap();
+            let mut m: HashMap<String, TerminalSessionRecord> =
+                serde_json::from_slice(&raw).unwrap();
+            m.get_mut("lone-ghost").unwrap().last_seen_at = now - 72 * 3_600_000;
+            let bytes = serde_json::to_vec_pretty(&m).unwrap();
+            std::fs::write(&path, bytes).unwrap();
+        }
+        let store = SessionLifecycleStore::open(&path).unwrap();
+
+        // Without a marker the lone ghost anchors itself → restores (the
+        // marker is virtually always present in practice).
+        assert_eq!(store.restorable_records(now, None).len(), 1);
+        // With the prior marker's timestamp (clean shutdown just before now)
+        // the ghost is 72h behind the anchor → excluded.
+        assert!(
+            store.restorable_records(now, Some(now - 30_000)).is_empty(),
+            "marker_at must out-anchor a lone stale ghost"
+        );
+    }
+
+    // --- classify_no_match() — every branch ---------------------------------
+
+    #[test]
+    fn classify_no_match_confirms_before_close() {
+        // Below the threshold: keep confirming (caller increments).
+        for prior in 0..NO_TERMINAL_CLOSE_TICKS - 1 {
+            assert_eq!(
+                classify_no_match(prior, false),
+                PollAction::NeedsConfirm,
+                "{prior} prior no-match ticks must NeedsConfirm"
+            );
+        }
+        // The Nth consecutive no-match tick closes the orphan.
+        assert_eq!(
+            classify_no_match(NO_TERMINAL_CLOSE_TICKS - 1, false),
+            PollAction::Close
+        );
+        assert_eq!(
+            classify_no_match(NO_TERMINAL_CLOSE_TICKS + 5, false),
+            PollAction::Close
+        );
+    }
+
+    #[test]
+    fn classify_no_match_restore_pending_always_skips() {
+        // A mid-restore record keeps its OLD terminal_id until the verified
+        // re-assert, so it ALWAYS misses the live-terminal match — it must
+        // never accumulate ticks, let alone close.
+        assert_eq!(classify_no_match(0, true), PollAction::Skip);
+        assert_eq!(
+            classify_no_match(NO_TERMINAL_CLOSE_TICKS + 5, true),
+            PollAction::Skip
+        );
+    }
+
     #[test]
     fn restorable_records_includes_in_grace_poll_dead() {
         let dir = tempdir().unwrap();
@@ -944,7 +1156,7 @@ mod tests {
         let store = SessionLifecycleStore::open(&path).unwrap();
 
         let ids: Vec<String> = store
-            .restorable_records(now)
+            .restorable_records(now, None)
             .into_iter()
             .map(|r| r.claude_session_id)
             .collect();

--- a/src-tauri/src/session/shutdown_marker.rs
+++ b/src-tauri/src/session/shutdown_marker.rs
@@ -30,6 +30,7 @@
 //! rather over-report a crash banner than silently hide a real crash).
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -70,25 +71,73 @@ pub fn marker_path(api_port: u16) -> PathBuf {
 /// This must be called BEFORE [`mark_running`] overwrites the marker for the
 /// current process.
 pub fn was_unclean_shutdown(path: &Path) -> bool {
+    match read_prior(path) {
+        Some(m) => !m.clean,
+        // Absent (first ever boot, or the file was never written) — treat as
+        // unclean is the SAFE default, but the very first boot legitimately
+        // has no marker. We still report crash-recovery=true; the recovery
+        // summary only surfaces a banner when there are sessions to resume,
+        // so a clean first boot with zero sessions shows nothing.
+        None => true,
+    }
+}
+
+/// Read the prior marker verbatim, if present and well-formed. Corrupt and
+/// absent markers both read as `None` (and classify as unclean).
+fn read_prior(path: &Path) -> Option<ShutdownMarker> {
     match std::fs::read(path) {
         Ok(bytes) => match serde_json::from_slice::<ShutdownMarker>(&bytes) {
-            Ok(m) => !m.clean,
+            Ok(m) => Some(m),
             Err(e) => {
                 warn!(
                     error = %e,
                     path = %path.display(),
                     "shutdown_marker: corrupt marker — treating as unclean (crash recovery)"
                 );
-                true
+                None
             }
         },
-        // Absent (first ever boot, or the file was never written) — treat as
-        // unclean is the SAFE default, but the very first boot legitimately
-        // has no marker. We still report crash-recovery=true; the recovery
-        // summary only surfaces a banner when there are sessions to resume,
-        // so a clean first boot with zero sessions shows nothing.
-        Err(_) => true,
+        Err(_) => None,
     }
+}
+
+/// The single boot-time shutdown-marker classification, captured exactly once
+/// per process by [`classify_boot`].
+#[derive(Debug, Clone, Copy)]
+pub struct BootClassification {
+    /// `true` iff the previous shutdown was NOT clean (marker absent, corrupt,
+    /// or `clean:false`) — this boot is crash recovery.
+    pub crash_recovery: bool,
+    /// `at` of the PRIOR marker (before this boot overwrote it): the previous
+    /// process's last recorded moment of life — its clean-shutdown time, or
+    /// its own boot time if it crashed. `None` when the marker was absent or
+    /// corrupt. Feeds the restore path's anchored-recency rule.
+    pub prior_marker_at: Option<i64>,
+}
+
+static BOOT_CLASSIFICATION: OnceLock<BootClassification> = OnceLock::new();
+
+/// Classify this boot from the on-disk marker, exactly once per process.
+///
+/// The marker is single-read by construction: the first call reads the prior
+/// marker, immediately overwrites it `clean:false` for the NOW-running
+/// process ([`mark_running`]), and stashes the result; every later call (any
+/// consumer, any thread) returns the stashed classification without touching
+/// the file. A command-time re-read would always see the `clean:false` we
+/// just wrote and misclassify every boot as a crash.
+///
+/// Call this from a synchronous boot site (before the API server / frontend
+/// can race it); consumers read the stash via this same function.
+pub fn classify_boot(path: &Path) -> BootClassification {
+    *BOOT_CLASSIFICATION.get_or_init(|| {
+        let prior = read_prior(path);
+        let classification = BootClassification {
+            crash_recovery: prior.as_ref().map(|m| !m.clean).unwrap_or(true),
+            prior_marker_at: prior.map(|m| m.at),
+        };
+        mark_running(path);
+        classification
+    })
 }
 
 /// Write the marker for the NOW-running process as `clean:false`. Call once,
@@ -203,6 +252,33 @@ mod tests {
 
         // Boot 3: prior marker is still clean:false → crash recovery.
         assert!(was_unclean_shutdown(&path));
+    }
+
+    /// The single test allowed to touch the process-wide `BOOT_CLASSIFICATION`
+    /// OnceLock — a second such test would read this one's stash.
+    #[test]
+    fn classify_boot_single_read_semantics() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("last-shutdown.json");
+        mark_clean_shutdown(&path);
+
+        let first = classify_boot(&path);
+        assert!(
+            !first.crash_recovery,
+            "prior clean marker → planned restart"
+        );
+        assert!(first.prior_marker_at.is_some(), "prior at captured");
+
+        // classify_boot immediately re-marked the file `clean:false` for the
+        // now-running process — a naive re-READ would misclassify as crash...
+        assert!(was_unclean_shutdown(&path));
+        // ...but a second consumer gets the boot-time STASH, not the file.
+        let second = classify_boot(&path);
+        assert!(
+            !second.crash_recovery,
+            "stash survives the marker overwrite"
+        );
+        assert_eq!(second.prior_marker_at, first.prior_marker_at);
     }
 
     #[test]

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -25,6 +25,15 @@ pub struct TranscriptSession {
     pub first_message_preview: Option<String>, // first ~80 chars of first user message
     pub has_plans: bool,                       // true if any message has planContent
     pub display_name: String,                  // human-readable title derived from content
+    /// Working directory the CLI recorded in the transcript (the top-level
+    /// `cwd` field on JSONL records). `None` when no early record carries
+    /// one. Lets the session-id capture poll reject a freshest-mtime
+    /// candidate whose cwd contradicts the pane's actual working dir (item 6
+    /// of the boot-restore remediation — the workspace-root-fallback
+    /// mis-bind). Omitted from the serialized JSON when absent to preserve
+    /// the legacy wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
     /// Optional override for the frontend's computed `liveStatus`.
     ///
     /// `None` for real on-disk transcripts (the field is omitted from the
@@ -327,6 +336,7 @@ pub fn list_sessions(
 
         // Extract started_at from first record's timestamp
         let started_at = extract_first_timestamp(&content);
+        let cwd = extract_cwd(&content);
 
         let session = TranscriptSession {
             session_id,
@@ -338,6 +348,7 @@ pub fn list_sessions(
             first_message_preview,
             has_plans,
             display_name,
+            cwd,
             // Real on-disk sessions never carry a status override; the
             // frontend computes `liveStatus` from tab/digest correlation.
             injected_live_status: None,
@@ -825,6 +836,7 @@ pub fn get_latest_session_id(
                         let has_plans = content.contains("\"planContent\"");
                         let first_message_preview = extract_first_user_preview(&content);
                         let started_at = extract_first_timestamp(&content);
+                        let cwd = extract_cwd(&content);
                         let display_name =
                             generate_display_name(&first_message_preview, &last_modified);
 
@@ -838,6 +850,7 @@ pub fn get_latest_session_id(
                             first_message_preview,
                             has_plans,
                             display_name,
+                            cwd,
                             // Real on-disk session — no override.
                             injected_live_status: None,
                             injected_tab: None,
@@ -1001,6 +1014,27 @@ fn strip_generic_prefix(text: &str) -> &str {
         }
     }
     text
+}
+
+/// Extract the working directory from the first records of a JSONL
+/// transcript (the top-level `cwd` field Claude Code stamps on every
+/// user/assistant record). Scans the same early window as
+/// [`extract_first_timestamp`].
+fn extract_cwd(content: &str) -> Option<String> {
+    for line in content.lines().take(10) {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(record) = serde_json::from_str::<serde_json::Value>(line) {
+            if let Some(cwd) = record.get("cwd").and_then(|c| c.as_str()) {
+                if !cwd.is_empty() {
+                    return Some(cwd.to_string());
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Extract the timestamp from the first record in a JSONL transcript.
@@ -1526,6 +1560,20 @@ mod tests {
         let preview = extract_first_user_preview(&content).unwrap();
         assert!(preview.len() <= 84); // 80 chars + "..."
         assert!(preview.ends_with("..."));
+    }
+
+    #[test]
+    fn test_extract_cwd_from_early_records() {
+        let content = r#"{"type":"system","uuid":"s1","timestamp":"2026-01-01T00:00:00Z"}
+{"type":"user","uuid":"u1","cwd":"D:\\qontinui-root\\sub","timestamp":"2026-01-01T00:00:01Z","message":{"role":"user","content":"hi"}}"#;
+        assert_eq!(
+            extract_cwd(content),
+            Some("D:\\qontinui-root\\sub".to_string())
+        );
+        // No cwd anywhere → None (the capture poll then can't discriminate
+        // and falls back to the timeout-unbound mitigation).
+        assert_eq!(extract_cwd(minimal_user_jsonl()), None);
+        assert_eq!(extract_cwd(""), None);
     }
 
     #[test]

--- a/src/components/terminal/ResumeConfirmBanner.tsx
+++ b/src/components/terminal/ResumeConfirmBanner.tsx
@@ -1,0 +1,99 @@
+/**
+ * "Confirm resume" affordance for restored tabs whose registry binding is not
+ * proven (item 5 of `2026-06-13-boot-restore-wrong-sessions-remediation`).
+ *
+ * A record whose `bindOrigin` is not `"pinned"` was bound by the
+ * freshest-transcript mtime guess (or predates the field) — the session id
+ * may belong to a FOREIGN session (e.g. a VS Code CLI session in the same
+ * project that won the mtime race). The boot restore still creates the tab so
+ * the screen layout is preserved, but types NO resume command; this banner
+ * lists those tabs with a one-click operator confirm (runs the same
+ * type-and-verify path as `ResumeFailedBanner`'s retry) and a decline (closes
+ * the registry record so the binding stops resurrecting).
+ *
+ * Renders nothing when no tab awaits confirmation. Visual language follows
+ * {@link ResumeFailedBanner} (top-right advisory column).
+ */
+
+import { HelpCircle, Play, X } from "lucide-react";
+import type { TerminalTab } from "./useTerminalManager";
+
+export interface ResumeConfirmBannerProps {
+  tabs: TerminalTab[];
+  /** Operator confirmed the binding — type and verify the resume. */
+  onConfirmResume: (tabId: string) => void;
+  /** Operator declined — close the registry record, keep the plain shell. */
+  onDeclineResume: (tabId: string) => void;
+}
+
+/** The tabs this banner surfaces — exported for unit tests. */
+export function confirmPendingTabs(tabs: TerminalTab[]): TerminalTab[] {
+  return tabs.filter((t) => t.resumeNeedsConfirm && t.isAlive !== false);
+}
+
+export function ResumeConfirmBanner({
+  tabs,
+  onConfirmResume,
+  onDeclineResume,
+}: ResumeConfirmBannerProps) {
+  const pending = confirmPendingTabs(tabs);
+  if (pending.length === 0) return null;
+
+  // top-44: below ResumeFailedBanner (top-2) and CoordWarningBanner (top-24),
+  // which can all be visible after a messy restore.
+  return (
+    <div
+      data-ui-bridge-id="terminal.resume-confirm-banner"
+      className="absolute top-44 right-2 z-30 w-[360px] rounded border shadow-lg p-2.5 bg-[#e0af68]/10 border-[#e0af68]/40"
+    >
+      <div className="flex items-start gap-2">
+        <HelpCircle className="w-3.5 h-3.5 shrink-0 mt-0.5 text-[#e0af68]" />
+        <div className="flex-1 min-w-0">
+          <div className="text-[12px] font-semibold text-[#c0caf5] leading-snug">
+            {pending.length === 1
+              ? "Unverified session binding — resume?"
+              : `${pending.length} unverified session bindings — resume?`}
+          </div>
+          <div className="mt-0.5 text-[10px] text-[#a9b1d6] leading-snug">
+            These sessions were matched by transcript timing, not pinned by id — they may belong
+            to another window.
+          </div>
+          <ul className="mt-1.5 space-y-1">
+            {pending.map((t) => (
+              <li
+                key={t.id}
+                data-ui-bridge-id="terminal.resume-confirm-banner-item"
+                data-terminal-id={t.id}
+                className="flex items-center gap-2 text-[11px] leading-snug"
+              >
+                <span className="text-[#c0caf5] font-medium truncate flex-1">{t.title}</span>
+                <button
+                  type="button"
+                  data-ui-bridge-id="terminal.resume-confirm-accept"
+                  data-terminal-id={t.id}
+                  onClick={() => onConfirmResume(t.id)}
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-[#9ece6a]/40 text-[#9ece6a] hover:bg-[#9ece6a]/15 text-[10px]"
+                  title="Type the resume command and verify the Claude UI handshake"
+                >
+                  <Play className="w-2.5 h-2.5" />
+                  Resume
+                </button>
+                <button
+                  type="button"
+                  data-ui-bridge-id="terminal.resume-confirm-decline"
+                  data-terminal-id={t.id}
+                  onClick={() => onDeclineResume(t.id)}
+                  className="flex items-center gap-1 px-1.5 py-0.5 rounded border border-[#f7768e]/40 text-[#f7768e] hover:bg-[#f7768e]/15 text-[10px]"
+                  title="Close the registry record — keep the pane as a plain shell"
+                >
+                  <X className="w-2.5 h-2.5" />
+                  Don&apos;t resume
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -36,6 +36,7 @@ import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 import { callRegistry, useTerminalCommands } from "./commands";
 import { useTerminalInitialization, runVerifiedResume } from "./useTerminalInitialization";
 import { ResumeFailedBanner } from "./ResumeFailedBanner";
+import { ResumeConfirmBanner } from "./ResumeConfirmBanner";
 import { useZoneActions } from "./useZoneActions";
 import { writeWhenReady as writeWhenReadyHelper } from "./writeWhenReady";
 import { setTerminalSessions, type TerminalSessionEntry } from "@/lib/terminal-sessions-registry";
@@ -719,6 +720,23 @@ function TerminalPageInner({
     },
   });
 
+  // Re-assert payload for the verified-resume path: the registry record is
+  // re-marked open under the live tab id only AFTER the handshake verifies
+  // (item 3 of the boot-restore remediation — never refresh a ghost's
+  // lastSeenAt on an unproven resume). Zone comes from the live assignments.
+  const buildReassertPayload = useCallback(
+    (tab: { id: string; title: string; workingDir?: string; claudeConfigDir?: string }) => ({
+      pageId,
+      zoneIndex: Number(
+        Object.entries(zoneLayout.assignments).find(([, id]) => id === tab.id)?.[0] ?? -1,
+      ),
+      title: tab.title,
+      workingDir: tab.workingDir,
+      configDir: tab.claudeConfigDir,
+    }),
+    [pageId, zoneLayout.assignments],
+  );
+
   // Operator-clickable retry for a restored tab whose resume verification
   // failed (Phase 3, #548): re-run the same type-and-verify path. The durable
   // restore-pending marker is still set from the failed attempt, so the
@@ -734,6 +752,53 @@ function TerminalPageInner({
         claudeSessionId: tab.claudeSessionId,
         configDir: tab.claudeConfigDir,
         updateTab,
+        reassert: buildReassertPayload(tab),
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [updateTab, buildReassertPayload],
+  );
+
+  // Operator confirmed a quarantined (mtime-guessed) binding — run the same
+  // verified-resume path the pinned restore uses (item 5 of the boot-restore
+  // remediation). The restore-pending marker has been set since boot.
+  const handleConfirmResume = useCallback(
+    (tabId: string) => {
+      const tab = tabsRef.current.find((t) => t.id === tabId);
+      if (!tab?.claudeSessionId) return;
+      updateTab(tabId, { resumeNeedsConfirm: false, isReconnecting: true });
+      void runVerifiedResume({
+        terminalRefs: terminalRefs.current,
+        tabId,
+        claudeSessionId: tab.claudeSessionId,
+        configDir: tab.claudeConfigDir,
+        updateTab,
+        reassert: buildReassertPayload(tab),
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [updateTab, buildReassertPayload],
+  );
+
+  // Operator declined a quarantined binding — the session id likely belongs
+  // to another window (the mis-bound VS Code case). Close the registry record
+  // so it stops resurrecting; the pane stays as a plain shell.
+  const handleDeclineResume = useCallback(
+    (tabId: string) => {
+      const tab = tabsRef.current.find((t) => t.id === tabId);
+      if (!tab?.claudeSessionId) return;
+      updateTab(tabId, { resumeNeedsConfirm: false });
+      const claudeSessionId = tab.claudeSessionId;
+      invoke("terminal_session_clear_restore_pending", { claudeSessionId }).catch((err) => {
+        logger.warn(`clear restore-pending (declined) failed for ${claudeSessionId}: ${err}`);
+      });
+      invoke("terminal_session_record_close", {
+        claudeSessionId,
+        reason: "operator-declined-resume",
+      }).catch((err) => {
+        logger.warn(
+          `terminal_session_record_close (operator-declined-resume) failed for ${claudeSessionId}: ${err}`,
+        );
       });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -1165,6 +1230,15 @@ function TerminalPageInner({
                 here with an explicit operator retry instead of silently
                 posing as resumed. Same top-right advisory column. */}
             <ResumeFailedBanner tabs={tabs} onRetryResume={handleRetryResume} />
+            {/* Item 5 (boot-restore remediation) — cold-restored tabs whose
+                registry binding is mtime-guessed (bindOrigin !== "pinned")
+                wait here for an explicit operator confirm instead of blindly
+                resuming possibly-foreign content. */}
+            <ResumeConfirmBanner
+              tabs={tabs}
+              onConfirmResume={handleConfirmResume}
+              onDeclineResume={handleDeclineResume}
+            />
           </div>
 
           {/* Phase 2 — `isMultiZone` gate dropped so the Unassigned (N) list

--- a/src/components/terminal/resumeVerification.test.ts
+++ b/src/components/terminal/resumeVerification.test.ts
@@ -19,6 +19,7 @@ import {
   stripAnsi,
   detectClaudeHandshake,
   detectResumePicker,
+  detectResumeFailure,
   buildPickerAnswer,
   waitForClaudeHandshake,
   typeResumeAndVerify,
@@ -86,7 +87,48 @@ describe("detectResumePicker / buildPickerAnswer", () => {
   });
 });
 
+// Item 4 (boot-restore remediation) — "Claude TUI appeared" ≠ "the requested
+// session resumed". The CLI's explicit rejection text must refute the
+// verification even when TUI frames are also present.
+describe("detectResumeFailure", () => {
+  // Captured from a real bogus `claude --resume <uuid>` (v2.1.x).
+  const NOT_FOUND = "No conversation found with session ID: 00000000-dead-beef";
+  const PRINT_MODE_ERR =
+    "Error: --resume requires a valid session ID or session title when used with --print.";
+
+  it.each([
+    ["not-found rejection", NOT_FOUND],
+    ["print-mode arg error", PRINT_MODE_ERR],
+    ["ANSI-wrapped rejection", `\x1b[31m${NOT_FOUND}\x1b[0m`],
+    ["rejection followed by a fresh-session TUI", `${NOT_FOUND}\n${CLAUDE_UI}`],
+  ])("recognizes the CLI rejecting the resume: %s", (_name, text) => {
+    expect(detectResumeFailure(text)).toBe(true);
+  });
+
+  it.each([
+    ["ordinary Claude UI", CLAUDE_UI],
+    ["bare shell", PLAIN_SHELL],
+    ["empty buffer", ""],
+  ])("does NOT match healthy output: %s", (_name, text) => {
+    expect(detectResumeFailure(text)).toBe(false);
+  });
+});
+
 describe("waitForClaudeHandshake", () => {
+  it("refutes (checked BEFORE the handshake) when the CLI rejected the resume", async () => {
+    // The incident shape: rejection text and Claude UI frames in the same
+    // tail — the wrong-content pane must NOT verify.
+    const readTail = vi.fn(
+      async () => `No conversation found with session ID: ghost-1\n${CLAUDE_UI}`,
+    );
+    const out = await waitForClaudeHandshake("tab-1", {
+      timeoutMs: 500,
+      intervalMs: 1,
+      readTail,
+    });
+    expect(out).toBe("refuted");
+  });
+
   it("verifies as soon as a probe shows the Claude UI", async () => {
     const tails = [PLAIN_SHELL, PLAIN_SHELL, CLAUDE_UI];
     const readTail = vi.fn(async () => tails.shift() ?? CLAUDE_UI);
@@ -203,5 +245,21 @@ describe("typeResumeAndVerify (retry-once state machine)", () => {
     expect(out).toBe("failed");
     // Exactly two typed attempts — the spec is retry ONCE, not retry forever.
     expect(writes.filter((w) => w === CMD)).toHaveLength(2);
+  });
+
+  it("fails WITHOUT retrying when the CLI explicitly rejected the resume", async () => {
+    // A deterministic rejection ("No conversation found...") can't change on
+    // a retype — burn no retry and park as failed immediately.
+    const writes: string[] = [];
+    const write = (_refs: never, _tab: string, text: string) => void writes.push(text);
+    const out = await typeResumeAndVerify(new Map() as never, "tab-1", CMD, {
+      write: write as never,
+      settleMs: 1,
+      timeoutMs: 500,
+      intervalMs: 1,
+      readTail: async () => "No conversation found with session ID: abc-123",
+    });
+    expect(out).toBe("failed");
+    expect(writes.filter((w) => w === CMD)).toHaveLength(1);
   });
 });

--- a/src/components/terminal/resumeVerification.ts
+++ b/src/components/terminal/resumeVerification.ts
@@ -107,6 +107,34 @@ export function detectClaudeHandshake(text: string): boolean {
   return CLAUDE_HANDSHAKE_PATTERNS.some((p) => p.test(stripped));
 }
 
+/**
+ * Negative markers: the CLI explicitly REJECTED the resume. "Claude TUI
+ * appeared" is not "the requested session resumed" — a `--resume` with a
+ * stale/bogus id can print an error (and, on some CLI versions, fall through
+ * to a fresh session / session picker whose frames still match the handshake
+ * patterns above). These are checked BEFORE the handshake patterns so wrong
+ * content can never verify as a successful restore.
+ *
+ * Strings captured from a real bogus `claude --resume <uuid>` (v2.1.x):
+ *   `No conversation found with session ID: <id>`
+ * and the print-mode arg error:
+ *   `Error: --resume requires a valid session ID ...`
+ *
+ * Kept deliberately specific (full sentence fragments, not bare words) — the
+ * scan runs over the scrollback tail, and an overly broad pattern could match
+ * legit conversation content.
+ */
+const CLAUDE_RESUME_FAILURE_PATTERNS: RegExp[] = [
+  /No conversation found with session ID/i,
+  /--resume requires a valid session ID/i,
+];
+
+/** True when the pane's recent output shows the CLI rejecting the resume. */
+export function detectResumeFailure(text: string): boolean {
+  const stripped = stripAnsi(text);
+  return CLAUDE_RESUME_FAILURE_PATTERNS.some((p) => p.test(stripped));
+}
+
 /** How many trailing characters of the (decoded) ring to scan per probe. */
 const TAIL_SCAN_CHARS = 16_000;
 
@@ -145,19 +173,23 @@ export interface HandshakeWaitOptions {
 }
 
 /**
- * Poll the pane's scrollback until the Claude UI handshake appears or the
- * timeout elapses. Resolves `"verified"` or `"timeout"`; never throws.
+ * Poll the pane's scrollback until the Claude UI handshake appears, the CLI
+ * explicitly rejects the resume, or the timeout elapses. Resolves
+ * `"verified"`, `"refuted"` (negative pattern seen — checked FIRST, so a
+ * fresh-session fallback whose TUI frames match the handshake can never
+ * read as success), or `"timeout"`; never throws.
  */
 export async function waitForClaudeHandshake(
   tabId: string,
   options: HandshakeWaitOptions = {},
-): Promise<"verified" | "timeout"> {
+): Promise<"verified" | "refuted" | "timeout"> {
   const { timeoutMs = 15_000, intervalMs = 1_000, readTail = readScrollbackTail, onProbe } = options;
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     const tail = await readTail(tabId);
     if (tail !== null) {
       onProbe?.(tail);
+      if (detectResumeFailure(tail)) return "refuted";
       if (detectClaudeHandshake(tail)) return "verified";
     }
     if (Date.now() >= deadline) return "timeout";
@@ -230,6 +262,14 @@ export async function typeResumeAndVerify(
     await new Promise((r) => setTimeout(r, settleMs));
     const outcome = await waitForClaudeHandshake(tabId, { ...waitOpts, onProbe: probe });
     if (outcome === "verified") return "verified";
+    if (outcome === "refuted") {
+      // The CLI deterministically rejected the session id — retyping the
+      // same command cannot change the answer. Park as failed immediately.
+      console.warn(
+        `[resumeVerification] resume explicitly rejected for ${tabId} (attempt ${attempt}/${attempts})`,
+      );
+      return "failed";
+    }
     console.warn(
       `[resumeVerification] handshake not observed for ${tabId} (attempt ${attempt}/${attempts})`,
     );

--- a/src/components/terminal/types.ts
+++ b/src/components/terminal/types.ts
@@ -42,6 +42,13 @@ export interface TerminalSessionRecord {
   /** Why the session closed. */
   closeReason?: string;
   /**
+   * How `claudeSessionId` was bound: `"pinned"` (`--session-id` / `--resume`
+   * — exact) or `"guessed"` (freshest-transcript mtime guess). Absent on
+   * records predating the field — read as guessed. Restore auto-resumes only
+   * `pinned` rows; everything else is quarantined behind an operator confirm.
+   */
+  bindOrigin?: string;
+  /**
    * Epoch ms a boot-restore began re-typing this session's resume command
    * (backend-owned; while set the liveness poll never flips the record
    * `poll-dead`). Cleared once the resume handshake is verified.

--- a/src/components/terminal/useTabSessionIdCapture.test.ts
+++ b/src/components/terminal/useTabSessionIdCapture.test.ts
@@ -31,16 +31,21 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => mockInvoke(...args),
 }));
 
+import { cwdConflicts } from "./useTabSessionIdCapture";
+
 interface TranscriptSessionPayload {
   session_id: string;
   config_dir: string;
   project_path: string;
   last_modified: string;
+  cwd?: string | null;
 }
 
 // Decision helper that mirrors the hook's per-tick claim logic.
 // Freshness (last_modified > spawnTimestamp) is enforced backend-side
-// via `sinceMs`; the hook trusts any non-null payload it receives.
+// via `sinceMs`; the hook trusts any non-null payload it receives —
+// except a candidate whose recorded cwd CONTRADICTS the pane's known
+// working dir (item 6, the workspace-root-fallback mis-bind).
 function decideClaim(
   tab: TerminalTab | undefined,
   payload: TranscriptSessionPayload | null,
@@ -49,6 +54,7 @@ function decideClaim(
   if (!tab) return null;
   if (tab.claudeSessionId) return null;
   if (!payload) return null;
+  if (cwdConflicts(tab.workingDir, payload.cwd)) return null;
   if (alreadyClaimed.has(payload.session_id)) return null;
   return {
     claudeSessionId: payload.session_id,
@@ -97,6 +103,67 @@ describe("decideClaim — happy path", () => {
       claimed,
     );
     expect(result).toBeNull();
+  });
+});
+
+// Item 6 (boot-restore remediation) — the freshest-mtime race: a foreign
+// session (e.g. a VS Code CLI in another directory) writes its JSONL after
+// the pane spawn and wins the mtime sort. When the transcript records a cwd
+// that contradicts the pane's working dir, the candidate must be rejected —
+// better unregistered than mis-bound.
+describe("decideClaim — foreign-cwd mtime race (item 6)", () => {
+  const payloadWithCwd = (sessionId: string, cwd: string | null): TranscriptSessionPayload => ({
+    session_id: sessionId,
+    config_dir: "C:/claude/.claude-default",
+    project_path: "D:/repo",
+    last_modified: new Date().toISOString(),
+    cwd,
+  });
+
+  it("rejects a candidate recorded in a different directory", () => {
+    const result = decideClaim(
+      tab("tab-1", "D:/repo/sub"),
+      payloadWithCwd("foreign-session", "D:/elsewhere"),
+      new Set(),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("binds the matching-cwd candidate (Windows-tolerant path equality)", () => {
+    const result = decideClaim(
+      tab("tab-1", "D:/repo/sub"),
+      payloadWithCwd("own-session", "d:\\repo\\sub\\"),
+      new Set(),
+    );
+    expect(result?.claudeSessionId).toBe("own-session");
+  });
+
+  it("cannot discriminate when either side is unknown — claims (legacy behavior)", () => {
+    // No cwd on the payload (old backend) and no workingDir on the tab: the
+    // check must not regress the pre-field behavior.
+    expect(
+      decideClaim(tab("tab-1", "D:/repo"), payloadWithCwd("s-1", null), new Set()),
+    ).not.toBeNull();
+    expect(
+      decideClaim(tab("tab-1", ""), payloadWithCwd("s-2", "D:/elsewhere"), new Set()),
+    ).not.toBeNull();
+  });
+});
+
+describe("cwdConflicts", () => {
+  it("normalizes slashes, trailing separators, and case", () => {
+    expect(cwdConflicts("D:/repo/sub", "d:\\repo\\sub\\")).toBe(false);
+    expect(cwdConflicts("D:/repo/sub", "D:/repo/sub")).toBe(false);
+    expect(cwdConflicts("D:/repo/sub", "D:/repo/other")).toBe(true);
+    // Subdirectory is NOT equality — a parent/child mismatch is a conflict.
+    expect(cwdConflicts("D:/repo", "D:/repo/sub")).toBe(true);
+  });
+
+  it("returns false (no conflict) when either side is unknown", () => {
+    expect(cwdConflicts(undefined, "D:/x")).toBe(false);
+    expect(cwdConflicts("", "D:/x")).toBe(false);
+    expect(cwdConflicts("D:/x", null)).toBe(false);
+    expect(cwdConflicts("D:/x", undefined)).toBe(false);
   });
 });
 

--- a/src/components/terminal/useTabSessionIdCapture.ts
+++ b/src/components/terminal/useTabSessionIdCapture.ts
@@ -54,6 +54,31 @@ interface TranscriptSessionPayload {
   config_dir: string;
   project_path: string;
   last_modified: string; // ISO 8601
+  /** Working dir the CLI recorded in the transcript (absent on old payloads). */
+  cwd?: string | null;
+}
+
+/**
+ * True when a candidate transcript's recorded `cwd` CONTRADICTS the pane's
+ * known working dir — the freshest-mtime guess picked a session launched
+ * somewhere else (item 6 of the boot-restore remediation: the capture's
+ * `workingDir` can fall back to the broad workspace root, letting a
+ * foreign-dir session win the mtime race). Unknown on either side → `false`
+ * (can't discriminate; the timeout-unbound mitigation still applies).
+ * Windows-tolerant equality: slashes normalized, trailing separators
+ * trimmed, case-insensitive. Exported for unit tests.
+ */
+export function cwdConflicts(
+  tabWorkingDir: string | undefined,
+  candidateCwd: string | null | undefined,
+): boolean {
+  if (!tabWorkingDir || !candidateCwd) return false;
+  const norm = (p: string) =>
+    p
+      .replace(/\\/g, "/")
+      .replace(/\/+$/, "")
+      .toLowerCase();
+  return norm(tabWorkingDir) !== norm(candidateCwd);
 }
 
 const POLL_INTERVAL_MS = 500;
@@ -236,6 +261,21 @@ export function useTabSessionIdCapture({
           const data = resp.success ? (resp.data as TranscriptSessionPayload | null) : null;
           if (!data) {
             if (debug()) logger.debug("[tabSidCapture] probe-null", { tabId });
+          } else if (cwdConflicts(tab.workingDir, data.cwd)) {
+            // The candidate transcript was recorded in a DIFFERENT directory
+            // than this pane — a foreign session won the mtime race (the
+            // capture's workingDir may have been the broad workspace-root
+            // fallback). Reject and keep polling; staying unbound is better
+            // than binding wrong content. `tab` is re-read every tick, so a
+            // late shell-integration cwd event sharpens this check mid-poll.
+            if (debug()) {
+              logger.debug("[tabSidCapture] cwd-mismatch", {
+                tabId,
+                sessionId: data.session_id,
+                tabWorkingDir: tab.workingDir,
+                candidateCwd: data.cwd,
+              });
+            }
           } else if (claimedSessionIds.current.has(data.session_id)) {
             if (debug()) {
               logger.debug("[tabSidCapture] already-claimed", {

--- a/src/components/terminal/useTerminalInitialization.test.ts
+++ b/src/components/terminal/useTerminalInitialization.test.ts
@@ -236,6 +236,96 @@ describe("runVerifiedResume", () => {
       expect.anything(),
     );
   });
+
+  // Item 3 (boot-restore remediation) — the registry re-assert is deferred
+  // until the handshake VERIFIES. Re-asserting at tab creation refreshed
+  // ghosts' lastSeenAt before anything was proven (ghost immortality).
+  it("verified + reassert → re-asserts the open record under the live tab id", async () => {
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle([]),
+      tabId: "tab-new",
+      claudeSessionId: "sess-1",
+      configDir: "C:/cfg",
+      updateTab,
+      reassert: {
+        pageId: "default",
+        zoneIndex: 3,
+        title: "Claude 1",
+        workingDir: "C:/repo",
+        configDir: "C:/cfg",
+      },
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 50,
+        intervalMs: 1,
+        readTail: async () => CLAUDE_UI,
+      },
+    });
+    expect(out).toBe("verified");
+    expect(mockInvoke).toHaveBeenCalledWith("terminal_session_record_open", {
+      claudeSessionId: "sess-1",
+      configDir: "C:/cfg",
+      workingDir: "C:/repo",
+      pageId: "default",
+      zoneIndex: 3,
+      title: "Claude 1",
+      terminalId: "tab-new",
+    });
+  });
+
+  it("failed resume → never re-asserts the record (original lastSeenAt ages normally)", async () => {
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle([]),
+      tabId: "tab-new",
+      claudeSessionId: "ghost-1",
+      updateTab,
+      reassert: { pageId: "default", zoneIndex: 2, title: "Ghost" },
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 5,
+        intervalMs: 1,
+        readTail: async () => PLAIN_SHELL,
+      },
+    });
+    expect(out).toBe("failed");
+    expect(mockInvoke).not.toHaveBeenCalledWith("terminal_session_record_open", expect.anything());
+  });
+
+  // Item 4 — a CLI rejection ("No conversation found...") must park the tab
+  // as failed even though Claude TUI frames may also be present, and must
+  // not waste the retry (the answer is deterministic).
+  it("explicit CLI rejection → failed without retry, marker kept", async () => {
+    const writes: string[] = [];
+    const updateTab = vi.fn();
+    const out = await runVerifiedResume({
+      terminalRefs: refsWithHandle(writes),
+      tabId: "tab-1",
+      claudeSessionId: "bogus-1",
+      updateTab,
+      verifyOptions: {
+        settleMs: 1,
+        timeoutMs: 50,
+        intervalMs: 1,
+        // The incident shape: error text AND Claude UI frames both visible.
+        readTail: async () =>
+          `No conversation found with session ID: bogus-1\n${CLAUDE_UI}`,
+      },
+    });
+    expect(out).toBe("failed");
+    // No retry: the same command typed exactly once.
+    expect(writes.filter((w) => w.includes("--resume bogus-1\r"))).toHaveLength(1);
+    expect(updateTab).toHaveBeenCalledWith("tab-1", {
+      isReconnecting: false,
+      resumeFailed: true,
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "terminal_session_clear_restore_pending",
+      expect.anything(),
+    );
+    expect(mockInvoke).not.toHaveBeenCalledWith("terminal_session_record_open", expect.anything());
+  });
 });
 
 // #548 item 3 — the typed resume must suppress the CLI's "Resume from

--- a/src/components/terminal/useTerminalInitialization.ts
+++ b/src/components/terminal/useTerminalInitialization.ts
@@ -96,16 +96,35 @@ export function buildResumeCmd(
 }
 
 /**
+ * Re-assert payload for [`runVerifiedResume`]'s verified branch: the durable
+ * registry record is re-marked `open` under the NEW terminal id only AFTER
+ * the resume handshake verifies. Re-asserting at tab creation (the old
+ * behavior) refreshed `lastSeenAt` on every cold-restored record — including
+ * ghosts whose resume then failed — resetting both the prune clock and the
+ * restore recency cap, so a ghost restored forever ("ghost immortality").
+ */
+export interface ReassertRecordPayload {
+  pageId: string;
+  zoneIndex: number;
+  title?: string;
+  workingDir?: string;
+  configDir?: string;
+}
+
+/**
  * Type the resume command for a restored tab and VERIFY the Claude UI
  * handshake actually appeared (Phase 3, issue #548): on first failure the
  * same command is retyped once; on persistent failure the tab is parked in an
  * explicit `resumeFailed` state (operator-clickable retry via
  * `ResumeFailedBanner`) and the durable restore-pending marker is left SET so
  * the backend liveness poll keeps protecting the `open` record. Only a
- * verified handshake clears the marker and the reconnecting affordance.
+ * verified handshake clears the marker and the reconnecting affordance — and
+ * only a verified handshake re-asserts the registry record under the new
+ * terminal id (`reassert`); on failure the original row is left untouched
+ * (original `lastSeenAt`, old `terminalId`), so it ages and prunes normally.
  *
- * Used by the boot-restore drain below AND by the operator retry path in
- * `TerminalPage`. Exported (with injectable verify options) so the
+ * Used by the boot-restore drain below AND by the operator retry/confirm
+ * paths in `TerminalPage`. Exported (with injectable verify options) so the
  * verified/failed state machine is unit-testable without booting React.
  */
 export async function runVerifiedResume(params: {
@@ -117,9 +136,12 @@ export async function runVerifiedResume(params: {
     id: string,
     updates: Partial<{ isReconnecting?: boolean; resumeFailed?: boolean }>,
   ) => void;
+  /** When set, the verified branch re-asserts the record under `tabId`. */
+  reassert?: ReassertRecordPayload;
   verifyOptions?: TypeAndVerifyOptions;
 }): Promise<"verified" | "failed"> {
-  const { terminalRefs, tabId, claudeSessionId, configDir, updateTab, verifyOptions } = params;
+  const { terminalRefs, tabId, claudeSessionId, configDir, updateTab, reassert, verifyOptions } =
+    params;
   const policy = getResumeSummaryPolicy();
   const resumeCmd = buildResumeCmd(claudeSessionId, configDir, policy);
   const outcome = await typeResumeAndVerify(terminalRefs, tabId, resumeCmd, {
@@ -131,8 +153,27 @@ export async function runVerifiedResume(params: {
   });
   if (outcome === "verified") {
     updateTab(tabId, { isReconnecting: false, resumeFailed: false });
-    // Verified handshake — release the liveness-poll restore guard so normal
-    // classification resumes for this session.
+    // Verified handshake — NOW re-assert the open record under the freshly
+    // created terminal id so the registry's `terminalId` tracks the live tab
+    // (the next restart reconnect-matches on this id). Deliberately deferred
+    // past verification: a failed resume must leave the original row's
+    // `lastSeenAt` untouched so a ghost ages and prunes instead of restoring
+    // forever.
+    if (reassert) {
+      invoke("terminal_session_record_open", {
+        claudeSessionId,
+        configDir: reassert.configDir,
+        workingDir: reassert.workingDir,
+        pageId: reassert.pageId,
+        zoneIndex: reassert.zoneIndex,
+        title: reassert.title,
+        terminalId: tabId,
+      }).catch((err) => {
+        console.warn(`[TerminalPage] re-record open failed for ${claudeSessionId}:`, err);
+      });
+    }
+    // Release the liveness-poll restore guard so normal classification
+    // resumes for this session.
     invoke("terminal_session_clear_restore_pending", { claudeSessionId }).catch((err) => {
       // Best-effort: the poll self-heals a stale marker on the next
       // confident-alive tick.
@@ -197,6 +238,7 @@ interface UseTerminalInitializationParams {
       claudeConfigDir?: string;
       isReconnecting?: boolean;
       resumeFailed?: boolean;
+      resumeNeedsConfirm?: boolean;
     }>,
   ) => void;
   zoneLayout: {
@@ -316,6 +358,7 @@ export function useTerminalInitialization({
       isClaudeSession?: boolean;
       claudeSessionId?: string;
       claudeConfigDir?: string;
+      reassert?: ReassertRecordPayload;
     }> = [];
 
     (async () => {
@@ -403,20 +446,34 @@ export function useTerminalInitialization({
 
           // b) Cold restart (no live pty): recreate the tab, bind its recorded
           //    zone, attach the session id, and queue a `claude --resume` via
-          //    the existing drain loop. Re-assert the OPEN record under the new
-          //    ephemeral terminal id so the registry tracks the live tab.
+          //    the existing drain loop. The OPEN record is re-asserted under
+          //    the new terminal id only AFTER the resume handshake verifies
+          //    (`runVerifiedResume`) — re-asserting here refreshed ghosts'
+          //    `lastSeenAt` before anything was proven, making them immortal.
           const tabId = await createTerminal(rec.title, rec.workingDir);
           if (!tabId) continue;
           if (rec.zoneIndex >= 0) {
             zoneLayout.assignTabToZone(rec.zoneIndex, tabId);
             applyZoneCosmetics(rec.zoneIndex);
           }
+
+          // bindOrigin quarantine: only a `pinned` binding (`--session-id` /
+          // `--resume` — exact) may auto-type `claude --resume`. A `guessed`
+          // (or pre-field absent) binding came from the freshest-transcript
+          // mtime race and may belong to a FOREIGN session (e.g. a VS Code
+          // CLI session in the same project) — surface a one-click operator
+          // confirm instead of blindly resuming wrong content. The tab is
+          // still created so the screen layout is preserved.
+          const pinned = rec.bindOrigin === "pinned";
+
           updateTab(tabId, {
             claudeSessionId: rec.claudeSessionId,
             claudeConfigDir: safeConfigDir,
-            // Show a "resuming" affordance until `claude --resume` lands;
-            // cleared in the drain loop after the resume command is written.
-            isReconnecting: true,
+            // Pinned: show the "resuming" affordance until the verified
+            // resume drains. Guessed: park awaiting operator confirm.
+            ...(pinned && validSessionId
+              ? { isReconnecting: true }
+              : { resumeNeedsConfirm: validSessionId }),
           });
           rememberSessionId(tabId, rec.claudeSessionId, safeConfigDir);
 
@@ -425,16 +482,27 @@ export function useTerminalInitialization({
               tabId,
               scrollbackPath:
                 rec.zoneIndex >= 0 ? cosmeticsByZone.get(rec.zoneIndex)?.scrollbackPath : undefined,
-              isClaudeSession: true,
+              // Auto-resume only proven (pinned) bindings; quarantined tabs
+              // still get their scrollback restored by the drain.
+              isClaudeSession: pinned,
               claudeSessionId: rec.claudeSessionId,
               claudeConfigDir: safeConfigDir,
+              reassert: {
+                pageId,
+                zoneIndex: rec.zoneIndex,
+                title: rec.title,
+                workingDir: rec.workingDir,
+                configDir: rec.configDir,
+              },
             });
             // Durable, backend-owned restore-pending marker (Phase 3, #548):
-            // from here until the resume handshake is VERIFIED the liveness
-            // poll must never flip this record `poll-dead` — a failed restore
-            // leaves the `open` record intact for the next attempt. Cleared in
-            // `runVerifiedResume` on verified handshake (and self-healed by
-            // the poll once it sees the session confidently alive).
+            // from here until the resume handshake is VERIFIED (or the
+            // operator confirms/declines a quarantined binding) the liveness
+            // poll must never flip this record `poll-dead`/`no-terminal` — a
+            // failed restore leaves the `open` record intact for the next
+            // attempt. Cleared in `runVerifiedResume` on verified handshake
+            // (and self-healed by the poll once it sees the session
+            // confidently alive).
             invoke("terminal_session_mark_restore_pending", {
               claudeSessionId: rec.claudeSessionId,
             }).catch((err) => {
@@ -444,21 +512,6 @@ export function useTerminalInitialization({
               );
             });
           }
-
-          // Re-assert the OPEN record under the freshly created terminal id so
-          // the registry's `terminalId` tracks the live tab (the next restart
-          // reconnect-matches on this id).
-          invoke("terminal_session_record_open", {
-            claudeSessionId: rec.claudeSessionId,
-            configDir: rec.configDir,
-            workingDir: rec.workingDir,
-            pageId,
-            zoneIndex: rec.zoneIndex,
-            title: rec.title,
-            terminalId: tabId,
-          }).catch((err) => {
-            console.warn(`[TerminalPage] re-record open failed for ${rec.claudeSessionId}:`, err);
-          });
         }
 
         // 4) Plan tabs are cosmetic-only state held in the snapshot (no PTY, no
@@ -533,6 +586,7 @@ export function useTerminalInitialization({
                     claudeSessionId: restore.claudeSessionId,
                     configDir: restore.claudeConfigDir,
                     updateTab,
+                    reassert: restore.reassert,
                   });
                 }
               }

--- a/src/components/terminal/useTerminalManager.ts
+++ b/src/components/terminal/useTerminalManager.ts
@@ -30,6 +30,15 @@ export interface TerminalTab {
    * restore-pending marker so the liveness poll can't flip it `poll-dead`.
    */
   resumeFailed?: boolean;
+  /**
+   * True when this tab was cold-restored from a registry record whose
+   * `bindOrigin` is NOT `"pinned"` (mtime-guessed or pre-field) — the binding
+   * may belong to a foreign session, so no resume command is typed. Surfaced
+   * as a per-pane operator confirm (`ResumeConfirmBanner`): confirming runs
+   * the verified resume, declining closes the record. While set, the durable
+   * record keeps its backend restore-pending marker.
+   */
+  resumeNeedsConfirm?: boolean;
   /** Claude Code session ID running in this tab (set on resume). */
   claudeSessionId?: string;
   /** Claude config dir for the session (set on resume). */
@@ -552,6 +561,7 @@ export function useTerminalManager(pageId: string = "default", windowLabel: stri
           | "claudeConfigDir"
           | "isReconnecting"
           | "resumeFailed"
+          | "resumeNeedsConfirm"
         >
       >,
     ) => {

--- a/src/components/terminal/useZoneLayout.restore.test.ts
+++ b/src/components/terminal/useZoneLayout.restore.test.ts
@@ -20,6 +20,7 @@ import {
   reconcileAssignments,
   pickLayout,
   computeAutoGrowLayoutId,
+  computeZoneCapacityGrowth,
   LAYOUT_PRESETS,
 } from "./useZoneLayout";
 
@@ -132,5 +133,53 @@ describe("Phase 1 auto-grow — layout grows to fit live tabs across ALL ingest 
     // Grew to full-grid for 9 tabs; now only 2 remain. Auto-grow returns null
     // (shrinking is out of scope — grow only).
     expect(computeAutoGrowLayoutId("full-grid", 2)).toBeNull();
+  });
+});
+
+// Item 10 (boot-restore remediation) — recorded zone bindings must survive a
+// restore even when excluded records leave GAPS in the zone indices. The
+// count-based auto-grow alone can pick a layout too small for the highest
+// recorded zone (2 surviving records at zones 0 and 3 → pickLayout(2) =
+// "split", zone 3 unrenderable), and `applyLayout` then compacts the zone-3
+// binding into the first empty slot — drifting the operator's spatial memory.
+// `assignTabToZone` now grows by zone INDEX via this pure helper.
+describe("computeZoneCapacityGrowth — gap-preserving restore growth", () => {
+  it("grows 'split' so a recorded zone 3 stays at zone 3 (the fixture repro)", () => {
+    const target = computeZoneCapacityGrowth("split", 3);
+    expect(target).toBe("quad");
+    expect(zoneCount(target!)).toBeGreaterThan(3);
+  });
+
+  it("returns null when the zone already fits", () => {
+    expect(computeZoneCapacityGrowth("quad", 3)).toBeNull();
+    expect(computeZoneCapacityGrowth("full-grid", 8)).toBeNull();
+    expect(computeZoneCapacityGrowth("single", 0)).toBeNull();
+  });
+
+  it("picks the smallest uniform preset that renders the zone", () => {
+    expect(computeZoneCapacityGrowth("single", 1)).toBe("split");
+    expect(computeZoneCapacityGrowth("split", 4)).toBe("six-pack");
+    expect(computeZoneCapacityGrowth("six-pack", 7)).toBe("full-grid");
+  });
+
+  it("returns null beyond the full-grid ceiling (compaction is the honest fallback)", () => {
+    expect(computeZoneCapacityGrowth("full-grid", 9)).toBeNull();
+    expect(computeZoneCapacityGrowth("split", 42)).toBeNull();
+  });
+
+  it("restored records at zones 0 and 3 both render after index-driven growth", () => {
+    // The plan's verification fixture: rows at zones 0 and 3, nothing else.
+    // Count-based growth alone would stay at 'split' (2 tabs); index-driven
+    // growth reaches 'quad' so reconcile preserves both recorded bindings.
+    const target = computeZoneCapacityGrowth("split", 3)!;
+    const afterRecordBind = { 0: "claudeA", 3: "claudeB" };
+    const next = reconcileAssignments(
+      afterRecordBind,
+      ["claudeA", "claudeB"],
+      zoneCount(target),
+      new Set([0, 3]),
+    );
+    expect(next[0]).toBe("claudeA");
+    expect(next[3]).toBe("claudeB");
   });
 });

--- a/src/components/terminal/useZoneLayout.ts
+++ b/src/components/terminal/useZoneLayout.ts
@@ -189,6 +189,35 @@ export function computeAutoGrowLayoutId(
   return targetId;
 }
 
+/**
+ * Decide whether the layout must GROW so that `zoneIndex` is renderable,
+ * returning the target layout id or `null` when the zone already fits (or no
+ * larger preset exists). Pure sibling of [`computeAutoGrowLayoutId`], keyed by
+ * a zone INDEX instead of the tab count (item 10 of the boot-restore
+ * remediation): when restore excludes a record, the surviving records' zone
+ * indices have GAPS (e.g. rows at zones 0 and 3 with 2 tabs), so the
+ * count-based grow can pick a layout too small for the highest recorded zone
+ * and `applyLayout` would silently compact it — breaking the operator's
+ * spatial memory. Same grow-only / uniform-preset / `full-grid`-cap rules as
+ * the count-based path; a zone index beyond the 9-zone ceiling stays
+ * un-growable (the caller's compaction is then the honest fallback).
+ */
+export function computeZoneCapacityGrowth(
+  currentLayoutId: string,
+  zoneIndex: number,
+): string | null {
+  const current = LAYOUT_PRESETS.find((l) => l.id === currentLayoutId) ?? LAYOUT_PRESETS[0];
+  if (zoneIndex < current.zones.length) return null;
+  const targetId = pickLayout(zoneIndex + 1);
+  const target = LAYOUT_PRESETS.find((l) => l.id === targetId);
+  if (!target) return null;
+  // Grow only — and only when the target actually renders the zone.
+  if (target.zones.length <= current.zones.length || zoneIndex >= target.zones.length) {
+    return null;
+  }
+  return targetId;
+}
+
 // ── Zone Assignment ────────────────────────────────────────────────────────
 
 /** Maps zone index → tab ID */
@@ -404,33 +433,45 @@ export function useZoneLayout(
     [applyLayout],
   );
 
-  const assignTabToZone = useCallback((zoneIndex: number, tabId: string) => {
-    // Reserve the zone so the creation-order auto-fill can't steal it while the
-    // tab is mid-creation (restore path). Cleared in the setter below once the
-    // zone holds its intended tab.
-    if (zoneIndex >= 0) reservedZonesRef.current.add(zoneIndex);
-    setAssignments((prev) => {
-      const next = { ...prev };
-      // If this tab is already in another zone, swap
-      for (const [idx, id] of Object.entries(next)) {
-        if (id === tabId && Number(idx) !== zoneIndex) {
-          // Swap: put the displaced tab into the old slot
-          const displaced = next[zoneIndex];
-          if (displaced) {
-            next[Number(idx)] = displaced;
-          } else {
-            delete next[Number(idx)];
+  const assignTabToZone = useCallback(
+    (zoneIndex: number, tabId: string) => {
+      // A recorded zone beyond the current layout's capacity must GROW the
+      // layout so the binding survives (item 10 — restore with gaps: excluded
+      // records leave the surviving zone indices sparse, so the count-based
+      // auto-grow alone can pick a layout too small for the highest recorded
+      // zone and the assignment would compact away). Beyond the full-grid
+      // ceiling there is nothing to grow into — the reconcile/compaction
+      // fallback then applies.
+      const growTarget = computeZoneCapacityGrowth(layoutId, zoneIndex);
+      if (growTarget) applyLayout(growTarget);
+      // Reserve the zone so the creation-order auto-fill can't steal it while the
+      // tab is mid-creation (restore path). Cleared in the setter below once the
+      // zone holds its intended tab.
+      if (zoneIndex >= 0) reservedZonesRef.current.add(zoneIndex);
+      setAssignments((prev) => {
+        const next = { ...prev };
+        // If this tab is already in another zone, swap
+        for (const [idx, id] of Object.entries(next)) {
+          if (id === tabId && Number(idx) !== zoneIndex) {
+            // Swap: put the displaced tab into the old slot
+            const displaced = next[zoneIndex];
+            if (displaced) {
+              next[Number(idx)] = displaced;
+            } else {
+              delete next[Number(idx)];
+            }
+            break;
           }
-          break;
         }
-      }
-      next[zoneIndex] = tabId;
-      // The zone now holds its intended tab — drop the reservation so a later
-      // genuine vacancy can be auto-filled normally.
-      reservedZonesRef.current.delete(zoneIndex);
-      return next;
-    });
-  }, []);
+        next[zoneIndex] = tabId;
+        // The zone now holds its intended tab — drop the reservation so a later
+        // genuine vacancy can be auto-filled normally.
+        reservedZonesRef.current.delete(zoneIndex);
+        return next;
+      });
+    },
+    [layoutId, applyLayout],
+  );
 
   const focusedTabId = assignments[focusedZone] ?? null;
 

--- a/src/components/terminal/zone-grid/ZoneLabel.tsx
+++ b/src/components/terminal/zone-grid/ZoneLabel.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { ChevronDown, Pin, Filter, ArrowDownToLine, Zap } from "lucide-react";
+import { useUIElement } from "@qontinui/ui-bridge";
 import type { TerminalTab } from "../useTerminalManager";
 import type { ZoneAssignments, SessionState } from "../useZoneLayout";
 import { STATE_BORDER_COLORS } from "./constants";
@@ -47,6 +48,18 @@ export function ZoneLabel({
   const selectorRef = useRef<HTMLDivElement>(null);
   const { popOutTab } = useTerminalWindowActions();
 
+  // Item 8 (boot-restore remediation) — session↔zone identity as a UI Bridge
+  // element. Without this, `ai/find <session title>` resolved nothing (zone
+  // headers were unregistered) and verifying which session occupies which
+  // zone required walking debug DOM text. The label carries the tab title so
+  // title-based find resolves; the data attributes expose the binding
+  // (`claudeSessionId` / `zoneIndex` / `resumeFailed`) to snapshot readers.
+  const { ref: headerRef } = useUIElement({
+    id: `terminal-zone-header-${zoneIndex}`,
+    type: "generic",
+    label: `Zone ${zoneIndex + 1} session header: ${tab.title}`,
+  });
+
   useEffect(() => {
     if (!showSelector) return;
     const handleClick = (e: MouseEvent) => {
@@ -60,6 +73,11 @@ export function ZoneLabel({
 
   return (
     <div
+      ref={headerRef}
+      data-claude-session-id={tab.claudeSessionId ?? undefined}
+      data-zone-index={zoneIndex}
+      data-resume-failed={tab.resumeFailed ? "true" : undefined}
+      data-resume-needs-confirm={tab.resumeNeedsConfirm ? "true" : undefined}
       className="absolute top-0 left-0 right-0 flex items-center gap-1.5 px-2 py-0.5 bg-[#13141f]/80 backdrop-blur-sm z-10 cursor-grab active:cursor-grabbing"
       draggable
       onDragStart={(e) => {


### PR DESCRIPTION
## Boot-restore restores the wrong sessions — residual defects after the #548 fix stack

Implements `plans/2026-06-13-boot-restore-wrong-sessions-remediation.md`. The
operator reported the runner still reloads with the *wrong* sessions on
restart despite the merged #548 stack; a /manual-test run on a temp runner
(LKG b120337b) reproduced a stale ghost record restoring on-page. This closes
the residual defects (all on current `origin/main`, build provenance verified —
not a stale-build artifact).

### Items (1 PR, 4 commits)

**1+2 — restore-selection P0 pair (backend)**
- `restorable_records` admits an `open` row only when `anchor - last_seen_at <= 10min`, where `anchor = max(all lastSeen, all closedAt, prior shutdown-marker at)` — recency relative to the registry's last moment of life, not wall-clock now. Excludes the 72h ghost on every boot kind; restores rows fresh at crash time even after multi-hour downtime; restores an unflushed-`pty-exit` `open` row on a clean boot.
- Boot crash/planned classification hoisted to a synchronous `main.rs` setup site via `shutdown_marker::classify_boot` (`OnceLock`, single-read): the prior marker is read once, immediately re-marked `clean:false`, and every consumer reads the stash. A command-time re-read would always see the `clean:false` we just wrote and misclassify every boot as a crash; the old ~3s-delayed `tokio::spawn` read could also race the frontend restore.
- The liveness poll now closes orphaned records (`open` row, no matching live terminal for 4 consecutive ticks ≈ 3 min) with reason `no-terminal`, which is **not** a grace-window reason → never re-qualifies for restore. `restore_pending` rows never accumulate no-match ticks.

**3+4+5 — restore-verification + identity (frontend)**
- **Ghost immortality:** the registry re-assert (which refreshes `lastSeenAt`) is deferred from tab-creation into `runVerifiedResume`'s *verified* branch. A failed/ghost resume leaves the original row's `lastSeenAt` untouched, so it ages and prunes instead of resurrecting forever.
- **Verification false-positive:** `detectResumeFailure` adds negative patterns (`No conversation found with session ID`, `--resume requires a valid session ID`) checked **before** the handshake patterns, so a bogus `--resume` that renders Claude TUI frames is refuted, not verified. A refutation parks the tab `resumeFailed` without burning the retry.
- **bindOrigin quarantine:** cold-restored rows whose `bindOrigin !== "pinned"` no longer auto-type `claude --resume` — they surface a per-pane operator confirm (`ResumeConfirmBanner`). Confirm runs the verified resume; decline closes the record so the mis-bound row stops resurrecting. The tab is still created so layout is preserved.

**6 — registration cwd narrowing (backend + frontend)**
- `TranscriptSession` gains a `cwd` field extracted from the JSONL records; the capture poll rejects a freshest-mtime candidate whose recorded cwd contradicts the pane's working dir (Windows-tolerant equality). Closes the workspace-root-fallback mis-bind. The same-project+configDir race stays covered by item 5's quarantine + the keep-polling-unbound mitigation.

**8+10 — UI Bridge observability + zone fidelity (frontend)**
- Zone headers register as UI Bridge elements (`terminal-zone-header-<idx>`) carrying the title (so `ai/find <session title>` resolves) and expose the binding via data attributes.
- `computeZoneCapacityGrowth` grows the layout by zone **index** in `assignTabToZone`, so a recorded zone 3 stays at zone 3 when restore leaves gaps (no silent compaction).

**7** — resolved-as-existing (`GET /terminals/{id}/buffer?format=text` already ships). **9** — local checkout ff'd to `origin/main`.

### Tests
- Backend: `cargo test` session + transcript modules green (243 passed); new coverage for the anchor rule, lone-ghost `marker_at` anchoring, `classify_no_match`, `classify_boot` single-read, `extract_cwd`.
- Frontend: 580 vitest tests green; new coverage for deferred re-assert, refuted resume, `cwdConflicts`/foreign-cwd race, and `computeZoneCapacityGrowth`.
- `tsc` clean, `cargo fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
