### PR TITLE
Terminal rendering robustness: retire idle paintGrid reconciliation, render-completion flow control, sync-output frame coalescing

### DIFF
--- a/src-tauri/src/terminal/grid.rs
+++ b/src-tauri/src/terminal/grid.rs
@@ -85,7 +85,11 @@ pub struct Grid {
     cur_fg: u32,
     cur_bg: u32,
     cur_attrs: u16,
-    /// DEC private mode flags we observe but do not gate on.
+    /// DEC private mode flags we observe but the grid itself does not gate
+    /// cell mutation on. `sync_output` (DEC 2026) is read by the session
+    /// reader thread via [`Grid::sync_output`] to coalesce a multi-read frame
+    /// into one emit; `alt_screen` (DEC 1049) is surfaced in the snapshot for
+    /// the bootstrap-paint guard.
     sync_output: bool,
     alt_screen: bool,
     dirty: bool,
@@ -129,6 +133,17 @@ impl Grid {
     }
     pub fn title(&self) -> Option<&str> {
         self.title.as_deref()
+    }
+
+    /// Whether the VT stream is currently inside a DEC mode 2026
+    /// (synchronized output) block — i.e. a `?2026h` was seen with no
+    /// matching `?2026l` yet. Full-screen TUIs (Claude Code) bracket a
+    /// whole-frame redraw in `?2026h … ?2026l` so the terminal can swap the
+    /// frame atomically. The reader thread reads this at the emit boundary to
+    /// coalesce a multi-read frame into a single `terminal-output` event,
+    /// killing mid-frame overdraw. Observe-only in the grid itself.
+    pub fn sync_output(&self) -> bool {
+        self.sync_output
     }
 
     pub fn resize(&mut self, cols: u16, rows: u16) {
@@ -201,6 +216,7 @@ impl Grid {
             rows: self.rows,
             cursor: self.cursor,
             title: self.title.clone(),
+            alt_screen: self.alt_screen,
             cells: self.cells.clone(),
         }
     }
@@ -398,6 +414,12 @@ pub struct GridSnapshot {
     pub cursor: Cursor,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// True when the grid is currently on the alternate screen (DEC `?1049h`).
+    /// The grid is single-buffer (no save/swap), so a snapshot taken while
+    /// this is true holds alt-screen content; the frontend bootstrap paint
+    /// hard-skips in that case rather than overlay alt content onto a fresh
+    /// xterm. See `paintGrid.ts` / `TerminalInstance.tsx`.
+    pub alt_screen: bool,
     pub cells: Vec<Cell>,
 }
 
@@ -944,6 +966,21 @@ mod tests {
         assert_eq!(cells[3].ch, 'D');
         assert_eq!(cells[4].ch, 'E');
         assert_eq!(cells[5].ch, 'F');
+    }
+
+    #[test]
+    fn sync_output_getter_tracks_dec_2026_open_and_close() {
+        let mut grid = Grid::new(80, 24);
+        assert!(!grid.sync_output(), "starts closed");
+        // Open the synchronized-output block.
+        feed(&mut grid, b"\x1b[?2026h");
+        assert!(grid.sync_output(), "open after ?2026h");
+        // Bytes inside the block keep it open (mid-frame).
+        feed(&mut grid, b"PARTIAL");
+        assert!(grid.sync_output(), "still open mid-frame");
+        // Close it.
+        feed(&mut grid, b"\x1b[?2026l");
+        assert!(!grid.sync_output(), "closed after ?2026l");
     }
 
     #[test]

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -78,6 +78,113 @@ fn tee_into_scrollback(
     }
 }
 
+/// Flow-control watermarks (bytes), mirroring VS Code's `FlowControlConstants`
+/// (High=100000, Low=5000 chars). The reader pauses once the unacked gap
+/// (`bytes_sent − bytes_acked`) exceeds [`FLOW_HIGH_WATERMARK`] and resumes
+/// only once it drops back below [`FLOW_LOW_WATERMARK`] — hysteresis so we
+/// don't thrash pause/resume one byte at a time. The frontend acks
+/// render-completed bytes in ~5000-byte units (see `flowControl.ts`), so the
+/// Low watermark matches one ack quantum.
+const FLOW_HIGH_WATERMARK: u64 = 100_000;
+const FLOW_LOW_WATERMARK: u64 = 5_000;
+
+/// Byte cap for a held DEC-2026 (synchronized-output) frame: flush the
+/// accumulated frame once it reaches this size even if `?2026l` hasn't
+/// arrived, so a runaway/never-closed `?2026h` block can't buffer unbounded.
+const SYNC_FLUSH_BYTE_CAP: usize = 256 * 1024;
+/// Time cap for a held sync frame: flush once the block has been open this
+/// long, so a slow producer mid-frame can't stall output past ~one frame.
+const SYNC_FLUSH_TIME_CAP: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// Synchronized-output (DEC 2026) frame coalescer for the reader thread.
+///
+/// Full-screen TUIs (Claude Code) bracket each whole-frame redraw in
+/// `?2026h … ?2026l`. Emitting per-PTY-read would split a frame across
+/// several `terminal-output` events, so xterm paints partial frames —
+/// mid-frame overdraw (symptom a). This accumulates the processed bytes of a
+/// frame that spans multiple reads and emits the whole frame as ONE event so
+/// xterm receives it in a single write (its RenderDebouncer then paints one
+/// reflow). The common case — a whole frame in one read — never holds: the
+/// parser's `sync_output` is already false post-advance, so [`Self::feed`]
+/// emits immediately.
+///
+/// `feed` is called once per read with the post-interceptor `data`, that
+/// data's stamped stream offset, and the live `sync_output` parser state
+/// observed AFTER the data was advanced into the grid. The `emit` callback
+/// receives `(payload, offset)` to broadcast as one event; `offset` is the
+/// absolute stream offset of the payload's first byte (a correct replay
+/// boundary — the first held byte's offset for a coalesced frame).
+struct SyncFrameCoalescer {
+    pending: Vec<u8>,
+    pending_offset: u64,
+    started_at: Option<std::time::Instant>,
+}
+
+impl SyncFrameCoalescer {
+    fn new() -> Self {
+        Self {
+            pending: Vec::new(),
+            pending_offset: 0,
+            started_at: None,
+        }
+    }
+
+    /// Feed one read's processed `data` (stamped at `offset`) plus the live
+    /// `in_sync` parser state observed right after advancing it into the grid.
+    /// Emits zero or one coalesced event via `emit`.
+    fn feed<F: FnMut(&[u8], u64)>(&mut self, data: &[u8], offset: u64, in_sync: bool, mut emit: F) {
+        if in_sync {
+            // Mid-frame: hold this chunk. Stamp the held frame's offset on the
+            // FIRST held byte (a correct replay boundary).
+            if self.pending.is_empty() {
+                self.pending_offset = offset;
+                self.started_at = Some(std::time::Instant::now());
+            }
+            self.pending.extend_from_slice(data);
+            // Byte-cap a runaway/never-closed block.
+            if self.pending.len() >= SYNC_FLUSH_BYTE_CAP {
+                emit(&self.pending, self.pending_offset);
+                self.pending.clear();
+                self.started_at = None;
+            }
+        } else if self.pending.is_empty() {
+            // Common case: no open frame, nothing held — emit immediately.
+            emit(data, offset);
+        } else {
+            // The block just closed in this read (it carried `?2026l`): emit
+            // the held prefix + this chunk as the single frame, stamped at the
+            // held frame's start offset.
+            self.pending.extend_from_slice(data);
+            emit(&self.pending, self.pending_offset);
+            self.pending.clear();
+            self.started_at = None;
+        }
+    }
+
+    /// Flush a held frame if it has been open at least [`SYNC_FLUSH_TIME_CAP`].
+    /// Called before each (blocking) read so a slow producer mid-frame still
+    /// flushes within ~one frame rather than waiting for the next byte.
+    fn flush_if_timed_out<F: FnMut(&[u8], u64)>(&mut self, mut emit: F) {
+        if let Some(started) = self.started_at {
+            if started.elapsed() >= SYNC_FLUSH_TIME_CAP && !self.pending.is_empty() {
+                emit(&self.pending, self.pending_offset);
+                self.pending.clear();
+                self.started_at = None;
+            }
+        }
+    }
+
+    /// Flush any remaining held frame (reader exit on EOF / read error) so the
+    /// last frame of a never-closed block isn't lost.
+    fn flush_remaining<F: FnMut(&[u8], u64)>(&mut self, mut emit: F) {
+        if !self.pending.is_empty() {
+            emit(&self.pending, self.pending_offset);
+            self.pending.clear();
+            self.started_at = None;
+        }
+    }
+}
+
 /// Tauri `terminal-output` wire shape: the shared `TerminalOutputEvent`
 /// (qontinui-types) is `deny_unknown_fields`, so the extra `offset` rides on
 /// this runner-local struct instead of forcing a schemas version bump. Only
