### PR TITLE
coord_doctor: accept macOS Keychain for the Claude-account check

### DIFF
--- a/src-tauri/src/ai_provider/oauth_refresh.rs
+++ b/src-tauri/src/ai_provider/oauth_refresh.rs
@@ -215,10 +215,36 @@ pub(crate) fn has_valid_credentials(config_dir: &str) -> bool {
 /// Spawn paths use this to decide whether an unset-`CLAUDE_CONFIG_DIR` spawn
 /// would land on a real login or 401-zombie under a dead default.
 pub(crate) fn default_location_has_valid_credentials() -> bool {
-    match find_creds_path(None) {
-        Some(path) => creds_path_is_valid(&path),
-        None => false,
+    if let Some(path) = find_creds_path(None) {
+        if creds_path_is_valid(&path) {
+            return true;
+        }
     }
+    // macOS keeps Claude Code's OAuth credentials in the login Keychain
+    // (service "Claude Code-credentials"), NOT in ~/.claude/.credentials.json.
+    // Without this, a logged-in macOS operator with an empty account roster
+    // trips the spawn-path "no authenticated Claude account — run /login" abort
+    // (e.g. `/spawn-ai`) even though a `claude` subprocess inheriting the unset
+    // CLAUDE_CONFIG_DIR would authenticate fine via the Keychain.
+    #[cfg(target_os = "macos")]
+    {
+        if macos_keychain_has_claude_credentials() {
+            return true;
+        }
+    }
+    false
+}
+
+/// True iff the macOS login Keychain holds a Claude Code credentials item.
+/// Attribute-only query (no `-w`/`-g`), so it never reads the secret and never
+/// triggers a Keychain access-control prompt.
+#[cfg(target_os = "macos")]
+fn macos_keychain_has_claude_credentials() -> bool {
+    std::process::Command::new("security")
+        .args(["find-generic-password", "-s", "Claude Code-credentials"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 /// Shared validity core: an existing creds file that is unexpired, or expired

--- a/src-tauri/src/coord_doctor.rs
+++ b/src-tauri/src/coord_doctor.rs
@@ -459,10 +459,38 @@ fn creds_path_is_valid(creds_path: &Path) -> bool {
 }
 
 fn claude_account_has_valid_credentials(config_dir: Option<&str>) -> bool {
-    match find_creds_path(config_dir) {
-        Some(path) => creds_path_is_valid(&path),
-        None => false,
+    if let Some(path) = find_creds_path(config_dir) {
+        if creds_path_is_valid(&path) {
+            return true;
+        }
     }
+    // macOS stores Claude Code's OAuth credentials in the login Keychain
+    // (service "Claude Code-credentials"), NOT in ~/.claude/.credentials.json —
+    // so the file-only check above reports a logged-in operator as
+    // unauthenticated, telling them to "run /login" when they already have.
+    // Accept the Keychain item as proof of a Claude account.
+    #[cfg(target_os = "macos")]
+    {
+        if macos_keychain_has_claude_credentials() {
+            return true;
+        }
+    }
+    false
+}
+
+/// True iff the macOS login Keychain holds a Claude Code credentials item.
+///
+/// Queries item ATTRIBUTES only (no `-w`/`-g`), so it never reads the secret
+/// and therefore never triggers a Keychain access-control prompt. Presence of
+/// the item means the operator has completed `/login` on this machine (Claude
+/// Code refreshes the token itself, so on-disk expiry isn't meaningful here).
+#[cfg(target_os = "macos")]
+fn macos_keychain_has_claude_credentials() -> bool {
+    std::process::Command::new("security")
+        .args(["find-generic-password", "-s", "Claude Code-credentials"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
On macOS, Claude Code stores its OAuth credentials in the **login Keychain** (service `Claude Code-credentials`), not in `~/.claude/.credentials.json`. The `claude_account` doctor check (`coord_doctor.rs`) only inspected the file, so a logged-in operator was reported as:

> no authenticated Claude account (no valid ~/.claude/.credentials.json) — run /login

…even though they were logged in. Running `/login` didn't help — it just re-stores in the Keychain, so the file never appears.

## Fix
After the existing file checks fail, on macOS also accept the **presence of the Keychain item**. The query (`security find-generic-password -s "Claude Code-credentials"`) reads attributes only — no `-w`/`-g` — so it never reads the secret and never triggers a Keychain access-control prompt. Non-macOS behavior is unchanged.

## Verification
`cargo check` passes. The Keychain item exists on the affected macOS machine (`security find-generic-password -s "Claude Code-credentials"` → success), so the check now passes for a logged-in operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)