### PR TITLE
feat(terminal): repoint fleet auto-response rules web->coord + scoring resolution (Phase 4)

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -142,29 +142,11 @@ impl Default for BackoffConfig {
     }
 }
 
-/// One fleet-configured auto-response rule (fetch/cache wire shape).
-///
-/// Rules are fetched from the qontinui-web backend (device-JWT auth) and cached
-/// locally; this struct is ONLY that wire/cache shape — it is not part of the
-/// runner's persisted `Settings`. The server seeds and owns the rule set (the
-/// recovery rule for the transient "Server is temporarily limiting requests"
-/// rate-limit message ships server-side), so the runner never defaults a rule.
-/// When `pattern` (a regex) matches a live session's ANSI-stripped output, the
-/// runner submits `prompt` back into that session after the rule's `backoff`.
-/// Only `enabled` rules are acted on (the backend only returns enabled rules,
-/// so `enabled` defaults to `true`).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct AutoResponseRule {
-    pub id: String,
-    #[serde(default)]
-    pub name: String,
-    pub pattern: String,
-    pub prompt: String,
-    #[serde(default = "default_true")]
-    pub enabled: bool,
-    #[serde(default)]
-    pub backoff: BackoffConfig,
-}
+// NOTE: the old `AutoResponseRule` wire/cache struct was removed in Phase 4
+// (unified-automation). The rule source moved from the qontinui-web backend to
+// coord, whose projection (`FleetRule` with a tagged `action`) lives in
+// `terminal::auto_response_fleet`. `BackoffConfig` (above) is still the shared
+// backoff shape consumed by that projection.
 
 /// Settings for Claude API (direct HTTP calls)
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/terminal/auto_response.rs
+++ b/src-tauri/src/terminal/auto_response.rs
@@ -9,8 +9,9 @@
 //!
 //! ## Pieces
 //!
-//! - [`reload_rules`] compiles the fleet rule set (only `enabled` rules; bad
-//!   regexes are warned-and-skipped, never fatal) into [`COMPILED_RULES`].
+//! - [`reload_rules`] compiles the coord-projected fleet rule set (bad regexes
+//!   are warned-and-skipped, never fatal) into [`COMPILED_RULES`], carrying each
+//!   rule's [`CompiledAction`] (fixed text vs. coord scoring-resolve).
 //! - [`AutoResponseWatchHook`] is an [`super::interceptor::OutputHook`]
 //!   installed on every terminal's interceptor pipeline. It ANSI-strips +
 //!   normalizes a bounded rolling window per terminal (sharing
@@ -33,15 +34,29 @@ use std::time::{Duration, Instant};
 
 use tracing::{info, warn};
 
+use super::auto_response_fleet::{FleetRule, RuleAction};
 use super::interceptor::OutputHook;
 use super::output_scan::{normalize, AnsiStripper, WINDOW_KEEP};
 use crate::settings::BackoffConfig;
+
+/// The compiled, hot-path form of a rule's action.
+///
+/// `Fixed` is the fully-offline auto-continue (submit a fixed text). `Resolve`
+/// defers the response text to coord's resolve endpoint for the given
+/// `policy_id` — and injects nothing when coord can't confidently resolve.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CompiledAction {
+    /// Submit this fixed text into the matched session (offline-capable).
+    Fixed(String),
+    /// Resolve the response via coord's scoring endpoint for this policy id.
+    Resolve(String),
+}
 
 /// A fleet rule with its `pattern` pre-compiled to a [`regex::Regex`].
 pub struct CompiledRule {
     pub id: String,
     pub regex: regex::Regex,
-    pub prompt: String,
+    pub action: CompiledAction,
     pub backoff: BackoffConfig,
 }
 
@@ -51,22 +66,34 @@ static COMPILED_RULES: RwLock<Vec<CompiledRule>> = RwLock::new(Vec::new());
 
 /// Recompile the rule set from a freshly-fetched/cached fleet rule list.
 ///
