### PR TITLE
feat(backend-generator): Phase 1 — deterministic spec→FastAPI seam (Device + pairConfirm)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6338,6 +6338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "qontinui-backend-generator"
+version = "0.1.0"
+dependencies = [
+ "qontinui-types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "qontinui-code-graph"
 version = "0.1.0"
 dependencies = [
@@ -6529,7 +6538,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src-tauri", "src-tauri/clorinde", "crates/spec-check", "crates/qontinui-app-generator", "crates/comprehension"]
+members = ["src-tauri", "src-tauri/clorinde", "crates/spec-check", "crates/qontinui-app-generator", "crates/comprehension", "crates/qontinui-backend-generator"]
 resolver = "2"
 
 # Workspace-level profile overrides. Cargo only honors [profile.*] in the

--- a/crates/qontinui-backend-generator/.gitignore
+++ b/crates/qontinui-backend-generator/.gitignore
@@ -1,0 +1,2 @@
+# Materialized generated backends (runtime output, Fork B) — never source.
+/run/generated/

--- a/crates/qontinui-backend-generator/Cargo.toml
+++ b/crates/qontinui-backend-generator/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "qontinui-backend-generator"
+version = "0.1.0"
+edition = "2021"
+license = "AGPL-3.0-or-later"
+description = "Deterministic FastAPI backend generator: FunctionalSpec + Profile -> runnable backend source"
+
+[dependencies]
+qontinui-types = { path = "../../../qontinui-schemas/rust", version = ">=0.1.3, <2.0.0" }
+
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+# Phase 1 golden test reads the connect-runner fixtures from the schemas crate.

--- a/crates/qontinui-backend-generator/run/Dockerfile
+++ b/crates/qontinui-backend-generator/run/Dockerfile
@@ -1,0 +1,13 @@
+# Image for a generated FastAPI backend (Fork B runtime harness) — DEFERRED in Phase 1.
+# Built from a materialized ./generated/ tree. Pinned slim base; deps come from the
+# generated pyproject.toml. See run/README.md for the deferral note.
+FROM python:3.11-slim
+
+WORKDIR /srv
+COPY . /srv
+
+RUN pip install --no-cache-dir \
+    "fastapi" "uvicorn[standard]" "sqlalchemy>=2.0" "asyncpg" "alembic" "pydantic>=2"
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/crates/qontinui-backend-generator/run/README.md
+++ b/crates/qontinui-backend-generator/run/README.md
@@ -1,0 +1,47 @@
+# Runtime-verification harness (Fork B) — DEFERRED in Phase 1
+
+This directory is the **run target** the plan's Phase 1 steps 3–5 call for: bring a
+generated backend up in a throwaway container (disposable postgres + uvicorn), run
+migrations, then have the verify-phase hit the live endpoint and assemble a
+`CoverageEvidence` from the running server's behavior.
+
+## What ships in Phase 1 (deterministic, verified)
+
+The crate emits the backend **source** deterministically and the golden test
+(`tests/golden_phase1.rs`, 3 passing tests) proves the spec→routes/schema seam:
+
+- the emitted `pairConfirm` route's method+path is byte-equal to the shared
+  `endpoint_for(pairConfirm, profile)` == `POST /api/v1/devices/pair-confirm`
+  (the #1↔#2 agreement proof), and
+- the emitted `Device` model has one column per spec field.
+
+## What is honestly deferred (NOT proven in Phase 1)
+
+The plan's "coverage observed from a running server" premise requires:
+
+1. **A real handler body.** Phase 1 emits a deterministic typed *stub*
+   (`return {"deviceToken": ""}`). The real effect ("persists the pairing and returns a
+   device token") is authored by the `claude` CLI codegen subprocess
+   (`run_prompt_sync`, Fork A) — that is Phase 2/3, not the deterministic core.
+2. **Alembic migrations.** Phase 1 emits no `alembic/versions/*`, so there is no
+   `alembic upgrade` to create the `devices` table at boot.
+
+Because both are absent, bringing this compose stack up would NOT exercise a real
+pairing endpoint — wiring a hand-written migration + handler just to make it boot would
+be faking the runtime verification this phase explicitly must not fake. So the harness
+is checked in **ready but unexercised**, and the integration test
+(`tests/runtime_integration.rs`) is `#[ignore]`d with a body that documents exactly
+what it will assert once the Phase-2 bodies + migrations land.
+
+Docker *is* available on this machine (daemon reachable), but availability is not the
+blocker — the missing LLM-filled handler and migrations are.
+
+## Bringing it up (after Phase 2 lands)
+
+```sh
+# 1. materialize a generated backend into ./generated (see runtime_integration.rs)
+# 2. boot it
+docker compose -f run/docker-compose.yml up --build
+# 3. hit the live endpoint
+curl -i -X POST http://localhost:8000/api/v1/devices/pair-confirm
+```

--- a/crates/qontinui-backend-generator/run/docker-compose.yml
+++ b/crates/qontinui-backend-generator/run/docker-compose.yml
@@ -1,0 +1,41 @@
+# Runtime-verification harness (Fork B) for a generated backend — DEFERRED in Phase 1.
+#
+# This compose file is the run target the plan's Phase 1 step 3 calls for: bring the
+# generated backend up against a throwaway postgres under uvicorn so the verify-phase
+# can hit the live endpoint. It is intentionally NOT wired into CI in Phase 1 because
+# the generated handler body is a deterministic stub and no alembic migrations are
+# emitted yet (those are Phase 2/3, LLM-filled). It is checked in as the honest,
+# ready-to-use run scaffold — see ./README.md for what remains before it boots a real
+# server.
+#
+# Usage (once the Phase-2 migration + handler bodies land):
+#   1. Generate + materialize a backend into ./generated/ (see runtime_integration.rs).
+#   2. docker compose -f run/docker-compose.yml up --build
+#   3. The app serves on http://localhost:8000 ; POST /api/v1/devices/pair-confirm.
+
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: app
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 3s
+      retries: 20
+    # No host port published: the app reaches it over the compose network.
+
+  app:
+    build:
+      context: ./generated
+      dockerfile: ../Dockerfile
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/app
+    depends_on:
+      db:
+        condition: service_healthy
+    ports:
+      - "8000:8000"
+    command: ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/crates/qontinui-backend-generator/src/lib.rs
+++ b/crates/qontinui-backend-generator/src/lib.rs
@@ -1,0 +1,34 @@
+//! Backend generator (#2 of the website→mobile regeneration program) — Phase 1.
+//!
+//! Turns a frozen-v0 [`FunctionalSpec`] + [`Profile`] into the **source of a fresh,
+//! runnable FastAPI backend**. This crate owns the *deterministic* core: the package
+//! scaffold, the SQLAlchemy/Pydantic models, and the FastAPI routes. Per the plan's
+//! Fork A the *business-logic bodies* are later authored by a `claude` CLI codegen
+//! subprocess (`run_prompt_sync`); Phase 1 deliberately stops at a deterministic,
+//! verifiable scaffold so the spec→routes/schema seam is proven before any LLM enters.
+//!
+//! ## The load-bearing seam this crate proves (Phase 1)
+//!
+//! Every route this generator emits derives its `{method, path}` from the **shared**
+//! [`qontinui_types::endpoint_for::endpoint_for`] — the single function the app
+//! generator (#1) and this backend generator (#2) both call so they agree with no
+//! #1→#2 artifact dependency (cross-plan reconciliation §1). The golden test asserts
+//! the emitted `pairConfirm` route's method+path is byte-equal to
+//! `endpoint_for(pairConfirm, profile)` (`POST /api/v1/devices/pair-confirm`), and the
+//! emitted `Device` model has a column per spec field. That is the deterministic
+//! proof of the #1↔#2 agreement and of the spec→backend mapping.
+//!
+//! ## Honesty boundary
+//!
+//! This crate emits **source files as strings** ([`GeneratedBackend`]). It does NOT
+//! run the backend, migrate a database, or hit a live endpoint — that runtime
+//! verification (docker-compose postgres + uvicorn) is the integration tier and is
+//! deferred (see the crate's `tests/` and the `run/` scaffold). Coverage observed
+//! "from a running server" (the plan's premise) is therefore NOT proven here; only
+//! the deterministic generation core is.
+
+pub mod route_map;
+pub mod scaffold;
+
+pub use route_map::{openapi_document, route_for, RouteBinding};
+pub use scaffold::{generate_phase1, EmittedModel, EmittedRoute, GeneratedBackend};

--- a/crates/qontinui-backend-generator/src/route_map.rs
+++ b/crates/qontinui-backend-generator/src/route_map.rs
@@ -1,0 +1,57 @@
+//! Route derivation (Fork C) — **all** route method/path comes from the shared
+//! [`qontinui_types::endpoint_for::endpoint_for`]. This crate never re-derives paths;
+//! it only carries the derived [`Endpoint`] into emitted FastAPI source and the
+//! `openapi.json` aid. This is the mechanism by which the backend generator (#2) and
+//! the app generator (#1) agree on the API surface without a runtime handoff.
+
+use qontinui_types::endpoint_for::{endpoint_for, Endpoint};
+use qontinui_types::functional_spec::Operation;
+use qontinui_types::priorities_profile::Profile;
+
+/// An operation bound to its derived HTTP endpoint. The `endpoint` is produced
+/// **only** by [`endpoint_for`] — there is no second path-derivation path in this
+/// crate, which is what guarantees #1↔#2 agreement.
+#[derive(Debug, Clone)]
+pub struct RouteBinding {
+    /// The spec operation this route serves.
+    pub operation: Operation,
+    /// The derived `{method, path}` (from the shared `endpoint_for`).
+    pub endpoint: Endpoint,
+}
+
+/// Bind one operation to its derived endpoint via the shared rule.
+pub fn route_for(op: &Operation, profile: &Profile) -> RouteBinding {
+    RouteBinding {
+        operation: op.clone(),
+        endpoint: endpoint_for(op, profile),
+    }
+}
+
+/// Emit a minimal OpenAPI 3.1 document describing the bound routes. This is a
+/// **derived verification aid** (Fork C / reconciliation §1) — NOT a contract #1
+/// consumes; #1 derives the same endpoints from the shared `endpoint_for`. Returned
+/// as a `serde_json::Value` so the caller can serialize deterministically.
+pub fn openapi_document(routes: &[RouteBinding], title: &str) -> serde_json::Value {
+    let mut paths = serde_json::Map::new();
+    for r in routes {
+        let method = r.endpoint.method.to_ascii_lowercase();
+        let op_obj = serde_json::json!({
+            "operationId": r.operation.name,
+            "summary": format!("{} ({})", r.operation.name, r.operation.verb),
+            "responses": {
+                "201": { "description": "Created" }
+            }
+        });
+        let entry = paths
+            .entry(r.endpoint.path.clone())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+        if let serde_json::Value::Object(map) = entry {
+            map.insert(method, op_obj);
+        }
+    }
+    serde_json::json!({
+        "openapi": "3.1.0",
+        "info": { "title": title, "version": "0" },
+        "paths": serde_json::Value::Object(paths)
+    })
+}

--- a/crates/qontinui-backend-generator/src/scaffold.rs
+++ b/crates/qontinui-backend-generator/src/scaffold.rs
@@ -1,0 +1,462 @@
+//! Deterministic scaffold (Phase 1, no LLM) — emits the layered FastAPI skeleton plus
+//! one SQLAlchemy model + Pydantic schema per entity and one FastAPI route per
+//! operation. Mirrors the reference backend style (`qontinui-web/backend`:
+//! `Mapped[...]`, `mapped_column`, a declarative `Base`, `__tablename__`,
+//! `__table_args__`) and honors the `Profile` conventions (`pluralize` table names via
+//! the shared `endpoint_for` table rule, `snake_case` columns).
+//!
+//! Output is a [`GeneratedBackend`]: a map of relative path → file content, plus a
+//! structured view ([`EmittedModel`] / [`EmittedRoute`]) the golden test asserts
+//! against. Route method/path is taken **only** from [`crate::route_map`] (the shared
+//! `endpoint_for`), never re-derived here.
+
+use std::collections::BTreeMap;
+
+use qontinui_types::functional_spec::{Entity, EntityField, FunctionalSpec};
+use qontinui_types::priorities_profile::Profile;
+
+use crate::route_map::{openapi_document, route_for, RouteBinding};
+
+/// A generated backend: its files and a structured view of what was emitted.
+#[derive(Debug, Clone)]
+pub struct GeneratedBackend {
+    /// Relative-path → file-content for the whole emitted tree (deterministic order).
+    pub files: BTreeMap<String, String>,
+    /// One per spec entity, in spec order.
+    pub models: Vec<EmittedModel>,
+    /// One per spec operation, in spec order.
+    pub routes: Vec<EmittedRoute>,
+    /// The derived OpenAPI aid (Fork C) — a verification aid, not a #1 contract.
+    pub openapi: serde_json::Value,
+}
+
+impl GeneratedBackend {
+    /// Look up an emitted route by the spec operation name.
+    pub fn route(&self, operation_name: &str) -> Option<&EmittedRoute> {
+        self.routes.iter().find(|r| r.operation == operation_name)
+    }
+
+    /// Look up an emitted model by the spec entity name.
+    pub fn model(&self, entity_name: &str) -> Option<&EmittedModel> {
+        self.models.iter().find(|m| m.entity == entity_name)
+    }
+
+    /// Write the emitted file tree under `root` (creating parent dirs). Used by the
+    /// deferred runtime-integration tier to materialize the backend before bringing it
+    /// up under docker-compose. The deterministic golden tests do NOT touch disk.
+    pub fn materialize_to(&self, root: &std::path::Path) -> std::io::Result<()> {
+        for (rel, contents) in &self.files {
+            let dest = root.join(rel);
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            std::fs::write(&dest, contents)?;
+        }
+        Ok(())
+    }
+}
+
+/// A structured view of one emitted SQLAlchemy model.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmittedModel {
+    /// Spec entity name (`Device`).
+    pub entity: String,
+    /// Table name under the profile conventions (`devices`).
+    pub table: String,
+    /// One column name per spec [`EntityField`], in field order (plus the synthetic
+    /// `id` primary key first).
+    pub columns: Vec<String>,
+    /// The emitted python source for the model file.
+    pub source: String,
+}
+
+/// A structured view of one emitted FastAPI route. `method`/`path` are exactly the
+/// shared `endpoint_for` result.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EmittedRoute {
+    /// Spec operation name (`pairConfirm`).
+    pub operation: String,
+    /// HTTP method from `endpoint_for` (`POST`).
+    pub method: String,
+    /// Path from `endpoint_for` (`/api/v1/devices/pair-confirm`).
+    pub path: String,
+    /// The emitted python source for the route file.
+    pub source: String,
+}
+
+/// Generate a FastAPI backend scaffold for the given spec + profile (Phase 1 core).
+///
+/// Deterministic and side-effect-free: returns the file tree + structured view; it
+/// does NOT write to disk, run migrations, or start a server.
+pub fn generate_phase1(spec: &FunctionalSpec, profile: &Profile) -> GeneratedBackend {
+    let mut files: BTreeMap<String, String> = BTreeMap::new();
+
+    // --- Project skeleton (fixed, profile-aware) ---
+    files.insert("pyproject.toml".to_string(), emit_pyproject(spec, profile));
+    files.insert("app/__init__.py".to_string(), String::new());
+    files.insert("app/db/__init__.py".to_string(), String::new());
+    files.insert("app/db/base.py".to_string(), emit_db_base());
+    files.insert("app/db/session.py".to_string(), emit_db_session());
+    files.insert("app/models/__init__.py".to_string(), String::new());
+    files.insert("app/schemas/__init__.py".to_string(), String::new());
+    files.insert("app/api/__init__.py".to_string(), String::new());
+
+    // --- Models + schemas (one per entity) ---
+    let mut models = Vec::new();
+    for entity in &spec.entities {
+        let m = emit_model(entity, profile);
+        files.insert(
+            format!("app/models/{}.py", snake(&m.entity)),
+            m.source.clone(),
+        );
+        files.insert(
+            format!("app/schemas/{}.py", snake(&m.entity)),
+            emit_schema(entity),
+        );
+        models.push(m);
+    }
+
+    // --- Routes (one per operation), method/path from the shared endpoint_for ---
+    let mut routes = Vec::new();
+    let mut bindings: Vec<RouteBinding> = Vec::new();
+    for op in &spec.operations {
+        let binding = route_for(op, profile);
+        let r = emit_route(&binding);
+        files.insert(format!("app/api/{}.py", snake(&op.name)), r.source.clone());
+        routes.push(r);
+        bindings.push(binding);
+    }
+
+    // --- App entrypoint wiring every router ---
+    files.insert("app/main.py".to_string(), emit_main(spec, &bindings));
+
+    // --- OpenAPI aid (Fork C) ---
+    let openapi = openapi_document(&bindings, &project_title(spec));
+    files.insert(
+        "openapi.json".to_string(),
+        serde_json::to_string_pretty(&openapi).unwrap_or_else(|_| "{}".to_string()),
+    );
+
+    GeneratedBackend {
+        files,
+        models,
+        routes,
+        openapi,
+    }
+}
+
+// ===========================================================================
+// Model emission (SQLAlchemy 2.0, reference-backend style)
+// ===========================================================================
+
+fn emit_model(entity: &Entity, profile: &Profile) -> EmittedModel {
+    let table = table_name(entity, profile);
+    let class = pascal(&entity.name);
+
+    let mut columns: Vec<String> = vec!["id".to_string()];
+    let mut lines: Vec<String> = Vec::new();
+    // Synthetic primary key — every generated table gets one (REST resource identity).
+    lines.push(
+        "    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)".to_string(),
+    );
+    for f in &entity.fields {
+        let col = snake(&f.name);
+        let (py_ty, sa_ty) = sqlalchemy_type(f);
+        lines.push(format!(
+            "    {col}: Mapped[{py_ty}] = mapped_column({sa_ty}, nullable=False)"
+        ));
+        columns.push(col);
+    }
+
+    let source = format!(
+        "\"\"\"SQLAlchemy model for the `{name}` entity (generated, deterministic scaffold).\"\"\"\n\
+from sqlalchemy import String, Integer\n\
+from sqlalchemy.orm import Mapped, mapped_column\n\
+\n\
+from app.db.base import Base\n\
+\n\
+\n\
+class {class}(Base):\n\
+    __tablename__ = \"{table}\"\n\
+\n\
+{cols}\n",
+        name = entity.name,
+        class = class,
+        table = table,
+        cols = lines.join("\n"),
+    );
+
+    EmittedModel {
+        entity: entity.name.clone(),
+        table,
+        columns,
+        source,
+    }
+}
+
+/// Map a spec field type → (python type, SQLAlchemy column type). v0 conservative
+/// mapping; unknown coarse types fall back to `String`. Phase 2 widens this.
+fn sqlalchemy_type(f: &EntityField) -> (&'static str, &'static str) {
+    match f.field_type.as_str() {
+        "number" => ("int", "Integer"),
+        "bool" => ("bool", "Boolean"),
+        // string / enum / date / money / reference / unknown -> textual column in v0.
+        _ => ("str", "String"),
+    }
+}
+
+fn emit_schema(entity: &Entity) -> String {
+    let class = pascal(&entity.name);
+    let mut fields: Vec<String> = Vec::new();
+    for f in &entity.fields {
+        let (py_ty, _) = sqlalchemy_type(f);
+        fields.push(format!("    {}: {}", snake(&f.name), py_ty));
+    }
+    if fields.is_empty() {
+        fields.push("    pass".to_string());
+    }
+    format!(
+        "\"\"\"Pydantic schema for `{name}` (generated, deterministic scaffold).\"\"\"\n\
+from pydantic import BaseModel\n\
+\n\
+\n\
+class {class}Read(BaseModel):\n\
+    id: int\n\
+{fields}\n",
+        name = entity.name,
+        class = class,
+        fields = fields.join("\n"),
+    )
+}
+
+// ===========================================================================
+// Route emission (FastAPI) — method/path from the shared endpoint_for
+// ===========================================================================
+
+fn emit_route(binding: &RouteBinding) -> EmittedRoute {
+    let op = &binding.operation;
+    let method = binding.endpoint.method.clone();
+    let path = binding.endpoint.path.clone();
+    let decorator = method.to_ascii_lowercase();
+    let func = snake(&op.name);
+
+    // The handler body is a deterministic typed stub; per Fork A the real effect
+    // ("persists the pairing and returns a device token") is LLM-filled later. The
+    // stub returns the assumed-shape 201 so the route signature is real and testable.
+    let assumption = op
+        .effect
+        .as_ref()
+        .and_then(|e| e.assumption.clone())
+        .unwrap_or_else(|| "generated effect (assumed)".to_string());
+
+    let source = format!(
+        "\"\"\"FastAPI route for the `{op}` operation (generated scaffold).\n\
+\n\
+Route derived from the shared `endpoint_for`: {method} {path}\n\
+Assumed effect: {assumption}\n\
+\"\"\"\n\
+from fastapi import APIRouter, status\n\
+\n\
+router = APIRouter()\n\
+\n\
+\n\
+@router.{decorator}(\"{path}\", status_code=status.HTTP_201_CREATED)\n\
+async def {func}() -> dict:\n\
+    # TODO(codegen): LLM-filled body — {assumption}\n\
+    return {{\"deviceToken\": \"\"}}\n",
+        op = op.name,
+        method = method,
+        path = path,
+        assumption = assumption,
+        decorator = decorator,
+        func = func,
+    );
+
+    EmittedRoute {
+        operation: op.name.clone(),
+        method,
+        path,
+        source,
+    }
+}
+
+// ===========================================================================
+// Project skeleton files
+// ===========================================================================
+
+fn emit_main(spec: &FunctionalSpec, bindings: &[RouteBinding]) -> String {
+    let mut imports = Vec::new();
+    let mut includes = Vec::new();
+    for b in bindings {
+        let module = snake(&b.operation.name);
+        imports.push(format!("from app.api import {module}"));
+        includes.push(format!("app.include_router({module}.router)"));
+    }
+    let auth_note = spec
+        .auth
+        .as_ref()
+        .map(|a| format!("# auth model (spec): {}\n", a.model))
+        .unwrap_or_default();
+    format!(
+        "\"\"\"FastAPI application entrypoint (generated scaffold).\"\"\"\n\
+from fastapi import FastAPI\n\
+\n\
+{imports}\n\
+\n\
+{auth_note}app = FastAPI(title=\"{title}\")\n\
+\n\
+{includes}\n",
+        imports = imports.join("\n"),
+        auth_note = auth_note,
+        title = project_title(spec),
+        includes = includes.join("\n"),
+    )
+}
+
+fn emit_db_base() -> String {
+    "\"\"\"Declarative SQLAlchemy 2.0 Base (generated scaffold).\"\"\"\n\
+from sqlalchemy.orm import DeclarativeBase\n\
+\n\
+\n\
+class Base(DeclarativeBase):\n\
+    pass\n"
+        .to_string()
+}
+
+fn emit_db_session() -> String {
+    "\"\"\"Async SQLAlchemy session factory (generated scaffold).\"\"\"\n\
+import os\n\
+\n\
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine\n\
+\n\
+DATABASE_URL = os.environ.get(\n\
+    \"DATABASE_URL\", \"postgresql+asyncpg://postgres:postgres@localhost:5432/app\"\n\
+)\n\
+engine = create_async_engine(DATABASE_URL, future=True)\n\
+SessionLocal = async_sessionmaker(engine, expire_on_commit=False)\n"
+        .to_string()
+}
+
+fn emit_pyproject(spec: &FunctionalSpec, profile: &Profile) -> String {
+    format!(
+        "[project]\n\
+name = \"{slug}\"\n\
+version = \"0.1.0\"\n\
+description = \"Generated backend for {url} (stack: {lang}/{fw}/{store}/{api})\"\n\
+requires-python = \">=3.11\"\n\
+dependencies = [\n\
+    \"fastapi\",\n\
+    \"uvicorn[standard]\",\n\
+    \"sqlalchemy>=2.0\",\n\
+    \"asyncpg\",\n\
+    \"alembic\",\n\
+    \"pydantic>=2\",\n\
+]\n",
+        slug = slug(spec),
+        url = spec.target.source_url,
+        lang = profile.backend.language,
+        fw = profile.backend.framework,
+        store = profile.backend.datastore,
+        api = api_style_str(profile),
+    )
+}
+
+fn api_style_str(profile: &Profile) -> &'static str {
+    use qontinui_types::priorities_profile::ApiStyle;
+    match profile.backend.api_style {
+        ApiStyle::Rest => "rest",
+        ApiStyle::Graphql => "graphql",
+    }
+}
+
+// ===========================================================================
+// Naming helpers
+// ===========================================================================
+
+/// Table name for an entity under the profile conventions. Derived by reusing the
+/// shared `endpoint_for` path rule (so the table name and the route path cannot drift):
+/// `endpoint_for(create<Entity>, profile).path` == `/api/v1/{table}`, last segment = table.
+fn table_name(entity: &Entity, profile: &Profile) -> String {
+    use qontinui_types::endpoint_for::endpoint_for;
+    use qontinui_types::functional_spec::{Operation, SpecProvenance};
+    // A synthetic bare-CRUD op `create<Entity>` addresses the collection, so its
+    // derived path's final segment is exactly the profile-conventioned table name.
+    let probe = Operation {
+        name: format!("create{}", entity.name),
+        verb: "create".to_string(),
+        entity: Some(entity.name.clone()),
+        inputs: vec![],
+        effect: None,
+        confidence: SpecProvenance::Observed,
+        provenance: None,
+        credibility: None,
+    };
+    let ep = endpoint_for(&probe, profile);
+    ep.path
+        .rsplit('/')
+        .next()
+        .unwrap_or(&entity.name)
+        .to_string()
+}
+
+fn project_title(spec: &FunctionalSpec) -> String {
+    slug(spec)
+}
+
+/// A filesystem-safe slug from the spec target URL (the artifacts dir name in Fork B).
+fn slug(spec: &FunctionalSpec) -> String {
+    let url = &spec.target.source_url;
+    let stripped = url
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let mut out = String::with_capacity(stripped.len());
+    for ch in stripped.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+        } else if (ch == '.' || ch == '/' || ch == '-' || ch == '_')
+            && !out.ends_with('-')
+            && !out.is_empty()
+        {
+            out.push('-');
+        }
+    }
+    out.trim_matches('-').to_string()
+}
+
+/// `PascalCase`/`camelCase`/`kebab`/`space` → `snake_case`.
+fn snake(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 4);
+    for (i, ch) in s.chars().enumerate() {
+        if ch == '-' || ch == '_' || ch == ' ' {
+            if !out.ends_with('_') && !out.is_empty() {
+                out.push('_');
+            }
+        } else if ch.is_ascii_uppercase() {
+            if i != 0 && !out.ends_with('_') {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+/// `camelCase`/`snake`/`kebab` → `PascalCase`.
+fn pascal(s: &str) -> String {
+    let snaked = snake(s);
+    let mut out = String::with_capacity(snaked.len());
+    let mut upper_next = true;
+    for ch in snaked.chars() {
+        if ch == '_' {
+            upper_next = true;
+        } else if upper_next {
+            out.extend(ch.to_uppercase());
+            upper_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/crates/qontinui-backend-generator/tests/golden_phase1.rs
+++ b/crates/qontinui-backend-generator/tests/golden_phase1.rs
@@ -1,0 +1,200 @@
+//! Phase 1 golden test — the deterministic spec→backend seam.
+//!
+//! Proves, WITHOUT running anything:
+//!   (1) the emitted `pairConfirm` route's method+path is byte-equal to the shared
+//!       `endpoint_for(pairConfirm, profile)` (== `POST /api/v1/devices/pair-confirm`)
+//!       — this is the #1↔#2 agreement proof (both sides derive routes from the same
+//!       function), and
+//!   (2) the emitted `Device` model has one column per spec `Device` field.
+//!
+//! These two assertions are the falsifiable core of Phase 1's deterministic tier.
+//! Runtime verification (compose postgres + uvicorn, hit the live endpoint) is a
+//! separate, deferred integration tier — see `tests/runtime_integration.rs`.
+
+use std::path::PathBuf;
+
+use qontinui_backend_generator::generate_phase1;
+use qontinui_types::endpoint_for::endpoint_for;
+use qontinui_types::functional_spec::FunctionalSpec;
+use qontinui_types::priorities_profile::Profile;
+
+/// The connect-runner fixtures live in the sibling schemas crate (read-only).
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../qontinui-schemas/rust/tests/fixtures/functional_spec")
+}
+
+fn load_spec() -> FunctionalSpec {
+    let p = fixtures_dir().join("connect-runner.functional_spec.json");
+    let raw = std::fs::read_to_string(&p)
+        .unwrap_or_else(|e| panic!("read spec fixture {}: {e}", p.display()));
+    serde_json::from_str(&raw).expect("parse connect-runner functional_spec")
+}
+
+fn load_profile() -> Profile {
+    let p = fixtures_dir().join("connect-runner.profile.json");
+    let raw = std::fs::read_to_string(&p)
+        .unwrap_or_else(|e| panic!("read profile fixture {}: {e}", p.display()));
+    serde_json::from_str(&raw).expect("parse connect-runner profile")
+}
+
+#[test]
+fn pair_confirm_route_method_and_path_equal_shared_endpoint_for() {
+    let spec = load_spec();
+    let profile = load_profile();
+
+    let pair_confirm = spec
+        .operations
+        .iter()
+        .find(|o| o.name == "pairConfirm")
+        .expect("fixture has a pairConfirm operation");
+
+    // The canonical derivation — the one #1 (app-gen) also calls.
+    let canonical = endpoint_for(pair_confirm, &profile);
+
+    let backend = generate_phase1(&spec, &profile);
+    let route = backend
+        .route("pairConfirm")
+        .expect("generator emitted a pairConfirm route");
+
+    // (1) The emitted route is byte-equal to the shared endpoint_for result.
+    assert_eq!(
+        route.method, canonical.method,
+        "emitted method must equal endpoint_for"
+    );
+    assert_eq!(
+        route.path, canonical.path,
+        "emitted path must equal endpoint_for"
+    );
+
+    // And both equal the observed reality the fixture provenance records.
+    assert_eq!(route.method, "POST");
+    assert_eq!(route.path, "/api/v1/devices/pair-confirm");
+
+    // The emitted FastAPI source actually carries that method+path in its decorator.
+    assert!(
+        route
+            .source
+            .contains("@router.post(\"/api/v1/devices/pair-confirm\""),
+        "emitted route source must wire POST /api/v1/devices/pair-confirm; got:\n{}",
+        route.source
+    );
+
+    // The OpenAPI aid (Fork C) lists the same path under the same lowercased method.
+    let path_obj = &backend.openapi["paths"]["/api/v1/devices/pair-confirm"];
+    assert!(
+        path_obj.get("post").is_some(),
+        "openapi aid must list POST /api/v1/devices/pair-confirm; got:\n{}",
+        serde_json::to_string_pretty(&backend.openapi).unwrap()
+    );
+}
+
+#[test]
+fn device_model_has_a_column_per_spec_field() {
+    let spec = load_spec();
+    let profile = load_profile();
+
+    let device = spec
+        .entities
+        .iter()
+        .find(|e| e.name == "Device")
+        .expect("fixture has a Device entity");
+    let expected_cols: Vec<String> = device.fields.iter().map(|f| f.name.clone()).collect();
+    // Sanity: the fixture's four observed/inferred fields.
+    assert_eq!(
+        expected_cols,
+        vec![
+            "deviceName".to_string(),
+            "deviceId".to_string(),
+            "state".to_string(),
+            "callback".to_string()
+        ]
+    );
+
+    let backend = generate_phase1(&spec, &profile);
+    let model = backend
+        .model("Device")
+        .expect("generator emitted a Device model");
+
+    // Table name from the profile conventions (pluralize + snake_case).
+    assert_eq!(model.table, "devices");
+
+    // Every spec field is present as a snake_case column (plus the synthetic id PK).
+    for field in &device.fields {
+        let col = snake_local(&field.name);
+        assert!(
+            model.columns.contains(&col),
+            "model must have a column for spec field `{}` (expected `{}`); columns = {:?}",
+            field.name,
+            col,
+            model.columns
+        );
+        // The emitted SQLAlchemy source carries the mapped_column too.
+        assert!(
+            model.source.contains(&format!("{col}: Mapped[")),
+            "model source must declare `{col}` as a Mapped column;\nsource:\n{}",
+            model.source
+        );
+    }
+
+    // One column per field + one synthetic id PK.
+    assert_eq!(
+        model.columns.len(),
+        device.fields.len() + 1,
+        "exactly one column per field plus the id PK; columns = {:?}",
+        model.columns
+    );
+    assert_eq!(model.columns.first().map(String::as_str), Some("id"));
+}
+
+#[test]
+fn dropping_a_field_drops_its_column_deterministic_gap_proof() {
+    // Deterministic analogue of the plan's "broken variant surfaces a gap": at the
+    // generation tier, removing a spec field must remove exactly its column — proving
+    // the emitted schema reflects the spec, not a hardcoded shape. (The *runtime*
+    // gap-from-live-server proof is the deferred integration tier.)
+    let mut spec = load_spec();
+    let profile = load_profile();
+
+    let full = generate_phase1(&spec, &profile);
+    let full_cols = full.model("Device").unwrap().columns.clone();
+    assert!(full_cols.contains(&"callback".to_string()));
+
+    // Drop the `callback` field.
+    let device = spec
+        .entities
+        .iter_mut()
+        .find(|e| e.name == "Device")
+        .unwrap();
+    device.fields.retain(|f| f.name != "callback");
+
+    let dropped = generate_phase1(&spec, &profile);
+    let dropped_cols = dropped.model("Device").unwrap().columns.clone();
+
+    assert!(
+        !dropped_cols.contains(&"callback".to_string()),
+        "dropping the spec field must drop its column"
+    );
+    assert_eq!(
+        dropped_cols.len(),
+        full_cols.len() - 1,
+        "exactly the dropped field's column disappears"
+    );
+}
+
+/// Local copy of the generator's snake_case rule, kept in the test so the assertion
+/// is independent of the crate's private helper.
+fn snake_local(s: &str) -> String {
+    let mut out = String::new();
+    for (i, ch) in s.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i != 0 && !out.ends_with('_') {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}

--- a/crates/qontinui-backend-generator/tests/runtime_integration.rs
+++ b/crates/qontinui-backend-generator/tests/runtime_integration.rs
@@ -1,0 +1,63 @@
+//! Runtime-verification integration tier (Fork B) — **DEFERRED, `#[ignore]`d**.
+//!
+//! This is the test that proves the plan's load-bearing premise: that a generated
+//! backend can be brought up, hit, and have coverage *observed from the running server*.
+//! It is `#[ignore]`d in Phase 1 and does NOT assert against a live server, because the
+//! deterministic scaffold emits a stub handler and no alembic migrations — so there is
+//! no real pairing endpoint to exercise yet (see `run/README.md`). Hand-writing those
+//! just to make this pass would be faking runtime verification, which Phase 1 forbids.
+//!
+//! What it WILL do once the Phase-2 LLM-filled handler + migrations land:
+//!   1. `generate_phase1(spec, profile)` then `materialize_to(run/generated)`.
+//!   2. `docker compose -f run/docker-compose.yml up --build -d` (throwaway postgres),
+//!      `alembic upgrade head`.
+//!   3. `POST /api/v1/devices/pair-confirm` with a valid pairing → assert 201 + a
+//!      token-shaped body; introspect the live schema for the `devices` table + its
+//!      four columns; confirm the session middleware gates the route.
+//!   4. Assemble a `CoverageEvidence { covered, gaps, filled_assumed }` from those LIVE
+//!      observations and assert `evaluate_completeness` reports `entities.Device*` +
+//!      `operations.pairConfirm` covered, `operations.pairConfirm.effect` filled.
+//!   5. A deliberately broken variant (500 / dropped column) must surface the matching
+//!      ref as a `CoverageGap` — proving evidence reflects the running server.
+//!
+//! Run (manually, after Phase 2): `cargo test -p qontinui-backend-generator --
+//! --ignored runtime_pair_confirm_observed_from_live_server`.
+
+use std::path::PathBuf;
+
+use qontinui_backend_generator::generate_phase1;
+use qontinui_types::functional_spec::FunctionalSpec;
+use qontinui_types::priorities_profile::Profile;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../qontinui-schemas/rust/tests/fixtures/functional_spec")
+}
+
+#[test]
+#[ignore = "runtime tier deferred: needs Phase-2 LLM-filled handler + alembic migrations; \
+            Phase 1 must not fake runtime verification (see run/README.md)"]
+fn runtime_pair_confirm_observed_from_live_server() {
+    // Deterministic prerequisite that DOES hold today: the generator materializes a
+    // tree containing app/main.py + the Device model + the pair-confirm route. This is
+    // the only part this stub exercises; the live bring-up + HTTP probe + CoverageEvidence
+    // assembly is intentionally NOT implemented until the Phase-2 bodies land.
+    let spec: FunctionalSpec = serde_json::from_str(
+        &std::fs::read_to_string(fixtures_dir().join("connect-runner.functional_spec.json"))
+            .expect("read spec fixture"),
+    )
+    .expect("parse spec");
+    let profile: Profile = serde_json::from_str(
+        &std::fs::read_to_string(fixtures_dir().join("connect-runner.profile.json"))
+            .expect("read profile fixture"),
+    )
+    .expect("parse profile");
+
+    let backend = generate_phase1(&spec, &profile);
+    assert!(backend.files.contains_key("app/main.py"));
+    assert!(backend.files.contains_key("app/models/device.py"));
+    assert!(backend.files.contains_key("app/api/pair_confirm.py"));
+
+    // DEFERRED: docker compose up + alembic upgrade + live POST + CoverageEvidence.
+    // See run/README.md. Do not implement until the real handler body + migrations exist.
+}


### PR DESCRIPTION
## Phase 1 of `2026-06-14-backend-generator-from-spec.md` — deterministic core only

New standalone crate **`qontinui-backend-generator`** (sibling to #1's app-generator), node #2 of the website→mobile regeneration program. This PR delivers **Phase 1's deterministic, verifiable core** — the most-falsifiable probe — and **does not fake runtime verification**.

### What it builds
From the connect-runner `FunctionalSpec` + `Profile`, deterministically emit a FastAPI backend source tree for the `Device` entity + `pairConfirm` operation:
- SQLAlchemy 2.0 model per entity (`Mapped`/`mapped_column`/`Base`/`__tablename__`, reference-backend style) — one column per spec field + synthetic `id` PK
- Pydantic schema per entity
- FastAPI route per operation whose `{method, path}` come **only** from the shared `qontinui_types::endpoint_for` — never re-derived. This is the **#1↔#2 agreement mechanism**: both generators derive routes from the same function, no #1→#2 artifact dependency.
- project skeleton (`pyproject.toml`, `app/db`, `app/main.py` wiring routers)
- a derived `openapi.json` aid (Fork C) — a **verification aid, not a contract #1 consumes**

### Verification (deterministic tier — green)
`cargo test -p qontinui-backend-generator` → **3 passing**, 1 ignored:
- `pair_confirm_route_method_and_path_equal_shared_endpoint_for` — emitted route method+path **byte-equal** to `endpoint_for(pairConfirm, profile)` == `POST /api/v1/devices/pair-confirm` (asserted against the canonical fn, the literal, the source decorator, and the openapi aid)
- `device_model_has_a_column_per_spec_field` — table `devices` (pluralize+snake_case), one column per spec field + id PK
- `dropping_a_field_drops_its_column_deterministic_gap_proof` — deterministic gap proof
- `runtime_pair_confirm_observed_from_live_server` — `#[ignore]`d (see below)

`cargo fmt` / `cargo clippy -- -D warnings` clean.

### Runtime tier — honestly DEFERRED (NOT faked)
The plan's premise "coverage observed from a running server" requires an **LLM-filled handler body** (Fork A, `run_prompt_sync`) and **alembic migrations** — both Phase 2/3. The Phase-1 handler is a deterministic typed stub and no migrations are emitted, so bringing the stack up would not exercise a real endpoint. Docker IS available here, but that is not the blocker. The compose/uvicorn harness (`run/docker-compose.yml`, `run/Dockerfile`, `run/README.md`) is checked in **ready-but-unexercised**, and `tests/runtime_integration.rs` is `#[ignore]`d documenting exactly what it will assert once Phase 2 lands. **This PR does not claim end-to-end verification.**

### Cross-plan seam reconciliation (honored)
All route derivation goes through the shared `endpoint_for`; #2 owns `entities.*` / `auth.*` / `operations.<op>.effect` coverage; the emitted `openapi.json` is a derived aid, not a contract #1 consumes.

Session-Id: c85ec3fa-a426-4c02-9513-b3a68cba5fa7