### PR TITLE
feat: emit agent_logs from transcript watcher for PTY CLI sessions (gated, Phase 2)

### DIFF
--- a/src-tauri/src/claude_session/coord_register.rs
+++ b/src-tauri/src/claude_session/coord_register.rs
@@ -508,6 +508,20 @@ impl AgentLogEmitter {
         }
     }
 
+    /// Emit an arbitrary `LogEntry` with the given `level` / `event` /
+    /// `payload`, stamped with this emitter's identity. Used by callers that
+    /// produce non-`stdout` events (e.g. the transcript watcher's `assistant` /
+    /// `tool_use` lines). Empty `event` is dropped — coord 400s an empty event,
+    /// so swallowing it here keeps the batch valid.
+    pub fn emit(&self, level: &str, event: &str, payload: Option<serde_json::Value>) {
+        if event.trim().is_empty() {
+            return;
+        }
+        let _ = self
+            .tx
+            .send(EmitMsg::Entry(self.entry(level, event, payload)));
+    }
+
     /// `session_started` milestone — one line at session start.
     pub fn started(&self, purpose: &str) {
         let _ = self.tx.send(EmitMsg::Entry(self.entry(

--- a/src-tauri/src/terminal/transcript.rs
+++ b/src-tauri/src/terminal/transcript.rs
@@ -703,6 +703,115 @@ pub fn parse_line_for_touched_files(
     ))
 }
 
+// ── Agent-log Extraction (Phase 2 — transcript → coord.agent_logs) ───────────
+//
+// These helpers walk an `{type:"assistant"}` JSONL record and emit the
+// meaningful conversational content — assistant text + tool_use invocations —
+// as `AgentLogObs` rows. The transcript watcher converts each into a
+// `coord.agent_logs` entry so PTY-launched CLI Claude sessions become visible
+// on the `/admin/coord/agents` dashboard (the runner-managed-session path is
+// covered separately by the `AgentLogEmitter` Phase-1 milestones). Pure (no
+// I/O); shares the same `serde_json::Value` walking style as
+// `extract_touched_files_from_assistant_record`.
+
+/// Cap on emitted payload text (assistant text and serialized tool input). Keeps
+/// per-line coord traffic bounded for verbose assistant turns / large tool
+/// inputs; the watcher streams a continuous tail, not a one-shot snapshot.
+const AGENT_LOG_TEXT_CAP: usize = 8 * 1024;
+
+/// One meaningful observation extracted from an assistant transcript record,
+/// ready to become a `coord.agent_logs` entry. The watcher maps each to an
+/// `AgentLogEmitter::emit(level, event, payload)` call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentLogObs {
+    /// An assistant text block. `event:"assistant"`, `payload:{text}`.
+    Assistant { text: String },
+    /// A tool invocation. `event:"tool_use"`, `payload:{tool, input?}`.
+    ToolUse {
+        tool: String,
+        /// Compact-serialized, truncated tool input (omitted when absent).
+        input: Option<String>,
+    },
+}
+
+/// Truncate `s` to at most `AGENT_LOG_TEXT_CAP` bytes on a char boundary,
+/// appending an ellipsis marker when it was cut. Bounds per-line volume.
+fn truncate_for_log(s: &str) -> String {
+    if s.len() <= AGENT_LOG_TEXT_CAP {
+        return s.to_string();
+    }
+    let mut end = AGENT_LOG_TEXT_CAP;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…[truncated]", &s[..end])
+}
+
+/// Walk `content[]` of an `{type:"assistant"}` record and emit an `AgentLogObs`
+/// for each text block (assistant turn) and each `tool_use` block (tool
+/// invocation), in document order. Skips `thinking`, `tool_result`, and other
+/// noise. Non-assistant records and missing/blank text yield nothing.
+pub fn extract_agent_log_obs_from_assistant_record(record: &serde_json::Value) -> Vec<AgentLogObs> {
+    let Some(content) = record
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+    else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for block in content {
+        let block_type = block
+            .get("type")
+            .and_then(|t| t.as_str())
+            .unwrap_or_default();
+        match block_type {
+            "text" => {
+                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                    if !text.trim().is_empty() {
+                        out.push(AgentLogObs::Assistant {
+                            text: truncate_for_log(text),
+                        });
+                    }
+                }
+            }
+            "tool_use" => {
+                let Some(tool) = block.get("name").and_then(|n| n.as_str()) else {
+                    continue;
+                };
+                let input = block
+                    .get("input")
+                    .filter(|i| !i.is_null())
+                    .map(|i| truncate_for_log(&serde_json::to_string(i).unwrap_or_default()));
+                out.push(AgentLogObs::ToolUse {
+                    tool: tool.to_string(),
+                    input,
+                });
+            }
+            _ => {} // thinking / tool_result / etc. — skip.
+        }
+    }
+    out
+}
+
+/// Convenience wrapper: parse one JSONL line, dispatch by `type`, and return
+/// agent-log observations (empty for non-assistant or malformed records — the
+/// watcher tolerates noise and never fails on a single bad line).
+pub fn parse_line_for_agent_log(line: &str) -> Vec<AgentLogObs> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    let Ok(record) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+        return Vec::new();
+    };
+    if record.get("type").and_then(|t| t.as_str()) != Some("assistant") {
+        return Vec::new();
+    }
+    extract_agent_log_obs_from_assistant_record(&record)
+}
+
 /// Test-only re-export of `is_workflow_session` so the `transcript_watcher`
 /// module can apply the same first-5-lines filter without duplicating the
 /// logic. The function itself stays private to this module.
