### PR TITLE
test(relay): debug-only forced-panic endpoint to prove supervisor self-heal

### DIFF
--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -220,8 +220,42 @@ async fn relay_kick_handler() -> axum::response::Json<Value> {
 
 /// Router exposing the relay's web-integration diagnostic + control
 /// endpoints. Merged into the base router in `mcp_api::start_server`.
+/// Debug-only forced-panic trip switch for the relay loop. Flipped to `true`
+/// by [`relay_force_panic_handler`]; consumed (swapped back to `false`) at the
+/// top of [`relay_loop`], where it triggers a `panic!`. This is the external
+/// trigger needed to prove `task_supervisor::spawn_supervised` respawns the
+/// relay after a panic on a LIVE runner (relay-supervision fix, brief step 3:
+/// "induce the failure and prove self-heal WITHOUT a process restart"). Never
+/// compiled into release builds.
+#[cfg(debug_assertions)]
+static FORCE_RELAY_PANIC: AtomicBool = AtomicBool::new(false);
+
+/// `POST /web-integration/relay/__debug/force-panic` (debug builds only) —
+/// arm the relay loop's forced-panic trip switch and kick it so the loop
+/// wakes, re-iterates, and panics on its next pass. The supervisor should
+/// then respawn the loop (after its backoff) and the relay reconnects on its
+/// own — observable as `ws_connected` flipping `true → false → true` with no
+/// process restart. Localhost-bound + unauthenticated like the rest of the
+/// runner's local API; absent entirely from release builds.
+#[cfg(debug_assertions)]
+async fn relay_force_panic_handler() -> axum::response::Json<Value> {
+    FORCE_RELAY_PANIC.store(true, Ordering::SeqCst);
+    commands::kick_cloud_relay().await;
+    axum::response::Json(serde_json::json!({
+        "ok": true,
+        "armed": true,
+        "note": "relay loop will panic on its next iteration; the task \
+                 supervisor should respawn it and reconnect",
+    }))
+}
+
+// In release builds the `#[cfg(debug_assertions)]` route below is absent, so
+// `router` is bound then returned directly — clippy's `let_and_return` would
+// fire on that path only. The binding is intentional (it's conditionally
+// extended in debug builds), so the lint is allowed for both configs.
+#[allow(clippy::let_and_return)]
 pub fn routes() -> axum::Router<Arc<ApiState>> {
-    axum::Router::new()
+    let router = axum::Router::new()
         .route(
             "/web-integration/status",
             axum::routing::get(web_integration_status_handler),
@@ -229,7 +263,17 @@ pub fn routes() -> axum::Router<Arc<ApiState>> {
         .route(
             "/web-integration/relay/kick",
             axum::routing::post(relay_kick_handler),
-        )
+        );
+
+    // Debug-only forced-panic endpoint (relay-supervisor self-heal proof).
+    // Stripped from release builds along with its handler + trip switch.
+    #[cfg(debug_assertions)]
+    let router = router.route(
+        "/web-integration/relay/__debug/force-panic",
+        axum::routing::post(relay_force_panic_handler),
+    );
+
+    router
 }
 
 /// Return true iff `e` is a tungstenite handshake error with HTTP 401
@@ -399,6 +443,17 @@ async fn relay_loop(
         if *shutdown_rx.borrow() {
             info!("Backend relay shutting down");
             return;
+        }
+
+        // Debug-only forced-panic trip switch. When armed via
+        // `POST /web-integration/relay/__debug/force-panic` (also debug-only),
+        // panic here so the live-runner self-heal of
+        // `task_supervisor::spawn_supervised` can be exercised end-to-end
+        // (relay loop dies → supervisor catch_unwind → respawn → reconnect),
+        // the one proof a unit test can't give. Compiled out of release builds.
+        #[cfg(debug_assertions)]
+        if FORCE_RELAY_PANIC.swap(false, Ordering::SeqCst) {
+            panic!("forced debug panic — relay-supervisor self-heal verification");
         }
 
         // Re-read settings on every iteration so backend URL / token


### PR DESCRIPTION
## What
Adds a `#[cfg(debug_assertions)]`-only `POST /web-integration/relay/__debug/force-panic`
endpoint that arms a `FORCE_RELAY_PANIC` trip switch consumed at the top of `relay_loop`,
forcing the relay loop to `panic!` on its next iteration (the endpoint also kicks the loop so
it wakes immediately). The endpoint, its handler, and the static are all behind
`#[cfg(debug_assertions)]` and are **never compiled into release builds**.

## Why
The relay-supervision fix (#445 / #504) made `relay_loop` (and the device-JWT refresher)
respawn-on-panic via `task_supervisor::spawn_supervised`. The respawn logic is unit-tested,
but its **live** self-heal — `2026-06-06-runner-relay-supervision-fix-brief` step 3, "induce
the failure and prove self-heal WITHOUT a process restart" — had no external trigger to force
a panic on a running runner. This adds that trigger (debug builds / temp runners only) so the
self-heal is demonstrable end-to-end.

## Verified live (2026-06-15, temp runner built from this branch, Tier 2)
Forcing a panic produced the full self-heal chain in the runner log:

```
ERROR PANIC at backend_relay.rs:451: forced debug panic — relay-supervisor self-heal verification
WARN  task_supervisor: Backend relay loop PANICKED after 107.9s — respawning (it would otherwise stay dead until a runner restart)
INFO  Connecting to runner WS: wss://api.qontinui.io/api/v1/devices/ws
INFO  Connected to runner WS at wss://api.qontinui.io/api/v1/devices/ws
```

`ws_connected` recovered `true → false → true` in ~1.4s, with the runner **process** uptime
continuous (111s → 137s, no restart). `cargo fmt` + `clippy -D warnings` clean (pre-push +
local `--bin qontinui-runner --features custom-protocol`).

## Safety
Release builds are unaffected: the route is not registered, the handler and the
`FORCE_RELAY_PANIC` static are absent. Localhost-bound + unauthenticated like the rest of the
runner's local diagnostic API.

Session-Id: 19c57af7-b654-45a6-8cc7-c5ef66d7ca37