### PR TITLE
docs(specs): refresh stale sidebar-nav prose for the lean IA

### DIFF
--- a/specs/pages/activity-timeline/spec.uibridge.json
+++ b/specs/pages/activity-timeline/spec.uibridge.json
@@ -20,7 +20,7 @@
         }
       ],
       "category": "element-presence",
-      "description": "The Activity Timeline lives under the Observe sidebar group and is a runner-only page. Users navigate to it by clicking 'Activity Timeline' in the sidebar.",
+      "description": "The Activity Timeline is a runner-only page in the INSIGHTS sidebar group. As of the 2026-06 lean Terminal-first IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General), so it is not in the default sidebar; enable that toggle (or deep-link) to reach it.",
       "id": "timeline-navigation",
       "name": "Page Navigation",
       "source": "migrated"
@@ -499,7 +499,7 @@
     {
       "assertions": [],
       "category": "element-presence",
-      "description": "Frontend: ActivityTimelinePanel (React, components/activity-timeline/ActivityTimelinePanel.tsx) uses useState for query, results, stats, loading, searched, showFilters, appFilter, sourceFilter. Search invokes Tauri command 'search_activity_timeline' or 'search_activity_timeline_filtered' depending on filter state. Stats fetched via 'get_activity_timeline_stats'. Results rendered as bordered cards with color-coded source badges (blue=ui_bridge, green=accessibility, amber=ocr). The component is lazy-loaded in TabContent.tsx. Tab ID 'activity-timeline' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under OBSERVE_ITEMS with Activity icon and #06B6D4 cyan color. BackgroundObserver service (services/background-observer-service.ts) wraps BackgroundObserver class, calls getGlobalRegistry().captureSnapshot() for control snapshots, and invokes insert_activity_entry Tauri command to persist captures. Hash computation uses crypto.subtle SHA-256 with FNV-1a fallback for non-secure (HTTP) contexts.",
+      "description": "Frontend: ActivityTimelinePanel (React, components/activity-timeline/ActivityTimelinePanel.tsx) uses useState for query, results, stats, loading, searched, showFilters, appFilter, sourceFilter. Search invokes Tauri command 'search_activity_timeline' or 'search_activity_timeline_filtered' depending on filter state. Stats fetched via 'get_activity_timeline_stats'. Results rendered as bordered cards with color-coded source badges (blue=ui_bridge, green=accessibility, amber=ocr). The component is lazy-loaded in TabContent.tsx. Tab ID 'activity-timeline' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under INSIGHTS_ITEMS (hidden: true — revealed by the 'Show advanced automation features' toggle) with Activity icon and #06B6D4 cyan color. BackgroundObserver service (services/background-observer-service.ts) wraps BackgroundObserver class, calls getGlobalRegistry().captureSnapshot() for control snapshots, and invokes insert_activity_entry Tauri command to persist captures. Hash computation uses crypto.subtle SHA-256 with FNV-1a fallback for non-secure (HTTP) contexts.",
       "id": "timeline-implementation",
       "name": "Implementation Details",
       "source": "migrated"
@@ -518,7 +518,7 @@
   "stateMachine": {
     "states": [
       {
-        "description": "The Activity Timeline lives under the Observe sidebar group and is a runner-only page. Users navigate to it by clicking 'Activity Timeline' in the sidebar.",
+        "description": "The Activity Timeline is a runner-only page in the INSIGHTS sidebar group. As of the 2026-06 lean Terminal-first IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General), so it is not in the default sidebar; enable that toggle (or deep-link) to reach it.",
         "elements": [
           {}
         ],
@@ -632,7 +632,7 @@
         "transitions": []
       },
       {
-        "description": "Frontend: ActivityTimelinePanel (React, components/activity-timeline/ActivityTimelinePanel.tsx) uses useState for query, results, stats, loading, searched, showFilters, appFilter, sourceFilter. Search invokes Tauri command 'search_activity_timeline' or 'search_activity_timeline_filtered' depending on filter state. Stats fetched via 'get_activity_timeline_stats'. Results rendered as bordered cards with color-coded source badges (blue=ui_bridge, green=accessibility, amber=ocr). The component is lazy-loaded in TabContent.tsx. Tab ID 'activity-timeline' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under OBSERVE_ITEMS with Activity icon and #06B6D4 cyan color. BackgroundObserver service (services/background-observer-service.ts) wraps BackgroundObserver class, calls getGlobalRegistry().captureSnapshot() for control snapshots, and invokes insert_activity_entry Tauri command to persist captures. Hash computation uses crypto.subtle SHA-256 with FNV-1a fallback for non-secure (HTTP) contexts.",
+        "description": "Frontend: ActivityTimelinePanel (React, components/activity-timeline/ActivityTimelinePanel.tsx) uses useState for query, results, stats, loading, searched, showFilters, appFilter, sourceFilter. Search invokes Tauri command 'search_activity_timeline' or 'search_activity_timeline_filtered' depending on filter state. Stats fetched via 'get_activity_timeline_stats'. Results rendered as bordered cards with color-coded source badges (blue=ui_bridge, green=accessibility, amber=ocr). The component is lazy-loaded in TabContent.tsx. Tab ID 'activity-timeline' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under INSIGHTS_ITEMS (hidden: true — revealed by the 'Show advanced automation features' toggle) with Activity icon and #06B6D4 cyan color. BackgroundObserver service (services/background-observer-service.ts) wraps BackgroundObserver class, calls getGlobalRegistry().captureSnapshot() for control snapshots, and invokes insert_activity_entry Tauri command to persist captures. Hash computation uses crypto.subtle SHA-256 with FNV-1a fallback for non-secure (HTTP) contexts.",
         "elements": [],
         "id": "timeline-implementation",
         "isInitial": false,

--- a/specs/pages/activity-timeline/state-machine.derived.json
+++ b/specs/pages/activity-timeline/state-machine.derived.json
@@ -6,7 +6,7 @@
                    {
                        "id":  "timeline-navigation",
                        "name":  "Page Navigation",
-                       "description":  "The Activity Timeline lives under the Observe sidebar group and is a runner-only page. Users navigate to it by clicking \u0027Activity Timeline\u0027 in the sidebar.",
+                       "description":  "The Activity Timeline is a runner-only page in the INSIGHTS sidebar group, demoted behind the advanced-automation toggle in the lean default sidebar. Users navigate to it by clicking \u0027Activity Timeline\u0027 in the sidebar.",
                        "provenance":  {
                                           "source":  "migrated"
                                       },
@@ -262,7 +262,7 @@
                    {
                        "id":  "timeline-implementation",
                        "name":  "Implementation Details",
-                       "description":  "Frontend: ActivityTimelinePanel (React, components/activity-timeline/ActivityTimelinePanel.tsx) uses useState for query, results, stats, loading, searched, showFilters, appFilter, sourceFilter. Search invokes Tauri command \u0027search_activity_timeline\u0027 or \u0027search_activity_timeline_filtered\u0027 depending on filter state. Stats fetched via \u0027get_activity_timeline_stats\u0027. Results rendered as bordered cards with color-coded source badges (blue=ui_bridge, green=accessibility, amber=ocr). The component is lazy-loaded in TabContent.tsx. Tab ID \u0027activity-timeline\u0027 registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under OBSERVE_ITEMS with Activity icon and #06B6D4 cyan color. BackgroundObserver service (services/background-observer-service.ts) wraps BackgroundObserver class, calls getGlobalRegistry().captureSnapshot() for control snapshots, and invokes insert_activity_entry Tauri command to persist captures. Hash computation uses crypto.subtle SHA-256 with FNV-1a fallback for non-secure (HTTP) contexts.",
+                       "description":  "Frontend: ActivityTimelinePanel (React, components/activity-timeline/ActivityTimelinePanel.tsx) uses useState for query, results, stats, loading, searched, showFilters, appFilter, sourceFilter. Search invokes Tauri command \u0027search_activity_timeline\u0027 or \u0027search_activity_timeline_filtered\u0027 depending on filter state. Stats fetched via \u0027get_activity_timeline_stats\u0027. Results rendered as bordered cards with color-coded source badges (blue=ui_bridge, green=accessibility, amber=ocr). The component is lazy-loaded in TabContent.tsx. Tab ID \u0027activity-timeline\u0027 registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under INSIGHTS_ITEMS (hidden: true — revealed by the 'Show advanced automation features' toggle) with Activity icon and #06B6D4 cyan color. BackgroundObserver service (services/background-observer-service.ts) wraps BackgroundObserver class, calls getGlobalRegistry().captureSnapshot() for control snapshots, and invokes insert_activity_entry Tauri command to persist captures. Hash computation uses crypto.subtle SHA-256 with FNV-1a fallback for non-secure (HTTP) contexts.",
                        "provenance":  {
                                           "source":  "migrated"
                                       },

--- a/specs/pages/automation-health/spec.uibridge.json
+++ b/specs/pages/automation-health/spec.uibridge.json
@@ -119,7 +119,7 @@
         }
       ],
       "category": "element-presence",
-      "description": "The dashboard is accessible via the 'Automation Health' item in the OBSERVE sidebar group. It appears alongside LLM Analytics, Reflection, and other observability views. The sidebar item shows an Activity icon with green accent (#10B981).",
+      "description": "The dashboard is accessible via the 'Automation Health' item in the INSIGHTS sidebar group, alongside Reflection and other analysis views. As of the 2026-06 lean IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General) and is not in the default sidebar. The sidebar item shows an Activity icon with green accent (#10B981).",
       "id": "health-navigation",
       "name": "Navigation and Tab Access",
       "source": "migrated"
@@ -899,7 +899,7 @@
         "transitions": []
       },
       {
-        "description": "The dashboard is accessible via the 'Automation Health' item in the OBSERVE sidebar group. It appears alongside LLM Analytics, Reflection, and other observability views. The sidebar item shows an Activity icon with green accent (#10B981).",
+        "description": "The dashboard is accessible via the 'Automation Health' item in the INSIGHTS sidebar group, alongside Reflection and other analysis views. As of the 2026-06 lean IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General) and is not in the default sidebar. The sidebar item shows an Activity icon with green accent (#10B981).",
         "elements": [
           {
             "role": "button",

--- a/specs/pages/automation-health/state-machine.derived.json
+++ b/specs/pages/automation-health/state-machine.derived.json
@@ -140,7 +140,7 @@
                                               "enabled":  true
                                           }
                                       ],
-                       "description":  "The dashboard is accessible via the \u0027Automation Health\u0027 item in the OBSERVE sidebar group. It appears alongside LLM Analytics, Reflection, and other observability views. The sidebar item shows an Activity icon with green accent (#10B981).",
+                       "description":  "The dashboard is accessible via the \u0027Automation Health\u0027 item in the INSIGHTS sidebar group, alongside Reflection and other analysis views. As of the 2026-06 lean IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General) and is not in the default sidebar. The sidebar item shows an Activity icon with green accent (#10B981).",
                        "provenance":  {
                                           "source":  "migrated"
                                       }

--- a/specs/pages/skills/spec.uibridge.json
+++ b/specs/pages/skills/spec.uibridge.json
@@ -100,7 +100,7 @@
         }
       ],
       "category": "element-presence",
-      "description": "The Skills page is reachable from the runner sidebar under the OBSERVE navigation group, positioned after Meta-Optimizer. The sidebar entry uses a Zap icon with amber (#F59E0B) color. The tab ID is 'skills' and the page is lazy-loaded via React.lazy.",
+      "description": "The Skills page is reachable from the runner sidebar under the DEV navigation group (dev-only, hiddenInProd), positioned after Meta-Optimizer. The sidebar entry uses a Zap icon with amber (#F59E0B) color. The tab ID is 'skills' and the page is lazy-loaded via React.lazy.",
       "id": "skills-navigation",
       "name": "Page Navigation",
       "source": "migrated"
@@ -727,7 +727,7 @@
         "transitions": []
       },
       {
-        "description": "The Skills page is reachable from the runner sidebar under the OBSERVE navigation group, positioned after Meta-Optimizer. The sidebar entry uses a Zap icon with amber (#F59E0B) color. The tab ID is 'skills' and the page is lazy-loaded via React.lazy.",
+        "description": "The Skills page is reachable from the runner sidebar under the DEV navigation group (dev-only, hiddenInProd), positioned after Meta-Optimizer. The sidebar entry uses a Zap icon with amber (#F59E0B) color. The tab ID is 'skills' and the page is lazy-loaded via React.lazy.",
         "elements": [
           {
             "textContent": "Skills"

--- a/specs/pages/skills/state-machine.derived.json
+++ b/specs/pages/skills/state-machine.derived.json
@@ -104,7 +104,7 @@
                                               "enabled":  true
                                           }
                                       ],
-                       "description":  "The Skills page is reachable from the runner sidebar under the OBSERVE navigation group, positioned after Meta-Optimizer. The sidebar entry uses a Zap icon with amber (#F59E0B) color. The tab ID is \u0027skills\u0027 and the page is lazy-loaded via React.lazy.",
+                       "description":  "The Skills page is reachable from the runner sidebar under the DEV navigation group (dev-only, hiddenInProd), positioned after Meta-Optimizer. The sidebar entry uses a Zap icon with amber (#F59E0B) color. The tab ID is \u0027skills\u0027 and the page is lazy-loaded via React.lazy.",
                        "provenance":  {
                                           "source":  "migrated"
                                       }

--- a/specs/pages/watchers/spec.uibridge.json
+++ b/specs/pages/watchers/spec.uibridge.json
@@ -22,7 +22,7 @@
         }
       ],
       "category": "element-presence",
