### PR TITLE
runner: route UI-Bridge custom actions through the /control/ action endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6529,7 +6529,7 @@ dependencies = [
 
 [[package]]
 name = "qontinui-types"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "hex",

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -757,6 +757,89 @@ pub(crate) fn extract_custom_actions(elem_data: &serde_json::Value) -> Option<Ve
     Some(names)
 }
 
+/// Fold an element's registered `customActions` into its advertised `actions`
+/// array, IN PLACE, so a single element JSON object advertises both built-in
+/// and custom actions in the one list that discover/snapshot consumers read.
+///
+/// Background: the SDK serializes an element with built-in actions in `actions`
+/// (a string array) and registered custom actions in a SEPARATE `customActions`
+/// string array (`Object.keys(el.customActions)` — see
+/// `serializeRegisteredElement` in `@qontinui/ui-bridge`). An agent inspecting
+/// the discover/snapshot output's `actions` list therefore could NOT see
+/// `pasteText`/`getScrollback` on a `terminal-input-<id>` element even though
+/// the `/control/element/{id}/action` route dispatches them. This mirrors the
+/// frontend control-event dispatcher (`useControlEvents.ts`), which merges
+/// `builtinActions + customActions` when deciding which actions are allowed.
+///
+/// Behavior:
+///   - Custom-action names already present in `actions` are NOT duplicated.
+///   - `customActions` itself is left untouched (additive — clients that read
+///     the dedicated field keep working).
+///   - An element with no `customActions`, or no `actions`/non-array `actions`,
+///     is left unchanged (when `actions` is absent but custom actions exist, we
+///     create an `actions` array from the custom names so the element advertises
+///     them at all).
+fn fold_custom_actions_into_element(elem: &mut serde_json::Value) {
+    let custom = match extract_custom_actions(elem) {
+        Some(c) if !c.is_empty() => c,
+        _ => return,
+    };
+    let obj = match elem.as_object_mut() {
+        Some(o) => o,
+        None => return,
+    };
+    // Take the existing `actions` array (if it is one); else start empty.
+    let mut actions: Vec<serde_json::Value> = obj
+        .get("actions")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    // Existing string entries — used to avoid duplicating a custom name the
+    // SDK already enumerated in `actions`.
+    let existing: std::collections::HashSet<String> = actions
+        .iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect();
+    for name in custom {
+        if !existing.contains(&name) {
+            actions.push(serde_json::Value::String(name));
+        }
+    }
+    obj.insert("actions".to_string(), serde_json::Value::Array(actions));
+}
+
+/// Walk a discover/snapshot IPC payload and fold every element's
+/// `customActions` into its advertised `actions` array (see
+/// [`fold_custom_actions_into_element`]). Handles the three element-array
+/// layouts the SDK emits — identical to `count_elements_in_discover_payload`:
+///   - a bare top-level array,
+///   - `{ elements: [...] }` (discover + snapshot),
+///   - `{ data: { elements: [...] } }`.
+///
+/// Pure + idempotent: applying it twice yields the same result (the dedup in
+/// `fold_custom_actions_into_element` makes the second pass a no-op).
+fn advertise_custom_actions_in_payload(data: &mut serde_json::Value) {
+    fn fold_array(arr: &mut [serde_json::Value]) {
+        for elem in arr.iter_mut() {
+            fold_custom_actions_into_element(elem);
+        }
+    }
+    if let Some(arr) = data.as_array_mut() {
+        fold_array(arr);
+        return;
+    }
+    if let Some(arr) = data.get_mut("elements").and_then(|v| v.as_array_mut()) {
+        fold_array(arr);
+    }
+    if let Some(arr) = data
+        .get_mut("data")
+        .and_then(|d| d.get_mut("elements"))
+        .and_then(|v| v.as_array_mut())
+    {
+        fold_array(arr);
+    }
+}
+
 /// True when the element advertises an explicit supported-actions list AND
 /// the requested action is not in it. `None` (we don't know) → returns
 /// `false` (don't accuse — degrade gracefully).
