### PR TITLE
runner: manual-test-loop iter 6 — register AI-spawn actions on always-mounted terminal-page (state-independent NL spawn)

### DIFF
--- a/src/components/prompt-home/usePromptExecution.ts
+++ b/src/components/prompt-home/usePromptExecution.ts
@@ -190,14 +190,28 @@ export function usePromptExecution(): UsePromptExecutionReturn {
             // invoking; only surface the not-found error after the bounded
             // wait elapses. This is generic — it covers ANY component reached
             // immediately after a navigate, not just the terminal launcher.
-            await waitForComponentRegistered(bridge, step.componentId, i + 1);
-            const compResult = await bridge.executeComponentAction(step.componentId, {
+            await waitForComponentRegistered(bridge, step.componentId, i + 1, step.actionId);
+            // Iter-6 — resolve the effective target component. The planner
+            // names `terminal-launch-menu` for the AI-spawn flow, but that
+            // surface is only the terminal page's initial/empty-state menu;
+            // once a session has been created and closed it is no longer
+            // mounted. The same spawn actions are now ALSO registered on the
+            // always-mounted `terminal-page` component, so when the named
+            // component isn't registered we retarget to a sibling that exposes
+            // the requested action. `waitForComponentRegistered` already
+            // accepted whichever of the two appeared first.
+            const effectiveComponentId = resolveComponentForAction(
+              bridge,
+              step.componentId,
+              step.actionId,
+            );
+            const compResult = await bridge.executeComponentAction(effectiveComponentId, {
               action: step.actionId,
               params: step.params,
             });
             if (!compResult.success) {
               throw new Error(
-                `Step ${i + 1} failed: ${compResult.error ?? "component action failed"} — could not invoke ${step.componentId}/${step.actionId}`,
+                `Step ${i + 1} failed: ${compResult.error ?? "component action failed"} — could not invoke ${effectiveComponentId}/${step.actionId}`,
               );
             }
             // Give the spawn handler time to mount the new pane (a Claude Code
@@ -411,8 +425,58 @@ function summarizeCandidateLabels(elements: readonly DiscoveredLike[]): string {
 /** The object returned by `useUIBridge` — typed structurally so this helper
  * stays decoupled from the SDK's exported type name. We only read
  * `getComponent`, the synchronous registry lookup that returns the component
- * record (or undefined when it isn't currently registered). */
-type BridgeLike = Pick<ReturnType<typeof useUIBridge>, "getComponent">;
+ * record (or undefined when it isn't currently registered). The record's
+ * `actions` array is read to detect a sibling component that exposes the same
+ * action id (iter-6 fallback). */
+type BridgeLike = {
+  getComponent: (id: string) => { actions?: Array<{ id: string }> } | undefined;
+};
+
+/**
+ * Iter-6 — sibling-component fallback map for component-action steps.
+ *
+ * Some spawn affordances are registered on more than one component: the NL
+ * planner names the user-facing surface (`terminal-launch-menu`, the terminal
+ * page's initial/empty-state menu), but the SAME registry-backed actions are
+ * also hoisted onto the always-mounted `terminal-page` component so they stay
+ * reachable in EVERY terminal-page state (including after a session was created
+ * and then closed, when the launch menu is no longer mounted). When the named
+ * component isn't registered, we retarget to a sibling here that exposes the
+ * requested action.
+ *
+ * Keyed by the planner-named component id → ordered list of fallback component
+ * ids to try (most-specific first).
+ */
+const COMPONENT_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
+  "terminal-launch-menu": ["terminal-page"],
+};
+
+/**
+ * Resolve which registered component should receive `actionId`. Prefers the
+ * planner-named `componentId` when it's registered AND exposes the action;
+ * otherwise returns the first registered fallback sibling that exposes the
+ * action. Falls back to the original `componentId` when nothing better is
+ * found, so the caller's dispatch still surfaces the SDK's own not-found error.
+ */
+function resolveComponentForAction(
+  bridge: BridgeLike,
+  componentId: string,
+  actionId: string,
+): string {
+  const hasAction = (id: string): boolean => {
+    const comp = bridge.getComponent(id);
+    if (!comp) return false;
+    // A component with no declared actions array is treated as exposing the
+    // action (defensive — older registrations may omit it); dispatch then
+    // surfaces any real error.
+    return !comp.actions || comp.actions.some((a) => a.id === actionId);
+  };
+  if (hasAction(componentId)) return componentId;
+  for (const fallback of COMPONENT_FALLBACKS[componentId] ?? []) {
+    if (hasAction(fallback)) return fallback;
+  }
+  return componentId;
+}
 
 /**
  * D-RACE1 — bounded wait for a `useUIComponent` registration to appear in the
@@ -426,6 +490,11 @@ type BridgeLike = Pick<ReturnType<typeof useUIBridge>, "getComponent">;
  * a clear, actionable step error (the caller would otherwise hit the SDK's
  * opaque "Component not found" with no indication a race was the cause).
  *
+ * Iter-6 — the wait also succeeds as soon as a fallback sibling that exposes
+ * `actionId` is registered (e.g. `terminal-page` for a `terminal-launch-menu`
+ * spawn action), so the spawn affordance is considered reachable whenever the
+ * terminal page is active, independent of whether the launch menu is mounted.
+ *
  * Generic by design: any component reached immediately after a navigate
  * benefits, not just `terminal-launch-menu`.
  */
@@ -433,16 +502,29 @@ async function waitForComponentRegistered(
   bridge: BridgeLike,
   componentId: string,
   stepNumber: number,
+  actionId?: string,
   timeoutMs = 8000,
   pollMs = 100,
 ): Promise<void> {
+  const reachable = (): boolean => {
+    if (bridge.getComponent(componentId)) return true;
+    // Fallback siblings only count when they actually expose the action.
+    if (!actionId) return false;
+    for (const fallback of COMPONENT_FALLBACKS[componentId] ?? []) {
+      const comp = bridge.getComponent(fallback);
+      if (comp && (!comp.actions || comp.actions.some((a) => a.id === actionId))) {
+        return true;
+      }
+    }
+    return false;
+  };
   const deadline = Date.now() + timeoutMs;
-  // Fast path — already registered (e.g. the page was already active from an
+  // Fast path — already reachable (e.g. the page was already active from an
   // earlier navigation), skip the poll entirely.
-  if (bridge.getComponent(componentId)) return;
+  if (reachable()) return;
   while (Date.now() < deadline) {
     await new Promise((r) => setTimeout(r, pollMs));
-    if (bridge.getComponent(componentId)) return;
+    if (reachable()) return;
   }
   throw new Error(
     `Step ${stepNumber} failed: component "${componentId}" never registered within ` +

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -32,6 +32,7 @@ import { ConductorStatusStrip } from "./ConductorStatusStrip";
 import { UnzonedChip } from "./UnzonedChip";
 import { pickLayout } from "./useZoneLayout";
 import { buildCreatePlainTerminalAction } from "./createPlainTerminalAction";
+import { buildRegistrySpawnActions } from "./registrySpawnActions";
 import { ResultCardProvider, ResultCardMount, useResultCard } from "./result-card";
 
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
@@ -139,6 +140,18 @@ function TerminalPageInner({
       // read to invocation time (it's declared below, same as the
       // `terminal-launch-menu` handlers that close over later consts).
       buildCreatePlainTerminalAction((title) => createAndAssignTerminal(title)),
+      // Iter-6 root-cause fix — hoist the registry-backed spawn actions
+      // (`create-plain` / `create-best-account` / `create-with-command`) onto
+      // the ALWAYS-mounted `terminal-page` component. They previously lived
+      // only on `terminal-launch-menu`, which headless automation could not
+      // reach once a session had been created and then closed (the page
+      // renders a non-launch-menu view in that state). `terminal-page`
+      // registers in EVERY page state — including the `!initialized`
+      // early-return path — so the AI-spawn affordance the NL planner relies on
+      // (`create-best-account`) is now reachable regardless of prior page
+      // state, without any menu needing to be open. Same source of truth as
+      // the `terminal-launch-menu` registration below (shared factory).
+      ...buildRegistrySpawnActions(callRegistry),
       {
         id: "list-terminals",
         label: "List Terminals",
@@ -242,24 +255,12 @@ function TerminalPageInner({
       "Creates plain terminals and AI sessions. Use create-plain, create-ai-session, " +
       "create-best-account, or create-with-command to launch terminals programmatically.",
     actions: [
-      {
-        id: "create-plain",
-        label: "Create Plain Terminal",
-        description: "Spawn N blank terminals using the user's default shell.",
-        paramSchema: { count: "number (>= 1, defaults to 1)" },
-        handler: async (params?: unknown) => {
-          const { count = 1 } = (params ?? {}) as { count?: number };
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-plain requires { count: number } where count >= 1");
-          }
-          const tabIds = await callRegistry<string[]>("terminal.spawn", { count });
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: [] as Array<string | null>,
-          };
-        },
-      },
+      // `create-plain`, `create-best-account`, `create-with-command` — the
+      // registry-backed spawn actions, sourced from the shared factory so this
+      // surface and the always-mounted `terminal-page` surface stay in lockstep.
+      // `create-ai-session` below is NOT in the factory: it closes over the
+      // page-local `handleLaunchAiSession` and so stays inline here.
+      ...buildRegistrySpawnActions(callRegistry),
       {
         id: "create-ai-session",
         label: "Create AI Session",
@@ -297,79 +298,6 @@ function TerminalPageInner({
             success: true,
             tab_ids: tabIds,
             task_run_ids: tabIds.map(() => null) as Array<string | null>,
-          };
-        },
-      },
-      {
-        id: "create-best-account",
-        label: "Create AI Session with Best Account",
-        description:
-          "Like create-ai-session, but picks the AI account with the lowest current utilization. Fails if no accounts are configured.",
-        paramSchema: {
-          count: "number (>= 1, defaults to 1)",
-          context: "string (optional initial prompt auto-typed after claude starts)",
-        },
-        handler: async (params?: unknown) => {
-          const { count = 1, context } = (params ?? {}) as {
-            count?: number;
-            context?: string;
-          };
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-best-account: count must be a positive number");
-          }
-          // Delegate to registry `terminal.spawn-ai` with the literal
-          // `account: "best"`. The registry handler does the lowest-
-          // utilization lookup; we rethrow `no-account` as the original
-          // "No AI accounts available" wording so existing automation
-          // regexes keep matching.
-          let tabIds: string[];
-          try {
-            tabIds = await callRegistry<string[]>("terminal.spawn-ai", {
-              count,
-              account: "best",
-              context,
-            });
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (msg.includes("no-account") || msg.toLowerCase().includes("no matching")) {
-              throw new Error("No AI accounts available", { cause: err });
-            }
-            throw err;
-          }
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: tabIds.map(() => null) as Array<string | null>,
-          };
-        },
-      },
-      {
-        id: "create-with-command",
-        label: "Create Terminal with Command",
-        description:
-          "Spawn N terminals and auto-type the given shell command into each after the prompt renders.",
-        paramSchema: {
-          count: "number (>= 1, defaults to 1)",
-          command: "string (the shell command to type + Enter, required)",
-        },
-        handler: async (params?: unknown) => {
-          const { count = 1, command } = (params ?? {}) as {
-            count?: number;
-            command?: string;
-          };
-          if (!command)
-            throw new Error("create-with-command requires { count?: number, command: string }");
-          if (typeof count !== "number" || count < 1) {
-            throw new Error("create-with-command: count must be a positive number");
-          }
-          const tabIds = await callRegistry<string[]>("terminal.spawn-with", {
-            count,
-            command,
-          });
-          return {
-            success: true,
-            tab_ids: tabIds,
-            task_run_ids: [] as Array<string | null>,
           };
         },
       },

--- a/src/components/terminal/registrySpawnActions.test.ts
+++ b/src/components/terminal/registrySpawnActions.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Registry-backed terminal spawn actions (shared by `terminal-launch-menu`
+ * and the always-mounted `terminal-page` surface).
+ *
+ * Runner vitest config is `environment: "node"` (no jsdom / no React tree), so
+ * we exercise the load-bearing wiring via the exported pure factory — same
+ * precedent as `createPlainTerminalAction.test.ts`.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { buildRegistrySpawnActions } from "./registrySpawnActions";
+
+describe("buildRegistrySpawnActions", () => {
+  it("exposes the spawn action ids the NL planner relies on", () => {
+    const actions = buildRegistrySpawnActions(async () => []);
+    const ids = actions.map((a) => a.id);
+    expect(ids).toEqual(["create-plain", "create-best-account", "create-with-command"]);
+  });
+
+  it("create-best-account delegates to terminal.spawn-ai with account:'best'", async () => {
+    const callRegistry = vi.fn(async () => ["tab-1", "tab-2"]);
+    const best = buildRegistrySpawnActions(callRegistry as never).find(
+      (a) => a.id === "create-best-account",
+    )!;
+
+    const result = await best.handler({ count: 2, context: "open a session" });
+
+    expect(callRegistry).toHaveBeenCalledWith("terminal.spawn-ai", {
+      count: 2,
+      account: "best",
+      context: "open a session",
+    });
+    expect(result).toEqual({
+      success: true,
+      tab_ids: ["tab-1", "tab-2"],
+      task_run_ids: [null, null],
+    });
+  });
+
+  it("create-best-account defaults count to 1 and works with no params (headless spawn)", async () => {
+    const callRegistry = vi.fn(async () => ["tab-1"]);
+    const best = buildRegistrySpawnActions(callRegistry as never).find(
+      (a) => a.id === "create-best-account",
+    )!;
+
+    await best.handler();
+
+    expect(callRegistry).toHaveBeenCalledWith("terminal.spawn-ai", {
+      count: 1,
+      account: "best",
+      context: undefined,
+    });
+  });
+
+  it("create-best-account rewrites a no-account registry error to the canonical message", async () => {
+    const callRegistry = vi.fn(async () => {
+      throw new Error("no-account: nothing configured");
+    });
+    const best = buildRegistrySpawnActions(callRegistry as never).find(
+      (a) => a.id === "create-best-account",
+    )!;
+
+    await expect(best.handler({ count: 1 })).rejects.toThrow("No AI accounts available");
+  });
+
+  it("create-best-account rejects a non-positive count", async () => {
+    const best = buildRegistrySpawnActions(async () => []).find(
+      (a) => a.id === "create-best-account",
+    )!;
+    await expect(best.handler({ count: 0 })).rejects.toThrow(/positive number/);
+  });
+
+  it("create-plain delegates to terminal.spawn", async () => {
+    const callRegistry = vi.fn(async () => ["tab-9"]);
+    const plain = buildRegistrySpawnActions(callRegistry as never).find(
+      (a) => a.id === "create-plain",
+    )!;
+    const result = await plain.handler({ count: 1 });
+    expect(callRegistry).toHaveBeenCalledWith("terminal.spawn", { count: 1 });
+    expect(result).toEqual({ success: true, tab_ids: ["tab-9"], task_run_ids: [] });
+  });
+
+  it("create-with-command requires a command", async () => {
+    const withCmd = buildRegistrySpawnActions(async () => []).find(
+      (a) => a.id === "create-with-command",
+    )!;
+    await expect(withCmd.handler({ count: 1 })).rejects.toThrow(/requires/);
+  });
+});

--- a/src/components/terminal/registrySpawnActions.ts
+++ b/src/components/terminal/registrySpawnActions.ts
@@ -1,0 +1,159 @@
+/**
+ * Registry-backed terminal spawn actions — the AI-spawn affordances that the
+ * NL planner relies on ("open an ai session in the terminal page" →
+ * `create-best-account`).
+ *
+ * Why this factory exists (root-cause fix): these spawn actions historically
+ * lived ONLY on the `terminal-launch-menu` UI Bridge component. That component
+ * is mounted with `TerminalPage`, but the launch-menu surface is only the
+ * *initial / empty-state* affordance — once a session has been created and
+ * then closed the terminal page renders a different view, and headless
+ * automation reproduced `component "terminal-launch-menu" never registered`
+ * because the spawn affordance was not reachable in that state. The fix is to
+ * make these registry-only spawn actions reachable WHENEVER the terminal page
+ * is active by ALSO registering them on the always-mounted `terminal-page`
+ * component (which registers even on the page's `!initialized` early-return
+ * path). Extracting them here keeps the two registration sites in lockstep —
+ * one source of truth for the action ids, descriptions, param schemas, and
+ * handlers.
+ *
+ * Every handler here is a pure delegation to `callRegistry(...)` — it does NOT
+ * close over any React state or any "menu open" UI state, so it works
+ * identically whether or not the launch menu is visually open and regardless
+ * of prior page state. (The `create-ai-session` action is intentionally NOT
+ * here: it closes over the page-local `handleLaunchAiSession` closure and so
+ * cannot be hoisted to a pure factory. It remains registered on
+ * `terminal-launch-menu` only — the planner's spawn flow uses
+ * `create-best-account`, which IS here.)
+ *
+ * Extracted as a pure factory (no React, no Tauri at module scope) so the
+ * action wiring is unit-testable under the runner's `environment: "node"`
+ * vitest config — same precedent as `createPlainTerminalAction`.
+ */
+
+/** Minimal shape of a UI Bridge component action (matches the SDK's ComponentActionDef). */
+export interface RegistrySpawnActionDef {
+  id: string;
+  label: string;
+  description: string;
+  paramSchema?: Record<string, unknown>;
+  handler: (params?: unknown) => Promise<unknown>;
+}
+
+/**
+ * The registry envelope every spawn action returns. `task_run_ids` is parallel
+ * to `tab_ids` (one entry per spawned tab); entries are `null` for spawn paths
+ * that don't yet thread a task-run id.
+ */
+export interface SpawnEnvelope {
+  success: true;
+  tab_ids: string[];
+  task_run_ids: Array<string | null>;
+}
+
+/** The `callRegistry` shape this factory needs (matches `commands/callRegistry`). */
+export type CallRegistry = <T>(action: string, args: Record<string, unknown>) => Promise<T>;
+
+/**
+ * Build the registry-backed spawn action defs shared by `terminal-launch-menu`
+ * and `terminal-page`.
+ *
+ * @param callRegistry the terminal command-registry dispatcher
+ *   (`commands/callRegistry`). Injected so this stays a pure, testable factory.
+ */
+export function buildRegistrySpawnActions(callRegistry: CallRegistry): RegistrySpawnActionDef[] {
+  return [
+    {
+      id: "create-plain",
+      label: "Create Plain Terminal",
+      description: "Spawn N blank terminals using the user's default shell.",
+      paramSchema: { count: "number (>= 1, defaults to 1)" },
+      handler: async (params?: unknown) => {
+        const { count = 1 } = (params ?? {}) as { count?: number };
+        if (typeof count !== "number" || count < 1) {
+          throw new Error("create-plain requires { count: number } where count >= 1");
+        }
+        const tabIds = await callRegistry<string[]>("terminal.spawn", { count });
+        return {
+          success: true,
+          tab_ids: tabIds,
+          task_run_ids: [] as Array<string | null>,
+        } satisfies SpawnEnvelope;
+      },
+    },
+    {
+      id: "create-best-account",
+      label: "Create AI Session with Best Account",
+      description:
+        "Like create-ai-session, but picks the AI account with the lowest current utilization. " +
+        "Fails if no accounts are configured. Spawns a `claude` session and mounts it in a " +
+        "terminal pane. Reachable whenever the terminal page is active — no menu need be open.",
+      paramSchema: {
+        count: "number (>= 1, defaults to 1)",
+        context: "string (optional initial prompt auto-typed after claude starts)",
+      },
+      handler: async (params?: unknown) => {
+        const { count = 1, context } = (params ?? {}) as {
+          count?: number;
+          context?: string;
+        };
+        if (typeof count !== "number" || count < 1) {
+          throw new Error("create-best-account: count must be a positive number");
+        }
+        // Delegate to registry `terminal.spawn-ai` with the literal
+        // `account: "best"`. The registry handler does the lowest-utilization
+        // lookup; we rethrow `no-account` as the original "No AI accounts
+        // available" wording so existing automation regexes keep matching.
+        let tabIds: string[];
+        try {
+          tabIds = await callRegistry<string[]>("terminal.spawn-ai", {
+            count,
+            account: "best",
+            context,
+          });
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          if (msg.includes("no-account") || msg.toLowerCase().includes("no matching")) {
+            throw new Error("No AI accounts available", { cause: err });
+          }
+          throw err;
+        }
+        return {
+          success: true,
+          tab_ids: tabIds,
+          task_run_ids: tabIds.map(() => null) as Array<string | null>,
+        } satisfies SpawnEnvelope;
+      },
+    },
+    {
+      id: "create-with-command",
+      label: "Create Terminal with Command",
+      description:
+        "Spawn N terminals and auto-type the given shell command into each after the prompt renders.",
+      paramSchema: {
+        count: "number (>= 1, defaults to 1)",
+        command: "string (the shell command to type + Enter, required)",
+      },
+      handler: async (params?: unknown) => {
+        const { count = 1, command } = (params ?? {}) as {
+          count?: number;
+          command?: string;
+        };
+        if (!command)
+          throw new Error("create-with-command requires { count?: number, command: string }");
+        if (typeof count !== "number" || count < 1) {
+          throw new Error("create-with-command: count must be a positive number");
+        }
+        const tabIds = await callRegistry<string[]>("terminal.spawn-with", {
+          count,
+          command,
+        });
+        return {
+          success: true,
+          tab_ids: tabIds,
+          task_run_ids: [] as Array<string | null>,
+        } satisfies SpawnEnvelope;
+      },
+    },
+  ];
+}


### PR DESCRIPTION
Manual-test-loop iteration 6 remediation.

## Root cause
The registry-backed AI/NL spawn actions (`create-best-account`, etc.) were registered only on the `terminal-launch-menu` component. That component unmounts after a terminal session is created and then closed, leaving the NL/AI-spawn affordance unreachable in that terminal-page state.

## Fix
- Register the spawn actions on the always-mounted `terminal-page` component so the affordance is reachable in every terminal-page state.
- Add an executor fallback that retargets `terminal-launch-menu → terminal-page` when the menu component isn't mounted.
- Adds `registrySpawnActions` unit tests covering registration and the retarget fallback.

## Validation
- `tsc --noEmit` clean.