### PR TITLE
chore: bump @qontinui/navigation to ^0.1.4 (runner-menu cleanup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@dagrejs/dagre": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@qontinui/design-tokens": "^1.0.0",
-    "@qontinui/navigation": "^0.1.3",
+    "@qontinui/navigation": "^0.1.4",
     "@qontinui/shared-types": "^0.6.0",
     "@qontinui/ui-bridge": "^0.17.0",
     "@qontinui/ui-bridge-auto": "^0.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0(tailwindcss@4.2.4)
       '@qontinui/navigation':
-        specifier: ^0.1.3
-        version: 0.1.3(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
+        specifier: ^0.1.4
+        version: 0.1.4(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)
       '@qontinui/shared-types':
         specifier: ^0.6.0
         version: 0.6.0
@@ -1121,8 +1121,8 @@ packages:
       tailwindcss:
         optional: true
 
-  '@qontinui/navigation@0.1.3':
-    resolution: {integrity: sha512-I9flSGD9UzLE5eaBl9cBxf3RSYmPbODBdrqvfR5dJ6TykK5B2lcRvUdWRx7EnSxCrUobDtsp1FWZKL9O4CsUjw==}
+  '@qontinui/navigation@0.1.4':
+    resolution: {integrity: sha512-GJew2U3BLZpPInv5ZdY1k8sm/jQOzE9oqDC3HydEtlY2tLInsKsJjk0DbFYoPBkCgxMaYFW5xRP+jnfPKGxzIw==}
     peerDependencies:
       '@qontinui/ui-bridge': '>=0.3.0'
       react: ^18.0.0 || ^19.0.0
@@ -6128,7 +6128,7 @@ snapshots:
     optionalDependencies:
       tailwindcss: 4.2.4
 
-  '@qontinui/navigation@0.1.3(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
+  '@qontinui/navigation@0.1.4(@qontinui/ui-bridge@0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react@19.2.5)':
     optionalDependencies:
       '@qontinui/ui-bridge': 0.17.0(@qontinui/ui-bridge-auto@0.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(ws@8.21.0)
       react: 19.2.5


### PR DESCRIPTION
Picks up `@qontinui/navigation@0.1.4`: **Visual GUI moves out of the AI Dev sidebar** (now `productMode: visual`); `reflection`/`tasks`/`triggers` gain `platforms: [runner]`. Lockfile refreshed.