@@ -2241,6 +2324,16 @@ pub async fn ui_bridge_discover_handler(
 
     match ui_bridge_request_sync(&state, "discover", payload).await {
         Ok(mut data) => {
+            // Fold each element's registered `customActions` into its
+            // advertised `actions` array so a discover consumer sees e.g.
+            // `pasteText`/`getScrollback` on a `terminal-input-<id>` element
+            // (which the `/control/element/{id}/action` route already
+            // dispatches). Mirrors the frontend dispatcher's
+            // `builtinActions + customActions` merge in `useControlEvents.ts`.
+            // Applied BEFORE caching so `/control/last-discovered` advertises
+            // them too.
+            advertise_custom_actions_in_payload(&mut data);
+
             // Populate the last-discovered cache. Best-effort — never
             // block the response on a write lock.
             let element_count = count_elements_in_discover_payload(&data);
@@ -2455,6 +2548,13 @@ pub async fn ui_bridge_get_snapshot_handler(
 
     match snapshot_result {
         Ok(mut data) => {
+            // Fold each element's registered `customActions` into its
+            // advertised `actions` array (same as the discover handler) so a
+            // snapshot consumer sees custom actions like `pasteText` /
+            // `getScrollback` alongside the built-ins. Applied before the
+            // post-fetch filters so the filtered output carries them too.
+            advertise_custom_actions_in_payload(&mut data);
+
             // Apply post-fetch filters. We do this before enrichment so the
             // architecture summary still attaches to the filtered response.
             //
@@ -5053,7 +5153,8 @@ mod action_not_supported_tests {
     //! template changes here, this test must change in lockstep, which
     //! is exactly the regression guard we want.
     use super::{
-        extract_custom_actions, extract_supported_actions, is_action_advertised, UiBridgeError,
+        advertise_custom_actions_in_payload, extract_custom_actions, extract_supported_actions,
+        fold_custom_actions_into_element, is_action_advertised, UiBridgeError,
     };
     use crate::mcp::types::ApiResponse;
     use crate::mcp::ui_bridge::recovery_executor::{RecoveryOutcome, RecoveryVia};
@@ -5198,6 +5299,161 @@ mod action_not_supported_tests {
         assert!(is_action_advertised("sendKeys", &supported));
         // A truly unknown action is still rejected.
         assert!(!is_action_advertised("teleport", &supported));
+    }
+
+    // ── Discover/snapshot serialization fold (the advertisement gap) ────
+    // These exercise the ACTUAL response-serialization path the discover and
+    // snapshot handlers run on the IPC payload — not just the extract_*
+    // helpers — proving a registered custom action now appears in the
+    // advertised `actions` array a discover consumer reads.
+
+    #[test]
+    fn fold_appends_custom_actions_into_element_actions() {
+        let mut elem = json!({
+            "id": "terminal-input-abc",
+            "actions": ["focus", "blur"],
+            "customActions": ["pasteText", "getScrollback"],
+        });
+        fold_custom_actions_into_element(&mut elem);
+        let actions = extract_supported_actions(&elem).expect("actions present");
+        // Built-ins preserved, custom actions now ALSO advertised in `actions`.
+        assert!(actions.contains(&"focus".to_string()));
+        assert!(actions.contains(&"blur".to_string()));
+        assert!(
+            actions.contains(&"pasteText".to_string()),
+            "pasteText must now appear in advertised actions: {actions:?}"
+        );
+        assert!(
+            actions.contains(&"getScrollback".to_string()),
+            "getScrollback must now appear in advertised actions: {actions:?}"
+        );
+        // The dedicated `customActions` field is left intact (additive).
+        assert!(elem
+            .get("customActions")
+            .and_then(|v| v.as_array())
+            .is_some());
+    }
+
+    #[test]
+    fn fold_does_not_duplicate_already_listed_action() {
+        // If the SDK already enumerated a name in `actions`, folding must not
+        // produce a duplicate.
+        let mut elem = json!({
+            "id": "x",
+            "actions": ["focus", "pasteText"],
+            "customActions": ["pasteText", "getScrollback"],
+        });
+        fold_custom_actions_into_element(&mut elem);
+        let actions = extract_supported_actions(&elem).expect("actions present");
+        let paste_count = actions.iter().filter(|a| *a == "pasteText").count();
+        assert_eq!(
+            paste_count, 1,
+            "pasteText must not be duplicated: {actions:?}"
+        );
+    }
+
+    #[test]
+    fn fold_synthesizes_actions_when_only_custom_present() {
+        // Element with NO built-in `actions` array but custom actions present:
+        // create an `actions` list from the custom names so it advertises them.
+        let mut elem = json!({
+            "id": "x",
+            "customActions": ["pasteText"],
+        });
+        fold_custom_actions_into_element(&mut elem);
+        let actions = extract_supported_actions(&elem).expect("actions synthesized");
+        assert_eq!(actions, vec!["pasteText".to_string()]);
+    }
+
+    #[test]
+    fn fold_leaves_element_without_custom_actions_unchanged() {
+        let mut elem = json!({ "id": "btn", "actions": ["click", "focus"] });
+        let before = elem.clone();
+        fold_custom_actions_into_element(&mut elem);
+        assert_eq!(elem, before);
+    }
+
+    #[test]
+    fn advertise_custom_actions_walks_elements_array_shape() {
+        // The discover/snapshot `{ elements: [...] }` payload shape — the one
+        // the handlers actually receive from the SDK. Prove the terminal-input
+        // element advertises pasteText/getScrollback after the fold.
+        let mut payload = json!({
+            "elements": [
+                {
+                    "id": "terminal-input-term-1",
+                    "type": "input",
+                    "actions": ["focus", "blur"],
+                    "customActions": ["sendKeys", "pasteText", "getScrollback"],
+                },
+                { "id": "btn-save", "actions": ["click", "focus", "blur"] },
+            ],
+            "count": 2,
+        });
+        advertise_custom_actions_in_payload(&mut payload);
+
+        let elems = payload["elements"].as_array().expect("elements array");
+        let term = &elems[0];
+        let term_actions = extract_supported_actions(term).expect("actions present");
+        assert!(
+            term_actions.contains(&"pasteText".to_string()),
+            "{term_actions:?}"
+        );
+        assert!(
+            term_actions.contains(&"getScrollback".to_string()),
+            "{term_actions:?}"
+        );
+        assert!(
+            term_actions.contains(&"sendKeys".to_string()),
+            "{term_actions:?}"
+        );
+        assert!(
+            term_actions.contains(&"focus".to_string()),
+            "{term_actions:?}"
+        );
+
+        // A plain button without custom actions is untouched.
+        let btn_actions = extract_supported_actions(&elems[1]).expect("actions present");
+        assert_eq!(
+            btn_actions,
+            vec!["click".to_string(), "focus".to_string(), "blur".to_string()]
+        );
+    }
+
+    #[test]
+    fn advertise_custom_actions_walks_nested_data_elements_shape() {
+        // The `{ data: { elements: [...] } }` layout (one of the three the
+        // discover cache-count helper recognizes).
+        let mut payload = json!({
+            "data": { "elements": [
+                {
+                    "id": "terminal-input-term-1",
+                    "actions": ["focus"],
+                    "customActions": ["pasteText"],
+                },
+            ]},
+        });
+        advertise_custom_actions_in_payload(&mut payload);
+        let term = &payload["data"]["elements"][0];
+        let actions = extract_supported_actions(term).expect("actions present");
+        assert!(actions.contains(&"pasteText".to_string()), "{actions:?}");
+    }
+
+    #[test]
+    fn advertise_custom_actions_is_idempotent() {
+        let mut payload = json!({
+            "elements": [
+                {
+                    "id": "terminal-input-term-1",
+                    "actions": ["focus", "blur"],
+                    "customActions": ["pasteText", "getScrollback"],
+                },
+            ],
+        });
+        advertise_custom_actions_in_payload(&mut payload);
+        let once = payload.clone();
+        advertise_custom_actions_in_payload(&mut payload);
+        assert_eq!(payload, once, "fold must be idempotent");
     }
 
     #[test]

--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -711,6 +711,52 @@ pub(crate) fn extract_supported_actions(elem_data: &serde_json::Value) -> Option
     Some(names)
 }
 
+/// Extract the element's registered **custom-action** names from a
+/// `get_element` / discover payload.
+///
+/// The SDK serializes registered elements with a separate `customActions`
+/// field (see `@qontinui/ui-bridge`'s `serializeRegisteredElement` —
+/// `customActions: el.customActions ? Object.keys(el.customActions) : void 0`),
+/// distinct from the built-in `actions` array. These are arbitrary
+/// per-element handlers (e.g. `pasteText`, `getScrollback`, `sendKeys` on a
+/// `terminal-input-<id>` element) that the frontend's control-event handler
+/// dispatches via `registered.customActions[action].handler(params)` — they
+/// are NOT in `SUPPORTED_ACTION_NAMES` and never will be (the runner can't
+/// enumerate app-defined actions ahead of time).
+///
+/// Returns `None` when the field is absent OR present but not an array
+/// (mirrors `extract_supported_actions` — `None` = "we don't know"); an
+/// explicit empty array → `Some(vec![])`. Entries are accepted as bare
+/// strings (the canonical SDK shape) or `{ name | action }` objects for
+/// parity with `extract_supported_actions`.
+///
+/// Used by the `/control/element/{id}/action` handler so a registered custom
+/// action (a) passes the action-name gate instead of a blanket 400
+/// "Unknown action", and (b) is folded into the advertised-actions list so
+/// `is_action_advertised` accepts it — matching the SDK route, whose frontend
+/// dispatcher already merges `customActions` into its allowed-actions check
+/// (`useControlEvents.ts`).
+pub(crate) fn extract_custom_actions(elem_data: &serde_json::Value) -> Option<Vec<String>> {
+    let arr = elem_data.get("customActions").and_then(|v| v.as_array())?;
+    let names: Vec<String> = arr
+        .iter()
+        .filter_map(|entry| {
+            if let Some(s) = entry.as_str() {
+                Some(s.to_string())
+            } else if let Some(obj) = entry.as_object() {
+                obj.get("name")
+                    .or_else(|| obj.get("action"))
+                    .or_else(|| obj.get("id"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    Some(names)
+}
+
 /// True when the element advertises an explicit supported-actions list AND
 /// the requested action is not in it. `None` (we don't know) → returns
 /// `false` (don't accuse — degrade gracefully).
@@ -927,27 +973,27 @@ pub async fn ui_bridge_execute_action_handler(
         }
     }
 
-    // ── Invalid-action gate ─────────────────────────────────────────────
-    // Reject unknown action names BEFORE the registry lookup, the
+    // ── Invalid-action gate (built-in vs. custom) ──────────────────────
+    // Reject genuinely unknown action names BEFORE the registry lookup, the
     // stale-registry retry, and the Phase 5 RecoveryExecutor. Without this
     // gate a typo (e.g. `"press"`) reached `execute_action` -> IPC failure
     // -> RecoveryExecutor::llm_fallback, which synthesized a click on a
     // random "Active" button and returned HTTP 200 `success:true`
     // (verified empirically 2026-05-21). Mirrors the `tab/activate`
     // -> `knownTabs` 400 envelope shape; see `validate_action_name`.
-    if let Err(detail) = validate_action_name(&request.action) {
-        warn!(
-            "execute_action: rejecting unknown action '{}' on element {} (supported: {})",
-            request.action,
-            id,
-            SUPPORTED_ACTION_NAMES.join(", ")
-        );
-        let msg = detail.message.clone();
-        return Err((
-            StatusCode::BAD_REQUEST,
-            Json(api_error_detailed(msg, detail)),
-        ));
-    }
+    //
+    // BUT: `SUPPORTED_ACTION_NAMES` only enumerates the built-in dispatcher
+    // vocabulary — it cannot know about app-registered **custom actions**
+    // (e.g. `pasteText`/`getScrollback`/`sendKeys` on a `terminal-input-<id>`
+    // element). The SDK route (`/sdk/element/{id}/action`) skips this gate
+    // entirely and forwards straight to the frontend custom-action
+    // dispatcher, so custom actions worked there but were 400'd here. We now
+    // mirror the SDK/frontend behavior: a non-built-in name is NOT rejected
+    // outright; instead we defer to the per-element check below, which fetches
+    // the element's `customActions` and rejects ("Unknown action") only when
+    // the name is neither a built-in nor a registered custom action on THIS
+    // element. Built-in behavior is unchanged.
+    let action_is_builtin = validate_action_name(&request.action).is_ok();
 
     // ── Type-action param-shape gate ────────────────────────────────────
     // Reject `{action:"type", params:{value:"foo"}}` and `{action:"type",
@@ -1100,6 +1146,16 @@ pub async fn ui_bridge_execute_action_handler(
     // requested action against the element's metadata without an extra
     // IPC round-trip. None on fetch failure → the discriminator skips
     // (we never invent a supported list).
+    //
+    // We fold the element's registered **custom actions** (the separate
+    // `customActions` field the SDK serializes — `pasteText`, `getScrollback`,
+    // `sendKeys`, …) into the same supported list so `is_action_advertised`
+    // treats them as first-class, exactly as the frontend's control-event
+    // dispatcher does (`useControlEvents.ts` merges builtins + customActions).
+    // `action_is_registered_custom` records whether the requested name is one
+    // of THIS element's custom actions, which drives the deferred
+    // "Unknown action" rejection below for non-built-in names.
+    let mut action_is_registered_custom = false;
     let element_supported_actions: Option<Vec<String>> = match ui_bridge_request_sync(
         &state,
         "get_element",
@@ -1162,10 +1218,60 @@ pub async fn ui_bridge_execute_action_handler(
                 }));
             }
 
-            extract_supported_actions(&elem_data)
+            // Merge built-in advertised actions with registered custom-action
+            // names. `customActions` is the SDK's separate field; absent → no
+            // custom actions on this element. Record whether the requested name
+            // is one of them for the deferred unknown-action gate below.
+            let custom = extract_custom_actions(&elem_data);
+            if let Some(ref custom_names) = custom {
+                if custom_names.iter().any(|c| c == &action_name) {
+                    action_is_registered_custom = true;
+                }
+            }
+            match (extract_supported_actions(&elem_data), custom) {
+                (Some(mut builtin), Some(custom_names)) => {
+                    builtin.extend(custom_names);
+                    Some(builtin)
+                }
+                (Some(builtin), None) => Some(builtin),
+                // No advertised `actions` but custom actions present: surface
+                // the custom names so `is_action_advertised` can accept them
+                // (otherwise a custom-only element would advertise nothing).
+                (None, Some(custom_names)) => Some(custom_names),
+                (None, None) => None,
+            }
         }
         Err(_) => None,
     };
+
+    // ── Deferred unknown-action gate ────────────────────────────────────
+    // Now that we know the element's registered custom actions, reject a
+    // non-built-in name only when it is ALSO not a custom action on this
+    // element — the same "Unknown action" 400 the whitelist used to emit
+    // eagerly, but no longer firing on legitimate custom actions that the
+    // SDK route already accepts. A non-built-in name on an element whose
+    // metadata we couldn't fetch (`element_supported_actions == None`) is
+    // allowed through to IPC: we never manufacture a rejection from a failed
+    // probe (mirrors the permissive `None` semantics of `is_action_advertised`).
+    if !action_is_builtin && !action_is_registered_custom && element_supported_actions.is_some() {
+        let detail = validate_action_name(&request.action)
+            .err()
+            .unwrap_or_else(|| {
+                UiBridgeError::invalid_action(&request.action, SUPPORTED_ACTION_NAMES)
+            });
+        warn!(
+            "execute_action: rejecting unknown action '{}' on element {} — \
+             not a built-in and not a registered custom action (built-ins: {})",
+            request.action,
+            id,
+            SUPPORTED_ACTION_NAMES.join(", ")
+        );
+        let msg = detail.message.clone();
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(api_error_detailed(msg, detail)),
+        ));
+    }
 
     // ── Pre-IPC ACTION_NOT_SUPPORTED gate ──────────────────────────────
     //
@@ -4946,7 +5052,9 @@ mod action_not_supported_tests {
     //! `serde_json::json!{...}` recipe the handler uses — if the body
     //! template changes here, this test must change in lockstep, which
     //! is exactly the regression guard we want.
-    use super::{extract_supported_actions, is_action_advertised, UiBridgeError};
+    use super::{
+        extract_custom_actions, extract_supported_actions, is_action_advertised, UiBridgeError,
+    };
     use crate::mcp::types::ApiResponse;
     use crate::mcp::ui_bridge::recovery_executor::{RecoveryOutcome, RecoveryVia};
     use serde_json::json;
@@ -5017,6 +5125,79 @@ mod action_not_supported_tests {
     fn is_action_advertised_unknown_supported_list_is_permissive() {
         // None → we don't know what the element supports; never accuse.
         assert!(is_action_advertised("setValue", &None));
+    }
+
+    // ── Custom-action reachability via the /control/ route ──────────────
+    // The control route used to 400 "Unknown action" for app-registered
+    // custom actions (pasteText/getScrollback/sendKeys on terminal-input)
+    // even though the SDK route + frontend dispatcher accept them. These
+    // tests lock down the two pure helpers that make the control route now
+    // reach + advertise custom actions.
+
+    #[test]
+    fn extract_custom_actions_from_string_array() {
+        // The SDK serializes `customActions` as a bare string array
+        // (`Object.keys(el.customActions)`), distinct from `actions`.
+        let elem = json!({
+            "id": "terminal-input-abc",
+            "actions": ["focus", "blur"],
+            "customActions": ["sendKeys", "pasteText", "getScrollback"],
+        });
+        let got = extract_custom_actions(&elem).expect("present array");
+        assert_eq!(got, vec!["sendKeys", "pasteText", "getScrollback"]);
+    }
+
+    #[test]
+    fn extract_custom_actions_from_object_array() {
+        // Accept `{ name | action | id }` objects for parity with
+        // extract_supported_actions.
+        let elem = json!({
+            "id": "terminal-input-abc",
+            "customActions": [
+                { "id": "pasteText" },
+                { "name": "getScrollback" },
+                { "action": "sendKeys" },
+            ],
+        });
+        let got = extract_custom_actions(&elem).expect("present array");
+        assert_eq!(got, vec!["pasteText", "getScrollback", "sendKeys"]);
+    }
+
+    #[test]
+    fn extract_custom_actions_absent_is_none() {
+        let elem = json!({ "id": "btn-1", "actions": ["click"] });
+        assert!(extract_custom_actions(&elem).is_none());
+    }
+
+    #[test]
+    fn extract_custom_actions_non_array_is_none() {
+        let elem = json!({ "id": "btn-1", "customActions": "pasteText" });
+        assert!(extract_custom_actions(&elem).is_none());
+    }
+
+    #[test]
+    fn custom_action_advertised_once_folded_into_supported_list() {
+        // Reproduce the handler's fold: built-in `actions` + `customActions`
+        // → one supported list. `is_action_advertised` must then ACCEPT a
+        // registered custom action (pasteText) the same way it accepts a
+        // built-in, while still REJECTING a genuinely unknown action.
+        let elem = json!({
+            "id": "terminal-input-abc",
+            "actions": ["focus", "blur"],
+            "customActions": ["sendKeys", "pasteText", "getScrollback"],
+        });
+        let mut builtin = extract_supported_actions(&elem).expect("actions present");
+        builtin.extend(extract_custom_actions(&elem).expect("customActions present"));
+        let supported = Some(builtin);
+
+        // Built-in still accepted.
+        assert!(is_action_advertised("focus", &supported));
+        // Custom actions now accepted (the bug: these were 400'd before).
+        assert!(is_action_advertised("pasteText", &supported));
+        assert!(is_action_advertised("getScrollback", &supported));
+        assert!(is_action_advertised("sendKeys", &supported));
+        // A truly unknown action is still rejected.
+        assert!(!is_action_advertised("teleport", &supported));
     }
 
     #[test]


### PR DESCRIPTION
## Control-route custom-action gap

`POST /ui-bridge/control/element/{id}/action` rejected app-registered **custom actions** (`pasteText`, `getScrollback`, `sendKeys`, `writeToTerminal` on the `terminal-input-<id>` element) with `400 "Unknown action"`, even though:

- the **SDK route** `POST /ui-bridge/sdk/element/{id}/action` accepts them (it skips the whitelist and forwards straight to the frontend custom-action dispatcher), and
- the **frontend** control-event handler (`useControlEvents.ts`) already merges `builtinActions + customActions` into its allowed-actions check.

Two Rust gates in `elements.rs` blocked them:
1. `validate_action_name` (the `SUPPORTED_ACTION_NAMES` whitelist) ran eagerly, before any element fetch — it only enumerates built-in dispatcher actions and can't know per-element custom actions.
2. `is_action_advertised` compared only against the element's built-in `actions` array (`["focus","blur"]`), not its `customActions`.

## Fix (control-route only)

- **Defer the whitelist rejection.** A non-built-in action name is no longer rejected up front. After the existing `get_element` probe, reject `"Unknown action"` only when the name is neither a built-in **nor** a registered custom action on that element. A failed probe stays permissive (matches `is_action_advertised`'s `None` semantics).
- **Fold the element's `customActions`** (the SDK's separately-serialized field) into the supported-actions list, so `is_action_advertised` accepts them and discover/snapshot effectively expose them as dispatchable — matching the SDK/frontend behavior.
- New helper `extract_custom_actions` + 5 focused unit tests.

The **SDK route and frontend are untouched** — this is a control-route-only gap.

Follows up the merged #594 (paste fix + `pasteText` test hook): that hook worked via the SDK route but not via `/control/`; now both routes reach it.

## Validation

- `cargo check --bin qontinui-runner` clean.
- `cargo clippy --all-targets -- -D warnings` clean (pre-push gate Passed).
- `cargo test --bin qontinui-runner action_not_supported_tests` — 14 passed (5 new).

Also syncs `Cargo.lock` `qontinui-types 0.5.0 -> 0.6.0` (path dep on qontinui-schemas, already released on schemas `main`; the runner lockfile was stale and the cargo pre-push gate kept re-dirtying it).
