### PR TITLE
ci: trigger CI on merge-candidate/** refs (wire runner into coord merge engine)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,21 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    # `merge-candidate/**` etc.: the coord merge engine validates a proposal by
+    # pushing the rebased tip to `refs/heads/merge-candidate/<proposal_id>` and
+    # waiting for that ref's CI to go green before landing. Without these globs
+    # a candidate push matched no trigger, so runner CI never ran for a
+    # candidate → coord's awaiting-ci poll of `coord.pr_check_runs` stayed empty
+    # → proposals livelocked (the 2026-06-13 runner #566 incident). coord/web
+    # already trigger on these; runner was never wired. Runner's CI has no
+    # `paths:` filter, so adding the branches here suffices (no separate
+    # workflow needed — see plan 2026-06-13-merge-candidate-ci-coverage-...).
+    branches:
+      - main
+      - develop
+      - 'merge-candidate/**'
+      - 'merge-candidate-spec/**'
+      - 'merge-candidate-batch/**'
   pull_request:
     branches: [main, develop]
 


### PR DESCRIPTION
## What

Adds `merge-candidate/**`, `merge-candidate-spec/**`, `merge-candidate-batch/**` to runner `ci.yml`'s `push` trigger.

## Why

The coord merge engine validates a proposal by pushing the rebased tip to `refs/heads/merge-candidate/<proposal_id>` and waiting for that ref's CI to go green (it polls `coord.pr_check_runs` by `(repo, head_sha)`). Runner CI triggered only on `push`/`pull_request` to `[main, develop]`, so candidate pushes fired **no** CI → the poll stayed empty → runner proposals **livelocked** in `awaiting-ci` (the runner #566 incident). coord (`candidate-ci.yml`) and web already trigger on these refs; runner was never wired when promoted into the merge queue.

Runner's `ci.yml` has no `paths:` filter, so adding the globs to the existing `push` trigger is necessary and sufficient — no separate workflow / `workflow_call` refactor needed.

## Bootstrap note

This PR is landed **directly** (not via the coord merge queue): a PR that *adds* the candidate trigger can't itself go through the candidate-CI flow (chicken-and-egg), and runner's full CI (~1h28m) exceeds the engine's 30-min candidate-CI timeout (the separate Phase-2 concern). runner `main` is unprotected; the change is an additive trigger that cannot affect existing CI. Phase 1 of plan `2026-06-13-merge-candidate-ci-coverage-and-long-ci-resilience`.