### PR TITLE
fix(agent-runtime): provision coord-mcp for headless gate continuations

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -2166,6 +2166,12 @@ async fn run_continuation_headless(
     // config dir that `spawn_claude_child` reads). spawn_blocking: the selector
     // reads settings + cooldown state.
     let _ = tokio::task::spawn_blocking(crate::ai_provider::pick_best_account).await;
+    // Provision coord-mcp for the headless session so it receives coord's
+    // session-start `instructions` preamble and can call coord_declare_intent —
+    // parity with the terminal continuation path (which provisions the bound_port
+    // proxy shape). Headless has no bound port → `None` selects the device-JWT
+    // static-bearer shape.
+    crate::coord_mcp::provision_coord_mcp_for_session(workdir, None);
     match spawn_claude_child(workdir, initial_prompt).await {
         Ok(mut child) => {
             let pid = child.id().map(|p| p as i64);


### PR DESCRIPTION
## What

Headless gate continuations (`run_continuation_headless`, `agent_runtime.rs:2159`) spawned the `claude` child **without provisioning coord-mcp**, while the terminal path (`run_continuation_terminal`, :1994) and general agent spawns (`run_agent_subprocess`, :2256) both do. So a headless continuation whose cwd is a fresh `.agent-worktrees/<id>/<repo>` worktree got no `.mcp.json` → no coord tools, and (with coord PR #695) would miss the new session-start `instructions` preamble.

Fix: call `provision_coord_mcp_for_session(workdir, None)` in the headless path before spawning. `None` (no bound port) selects the device-JWT static-bearer `.mcp.json` shape. This restores parity with the terminal path and with the coverage the unmerged c3910052 prompt-prepend had — without prepending anything to the prompt.

## Context

Part of plan `2026-06-18-coord-mcp-instructions-session-preamble`: the inter-session coordination preamble is moving into coord's MCP `initialize` `instructions` field (coord PR #695), which reaches every coord-mcp-configured session. This PR ensures the headless spawn path is one of them. The c3910052 prompt-prepend is intentionally NOT merged.

`cargo check --bin qontinui-runner` clean.