@@ -1778,6 +1887,66 @@ mod tests {
         assert_eq!(touched[0].tool, ToolKind::Write);
         assert_eq!(touched[0].file_path, "/new/file.rs");
         assert_eq!(touched[0].session_id, "sess-I");
+    }
+
+    // ── Agent-log extraction (Phase 2) ───────────────────────────────────────
+
+    #[test]
+    fn test_parse_line_for_agent_log_assistant_and_tool_use_in_order() {
+        // An assistant record carrying a text block followed by a tool_use
+        // block yields both observations in document order.
+        let line = r#"{"type":"assistant","uuid":"a-1","timestamp":"2026-05-09T01:02:03Z","message":{"role":"assistant","content":[{"type":"text","text":"Reading the file now."},{"type":"tool_use","id":"t","name":"Read","input":{"file_path":"/a/b.rs"}}]}}"#;
+        let obs = parse_line_for_agent_log(line);
+        assert_eq!(
+            obs,
+            vec![
+                AgentLogObs::Assistant {
+                    text: "Reading the file now.".to_string()
+                },
+                AgentLogObs::ToolUse {
+                    tool: "Read".to_string(),
+                    input: Some(r#"{"file_path":"/a/b.rs"}"#.to_string()),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_line_for_agent_log_skips_user_lines() {
+        // A `user` record (and other non-assistant noise) produces no
+        // observations — the watcher only streams assistant activity.
+        let user = r#"{"type":"user","uuid":"u1","timestamp":"2026-05-09T00:00:01Z","message":{"role":"user","content":"hi"}}"#;
+        assert!(parse_line_for_agent_log(user).is_empty());
+
+        // Empty / malformed lines are tolerated (no panic, no output).
+        assert!(parse_line_for_agent_log("").is_empty());
+        assert!(parse_line_for_agent_log("   ").is_empty());
+        assert!(parse_line_for_agent_log("{not json").is_empty());
+    }
+
+    #[test]
+    fn test_parse_line_for_agent_log_skips_thinking_and_empty_text() {
+        // `thinking` blocks and blank text blocks are skipped; a tool_use with
+        // no input emits a ToolUse with `input: None`.
+        let line = r#"{"type":"assistant","uuid":"a-2","timestamp":"2026-05-09T01:02:03Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"   "},{"type":"tool_use","id":"t","name":"TodoWrite"}]}}"#;
+        let obs = parse_line_for_agent_log(line);
+        assert_eq!(
+            obs,
+            vec![AgentLogObs::ToolUse {
+                tool: "TodoWrite".to_string(),
+                input: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn test_truncate_for_log_caps_oversized_text() {
+        let big = "x".repeat(AGENT_LOG_TEXT_CAP + 100);
+        let out = truncate_for_log(&big);
+        assert!(out.len() < big.len());
+        assert!(out.ends_with("…[truncated]"));
+        // Small text is passed through verbatim.
+        assert_eq!(truncate_for_log("small"), "small");
     }
 
     // ── get_latest_session_id `since` filter (Phase 1.5) ─────────────────────

--- a/src-tauri/src/terminal/transcript_watcher.rs
+++ b/src-tauri/src/terminal/transcript_watcher.rs
@@ -26,6 +26,7 @@
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use once_cell::sync::OnceCell;
+use serde_json::json;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -35,10 +36,10 @@ use tokio::sync::{mpsc, Mutex as TokioMutex, Notify};
 use tracing::{debug, info, warn};
 
 use super::transcript::{
-    find_claude_config_dirs, is_workflow_session_marker, list_sessions,
-    parse_line_for_touched_files,
+    find_claude_config_dirs, is_workflow_session_marker, list_sessions, parse_line_for_agent_log,
+    parse_line_for_touched_files, AgentLogObs,
 };
-use crate::claude_session::coord_register::AiCoordRegistrar;
+use crate::claude_session::coord_register::{AgentLogEmitter, AiCoordRegistrar};
 
 /// Ceiling for "recent enough to schedule a tail task on startup". Older
 /// JSONLs are skipped — they belong to closed sessions whose tabs the user
@@ -399,6 +400,28 @@ async fn tail_session(
     let mut workflow_check_buf = String::new();
     let mut did_workflow_recheck = false;
 
+    // ── Interactive-agent log emitter (Phase 2) ───────────────────────────────
+    //
+    // Stream this PTY CLI session's assistant text + tool_use activity to
+    // coord's `agent_logs` ingest so it appears on `/admin/coord/agents`. The
+    // emitter is keyed on the transcript's own session UUID (the `.jsonl`
+    // stem); coord's Phase-1a fallback resolves the tenant from the `device_id`
+    // the emitter stamps, so there is NO separate `coord.sessions` registration
+    // step here. `start()` is a strict no-op (returns `None`, spawns no thread)
+    // when the gate `QONTINUI_AGENT_LOGS_FROM_SESSIONS` is OFF, the `device_id`
+    // is unreadable, or `session_id` isn't a UUID — so the per-line emit below
+    // costs nothing in the common (gate-off) case. Held for the tail's
+    // lifetime; the drain thread flushes on channel disconnect at function exit
+    // (RAII) — we deliberately emit NO `session_closed` milestone since a tail
+    // teardown (cancel / rotation / workflow re-check) isn't a reliable
+    // CLI-session-end signal.
+    let agent_log_emitter = uuid::Uuid::parse_str(&session_id)
+        .ok()
+        .and_then(AgentLogEmitter::start);
+    if let Some(em) = agent_log_emitter.as_ref() {
+        em.started("interactive CLI session");
+    }
+
     debug!(
         "transcript_watcher: tail started for {} at offset {} ({})",
         session_id,
@@ -513,6 +536,29 @@ async fn tail_session(
                     tauri::async_runtime::spawn_blocking(move || {
                         super::commit_report::handle_push_observation(&obs, &reg);
                     });
+                }
+            }
+
+            // ── Interactive-agent log emit (Phase 2) ──────────────────────
+            //
+            // Stream assistant text + tool_use observations from this
+            // transcript line to coord. Pushing is a non-blocking channel
+            // send (safe from async); the gate/device-id check already
+            // happened in `start()`, so this is a strict no-op when off.
+            if let Some(em) = agent_log_emitter.as_ref() {
+                for obs in parse_line_for_agent_log(&line) {
+                    match obs {
+                        AgentLogObs::Assistant { text } => {
+                            em.emit("info", "assistant", Some(json!({ "text": text })));
+                        }
+                        AgentLogObs::ToolUse { tool, input } => {
+                            let mut payload = json!({ "tool": tool });
+                            if let Some(input) = input {
+                                payload["input"] = json!(input);
+                            }
+                            em.emit("info", "tool_use", Some(payload));
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## What
Phase 2 of the interactive-agent-logs work. Phase 1 (landed: runner `87092cb9`, coord `5db66cfcb`) streamed `coord.agent_logs` only for **runner-managed** interactive sessions. **Standalone / PTY CLI** Claude sessions (a `claude` CLI the user runs in a runner terminal) are tailed by `transcript_watcher.rs` but produced no `agent_logs` rows, so they stayed invisible on `/admin/coord/agents`. This extends the tail to emit their activity, reusing the Phase-1 emitter + the same gate.

## How
- **`transcript.rs`**: `AgentLogObs` enum (`Assistant{text}` / `ToolUse{tool,input?}`) + `parse_line_for_agent_log` / `extract_agent_log_obs_from_assistant_record` — reuses the canonical transcript reader's content-walking (`message.content[]` → `text` / `tool_use`, skips thinking/tool_result/user/system), tolerant (malformed/empty → empty vec, never fails). 8KB payload truncation (`AGENT_LOG_TEXT_CAP`, char-boundary safe).
- **`transcript_watcher.rs`** (`tail_session`): build an `AgentLogEmitter` once, keyed on the transcript's own **session UUID** (the `.jsonl` stem); emit `assistant` / `tool_use` per line inside the existing per-line loop (non-blocking channel send, safe from the async tail). **No separate `coord.sessions` registration** — coord's Phase-1a device-id tenant fallback (now live on coord main) resolves the tenant from the `device_id` the emitter stamps. RAII flush on tail exit; **no `session_closed`** milestone (a tail teardown — cancel/rotation/workflow re-check — isn't a reliable CLI-end signal).
- **`coord_register.rs`**: add `AgentLogEmitter::emit(level,event,payload)` for non-`stdout` events (Phase 1's `stream_line` untouched).

## Gate / safety
Same **default-OFF** `QONTINUI_AGENT_LOGS_FROM_SESSIONS` as Phase 1 — `AgentLogEmitter::start()` returns `None` (no thread, strict no-op) when the gate is OFF, the `device_id` is unreadable, or the `session_id` isn't a UUID. `is_workflow_session_marker` already tears the tail down for workflow sessions, so only interactive CLI sessions reach the emit path (exactly Phase 2's scope). Zero new always-on coord traffic.

## Boundary (out of scope, documented)
Standalone CLI on a machine with **no runner** can't be covered — no process to tail or hold a device token. Future option: a Claude Code hook POSTing to coord (separate auth workstream).

## Tests / verify
3 mapping unit tests (assistant+tool_use ordering, skipped user/malformed, skipped thinking/empty-text + input-less tool_use) + a truncation-cap test. `cargo check` green; `git diff --stat` = 3 files (no repo-wide reformat).

Plan: `2026-06-17-interactive-agent-logs-to-coord-dashboard` (Phase 2).