### PR TITLE
runner: fix terminal paste — bracketed-paste + newline normalization (+ pasteText test hook)

### DIFF
--- a/src/components/terminal/TerminalInstance.tsx
+++ b/src/components/terminal/TerminalInstance.tsx
@@ -11,6 +11,7 @@ import { paintGrid, type GridSnapshot } from "./paintGrid";
 import { getTerminalDebug, recordPaintGrid } from "./terminalDebug";
 import { instanceStorage } from "@/lib/instance-storage";
 import { consumeInputChunk } from "./consumeInputChunk";
+import { preparePasteData } from "./preparePaste";
 import { wheelToLineDelta, DEFAULT_CELL_HEIGHT_PX } from "./wheelScroll";
 import { matchScrollShortcut } from "./scrollKeys";
 import { trimReplayedChunk, type OffsetChunk } from "./scrollbackReplay";
@@ -366,6 +367,7 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
       let observer: ResizeObserver | null = null;
       let blockNativePaste: ((e: Event) => void) | null = null;
       let wheelScrollOverride: ((e: WheelEvent) => void) | null = null;
+      let contextMenuCopyPaste: ((e: MouseEvent) => void) | null = null;
       // Ensure the dev instrumentation hook (window.__qontinuiTerminal) exists
       // so it's discoverable from the console even before any paint fires.
       getTerminalDebug();
