### PR TITLE
feat(runner): enrich spawn-outcome telemetry + self-heal root coord-mcp config (Phase 4b/5b)

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -168,10 +168,77 @@ pub struct GateContinuationPayload {
 /// The `source` discriminator coord stamps on a gate-continuation spawn frame.
 const GATE_CONTINUATION_SOURCE: &str = "gate_continuation";
 
+/// Typed spawn lifecycle phase coord keys an outcome to. The runner emits ONLY
+/// phases it can observe from its own subprocess bookkeeping — never
+/// `subagent_resolved`, which lives inside `claude` and the runner cannot see.
+///
+/// `launched` accompanies a `spawn-complete` (the child process started);
+/// `exited` accompanies a `spawn-failed` (the child failed to start, exited
+/// non-zero, or a dispatch was refused). Serialized snake_case so coord's
+/// ingest can match a string discriminator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum SpawnPhase {
+    Launched,
+    Exited,
+}
+
+/// PR/head context coord uses to key a spawn outcome to a specific change.
+/// `push_ref` is the agent worktree's push target (a git ref); `pr` is the PR
+/// number when it is derivable from that ref (e.g. `refs/pull/123/head`) and
+/// `None` otherwise — the runner never guesses a PR it cannot read off the ref.
+///
+/// Skipped entirely from the wire when both fields are absent so a spawn with
+/// no PR context (gate continuations) serializes the legacy body verbatim.
+#[derive(Debug, Clone, Default, Serialize)]
+struct SpawnPrContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    push_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr: Option<u64>,
+}
+
+impl SpawnPrContext {
+    /// True iff there is no PR context to emit — used to skip the whole
+    /// `push_ref`/`pr` block from the body when empty (legacy-shape parity).
+    fn is_empty(&self) -> bool {
+        self.push_ref.is_none() && self.pr.is_none()
+    }
+
+    /// Build a context from an optional push ref, deriving `pr` when the ref
+    /// carries a `refs/pull/<n>/...` segment (the only ref shape from which a
+    /// PR number is unambiguous). All other ref shapes leave `pr` absent.
+    fn from_push_ref(push_ref: Option<&str>) -> Self {
+        let pr = push_ref.and_then(pr_number_from_push_ref);
+        SpawnPrContext {
+            push_ref: push_ref.map(|s| s.to_string()),
+            pr,
+        }
+    }
+}
+
+/// Extract a PR number from a `refs/pull/<n>/head` (or `/merge`) push ref.
+/// Returns `None` for any ref that is not in the GitHub pull-ref shape — the
+/// runner only reports a PR it can read directly off the ref, never one it
+/// would have to infer.
+fn pr_number_from_push_ref(push_ref: &str) -> Option<u64> {
+    let rest = push_ref.strip_prefix("refs/pull/")?;
+    let (num, _) = rest.split_once('/')?;
+    num.parse::<u64>().ok()
+}
+
 #[derive(Debug, Clone, Serialize)]
 struct SpawnCompleteBody {
     pid: Option<i64>,
     note: Option<String>,
+    /// Phase 4b: typed lifecycle phase (`launched`). Skipped when the enriched
+    /// telemetry flag is off so the body is byte-identical to the legacy shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<SpawnPhase>,
+    /// Phase 4b: PR/head context. Flattened so `push_ref`/`pr` sit at the top
+    /// level alongside `phase`; skipped entirely when empty.
+    #[serde(flatten, skip_serializing_if = "SpawnPrContext::is_empty")]
+    pr_context: SpawnPrContext,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -179,6 +246,25 @@ struct SpawnFailedBody {
     reason: String,
     exit_code: Option<i64>,
     restarts_attempted: Option<u32>,
+    /// Phase 4b: typed lifecycle phase (`exited`). Skipped when the enriched
+    /// telemetry flag is off so the body is byte-identical to the legacy shape.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phase: Option<SpawnPhase>,
+    /// Phase 4b: PR/head context. Flattened so `push_ref`/`pr` sit at the top
+    /// level alongside `phase`; skipped entirely when empty.
+    #[serde(flatten, skip_serializing_if = "SpawnPrContext::is_empty")]
+    pr_context: SpawnPrContext,
+}
+
+/// Env flag (default ON) gating Phase 4b's enriched spawn-outcome telemetry.
+/// When unset or any value other than `"0"`, `report_spawn_complete` /
+/// `report_spawn_failed` stamp the typed `phase` + `push_ref`/`pr` context onto
+/// their existing POST bodies (additive — coord ingest tolerates the extra
+/// keys). Set `QONTINUI_SPAWN_OUTCOME_ENABLED=0` for a clean revert: the bodies
+/// then serialize byte-identical to the pre-4b shape (`phase`/`push_ref`/`pr`
+/// all skipped) so a coord that has not yet learned the new keys is unaffected.
+fn spawn_outcome_enrichment_enabled() -> bool {
+    std::env::var("QONTINUI_SPAWN_OUTCOME_ENABLED").as_deref() != Ok("0")
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1602,7 +1688,7 @@ async fn run_gate_continuation_inner(
             // re-delivered once a cap slot frees, OR cancelled by the operator /
             // takeover path. The `spawn-failed` agent post above is the operator
             // signal; the gate's continuation lifecycle is intentionally untouched.
-            report_spawn_failed(uuid::Uuid::now_v7(), &reason, None, 0).await;
+            report_spawn_failed(uuid::Uuid::now_v7(), &reason, None, 0, None).await;
             return Ok(());
         }
     }
@@ -1840,7 +1926,7 @@ async fn run_continuation_terminal(
             let reason = "no Tauri AppHandle (runner has no webview runtime) — \
                           cannot open a visible terminal";
             warn!("agent_runtime: gate-continuation terminal: {reason}");
-            report_spawn_failed(agent_id, reason, None, 0).await;
+            report_spawn_failed(agent_id, reason, None, 0, None).await;
             return Err(anyhow::anyhow!(reason));
         }
     };
