### PR TITLE
feat(app-generator): Phase 2 — whole-page FunctionalSpec inversion (multi-screen + nav + data layer)

### DIFF
--- a/crates/qontinui-app-generator/src/app.rs
+++ b/crates/qontinui-app-generator/src/app.rs
@@ -1,0 +1,513 @@
+//! Phase 2 — whole-page inversion: `FunctionalSpec` -> a multi-screen, navigable,
+//! data-layer-wired Expo app (deterministic core).
+//!
+//! Phase 1 ([`crate::screen::generate_screen`]) proved the load-bearing observability
+//! seam for **one** `IrState`. Phase 2 lifts that to the whole page:
+//!
+//! - every [`IrState`] -> one instrumented `app/<id>.tsx` screen (Phase-1 renderer reused
+//!   verbatim — the instrumentation stays byte-identical so the snapshot can never drift);
+//! - every [`IrTransition`] -> a navigator edge + a deterministic `onPress` handler wired
+//!   onto the transition's `action.target` element (the button the transition fires from),
+//!   routing `from_states[0]` -> `activate_states[0]`;
+//! - every [`Operation`] -> one typed data-layer service method whose URL is derived by
+//!   the **shared** [`qontinui_types::endpoint_for::endpoint_for`] (the single #1<->#2
+//!   contract — never re-derived here), wired into the matching transition handler.
+//!
+//! What stays out of Phase 2 (deferred, honestly): the **LLM presentational fill** (D2 —
+//! layout/styling via `run_claude_cli`) and the **on-device render+snapshot** verify leg
+//! (no generated-screen render harness exists — the mobile app on the device is a fixed
+//! production build; see `tests/runtime_render_deferred.rs`). The deterministic
+//! matcher-correctness proof — every emitted screen's instrumentation manifest scores a
+//! `FullMatch` against the **real** `qontinui_spec_check::evaluate` — is what Phase 2
+//! verifies, exactly as Phase 1 did for one state.
+
+use qontinui_types::endpoint_for::{endpoint_for, Endpoint};
+use qontinui_types::functional_spec::{FunctionalSpec, Operation};
+use qontinui_types::ir::{IrTransition, IrTransitionAction};
+use qontinui_types::priorities_profile::Profile;
+
+use crate::screen::{generate_screen, ScreenArtifact};
+
+/// One inverted navigation edge: the source screen, the destination screen, and the
+/// element id on the source screen whose press fires the transition (resolved against the
+/// source screen's instrumented elements so the handler is wired to a real, snapshot-able
+/// button — the same element the matcher would find for the transition's `action.target`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NavEdge {
+    /// Transition id (`IrTransition.id`).
+    pub transition_id: String,
+    /// Source screen route (`from_states[0]`).
+    pub from_state: String,
+    /// Destination screen route (`activate_states[0]`).
+    pub to_state: String,
+    /// The instrumented element id on the source screen the press handler attaches to.
+    /// `None` when no source-screen element matches the transition's `action.target`
+    /// (a *dangling* transition — surfaced rather than silently wired to nothing).
+    pub trigger_element_id: Option<String>,
+    /// The operation (if any) this transition's handler also invokes, by op name.
+    pub invokes_operation: Option<String>,
+}
+
+/// One inverted data-layer service method: the operation it serves and the endpoint it
+/// calls (URL derived once via the shared [`endpoint_for`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServiceMethod {
+    /// Operation name (`Operation.name`) — the method name on the generated client.
+    pub operation: String,
+    /// The derived `{ method, path }` the call targets.
+    pub endpoint: Endpoint,
+}
+
+/// The whole-page inversion result: one screen per state, the nav graph, the data layer,
+/// and the emitted data-layer client source. The `produced_refs` are the dotted spec refs
+/// the generator produced (the D4 contract the verify phase consumes).
+#[derive(Debug, Clone)]
+pub struct GeneratedApp {
+    /// One screen artifact per `IrState`, in spec order.
+    pub screens: Vec<ScreenArtifact>,
+    /// One nav edge per `IrTransition`, in spec order.
+    pub nav_edges: Vec<NavEdge>,
+    /// One service method per `Operation`, in spec order.
+    pub services: Vec<ServiceMethod>,
+    /// The emitted typed data-layer client (`api/client.ts`).
+    pub data_layer_tsx: String,
+    /// The dotted spec refs this generator produced — `uiStates.<id>`,
+    /// `navigation.<id>`, `operations.<name>` (the `enumerate_nodes` convention).
+    pub produced_refs: Vec<String>,
+}
+
+/// Invert a whole `FunctionalSpec` (+ `Profile` for endpoint derivation) into a
+/// `GeneratedApp`. Deterministic; no LLM. Mirrors the per-screen instrumentation of
+/// Phase 1 across every state, plus the navigation + data-layer wiring of Phase 2.
+pub fn generate_app(spec: &FunctionalSpec, profile: &Profile) -> GeneratedApp {
+    // 1. One instrumented screen per state (Phase-1 renderer, reused verbatim — the
+    //    instrumentation bytes the snapshot depends on are produced HERE and never touched
+    //    by the handler wiring below).
+    let mut screens: Vec<ScreenArtifact> = spec.ui_states.iter().map(generate_screen).collect();
+
+    // 2. One data-layer service method per operation (URL via the shared endpoint_for).
+    let services: Vec<ServiceMethod> = spec
+        .operations
+        .iter()
+        .map(|op| ServiceMethod {
+            operation: op.name.clone(),
+            endpoint: endpoint_for(op, profile),
+        })
+        .collect();
+
+    // 3. One nav edge per transition, with its trigger element resolved against the
+    //    SOURCE screen's instrumented elements + its operation invocation linked.
+    let nav_edges: Vec<NavEdge> = spec
+        .navigation
+        .iter()
+        .map(|t| invert_transition(t, &screens, &spec.operations))
+        .collect();
+
+    // 3b. Wire each resolved transition's navigation + (linked) data-layer call into its
+    //     source screen's emitted `.tsx`, as a NON-INSTRUMENTATION annotation (a comment
+    //     block documenting the handler the byte-stable Phase-1 placeholder stands in for).
+    //     The instrumentation (hooks/host components) is left byte-identical so the
+    //     snapshot — and therefore the matcher result — never drifts.
+    for edge in &nav_edges {
+        if let Some(trigger_id) = &edge.trigger_element_id {
+            if let Some(screen) = screens.iter_mut().find(|s| s.state_id == edge.from_state) {
+                screen
+                    .tsx
+                    .push_str(&render_handler_annotation(edge, trigger_id));
+            }
+        }
+    }
+
+    let data_layer_tsx = render_data_layer(&services);
+
+    // 4. The dotted refs produced (the D4 verify contract; gated to covered downstream).
+    let mut produced_refs =
+        Vec::with_capacity(spec.ui_states.len() + spec.navigation.len() + spec.operations.len());
+    for s in &spec.ui_states {
+        produced_refs.push(format!("uiStates.{}", s.id));
+    }
+    for t in &spec.navigation {
+        produced_refs.push(format!("navigation.{}", t.id));
+    }
+    for op in &spec.operations {
+        produced_refs.push(format!("operations.{}", op.name));
+    }
+
+    GeneratedApp {
+        screens,
+        nav_edges,
+        services,
+        data_layer_tsx,
+        produced_refs,
+    }
+}
+
+/// Invert one transition into a [`NavEdge`], resolving the trigger element against the
+/// source screen's instrumented elements (so the press handler is wired to a real,
+/// snapshot-able button) and linking any operation the handler invokes.
+fn invert_transition(
+    t: &IrTransition,
+    screens: &[ScreenArtifact],
+    operations: &[Operation],
+) -> NavEdge {
+    let from_state = t.from_states.first().cloned().unwrap_or_default();
+    let to_state = t.activate_states.first().cloned().unwrap_or_default();
+
+    // Resolve the trigger element: find the source screen, then the instrumented element
+    // whose role/text satisfies the first action's target criteria. This is the SAME
+    // resolution the matcher performs for the transition's target — so a wired handler
+    // implies the matcher would find the button (Phase-3 coverage gate prereq).
+    let trigger_element_id = t
+        .actions
+        .first()
+        .and_then(|action| resolve_trigger(&from_state, action, screens));
+
+    // A click-action whose target text names an operation-bearing button is linked to the
+    // operation whose handler the press should invoke. We link by the navigation effect:
+    // a write/destructive transition that fires from a state invokes the page's operation.
+    let invokes_operation = link_operation(t, operations);
+
+    NavEdge {
+        transition_id: t.id.clone(),
+        from_state,
+        to_state,
+        trigger_element_id,
+        invokes_operation,
+    }
+}
+
+/// Find the instrumented element on the source screen that the transition's action
+/// targets, returning its element id. The match mirrors the matcher's element search:
+/// role must agree (when declared) and the target's text/textContains must be contained
+/// in the element's visible text (case/space-insensitive).
+fn resolve_trigger(
+    from_state: &str,
+    action: &IrTransitionAction,
+    screens: &[ScreenArtifact],
+) -> Option<String> {
+    let screen = screens.iter().find(|s| s.state_id == from_state)?;
+    let want_role = action.target.role.as_deref();
+    let want_text = action
+        .target
+        .text
+        .as_deref()
+        .or(action.target.text_contains.as_deref())
+        .map(norm);
+
+    screen
+        .elements
+        .iter()
+        .find(|el| {
+            let role_ok = match want_role {
+                Some(r) => el.accessibility_role.as_deref().map(norm) == Some(norm(r)),
+                None => true,
+            };
+            let text_ok = match &want_text {
+                Some(needle) => el
+                    .visible_text
+                    .as_deref()
+                    .map(|t| norm(t).contains(needle))
+                    .unwrap_or(false),
+                None => true,
+            };
+            role_ok && text_ok
+        })
+        .map(|el| el.element_id.clone())
+}
+
+/// Link a transition to the operation its press handler invokes. v0 heuristic matching
+/// the connect-runner shape: a write-effecting transition (or one whose only action is a
+/// click) that activates a result state invokes the spec's single mutating operation. When
+/// exactly one create/update/delete/custom operation exists, the transition is linked to
+/// it; otherwise (ambiguous) no link is wired (surfaced, not guessed).
+fn link_operation(t: &IrTransition, operations: &[Operation]) -> Option<String> {
+    let is_click = t
+        .actions
+        .first()
+        .map(|a| a.kind.eq_ignore_ascii_case("click"))
+        .unwrap_or(false);
+    if !is_click {
+        return None;
+    }
+    let mutating: Vec<&Operation> = operations
+        .iter()
+        .filter(|op| !op.verb.eq_ignore_ascii_case("read"))
+        .collect();
+    match mutating.as_slice() {
+        [single] => Some(single.name.clone()),
+        _ => None,
+    }
+}
+
+/// Render the deterministic typed data-layer client (`api/client.ts`): one method per
+/// operation, each calling its derived endpoint through the `qontinui-mobile`
+/// `HttpTransport` convention (base URL + bearer, per D3). Instrumentation-free (the data
+/// layer isn't snapshot-matched); kept deterministic so the endpoint contract is stable.
+fn render_data_layer(services: &[ServiceMethod]) -> String {
+    let mut s = String::new();
+    s.push_str("// AUTO-GENERATED by qontinui-app-generator (data layer, Phase 2).\n");
+    s.push_str("// Endpoints derived via the shared qontinui_types::endpoint_for — the\n");
+    s.push_str("// single #1<->#2 contract; do not hand-edit the method/path pairs.\n\n");
+    s.push_str("import { HttpTransport } from './core/HttpTransport';\n\n");
+    s.push_str("export class GeneratedApiClient {\n");
+    s.push_str("  constructor(private readonly http: HttpTransport) {}\n\n");
+    for m in services {
+        let method_name = camel_case(&m.operation);
+        let http_verb = m.endpoint.method.to_ascii_lowercase();
+        s.push_str(&format!(
+            "  /** {} -> {} {} */\n",
+            m.operation, m.endpoint.method, m.endpoint.path
+        ));
+        s.push_str(&format!("  {method_name}(body?: unknown) {{\n",));
+        s.push_str(&format!(
+            "    return this.http.{http_verb}({}, body);\n",
+            ts_string(&m.endpoint.path)
+        ));
+        s.push_str("  }\n\n");
+    }
+    s.push_str("}\n");
+    s
+}
+
+/// Render the transition-handler annotation appended to a source screen's `.tsx`.
+///
+/// Phase 1 emitted a byte-stable `onPress` placeholder on the press element so the SDK's
+/// dead-button backstop is satisfied and the instrumentation stays deterministic. Phase 2
+/// records — as a trailing comment block keyed to the trigger element id — the concrete
+/// navigation + data-layer call that placeholder stands in for, so the emitted source
+/// documents the wired behavior WITHOUT mutating any instrumentation bytes the snapshot
+/// depends on. (The executable handler body is filled by the Phase-2 LLM presentational
+/// pass / a later codegen step; the deterministic core pins the contract.)
+fn render_handler_annotation(edge: &NavEdge, trigger_id: &str) -> String {
+    let mut s = String::new();
+    s.push_str("\n// --- transition wiring (Phase 2, deterministic contract) ---\n");
+    s.push_str(&format!(
+        "// element {trigger_id}: onPress -> router.push('/{}')",
+        edge.to_state
+    ));
+    if let Some(op) = &edge.invokes_operation {
+        s.push_str(&format!(" after api.{}()", camel_case(op)));
+    }
+    s.push('\n');
+    s.push_str(&format!("// transition: {}\n", edge.transition_id));
+    s
+}
+
+/// Normalize text the way the matcher does (case-fold + whitespace-collapse) for the
+/// generator's local trigger resolution. Mirrors `spec_check`'s `normalize_text` intent
+/// without taking a dep on it (kept local + deterministic).
+fn norm(s: &str) -> String {
+    s.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+/// `pair-confirm`/`pairConfirm` -> `pairConfirm` (camelCase method name).
+fn camel_case(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut upper_next = false;
+    let mut first = true;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            if first {
+                out.push(ch.to_ascii_lowercase());
+                first = false;
+            } else if upper_next {
+                out.push(ch.to_ascii_uppercase());
+                upper_next = false;
+            } else {
+                out.push(ch);
+            }
+        } else {
+            upper_next = !first;
+        }
+    }
+    if out.is_empty() {
+        "call".to_string()
+    } else {
+        out
+    }
+}
+
+/// Render a Rust string as a single-quoted TS string literal.
+fn ts_string(s: &str) -> String {
+    format!("'{}'", s.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use qontinui_types::ir::{IrElementCriteria, IrState};
+
+    fn profile() -> Profile {
+        serde_json::from_str(
+            r#"{"profileVersion":"0","backend":{"language":"python","framework":"fastapi","datastore":"postgres","apiStyle":"rest"},"architecture":{"pattern":"layered","testingBar":"unit","minCoveragePct":80},"conventions":{"naming":"snake_case","entityToTable":"pluralize"}}"#,
+        )
+        .unwrap()
+    }
+
+    fn op(name: &str, verb: &str, entity: Option<&str>) -> Operation {
+        serde_json::from_value(serde_json::json!({
+            "name": name, "verb": verb, "entity": entity, "confidence": "observed"
+        }))
+        .unwrap()
+    }
+
+    fn click_transition(id: &str, from: &str, to: &str, role: &str, text: &str) -> IrTransition {
+        IrTransition {
+            id: id.into(),
+            name: id.into(),
+            from_states: vec![from.into()],
+            activate_states: vec![to.into()],
+            actions: vec![IrTransitionAction {
+                kind: "click".into(),
+                target: IrElementCriteria {
+                    role: Some(role.into()),
+                    text_contains: Some(text.into()),
+                    ..Default::default()
+                },
+                params: None,
+                wait_after: None,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn state_with_button(id: &str) -> IrState {
+        serde_json::from_value(serde_json::json!({
+            "id": id, "name": id,
+            "assertions": [{
+                "id": format!("{id}-connect-button"),
+                "description": "Connect",
+                "category": "element-presence",
+                "severity": "critical",
+                "assertionType": "exists",
+                "target": {"type":"search","criteria":{"role":"button","text":"Connect"},"label":"Connect"},
+                "source":"discovery","reviewed":false,"enabled":true
+            }]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn transition_trigger_resolves_to_a_real_source_screen_element() {
+        let from = state_with_button("pairing-confirm");
+        let to = state_with_button("pairing-error");
+        let spec = FunctionalSpec {
+            spec_version: "0".into(),
+            target: serde_json::from_value(serde_json::json!({"sourceUrl":"x"})).unwrap(),
+            entities: vec![],
+            operations: vec![op("pairConfirm", "create", Some("Device"))],
+            ui_states: vec![from, to],
+            navigation: vec![click_transition(
+                "show-pairing-error",
+                "pairing-confirm",
+                "pairing-error",
+                "button",
+                "Connect",
+            )],
+            auth: None,
+            assumptions: vec![],
+        };
+        let app = generate_app(&spec, &profile());
+        assert_eq!(app.screens.len(), 2);
+        assert_eq!(app.nav_edges.len(), 1);
+        let edge = &app.nav_edges[0];
+        assert_eq!(edge.from_state, "pairing-confirm");
+        assert_eq!(edge.to_state, "pairing-error");
+        // The handler wires to a REAL instrumented button on the source screen.
+        assert!(
+            edge.trigger_element_id.is_some(),
+            "transition must wire to a real source-screen element, not nothing"
+        );
+        // The single mutating operation is linked to the click transition.
+        assert_eq!(edge.invokes_operation.as_deref(), Some("pairConfirm"));
+    }
+
+    #[test]
+    fn data_layer_derives_endpoint_via_shared_endpoint_for() {
+        let spec = FunctionalSpec {
+            spec_version: "0".into(),
+            target: serde_json::from_value(serde_json::json!({"sourceUrl":"x"})).unwrap(),
+            entities: vec![],
+            operations: vec![op("pairConfirm", "create", Some("Device"))],
+            ui_states: vec![],
+            navigation: vec![],
+            auth: None,
+            assumptions: vec![],
+        };
+        let app = generate_app(&spec, &profile());
+        assert_eq!(app.services.len(), 1);
+        let m = &app.services[0];
+        // The shared rule: custom op pairConfirm on Device -> POST /api/v1/devices/pair-confirm.
+        assert_eq!(m.endpoint.method, "POST");
+        assert_eq!(m.endpoint.path, "/api/v1/devices/pair-confirm");
+        assert!(app
+            .data_layer_tsx
+            .contains("'/api/v1/devices/pair-confirm'"));
+        assert!(app.data_layer_tsx.contains("pairConfirm(body?: unknown)"));
+    }
+
+    #[test]
+    fn produced_refs_use_the_dotted_enumerate_convention() {
+        let spec = FunctionalSpec {
+            spec_version: "0".into(),
+            target: serde_json::from_value(serde_json::json!({"sourceUrl":"x"})).unwrap(),
+            entities: vec![],
+            operations: vec![op("pairConfirm", "create", Some("Device"))],
+            ui_states: vec![state_with_button("pairing-confirm")],
+            navigation: vec![click_transition(
+                "show-pairing-error",
+                "pairing-confirm",
+                "pairing-error",
+                "button",
+                "Connect",
+            )],
+            auth: None,
+            assumptions: vec![],
+        };
+        let app = generate_app(&spec, &profile());
+        assert!(app
+            .produced_refs
+            .contains(&"uiStates.pairing-confirm".to_string()));
+        assert!(app
+            .produced_refs
+            .contains(&"navigation.show-pairing-error".to_string()));
+        assert!(app
+            .produced_refs
+            .contains(&"operations.pairConfirm".to_string()));
+    }
+
+    #[test]
+    fn dangling_transition_surfaces_as_unwired_not_silently_dropped() {
+        // A transition whose target button does NOT exist on the source screen yields a
+        // None trigger — surfaced, not silently wired to a nonexistent element.
+        let from = state_with_button("pairing-confirm"); // has a Connect button
+        let spec = FunctionalSpec {
+            spec_version: "0".into(),
+            target: serde_json::from_value(serde_json::json!({"sourceUrl":"x"})).unwrap(),
+            entities: vec![],
+            operations: vec![],
+            ui_states: vec![from],
+            navigation: vec![click_transition(
+                "go-nowhere",
+                "pairing-confirm",
+                "elsewhere",
+                "button",
+                "Submit", // no "Submit" button on the source screen
+            )],
+            auth: None,
+            assumptions: vec![],
+        };
+        let app = generate_app(&spec, &profile());
+        assert_eq!(app.nav_edges[0].trigger_element_id, None);
+    }
+
+    #[test]
+    fn camel_case_handles_kebab_and_camel() {
+        assert_eq!(camel_case("pair-confirm"), "pairConfirm");
+        assert_eq!(camel_case("pairConfirm"), "pairConfirm");
+        assert_eq!(camel_case("create_invoice"), "createInvoice");
+    }
+}

--- a/crates/qontinui-app-generator/src/lib.rs
+++ b/crates/qontinui-app-generator/src/lib.rs
@@ -6,7 +6,7 @@
 //! website->mobile regeneration program
 //! (`plans/2026-06-14-app-generator-ir-inversion.md`, node #1).
 //!
-//! ## Phase 1 scope (this crate, deterministic core)
+//! ## Phase 1 scope (per-screen observability seam, deterministic core)
 //!
 //! - [`screen::generate_screen`] — `IrState` -> [`screen::ScreenArtifact`] (the emitted
 //!   `.tsx` + the structured instrumentation manifest). Pure-deterministic; no LLM.
@@ -19,6 +19,22 @@
 //!   golden test can run the real `qontinui_spec_check::evaluate` matcher and prove the
 //!   mapping is matcher-correct **deterministically**, without an Expo render.
 //!
+//! ## Phase 2 scope (whole-page inversion, deterministic core)
+//!
+//! - [`app::generate_app`] — `FunctionalSpec` + `Profile` -> [`app::GeneratedApp`]: one
+//!   instrumented screen per `IrState` (reusing the Phase-1 renderer verbatim), one
+//!   navigator edge per `IrTransition` whose press handler is resolved to a **real**
+//!   source-screen element, and one data-layer service method per `Operation` whose URL is
+//!   derived by the **shared** [`qontinui_types::endpoint_for::endpoint_for`] (the single
+//!   #1<->#2 contract — never re-derived). The whole-page golden test
+//!   (`tests/golden_full_app.rs`) runs the real matcher over **every** state and asserts a
+//!   `FullMatch`, lifting the Phase-1 per-screen proof to the entire connect-runner page.
+//! - Deferred (honestly): the **LLM presentational fill** (layout/styling via
+//!   `run_claude_cli`) and the **on-device render+snapshot** verify leg — there is no
+//!   generated-screen render harness (the device runs a fixed production Expo build, not a
+//!   dev-client that can load an arbitrary emitted `.tsx`). See the deferred test for the
+//!   precise gap + the harness proposal.
+//!
 //! ## Runtime-deferred (NOT in this crate)
 //!
 //! The full verify loop the plan describes (run the emitted screen under the UI Bridge
@@ -27,10 +43,12 @@
 //! toolchain. The crate leaves the wiring in place via [`snapshot_element_from`] and
 //! documents the deferral in `tests/runtime_render_deferred.rs`.
 
+pub mod app;
 pub mod criteria;
 pub mod instrument;
 pub mod screen;
 
+pub use app::{generate_app, GeneratedApp, NavEdge, ServiceMethod};
 pub use criteria::ParsedCriteria;
 pub use instrument::InstrumentedElement;
 pub use screen::{generate_screen, ScreenArtifact};

--- a/crates/qontinui-app-generator/tests/golden_full_app.rs
+++ b/crates/qontinui-app-generator/tests/golden_full_app.rs
@@ -1,0 +1,252 @@
+//! Phase-2 golden test: invert the **whole** connect-runner `FunctionalSpec`
+//! (both `IrState`s + the `IrTransition` + the `pairConfirm` operation) into a
+//! multi-screen, navigable, data-layer-wired app, and prove the inversion correct against
+//! the **real** matcher + the **real** shared endpoint derivation — deterministically,
+//! without an Expo render.
+//!
+//! What this verifies that Phase 1 did not:
+//!
+//! 1. **Every** state (`pairing-confirm` AND `pairing-error`) inverts to instrumentation
+//!    that scores `FullMatch` against the real `qontinui_spec_check::evaluate` — proving
+//!    the per-screen observability seam holds across the whole page, not just one screen.
+//! 2. The `show-pairing-error` transition's trigger resolves to a **real** instrumented
+//!    button on its source screen (`pairing-confirm`) — the same element the matcher would
+//!    find for the transition's `action.target` (the Phase-3 nav-coverage prereq).
+//! 3. The `pairConfirm` operation inverts to a data-layer call at the endpoint the
+//!    **shared** `endpoint_for` derives (`POST /api/v1/devices/pair-confirm`) — the one
+//!    #1<->#2 contract, byte-checked in the emitted client.
+//!
+//! The on-device render+snapshot leg remains runtime-deferred (no generated-screen render
+//! harness exists; the device runs a fixed production build). See
+//! `runtime_render_deferred.rs`.
+
+use qontinui_app_generator::{generate_app, snapshot_element_from};
+use qontinui_types::functional_spec::FunctionalSpec;
+use qontinui_types::ir::IrPageSpec;
+use qontinui_types::priorities_profile::Profile;
+use qontinui_types::ui_bridge::UIBridgeSnapshot;
+
+use qontinui_spec_check::{evaluate, MatchOutcome};
+
+const FIXTURE_DIR: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../qontinui-schemas/rust/tests/fixtures/functional_spec"
+);
+
+fn load_spec() -> FunctionalSpec {
+    let path = format!("{FIXTURE_DIR}/connect-runner.functional_spec.json");
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    serde_json::from_str(&raw).expect("connect-runner fixture parses as FunctionalSpec")
+}
+
+fn load_profile() -> Profile {
+    let path = format!("{FIXTURE_DIR}/connect-runner.profile.json");
+    let raw = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    serde_json::from_str(&raw).expect("connect-runner profile parses as Profile")
+}
+
+#[test]
+fn whole_page_inverts_to_one_screen_per_state_and_one_edge_per_transition() {
+    let spec = load_spec();
+    let app = generate_app(&spec, &load_profile());
+
+    assert_eq!(
+        app.screens.len(),
+        spec.ui_states.len(),
+        "one screen per state"
+    );
+    assert_eq!(
+        app.nav_edges.len(),
+        spec.navigation.len(),
+        "one nav edge per transition"
+    );
+    assert_eq!(
+        app.services.len(),
+        spec.operations.len(),
+        "one service method per operation"
+    );
+
+    // Both fixture states are present as screens.
+    let ids: Vec<&str> = app.screens.iter().map(|s| s.state_id.as_str()).collect();
+    assert!(ids.contains(&"pairing-confirm"));
+    assert!(ids.contains(&"pairing-error"));
+}
+
+#[test]
+fn every_state_scores_full_match_against_the_real_matcher() {
+    // The whole-page observability proof: project EVERY generated screen's instrumentation
+    // manifest into the snapshot the native SDK would register, run the REAL matcher over
+    // the whole IrPageSpec, and assert every state matches. This is the Phase-1 proof,
+    // lifted to all states at once.
+    let spec = load_spec();
+    let app = generate_app(&spec, &load_profile());
+
+    // One snapshot carrying every instrumented element across every screen (the matcher
+    // searches the whole element set per state, mirroring an app whose elements are all
+    // mounted/observable — Phase-3 will instead snapshot each state in isolation).
+    let elements = app
+        .screens
+        .iter()
+        .flat_map(|s| s.elements.iter())
+        .map(snapshot_element_from)
+        .collect();
+
+    let snapshot = UIBridgeSnapshot {
+        timestamp: 0,
+        elements,
+        components: Vec::new(),
+        workflows: Vec::new(),
+        modal_stack: None,
+        toasts: None,
+        undo_redo: None,
+        current_route: Some("/pairing-confirm".into()),
+        segments: vec!["pairing-confirm".into()],
+    };
+
+    let page = IrPageSpec {
+        version: "1.0".into(),
+        id: "connect-runner".into(),
+        name: "Connect Runner".into(),
+        description: None,
+        metadata: None,
+        provenance: None,
+        states: spec.ui_states.clone(),
+        transitions: spec.navigation.clone(),
+        synthesized_groups: None,
+        initial_state: Some("pairing-confirm".into()),
+        api_assertions: None,
+    };
+
+    let result = evaluate(&snapshot, &page);
+
+    // Every state in the fixture scores a full per-state match.
+    for state in &spec.ui_states {
+        let sr = result
+            .state_results
+            .iter()
+            .find(|s| s.state_id == state.id)
+            .unwrap_or_else(|| panic!("matcher returns a result for {}", state.id));
+        assert_eq!(
+            sr.match_rate, 1.0,
+            "state {} must score a full per-state match (every assertion's element exists)",
+            state.id
+        );
+    }
+
+    assert_eq!(
+        result.summary.match_outcome,
+        MatchOutcome::FullMatch,
+        "overall outcome is FullMatch across the whole page"
+    );
+    assert_eq!(
+        result.summary.severity_counts.critical, 0,
+        "no critical misses anywhere on the page"
+    );
+}
+
+#[test]
+fn pairing_error_alert_and_copy_invert_to_matchable_elements() {
+    // pairing-error carries {role: alert} (critical) + {textContains: invalid} (warning).
+    // Confirm the alert assertion (the load-bearing one) inverts to a real element the
+    // matcher finds — this is the second state Phase 1 never exercised.
+    let spec = load_spec();
+    let app = generate_app(&spec, &load_profile());
+    let err = app
+        .screens
+        .iter()
+        .find(|s| s.state_id == "pairing-error")
+        .expect("pairing-error screen generated");
+
+    let alert = err
+        .elements
+        .iter()
+        .find(|e| e.accessibility_role.as_deref() == Some("alert"))
+        .expect("the alert assertion inverts to an alert-role element");
+    assert!(!alert.needs_press, "an alert is not a press target");
+    assert!(
+        err.tsx.contains("accessibilityRole: 'alert'"),
+        "emitted pairing-error screen forwards accessibilityRole=alert"
+    );
+
+    let copy = err
+        .elements
+        .iter()
+        .find(|e| {
+            e.visible_text
+                .as_deref()
+                .map(|t| t.contains("invalid"))
+                .unwrap_or(false)
+        })
+        .expect("the textContains:invalid assertion inverts to an invalid-bearing element");
+    assert!(err.tsx.contains(copy.visible_text.as_deref().unwrap()));
+}
+
+#[test]
+fn transition_handler_is_wired_into_the_source_screen_and_invokes_the_operation() {
+    let spec = load_spec();
+    let app = generate_app(&spec, &load_profile());
+
+    let edge = &app.nav_edges[0];
+    assert_eq!(edge.transition_id, "show-pairing-error");
+    assert_eq!(edge.from_state, "pairing-confirm");
+    assert_eq!(edge.to_state, "pairing-error");
+    // The transition fires from a REAL instrumented button on the source screen.
+    assert!(
+        edge.trigger_element_id.is_some(),
+        "the show-pairing-error transition must wire to a real Connect button"
+    );
+    // The single mutating operation (pairConfirm) is linked to the click.
+    assert_eq!(edge.invokes_operation.as_deref(), Some("pairConfirm"));
+
+    // The source screen's emitted source documents the navigation + data-layer call.
+    let confirm = app
+        .screens
+        .iter()
+        .find(|s| s.state_id == "pairing-confirm")
+        .unwrap();
+    assert!(
+        confirm.tsx.contains("router.push('/pairing-error')"),
+        "source screen documents the navigation target"
+    );
+    assert!(
+        confirm.tsx.contains("api.pairConfirm()"),
+        "source screen documents the linked data-layer call"
+    );
+}
+
+#[test]
+fn data_layer_targets_the_observed_endpoint_via_shared_derivation() {
+    let spec = load_spec();
+    let app = generate_app(&spec, &load_profile());
+
+    let m = app
+        .services
+        .iter()
+        .find(|m| m.operation == "pairConfirm")
+        .expect("pairConfirm service method generated");
+    // The shared endpoint_for rule: custom op pairConfirm on Device ->
+    // POST /api/v1/devices/pair-confirm — the page's actually-observed endpoint.
+    assert_eq!(m.endpoint.method, "POST");
+    assert_eq!(m.endpoint.path, "/api/v1/devices/pair-confirm");
+    assert!(app
+        .data_layer_tsx
+        .contains("this.http.post('/api/v1/devices/pair-confirm'"));
+}
+
+#[test]
+fn generation_is_deterministic() {
+    // Byte-for-byte reproducibility across two runs (no LLM, no clock, no map iteration
+    // order) — the property the whole observability seam rests on.
+    let spec = load_spec();
+    let profile = load_profile();
+    let a = generate_app(&spec, &profile);
+    let b = generate_app(&spec, &profile);
+    let a_tsx: Vec<&String> = a.screens.iter().map(|s| &s.tsx).collect();
+    let b_tsx: Vec<&String> = b.screens.iter().map(|s| &s.tsx).collect();
+    assert_eq!(
+        a_tsx, b_tsx,
+        "screen sources are byte-identical across runs"
+    );
+    assert_eq!(a.data_layer_tsx, b.data_layer_tsx);
+    assert_eq!(a.produced_refs, b.produced_refs);
+}

--- a/crates/qontinui-app-generator/tests/golden_pairing_confirm.rs
+++ b/crates/qontinui-app-generator/tests/golden_pairing_confirm.rs
@@ -100,8 +100,10 @@ fn each_assertion_yields_a_correspondingly_instrumented_element() {
         "emitted screen renders the Connect visible text"
     );
 
-    // The authorization-copy assertion (criteria {text_contains: authorize}, snake_case
-    // in the fixture) → a text element whose visible copy CONTAINS "authorize".
+    // The authorization-copy assertion (criteria {textContains: authorize}, now camelCase
+    // in the fixture) → a text element whose visible copy CONTAINS "authorize". (The
+    // generator's tolerant ParsedCriteria honors either casing; the fixture having moved to
+    // camelCase means the MATCHER now reads this assertion too — see the note below.)
     let copy = artifact
         .elements
         .iter()
@@ -169,14 +171,13 @@ fn inverted_state_scores_full_match_against_the_real_matcher() {
         .find(|s| s.state_id == "pairing-confirm")
         .expect("matcher returns a result for pairing-confirm");
 
-    // NOTE on the fixture's snake_case `text_contains`: the MATCHER drops snake_case
-    // criteria keys (it parses strict camelCase IrElementCriteria), so the
-    // authorization-copy assertion's criteria is read as EMPTY by the matcher and
-    // matches vacuously (passes). The GENERATOR honors snake_case and instruments the
-    // copy element regardless. Either way the connect-button assertion (camelCase-clean
-    // {role, text}) is the load-bearing one and matches a real element — so the state
-    // scores 1.0. The cross-crate reconciliation (comprehension emit camelCase) is
-    // surfaced in the report; this assert pins the current behavior.
+    // NOTE: the fixture now writes the authorization-copy criteria as camelCase
+    // `textContains` (the cross-crate reconciliation §8.4 landed), so the MATCHER reads it
+    // too — the copy assertion matches a REAL authorize-bearing element (no longer vacuous).
+    // Both the connect-button assertion ({role, text}) and the copy assertion ({textContains})
+    // resolve to real instrumented elements, so the state scores 1.0 on substance, not on a
+    // vacuous pass. The generator's tolerant ParsedCriteria still honors snake_case for
+    // resilience against any pre-reconciliation fixtures; this assert pins the behavior.
     assert_eq!(
         sr.match_rate, 1.0,
         "pairing-confirm scores a full per-state match"

--- a/crates/qontinui-app-generator/tests/runtime_render_deferred.rs
+++ b/crates/qontinui-app-generator/tests/runtime_render_deferred.rs
@@ -15,17 +15,44 @@
 //!
 //! The ON-DEVICE leg — actually rendering the emitted `.tsx` in Expo and reading back a
 //! NativeBridgeSnapshot from the running app — requires a Metro bundler + an Expo
-//! device/simulator harness that is NOT part of the Rust toolchain and is not trivially
-//! present in this environment. Per the task constraint, it is left UNVERIFIED rather
-//! than faked. This `#[ignore]`d test documents exactly what the runtime harness must
-//! do and where the seam attaches (`snapshot_element_from` is the deterministic
-//! stand-in; the real path replaces it with a live snapshot fetch from the running app).
+//! device/simulator harness that is NOT part of the Rust toolchain. Per the task
+//! constraint, it is left UNVERIFIED rather than faked. This `#[ignore]`d test documents
+//! exactly what the runtime harness must do and where the seam attaches
+//! (`snapshot_element_from` is the deterministic stand-in; the real path replaces it with
+//! a live snapshot fetch from the running app).
 //!
-//! To run the real verification once an Expo harness exists:
-//!   1. Write `artifact.tsx` to the generated Expo app's `app/<id>.tsx`.
-//!   2. Boot the app under `@qontinui/ui-bridge-native` with the native HTTP server.
-//!   3. GET the bridge snapshot endpoint -> deserialize into `UIBridgeSnapshot`.
-//!   4. `evaluate(&live_snapshot, &page)` and assert `match_rate == 1.0`.
+//! ## Why there is no render path TODAY (verified 2026-06-17)
+//!
+//! The connected device (`RFCW6041HHN`) runs `io.qontinui.mobile`, a **fixed production
+//! Expo build** (`flags=0x0` — NOT debuggable; versionCode 86; signed APK). It cannot
+//! attach to Metro, so it cannot load an arbitrary generated `.tsx`. `qontinui-mobile`
+//! has **no** generated-screen preview/sandbox route, no watched-dir screen loader, and
+//! no Storybook-like harness — its Expo Router screens are the fixed app routes. The
+//! runner UI Bridge (`:9876`) snapshots the runner's OWN Tauri webview (confirmed: GET
+//! `/ui-bridge/sdk/snapshot?appId=qontinui-mobile` returns the runner's
+//! `activeTab:"terminal"` tree, not the mobile's). Snapshotting the existing mobile app
+//! would verify the FIXED app, not the generator's emitted screen — so it proves nothing
+//! about this crate. **Conclusion: no on-device render of a GENERATED screen is reachable
+//! without first building a render harness.**
+//!
+//! ## Concrete harness proposal (what would close the gap)
+//!
+//! Smallest viable: a **`development`-profile dev-client build** of `qontinui-mobile`
+//! (`eas.json` already defines it: `developmentClient: true`) installed on the device,
+//! plus a tiny **generated-screen preview route** added to the app — e.g.
+//! `app/__appgen-preview.tsx` that dynamically renders the screen written to a
+//! Metro-watched `app/_generated/<id>.tsx`. Then the loop is:
+//!   1. `generate_app(spec, profile)` -> write each `screen.tsx` to `app/_generated/<id>.tsx`.
+//!   2. `expo start --dev-client`; reload the dev-client on the device (Metro picks up the
+//!      watched file).
+//!   3. Navigate to `__appgen-preview?screen=<id>` (deep link via the `qontinui://` scheme).
+//!   4. Fetch the device's `@qontinui/ui-bridge-native` snapshot (mDNS / cloud-relay /
+//!      `adb reverse`) -> deserialize into `UIBridgeSnapshot`.
+//!   5. `evaluate(&live_snapshot, &page)` and assert `match_rate == 1.0` — the SAME
+//!      assertion the deterministic golden test makes, now against a real render.
+//!
+//! This is a `qontinui-mobile` + harness change, deliberately out of this crate's scope;
+//! it is the single remaining gap between the deterministic proof and a true on-device run.
 
 #[test]
 #[ignore = "runtime: requires an Expo/Metro + device|simulator harness (not in the Rust toolchain); the deterministic matcher-correctness proof lives in golden_pairing_confirm.rs"]


### PR DESCRIPTION
## What

Phase 2 of the app-generator (node #1 of the website→mobile regeneration program, plan `2026-06-14-app-generator-ir-inversion.md`). Lifts the Phase-1 **per-screen** observability seam to the **whole** connect-runner page — deterministically, proven against the **real** matcher and the **real** shared endpoint derivation.

- `app::generate_app(spec, profile) -> GeneratedApp`:
  - **one instrumented screen per `IrState`** (Phase-1 `generate_screen` reused verbatim — the instrumentation bytes the snapshot depends on are never mutated);
  - **one `NavEdge` per `IrTransition`**, whose press handler is resolved to a **real** source-screen element (matching the matcher's own element search); a transition whose target button doesn't exist surfaces as `trigger_element_id: None` (dangling — not silently wired);
  - **one `ServiceMethod` per `Operation`**, whose URL is derived by the **shared** `qontinui_types::endpoint_for` (the single #1↔#2 contract — never re-derived here);
  - transition wiring recorded as a **non-instrumentation** annotation on the source screen (`router.push` + `api.<op>()`), keeping the snapshot byte-stable.
- `produced_refs` use the `enumerate_nodes` dotted convention (`uiStates.*` / `navigation.*` / `operations.*`) — the D4 verify contract.

## Verified (deterministic, no Expo render)

`tests/golden_full_app.rs` runs `qontinui_spec_check::evaluate` over the **whole** page and asserts **every** state (`pairing-confirm` AND `pairing-error`) scores `FullMatch` — the Phase-1 proof lifted to all states. Plus golden checks for the shared-endpoint derivation (`POST /api/v1/devices/pair-confirm`), the transition trigger resolving to a real Connect button + invoking `pairConfirm`, and byte-for-byte determinism.

Suite: 19 unit + 6 full-app golden + 3 Phase-1 golden, all green. fmt + clippy (`-D warnings`) clean.

## On-device render — honestly deferred (the real blocker)

A real on-mobile render of a **generated** screen was **NOT achievable**, and no snapshot was faked. The connected device (`RFCW6041HHN`) runs `io.qontinui.mobile`, a **fixed, non-debuggable production Expo build** (`flags=0x0`, versionCode 86, signed APK) — it cannot attach to Metro to load an arbitrary emitted `.tsx`. `qontinui-mobile` has no generated-screen preview/sandbox route, no watched-dir loader, no Storybook harness. The runner UI Bridge (`:9876`) snapshots only its **own** Tauri webview (confirmed: `GET /ui-bridge/sdk/snapshot?appId=qontinui-mobile` returns the runner's `activeTab:"terminal"` tree). Snapshotting the existing mobile app would verify the **fixed** app, not the generator.

`tests/runtime_render_deferred.rs` (`#[ignore]`d) now documents this conclusion and a **concrete harness proposal**: a `development`-profile dev-client build (already defined in `eas.json`) + a `app/__appgen-preview.tsx` route rendering screens written to a Metro-watched `app/_generated/<id>.tsx`, then snapshot via mDNS/cloud-relay/`adb reverse` and run the SAME `evaluate(...)==1.0` assertion against the real render. That `qontinui-mobile`+harness change is the single remaining gap and is deliberately out of this crate's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)