### PR TITLE
Make setup-wizard folder scan work out of the box

### DIFF
--- a/scripts/sync-setup-mcp.sh
+++ b/scripts/sync-setup-mcp.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# sync-setup-mcp.sh — refresh the vendored qontinui-setup-mcp package source.
+#
+# The setup wizard's folder scan runs `python -m qontinui_setup_mcp.cli` from a
+# bundled copy of the (pure-stdlib) qontinui-setup-mcp package, so an end-user
+# install needs no pip install and no sibling checkout. The single source of
+# truth is the upstream repo; this script re-vendors its package source into
+# `src-tauri/resources/qontinui-setup-mcp/src/` (which tauri.conf.json bundles).
+#
+# Run this whenever upstream changes. CI should run it and fail if it produces
+# a diff (i.e. the vendored copy drifted from the pinned upstream).
+#
+#   ./scripts/sync-setup-mcp.sh                 # use sibling ../qontinui-setup-mcp if present, else clone
+#   ./scripts/sync-setup-mcp.sh <git-ref>       # vendor a specific ref/branch/sha
+#
+set -euo pipefail
+
+REPO_URL="https://github.com/qontinui/qontinui-setup-mcp"
+RUNNER_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+DEST="$RUNNER_ROOT/src-tauri/resources/qontinui-setup-mcp/src"
+REF="${1:-}"
+
+# Resolve a source checkout: prefer a sibling clone, else shallow-clone to tmp.
+SIBLING="$RUNNER_ROOT/../qontinui-setup-mcp"
+CLEANUP=""
+if [ -d "$SIBLING/.git" ] && [ -z "$REF" ]; then
+  SRC_REPO="$SIBLING"
+else
+  TMP="$(mktemp -d)"; CLEANUP="$TMP"
+  git clone --quiet "$REPO_URL" "$TMP"
+  [ -n "$REF" ] && git -C "$TMP" checkout --quiet "$REF"
+  SRC_REPO="$TMP"
+fi
+
+SHA="$(git -C "$SRC_REPO" rev-parse HEAD)"
+
+# Re-vendor: replace the package dir wholesale, strip caches.
+rm -rf "$DEST"
+mkdir -p "$DEST"
+cp -R "$SRC_REPO/src/qontinui_setup_mcp" "$DEST/qontinui_setup_mcp"
+find "$DEST" -name '__pycache__' -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+# Record provenance.
+cat > "$RUNNER_ROOT/src-tauri/resources/qontinui-setup-mcp/VENDOR.md" <<EOF
+# Vendored: qontinui-setup-mcp
+
+AUTO-VENDORED — do not edit these files by hand. They are a copy of the
+\`qontinui_setup_mcp\` package from $REPO_URL, bundled into the app so the
+setup-wizard folder scan works out of the box (no pip install, no sibling
+checkout). The scan CLI is pure-stdlib; \`mcp\`/\`httpx\` are server-only and
+are intentionally NOT vendored.
+
+- Upstream: $REPO_URL
+- Pinned commit: $SHA
+- Refresh: \`./scripts/sync-setup-mcp.sh\` (from the runner repo root)
+EOF
+
+[ -n "$CLEANUP" ] && rm -rf "$CLEANUP"
+echo "Vendored qontinui-setup-mcp @ $SHA -> $DEST"

--- a/src-tauri/resources/qontinui-setup-mcp/VENDOR.md
+++ b/src-tauri/resources/qontinui-setup-mcp/VENDOR.md
@@ -1,0 +1,11 @@
+# Vendored: qontinui-setup-mcp
+
+AUTO-VENDORED — do not edit these files by hand. They are a copy of the
+`qontinui_setup_mcp` package from https://github.com/qontinui/qontinui-setup-mcp, bundled into the app so the
+setup-wizard folder scan works out of the box (no pip install, no sibling
+checkout). The scan CLI is pure-stdlib; `mcp`/`httpx` are server-only and
+are intentionally NOT vendored.
+
+- Upstream: https://github.com/qontinui/qontinui-setup-mcp
+- Pinned commit: f6aebb9c3387c5de7a3071d5d8e7063fd0f632e2
+- Refresh: `./scripts/sync-setup-mcp.sh` (from the runner repo root)

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/__init__.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Qontinui Setup MCP Server — guided runner setup and configuration."""
+
+__version__ = "0.1.0"

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/__main__.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running as `python -m qontinui_setup_mcp`."""
+
+from qontinui_setup_mcp.server import run
+
+run()

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/cli.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/cli.py
@@ -1,0 +1,147 @@
+"""CLI entry point for subprocess invocation by the Rust runner.
+
+Provides a thin CLI wrapper around the offline discovery and validation
+functions so that the runner can call them via ``python -m qontinui_setup_mcp.cli``
+without needing the full MCP server or an HTTP connection.
+
+Usage::
+
+    python -m qontinui_setup_mcp.cli scan_workspace /path/to/dir --max-depth 3
+    python -m qontinui_setup_mcp.cli detect_framework /path/to/project
+    python -m qontinui_setup_mcp.cli suggest_log_sources /path/to/project
+    python -m qontinui_setup_mcp.cli check_prerequisites
+    python -m qontinui_setup_mcp.cli check_prerequisites --checks node python git
+
+Exit codes:
+    0 — success (JSON result on stdout)
+    1 — error (message on stderr)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from typing import Any
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser with subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="qontinui_setup_mcp.cli",
+        description="Qontinui setup utilities — offline discovery and validation.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # -- scan_workspace --------------------------------------------------------
+    sp_scan = subparsers.add_parser(
+        "scan_workspace",
+        help="Scan a directory tree for software projects.",
+    )
+    sp_scan.add_argument(
+        "path",
+        help="Root directory to scan.",
+    )
+    sp_scan.add_argument(
+        "--max-depth",
+        type=int,
+        default=3,
+        help="Maximum directory depth to descend (default: 3).",
+    )
+
+    # -- detect_framework ------------------------------------------------------
+    sp_detect = subparsers.add_parser(
+        "detect_framework",
+        help="Detect the primary framework of a project.",
+    )
+    sp_detect.add_argument(
+        "project_path",
+        help="Path to the project root.",
+    )
+
+    # -- suggest_log_sources ---------------------------------------------------
+    sp_suggest = subparsers.add_parser(
+        "suggest_log_sources",
+        help="Discover log files and suggest log source configs.",
+    )
+    sp_suggest.add_argument(
+        "project_path",
+        help="Path to the project root.",
+    )
+
+    # -- suggest_workspace_sources ---------------------------------------------
+    sp_ws = subparsers.add_parser(
+        "suggest_workspace_sources",
+        help="Discover dev-log sources at the workspace root level.",
+    )
+    sp_ws.add_argument(
+        "workspace_path",
+        help="Root directory of the workspace.",
+    )
+
+    # -- check_prerequisites ---------------------------------------------------
+    sp_prereqs = subparsers.add_parser(
+        "check_prerequisites",
+        help="Check if required system tools are installed.",
+    )
+    sp_prereqs.add_argument(
+        "--checks",
+        nargs="+",
+        default=None,
+        help="Specific tools to check (e.g. node python git). Omit to check all.",
+    )
+
+    return parser
+
+
+async def _dispatch(args: argparse.Namespace) -> Any:
+    """Dispatch the parsed CLI arguments to the appropriate async function."""
+    command: str = args.command
+
+    if command == "scan_workspace":
+        from qontinui_setup_mcp.discovery.scanner import scan_workspace
+
+        return await scan_workspace(path=args.path, max_depth=args.max_depth)
+
+    if command == "detect_framework":
+        from qontinui_setup_mcp.discovery.frameworks import detect_framework
+
+        return await detect_framework(project_path=args.project_path)
+
+    if command == "suggest_log_sources":
+        from qontinui_setup_mcp.discovery.log_finder import suggest_log_sources
+
+        return await suggest_log_sources(project_path=args.project_path)
+
+    if command == "suggest_workspace_sources":
+        from qontinui_setup_mcp.discovery.log_finder import suggest_workspace_sources
+
+        return await suggest_workspace_sources(workspace_path=args.workspace_path)
+
+    if command == "check_prerequisites":
+        from qontinui_setup_mcp.validation.prerequisites import check_prerequisites
+
+        return await check_prerequisites(checks=args.checks)
+
+    # Should never happen due to argparse required=True, but guard anyway.
+    raise ValueError(f"Unknown command: {command}")
+
+
+def main() -> None:
+    """Parse arguments, run the async dispatch, and print JSON to stdout."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        result = asyncio.run(_dispatch(args))
+        json.dump(result, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+        sys.exit(0)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/client.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/client.py
@@ -1,0 +1,164 @@
+"""HTTP client for the qontinui-runner API (port 9876)."""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 9876
+DEFAULT_TIMEOUT = 30.0
+
+
+def _get_windows_host() -> str:
+    """Get the Windows host IP when running inside WSL."""
+    try:
+        with open("/etc/resolv.conf") as f:
+            for line in f:
+                if line.startswith("nameserver"):
+                    return line.split()[1]
+    except (FileNotFoundError, IndexError):
+        pass
+    return DEFAULT_HOST
+
+
+def _detect_host() -> str:
+    """Auto-detect the correct host for reaching the runner."""
+    env_host = os.environ.get("QONTINUI_RUNNER_HOST")
+    if env_host:
+        return env_host
+    if platform.system() == "Linux" and os.path.exists("/proc/version"):
+        try:
+            with open("/proc/version") as f:
+                if "microsoft" in f.read().lower():
+                    return _get_windows_host()
+        except OSError:
+            pass
+    return DEFAULT_HOST
+
+
+@dataclass
+class RunnerResponse:
+    """Wrapper for runner API responses."""
+
+    success: bool
+    data: Any = None
+    error: str | None = None
+
+
+@dataclass
+class RunnerClient:
+    """Async HTTP client for the qontinui-runner settings API."""
+
+    host: str = field(default_factory=_detect_host)
+    port: int = field(
+        default_factory=lambda: int(
+            os.environ.get("QONTINUI_RUNNER_PORT", str(DEFAULT_PORT))
+        )
+    )
+    _client: httpx.AsyncClient | None = field(default=None, init=False, repr=False)
+
+    @property
+    def base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url, timeout=DEFAULT_TIMEOUT
+            )
+        return self._client
+
+    async def close(self) -> None:
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        json: Any | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> RunnerResponse:
+        """Make an HTTP request to the runner API."""
+        client = await self._get_client()
+        try:
+            response = await client.request(method, path, json=json, timeout=timeout)
+            response.raise_for_status()
+            body = response.json()
+            return RunnerResponse(
+                success=body.get("success", True),
+                data=body.get("data"),
+                error=body.get("error"),
+            )
+        except httpx.ConnectError:
+            return RunnerResponse(
+                success=False,
+                error=f"Cannot connect to runner at {self.base_url}. Is it running?",
+            )
+        except httpx.HTTPStatusError as e:
+            try:
+                body = e.response.json()
+                return RunnerResponse(
+                    success=False,
+                    error=body.get("error", str(e)),
+                )
+            except Exception:
+                return RunnerResponse(success=False, error=str(e))
+        except Exception as e:
+            return RunnerResponse(success=False, error=str(e))
+
+    # ── Health ──────────────────────────────────────────────────────────
+
+    async def health(self) -> RunnerResponse:
+        return await self._request("GET", "/health")
+
+    # ── Log Sources ─────────────────────────────────────────────────────
+
+    async def get_log_source_settings(self) -> RunnerResponse:
+        return await self._request("GET", "/log-sources/settings")
+
+    async def put_log_source_settings(self, settings: dict[str, Any]) -> RunnerResponse:
+        return await self._request("PUT", "/log-sources/settings", json=settings)
+
+    async def set_ai_selection_mode(self, mode: str) -> RunnerResponse:
+        return await self._request("PUT", "/log-sources/ai-mode", json={"mode": mode})
+
+    async def set_default_profile(self, profile_id: str | None) -> RunnerResponse:
+        return await self._request(
+            "PUT", "/log-sources/default-profile", json={"profile_id": profile_id}
+        )
+
+    # ── AI Settings ─────────────────────────────────────────────────────
+
+    async def get_ai_settings(self) -> RunnerResponse:
+        return await self._request("GET", "/settings/ai")
+
+    async def put_ai_settings(self, settings: dict[str, Any]) -> RunnerResponse:
+        return await self._request("PUT", "/settings/ai", json=settings)
+
+    async def store_api_key(self, provider: str, api_key: str) -> RunnerResponse:
+        return await self._request(
+            "POST",
+            "/settings/ai/api-key",
+            json={"provider": provider, "api_key": api_key},
+        )
+
+    async def check_api_key(self, provider: str) -> RunnerResponse:
+        return await self._request("GET", f"/settings/ai/has-key/{provider}")
+
+    async def test_ai_connection(self) -> RunnerResponse:
+        return await self._request("POST", "/settings/ai/test-connection")
+
+    # ── Device Info ─────────────────────────────────────────────────────
+
+    async def get_device_info(self) -> RunnerResponse:
+        return await self._request("GET", "/settings/device-info")

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/__init__.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration tools — runner API wrappers for settings management."""

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/ai_provider.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/ai_provider.py
@@ -1,0 +1,191 @@
+"""AI provider configuration via the runner API.
+
+Wraps the runner's AI settings endpoints with a convenient interface
+for reading, updating, and testing provider configurations.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from qontinui_setup_mcp.client import RunnerClient
+
+logger = logging.getLogger(__name__)
+
+# Provider keys that correspond to CLI-based providers.
+_CLI_PROVIDERS: frozenset[str] = frozenset({"claude_cli", "gemini_cli"})
+
+# Provider keys that correspond to API-based providers.
+_API_PROVIDERS: frozenset[str] = frozenset({"claude_api", "gemini_api"})
+
+# All recognized provider keys.
+_VALID_PROVIDERS: frozenset[str] = _CLI_PROVIDERS | _API_PROVIDERS
+
+
+async def get_ai_settings(client: RunnerClient) -> dict[str, Any]:
+    """Get current AI provider settings.
+
+    Returns the full settings object with any sensitive data stripped
+    (API keys are never present in the settings response from the runner,
+    but this function serves as a safety boundary).
+    """
+    resp = await client.get_ai_settings()
+    if not resp.success:
+        return {"success": False, "error": resp.error or "Failed to fetch AI settings"}
+
+    settings: dict[str, Any] = resp.data if isinstance(resp.data, dict) else {}
+
+    # Defensive strip: remove any keys that look like secrets.
+    _strip_sensitive(settings)
+
+    return {"success": True, **settings}
+
+
+async def set_ai_provider(
+    client: RunnerClient,
+    provider: str,
+    model: str | None = None,
+    cli_execution_mode: str | None = None,
+) -> dict[str, Any]:
+    """Configure the AI provider via read-modify-write.
+
+    Args:
+        client: The runner HTTP client.
+        provider: One of ``"claude_cli"``, ``"claude_api"``, ``"gemini_cli"``,
+            or ``"gemini_api"``.
+        model: Optional model identifier.  When provided, the model field
+            inside the provider's sub-key is updated (e.g.
+            ``settings["claude_api"]["model"]``).
+        cli_execution_mode: Optional execution mode for CLI providers
+            (e.g. ``"auto"``, ``"windows_native"``, ``"wsl"``, ``"native"``).
+            Ignored if *provider* is not a CLI provider.
+
+    Returns:
+        ``{"success": True}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    if provider not in _VALID_PROVIDERS:
+        return {
+            "success": False,
+            "error": (
+                f"Invalid provider '{provider}'. "
+                f"Must be one of: {', '.join(sorted(_VALID_PROVIDERS))}"
+            ),
+        }
+
+    # Read current settings.
+    resp = await client.get_ai_settings()
+    if not resp.success:
+        return {"success": False, "error": resp.error or "Failed to read AI settings"}
+
+    settings: dict[str, Any] = resp.data if isinstance(resp.data, dict) else {}
+
+    # Set the active provider.
+    settings["provider"] = provider
+
+    # Ensure the provider sub-key exists.
+    if provider not in settings or not isinstance(settings[provider], dict):
+        settings[provider] = {}
+
+    # Update model if provided.
+    if model is not None:
+        settings[provider]["model"] = model
+
+    # Update CLI execution mode if applicable.
+    if cli_execution_mode is not None and provider in _CLI_PROVIDERS:
+        settings[provider]["execution_mode"] = cli_execution_mode
+
+    put_resp = await client.put_ai_settings(settings)
+    if not put_resp.success:
+        return {
+            "success": False,
+            "error": put_resp.error or "Failed to save AI settings",
+        }
+
+    return {"success": True}
+
+
+async def store_api_key(
+    client: RunnerClient,
+    provider: str,
+    api_key: str,
+) -> dict[str, Any]:
+    """Store an API key in the OS keychain via the runner.
+
+    Args:
+        client: The runner HTTP client.
+        provider: The provider name (e.g. ``"claude_api"``, ``"gemini_api"``).
+        api_key: The API key value.
+
+    Returns:
+        ``{"success": True}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    resp = await client.store_api_key(provider, api_key)
+    if not resp.success:
+        return {"success": False, "error": resp.error or "Failed to store API key"}
+    return {"success": True}
+
+
+async def check_api_key(client: RunnerClient, provider: str) -> dict[str, Any]:
+    """Check whether an API key exists for a given provider.
+
+    Returns:
+        ``{"success": True, "has_key": bool}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    resp = await client.check_api_key(provider)
+    if not resp.success:
+        return {"success": False, "error": resp.error or "Failed to check API key"}
+
+    has_key: bool = False
+    if isinstance(resp.data, dict):
+        has_key = bool(resp.data.get("has_key", False))
+    elif isinstance(resp.data, bool):
+        has_key = resp.data
+
+    return {"success": True, "has_key": has_key}
+
+
+async def test_ai_connection(client: RunnerClient) -> dict[str, Any]:
+    """Test AI connectivity using the currently configured provider.
+
+    Returns:
+        ``{"success": True, ...}`` with connection test details on success,
+        or ``{"success": False, "error": "..."}`` on failure.
+    """
+    resp = await client.test_ai_connection()
+    if not resp.success:
+        return {"success": False, "error": resp.error or "AI connection test failed"}
+
+    result: dict[str, Any] = {"success": True}
+    if isinstance(resp.data, dict):
+        result.update(resp.data)
+
+    return result
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _strip_sensitive(settings: dict[str, Any]) -> None:
+    """Remove any keys that look like they might contain secrets (in-place).
+
+    The runner API should never expose raw keys, but this provides a
+    defense-in-depth layer.
+    """
+    sensitive_keys = {"api_key", "secret", "token", "password", "credential"}
+    keys_to_remove: list[str] = []
+
+    for key in settings:
+        if any(s in key.lower() for s in sensitive_keys):
+            keys_to_remove.append(key)
+
+    for key in keys_to_remove:
+        del settings[key]
+
+    # Recurse into nested dicts.
+    for value in settings.values():
+        if isinstance(value, dict):
+            _strip_sensitive(value)

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/log_sources.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/log_sources.py
@@ -1,0 +1,234 @@
+"""Log source CRUD operations via the runner API.
+
+All mutating operations use a read-modify-write pattern against the
+full log-source settings object (GET → modify → PUT).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from qontinui_setup_mcp.client import RunnerClient
+
+logger = logging.getLogger(__name__)
+
+
+async def get_log_sources(client: RunnerClient) -> dict[str, Any]:
+    """Get all configured log sources.
+
+    Returns the full settings object containing ``sources``, ``profiles``,
+    ``default_profile_id``, ``ai_selection_mode``, and
+    ``include_all_when_no_profile``.
+    """
+    resp = await client.get_log_source_settings()
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to fetch log source settings",
+        }
+    return {"success": True, **resp.data}
+
+
+async def add_log_source(
+    client: RunnerClient, source: dict[str, Any]
+) -> dict[str, Any]:
+    """Add a new log source via read-modify-write.
+
+    If the *source* dict does not contain an ``"id"`` key, a UUID4 is
+    generated automatically.
+
+    Returns:
+        ``{"success": True, "source_id": "<id>"}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    # Ensure the source has an id.
+    if "id" not in source or not source["id"]:
+        source["id"] = str(uuid.uuid4())
+    source_id: str = source["id"]
+
+    # Read current settings.
+    resp = await client.get_log_source_settings()
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to read current settings",
+        }
+
+    settings: dict[str, Any] = resp.data
+
+    # Append the new source.
+    sources: list[dict[str, Any]] = settings.get("sources", [])
+    sources.append(source)
+    settings["sources"] = sources
+
+    # Write back.
+    put_resp = await client.put_log_source_settings(settings)
+    if not put_resp.success:
+        return {"success": False, "error": put_resp.error or "Failed to save settings"}
+
+    return {"success": True, "source_id": source_id}
+
+
+async def update_log_source(
+    client: RunnerClient,
+    source_id: str,
+    updates: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an existing log source by ID via read-modify-write.
+
+    Merges *updates* into the existing source dict.  The ``"id"`` field
+    cannot be changed.
+
+    Returns:
+        ``{"success": True}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    resp = await client.get_log_source_settings()
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to read current settings",
+        }
+
+    settings: dict[str, Any] = resp.data
+    sources: list[dict[str, Any]] = settings.get("sources", [])
+
+    # Find the source to update.
+    target: dict[str, Any] | None = None
+    for src in sources:
+        if src.get("id") == source_id:
+            target = src
+            break
+
+    if target is None:
+        return {"success": False, "error": f"Log source '{source_id}' not found"}
+
+    # Merge updates (preserve the id).
+    updates.pop("id", None)
+    target.update(updates)
+
+    settings["sources"] = sources
+
+    put_resp = await client.put_log_source_settings(settings)
+    if not put_resp.success:
+        return {"success": False, "error": put_resp.error or "Failed to save settings"}
+
+    return {"success": True}
+
+
+async def remove_log_source(client: RunnerClient, source_id: str) -> dict[str, Any]:
+    """Remove a log source by ID via read-modify-write.
+
+    Also removes the source ID from any profiles that reference it.
+
+    Returns:
+        ``{"success": True}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    resp = await client.get_log_source_settings()
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to read current settings",
+        }
+
+    settings: dict[str, Any] = resp.data
+    sources: list[dict[str, Any]] = settings.get("sources", [])
+
+    original_count = len(sources)
+    settings["sources"] = [s for s in sources if s.get("id") != source_id]
+
+    if len(settings["sources"]) == original_count:
+        return {"success": False, "error": f"Log source '{source_id}' not found"}
+
+    # Remove the source from any profiles that reference it.
+    profiles: list[dict[str, Any]] = settings.get("profiles", [])
+    for profile in profiles:
+        source_ids: list[str] = profile.get("source_ids", [])
+        if source_id in source_ids:
+            profile["source_ids"] = [sid for sid in source_ids if sid != source_id]
+
+    put_resp = await client.put_log_source_settings(settings)
+    if not put_resp.success:
+        return {"success": False, "error": put_resp.error or "Failed to save settings"}
+
+    return {"success": True}
+
+
+async def apply_suggested_sources(
+    client: RunnerClient,
+    project_path: str,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Discover log sources for a project and add them to the runner.
+
+    Uses :func:`qontinui_setup_mcp.discovery.log_finder.suggest_log_sources`
+    to scan *project_path* for common log locations, then adds each
+    suggested source via the runner API.
+
+    Args:
+        client: The runner HTTP client.
+        project_path: Filesystem path to the project root.
+        dry_run: If ``True``, return what would be added without persisting.
+
+    Returns:
+        ``{"success": True, "sources_added": [...], "framework": {...}, "dry_run": bool}``
+        on success, or ``{"success": False, "error": "..."}`` on failure.
+    """
+    try:
+        from qontinui_setup_mcp.discovery.log_finder import suggest_log_sources
+    except ImportError:
+        return {
+            "success": False,
+            "error": "Log finder module not available (qontinui_setup_mcp.discovery.log_finder)",
+        }
+
+    try:
+        result = await suggest_log_sources(project_path)
+    except Exception as exc:
+        logger.exception("Failed to discover log sources for %s", project_path)
+        return {"success": False, "error": f"Discovery failed: {exc}"}
+
+    suggested: list[dict[str, Any]] = result.get("suggested_sources", [])
+    framework: dict[str, Any] = result.get("framework", {})
+
+    if dry_run:
+        return {
+            "success": True,
+            "sources_added": suggested,
+            "framework": framework,
+            "dry_run": True,
+        }
+
+    # Read current settings once, add all sources, write once.
+    resp = await client.get_log_source_settings()
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to read current settings",
+        }
+
+    settings: dict[str, Any] = resp.data
+    sources: list[dict[str, Any]] = settings.get("sources", [])
+
+    added: list[dict[str, Any]] = []
+    for source in suggested:
+        if "id" not in source or not source["id"]:
+            source["id"] = str(uuid.uuid4())
+        sources.append(source)
+        added.append(source)
+
+    settings["sources"] = sources
+
+    put_resp = await client.put_log_source_settings(settings)
+    if not put_resp.success:
+        return {"success": False, "error": put_resp.error or "Failed to save settings"}
+
+    return {
+        "success": True,
+        "sources_added": added,
+        "framework": framework,
+        "dry_run": False,
+    }

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/profiles.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/configuration/profiles.py
@@ -1,0 +1,96 @@
+"""Log source profile management via the runner API.
+
+Profiles group log sources into named sets that can be activated
+together.  Mutating operations use a read-modify-write pattern
+against the full log-source settings object.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from qontinui_setup_mcp.client import RunnerClient
+
+logger = logging.getLogger(__name__)
+
+
+async def create_log_profile(
+    client: RunnerClient,
+    name: str,
+    source_ids: list[str],
+    description: str | None = None,
+) -> dict[str, Any]:
+    """Create a new log source profile via read-modify-write.
+
+    Generates a UUID4 for the profile ID, appends the profile to the
+    settings, and writes back the full settings object.
+
+    Args:
+        client: The runner HTTP client.
+        name: Human-readable profile name.
+        source_ids: List of log source IDs to include in this profile.
+        description: Optional description of the profile.
+
+    Returns:
+        ``{"success": True, "profile_id": "<id>"}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    profile_id = str(uuid.uuid4())
+
+    # Read current settings.
+    resp = await client.get_log_source_settings()
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to read current settings",
+        }
+
+    settings: dict[str, Any] = resp.data
+
+    # Build the new profile.
+    profile: dict[str, Any] = {
+        "id": profile_id,
+        "name": name,
+        "description": description,
+        "source_ids": source_ids,
+    }
+
+    # Append to profiles list.
+    profiles: list[dict[str, Any]] = settings.get("profiles", [])
+    profiles.append(profile)
+    settings["profiles"] = profiles
+
+    # Write back.
+    put_resp = await client.put_log_source_settings(settings)
+    if not put_resp.success:
+        return {"success": False, "error": put_resp.error or "Failed to save settings"}
+
+    return {"success": True, "profile_id": profile_id}
+
+
+async def set_default_profile(
+    client: RunnerClient,
+    profile_id: str | None,
+) -> dict[str, Any]:
+    """Set the default active log source profile.
+
+    Uses the runner's dedicated ``set_default_profile`` endpoint rather
+    than the full read-modify-write pattern.
+
+    Args:
+        client: The runner HTTP client.
+        profile_id: The profile ID to set as default, or ``None`` to clear.
+
+    Returns:
+        ``{"success": True}`` on success, or
+        ``{"success": False, "error": "..."}`` on failure.
+    """
+    resp = await client.set_default_profile(profile_id)
+    if not resp.success:
+        return {
+            "success": False,
+            "error": resp.error or "Failed to set default profile",
+        }
+    return {"success": True}

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/__init__.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/__init__.py
@@ -1,0 +1,1 @@
+"""Discovery tools — offline workspace and project analysis."""

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/frameworks.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/frameworks.py
@@ -1,0 +1,883 @@
+"""Framework detection registry and detection logic.
+
+Provides a registry of well-known frameworks with their fingerprints (manifest
+files, dependency names, log locations, error patterns) and an async detection
+function that inspects a project directory to identify the best-matching
+framework.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Framework definition
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FrameworkDefinition:
+    """Describes a framework's detection fingerprint and log conventions."""
+
+    name: str
+    key: str
+    language: str
+    category: str  # "frontend" | "backend" | "fullstack" | "mobile" | "system"
+    detection_files: list[str] = field(default_factory=list)
+    detection_deps: list[str] = field(default_factory=list)
+    manifest_file: str = ""
+    default_log_locations: list[str] = field(default_factory=list)
+    default_log_format: str = "plaintext"  # "plaintext" | "json" | "jsonl"
+    default_parser: str = "generic"  # "javascript" | "python" | "rust" | "generic"
+    error_patterns: list[str] = field(default_factory=list)
+    warning_patterns: list[str] = field(default_factory=list)
+    keywords: list[str] = field(default_factory=list)
+    logs_to_file_by_default: bool = False
+    build_tool: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Shared pattern sets
+# ---------------------------------------------------------------------------
+
+_JS_ERROR_PATTERNS: list[str] = [
+    r"(?i)\berror\b",
+    r"ERR!",
+    r"TypeError",
+    r"ReferenceError",
+    r"SyntaxError",
+    r"RangeError",
+    r"Unhandled(?:Rejection|Promise)",
+    r"FATAL",
+    r"Module not found",
+]
+_JS_WARNING_PATTERNS: list[str] = [
+    r"(?i)\bwarn(?:ing)?\b",
+    r"(?i)deprecated",
+    r"ExperimentalWarning",
+]
+
+_PY_ERROR_PATTERNS: list[str] = [
+    r"(?i)\berror\b",
+    r"Traceback \(most recent call last\)",
+    r"(?:Key|Value|Type|Attribute|Import|Runtime|OS)Error",
+    r"FATAL",
+    r"CRITICAL",
+]
+_PY_WARNING_PATTERNS: list[str] = [
+    r"(?i)\bwarn(?:ing)?\b",
+    r"(?i)deprecated",
+    r"DeprecationWarning",
+    r"FutureWarning",
+]
+
+_RUST_ERROR_PATTERNS: list[str] = [
+    r"(?i)\berror\b",
+    r"panicked at",
+    r"thread '.*' panicked",
+    r"FATAL",
+    r"unwrap\(\) on .* value",
+]
+_RUST_WARNING_PATTERNS: list[str] = [
+    r"(?i)\bwarn(?:ing)?\b",
+    r"(?i)deprecated",
+]
+
+_GENERIC_ERROR_PATTERNS: list[str] = [
+    r"(?i)\berror\b",
+    r"(?i)\bfatal\b",
+    r"(?i)\bpanic\b",
+    r"CRITICAL",
+]
+_GENERIC_WARNING_PATTERNS: list[str] = [
+    r"(?i)\bwarn(?:ing)?\b",
+    r"(?i)deprecated",
+]
+
+
+# ---------------------------------------------------------------------------
+# Framework registry
+# ---------------------------------------------------------------------------
+
+FRAMEWORK_REGISTRY: list[FrameworkDefinition] = [
+    # ── Node.js / TypeScript ──────────────────────────────────────────────
+    FrameworkDefinition(
+        name="Next.js",
+        key="nextjs",
+        language="typescript",
+        category="fullstack",
+        detection_files=["next.config.js", "next.config.mjs", "next.config.ts"],
+        detection_deps=["next"],
+        manifest_file="package.json",
+        default_log_locations=[".next/server/logs"],
+        default_log_format="plaintext",
+        default_parser="javascript",
+        error_patterns=_JS_ERROR_PATTERNS,
+        warning_patterns=_JS_WARNING_PATTERNS,
+        keywords=[
+            "next",
+            "nextjs",
+            "react",
+            "ssr",
+            "server-side rendering",
+            "app router",
+            "pages router",
+            "middleware",
+            "api route",
+        ],
+        logs_to_file_by_default=False,
+        build_tool="webpack/turbopack",
+    ),
+    FrameworkDefinition(
+        name="React/Vite",
+        key="react-vite",
+        language="typescript",
+        category="frontend",
+        detection_files=[],
+        detection_deps=["vite", "@vitejs/plugin-react"],
+        manifest_file="package.json",
+        default_log_locations=[],
+        default_log_format="plaintext",
+        default_parser="javascript",
+        error_patterns=_JS_ERROR_PATTERNS,
+        warning_patterns=_JS_WARNING_PATTERNS,
+        keywords=[
+            "vite",
+            "react",
+            "hmr",
+            "hot module replacement",
+            "bundle",
+            "rollup",
+            "esbuild",
+        ],
+        logs_to_file_by_default=False,
+        build_tool="vite",
+    ),
+    FrameworkDefinition(
+        name="Express",
+        key="express",
+        language="typescript",
+        category="backend",
+        detection_files=[],
+        detection_deps=["express"],
+        manifest_file="package.json",
+        default_log_locations=["logs"],
+        default_log_format="plaintext",
+        default_parser="javascript",
+        error_patterns=_JS_ERROR_PATTERNS,
+        warning_patterns=_JS_WARNING_PATTERNS,
+        keywords=[
+            "express",
+            "middleware",
+            "router",
+            "http",
+            "request",
+            "response",
+            "rest",
+            "api",
+        ],
+        logs_to_file_by_default=False,
+    ),
+    FrameworkDefinition(
+        name="NestJS",
+        key="nestjs",
+        language="typescript",
+        category="backend",
+        detection_files=[],
+        detection_deps=["@nestjs/core"],
+        manifest_file="package.json",
+        default_log_locations=["logs"],
+        default_log_format="json",
+        default_parser="javascript",
+        error_patterns=_JS_ERROR_PATTERNS,
+        warning_patterns=_JS_WARNING_PATTERNS,
+        keywords=[
+            "nestjs",
+            "nest",
+            "decorator",
+            "module",
+            "controller",
+            "provider",
+            "guard",
+            "interceptor",
+            "pipe",
+        ],
+        logs_to_file_by_default=False,
+    ),
+    FrameworkDefinition(
+        name="React Native",
+        key="react-native",
+        language="typescript",
+        category="mobile",
+        detection_files=[],
+        detection_deps=["react-native"],
+        manifest_file="package.json",
+        default_log_locations=[],
+        default_log_format="plaintext",
+        default_parser="javascript",
+        error_patterns=_JS_ERROR_PATTERNS,
+        warning_patterns=_JS_WARNING_PATTERNS,
+        keywords=[
+            "react-native",
+            "metro",
+            "bridge",
+            "native module",
+            "expo",
+            "ios",
+            "android",
+        ],
+        logs_to_file_by_default=False,
+        build_tool="metro",
+    ),
+    # ── Python ────────────────────────────────────────────────────────────
+    FrameworkDefinition(
+        name="Django",
+        key="django",
+        language="python",
+        category="fullstack",
+        detection_files=["manage.py"],
+        detection_deps=["django"],
+        manifest_file="pyproject.toml",
+        default_log_locations=["logs"],
+        default_log_format="plaintext",
+        default_parser="python",
+        error_patterns=_PY_ERROR_PATTERNS,
+        warning_patterns=_PY_WARNING_PATTERNS,
+        keywords=[
+            "django",
+            "manage.py",
+            "wsgi",
+            "asgi",
+            "migration",
+            "orm",
+            "template",
+            "middleware",
+            "settings",
+        ],
+        logs_to_file_by_default=False,
+    ),
+    FrameworkDefinition(
+        name="Flask",
+        key="flask",
+        language="python",
+        category="backend",
+        detection_files=[],
+        detection_deps=["flask"],
+        manifest_file="pyproject.toml",
+        default_log_locations=["logs"],
+        default_log_format="plaintext",
+        default_parser="python",
+        error_patterns=_PY_ERROR_PATTERNS,
+        warning_patterns=_PY_WARNING_PATTERNS,
+        keywords=[
+            "flask",
+            "werkzeug",
+            "jinja",
+            "blueprint",
+            "wsgi",
+            "route",
+            "endpoint",
+        ],
+        logs_to_file_by_default=False,
+    ),
+    FrameworkDefinition(
+        name="FastAPI",
+        key="fastapi",
+        language="python",
+        category="backend",
+        detection_files=[],
+        detection_deps=["fastapi"],
+        manifest_file="pyproject.toml",
+        default_log_locations=["logs"],
+        default_log_format="json",
+        default_parser="python",
+        error_patterns=_PY_ERROR_PATTERNS,
+        warning_patterns=_PY_WARNING_PATTERNS,
+        keywords=[
+            "fastapi",
+            "uvicorn",
+            "starlette",
+            "pydantic",
+            "openapi",
+            "async",
+            "endpoint",
+            "router",
+        ],
+        logs_to_file_by_default=False,
+    ),
+    # ── Rust ──────────────────────────────────────────────────────────────
+    FrameworkDefinition(
+        name="Tauri",
+        key="tauri",
+        language="rust",
+        category="frontend",
+        detection_files=["tauri.conf.json", "tauri.conf.json5"],
+        detection_deps=["tauri"],
+        manifest_file="Cargo.toml",
+        default_log_locations=[],
+        default_log_format="plaintext",
+        default_parser="rust",
+        error_patterns=_RUST_ERROR_PATTERNS,
+        warning_patterns=_RUST_WARNING_PATTERNS,
+        keywords=[
+            "tauri",
+            "webview",
+            "ipc",
+            "invoke",
+            "command",
+            "window",
+            "desktop",
+            "system tray",
+        ],
+        logs_to_file_by_default=False,
+        build_tool="cargo",
+    ),
+    FrameworkDefinition(
+        name="Rust/Cargo",
+        key="rust-cargo",
+        language="rust",
+        category="system",
+        detection_files=["Cargo.toml"],
+        detection_deps=[],
+        manifest_file="Cargo.toml",
+        default_log_locations=[],
+        default_log_format="plaintext",
+        default_parser="rust",
+        error_patterns=_RUST_ERROR_PATTERNS,
+        warning_patterns=_RUST_WARNING_PATTERNS,
+        keywords=[
+            "rust",
+            "cargo",
+            "crate",
+            "trait",
+            "impl",
+            "borrow",
+            "lifetime",
+            "async",
+            "tokio",
+        ],
+        logs_to_file_by_default=False,
+        build_tool="cargo",
+    ),
+    # ── Other ─────────────────────────────────────────────────────────────
+    FrameworkDefinition(
+        name="Go",
+        key="go",
+        language="go",
+        category="backend",
+        detection_files=["go.mod"],
+        detection_deps=[],
+        manifest_file="go.mod",
+        default_log_locations=[],
+        default_log_format="plaintext",
+        default_parser="generic",
+        error_patterns=_GENERIC_ERROR_PATTERNS + [r"goroutine \d+"],
+        warning_patterns=_GENERIC_WARNING_PATTERNS,
+        keywords=[
+            "go",
+            "golang",
+            "goroutine",
+            "channel",
+            "interface",
+            "struct",
+            "module",
+            "package",
+        ],
+        logs_to_file_by_default=False,
+    ),
+    FrameworkDefinition(
+        name="Spring Boot",
+        key="spring-boot",
+        language="java",
+        category="backend",
+        detection_files=["pom.xml", "build.gradle"],
+        detection_deps=["org.springframework.boot"],
+        manifest_file="pom.xml",
+        default_log_locations=["logs", "target/logs"],
+        default_log_format="plaintext",
+        default_parser="generic",
+        error_patterns=_GENERIC_ERROR_PATTERNS
+        + [
+            r"(?:java\.lang\.\w+)?Exception",
+            r"at [\w.$]+\([\w.]+:\d+\)",
+        ],
+        warning_patterns=_GENERIC_WARNING_PATTERNS,
+        keywords=[
+            "spring",
+            "boot",
+            "bean",
+            "controller",
+            "service",
+            "repository",
+            "autowired",
+            "configuration",
+        ],
+        logs_to_file_by_default=True,
+    ),
+    FrameworkDefinition(
+        name="Rails",
+        key="rails",
+        language="ruby",
+        category="fullstack",
+        detection_files=["Gemfile", "config/routes.rb"],
+        detection_deps=["rails"],
+        manifest_file="Gemfile",
+        default_log_locations=["log"],
+        default_log_format="plaintext",
+        default_parser="generic",
+        error_patterns=_GENERIC_ERROR_PATTERNS
+        + [
+            r"ActionController::\w+Error",
+            r"ActiveRecord::\w+Error",
+        ],
+        warning_patterns=_GENERIC_WARNING_PATTERNS,
+        keywords=[
+            "rails",
+            "ruby",
+            "activerecord",
+            "migration",
+            "rake",
+            "controller",
+            "model",
+            "view",
+            "gem",
+        ],
+        logs_to_file_by_default=True,
+    ),
+    FrameworkDefinition(
+        name="Flutter",
+        key="flutter",
+        language="dart",
+        category="mobile",
+        detection_files=["pubspec.yaml"],
+        detection_deps=["flutter"],
+        manifest_file="pubspec.yaml",
+        default_log_locations=[],
+        default_log_format="plaintext",
+        default_parser="generic",
+        error_patterns=_GENERIC_ERROR_PATTERNS
+        + [
+            r"FlutterError",
+            r"════════",
+        ],
+        warning_patterns=_GENERIC_WARNING_PATTERNS,
+        keywords=[
+            "flutter",
+            "dart",
+            "widget",
+            "stateful",
+            "stateless",
+            "build",
+            "pubspec",
+            "material",
+            "cupertino",
+        ],
+        logs_to_file_by_default=False,
+        build_tool="flutter",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Registry lookup
+# ---------------------------------------------------------------------------
+
+
+def get_framework_definition(key: str) -> FrameworkDefinition | None:
+    """Return the :class:`FrameworkDefinition` matching *key*, or ``None``."""
+    for fw in FRAMEWORK_REGISTRY:
+        if fw.key == key:
+            return fw
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Manifest parsing helpers
+# ---------------------------------------------------------------------------
+
+_LANGUAGE_FROM_MANIFEST: dict[str, str] = {
+    "package.json": "typescript",
+    "pyproject.toml": "python",
+    "Cargo.toml": "rust",
+    "go.mod": "go",
+    "pom.xml": "java",
+    "build.gradle": "java",
+    "build.gradle.kts": "java",
+    "Gemfile": "ruby",
+    "pubspec.yaml": "dart",
+}
+
+_CATEGORY_FROM_MANIFEST: dict[str, str] = {
+    "package.json": "fullstack",
+    "pyproject.toml": "backend",
+    "Cargo.toml": "system",
+    "go.mod": "backend",
+    "pom.xml": "backend",
+    "build.gradle": "backend",
+    "build.gradle.kts": "backend",
+    "Gemfile": "backend",
+    "pubspec.yaml": "mobile",
+}
+
+
+def _read_text_safe(path: Path) -> str | None:
+    """Read a file as UTF-8, returning ``None`` on any error."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        logger.debug("Could not read %s", path)
+        return None
+
+
+def _extract_node_deps(data: dict[str, Any]) -> set[str]:
+    """Extract all dependency names from a parsed ``package.json``."""
+    deps: set[str] = set()
+    for section in ("dependencies", "devDependencies", "peerDependencies"):
+        section_data = data.get(section)
+        if isinstance(section_data, dict):
+            deps.update(section_data.keys())
+    return deps
+
+
+def _extract_pyproject_deps(text: str) -> set[str]:
+    """Extract dependency names from ``pyproject.toml`` text."""
+    import tomllib
+
+    deps: set[str] = set()
+    try:
+        data = tomllib.loads(text)
+    except Exception:
+        logger.debug("Failed to parse pyproject.toml")
+        return deps
+
+    # [tool.poetry.dependencies]
+    poetry_deps = data.get("tool", {}).get("poetry", {}).get("dependencies", {})
+    if isinstance(poetry_deps, dict):
+        deps.update(poetry_deps.keys())
+
+    # [tool.poetry.group.*.dependencies]
+    groups = data.get("tool", {}).get("poetry", {}).get("group", {})
+    if isinstance(groups, dict):
+        for group in groups.values():
+            if isinstance(group, dict):
+                group_deps = group.get("dependencies", {})
+                if isinstance(group_deps, dict):
+                    deps.update(group_deps.keys())
+
+    # [project.dependencies] — PEP 621 style (list of requirement strings)
+    project_deps = data.get("project", {}).get("dependencies", [])
+    if isinstance(project_deps, list):
+        for req in project_deps:
+            if isinstance(req, str):
+                # Extract package name (before any version specifier).
+                name = re.split(r"[><=!~;\s\[]", req, maxsplit=1)[0].strip()
+                if name:
+                    deps.add(name.lower())
+
+    # [project.optional-dependencies]
+    optional = data.get("project", {}).get("optional-dependencies", {})
+    if isinstance(optional, dict):
+        for group_reqs in optional.values():
+            if isinstance(group_reqs, list):
+                for req in group_reqs:
+                    if isinstance(req, str):
+                        name = re.split(r"[><=!~;\s\[]", req, maxsplit=1)[0].strip()
+                        if name:
+                            deps.add(name.lower())
+
+    # Normalise (pip treats hyphens/underscores as equivalent).
+    return {d.lower().replace("-", "_").replace(".", "_") for d in deps}
+
+
+def _extract_cargo_deps(text: str) -> set[str]:
+    """Extract dependency names from ``Cargo.toml`` text."""
+    import tomllib
+
+    deps: set[str] = set()
+    try:
+        data = tomllib.loads(text)
+    except Exception:
+        logger.debug("Failed to parse Cargo.toml")
+        return deps
+
+    for section in ("dependencies", "dev-dependencies", "build-dependencies"):
+        section_data = data.get(section)
+        if isinstance(section_data, dict):
+            deps.update(section_data.keys())
+    return deps
+
+
+def _extract_gemfile_deps(text: str) -> set[str]:
+    """Extract gem names from a ``Gemfile``."""
+    deps: set[str] = set()
+    for match in re.finditer(r"""gem\s+['"]([^'"]+)['"]""", text):
+        deps.add(match.group(1))
+    return deps
+
+
+def _extract_pubspec_deps(text: str) -> set[str]:
+    """Extract dependency names from ``pubspec.yaml`` text.
+
+    Uses a simple regex approach to avoid requiring a YAML parser.
+    """
+    deps: set[str] = set()
+    in_deps = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        # Detect dependency sections.
+        if re.match(r"^(dependencies|dev_dependencies)\s*:", stripped):
+            in_deps = True
+            continue
+        # A top-level key (no leading whitespace) that isn't a dep section ends
+        # the current section.
+        if not line.startswith(" ") and not line.startswith("\t") and ":" in stripped:
+            in_deps = False
+            continue
+        if in_deps:
+            m = re.match(r"^\s+([\w_-]+)\s*:", stripped)
+            if m:
+                deps.add(m.group(1))
+    return deps
+
+
+def _text_contains_dep(text: str, dep: str) -> bool:
+    """Check whether *dep* appears in a text file (for pom.xml / build.gradle)."""
+    return dep in text
+
+
+# ---------------------------------------------------------------------------
+# Detection logic
+# ---------------------------------------------------------------------------
+
+# Ordered list of manifests to probe; earlier entries take precedence when
+# multiple manifests are found.
+_MANIFEST_PROBE_ORDER: list[str] = [
+    "package.json",
+    "pyproject.toml",
+    "Cargo.toml",
+    "go.mod",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "Gemfile",
+    "pubspec.yaml",
+]
+
+
+def _score_framework(
+    fw: FrameworkDefinition,
+    project_path: Path,
+    found_manifests: dict[str, str | None],
+    manifest_deps: dict[str, set[str]],
+) -> tuple[int, str]:
+    """Score a framework definition against the project.
+
+    Returns ``(score, detected_by)`` where *score* is 0 for no match and
+    higher for better matches. *detected_by* describes what triggered the
+    match.
+    """
+    score = 0
+    reasons: list[str] = []
+
+    # Manifest must be present for this framework to match.
+    if fw.manifest_file and fw.manifest_file not in found_manifests:
+        # Special case: build.gradle.kts counts for build.gradle manifests.
+        if (
+            fw.manifest_file == "pom.xml"
+            and "build.gradle" not in found_manifests
+            and "build.gradle.kts" not in found_manifests
+        ):
+            return 0, ""
+        if (
+            fw.manifest_file not in ("pom.xml",)
+            and fw.manifest_file not in found_manifests
+        ):
+            return 0, ""
+
+    # Detection files — each present file adds points.
+    for df in fw.detection_files:
+        # Support nested paths like "config/routes.rb".
+        check_path = project_path / df
+        if check_path.exists():
+            score += 10
+            reasons.append(f"file:{df}")
+
+    # Detection deps — each found dependency adds points (more specific).
+    deps = manifest_deps.get(fw.manifest_file, set())
+    # Also check build.gradle / build.gradle.kts / pom.xml via text search.
+    for dd in fw.detection_deps:
+        dd_lower = dd.lower().replace("-", "_").replace(".", "_")
+        # For node/python/rust deps, check parsed dependency sets.
+        if dd_lower in {d.lower().replace("-", "_").replace(".", "_") for d in deps}:
+            score += 20
+            reasons.append(f"dep:{dd}")
+        elif dd in deps:
+            score += 20
+            reasons.append(f"dep:{dd}")
+        else:
+            # For pom.xml / build.gradle, fall back to raw text search.
+            for manifest_name in ("pom.xml", "build.gradle", "build.gradle.kts"):
+                text = found_manifests.get(manifest_name)
+                if text and _text_contains_dep(text, dd):
+                    score += 20
+                    reasons.append(f"dep:{dd}(in {manifest_name})")
+                    break
+
+    if score == 0:
+        return 0, ""
+
+    return score, ", ".join(reasons)
+
+
+def _detect_sync(project_path_str: str) -> dict[str, Any]:
+    """Synchronous framework detection implementation."""
+    project_path = Path(project_path_str).resolve()
+    if not project_path.is_dir():
+        return {
+            "framework": "unknown",
+            "key": "unknown",
+            "language": "unknown",
+            "category": "unknown",
+            "build_tool": None,
+            "logs_to_file_by_default": False,
+            "detected_by": "path is not a directory",
+        }
+
+    # 1. Discover which manifests exist and read their text.
+    found_manifests: dict[str, str | None] = {}
+    for manifest_name in _MANIFEST_PROBE_ORDER:
+        manifest_path = project_path / manifest_name
+        if manifest_path.is_file():
+            found_manifests[manifest_name] = _read_text_safe(manifest_path)
+
+    # Also check for Tauri config in a src-tauri subdirectory.
+    for tauri_config in ("tauri.conf.json", "tauri.conf.json5"):
+        for sub in ("", "src-tauri"):
+            check = (
+                project_path / sub / tauri_config
+                if sub
+                else project_path / tauri_config
+            )
+            if check.is_file():
+                # Record as a detection file hit; use manifest key for text.
+                found_manifests.setdefault(f"_tauri_config:{tauri_config}", "")
+
+    if not found_manifests:
+        return {
+            "framework": "unknown",
+            "key": "unknown",
+            "language": "unknown",
+            "category": "unknown",
+            "build_tool": None,
+            "logs_to_file_by_default": False,
+            "detected_by": "no manifest files found",
+        }
+
+    # 2. Parse dependencies from manifests.
+    manifest_deps: dict[str, set[str]] = {}
+
+    if "package.json" in found_manifests:
+        text = found_manifests["package.json"]
+        if text:
+            try:
+                data = json.loads(text)
+                manifest_deps["package.json"] = _extract_node_deps(data)
+            except json.JSONDecodeError:
+                logger.debug("Failed to parse package.json")
+                manifest_deps["package.json"] = set()
+        else:
+            manifest_deps["package.json"] = set()
+
+    if "pyproject.toml" in found_manifests:
+        text = found_manifests["pyproject.toml"]
+        manifest_deps["pyproject.toml"] = (
+            _extract_pyproject_deps(text) if text else set()
+        )
+
+    if "Cargo.toml" in found_manifests:
+        text = found_manifests["Cargo.toml"]
+        manifest_deps["Cargo.toml"] = _extract_cargo_deps(text) if text else set()
+
+    if "Gemfile" in found_manifests:
+        text = found_manifests["Gemfile"]
+        manifest_deps["Gemfile"] = _extract_gemfile_deps(text) if text else set()
+
+    if "pubspec.yaml" in found_manifests:
+        text = found_manifests["pubspec.yaml"]
+        manifest_deps["pubspec.yaml"] = _extract_pubspec_deps(text) if text else set()
+
+    # go.mod — no dep parsing needed; detection_files match is sufficient.
+    if "go.mod" in found_manifests:
+        manifest_deps["go.mod"] = set()
+
+    # pom.xml and build.gradle use raw text matching, no parsed dep set.
+    for gradle_name in ("pom.xml", "build.gradle", "build.gradle.kts"):
+        if gradle_name in found_manifests:
+            manifest_deps.setdefault(gradle_name, set())
+
+    # 3. Score each framework in the registry.
+    best_score = 0
+    best_fw: FrameworkDefinition | None = None
+    best_reason = ""
+
+    for fw in FRAMEWORK_REGISTRY:
+        score, reason = _score_framework(
+            fw, project_path, found_manifests, manifest_deps
+        )
+        if score > best_score:
+            best_score = score
+            best_fw = fw
+            best_reason = reason
+
+    # 4. Build the result.
+    if best_fw is not None:
+        return {
+            "framework": best_fw.name,
+            "key": best_fw.key,
+            "language": best_fw.language,
+            "category": best_fw.category,
+            "build_tool": best_fw.build_tool,
+            "logs_to_file_by_default": best_fw.logs_to_file_by_default,
+            "detected_by": best_reason,
+        }
+
+    # Fallback: derive language/category from the first manifest found.
+    first_manifest = next(iter(found_manifests))
+    # Strip any internal prefix (e.g. "_tauri_config:...").
+    clean_manifest = (
+        first_manifest.split(":")[-1] if ":" in first_manifest else first_manifest
+    )
+    return {
+        "framework": "unknown",
+        "key": "unknown",
+        "language": _LANGUAGE_FROM_MANIFEST.get(clean_manifest, "unknown"),
+        "category": _CATEGORY_FROM_MANIFEST.get(clean_manifest, "unknown"),
+        "build_tool": None,
+        "logs_to_file_by_default": False,
+        "detected_by": f"manifest:{clean_manifest} (no framework matched)",
+    }
+
+
+async def detect_framework(project_path: str) -> dict[str, Any]:
+    """Detect the primary framework used by a project.
+
+    Inspects manifest files and their contents at *project_path* to identify
+    the best-matching framework from :data:`FRAMEWORK_REGISTRY`.
+
+    Args:
+        project_path: Absolute or relative path to the project root.
+
+    Returns:
+        A dict with keys ``framework``, ``key``, ``language``, ``category``,
+        ``build_tool``, ``logs_to_file_by_default``, and ``detected_by``.
+    """
+    return await asyncio.to_thread(_detect_sync, project_path)

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/log_finder.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/log_finder.py
@@ -1,0 +1,603 @@
+"""Find existing log files and directories in a project.
+
+Used by ``find_log_files`` and ``suggest_log_sources`` MCP tools to discover
+log output on disk and generate ready-to-use log source configurations that
+are compatible with the runner's ``GlobalLogSource`` format.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Directories to skip during traversal.
+SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "target",
+        "dist",
+        "build",
+        ".next",
+        ".cache",
+    }
+)
+
+#: Glob-style patterns for log files (matched case-insensitively).
+LOG_FILE_PATTERNS: frozenset[str] = frozenset(
+    {
+        "*.log",
+        "*.log.*",
+        "*.jsonl",
+        "*.err.log",
+    }
+)
+
+#: Well-known log directory names.
+LOG_DIR_NAMES: frozenset[str] = frozenset(
+    {
+        "logs",
+        "log",
+        ".logs",
+        ".dev-logs",
+    }
+)
+
+#: Common specific log filenames to look for explicitly.
+COMMON_LOG_FILES: frozenset[str] = frozenset(
+    {
+        "debug.log",
+        "error.log",
+        "app.log",
+        "access.log",
+        "npm-debug.log",
+        "yarn-error.log",
+        "lerna-debug.log",
+    }
+)
+
+#: Valid runner log-source categories.
+VALID_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "frontend",
+        "backend",
+        "api",
+        "mobile",
+        "database",
+        "build",
+        "testing",
+        "runner",
+        "general",
+    }
+)
+
+#: Default category when the framework's category cannot be mapped.
+DEFAULT_CATEGORY: str = "general"
+
+#: Maximum directory depth to descend.
+MAX_DEPTH: int = 4
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_guess(path: Path) -> str:
+    """Guess the log format based on file extension.
+
+    Returns ``"json"``, ``"jsonl"``, or ``"plaintext"``.
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return "json"
+    if suffix == ".jsonl":
+        return "jsonl"
+    return "plaintext"
+
+
+def _is_log_file(filename: str) -> bool:
+    """Return ``True`` if *filename* looks like a log file."""
+    lower = filename.lower()
+
+    # Exact match on common log files.
+    if lower in COMMON_LOG_FILES:
+        return True
+
+    # Extension-based checks.
+    if lower.endswith(".log"):
+        return True
+    if lower.endswith(".jsonl"):
+        return True
+    if lower.endswith(".err.log"):
+        return True
+
+    # Rotated logs like app.log.1, app.log.2, etc.
+    parts = lower.rsplit(".", 1)
+    if len(parts) == 2 and parts[1].isdigit():
+        base = parts[0]
+        if base.endswith(".log"):
+            return True
+
+    return False
+
+
+def _modified_iso(path: Path) -> str | None:
+    """Return the ISO-formatted last-modified time of *path*, or ``None``."""
+    try:
+        mtime = path.stat().st_mtime
+        return datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        return None
+
+
+def _file_size(path: Path) -> int:
+    """Return the file size in bytes, or ``0`` on error."""
+    try:
+        return path.stat().st_size
+    except OSError:
+        return 0
+
+
+def _map_framework_category(framework_category: str | None) -> str:
+    """Map a framework detection category to a valid runner log-source category."""
+    if framework_category is None:
+        return DEFAULT_CATEGORY
+
+    normalized = framework_category.lower().strip()
+
+    # Direct match.
+    if normalized in VALID_CATEGORIES:
+        return normalized
+
+    # Common mappings.
+    mapping: dict[str, str] = {
+        "fullstack": "backend",
+        "system": "backend",
+        "web-frontend": "frontend",
+        "web-backend": "backend",
+        "web": "frontend",
+        "server": "backend",
+        "rest-api": "api",
+        "graphql": "api",
+        "ios": "mobile",
+        "android": "mobile",
+        "react-native": "mobile",
+        "flutter": "mobile",
+        "db": "database",
+        "sql": "database",
+        "ci": "build",
+        "ci-cd": "build",
+        "bundler": "build",
+        "test": "testing",
+        "e2e": "testing",
+        "unit-test": "testing",
+        "automation": "runner",
+        "desktop": "runner",
+    }
+
+    return mapping.get(normalized, DEFAULT_CATEGORY)
+
+
+# ---------------------------------------------------------------------------
+# find_log_files
+# ---------------------------------------------------------------------------
+
+
+def _is_under_source_dir(path: Path, root: Path) -> bool:
+    """Return ``True`` if *path* is inside a ``src/`` directory relative to *root*."""
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return False
+    return any(part.lower() == "src" for part in rel.parts)
+
+
+def _scan_log_files_sync(root: str) -> list[dict[str, Any]]:
+    """Walk the directory tree synchronously and collect log files/dirs.
+
+    Returns a list of dicts describing each discovered log artefact.
+    """
+    root_path = Path(root).resolve()
+    if not root_path.is_dir():
+        logger.warning("find_log_files: %s is not a directory", root_path)
+        return []
+
+    root_depth = len(root_path.parts)
+    results: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    # Track discovered log directories so we can skip individual files inside them.
+    log_dir_paths: set[str] = set()
+
+    for dirpath, dirnames, filenames in os.walk(root_path, topdown=True):
+        current = Path(dirpath)
+        depth = len(current.parts) - root_depth
+
+        # Prune beyond max depth.
+        if depth >= MAX_DEPTH:
+            dirnames.clear()
+            continue
+
+        # Prune skipped directories (in-place so os.walk respects it).
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+
+        # Check if this directory itself is a log directory.
+        if current.name.lower() in LOG_DIR_NAMES and current != root_path:
+            # Skip .dev-logs in per-project scans — handled at workspace level.
+            if current.name.lower() == ".dev-logs":
+                dirnames.clear()
+                continue
+
+            # Skip log dirs under src/ (e.g., src/components/logs is source code).
+            if _is_under_source_dir(current, root_path):
+                continue
+
+            abs_str = str(current)
+            if abs_str not in seen_paths:
+                seen_paths.add(abs_str)
+                log_dir_paths.add(abs_str)
+                results.append(
+                    {
+                        "path": abs_str,
+                        "name": current.name,
+                        "type": "directory",
+                        "size_bytes": 0,
+                        "modified": _modified_iso(current),
+                        "format_guess": "plaintext",
+                    }
+                )
+
+        # Skip individual files if their parent directory is already a log source.
+        if str(current) in log_dir_paths:
+            continue
+
+        # Check files in the current directory.
+        for filename in filenames:
+            if _is_log_file(filename):
+                file_path = current / filename
+                abs_str = str(file_path)
+                if abs_str not in seen_paths:
+                    seen_paths.add(abs_str)
+                    results.append(
+                        {
+                            "path": abs_str,
+                            "name": filename,
+                            "type": "file",
+                            "size_bytes": _file_size(file_path),
+                            "modified": _modified_iso(file_path),
+                            "format_guess": _format_guess(file_path),
+                        }
+                    )
+
+    return results
+
+
+async def find_log_files(project_path: str) -> list[dict[str, Any]]:
+    """Scan a project directory for log files and log directories.
+
+    Looks for files matching common log-file patterns (``*.log``, ``*.jsonl``,
+    ``*.err.log``, etc.) and directories named ``logs``, ``log``, ``.logs``, or
+    ``.dev-logs``.  Directories such as ``node_modules``, ``.git``, and other
+    build artefact folders are skipped.
+
+    Args:
+        project_path: Root directory to scan.
+
+    Returns:
+        A list of dicts, each describing a discovered log file or directory
+        with keys ``path``, ``name``, ``type``, ``size_bytes``, ``modified``,
+        and ``format_guess``.
+    """
+    return await asyncio.to_thread(_scan_log_files_sync, project_path)
+
+
+# ---------------------------------------------------------------------------
+# suggest_log_sources
+# ---------------------------------------------------------------------------
+
+
+def _build_source_dict(
+    *,
+    name: str,
+    description: str,
+    category: str,
+    source_type: str,
+    path: str,
+    format_guess: str,
+    keywords: list[str] | None = None,
+    parser: str | None = None,
+    error_patterns: list[str] | None = None,
+    warning_patterns: list[str] | None = None,
+    pattern: str | None = None,
+) -> dict[str, Any]:
+    """Build a single log source config dict compatible with ``GlobalLogSource``."""
+    return {
+        "id": str(uuid4()),
+        "name": name,
+        "description": description,
+        "category": category,
+        "type": source_type,
+        "path": path,
+        "pattern": pattern if source_type == "directory" else None,
+        "tail_lines": 100,
+        "enabled": True,
+        "color": None,
+        "keywords": keywords or [],
+        "format": format_guess,
+        "parser": parser or "generic",
+        "timestamp_pattern": None,
+        "timezone": "local",
+        "error_patterns": error_patterns or [],
+        "warning_patterns": warning_patterns or [],
+        "ignore_patterns": [],
+        "poll_interval_ms": 5000,
+    }
+
+
+async def suggest_log_sources(project_path: str) -> dict[str, Any]:
+    """Combine framework detection and log file discovery.
+
+    Detects the project framework via
+    :func:`qontinui_setup_mcp.discovery.frameworks.detect_framework`, then
+    scans for existing log files with :func:`find_log_files`.  The results are
+    merged into a list of log-source config dicts that are directly compatible
+    with the runner's ``GlobalLogSource`` format.
+
+    Args:
+        project_path: Root directory of the project to analyse.
+
+    Returns:
+        A dict with keys:
+
+        - ``framework`` -- the framework detection result dict.
+        - ``found_log_files`` -- raw list from :func:`find_log_files`.
+        - ``suggested_sources`` -- list of ``GlobalLogSource``-compatible
+          config dicts ready to be pushed to the runner.
+        - ``needs_logging_setup`` -- ``True`` if the framework does not log to
+          files by default **and** no log files were found on disk.
+    """
+    from qontinui_setup_mcp.discovery.frameworks import detect_framework
+
+    # Run detection and scanning concurrently.
+    framework_result, found_log_files = await asyncio.gather(
+        detect_framework(project_path),
+        find_log_files(project_path),
+    )
+
+    # Extract framework metadata with safe defaults.
+    framework_name: str = framework_result.get("framework", "Unknown")
+    framework_key: str = framework_result.get("key", "unknown")
+    framework_category: str | None = framework_result.get("category")
+    framework_logs_to_files: bool = framework_result.get(
+        "logs_to_file_by_default", True
+    )
+
+    # Look up the full definition to get patterns, keywords, etc.
+    from qontinui_setup_mcp.discovery.frameworks import get_framework_definition
+
+    fw_def = get_framework_definition(framework_key)
+    framework_keywords: list[str] = list(fw_def.keywords) if fw_def else []
+    framework_parser: str = fw_def.default_parser if fw_def else "generic"
+    framework_error_patterns: list[str] = list(fw_def.error_patterns) if fw_def else []
+    framework_warning_patterns: list[str] = (
+        list(fw_def.warning_patterns) if fw_def else []
+    )
+    framework_default_log_locations: list[str] = (
+        list(fw_def.default_log_locations) if fw_def else []
+    )
+
+    project_name = Path(project_path).resolve().name
+    mapped_category = _map_framework_category(framework_category)
+
+    suggested_sources: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+
+    # 1. Sources from discovered log files / directories.
+    for entry in found_log_files:
+        entry_path: str = entry["path"]
+        if entry_path in seen_paths:
+            continue
+        seen_paths.add(entry_path)
+
+        entry_name: str = entry["name"]
+        source_type: str = entry["type"]
+        format_guess: str = entry["format_guess"]
+
+        suggested_sources.append(
+            _build_source_dict(
+                name=f"{framework_name} - {entry_name}",
+                description=f"Auto-discovered log source for {project_name}",
+                category=mapped_category,
+                source_type=source_type,
+                path=entry_path,
+                format_guess=format_guess,
+                keywords=framework_keywords,
+                parser=framework_parser,
+                error_patterns=framework_error_patterns,
+                warning_patterns=framework_warning_patterns,
+                pattern="*.log" if source_type == "directory" else None,
+            )
+        )
+
+    # 2. Add framework default log locations that exist on disk but were not
+    #    already discovered (e.g., they may reside outside the scanned depth).
+    for rel_path in framework_default_log_locations:
+        log_path = Path(project_path).resolve() / rel_path
+        abs_str = str(log_path)
+
+        if abs_str in seen_paths:
+            continue
+        if not log_path.exists():
+            continue
+
+        seen_paths.add(abs_str)
+
+        is_dir = log_path.is_dir()
+        entry_type = "directory" if is_dir else "file"
+        entry_format = "plaintext" if is_dir else _format_guess(log_path)
+
+        suggested_sources.append(
+            _build_source_dict(
+                name=f"{framework_name} - {log_path.name}",
+                description=f"Default log location for {framework_name}",
+                category=mapped_category,
+                source_type=entry_type,
+                path=abs_str,
+                format_guess=entry_format,
+                keywords=framework_keywords,
+                parser=framework_parser,
+                error_patterns=framework_error_patterns,
+                warning_patterns=framework_warning_patterns,
+                pattern="*.log" if is_dir else None,
+            )
+        )
+
+    needs_logging_setup = not framework_logs_to_files and len(found_log_files) == 0
+
+    return {
+        "framework": framework_result,
+        "found_log_files": found_log_files,
+        "suggested_sources": suggested_sources,
+        "needs_logging_setup": needs_logging_setup,
+    }
+
+
+# ---------------------------------------------------------------------------
+# suggest_workspace_sources — workspace-level log discovery
+# ---------------------------------------------------------------------------
+
+#: Patterns for categorising dev-log files by filename.
+_DEV_LOG_CLASSIFICATION: list[tuple[str, str, str, str]] = [
+    # (filename_contains, category, parser, display_name)
+    ("backend.log", "backend", "python", "Backend"),
+    ("backend.err.log", "backend", "python", "Backend Errors"),
+    ("frontend.log", "frontend", "javascript", "Frontend"),
+    ("frontend.err.log", "frontend", "javascript", "Frontend Errors"),
+    ("runner-tauri.log", "runner", "rust", "Runner"),
+    ("runner-actions.jsonl", "runner", "generic", "Runner Actions"),
+    ("runner-general.jsonl", "runner", "generic", "Runner General"),
+    ("runner-image-recognition.jsonl", "runner", "generic", "Image Recognition"),
+    ("runner-playwright.jsonl", "testing", "generic", "Playwright"),
+    ("ai-output.jsonl", "runner", "generic", "AI Output"),
+    ("supervisor.log", "runner", "generic", "Supervisor"),
+    ("supervisor.err.log", "runner", "generic", "Supervisor Errors"),
+]
+
+#: Log files to skip (temp copies, rotated, empty, huge debug dumps).
+_DEV_LOG_SKIP_PATTERNS: frozenset[str] = frozenset(
+    {
+        "-copy",
+        "-copy2",
+        "-temp",
+        "-temp2",
+        "python-ws-debug",
+        "backend-velocity",
+        "logcat.log",
+        "metro.log",
+        "runner-build.log",
+        "browser-events",
+    }
+)
+
+#: Color assignments for important source categories.
+_CATEGORY_COLORS: dict[str, str] = {
+    "backend": "#22c55e",
+    "frontend": "#3b82f6",
+    "runner": "#f97316",
+    "testing": "#a855f7",
+}
+
+
+def _classify_dev_log(filename: str) -> tuple[str, str, str, str] | None:
+    """Return ``(display_name, category, parser, format)`` for a dev-log file.
+
+    Returns ``None`` if the file should be skipped.
+    """
+    lower = filename.lower()
+
+    # Skip temp/debug/copy files.
+    for skip in _DEV_LOG_SKIP_PATTERNS:
+        if skip in lower:
+            return None
+
+    # Match against known patterns.
+    for pattern_file, category, parser, display_name in _DEV_LOG_CLASSIFICATION:
+        if lower == pattern_file:
+            fmt = "jsonl" if lower.endswith(".jsonl") else "plaintext"
+            return (display_name, category, parser, fmt)
+
+    return None
+
+
+def _scan_workspace_sources_sync(workspace_path: str) -> dict[str, Any]:
+    """Scan a workspace root for dev-log files and return classified sources."""
+    root = Path(workspace_path).resolve()
+    if not root.is_dir():
+        return {"sources": [], "dev_logs_dir": None}
+
+    # Look for .dev-logs directory.
+    dev_logs_dir = root / ".dev-logs"
+    if not dev_logs_dir.is_dir():
+        return {"sources": [], "dev_logs_dir": None}
+
+    sources: list[dict[str, Any]] = []
+
+    for entry in sorted(dev_logs_dir.iterdir()):
+        if not entry.is_file():
+            continue
+        if entry.stat().st_size == 0:
+            continue
+
+        classification = _classify_dev_log(entry.name)
+        if classification is None:
+            continue
+
+        display_name, category, parser, fmt = classification
+
+        source = _build_source_dict(
+            name=display_name,
+            description=f"Dev log from .dev-logs/{entry.name}",
+            category=category,
+            source_type="file",
+            path=str(entry),
+            format_guess=fmt,
+            parser=parser,
+        )
+        source["color"] = _CATEGORY_COLORS.get(category)
+        sources.append(source)
+
+    return {
+        "sources": sources,
+        "dev_logs_dir": str(dev_logs_dir),
+    }
+
+
+async def suggest_workspace_sources(workspace_path: str) -> dict[str, Any]:
+    """Discover dev-log sources at the workspace root level.
+
+    Scans for a ``.dev-logs`` directory in *workspace_path* and classifies
+    individual log files into categorised source configs (backend, frontend,
+    runner, etc.).
+
+    Args:
+        workspace_path: Root directory of the workspace (parent of projects).
+
+    Returns:
+        A dict with keys ``sources`` (list of ``GlobalLogSource``-compatible
+        dicts) and ``dev_logs_dir`` (path to the ``.dev-logs`` directory, or
+        ``None`` if not found).
+    """
+    return await asyncio.to_thread(_scan_workspace_sources_sync, workspace_path)

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/scanner.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/discovery/scanner.py
@@ -1,0 +1,148 @@
+"""Scan a directory tree to discover software projects by manifest files."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import TypedDict
+
+logger = logging.getLogger(__name__)
+
+# Directories to skip during traversal.
+SKIP_DIRS: frozenset[str] = frozenset(
+    {
+        "node_modules",
+        ".git",
+        "__pycache__",
+        ".venv",
+        "venv",
+        ".env",
+        "target",
+        "dist",
+        "build",
+        ".next",
+        ".cache",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+    }
+)
+
+# Mapping of manifest filename → project type.
+MANIFEST_MAP: dict[str, str] = {
+    "package.json": "node",
+    "pyproject.toml": "python",
+    "Cargo.toml": "rust",
+    "go.mod": "go",
+    "pom.xml": "java-maven",
+    "build.gradle": "java-gradle",
+    "build.gradle.kts": "java-gradle",
+    "Gemfile": "ruby",
+    "pubspec.yaml": "flutter",
+    "composer.json": "php",
+}
+
+# Glob-style extensions that need special handling.
+DOTNET_EXTENSIONS: frozenset[str] = frozenset({".sln", ".csproj"})
+
+
+class ProjectInfo(TypedDict):
+    """Information about a discovered project."""
+
+    path: str
+    name: str
+    type: str
+    manifest: str
+
+
+def _scan_sync(root: str, max_depth: int) -> list[ProjectInfo]:
+    """Walk the directory tree synchronously and collect projects.
+
+    A directory is considered a project only if it contains a ``.git``
+    directory (i.e., it is a git repository root).  This prevents
+    subdirectories with manifest files (like ``backend/`` inside a monorepo)
+    from appearing as separate projects.
+
+    The scan root itself is never reported — it is treated as a workspace
+    container, not a project.
+    """
+    root_path = Path(root).resolve()
+    if not root_path.is_dir():
+        logger.warning("scan_workspace: %s is not a directory", root_path)
+        return []
+
+    root_depth = len(root_path.parts)
+    projects: list[ProjectInfo] = []
+
+    for dirpath, dirnames, filenames in os.walk(root_path, topdown=True):
+        current = Path(dirpath)
+        depth = len(current.parts) - root_depth
+
+        # Check for .git BEFORE pruning it from dirnames.
+        has_git = ".git" in dirnames
+
+        # Prune skipped directories (in-place so os.walk respects it).
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+
+        # Stop descending beyond max_depth (but still check this directory).
+        if depth >= max_depth:
+            dirnames.clear()
+
+        # Only directories with .git are real project roots.
+        # Skip the scan root (depth 0) — it's a workspace container.
+        if not has_git or depth == 0:
+            continue
+
+        # Check for manifest files in this directory.
+        filenames_set = set(filenames)
+        found = False
+
+        # Exact-name manifests.
+        for manifest_name, project_type in MANIFEST_MAP.items():
+            if manifest_name in filenames_set:
+                projects.append(
+                    ProjectInfo(
+                        path=str(current),
+                        name=current.name,
+                        type=project_type,
+                        manifest=manifest_name,
+                    )
+                )
+                found = True
+                break
+
+        # .NET projects (*.sln, *.csproj).
+        if not found:
+            for filename in filenames:
+                if Path(filename).suffix in DOTNET_EXTENSIONS:
+                    projects.append(
+                        ProjectInfo(
+                            path=str(current),
+                            name=current.name,
+                            type="dotnet",
+                            manifest=filename,
+                        )
+                    )
+                    break
+
+    return projects
+
+
+async def scan_workspace(path: str, max_depth: int = 3) -> list[ProjectInfo]:
+    """Scan a directory tree for software projects.
+
+    Walks the filesystem up to *max_depth* levels below *path*, looking for
+    directories that are git repositories (contain a ``.git`` directory) with
+    well-known manifest files.
+
+    Args:
+        path: Root directory to scan.
+        max_depth: Maximum directory depth to descend (default ``3``).
+
+    Returns:
+        A list of :class:`ProjectInfo` dicts, one per discovered project.
+    """
+    return await asyncio.to_thread(_scan_sync, path, max_depth)

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/guidance/__init__.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/guidance/__init__.py
@@ -1,0 +1,1 @@
+"""Guidance tools — framework-specific logging advice."""

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/guidance/logging_advice.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/guidance/logging_advice.py
@@ -1,0 +1,480 @@
+"""Framework-specific instructions for setting up file-based logging.
+
+Many frameworks only log to stdout by default, so users need to configure
+them to write to files for the qontinui-runner to read.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+LOGGING_ADVICE: dict[str, dict[str, Any]] = {
+    "nextjs": {
+        "framework": "Next.js",
+        "logs_to_file_by_default": False,
+        "summary": "Next.js logs to stdout by default. Use a process manager or redirect output.",
+        "options": [
+            {
+                "method": "Process manager redirect",
+                "difficulty": "easy",
+                "description": "Redirect stdout/stderr when starting the dev server",
+                "instructions": (
+                    "Use a script or process manager to redirect output:\n"
+                    "\n"
+                    "```bash\n"
+                    "next dev > logs/next.log 2>&1\n"
+                    "```\n"
+                    "\n"
+                    "Or in package.json:\n"
+                    "```json\n"
+                    '"scripts": {\n'
+                    '  "dev:log": "next dev 2>&1 | tee logs/next.log"\n'
+                    "}\n"
+                    "```"
+                ),
+            },
+            {
+                "method": "Winston logger",
+                "difficulty": "moderate",
+                "description": (
+                    "Add Winston for structured file logging in API routes"
+                    " and server components"
+                ),
+                "instructions": (
+                    "Install Winston:\n"
+                    "```bash\n"
+                    "npm install winston\n"
+                    "```\n"
+                    "\n"
+                    "Create a logger utility (lib/logger.ts):\n"
+                    "```typescript\n"
+                    "import winston from 'winston';\n"
+                    "\n"
+                    "export const logger = winston.createLogger({\n"
+                    "  level: 'info',\n"
+                    "  format: winston.format.combine(\n"
+                    "    winston.format.timestamp(),\n"
+                    "    winston.format.json()\n"
+                    "  ),\n"
+                    "  transports: [\n"
+                    "    new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),\n"
+                    "    new winston.transports.File({ filename: 'logs/app.log' }),\n"
+                    "  ],\n"
+                    "});\n"
+                    "```\n"
+                    "\n"
+                    "Use in API routes and server code."
+                ),
+            },
+        ],
+    },
+    "react_vite": {
+        "framework": "React/Vite",
+        "logs_to_file_by_default": False,
+        "summary": "Vite dev server logs to stdout. Redirect output or use a logging library.",
+        "options": [
+            {
+                "method": "Process redirect",
+                "difficulty": "easy",
+                "description": "Redirect Vite dev server output to a file",
+                "instructions": (
+                    "```bash\n"
+                    "vite dev > logs/vite.log 2>&1\n"
+                    "```\n"
+                    "\n"
+                    "Or with tee:\n"
+                    "```bash\n"
+                    "vite dev 2>&1 | tee logs/vite.log\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "express": {
+        "framework": "Express",
+        "logs_to_file_by_default": False,
+        "summary": "Express logs to stdout by default. Use Morgan + Winston for file logging.",
+        "options": [
+            {
+                "method": "Morgan + Winston",
+                "difficulty": "moderate",
+                "description": (
+                    "Use Morgan for HTTP request logging and Winston for"
+                    " application logs, both writing to files"
+                ),
+                "instructions": (
+                    "Install packages:\n"
+                    "```bash\n"
+                    "npm install winston morgan\n"
+                    "```\n"
+                    "\n"
+                    "Setup:\n"
+                    "```javascript\n"
+                    "const winston = require('winston');\n"
+                    "const morgan = require('morgan');\n"
+                    "const fs = require('fs');\n"
+                    "const path = require('path');\n"
+                    "\n"
+                    "const logger = winston.createLogger({\n"
+                    "  transports: [\n"
+                    "    new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),\n"
+                    "    new winston.transports.File({ filename: 'logs/app.log' }),\n"
+                    "  ],\n"
+                    "});\n"
+                    "\n"
+                    "const accessLogStream = fs.createWriteStream(path.join(__dirname, 'logs/access.log'), { flags: 'a' });\n"
+                    "app.use(morgan('combined', { stream: accessLogStream }));\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "nestjs": {
+        "framework": "NestJS",
+        "logs_to_file_by_default": False,
+        "summary": "NestJS logs to stdout via its built-in logger. Use nest-winston for file output.",
+        "options": [
+            {
+                "method": "nest-winston",
+                "difficulty": "moderate",
+                "description": "Replace the built-in logger with Winston via nest-winston",
+                "instructions": (
+                    "Install:\n"
+                    "```bash\n"
+                    "npm install nest-winston winston\n"
+                    "```\n"
+                    "\n"
+                    "In main.ts:\n"
+                    "```typescript\n"
+                    "import { WinstonModule } from 'nest-winston';\n"
+                    "import * as winston from 'winston';\n"
+                    "\n"
+                    "const app = await NestFactory.create(AppModule, {\n"
+                    "  logger: WinstonModule.createLogger({\n"
+                    "    transports: [\n"
+                    "      new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),\n"
+                    "      new winston.transports.File({ filename: 'logs/app.log' }),\n"
+                    "    ],\n"
+                    "  }),\n"
+                    "});\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "django": {
+        "framework": "Django",
+        "logs_to_file_by_default": False,
+        "summary": "Django uses Python's logging module. Configure file handlers in settings.py.",
+        "options": [
+            {
+                "method": "Django LOGGING setting",
+                "difficulty": "easy",
+                "description": "Add file handlers to Django's LOGGING configuration",
+                "instructions": (
+                    "In settings.py:\n"
+                    "```python\n"
+                    "LOGGING = {\n"
+                    "    'version': 1,\n"
+                    "    'disable_existing_loggers': False,\n"
+                    "    'handlers': {\n"
+                    "        'file': {\n"
+                    "            'level': 'INFO',\n"
+                    "            'class': 'logging.FileHandler',\n"
+                    "            'filename': 'logs/django.log',\n"
+                    "        },\n"
+                    "        'error_file': {\n"
+                    "            'level': 'ERROR',\n"
+                    "            'class': 'logging.FileHandler',\n"
+                    "            'filename': 'logs/error.log',\n"
+                    "        },\n"
+                    "    },\n"
+                    "    'loggers': {\n"
+                    "        'django': {\n"
+                    "            'handlers': ['file', 'error_file'],\n"
+                    "            'level': 'INFO',\n"
+                    "            'propagate': True,\n"
+                    "        },\n"
+                    "    },\n"
+                    "}\n"
+                    "```\n"
+                    "\n"
+                    "Create the logs directory:\n"
+                    "```bash\n"
+                    "mkdir -p logs\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "flask": {
+        "framework": "Flask",
+        "logs_to_file_by_default": False,
+        "summary": "Flask logs to stdout. Add a file handler to the Flask app logger.",
+        "options": [
+            {
+                "method": "Python logging FileHandler",
+                "difficulty": "easy",
+                "description": "Add a RotatingFileHandler to Flask's logger",
+                "instructions": (
+                    "```python\n"
+                    "import logging\n"
+                    "from logging.handlers import RotatingFileHandler\n"
+                    "\n"
+                    "handler = RotatingFileHandler('logs/flask.log', maxBytes=10_000_000, backupCount=5)\n"
+                    "handler.setLevel(logging.INFO)\n"
+                    "app.logger.addHandler(handler)\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "fastapi": {
+        "framework": "FastAPI",
+        "logs_to_file_by_default": False,
+        "summary": "FastAPI/Uvicorn logs to stdout. Use structlog or Python logging for file output.",
+        "options": [
+            {
+                "method": "structlog + file handler",
+                "difficulty": "moderate",
+                "description": "Use structlog for structured JSON file logging",
+                "instructions": (
+                    "Install:\n"
+                    "```bash\n"
+                    "pip install structlog\n"
+                    "```\n"
+                    "\n"
+                    "Setup:\n"
+                    "```python\n"
+                    "import structlog\n"
+                    "import logging\n"
+                    "\n"
+                    "logging.basicConfig(\n"
+                    "    filename='logs/app.log',\n"
+                    "    level=logging.INFO,\n"
+                    "    format='%(message)s',\n"
+                    ")\n"
+                    "\n"
+                    "structlog.configure(\n"
+                    "    processors=[\n"
+                    "        structlog.processors.TimeStamper(fmt='iso'),\n"
+                    "        structlog.processors.JSONRenderer(),\n"
+                    "    ],\n"
+                    "    logger_factory=structlog.stdlib.LoggerFactory(),\n"
+                    ")\n"
+                    "```"
+                ),
+            },
+            {
+                "method": "Uvicorn log config",
+                "difficulty": "easy",
+                "description": "Configure Uvicorn to write access logs to a file",
+                "instructions": (
+                    "Run with log file:\n"
+                    "```bash\n"
+                    "uvicorn app:app --log-config logging.yaml\n"
+                    "```\n"
+                    "\n"
+                    "Or redirect:\n"
+                    "```bash\n"
+                    "uvicorn app:app 2>&1 | tee logs/uvicorn.log\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "rust_cargo": {
+        "framework": "Rust/Cargo",
+        "logs_to_file_by_default": False,
+        "summary": "Rust programs use the tracing or log crate. Add a file subscriber/appender.",
+        "options": [
+            {
+                "method": "tracing-appender",
+                "difficulty": "moderate",
+                "description": "Use tracing + tracing-appender for file logging",
+                "instructions": (
+                    "Add to Cargo.toml:\n"
+                    "```toml\n"
+                    "[dependencies]\n"
+                    'tracing = "0.1"\n'
+                    'tracing-subscriber = "0.3"\n'
+                    'tracing-appender = "0.2"\n'
+                    "```\n"
+                    "\n"
+                    "Setup:\n"
+                    "```rust\n"
+                    "use tracing_appender::rolling;\n"
+                    "use tracing_subscriber::fmt;\n"
+                    "\n"
+                    'let file_appender = rolling::daily("logs", "app.log");\n'
+                    "let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);\n"
+                    "\n"
+                    "fmt().with_writer(non_blocking).init();\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "go": {
+        "framework": "Go",
+        "logs_to_file_by_default": False,
+        "summary": "Go's log package writes to stderr by default. Redirect or use a structured logger.",
+        "options": [
+            {
+                "method": "log.SetOutput",
+                "difficulty": "easy",
+                "description": "Set the log package output to a file",
+                "instructions": (
+                    "```go\n"
+                    'f, err := os.OpenFile("logs/app.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)\n'
+                    "if err != nil {\n"
+                    "    log.Fatal(err)\n"
+                    "}\n"
+                    "defer f.Close()\n"
+                    "log.SetOutput(f)\n"
+                    "```"
+                ),
+            },
+            {
+                "method": "zerolog or zap",
+                "difficulty": "moderate",
+                "description": "Use a structured logging library with file output",
+                "instructions": (
+                    "With zerolog:\n"
+                    "```go\n"
+                    "import (\n"
+                    '    "os"\n'
+                    '    "github.com/rs/zerolog"\n'
+                    ")\n"
+                    "\n"
+                    'f, _ := os.Create("logs/app.log")\n'
+                    "logger := zerolog.New(f).With().Timestamp().Logger()\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "spring_boot": {
+        "framework": "Spring Boot",
+        "logs_to_file_by_default": True,
+        "summary": "Spring Boot logs to files by default via Logback. Check application.properties for log path.",
+        "options": [
+            {
+                "method": "application.properties",
+                "difficulty": "easy",
+                "description": "Configure log file path in application.properties",
+                "instructions": (
+                    "In application.properties:\n"
+                    "```properties\n"
+                    "logging.file.name=logs/spring.log\n"
+                    "logging.level.root=INFO\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "rails": {
+        "framework": "Rails",
+        "logs_to_file_by_default": True,
+        "summary": "Rails logs to log/ directory by default (development.log, production.log, test.log).",
+        "options": [
+            {
+                "method": "Default (already configured)",
+                "difficulty": "easy",
+                "description": "Rails already writes to log/ directory. Just point the runner at it.",
+                "instructions": (
+                    "Rails logs are at:\n"
+                    "- `log/development.log` (development)\n"
+                    "- `log/production.log` (production)\n"
+                    "- `log/test.log` (test)\n"
+                    "\n"
+                    "No additional configuration needed."
+                ),
+            },
+        ],
+    },
+    "tauri": {
+        "framework": "Tauri",
+        "logs_to_file_by_default": False,
+        "summary": "Tauri apps log via the tracing crate. Add tracing-appender for file output.",
+        "options": [
+            {
+                "method": "tracing-appender",
+                "difficulty": "moderate",
+                "description": "Same as Rust/Cargo -- use tracing-appender",
+                "instructions": (
+                    "See Rust/Cargo logging advice. Additionally, Tauri's plugin-log"
+                    " can write to the app data directory:\n"
+                    "\n"
+                    "```rust\n"
+                    "// In Cargo.toml:\n"
+                    '// tauri-plugin-log = "2"\n'
+                    "\n"
+                    "use tauri_plugin_log::{Target, TargetKind};\n"
+                    "\n"
+                    "tauri::Builder::default()\n"
+                    "    .plugin(tauri_plugin_log::Builder::new()\n"
+                    '        .targets([Target::new(TargetKind::LogDir { file_name: Some("app".into()) })])\n'
+                    "        .build())\n"
+                    "```"
+                ),
+            },
+        ],
+    },
+    "react_native": {
+        "framework": "React Native",
+        "logs_to_file_by_default": False,
+        "summary": (
+            "React Native logs via Metro bundler to stdout."
+            " Use react-native-fs for on-device file logging."
+        ),
+        "options": [
+            {
+                "method": "Metro output redirect",
+                "difficulty": "easy",
+                "description": "Redirect Metro bundler output to a file",
+                "instructions": (
+                    "```bash\nnpx react-native start 2>&1 | tee logs/metro.log\n```"
+                ),
+            },
+        ],
+    },
+    "flutter": {
+        "framework": "Flutter",
+        "logs_to_file_by_default": False,
+        "summary": (
+            "Flutter logs via dart:developer to the console."
+            " Use a logging package for file output."
+        ),
+        "options": [
+            {
+                "method": "Flutter run redirect",
+                "difficulty": "easy",
+                "description": "Redirect Flutter run output to a file",
+                "instructions": (
+                    "```bash\nflutter run 2>&1 | tee logs/flutter.log\n```"
+                ),
+            },
+        ],
+    },
+}
+
+
+async def get_logging_advice(framework: str) -> dict[str, Any]:
+    """Get framework-specific logging advice.
+
+    Args:
+        framework: framework key (e.g. "nextjs", "fastapi", "django")
+
+    Returns:
+        The advice dict for that framework, or an error dict if framework
+        not found. Includes an "available_frameworks" list in the error case.
+    """
+    advice = LOGGING_ADVICE.get(framework)
+    if advice is not None:
+        return advice
+
+    return {
+        "error": f"No logging advice found for framework: {framework}",
+        "available_frameworks": sorted(LOGGING_ADVICE.keys()),
+    }

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/server.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/server.py
@@ -1,0 +1,863 @@
+"""MCP server for guided qontinui-runner setup and configuration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    GetPromptResult,
+    Prompt,
+    PromptArgument,
+    PromptMessage,
+    TextContent,
+    Tool,
+)
+
+from qontinui_setup_mcp.client import RunnerClient
+from qontinui_setup_mcp.configuration.ai_provider import (
+    check_api_key,
+    get_ai_settings,
+    set_ai_provider,
+    store_api_key,
+    test_ai_connection,
+)
+
+# ── Imports: configuration ──────────────────────────────────────────────
+from qontinui_setup_mcp.configuration.log_sources import (
+    add_log_source,
+    apply_suggested_sources,
+    get_log_sources,
+    remove_log_source,
+    update_log_source,
+)
+from qontinui_setup_mcp.configuration.profiles import (
+    create_log_profile,
+    set_default_profile,
+)
+from qontinui_setup_mcp.discovery.frameworks import detect_framework
+from qontinui_setup_mcp.discovery.log_finder import find_log_files, suggest_log_sources
+
+# ── Imports: discovery ──────────────────────────────────────────────────
+from qontinui_setup_mcp.discovery.scanner import scan_workspace
+
+# ── Imports: guidance ───────────────────────────────────────────────────
+from qontinui_setup_mcp.guidance.logging_advice import get_logging_advice
+from qontinui_setup_mcp.validation.connection import (
+    check_runner_connection,
+    get_setup_status,
+)
+from qontinui_setup_mcp.validation.log_validator import validate_log_sources
+
+# ── Imports: validation ─────────────────────────────────────────────────
+from qontinui_setup_mcp.validation.prerequisites import check_prerequisites
+
+logger = logging.getLogger(__name__)
+
+# ── Global state ────────────────────────────────────────────────────────
+
+server = Server("qontinui-setup-mcp")
+client: RunnerClient | None = None
+
+
+def _get_client() -> RunnerClient:
+    global client
+    if client is None:
+        client = RunnerClient()
+    return client
+
+
+def _text(data: Any) -> list[TextContent]:
+    """Wrap a result as JSON TextContent."""
+    return [TextContent(type="text", text=json.dumps(data, indent=2, default=str))]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  TOOL DEFINITIONS
+# ═══════════════════════════════════════════════════════════════════════
+
+TOOLS: list[Tool] = [
+    # ── Discovery (LOCAL) ───────────────────────────────────────────────
+    Tool(
+        name="scan_workspace",
+        description=(
+            "Scan a directory tree for software projects. "
+            "Detects package.json, pyproject.toml, Cargo.toml, go.mod, etc. "
+            "Works offline — does not require the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Directory to scan (absolute path)",
+                },
+                "max_depth": {
+                    "type": "integer",
+                    "description": "Max directory depth to traverse (default 3)",
+                    "default": 3,
+                },
+            },
+            "required": ["path"],
+        },
+    ),
+    Tool(
+        name="detect_framework",
+        description=(
+            "Analyze a project to identify its framework, language, and build tool. "
+            "Parses manifest files (package.json, pyproject.toml, etc.) and checks dependencies. "
+            "Works offline."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to the project root",
+                },
+            },
+            "required": ["project_path"],
+        },
+    ),
+    Tool(
+        name="find_log_files",
+        description=(
+            "Find existing log files and log directories in a project. "
+            "Looks for *.log, *.jsonl, common log directories, etc. "
+            "Works offline."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to the project root",
+                },
+            },
+            "required": ["project_path"],
+        },
+    ),
+    Tool(
+        name="suggest_log_sources",
+        description=(
+            "Generate ready-to-use log source configurations for a project. "
+            "Combines framework detection with log file discovery. "
+            "Returns configs compatible with the runner's log source settings. "
+            "Works offline."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to the project root",
+                },
+            },
+            "required": ["project_path"],
+        },
+    ),
+    # ── Log Source Configuration (REQUIRE runner) ───────────────────────
+    Tool(
+        name="get_log_sources",
+        description=(
+            "Get all configured log sources from the runner. "
+            "Returns the full log source settings including sources, profiles, and AI selection mode. "
+            "Requires the runner to be running."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    Tool(
+        name="add_log_source",
+        description=(
+            "Add a new log source to the runner configuration. "
+            "Provide the source details; an ID will be generated if not included. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Display name for the log source",
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Absolute path to the log file or directory",
+                },
+                "category": {
+                    "type": "string",
+                    "enum": [
+                        "frontend",
+                        "backend",
+                        "api",
+                        "mobile",
+                        "database",
+                        "build",
+                        "testing",
+                        "runner",
+                        "general",
+                    ],
+                    "description": "Log source category",
+                },
+                "format": {
+                    "type": "string",
+                    "enum": ["plaintext", "json", "jsonl"],
+                    "description": "Log format (default: plaintext)",
+                    "default": "plaintext",
+                },
+                "parser": {
+                    "type": "string",
+                    "enum": ["python", "javascript", "rust", "generic"],
+                    "description": "Log parser (default: generic)",
+                    "default": "generic",
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["file", "directory"],
+                    "description": "Whether the path is a file or directory (default: file)",
+                    "default": "file",
+                },
+                "pattern": {
+                    "type": "string",
+                    "description": "Glob pattern for matching files in a directory (e.g. '*.log')",
+                },
+                "keywords": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Keywords for log relevance filtering",
+                },
+                "error_patterns": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Regex patterns to identify error lines",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional description of the log source",
+                },
+            },
+            "required": ["name", "path", "category"],
+        },
+    ),
+    Tool(
+        name="update_log_source",
+        description=(
+            "Update an existing log source by ID. "
+            "Only include the fields you want to change. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source_id": {
+                    "type": "string",
+                    "description": "ID of the log source to update",
+                },
+                "name": {"type": "string"},
+                "path": {"type": "string"},
+                "category": {"type": "string"},
+                "format": {"type": "string"},
+                "parser": {"type": "string"},
+                "enabled": {"type": "boolean"},
+                "keywords": {"type": "array", "items": {"type": "string"}},
+                "error_patterns": {"type": "array", "items": {"type": "string"}},
+                "warning_patterns": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["source_id"],
+        },
+    ),
+    Tool(
+        name="remove_log_source",
+        description="Remove a log source by ID. Also removes it from any profiles. Requires the runner.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source_id": {
+                    "type": "string",
+                    "description": "ID of the log source to remove",
+                },
+            },
+            "required": ["source_id"],
+        },
+    ),
+    Tool(
+        name="apply_suggested_sources",
+        description=(
+            "Discover log sources for a project and add them all to the runner in one step. "
+            "Combines suggest_log_sources + add. Use dry_run=true to preview without changes. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "project_path": {
+                    "type": "string",
+                    "description": "Path to the project root",
+                },
+                "dry_run": {
+                    "type": "boolean",
+                    "description": "If true, return what would be added without making changes (default: false)",
+                    "default": False,
+                },
+            },
+            "required": ["project_path"],
+        },
+    ),
+    # ── Log Source Profiles (REQUIRE runner) ────────────────────────────
+    Tool(
+        name="create_log_profile",
+        description=(
+            "Create a named profile that groups log sources together. "
+            "Profiles let you switch between different sets of log sources. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Profile display name"},
+                "source_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "IDs of log sources to include in this profile",
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Optional profile description",
+                },
+            },
+            "required": ["name", "source_ids"],
+        },
+    ),
+    Tool(
+        name="set_default_profile",
+        description="Set the default active log source profile. Pass null to clear. Requires the runner.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "profile_id": {
+                    "type": ["string", "null"],
+                    "description": "Profile ID to set as default, or null to clear",
+                },
+            },
+            "required": ["profile_id"],
+        },
+    ),
+    # ── AI Provider (REQUIRE runner) ────────────────────────────────────
+    Tool(
+        name="get_ai_settings",
+        description=(
+            "Get the current AI provider configuration from the runner. "
+            "Returns provider, model, and execution mode settings (no API keys). "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    Tool(
+        name="set_ai_provider",
+        description=(
+            "Configure the AI provider and settings. "
+            "Supports claude_cli, claude_api, gemini_cli, gemini_api. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "enum": ["claude_cli", "claude_api", "gemini_cli", "gemini_api"],
+                    "description": "AI provider to use",
+                },
+                "model": {
+                    "type": "string",
+                    "description": "Model name (e.g. 'claude-sonnet-4-20250514', 'gemini-3-flash-preview')",
+                },
+                "cli_execution_mode": {
+                    "type": "string",
+                    "enum": ["auto", "windows_native", "wsl", "native"],
+                    "description": "CLI execution mode (only for *_cli providers)",
+                },
+            },
+            "required": ["provider"],
+        },
+    ),
+    Tool(
+        name="store_api_key",
+        description=(
+            "Store an API key in the OS keychain for a provider. "
+            "The key is stored securely and never returned by the API. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "Provider name (e.g. 'claude_api', 'gemini_api')",
+                },
+                "api_key": {"type": "string", "description": "The API key to store"},
+            },
+            "required": ["provider", "api_key"],
+        },
+    ),
+    Tool(
+        name="check_api_key",
+        description="Check if an API key exists in the keychain for a provider. Requires the runner.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "provider": {"type": "string", "description": "Provider name to check"},
+            },
+            "required": ["provider"],
+        },
+    ),
+    Tool(
+        name="test_ai_connection",
+        description="Test AI connectivity with the currently configured provider. Requires the runner.",
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    # ── Validation (LOCAL + runner hybrid) ──────────────────────────────
+    Tool(
+        name="check_prerequisites",
+        description=(
+            "Check if required system tools are installed (node, python, rust, git, etc.). "
+            "Reports version and path for each tool. "
+            "Works offline."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "checks": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Specific tools to check. If omitted, checks all. "
+                        "Options: node, python, rust, cargo, git, npm, yarn, poetry, claude_cli, gemini_cli, docker"
+                    ),
+                },
+            },
+        },
+    ),
+    Tool(
+        name="check_runner_connection",
+        description="Test connectivity to the qontinui-runner HTTP API.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "host": {
+                    "type": "string",
+                    "description": "Runner host (default: auto-detect)",
+                },
+                "port": {
+                    "type": "integer",
+                    "description": "Runner port (default: 9876)",
+                },
+            },
+        },
+    ),
+    Tool(
+        name="validate_log_sources",
+        description=(
+            "Validate all configured log sources — check paths exist, are readable, and have recent data. "
+            "Requires the runner."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "check_freshness": {
+                    "type": "boolean",
+                    "description": "Check if log files were modified in the last 24 hours (default: true)",
+                    "default": True,
+                },
+            },
+        },
+    ),
+    Tool(
+        name="get_setup_status",
+        description=(
+            "Get a full setup overview with completion percentage and recommendations. "
+            "Checks runner connectivity, AI config, log sources, prerequisites, and more. "
+            "Returns partial results if the runner is not connected."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {},
+        },
+    ),
+    # ── Guidance (LOCAL) ────────────────────────────────────────────────
+    Tool(
+        name="get_logging_advice",
+        description=(
+            "Get framework-specific instructions for setting up file-based logging. "
+            "Many frameworks (Next.js, React, etc.) only log to stdout by default. "
+            "This tool explains how to configure them for file logging. "
+            "Works offline."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "framework": {
+                    "type": "string",
+                    "description": (
+                        "Framework key (e.g. 'nextjs', 'fastapi', 'django', 'express', 'react_vite', "
+                        "'nestjs', 'flask', 'rust_cargo', 'go', 'spring_boot', 'rails', 'tauri', "
+                        "'react_native', 'flutter')"
+                    ),
+                },
+            },
+            "required": ["framework"],
+        },
+    ),
+]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  MCP PROMPTS
+# ═══════════════════════════════════════════════════════════════════════
+
+PROMPTS: list[Prompt] = [
+    Prompt(
+        name="setup_runner_for_project",
+        description=(
+            "Full guided setup workflow for configuring the qontinui-runner for a project. "
+            "Discovers the project, suggests log sources, checks prerequisites, and validates the setup."
+        ),
+        arguments=[
+            PromptArgument(
+                name="project_path",
+                description="Absolute path to the project to set up",
+                required=True,
+            ),
+        ],
+    ),
+    Prompt(
+        name="diagnose_setup_issues",
+        description=(
+            "Analyze the current runner setup, find problems, and suggest fixes. "
+            "Checks connectivity, validates log sources, verifies AI config, and checks prerequisites."
+        ),
+        arguments=[],
+    ),
+    Prompt(
+        name="add_project_logs",
+        description=(
+            "Quick workflow to discover and add log sources for a project. "
+            "Scans the project, suggests sources, and applies them."
+        ),
+        arguments=[
+            PromptArgument(
+                name="project_path",
+                description="Absolute path to the project",
+                required=True,
+            ),
+        ],
+    ),
+]
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  HANDLERS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@server.list_tools()  # type: ignore[untyped-decorator, no-untyped-call]
+async def list_tools() -> list[Tool]:
+    return TOOLS
+
+
+@server.call_tool()  # type: ignore[untyped-decorator]
+async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+    """Dispatch tool calls to their implementations."""
+    try:
+        result = await _dispatch_tool(name, arguments)
+        return _text(result)
+    except Exception as e:
+        logger.exception("Tool %s failed", name)
+        return _text({"error": str(e)})
+
+
+async def _dispatch_tool(name: str, args: dict[str, Any]) -> Any:
+    """Route a tool call to the correct function."""
+    c = _get_client()
+
+    # ── Discovery (LOCAL) ───────────────────────────────────────────
+    if name == "scan_workspace":
+        return await scan_workspace(
+            path=args["path"],
+            max_depth=args.get("max_depth", 3),
+        )
+
+    if name == "detect_framework":
+        return await detect_framework(project_path=args["project_path"])
+
+    if name == "find_log_files":
+        return await find_log_files(project_path=args["project_path"])
+
+    if name == "suggest_log_sources":
+        return await suggest_log_sources(project_path=args["project_path"])
+
+    # ── Log Source Configuration (REQUIRE runner) ───────────────────
+    if name == "get_log_sources":
+        return await get_log_sources(c)
+
+    if name == "add_log_source":
+        source: dict[str, Any] = {k: v for k, v in args.items() if v is not None}
+        return await add_log_source(c, source)
+
+    if name == "update_log_source":
+        source_id = args["source_id"]
+        updates = {k: v for k, v in args.items() if k != "source_id" and v is not None}
+        return await update_log_source(c, source_id, updates)
+
+    if name == "remove_log_source":
+        return await remove_log_source(c, args["source_id"])
+
+    if name == "apply_suggested_sources":
+        return await apply_suggested_sources(
+            c,
+            project_path=args["project_path"],
+            dry_run=args.get("dry_run", False),
+        )
+
+    # ── Log Source Profiles (REQUIRE runner) ────────────────────────
+    if name == "create_log_profile":
+        return await create_log_profile(
+            c,
+            name=args["name"],
+            source_ids=args["source_ids"],
+            description=args.get("description"),
+        )
+
+    if name == "set_default_profile":
+        return await set_default_profile(c, profile_id=args["profile_id"])
+
+    # ── AI Provider (REQUIRE runner) ────────────────────────────────
+    if name == "get_ai_settings":
+        return await get_ai_settings(c)
+
+    if name == "set_ai_provider":
+        return await set_ai_provider(
+            c,
+            provider=args["provider"],
+            model=args.get("model"),
+            cli_execution_mode=args.get("cli_execution_mode"),
+        )
+
+    if name == "store_api_key":
+        return await store_api_key(
+            c, provider=args["provider"], api_key=args["api_key"]
+        )
+
+    if name == "check_api_key":
+        return await check_api_key(c, provider=args["provider"])
+
+    if name == "test_ai_connection":
+        return await test_ai_connection(c)
+
+    # ── Validation (LOCAL + runner hybrid) ──────────────────────────
+    if name == "check_prerequisites":
+        return await check_prerequisites(checks=args.get("checks"))
+
+    if name == "check_runner_connection":
+        rc = (
+            RunnerClient(
+                host=args["host"],
+                port=args["port"],
+            )
+            if ("host" in args or "port" in args)
+            else c
+        )
+        return await check_runner_connection(rc)
+
+    if name == "validate_log_sources":
+        return await validate_log_sources(
+            c, check_freshness=args.get("check_freshness", True)
+        )
+
+    if name == "get_setup_status":
+        return await get_setup_status(c)
+
+    # ── Guidance (LOCAL) ────────────────────────────────────────────
+    if name == "get_logging_advice":
+        return await get_logging_advice(framework=args["framework"])
+
+    return {"error": f"Unknown tool: {name}"}
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  PROMPT HANDLERS
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@server.list_prompts()  # type: ignore[untyped-decorator, no-untyped-call]
+async def list_prompts() -> list[Prompt]:
+    return PROMPTS
+
+
+@server.get_prompt()  # type: ignore[untyped-decorator, no-untyped-call]
+async def get_prompt(name: str, arguments: dict[str, str] | None) -> GetPromptResult:
+    """Build prompt content for each prompt template."""
+    args = arguments or {}
+
+    if name == "setup_runner_for_project":
+        return await _build_setup_prompt(args.get("project_path", "."))
+
+    if name == "diagnose_setup_issues":
+        return await _build_diagnose_prompt()
+
+    if name == "add_project_logs":
+        return await _build_add_logs_prompt(args.get("project_path", "."))
+
+    return GetPromptResult(
+        description=f"Unknown prompt: {name}",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text=f"Unknown prompt: {name}"),
+            )
+        ],
+    )
+
+
+async def _build_setup_prompt(project_path: str) -> GetPromptResult:
+    """Build the full guided setup prompt."""
+    c = _get_client()
+
+    # Gather context in parallel
+    framework_task = detect_framework(project_path)
+    suggestions_task = suggest_log_sources(project_path)
+    prereqs_task = check_prerequisites()
+    connection_task = check_runner_connection(c)
+
+    framework, suggestions, prereqs, connection = await asyncio.gather(
+        framework_task, suggestions_task, prereqs_task, connection_task
+    )
+
+    context_parts = [
+        f"# Runner Setup for Project: {project_path}\n",
+        f"## Framework Detection\n```json\n{json.dumps(framework, indent=2, default=str)}\n```\n",
+        f"## Suggested Log Sources\n```json\n{json.dumps(suggestions, indent=2, default=str)}\n```\n",
+        f"## Prerequisites\n```json\n{json.dumps(prereqs, indent=2, default=str)}\n```\n",
+        f"## Runner Connection\n```json\n{json.dumps(connection, indent=2, default=str)}\n```\n",
+    ]
+
+    if suggestions.get("needs_logging_setup"):
+        key = framework.get("key", "")
+        if key:
+            advice = await get_logging_advice(key)
+            context_parts.append(
+                f"## Logging Setup Advice\n```json\n{json.dumps(advice, indent=2, default=str)}\n```\n"
+            )
+
+    context = "\n".join(context_parts)
+
+    instructions = (
+        "You are helping set up the qontinui-runner for this project. "
+        "Based on the context above:\n\n"
+        "1. Review the detected framework and prerequisites\n"
+        "2. If the runner is connected, apply the suggested log sources (use apply_suggested_sources)\n"
+        "3. If logging setup is needed, guide the user through configuring file-based logging\n"
+        "4. Check AI provider configuration and help set it up if needed\n"
+        "5. Run get_setup_status to verify everything is configured\n"
+        "6. Provide a summary of what was done and any remaining steps"
+    )
+
+    return GetPromptResult(
+        description=f"Setup runner for {project_path}",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text=f"{context}\n\n{instructions}"),
+            )
+        ],
+    )
+
+
+async def _build_diagnose_prompt() -> GetPromptResult:
+    """Build the diagnosis prompt with current state."""
+    c = _get_client()
+
+    status = await get_setup_status(c)
+
+    context = f"# Current Setup Status\n```json\n{json.dumps(status, indent=2, default=str)}\n```\n"
+
+    # If connected, also validate log sources
+    if status.get("runner_connected"):
+        validation = await validate_log_sources(c)
+        context += f"\n## Log Source Validation\n```json\n{json.dumps(validation, indent=2, default=str)}\n```\n"
+
+    instructions = (
+        "You are diagnosing the qontinui-runner setup. "
+        "Based on the context above:\n\n"
+        "1. Identify any issues (failed checks, invalid log sources, missing config)\n"
+        "2. For each issue, explain the problem and provide a fix\n"
+        "3. Use the available tools to fix issues where possible\n"
+        "4. Run get_setup_status again after fixes to verify improvement"
+    )
+
+    return GetPromptResult(
+        description="Diagnose runner setup issues",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text=f"{context}\n\n{instructions}"),
+            )
+        ],
+    )
+
+
+async def _build_add_logs_prompt(project_path: str) -> GetPromptResult:
+    """Build the quick add-logs prompt."""
+    suggestions = await suggest_log_sources(project_path)
+
+    context = f"# Log Source Discovery for {project_path}\n```json\n{json.dumps(suggestions, indent=2, default=str)}\n```\n"
+
+    instructions = (
+        "You are adding log sources for this project to the qontinui-runner. "
+        "Based on the discovery results:\n\n"
+        "1. Review the suggested log sources\n"
+        "2. Apply them using apply_suggested_sources (consider a dry_run first)\n"
+        "3. If logging setup is needed, provide guidance using get_logging_advice\n"
+        "4. Validate the new sources with validate_log_sources"
+    )
+
+    return GetPromptResult(
+        description=f"Add log sources for {project_path}",
+        messages=[
+            PromptMessage(
+                role="user",
+                content=TextContent(type="text", text=f"{context}\n\n{instructions}"),
+            )
+        ],
+    )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+#  ENTRY POINT
+# ═══════════════════════════════════════════════════════════════════════
+
+
+async def main() -> None:
+    """Run the MCP server on stdio."""
+    logger.info("Starting qontinui-setup-mcp server")
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream, write_stream, server.create_initialization_options()
+        )
+
+
+def run() -> None:
+    """Entry point for the MCP server."""
+    asyncio.run(main())

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/__init__.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation tools — prerequisite checks, log validation, connectivity."""

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/connection.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/connection.py
@@ -1,0 +1,350 @@
+"""Test runner connectivity and get full setup status."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from qontinui_setup_mcp.client import RunnerClient
+
+from .log_validator import validate_log_sources
+from .prerequisites import check_prerequisites
+
+logger = logging.getLogger(__name__)
+
+# Points allocated to each setup check (must sum to 100).
+_POINTS = {
+    "runner_connectivity": 20,
+    "ai_provider_configured": 20,
+    "api_key_stored": 15,
+    "log_sources_configured": 20,
+    "log_source_valid": 15,
+    "prerequisites": 10,
+}
+
+# Core prerequisite tools that should be present for development.
+_CORE_PREREQUISITES = ["node", "python", "git"]
+
+
+async def check_runner_connection(client: RunnerClient) -> dict[str, Any]:
+    """Test runner HTTP API connectivity.
+
+    Calls the runner health endpoint and, on success, also fetches device
+    information.
+
+    Returns:
+        A dict with *connected*, *host*, *port*, *error*, and *device_info*.
+    """
+    result: dict[str, Any] = {
+        "connected": False,
+        "host": client.host,
+        "port": client.port,
+        "error": None,
+        "device_info": None,
+    }
+
+    health = await client.health()
+    if not health.success:
+        result["error"] = health.error or "Runner health check failed"
+        return result
+
+    result["connected"] = True
+
+    # Opportunistically fetch device info
+    device = await client.get_device_info()
+    if device.success and device.data:
+        result["device_info"] = device.data
+
+    return result
+
+
+async def get_setup_status(client: RunnerClient) -> dict[str, Any]:
+    """Get a full setup overview with completion percentage and recommendations.
+
+    Checks (each worth points toward completion %):
+        1. Runner connectivity (20 pts)
+        2. AI provider configured (20 pts)
+        3. API key stored (15 pts)
+        4. Log sources configured (20 pts)
+        5. At least one log source valid (15 pts)
+        6. Prerequisites — node, python, git (10 pts)
+
+    Returns a dict with *completion_percentage*, *runner_connected*, *checks*,
+    *recommendations*, *ai_provider*, *log_source_count*, and *device_info*.
+    """
+    checks: list[dict[str, Any]] = []
+    recommendations: list[str] = []
+    earned_points = 0
+    runner_connected = False
+    ai_provider: str | None = None
+    log_source_count = 0
+    device_info: dict[str, Any] | None = None
+
+    # ── 1. Runner connectivity ──────────────────────────────────────────
+    conn = await check_runner_connection(client)
+    runner_connected = conn["connected"]
+    device_info = conn.get("device_info")
+
+    if runner_connected:
+        earned_points += _POINTS["runner_connectivity"]
+        checks.append(
+            {
+                "name": "Runner connectivity",
+                "status": "pass",
+                "detail": f"Connected to runner at {client.host}:{client.port}",
+                "points": _POINTS["runner_connectivity"],
+            }
+        )
+    else:
+        checks.append(
+            {
+                "name": "Runner connectivity",
+                "status": "fail",
+                "detail": conn.get("error", "Cannot reach runner"),
+                "points": 0,
+            }
+        )
+        recommendations.append(
+            "Start the qontinui-runner (dev-start.ps1 -Runner) and try again."
+        )
+
+    # ── 2 & 3. AI provider + API key ───────────────────────────────────
+    if runner_connected:
+        ai_resp = await client.get_ai_settings()
+        if ai_resp.success and ai_resp.data:
+            provider = (
+                ai_resp.data.get("provider")
+                or ai_resp.data.get("ai_provider")
+                or ai_resp.data.get("default_provider")
+            )
+            if provider:
+                ai_provider = provider
+                earned_points += _POINTS["ai_provider_configured"]
+                checks.append(
+                    {
+                        "name": "AI provider configured",
+                        "status": "pass",
+                        "detail": f"Provider set to '{provider}'",
+                        "points": _POINTS["ai_provider_configured"],
+                    }
+                )
+
+                # Check API key for the configured provider
+                key_resp = await client.check_api_key(provider)
+                if key_resp.success and key_resp.data:
+                    has_key = (
+                        key_resp.data.get("has_key", False)
+                        if isinstance(key_resp.data, dict)
+                        else bool(key_resp.data)
+                    )
+                else:
+                    has_key = False
+
+                if has_key:
+                    earned_points += _POINTS["api_key_stored"]
+                    checks.append(
+                        {
+                            "name": "API key stored",
+                            "status": "pass",
+                            "detail": f"API key present for '{provider}'",
+                            "points": _POINTS["api_key_stored"],
+                        }
+                    )
+                else:
+                    checks.append(
+                        {
+                            "name": "API key stored",
+                            "status": "fail",
+                            "detail": f"No API key found for '{provider}'",
+                            "points": 0,
+                        }
+                    )
+                    recommendations.append(
+                        f"Store an API key for the '{provider}' provider."
+                    )
+            else:
+                checks.append(
+                    {
+                        "name": "AI provider configured",
+                        "status": "fail",
+                        "detail": "No AI provider selected",
+                        "points": 0,
+                    }
+                )
+                checks.append(
+                    {
+                        "name": "API key stored",
+                        "status": "fail",
+                        "detail": "Cannot check key — no provider configured",
+                        "points": 0,
+                    }
+                )
+                recommendations.append(
+                    "Configure an AI provider in the runner settings."
+                )
+        else:
+            checks.append(
+                {
+                    "name": "AI provider configured",
+                    "status": "fail",
+                    "detail": ai_resp.error or "Could not retrieve AI settings",
+                    "points": 0,
+                }
+            )
+            checks.append(
+                {
+                    "name": "API key stored",
+                    "status": "fail",
+                    "detail": "Cannot check key — AI settings unavailable",
+                    "points": 0,
+                }
+            )
+            recommendations.append("Configure AI settings in the runner.")
+    else:
+        # Runner offline — skip AI checks
+        checks.append(
+            {
+                "name": "AI provider configured",
+                "status": "fail",
+                "detail": "Skipped — runner not connected",
+                "points": 0,
+            }
+        )
+        checks.append(
+            {
+                "name": "API key stored",
+                "status": "fail",
+                "detail": "Skipped — runner not connected",
+                "points": 0,
+            }
+        )
+
+    # ── 4 & 5. Log sources ─────────────────────────────────────────────
+    if runner_connected:
+        log_validation = await validate_log_sources(client, check_freshness=True)
+        log_source_count = log_validation["summary"]["total"]
+        valid_count = log_validation["summary"]["valid"]
+
+        if log_source_count > 0:
+            earned_points += _POINTS["log_sources_configured"]
+            checks.append(
+                {
+                    "name": "Log sources configured",
+                    "status": "pass",
+                    "detail": f"{log_source_count} log source(s) configured",
+                    "points": _POINTS["log_sources_configured"],
+                }
+            )
+
+            if valid_count > 0:
+                earned_points += _POINTS["log_source_valid"]
+                checks.append(
+                    {
+                        "name": "Log source valid",
+                        "status": "pass",
+                        "detail": f"{valid_count}/{log_source_count} source(s) valid",
+                        "points": _POINTS["log_source_valid"],
+                    }
+                )
+            else:
+                checks.append(
+                    {
+                        "name": "Log source valid",
+                        "status": "warn",
+                        "detail": "No log sources passed validation",
+                        "points": 0,
+                    }
+                )
+                recommendations.append(
+                    "Check that log source paths exist and are readable."
+                )
+        else:
+            checks.append(
+                {
+                    "name": "Log sources configured",
+                    "status": "fail",
+                    "detail": "No log sources configured",
+                    "points": 0,
+                }
+            )
+            checks.append(
+                {
+                    "name": "Log source valid",
+                    "status": "fail",
+                    "detail": "No log sources to validate",
+                    "points": 0,
+                }
+            )
+            recommendations.append(
+                "Add at least one log source in the runner settings."
+            )
+    else:
+        checks.append(
+            {
+                "name": "Log sources configured",
+                "status": "fail",
+                "detail": "Skipped — runner not connected",
+                "points": 0,
+            }
+        )
+        checks.append(
+            {
+                "name": "Log source valid",
+                "status": "fail",
+                "detail": "Skipped — runner not connected",
+                "points": 0,
+            }
+        )
+
+    # ── 6. Prerequisites ────────────────────────────────────────────────
+    prereq_result = await check_prerequisites(checks=_CORE_PREREQUISITES)
+    prereq_summary = prereq_result["summary"]
+
+    if prereq_summary["missing"] == 0:
+        earned_points += _POINTS["prerequisites"]
+        checks.append(
+            {
+                "name": "Core prerequisites",
+                "status": "pass",
+                "detail": (
+                    f"All {prereq_summary['total']} core tools installed "
+                    f"({', '.join(_CORE_PREREQUISITES)})"
+                ),
+                "points": _POINTS["prerequisites"],
+            }
+        )
+    else:
+        missing_tools = [
+            r["tool"] for r in prereq_result["results"] if not r["installed"]
+        ]
+        if prereq_summary["installed"] > 0:
+            status = "warn"
+            earned_points += _POINTS["prerequisites"] // 2
+            points_awarded = _POINTS["prerequisites"] // 2
+        else:
+            status = "fail"
+            points_awarded = 0
+
+        checks.append(
+            {
+                "name": "Core prerequisites",
+                "status": status,
+                "detail": f"Missing: {', '.join(missing_tools)}",
+                "points": points_awarded,
+            }
+        )
+        recommendations.append(f"Install missing tools: {', '.join(missing_tools)}.")
+
+    # ── Final summary ───────────────────────────────────────────────────
+    total_possible = sum(_POINTS.values())
+    completion_percentage = int(round(earned_points / total_possible * 100))
+
+    return {
+        "completion_percentage": completion_percentage,
+        "runner_connected": runner_connected,
+        "checks": checks,
+        "recommendations": recommendations,
+        "ai_provider": ai_provider,
+        "log_source_count": log_source_count,
+        "device_info": device_info,
+    }

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/log_validator.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/log_validator.py
@@ -1,0 +1,154 @@
+"""Validate that configured log sources exist and are accessible."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from qontinui_setup_mcp.client import RunnerClient
+
+logger = logging.getLogger(__name__)
+
+# A log source is considered "fresh" if modified within this window.
+FRESHNESS_THRESHOLD_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+def _validate_single_source(
+    source: dict[str, Any],
+    check_freshness: bool,
+) -> dict[str, Any]:
+    """Synchronously validate a single log source on the filesystem."""
+    source_id: str = source.get("id", "unknown")
+    name: str = source.get("name", source_id)
+    path_str: str = source.get("path", "")
+
+    result: dict[str, Any] = {
+        "id": source_id,
+        "name": name,
+        "path": path_str,
+        "exists": False,
+        "readable": False,
+        "fresh": None,
+        "size_bytes": None,
+        "last_modified": None,
+        "issues": [],
+    }
+
+    if not path_str:
+        result["issues"].append("No path configured for this log source")
+        return result
+
+    p = Path(path_str)
+
+    # --- existence ---
+    if not p.exists():
+        result["issues"].append(f"Path does not exist: {path_str}")
+        return result
+    result["exists"] = True
+
+    # --- readability ---
+    if not os.access(path_str, os.R_OK):
+        result["issues"].append(f"Path is not readable: {path_str}")
+        return result
+    result["readable"] = True
+
+    # --- stat info ---
+    try:
+        stat = p.stat()
+    except OSError as exc:
+        result["issues"].append(f"Could not stat path: {exc}")
+        return result
+
+    if p.is_file():
+        result["size_bytes"] = stat.st_size
+        if stat.st_size == 0:
+            result["issues"].append("File is empty")
+
+    mtime = stat.st_mtime
+    result["last_modified"] = datetime.fromtimestamp(mtime, tz=timezone.utc).isoformat()
+
+    # --- freshness ---
+    if check_freshness:
+        age_seconds = time.time() - mtime
+        is_fresh = age_seconds <= FRESHNESS_THRESHOLD_SECONDS
+        result["fresh"] = is_fresh
+        if not is_fresh:
+            hours_ago = int(age_seconds / 3600)
+            result["issues"].append(
+                f"File has not been modified in {hours_ago} hours "
+                f"(threshold: {FRESHNESS_THRESHOLD_SECONDS // 3600}h)"
+            )
+
+    return result
+
+
+async def validate_log_sources(
+    client: RunnerClient,
+    check_freshness: bool = True,
+) -> dict[str, Any]:
+    """Validate all configured log sources.
+
+    Fetches the current log-source settings from the runner, then checks each
+    source path on the local filesystem for existence, readability, freshness,
+    and non-emptiness.
+
+    Args:
+        client: A connected :class:`RunnerClient` instance.
+        check_freshness: When *True* (default), flag files that have not been
+            modified in the last 24 hours.
+
+    Returns:
+        A dict with:
+            ``sources`` — per-source validation results.
+            ``summary`` — dict with *total*, *valid*, *issues* counts.
+    """
+    response = await client.get_log_source_settings()
+
+    if not response.success:
+        return {
+            "sources": [],
+            "summary": {"total": 0, "valid": 0, "issues": 0},
+            "error": response.error or "Failed to retrieve log source settings",
+        }
+
+    # The data payload is expected to contain a list of source objects.
+    # Support both a top-level list and a dict with a "sources" key.
+    data = response.data
+    if isinstance(data, dict):
+        sources_list: list[dict[str, Any]] = data.get("sources", [])
+    elif isinstance(data, list):
+        sources_list = data
+    else:
+        sources_list = []
+
+    if not sources_list:
+        return {
+            "sources": [],
+            "summary": {"total": 0, "valid": 0, "issues": 0},
+        }
+
+    loop = asyncio.get_running_loop()
+
+    # Validate each source concurrently in the thread pool
+    tasks = [
+        loop.run_in_executor(None, _validate_single_source, src, check_freshness)
+        for src in sources_list
+    ]
+    results: list[dict[str, Any]] = await asyncio.gather(*tasks)
+
+    valid_count = sum(1 for r in results if not r["issues"])
+    issues_count = sum(1 for r in results if r["issues"])
+
+    return {
+        "sources": results,
+        "summary": {
+            "total": len(results),
+            "valid": valid_count,
+            "issues": issues_count,
+        },
+    }

--- a/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/prerequisites.py
+++ b/src-tauri/resources/qontinui-setup-mcp/src/qontinui_setup_mcp/validation/prerequisites.py
@@ -1,0 +1,177 @@
+"""Check if required system tools are installed."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import subprocess
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+TOOLS: dict[str, dict[str, str]] = {
+    "node": {
+        "command": "node",
+        "version_flag": "--version",
+        "description": "Node.js runtime",
+    },
+    "python": {
+        "command": "python",
+        "version_flag": "--version",
+        "description": "Python runtime",
+    },
+    "rust": {
+        "command": "rustc",
+        "version_flag": "--version",
+        "description": "Rust compiler",
+    },
+    "cargo": {
+        "command": "cargo",
+        "version_flag": "--version",
+        "description": "Rust package manager",
+    },
+    "git": {
+        "command": "git",
+        "version_flag": "--version",
+        "description": "Git version control",
+    },
+    "npm": {
+        "command": "npm",
+        "version_flag": "--version",
+        "description": "Node package manager",
+    },
+    "yarn": {
+        "command": "yarn",
+        "version_flag": "--version",
+        "description": "Yarn package manager",
+    },
+    "poetry": {
+        "command": "poetry",
+        "version_flag": "--version",
+        "description": "Python dependency manager",
+    },
+    "claude_cli": {
+        "command": "claude",
+        "version_flag": "--version",
+        "description": "Claude CLI",
+    },
+    "gemini_cli": {
+        "command": "gemini",
+        "version_flag": "--version",
+        "description": "Gemini CLI",
+    },
+    "docker": {
+        "command": "docker",
+        "version_flag": "--version",
+        "description": "Docker",
+    },
+}
+
+
+def _parse_version(raw: str) -> str | None:
+    """Extract a clean version string from command output.
+
+    Takes the first line and strips common prefixes like 'v', 'Python ', etc.
+    """
+    if not raw or not raw.strip():
+        return None
+    first_line = raw.strip().splitlines()[0].strip()
+    if not first_line:
+        return None
+    return first_line
+
+
+def _check_single_tool(tool_key: str, tool_info: dict[str, str]) -> dict[str, Any]:
+    """Synchronously check a single tool's availability and version."""
+    command = tool_info["command"]
+    version_flag = tool_info["version_flag"]
+    description = tool_info["description"]
+
+    result: dict[str, Any] = {
+        "tool": tool_key,
+        "installed": False,
+        "version": None,
+        "path": None,
+        "description": description,
+    }
+
+    path = shutil.which(command)
+    if path is None:
+        return result
+
+    result["path"] = path
+
+    try:
+        proc = subprocess.run(
+            [command, version_flag],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        # Some tools print version to stderr (e.g., rustc, java)
+        raw_output = proc.stdout or proc.stderr
+        version = _parse_version(raw_output)
+        if version:
+            result["installed"] = True
+            result["version"] = version
+        else:
+            # Tool found on PATH but produced no version output — still
+            # treat as installed since shutil.which found it.
+            result["installed"] = True
+    except FileNotFoundError:
+        # shutil.which found it but it can't actually be executed
+        logger.debug("Tool %s found at %s but could not be executed", command, path)
+    except subprocess.TimeoutExpired:
+        # Tool exists but hung getting version — mark installed with no version
+        logger.debug("Tool %s timed out getting version", command)
+        result["installed"] = True
+    except OSError as exc:
+        logger.debug("OS error checking tool %s: %s", command, exc)
+
+    return result
+
+
+async def check_prerequisites(checks: list[str] | None = None) -> dict[str, Any]:
+    """Check if system tools are installed.
+
+    Args:
+        checks: list of tool keys to check (must be keys in ``TOOLS``).
+            If *None*, all known tools are checked.
+
+    Returns:
+        A dict with:
+            ``results`` — list of per-tool dicts with keys *tool*, *installed*,
+            *version*, *path*, *description*.
+            ``summary`` — dict with *total*, *installed*, *missing* counts.
+    """
+    if checks is not None:
+        # Filter to only requested tools, silently skip unknown keys
+        tools_to_check = {k: v for k, v in TOOLS.items() if k in checks}
+    else:
+        tools_to_check = TOOLS
+
+    loop = asyncio.get_running_loop()
+
+    # Run all checks concurrently via the thread pool
+    tasks = {
+        key: loop.run_in_executor(None, _check_single_tool, key, info)
+        for key, info in tools_to_check.items()
+    }
+
+    results: list[dict[str, Any]] = []
+    for key in tools_to_check:
+        result = await tasks[key]
+        results.append(result)
+
+    installed_count = sum(1 for r in results if r["installed"])
+    total = len(results)
+
+    return {
+        "results": results,
+        "summary": {
+            "total": total,
+            "installed": installed_count,
+            "missing": total - installed_count,
+        },
+    }

--- a/src-tauri/src/commands/setup_wizard.rs
+++ b/src-tauri/src/commands/setup_wizard.rs
@@ -84,13 +84,28 @@ fn find_setup_mcp_src_dir() -> Option<std::path::PathBuf> {
         }
     }
 
-    // Check each candidate for the setup-mcp package
+    // Check each candidate (and its bundled-resource subdir) for the package.
+    // Dev/workspace layout: `<root>/qontinui-setup-mcp/src`. Packaged apps place
+    // bundled resources under a platform dir (macOS `<App>.app/Contents/Resources`,
+    // Windows next to the exe), so also probe `Resources/` at each level so an
+    // out-of-the-box install finds the source without a pip install.
     for candidate in &candidates {
-        let src_dir = candidate.join("qontinui-setup-mcp").join("src");
-        let module_init = src_dir.join("qontinui_setup_mcp").join("__init__.py");
-        if module_init.exists() {
-            info!("Found qontinui-setup-mcp source at: {}", src_dir.display());
-            return Some(src_dir);
+        for base in [
+            candidate.clone(),
+            // Vendored in-repo copy (dev builds, no sibling checkout needed):
+            // `<runner>/src-tauri/resources/qontinui-setup-mcp/src`.
+            candidate.join("src-tauri").join("resources"),
+            candidate.join("resources"),
+            // Packaged-app resource dirs (macOS `.app/Contents/Resources`,
+            // Linux/Windows `resources/`).
+            candidate.join("Resources"),
+        ] {
+            let src_dir = base.join("qontinui-setup-mcp").join("src");
+            let module_init = src_dir.join("qontinui_setup_mcp").join("__init__.py");
+            if module_init.exists() {
+                info!("Found qontinui-setup-mcp source at: {}", src_dir.display());
+                return Some(src_dir);
+            }
         }
     }
 
@@ -112,12 +127,51 @@ fn find_setup_mcp_src_dir() -> Option<std::path::PathBuf> {
     None
 }
 
+/// Resolve a Python 3.12+ interpreter for the setup CLI.
+///
+/// End-user machines vary: some have `python`, some only `python3`, some a
+/// versioned `python3.12`, and macOS ships an old `/usr/bin/python3` (3.9) that
+/// must be skipped. Probe a preference-ordered candidate list and return the
+/// first that reports >= 3.12. `QONTINUI_PYTHON` overrides the search so an
+/// operator can pin a specific interpreter (or a bundled one).
+fn resolve_python() -> Option<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    if let Ok(p) = std::env::var("QONTINUI_PYTHON") {
+        if !p.is_empty() {
+            candidates.push(p);
+        }
+    }
+    for c in ["python3.13", "python3.12", "python3", "python"] {
+        candidates.push(c.to_string());
+    }
+    candidates.into_iter().find(|cand| {
+        crate::process_helpers::no_window(cand)
+            .args([
+                "-c",
+                "import sys; sys.exit(0 if sys.version_info >= (3, 12) else 1)",
+            ])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    })
+}
+
 /// Run a qontinui-setup-mcp CLI command and return parsed JSON output.
 ///
 /// Automatically sets PYTHONPATH to include the qontinui-setup-mcp source
 /// directory so the module can be found without requiring pip installation.
 fn run_setup_cli(args: &[&str]) -> Result<Value, String> {
-    let mut cmd = crate::process_helpers::no_window("python");
+    let python = resolve_python().ok_or_else(|| {
+        String::from(AppError::ProcessError(
+            "No Python 3.12+ interpreter found (tried $QONTINUI_PYTHON, \
+             python3.13, python3.12, python3, python). Install Python 3.12+ \
+             or set QONTINUI_PYTHON to its path."
+                .to_string(),
+        ))
+    })?;
+    let mut cmd = crate::process_helpers::no_window(&python);
     cmd.args(
         std::iter::once("-m")
             .chain(std::iter::once("qontinui_setup_mcp.cli"))
@@ -129,10 +183,15 @@ fn run_setup_cli(args: &[&str]) -> Result<Value, String> {
     // Set PYTHONPATH so the module can be found from source
     if let Some(src_dir) = find_setup_mcp_src_dir() {
         let src_dir_str = src_dir.to_string_lossy().to_string();
-        // Prepend to existing PYTHONPATH if set, otherwise just use the src dir
+        // Prepend to existing PYTHONPATH if set, otherwise just use the src dir.
+        // Use the platform PYTHONPATH separator (':' on Unix, ';' on Windows) —
+        // a hardcoded ';' silently broke source resolution on macOS/Linux
+        // whenever PYTHONPATH was already set (e.g. under Anaconda), forcing a
+        // fallback to a pip-installed copy that out-of-the-box users don't have.
         let python_path = match std::env::var("PYTHONPATH") {
             Ok(existing) if !existing.is_empty() => {
-                format!("{};{}", src_dir_str, existing)
+                let sep = if cfg!(windows) { ';' } else { ':' };
+                format!("{}{}{}", src_dir_str, sep, existing)
             }
             _ => src_dir_str,
         };

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,6 +28,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "resources": {
+      "resources/qontinui-setup-mcp/src/qontinui_setup_mcp": "qontinui-setup-mcp/src/qontinui_setup_mcp"
+    },
     "createUpdaterArtifacts": true
   },
   "plugins": {


### PR DESCRIPTION
## Problem
The first-launch setup wizard scanned a folder via `python -m qontinui_setup_mcp.cli`, but the package was neither bundled nor guaranteed installed, so the scan failed for anyone without it pip-installed into a PATH python (`ModuleNotFoundError: No module named 'qontinui_setup_mcp'`).

## Fix
- **Vendor** the pure-stdlib `qontinui_setup_mcp` package as a bundled Tauri resource (`src-tauri/resources/qontinui-setup-mcp/src`), kept in lockstep with upstream via `scripts/sync-setup-mcp.sh`. The scan CLI imports only stdlib (`mcp`/`httpx` are server-only), so no pip install or deps are needed. The in-repo path is present in every checkout, so it ships in the bundle and never breaks the supervisor's `.spawn-*` worktree builds.
- **Interpreter discovery**: probe `python3.13/3.12/python3/python` for ≥3.12 (with `QONTINUI_PYTHON` override) instead of assuming a bare `python` on PATH.
- **Fix** the hardcoded Windows `;` PYTHONPATH separator (broke source resolution on macOS/Linux when `PYTHONPATH` was preset, e.g. Anaconda).
- `find_setup_mcp_src_dir` now locates the source in vendored, sibling, and packaged-app (`.app/Contents/Resources`) layouts.

## Verification
`cargo check` passes with the in-repo resource. The scan returns the expected project list (`scan_workspace`), and end-to-end the runner's setup scan succeeds on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)