@@ -1851,7 +1937,7 @@ async fn run_continuation_terminal(
         None => {
             let reason = "TerminalManager state not managed — cannot create terminal session";
             warn!("agent_runtime: gate-continuation terminal: {reason}");
-            report_spawn_failed(agent_id, reason, None, 0).await;
+            report_spawn_failed(agent_id, reason, None, 0, None).await;
             return Err(anyhow::anyhow!(reason));
         }
     };
@@ -1860,7 +1946,7 @@ async fn run_continuation_terminal(
         None => {
             let reason = "SessionRegistry state not managed — cannot register terminal session";
             warn!("agent_runtime: gate-continuation terminal: {reason}");
-            report_spawn_failed(agent_id, reason, None, 0).await;
+            report_spawn_failed(agent_id, reason, None, 0, None).await;
             return Err(anyhow::anyhow!(reason));
         }
     };
@@ -1936,7 +2022,7 @@ async fn run_continuation_terminal(
             "no authenticated Claude account on this runner — run /login (instance={instance})"
         );
         warn!("agent_runtime: gate-continuation terminal aborted — {reason}");
-        report_spawn_failed(agent_id, &reason, None, 0).await;
+        report_spawn_failed(agent_id, &reason, None, 0, None).await;
         return Err(anyhow::anyhow!(reason));
     }
 
