### PR TITLE
runner: discoverable create-plain-terminal UI Bridge action on terminal-page

### DIFF
--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -30,6 +30,7 @@ import { SuggestionsProvider } from "./suggestions";
 import { StatusStrip } from "./StatusStrip";
 import { UnzonedChip } from "./UnzonedChip";
 import { pickLayout } from "./useZoneLayout";
+import { buildCreatePlainTerminalAction } from "./createPlainTerminalAction";
 import { ResultCardProvider, ResultCardMount, useResultCard } from "./result-card";
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
@@ -128,6 +129,15 @@ function TerminalPageInner({
           await createTerminal();
         },
       },
+      // Discoverable, named plain-terminal launcher on the now-primary
+      // `terminal-page` surface. Unlike `create-terminal` (raw createTerminal,
+      // no zone assignment / layout growth), this routes through the same
+      // `createAndAssignTerminal` mount path the launch menu's `create-plain`
+      // uses, so a single invocation reliably yields a mounted xterm — even
+      // from a fresh page. The inner arrow defers the `createAndAssignTerminal`
+      // read to invocation time (it's declared below, same as the
+      // `terminal-launch-menu` handlers that close over later consts).
+      buildCreatePlainTerminalAction((title) => createAndAssignTerminal(title)),
       {
         id: "list-terminals",
         label: "List Terminals",

--- a/src/components/terminal/createPlainTerminalAction.test.ts
+++ b/src/components/terminal/createPlainTerminalAction.test.ts
@@ -1,0 +1,49 @@
+/**
+ * `create-plain-terminal` UI Bridge action wiring (terminal-page surface).
+ *
+ * Runner vitest config is `environment: "node"` (no jsdom / no React tree),
+ * so we exercise the load-bearing wiring via the exported pure factory —
+ * same precedent as `aiLaunchCommand.test.ts` / `LaunchMenu.test.tsx`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  buildCreatePlainTerminalAction,
+  CREATE_PLAIN_TERMINAL_ACTION_ID,
+} from "./createPlainTerminalAction";
+
+describe("buildCreatePlainTerminalAction", () => {
+  it("exposes a stable, discoverable action id + label", () => {
+    const action = buildCreatePlainTerminalAction(async () => "tab-1");
+    expect(action.id).toBe(CREATE_PLAIN_TERMINAL_ACTION_ID);
+    expect(action.id).toBe("create-plain-terminal");
+    expect(action.label).toBe("Create Plain Terminal");
+    expect(action.description).toMatch(/plain/i);
+  });
+
+  it("invokes the createAndAssignTerminal (mount) path and reports the new tab id", async () => {
+    const createAndAssign = vi.fn(async () => "tab-42");
+    const action = buildCreatePlainTerminalAction(createAndAssign);
+
+    const result = await action.handler();
+
+    expect(createAndAssign).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ success: true, tab_id: "tab-42" });
+  });
+
+  it("each invocation creates exactly one new plain terminal (idempotent per call)", async () => {
+    const createAndAssign = vi.fn(async () => "tab-x");
+    const action = buildCreatePlainTerminalAction(createAndAssign);
+
+    await action.handler();
+    await action.handler();
+
+    expect(createAndAssign).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports success:false with a null tab_id when the backend declines to create one", async () => {
+    const action = buildCreatePlainTerminalAction(async () => null);
+    const result = await action.handler();
+    expect(result).toEqual({ success: false, tab_id: null });
+  });
+});

--- a/src/components/terminal/createPlainTerminalAction.ts
+++ b/src/components/terminal/createPlainTerminalAction.ts
@@ -1,0 +1,64 @@
+/**
+ * `create-plain-terminal` — a discoverable UI Bridge action on the
+ * `terminal-page` component that spawns a plain (non-AI) PTY terminal into
+ * the active page/zone and mounts its `<TerminalInstance>` (xterm).
+ *
+ * Why this exists (real friction): when external automation/verification
+ * needs to drive the now-primary terminal surface headlessly, there was no
+ * discoverable on-page action that *creates and mounts* a plain terminal.
+ * The auto-discovered `button-add-terminal-page-1` only adds an empty
+ * page/zone (no session), `tab-switch-to-terminal` only navigates, and the
+ * `terminal-launch-menu.create-plain` action lives on the launch-menu
+ * component (and reshapes to a registry `{success, tab_ids}` envelope). This
+ * action surfaces the plain-terminal create directly on the `terminal-page`
+ * component so a single invocation reliably yields a mounted xterm.
+ *
+ * It deliberately routes through the SAME frontend create path the launch
+ * menu uses — `createAndAssignTerminal()` (TerminalPage → useZoneActions) —
+ * which calls `createTerminal()` and then auto-adjusts the zone layout so the
+ * new tab is assigned to a zone and an `<TerminalInstance>` mounts. It is NOT
+ * a raw backend `POST /terminals` (that would not mount the xterm here).
+ *
+ * Robust-from-fresh-page: `useTerminalPages` always seeds a `"default"` page
+ * and `createAndAssignTerminal` grows/selects the zone layout as needed, so a
+ * single invocation on a cold page still produces a mounted xterm.
+ *
+ * Extracted as a pure factory (no React, no Tauri) so the action wiring is
+ * unit-testable under the runner's `environment: "node"` vitest config —
+ * same precedent as `LaunchMenu`'s exported pure helpers.
+ */
+
+/** The action id agents invoke on the `terminal-page` component. */
+export const CREATE_PLAIN_TERMINAL_ACTION_ID = "create-plain-terminal";
+
+/** Minimal shape of a UI Bridge component action (matches the SDK's ComponentActionDef). */
+export interface PlainTerminalActionDef {
+  id: string;
+  label: string;
+  description: string;
+  handler: (params?: unknown) => Promise<{ success: boolean; tab_id: string | null }>;
+}
+
+/**
+ * Build the `create-plain-terminal` action def.
+ *
+ * @param createAndAssignTerminal the TerminalPage create path that spawns a
+ *   plain PTY tab, assigns it to a zone, and mounts its xterm. Returns the new
+ *   tab id (or `null`/`undefined` if the backend declined to create one).
+ */
+export function buildCreatePlainTerminalAction(
+  createAndAssignTerminal: (title?: string) => Promise<string | null>,
+): PlainTerminalActionDef {
+  return {
+    id: CREATE_PLAIN_TERMINAL_ACTION_ID,
+    label: "Create Plain Terminal",
+    description:
+      "Spawn one plain (non-AI) PTY terminal in the user's default shell, assign it to " +
+      "the active page's next free zone, and mount its xterm. Robust from a fresh page. " +
+      "Returns { success, tab_id }. Use this to drive the terminal surface headlessly.",
+    handler: async () => {
+      const tabId = await createAndAssignTerminal();
+      return { success: Boolean(tabId), tab_id: tabId ?? null };
+    },
+  };
+}


### PR DESCRIPTION
## What

Adds a named, discoverable UI Bridge action **`create-plain-terminal`** on the `terminal-page` component so external automation/verification can launch a plain (non-AI) terminal headlessly on the now-primary terminal surface.

## Why (real friction)

When verifying a terminal-rendering change there was **no discoverable on-page UI-bridge element/action that *creates and mounts* a plain terminal**:
- `button-add-terminal-page-1` (auto-discovered) only adds an empty page/zone — no session.
- `tab-switch-to-terminal` only navigates.
- `terminal-launch-menu.create-plain` exists but lives on the launch-menu component (and reshapes to a registry `{success, tab_ids}` envelope), not on the primary `terminal-page` surface.

## How

- New action `create-plain-terminal` registered on the **`terminal-page`** `useUIComponent` (TerminalPage.tsx), alongside the existing `create-terminal` / `list-terminals` actions.
- It routes through the **same frontend create path the launch menu uses** — `createAndAssignTerminal()` (TerminalPage → `useZoneActions`), which calls `createTerminal()` and grows/selects the zone layout so the new tab is assigned a zone and an `<TerminalInstance>` (xterm) **mounts**. It is *not* a raw backend `POST /terminals` (that would not mount the xterm here).
- **Robust from a fresh page:** `useTerminalPages` always seeds a `"default"` page and `createAndAssignTerminal` grows the layout, so a single invocation on a cold page yields a mounted xterm. Each invocation creates exactly one new plain terminal. Returns `{ success, tab_id }`.
- Wiring extracted into a pure, React/Tauri-free factory `buildCreatePlainTerminalAction` (`createPlainTerminalAction.ts`) so it is unit-testable under the runner's `environment: "node"` vitest config — same precedent as the `LaunchMenu` exported helpers.

## Tests

- New `createPlainTerminalAction.test.ts` (4 tests): stable id/label, invokes the create-and-assign mount path + returns the new tab id, one-terminal-per-invocation, and success:false/null on decline.
- `npx tsc --noEmit` clean; `npx eslint` on changed files clean; `npx vitest run src/components/terminal` → 47 files / 601 tests pass.

## On-page verification

Verified end-to-end on a temp runner built from this branch (results appended below).