@@ -672,8 +674,14 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
               .then((text) => {
                 if (text) {
                   // Write directly to PTY instead of paste to avoid double
-                  // paste when WebView2 also fires a native paste event.
-                  const bytes = encoder.encode(text);
+                  // paste when WebView2 also fires a native paste event. Run
+                  // the clipboard text through the same bracketed-paste +
+                  // newline normalization xterm's own paste would apply — a raw
+                  // write breaks multi-line paste into TUIs that enable
+                  // bracketed paste mode (Claude Code, vim, fzf). See
+                  // `preparePaste.ts`.
+                  const prepared = preparePasteData(text, backend.bracketedPasteMode);
+                  const bytes = encoder.encode(prepared);
                   invoke("terminal_write", { terminalId, data: uint8ToBase64(bytes) }).catch(
                     () => {},
                   );
@@ -763,6 +771,40 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         };
         inputEl?.addEventListener("paste", blockNativePaste, true);
 
+        // Right-click copy/paste (VS Code `terminal.integrated.rightClickBehavior:
+        // "copyPaste"` parity): with a selection, right-click copies it (and
+        // clears the highlight as feedback); with no selection, it pastes the
+        // clipboard. We preventDefault + stopPropagation so neither the WebView2
+        // context menu nor the enclosing zone's `onContextMenu` (which opens the
+        // zone menu) fires — inside the terminal body, right-click belongs to
+        // copy/paste.
+        contextMenuCopyPaste = (e: MouseEvent) => {
+          const b = backendRef.current;
+          if (!b) return;
+          e.preventDefault();
+          e.stopPropagation();
+          if (b.hasSelection()) {
+            const selection = b.getSelection();
+            if (selection) {
+              navigator.clipboard.writeText(selection).catch(() => {});
+              b.clearSelection();
+            }
+            return;
+          }
+          // No selection → paste, mirroring the Ctrl+V path (bracketed-paste +
+          // newline normalization; see `preparePaste.ts`).
+          navigator.clipboard
+            .readText()
+            .then((text) => {
+              if (!text) return;
+              const prepared = preparePasteData(text, b.bracketedPasteMode);
+              const bytes = encoder.encode(prepared);
+              invoke("terminal_write", { terminalId, data: uint8ToBase64(bytes) }).catch(() => {});
+            })
+            .catch(() => {});
+        };
+        container.addEventListener("contextmenu", contextMenuCopyPaste);
+
         // Register terminal input with UI Bridge for external automation.
         const bridgeRegistry = uiBridge?.registry;
         if (bridgeRegistry && inputEl) {
@@ -804,12 +846,30 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
                 handler: async () => {
                   const text = await navigator.clipboard.readText().catch(() => "");
                   if (text) {
-                    const bytes = encoder.encode(text);
+                    // Same bracketed-paste + newline normalization as the
+                    // Ctrl+V path (see `preparePaste.ts`).
+                    const prepared = preparePasteData(text, backend.bracketedPasteMode);
+                    const bytes = encoder.encode(prepared);
                     invoke("terminal_write", {
                       terminalId: termId,
                       data: uint8ToBase64(bytes),
                     }).catch(() => {});
                   }
+                },
+              },
+              pasteText: {
+                id: "pasteText",
+                description:
+                  "Paste literal text through the Ctrl+V path (bracketed-paste aware); no clipboard/keyboard. For automated tests.",
+                handler: (params?: unknown) => {
+                  const { text } = (params || {}) as { text?: string };
+                  if (!text) return;
+                  const b = backendRef.current;
+                  const prepared = preparePasteData(text, b?.bracketedPasteMode ?? false);
+                  const bytes = encoder.encode(prepared);
+                  invoke("terminal_write", { terminalId: termId, data: uint8ToBase64(bytes) }).catch(
+                    () => {},
+                  );
                 },
               },
               getScrollback: {
@@ -1138,6 +1198,9 @@ export const TerminalInstance = forwardRef<TerminalInstanceHandle, TerminalInsta
         observer?.disconnect();
         if (wheelScrollOverride) {
           container.removeEventListener("wheel", wheelScrollOverride, { capture: true });
+        }
+        if (contextMenuCopyPaste) {
+          container.removeEventListener("contextmenu", contextMenuCopyPaste);
         }
         for (const d of disposables) d.dispose();
         const inputEl = backendRef.current?.getInputElement();

--- a/src/components/terminal/backends/GhosttyBackend.ts
+++ b/src/components/terminal/backends/GhosttyBackend.ts
@@ -94,12 +94,28 @@ export class GhosttyBackend implements ITerminalBackend {
     return { dispose() {} };
   }
 
+  get bracketedPasteMode(): boolean {
+    // ghostty-web mirrors xterm's `modes` object on builds that expose it;
+    // guard so a build without it degrades to unbracketed paste instead of
+    // throwing.
+    const t = this.term as unknown as { modes?: { bracketedPasteMode?: boolean } };
+    return t.modes?.bracketedPasteMode ?? false;
+  }
+
   getSelection(): string {
     return this.term.getSelection();
   }
 
   hasSelection(): boolean {
     return this.term.hasSelection();
+  }
+
+  clearSelection(): void {
+    // Guard: degrade to a no-op on a ghostty-web build without clearSelection
+    // rather than throwing (the right-click copy still lands; only the visual
+    // deselect is skipped).
+    const t = this.term as unknown as { clearSelection?: () => void };
+    t.clearSelection?.();
   }
 
   onSelectionChange(cb: () => void): IDisposable {

--- a/src/components/terminal/backends/XtermBackend.ts
+++ b/src/components/terminal/backends/XtermBackend.ts
@@ -200,12 +200,20 @@ export class XtermBackend implements ITerminalBackend {
     return this.term.onBinary(cb);
   }
 
+  get bracketedPasteMode(): boolean {
+    return this.term.modes.bracketedPasteMode;
+  }
+
   getSelection(): string {
     return this.term.getSelection();
   }
 
   hasSelection(): boolean {
     return this.term.hasSelection();
+  }
+
+  clearSelection(): void {
+    this.term.clearSelection();
   }
 
   onSelectionChange(cb: () => void): IDisposable {

--- a/src/components/terminal/backends/types.ts
+++ b/src/components/terminal/backends/types.ts
@@ -155,10 +155,20 @@ export interface ITerminalBackend {
   onData(cb: (data: string) => void): IDisposable;
   /** Subscribe to binary input (e.g. paste with special chars). Optional — may be a no-op. */
   onBinary(cb: (data: string) => void): IDisposable;
+  /**
+   * Whether the foreground app has enabled bracketed paste mode (DEC mode
+   * 2004). The runner intercepts Ctrl+V and writes to the PTY itself, so it
+   * must replicate the bracketing/normalization xterm's own paste would do —
+   * this exposes the mode state needed to decide. False on backends that don't
+   * track it. See `preparePaste.ts`.
+   */
+  readonly bracketedPasteMode: boolean;
 
   // -- Selection ------------------------------------------------------------
   getSelection(): string;
   hasSelection(): boolean;
+  /** Clear the active text selection (e.g. after a right-click copy). */
+  clearSelection(): void;
   onSelectionChange(cb: () => void): IDisposable;
 
   // -- Buffer access --------------------------------------------------------

--- a/src/components/terminal/preparePaste.test.ts
+++ b/src/components/terminal/preparePaste.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { preparePasteData } from "./preparePaste";
+
+const START = "\x1b[200~";
+const END = "\x1b[201~";
+
+describe("preparePasteData", () => {
+  describe("bracketed paste mode ON (Claude Code, vim, fzf, …)", () => {
+    it("wraps single-line text in the paste envelope", () => {
+      expect(preparePasteData("hello", true)).toBe(`${START}hello${END}`);
+    });
+
+    it("keeps embedded newlines as literal CR inside the envelope (no per-line submit)", () => {
+      // The whole multi-line blob stays inside one envelope — the app treats
+      // it as a single paste, not N Enter presses.
+      expect(preparePasteData("line1\nline2\nline3", true)).toBe(
+        `${START}line1\rline2\rline3${END}`,
+      );
+    });
+
+    it("normalizes CRLF to a single CR", () => {
+      expect(preparePasteData("a\r\nb", true)).toBe(`${START}a\rb${END}`);
+    });
+
+    it("strips embedded paste markers so pasted terminal output can't break out", () => {
+      const malicious = `safe${END}rm -rf /`;
+      const result = preparePasteData(malicious, true);
+      // Exactly one start and one end marker — the wrapping pair only.
+      expect(result.startsWith(START)).toBe(true);
+      expect(result.endsWith(END)).toBe(true);
+      expect(result.split(END)).toHaveLength(2); // only the trailing wrapper
+      expect(result).toBe(`${START}saferm -rf /${END}`);
+    });
+
+    it("strips embedded start markers too", () => {
+      expect(preparePasteData(`${START}x`, true)).toBe(`${START}x${END}`);
+    });
+
+    it("wraps empty text in a bare envelope", () => {
+      expect(preparePasteData("", true)).toBe(`${START}${END}`);
+    });
+  });
+
+  describe("bracketed paste mode OFF (bare shell prompt)", () => {
+    it("passes single-line text through unchanged", () => {
+      expect(preparePasteData("ls -la", false)).toBe("ls -la");
+    });
+
+    it("normalizes newlines to CR (real Enter) without an envelope", () => {
+      expect(preparePasteData("a\nb\r\nc", false)).toBe("a\rb\rc");
+    });
+
+    it("does not add or strip markers", () => {
+      expect(preparePasteData(`keep${END}this`, false)).toBe(`keep${END}this`);
+    });
+  });
+});

--- a/src/components/terminal/preparePaste.ts
+++ b/src/components/terminal/preparePaste.ts
@@ -1,0 +1,52 @@
+/**
+ * Prepare clipboard text for delivery to a PTY, mirroring what xterm.js does
+ * inside `Terminal.paste()` (see xterm's `browser/Clipboard.ts`).
+ *
+ * The runner intercepts Ctrl+V itself and writes the result straight to the
+ * Rust PTY via `terminal_write` (Tauri's webview doesn't fire the browser
+ * clipboard events xterm relies on, and a native paste would double-write).
+ * That direct path previously sent the RAW clipboard text, which broke pasting
+ * into TUIs that enable bracketed paste mode (Claude Code, vim, fzf, …):
+ *
+ *   - Without the `ESC[200~ … ESC[201~` envelope, the app sees the paste as a
+ *     stream of keystrokes. Every embedded newline reads as Enter, so a
+ *     multi-line paste is submitted line-by-line and only the trailing
+ *     fragment survives in the input ("only the last few lines paste").
+ *   - The newline burst also forces the TUI to re-render mid-paste, colliding
+ *     with terminal line-wrapping ("misplaced spaces and characters").
+ *
+ * This helper is the pure core so it can be unit-tested without standing up
+ * xterm.js or a real PTY (same rationale as {@link consumeInputChunk}).
+ */
+
+/** Bracketed paste start marker (DEC mode 2004). */
+const BRACKET_START = "\x1b[200~";
+/** Bracketed paste end marker. */
+const BRACKET_END = "\x1b[201~";
+
+/**
+ * @param text                Raw clipboard text.
+ * @param bracketedPasteMode  Whether the foreground app enabled DEC mode 2004.
+ * @returns The byte string to write to the PTY.
+ */
+export function preparePasteData(text: string, bracketedPasteMode: boolean): string {
+  // Normalize line endings to CR. A real terminal sends \r on Enter, a shell
+  // treats \r as submit, and a TUI reading bracketed paste expects \r between
+  // lines. Matches xterm's `prepareTextForTerminal`: `\r\n` and lone `\n` → `\r`.
+  let normalized = text.replace(/\r?\n/g, "\r");
+
+  if (!bracketedPasteMode) {
+    // No envelope to protect — deliver as-is (the app sees raw keystrokes,
+    // exactly as if typed).
+    return normalized;
+  }
+
+  // Strip any embedded paste markers before wrapping. Copying output from
+  // another terminal session can carry a literal `ESC[201~` in the clipboard;
+  // left in place it would close the envelope early and let the remainder be
+  // interpreted as commands. xterm doesn't guard this, but the runner's whole
+  // purpose is shuttling terminal text between panes, so the risk is real here.
+  normalized = normalized.split(BRACKET_START).join("").split(BRACKET_END).join("");
+
+  return BRACKET_START + normalized + BRACKET_END;
+}


### PR DESCRIPTION
## What

Fixes multi-line paste truncation in the runner terminal and adds an autonomy hook for verifying it.

### The bug
The Ctrl+V handler wrote raw clipboard text straight to the PTY, skipping the bracketed-paste envelope + newline normalization that xterm's own `Terminal.paste()` applies. Into a TUI that enables bracketed-paste mode (Claude Code, vim, fzf), a multi-line paste was then submitted line-by-line and only a trailing fragment survived ("only the last few lines paste"), with misplaced spaces from mid-paste re-renders.

### The fix
- **`preparePaste.ts`** — pure, unit-tested helper mirroring xterm: normalizes `\r\n`/`\n` → `\r`; when the foreground app has DEC mode 2004 enabled, wraps in the `ESC[200~ … ESC[201~` envelope (stripping any embedded markers first so pasted terminal output can't break out).
- Routes the **Ctrl+V handler**, the UI-Bridge **`paste`** action, and a new **right-click** handler through `preparePasteData`.
- **Right-click copy/paste** (VS Code `rightClickBehavior: copyPaste` parity): with a selection → copy + clear highlight; with none → paste.
- Backends expose `readonly bracketedPasteMode` and `clearSelection()` on `ITerminalBackend`; implemented natively on Xterm, guarded casts on Ghostty.

### Autonomy hook
- New **`pasteText`** UI-Bridge custom action: pastes literal text through the exact Ctrl+V path with **no clipboard/keyboard**, so an automated client can trigger and verify a bracketed paste deterministically.

## Validation
- `tsc --noEmit`: clean
- `eslint` (6 touched files): clean
- `vitest`: 16 passed (`preparePaste.test.ts` + `TerminalInstance.test.tsx`)

## Notes
- Branched off `origin/main`; no pop-out-terminal-page code carried.
- Does not merge.