@@ -2029,7 +2115,7 @@ async fn run_continuation_terminal(
             // window is not yanked to this tab — `terminal-created` is a global
             // broadcast, but a focus action must target only `main`.
             emit_terminal_focus_request(&app, &terminal_id);
-            report_spawn_complete(agent_id, None, Some("gate continuation (terminal)")).await;
+            report_spawn_complete(agent_id, None, Some("gate continuation (terminal)"), None).await;
             Ok(())
         }
         Err(e) => {
@@ -2038,6 +2124,7 @@ async fn run_continuation_terminal(
                 &format!("terminal session create failed: {e}"),
                 None,
                 0,
+                None,
             )
             .await;
             Err(anyhow::anyhow!(e))
@@ -2175,7 +2262,7 @@ async fn run_continuation_headless(
     match spawn_claude_child(workdir, initial_prompt).await {
         Ok(mut child) => {
             let pid = child.id().map(|p| p as i64);
-            report_spawn_complete(agent_id, pid, Some("gate continuation")).await;
+            report_spawn_complete(agent_id, pid, Some("gate continuation"), None).await;
             let exit = pump_subprocess(agent_id, &mut child, log_path.as_deref()).await;
             match exit {
                 Ok(0) => {
@@ -2191,18 +2278,20 @@ async fn run_continuation_headless(
                         &format!("non-zero exit code {code}"),
                         Some(code),
                         0,
+                        None,
                     )
                     .await;
                     Ok(())
                 }
                 Err(e) => {
-                    report_spawn_failed(agent_id, &format!("pump failure: {e}"), None, 0).await;
+                    report_spawn_failed(agent_id, &format!("pump failure: {e}"), None, 0, None)
+                        .await;
                     Err(e)
                 }
             }
         }
         Err(e) => {
-            report_spawn_failed(agent_id, &format!("spawn failure: {e}"), None, 0).await;
+            report_spawn_failed(agent_id, &format!("spawn failure: {e}"), None, 0, None).await;
             Err(e)
         }
     }
@@ -2236,6 +2325,12 @@ async fn run_agent_subprocess(
         }
     }
 
+    // Phase 4b: the primary worktree's push_ref is the PR/head this spawn works
+    // against — thread it into every lifecycle post so coord can key the spawn
+    // outcome to a specific PR. The path rewrite above does not touch push_ref,
+    // so read it once here and reuse for all of this spawn's reports.
+    let primary_push_ref = payload.worktrees.first().and_then(|wt| wt.push_ref.clone());
+
     // Step 1: materialize worktrees.
     if let Err(e) = materialize_worktrees(&payload).await {
         report_spawn_failed(
@@ -2243,6 +2338,7 @@ async fn run_agent_subprocess(
             &format!("worktree materialization failed: {e:#}"),
             None,
             0,
+            primary_push_ref.as_deref(),
         )
         .await;
         return Err(e);
@@ -2298,7 +2394,8 @@ async fn run_agent_subprocess(
                 let pid = child.id().map(|p| p as i64);
                 // First successful spawn = post spawn-complete with pid.
                 if restarts == 0 {
-                    report_spawn_complete(payload.agent_id, pid, None).await;
+                    report_spawn_complete(payload.agent_id, pid, None, primary_push_ref.as_deref())
+                        .await;
                 } else {
                     info!(
                         "agent_runtime: restart {restarts} succeeded agent_id={}",
@@ -2389,6 +2486,7 @@ async fn run_agent_subprocess(
             .unwrap_or("subprocess exited with no recorded reason"),
         final_exit_code,
         restarts,
+        primary_push_ref.as_deref(),
     )
     .await;
     Ok(())
@@ -2816,13 +2914,28 @@ async fn heartbeat_once(payload: &LaunchPayload) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn report_spawn_complete(agent_id: uuid::Uuid, pid: Option<i64>, note: Option<&str>) {
+async fn report_spawn_complete(
+    agent_id: uuid::Uuid,
+    pid: Option<i64>,
+    note: Option<&str>,
+    push_ref: Option<&str>,
+) {
     let Some(base) = coord_http_base() else {
         return;
+    };
+    let (phase, pr_context) = if spawn_outcome_enrichment_enabled() {
+        (
+            Some(SpawnPhase::Launched),
+            SpawnPrContext::from_push_ref(push_ref),
+        )
+    } else {
+        (None, SpawnPrContext::default())
     };
     let body = SpawnCompleteBody {
         pid,
         note: note.map(|s| s.to_string()),
+        phase,
+        pr_context,
     };
     let url = format!("{base}/agents/{agent_id}/spawn-complete");
     let client = match reqwest::Client::builder()
@@ -2851,14 +2964,25 @@ async fn report_spawn_failed(
     reason: &str,
     exit_code: Option<i64>,
     restarts_attempted: u32,
+    push_ref: Option<&str>,
 ) {
     let Some(base) = coord_http_base() else {
         return;
+    };
+    let (phase, pr_context) = if spawn_outcome_enrichment_enabled() {
+        (
+            Some(SpawnPhase::Exited),
+            SpawnPrContext::from_push_ref(push_ref),
+        )
+    } else {
+        (None, SpawnPrContext::default())
     };
     let body = SpawnFailedBody {
         reason: reason.to_string(),
         exit_code,
         restarts_attempted: Some(restarts_attempted),
+        phase,
+        pr_context,
     };
     let url = format!("{base}/agents/{agent_id}/spawn-failed");
     let client = match reqwest::Client::builder()
@@ -2893,6 +3017,100 @@ mod tests {
     /// Sentinel returned by the test mint closure so a mint outcome is
     /// unambiguous and deterministic (no uuid in tests).
     const MINTED: &str = "MINTED";
+
+    /// Phase 4b — a PR number is derived ONLY from a `refs/pull/<n>/...` ref;
+    /// every other ref shape (the common agent push ref) leaves `pr` absent so
+    /// the runner never reports a PR it would have to guess.
+    #[test]
+    fn pr_number_derived_only_from_pull_ref() {
+        assert_eq!(pr_number_from_push_ref("refs/pull/614/head"), Some(614));
+        assert_eq!(pr_number_from_push_ref("refs/pull/12/merge"), Some(12));
+        // Agent push refs and branch refs carry no PR number.
+        assert_eq!(pr_number_from_push_ref("refs/agent/abc-def"), None);
+        assert_eq!(pr_number_from_push_ref("refs/heads/main"), None);
+        // Malformed pull refs: no number segment / non-numeric.
+        assert_eq!(pr_number_from_push_ref("refs/pull/"), None);
+        assert_eq!(pr_number_from_push_ref("refs/pull/notanum/head"), None);
+    }
+
+    /// Phase 4b — the EXACT wire shape coord's ingest must match. The enriched
+    /// `spawn-complete` body carries `phase: "launched"` plus `push_ref` (and a
+    /// derived `pr` when the ref is a pull ref), additive to the legacy
+    /// `pid`/`note`. Coord keys the outcome off these keys.
+    #[test]
+    fn spawn_complete_body_enriched_shape() {
+        let body = SpawnCompleteBody {
+            pid: Some(4321),
+            note: None,
+            phase: Some(SpawnPhase::Launched),
+            pr_context: SpawnPrContext::from_push_ref(Some("refs/pull/614/head")),
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["pid"], 4321);
+        assert_eq!(v["phase"], "launched");
+        assert_eq!(v["push_ref"], "refs/pull/614/head");
+        assert_eq!(v["pr"], 614);
+    }
+
+    /// Phase 4b — the enriched `spawn-failed` body carries `phase: "exited"`
+    /// alongside the existing `reason`/`exit_code`/`restarts_attempted`, plus a
+    /// `push_ref` with NO `pr` key when the ref is not a pull ref.
+    #[test]
+    fn spawn_failed_body_enriched_shape() {
+        let body = SpawnFailedBody {
+            reason: "non-zero exit code 1".to_string(),
+            exit_code: Some(1),
+            restarts_attempted: Some(2),
+            phase: Some(SpawnPhase::Exited),
+            pr_context: SpawnPrContext::from_push_ref(Some("refs/agent/abc-def")),
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert_eq!(v["reason"], "non-zero exit code 1");
+        assert_eq!(v["exit_code"], 1);
+        assert_eq!(v["restarts_attempted"], 2);
+        assert_eq!(v["phase"], "exited");
+        assert_eq!(v["push_ref"], "refs/agent/abc-def");
+        // No PR derivable from an agent ref → `pr` is omitted entirely.
+        assert!(
+            v.get("pr").is_none(),
+            "pr must be absent for a non-pull ref"
+        );
+    }
+
+    /// Phase 4b — with the enrichment fields cleared (the revert / flag-off
+    /// shape), the body serializes byte-identical to the legacy pre-4b shape:
+    /// `phase`, `push_ref`, and `pr` are all skipped.
+    #[test]
+    fn spawn_body_legacy_shape_when_unenriched() {
+        let body = SpawnCompleteBody {
+            pid: Some(7),
+            note: Some("gate continuation".to_string()),
+            phase: None,
+            pr_context: SpawnPrContext::default(),
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(obj.len(), 2, "only the legacy pid+note keys: {v}");
+        assert!(obj.contains_key("pid"));
+        assert!(obj.contains_key("note"));
+
+        let failed = SpawnFailedBody {
+            reason: "x".to_string(),
+            exit_code: None,
+            restarts_attempted: Some(0),
+            phase: None,
+            pr_context: SpawnPrContext::default(),
+        };
+        let fv = serde_json::to_value(&failed).unwrap();
+        let fobj = fv.as_object().unwrap();
+        assert_eq!(
+            fobj.len(),
+            3,
+            "only the legacy reason+exit_code+restarts_attempted keys: {fv}"
+        );
+        assert!(!fobj.contains_key("phase"));
+        assert!(!fobj.contains_key("push_ref"));
+    }
 
     fn page(id: &str, n: usize) -> (String, usize) {
         (id.to_string(), n)

--- a/src-tauri/src/coord_mcp.rs
+++ b/src-tauri/src/coord_mcp.rs
@@ -628,6 +628,20 @@ fn read_proxy_port(workdir: &str) -> Option<u16> {
     port_str.parse::<u16>().ok()
 }
 
+/// Read the per-session proxy NONCE out of an existing coord-mcp `.mcp.json`, if
+/// the file holds the PROXY shape (an `X-Coord-Mcp-Proxy-Key` header). Returns
+/// `None` for an absent/unparseable file or a non-proxy shape. Used by the
+/// root-config self-heal: a nonce no longer in the live registry (evicted on a
+/// re-provision, or simply never restored) means the config would 401 the
+/// proxy, so it must be rewritten even when the port still matches.
+fn read_proxy_nonce(config_path: &Path) -> Option<String> {
+    let s = std::fs::read_to_string(config_path).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&s).ok()?;
+    v.pointer("/mcpServers/coord-mcp/headers/X-Coord-Mcp-Proxy-Key")
+        .and_then(|n| n.as_str())
+        .map(String::from)
+}
+
 /// Boot-time reconcile decision for one session's `.mcp.json` (Phase 3c). Pure
 /// over its inputs (no I/O) so the rewrite predicate is unit-testable:
 ///
@@ -653,13 +667,103 @@ pub(crate) fn reconcile_action(
     }
 }
 
-/// Boot-time session-config reconcile (Phase 3c). For each live session workdir,
-/// if its `.mcp.json` coord-mcp proxy port ≠ the instance's CURRENT bound port,
-/// rewrite it via [`write_coord_mcp_proxy_config`] (correct port + a freshly
-/// persisted nonce), guarded by [`coord_mcp_safe_to_write`] so it never clobbers
-/// an agent-spawn's static-bearer config. Combined with Phase 3b (persisted
-/// nonces), the common same-port restart needs no rewrite at all — this covers
-/// only the instance/port-change case. Returns the number of configs rewritten.
+/// Resolve the `qontinui-root` directory the checked-in repo-root `.mcp.json`
+/// lives in. Mirror of `agent_runtime::qontinui_root_dir`, inlined so this leaf
+/// module does NOT depend on `agent_runtime` (which depends back on us — the
+/// cycle this module was extracted to break). `QONTINUI_ROOT` env first, then
+/// the Windows `D:/qontinui-root` well-known path, then `~/qontinui-root`.
+fn qontinui_root_dir() -> Option<std::path::PathBuf> {
+    if let Ok(s) = std::env::var("QONTINUI_ROOT") {
+        let p = std::path::PathBuf::from(s);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let p = std::path::PathBuf::from("D:/qontinui-root");
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    dirs::home_dir()
+        .map(|h| h.join("qontinui-root"))
+        .filter(|p| p.is_dir())
+}
+
+/// True iff the root `.mcp.json` at `root_dir` holds a coord-mcp PROXY config
+/// that is STALE for the current `bound_port` — its proxy port differs OR its
+/// nonce is not in the live registry. Either case 401s/misroutes a spawned
+/// agent that inherits the root file, so it must be rewritten. Returns `false`
+/// (leave it) for an absent file, a non-proxy (static-bearer) shape, or a
+/// proxy config whose port matches AND whose nonce is currently registered.
+///
+/// Split out as a pure-over-its-inputs predicate so the self-heal decision is
+/// unit-testable without env or the process-global nonce map mutation order.
+fn root_config_is_stale(root_dir: &Path, bound_port: u16) -> bool {
+    let path = root_dir.join(".mcp.json");
+    let Some(port) = read_proxy_port(&root_dir.to_string_lossy()) else {
+        // Absent, unparseable, or a static-bearer (agent) shape — not ours to
+        // refresh here. (The session reconcile's `coord_mcp_safe_to_write`
+        // guard owns the agent-config-protection contract; we never touch one.)
+        return false;
+    };
+    if port != bound_port {
+        return true;
+    }
+    // Port matches: the only remaining staleness is an evicted/unrestored nonce
+    // the live proxy would 401.
+    match read_proxy_nonce(&path) {
+        Some(nonce) => !proxy_nonce_is_valid(&nonce),
+        None => true,
+    }
+}
+
+/// Boot-time self-heal of the CHECKED-IN repo-root `.mcp.json` (Phase 5b),
+/// resolving the root dir from the environment. Delegates to
+/// [`reconcile_root_config_at`] — split so the rewrite is unit-testable against
+/// an explicit temp dir WITHOUT mutating the process-global `QONTINUI_ROOT`
+/// (the module deliberately avoids global-env mutation; see the test helpers).
+fn reconcile_root_config(bound_port: u16) -> bool {
+    match qontinui_root_dir() {
+        Some(root_dir) => reconcile_root_config_at(&root_dir, bound_port),
+        None => false,
+    }
+}
+
+/// Self-heal the repo-root `.mcp.json` under `root_dir` (Phase 5b). The root
+/// config is the loopback PROXY shape (port + per-session nonce); a spawned
+/// agent that inherits it (cwd up the tree, no per-worktree config) breaks if
+/// the nonce was evicted or the port moved across a restart/instance change.
+/// When [`root_config_is_stale`] flags it, rewrite via the SAME
+/// [`write_coord_mcp_proxy_config`] helper the session path uses (fresh
+/// registered nonce + the current bound port) — guarded by
+/// [`coord_mcp_safe_to_write`] so a hand-rolled static-bearer root file is never
+/// clobbered. Returns `true` iff the root file was rewritten.
+fn reconcile_root_config_at(root_dir: &Path, bound_port: u16) -> bool {
+    if !root_config_is_stale(root_dir, bound_port) {
+        return false;
+    }
+    let root = root_dir.to_string_lossy().to_string();
+    if !coord_mcp_safe_to_write(&root) {
+        return false;
+    }
+    write_coord_mcp_proxy_config(&root, bound_port);
+    info!("coord_mcp: boot self-heal rewrote root {root}/.mcp.json to bound port :{bound_port}");
+    true
+}
+
+/// Boot-time session-config reconcile (Phase 3c) + root-config self-heal
+/// (Phase 5b). For each live session workdir, if its `.mcp.json` coord-mcp proxy
+/// port ≠ the instance's CURRENT bound port, rewrite it via
+/// [`write_coord_mcp_proxy_config`] (correct port + a freshly persisted nonce),
+/// guarded by [`coord_mcp_safe_to_write`] so it never clobbers an agent-spawn's
+/// static-bearer config. Combined with Phase 3b (persisted nonces), the common
+/// same-port restart needs no rewrite at all — this covers only the
+/// instance/port-change case. ALSO self-heals the checked-in repo-root
+/// `.mcp.json` (see [`reconcile_root_config`]) so a spawned agent inheriting the
+/// root file is never broken by an evicted nonce / stale port. Returns the
+/// number of configs rewritten (sessions + the root file).
 ///
 /// Wired into the same startup path as the other auto-start tasks (see
 /// `mcp_api::start_server`), AFTER [`restore_proxy_nonces_from_store`] so a
@@ -683,8 +787,12 @@ where
         rewritten += 1;
         info!("coord_mcp: reconciled {workdir}/.mcp.json to bound port :{bound_port}");
     }
+    // Belt-and-braces: self-heal the checked-in repo-root config too (Phase 5b).
+    if reconcile_root_config(bound_port) {
+        rewritten += 1;
+    }
     if rewritten > 0 {
-        info!("coord_mcp: boot reconcile rewrote {rewritten} session config(s) to the current bound port");
+        info!("coord_mcp: boot reconcile rewrote {rewritten} config(s) to the current bound port");
     }
     rewritten
 }
@@ -1213,6 +1321,13 @@ mod tests {
         use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
         let base = std::env::temp_dir().join(format!("coord-mcp-recon-{}", uuid::Uuid::now_v7()));
 
+        // Point the root-config self-heal (Phase 5b) at `base` — which holds no
+        // `.mcp.json` — so this test exercises ONLY the session path and never
+        // touches the operator's real `qontinui-root/.mcp.json`. Restored below.
+        std::fs::create_dir_all(&base).unwrap();
+        let prev_root = std::env::var("QONTINUI_ROOT").ok();
+        std::env::set_var("QONTINUI_ROOT", &base);
+
         // Stale proxy config on :9999 → must be rewritten to :9876.
         let stale = base.join("stale");
         std::fs::create_dir_all(&stale).unwrap();
@@ -1274,5 +1389,118 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&base);
+        match prev_root {
+            Some(p) => std::env::set_var("QONTINUI_ROOT", p),
+            None => std::env::remove_var("QONTINUI_ROOT"),
+        }
+    }
+
+    /// Phase 5b — the boot self-heal rewrites a stale ROOT `.mcp.json` (the
+    /// checked-in repo-root coord-mcp config) to the current bound port + a
+    /// freshly-registered nonce, so a spawned agent inheriting the root file is
+    /// never broken by an evicted nonce / stale port. Drives the env-free
+    /// `reconcile_root_config_at` so it neither mutates `QONTINUI_ROOT` nor
+    /// touches the operator's real root config. Covers all three staleness
+    /// dimensions: wrong port, dead nonce (right port), and the leave-alone
+    /// cases (matching port + live nonce, absent file, foreign static-bearer).
+    #[test]
+    fn reconcile_root_config_self_heals_stale_root_mcp_json() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+        // --- Case 1: stale PORT → rewrite. ---
+        let root = std::env::temp_dir().join(format!("coord-mcp-root-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join(".mcp.json"),
+            r#"{"mcpServers":{"coord-mcp":{"type":"http","url":"http://127.0.0.1:9999/coord-mcp","headers":{"X-Coord-Mcp-Proxy-Key":"deadnonce"}}}}"#,
+        )
+        .unwrap();
+        assert!(root_config_is_stale(&root, 9876), "wrong port is stale");
+        assert!(
+            reconcile_root_config_at(&root, 9876),
+            "a stale-port root config must be rewritten"
+        );
+        // Rewritten to the bound port with a freshly-registered nonce.
+        assert_eq!(read_proxy_port(&root.to_string_lossy()), Some(9876));
+        let new_nonce = read_proxy_nonce(&root.join(".mcp.json")).unwrap();
+        assert!(
+            proxy_nonce_is_valid(&new_nonce),
+            "the rewritten root config must carry a freshly-registered nonce"
+        );
+        assert_ne!(new_nonce, "deadnonce");
+        // And NO baked Authorization bearer (proxy shape).
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(root.join(".mcp.json")).unwrap())
+                .unwrap();
+        assert!(v["mcpServers"]["coord-mcp"]["headers"]
+            .get("Authorization")
+            .is_none());
+
+        // --- Case 2: matching port + LIVE nonce → leave (no rewrite). ---
+        // The case-1 rewrite left a live nonce on port 9876; a second pass is a
+        // no-op and must NOT mint a new nonce.
+        assert!(
+            !root_config_is_stale(&root, 9876),
+            "matching port + live nonce is not stale"
+        );
+        assert!(
+            !reconcile_root_config_at(&root, 9876),
+            "a fresh root config must not be rewritten again"
+        );
+        assert_eq!(
+            read_proxy_nonce(&root.join(".mcp.json")).unwrap(),
+            new_nonce
+        );
+
+        // --- Case 3: matching port but DEAD nonce → rewrite. ---
+        let dead = std::env::temp_dir().join(format!("coord-mcp-root-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&dead).unwrap();
+        std::fs::write(
+            dead.join(".mcp.json"),
+            r#"{"mcpServers":{"coord-mcp":{"type":"http","url":"http://127.0.0.1:9876/coord-mcp","headers":{"X-Coord-Mcp-Proxy-Key":"notregistered"}}}}"#,
+        )
+        .unwrap();
+        assert!(
+            root_config_is_stale(&dead, 9876),
+            "right port but an unregistered nonce is stale"
+        );
+        assert!(reconcile_root_config_at(&dead, 9876));
+        assert!(proxy_nonce_is_valid(
+            &read_proxy_nonce(&dead.join(".mcp.json")).unwrap()
+        ));
+
+        // --- Case 4: absent root file → leave. ---
+        let empty = std::env::temp_dir().join(format!("coord-mcp-root-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&empty).unwrap();
+        assert!(
+            !root_config_is_stale(&empty, 9876),
+            "absent file is not stale"
+        );
+        assert!(!reconcile_root_config_at(&empty, 9876));
+        assert!(!empty.join(".mcp.json").exists());
+
+        // --- Case 5: foreign STATIC-BEARER (agent) root → never clobbered. ---
+        let agent_payload = URL_SAFE_NO_PAD.encode(br#"{"sub_type":"agent"}"#);
+        let agent_jwt = format!("h.{agent_payload}.s");
+        let agent_cfg = format!(
+            r#"{{"mcpServers":{{"coord-mcp":{{"type":"http","url":"https://c/mcp","headers":{{"Authorization":"Bearer {agent_jwt}"}}}}}}}}"#
+        );
+        let agent = std::env::temp_dir().join(format!("coord-mcp-root-{}", uuid::Uuid::now_v7()));
+        std::fs::create_dir_all(&agent).unwrap();
+        std::fs::write(agent.join(".mcp.json"), &agent_cfg).unwrap();
+        // A static-bearer shape has no proxy URL → not flagged stale (and even if
+        // it were, `coord_mcp_safe_to_write` would refuse the rewrite).
+        assert!(!root_config_is_stale(&agent, 9876));
+        assert!(!reconcile_root_config_at(&agent, 9876));
+        assert_eq!(
+            std::fs::read_to_string(agent.join(".mcp.json")).unwrap(),
+            agent_cfg,
+            "a static-bearer root config must never be clobbered"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&dead);
+        let _ = std::fs::remove_dir_all(&empty);
+        let _ = std::fs::remove_dir_all(&agent);
     }
 }


### PR DESCRIPTION
Runner side of `plans/2026-06-18-merge-train-observability-and-agent-introspection.md`.

## Phase 4b — spawn-outcome telemetry enrichment
`report_spawn_complete`/`report_spawn_failed` now additively carry the spawn's PR context (`push_ref`, derived `pr`) + a typed `phase` (`"launched"`/`"exited"`) so coord can key a spawn outcome to a specific PR/head instead of joining heuristically. Enriched the EXISTING `/agents/:id/spawn-complete` + `/agents/:id/spawn-failed` bodies (no new endpoint — lowest risk; coord ingest tolerates the extra keys). Gated by `QONTINUI_SPAWN_OUTCOME_ENABLED` (default ON); with it off the bodies serialize byte-identical to the pre-4b shape. The runner only emits facts it observes — no `subagent_resolved` (opaque); `pr` is derived only from a `refs/pull/<n>/head|merge` ref.

## Phase 5b — coord-mcp config self-heal on boot
`reconcile_session_configs` now also rewrites a stale root `.mcp.json` (wrong port, or a nonce evicted from the live registry) on every runner boot, eliminating the failure class where a spawned agent inherits a broken root config. Worktree-provisioned config stays the primary path; a foreign/static-bearer root file is never clobbered.

## Verification
- `cargo fmt -- --check` clean; `cargo clippy -- -D warnings` (the CI gate) — clean, exit 0.
- New tests: `pr` derived only from pull refs, enriched/legacy body shapes (proves byte-identical legacy serialization when disabled), root-config self-heal (stale port→rewrite, live nonce→leave, dead nonce→rewrite, absent→leave, foreign→never clobbered). `cargo test coord_mcp` 12/12, `agent_runtime::tests` 64/64.

Pairs with qontinui-coord PR #701 (coord ingests these fields into `agent_logs.payload`). Order-independent (both additive-tolerant).