-/// Only `enabled` rules are compiled. A rule whose `pattern` fails to compile
-/// is warned-and-skipped — one bad regex never wedges the whole feature. The
-/// whole `Vec` is replaced atomically so the hot path never sees a partial set.
-pub fn reload_rules(rules: Vec<crate::settings::AutoResponseRule>) {
+/// Coord projects only the applicable rules (no `enabled` filter on the wire),
+/// so every rule here is compiled. A rule whose `pattern` fails to compile is
+/// warned-and-skipped — one bad regex never wedges the whole feature. The whole
+/// `Vec` is replaced atomically so the hot path never sees a partial set.
+///
+/// `case_insensitive` is honored via [`regex::RegexBuilder`]; an inline `(?i)`
+/// in the pattern also works (and the two compose — either turns on the flag).
+pub fn reload_rules(rules: Vec<FleetRule>) {
     let mut compiled = Vec::new();
     for rule in rules {
-        if !rule.enabled {
-            continue;
-        }
-        match regex::Regex::new(&rule.pattern) {
-            Ok(regex) => compiled.push(CompiledRule {
-                id: rule.id,
-                regex,
-                prompt: rule.prompt,
-                backoff: rule.backoff,
-            }),
+        match regex::RegexBuilder::new(&rule.pattern)
+            .case_insensitive(rule.case_insensitive)
+            .build()
+        {
+            Ok(regex) => {
+                let action = match rule.action {
+                    RuleAction::SubmitPrompt { text } => CompiledAction::Fixed(text),
+                    RuleAction::ResolveByScoring { policy_id } => {
+                        CompiledAction::Resolve(policy_id)
+                    }
+                };
+                compiled.push(CompiledRule {
+                    id: rule.id,
+                    regex,
+                    action,
+                    backoff: rule.backoff,
+                });
+            }
             Err(e) => warn!(
                 rule_id = %rule.id,
                 pattern = %rule.pattern,
@@ -138,7 +165,7 @@ impl OutputHook for AutoResponseWatchHook {
         // Unlike the usage-limit hook this does NOT clear the window on a match:
         // backoff/no-stack live in the scheduler, and clearing would drop the
         // tail of a chunk that contained the match.
-        let matches: Vec<(String, String, BackoffConfig)> = {
+        let matches: Vec<(String, CompiledAction, BackoffConfig, String)> = {
             let Ok(mut states) = self.states.lock() else {
                 return data.to_vec();
             };
@@ -158,16 +185,25 @@ impl OutputHook for AutoResponseWatchHook {
             let Ok(rules) = COMPILED_RULES.read() else {
                 return data.to_vec();
             };
+            // Carry the matched normalized window as the resolve context — the
+            // scheduler passes it to coord verbatim for the scoring decision.
             rules
                 .iter()
                 .filter(|r| r.regex.is_match(&normalized))
-                .map(|r| (r.id.clone(), r.prompt.clone(), r.backoff.clone()))
+                .map(|r| {
+                    (
+                        r.id.clone(),
+                        r.action.clone(),
+                        r.backoff.clone(),
+                        normalized.clone(),
+                    )
+                })
                 .collect()
         }; // states + rules locks released here
 
         // Dispatch to the scheduler with NO hook locks held.
-        for (rule_id, prompt, backoff) in matches {
-            scheduler::on_match(terminal_id, &rule_id, &prompt, &backoff);
+        for (rule_id, action, backoff, context) in matches {
+            scheduler::on_match(terminal_id, &rule_id, &action, &backoff, &context);
         }
 
         data.to_vec()
@@ -262,24 +298,54 @@ mod scheduler {
         entry.pending = false;
     }
 
-    /// Entry point from the hook: schedule a backed-off prompt submission for a
-    /// matched rule. No-op when a response is already pending for this pair.
-    pub(super) fn on_match(tid: &str, rid: &str, prompt: &str, cfg: &BackoffConfig) {
+    /// Entry point from the hook: schedule a backed-off response for a matched
+    /// rule. No-op when a response is already pending for this pair.
+    ///
+    /// `Fixed` actions submit the fixed text after the backoff (fully offline).
+    /// `Resolve` actions, after the backoff, call coord's resolve endpoint with
+    /// `context` and submit ONLY the confidently-resolved `response_text`; on
+    /// `resolved:false`, a coord error, or judge-unavailable they inject NOTHING
+    /// and let the next match retry under backoff.
+    pub(super) fn on_match(
+        tid: &str,
+        rid: &str,
+        action: &CompiledAction,
+        cfg: &BackoffConfig,
+        context: &str,
+    ) {
         let Some(delay) = register_match(tid, rid, cfg, Instant::now()) else {
             return;
         };
         let tid = tid.to_string();
         let rid = rid.to_string();
-        let prompt = prompt.to_string();
+        let action = action.clone();
+        let context = context.to_string();
         info!(
             terminal_id = %tid,
             rule_id = %rid,
             delay_secs = delay.as_secs(),
-            "auto_response: scheduling prompt submission"
+            "auto_response: scheduling response"
         );
         tauri::async_runtime::spawn(async move {
             tokio::time::sleep(delay).await;
-            submit_to_session(&tid, &prompt).await;
+            match action {
+                CompiledAction::Fixed(text) => {
+                    submit_to_session(&tid, &text).await;
+                }
+                CompiledAction::Resolve(policy_id) => {
+                    match resolve_response(&policy_id, &context).await {
+                        Some(text) => submit_to_session(&tid, &text).await,
+                        None => info!(
+                            terminal_id = %tid,
+                            rule_id = %rid,
+                            "auto_response: coord did not resolve — injecting nothing"
+                        ),
+                    }
+                }
+            }
+            // Always bump backoff: a `resolved:false` / error still consumed an
+            // attempt, so the next match waits longer (and the reset-window
+            // restarts attempts once the burst is over).
             record_fired(&tid, &rid, Instant::now());
         });
     }
@@ -313,40 +379,235 @@ mod scheduler {
             );
         }
     }
+
+    /// Call coord's resolve endpoint for `policy_id` with `context`. Returns
+    /// `Some(response_text)` ONLY when coord returns `resolved:true`; returns
+    /// `None` on `resolved:false`, any network/parse error, a missing coord
+    /// base, or judge-unavailable — the caller injects nothing in every `None`
+    /// case (NEVER a fallback/guess).
+    pub(super) async fn resolve_response(policy_id: &str, context: &str) -> Option<String> {
+        super::resolve::resolve_via_coord(policy_id, context).await
+    }
+}
+
+/// Coord scoring-resolve call, factored out of the scheduler so it is
+/// unit-testable at the parse boundary without a live server.
+mod resolve {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Serialize};
+    use tracing::{debug, warn};
+
+    /// POST body for `{coord_base}/coord/policies/resolve`.
+    #[derive(Serialize)]
+    struct ResolveRequest<'a> {
+        policy_id: &'a str,
+        context: &'a str,
+    }
+
+    /// Response from `{coord_base}/coord/policies/resolve` (always HTTP 200).
+    #[derive(Debug, Deserialize, PartialEq)]
+    pub(super) struct ResolveResponse {
+        pub resolved: bool,
+        #[serde(default)]
+        pub response_text: Option<String>,
+        #[serde(default)]
+        #[allow(dead_code)]
+        pub reason: Option<String>,
+    }
+
+    /// Coord resolve endpoint URL, or `None` when no coord base is configured.
+    fn resolve_endpoint_url() -> Option<String> {
+        match qontinui_runner_lib::profiles::resolve_coord_base() {
+            qontinui_runner_lib::profiles::CoordBase::Configured(base) => Some(format!(
+                "{}/coord/policies/resolve",
+                base.trim_end_matches('/')
+            )),
+            _ => None,
+        }
+    }
+
+    /// Map a parsed resolve response to the response text to inject.
+    ///
+    /// `Some` ONLY when `resolved` is true AND a non-empty `response_text` is
+    /// present. `resolved:false`, a missing/empty text → `None` (inject
+    /// nothing). Pure + total — the unit-test seam for the resolve branch.
+    pub(super) fn response_text_to_inject(resp: &ResolveResponse) -> Option<String> {
+        if !resp.resolved {
+            return None;
+        }
+        match resp.response_text.as_deref() {
+            Some(t) if !t.is_empty() => Some(t.to_string()),
+            _ => None,
+        }
+    }
+
+    /// POST the resolve request and return the text to inject, or `None` on any
+    /// unresolved / error condition.
+    pub(super) async fn resolve_via_coord(policy_id: &str, context: &str) -> Option<String> {
+        let url = resolve_endpoint_url()?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .ok()?;
+        let body = ResolveRequest { policy_id, context };
+        // Device-JWT bearer on a POST — the same write-path attach the coord
+        // producers use (collapses to anonymous when unpaired).
+        let req = qontinui_runner_lib::auth::attach_device_auth(client.post(&url));
+        let resp = match req.json(&body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(error = %e, "auto_response: resolve POST failed — injecting nothing");
+                return None;
+            }
+        };
+        if !resp.status().is_success() {
+            warn!(status = %resp.status(), "auto_response: resolve non-2xx — injecting nothing");
+            return None;
+        }
+        let parsed: ResolveResponse = match resp.json().await {
+            Ok(p) => p,
+            Err(e) => {
+                warn!(error = %e, "auto_response: resolve parse failed — injecting nothing");
+                return None;
+            }
+        };
+        debug!(
+            resolved = parsed.resolved,
+            "auto_response: coord resolve result"
+        );
+        response_text_to_inject(&parsed)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn rule(id: &str, pattern: &str) -> crate::settings::AutoResponseRule {
-        crate::settings::AutoResponseRule {
+    /// Serializes tests that mutate/read the shared [`COMPILED_RULES`] static.
+    /// `cargo test` runs tests concurrently, so without this a sibling test's
+    /// `reload_rules(vec![])` can empty the static mid-test (e.g. between the two
+    /// `process` calls of the window-accumulation test, flipping `rules_active()`
+    /// false so the second chunk is dropped). Poison-tolerant.
+    static RULES_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn rule(id: &str, pattern: &str) -> FleetRule {
+        FleetRule {
             id: id.to_string(),
-            name: String::new(),
             pattern: pattern.to_string(),
-            prompt: "please continue".to_string(),
-            enabled: true,
+            case_insensitive: false,
             backoff: BackoffConfig::default(),
+            action: RuleAction::SubmitPrompt {
+                text: "please continue".to_string(),
+            },
         }
     }
 
     #[test]
-    fn reload_drops_disabled_and_invalid_rules() {
-        let mut bad = rule("bad", "(unclosed");
-        let mut disabled = rule("disabled", "ok");
-        disabled.enabled = false;
-        bad.enabled = true;
-        reload_rules(vec![rule("good", "rate limited"), bad, disabled]);
+    fn reload_drops_invalid_rules() {
+        let _guard = RULES_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let bad = rule("bad", "(unclosed");
+        reload_rules(vec![rule("good", "rate limited"), bad]);
         let guard = COMPILED_RULES.read().unwrap();
         assert_eq!(guard.len(), 1);
         assert_eq!(guard[0].id, "good");
+        assert_eq!(
+            guard[0].action,
+            CompiledAction::Fixed("please continue".to_string())
+        );
         drop(guard);
         // Leave the static empty for other tests.
         reload_rules(vec![]);
     }
 
     #[test]
+    fn reload_compiles_resolve_action_and_case_insensitive() {
+        let _guard = RULES_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let mut r = rule("ci", "Rate Limited");
+        r.case_insensitive = true;
+        r.action = RuleAction::ResolveByScoring {
+            policy_id: "pol-1".to_string(),
+        };
+        reload_rules(vec![r]);
+        let guard = COMPILED_RULES.read().unwrap();
+        assert_eq!(guard.len(), 1);
+        // case_insensitive honored even though the pattern has no inline (?i).
+        assert!(guard[0].regex.is_match("rate limited"));
+        assert_eq!(
+            guard[0].action,
+            CompiledAction::Resolve("pol-1".to_string())
+        );
+        drop(guard);
+        reload_rules(vec![]);
+    }
+
+    #[test]
+    fn resolve_response_injects_only_on_resolved_true() {
+        use super::resolve::{response_text_to_inject, ResolveResponse};
+
+        // resolved:true with text → inject that text.
+        let ok = ResolveResponse {
+            resolved: true,
+            response_text: Some("the winner".to_string()),
+            reason: None,
+        };
+        assert_eq!(response_text_to_inject(&ok), Some("the winner".to_string()));
+
+        // resolved:false → inject nothing (NEVER a fallback/guess).
+        let no = ResolveResponse {
+            resolved: false,
+            response_text: None,
+            reason: Some("no_confident_winner".to_string()),
+        };
+        assert_eq!(response_text_to_inject(&no), None);
+
+        // judge-unavailable shape → inject nothing.
+        let unavail = ResolveResponse {
+            resolved: false,
+            response_text: None,
+            reason: Some("judge_unavailable".to_string()),
+        };
+        assert_eq!(response_text_to_inject(&unavail), None);
+
+        // Defensive: resolved:true but empty/missing text → inject nothing.
+        let empty = ResolveResponse {
+            resolved: true,
+            response_text: Some(String::new()),
+            reason: None,
+        };
+        assert_eq!(response_text_to_inject(&empty), None);
+    }
+
+    #[test]
+    fn resolve_response_parses_both_coord_shapes() {
+        use super::resolve::ResolveResponse;
+
+        let yes: ResolveResponse =
+            serde_json::from_str(r#"{"resolved":true,"response_text":"go"}"#).unwrap();
+        assert_eq!(
+            yes,
+            ResolveResponse {
+                resolved: true,
+                response_text: Some("go".to_string()),
+                reason: None,
+            }
+        );
+
+        let no: ResolveResponse =
+            serde_json::from_str(r#"{"resolved":false,"reason":"judge_unavailable"}"#).unwrap();
+        assert_eq!(
+            no,
+            ResolveResponse {
+                resolved: false,
+                response_text: None,
+                reason: Some("judge_unavailable".to_string()),
+            }
+        );
+    }
+
+    #[test]
     fn hook_matches_regex_over_ansi_window_split_across_calls() {
+        let _guard = RULES_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reload_rules(vec![rule("rl", "rate limited")]);
         let hook = AutoResponseWatchHook::new();
         // A normalized window must collect the match even when the phrase and

--- a/src-tauri/src/terminal/auto_response_fleet.rs
+++ b/src-tauri/src/terminal/auto_response_fleet.rs
@@ -1,11 +1,18 @@
 //! Fleet auto-response rule fetch loop + on-disk cache.
 //!
-//! Polls the qontinui-web backend (`GET /api/v1/runner/auto-response-rules`,
-//! device-JWT auth) for the operator-configured auto-response rule set, caches
-//! the result on disk, and hands it to [`super::auto_response::reload_rules`].
-//! The on-disk cache lets the runner re-arm the rules immediately at boot
-//! (before the first successful fetch) so a session that hit the transient
-//! rate-limit message during a runner restart is still recovered.
+//! Polls coord (`GET /coord/policies/runner-rules`, device-JWT auth) for the
+//! operator-configured auto-response rule set, caches the result on disk, and
+//! hands it to [`super::auto_response::reload_rules`]. The on-disk cache lets
+//! the runner re-arm the rules immediately at boot (before the first successful
+//! fetch) so a session that hit the transient rate-limit message during a
+//! runner restart is still recovered.
+//!
+//! Phase 4 (unified-automation): the rule source moved from the qontinui-web
+//! backend to coord, and rules now carry a tagged `action` — either a fixed
+//! `submit_prompt` (the offline-capable auto-continue) or a `resolve_by_scoring`
+//! that defers the response text to coord's LLM-judge resolve endpoint. The
+//! built-in rate-limit rule is now SERVER-seeded in coord (system-tenant
+//! default) and arrives over the wire — it is no longer hardcoded here.
 //!
 //! Best-effort throughout: every network/IO error is logged and swallowed —
 //! the runner keeps whatever rules it already has and retries next tick. The
@@ -19,17 +26,87 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
-use crate::settings::AutoResponseRule;
+use crate::settings::BackoffConfig;
 
-/// Wire shape of `GET /api/v1/runner/auto-response-rules`. The backend returns
-/// only ENABLED rules, plus an `updated_at` timestamp (the `ETag` is delivered
-/// both here and as an HTTP response header; we read the header).
+/// The action a fleet rule takes when its regex matches.
+///
+/// Tagged on `kind` to match the coord projection. `submit_prompt` is the
+/// fully-offline auto-continue (a fixed text submitted into the session);
+/// `resolve_by_scoring` defers the response text to coord's resolve endpoint
+/// (an LLM-judge over scored policy options) and injects nothing if coord can't
+/// confidently resolve.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RuleAction {
+    /// Submit a fixed text into the matched session. Offline-capable.
+    SubmitPrompt { text: String },
+    /// Resolve the response via coord's scoring/judge endpoint for `policy_id`.
+    ResolveByScoring { policy_id: String },
+}
+
+/// A fleet rule as projected by `GET /coord/policies/runner-rules`.
+///
+/// `case_insensitive` and `backoff` may be omitted (→ `false` / default). The
+/// `action` is normally present, but a pre-upgrade on-disk cache (written by the
+/// PR-#571 shape) has no `action` and a bare `prompt` field instead; the custom
+/// [`Deserialize`] below maps that stale shape to `SubmitPrompt { text: prompt }`
+/// so a version-bump cache load still arms the offline auto-continue rather than
+/// failing the whole cache.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct FleetRule {
+    pub id: String,
+    pub pattern: String,
+    pub case_insensitive: bool,
+    pub backoff: BackoffConfig,
+    pub action: RuleAction,
+}
+
+impl<'de> Deserialize<'de> for FleetRule {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        /// Permissive raw shape: accepts the coord projection (`action`) AND a
+        /// stale PR-#571 cache row (bare `prompt`, no `action`).
+        #[derive(Deserialize)]
+        struct Raw {
+            id: String,
+            pattern: String,
+            #[serde(default)]
+            case_insensitive: bool,
+            #[serde(default)]
+            backoff: BackoffConfig,
+            #[serde(default)]
+            action: Option<RuleAction>,
+            /// Legacy field from the pre-Phase-4 on-disk cache.
+            #[serde(default)]
+            prompt: Option<String>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        let action = match raw.action {
+            Some(a) => a,
+            // Stale cache: synthesize the offline auto-continue from `prompt`.
+            None => RuleAction::SubmitPrompt {
+                text: raw.prompt.unwrap_or_default(),
+            },
+        };
+        Ok(FleetRule {
+            id: raw.id,
+            pattern: raw.pattern,
+            case_insensitive: raw.case_insensitive,
+            backoff: raw.backoff,
+            action,
+        })
+    }
+}
+
+/// Wire shape of `GET /coord/policies/runner-rules`. Coord returns only the
+/// applicable rules; the `ETag` is delivered as an HTTP response header (read
+/// from the header, not the body).
 #[derive(Deserialize)]
 struct FleetRulesResponse {
-    rules: Vec<AutoResponseRule>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    updated_at: Option<String>,
+    rules: Vec<FleetRule>,
 }
 
 /// On-disk cache of the last successful fetch.
@@ -37,7 +114,7 @@ struct FleetRulesResponse {
 struct CachedFleetRules {
     etag: Option<String>,
     fetched_at: String,
-    rules: Vec<AutoResponseRule>,
+    rules: Vec<FleetRule>,
 }
 
 /// Last seen `ETag`, used to send `If-None-Match` and get cheap 304s.
@@ -56,12 +133,20 @@ fn cache_path_in(base: PathBuf) -> Option<PathBuf> {
     )
 }
 
-/// Rules endpoint on the qontinui-web backend.
-fn rules_endpoint_url() -> String {
-    format!(
-        "{}/api/v1/runner/auto-response-rules",
-        crate::api_config::get_api_base_url()
-    )
+/// Rules endpoint on coord (`{coord_base}/coord/policies/runner-rules`).
+///
+/// Resolves the coord base via the shared resolver (`COORD_HTTP_URL` env →
+/// active profile `coord_url`, ws→http) — the SAME path every other coord
+/// reader uses. Returns `None` when nothing is configured, so the fetch tick
+/// cleanly skips (no localhost fallback, no web URL).
+fn rules_endpoint_url() -> Option<String> {
+    match qontinui_runner_lib::profiles::resolve_coord_base() {
+        qontinui_runner_lib::profiles::CoordBase::Configured(base) => Some(format!(
+            "{}/coord/policies/runner-rules",
+            base.trim_end_matches('/')
+        )),
+        _ => None,
+    }
 }
 
 /// Read the on-disk cache from `path`, if present and parseable.
@@ -103,14 +188,17 @@ fn write_cache_at(path: &PathBuf, cached: &CachedFleetRules) {
 /// network / non-2xx errors `warn!` and return `Ok(())` (keep current rules);
 /// a 304 returns `Ok(())` unchanged.
 pub async fn fetch_and_reload_once() -> Result<(), String> {
-    let url = rules_endpoint_url();
+    let Some(url) = rules_endpoint_url() else {
+        debug!("auto_response_fleet: no coord base configured — skipping fetch");
+        return Ok(());
+    };
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
         .build()
         .map_err(|e| format!("reqwest client build: {e}"))?;
 
-    // Device-JWT bearer attached the same way coord_http does.
-    let mut req = qontinui_runner_lib::auth::attach_device_auth(client.get(&url));
+    // Device-JWT bearer attached the same way every coord reader does.
+    let mut req = crate::coord_http::coord_get(&client, &url);
     if let Some(etag) = LAST_ETAG.lock().ok().and_then(|g| g.clone()) {
         req = req.header("If-None-Match", etag);
     }
@@ -218,17 +306,90 @@ pub fn spawn_fetch_loop() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::settings::{AutoResponseRule, BackoffConfig};
+    use crate::settings::BackoffConfig;
 
-    fn sample_rule() -> AutoResponseRule {
-        AutoResponseRule {
+    fn sample_rule() -> FleetRule {
+        FleetRule {
             id: "r1".to_string(),
-            name: "rate-limit-recover".to_string(),
             pattern: "rate limited".to_string(),
-            prompt: "please continue".to_string(),
-            enabled: true,
+            case_insensitive: false,
             backoff: BackoffConfig::default(),
+            action: RuleAction::SubmitPrompt {
+                text: "please continue".to_string(),
+            },
         }
+    }
+
+    #[test]
+    fn coord_projection_deserializes_both_action_kinds() {
+        let body = r#"{
+            "rules": [
+                {
+                    "id": "rate-limit",
+                    "pattern": "(?i)rate limited",
+                    "case_insensitive": true,
+                    "backoff": {"initial_delay_secs": 60, "multiplier": 2.0, "max_delay_secs": null},
+                    "action": {"kind": "submit_prompt", "text": "Please continue."}
+                },
+                {
+                    "id": "needs-judge",
+                    "pattern": "which option",
+                    "action": {"kind": "resolve_by_scoring", "policy_id": "11111111-1111-1111-1111-111111111111"}
+                }
+            ]
+        }"#;
+        let parsed: FleetRulesResponse = serde_json::from_str(body).expect("coord body parses");
+        assert_eq!(parsed.rules.len(), 2);
+
+        assert_eq!(parsed.rules[0].id, "rate-limit");
+        assert!(parsed.rules[0].case_insensitive);
+        assert_eq!(
+            parsed.rules[0].action,
+            RuleAction::SubmitPrompt {
+                text: "Please continue.".to_string()
+            }
+        );
+
+        assert_eq!(parsed.rules[1].id, "needs-judge");
+        // Omitted case_insensitive / backoff default cleanly.
+        assert!(!parsed.rules[1].case_insensitive);
+        assert_eq!(parsed.rules[1].backoff, BackoffConfig::default());
+        assert_eq!(
+            parsed.rules[1].action,
+            RuleAction::ResolveByScoring {
+                policy_id: "11111111-1111-1111-1111-111111111111".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn stale_cache_without_action_maps_prompt_to_submit_prompt() {
+        // A pre-Phase-4 (PR #571) cache row: bare `prompt`, no `action`, plus
+        // dropped legacy fields (`name`, `enabled`) that must be tolerated.
+        let stale = r#"{
+            "etag": "W/\"old\"",
+            "fetched_at": "2026-06-13T00:00:00Z",
+            "rules": [
+                {
+                    "id": "rate-limit",
+                    "name": "rate-limit-recover",
+                    "pattern": "rate limited",
+                    "prompt": "please continue",
+                    "enabled": true,
+                    "backoff": {"initial_delay_secs": 60, "multiplier": 2.0, "max_delay_secs": null}
+                }
+            ]
+        }"#;
+        let cached: CachedFleetRules =
+            serde_json::from_str(stale).expect("stale cache still loads");
+        assert_eq!(cached.rules.len(), 1);
+        assert_eq!(
+            cached.rules[0].action,
+            RuleAction::SubmitPrompt {
+                text: "please continue".to_string()
+            },
+            "absent action should synthesize SubmitPrompt from the legacy prompt"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 4 of the **Unified Automation-Rule framework** (plan `2026-06-13-unified-automation-rule-framework`). The runner fetches terminal auto-response rules from **coord** (canonical tenant-scoped policy store) instead of the web backend, and gains a policy-scored resolution action.

**Depends on:** coord PR qontinui/qontinui-coord#641 (the `/coord/policies/runner-rules` + `/coord/policies/resolve` endpoints). **Deploy ordering:** coord must be live AND this build rolled out to the fleet **before** web removes `/api/v1/runner/auto-response-rules` (Phase 5).

- Fetch repoint: `rules_endpoint_url()` → `{coord_base}/coord/policies/runner-rules` via `resolve_coord_base()` (`COORD_HTTP_URL`/profile), device-JWT. `If-None-Match`/304 + atomic on-disk cache unchanged. No coord base → skip tick (no localhost fallback).
- Wire shape: `FleetRule{id, pattern, case_insensitive?, backoff?, action}`, `RuleAction = submit_prompt{text} | resolve_by_scoring{policy_id}`. Custom `Deserialize` tolerates a pre-upgrade cache (bare `prompt` → `SubmitPrompt`) so the offline auto-continue survives the version bump.
- `CompiledRule` → `CompiledAction{Fixed|Resolve}`; `case_insensitive` via `RegexBuilder` (inline `(?i)` still honored).
- Resolve match → `POST /coord/policies/resolve {policy_id, context}`; submits `response_text` **only** on `resolved:true` + non-empty. `resolved:false` / network error / judge-unavailable → injects nothing, backoff retries. Fixed-action path stays fully offline (built-in rate-limit auto-continue, now coord-seeded, still fires from cache with coord down).
- Removed orphaned `settings::AutoResponseRule`; serialized `COMPILED_RULES`-mutating tests (fixes a latent shared-static flake).

**Verification:** `cargo check` clean; 16 auto-response/output_scan tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)