-      "description": "The Watchers page is under the Observe sidebar group, adjacent to Activity Timeline. It is a runner-only page.",
+      "description": "The Watchers page is in the AUTOMATE sidebar group (alongside Scheduled Tasks and Triggers). As of the 2026-06 lean IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General) and is not in the default sidebar. It is a runner-only page.",
       "id": "watchers-navigation",
       "name": "Page Navigation",
       "source": "migrated"
@@ -671,7 +671,7 @@
     {
       "assertions": [],
       "category": "element-presence",
-      "description": "Frontend: WatcherManagementPanel (React, components/activity-timeline/WatcherManagementPanel.tsx) uses useState for watchers list, showForm toggle, form data, editingId, and loading state. useEffect calls loadWatchers() on mount via list_watchers Tauri command. Form defaults: name='', timelineQuery='', scheduleInterval='5 minutes', lookbackWindow='15 minutes', actionType='LogOnly', reasoningPrompt=default template with placeholders. Create calls create_watcher with JSON-serialized schedule ({type:'interval',value:scheduleInterval}) and action ({type:actionType}). Toggle calls set_watcher_enabled with inverted boolean. Delete calls delete_watcher. All mutations call loadWatchers() after completion. The component is lazy-loaded in TabContent.tsx. Tab ID 'watchers' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under OBSERVE_ITEMS with Eye icon and #06B6D4 cyan color, runner-only platform. Watcher cards rendered with border-border, hover:bg-accent/50. Enabled toggle uses ToggleRight (text-green-500), disabled uses ToggleLeft (default muted). Delete button uses hover:text-destructive. Query displayed in code element with bg-muted.",
+      "description": "Frontend: WatcherManagementPanel (React, components/activity-timeline/WatcherManagementPanel.tsx) uses useState for watchers list, showForm toggle, form data, editingId, and loading state. useEffect calls loadWatchers() on mount via list_watchers Tauri command. Form defaults: name='', timelineQuery='', scheduleInterval='5 minutes', lookbackWindow='15 minutes', actionType='LogOnly', reasoningPrompt=default template with placeholders. Create calls create_watcher with JSON-serialized schedule ({type:'interval',value:scheduleInterval}) and action ({type:actionType}). Toggle calls set_watcher_enabled with inverted boolean. Delete calls delete_watcher. All mutations call loadWatchers() after completion. The component is lazy-loaded in TabContent.tsx. Tab ID 'watchers' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under AUTOMATE_ITEMS (hidden: true — revealed by the 'Show advanced automation features' toggle) with Eye icon and #06B6D4 cyan color, runner-only platform. Watcher cards rendered with border-border, hover:bg-accent/50. Enabled toggle uses ToggleRight (text-green-500), disabled uses ToggleLeft (default muted). Delete button uses hover:text-destructive. Query displayed in code element with bg-muted.",
       "id": "watchers-implementation",
       "name": "Implementation Details",
       "source": "migrated"
@@ -679,7 +679,7 @@
     {
       "assertions": [],
       "category": "element-presence",
-      "description": "Watchers depend entirely on the activity timeline for their data source. A watcher's timeline_query is executed against the same activity_timeline PostgreSQL table that the Activity Timeline page searches. The three capture sources that feed the timeline (BackgroundObserver, Python bridge, BackgroundCaptureService) indirectly feed watchers. The lookback_window determines how far back a watcher searches, preventing it from reasoning over stale data. Watchers and the Activity Timeline share the same Observe sidebar group and are positioned adjacent to each other in the navigation.",
+      "description": "Watchers depend entirely on the activity timeline for their data source. A watcher's timeline_query is executed against the same activity_timeline PostgreSQL table that the Activity Timeline page searches. The three capture sources that feed the timeline (BackgroundObserver, Python bridge, BackgroundCaptureService) indirectly feed watchers. The lookback_window determines how far back a watcher searches, preventing it from reasoning over stale data. Watchers and the Activity Timeline are both demoted behind the advanced-automation toggle in the lean default sidebar (Watchers in AUTOMATE, Activity Timeline in INSIGHTS).",
       "id": "watchers-relationship-to-timeline",
       "name": "Relationship to Activity Timeline",
       "source": "migrated"
@@ -698,7 +698,7 @@
   "stateMachine": {
     "states": [
       {
-        "description": "The Watchers page is under the Observe sidebar group, adjacent to Activity Timeline. It is a runner-only page.",
+        "description": "The Watchers page is in the AUTOMATE sidebar group (alongside Scheduled Tasks and Triggers). As of the 2026-06 lean IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General) and is not in the default sidebar. It is a runner-only page.",
         "elements": [
           {
             "textContent": "Watchers"
@@ -847,7 +847,7 @@
         "transitions": []
       },
       {
-        "description": "Frontend: WatcherManagementPanel (React, components/activity-timeline/WatcherManagementPanel.tsx) uses useState for watchers list, showForm toggle, form data, editingId, and loading state. useEffect calls loadWatchers() on mount via list_watchers Tauri command. Form defaults: name='', timelineQuery='', scheduleInterval='5 minutes', lookbackWindow='15 minutes', actionType='LogOnly', reasoningPrompt=default template with placeholders. Create calls create_watcher with JSON-serialized schedule ({type:'interval',value:scheduleInterval}) and action ({type:actionType}). Toggle calls set_watcher_enabled with inverted boolean. Delete calls delete_watcher. All mutations call loadWatchers() after completion. The component is lazy-loaded in TabContent.tsx. Tab ID 'watchers' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under OBSERVE_ITEMS with Eye icon and #06B6D4 cyan color, runner-only platform. Watcher cards rendered with border-border, hover:bg-accent/50. Enabled toggle uses ToggleRight (text-green-500), disabled uses ToggleLeft (default muted). Delete button uses hover:text-destructive. Query displayed in code element with bg-muted.",
+        "description": "Frontend: WatcherManagementPanel (React, components/activity-timeline/WatcherManagementPanel.tsx) uses useState for watchers list, showForm toggle, form data, editingId, and loading state. useEffect calls loadWatchers() on mount via list_watchers Tauri command. Form defaults: name='', timelineQuery='', scheduleInterval='5 minutes', lookbackWindow='15 minutes', actionType='LogOnly', reasoningPrompt=default template with placeholders. Create calls create_watcher with JSON-serialized schedule ({type:'interval',value:scheduleInterval}) and action ({type:actionType}). Toggle calls set_watcher_enabled with inverted boolean. Delete calls delete_watcher. All mutations call loadWatchers() after completion. The component is lazy-loaded in TabContent.tsx. Tab ID 'watchers' registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under AUTOMATE_ITEMS (hidden: true — revealed by the 'Show advanced automation features' toggle) with Eye icon and #06B6D4 cyan color, runner-only platform. Watcher cards rendered with border-border, hover:bg-accent/50. Enabled toggle uses ToggleRight (text-green-500), disabled uses ToggleLeft (default muted). Delete button uses hover:text-destructive. Query displayed in code element with bg-muted.",
         "elements": [],
         "id": "watchers-implementation",
         "isInitial": false,
@@ -855,7 +855,7 @@
         "transitions": []
       },
       {
-        "description": "Watchers depend entirely on the activity timeline for their data source. A watcher's timeline_query is executed against the same activity_timeline PostgreSQL table that the Activity Timeline page searches. The three capture sources that feed the timeline (BackgroundObserver, Python bridge, BackgroundCaptureService) indirectly feed watchers. The lookback_window determines how far back a watcher searches, preventing it from reasoning over stale data. Watchers and the Activity Timeline share the same Observe sidebar group and are positioned adjacent to each other in the navigation.",
+        "description": "Watchers depend entirely on the activity timeline for their data source. A watcher's timeline_query is executed against the same activity_timeline PostgreSQL table that the Activity Timeline page searches. The three capture sources that feed the timeline (BackgroundObserver, Python bridge, BackgroundCaptureService) indirectly feed watchers. The lookback_window determines how far back a watcher searches, preventing it from reasoning over stale data. Watchers and the Activity Timeline are both demoted behind the advanced-automation toggle in the lean default sidebar (Watchers in AUTOMATE, Activity Timeline in INSIGHTS).",
         "elements": [],
         "id": "watchers-relationship-to-timeline",
         "isInitial": false,

--- a/specs/pages/watchers/state-machine.derived.json
+++ b/specs/pages/watchers/state-machine.derived.json
@@ -42,7 +42,7 @@
                                               "enabled":  true
                                           }
                                       ],
-                       "description":  "The Watchers page is under the Observe sidebar group, adjacent to Activity Timeline. It is a runner-only page.",
+                       "description":  "The Watchers page is in the AUTOMATE sidebar group (alongside Scheduled Tasks and Triggers). As of the 2026-06 lean IA it is demoted behind the 'Show advanced automation features' toggle (Settings → General) and is not in the default sidebar. It is a runner-only page.",
                        "provenance":  {
                                           "source":  "migrated"
                                       }
@@ -471,7 +471,7 @@
                        "assertions":  [
 
                                       ],
-                       "description":  "Frontend: WatcherManagementPanel (React, components/activity-timeline/WatcherManagementPanel.tsx) uses useState for watchers list, showForm toggle, form data, editingId, and loading state. useEffect calls loadWatchers() on mount via list_watchers Tauri command. Form defaults: name=\u0027\u0027, timelineQuery=\u0027\u0027, scheduleInterval=\u00275 minutes\u0027, lookbackWindow=\u002715 minutes\u0027, actionType=\u0027LogOnly\u0027, reasoningPrompt=default template with placeholders. Create calls create_watcher with JSON-serialized schedule ({type:\u0027interval\u0027,value:scheduleInterval}) and action ({type:actionType}). Toggle calls set_watcher_enabled with inverted boolean. Delete calls delete_watcher. All mutations call loadWatchers() after completion. The component is lazy-loaded in TabContent.tsx. Tab ID \u0027watchers\u0027 registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under OBSERVE_ITEMS with Eye icon and #06B6D4 cyan color, runner-only platform. Watcher cards rendered with border-border, hover:bg-accent/50. Enabled toggle uses ToggleRight (text-green-500), disabled uses ToggleLeft (default muted). Delete button uses hover:text-destructive. Query displayed in code element with bg-muted.",
+                       "description":  "Frontend: WatcherManagementPanel (React, components/activity-timeline/WatcherManagementPanel.tsx) uses useState for watchers list, showForm toggle, form data, editingId, and loading state. useEffect calls loadWatchers() on mount via list_watchers Tauri command. Form defaults: name=\u0027\u0027, timelineQuery=\u0027\u0027, scheduleInterval=\u00275 minutes\u0027, lookbackWindow=\u002715 minutes\u0027, actionType=\u0027LogOnly\u0027, reasoningPrompt=default template with placeholders. Create calls create_watcher with JSON-serialized schedule ({type:\u0027interval\u0027,value:scheduleInterval}) and action ({type:actionType}). Toggle calls set_watcher_enabled with inverted boolean. Delete calls delete_watcher. All mutations call loadWatchers() after completion. The component is lazy-loaded in TabContent.tsx. Tab ID \u0027watchers\u0027 registered in tab-types.ts. Sidebar item in qontinui-navigation/src/groups.ts under AUTOMATE_ITEMS (hidden: true — revealed by the 'Show advanced automation features' toggle) with Eye icon and #06B6D4 cyan color, runner-only platform. Watcher cards rendered with border-border, hover:bg-accent/50. Enabled toggle uses ToggleRight (text-green-500), disabled uses ToggleLeft (default muted). Delete button uses hover:text-destructive. Query displayed in code element with bg-muted.",
                        "provenance":  {
                                           "source":  "migrated"
                                       }
@@ -482,7 +482,7 @@
                        "assertions":  [
 
                                       ],
-                       "description":  "Watchers depend entirely on the activity timeline for their data source. A watcher\u0027s timeline_query is executed against the same activity_timeline PostgreSQL table that the Activity Timeline page searches. The three capture sources that feed the timeline (BackgroundObserver, Python bridge, BackgroundCaptureService) indirectly feed watchers. The lookback_window determines how far back a watcher searches, preventing it from reasoning over stale data. Watchers and the Activity Timeline share the same Observe sidebar group and are positioned adjacent to each other in the navigation.",
+                       "description":  "Watchers depend entirely on the activity timeline for their data source. A watcher\u0027s timeline_query is executed against the same activity_timeline PostgreSQL table that the Activity Timeline page searches. The three capture sources that feed the timeline (BackgroundObserver, Python bridge, BackgroundCaptureService) indirectly feed watchers. The lookback_window determines how far back a watcher searches, preventing it from reasoning over stale data. Watchers and the Activity Timeline are both demoted behind the advanced-automation toggle in the lean default sidebar (Watchers in AUTOMATE, Activity Timeline in INSIGHTS).",
                        "provenance":  {
                                           "source":  "migrated"
                                       }


### PR DESCRIPTION
Follow-up to the lean Terminal-first nav (#617 / @qontinui/navigation 0.1.5).

Four page specs carried **descriptive prose** referencing the retired `OBSERVE` sidebar group and "click it in the sidebar" instructions for items now demoted behind the **Show advanced automation features** toggle:

| Spec | Was | Now |
|------|-----|-----|
| activity-timeline | OBSERVE | INSIGHTS (+ toggle note) |
| automation-health | OBSERVE | INSIGHTS (+ toggle note) |
| watchers | OBSERVE | AUTOMATE (+ toggle note) |
| skills | OBSERVE | DEV (dev-only) |

**Scope:** `description` fields only — **no assertions/transitions changed**. These specs assert page *content* (not the main sidebar), so the nav demotion never affected spec-check matching; this is pure documentation-accuracy. IR (`state-machine.derived.json`) + projection (`spec.uibridge.json`) kept in sync (no spec-freshness gate exists). 21 ins / 21 del, all JSON re-validated.