### PR TITLE
fix(pre-push): tolerate path-dep Cargo.lock churn in the cargo gate

### DIFF
--- a/.pre-commit-hooks/cargo-prepush.sh
+++ b/.pre-commit-hooks/cargo-prepush.sh
@@ -28,7 +28,33 @@ if remote_ref=$(git rev-parse --symbolic-full-name @{u} 2>/dev/null); then
   fi
 fi
 
-cd "$(git rev-parse --show-toplevel)/src-tauri"
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT/src-tauri"
+
+# A path dependency on a sibling repo (e.g. qontinui-schemas/rust) that sits
+# ahead of the version pinned in the committed Cargo.lock makes every cargo
+# invocation rewrite Cargo.lock. That churn is environment-local — it depends
+# on which ref the sibling checkout is parked at (a feature branch cut before
+# a sibling version bump, a sibling that's been pulled ahead, etc.) — and must
+# NOT be committed. But pre-commit reports the hook as Failed whenever it
+# leaves a tracked file modified, even when the gate itself passed. Snapshot
+# Cargo.lock and restore it on exit so the gate is non-mutating regardless of
+# local skew. A Cargo.lock change the developer actually intends rides in their
+# own staged diff (which pre-commit hands us as the baseline), so this never
+# reverts an intended update.
+LOCK="$ROOT/Cargo.lock"
+LOCK_BAK=""
+if [[ -f "$LOCK" ]]; then
+  LOCK_BAK="$(mktemp)"
+  cp -p "$LOCK" "$LOCK_BAK"
+fi
+restore_lock() {
+  if [[ -n "$LOCK_BAK" ]]; then
+    cp -p "$LOCK_BAK" "$LOCK"
+    rm -f "$LOCK_BAK"
+  fi
+}
+trap restore_lock EXIT
 
 echo "[pre-push] cargo fmt -- --check"
 if ! cargo fmt -- --check; then


### PR DESCRIPTION
## Problem

The pre-push cargo gate (`.pre-commit-hooks/cargo-prepush.sh`) fails for a reason unrelated to code quality: the runner depends on sibling repos by **path** (`qontinui-types = { path = "../../qontinui-schemas/rust" }`). When the local sibling checkout sits **ahead** of the version pinned in the committed `Cargo.lock` — e.g. a feature branch cut before a sibling version bump, or a sibling pulled ahead — every local `cargo` invocation rewrites `Cargo.lock` (`qontinui-types v0.5.0 -> v0.6.0`).

That churn is environment-local and must not be committed, but the pre-commit framework marks **any** hook that leaves a tracked file modified as `Failed` — even though the fmt + clippy gate passed. The tell:

```
[pre-push] cargo gate passed.
cargo fmt + clippy (pre-push)...........................................Failed
```

Net effect: you can't push runner changes from a dev machine whose sibling repos are ahead, except via `QONTINUI_PREPUSH_SKIP=1` every time.

## Fix

Snapshot `Cargo.lock` before the cargo commands and restore it on exit (both pass and fail paths, via `trap ... EXIT`), so the gate is **non-mutating** regardless of local path-dep skew. The fmt/clippy checks are unchanged.

A `Cargo.lock` change the developer actually intends still rides in their own staged diff (which pre-commit hands the hook as the baseline), so this never reverts an intended update.

## Testing

- `bash -n` clean.
- Verified in isolation that `Cargo.lock` is restored to its pre-gate contents after a simulated mid-gate rewrite, on **both** the exit-0 and exit-1 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)