### PR TITLE
feat(coord-mcp): fleet-wide runner->coord credential & gate-access reliability

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -269,6 +269,14 @@ path = "src/bin/qontinui_specs.rs"
 name = "qontinui-git-credential"
 path = "src/bin/qontinui_git_credential.rs"
 
+# `coord doctor` headless self-check (plan 2026-06-13 Phase 4). Reuses the
+# lib-crate `coord_doctor` module (driver + 7-check wiring) so it produces the
+# same report as the in-app Tauri command. Runnable on any machine to diagnose
+# "no credentials / can't set gates" with the one failing link + its fix.
+[[bin]]
+name = "coord_doctor"
+path = "src/bin/coord_doctor.rs"
+
 # Install-interception Windows `.exe` shadow stub (plan §6). The materializer
 # copies this binary into the per-terminal shim dir as cargo.exe/pip.exe/pip3.exe
 # so it can shadow the real `.exe` under PowerShell/cmd (a `.cmd` cannot — `.EXE`

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -1981,12 +1981,15 @@ async fn run_continuation_terminal(
     // coord identity and fell back to the operator-bearer stopgap. Uses the
     // runner's own device JWT; guarded against non-verifying bearers + clobber.
     // Device-JWT sessions get the loopback live-token PROXY shape, so the
-    // ACTUALLY-BOUND API port is resolved from the managed AppState (the
-    // env-default 9876 is wrong on secondary/temp runners).
+    // ACTUALLY-BOUND API port must come from the managed AppState. Phase 3a:
+    // when AppState isn't reachable we pass `None` (fail-closed) rather than the
+    // env-default 9876 — that default is wrong on secondary/temp runners and
+    // writes a dead-but-valid-looking proxy config (the F1 root cause).
+    // Provisioning then refuses the device-path write + drops a degraded
+    // breadcrumb instead of pointing the session at a port nothing serves.
     let bound_port = app
         .try_state::<Arc<crate::commands::AppState>>()
-        .map(|s| crate::mcp::types::runner_api_port(s.inner()))
-        .unwrap_or_else(crate::mcp::types::get_mcp_api_port);
+        .map(|s| crate::mcp::types::runner_api_port(s.inner()));
     crate::coord_mcp::provision_coord_mcp_for_session(workdir, bound_port);
 
     let result = crate::commands::terminal::create_terminal_session_backend(

--- a/src-tauri/src/agent_worktree/isolated_edit.rs
+++ b/src-tauri/src/agent_worktree/isolated_edit.rs
@@ -647,7 +647,11 @@ pub async fn acquire_for_terminal(
     // The bound API port (for the device-path loopback proxy URL) is resolved
     // via the process-global AppHandle's managed AppState — this chokepoint has
     // no AppState parameter and threading one through its six call sites would
-    // ripple far past the provisioning concern.
+    // ripple far past the provisioning concern. `resolve_bound_api_port()` now
+    // returns `Option<u16>`: `None` (no managed AppState) means the device path
+    // FAILS CLOSED inside provisioning (no dead-port config written + a degraded
+    // breadcrumb) rather than silently substituting the bootstrap default — the
+    // F1 root cause. We pass it through unchanged.
     if let Some(wd) = &out.0 {
         crate::coord_mcp::provision_coord_mcp_for_session(
             wd,

--- a/src-tauri/src/auth.rs
+++ b/src-tauri/src/auth.rs
@@ -125,11 +125,23 @@ impl AuthManager {
     }
 
     /// Creates an AuthManager with a custom SecureStorage for testing.
+    ///
+    /// Uses a UNIQUE per-instance keychain `service_name` so parallel tests do
+    /// NOT collide on the single process-/OS-global keychain slot. The file
+    /// store is already isolated via [`SecureStorage::with_path`], but the
+    /// keychain backup (`store_tokens_in_keychain` / the `get_access_token`
+    /// fallback) writes/reads `Entry::new(service_name, "access_token")` — a
+    /// FIXED slot under the real `SERVICE_NAME`. Two parallel tests that both
+    /// store/clear tokens would otherwise stomp that one shared slot, so a test
+    /// expecting an empty slot reads a sibling's keychain token (the flaky
+    /// `needs_refresh_when_no_token` / `test_token_storage` cross-test
+    /// pollution). A per-test service name makes the keychain backup as isolated
+    /// as the file store.
     #[cfg(test)]
     pub fn with_storage(secure_storage: SecureStorage) -> Self {
         Self {
             secure_storage,
-            service_name: SERVICE_NAME.to_string(),
+            service_name: format!("com.qontinui.runner.test.{}", uuid::Uuid::now_v7()),
         }
     }
 

--- a/src-tauri/src/bin/coord_doctor.rs
+++ b/src-tauri/src/bin/coord_doctor.rs
@@ -1,0 +1,57 @@
+//! `coord_doctor` — headless runner self-check for coord access + gate
+//! registration (plan 2026-06-13 Phase 4).
+//!
+//! Runs the SAME seven ordered checks as the in-app `coord_doctor` Tauri
+//! command (both delegate to `qontinui_runner_lib::coord_doctor`), STOPS at the
+//! first red, and prints the link + its fix. Green on all seven ⇒ "this runner
+//! can set gates."
+//!
+//! ## Bound-port caveat
+//!
+//! This headless bin has no running Tauri runtime, so it cannot observe the
+//! runner's ACTUALLY-BOUND loopback API port (check 6 needs it to compare
+//! against the `.mcp.json` URL). It passes `bound_api_port: None`, and check 6
+//! reports the port as unverifiable — run the in-app command (Settings → coord
+//! doctor) for the authoritative `.mcp.json` port verdict. Checks 1-5 and 7 are
+//! fully authoritative headless.
+//!
+//! ## Usage
+//!
+//! ```text
+//! coord_doctor          # human-readable report; exit 0 = can set gates, 1 = blocked
+//! coord_doctor --json   # machine-readable DoctorReport JSON
+//! ```
+
+use std::process::ExitCode;
+
+use qontinui_runner_lib::coord_doctor::{diagnose, DoctorInputs};
+
+fn main() -> ExitCode {
+    let json = std::env::args().any(|a| a == "--json");
+
+    let inputs = DoctorInputs {
+        // Headless: no live runtime → bound port unknown (see module docs).
+        bound_api_port: None,
+        // Default Claude config location (the spawn-inherited ambient default).
+        claude_config_dir: None,
+    };
+    let report = diagnose(&inputs);
+
+    if json {
+        match serde_json::to_string_pretty(&report) {
+            Ok(s) => println!("{s}"),
+            Err(e) => {
+                eprintln!("coord_doctor: failed to serialize report: {e}");
+                return ExitCode::from(2);
+            }
+        }
+    } else {
+        print!("{}", report.render());
+    }
+
+    if report.overall_ok {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}

--- a/src-tauri/src/coord_doctor.rs
+++ b/src-tauri/src/coord_doctor.rs
@@ -1,0 +1,924 @@
+//! `coord doctor` — one-command runner self-check for coord access + gate
+//! registration (plan 2026-06-13 Phase 4).
+//!
+//! Runs SEVEN ordered checks, STOPS at the first red, and reports that link +
+//! its fix. Green on all seven ⇒ "this runner can set gates." The output is
+//! copy-pasteable and **identical across machines**, so MSI / spaceship / a
+//! fresh box all self-diagnose the same way.
+//!
+//! # Why this lives in the lib crate
+//!
+//! Two consumers need it: the headless standalone bin (`src/bin/coord_doctor.rs`)
+//! and the in-app Tauri command (`crate::coord_doctor_cmd` in the runner
+//! binary). A `src/bin/*` crate cannot import the runner binary's module tree,
+//! so the reusable core (types + the first-red-stops DRIVER + the report
+//! FORMATTER + `diagnose`) lives here in `qontinui_runner_lib` where both can
+//! reach it.
+//!
+//! The checks reuse the same on-disk + secure-storage state the live predicates
+//! read (`auth`, `pair`, `secure_storage`, `profiles` are all lib modules that
+//! compile into the runner binary too), so the bin and the Tauri command
+//! produce the SAME report. The one fact only the running runtime knows — the
+//! ACTUALLY-BOUND API port (check 6) — is injected via [`DoctorInputs`]: the
+//! Tauri command passes the live `coord_mcp::resolve_bound_api_port()`, the
+//! standalone bin passes `None` (and check 6 honestly reports "bound port
+//! unknown — run from inside the running runner").
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use base64::Engine as _;
+
+// ===========================================================================
+// Result types (pure data — serialize straight to the Tauri command / JSON)
+// ===========================================================================
+
+/// One check's outcome. `name` identifies the link; `ok` is the verdict;
+/// `detail` is a one-line human explanation; `fix` is the actionable next step
+/// (only meaningful when `!ok`, but always carried so the report is uniform).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct CheckResult {
+    pub name: String,
+    pub ok: bool,
+    pub detail: String,
+    pub fix: String,
+}
+
+/// The whole self-check: the ordered checks actually RUN (the driver stops
+/// after the first red, so later checks are absent), plus the overall verdict.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct DoctorReport {
+    pub checks: Vec<CheckResult>,
+    pub overall_ok: bool,
+}
+
+impl DoctorReport {
+    /// Render the copy-pasteable, machine-identical text report. The ordering
+    /// + the trailing verdict line are the contract — keep them stable so the
+    /// output diffs cleanly across machines.
+    pub fn render(&self) -> String {
+        let mut out = String::new();
+        out.push_str("coord doctor — runner gate-access self-check\n");
+        out.push_str("============================================\n");
+        for (i, c) in self.checks.iter().enumerate() {
+            let mark = if c.ok { "PASS" } else { "FAIL" };
+            out.push_str(&format!(
+                "{}. [{}] {} — {}\n",
+                i + 1,
+                mark,
+                c.name,
+                c.detail
+            ));
+            if !c.ok {
+                out.push_str(&format!("      fix: {}\n", c.fix));
+            }
+        }
+        out.push_str("--------------------------------------------\n");
+        if self.overall_ok {
+            out.push_str("OK: this runner can set gates.\n");
+        } else {
+            // The first (only) red is the one to fix; name it again so a
+            // glance at the last line is enough.
+            let first_red = self.checks.iter().find(|c| !c.ok);
+            match first_red {
+                Some(c) => out.push_str(&format!("BLOCKED at: {} — {}\n", c.name, c.fix)),
+                None => out.push_str("BLOCKED (no check ran).\n"),
+            }
+        }
+        out
+    }
+}
+
+// ===========================================================================
+// Pure first-red-stops driver (injectable check fns → unit-testable)
+// ===========================================================================
+
+/// A single check: a static name + fix, plus a thunk that runs the predicate
+/// and returns `(ok, detail)`. The thunk is `FnOnce` so a check can own
+/// resources; the driver only ever calls it once.
+pub struct Check<'a> {
+    pub name: &'static str,
+    pub fix: &'static str,
+    pub run: Box<dyn FnOnce() -> (bool, String) + 'a>,
+}
+
+impl<'a> Check<'a> {
+    pub fn new(
+        name: &'static str,
+        fix: &'static str,
+        run: impl FnOnce() -> (bool, String) + 'a,
+    ) -> Self {
+        Self {
+            name,
+            fix,
+            run: Box::new(run),
+        }
+    }
+}
+
+/// Run `checks` in order, STOPPING at (and including) the first red. Returns a
+/// [`DoctorReport`] whose `checks` are exactly the ones that ran. Pure over the
+/// injected closures — the unit tests drive it with fake checks to assert the
+/// ordering / first-red-stops behavior without any live runner.
+pub fn run_checks(checks: Vec<Check<'_>>) -> DoctorReport {
+    let mut results = Vec::with_capacity(checks.len());
+    let mut overall_ok = true;
+    for check in checks {
+        let name = check.name;
+        let fix = check.fix;
+        let (ok, detail) = (check.run)();
+        results.push(CheckResult {
+            name: name.to_string(),
+            ok,
+            detail,
+            fix: fix.to_string(),
+        });
+        if !ok {
+            overall_ok = false;
+            break; // first red stops the chain
+        }
+    }
+    DoctorReport {
+        checks: results,
+        overall_ok,
+    }
+}
+
+// ===========================================================================
+// Real wiring — the 7 checks, reusing existing predicates / on-disk state.
+// ===========================================================================
+
+/// Runtime-only facts the lib can't observe on its own. Injected so the Tauri
+/// command (running inside the live runner) and the standalone bin produce the
+/// same report shape, differing only where the bin genuinely cannot know the
+/// live bound port.
+#[derive(Debug, Clone, Default)]
+pub struct DoctorInputs {
+    /// The runner's ACTUALLY-BOUND loopback API port, from the live managed
+    /// `AppState` (`coord_mcp::resolve_bound_api_port()`). `None` from the
+    /// standalone bin (no running runtime) ⇒ check 6 reports the port as
+    /// unverifiable rather than guessing.
+    pub bound_api_port: Option<u16>,
+    /// Optional explicit Claude config dir to check for check 1; `None` means
+    /// "the ambient default location" (matches the spawn path's behavior).
+    pub claude_config_dir: Option<String>,
+}
+
+/// Run the full 7-check self-check and return the structured report.
+///
+/// Each check reuses the canonical state:
+/// 1. Claude account — `.credentials.json` validity (same paths + expiry logic
+///    as `ai_provider::oauth_refresh::default_location_has_valid_credentials`).
+/// 2. Tier — `settings.json::tier == "qontinui_account"`
+///    (`settings::load_settings().tier == RunnerTier::QontinuiAccount`).
+/// 3. Paired + signed in — `paired_user.json`
+///    (`pair::read_paired_user_id_from_disk`) + a bearer in the access-token
+///    slot (`auth::AuthManager::get_access_token`).
+/// 4. Tenant resolvable — OAuth claim → outgoing-JWT claim →
+///    `machine.json::active_tenant_id` (mirrors
+///    `device_jwt_refresher::resolve_pair_tenant_id`).
+/// 5. Device JWT live — `auth::AuthManager::device_jwt_needs_refresh()` ==
+///    `Ok(false)` with a token present.
+/// 6. `.mcp.json` valid — its coord-mcp port == the bound port AND its nonce
+///    is registered + the bearer is a device JWT (mirrors
+///    `coord_mcp::proxy_request_gate`).
+/// 7. Coord reachable — a one-shot `tools/list` round-trips 200 against the
+///    configured coord-mcp endpoint.
+pub fn diagnose(inputs: &DoctorInputs) -> DoctorReport {
+    let cfg_dir = inputs.claude_config_dir.clone();
+    let bound_port = inputs.bound_api_port;
+
+    let checks = vec![
+        Check::new("claude_account", "run /login", move || {
+            let ok = claude_account_has_valid_credentials(cfg_dir.as_deref());
+            if ok {
+                (
+                    true,
+                    "a Claude account with live credentials is present".into(),
+                )
+            } else {
+                (
+                    false,
+                    "no authenticated Claude account (no valid ~/.claude/.credentials.json)".into(),
+                )
+            }
+        }),
+        Check::new("tier", "set runner tier to Qontinui account", || {
+            let tier = read_runner_tier();
+            if tier.as_deref() == Some("qontinui_account") {
+                (true, "runner tier is Qontinui account".into())
+            } else {
+                (
+                    false,
+                    format!(
+                        "runner tier is {} (not qontinui_account)",
+                        tier.as_deref().unwrap_or("local")
+                    ),
+                )
+            }
+        }),
+        {
+            let auth_ref = crate::auth::AuthManager::new();
+            Check::new("paired_signed_in", "sign in / re-pair", move || {
+                let paired = crate::pair::read_paired_user_id_from_disk().is_some();
+                let bearer = auth_ref
+                    .get_access_token()
+                    .ok()
+                    .filter(|t| !t.trim().is_empty())
+                    .is_some();
+                match (paired, bearer) {
+                    (true, true) => (
+                        true,
+                        "paired_user.json present and a bearer is stored".into(),
+                    ),
+                    (false, _) => (false, "paired_user.json missing — runner not paired".into()),
+                    (true, false) => (
+                        false,
+                        "paired but access-token slot is empty — sign in".into(),
+                    ),
+                }
+            })
+        },
+        {
+            let auth_ref = crate::auth::AuthManager::new();
+            Check::new(
+                "tenant_resolvable",
+                "machine.json missing active_tenant_id",
+                move || {
+                    let bearer = auth_ref.get_access_token().ok().unwrap_or_default();
+                    match resolve_tenant_for_doctor(&bearer) {
+                        Some((tid, src)) => (true, format!("tenant {tid} resolved from {src}")),
+                        None => (
+                            false,
+                            "no tenant_id from OAuth claim, outgoing device-JWT, or \
+                             machine.json::active_tenant_id"
+                                .into(),
+                        ),
+                    }
+                },
+            )
+        },
+        {
+            let auth_ref = crate::auth::AuthManager::new();
+            Check::new(
+                DEVICE_JWT_LIVE_CHECK_NAME,
+                DEVICE_JWT_LIVE_CHECK_FIX,
+                move || device_jwt_live_predicate(&auth_ref),
+            )
+        },
+        {
+            let auth_ref = crate::auth::AuthManager::new();
+            Check::new(
+                "mcp_json_valid",
+                "stale config — reprovision",
+                move || mcp_json_check(bound_port, &auth_ref),
+            )
+        },
+        Check::new(
+            "coord_reachable",
+            "coord unreachable",
+            coord_reachable_check,
+        ),
+    ];
+
+    run_checks(checks)
+}
+
+// ===========================================================================
+// Check 5 (device JWT live) — extracted so the Phase-5 provisioning gate can
+// reuse the EXACT predicate `diagnose` runs (no second device-JWT impl).
+// ===========================================================================
+
+/// The stable `name`/`fix` for check 5, shared between [`diagnose`] and
+/// [`device_jwt_live_check`] so the provisioning gate and the full doctor
+/// report name the link identically.
+pub const DEVICE_JWT_LIVE_CHECK_NAME: &str = "device_jwt_live";
+pub const DEVICE_JWT_LIVE_CHECK_FIX: &str = "kick refresher / re-pair";
+
+/// The check-5 predicate over an `AuthManager`: a live device JWT is present
+/// and not near expiry. `(ok, detail)`. The single source of truth for "does
+/// this runner hold a usable coord device JWT" — both the full [`diagnose`]
+/// chain and the Phase-5 provisioning gate call it.
+fn device_jwt_live_predicate(auth: &crate::auth::AuthManager) -> (bool, String) {
+    match auth.device_jwt_needs_refresh() {
+        Ok(false) => {
+            if auth
+                .get_access_token()
+                .ok()
+                .filter(|t| !t.trim().is_empty())
+                .is_some()
+            {
+                (true, "device JWT present and not near expiry".into())
+            } else {
+                (false, "no device JWT in the access-token slot".into())
+            }
+        }
+        Ok(true) => (
+            false,
+            "device JWT missing, expired, or near expiry (needs refresh)".into(),
+        ),
+        Err(e) => (false, format!("could not read device-JWT freshness: {e}")),
+    }
+}
+
+/// Run ONLY check 5 (device JWT live) against the default `AuthManager` and
+/// return its structured [`CheckResult`]. This is the single check Phase 5
+/// gates "ready" on: a runner is provisioning-complete only once it holds a
+/// live coord device JWT. Reuses [`device_jwt_live_predicate`] — it does NOT
+/// reimplement the device-JWT freshness logic.
+pub fn device_jwt_live_check() -> CheckResult {
+    let auth = crate::auth::AuthManager::new();
+    let (ok, detail) = device_jwt_live_predicate(&auth);
+    CheckResult {
+        name: DEVICE_JWT_LIVE_CHECK_NAME.to_string(),
+        ok,
+        detail,
+        fix: DEVICE_JWT_LIVE_CHECK_FIX.to_string(),
+    }
+}
+
+// ===========================================================================
+// Phase 5 — provisioning completeness gate.
+//
+// A runner should not report "ready" until it holds a live coord device JWT
+// (doctor check 5). The gate is ADVISORY by default — it surfaces the gap
+// (via the Phase-1b credential-status path) and logs loudly WITHOUT blocking
+// the runner from starting (a hard block could brick a runner mid-provision).
+// Setting `QONTINUI_PROVISIONING_GATE_ENFORCE` to a non-`0` value flips it to
+// ENFORCING: readiness is withheld until check 5 passes.
+// ===========================================================================
+
+/// Env flag that flips the provisioning gate from advisory (default) to
+/// enforcing. Unset / `0` / `false` ⇒ advisory.
+pub const PROVISIONING_GATE_ENFORCE_ENV: &str = "QONTINUI_PROVISIONING_GATE_ENFORCE";
+
+/// Outcome of the provisioning-completeness gate over doctor check 5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProvisioningReadiness {
+    /// Check 5 passed (a live device JWT) ⇒ provisioning-complete, report ready.
+    Ready,
+    /// Check 5 failed but the gate is ADVISORY ⇒ surface + log, but DO NOT
+    /// withhold ready (never brick a runner mid-provision).
+    IncompleteAdvisory,
+    /// Check 5 failed AND the gate is ENFORCING ⇒ withhold ready; the runner
+    /// is provisioning-incomplete until a device JWT goes live.
+    IncompleteEnforced,
+}
+
+impl ProvisioningReadiness {
+    /// Whether the runner may report "ready" given this verdict. `true` for
+    /// `Ready` and for `IncompleteAdvisory` (advisory never blocks); only
+    /// `IncompleteEnforced` withholds readiness.
+    pub fn ready_to_report(self) -> bool {
+        !matches!(self, ProvisioningReadiness::IncompleteEnforced)
+    }
+
+    /// Whether the runner is provisioning-INCOMPLETE (check 5 red), regardless
+    /// of advisory-vs-enforce. Drives the Phase-1b credential-status surface.
+    pub fn is_incomplete(self) -> bool {
+        !matches!(self, ProvisioningReadiness::Ready)
+    }
+}
+
+/// Pure provisioning-gate predicate: given check 5's pass/fail and whether the
+/// gate is enforcing, decide the readiness verdict. Pure over its two inputs so
+/// it is unit-testable with no live runner / no env. The caller resolves
+/// `check5_ok` from [`device_jwt_live_check`] and `enforce` from
+/// [`provisioning_gate_enforce_enabled`].
+pub fn provisioning_readiness(check5_ok: bool, enforce: bool) -> ProvisioningReadiness {
+    match (check5_ok, enforce) {
+        (true, _) => ProvisioningReadiness::Ready,
+        (false, false) => ProvisioningReadiness::IncompleteAdvisory,
+        (false, true) => ProvisioningReadiness::IncompleteEnforced,
+    }
+}
+
+/// Resolve the advisory-vs-enforce flag from
+/// [`PROVISIONING_GATE_ENFORCE_ENV`]. Enforcing only when the var is set to a
+/// non-empty value other than `0`/`false` (default: advisory).
+pub fn provisioning_gate_enforce_enabled() -> bool {
+    match std::env::var(PROVISIONING_GATE_ENFORCE_ENV) {
+        Ok(v) => {
+            let v = v.trim();
+            !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+        }
+        Err(_) => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 1 — Claude account credentials (relocated pure file logic).
+//
+// Mirrors `ai_provider::oauth_refresh::{find_creds_path, creds_path_is_valid,
+// is_expired}` for the UNEXPIRED case (the doctor reports a verdict; it does
+// NOT silently refresh, so it deliberately does not invoke the OAuth refresh
+// grant — an expired-but-refreshable account reads as red, prompting /login,
+// which is the honest doctor answer rather than a side-effecting refresh).
+// ---------------------------------------------------------------------------
+
+fn find_creds_path(config_dir: Option<&str>) -> Option<PathBuf> {
+    if let Some(dir) = config_dir {
+        let p = PathBuf::from(dir).join(".credentials.json");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        let p = PathBuf::from(&dir).join(".credentials.json");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".claude").join(".credentials.json");
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+/// True iff the creds file exists and its `claudeAiOauth.expiresAt` (ms) is in
+/// the future (or absent — a creds file with no expiry is treated as live,
+/// matching the source predicate's `is_expired == false` branch).
+fn creds_path_is_valid(creds_path: &Path) -> bool {
+    let content = match std::fs::read_to_string(creds_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let json: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let expires_at_ms = json["claudeAiOauth"]["expiresAt"].as_i64().unwrap_or(0);
+    if expires_at_ms == 0 {
+        return true; // no expiry recorded → treat as live
+    }
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    expires_at_ms > now_ms
+}
+
+fn claude_account_has_valid_credentials(config_dir: Option<&str>) -> bool {
+    match find_creds_path(config_dir) {
+        Some(path) => creds_path_is_valid(&path),
+        None => false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check 2 — runner tier. Minimal read of `settings.json::tier` (the same file
+// `settings::load_settings()` reads), so the lib needn't pull the whole
+// `Settings` struct. Returns the snake_case tier string.
+// ---------------------------------------------------------------------------
+
+fn settings_json_path() -> Option<PathBuf> {
+    let dir = std::env::var("QONTINUI_CONFIG_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::config_dir().map(|d| d.join("com.qontinui.runner")))?;
+    Some(dir.join("settings.json"))
+}
+
+/// The persisted runner tier as the serde snake_case string
+/// (`"local"` | `"local_provider"` | `"qontinui_account"`), or `None` when the
+/// settings file is absent/unreadable (which `Settings::default()` would treat
+/// as `Local`).
+fn read_runner_tier() -> Option<String> {
+    let path = settings_json_path()?;
+    let bytes = std::fs::read(path).ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    json.get("tier")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Check 4 — tenant resolution. Mirrors
+// `device_jwt_refresher::resolve_pair_tenant_id`'s ordered chain without
+// depending on the runner binary: OAuth/runner-bearer claim → outgoing
+// device-JWT claim (same slot) → machine.json::active_tenant_id.
+// ---------------------------------------------------------------------------
+
+fn read_active_tenant_id_from_machine_json() -> Option<uuid::Uuid> {
+    let path = dirs::home_dir()?.join(".qontinui").join("machine.json");
+    let bytes = std::fs::read(path).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let raw = value.get("active_tenant_id").and_then(|v| v.as_str())?;
+    uuid::Uuid::parse_str(raw.trim()).ok()
+}
+
+/// `(tenant, source-label)` from the ordered chain, or `None`. `bearer` is the
+/// access-token-slot token, which doubles as both the "OAuth claim" and the
+/// "outgoing device-JWT" source here (the doctor has one bearer in hand).
+fn resolve_tenant_for_doctor(bearer: &str) -> Option<(uuid::Uuid, &'static str)> {
+    if let Some(t) = crate::pair::tenant_id_from_oauth_claim(bearer)
+        .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
+    {
+        return Some((t, "access-token JWT claim"));
+    }
+    if let Some(t) = read_active_tenant_id_from_machine_json() {
+        return Some((t, "machine.json::active_tenant_id"));
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Check 6 — `.mcp.json` validity. Mirrors `coord_mcp::proxy_request_gate`:
+// the config's coord-mcp port must equal the live bound port, its nonce must
+// be a registered loopback key (persisted in secure storage), and the stored
+// bearer must decode `sub_type == "device"`.
+// ---------------------------------------------------------------------------
+
+/// Extract `(port, nonce)` from a session `.mcp.json`'s coord-mcp loopback
+/// proxy entry, if it is the proxy shape (`url` = `http://127.0.0.1:<port>/
+/// coord-mcp`, header `X-Coord-Mcp-Proxy-Key`). `None` for a static-bearer
+/// (agent-path) config or a non-coord config.
+fn parse_mcp_json_proxy(path: &Path) -> Option<(u16, String)> {
+    let bytes = std::fs::read(path).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let server = v.get("mcpServers")?.get("coord-mcp")?;
+    let url = server.get("url")?.as_str()?;
+    // Expect http://127.0.0.1:<port>/coord-mcp
+    let after = url.strip_prefix("http://127.0.0.1:")?;
+    let port_str = after.strip_suffix("/coord-mcp")?;
+    let port: u16 = port_str.parse().ok()?;
+    let nonce = server
+        .get("headers")?
+        .get("X-Coord-Mcp-Proxy-Key")?
+        .as_str()?
+        .to_string();
+    Some((port, nonce))
+}
+
+fn jwt_sub_type(token: &str) -> Option<String> {
+    let parts: Vec<&str> = token.trim().split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(parts[1])
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(parts[1]))
+        .ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    json.get("sub_type")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+fn mcp_json_check(bound_port: Option<u16>, auth: &crate::auth::AuthManager) -> (bool, String) {
+    // Look for a coord-mcp proxy `.mcp.json` in the cwd, then the repo root.
+    let candidates: Vec<PathBuf> = {
+        let mut v = Vec::new();
+        if let Ok(cwd) = std::env::current_dir() {
+            v.push(cwd.join(".mcp.json"));
+            // one level up (common: cwd is a sub-repo, config at repo root)
+            if let Some(parent) = cwd.parent() {
+                v.push(parent.join(".mcp.json"));
+            }
+        }
+        v
+    };
+    let found = candidates
+        .into_iter()
+        .find_map(|p| parse_mcp_json_proxy(&p).map(|pr| (p, pr)));
+    let Some((path, (cfg_port, nonce))) = found else {
+        return (
+            false,
+            "no coord-mcp proxy .mcp.json found in cwd or repo root".into(),
+        );
+    };
+
+    // Port == bound port (when we know the bound port).
+    match bound_port {
+        Some(bp) if bp != cfg_port => {
+            return (
+                false,
+                format!(
+                    "{}: coord-mcp port :{cfg_port} != bound port :{bp}",
+                    path.display()
+                ),
+            );
+        }
+        None => {
+            // The standalone bin can't know the live bound port. Validate the
+            // nonce + bearer (still meaningful) but flag the port unverified.
+            // Treat as red so the operator runs it from inside the runner for
+            // the authoritative answer — honest about uncertainty.
+            let nonce_ok = nonce_is_registered(&nonce);
+            return (
+                false,
+                format!(
+                    "{}: bound port unknown (run from inside the running runner); \
+                     nonce {} registered",
+                    path.display(),
+                    if nonce_ok { "is" } else { "is NOT" }
+                ),
+            );
+        }
+        _ => {}
+    }
+
+    // Nonce must be a registered loopback key (persisted store).
+    if !nonce_is_registered(&nonce) {
+        return (
+            false,
+            format!("{}: nonce is not a registered proxy key", path.display()),
+        );
+    }
+
+    // Bearer must decode sub_type == device (mirrors proxy_request_gate).
+    let bearer = auth.get_access_token().ok().unwrap_or_default();
+    match jwt_sub_type(&bearer).as_deref() {
+        Some("device") => (
+            true,
+            format!(".mcp.json port :{cfg_port}, nonce registered, device bearer"),
+        ),
+        other => (
+            false,
+            format!("access-token bearer is not a coord DEVICE JWT (sub_type={other:?})"),
+        ),
+    }
+}
+
+/// Whether `nonce` is in the persisted coord-mcp loopback nonce set. Mirrors
+/// `coord_mcp::proxy_nonce_is_valid` for the headless/bin path (which has no
+/// in-memory `PROXY_NONCES` map — it reads the encrypted store the running
+/// runner mirrors to).
+fn nonce_is_registered(nonce: &str) -> bool {
+    if nonce.is_empty() {
+        return false;
+    }
+    let map: HashMap<String, String> = match crate::secure_storage::SecureStorage::new() {
+        Ok(s) => s.load_coord_mcp_nonces(),
+        Err(_) => return false,
+    };
+    map.contains_key(nonce)
+}
+
+// ---------------------------------------------------------------------------
+// Check 7 — coord reachable. One-shot `tools/list` JSON-RPC against the
+// configured coord `/mcp` endpoint, with the device bearer if present.
+// ---------------------------------------------------------------------------
+
+fn coord_reachable_check() -> (bool, String) {
+    let base = match crate::profiles::resolve_coord_base() {
+        crate::profiles::CoordBase::Configured(b) | crate::profiles::CoordBase::DevLocalhost(b) => {
+            b
+        }
+        crate::profiles::CoordBase::Unset => "http://localhost:9870".to_string(),
+    };
+    let url = format!("{}/mcp", base.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+    });
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => return (false, format!("could not build HTTP client: {e}")),
+    };
+    let mut rb = client.post(&url).json(&body);
+    if let Some(bearer) = crate::auth::AuthManager::new()
+        .get_access_token()
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+    {
+        rb = rb.header("Authorization", format!("Bearer {bearer}"));
+    }
+    match rb.send() {
+        Ok(resp) if resp.status().is_success() => {
+            (true, format!("coord /mcp tools/list returned 200 ({url})"))
+        }
+        Ok(resp) => (
+            false,
+            format!("coord /mcp returned HTTP {} ({url})", resp.status()),
+        ),
+        Err(e) => (false, format!("coord /mcp unreachable ({url}): {e}")),
+    }
+}
+
+// ===========================================================================
+// Tests — the pure driver (ordering / first-red-stops) is fully exercised
+// here without any live runner.
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn green(name: &'static str) -> Check<'static> {
+        Check::new(name, "fix-it", || (true, "green".into()))
+    }
+    fn red(name: &'static str) -> Check<'static> {
+        Check::new(name, "fix-it", || (false, "red".into()))
+    }
+
+    #[test]
+    fn all_green_runs_every_check_and_passes() {
+        let report = run_checks(vec![green("a"), green("b"), green("c")]);
+        assert!(report.overall_ok);
+        assert_eq!(report.checks.len(), 3);
+        assert!(report.checks.iter().all(|c| c.ok));
+    }
+
+    #[test]
+    fn stops_at_first_red_and_omits_later_checks() {
+        let report = run_checks(vec![green("a"), red("b"), green("c")]);
+        assert!(!report.overall_ok);
+        // Only a (green) + b (red) ran; c never executed.
+        assert_eq!(report.checks.len(), 2);
+        assert_eq!(report.checks[0].name, "a");
+        assert!(report.checks[0].ok);
+        assert_eq!(report.checks[1].name, "b");
+        assert!(!report.checks[1].ok);
+    }
+
+    #[test]
+    fn first_check_red_short_circuits_immediately() {
+        let report = run_checks(vec![red("a"), green("b")]);
+        assert!(!report.overall_ok);
+        assert_eq!(report.checks.len(), 1);
+        assert_eq!(report.checks[0].name, "a");
+    }
+
+    #[test]
+    fn checks_run_in_declared_order() {
+        // A side-effect log proves the driver preserves order and stops.
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        let log: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+        let mk = |name: &'static str, ok: bool| {
+            let log = log.clone();
+            Check::new(name, "fix", move || {
+                log.borrow_mut().push(name);
+                (ok, "d".into())
+            })
+        };
+        let _ = run_checks(vec![
+            mk("one", true),
+            mk("two", true),
+            mk("three", false),
+            mk("four", true),
+        ]);
+        assert_eq!(*log.borrow(), vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn render_marks_pass_fail_and_names_the_block() {
+        let report = run_checks(vec![green("alpha"), red("beta"), green("gamma")]);
+        let text = report.render();
+        assert!(text.contains("[PASS] alpha"));
+        assert!(text.contains("[FAIL] beta"));
+        // gamma never ran → not in the report.
+        assert!(!text.contains("gamma"));
+        assert!(text.contains("BLOCKED at: beta"));
+        assert!(text.contains("fix: fix-it"));
+    }
+
+    #[test]
+    fn render_all_green_says_can_set_gates() {
+        let report = run_checks(vec![green("a"), green("b")]);
+        let text = report.render();
+        assert!(text.contains("OK: this runner can set gates."));
+    }
+
+    #[test]
+    fn empty_check_set_is_vacuously_ok() {
+        let report = run_checks(vec![]);
+        assert!(report.overall_ok);
+        assert!(report.checks.is_empty());
+    }
+
+    // ---- pure helpers ----
+
+    #[test]
+    fn parse_mcp_json_proxy_reads_port_and_nonce() {
+        let dir = std::env::temp_dir().join("qontinui_doctor_test_mcp");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".mcp.json");
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"coord-mcp":{"type":"http",
+               "url":"http://127.0.0.1:9877/coord-mcp",
+               "headers":{"X-Coord-Mcp-Proxy-Key":"abc123"}}}}"#,
+        )
+        .unwrap();
+        let (port, nonce) = parse_mcp_json_proxy(&path).expect("parses proxy config");
+        assert_eq!(port, 9877);
+        assert_eq!(nonce, "abc123");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn parse_mcp_json_proxy_none_for_static_bearer_config() {
+        let dir = std::env::temp_dir().join("qontinui_doctor_test_mcp2");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".mcp.json");
+        // Agent/static-bearer shape has no loopback url → not a proxy config.
+        std::fs::write(
+            &path,
+            r#"{"mcpServers":{"coord-mcp":{"type":"http",
+               "url":"https://coord.qontinui.io/mcp",
+               "headers":{"Authorization":"Bearer xyz"}}}}"#,
+        )
+        .unwrap();
+        assert!(parse_mcp_json_proxy(&path).is_none());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn jwt_sub_type_decodes_device() {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"alg":"EdDSA","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(br#"{"sub":"x","sub_type":"device"}"#);
+        let token = format!("{header}.{payload}.sig");
+        assert_eq!(jwt_sub_type(&token).as_deref(), Some("device"));
+        // An agent JWT decodes to agent, an opaque token to None.
+        let agent_payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"sub_type":"agent"}"#);
+        let agent = format!("{header}.{agent_payload}.sig");
+        assert_eq!(jwt_sub_type(&agent).as_deref(), Some("agent"));
+        assert_eq!(jwt_sub_type("opaque-token"), None);
+    }
+
+    // ---- Phase 5 — provisioning completeness gate (pure predicate) ----
+
+    #[test]
+    fn provisioning_ready_when_check5_passes_regardless_of_enforce() {
+        // A live device JWT ⇒ Ready, advisory or enforcing.
+        assert_eq!(
+            provisioning_readiness(true, false),
+            ProvisioningReadiness::Ready
+        );
+        assert_eq!(
+            provisioning_readiness(true, true),
+            ProvisioningReadiness::Ready
+        );
+        assert!(provisioning_readiness(true, true).ready_to_report());
+        assert!(!provisioning_readiness(true, true).is_incomplete());
+    }
+
+    #[test]
+    fn provisioning_incomplete_advisory_does_not_withhold_ready() {
+        // Check 5 red + advisory ⇒ incomplete, but STILL allowed to report
+        // ready (never brick a runner mid-provision).
+        let v = provisioning_readiness(false, false);
+        assert_eq!(v, ProvisioningReadiness::IncompleteAdvisory);
+        assert!(v.is_incomplete(), "must surface as provisioning-incomplete");
+        assert!(
+            v.ready_to_report(),
+            "advisory must NOT withhold ready (no hard block)"
+        );
+    }
+
+    #[test]
+    fn provisioning_incomplete_enforced_withholds_ready() {
+        // Check 5 red + enforcing ⇒ incomplete AND ready withheld.
+        let v = provisioning_readiness(false, true);
+        assert_eq!(v, ProvisioningReadiness::IncompleteEnforced);
+        assert!(v.is_incomplete());
+        assert!(
+            !v.ready_to_report(),
+            "enforcing must withhold ready until a device JWT is live"
+        );
+    }
+
+    #[test]
+    fn provisioning_gate_enforce_env_parsing() {
+        // Save/restore the process-global so this test is self-contained. This
+        // is the ONLY test that touches the flag; no sibling reads it, so the
+        // save/restore is sufficient (and there's no parallel reader to race).
+        let prev = std::env::var(PROVISIONING_GATE_ENFORCE_ENV).ok();
+
+        std::env::remove_var(PROVISIONING_GATE_ENFORCE_ENV);
+        assert!(
+            !provisioning_gate_enforce_enabled(),
+            "unset ⇒ advisory (default)"
+        );
+
+        for off in ["0", "", "false", "False", "  "] {
+            std::env::set_var(PROVISIONING_GATE_ENFORCE_ENV, off);
+            assert!(
+                !provisioning_gate_enforce_enabled(),
+                "{off:?} must read as advisory"
+            );
+        }
+        for on in ["1", "true", "yes", "enforce"] {
+            std::env::set_var(PROVISIONING_GATE_ENFORCE_ENV, on);
+            assert!(
+                provisioning_gate_enforce_enabled(),
+                "{on:?} must read as enforcing"
+            );
+        }
+
+        match prev {
+            Some(p) => std::env::set_var(PROVISIONING_GATE_ENFORCE_ENV, p),
+            None => std::env::remove_var(PROVISIONING_GATE_ENFORCE_ENV),
+        }
+    }
+}

--- a/src-tauri/src/coord_doctor_cmd.rs
+++ b/src-tauri/src/coord_doctor_cmd.rs
@@ -1,0 +1,38 @@
+//! In-app `coord doctor` Tauri command (plan 2026-06-13 Phase 4).
+//!
+//! Thin runner-binary wrapper over the lib-crate self-check
+//! (`qontinui_runner_lib::coord_doctor`). The reusable logic — types, the
+//! first-red-stops driver, the report formatter, and the 7-check wiring — lives
+//! in the lib so the standalone `coord_doctor` bin can share it. This module's
+//! only job is to inject the one fact only the LIVE runtime knows: the
+//! ACTUALLY-BOUND loopback API port (check 6), resolved via
+//! [`crate::coord_mcp::resolve_bound_api_port`] (the same managed-`AppState`
+//! port the proxy `.mcp.json` writer uses). With that injected, the Tauri
+//! command and the headless bin produce an IDENTICAL report.
+//!
+//! Follow-up (out of scope here): a Settings-UI button wired to these commands
+//! — that needs temp-runner visual verification and lands in a separate UI
+//! phase.
+
+use qontinui_runner_lib::coord_doctor::{diagnose, DoctorInputs, DoctorReport};
+
+/// Run the full `coord doctor` self-check and return the structured report.
+/// Reuses the live bound API port so check 6 (`.mcp.json` port == bound port)
+/// is authoritative in-app (the headless bin can't know it and reports that
+/// link as unverifiable). The frontend renders `DoctorReport`; the
+/// `render()`-formatted text is available via [`coord_doctor_text`].
+#[tauri::command]
+pub fn coord_doctor_run() -> DoctorReport {
+    let inputs = DoctorInputs {
+        bound_api_port: crate::coord_mcp::resolve_bound_api_port(),
+        claude_config_dir: None,
+    };
+    diagnose(&inputs)
+}
+
+/// Same self-check, returned as the copy-pasteable text report (identical to
+/// the standalone bin's stdout). Convenient for a "copy report" button.
+#[tauri::command]
+pub fn coord_doctor_text() -> String {
+    coord_doctor_run().render()
+}

--- a/src-tauri/src/coord_mcp.rs
+++ b/src-tauri/src/coord_mcp.rs
@@ -17,8 +17,11 @@
 //! own loopback `POST /coord-mcp` route, which injects a freshly-read device
 //! JWT per request (see `mcp_api::coord_mcp_proxy_handler`). Authentication to
 //! the proxy is a per-session nonce ([`COORD_MCP_PROXY_KEY_HEADER`]) held in an
-//! in-memory map — it dies with the runner, and every spawn path rewrites
-//! `.mcp.json`, so a restart self-heals.
+//! in-memory map that is ALSO mirrored to the encrypted local store
+//! (plan 2026-06-13 Phase 3b, gated by `COORD_MCP_PERSIST_NONCES`, default ON)
+//! so an already-written `.mcp.json` keeps validating across a runner
+//! rebuild/restart — the MCP client never re-reads the file, so a process-only
+//! nonce would 401 every live agent after a routine restart.
 //!
 //! SCOPE-ELEVATION TRAP: agent-spawn sessions deliberately carry a narrower
 //! coord-minted `SubType::Agent` JWT. The proxy attaches the live DEVICE JWT,
@@ -73,20 +76,137 @@ pub(crate) fn coord_mcp_url() -> String {
 }
 
 /// In-memory nonce registry for the loopback `/coord-mcp` proxy:
-/// nonce → workdir it was provisioned into. Process-lifetime only by design
-/// (resolved Q2 of the plan): every spawn path rewrites `.mcp.json`, so a
-/// runner restart re-mints nonces and self-heals.
+/// nonce → workdir it was provisioned into. Mirrored to the encrypted local
+/// store (Phase 3b) when `COORD_MCP_PERSIST_NONCES` is not `0`, so the set
+/// survives a runner rebuild/restart and an already-written `.mcp.json` keeps
+/// validating (the MCP client never re-reads the file). With persistence
+/// disabled this degrades to the prior process-lifetime-only behavior.
 static PROXY_NONCES: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
+
+/// Guards [`restore_proxy_nonces_from_store`] so a second boot-restore (e.g. an
+/// idempotent auto-start re-invocation) never re-loads over live in-memory
+/// nonces minted since the first restore.
+static PROXY_NONCES_RESTORED: OnceLock<()> = OnceLock::new();
 
 fn proxy_nonces() -> &'static Mutex<HashMap<String, String>> {
     PROXY_NONCES.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
+/// True unless `COORD_MCP_PERSIST_NONCES` is explicitly set to `0` — persistence
+/// is ON by default (resolved in the plan: the nonce is a loopback-only key, so
+/// persisting it at rest is acceptable and is the only thing that keeps an
+/// already-running agent alive across a restart). `=0` reverts to the prior
+/// in-memory-only behavior.
+fn nonce_persistence_enabled() -> bool {
+    // In production: ON unless explicitly `=0`. In test builds: OFF unless
+    // explicitly enabled — so the many nonce-minting unit tests never touch the
+    // developer's real encrypted store; the persistence tests opt IN by setting
+    // the env (under a serializing lock) to a temp store dir.
+    match std::env::var("COORD_MCP_PERSIST_NONCES") {
+        Ok(v) => v.trim() != "0",
+        Err(_) => !cfg!(test),
+    }
+}
+
+/// Mirror the live in-memory nonce map into the encrypted local store. No-op
+/// when persistence is disabled. Best-effort: a store failure only `warn!`s —
+/// the in-memory map stays authoritative for this process.
+///
+/// Opens the DEFAULT [`SecureStorage`] (honoring `QONTINUI_SECURE_STORAGE_DIR`)
+/// and delegates to [`persist_proxy_nonces_with_store`]. Tests inject their own
+/// store via the `_with_store` seam so they never touch the developer's real
+/// encrypted store NOR the process-global env (which would race sibling tests
+/// that read the default store, e.g. `auth::device_jwt_tests`).
+fn persist_proxy_nonces(map: &HashMap<String, String>) {
+    if !nonce_persistence_enabled() {
+        return;
+    }
+    match crate::secure_storage::SecureStorage::new() {
+        Ok(store) => persist_proxy_nonces_with_store(&store, map),
+        Err(e) => {
+            warn!("coord_mcp: secure storage unavailable, proxy nonces not persisted: {e}");
+        }
+    }
+}
+
+/// Mirror `map` into the GIVEN store. The store is injected so the persistence
+/// path is unit-testable against a temp-dir [`SecureStorage::with_path`] without
+/// mutating `QONTINUI_SECURE_STORAGE_DIR` (which is process-global and pollutes
+/// every other test that reads the default store). The `nonce_persistence_enabled`
+/// gate is the CALLER's concern — handing a store IS the decision to persist.
+fn persist_proxy_nonces_with_store(
+    store: &crate::secure_storage::SecureStorage,
+    map: &HashMap<String, String>,
+) {
+    if let Err(e) = store.store_coord_mcp_nonces(map) {
+        warn!("coord_mcp: failed to persist proxy nonces: {e}");
+    }
+}
+
+/// Restore persisted proxy nonces into the in-memory registry on boot (Phase
+/// 3b). Idempotent + run-once: merges the persisted set UNDER any nonces already
+/// minted this process (live mints win on key collision, which cannot happen in
+/// practice — the persisted set predates this process). No-op when persistence
+/// is disabled. Wire this into the same startup path as the other auto-start
+/// tasks so already-written `.mcp.json` nonces keep validating post-restart.
+pub(crate) fn restore_proxy_nonces_from_store() {
+    if !nonce_persistence_enabled() {
+        return;
+    }
+    if PROXY_NONCES_RESTORED.set(()).is_err() {
+        return; // already restored once this process
+    }
+    let store = match crate::secure_storage::SecureStorage::new() {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("coord_mcp: secure storage unavailable, cannot restore proxy nonces: {e}");
+            return;
+        }
+    };
+    restore_proxy_nonces_from(&store);
+}
+
+/// Merge the persisted nonce set from the GIVEN store into the live in-memory
+/// registry (live mints win on collision). The store is injected so the
+/// restore path is unit-testable against a temp-dir store without the
+/// run-once `PROXY_NONCES_RESTORED` guard or any global-env mutation. Returns
+/// the live map size after the merge.
+fn restore_proxy_nonces_from(store: &crate::secure_storage::SecureStorage) -> usize {
+    let persisted = store.load_coord_mcp_nonces();
+    if persisted.is_empty() {
+        return proxy_nonces()
+            .lock()
+            .expect("proxy nonce map poisoned")
+            .len();
+    }
+    let restored = {
+        let mut map = proxy_nonces().lock().expect("proxy nonce map poisoned");
+        for (nonce, workdir) in persisted {
+            map.entry(nonce).or_insert(workdir);
+        }
+        map.len()
+    };
+    info!("coord_mcp: restored {restored} persisted proxy nonce(s) from secure storage");
+    restored
+}
+
 /// Mint + register a fresh per-session proxy nonce for `workdir`, returning it.
 /// Any prior nonce registered for the same workdir is evicted — a re-provision
 /// rewrites `.mcp.json`, so the old nonce is unreachable and keeping it would
-/// only widen the accept set.
+/// only widen the accept set. The updated set is mirrored to the encrypted
+/// store (Phase 3b) so it survives a restart.
 fn register_proxy_nonce(workdir: &str) -> String {
+    let (nonce, snapshot) = mint_and_register_nonce(workdir);
+    persist_proxy_nonces(&snapshot);
+    nonce
+}
+
+/// Mint a fresh nonce, evict any prior nonce for `workdir`, insert it, and
+/// return `(nonce, snapshot)` — WITHOUT persisting. Split from the persistence
+/// step so a test can mint and then mirror to an INJECTED store
+/// ([`persist_proxy_nonces_with_store`]) instead of the default store reached
+/// via the process-global `QONTINUI_SECURE_STORAGE_DIR`.
+fn mint_and_register_nonce(workdir: &str) -> (String, HashMap<String, String>) {
     // Two v4 UUIDs (~244 bits of randomness) — v4, NOT v7: the v7 prefix is a
     // timestamp, which would gut the entropy this nonce exists to provide.
     let nonce = format!(
@@ -94,10 +214,13 @@ fn register_proxy_nonce(workdir: &str) -> String {
         uuid::Uuid::new_v4().simple(),
         uuid::Uuid::new_v4().simple()
     );
-    let mut map = proxy_nonces().lock().expect("proxy nonce map poisoned");
-    map.retain(|_, wd| wd != workdir);
-    map.insert(nonce.clone(), workdir.to_string());
-    nonce
+    let snapshot = {
+        let mut map = proxy_nonces().lock().expect("proxy nonce map poisoned");
+        map.retain(|_, wd| wd != workdir);
+        map.insert(nonce.clone(), workdir.to_string());
+        map.clone()
+    };
+    (nonce, snapshot)
 }
 
 /// True iff `nonce` is a currently-registered per-session proxy key.
@@ -154,18 +277,22 @@ pub(crate) fn proxy_request_gate(
 
 /// Resolve the runner's ACTUALLY-BOUND local API port for loopback URLs:
 /// the managed `AppState.api_port` (set at bind time) via the process-global
-/// `AppHandle`, falling back to [`crate::mcp::types::get_mcp_api_port`] only
-/// when no Tauri runtime / managed state exists (headless or unit-test
-/// contexts that genuinely predate the bind). The env-default 9876 fallback is
-/// wrong on secondary/temp runners, which is why the bound port is preferred.
-pub(crate) fn resolve_bound_api_port() -> u16 {
+/// `AppHandle`. Returns `None` — fail-closed, Phase 3a — when no Tauri runtime
+/// / managed `AppState` is reachable, rather than degrading to the bootstrap
+/// [`crate::mcp::types::get_mcp_api_port`] default (`MCP_API_PORT=9876`). That
+/// default is correct only by luck on a single-runner box and silently WRONG on
+/// any secondary/temp runner bound to a different port (the F1 root cause: a
+/// `:9876` URL written into a config whose live proxy is on `:9877`). Callers
+/// MUST treat `None` as "refuse to write a proxy config" — a dead config that
+/// looks valid is worse than an absent one.
+pub(crate) fn resolve_bound_api_port() -> Option<u16> {
     if let Some(app) = crate::tauri_app_handle::current() {
         use tauri::Manager;
         if let Some(state) = app.try_state::<std::sync::Arc<crate::commands::AppState>>() {
-            return crate::mcp::types::runner_api_port(state.inner());
+            return Some(crate::mcp::types::runner_api_port(state.inner()));
         }
     }
-    crate::mcp::types::get_mcp_api_port()
+    None
 }
 
 /// The coord-native `/mcp` endpoint is live (coord PR #277 Phase-2 cutover),
@@ -217,6 +344,84 @@ pub(crate) fn write_coord_mcp_proxy_config(primary_wt: &str, bound_port: u16) {
     write_mcp_json(primary_wt, &mcp_config);
 }
 
+/// Filename of the Phase-1a degraded-only breadcrumb dropped into a session
+/// workdir when coord-mcp provisioning is degraded (no JWT, unresolvable port,
+/// or a failed reachability probe). Referenced by the `/gate` skill + CLAUDE.md.
+pub(crate) const COORD_MCP_STATUS_FILE: &str = ".coord-mcp-status";
+
+/// Write a SHORT, single-line degraded breadcrumb into `workdir` (Phase 1a).
+/// Emitted ONLY when coord-mcp is degraded — a healthy session writes nothing
+/// (the file is removed by [`clear_degraded_breadcrumb`] on a successful probe),
+/// so its mere presence is the signal. Best-effort: a write failure only logs.
+fn write_degraded_breadcrumb(workdir: &str, reason: &str) {
+    let line =
+        format!("coord-mcp UNREACHABLE ({reason}) — gate registration degraded; use /gate\n");
+    let path = Path::new(workdir).join(COORD_MCP_STATUS_FILE);
+    if let Err(e) = std::fs::write(&path, line) {
+        warn!("coord_mcp: failed to write degraded breadcrumb in {workdir}: {e}");
+    }
+}
+
+/// Remove a stale degraded breadcrumb once coord-mcp is confirmed reachable, so
+/// a session that recovered (e.g. a reconcile fixed the port) does not keep
+/// showing a stale UNREACHABLE marker. Best-effort + idempotent (absent = ok).
+fn clear_degraded_breadcrumb(workdir: &str) {
+    let path = Path::new(workdir).join(COORD_MCP_STATUS_FILE);
+    let _ = std::fs::remove_file(path);
+}
+
+/// One-shot, non-blocking coord-mcp reachability probe (Phase 1a). Fires a
+/// `tools/list` JSON-RPC at the configured loopback proxy
+/// (`http://127.0.0.1:<port>/coord-mcp`) carrying the session's nonce header,
+/// with a short timeout, on a DETACHED thread so it never blocks or panics
+/// session provisioning. On a non-2xx / transport failure it drops the
+/// degraded breadcrumb; on success it clears any stale one and writes nothing.
+fn probe_and_breadcrumb_proxy(workdir: &str, port: u16) {
+    // Resolve the nonce we just wrote for this workdir so the probe authenticates
+    // exactly as the session's MCP client will.
+    let nonce = {
+        let map = proxy_nonces().lock().expect("proxy nonce map poisoned");
+        map.iter()
+            .find(|(_, wd)| wd.as_str() == workdir)
+            .map(|(n, _)| n.clone())
+    };
+    let Some(nonce) = nonce else {
+        return; // no nonce → nothing to probe against (already handled upstream)
+    };
+    let workdir = workdir.to_string();
+    std::thread::spawn(move || {
+        let url = format!("http://127.0.0.1:{port}/coord-mcp");
+        let body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {}
+        });
+        let client = match reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return, // can't build a client — skip silently (best-effort)
+        };
+        let reachable = client
+            .post(&url)
+            .header(COORD_MCP_PROXY_KEY_HEADER, &nonce)
+            .json(&body)
+            .send()
+            .map(|r| r.status().is_success())
+            .unwrap_or(false);
+        if reachable {
+            clear_degraded_breadcrumb(&workdir);
+        } else {
+            write_degraded_breadcrumb(
+                &workdir,
+                &format!("port :{port} probe failed (dead port | 401 stale nonce | coord down)"),
+            );
+        }
+    });
+}
+
 fn write_mcp_json(primary_wt: &str, mcp_config: &serde_json::Value) {
     let mcp_path = Path::new(primary_wt).join(".mcp.json");
     match std::fs::write(
@@ -260,13 +465,20 @@ fn write_mcp_json(primary_wt: &str, mcp_config: &serde_json::Value) {
 // last dark runner-spawned session kind (plan
 // 2026-06-09-provision-coord-mcp-operator-tabs). Both modules compile into the
 // runner bin crate, so `pub(crate)` is the minimal visibility that reaches it.
-pub(crate) fn provision_coord_mcp_for_session(workdir: &str, bound_port: u16) {
+pub(crate) fn provision_coord_mcp_for_session(workdir: &str, bound_port: Option<u16>) {
     let jwt = match crate::auth::AuthManager::new().get_access_token() {
         Ok(t) if !t.trim().is_empty() => t,
         _ => {
             info!(
                 "coord_mcp: no device JWT in access_token slot — skipping \
                  coord-mcp provisioning for {workdir}"
+            );
+            // 1a breadcrumb: a session with no device JWT cannot reach coord —
+            // surface it so the agent self-routes to `/gate` instead of finding
+            // a silently-absent MCP tool.
+            write_degraded_breadcrumb(
+                workdir,
+                "no device JWT in runner access_token slot — coord-mcp not provisioned",
             );
             return;
         }
@@ -291,7 +503,7 @@ pub(crate) fn provision_coord_mcp_for_session(workdir: &str, bound_port: u16) {
 /// static-bearer shape UNCHANGED — agent JWTs are deliberately narrower than
 /// the device JWT the proxy injects, so an agent session must never be routed
 /// through the proxy (scope elevation).
-fn provision_coord_mcp_with_jwt(workdir: &str, jwt: &str, bound_port: u16) {
+fn provision_coord_mcp_with_jwt(workdir: &str, jwt: &str, bound_port: Option<u16>) {
     let sub_type = jwt_unverified_claim(jwt, "sub_type");
     match sub_type.as_deref() {
         Some("device") | Some("agent") => {}
@@ -314,7 +526,32 @@ fn provision_coord_mcp_with_jwt(workdir: &str, jwt: &str, bound_port: u16) {
     }
 
     if sub_type.as_deref() == Some("device") {
-        write_coord_mcp_proxy_config(workdir, bound_port);
+        // Phase 3a — fail-closed on an unknown bound port. The device path
+        // writes a loopback proxy URL; if we can't resolve the ACTUALLY-BOUND
+        // port we must NOT write a config pointing at the bootstrap default
+        // (`:9876`), which is wrong on any secondary/temp runner and produces a
+        // dead-but-valid-looking config (the F1 root cause). Refuse, warn, and
+        // drop a 1a breadcrumb so the agent routes to `/gate`.
+        let port = match bound_port {
+            Some(p) => p,
+            None => {
+                warn!(
+                    "coord_mcp: refusing to write a proxy .mcp.json for {workdir} — \
+                     the bound API port is unresolvable (no managed AppState); a \
+                     bootstrap-default port would be dead on a secondary runner. \
+                     Run `coord doctor` / reprovision once the runtime is up."
+                );
+                write_degraded_breadcrumb(
+                    workdir,
+                    "bound API port unresolvable — proxy config NOT written (would point at a dead port)",
+                );
+                return;
+            }
+        };
+        write_coord_mcp_proxy_config(workdir, port);
+        // 1a — one-shot, non-blocking reachability probe; writes a breadcrumb
+        // only on failure, nothing on success (discoverability without clutter).
+        probe_and_breadcrumb_proxy(workdir, port);
     } else {
         write_coord_mcp_config(workdir, jwt);
     }
@@ -375,9 +612,101 @@ fn coord_mcp_safe_to_write(workdir: &str) -> bool {
     }
 }
 
+/// Read the loopback proxy port out of an existing coord-mcp `.mcp.json`, if the
+/// file holds the PROXY shape (`url == http://127.0.0.1:<port>/coord-mcp`).
+/// Returns `None` for an absent/unparseable file or a non-proxy (static-bearer)
+/// shape — the latter is the agent path, which the reconcile must never touch.
+fn read_proxy_port(workdir: &str) -> Option<u16> {
+    let path = Path::new(workdir).join(".mcp.json");
+    let s = std::fs::read_to_string(path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&s).ok()?;
+    let url = v
+        .pointer("/mcpServers/coord-mcp/url")
+        .and_then(|u| u.as_str())?;
+    let rest = url.strip_prefix("http://127.0.0.1:")?;
+    let port_str = rest.strip_suffix("/coord-mcp")?;
+    port_str.parse::<u16>().ok()
+}
+
+/// Boot-time reconcile decision for one session's `.mcp.json` (Phase 3c). Pure
+/// over its inputs (no I/O) so the rewrite predicate is unit-testable:
+///
+/// - `Rewrite` — the config holds the proxy shape on a port ≠ the instance's
+///   current bound port → rewrite it to the correct port (+ a fresh persisted
+///   nonce) so the next MCP read targets a live proxy.
+/// - `Leave` — no `.mcp.json` proxy port readable, OR the port already matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReconcileAction {
+    Rewrite,
+    Leave,
+}
+
+/// Pure reconcile predicate: given the session's currently-written proxy port
+/// (if any) and the instance's current bound port, decide whether to rewrite.
+pub(crate) fn reconcile_action(
+    current_proxy_port: Option<u16>,
+    bound_port: u16,
+) -> ReconcileAction {
+    match current_proxy_port {
+        Some(p) if p != bound_port => ReconcileAction::Rewrite,
+        _ => ReconcileAction::Leave,
+    }
+}
+
+/// Boot-time session-config reconcile (Phase 3c). For each live session workdir,
+/// if its `.mcp.json` coord-mcp proxy port ≠ the instance's CURRENT bound port,
+/// rewrite it via [`write_coord_mcp_proxy_config`] (correct port + a freshly
+/// persisted nonce), guarded by [`coord_mcp_safe_to_write`] so it never clobbers
+/// an agent-spawn's static-bearer config. Combined with Phase 3b (persisted
+/// nonces), the common same-port restart needs no rewrite at all — this covers
+/// only the instance/port-change case. Returns the number of configs rewritten.
+///
+/// Wired into the same startup path as the other auto-start tasks (see
+/// `mcp_api::start_server`), AFTER [`restore_proxy_nonces_from_store`] so a
+/// rewrite reuses the restored map where possible.
+pub(crate) fn reconcile_session_configs<I>(workdirs: I, bound_port: u16) -> usize
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut rewritten = 0usize;
+    for workdir in workdirs {
+        if reconcile_action(read_proxy_port(&workdir), bound_port) != ReconcileAction::Rewrite {
+            continue;
+        }
+        if !coord_mcp_safe_to_write(&workdir) {
+            // An agent-spawn static-bearer config (or a user's own file) — never
+            // clobber. (A proxy-shaped config is ours-refreshable, so this only
+            // skips configs we must not touch.)
+            continue;
+        }
+        write_coord_mcp_proxy_config(&workdir, bound_port);
+        rewritten += 1;
+        info!("coord_mcp: reconciled {workdir}/.mcp.json to bound port :{bound_port}");
+    }
+    if rewritten > 0 {
+        info!("coord_mcp: boot reconcile rewrote {rewritten} session config(s) to the current bound port");
+    }
+    rewritten
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A temp-dir-backed [`SecureStorage`] for the persistence tests — injected
+    /// directly into the `_with_store` seam so a test NEVER mutates the
+    /// process-global `QONTINUI_SECURE_STORAGE_DIR`. Mutating that env var raced
+    /// sibling tests that read the DEFAULT store (notably
+    /// `auth::device_jwt_tests::needs_refresh_when_no_token`), which is why this
+    /// module no longer touches global env at all.
+    fn temp_store(tag: &str) -> (std::path::PathBuf, crate::secure_storage::SecureStorage) {
+        let dir =
+            std::env::temp_dir().join(format!("coord-mcp-{tag}-store-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let store = crate::secure_storage::SecureStorage::with_path(dir.join("nonces.enc"))
+            .expect("temp secure storage");
+        (dir, store)
+    }
 
     #[test]
     fn write_coord_mcp_config_emits_http_bearer_shape() {
@@ -655,7 +984,7 @@ mod tests {
         // A) device bearer + clean dir → provisions the loopback PROXY shape on
         //    the passed bound port: nonce header, NO static bearer.
         let d = new_dir();
-        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &dev, 19876);
+        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &dev, Some(19876));
         let written =
             std::fs::read_to_string(mcp_of(&d)).expect("device bearer must provision .mcp.json");
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
@@ -681,7 +1010,7 @@ mod tests {
         //    injects — agent sessions must never route through the proxy).
         let d = new_dir();
         let agent_jwt = mk("agent");
-        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &agent_jwt, 19876);
+        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &agent_jwt, Some(19876));
         let written =
             std::fs::read_to_string(mcp_of(&d)).expect("agent bearer must provision .mcp.json");
         let v: serde_json::Value = serde_json::from_str(&written).unwrap();
@@ -702,7 +1031,7 @@ mod tests {
         // C) non-coord bearer (e.g. a Cognito access token, sub_type=access) →
         //    sub_type gate skips; no file is written (would 401 coord's verifier).
         let d = new_dir();
-        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &mk("access"), 19876);
+        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &mk("access"), Some(19876));
         assert!(
             !mcp_of(&d).exists(),
             "a non-device/agent bearer must NOT be written"
@@ -717,12 +1046,233 @@ mod tests {
             mk("agent")
         );
         std::fs::write(mcp_of(&d), &agent_cfg).unwrap();
-        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &dev, 19876);
+        provision_coord_mcp_with_jwt(&d.to_string_lossy(), &dev, Some(19876));
         assert_eq!(
             std::fs::read_to_string(mcp_of(&d)).unwrap(),
             agent_cfg,
             "a device bearer must not downgrade an existing agent-JWT config"
         );
         let _ = std::fs::remove_dir_all(&d);
+    }
+
+    /// Phase 3a — fail-closed: a DEVICE bearer with an UNKNOWN bound port
+    /// (`None`) must NOT write a proxy `.mcp.json` (which would point at a dead
+    /// bootstrap-default port), and must drop the degraded breadcrumb instead.
+    /// This is the F1 root-cause guard.
+    #[test]
+    fn device_path_with_no_bound_port_writes_no_proxy_config() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let dev = {
+            let payload = URL_SAFE_NO_PAD.encode(br#"{"sub_type":"device"}"#);
+            format!("h.{payload}.s")
+        };
+        let d = std::env::temp_dir().join(format!("coord-mcp-noport-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&d).unwrap();
+        let wd = d.to_string_lossy().to_string();
+
+        // None bound port → fail-closed.
+        provision_coord_mcp_with_jwt(&wd, &dev, None);
+
+        assert!(
+            !d.join(".mcp.json").exists(),
+            "an unresolvable bound port must NOT write a (dead) proxy .mcp.json"
+        );
+        let crumb = std::fs::read_to_string(d.join(COORD_MCP_STATUS_FILE))
+            .expect("a degraded breadcrumb must be written when the port is unresolvable");
+        assert!(
+            crumb.contains("coord-mcp UNREACHABLE") && crumb.contains("/gate"),
+            "breadcrumb must be the actionable degraded line: {crumb}"
+        );
+
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    /// Phase 3a — a non-degraded healthy DEVICE provision (a real `Some(port)`)
+    /// must NOT leave a degraded breadcrumb from the write path itself (the
+    /// async probe may add one later if the port is dead, but the synchronous
+    /// write must not).
+    #[test]
+    fn device_path_with_bound_port_writes_proxy_and_no_synchronous_breadcrumb() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let dev = {
+            let payload = URL_SAFE_NO_PAD.encode(br#"{"sub_type":"device"}"#);
+            format!("h.{payload}.s")
+        };
+        let d = std::env::temp_dir().join(format!("coord-mcp-port-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&d).unwrap();
+        let wd = d.to_string_lossy().to_string();
+
+        provision_coord_mcp_with_jwt(&wd, &dev, Some(34567));
+
+        assert!(
+            d.join(".mcp.json").exists(),
+            "a resolvable bound port must write the proxy .mcp.json"
+        );
+        let port = read_proxy_port(&wd);
+        assert_eq!(port, Some(34567), "config must carry the passed bound port");
+
+        let _ = std::fs::remove_dir_all(&d);
+    }
+
+    /// Phase 3b — persist→restore round-trip: a minted nonce is mirrored to the
+    /// store, and `restore_proxy_nonces_from_store` re-loads it into a fresh
+    /// in-memory map so it still validates after a (simulated) restart.
+    #[test]
+    fn persisted_nonce_survives_restore_round_trip() {
+        // Inject a temp-dir store directly — NO process-global env mutation, so
+        // this test cannot pollute sibling tests that read the default store.
+        let (store_dir, store) = temp_store("nonce");
+
+        // Mint a nonce in the live map, then mirror the snapshot to the INJECTED
+        // store (the `register_proxy_nonce` body, split across its seams).
+        let workdir = store_dir.join("session-wd").to_string_lossy().to_string();
+        let (nonce, snapshot) = mint_and_register_nonce(&workdir);
+        persist_proxy_nonces_with_store(&store, &snapshot);
+        assert!(proxy_nonce_is_valid(&nonce));
+
+        // It is actually on disk (independent of the in-memory map).
+        let persisted = store.load_coord_mcp_nonces();
+        assert_eq!(
+            persisted.get(&nonce).map(String::as_str),
+            Some(workdir.as_str()),
+            "the minted nonce must be mirrored to the encrypted store"
+        );
+
+        // Simulate a restart: drop the nonce from the in-memory map, then
+        // restore from the injected store via the same merge the boot path runs.
+        {
+            let mut map = proxy_nonces().lock().unwrap();
+            map.remove(&nonce);
+        }
+        assert!(
+            !proxy_nonce_is_valid(&nonce),
+            "precondition: the nonce is gone from the in-memory map"
+        );
+        restore_proxy_nonces_from(&store);
+        assert!(
+            proxy_nonce_is_valid(&nonce),
+            "a persisted nonce must validate again after a restore"
+        );
+
+        let _ = std::fs::remove_dir_all(&store_dir);
+    }
+
+    /// Phase 3b — `persist_proxy_nonces` honors the `nonce_persistence_enabled`
+    /// gate: when persistence is disabled (test default, `COORD_MCP_PERSIST_NONCES`
+    /// unset under `cfg(test)`), the DEFAULT-store path is a no-op. We assert the
+    /// gate directly (a pure predicate) rather than mutating env + probing the
+    /// real store — the injected-store seam makes the disk write deterministic and
+    /// the gate is the only behavior worth pinning here.
+    #[test]
+    fn persistence_disabled_skips_default_store_write() {
+        // Under cfg(test) with the env var unset, persistence is OFF by default
+        // (see `nonce_persistence_enabled`), so `register_proxy_nonce`'s
+        // default-store mirror is a guaranteed no-op — minting touches only the
+        // in-memory map. A minted nonce is therefore valid in-memory but the
+        // default store is never written. We verify the gate is the thing that
+        // makes that true.
+        assert!(
+            !nonce_persistence_enabled(),
+            "test builds must default persistence OFF so nonce-minting tests \
+             never write the developer's real store"
+        );
+        // And minting still registers in-memory (the persist step is skipped).
+        let (nonce, _snapshot) = mint_and_register_nonce("/tmp/coord-mcp-persist-off-wd");
+        assert!(
+            proxy_nonce_is_valid(&nonce),
+            "minting must register the nonce in-memory regardless of persistence"
+        );
+    }
+
+    /// Phase 3c — the pure reconcile predicate: rewrite only when a proxy port
+    /// is present AND differs from the current bound port.
+    #[test]
+    fn reconcile_action_rewrites_only_on_port_mismatch() {
+        assert_eq!(
+            reconcile_action(Some(9877), 9876),
+            ReconcileAction::Rewrite,
+            "stale port → rewrite"
+        );
+        assert_eq!(
+            reconcile_action(Some(9876), 9876),
+            ReconcileAction::Leave,
+            "matching port → leave"
+        );
+        assert_eq!(
+            reconcile_action(None, 9876),
+            ReconcileAction::Leave,
+            "no readable proxy port (absent / static-bearer agent config) → leave"
+        );
+    }
+
+    /// Phase 3c — end-to-end reconcile over a workdir set: a stale-port proxy
+    /// config is rewritten to the bound port; a matching one and an agent
+    /// (static-bearer) config are left untouched.
+    #[test]
+    fn reconcile_session_configs_rewrites_stale_leaves_agent() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        let base = std::env::temp_dir().join(format!("coord-mcp-recon-{}", uuid::Uuid::now_v7()));
+
+        // Stale proxy config on :9999 → must be rewritten to :9876.
+        let stale = base.join("stale");
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::write(
+            stale.join(".mcp.json"),
+            r#"{"mcpServers":{"coord-mcp":{"type":"http","url":"http://127.0.0.1:9999/coord-mcp","headers":{"X-Coord-Mcp-Proxy-Key":"old"}}}}"#,
+        )
+        .unwrap();
+
+        // Already-correct proxy config on :9876 → must be left as-is.
+        let ok = base.join("ok");
+        std::fs::create_dir_all(&ok).unwrap();
+        std::fs::write(
+            ok.join(".mcp.json"),
+            r#"{"mcpServers":{"coord-mcp":{"type":"http","url":"http://127.0.0.1:9876/coord-mcp","headers":{"X-Coord-Mcp-Proxy-Key":"keep"}}}}"#,
+        )
+        .unwrap();
+
+        // Agent static-bearer config → must NEVER be clobbered.
+        let agent_payload = URL_SAFE_NO_PAD.encode(br#"{"sub_type":"agent"}"#);
+        let agent_jwt = format!("h.{agent_payload}.s");
+        let agent_cfg = format!(
+            r#"{{"mcpServers":{{"coord-mcp":{{"type":"http","url":"https://c/mcp","headers":{{"Authorization":"Bearer {agent_jwt}"}}}}}}}}"#
+        );
+        let agent = base.join("agent");
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(agent.join(".mcp.json"), &agent_cfg).unwrap();
+
+        let workdirs = vec![
+            stale.to_string_lossy().to_string(),
+            ok.to_string_lossy().to_string(),
+            agent.to_string_lossy().to_string(),
+        ];
+        let rewritten = reconcile_session_configs(workdirs, 9876);
+        assert_eq!(
+            rewritten, 1,
+            "only the stale-port proxy config is rewritten"
+        );
+
+        // Stale rewritten to the bound port (+ a fresh registered nonce).
+        assert_eq!(read_proxy_port(&stale.to_string_lossy()), Some(9876));
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(stale.join(".mcp.json")).unwrap())
+                .unwrap();
+        let new_nonce = v["mcpServers"]["coord-mcp"]["headers"]["X-Coord-Mcp-Proxy-Key"]
+            .as_str()
+            .unwrap();
+        assert!(
+            proxy_nonce_is_valid(new_nonce),
+            "the rewritten config must carry a freshly-registered nonce"
+        );
+
+        // Correct config untouched; agent config preserved verbatim.
+        assert_eq!(read_proxy_port(&ok.to_string_lossy()), Some(9876));
+        assert_eq!(
+            std::fs::read_to_string(agent.join(".mcp.json")).unwrap(),
+            agent_cfg,
+            "an agent static-bearer config must never be clobbered by the reconcile"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src-tauri/src/heartbeat.rs
+++ b/src-tauri/src/heartbeat.rs
@@ -180,12 +180,30 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
             // Read the /health-driven embedding probe cache. `None` (probe
             // hasn't run yet) collapses to "healthy" so a pre-probe heartbeat
             // doesn't flap to "degraded" on boot.
-            let derived_status = crate::ui_error::compute_derived_status(
+            let base_status = crate::ui_error::compute_derived_status(
                 ui_error_snapshot.is_some(),
                 recent_crash_snapshot.is_some(),
                 crate::mcp_api::embedding_reachable_cached(),
-            )
-            .to_string();
+            );
+
+            // Phase 5 — provisioning completeness gate. A runner is
+            // provisioning-complete only once it holds a live coord device JWT
+            // (doctor check 5). ADVISORY by default: surface + log loudly but
+            // never withhold ready (a hard block could brick a runner
+            // mid-provision). `QONTINUI_PROVISIONING_GATE_ENFORCE` flips it to
+            // ENFORCING, where readiness is withheld until check 5 passes. The
+            // device-JWT predicate is REUSED from `coord_doctor` (not
+            // re-implemented); the credential-gap is ALSO surfaced to the fleet
+            // by `device_jwt_refresher`'s Phase-1b coord_credential status, so
+            // the same `runner_coord_credentials_missing` alert lights up — we
+            // do not invent a second signal here.
+            let check5 = qontinui_runner_lib::coord_doctor::device_jwt_live_check();
+            let readiness = qontinui_runner_lib::coord_doctor::provisioning_readiness(
+                check5.ok,
+                qontinui_runner_lib::coord_doctor::provisioning_gate_enforce_enabled(),
+            );
+            let derived_status =
+                provisioning_gated_status(base_status, readiness, &check5.detail).to_string();
 
             // Send to web backend every 30s (every other tick)
             if tick_count.is_multiple_of(2) {
@@ -273,6 +291,64 @@ pub fn start_heartbeat(app_state: Arc<AppState>) {
     });
 }
 
+/// The heartbeat `derived_status` value a runner reports when it is
+/// provisioning-incomplete under the ENFORCING gate: it has not yet met the
+/// completeness bar (a live coord device JWT) so it withholds a "ready"
+/// (healthy) status. Distinct from `errored`/`degraded` so consumers can tell
+/// "still provisioning" apart from "broke at runtime".
+pub(crate) const PROVISIONING_INCOMPLETE_STATUS: &str = "provisioning_incomplete";
+
+/// Apply the Phase-5 provisioning gate to the base derived status.
+///
+/// Pure over its inputs (the side-effecting log is the one exception, and is
+/// the loud-surface the plan asks for) so the status decision is unit-testable.
+///
+/// - [`ProvisioningReadiness::Ready`] ⇒ pass the base status through unchanged.
+/// - [`ProvisioningReadiness::IncompleteAdvisory`] ⇒ log loudly, but DO NOT
+///   change the status (advisory never withholds ready / never bricks a runner
+///   mid-provision).
+/// - [`ProvisioningReadiness::IncompleteEnforced`] ⇒ withhold ready by
+///   overriding to [`PROVISIONING_INCOMPLETE_STATUS`] — UNLESS the base status
+///   is already a worse signal (`errored`/`degraded`), which must win so a real
+///   runtime fault is never masked by the provisioning state.
+fn provisioning_gated_status(
+    base_status: &'static str,
+    readiness: qontinui_runner_lib::coord_doctor::ProvisioningReadiness,
+    check_detail: &str,
+) -> &'static str {
+    use qontinui_runner_lib::coord_doctor::ProvisioningReadiness;
+    match readiness {
+        ProvisioningReadiness::Ready => base_status,
+        ProvisioningReadiness::IncompleteAdvisory => {
+            tracing::warn!(
+                "provisioning gate (advisory): runner has NO live coord device JWT \
+                 (doctor check device_jwt_live: {check_detail}). Reporting ready anyway; \
+                 set {} to withhold ready until a device JWT is live. \
+                 Run `coord doctor` for the failing link + fix.",
+                qontinui_runner_lib::coord_doctor::PROVISIONING_GATE_ENFORCE_ENV,
+            );
+            base_status
+        }
+        ProvisioningReadiness::IncompleteEnforced => {
+            // A real runtime fault must still win over "still provisioning".
+            if base_status == "errored" || base_status == "degraded" {
+                tracing::warn!(
+                    "provisioning gate (enforcing): runner has NO live coord device JWT \
+                     ({check_detail}), but a worse status ({base_status}) wins."
+                );
+                base_status
+            } else {
+                tracing::warn!(
+                    "provisioning gate (enforcing): WITHHOLDING ready — runner has no live \
+                     coord device JWT ({check_detail}). Reporting {PROVISIONING_INCOMPLETE_STATUS}. \
+                     Run `coord doctor` for the fix."
+                );
+                PROVISIONING_INCOMPLETE_STATUS
+            }
+        }
+    }
+}
+
 /// Get the local IP address (non-loopback).
 fn get_local_ip() -> Option<String> {
     // Use a UDP socket trick to find the local IP without actually sending data
@@ -346,5 +422,63 @@ mod tests {
 
         let v6_loopback: std::net::SocketAddr = "[::1]:9876".parse().unwrap();
         assert!(!crate::mcp_api::lan_reachable_for_bound_addr(&v6_loopback));
+    }
+
+    // ---- Phase 5 — provisioning gate applied to derived_status ----
+
+    use qontinui_runner_lib::coord_doctor::ProvisioningReadiness;
+
+    #[test]
+    fn provisioning_gate_ready_passes_base_status_through() {
+        // A live device JWT ⇒ no change to whatever the base status was.
+        assert_eq!(
+            provisioning_gated_status("healthy", ProvisioningReadiness::Ready, "ok"),
+            "healthy"
+        );
+        assert_eq!(
+            provisioning_gated_status("degraded", ProvisioningReadiness::Ready, "ok"),
+            "degraded"
+        );
+    }
+
+    #[test]
+    fn provisioning_gate_advisory_does_not_change_status() {
+        // Advisory surfaces (logs) but never withholds ready — base passes through.
+        assert_eq!(
+            provisioning_gated_status(
+                "healthy",
+                ProvisioningReadiness::IncompleteAdvisory,
+                "no device JWT in the access-token slot",
+            ),
+            "healthy",
+            "advisory must NOT withhold ready"
+        );
+    }
+
+    #[test]
+    fn provisioning_gate_enforced_withholds_ready() {
+        // Enforcing + incomplete + otherwise-healthy ⇒ provisioning_incomplete.
+        assert_eq!(
+            provisioning_gated_status(
+                "healthy",
+                ProvisioningReadiness::IncompleteEnforced,
+                "no device JWT in the access-token slot",
+            ),
+            PROVISIONING_INCOMPLETE_STATUS
+        );
+    }
+
+    #[test]
+    fn provisioning_gate_enforced_lets_worse_status_win() {
+        // A real runtime fault (errored/degraded) must NOT be masked by the
+        // provisioning-incomplete override.
+        assert_eq!(
+            provisioning_gated_status("errored", ProvisioningReadiness::IncompleteEnforced, "x"),
+            "errored"
+        );
+        assert_eq!(
+            provisioning_gated_status("degraded", ProvisioningReadiness::IncompleteEnforced, "x"),
+            "degraded"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -32,6 +32,14 @@ pub mod pair;
 // `cognito_sign_in` Tauri command in `commands::auth` drives it.
 pub mod cognito;
 
+// `coord doctor` self-check (plan 2026-06-13 Phase 4). Lifted into the lib so
+// BOTH the standalone `coord_doctor` bin and the in-app Tauri command
+// (`crate::coord_doctor` in the runner binary) share one driver + formatter +
+// the 7-check wiring. Reuses the lib's `auth`/`pair`/`secure_storage`/`profiles`
+// modules (which compile into the runner binary too), so the bin and the
+// command produce an identical report.
+pub mod coord_doctor;
+
 // ============================================================================
 // Main window label abstraction
 // ============================================================================

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -45,6 +45,7 @@ mod config_storage;
 mod constraint_engine;
 mod container;
 mod context;
+mod coord_doctor_cmd;
 mod coord_http;
 mod coord_mcp;
 mod coord_questions;
@@ -1165,6 +1166,8 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
             commands::cost_dashboard::get_active_budget_status,
             commands::cost_dashboard::get_cost_dashboard,
             crash_dumps::dismiss_recent_crash,
+            coord_doctor_cmd::coord_doctor_run,
+            coord_doctor_cmd::coord_doctor_text,
             commands::dag_workflows::export_dag_workflow,
             commands::dag_workflows::import_dag_workflow,
             commands::dag_workflows::import_dag_workflows_from_project,

--- a/src-tauri/src/mcp/device_jwt_refresher.rs
+++ b/src-tauri/src/mcp/device_jwt_refresher.rs
@@ -112,6 +112,205 @@ pub(crate) fn next_action(tier: RunnerTier, needs_refresh: bool) -> Decision {
     Decision::Pair
 }
 
+// ===========================================================================
+// Phase 1b — coord-credential health signal (runner publishes; coord derives
+// the fleet alert in `evaluate()`).
+// ===========================================================================
+
+/// Outcome of the `Pair` arm as seen by the health-mapping fn. The arm can
+/// either bail before re-minting (no bearer / no tenant / pair-cli failure
+/// leaving an EXPIRED jwt behind) or complete (a fresh `Replaced`, or a
+/// `KeptExisting`/`PersistFailed` whose existing JWT is still valid). Factored
+/// out so [`coord_credential_health`] is a pure fn over an enum the loop can
+/// construct at each arm without re-deriving any state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PairProgress {
+    /// `Decision::Pair` reached but the loop bailed before re-minting because
+    /// no Cognito/device bearer was resolvable. The string is the specific
+    /// failing source for the operator-facing `reason`.
+    BailNoBearer,
+    /// `Decision::Pair` reached but no `tenant_id` resolved from any source
+    /// (OAuth claim → outgoing device-JWT → machine.json). Gate-blocking.
+    BailNoTenant,
+    /// `Decision::Pair` ran `try_refresh_once`, which returned a non-2xx
+    /// (`KeptExisting`) or a persist failure (`PersistFailed`), AND the JWT
+    /// still in the slot is EXPIRED (or absent) — the runner is now
+    /// credential-dark even though it tried. Degraded, not gate-blocking-by-
+    /// config: the tenant resolved, the mint just failed.
+    BailRefreshFailedExpired,
+    /// The `Pair` arm completed with a usable JWT — either a fresh `Replaced`
+    /// or a `KeptExisting`/`PersistFailed` whose existing JWT is still valid.
+    Healthy,
+}
+
+/// Compact coord-credential health the runner stamps into its
+/// `coord.device_status.details` on every heartbeat (plan 2026-06-13 Phase 1b).
+/// Coord's `fleet_health::evaluate()` reads this to derive the device-scoped
+/// `coord_credentials_missing` alert; the runner itself never touches coord's
+/// alert machinery.
+///
+/// Wire shape (under `details.coord_credential`):
+/// `{ "ok": <bool>, "reason": <string|null> }`.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct CoordCredentialHealth {
+    pub ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl CoordCredentialHealth {
+    fn ok() -> Self {
+        Self {
+            ok: true,
+            reason: None,
+        }
+    }
+    fn bad(reason: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            reason: Some(reason.into()),
+        }
+    }
+}
+
+/// Pure map: refresher decision (plus, for `Pair`, how far the arm got) →
+/// the `coord_credential` health the heartbeat publishes. No I/O — the loop
+/// constructs the `PairProgress` at each arm and calls this so the mapping is
+/// unit-testable in the same style as [`next_action`].
+///
+/// - [`Decision::Idle`] (JWT fresh)            → `{ok:true,  reason:null}`.
+/// - [`Decision::IdleWrongTier`]               → `{ok:false, reason:"runner tier is not Qontinui account"}`.
+/// - [`Decision::Pair`] + [`PairProgress::Healthy`]               → `{ok:true}`.
+/// - [`Decision::Pair`] + bail variants        → `{ok:false, reason:<specific failing source>}`.
+///
+/// `pair_progress` is only consulted for [`Decision::Pair`]; callers pass
+/// `None` for the idle arms.
+pub(crate) fn coord_credential_health(
+    decision: Decision,
+    pair_progress: Option<PairProgress>,
+) -> CoordCredentialHealth {
+    match decision {
+        Decision::Idle => CoordCredentialHealth::ok(),
+        Decision::IdleWrongTier => {
+            CoordCredentialHealth::bad("runner tier is not Qontinui account")
+        }
+        Decision::Pair => match pair_progress {
+            Some(PairProgress::Healthy) | None => CoordCredentialHealth::ok(),
+            Some(PairProgress::BailNoBearer) => CoordCredentialHealth::bad(
+                "no Cognito session and access_token slot empty — user must sign in",
+            ),
+            Some(PairProgress::BailNoTenant) => CoordCredentialHealth::bad(
+                "no resolvable tenant_id (OAuth claim, outgoing device-JWT, or \
+                 machine.json::active_tenant_id all absent)",
+            ),
+            Some(PairProgress::BailRefreshFailedExpired) => CoordCredentialHealth::bad(
+                "device-JWT re-mint failed (coord non-2xx or persist error) and the \
+                 existing JWT is expired — runner is credential-dark",
+            ),
+        },
+    }
+}
+
+/// True iff the device-JWT in the `access_token` slot is absent, opaque
+/// (no decodable `exp`), or its `exp` is already in the past. Used to decide
+/// whether a failed re-mint left the runner credential-DARK
+/// ([`PairProgress::BailRefreshFailedExpired`]) vs. merely hit a transient
+/// coord error while still holding a valid (not-yet-expired) JWT.
+fn slot_jwt_is_expired_or_absent(auth_manager: &crate::auth::AuthManager) -> bool {
+    match auth_manager.access_token_exp() {
+        Some(exp) => chrono::Utc::now().timestamp() >= exp,
+        None => true, // absent or opaque/undecodable → treat as not-live
+    }
+}
+
+/// Best-effort publish of the coord-credential health into the runner's
+/// `coord.device_status.details.coord_credential` via the existing
+/// `POST {coord}/coord/status` upsert path (the same endpoint
+/// `qontinui_profile`/coord-sync use; we reuse it rather than invent a new
+/// route). Resolves `device_id`/`tenant_id`/coord-base exactly like the rest of
+/// the runner:
+///   - coord base: `COORD_HTTP_URL` env → active profile (`coord_base_url`),
+///   - device_id: `QONTINUI_MACHINE_ID` env → `machine.json::device_id`,
+///   - tenant_id: `resolve_active_tenant_id()` (machine.json::active_tenant_id),
+///     falling back to the outgoing device-JWT's `tenant_id` claim.
+///
+/// A publish failure ONLY `warn!`s — it must never break the refresher loop
+/// (the loop's job is keeping the JWT fresh; telemetry is strictly best-effort).
+async fn publish_coord_credential_status(
+    auth_manager: &crate::auth::AuthManager,
+    health: &CoordCredentialHealth,
+) {
+    // device_id: env override first (multi-instance / test), else machine.json.
+    let device_id = std::env::var("QONTINUI_MACHINE_ID")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string())
+        .or_else(|| qontinui_runner_lib::pair::read_device_id_from_disk().ok());
+    let Some(device_id) = device_id else {
+        // No stable identity → coord can't key the row; skip silently-ish.
+        warn!(
+            "device_jwt_refresher: cannot publish coord_credential status — \
+             no device_id (QONTINUI_MACHINE_ID unset, machine.json unreadable)"
+        );
+        return;
+    };
+    let Ok(device_uuid) = uuid::Uuid::parse_str(device_id.trim()) else {
+        warn!(
+            "device_jwt_refresher: device_id {device_id} is not a UUID — skipping status publish"
+        );
+        return;
+    };
+
+    // tenant_id: machine.json::active_tenant_id, then the outgoing device-JWT
+    // claim (still parseable when expired). NULL is acceptable on the wire
+    // (coord's StatusUpsert.tenant_id is Option), but we send it when known so
+    // the row is tenant-scoped.
+    let tenant_id = crate::session::dual_write::resolve_active_tenant_id().or_else(|| {
+        auth_manager
+            .get_access_token()
+            .ok()
+            .as_deref()
+            .and_then(qontinui_runner_lib::pair::tenant_id_from_oauth_claim)
+            .and_then(|s| uuid::Uuid::parse_str(s.trim()).ok())
+    });
+
+    let base = crate::coord_mcp::coord_base_url();
+    let url = format!("{base}/coord/status");
+    let mut body = serde_json::json!({
+        "device_id": device_uuid,
+        "details": { "coord_credential": health },
+    });
+    if let Some(t) = tenant_id {
+        body["tenant_id"] = serde_json::json!(t);
+    }
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("device_jwt_refresher: status-publish client build failed: {e}");
+            return;
+        }
+    };
+    match client.post(&url).json(&body).send().await {
+        Ok(resp) if resp.status().is_success() => {}
+        Ok(resp) => {
+            warn!(
+                "device_jwt_refresher: coord_credential status publish got HTTP {} \
+                 (best-effort; loop continues)",
+                resp.status()
+            );
+        }
+        Err(e) => {
+            warn!(
+                "device_jwt_refresher: coord_credential status publish failed: {e} (best-effort)"
+            );
+        }
+    }
+}
+
 /// State for the device-JWT refresher task. Owns the watch channels for
 /// shutdown + kick and the join handle so callers can stop / re-kick.
 pub struct RefresherState {
@@ -459,6 +658,14 @@ async fn refresher_loop(
 
         match decision {
             Decision::IdleWrongTier => {
+                // Phase 1b: publish the credential-dark signal so coord's
+                // fleet `evaluate()` lights up a device-scoped alert. Best-
+                // effort — never blocks the idle wait below.
+                publish_coord_credential_status(
+                    &auth_manager,
+                    &coord_credential_health(decision, None),
+                )
+                .await;
                 // Nothing to do until tier changes. Block on shutdown or
                 // kick (set_runner_tier kicks us on every transition).
                 tokio::select! {
@@ -470,6 +677,13 @@ async fn refresher_loop(
                 }
             }
             Decision::Idle => {
+                // Phase 1b: a fresh JWT → publish ok so any stale alert self-
+                // clears on coord's next firing-set reconcile.
+                publish_coord_credential_status(
+                    &auth_manager,
+                    &coord_credential_health(decision, None),
+                )
+                .await;
                 // JWT is fresh — sleep until next check or wake on kick.
                 if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx).await {
                     return;
@@ -494,6 +708,15 @@ async fn refresher_loop(
                                 "device_jwt_refresher: no Cognito session and access_token slot \
                                  empty — user must sign in to Qontinui before the refresher can pair"
                             );
+                            // Phase 1b: credential-dark (not signed in).
+                            publish_coord_credential_status(
+                                &auth_manager,
+                                &coord_credential_health(
+                                    decision,
+                                    Some(PairProgress::BailNoBearer),
+                                ),
+                            )
+                            .await;
                             if wait_with_signals(
                                 REFRESH_CHECK_INTERVAL,
                                 &mut shutdown_rx,
@@ -552,6 +775,12 @@ async fn refresher_loop(
                             "device_jwt_refresher: paired_user.json missing — \
                              runner not paired yet (refresher idling until kick)"
                         );
+                        // Phase 1b: not paired → credential-dark (not signed in).
+                        publish_coord_credential_status(
+                            &auth_manager,
+                            &coord_credential_health(decision, Some(PairProgress::BailNoBearer)),
+                        )
+                        .await;
                         if wait_with_signals(REFRESH_CHECK_INTERVAL, &mut shutdown_rx, &mut kick_rx)
                             .await
                         {
@@ -560,6 +789,18 @@ async fn refresher_loop(
                         continue;
                     }
                 };
+
+                // Phase 1b: resolve the tenant ONCE up front so the post-outcome
+                // health mapping can distinguish "no tenant resolved" (gate-
+                // blocking config) from "tenant fine, the mint just failed"
+                // (degraded). `try_refresh_once` re-resolves internally; the two
+                // resolutions agree because both call `resolve_active_tenant_id`
+                // + the same OAuth/outgoing-JWT fallback chain.
+                let machine_tenant = crate::session::dual_write::resolve_active_tenant_id();
+                let outgoing_jwt = auth_manager.get_access_token().ok();
+                let tenant_resolved =
+                    resolve_pair_tenant_id(&bearer_token, outgoing_jwt.as_deref(), machine_tenant)
+                        .is_some();
 
                 // Phase 5.2: try_refresh_once encapsulates the
                 // pair-cli HTTP call + JWT persistence. It preserves
@@ -570,10 +811,10 @@ async fn refresher_loop(
                     &bearer_token,
                     &device_id,
                     &user_id,
-                    crate::session::dual_write::resolve_active_tenant_id(),
+                    machine_tenant,
                 )
                 .await;
-                match outcome {
+                let progress = match &outcome {
                     RefreshOutcome::Replaced { new_jwt } => {
                         info!(
                             "device_jwt_refresher: device-JWT refreshed (len={})",
@@ -581,15 +822,32 @@ async fn refresher_loop(
                         );
                         // Wake the relay so it reconnects with the new JWT.
                         crate::mcp::backend_relay::commands::kick_cloud_relay().await;
+                        PairProgress::Healthy
                     }
-                    RefreshOutcome::KeptExisting => {
-                        // Coord error (401 / 503 / etc.) or transport failure —
-                        // existing JWT preserved. Will retry next tick.
+                    RefreshOutcome::KeptExisting | RefreshOutcome::PersistFailed(_) => {
+                        if let RefreshOutcome::PersistFailed(e) = &outcome {
+                            warn!("device_jwt_refresher: persist new JWT failed: {e}");
+                        }
+                        // The mint did NOT advance the slot. Classify why:
+                        //   - no tenant resolvable → gate-blocking config red,
+                        //   - tenant fine but the slot JWT is now expired/absent
+                        //     → degraded "credential-dark" red,
+                        //   - tenant fine and the slot JWT is still valid →
+                        //     healthy (a transient coord 5xx we'll retry).
+                        if !tenant_resolved {
+                            PairProgress::BailNoTenant
+                        } else if slot_jwt_is_expired_or_absent(&auth_manager) {
+                            PairProgress::BailRefreshFailedExpired
+                        } else {
+                            PairProgress::Healthy
+                        }
                     }
-                    RefreshOutcome::PersistFailed(e) => {
-                        warn!("device_jwt_refresher: persist new JWT failed: {e}");
-                    }
-                }
+                };
+                publish_coord_credential_status(
+                    &auth_manager,
+                    &coord_credential_health(decision, Some(progress)),
+                )
+                .await;
 
                 // Brief sleep before next iteration (success or failure)
                 // so we don't hammer coord on persistent errors.
@@ -707,6 +965,88 @@ mod tests {
         // Even with no needs-refresh signal, wrong-tier still wins.
         let d3 = next_action(RunnerTier::LocalProvider, false);
         assert_eq!(d3, Decision::IdleWrongTier);
+    }
+
+    // ---- coord_credential_health mapping (pure, Phase 1b) ----
+
+    #[test]
+    fn health_idle_is_ok() {
+        let h = coord_credential_health(Decision::Idle, None);
+        assert!(h.ok);
+        assert_eq!(h.reason, None);
+    }
+
+    #[test]
+    fn health_wrong_tier_is_red_with_tier_reason() {
+        let h = coord_credential_health(Decision::IdleWrongTier, None);
+        assert!(!h.ok);
+        assert_eq!(
+            h.reason.as_deref(),
+            Some("runner tier is not Qontinui account")
+        );
+    }
+
+    #[test]
+    fn health_pair_healthy_is_ok() {
+        // A successful Replaced / still-valid KeptExisting → ok.
+        let h = coord_credential_health(Decision::Pair, Some(PairProgress::Healthy));
+        assert!(h.ok);
+        assert_eq!(h.reason, None);
+        // And `None` progress (defensive default) is also ok, never a false red.
+        let h2 = coord_credential_health(Decision::Pair, None);
+        assert!(h2.ok);
+    }
+
+    #[test]
+    fn health_pair_bail_no_bearer_is_red_signin() {
+        let h = coord_credential_health(Decision::Pair, Some(PairProgress::BailNoBearer));
+        assert!(!h.ok);
+        assert!(
+            h.reason.as_deref().unwrap().contains("sign in"),
+            "no-bearer reason must name the sign-in failing source, got {:?}",
+            h.reason
+        );
+    }
+
+    #[test]
+    fn health_pair_bail_no_tenant_is_red_tenant() {
+        let h = coord_credential_health(Decision::Pair, Some(PairProgress::BailNoTenant));
+        assert!(!h.ok);
+        assert!(
+            h.reason.as_deref().unwrap().contains("tenant"),
+            "no-tenant reason must name the tenant failing source, got {:?}",
+            h.reason
+        );
+    }
+
+    #[test]
+    fn health_pair_bail_refresh_failed_expired_is_red_dark() {
+        let h =
+            coord_credential_health(Decision::Pair, Some(PairProgress::BailRefreshFailedExpired));
+        assert!(!h.ok);
+        assert!(
+            h.reason.as_deref().unwrap().contains("credential-dark"),
+            "failed-mint-expired reason must flag credential-dark, got {:?}",
+            h.reason
+        );
+    }
+
+    #[test]
+    fn health_serializes_to_ok_reason_shape() {
+        // Wire contract: `{ "ok": <bool>, "reason": <string|null> }`. The
+        // `ok` case skips `reason` (Option::is_none), which deserializes back
+        // to null on the coord side — the consumer treats absent == null.
+        let ok = serde_json::to_value(coord_credential_health(Decision::Idle, None)).unwrap();
+        assert_eq!(ok["ok"], serde_json::Value::Bool(true));
+        assert!(ok.get("reason").is_none(), "ok health omits reason");
+
+        let red =
+            serde_json::to_value(coord_credential_health(Decision::IdleWrongTier, None)).unwrap();
+        assert_eq!(red["ok"], serde_json::Value::Bool(false));
+        assert!(
+            red["reason"].is_string(),
+            "red health carries a reason string"
+        );
     }
 
     // ---- resolve_pair_tenant_id ordering (pure, no disk / no AuthManager) ----

--- a/src-tauri/src/mcp_api.rs
+++ b/src-tauri/src/mcp_api.rs
@@ -1471,6 +1471,51 @@ pub fn create_router(
         });
     }
 
+    // Restore persisted coord-mcp proxy nonces + reconcile session configs to
+    // the current bound port (plan 2026-06-13 Phases 3b + 3c). 3b makes an
+    // already-written `.mcp.json` keep validating across a restart (the nonce
+    // is a loopback-only key, persisted at rest under COORD_MCP_PERSIST_NONCES);
+    // 3c rewrites any live session whose proxy URL names a stale port back to
+    // the instance's current bound port. Ordered AFTER the restore so a rewrite
+    // reuses the restored map where possible, and guarded by
+    // `coord_mcp_safe_to_write` so it never clobbers an agent-spawn config.
+    {
+        let reconcile_app_handle = app_handle.clone();
+        let reconcile_bound_port = api_state
+            .app_state
+            .api_port
+            .load(std::sync::atomic::Ordering::Relaxed);
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            // Phase 3b — restore the persisted nonce map FIRST (run-once).
+            crate::coord_mcp::restore_proxy_nonces_from_store();
+
+            // Phase 3c — reconcile live session `.mcp.json` ports. Pull the live
+            // session workdirs from the managed lifecycle store (open records).
+            use tauri::Manager;
+            let workdirs: Vec<String> = match reconcile_app_handle
+                .try_state::<std::sync::Arc<crate::session::session_lifecycle_store::SessionLifecycleStore>>(
+                ) {
+                Some(store) => store
+                    .inner()
+                    .open_records()
+                    .into_iter()
+                    .filter_map(|r| r.working_dir)
+                    .collect(),
+                None => Vec::new(),
+            };
+            if !workdirs.is_empty() {
+                let rewritten =
+                    crate::coord_mcp::reconcile_session_configs(workdirs, reconcile_bound_port);
+                if rewritten > 0 {
+                    info!(
+                        "coord_mcp boot reconcile: rewrote {rewritten} session config(s) to bound port :{reconcile_bound_port}"
+                    );
+                }
+            }
+        });
+    }
+
     // Sync workflows from web backend on startup (background task)
     {
         let sync_pg_db = api_state.app_state.pg_db.clone();

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -68,6 +68,15 @@ struct StoredTokens {
     oauth_refresh_token: Option<String>,
     #[serde(default)]
     oauth_expires_at: Option<i64>,
+    /// Persisted coord-mcp loopback proxy nonces: nonce → workdir it was
+    /// provisioned into (plan 2026-06-13 Phase 3b). The nonce is a
+    /// **loopback-only** proxy key (127.0.0.1) — NOT a bearer — so persisting it
+    /// at rest leaks nothing exploitable off-box, and it is the only way an
+    /// already-running agent's already-read `.mcp.json` keeps validating across a
+    /// runner rebuild/restart (the MCP client never re-reads the file). Carries
+    /// `#[serde(default)]` so a pre-Phase-3b `.enc` deserializes.
+    #[serde(default)]
+    coord_mcp_nonces: std::collections::HashMap<String, String>,
 }
 
 /// Secure file-based storage manager.
@@ -358,6 +367,32 @@ impl SecureStorage {
         self.save_tokens(&tokens)?;
         info!("Cognito (oauth) tokens cleared from secure file storage");
         Ok(())
+    }
+
+    /// Persist the full coord-mcp loopback proxy nonce map (nonce → workdir),
+    /// replacing any prior persisted set (plan 2026-06-13 Phase 3b). Called by
+    /// the in-memory `PROXY_NONCES` registry on every mint/eviction so the
+    /// durable copy tracks the live set. Best-effort: a write failure is
+    /// surfaced to the caller, which logs and continues (the in-memory map
+    /// remains authoritative for this process lifetime).
+    pub fn store_coord_mcp_nonces(
+        &self,
+        nonces: &std::collections::HashMap<String, String>,
+    ) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens.coord_mcp_nonces = nonces.clone();
+        self.save_tokens(&tokens)?;
+        Ok(())
+    }
+
+    /// Load the persisted coord-mcp loopback proxy nonce map (nonce → workdir).
+    /// Returns an empty map when the store is absent / unreadable / pre-Phase-3b
+    /// — a missing nonce simply 401s and the next provisioning re-mints, so an
+    /// empty restore is the safe default (today's in-memory-only behavior).
+    pub fn load_coord_mcp_nonces(&self) -> std::collections::HashMap<String, String> {
+        self.load_tokens()
+            .map(|t| t.coord_mcp_nonces)
+            .unwrap_or_default()
     }
 
     /// Deletes the storage file entirely.


### PR DESCRIPTION
Plan `2026-06-13-runner-coord-credential-and-gate-access-reliability` — runner phases (1a, 1b-runner, 3a, 3b, 3c, 4, 5). Pairs with coord PR #612 (Phase 1b consumer) and claude-config PR #85 (Phase 2 `/gate`).

Closes the provisioning-fragility class behind two incidents: a stale/mis-ported `.mcp.json` (agent couldn't find coord tools) and runners with no device JWT reporting "no credentials".

- **3a** bound-port fail-closed: `resolve_bound_api_port -> Option<u16>`; never writes the bootstrap `get_mcp_api_port()` fallback into a session config (both degrading callers fixed).
- **1a** session-start `tools/list` probe → degraded-only `.coord-mcp-status` breadcrumb (healthy sessions write nothing).
- **3b** `PROXY_NONCES` persisted via `SecureStorage`, boot-restored (`COORD_MCP_PERSIST_NONCES`) — a restart no longer 401s written configs.
- **3c** boot-time reconcile rewrites port-mismatched proxy configs (guarded by `coord_mcp_safe_to_write`).
- **1b** `device_jwt_refresher` publishes `coord_credential` health on its heartbeat (coord derives the device-scoped alert).
- **4** `coord doctor`: 7 ordered checks, first-red-stops, standalone bin + Tauri command.
- **5** provisioning completeness gate on doctor check 5 — advisory by default, enforce via `QONTINUI_PROVISIONING_GATE_ENFORCE`.

**Verify:** `cargo check` green; full `--lib` suite **252 passed / 0 failed** at default parallelism (also fixed a pre-existing parallel-test keychain flake). Deferred: Phase-4 Settings-UI button (temp-runner visual verify) + Phase-5 onboarding doc.