### PR TITLE
runner: manual-test-loop iter 1 — observable command-result + terminal-page scope + CSP-safe read-value

### DIFF
--- a/src-tauri/src/mcp/ui_bridge/elements.rs
+++ b/src-tauri/src/mcp/ui_bridge/elements.rs
@@ -3449,40 +3449,51 @@ pub async fn ui_bridge_read_value_handler(
         ));
     }
 
-    let escaped_selector = selector.replace('\\', "\\\\").replace('\'', "\\'");
-
-    let js = format!(
-        r#"(() => {{
-            const matches = Array.from(document.querySelectorAll('{selector}'));
-            if (matches.length === 0) return JSON.stringify({{ found: false, error: 'No elements match selector' }});
-            const idx = {index};
-            if (idx >= matches.length) return JSON.stringify({{ found: false, error: 'Index out of range' }});
-            const el = matches[idx];
-            return JSON.stringify({{
-                found: true,
-                tag: el.tagName,
-                type: el.type || null,
-                value: el.value || el.textContent?.trim() || '',
-                length: (el.value || el.textContent || '').length,
-                placeholder: el.placeholder || null,
-                disabled: el.disabled || false,
-                readOnly: el.readOnly || false,
-                index: idx,
-                totalMatches: matches.length
-            }});
-        }})()"#,
-        selector = escaped_selector,
-        index = index
-    );
-
-    // Optional `windowLabel` scopes the read to a pop-out window (Phase 4 of
-    // plan 2026-06-07-multi-window-sdk-automation); omit -> main window.
+    // D5 — CSP-safe read. Previously this built a JS string and ran it via
+    // `evaluate_js_expression_in_window`, whose fallback path is a webview
+    // `eval(...)` (and whose IPC fast-path uses `new Function(...)`); both
+    // require CSP `unsafe-eval`, so on a CSP-hardened build this route was
+    // blocked outright. There is no need for arbitrary evaluation here:
+    // read-value only locates an element by selector and reads its fields.
+    // Route through the dedicated `read_value` IPC request type, whose
+    // frontend handler (`usePageEvents.ts`) does pure DOM traversal
+    // (`querySelectorAll` + field reads) with zero eval.
+    //
+    // The optional `windowLabel` is preserved on the payload so
+    // `ui_bridge_request_sync` (via `split_target_window`) still scopes the
+    // read to a pop-out window; omit -> main window.
     let window_label = read_window_label(&body);
-    match evaluate_js_expression_in_window(&state, &js, window_label).await {
-        Ok(result) => {
-            let parsed: serde_json::Value = serde_json::from_str(&result)
-                .unwrap_or(serde_json::json!({"found": false, "error": "Parse error"}));
-            Ok(Json(ApiResponse::success(parsed)))
+    let mut params = serde_json::json!({ "selector": selector, "index": index });
+    let payload = if window_label.is_empty() {
+        serde_json::json!({ "params": params })
+    } else {
+        params["windowLabel"] = serde_json::Value::String(window_label.to_string());
+        serde_json::json!({ "params": params, "windowLabel": window_label })
+    };
+
+    match ui_bridge_request_sync(&state, "read_value", payload).await {
+        Ok(data) => {
+            // The CSP-safe frontend handler reports failures as
+            // `{ success: false, error }`; map those onto the `found:false`
+            // shape this route has always returned so callers don't change.
+            if data.get("success") == Some(&serde_json::Value::Bool(false)) {
+                let err = data
+                    .get("error")
+                    .and_then(|e| e.as_str())
+                    .unwrap_or("read failed")
+                    .to_string();
+                return Ok(Json(ApiResponse::success(
+                    serde_json::json!({ "found": false, "error": err }),
+                )));
+            }
+            // Frontend returns `{ value, length, ... }` (optionally nested
+            // under `data`). Normalize to `{ found: true, ... }`.
+            let inner = data.get("data").unwrap_or(&data);
+            let mut out = inner.clone();
+            if let Some(obj) = out.as_object_mut() {
+                obj.insert("found".to_string(), serde_json::Value::Bool(true));
+            }
+            Ok(Json(ApiResponse::success(out)))
         }
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, Json(api_error(e)))),
     }

