### PR TITLE
Fleet auto-response rules engine (server rate-limit auto-continue)

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -595,6 +595,16 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // periodic publishers begin their cadences.
                 fleet::publish_on_startup(&fleet_publish_pg, fleet::MachineRole::Agent).await;
 
+                // Fleet auto-response rules: arm from the on-disk cache first
+                // (so a session that hit the transient rate-limit message during
+                // a restart is recovered before the first network fetch), then
+                // start the periodic fetch loop that refreshes the rule set from
+                // the qontinui-web backend. Best-effort: a coord/web outage
+                // leaves the cached rules in place. See
+                // `terminal::auto_response_fleet`.
+                terminal::auto_response_fleet::reload_from_cache_at_boot();
+                terminal::auto_response_fleet::spawn_fetch_loop();
+
                 // Plan 2026-05-19-coordinator-production-readiness.md
                 // Phase 1 — periodic primary-tree state publisher. These
                 // four tasks share one worker thread; they're all
@@ -2256,6 +2266,18 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                             );
                         },
                     )),
+                ));
+
+                // Fleet auto-response watcher: every terminal PTY's output also
+                // flows through this hook, which matches fleet-configured regex
+                // rules against the (ANSI-stripped) output and submits each
+                // rule's prompt back into the SAME live session after a per-rule
+                // exponential backoff. Recovers a session stranded by the
+                // transient "Server is temporarily limiting requests" rate-limit
+                // message (distinct from a usage limit, handled above). See
+                // `terminal::auto_response` for the engine + scheduler.
+                term_for_session.interceptor().add_hook(Box::new(
+                    terminal::auto_response::AutoResponseWatchHook::new(),
                 ));
 
                 // Infrequent liveness poll for lazy close-detection. Every

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -107,6 +107,65 @@ impl Default for ClaudeCliSettings {
     }
 }
 
+/// Per-rule exponential-backoff schedule for the fleet auto-response feature.
+///
+/// When a terminal Claude session's PTY output matches an auto-response rule's
+/// regex, the runner submits the rule's prompt back into that same live session
+/// after a delay that grows exponentially per consecutive match
+/// (`initial_delay_secs * multiplier^attempts`). This throttles the recovery so
+/// a session that keeps re-emitting the matched line (e.g. the transient "Server
+/// is temporarily limiting requests" rate-limit message) is nudged with backoff
+/// rather than hammered. By default the growth is UNBOUNDED (`max_delay_secs`
+/// is `None`); set a cap to clamp the delay.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BackoffConfig {
+    #[serde(default = "default_backoff_initial_secs")]
+    pub initial_delay_secs: u64,
+    #[serde(default = "default_backoff_multiplier")]
+    pub multiplier: f64,
+    #[serde(default)]
+    pub max_delay_secs: Option<u64>,
+}
+fn default_backoff_initial_secs() -> u64 {
+    60
+}
+fn default_backoff_multiplier() -> f64 {
+    2.0
+}
+impl Default for BackoffConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay_secs: default_backoff_initial_secs(),
+            multiplier: default_backoff_multiplier(),
+            max_delay_secs: None,
+        }
+    }
+}
+
+/// One fleet-configured auto-response rule (fetch/cache wire shape).
+///
+/// Rules are fetched from the qontinui-web backend (device-JWT auth) and cached
+/// locally; this struct is ONLY that wire/cache shape — it is not part of the
+/// runner's persisted `Settings`. The server seeds and owns the rule set (the
+/// recovery rule for the transient "Server is temporarily limiting requests"
+/// rate-limit message ships server-side), so the runner never defaults a rule.
+/// When `pattern` (a regex) matches a live session's ANSI-stripped output, the
+/// runner submits `prompt` back into that session after the rule's `backoff`.
+/// Only `enabled` rules are acted on (the backend only returns enabled rules,
+/// so `enabled` defaults to `true`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AutoResponseRule {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    pub pattern: String,
+    pub prompt: String,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub backoff: BackoffConfig,
+}
+
 /// Settings for Claude API (direct HTTP calls)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ClaudeApiSettings {

