### PR TITLE
feat: demote workflow-authoring nav behind advanced-automation toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@dagrejs/dagre": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@qontinui/design-tokens": "^1.0.0",
-    "@qontinui/navigation": "^0.1.0",
+    "@qontinui/navigation": "^0.1.3",
     "@qontinui/shared-types": "^0.6.0",
     "@qontinui/ui-bridge": "^0.17.0",
     "@qontinui/ui-bridge-auto": "^0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
-        specifier: ^0.1.0
-        version: 0.1.1(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
+        specifier: ^0.1.3
+        version: 0.1.3(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1121,8 +1121,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@qontinui/navigation@0.1.1':
-    resolution: {integrity: sha512-X8MZfhzrTFvMO2VRLTiSeCldfZHcbxwX+au7mw6QibuQq9CnriGUVrSx9eubgJ/ZfNvH/hNVJ93tLFeE3KPhoQ==}
+  '@qontinui/navigation@0.1.3':
+    resolution: {integrity: sha512-I9flSGD9UzLE5eaBl9cBxf3RSYmPbODBdrqvfR5dJ6TykK5B2lcRvUdWRx7EnSxCrUobDtsp1FWZKL9O4CsUjw==}
     peerDependencies:
       '@qontinui/ui-bridge': '>=0.3.0'
       react: ^18.0.0 || ^19.0.0
@@ -6128,7 +6128,7 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.1(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.3(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
     optionalDependencies:
       '@qontinui/ui-bridge': 0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
       react: 19.2.5

--- a/src/components/navigation/Sidebar.tsx
+++ b/src/components/navigation/Sidebar.tsx
@@ -108,6 +108,7 @@ import {
   getRunnerNavigation,
   getChildrenForPlatform,
   setProductMode,
+  setShowHiddenItems,
   STORAGE_KEYS,
   createInitialState,
   navigationReducer,
@@ -118,6 +119,7 @@ import {
   useNavigationItem,
 } from "@qontinui/navigation";
 import { useProductMode, type ProductMode } from "@/contexts/ProductModeContext";
+import { useAdvancedAutomation } from "@/contexts/AdvancedAutomationContext";
 
 // ============================================================================
 // Icon Mapping
@@ -842,11 +844,18 @@ export function Sidebar({ activeTab, onTabChange, collapsed, onCollapsedChange }
   // Product mode filtering
   const { mode: productMode, setMode: setProductModeState } = useProductMode();
 
-  // Sync product mode to shared navigation package and rebuild groups
+  // "Show advanced automation features" — reveals the workflow-authoring nav
+  // items flagged `hidden: true` in @qontinui/navigation when enabled.
+  const { showAdvancedAutomation } = useAdvancedAutomation();
+
+  // Sync product mode + hidden-item visibility to shared navigation package and
+  // rebuild groups. Both must run before buildNavigationGroups() so the freshly
+  // built groups reflect the current toggle states.
   const navigationGroups = useMemo(() => {
     setProductMode(productMode);
+    setShowHiddenItems(showAdvancedAutomation);
     return buildNavigationGroups();
-  }, [productMode]);
+  }, [productMode, showAdvancedAutomation]);
 
   // Flyout state
   const [openFlyout, setOpenFlyout] = useState<{

--- a/src/components/settings/GeneralSettings.tsx
+++ b/src/components/settings/GeneralSettings.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { Settings as SettingsIcon, FileText } from "lucide-react";
 import { SectionHeader } from "./SectionHeader";
+import { useAdvancedAutomation } from "@/contexts/AdvancedAutomationContext";
 import type { AppSettings, LogFunction } from "./types";
 
 interface TauriResult<T> {
@@ -37,6 +38,11 @@ export function GeneralSettings({ onLog }: GeneralSettingsProps) {
   // solution for overnight scheduled tasks: the OS auto-starts the runner at
   // login, so scheduled tasks fire even if the user closed the runner.
   const [autostartEnabled, setAutostartEnabled] = useState<boolean>(false);
+
+  // "Show advanced automation features" — persisted in localStorage via the
+  // AdvancedAutomationContext and consumed reactively by the Sidebar, which
+  // calls setShowHiddenItems() to reveal the workflow-authoring nav items.
+  const { showAdvancedAutomation, setShowAdvancedAutomation } = useAdvancedAutomation();
 
   const loadAppSettings = async () => {
     try {
@@ -140,6 +146,12 @@ export function GeneralSettings({ onLog }: GeneralSettingsProps) {
     }
   };
 
+  const handleToggleShowAdvancedAutomation = () => {
+    const newValue = !showAdvancedAutomation;
+    setShowAdvancedAutomation(newValue);
+    onLog("success", `Advanced automation features ${newValue ? "shown" : "hidden"}`);
+  };
+
   const handleToggleIncludeSummaryStep = async () => {
     const newValue = !includeSummaryStep;
     setIncludeSummaryStep(newValue);
@@ -235,6 +247,29 @@ export function GeneralSettings({ onLog }: GeneralSettingsProps) {
         </h4>
 
         <div className="space-y-2">
+          <label className="flex items-center justify-between cursor-pointer p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
+            <div className="space-y-1">
+              <div className="text-sm font-medium">Show advanced automation features</div>
+              <div className="text-xs text-muted-foreground">
+                Reveals the workflow-authoring tools (Workflow Builder, DAG Editor, Orchestration
+                loop, Step Builders) in the sidebar. The Terminal is the primary way to run AI work;
+                these are advanced surfaces for building reusable, gated, scheduled workflows.
+              </div>
+            </div>
+            <button
+              onClick={handleToggleShowAdvancedAutomation}
+              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                showAdvancedAutomation ? "bg-primary" : "bg-muted"
+              }`}
+            >
+              <span
+                className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${
+                  showAdvancedAutomation ? "translate-x-4" : "translate-x-1"
+                }`}
+              />
+            </button>
+          </label>
+
           <label className="flex items-center justify-between cursor-pointer p-3 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors">
             <div className="space-y-1">
               <div className="text-sm font-medium">Include AI Summary in New Workflows</div>

--- a/src/contexts/AdvancedAutomationContext.tsx
+++ b/src/contexts/AdvancedAutomationContext.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useState, useCallback } from "react";
+
+/**
+ * "Show advanced automation features" setting.
+ *
+ * When enabled, the workflow-authoring nav items flagged `hidden: true` in the
+ * shared `@qontinui/navigation` package (Workflow Builder, DAG Editor,
+ * Orchestration loop, Step Builders) reappear in the sidebar. The Sidebar reads
+ * this reactively and calls `setShowHiddenItems(enabled)` before rebuilding its
+ * navigation groups, so toggling the setting updates the sidebar live (no
+ * reload). The route/tab ids stay registered regardless — hiding only affects
+ * sidebar rendering, so Terminal "save as workflow" / Specs deep-links into the
+ * builder keep working.
+ *
+ * Persisted in localStorage so the preference survives restarts. Default OFF.
+ */
+
+const STORAGE_KEY = "showAdvancedAutomation";
+
+interface AdvancedAutomationContextValue {
+  showAdvancedAutomation: boolean;
+  setShowAdvancedAutomation: (show: boolean) => void;
+}
+
+const AdvancedAutomationContext = createContext<AdvancedAutomationContextValue>({
+  showAdvancedAutomation: false,
+  setShowAdvancedAutomation: () => {},
+});
+
+export function AdvancedAutomationProvider({ children }: { children: React.ReactNode }) {
+  const [showAdvancedAutomation, setShowState] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) === "true";
+    } catch {
+      // Ignore
+    }
+    return false;
+  });
+
+  const setShowAdvancedAutomation = useCallback((show: boolean) => {
+    setShowState(show);
+    try {
+      localStorage.setItem(STORAGE_KEY, show ? "true" : "false");
+    } catch {
+      // Ignore
+    }
+  }, []);
+
+  return (
+    <AdvancedAutomationContext.Provider
+      value={{ showAdvancedAutomation, setShowAdvancedAutomation }}
+    >
+      {children}
+    </AdvancedAutomationContext.Provider>
+  );
+}
+
+export function useAdvancedAutomation() {
+  return useContext(AdvancedAutomationContext);
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { setDevelopmentMode } from "@qontinui/navigation";
 import { ProductModeProvider } from "./contexts/ProductModeContext";
+import { AdvancedAutomationProvider } from "./contexts/AdvancedAutomationContext";
 import App from "./App";
 import ErrorBoundary from "./ErrorBoundary";
 import { setScriptEmitter, TauriScriptEmitter } from "./lib/step-output-handlers/script-emitter";
@@ -52,7 +53,9 @@ if (!rootElement) {
     <QueryClientProvider client={queryClient}>
       <ErrorBoundary>
         <ProductModeProvider>
-          <App />
+          <AdvancedAutomationProvider>
+            <App />
+          </AdvancedAutomationProvider>
         </ProductModeProvider>
       </ErrorBoundary>
     </QueryClientProvider>


### PR DESCRIPTION
## What

Demotes the workflow-authoring sidebar items (Workflow Builder, DAG Editor, Orchestration, Step Builders) out of the default navigation. They reappear only when the user enables a new **Settings → General → "Show advanced automation features"** toggle (default OFF).

## How

- Bumps `@qontinui/navigation` to `^0.1.3` (adds the `hidden` flag + `setShowHiddenItems()` gate).
- New `AdvancedAutomationContext` (localStorage key `showAdvancedAutomation`, default OFF), provider mounted in `main.tsx`.
- `Sidebar.tsx` calls `setShowHiddenItems(showAdvancedAutomation)` in the nav-build memo (with the flag in deps) so toggling updates the sidebar live.
- Toggle added to `GeneralSettings.tsx`.

## Deep-links preserved

`hidden` only affects sidebar rendering — tab ids stay registered in `tab-types.ts`/`TabContent.tsx`. Verified the Terminal "save as workflow" path (`useWorkflowGeneration.ts` → `setActiveTab("unified-workflow-builder")`) and the Library/Specs deep-links still resolve. No gating added to those paths.

## Verified

On a freshly-rebuilt temp runner: four items hidden by default, all other nav intact, deep-links work; flipping the toggle reveals all four live. `tsc --noEmit` + eslint clean.

Depends on `@qontinui/navigation@0.1.3` (already published to npm; qontinui-navigation#5 is the source).