### PR TITLE
feat(runner): wire per-agent durability + observability daemons into live spawn path

### DIFF
--- a/src-tauri/src/agent_daemons/mod.rs
+++ b/src-tauri/src/agent_daemons/mod.rs
@@ -68,6 +68,23 @@ pub fn spawn_for_agent(allocate: &AllocateResult, coord_http_base: String, machi
         );
         return;
     };
+    spawn_for_agent_with_token(allocate, coord_http_base, machine_id, token);
+}
+
+/// Spawn (and retain) the pusher + poller for one agent against a
+/// **caller-supplied** token slot — the live coord-driven spawn path
+/// ([`crate::agent_runtime::run_agent_subprocess`]) hands in the SAME
+/// [`SharedToken`] it already registered in `coord_mcp::AGENT_TOKENS`,
+/// so the proxy, heartbeat, pusher, and poller all read one slot
+/// (single-slot invariant — `agent_token/mod.rs:1`). Callers that don't
+/// already own a slot use [`spawn_for_agent`], which builds one from the
+/// allocation and delegates here.
+pub fn spawn_for_agent_with_token(
+    allocate: &AllocateResult,
+    coord_http_base: String,
+    machine_id: Uuid,
+    token: crate::agent_token::SharedToken,
+) {
     let agent_id = match Uuid::parse_str(&allocate.agent_id) {
         Ok(id) => id,
         Err(e) => {
@@ -97,6 +114,27 @@ pub fn spawn_for_agent(allocate: &AllocateResult, coord_http_base: String, machi
         g.insert(agent_id, daemons);
         info!(
             "agent_daemons: agent_id={agent_id} pusher+poller live (agents tracked={})",
+            g.len()
+        );
+    }
+}
+
+/// Stop both per-agent daemons by removing the agent's entry from the
+/// registry — dropping the [`AgentDaemons`] signals each handle's task
+/// to exit on its next tick. Called from the spawn-wrapper completion
+/// path when the agent process is gone. Best-effort and defensive: a
+/// no-op if the registry is uninitialized (nothing was ever spawned) or
+/// the lock is poisoned (a teardown failure must never panic the runner).
+pub fn stop_for_agent(agent_id: Uuid) {
+    let Some(reg) = REGISTRY.get() else {
+        return;
+    };
+    let Ok(mut g) = reg.lock() else {
+        return;
+    };
+    if g.remove(&agent_id).is_some() {
+        info!(
+            "agent_daemons: agent_id={agent_id} pusher+poller stopped (agents tracked={})",
             g.len()
         );
     }
@@ -184,5 +222,14 @@ mod tests {
             1,
             "re-allocation of the same agent must replace, not accumulate"
         );
+        // Teardown removes the entry (dropping it stops both daemons).
+        stop_for_agent(id);
+        assert!(
+            !tracked_contains(id),
+            "stop_for_agent must untrack the agent"
+        );
+        // Idempotent: stopping an already-stopped agent is a no-op.
+        stop_for_agent(id);
+        assert!(!tracked_contains(id));
     }
 }

--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -819,6 +819,8 @@ fn spawn_run_task(payload: LaunchPayload) {
         // Drop the agent's live-token slot so its proxy nonce hard-fails closed
         // (the agent process is gone; any lingering `.mcp.json` nonce must 401).
         crate::coord_mcp::remove_agent_token(agent_id);
+        // Stop the per-agent durability + observability daemons (pusher/poller).
+        crate::agent_daemons::stop_for_agent(agent_id);
     });
 }
 
@@ -2309,6 +2311,35 @@ async fn run_continuation_headless(
 // Subprocess lifecycle
 // =============================================================================
 
+/// Map a coord-delivered LaunchPayload onto the AllocateResult shape the
+/// per-agent daemons (agent_pusher / dirty_poller) consume. The daemons'
+/// stable contract is AllocateResult (also produced by the isolated_edit
+/// path); this keeps spawn_for_agent's signature untouched.
+fn payload_to_allocate_result(payload: &LaunchPayload) -> crate::agent_worktree::AllocateResult {
+    use crate::agent_worktree::{AllocateResult, MaterializedWorktree};
+    AllocateResult {
+        agent_id: payload.agent_id.to_string(),
+        worktrees: payload
+            .worktrees
+            .iter()
+            .map(|w| MaterializedWorktree {
+                repo: w.repo.clone(),
+                branch: w.branch.clone(),
+                parent_sha: w.parent_sha.clone(),
+                worktree_path: std::path::PathBuf::from(&w.worktree_path),
+                push_ref: w
+                    .push_ref
+                    .clone()
+                    .unwrap_or_else(|| crate::agent_worktree::remote_agent_ref(&w.branch)),
+            })
+            .collect(),
+        token: payload.jwt.clone(),
+        token_jti: uuid::Uuid::nil(), // bookkeeping only; maybe_refresh sends the bearer, not the jti
+        token_exp: payload.jwt_exp,
+        active_claims: Vec::new(), // unread by either daemon
+    }
+}
+
 /// End-to-end run of one agent subprocess:
 /// 1. `git worktree add` each allocated worktree.
 /// 2. Spawn `claude` CLI in the first worktree with the initial prompt.
@@ -2374,7 +2405,7 @@ async fn run_agent_subprocess(
             jti: uuid::Uuid::nil(),
             exp: payload.jwt_exp,
         }));