--- a/src-tauri/src/terminal/auto_response.rs
+++ b/src-tauri/src/terminal/auto_response.rs
@@ -1,0 +1,451 @@
+//! Fleet-configured auto-response engine.
+//!
+//! When a terminal Claude session's PTY output matches a fleet-configured
+//! regex rule, the runner submits that rule's prompt back into the SAME live
+//! session after a per-rule exponential backoff. This recovers a session
+//! stranded by the transient "API Error: Server is temporarily limiting
+//! requests (not your usage limit) · Rate limited" message — distinct from a
+//! usage limit (handled by [`super::account_migration`], NOT this feature).
+//!
+//! ## Pieces
+//!
+//! - [`reload_rules`] compiles the fleet rule set (only `enabled` rules; bad
+//!   regexes are warned-and-skipped, never fatal) into [`COMPILED_RULES`].
+//! - [`AutoResponseWatchHook`] is an [`super::interceptor::OutputHook`]
+//!   installed on every terminal's interceptor pipeline. It ANSI-strips +
+//!   normalizes a bounded rolling window per terminal (sharing
+//!   [`super::output_scan`] with the usage-limit hook) and, for each rule
+//!   whose regex matches, hands the match to the [`scheduler`].
+//! - [`scheduler`] tracks per `(terminal, rule)` backoff state and, after the
+//!   computed delay, submits the rule's prompt into the live session via
+//!   [`super::session::TerminalSession::submit_prompt`]. No max-retry cap —
+//!   the backoff grows unbounded by default so a persistently-rate-limited
+//!   session is nudged ever-more-gently rather than abandoned.
+//!
+//! Hot-path discipline: `process` runs on the PTY reader thread for every
+//! chunk. It early-outs to a single atomic-ish [`RwLock`] read when no rules
+//! are loaded, and never holds the per-terminal state lock across the
+//! scheduler call.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+use tracing::{info, warn};
+
+use super::interceptor::OutputHook;
+use super::output_scan::{normalize, AnsiStripper, WINDOW_KEEP};
+use crate::settings::BackoffConfig;
+
+/// A fleet rule with its `pattern` pre-compiled to a [`regex::Regex`].
+pub struct CompiledRule {
+    pub id: String,
+    pub regex: regex::Regex,
+    pub prompt: String,
+    pub backoff: BackoffConfig,
+}
+
+/// The live, compiled rule set. Swapped wholesale by [`reload_rules`]; read on
+/// the PTY hot path via [`rules_active`] and the per-chunk match scan.
+static COMPILED_RULES: RwLock<Vec<CompiledRule>> = RwLock::new(Vec::new());
+
+/// Recompile the rule set from a freshly-fetched/cached fleet rule list.
+///
+/// Only `enabled` rules are compiled. A rule whose `pattern` fails to compile
+/// is warned-and-skipped — one bad regex never wedges the whole feature. The
+/// whole `Vec` is replaced atomically so the hot path never sees a partial set.
+pub fn reload_rules(rules: Vec<crate::settings::AutoResponseRule>) {
+    let mut compiled = Vec::new();
+    for rule in rules {
+        if !rule.enabled {
+            continue;
+        }
+        match regex::Regex::new(&rule.pattern) {
+            Ok(regex) => compiled.push(CompiledRule {
+                id: rule.id,
+                regex,
+                prompt: rule.prompt,
+                backoff: rule.backoff,
+            }),
+            Err(e) => warn!(
+                rule_id = %rule.id,
+                pattern = %rule.pattern,
+                error = %e,
+                "auto_response: skipping rule with invalid regex"
+            ),
+        }
+    }
+    let count = compiled.len();
+    if let Ok(mut guard) = COMPILED_RULES.write() {
+        *guard = compiled;
+    }
+    info!(count, "auto_response: rules reloaded");
+}
+
+/// True iff at least one rule is loaded — the PTY hot-path early-out.
+fn rules_active() -> bool {
+    COMPILED_RULES
+        .read()
+        .map(|g| !g.is_empty())
+        .unwrap_or(false)
+}
+
+// ── The hook ────────────────────────────────────────────────────────────────
+
+struct TermScanState {
+    stripper: AnsiStripper,
+    window: String,
+}
+
+impl Default for TermScanState {
+    fn default() -> Self {
+        Self {
+            stripper: AnsiStripper::default(),
+            window: String::with_capacity(WINDOW_KEEP * 2),
+        }
+    }
+}
+
+/// Output hook that fires the auto-response scheduler whenever a fleet rule's
+/// regex matches a PTY's recent (ANSI-stripped, normalized) output. Pure
+/// pass-through for the data itself — it never modifies the stream.
+pub struct AutoResponseWatchHook {
+    states: Mutex<HashMap<String, TermScanState>>,
+}
+
+impl AutoResponseWatchHook {
+    pub fn new() -> Self {
+        Self {
+            states: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for AutoResponseWatchHook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OutputHook for AutoResponseWatchHook {
+    fn process(&self, terminal_id: &str, data: &[u8]) -> Vec<u8> {
+        // Hot-path early-out: nothing to do when no rules are loaded.
+        if !rules_active() {
+            return data.to_vec();
+        }
+
+        // Feed + normalize the per-terminal window, then collect the matches.
+        // Unlike the usage-limit hook this does NOT clear the window on a match:
+        // backoff/no-stack live in the scheduler, and clearing would drop the
+        // tail of a chunk that contained the match.
+        let matches: Vec<(String, String, BackoffConfig)> = {
+            let Ok(mut states) = self.states.lock() else {
+                return data.to_vec();
+            };
+            let st = states.entry(terminal_id.to_string()).or_default();
+            st.stripper.feed(data, &mut st.window);
+
+            // Bound the rolling window without splitting a UTF-8 char.
+            if st.window.len() > WINDOW_KEEP {
+                let cut = st.window.len() - WINDOW_KEEP;
+                let cut = (cut..st.window.len())
+                    .find(|i| st.window.is_char_boundary(*i))
+                    .unwrap_or(0);
+                st.window.drain(..cut);
+            }
+
+            let normalized = normalize(&st.window);
+            let Ok(rules) = COMPILED_RULES.read() else {
+                return data.to_vec();
+            };
+            rules
+                .iter()
+                .filter(|r| r.regex.is_match(&normalized))
+                .map(|r| (r.id.clone(), r.prompt.clone(), r.backoff.clone()))
+                .collect()
+        }; // states + rules locks released here
+
+        // Dispatch to the scheduler with NO hook locks held.
+        for (rule_id, prompt, backoff) in matches {
+            scheduler::on_match(terminal_id, &rule_id, &prompt, &backoff);
+        }
+
+        data.to_vec()
+    }
+}
+
+// ── Scheduler ────────────────────────────────────────────────────────────────
+
+mod scheduler {
+    use super::*;
+
+    /// Per `(terminal_id, rule_id)` backoff bookkeeping.
+    struct PairState {
+        attempts: u32,
+        last_fired: Instant,
+        pending: bool,
+    }
+
+    /// `(terminal_id, rule_id)` -> backoff state. Option-wrapped so the static
+    /// is const-initializable (mirrors `account_migration::MIGRATION_HISTORY`).
+    static STATE: Mutex<Option<HashMap<(String, String), PairState>>> = Mutex::new(None);
+
+    /// After this idle gap, a fresh match restarts the backoff at attempt 0 —
+    /// the previous burst is considered resolved.
+    pub(super) const RESET_WINDOW: Duration = Duration::from_secs(15 * 60);
+
+    /// Pure backoff math: `initial * multiplier^attempts`, capped at
+    /// `max_delay_secs` when set, else unbounded. Saturates (never overflows or
+    /// panics) when the f64 result is non-finite or exceeds `u64::MAX`.
+    pub(super) fn compute_delay(cfg: &BackoffConfig, attempts: u32) -> Duration {
+        let raw = cfg.initial_delay_secs as f64 * cfg.multiplier.powi(attempts as i32);
+        let mut secs = if !raw.is_finite() || raw >= u64::MAX as f64 {
+            u64::MAX
+        } else if raw < 0.0 {
+            0
+        } else {
+            raw as u64
+        };
+        if let Some(cap) = cfg.max_delay_secs {
+            secs = secs.min(cap);
+        }
+        Duration::from_secs(secs)
+    }
+
+    /// Register a match for `(tid, rid)`. Returns `None` when a fire is already
+    /// pending (no-stack — one in-flight response per pair). Otherwise sets
+    /// pending, resets attempts to 0 if the last fire was outside
+    /// [`RESET_WINDOW`], and returns the delay to wait before submitting.
+    /// `now` is a parameter for deterministic tests.
+    pub(super) fn register_match(
+        tid: &str,
+        rid: &str,
+        cfg: &BackoffConfig,
+        now: Instant,
+    ) -> Option<Duration> {
+        let mut guard = STATE.lock().ok()?;
+        let map = guard.get_or_insert_with(HashMap::new);
+        let key = (tid.to_string(), rid.to_string());
+        let entry = map.entry(key).or_insert_with(|| PairState {
+            attempts: 0,
+            last_fired: now,
+            pending: false,
+        });
+
+        if entry.pending {
+            return None; // already a response in flight for this pair
+        }
+        if now.duration_since(entry.last_fired) > RESET_WINDOW {
+            entry.attempts = 0;
+        }
+        let delay = compute_delay(cfg, entry.attempts);
+        entry.pending = true;
+        Some(delay)
+    }
+
+    /// Mark a `(tid, rid)` fire complete: bump attempts, stamp `last_fired`,
+    /// clear `pending` so the next match can schedule again.
+    pub(super) fn record_fired(tid: &str, rid: &str, now: Instant) {
+        let Ok(mut guard) = STATE.lock() else {
+            return;
+        };
+        let map = guard.get_or_insert_with(HashMap::new);
+        let entry = map
+            .entry((tid.to_string(), rid.to_string()))
+            .or_insert_with(|| PairState {
+                attempts: 0,
+                last_fired: now,
+                pending: false,
+            });
+        entry.attempts = entry.attempts.saturating_add(1);
+        entry.last_fired = now;
+        entry.pending = false;
+    }
+
+    /// Entry point from the hook: schedule a backed-off prompt submission for a
+    /// matched rule. No-op when a response is already pending for this pair.
+    pub(super) fn on_match(tid: &str, rid: &str, prompt: &str, cfg: &BackoffConfig) {
+        let Some(delay) = register_match(tid, rid, cfg, Instant::now()) else {
+            return;
+        };
+        let tid = tid.to_string();
+        let rid = rid.to_string();
+        let prompt = prompt.to_string();
+        info!(
+            terminal_id = %tid,
+            rule_id = %rid,
+            delay_secs = delay.as_secs(),
+            "auto_response: scheduling prompt submission"
+        );
+        tauri::async_runtime::spawn(async move {
+            tokio::time::sleep(delay).await;
+            submit_to_session(&tid, &prompt).await;
+            record_fired(&tid, &rid, Instant::now());
+        });
+    }
+
+    /// Resolve the live session for `tid` and submit `prompt` into it. If the
+    /// session is gone (closed during the backoff), log and return — the
+    /// scheduler state is reaped lazily by the next reload / process anyway.
+    async fn submit_to_session(tid: &str, prompt: &str) {
+        use std::sync::Arc;
+
+        use tauri::Manager;
+
+        let Some(app) = crate::tauri_app_handle::current() else {
+            return;
+        };
+        let Some(tm) = app.try_state::<Arc<crate::terminal::TerminalManager>>() else {
+            return;
+        };
+        let Some(session) = tm.get(tid) else {
+            info!(
+                terminal_id = %tid,
+                "auto_response: session gone before scheduled submission — skipping"
+            );
+            return;
+        };
+        if let Err(e) = session.submit_prompt(prompt) {
+            warn!(
+                terminal_id = %tid,
+                error = %e,
+                "auto_response: failed to submit scheduled prompt"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule(id: &str, pattern: &str) -> crate::settings::AutoResponseRule {
+        crate::settings::AutoResponseRule {
+            id: id.to_string(),
+            name: String::new(),
+            pattern: pattern.to_string(),
+            prompt: "please continue".to_string(),
+            enabled: true,
+            backoff: BackoffConfig::default(),
+        }
+    }
+
+    #[test]
+    fn reload_drops_disabled_and_invalid_rules() {
+        let mut bad = rule("bad", "(unclosed");
+        let mut disabled = rule("disabled", "ok");
+        disabled.enabled = false;
+        bad.enabled = true;
+        reload_rules(vec![rule("good", "rate limited"), bad, disabled]);
+        let guard = COMPILED_RULES.read().unwrap();
+        assert_eq!(guard.len(), 1);
+        assert_eq!(guard[0].id, "good");
+        drop(guard);
+        // Leave the static empty for other tests.
+        reload_rules(vec![]);
+    }
+
+    #[test]
+    fn hook_matches_regex_over_ansi_window_split_across_calls() {
+        reload_rules(vec![rule("rl", "rate limited")]);
+        let hook = AutoResponseWatchHook::new();
+        // A normalized window must collect the match even when the phrase and
+        // an ANSI color code are split across two process() calls. We assert on
+        // the normalized window match directly (the scheduler spawn needs a
+        // tauri runtime, which a unit test lacks) by re-deriving it the same
+        // way the hook does.
+        let _ = OutputHook::process(&hook, "t1", b"API Error: Server is rate \x1b[31m");
+        let _ = OutputHook::process(&hook, "t1", b"limited now");
+        let states = hook.states.lock().unwrap();
+        let window = &states.get("t1").unwrap().window;
+        assert!(
+            normalize(window).contains("rate limited"),
+            "window did not contain the phrase: {:?}",
+            normalize(window)
+        );
+        drop(states);
+        reload_rules(vec![]);
+    }
+
+    #[test]
+    fn compute_delay_unbounded() {
+        let cfg = BackoffConfig {
+            initial_delay_secs: 60,
+            multiplier: 2.0,
+            max_delay_secs: None,
+        };
+        let got: Vec<u64> = (0..5)
+            .map(|a| scheduler::compute_delay(&cfg, a).as_secs())
+            .collect();
+        assert_eq!(got, vec![60, 120, 240, 480, 960]);
+    }
+
+    #[test]
+    fn compute_delay_capped() {
+        let cfg = BackoffConfig {
+            initial_delay_secs: 60,
+            multiplier: 2.0,
+            max_delay_secs: Some(300),
+        };
+        let got: Vec<u64> = (0..5)
+            .map(|a| scheduler::compute_delay(&cfg, a).as_secs())
+            .collect();
+        assert_eq!(got, vec![60, 120, 240, 300, 300]);
+    }
+
+    #[test]
+    fn compute_delay_saturates_without_panic() {
+        let cfg = BackoffConfig {
+            initial_delay_secs: 60,
+            multiplier: 2.0,
+            max_delay_secs: None,
+        };
+        // 2^10000 overflows f64 to +inf — must saturate, not panic.
+        let d = scheduler::compute_delay(&cfg, 10_000);
+        assert_eq!(d.as_secs(), u64::MAX);
+    }
+
+    #[test]
+    fn register_match_no_stack_while_pending() {
+        let cfg = BackoffConfig::default();
+        let now = Instant::now();
+        assert!(scheduler::register_match("term-A", "r1", &cfg, now).is_some());
+        // Second match before the first fires must NOT schedule again.
+        assert!(scheduler::register_match("term-A", "r1", &cfg, now).is_none());
+    }
+
+    #[test]
+    fn reset_window_restarts_attempts() {
+        let cfg = BackoffConfig {
+            initial_delay_secs: 60,
+            multiplier: 2.0,
+            max_delay_secs: None,
+        };
+        let t0 = Instant::now();
+        // attempt 0 -> 60s
+        assert_eq!(
+            scheduler::register_match("term-B", "r1", &cfg, t0)
+                .unwrap()
+                .as_secs(),
+            60
+        );
+        scheduler::record_fired("term-B", "r1", t0);
+        // Soon after: attempt 1 -> 120s
+        let t1 = t0 + Duration::from_secs(10);
+        assert_eq!(
+            scheduler::register_match("term-B", "r1", &cfg, t1)
+                .unwrap()
+                .as_secs(),
+            120
+        );
+        scheduler::record_fired("term-B", "r1", t1);
+        // After the reset window, attempts restart at 0 -> 60s again.
+        let t2 = t1 + scheduler::RESET_WINDOW + Duration::from_secs(1);
+        assert_eq!(
+            scheduler::register_match("term-B", "r1", &cfg, t2)
+                .unwrap()
+                .as_secs(),
+            60
+        );
+    }
+}

--- a/src-tauri/src/terminal/auto_response_fleet.rs
+++ b/src-tauri/src/terminal/auto_response_fleet.rs
@@ -1,0 +1,261 @@
+//! Fleet auto-response rule fetch loop + on-disk cache.
+//!
+//! Polls the qontinui-web backend (`GET /api/v1/runner/auto-response-rules`,
+//! device-JWT auth) for the operator-configured auto-response rule set, caches
+//! the result on disk, and hands it to [`super::auto_response::reload_rules`].
+//! The on-disk cache lets the runner re-arm the rules immediately at boot
+//! (before the first successful fetch) so a session that hit the transient
+//! rate-limit message during a runner restart is still recovered.
+//!
+//! Best-effort throughout: every network/IO error is logged and swallowed —
+//! the runner keeps whatever rules it already has and retries next tick. The
+//! poll mirrors `fleet::spawn_heartbeat` (interval + `MissedTickBehavior::Skip`)
+//! and the cache mirrors `fleet`'s `last_budget.json` (atomic tmp+rename).
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, warn};
+
+use crate::settings::AutoResponseRule;
+
+/// Wire shape of `GET /api/v1/runner/auto-response-rules`. The backend returns
+/// only ENABLED rules, plus an `updated_at` timestamp (the `ETag` is delivered
+/// both here and as an HTTP response header; we read the header).
+#[derive(Deserialize)]
+struct FleetRulesResponse {
+    rules: Vec<AutoResponseRule>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    updated_at: Option<String>,
+}
+
+/// On-disk cache of the last successful fetch.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct CachedFleetRules {
+    etag: Option<String>,
+    fetched_at: String,
+    rules: Vec<AutoResponseRule>,
+}
+
+/// Last seen `ETag`, used to send `If-None-Match` and get cheap 304s.
+static LAST_ETAG: Mutex<Option<String>> = Mutex::new(None);
+
+/// Cache file location: `~/.qontinui/fleet-auto-response-rules.json`.
+fn cache_path() -> Option<PathBuf> {
+    cache_path_in(dirs::home_dir()?)
+}
+
+/// Cache path under an arbitrary base dir — injectable for tests.
+fn cache_path_in(base: PathBuf) -> Option<PathBuf> {
+    Some(
+        base.join(".qontinui")
+            .join("fleet-auto-response-rules.json"),
+    )
+}
+
+/// Rules endpoint on the qontinui-web backend.
+fn rules_endpoint_url() -> String {
+    format!(
+        "{}/api/v1/runner/auto-response-rules",
+        crate::api_config::get_api_base_url()
+    )
+}
+
+/// Read the on-disk cache from `path`, if present and parseable.
+fn read_cache_at(path: &PathBuf) -> Option<CachedFleetRules> {
+    let bytes = std::fs::read(path).ok()?;
+    match serde_json::from_slice::<CachedFleetRules>(&bytes) {
+        Ok(c) => Some(c),
+        Err(e) => {
+            debug!(error = %e, "auto_response_fleet: cache parse failed — ignoring");
+            None
+        }
+    }
+}
+
+/// Write `cached` to `path` atomically (tmp + rename). All IO errors are
+/// debug-logged and swallowed.
+fn write_cache_at(path: &PathBuf, cached: &CachedFleetRules) {
+    let Ok(pretty) = serde_json::to_vec_pretty(cached) else {
+        debug!("auto_response_fleet: cache serialize failed");
+        return;
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            debug!(error = %e, "auto_response_fleet: cache mkdir failed");
+            return;
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, &pretty) {
+        debug!(error = %e, "auto_response_fleet: cache write failed");
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        debug!(error = %e, "auto_response_fleet: cache rename failed");
+    }
+}
+
+/// Fetch the rule set once and reload the engine on success. Best-effort:
+/// network / non-2xx errors `warn!` and return `Ok(())` (keep current rules);
+/// a 304 returns `Ok(())` unchanged.
+pub async fn fetch_and_reload_once() -> Result<(), String> {
+    let url = rules_endpoint_url();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("reqwest client build: {e}"))?;
+
+    // Device-JWT bearer attached the same way coord_http does.
+    let mut req = qontinui_runner_lib::auth::attach_device_auth(client.get(&url));
+    if let Some(etag) = LAST_ETAG.lock().ok().and_then(|g| g.clone()) {
+        req = req.header("If-None-Match", etag);
+    }
+
+    let resp = match req.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(url = %url, error = %e, "auto_response_fleet: fetch failed — keeping current rules");
+            return Ok(());
+        }
+    };
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_MODIFIED {
+        debug!("auto_response_fleet: rules unchanged (304)");
+        return Ok(());
+    }
+    if !status.is_success() {
+        warn!(%status, url = %url, "auto_response_fleet: non-2xx — keeping current rules");
+        return Ok(());
+    }
+
+    // Capture the ETag header before consuming the body.
+    let etag = resp
+        .headers()
+        .get(reqwest::header::ETAG)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let parsed: FleetRulesResponse = match resp.json().await {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(error = %e, "auto_response_fleet: response parse failed — keeping current rules");
+            return Ok(());
+        }
+    };
+
+    let cached = CachedFleetRules {
+        etag: etag.clone(),
+        fetched_at: chrono::Utc::now().to_rfc3339(),
+        rules: parsed.rules.clone(),
+    };
+    if let Some(path) = cache_path() {
+        write_cache_at(&path, &cached);
+    }
+    if let Ok(mut g) = LAST_ETAG.lock() {
+        *g = etag;
+    }
+    info!(
+        count = parsed.rules.len(),
+        "auto_response_fleet: rules fetched"
+    );
+    crate::terminal::auto_response::reload_rules(parsed.rules);
+    Ok(())
+}
+
+/// Seed the engine from the on-disk cache at boot — arms rules before the first
+/// network fetch. With no cache the engine starts dormant (empty rule set).
+pub fn reload_from_cache_at_boot() {
+    let cached = cache_path().and_then(|p| read_cache_at(&p));
+    match cached {
+        Some(c) => {
+            if let Ok(mut g) = LAST_ETAG.lock() {
+                *g = c.etag.clone();
+            }
+            info!(
+                count = c.rules.len(),
+                "auto_response_fleet: seeding rules from cache at boot"
+            );
+            crate::terminal::auto_response::reload_rules(c.rules);
+        }
+        None => {
+            crate::terminal::auto_response::reload_rules(vec![]);
+        }
+    }
+}
+
+/// Spawn the periodic fetch loop. Interval from
+/// `QONTINUI_AUTO_RESPONSE_FETCH_INTERVAL_SECS` (default 300s, floored at 1s);
+/// `MissedTickBehavior::Skip` mirrors `fleet::spawn_heartbeat`.
+pub fn spawn_fetch_loop() {
+    let secs: u64 = std::env::var("QONTINUI_AUTO_RESPONSE_FETCH_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(300)
+        .max(1);
+
+    info!(
+        interval_secs = secs,
+        "auto_response_fleet: starting periodic rule fetch loop"
+    );
+
+    tauri::async_runtime::spawn(async move {
+        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            if let Err(e) = fetch_and_reload_once().await {
+                warn!(error = %e, "auto_response_fleet: fetch tick errored");
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{AutoResponseRule, BackoffConfig};
+
+    fn sample_rule() -> AutoResponseRule {
+        AutoResponseRule {
+            id: "r1".to_string(),
+            name: "rate-limit-recover".to_string(),
+            pattern: "rate limited".to_string(),
+            prompt: "please continue".to_string(),
+            enabled: true,
+            backoff: BackoffConfig::default(),
+        }
+    }
+
+    #[test]
+    fn cache_roundtrips() {
+        let tmp =
+            std::env::temp_dir().join(format!("qontinui-autoresp-cache-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        let path = cache_path_in(tmp.clone()).unwrap();
+        let cached = CachedFleetRules {
+            etag: Some("W/\"abc\"".to_string()),
+            fetched_at: "2026-06-13T00:00:00Z".to_string(),
+            rules: vec![sample_rule()],
+        };
+        write_cache_at(&path, &cached);
+        let read = read_cache_at(&path).expect("cache should read back");
+        assert_eq!(read, cached);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn empty_cache_boot_is_dormant() {
+        // Reloading an empty rule set must leave the engine with no rules.
+        crate::terminal::auto_response::reload_rules(vec![]);
+        let missing = cache_path_in(
+            std::env::temp_dir().join(format!("qontinui-autoresp-none-{}", std::process::id())),
+        )
+        .unwrap();
+        assert!(read_cache_at(&missing).is_none());
+    }
+}

--- a/src-tauri/src/terminal/mod.rs
+++ b/src-tauri/src/terminal/mod.rs
@@ -5,12 +5,15 @@
 //! with proper environment for running Claude CLI and other dev tools.
 
 pub mod account_migration;
+pub mod auto_response;
+pub mod auto_response_fleet;
 pub mod claude_resume_sniff;
 pub mod commit_report;
 pub mod coord_warn;
 pub mod grid;
 pub mod interceptor;
 pub mod manager;
+pub mod output_scan;
 pub mod session;
 pub mod transcript;
 pub mod transcript_watcher;

--- a/src-tauri/src/terminal/output_scan.rs
+++ b/src-tauri/src/terminal/output_scan.rs
@@ -1,0 +1,131 @@
+//! Shared PTY-output scanning primitives.
+//!
+//! Byte-level ANSI stripping and text normalization used by the terminal
+//! output hooks ([`super::usage_limit`] and [`super::auto_response`]). Both
+//! hooks watch every PTY's output for patterns split arbitrarily across read
+//! chunks, so they need the same stateful escape-sequence stripper and the
+//! same lowercase/whitespace-collapse normalization. Those primitives live
+//! here so neither hook owns the other.
+//!
+//! Hot-path discipline: these run on the PTY reader thread for every chunk —
+//! one pass of a byte-level state machine plus a bounded normalization, no
+//! regex, no locks.
+
+/// Stripped-text rolling window kept per terminal. Must comfortably exceed
+/// the longest pattern so a phrase split across two PTY chunks still matches
+/// after the second chunk arrives.
+pub(crate) const WINDOW_KEEP: usize = 256;
+
+// ── ANSI stripping ──────────────────────────────────────────────────────────
+
+/// Byte-level escape-sequence stripper, stateful so sequences split across
+/// PTY read chunks are still consumed (a split CSI must not leak fragments
+/// into the text window between two words of a matched message).
+#[derive(Default)]
+pub(crate) struct AnsiStripper {
+    state: StripState,
+}
+
+#[derive(Default, Clone, Copy, PartialEq)]
+enum StripState {
+    #[default]
+    Ground,
+    /// Saw ESC, awaiting the introducer byte.
+    Escape,
+    /// Inside `ESC [ … <final>` — consume until a final byte `0x40..=0x7E`.
+    Csi,
+    /// Inside `ESC ] … (BEL | ESC \)` — consume until the terminator.
+    Osc,
+    /// Inside an OSC, saw ESC — next `\` ends the OSC.
+    OscEscape,
+}
+
+impl AnsiStripper {
+    /// Feed raw PTY bytes; append printable text (with control bytes mapped
+    /// to single spaces) onto `out`.
+    pub(crate) fn feed(&mut self, data: &[u8], out: &mut String) {
+        for &b in data {
+            match self.state {
+                StripState::Ground => match b {
+                    0x1b => self.state = StripState::Escape,
+                    b'\r' | b'\n' | b'\t' => out.push(' '),
+                    0x00..=0x1f | 0x7f => {} // other control bytes — drop
+                    _ => out.push(b as char), // lossy-ASCII: multibyte UTF-8
+                                              // bytes land as garbage chars,
+                                              // which never match the ASCII
+                                              // patterns and are trimmed away
+                                              // by the rolling window.
+                },
+                StripState::Escape => match b {
+                    b'[' => self.state = StripState::Csi,
+                    b']' => self.state = StripState::Osc,
+                    // Two-byte sequences (ESC + one char) and anything
+                    // unrecognized: swallow and return to ground.
+                    _ => self.state = StripState::Ground,
+                },
+                StripState::Csi => {
+                    if (0x40..=0x7e).contains(&b) {
+                        self.state = StripState::Ground;
+                    }
+                }
+                StripState::Osc => match b {
+                    0x07 => self.state = StripState::Ground,
+                    0x1b => self.state = StripState::OscEscape,
+                    _ => {}
+                },
+                StripState::OscEscape => {
+                    self.state = if b == b'\\' {
+                        StripState::Ground
+                    } else {
+                        StripState::Osc
+                    };
+                }
+            }
+        }
+    }
+}
+
+// ── Normalization ────────────────────────────────────────────────────────────
+
+/// Lowercase + collapse whitespace runs to single spaces, so TUI padding /
+/// line wraps inside a message don't break the substring (or regex) match.
+pub(crate) fn normalize(window: &str) -> String {
+    let mut out = String::with_capacity(window.len());
+    let mut last_space = false;
+    for c in window.chars() {
+        if c.is_whitespace() {
+            if !last_space {
+                out.push(' ');
+            }
+            last_space = true;
+        } else {
+            for lc in c.to_lowercase() {
+                out.push(lc);
+            }
+            last_space = false;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_lowercases_and_collapses_whitespace() {
+        assert_eq!(normalize("USAGE   LIMIT\n REACHED"), "usage limit reached");
+        assert_eq!(normalize("  Hello\t\tWorld  "), " hello world ");
+    }
+
+    #[test]
+    fn ansi_stripper_consumes_csi_split_across_feeds() {
+        let mut s = AnsiStripper::default();
+        let mut out = String::new();
+        // CSI starts at the end of feed 1 and finishes at the start of feed 2 —
+        // the fragment must not leak into the text window.
+        s.feed(b"usage \x1b[38;5;", &mut out);
+        s.feed(b"196mlimit", &mut out);
+        assert_eq!(out, "usage limit");
+    }
+}

--- a/src-tauri/src/terminal/usage_limit.rs
+++ b/src-tauri/src/terminal/usage_limit.rs
@@ -27,6 +27,7 @@ use std::time::{Duration, Instant};
 use tracing::{debug, info};
 
 use super::interceptor::OutputHook;
+use super::output_scan::{normalize, AnsiStripper, WINDOW_KEEP};
 
 /// Lowercased substrings that indicate the Claude CLI hit a usage limit.
 ///
@@ -48,102 +49,7 @@ const USAGE_LIMIT_PATTERNS: &[&str] = &[
 /// hammer the probe path.
 const HINT_DEBOUNCE: Duration = Duration::from_secs(300);
 
-/// Stripped-text rolling window kept per terminal. Must comfortably exceed
-/// the longest pattern so a phrase split across two PTY chunks still matches
-/// after the second chunk arrives.
-const WINDOW_KEEP: usize = 256;
-
-// ── ANSI stripping ──────────────────────────────────────────────────────────
-
-/// Byte-level escape-sequence stripper, stateful so sequences split across
-/// PTY read chunks are still consumed (a split CSI must not leak fragments
-/// into the text window between two words of a limit message).
-#[derive(Default)]
-struct AnsiStripper {
-    state: StripState,
-}
-
-#[derive(Default, Clone, Copy, PartialEq)]
-enum StripState {
-    #[default]
-    Ground,
-    /// Saw ESC, awaiting the introducer byte.
-    Escape,
-    /// Inside `ESC [ … <final>` — consume until a final byte `0x40..=0x7E`.
-    Csi,
-    /// Inside `ESC ] … (BEL | ESC \)` — consume until the terminator.
-    Osc,
-    /// Inside an OSC, saw ESC — next `\` ends the OSC.
-    OscEscape,
-}
-
-impl AnsiStripper {
-    /// Feed raw PTY bytes; append printable text (with control bytes mapped
-    /// to single spaces) onto `out`.
-    fn feed(&mut self, data: &[u8], out: &mut String) {
-        for &b in data {
-            match self.state {
-                StripState::Ground => match b {
-                    0x1b => self.state = StripState::Escape,
-                    b'\r' | b'\n' | b'\t' => out.push(' '),
-                    0x00..=0x1f | 0x7f => {} // other control bytes — drop
-                    _ => out.push(b as char), // lossy-ASCII: multibyte UTF-8
-                                              // bytes land as garbage chars,
-                                              // which never match the ASCII
-                                              // patterns and are trimmed away
-                                              // by the rolling window.
-                },
-                StripState::Escape => match b {
-                    b'[' => self.state = StripState::Csi,
-                    b']' => self.state = StripState::Osc,
-                    // Two-byte sequences (ESC + one char) and anything
-                    // unrecognized: swallow and return to ground.
-                    _ => self.state = StripState::Ground,
-                },
-                StripState::Csi => {
-                    if (0x40..=0x7e).contains(&b) {
-                        self.state = StripState::Ground;
-                    }
-                }
-                StripState::Osc => match b {
-                    0x07 => self.state = StripState::Ground,
-                    0x1b => self.state = StripState::OscEscape,
-                    _ => {}
-                },
-                StripState::OscEscape => {
-                    self.state = if b == b'\\' {
-                        StripState::Ground
-                    } else {
-                        StripState::Osc
-                    };
-                }
-            }
-        }
-    }
-}
-
 // ── Pattern matching ────────────────────────────────────────────────────────
-
-/// Lowercase + collapse whitespace runs to single spaces, so TUI padding /
-/// line wraps inside a message don't break the substring match.
-fn normalize(window: &str) -> String {
-    let mut out = String::with_capacity(window.len());
-    let mut last_space = false;
-    for c in window.chars() {
-        if c.is_whitespace() {
-            if !last_space {
-                out.push(' ');
-            }
-            last_space = true;
-        } else {
-            for lc in c.to_lowercase() {
-                out.push(lc);
-            }
-            last_space = false;
-        }
-    }
-    out
-}
 
 /// First matching usage-limit pattern in the (raw, un-normalized) window,
 /// if any.


### PR DESCRIPTION
## What

Auto-recovers a terminal Claude session stranded by the transient **"API Error: Server is temporarily limiting requests (not your usage limit) · Rate limited"** overload. Unlike a usage limit (handled by account migration), this 429/529 is recoverable on the **same** account — so the runner waits out a backoff and resubmits a prompt into the same live session.

Generalized into **fleet-wide, user-editable `{regex → prompt}` rules** fetched from qontinui-web (see qontinui-web PR #580). The seeded default rule matches the rate-limit phrase and submits "Please continue." with **unbounded exponential backoff**.

## How
- `terminal/output_scan.rs` — shared ANSI-strip + `normalize` + window const, **extracted from `usage_limit.rs`** (which now reuses it; its 11 tests unchanged).
- `terminal/auto_response.rs` — compiled-rule cache (`RwLock<Vec<CompiledRule>>` + `reload_rules`, invalid regex skipped), an `OutputHook` that regex-scans each PTY's normalized rolling window, and a per-`(terminal,rule)` backoff scheduler: `initial * multiplier^attempts` (saturating; optional cap), **no max-retry**, no-stack `pending` guard, 15-min reset window. Submits via `TerminalSession::submit_prompt`.
- `terminal/auto_response_fleet.rs` — device-JWT fetch loop (`GET /api/v1/runner/auto-response-rules`, `ETag`/`If-None-Match` → 304), JSON cache at `~/.qontinui/fleet-auto-response-rules.json` (offline fallback). Default poll 300s (`QONTINUI_AUTO_RESPONSE_FETCH_INTERVAL_SECS`).
- `settings.rs` — `AutoResponseRule` / `BackoffConfig` wire+cache types (no local seed; server seeds the default).
- `main.rs` — installs the hook beside the usage-limit hook; boot cache reload + spawn fetch loop in the fleet-publishers block.

Empty rule set ⇒ feature dormant (cheap `rules_active()` early-out on the hot path).

## Verification
`cargo test output_scan auto_response usage_limit` → **22 passed** (delay math unbounded/capped/saturating, no-stack, reset window, regex-over-ANSI-window, disabled/invalid dropped, cache roundtrip, dormant boot; all usage_limit tests intact). `cargo check` + `cargo clippy` clean; `cargo fmt` applied.

Pairs with qontinui-web #580 (storage + editor UI + the runner endpoint).