### PR TITLE
Fix terminal failing to open under zsh ("no such option: rcfile")

### DIFF
--- a/src-tauri/resources/shell-integration.zsh
+++ b/src-tauri/resources/shell-integration.zsh
@@ -1,0 +1,79 @@
+#!/usr/bin/env zsh
+# Qontinui Shell Integration for Zsh (OSC 633 / VS Code compatible)
+#
+# Loaded via ZDOTDIR: the runner points $ZDOTDIR at a temp dir whose `.zshrc`
+# is this file, so zsh sources it instead of ~/.zshrc. zsh has no `--rcfile`
+# flag (that's bash) — ZDOTDIR is the supported mechanism.
+#
+# Because ZDOTDIR redirects ALL of zsh's startup files away from $HOME, we must
+# re-source the user's real config explicitly to preserve their PATH/aliases/etc.
+
+# Restore the user's real zsh environment (in normal startup order). These were
+# skipped because ZDOTDIR points away from $HOME.
+[ -f "$HOME/.zshenv" ]   && source "$HOME/.zshenv"
+[ -f "$HOME/.zprofile" ] && source "$HOME/.zprofile"
+[ -f "$HOME/.zshrc" ]    && source "$HOME/.zshrc"
+
+# Guard: only install the integration hooks once.
+if [ "${QONTINUI_INTEGRATION}" = "1" ]; then
+    return 0 2>/dev/null
+fi
+export QONTINUI_INTEGRATION=1
+
+autoload -Uz add-zsh-hook
+
+# OSC 633 helper — write directly to /dev/tty so it never pollutes stdout.
+__qontinui_osc633() { printf '\033]633;%s\007' "$1" > /dev/tty }
+
+# precmd: fires before each prompt. Emit D;<exit-code> and P;Cwd=<path>.
+__qontinui_precmd() {
+    local code=$?
+    __qontinui_osc633 "D;${code}"
+    __qontinui_osc633 "P;Cwd=${PWD}"
+}
+
+# preexec: fires before a user-typed command runs. Emit E;<cmd> and C.
+__qontinui_preexec() {
+    local cmd="$1"
+    local escaped="${cmd//;/\\x3b}"
+    __qontinui_osc633 "E;${escaped}"
+    __qontinui_osc633 "C"
+}
+
+add-zsh-hook precmd __qontinui_precmd
+add-zsh-hook preexec __qontinui_preexec
+
+# Wrap PROMPT with A (prompt start) and B (command ready) markers. %{...%} marks
+# them zero-width so zsh doesn't miscount the prompt length.
+PROMPT="%{$(printf '\033]633;A\007')%}${PROMPT}%{$(printf '\033]633;B\007')%}"
+
+# ── Claude Code runner context ─────────────────────────────────────────────
+# Wrap `claude` so sessions launched from this terminal know they run inside
+# the Qontinui Runner (mirrors shell-integration.bash).
+if [ "${QONTINUI_RUNNER_TERMINAL}" = "1" ]; then
+    __qontinui_api_port="${QONTINUI_RUNNER_API_PORT:-9876}"
+    __qontinui_runner_context="You are running inside the Qontinui Runner desktop application terminal.
+The runner provides AI-driven development automation with structured workflows and verification feedback loops.
+
+Runner HTTP API at http://localhost:${__qontinui_api_port}.
+Key endpoints:
+- GET /task-runs/running - list running task runs
+- GET /task-runs/{id}/output?tail_chars=N - live AI conversation output
+- GET /task-runs/{id}/workflow-state - workflow execution state
+- POST /unified-workflows/execute-inline - execute a workflow inline
+- GET /unified-workflows - list saved workflows
+
+Runner SQLite DB (Windows): ~/AppData/Roaming/com.qontinui.runner/runner.db
+Key tables: task_runs, task_run_events, unified_workflows, workflow_verification_phase_results"
+
+    claude() {
+        case "${1:-}" in
+            mcp|config|update|doctor|api-key)
+                command claude "$@"
+                ;;
+            *)
+                command claude --append-system-prompt "$__qontinui_runner_context" "$@"
+                ;;
+        esac
+    }
+fi

--- a/src-tauri/src/terminal/session.rs
+++ b/src-tauri/src/terminal/session.rs
@@ -25,12 +25,25 @@ use super::types::{TerminalExitEvent, TerminalId, TerminalInfo};
 const PS1_INTEGRATION: &str = include_str!("../../resources/shell-integration.ps1");
 #[cfg(not(target_os = "windows"))]
 const BASH_INTEGRATION: &str = include_str!("../../resources/shell-integration.bash");
