### PR TITLE
runner: manual-test-loop iter 7 — register page-terminal spawn affordance via reliable path (fix NL AI-session spawn)

### DIFF
--- a/src/components/app/TabContent.tsx
+++ b/src/components/app/TabContent.tsx
@@ -25,6 +25,8 @@ import type { useProjectSelection } from "@/hooks/useProjectSelection";
 import type { MainTabId, LogSubTab } from "./tab-types";
 import type { ErrorMonitorScope } from "./useAppNavigation";
 import { LogSourcesConfigTab } from "./LogSourcesConfigTab";
+import { buildRegistrySpawnActions } from "@/components/terminal/registrySpawnActions";
+import { callRegistry } from "@/components/terminal/commands";
 
 import { LogsTab } from "@/components/LogsTab";
 import { CaptureTab } from "@/components/CaptureTab";
@@ -154,17 +156,33 @@ const MemoryFederationPage = lazy(() =>
   })),
 );
 
-/** Register the active page with UI Bridge for AI discoverability */
+/** Register the active page with UI Bridge for AI discoverability.
+ *
+ * `actions` defaults to none. The terminal tab supplies the registry-backed
+ * spawn actions here (see `case "terminal"`) because — unlike most pages —
+ * the terminal page tree is rendered in an always-mounted, CSS-hidden block
+ * OUTSIDE this switch, and its in-tree `useUIComponent("terminal-page")`
+ * registration does NOT reliably land in the live registry (observed on the
+ * primary runner: `terminal-page` / `terminal-launch-menu` register 0
+ * components while this active-tab `page-<id>` registration path DOES land —
+ * e.g. `page-prompt-home`). Registering the spawn affordance on the
+ * active-tab `page-terminal` component routes it through the proven path, so
+ * the homepage NL planner's `create-best-account` flow is reachable whenever
+ * the terminal tab is active. Handlers delegate to the terminal command
+ * registry (`callRegistry`), which the always-mounted terminal tree populates
+ * via `useTerminalCommands`. */
 function PageRegistration({
   id,
   name,
   description,
+  actions,
 }: {
   id: string;
   name: string;
   description: string;
+  actions?: Parameters<typeof useUIComponent>[0]["actions"];
 }) {
-  useUIComponent({ id: `page-${id}`, name, description, actions: [] });
+  useUIComponent({ id: `page-${id}`, name, description, actions: actions ?? [] });
   return null;
 }
 