@@ -447,19 +554,92 @@ impl TerminalSession {
             .spawn(move || {
                 let mut parser = vte::Parser::new();
                 let mut buf = [0u8; 8192];
+                // Phase 4 — sync-output (DEC 2026) frame coalescing. While the
+                // VT parser is inside a `?2026h … ?2026l` block (Claude's TUI
+                // brackets each full-frame redraw this way), accumulate the
+                // processed bytes here instead of emitting per-read. Once the
+                // block closes — or a safety cap trips so a never-closed block
+                // can't stall output — emit the whole frame as ONE
+                // `terminal-output` event so xterm receives the frame in a
+                // single write and its RenderDebouncer paints one reflow.
+                //
+                // The common case (a whole frame in one read) is unaffected:
+                // `sync_output` is already false post-advance, so we emit
+                // immediately with no holding. Only frames that span multiple
+                // reads are held.
+                let mut coalescer = SyncFrameCoalescer::new();
+                // Flow-control hysteresis state: once the unacked gap crosses
+                // the High watermark we stay paused until it falls back under
+                // Low (see FLOW_HIGH_WATERMARK / FLOW_LOW_WATERMARK).
+                let mut paused = false;
+
+                // Emit one `terminal-output` event for `payload` stamped at
+                // absolute `offset`, mirror it to SSE + the backend relay, and
+                // advance the flow-control "sent" counter by the emitted length
+                // (so backpressure tracks bytes actually delivered to the
+                // frontend, not bytes still held in the coalescer).
+                let emit_chunk = |payload: &[u8], offset: u64| {
+                    let encoded = STANDARD.encode(payload);
+                    // Broadcast to HTTP/SSE subscribers (ignore if no receivers)
+                    let _ = reader_output_tx.send(encoded.clone());
+                    let event = TerminalOutputWire {
+                        terminal_id: &reader_id,
+                        data: &encoded,
+                        offset,
+                    };
+                    if let Err(e) = reader_app.emit("terminal-output", &event) {
+                        warn!(
+                            terminal_id = %reader_id,
+                            error = %e,
+                            "Failed to emit terminal output event"
+                        );
+                    }
+                    // Broadcast to backend relay for remote mobile access
+                    crate::event_system::broadcast_ws_notification(
+                        &reader_app,
+                        "terminal-output",
+                        &serde_json::json!({
+                            "terminal_id": &reader_id,
+                            "data": &event.data,
+                        }),
+                    );
+                    reader_bytes_sent.fetch_add(payload.len() as u64, Ordering::Relaxed);
+                };
+
                 loop {
                     if !reader_alive.load(Ordering::Relaxed) {
                         break;
                     }
 
-                    // Flow control: pause if frontend is too far behind
+                    // Flow control (Phase 3): char-count watermarks with
+                    // hysteresis, mirroring VS Code. The gap is measured
+                    // against EMITTED bytes (a held frame in the coalescer
+                    // hasn't been sent yet), so a held frame doesn't trip
+                    // backpressure on its own. Pause once the unacked gap
+                    // exceeds High; resume only once it drops below Low — so a
+                    // burst that overruns xterm's input buffer is throttled at
+                    // the producer until the renderer's acks catch up.
                     let sent = reader_bytes_sent.load(Ordering::Relaxed);
                     let acked = reader_bytes_acked.load(Ordering::Relaxed);
-                    if sent > acked + 1_048_576 {
-                        // 1MB backpressure threshold
+                    let gap = sent.saturating_sub(acked);
+                    if paused {
+                        if gap > FLOW_LOW_WATERMARK {
+                            thread::sleep(std::time::Duration::from_millis(10));
+                            continue;
+                        }
+                        paused = false;
+                    } else if gap > FLOW_HIGH_WATERMARK {
+                        paused = true;
                         thread::sleep(std::time::Duration::from_millis(10));
                         continue;
                     }
+
+                    // Time-cap a held sync block: if the block has been open ≥
+                    // SYNC_FLUSH_TIME_CAP, flush it now rather than waiting for
+                    // the next read to return. (The read below blocks, so a
+                    // slow PTY mid-frame could otherwise hold a frame past one
+                    // frame interval until the next byte arrives.)
+                    coalescer.flush_if_timed_out(&emit_chunk);
 
                     match reader.read(&mut buf) {
                         Ok(0) => {
@@ -516,31 +696,22 @@ impl TerminalSession {
                                 }
                             }
 
-                            let encoded = STANDARD.encode(&data);
-                            // Broadcast to HTTP/SSE subscribers (ignore if no receivers)
-                            let _ = reader_output_tx.send(encoded.clone());
-                            let event = TerminalOutputWire {
-                                terminal_id: &reader_id,
-                                data: &encoded,
-                                offset: chunk_offset,
-                            };
-                            if let Err(e) = reader_app.emit("terminal-output", &event) {
-                                warn!(
-                                    terminal_id = %reader_id,
-                                    error = %e,
-                                    "Failed to emit terminal output event"
-                                );
-                            }
-                            // Broadcast to backend relay for remote mobile access
-                            crate::event_system::broadcast_ws_notification(
-                                &reader_app,
-                                "terminal-output",
-                                &serde_json::json!({
-                                    "terminal_id": &reader_id,
-                                    "data": &event.data,
-                                }),
-                            );
-                            reader_bytes_sent.fetch_add(n as u64, Ordering::Relaxed);
+                            // Sync-output-aware emit (Phase 4). Read the live
+                            // DEC-2026 state straight after the advance above:
+                            // if a `?2026h` is still open we're mid-frame, so
+                            // accumulate and defer the emit; otherwise flush
+                            // (any held prefix + this chunk) as one event.
+                            let in_sync = reader_grid
+                                .lock()
+                                .ok()
+                                .map(|g| g.sync_output())
+                                .unwrap_or(false);
+
+                            // Coalesce sync-output frames (Phase 4). The
+                            // scrollback ring + total counter were already fed
+                            // per-read above, so total-byte accounting stays
+                            // correct whether or not the coalescer holds.
+                            coalescer.feed(&data, chunk_offset, in_sync, &emit_chunk);
                         }
                         Err(e) => {
                             // On Windows, the PTY reader returns an error when the child exits
@@ -549,6 +720,10 @@ impl TerminalSession {
                         }
                     }
                 }
+                // Flush any frame still held in a never-closed sync block so
+                // the last frame isn't lost when the reader exits (EOF / read
+                // error on child exit).
+                coalescer.flush_remaining(&emit_chunk);
                 debug!(terminal_id = %reader_id, "Reader thread exiting");
             })
             .map_err(|e| format!("Failed to spawn reader thread: {}", e))?;
@@ -1362,6 +1537,90 @@ mod tests {
             app_handle: None,
             input_line_buf: Arc::new(Mutex::new(String::new())),
         }
+    }
+
+    /// Drive a `SyncFrameCoalescer` across a sequence of `(data, offset,
+    /// in_sync)` reads and return the emitted `(payload, offset)` events.
+    fn run_coalescer(reads: &[(&[u8], u64, bool)]) -> Vec<(Vec<u8>, u64)> {
+        let mut c = SyncFrameCoalescer::new();
+        let emitted = Arc::new(Mutex::new(Vec::<(Vec<u8>, u64)>::new()));
+        for (data, offset, in_sync) in reads {
+            let sink = emitted.clone();
+            c.feed(data, *offset, *in_sync, move |p, o| {
+                sink.lock().unwrap().push((p.to_vec(), o));
+            });
+        }
+        let sink = emitted.clone();
+        c.flush_remaining(move |p, o| sink.lock().unwrap().push((p.to_vec(), o)));
+        Arc::try_unwrap(emitted).unwrap().into_inner().unwrap()
+    }
+
+    #[test]
+    fn whole_frame_in_one_read_emits_immediately() {
+        // sync_output already false post-advance → no holding, one event.
+        let events = run_coalescer(&[(b"\x1b[?2026hFRAME\x1b[?2026l", 0, false)]);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, b"\x1b[?2026hFRAME\x1b[?2026l");
+        assert_eq!(events[0].1, 0);
+    }
+
+    #[test]
+    fn multi_read_sync_frame_coalesces_into_one_emit() {
+        // A frame split across three reads: open (in_sync), middle (in_sync),
+        // close (in_sync flips false in the read that carried `?2026l`).
+        // Offsets are the absolute stream positions of each read.
+        let events = run_coalescer(&[
+            (b"\x1b[?2026hPART1", 10, true),
+            (b"PART2", 23, true),
+            (b"PART3\x1b[?2026l", 28, false),
+        ]);
+        assert_eq!(events.len(), 1, "the frame must coalesce into ONE event");
+        assert_eq!(events[0].0, b"\x1b[?2026hPART1PART2PART3\x1b[?2026l");
+        // Offset must be the FIRST held byte's offset (the replay boundary).
+        assert_eq!(events[0].1, 10);
+    }
+
+    #[test]
+    fn non_sync_chunks_each_emit_separately() {
+        let events = run_coalescer(&[(b"alpha", 0, false), (b"beta", 5, false)]);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], (b"alpha".to_vec(), 0));
+        assert_eq!(events[1], (b"beta".to_vec(), 5));
+    }
+
+    #[test]
+    fn byte_cap_flushes_a_never_closed_sync_block() {
+        let mut c = SyncFrameCoalescer::new();
+        let emitted = Arc::new(Mutex::new(Vec::<(Vec<u8>, u64)>::new()));
+        // First read opens the block and is under the cap.
+        let big = vec![b'x'; SYNC_FLUSH_BYTE_CAP];
+        {
+            let sink = emitted.clone();
+            c.feed(b"\x1b[?2026h", 0, true, move |p, o| {
+                sink.lock().unwrap().push((p.to_vec(), o));
+            });
+        }
+        // Second read pushes the held buffer past the byte cap → forced flush
+        // even though `?2026l` never arrived.
+        {
+            let sink = emitted.clone();
+            c.feed(&big, 8, true, move |p, o| {
+                sink.lock().unwrap().push((p.to_vec(), o));
+            });
+        }
+        let events = emitted.lock().unwrap();
+        assert_eq!(events.len(), 1, "byte cap must force a flush");
+        assert_eq!(events[0].1, 0, "flush keeps the first held byte's offset");
+        assert!(events[0].0.len() >= SYNC_FLUSH_BYTE_CAP);
+    }
+
+    #[test]
+    fn flush_remaining_emits_a_held_unclosed_frame_on_exit() {
+        // Reader exits (EOF) mid-frame — the held prefix must still be emitted.
+        let events = run_coalescer(&[(b"\x1b[?2026hHALF", 100, true)]);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].0, b"\x1b[?2026hHALF");
+        assert_eq!(events[0].1, 100);
     }
 
     #[test]