-        crate::coord_mcp::register_agent_token(payload.agent_id, slot);
+        crate::coord_mcp::register_agent_token(payload.agent_id, slot.clone());
         match crate::coord_mcp::resolve_bound_api_port() {
             Some(port) => {
                 crate::coord_mcp::write_coord_mcp_agent_proxy_config(
@@ -2397,6 +2428,24 @@ async fn run_agent_subprocess(
                 crate::coord_mcp::write_degraded_breadcrumb(
                     &primary_wt,
                     "bound API port unresolvable — agent proxy config NOT written (would point at a dead port)",
+                );
+            }
+        }
+
+        // Wire the per-agent durability (agent_pusher) + observability (dirty_poller)
+        // daemons onto the SAME refreshing token slot registered in AGENT_TOKENS, so
+        // the proxy, heartbeat, pusher, and poller all read one slot (single-slot
+        // invariant — agent_token/mod.rs:1). Best-effort: skipped without a JWT or a
+        // configured coord base (dev/no-coord), and each daemon self-skips when it has
+        // no work (no push targets / no worktrees).
+        if !payload.jwt.is_empty() {
+            if let Some(base) = coord_http_base() {
+                let allocate = payload_to_allocate_result(&payload);
+                crate::agent_daemons::spawn_for_agent_with_token(
+                    &allocate,
+                    base,
+                    payload.target_device_id,
+                    slot.clone(),
                 );
             }
         }


### PR DESCRIPTION
## What

`agent_daemons::spawn_for_agent` lost its only caller when #443 removed the `/agents/allocate-local` endpoint, orphaning two per-agent daemons:
- **`agent_pusher`** — periodic `git push` of each worktree branch to coord's git origin (~5 min, jittered), bounding work-loss if a machine dies mid-session.
- **`dirty_poller`** — POSTs each worktree's real `git status`/`shortstat` to coord's `/agents/:id/dirty-state` (~5 s), feeding the dashboard worktree heatmap.

Both have been **dead in production** since #443 — nothing pushes agent work on a cadence (durability fully absent, verified: no push-on-exit exists anywhere) and the heatmap has no dirty-state source from spawned agents.

This re-wires both into the live coord-driven spawn path (`run_agent_subprocess`), **sharing the single `SharedToken` slot** already registered in `coord_mcp::AGENT_TOKENS` (from #592) — so the proxy, heartbeat, pusher, and poller all read one refreshing slot (single-slot invariant; no 2× refresh load).

## Changes
- `agent_daemons`: `spawn_for_agent_with_token(token)` (caller-supplied slot) + `stop_for_agent(agent_id)`; `spawn_for_agent` delegates after its no-JWT skip.
- `agent_runtime`: `payload_to_allocate_result` adapter (`LaunchPayload` → `AllocateResult`); spawn the daemons at the spawn site sharing the `AGENT_TOKENS` slot (gated on a JWT + a configured coord base); `stop_for_agent` on teardown.

## Stacking
**Stacked on #592** (`feat/agent-spawn-jwt-proxy`), which provides `coord_mcp::AGENT_TOKENS` and the spawn-site slot this shares. Merge #592 first. Base will retarget to `main` after #592 lands.

## Verification
- `cargo check` + `cargo clippy --bin qontinui-runner`: clean.
- Tests: `agent_daemons` 2/2 (incl. new `stop_for_agent` assertions), `agent_token` 2/2, `agent_runtime` 58/58.
- **Phase 2 (live temp-runner cadence verification — pusher pushes a branch to coord origin within one cycle; poller dirty-state lands on the heatmap)** is deferred until #592 merges and the stack is deployable (a temp runner's spawn-test builds the primary checkout, not this stacked worktree; the pusher also needs a live coord git origin + agent JWT). Tracked via a `pr_merged` gate on #592.

Plan: `2026-06-16-wire-agent-durability-daemons`.