+const ZSH_INTEGRATION: &str = include_str!("../../resources/shell-integration.zsh");
 
 /// Write a shell integration script to a temp file, returning the path on success.
 fn write_integration_script(content: &str, name: &str) -> Option<std::path::PathBuf> {
     let path = std::env::temp_dir().join(name);
     std::fs::write(&path, content).ok()?;
     Some(path)
+}
+
+/// Write the zsh integration as `<dir>/.zshrc` and return `<dir>` for use as
+/// `ZDOTDIR`. zsh has no `--rcfile`; pointing `ZDOTDIR` at a dir makes zsh
+/// source `$ZDOTDIR/.zshrc` instead of `~/.zshrc` (our script re-sources the
+/// user's real `~/.z*` files). Returns `None` so the caller can fall back to a
+/// plain shell if the temp dir can't be created.
+fn write_zsh_zdotdir(content: &str) -> Option<std::path::PathBuf> {
+    let dir = std::env::temp_dir().join("qontinui-zsh-integration");
+    std::fs::create_dir_all(&dir).ok()?;
+    std::fs::write(dir.join(".zshrc"), content).ok()?;
+    Some(dir)
 }
 
 /// Maximum scrollback buffer capacity (1 MB).
@@ -936,17 +949,40 @@ impl TerminalSession {
         #[cfg(not(target_os = "windows"))]
         {
             let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string());
+            let shell_name = std::path::Path::new(&shell)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("");
             let mut cmd = CommandBuilder::new(&shell);
-            // Use --rcfile to source our integration script (which re-sources ~/.bashrc internally).
-            // Fall back to --login if the script can't be written.
-            if let Some(script_path) =
-                write_integration_script(BASH_INTEGRATION, "qontinui-shell-integration.bash")
-            {
-                let rcfile = script_path.to_string_lossy().into_owned();
-                cmd.arg("--rcfile");
-                cmd.arg(rcfile.as_str());
-            } else {
-                cmd.arg("--login");
+            // Shell integration is shell-specific. `--rcfile` is a BASH flag —
+            // passing it to zsh (the macOS default) fails with
+            // "no such option: rcfile", so each shell needs its own mechanism.
+            match shell_name {
+                "zsh" => {
+                    // zsh: point ZDOTDIR at a dir whose `.zshrc` is our
+                    // integration (it re-sources the user's ~/.z* files). If we
+                    // can't write it, fall through to a plain zsh that sources
+                    // ~/.zshrc normally (no OSC 633, but a working terminal).
+                    if let Some(zdotdir) = write_zsh_zdotdir(ZSH_INTEGRATION) {
+                        cmd.env("ZDOTDIR", zdotdir.to_string_lossy().as_ref());
+                    }
+                }
+                // bash (and the empty/unknown-path default) keep the --rcfile
+                // path, with --login as the no-script fallback.
+                "bash" | "" => {
+                    if let Some(script_path) = write_integration_script(
+                        BASH_INTEGRATION,
+                        "qontinui-shell-integration.bash",
+                    ) {
+                        cmd.arg("--rcfile");
+                        cmd.arg(script_path.to_string_lossy().as_ref());
+                    } else {
+                        cmd.arg("--login");
+                    }
+                }
+                // Any other shell (fish, etc.): launch it plainly — never pass
+                // bash-only flags it would reject.
+                _ => {}
             }
             cmd
         }


### PR DESCRIPTION
## Problem
The terminal session builder reads `$SHELL` but unconditionally passes bash's `--rcfile` flag to inject its shell-integration script. On macOS (default shell **zsh**), zsh rejects it with `no such option: rcfile`, so **no terminal opens**.

## Fix
Branch on the shell in `build_shell_command`:
- **zsh** → use the supported `ZDOTDIR` mechanism: a temp dir whose `.zshrc` is a new `resources/shell-integration.zsh` (zsh port of the bash integration — re-sources the user's `~/.zshenv`/`~/.zprofile`/`~/.zshrc` and installs OSC 633 `precmd`/`preexec` hooks + the `claude` wrapper).
- **bash** → unchanged (`--rcfile`).
- **other shells** (fish, etc.) → launched plainly, never handed bash-only flags.

## Verification
`cargo check` passes. The terminal now opens under zsh instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)