--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -8,11 +8,13 @@ import { createTerminalBackend } from "./backends";
 import type { BackendType, ITerminalBackend, TerminalSearchResults } from "./backends";
 import { TerminalFindBar } from "./TerminalFindBar";
 import { paintGrid, type GridSnapshot } from "./paintGrid";
+import { getTerminalDebug, recordPaintGrid } from "./terminalDebug";
 import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
 import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
 import { matchScrollShortcut } from "./scrollKeys";
 import { trimReplayedChunk, type OffsetChunk } from "./scrollbackReplay";
+import { RenderAckAccumulator, ACK_FLOOR_INTERVAL_MS } from "./flowControl";
 import { useWindowAssignments } from "./contexts/WindowAssignmentsContext";
 
 /**
@@ -73,9 +75,10 @@ interface TerminalInstanceProps {
   onOutput?: (text: string) => void;
   /**
    * Called with the latest OSC 0 / OSC 2 title observed by the Rust grid.
-   * Fires after each `paintGrid` whenever the snapshot's `title` field
-   * differs from the previous value. Layer 4 polish wiring per
-   * `plans/terminal-grid-bootstrap-redesign.md`.
+   * Fires from the bootstrap paint and from the ~1s ack-timer title poll
+   * whenever the grid's `title` differs from the previous value. (The poll
+   * replaced the retired periodic idle paint as the title source — Phase 2 of
+   * `plans/2026-06-13-terminal-rendering-robustness.md`.)
    */
   onTitleChange?: (title: string) => void;
 }
@@ -177,10 +180,14 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     const backendType: BackendType =
       backendTypeProp ??
       ((instanceStorage.getItem("terminal-backend") as BackendType | null) || "xterm");
+    // Resolve GPU acceleration policy (xterm only): instanceStorage > "auto".
+    // "dom" forces the pure-DOM renderer (never ghosts) — user escape hatch
+    // and the force-DOM diagnostic lever for the ghosting investigation.
+    const gpuAcceleration: "auto" | "dom" =
+      instanceStorage.getItem("terminal-gpu-acceleration") === "dom" ? "dom" : "auto";
     const containerRef = useRef<HTMLDivElement>(null);
     const backendRef = useRef<ITerminalBackend | null>(null);
     const bytesReceivedRef = useRef(0);
-    const lastAckedRef = useRef(0);
     // Stable refs for callbacks to avoid effect re-runs
     const onExitRef = useRef(onExit);
     onExitRef.current = onExit;
@@ -209,7 +216,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
     isOwnedRef.current = isOwned(terminalId);
     /**
      * Most-recently reported title — guards `onTitleChange` against firing on
-     * every paintGrid (200ms idle cadence) when the title is unchanged.
+     * every title poll (~1s ack-timer cadence) when the title is unchanged.
      */
     const lastTitleRef = useRef<string | null>(null);
     const outputDecoderRef = useRef(new TextDecoder());
@@ -359,11 +366,9 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       let observer: ResizeObserver | null = null;
       let blockNativePaste: ((e: Event) => void) | null = null;
       let wheelScrollOverride: ((e: WheelEvent) => void) | null = null;
-      // Layer 2 bootstrap: idle-debounced grid re-paint. The live listener
-      // resets this timer on every received byte; when the stream goes
-      // quiet for IDLE_REPAINT_MS we re-fetch the Rust grid and overlay
-      // it via paintGrid so xterm and the grid stay in sync.
-      let idleTimer: ReturnType<typeof setTimeout> | null = null;
+      // Ensure the dev instrumentation hook (window.__qontinuiTerminal) exists
+      // so it's discoverable from the console even before any paint fires.
+      getTerminalDebug();
       // Bytes received before the backend finishes async init. Tauri does
       // NOT queue events before listen() resolves, and createTerminalBackend
       // (WASM load + open + key handlers + UI Bridge registration) takes
@@ -379,16 +384,114 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       // boundary are already in the buffer via the ring and must not be
       // written again.
       let replayedThrough = 0;
