### PR TITLE
feat: stream interactive session activity to coord agent_logs (gated, default-OFF)

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -59,7 +59,9 @@
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use serde::Serialize;
 use serde_json::json;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -78,6 +80,19 @@ fn registration_enabled() -> bool {
         ),
         Err(_) => true,
     }
+}
+
+/// Default-OFF env gate for streaming interactive-session activity to coord's
+/// `agent_logs` ingest (Phase 1c). ONLY a truthy value — `1` / `true` / `on` /
+/// `yes` (case-insensitive) — turns it ON; anything else (including unset)
+/// leaves it OFF, so the emitter is a strict no-op by default and never adds
+/// always-on coord traffic.
+pub fn agent_logs_from_sessions_enabled() -> bool {
+    matches!(
+        std::env::var("QONTINUI_AGENT_LOGS_FROM_SESSIONS")
+            .map(|v| v.trim().to_ascii_lowercase()),
+        Ok(ref v) if matches!(v.as_str(), "1" | "true" | "on" | "yes")
+    )
 }
 
 /// Registers authenticated `ClaudeSession`s into `coord.sessions` and owns the
@@ -361,6 +376,321 @@ impl AiCoordRegistrar {
 
 use crate::session::SessionKind;
 
+// ============================================================================
+// Interactive-agent log emitter (Phase 1b/1c)
+// ============================================================================
+//
+// Interactive / runner-managed Claude sessions register into `coord.sessions`
+// (Live Sessions panel) but emit no `coord.agent_logs` rows, so they are
+// invisible on the `/admin/coord/agents` dashboard. This emitter streams a
+// session's activity to coord's existing log ingest `POST /agents/:id/log`,
+// tagging each entry with the runner's `device_id` so coord's Phase-1a
+// fallback resolves the tenant from `coord.devices`.
+//
+// Wire shape is coord's [`LogEntry`] (`qontinui-coord/src/agent_logs.rs`):
+// `level` + `event` are REQUIRED and non-empty (coord 400s otherwise);
+// `payload` / `agent_session_id` / `device_id` / `occurred_at` are optional.
+// `agent_id` goes in the URL path, never the body.
+//
+// Identity: the coord session UUIDv7 is BOTH the URL `agent_id` AND the body
+// `agent_session_id` (one identity shared with Live Sessions). The runner's
+// `device_id` is read once from `~/.qontinui/machine.json`.
+//
+// Batching: a `std::sync::mpsc` channel feeds a background flush thread that
+// drains the queue into a single `Vec<LogEntry>` and POSTs the whole array in
+// one request (≤ `MAX_AGENT_LOG_BATCH`, mirroring coord's `MAX_BATCH_SIZE`).
+// A 5s periodic flush + try-immediate-then-requeue-on-failure + a final flush
+// on close mirror `agent_runtime::pump_subprocess`'s shape, but batched.
+//
+// Everything here is gated on [`agent_logs_from_sessions_enabled`] (default
+// OFF) at the construction site, so an OFF gate means no emitter is ever built
+// and zero coord traffic is added.
+
+/// Max entries per `POST /agents/:id/log` batch. Mirrors coord's
+/// `agent_logs::MAX_BATCH_SIZE`; coord 400s a larger batch.
+const MAX_AGENT_LOG_BATCH: usize = 500;
+
+/// Periodic flush cadence for the background drain thread.
+const AGENT_LOG_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Upper bound on buffered entries when coord is unreachable. Older entries
+/// drop FIFO so an offline coord can't grow the queue without bound. Generous
+/// (10×batch) since each entry is small.
+const AGENT_LOG_QUEUE_CAP: usize = MAX_AGENT_LOG_BATCH * 10;
+
+/// One `coord.agent_logs` row in coord's wire shape. `level` + `event` MUST be
+/// non-empty or coord rejects the whole batch with 400.
+#[derive(Debug, Clone, Serialize)]
+pub struct LogEntry {
+    pub level: String,
+    pub event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_session_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_id: Option<Uuid>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub occurred_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Messages the session pushes to the emitter's background drain thread.
+enum EmitMsg {
+    /// A fully-formed log entry to enqueue.
+    Entry(LogEntry),
+    /// Close signal — drain the queue one final time, then stop.
+    Close,
+}
+
+/// Cheap-to-clone handle the session threads push log entries into. The actual
+/// HTTP work happens on a single background drain thread; pushing is a
+/// non-blocking channel send. Dropping the last handle (or calling
+/// [`AgentLogEmitter::close`]) ends the drain thread after a final flush.
+#[derive(Clone)]
+pub struct AgentLogEmitter {
+    tx: std::sync::mpsc::Sender<EmitMsg>,
+    /// The coord session id — both the URL `agent_id` and the body
+    /// `agent_session_id`. Carried so emit helpers can stamp it without the
+    /// caller re-threading it.
+    agent_id: Uuid,
+    device_id: Option<Uuid>,
+}
+
+impl AgentLogEmitter {
+    /// Build an emitter for the coord session `agent_id`, reading `device_id`
+    /// once from `~/.qontinui/machine.json`. Returns `None` (no emitter, no
+    /// thread) when the gate is OFF or `device_id` is unreadable — both are
+    /// fail-safe no-ops: coord's Phase-1a tenant fallback needs the
+    /// `device_id`, so emitting without it is pointless.
+    pub fn start(agent_id: Uuid) -> Option<Self> {
+        if !agent_logs_from_sessions_enabled() {
+            return None;
+        }
+        let device_id = match read_device_id_uuid() {
+            Some(d) => d,
+            None => {
+                debug!(
+                    "agent_log_emitter: no readable device_id for agent {} — skipping emission",
+                    agent_id
+                );
+                return None;
+            }
+        };
+
+        let (tx, rx) = std::sync::mpsc::channel::<EmitMsg>();
+        std::thread::Builder::new()
+            .name(format!("agent-log-emit-{agent_id}"))
+            .spawn(move || drain_loop(agent_id, rx))
+            .map_err(|e| warn!("agent_log_emitter: failed to spawn drain thread: {e}"))
+            .ok()?;
+
+        info!(
+            "agent_log_emitter: streaming session {} to coord agent_logs",
+            agent_id
+        );
+        Some(Self {
+            tx,
+            agent_id,
+            device_id: Some(device_id),
+        })
+    }
+
+    /// Build a `LogEntry` stamped with this emitter's identity (agent session
+    /// id + device id), letting coord stamp `occurred_at`.
+    fn entry(&self, level: &str, event: &str, payload: Option<serde_json::Value>) -> LogEntry {
+        LogEntry {
+            level: level.to_string(),
+            event: event.to_string(),
+            payload,
+            agent_session_id: Some(self.agent_id),
+            device_id: self.device_id,
+            occurred_at: None,
+        }
+    }
+
+    /// `session_started` milestone — one line at session start.
+    pub fn started(&self, purpose: &str) {
+        let _ = self.tx.send(EmitMsg::Entry(self.entry(
+            "info",
+            "session_started",
+            Some(json!({ "purpose": purpose })),
+        )));
+    }
+
+    /// Per-stdout-line activity. Empty lines are dropped (no signal, and an
+    /// empty `event` would never happen here but an empty `text` is just
+    /// noise). `event` is the constant `"stdout"`; the raw line rides in
+    /// `payload.text`.
+    pub fn stream_line(&self, line: &str) {
+        if line.trim().is_empty() {
+            return;
+        }
+        let _ = self.tx.send(EmitMsg::Entry(self.entry(
+            "info",
+            "stdout",
+            Some(json!({ "text": line })),
+        )));
+    }
+
+    /// Terminal `session_closed` milestone, then signal the drain thread to do
+    /// its final flush and stop. Idempotent-safe: a second close just enqueues
+    /// another (harmless) terminal line if the channel is still open.
+    pub fn close(&self) {
+        let _ = self
+            .tx
+            .send(EmitMsg::Entry(self.entry("info", "session_closed", None)));
+        let _ = self.tx.send(EmitMsg::Close);
+    }
+}
+
+/// Read `device_id` from `~/.qontinui/machine.json` and parse it as a `Uuid`.
+/// Reuses the canonical disk reader in [`crate::pair`]. Any failure (missing
+/// file, unparseable, non-UUID) yields `None` — the emitter then skips.
+fn read_device_id_uuid() -> Option<Uuid> {
+    // `pair` lives in the `qontinui_runner_lib` crate (this module compiles into
+    // both the lib and the bin target, so the bin can't reach it via `crate::`).
+    let raw = qontinui_runner_lib::pair::read_device_id_from_disk().ok()?;
+    Uuid::parse_str(raw.trim()).ok()
+}
+
+/// Background drain loop: owns the reqwest client + the FIFO queue. Wakes on a
+/// channel recv with a `AGENT_LOG_FLUSH_INTERVAL` timeout so an idle session
+/// still flushes within ~5s. Drains the queue into one `Vec<LogEntry>`
+/// (≤ batch cap) and POSTs the whole array; on POST failure the un-sent tail
+/// is requeued (capped FIFO) for the next tick. Ends on `Close` or when all
+/// `AgentLogEmitter` handles drop (channel disconnect), with a final flush.
+fn drain_loop(agent_id: Uuid, rx: std::sync::mpsc::Receiver<EmitMsg>) {
+    let mut queue: std::collections::VecDeque<LogEntry> = std::collections::VecDeque::new();
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .ok();
+
+    loop {
+        match rx.recv_timeout(AGENT_LOG_FLUSH_INTERVAL) {
+            Ok(EmitMsg::Entry(e)) => {
+                if queue.len() >= AGENT_LOG_QUEUE_CAP {
+                    queue.pop_front();
+                }
+                queue.push_back(e);
+                // Coalesce a burst: pull any other immediately-ready entries
+                // without blocking, so a flurry of stdout lines POSTs as ONE
+                // batch rather than one request per line.
+                while let Ok(EmitMsg::Entry(e)) = rx.try_recv() {
+                    if queue.len() >= AGENT_LOG_QUEUE_CAP {
+                        queue.pop_front();
+                    }
+                    queue.push_back(e);
+                }
+                if queue.len() >= MAX_AGENT_LOG_BATCH {
+                    flush_batch(client.as_ref(), agent_id, &mut queue);
+                }
+            }
+            Ok(EmitMsg::Close) => {
+                flush_batch(client.as_ref(), agent_id, &mut queue);
+                break;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                flush_batch(client.as_ref(), agent_id, &mut queue);
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                flush_batch(client.as_ref(), agent_id, &mut queue);
+                break;
+            }
+        }
+    }
+    debug!("agent_log_emitter: drain thread for {} stopped", agent_id);
+}
+
+/// Drain up to `MAX_AGENT_LOG_BATCH` entries from the front of `queue` and POST
+/// them as one array. On failure (no client, no coord base, HTTP error) the
+/// drained slice is pushed back to the FRONT in order so nothing is lost and
+/// the next tick retries — bounded by the caller's queue cap. Best-effort:
+/// never panics, never blocks the session.
+fn flush_batch(
+    client: Option<&reqwest::blocking::Client>,
+    agent_id: Uuid,
+    queue: &mut std::collections::VecDeque<LogEntry>,
+) {
+    if queue.is_empty() {
+        return;
+    }
+    let Some(client) = client else {
+        return; // client build failed earlier — keep buffering (capped).
+    };
+    let Some(base) = coord_http_base() else {
+        return; // coord not configured — keep buffering (capped).
+    };
+
+    let take = queue.len().min(MAX_AGENT_LOG_BATCH);
+    let batch: Vec<LogEntry> = queue.drain(..take).collect();
+
+    // Best-effort bearer auth (mirrors the federation report path). The ingest
+    // route resolves the tenant from the body `device_id`, so a missing token
+    // is non-fatal — we just omit the header.
+    let token = crate::auth::AuthManager::new()
+        .get_access_token()
+        .ok()
+        .filter(|t| !t.is_empty());
+
+    let url = format!("{base}/agents/{agent_id}/log");
+    let mut req = client.post(&url).json(&batch);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+
+    match req.send() {
+        Ok(resp) if resp.status().is_success() => {
+            debug!(
+                "agent_log_emitter: flushed {} entries for {}",
+                batch.len(),
+                agent_id
+            );
+        }
+        Ok(resp) => {
+            warn!(
+                "agent_log_emitter: POST /agents/{}/log returned {} — requeueing {} entries",
+                agent_id,
+                resp.status(),
+                batch.len()
+            );
+            requeue_front(queue, batch);
+        }
+        Err(e) => {
+            debug!(
+                "agent_log_emitter: POST /agents/{}/log failed ({e}) — requeueing {} entries",
+                agent_id,
+                batch.len()
+            );
+            requeue_front(queue, batch);
+        }
+    }
+}
+
+/// Push a failed batch back to the FRONT of the queue in original order,
+/// trimming the tail to honor `AGENT_LOG_QUEUE_CAP` (drop oldest on overflow).
+fn requeue_front(queue: &mut std::collections::VecDeque<LogEntry>, batch: Vec<LogEntry>) {
+    for e in batch.into_iter().rev() {
+        queue.push_front(e);
+    }
+    while queue.len() > AGENT_LOG_QUEUE_CAP {
+        queue.pop_back();
+    }
+}
+
+/// Resolve the coord HTTP base (env `COORD_HTTP_URL` → active profile
+/// `coord_url`). `None` when nothing is configured — the emitter then keeps
+/// buffering (capped) rather than dropping, matching the other resolvers'
+/// no-localhost-fallback posture.
+fn coord_http_base() -> Option<String> {
+    match qontinui_runner_lib::profiles::resolve_coord_base() {
+        qontinui_runner_lib::profiles::CoordBase::Configured(base) => {
+            Some(base.trim_end_matches('/').to_string())
+        }
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -546,6 +876,79 @@ mod tests {
         reg.report_commits("o/r", "main", vec!["a".into()]);
         assert!(reg.inner.outbox.pending().unwrap().is_empty());
         std::env::remove_var("QONTINUI_COMMIT_LINEAGE_REPORT");
+    }
+
+    #[test]
+    fn agent_logs_gate_defaults_off_and_only_truthy_enables() {
+        let _env = env_lock();
+        std::env::remove_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS");
+        // Default (unset) is OFF — strict no-op posture.
+        assert!(!agent_logs_from_sessions_enabled());
+
+        for off in ["0", "false", "off", "", "no", "garbage"] {
+            std::env::set_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS", off);
+            assert!(
+                !agent_logs_from_sessions_enabled(),
+                "value {off:?} must NOT enable the gate"
+            );
+        }
+        for on in ["1", "true", "on", "yes", "TRUE", "On", "Yes"] {
+            std::env::set_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS", on);
+            assert!(
+                agent_logs_from_sessions_enabled(),
+                "value {on:?} must enable the gate"
+            );
+        }
+        std::env::remove_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS");
+    }
+
+    #[test]
+    fn emitter_off_gate_yields_no_emitter() {
+        let _env = env_lock();
+        std::env::set_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS", "0");
+        assert!(AgentLogEmitter::start(Uuid::new_v4()).is_none());
+        std::env::remove_var("QONTINUI_AGENT_LOGS_FROM_SESSIONS");
+    }
+
+    #[test]
+    fn log_entry_serializes_to_coord_wire_shape() {
+        let agent = Uuid::new_v4();
+        let device = Uuid::new_v4();
+        let entry = LogEntry {
+            level: "info".to_string(),
+            event: "stdout".to_string(),
+            payload: Some(json!({ "text": "hello" })),
+            agent_session_id: Some(agent),
+            device_id: Some(device),
+            occurred_at: None,
+        };
+        let v = serde_json::to_value(&entry).unwrap();
+        // Required non-empty fields coord validates.
+        assert_eq!(v["level"], json!("info"));
+        assert_eq!(v["event"], json!("stdout"));
+        assert_eq!(v["payload"]["text"], json!("hello"));
+        assert_eq!(v["agent_session_id"], json!(agent));
+        assert_eq!(v["device_id"], json!(device));
+        // `occurred_at` omitted (skip_serializing_if None) so coord stamps now().
+        assert!(v.get("occurred_at").is_none());
+    }
+
+    #[test]
+    fn requeue_front_preserves_order_and_honors_cap() {
+        let mk = |n: usize| LogEntry {
+            level: "info".to_string(),
+            event: format!("e{n}"),
+            payload: None,
+            agent_session_id: None,
+            device_id: None,
+            occurred_at: None,
+        };
+        let mut q: std::collections::VecDeque<LogEntry> = std::collections::VecDeque::new();
+        q.push_back(mk(100)); // an existing tail entry
+                              // Requeue a failed batch [1,2,3] — must land at the FRONT in order.
+        requeue_front(&mut q, vec![mk(1), mk(2), mk(3)]);
+        let events: Vec<String> = q.iter().map(|e| e.event.clone()).collect();
+        assert_eq!(events, vec!["e1", "e2", "e3", "e100"]);
     }
 
     #[test]

--- a/src-tauri/src/claude_session/runner.rs
+++ b/src-tauri/src/claude_session/runner.rs
@@ -2439,6 +2439,7 @@ pub fn run_claude_session_interactive(
         None, // worktree — promoted later via ClaudeSession::promote_to_worktree
         tool_policy,
         None, // cli_session_ctx — non-chat spawn; CLI generates its own id
+        None, // agent_log_emitter — non-interactive path, no coord agent_logs
     )?;
 
     // Register with Doctor health monitoring

--- a/src-tauri/src/claude_session/session.rs
+++ b/src-tauri/src/claude_session/session.rs
@@ -142,6 +142,12 @@ pub struct ClaudeSession {
     /// sessions and sessions that resumed into the shared checkout.
     isolated_edit_ctx:
         Arc<Mutex<Option<crate::agent_worktree::isolated_edit::IsolatedEditContext>>>,
+    /// Interactive-agent log emitter (Phase 1b/1c). When `Some`, the stdout
+    /// reader streams each line to coord's `agent_logs` ingest and the waiter
+    /// thread emits the terminal `session_closed` line + final flush. `None`
+    /// when the `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is OFF (default) or
+    /// the coord session id / device id couldn't be resolved — a strict no-op.
+    agent_log_emitter: Option<super::coord_register::AgentLogEmitter>,
 }
 
 // SAFETY: ClaudeSession contains a raw Windows handle (RawHandle = *mut c_void) for the stdout
@@ -172,6 +178,7 @@ impl ClaudeSession {
         worktree: Option<WorktreeInfo>,
         tool_policy: Option<&crate::workflow::dag_schema::ToolPolicy>,
         cli_session_ctx: Option<&crate::claude_session::runner::CliSessionContext>,
+        agent_log_emitter: Option<super::coord_register::AgentLogEmitter>,
     ) -> Result<Self, String> {
         info!(
             "Spawning interactive Claude session: {} in {}",
@@ -569,6 +576,10 @@ impl ClaudeSession {
         } else {
             None
         };
+        // Interactive-agent log emitter (Phase 1b) — clone the handle into the
+        // stdout reader so each line streams to coord. `None` when the gate is
+        // OFF (the common case); the reader then never touches it.
+        let agent_log_emitter_for_stdout = agent_log_emitter.clone();
 
         let stdout_handle = thread::spawn(move || {
             let mut all_text = String::new();
@@ -602,6 +613,13 @@ impl ClaudeSession {
                                 .unwrap_or_default()
                                 .as_secs();
                             last_activity_stdout.store(now, Ordering::Relaxed);
+
+                            // Phase 1b — stream the raw stdout line to coord's
+                            // agent_logs (batched/throttled inside the emitter).
+                            // No-op unless the gate is ON and the emitter built.
+                            if let Some(emitter) = agent_log_emitter_for_stdout.as_ref() {
+                                emitter.stream_line(&line);
+                            }
 
                             if let Some(text) = dispatcher::dispatch_line(
                                 &line,
@@ -1018,6 +1036,9 @@ impl ClaudeSession {
         // waiter so reconcile fires when the subprocess actually exits
         // (NOT when `spawn()` returns, which is just after init).
         let federation_ctx_for_waiter = federation_ctx.clone();
+        // Interactive-agent log emitter (Phase 1b) — the waiter emits the
+        // terminal `session_closed` line + final flush when the CLI exits.
+        let agent_log_emitter_for_waiter = agent_log_emitter.clone();
 
         thread::spawn(move || {
             // Wait for the child process to exit
@@ -1108,6 +1129,13 @@ impl ClaudeSession {
                 "Session {} process exited, state -> Closed (rate_limited={})",
                 session_id_for_waiter, is_rate_limited
             );
+
+            // Phase 1b — terminal coord agent_logs milestone + final flush.
+            // No-op unless the emitter was built (gate ON). Done last so the
+            // `session_closed` row reflects the real process-exit moment.
+            if let Some(emitter) = agent_log_emitter_for_waiter.as_ref() {
+                emitter.close();
+            }
         });
 
         // Wait briefly for the init handshake to complete
@@ -1157,6 +1185,13 @@ impl ClaudeSession {
             .map(|c| c.session_name.clone())
             .unwrap_or_else(|| session_id.to_string());
 
+        // Phase 1b — `session_started` milestone (no-op unless gate ON). Emit
+        // once the init handshake has completed so the line reflects a live,
+        // ready session rather than one that may still fail to initialize.
+        if let Some(emitter) = agent_log_emitter.as_ref() {
+            emitter.started(&holder_name);
+        }
+
         Ok(Self {
             session_id: session_id.to_string(),
             holder_name,
@@ -1184,6 +1219,7 @@ impl ClaudeSession {
             worktree,
             federation_ctx,
             isolated_edit_ctx: Arc::new(Mutex::new(None)),
+            agent_log_emitter,
         })
     }
 
@@ -1699,6 +1735,10 @@ impl ClaudeSession {
             Some(info.clone()),
             None, // tool_policy — worktree promotion preserves the original spawn's policy state
             None, // cli_session_ctx — promotion changes cwd + does its own replay; no --resume
+            // Carry the agent_logs emitter (same coord agent_id) across the
+            // respawn so promotion is continuous on the dashboard. The handle is
+            // a cheap clone over the same drain thread; `None` stays a no-op.
+            self.agent_log_emitter.clone(),
         )
         .map_err(|e| format!("promote_to_worktree: respawn failed: {}", e))?;
 
@@ -1798,6 +1838,10 @@ impl ClaudeSession {
             None, // worktree (rate-limit restart preserves the original cwd)
             None, // tool_policy (rate-limit restart preserves the original policy-less spawn)
             None, // cli_session_ctx — in-process restart does its own replay; no --resume
+            // agent_log_emitter — this associated fn has no `self` handle to the
+            // emitter; a rate-limit restart is a fresh process and the prior
+            // waiter already emitted `session_closed`. No-op here.
+            None,
         ) {
             Ok(new_session) => {
                 let new_session = Arc::new(new_session);

--- a/src-tauri/src/commands/ai_session.rs
+++ b/src-tauri/src/commands/ai_session.rs
@@ -458,6 +458,24 @@ pub async fn create_ai_session(
         });
     }
 
+    // Session-automation Phase 0 (R1) — register the authenticated session into
+    // coord.sessions carrying its task_run_id, so it is visible + addressable +
+    // correctly stale to coord. Best-effort: a registration failure never
+    // blocks the live AI session.
+    //
+    // Done BEFORE spawn (it only needs the task_run_id) so the minted coord
+    // session id is available to seed the Phase-1b agent_logs emitter, which the
+    // stdout reader + waiter threads need at spawn time. The R6 idempotency
+    // guard means this is the single Started write; the later (post-spawn)
+    // success re-register is a no-op.
+    let coord_session_id = ai_coord_registrar.register_session(&task_run_id, &name, None);
+
+    // Phase 1b/1c — build the interactive-agent log emitter when the
+    // `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is ON and the coord session id
+    // resolved. `None` (the default) is a strict no-op threaded through spawn.
+    let agent_log_emitter =
+        coord_session_id.and_then(crate::claude_session::coord_register::AgentLogEmitter::start);
+
     // 2. Spawn and wait for session to be ready.
     // ClaudeSession::spawn blocks until the CLI completes its init handshake,
     // so the session is Ready when this returns. This prevents a race condition
@@ -499,6 +517,7 @@ pub async fn create_ai_session(
             None,              // worktree
             None,              // tool_policy
             Some(&cli_session_ctx),
+            agent_log_emitter, // Phase 1b/1c agent_logs emitter (None unless gated)
         ) {
             Ok(session) => {
                 let session = Arc::new(session);
@@ -541,12 +560,9 @@ pub async fn create_ai_session(
                 task_run_id, e
             );
         }
-
-        // Session-automation Phase 0 (R1) — register the authenticated session
-        // into coord.sessions carrying its task_run_id, so it is visible +
-        // addressable + correctly stale to coord. Best-effort: a registration
-        // failure never blocks the live AI session.
-        ai_coord_registrar.register_session(&task_run_id, &name, None);
+        // NOTE: coord.sessions registration already happened above (pre-spawn,
+        // so the minted session id could seed the agent_logs emitter); the R6
+        // idempotency guard makes a re-register here unnecessary.
     }
 
     // 4. Return result
@@ -1814,6 +1830,18 @@ pub async fn resume_ai_sessions(
         // register, so its Drop releases the claim when the session ends.
         let reacquired_ctx_for_spawn = reacquired_ctx;
 
+        // R2 — re-register the resumed session with coord BEFORE spawn (the R6
+        // idempotency guard makes the later post-spawn register a no-op), so
+        // the minted coord session id can seed the Phase-1b agent_logs emitter
+        // the spawn's stdout/waiter threads consume. `None` registrar → no id.
+        let coord_session_id = ai_coord_registrar
+            .as_ref()
+            .and_then(|reg| reg.register_session(&task_run_id, &task_name, None));
+        // Phase 1b/1c emitter — `None` (default) unless the
+        // `QONTINUI_AGENT_LOGS_FROM_SESSIONS` gate is ON and the id resolved.
+        let agent_log_emitter = coord_session_id
+            .and_then(crate::claude_session::coord_register::AgentLogEmitter::start);
+
         let spawn_result = tokio::task::spawn_blocking(move || -> Result<(), String> {
             let session_ctx = AiSessionContext::setup(&trid, &name_for_ctx);
 
@@ -1838,6 +1866,7 @@ pub async fn resume_ai_sessions(
                 None, // worktree
                 None, // tool_policy
                 Some(&cli_session_ctx),
+                agent_log_emitter, // Phase 1b/1c agent_logs emitter (None unless gated)
             )
             .map_err(|e| format!("spawn failed: {}", e))?;
 
@@ -1893,12 +1922,9 @@ pub async fn resume_ai_sessions(
                     task_run_id, e
                 );
             }
-
-            // R2 — re-register the resumed session with coord (idempotent;
-            // a fresh coord row is minted carrying the same task_run_id).
-            if let Some(reg) = ai_coord_registrar.as_ref() {
-                reg.register_session(&task_run_id, &task_name, None);
-            }
+            // NOTE: coord.sessions re-registration already happened above
+            // (pre-spawn, to seed the agent_logs emitter); R6 idempotency makes
+            // a re-register here unnecessary.
         }
 
         match spawn_result {

--- a/src-tauri/src/mcp/backend_relay.rs
+++ b/src-tauri/src/mcp/backend_relay.rs
@@ -1922,6 +1922,7 @@ async fn handle_chat_create(api_state: &Arc<ApiState>, data: &Value) -> Option<V
             None,
             None, // tool_policy
             None, // cli_session_ctx
+            None, // agent_log_emitter — relay path, no coord agent_logs
         ) {
             Ok(session) => {
                 let session = Arc::new(session);

--- a/src-tauri/src/mcp/sessions.rs
+++ b/src-tauri/src/mcp/sessions.rs
@@ -167,6 +167,7 @@ async fn spawn_session(
             None,
             None, // tool_policy
             None, // cli_session_ctx
+            None, // agent_log_emitter — mcp session path, no coord agent_logs
         ) {
             Ok(s) => Arc::new(s),
             Err(e) => return Err(format!("spawn failed: {}", e)),

--- a/src-tauri/src/mcp/task_runs.rs
+++ b/src-tauri/src/mcp/task_runs.rs
@@ -2313,6 +2313,7 @@ pub async fn create_ai_session(
         None, // worktree
         None, // tool_policy
         None, // cli_session_ctx
+        None, // agent_log_emitter — mcp task-run path, no coord agent_logs
     ) {
         Ok(session) => {
             let session = Arc::new(session);

--- a/src-tauri/src/orchestration_loop/ai_session_executor.rs
+++ b/src-tauri/src/orchestration_loop/ai_session_executor.rs
@@ -290,6 +290,7 @@ pub async fn dispatch_subtask(
             None, // worktree (cwd already points at the worktree path)
             None, // tool_policy
             Some(&cli_session_ctx),
+            None, // agent_log_emitter — orchestration path, no coord agent_logs
         )?;
         let session = Arc::new(session);
 


### PR DESCRIPTION
## What
Interactive/runner-managed Claude sessions register into `coord.sessions` (Live Sessions panel) but produced **no** `coord.agent_logs` rows, so they were invisible on `/admin/coord/agents`. This adds a **gated, default-OFF** emitter that streams session activity to coord's existing `POST /agents/:agent_id/log` ingest.

## How
- **`AgentLogEmitter`** (`claude_session/coord_register.rs`): a dedicated blocking drain thread owns the queue + reqwest client; pushes are non-blocking channel sends. 5s flush tick, burst-coalescing so a flurry of stdout lines POSTs as **one** `Vec<LogEntry>` array (≤500, coord's `MAX_BATCH_SIZE`), requeue-on-failure (capped FIFO). Emits proper `LogEntry` rows (`level`+`event` non-empty — coord rejects empty), **not** `agent_runtime`'s `LogLine`.
- **Identity**: `agent_id` = `agent_session_id` = the coord session UUIDv7 (one identity shared with Live Sessions). `device_id` read once from `~/.qontinui/machine.json` so coord's device-id tenant fallback can scope the rows (companion coord PR #684). Emitter returns `None` (no thread, strict no-op) when the gate is OFF or either id is unresolved.
- **`session.rs`**: stdout reader streams each line; waiter emits the terminal `session_closed` + final flush; `session_started` after the init handshake. All `Option`-gated.
- **`commands/ai_session.rs`**: register `coord.sessions` **before** spawn (the stdout/waiter threads need the minted session id at spawn-start); the R6 idempotency guard makes the old post-spawn re-register redundant, so it's removed at both the create and resume sites.

## Gate
`QONTINUI_AGENT_LOGS_FROM_SESSIONS` — **default OFF**. Only `1`/`true`/`on`/`yes` enables it. When OFF, no thread spawns and every emit point is a no-op (zero new coord traffic).

## Tests / verify
4 unit tests (gate truthiness, off→None, `LogEntry` wire-shape, requeue order/cap). `cargo check` green.

Requires coord PR #684 (the device-id tenant fallback) to be live before the gate is flipped ON; both are independently safe to merge since this is default-OFF.

Plan: `2026-06-17-interactive-agent-logs-to-coord-dashboard`.