@@ -1076,7 +1094,25 @@ export function TabContent({
       );
 
     case "terminal":
-      return null;
+      // The terminal page tree itself is rendered in an always-mounted,
+      // CSS-hidden block in App.tsx (not through this switch), so this case
+      // renders no page UI. It DOES, however, register the `page-terminal`
+      // UI Bridge component carrying the registry-backed spawn actions
+      // (`create-plain` / `create-best-account` / `create-with-command`) on
+      // the active-tab registration path that is observed to reliably land in
+      // the live registry — unlike the in-tree `terminal-page` /
+      // `terminal-launch-menu` registrations, which do not. This is the
+      // headless-reachable AI-spawn affordance the homepage NL planner relies
+      // on. The handlers are pure delegations to `callRegistry`, populated by
+      // the always-mounted terminal tree's `useTerminalCommands`.
+      return (
+        <PageRegistration
+          id="terminal"
+          name="Terminal"
+          description="Multi-terminal workspace. Spawn plain shells or AI (claude) sessions: use create-best-account to open an AI session with the lowest-utilization account."
+          actions={buildRegistrySpawnActions(callRegistry)}
+        />
+      );
 
     case "automation-health":
       return (

--- a/src/components/prompt-home/resolveComponentForAction.test.ts
+++ b/src/components/prompt-home/resolveComponentForAction.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit coverage for the NL planner's component-action retarget fallback.
+ *
+ * The homepage NL planner names `terminal-launch-menu` for the AI-spawn flow,
+ * but that in-terminal-tree component (and `terminal-page`) are observed NOT to
+ * register in the live runner registry. The active-tab `page-terminal`
+ * component — registered via TabContent's `PageRegistration` path — DOES
+ * reliably register and exposes the same registry-backed spawn actions
+ * (`create-best-account`, etc.). `resolveComponentForAction` must retarget the
+ * planner-named component to `page-terminal` whenever the named component is
+ * absent but `page-terminal` is registered and exposes the requested action.
+ *
+ * Runner vitest config is `environment: "node"` — these helpers are pure
+ * (they read a structurally-typed `bridge.getComponent`), so no React tree is
+ * needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveComponentForAction, COMPONENT_FALLBACKS } from "./usePromptExecution";
+
+type Comp = { actions?: Array<{ id: string }> };
+
+/** Build a minimal bridge stub from an id → component map. */
+function bridgeWith(registry: Record<string, Comp>) {
+  return {
+    getComponent: (id: string): Comp | undefined => registry[id],
+  };
+}
+
+describe("resolveComponentForAction", () => {
+  it("retargets terminal-launch-menu → page-terminal when only page-terminal is registered", () => {
+    const bridge = bridgeWith({
+      "page-terminal": { actions: [{ id: "create-best-account" }, { id: "create-plain" }] },
+    });
+    expect(resolveComponentForAction(bridge, "terminal-launch-menu", "create-best-account")).toBe(
+      "page-terminal",
+    );
+  });
+
+  it("retargets terminal-page → page-terminal when terminal-page is absent", () => {
+    const bridge = bridgeWith({
+      "page-terminal": { actions: [{ id: "create-best-account" }] },
+    });
+    expect(resolveComponentForAction(bridge, "terminal-page", "create-best-account")).toBe(
+      "page-terminal",
+    );
+  });
+
+  it("prefers the planner-named component when it is registered and exposes the action", () => {
+    const bridge = bridgeWith({
+      "terminal-launch-menu": { actions: [{ id: "create-best-account" }] },
+      "page-terminal": { actions: [{ id: "create-best-account" }] },
+    });
+    expect(resolveComponentForAction(bridge, "terminal-launch-menu", "create-best-account")).toBe(
+      "terminal-launch-menu",
+    );
+  });
+
+  it("falls back through the chain to page-terminal when terminal-page lacks the action", () => {
+    const bridge = bridgeWith({
+      // terminal-page registered but WITHOUT the action; page-terminal has it.
+      "terminal-page": { actions: [{ id: "create-plain" }] },
+      "page-terminal": { actions: [{ id: "create-best-account" }] },
+    });
+    expect(resolveComponentForAction(bridge, "terminal-launch-menu", "create-best-account")).toBe(
+      "page-terminal",
+    );
+  });
+
+  it("returns the original component id when nothing better is registered", () => {
+    const bridge = bridgeWith({});
+    expect(resolveComponentForAction(bridge, "terminal-launch-menu", "create-best-account")).toBe(
+      "terminal-launch-menu",
+    );
+  });
+
+  it("lists page-terminal first in the terminal-launch-menu fallback chain (most reliable first)", () => {
+    expect(COMPONENT_FALLBACKS["terminal-launch-menu"][0]).toBe("page-terminal");
+    expect(COMPONENT_FALLBACKS["terminal-page"]).toContain("page-terminal");
+  });
+});

--- a/src/components/prompt-home/usePromptExecution.ts
+++ b/src/components/prompt-home/usePromptExecution.ts
@@ -447,8 +447,18 @@ type BridgeLike = {
  * Keyed by the planner-named component id → ordered list of fallback component
  * ids to try (most-specific first).
  */
-const COMPONENT_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
-  "terminal-launch-menu": ["terminal-page"],
+export const COMPONENT_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
+  // The planner names `terminal-launch-menu` for the AI-spawn flow. The same
+  // registry-backed spawn actions are exposed on the always-mounted
+  // `terminal-page` component AND on the active-tab `page-terminal` component.
+  // `page-terminal` is registered through the active-tab `PageRegistration`
+  // path (TabContent), which reliably lands in the live registry — unlike the
+  // in-terminal-tree `terminal-page` / `terminal-launch-menu` registrations,
+  // which were observed NOT to register at runtime. Order is most-reliable
+  // first so the retarget lands on `page-terminal` when present.
+  "terminal-launch-menu": ["page-terminal", "terminal-page"],
+  // Direct alias in case the planner names `terminal-page` itself.
+  "terminal-page": ["page-terminal"],
 };
 
 /**
@@ -458,7 +468,7 @@ const COMPONENT_FALLBACKS: Readonly<Record<string, readonly string[]>> = {
  * action. Falls back to the original `componentId` when nothing better is
  * found, so the caller's dispatch still surfaces the SDK's own not-found error.
  */
-function resolveComponentForAction(
+export function resolveComponentForAction(
   bridge: BridgeLike,
   componentId: string,
   actionId: string,


### PR DESCRIPTION
manual-test-loop iteration 7 remediation.

**Root cause:** the in-terminal-tree `useUIComponent` registrations (`terminal-page`, `terminal-launch-menu`) never land in the live runner registry, so the homepage NL spawn's component-action could never reach `create-best-account` — producing an 8s "never registered" timeout and no Claude session.

**Fix:**
- Register a `page-terminal` UI Bridge component carrying the registry spawn actions (incl. `create-best-account`) via the proven active-tab PageRegistration path (`case "terminal"` previously returned null).
- Extend executor fallbacks: `terminal-launch-menu` → `[page-terminal, terminal-page]`, `terminal-page` → `[page-terminal]`; export helpers for tests.
- New test `resolveComponentForAction.test.ts` (6 tests).