-      // Assigned once the backend exists (see Bug A note above). Until then
-      // the listener buffers bytes; we can't schedule a repaint that needs
-      // the backend.
-      let scheduleIdleRepaint: (() => void) | null = null;
+      // Phase 3 — render-based flow control. Tracks bytes the backend has
+      // actually RENDERED (its `write` completion callback fired), not bytes
+      // merely received off the wire, and decides when to ack the Rust reader
+      // (every ~AckSize rendered bytes; the floor timer below drains a trailing
+      // remainder). This replaces the old 250ms byte-count ack so a burst can't
+      // outrun xterm's ~50MB input buffer (which silently drops overflow)
+      // before backpressure engages.
+      const renderAck = new RenderAckAccumulator();
+      const sendAck = (bytes: number) => {
+        if (bytes <= 0) return;
+        invoke("terminal_ack", { terminalId, bytesAcked: bytes }).catch(() => {});
+      };
+      // Phase 4 — write coalescing. Per `terminal-output` event we trim the
+      // chunk against the ring-replay boundary and stage the unreplayed suffix
+      // here; a microtask flush concatenates everything staged into a SINGLE
+      // `backend.write()`. xterm's own RenderDebouncer then batches one reflow
+      // per frame — we add no rAF loop around xterm. The render-ack callback
+      // fires once for the whole coalesced write and accounts its full length.
+      let coalesceQueue: Uint8Array[] = [];
+      let coalesceLen = 0;
+      let flushScheduled = false;
+      const flushCoalesced = () => {
+        flushScheduled = false;
+        if (coalesceLen === 0) return;
+        const b = backendRef.current;
+        if (!b) {
+          coalesceQueue = [];
+          coalesceLen = 0;
+          return;
+        }
+        let merged: Uint8Array;
+        if (coalesceQueue.length === 1) {
+          merged = coalesceQueue[0];
+        } else {
+          merged = new Uint8Array(coalesceLen);
+          let at = 0;
+          for (const c of coalesceQueue) {
+            merged.set(c, at);
+            at += c.length;
+          }
+        }
+        const writtenLen = merged.length;
+        coalesceQueue = [];
+        coalesceLen = 0;
+        renderAck.onWriteIssued(writtenLen);
+        try {
+          b.write(merged, () => {
+            sendAck(renderAck.onRendered(writtenLen));
+          });
+        } catch (e) {
+          console.error(`[Terminal ${terminalId}] write error:`, e);
+          // The render callback won't fire for a failed write — settle the
+          // in-flight bytes so the accumulator and reader backpressure don't
+          // wedge on a permanently-unrendered chunk.
+          sendAck(renderAck.onRendered(writtenLen));
+        }
+      };
+      const scheduleFlush = () => {
+        if (flushScheduled) return;
+        flushScheduled = true;
+        queueMicrotask(flushCoalesced);
+      };
+      /**
+       * Apply a one-shot bootstrap paint of the Rust `GridSnapshot` into the
+       * backend, with the Phase-2 alt-screen guard.
+       *
+       * The periodic idle reconciliation paint was RETIRED in Phase 2: the
+       * Rust grid is single-buffer and can't model the alt screen that
+       * Claude's TUI lives on, so a periodic full-screen overlay could never
+       * be made safe. The live `terminal-output` stream is authoritative for
+       * forward motion; offset-dedup + remount ring-replay are the recovery
+       * path for missed chunks. paintGrid now runs ONLY for the two one-shot
+       * bootstraps (mount-gap + reconnect), and even those hard-skip when the
+       * snapshot reports the alt screen is active — overlaying a single-buffer
+       * snapshot that holds alt content onto a freshly-mounted xterm can
+       * mis-place rows. In that case we let the live stream + ring-replay
+       * populate instead.
+       *
+       * Title reporting is decoupled from the paint (see the ack timer) so
+       * titles still flow up even when the paint is skipped.
+       */
+      const bootstrapPaint = (
+        snapshot: GridSnapshot,
+        reason: "mount-bootstrap" | "reconnect-bootstrap",
+      ) => {
+        const b = backendRef.current;
+        if (!b) return;
+        const altScreen = snapshot.alt_screen === true;
+        const applied = !altScreen;
+        if (applied) {
+          paintGrid(b, snapshot);
+        }
+        reportTitleFromSnapshot(snapshot.title);
+        recordPaintGrid({
+          terminalId,
+          reason,
+          altScreen,
+          applied,
+          bytesWritten: bytesReceivedRef.current,
+          ts: Date.now(),
+        });
+      };
 
       /**
        * Emit `onTitleChange` if the snapshot's OSC 0/2 title is non-empty AND
-       * differs from the last reported value. Called after every paintGrid
-       * (initial bootstrap + every idle repaint) so the latest title from the
-       * Rust grid flows up to the tab title without spamming the callback.
+       * differs from the last reported value. Called from the bootstrap paint
+       * and from the ack-timer title poll so the latest title from the Rust
+       * grid flows up to the tab title without spamming the callback.
        */
       const reportTitleFromSnapshot = (title: string | undefined | null) => {
         if (!title) return;
@@ -417,8 +520,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
             return;
           }
 
-          const b = backendRef.current;
-          if (!b) return;
+          if (!backendRef.current) return;
           // A chunk emitted before the ring snapshot can still be DELIVERED
           // after the replay (event delivery and invoke responses are not
           // mutually ordered) — trim it to its unreplayed suffix so the
@@ -430,11 +532,13 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
             replayedThrough,
           );
           if (unreplayed) {
-            try {
-              b.write(unreplayed);
-            } catch (e) {
-              console.error(`[Terminal ${terminalId}] write error:`, e);
-            }
+            // Phase 4: stage the unreplayed suffix and flush once per microtask
+            // into a single coalesced backend.write() (offset-dedup already
+            // applied above, before coalescing). The render-ack accounts the
+            // coalesced length when its completion callback fires.
+            coalesceQueue.push(unreplayed);
+            coalesceLen += unreplayed.length;
+            scheduleFlush();
           }
           if (onOutputRef.current) {
             try {
@@ -445,7 +549,6 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
             }
           }
           bytesReceivedRef.current += bytes.length;
-          scheduleIdleRepaint?.();
         });
 
       // Cold-mount path: attach the live `terminal-output` listener IMMEDIATELY
@@ -471,7 +574,10 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
 
       // Async init because backend creation may require WASM loading
       (async () => {
-        const backend = await createTerminalBackend(backendType, TERMINAL_OPTIONS);
+        const backend = await createTerminalBackend(backendType, {
+          ...TERMINAL_OPTIONS,
+          gpuAcceleration,
+        });
         if (disposed) {
           backend.dispose();
           return;
@@ -784,15 +890,14 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         //      top of this effect, BEFORE createTerminalBackend. Bytes that
         //      arrived during async init were buffered into pendingBytes —
         //      drain them here now that the backend exists.
-        //   2. Every received byte resets a 200ms idle timer (defined
-        //      below). On idle we re-fetch the grid and paint — Claude's
-        //      TUI repaints always end with [?2026l + silence, so paint-
-        //      on-idle reconciles divergence accumulated during the burst.
+        //   2. Forward motion is owned ENTIRELY by the live `terminal-output`
+        //      stream (with offset-dedup + remount ring-replay as the recovery
+        //      path). The periodic idle reconciliation paint was retired in
+        //      Phase 2 — see `bootstrapPaint` above for why.
         //   3. After waiting for the container to have non-zero dims, fit
-        //      + terminal_resize + brief 50ms wait for SIGWINCH, then
-        //      fetch the GridSnapshot and paintGrid. paintGrid uses
-        //      absolute CUP per row inside a DECAWM-off bracket — safe to
-        //      write concurrently with live bytes.
+        //      + terminal_resize + brief 50ms wait for SIGWINCH, then fetch
+        //      the GridSnapshot for the one-shot mount-gap bootstrap paint
+        //      (alt-screen-guarded via bootstrapPaint).
         // Replay the Rust-side scrollback ring BEFORE any live/pending bytes
         // land. TerminalInstance remounts whenever the zone layout reshapes
         // (maximize / single-view toggle, layout switch, hidden↔assigned
@@ -839,31 +944,6 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         }
         pendingBytes = [];
         backendReady = true;
-
-        // Define the idle repaint scheduler now that the backend exists.
-        // The early-attached listener has been writing into pendingBytes
-        // and reading scheduleIdleRepaint via closure — we wire the
-        // implementation here.
-        const IDLE_REPAINT_MS = 200;
-        scheduleIdleRepaint = () => {
-          if (idleTimer) clearTimeout(idleTimer);
-          idleTimer = setTimeout(async () => {
-            if (disposed) return;
-            try {
-              const r = await invoke<{ success: boolean; data: GridSnapshot | null }>(
-                "terminal_get_grid",
-                { terminalId },
-              );
-              const b = backendRef.current;
-              if (r.success && r.data && b && !disposed) {
-                paintGrid(b, r.data);
-                reportTitleFromSnapshot(r.data.title);
-              }
-            } catch {
-              /* idle repaint best-effort; ignore failures */
-            }
-          }, IDLE_REPAINT_MS);
-        };
 
         // Wait for the container to have non-zero dimensions before
         // fitting. On fast initial mount the layout is already done; on
@@ -930,8 +1010,10 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
             { terminalId },
           );
           if (result.success && result.data && !disposed) {
-            paintGrid(backend, result.data);
-            reportTitleFromSnapshot(result.data.title);
+            bootstrapPaint(
+              result.data,
+              isReconnecting ? "reconnect-bootstrap" : "mount-bootstrap",
+            );
           }
         } catch (err) {
           console.warn(`[Terminal ${terminalId}] grid bootstrap failed:`, err);
@@ -957,11 +1039,10 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         }
         if (disposed) return;
 