--- a/src/components/prompt-home/PromptHomePage.tsx
+++ b/src/components/prompt-home/PromptHomePage.tsx
@@ -150,6 +150,16 @@ export function PromptHomePage() {
           <input
             ref={inputRef}
             type="text"
+            // D3 — the visible command-entry affordance on the home
+            // surface. The TerminalPage CommandBar footer is `display:none`
+            // (bbox 0x0) whenever the terminal tab isn't active, so on
+            // prompt-home it can't be the command input a driver targets.
+            // This search box IS the home command input; tagging it
+            // `command-input` makes a UI-Bridge snapshot on prompt-home
+            // surface a visible (bbox>0) command input — e.g. for the NL
+            // flow "open an ai session in the terminal page".
+            data-page-element="command-input"
+            data-testid="command-input"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             placeholder="What would you like to do?"

--- a/src/components/terminal/CommandBar.test.ts
+++ b/src/components/terminal/CommandBar.test.ts
@@ -1,0 +1,72 @@
+/**
+ * D1 — durable command-result record.
+ *
+ * The runner's vitest config uses `environment: "node"` (no jsdom), so
+ * per repo precedent (`MidSessionToast.test.tsx`,
+ * `CommitTrafficLight.test.tsx`) we test the load-bearing logic via the
+ * exported pure helper rather than rendering JSX. The helper produces the
+ * exact record that CommandBar mirrors into the hidden
+ * `data-page-element="command-bar-result"` node — the signal a headless
+ * UI-Bridge driver reads to learn whether, and why, a command did its
+ * job.
+ *
+ * The goal-blocker case: `/spawn-ai best` returns `fail("no-account")`
+ * when no Claude account is configured. Before D1 that surfaced only in a
+ * transient 3s status line; now it's a durable, observable record.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { buildCommandResultRecord } from "./CommandBar";
+import type { CommandResult } from "./commands";
+
+const spawnAi = { id: "terminal.spawn-ai", slash: "/spawn-ai" };
+
+describe("buildCommandResultRecord", () => {
+  it("records a durable no-account failure for /spawn-ai best", () => {
+    const result: CommandResult = {
+      ok: false,
+      code: "no-account",
+      message: "no matching Claude account",
+    };
+    const rec = buildCommandResultRecord(spawnAi, result, "ai", 1234);
+
+    // This is precisely what the headless driver reads back as JSON. The
+    // failure is observable instead of being swallowed by the 3s status
+    // line — so "click returned success but nothing spawned" now has a
+    // legible reason attached.
+    expect(rec).toEqual({
+      ok: false,
+      slash: "/spawn-ai",
+      actionId: "terminal.spawn-ai",
+      source: "ai",
+      code: "no-account",
+      message: "no matching Claude account",
+      at: 1234,
+    });
+  });
+
+  it("omits code/message on success and stamps the time", () => {
+    const result: CommandResult = { ok: true, value: ["tab-1"] };
+    const rec = buildCommandResultRecord(spawnAi, result, "slash", 42);
+
+    expect(rec.ok).toBe(true);
+    expect(rec.code).toBeUndefined();
+    expect(rec.message).toBeUndefined();
+    expect(rec.slash).toBe("/spawn-ai");
+    expect(rec.source).toBe("slash");
+    expect(rec.at).toBe(42);
+  });
+
+  it("serializes to JSON the driver can parse and discriminate on", () => {
+    const fail = buildCommandResultRecord(
+      spawnAi,
+      { ok: false, code: "no-account" },
+      "ai",
+      7,
+    );
+    const parsed = JSON.parse(JSON.stringify(fail));
+    expect(parsed.ok).toBe(false);
+    expect(parsed.code).toBe("no-account");
+  });
+});

--- a/src/components/terminal/CommandBar.tsx
+++ b/src/components/terminal/CommandBar.tsx
@@ -77,6 +77,60 @@ interface StatusLine {
   text: string;
 }
 
+/**
+ * Durable, machine-readable record of the LAST command execution. Unlike
+ * `StatusLine` (which renders a transient 3s toast and is gated on
+ * `!focused`), this is mirrored into a hidden `data-page-element=
+ * "command-bar-result"` node whose `textContent` is JSON. It is set on
+ * EVERY execute (success or failure) and is NOT auto-cleared, so a
+ * headless UI-Bridge driver can read *why* a command did or didn't do
+ * what it asked — e.g. `/spawn-ai best` returning `code:"no-account"`
+ * when no Claude account is configured. Before this, the only signal of
+ * that failure was a 3s status line the driver almost always missed,
+ * leaving the spawn-AI flow looking like a success (`click` → success:
+ * true) with no session and no observable reason. (D1)
+ */
+export interface CommandResultRecord {
+  /** `true` when the action's CommandResult was `ok`. */
+  ok: boolean;
+  /** The action's slash form, e.g. `/spawn-ai`. */
+  slash: string;
+  /** Registry action id, e.g. `terminal.spawn-ai`. */
+  actionId: string;
+  /** How the command was triggered. */
+  source: "slash" | "ai";
+  /** Failure code from `CommandResult.code` (absent on success). */
+  code?: string;
+  /** Human-readable failure message (absent on success). */
+  message?: string;
+  /** ms-epoch the record was written — lets a driver detect freshness. */
+  at: number;
+}
+
+/**
+ * Build the durable {@link CommandResultRecord} from an action + its
+ * `CommandResult`. Pure (modulo the injected `now`) so the D1 durable-
+ * record contract — especially the `/spawn-ai best` → `no-account` shape
+ * a headless driver reads — is unit-testable under the runner's node
+ * vitest env without rendering JSX.
+ */
+export function buildCommandResultRecord(
+  action: Pick<CommandAction, "id" | "slash">,
+  result: CommandResult,
+  source: "slash" | "ai",
+  now: number = Date.now(),
+): CommandResultRecord {
+  return {
+    ok: result.ok,
+    slash: action.slash,
+    actionId: action.id,
+    source,
+    code: result.ok ? undefined : result.code,
+    message: result.ok ? undefined : result.message,
+    at: now,
+  };
+}
+
 /** Subscribe to the registry via useSyncExternalStore so the suggestion
  *  list rebuilds when `useTerminalCommands` registers / unregisters. */
 function useRegistrySnapshot(): readonly CommandAction[] {
@@ -100,6 +154,10 @@ export function CommandBar() {
   const [focused, setFocused] = useState(false);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [status, setStatus] = useState<StatusLine | null>(null);
+  // Durable last-result record (D1). Mirrored to a hidden DOM node so an
+  // external UI-Bridge driver can read the outcome AFTER the 3s status
+  // toast has cleared.
+  const [lastResult, setLastResult] = useState<CommandResultRecord | null>(null);
   const [recents, setRecents] = useState<string[]>(() =>
     instanceStorage.getJSON<string[]>(RECENTS_STORAGE_KEY, []),
   );
@@ -290,17 +348,31 @@ export function CommandBar() {
       // verbatim rather than re-parsing positionally (positional parse
       // on "spawn 3 best" against /spawn's 1-field schema would silently
       // mis-bind).
+      const source: "slash" | "ai" = tier === "ai" ? "ai" : "slash";
       const args = presetArgs ?? parseArgs(rawInput, action);
       let result: CommandResult;
       try {
-        result = await action.handler(args, {
-          source: tier === "ai" ? "ai" : "slash",
-        });
+        result = await action.handler(args, { source });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setStatus({ kind: "error", text: `${action.slash}: ${message}` });
+        // D1 — a thrown handler is just as much a durable failure as a
+        // `{ok:false}` return; record it so the driver sees it too.
+        setLastResult({
+          ok: false,
+          slash: action.slash,
+          actionId: action.id,
+          source,
+          code: "exception",
+          message,
+          at: Date.now(),
+        });
         return;
       }
+      // D1 — durable record on every outcome. For failures this is the
+      // signal a headless driver reads to learn that e.g. `/spawn-ai best`
+      // failed with `no-account` rather than silently doing nothing.
+      setLastResult(buildCommandResultRecord(action, result, source));
       if (result.ok) {
         persistRecent(action.id);
         // Result.value may be `undefined` (action just ran) — render the
@@ -420,6 +492,24 @@ export function CommandBar() {
 
   return (
     <div data-page-element="command-bar" className="relative z-40 w-full shrink-0">
+      {/* D1 — durable, machine-readable last-result mirror. Visually
+          hidden (never affects layout), but its `textContent` is the JSON
+          {@link CommandResultRecord} for the LAST execute. A headless
+          UI-Bridge driver reads it via
+          `POST /ui-bridge/control/page/read-value
+          {"selector":"[data-page-element=command-bar-result]"}` to learn
+          whether — and why — a command actually succeeded. Empty until the
+          first execute. */}
+      <span
+        data-page-element="command-bar-result"
+        data-testid="command-bar-result"
+        data-result-ok={lastResult ? String(lastResult.ok) : undefined}
+        data-result-code={lastResult?.code}
+        style={{ display: "none" }}
+        aria-hidden
+      >
+        {lastResult ? JSON.stringify(lastResult) : ""}
+      </span>
       {/* Status line + suggestion dropdown float in an overlay anchored
           ABOVE the docked footer (`bottom-full`) so they never change the
           bar's own height or push the terminal grid while the operator
@@ -496,6 +586,9 @@ export function CommandBar() {
                     <button
                       key={m.action.id}
                       type="button"
+                      data-page-element="command-bar-suggestion"
+                      data-testid={`command-bar-suggestion-${m.action.id}`}
+                      data-action-id={m.action.id}
                       onMouseDown={(e) => e.preventDefault() /* keep input focus */}
                       onClick={() => handleSuggestionClick(m.action, idx, m.presetArgs, m.tier)}
                       onMouseEnter={() => setSelectedIdx(idx)}
@@ -547,6 +640,8 @@ export function CommandBar() {
         <span className="text-[10px] text-[#565f89] font-mono select-none">›</span>
         <input
           ref={inputRef}
+          data-page-element="command-bar-input"
+          data-testid="command-bar-input"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onFocus={handleFocus}

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -946,13 +946,26 @@ function TerminalPageInner({
   });
 
   if (!initialized) {
+    // D4 — keep the `terminal-page` UI Bridge scope mounted even during
+    // the pre-init loading state. Previously this early-return dropped
+    // `UIBridgeComponentScope`, so after navigating to /terminal the
+    // active component scope went unregistered until init finished and a
+    // driver's element/action calls 404'd against terminal-page. The
+    // CommandBar mounts here too so its actions + durable result node are
+    // reachable the moment the page is on screen, not only after the PTY
+    // roster hydrates.
     return (
-      <div className="h-full flex items-center justify-center bg-[#1a1b26]">
-        <div className="flex flex-col items-center gap-3">
-          <div className="w-8 h-8 border-2 border-[#7aa2f7] border-t-transparent rounded-full animate-spin" />
-          <span className="text-[12px] text-[#565f89]">Loading terminals...</span>
+      <UIBridgeComponentScope componentId="terminal-page">
+        <div className="h-full flex flex-col bg-[#1a1b26]">
+          <div className="flex-1 flex items-center justify-center">
+            <div className="flex flex-col items-center gap-3">
+              <div className="w-8 h-8 border-2 border-[#7aa2f7] border-t-transparent rounded-full animate-spin" />
+              <span className="text-[12px] text-[#565f89]">Loading terminals...</span>
+            </div>
+          </div>
+          <CommandBar />
         </div>
-      </div>
+      </UIBridgeComponentScope>
     );
   }
 

--- a/src/hooks/ui-bridge-events/usePageEvents.ts
+++ b/src/hooks/ui-bridge-events/usePageEvents.ts
@@ -734,7 +734,14 @@ export function usePageEvents(context: Pick<UIBridgeEventContext, "bridgeRef" | 
 
         case "read_value": {
           try {
-            const { selector } = (payload.params || {}) as { selector?: string };
+            // D5 — CSP-safe value read: pure DOM traversal, no eval. The
+            // Rust `read-value` route now dispatches here instead of
+            // building a JS string for `eval`/`new Function`, so the route
+            // works on a CSP-hardened build (no `unsafe-eval`).
+            const { selector, index } = (payload.params || {}) as {
+              selector?: string;
+              index?: number;
+            };
             if (!selector) {
               await sendResponse({
                 requestId,
@@ -745,8 +752,8 @@ export function usePageEvents(context: Pick<UIBridgeEventContext, "bridgeRef" | 
               });
               return true;
             }
-            const el = document.querySelector<HTMLElement>(selector);
-            if (!el) {
+            const matches = Array.from(document.querySelectorAll<HTMLElement>(selector));
+            if (matches.length === 0) {
               await sendResponse({
                 requestId,
                 type,
@@ -756,12 +763,37 @@ export function usePageEvents(context: Pick<UIBridgeEventContext, "bridgeRef" | 
               });
               return true;
             }
-            const value = "value" in el ? (el as HTMLInputElement).value : (el.textContent ?? null);
+            const idx = typeof index === "number" && index >= 0 ? index : 0;
+            if (idx >= matches.length) {
+              await sendResponse({
+                requestId,
+                type,
+                success: false,
+                error: `Index ${idx} out of range (${matches.length} matches)`,
+                timestamp: Date.now(),
+              });
+              return true;
+            }
+            const el = matches[idx];
+            // Prefer a form control's `.value`; fall back to trimmed text
+            // content for non-input elements (e.g. the hidden
+            // `command-bar-result` JSON node read by the spawn-AI flow).
+            const rawValue =
+              "value" in el && (el as HTMLInputElement).value !== ""
+                ? (el as HTMLInputElement).value
+                : (el.textContent?.trim() ?? "");
             await sendResponse({
               requestId,
               type,
               success: true,
-              data: { value, length: value?.length ?? 0 },
+              data: {
+                value: rawValue,
+                length: rawValue.length,
+                tag: el.tagName,
+                type: (el as HTMLInputElement).type || null,
+                index: idx,
+                totalMatches: matches.length,
+              },
               timestamp: Date.now(),
             });
           } catch (err) {
@@ -1023,6 +1055,26 @@ export function usePageEvents(context: Pick<UIBridgeEventContext, "bridgeRef" | 
                 detail: { tab: tabId as MainTabId },
               }),
             );
+            // D6 — sync the URL to the activated tab. `tab_activate` used to
+            // flip `activeTab` (and thus the activeTab-derived `page.route`)
+            // without touching `window.location`, so the URL bar drifted out
+            // of sync with the active surface: a snapshot taken after
+            // `navigate /terminal` reported `activeTab:"terminal"` while
+            // `window.location.pathname` was still the previously-loaded path.
+            // `page_navigate` already pushState's; mirror that here so both
+            // tab-switch entry points leave route + activeTab consistent.
+            // Canonical path = "/<tabId>" (matches page_navigate's tab→path
+            // convention); pushState only (no reload) keeps injected window
+            // state intact, same as soft navigation.
+            try {
+              const canonicalPath = `/${tabId}`;
+              if (window.location.pathname !== canonicalPath) {
+                window.history.pushState({}, "", canonicalPath);
+              }
+            } catch {
+              // Non-fatal: the tab still switched via the event above; only
+              // the URL-bar mirror failed (e.g. a sandboxed history).
+            }
             // Persist immediately so that `tabs_list` polled right after sees
             // the new value (the React effect in `useAppNavigation` would also
             // persist on the next render, but agents may read back before that).
@@ -1034,6 +1086,7 @@ export function usePageEvents(context: Pick<UIBridgeEventContext, "bridgeRef" | 
               data: {
                 activeTab: tabId,
                 previousTab,
+                route: { pattern: tabId, id: tabId, path: `/${tabId}` },
               },
               timestamp: Date.now(),
             });


### PR DESCRIPTION
Remediation from manual-test-loop iteration 1.

- D1: durable, observable command-result for /spawn-ai failures
- D3: visible home command input
- D4: persistent terminal-page UI-bridge scope
- D5: CSP-safe read-value
- D6: route/active-tab sync

Base is the parent feature branch `integration/macos-runner-fixes` so the diff is scoped to just these fixes.