-        // Prime the idle re-paint heartbeat once after bootstrap, so the
-        // timer ticks even when zero live events arrive (e.g. Claude
-        // already finished its initial render before the listener
-        // attached and no further bytes are coming for a while).
-        scheduleIdleRepaint?.();
+        // (Phase 2) The periodic idle re-paint heartbeat that used to be
+        // primed here was retired — forward motion is owned by the live
+        // `terminal-output` stream. The one-shot bootstrap paint above is the
+        // only paintGrid that runs now.
 
         // Reconnect callback fires only on actual reconnects (not first
         // mount), preserving the prior semantic.
@@ -988,18 +1069,42 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         observer = new ResizeObserver(() => fitTerminal());
         observer.observe(container);
 
-        // Flow control: periodically ack received bytes
+        // Flow control floor + title poll. The primary ack is RENDER-based
+        // (Phase 3): the coalesced write's completion callback acks every
+        // ~AckSize rendered bytes. This timer is the floor — it drains a
+        // trailing sub-AckSize remainder so the last bytes of a burst still
+        // ack and the Rust reader resumes even when no further output arrives
+        // to trip the AckSize threshold.
+        //
+        // It also carries the lightweight title poll (Phase 2): title
+        // reporting used to ride on the retired periodic idle paint, so it now
+        // piggybacks this timer. Every ~1s (every 4th tick) — and only when
+        // there is an `onTitleChange` consumer — we fetch the cheap text
+        // snapshot (`terminal_grid_text` does NOT clone the cell buffer, unlike
+        // `terminal_get_grid`) and report any new OSC 0/2 title.
+        // `reportTitle` already dedups against the last value, so unchanged
+        // titles are free.
+        let titlePollTick = 0;
         ackTimer = setInterval(() => {
-          const received = bytesReceivedRef.current;
-          const delta = received - lastAckedRef.current;
-          if (delta > 0) {
-            lastAckedRef.current = received;
-            invoke("terminal_ack", {
-              terminalId,
-              bytesAcked: delta,
-            }).catch(() => {});
+          // Drain any rendered-but-sub-AckSize remainder.
+          sendAck(renderAck.flush());
+
+          titlePollTick = (titlePollTick + 1) % 4;
+          if (titlePollTick === 0 && onTitleChangeRef.current) {
+            invoke<{ success: boolean; data: { title?: string | null } | null }>(
+              "terminal_grid_text",
+              { terminalId },
+            )
+              .then((r) => {
+                if (!disposed && r.success && r.data) {
+                  reportTitleFromSnapshot(r.data.title);
+                }
+              })
+              .catch(() => {
+                /* title poll best-effort; ignore failures */
+              });
           }
-        }, 250);
+        }, ACK_FLOOR_INTERVAL_MS);
 
         // OSC 633 shell integration handler
         disposables.push(
@@ -1024,8 +1129,11 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       // Cleanup
       return () => {
         disposed = true;
+        // Flush any microtask-staged coalesced write synchronously so trailing
+        // bytes reach the (about-to-be-disposed) backend rather than being
+        // dropped. Harmless if nothing is staged.
+        if (flushScheduled) flushCoalesced();
         if (ackTimer) clearInterval(ackTimer);
-        if (idleTimer) clearTimeout(idleTimer);
         if (fitTimerRef.current) clearTimeout(fitTimerRef.current);
         observer?.disconnect();
         if (wheelScrollOverride) {

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -5,6 +5,7 @@ import type {
   IDisposable,
   ITerminalBackend,
   ITerminalLinkProvider,
+  ITerminalTheme,
   TerminalBackendOptions,
 } from "./types";
 
@@ -70,11 +71,16 @@ export class GhosttyBackend implements ITerminalBackend {
     this.term.focus();
   }
 
-  write(data: Uint8Array | string): void {
+  write(data: Uint8Array | string, onRendered?: () => void): void {
     // Scan for OSC 633 sequences BEFORE writing to the terminal.
     // The interceptor is read-only — it never modifies the data.
     this.oscInterceptor.scan(data);
     this.term.write(data);
+    // ghostty-web's write has no async completion signal, so the chunk is
+    // considered rendered as soon as the synchronous write returns. Fire the
+    // render-completion callback immediately to keep the render-based ack
+    // (see TerminalInstance) accounting consistent across backends.
+    onRendered?.();
   }
 
   onData(cb: (data: string) => void): IDisposable {
@@ -112,6 +118,21 @@ export class GhosttyBackend implements ITerminalBackend {
     // GhosttyBackend wraps an xterm Terminal too, so the same in-place trim
     // applies (see XtermBackend.setScrollback).
     this.term.options.scrollback = lines;
+  }
+
+  setFontSize(px: number): void {
+    // ghostty-web is Canvas-only with no glyph texture atlas (so no
+    // clearTextureAtlas equivalent is needed). Set the option best-effort;
+    // guard so a build lacking it degrades to a no-op rather than throwing.
+    const o = this.term.options as { fontSize?: number };
+    o.fontSize = px;
+  }
+
+  setTheme(theme: ITerminalTheme): void {
+    // Canvas-only renderer — no atlas to invalidate. Set the option
+    // best-effort (see setFontSize).
+    const o = this.term.options as { theme?: ITerminalTheme };
+    o.theme = theme;
   }
 
   fit(): void {

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -10,6 +10,7 @@ import type {
   IDisposable,
   ITerminalBackend,
   ITerminalLinkProvider,
+  ITerminalTheme,
   TerminalBackendOptions,
   TerminalSearchOptions,
   TerminalSearchResults,
@@ -35,8 +36,20 @@ export class XtermBackend implements ITerminalBackend {
   private container: HTMLElement | null = null;
   /** OSC 633;A prompt-start markers, in registration (= buffer) order. */
   private promptMarkers: IMarker[] = [];
+  /** `"auto"` loads the WebGL/Canvas renderer; `"dom"` forces the DOM renderer. */
+  private readonly gpuAcceleration: "auto" | "dom";
+  /**
+   * Active GPU renderer once `open()` has run. `null` means the DOM renderer
+   * is active (either forced via `gpuAcceleration: "dom"` or after all GPU
+   * addons failed to load) — the DOM renderer has no glyph texture atlas, so
+   * `clearGlyphAtlas()` is a no-op in that state.
+   */
+  private gpuRenderer: WebglAddon | CanvasAddon | null = null;
+  /** `matchMedia` DPR listener teardown — see `open()`. */
+  private dprCleanup: (() => void) | null = null;
 
   constructor(options: TerminalBackendOptions = {}) {
+    this.gpuAcceleration = options.gpuAcceleration ?? "auto";
     this.term = new Terminal({
       fontSize: options.fontSize,
       fontFamily: options.fontFamily,
@@ -47,6 +60,9 @@ export class XtermBackend implements ITerminalBackend {
       theme: options.theme,
       altClickMovesCursor: options.altClickMovesCursor,
       wordSeparator: options.wordSeparator,
+      // Opaque cells avoid the thin/ghosted-text WebGL artifact that appears
+      // when xterm composites glyphs over a transparent background.
+      allowTransparency: false,
       allowProposedApi: true,
     });
 
@@ -81,35 +97,83 @@ export class XtermBackend implements ITerminalBackend {
     this.container = container;
     this.term.open(container);
 
-    // Load rendering addons BEFORE WebLinksAddon so the renderer's
-    // onShowLinkUnderline / onHideLinkUnderline are available when
-    // the link decorator initialises.
-    try {
-      const webgl = new WebglAddon();
-      webgl.onContextLoss(() => {
-        console.warn("[XtermBackend] WebGL context lost, falling back to Canvas");
-        webgl.dispose();
-        // Fall back to canvas renderer on context loss
+    // gpuAcceleration "dom": skip the GPU addons entirely → pure DOM renderer.
+    // The DOM renderer has no glyph texture atlas and therefore can never
+    // ghost; this is the user escape hatch / force-DOM diagnostic lever.
+    if (this.gpuAcceleration === "auto") {
+      // Load rendering addons BEFORE WebLinksAddon so the renderer's
+      // onShowLinkUnderline / onHideLinkUnderline are available when
+      // the link decorator initialises.
+      try {
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => {
+          console.warn("[XtermBackend] WebGL context lost, falling back to Canvas");
+          webgl.dispose();
+          this.gpuRenderer = null;
+          // Fall back to canvas renderer on context loss
+          try {
+            const canvas = new CanvasAddon();
+            this.term.loadAddon(canvas);
+            this.gpuRenderer = canvas;
+          } catch {
+            // DOM renderer is the final fallback — already active
+          }
+        });
+        this.term.loadAddon(webgl);
+        this.gpuRenderer = webgl;
+      } catch {
+        // WebGL not available, try canvas
         try {
-          this.term.loadAddon(new CanvasAddon());
+          const canvas = new CanvasAddon();
+          this.term.loadAddon(canvas);
+          this.gpuRenderer = canvas;
         } catch {
           // DOM renderer is the final fallback — already active
         }
-      });
-      this.term.loadAddon(webgl);
-    } catch {
-      // WebGL not available, try canvas
-      try {
-        this.term.loadAddon(new CanvasAddon());
-      } catch {
-        // DOM renderer is the final fallback — already active
       }
     }
 
     this.term.loadAddon(new WebLinksAddon());
+
+    // Clear the glyph texture atlas when the device pixel ratio changes
+    // (window dragged between monitors of different scaling, OS zoom change).
+    // A DPR change re-rasterises glyphs at a new size; an atlas keyed to the
+    // old DPR leaves stale, mis-scaled glyphs composited under new ones —
+    // a ghosting source. No-op on the DOM renderer (no atlas). Tracked via a
+    // re-armed `matchMedia` query since `resolution` MediaQueryLists fire
+    // once and then need re-subscribing at the new ratio.
+    if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+      let mql: MediaQueryList | null = null;
+      const onDprChange = () => {
+        this.clearGlyphAtlas();
+        arm();
+      };
+      const arm = () => {
+        if (mql) mql.removeEventListener("change", onDprChange);
+        mql = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+        mql.addEventListener("change", onDprChange);
+      };
+      arm();
+      this.dprCleanup = () => {
+        if (mql) mql.removeEventListener("change", onDprChange);
+        mql = null;
+      };
+    }
+  }
+
+  /**
+   * Clear the active GPU renderer's glyph texture atlas. No-op on the DOM
+   * renderer (`gpuRenderer === null`). Called on DPR / font-size / theme
+   * changes — each invalidates cached glyphs and a stale atlas ghosts.
+   */
+  private clearGlyphAtlas(): void {
+    this.gpuRenderer?.clearTextureAtlas();
   }
 
   dispose(): void {
+    this.dprCleanup?.();
+    this.dprCleanup = null;
+    this.gpuRenderer = null;
     this.term.dispose();
   }
 
@@ -121,8 +185,11 @@ export class XtermBackend implements ITerminalBackend {
     this.term.focus();
   }
 
-  write(data: Uint8Array | string): void {
-    this.term.write(data);
+  write(data: Uint8Array | string, onRendered?: () => void): void {
+    // xterm invokes the callback once the chunk is parsed and the resulting
+    // frame is rendered (its write queue drains), which is the render-completion
+    // signal the render-based ack relies on.
+    this.term.write(data, onRendered);
   }
 
   onData(cb: (data: string) => void): IDisposable {
@@ -157,6 +224,18 @@ export class XtermBackend implements ITerminalBackend {
     // xterm trims the active buffer to the new cap on assignment when it is
     // lowered, so this frees the dead pane's retained cell storage in place.
     this.term.options.scrollback = lines;
+  }
+
+  setFontSize(px: number): void {
+    this.term.options.fontSize = px;
+    // New cell metrics ⇒ the cached glyphs are the wrong size; invalidate.
+    this.clearGlyphAtlas();
+  }
+
+  setTheme(theme: ITerminalTheme): void {
+    this.term.options.theme = theme;
+    // Cached glyphs are colored, so a theme swap must invalidate the atlas.
+    this.clearGlyphAtlas();
   }
 
   fit(): void {

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -79,6 +79,16 @@ export interface TerminalBackendOptions {
   altClickMovesCursor?: boolean;
   /** Word-boundary characters for double-click selection (VS Code parity). */
   wordSeparator?: string;
+  /**
+   * GPU acceleration policy for the renderer (xterm only):
+   * - `"auto"` (default): load the WebGL renderer, falling back to Canvas then
+   *   DOM (the existing behavior).
+   * - `"dom"`: skip the WebGL/Canvas addons entirely → pure DOM renderer. The
+   *   DOM renderer has no glyph texture atlas, so it can never ghost. This is
+   *   both a user escape hatch and the force-DOM diagnostic lever for the
+   *   ghosting investigation. No-op on ghostty (Canvas-only, no WebGL).
+   */
+  gpuAcceleration?: "auto" | "dom";
 }
 
 // ---------------------------------------------------------------------------
@@ -128,8 +138,19 @@ export interface ITerminalBackend {
   focus(): void;
 
   // -- I/O ------------------------------------------------------------------
-  /** Write data to the terminal display (does NOT send to PTY). */
-  write(data: Uint8Array | string): void;
+  /**
+   * Write data to the terminal display (does NOT send to PTY).
+   *
+   * `onRendered`, when supplied, is invoked once the chunk has been parsed
+   * and rendered by the backend. This is the render-completion signal that
+   * drives the render-based flow-control ack (see `TerminalInstance`): we
+   * ack bytes the renderer has actually drained, not bytes merely received
+   * off the wire, so a burst can't outrun xterm's input buffer (~50MB cap,
+   * silently drops overflow) before backpressure engages. Mirrors xterm's
+   * `write(data, callback)`. Backends with no async completion signal call
+   * it synchronously right after their own write.
+   */
+  write(data: Uint8Array | string, onRendered?: () => void): void;
   /** Subscribe to user keyboard input. */
   onData(cb: (data: string) => void): IDisposable;
   /** Subscribe to binary input (e.g. paste with special chars). Optional — may be a no-op. */
@@ -153,6 +174,19 @@ export interface ITerminalBackend {
    * runtime scrollback control may no-op.
    */
   setScrollback(lines: number): void;
+  /**
+   * Change the rendered font size (px). On GPU-accelerated renderers this also
+   * clears the glyph texture atlas — a stale atlas keyed to the old cell
+   * metrics is a ghosting source. Backends without runtime font control may
+   * no-op.
+   */
+  setFontSize(px: number): void;
+  /**
+   * Swap the color theme. On GPU-accelerated renderers this also clears the
+   * glyph texture atlas (cached glyphs are colored, so a theme change must
+   * invalidate them). Backends without runtime theme control may no-op.
+   */
+  setTheme(theme: ITerminalTheme): void;
 
   // -- Layout ---------------------------------------------------------------
   /** Fit the terminal to its container. */

--- a/src/components/terminal/flowControl.test.ts
+++ b/src/components/terminal/flowControl.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pure-logic tests for the render-based ack accumulator extracted from
+ * `TerminalInstance`'s flow-control path. See `flowControl.ts` for why the
+ * accounting lives in a leaf module (TerminalInstance can't be imported under
+ * Node — it pulls `@xterm/addon-canvas`).
+ */
+
+import { describe, it, expect } from "vitest";
+import { RenderAckAccumulator, ACK_SIZE } from "./flowControl";
+
+describe("RenderAckAccumulator", () => {
+  it("does not ack before AckSize rendered bytes accumulate", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    acc.onWriteIssued(3000);
+    expect(acc.onRendered(3000)).toBe(0);
+    expect(acc.pending).toBe(3000);
+    expect(acc.outstanding).toBe(0);
+  });
+
+  it("fires an ack of the accumulated total once rendered bytes cross AckSize", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    acc.onWriteIssued(3000);
+    acc.onWriteIssued(3000);
+    expect(acc.onRendered(3000)).toBe(0); // 3000 < 5000
+    // 6000 >= AckSize → ack the full pending accumulator (6000), then reset.
+    expect(acc.onRendered(3000)).toBe(6000);
+    expect(acc.pending).toBe(0);
+  });
+
+  it("acks at exactly AckSize", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    acc.onWriteIssued(ACK_SIZE);
+    expect(acc.onRendered(ACK_SIZE)).toBe(ACK_SIZE);
+  });
+
+  it("tracks in-flight bytes between issue and render", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    acc.onWriteIssued(4000);
+    expect(acc.outstanding).toBe(4000);
+    expect(acc.pending).toBe(0);
+    acc.onRendered(4000);
+    expect(acc.outstanding).toBe(0);
+    expect(acc.pending).toBe(4000);
+  });
+
+  it("flush() returns the sub-AckSize trailing remainder (timer floor)", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    acc.onWriteIssued(1234);
+    expect(acc.onRendered(1234)).toBe(0); // below AckSize, no auto-ack
+    expect(acc.flush()).toBe(1234); // floor timer drains the remainder
+    expect(acc.flush()).toBe(0); // nothing left
+  });
+
+  it("clamps a double-fired render callback so it cannot over-ack", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    acc.onWriteIssued(2000);
+    acc.onRendered(2000);
+    // A spurious second callback for the same write: nothing in flight to
+    // settle, so it adds nothing.
+    expect(acc.onRendered(2000)).toBe(0);
+    expect(acc.pending).toBe(2000);
+  });
+
+  it("a single coalesced write accounts its full byte length", () => {
+    const acc = new RenderAckAccumulator(ACK_SIZE);
+    // Phase 4: many terminal-output events are coalesced into one backend
+    // write; the onRendered callback fires once for the whole coalesced length.
+    acc.onWriteIssued(8000);
+    expect(acc.onRendered(8000)).toBe(8000);
+  });
+});

--- a/src/components/terminal/flowControl.ts
+++ b/src/components/terminal/flowControl.ts
@@ -1,0 +1,94 @@
+/**
+ * Render-completion flow control + write coalescing primitives for the
+ * in-app terminal, extracted as a leaf module (zero imports) so the
+ * load-bearing accounting can be unit-tested without importing
+ * `TerminalInstance` — which transitively pulls `@xterm/addon-canvas`
+ * (touches `self` at module init and crashes under Node).
+ *
+ * Mirrors VS Code's `FlowControlConstants` (microsoft/vscode terminal):
+ * the frontend acks bytes the renderer has actually drained — not bytes
+ * merely received off the wire — and the Rust reader pauses/resumes around
+ * char-count watermarks so a burst can't outrun xterm's input buffer
+ * (~50MB cap, which silently drops overflow) before backpressure engages.
+ */
+
+/**
+ * Ack to the Rust reader once this many rendered bytes have accumulated.
+ * VS Code uses 5000 chars (`FlowControlConstants.CharCountAckSize`). The
+ * Rust side resumes once `sent - acked` drops back under its Low watermark,
+ * so acking in ~5000-byte units keeps the pause window short.
+ */
+export const ACK_SIZE = 5000;
+
+/**
+ * Slow timer floor (ms). The render-based ack fires as soon as accumulated
+ * rendered bytes cross {@link ACK_SIZE}; this timer is the floor that flushes
+ * a trailing sub-AckSize remainder (so the last few bytes of a burst still
+ * ack and the reader resumes) and also carries the title poll the periodic
+ * idle paint used to host. Matches the prior 250ms ack cadence.
+ */
+export const ACK_FLOOR_INTERVAL_MS = 250;
+
+/**
+ * Render-based ack accumulator. Tracks bytes that have been rendered by the
+ * backend (the `onRendered` callback fired) but not yet acked to the Rust
+ * reader, and decides when to flush an ack.
+ *
+ * Lifecycle per coalesced write:
+ *   1. `onWriteIssued(n)` when a write is dispatched to the backend — bumps
+ *      the in-flight (issued-but-not-yet-rendered) counter.
+ *   2. `onRendered(n)` inside the backend's render-completion callback —
+ *      moves those `n` bytes from in-flight into the pending-ack accumulator.
+ *   3. `takeAck()` returns the bytes to ack (and zeroes the accumulator) once
+ *      it has crossed {@link ACK_SIZE}, or when forced by the floor timer.
+ */
+export class RenderAckAccumulator {
+  /** Bytes written to the backend whose render callback hasn't fired yet. */
+  private inFlight = 0;
+  /** Rendered-but-not-yet-acked bytes. */
+  private pendingAck = 0;
+
+  constructor(private readonly ackSize: number = ACK_SIZE) {}
+
+  /** A write of `bytes` length was dispatched to the backend. */
+  onWriteIssued(bytes: number): void {
+    if (bytes > 0) this.inFlight += bytes;
+  }
+
+  /**
+   * The backend finished rendering `bytes` (its `onRendered` callback). Moves
+   * them out of in-flight and into the pending-ack accumulator. Returns the
+   * ack amount to send now (>0) when the accumulator has crossed AckSize,
+   * else 0. `bytes` is clamped to the outstanding in-flight count so a
+   * double-fired callback can't over-ack.
+   */
+  onRendered(bytes: number): number {
+    const settled = Math.min(bytes, this.inFlight);
+    this.inFlight -= settled;
+    this.pendingAck += settled;
+    if (this.pendingAck >= this.ackSize) {
+      return this.flush();
+    }
+    return 0;
+  }
+
+  /**
+   * Flush the floor: return any pending-ack bytes (sub-AckSize trailing
+   * remainder) and zero the accumulator. Returns 0 when nothing is pending.
+   */
+  flush(): number {
+    const ack = this.pendingAck;
+    this.pendingAck = 0;
+    return ack;
+  }
+
+  /** Bytes rendered but not yet acked (test/diagnostic visibility). */
+  get pending(): number {
+    return this.pendingAck;
+  }
+
+  /** Bytes written but not yet rendered (test/diagnostic visibility). */
+  get outstanding(): number {
+    return this.inFlight;
+  }
+}

--- a/src/components/terminal/paintGrid.ts
+++ b/src/components/terminal/paintGrid.ts
@@ -1,11 +1,11 @@
 /**
  * paintGrid — render a Rust-side `GridSnapshot` into an `ITerminalBackend`.
  *
- * Used by the Layer 2 live-first bootstrap as a "catch-up" mechanism, NOT
- * as the source of truth. The live `terminal-output` listener is
- * authoritative for forward motion; paintGrid fills the gap between mount
- * and listener attach (those bytes are dropped by Tauri but live in the
- * Rust grid) and re-syncs on idle.
+ * Used by the live-first bootstrap as a "catch-up" mechanism, NOT as the
+ * source of truth. The live `terminal-output` listener is authoritative for
+ * forward motion; paintGrid fills the gap between mount and listener attach
+ * (those bytes are dropped by Tauri but live in the Rust grid). The periodic
+ * idle re-sync was retired in Phase 2 — see the `paintGrid` doc below.
  *
  * Design constraints:
  *   - DECAWM-off (`\x1b[?7l` / `\x1b[?7h`) wraps the whole paint to prevent
@@ -65,6 +65,14 @@ export interface GridSnapshot {
   cursor: GridCursor;
   /** Optional OSC 0/2 title. */
   title?: string;
+  /**
+   * True when the Rust grid is on the alternate screen (DEC `?1049h`). The
+   * grid is single-buffer, so a snapshot taken in this state holds alt-screen
+   * content; the bootstrap paint hard-skips when this is true rather than
+   * overlay it onto a freshly-mounted xterm. Always present from the current
+   * runner build; optional so an older build (no field) degrades to `false`.
+   */
+  alt_screen?: boolean;
   /** Row-major: cells[row * cols + col]. Length === rows * cols. */
   cells: GridCell[];
 }
@@ -144,9 +152,15 @@ function safeChar(ch: string): string {
 
 /**
  * Paint a `GridSnapshot` into `backend`. Issues a single `backend.write()`.
- * Safe to call concurrently with live `backend.write()` from the
- * `terminal-output` listener — DECAWM-off + absolute CUP per row makes
- * this an idempotent overlay.
+ *
+ * DECAWM-off + absolute CUP per row makes this an idempotent overlay. As of
+ * Phase 2 (`plans/2026-06-13-terminal-rendering-robustness.md`) this is used
+ * ONLY for the two one-shot bootstraps (mount-gap + reconnect) in
+ * `TerminalInstance`, and the caller hard-skips it when the snapshot reports
+ * the alt screen is active. The periodic idle reconciliation that re-painted
+ * concurrently with the live stream was retired — the single-buffer grid
+ * cannot model the alt screen, so a concurrent full-screen overlay could not
+ * be made safe for a TUI like Claude.
  */
 export function paintGrid(backend: ITerminalBackend, snapshot: GridSnapshot): void {
   const { cols, rows, cells, cursor } = snapshot;

--- a/src/components/terminal/terminalDebug.ts
+++ b/src/components/terminal/terminalDebug.ts
@@ -1,0 +1,88 @@
+/**
+ * Dev-only terminal instrumentation hook.
+ *
+ * Exposes `window.__qontinuiTerminal` in the browser/webview console for
+ * diagnosing rendering issues (the "text on top of text" / ghosting class).
+ * Everything here is OFF by default and has zero cost on the hot path unless
+ * `debugOverlap` is explicitly enabled from the console.
+ *
+ * History: Phase 0 of `plans/2026-06-13-terminal-rendering-robustness.md` also
+ * shipped a `setIdleReconcile(false)` kill switch for the PERIODIC idle
+ * reconciliation paint. Phase 2 then *retired* that periodic paint entirely
+ * (the single-buffer Rust grid can't model the alt screen Claude's TUI lives
+ * on, so the full-screen overlay could never be made safe). With the periodic
+ * path gone the toggle would gate nothing, so it was removed rather than left
+ * wired to dead code. The overlap instrumentation below stays — it now tracks
+ * the surviving one-shot bootstrap paints.
+ */
+
+/** A single recorded paintGrid event for the console ring. */
+export interface PaintGridLogEntry {
+  terminalId: string;
+  /** Which paint fired it: the mount-gap bootstrap or the reconnect bootstrap. */
+  reason: "mount-bootstrap" | "reconnect-bootstrap";
+  /** Whether the snapshot reported the alt screen (DEC ?1049h) was active. */
+  altScreen: boolean;
+  /** Whether the paint was actually applied (false = hard-skipped on alt-screen). */
+  applied: boolean;
+  /** Total bytes written to this pane via the live stream up to this point. */
+  bytesWritten: number;
+  ts: number;
+}
+
+interface QontinuiTerminalDebug {
+  /**
+   * When true, paintGrid bootstrap events are pushed to a console ring and
+   * logged. Default false. Flip from the console:
+   * `window.__qontinuiTerminal.debugOverlap = true`.
+   */
+  debugOverlap: boolean;
+  /** Most recent paint events (newest last), capped at `ringSize`. */
+  paintLog: PaintGridLogEntry[];
+  /** Max entries retained in `paintLog`. */
+  ringSize: number;
+  /** Dump the ring to the console. */
+  dump(): PaintGridLogEntry[];
+}
+
+const RING_SIZE = 200;
+
+declare global {
+  interface Window {
+    __qontinuiTerminal?: QontinuiTerminalDebug;
+  }
+}
+
+/** Lazily create + return the singleton debug object (no-op off the browser). */
+export function getTerminalDebug(): QontinuiTerminalDebug | null {
+  if (typeof window === "undefined") return null;
+  if (!window.__qontinuiTerminal) {
+    const log: PaintGridLogEntry[] = [];
+    window.__qontinuiTerminal = {
+      debugOverlap: false,
+      paintLog: log,
+      ringSize: RING_SIZE,
+      dump() {
+        // eslint-disable-next-line no-console
+        console.table(this.paintLog);
+        return this.paintLog;
+      },
+    };
+  }
+  return window.__qontinuiTerminal;
+}
+
+/**
+ * Record a bootstrap paintGrid event. No-ops unless `debugOverlap` is on, so
+ * it is safe to call unconditionally on the (rare) bootstrap path.
+ */
+export function recordPaintGrid(entry: PaintGridLogEntry): void {
+  const dbg = getTerminalDebug();
+  if (!dbg || !dbg.debugOverlap) return;
+  dbg.paintLog.push(entry);
+  while (dbg.paintLog.length > dbg.ringSize) dbg.paintLog.shift();
+  // eslint-disable-next-line no-console
+  console.debug(
+    `[TerminalOverlap ${entry.terminalId}] ${entry.reason} altScreen=${entry.altScreen} applied=${entry.applied} bytes=${entry.bytesWritten}`,
+  );
+}


### PR DESCRIPTION
Fixes three in-app terminal bugs now that the terminal page is the primary runner surface:
- **(a)** text rendered on top of other text / ghosting
- **(b)** text sometimes not appearing under bursty output
- **(c)** 1–2s keystroke-to-render latency

## Changes (plan: 2026-06-13-terminal-rendering-robustness)

**Phase 0/2 — overdraw (a).** Retire the periodic Rust-grid idle reconciliation `paintGrid` overlay. The absolute-CUP per-row repaint raced the live `terminal-output` byte stream and could not model the single-buffer grid's alt screen (where Claude's TUI lives ~continuously) — the overdraw source. Add `alt_screen` to `GridSnapshot`; the surviving mount/reconnect bootstrap paints now hard-skip when the snapshot is on the alt screen. OSC title reporting decoupled onto the ack-timer poll.

**Phase 1 — renderer hardening (xterm-only).** `clearTextureAtlas()` on DPR / font-size / theme change; `gpuAcceleration` `auto|dom` escape hatch (`dom` skips the WebGL/Canvas addons → never ghosts); `allowTransparency: false`.

**Phase 3 — flow control (b).** `ITerminalBackend.write` gains an `onRendered` completion callback (xterm forwards it; ghostty calls it synchronously). Render-based ack at a 5000-byte AckSize with a 250ms timer floor, replacing the time-based ack. Rust reader pause/resume on High(100000)/Low(5000) char-count watermarks with hysteresis.

**Phase 4 — coalescing (b, c).** Frontend batches trimmed chunks per microtask into a single `backend.write` (offset-dedup preserved). Rust reader coalesces DEC-2026 synchronized-output frames (`grid.sync_output`) into one `terminal-output` emit, 50ms / 256KiB caps; the emitted offset stays a correct replay boundary.

## Verification
- `tsc --noEmit` clean; `vitest` 604 passed (incl. new `flowControl` + coalescing tests); `cargo check`/`clippy` clean; new Rust coalescer + `sync_output` + flow-control tests pass.
- Built on an isolated temp runner (supervisor spawn-test, `worktree_path`, `git_sha ad7c3284`, fresh frontend) — booted healthy; a live PTY session rendered command output correctly through the modified Rust pipeline with OSC 633 shell-integration markers intact (no loss/corruption).