### PR TITLE
feat(fleet): bundle /vet-plan + /implement-plan into runner, provision into spawned session cwd

### DIFF
--- a/src-tauri/src/agent_runtime.rs
+++ b/src-tauri/src/agent_runtime.rs
@@ -2081,6 +2081,9 @@ async fn run_continuation_terminal(
         .try_state::<Arc<crate::commands::AppState>>()
         .map(|s| crate::mcp::types::runner_api_port(s.inner()));
     crate::coord_mcp::provision_coord_mcp_for_session(workdir, bound_port);
+    // Bundle /vet-plan and /implement-plan into the session cwd so they resolve
+    // as project slash commands regardless of the device's ~/.claude.
+    crate::fleet_commands::provision_fleet_commands_for_session(workdir);
 
     let result = crate::commands::terminal::create_terminal_session_backend(
         &terminal_manager,
@@ -2404,6 +2407,9 @@ async fn run_agent_subprocess(
     if let Err(e) = provision_agent_definitions(&primary_wt) {
         warn!("agent_runtime: agent-def provisioning errored (continuing spawn): {e:#}");
     }
+    // Bundle /vet-plan and /implement-plan into the spawned worktree cwd so they
+    // resolve as project slash commands regardless of the device's ~/.claude.
+    crate::fleet_commands::provision_fleet_commands_for_session(&primary_wt);
 
     let log_path = agent_log_path(payload.agent_id);
 

--- a/src-tauri/src/fleet_commands.rs
+++ b/src-tauri/src/fleet_commands.rs
@@ -1,0 +1,128 @@
+//! Fleet-portable provisioning of the `/vet-plan` and `/implement-plan`
+//! project slash commands into a spawned session's working directory.
+//!
+//! `claude` discovers project slash commands from `<cwd>/.claude/commands/*.md`.
+//! A gate-continuation session is spawned with a fresh worktree as its cwd; on a
+//! non-operator device there is no `~/.claude/commands` and no
+//! `qontinui-claude-config` checkout, so the fleet vet/implement procedures would
+//! be unresolvable. This module BUNDLES the two command procedures into the
+//! runner binary via `include_str!` and writes them into the session cwd, so the
+//! commands resolve regardless of what (if anything) is in the device's home dir.
+//!
+//! This is the fleet-portable sibling of `provision_agent_definitions` in
+//! `agent_runtime.rs` (which copies subagent defs from a `qontinui-claude-config`
+//! checkout). Where that path requires an operator checkout, this one carries the
+//! assets in the binary — see that function's doc comment for the broader
+//! fleet-portability rationale.
+
+use std::path::Path;
+
+use tracing::{info, warn};
+
+/// `/vet-plan` procedure, bundled into the binary. Source of truth:
+/// `qontinui-claude-config/.claude/commands/vet-plan.md`, staged here at build time.
+const VET_PLAN: &str = include_str!("fleet_commands/vet-plan.md");
+
+/// `/implement-plan` procedure, bundled into the binary. Source of truth:
+/// `qontinui-claude-config/.claude/commands/implement-plan.md`, staged here.
+const IMPLEMENT_PLAN: &str = include_str!("fleet_commands/implement-plan.md");
+
+/// The command files to provision, as `(filename, contents)`. The filename is
+/// the slash-command name `claude` will expose (e.g. `vet-plan.md` -> `/vet-plan`).
+const FLEET_COMMANDS: &[(&str, &str)] = &[
+    ("vet-plan.md", VET_PLAN),
+    ("implement-plan.md", IMPLEMENT_PLAN),
+];
+
+/// Provision the bundled fleet command procedures into `<workdir>/.claude/commands/`
+/// so a `claude` session spawned with `workdir` as its cwd can resolve `/vet-plan`
+/// and `/implement-plan` as PROJECT-scoped slash commands — even on a device with
+/// no `~/.claude/commands` and no `qontinui-claude-config` checkout.
+///
+/// Fail-soft (mirrors `coord_mcp::provision_coord_mcp_for_session`): any IO error
+/// is logged via `tracing::warn!` and swallowed — a provisioning failure must
+/// never abort an otherwise-launchable spawn (the session simply lacks the
+/// commands, the same state as before this feature). Idempotent: existing files
+/// are overwritten.
+pub(crate) fn provision_fleet_commands_for_session(workdir: &str) {
+    let commands_dir = Path::new(workdir).join(".claude").join("commands");
+    match provision_fleet_commands_into(&commands_dir) {
+        Ok(written) => {
+            info!(
+                "fleet_commands: provisioned {written} fleet command(s) into {}",
+                commands_dir.display()
+            );
+        }
+        Err(e) => {
+            warn!(
+                "fleet_commands: failed to provision fleet commands into {} \
+                 (continuing spawn; /vet-plan and /implement-plan may not resolve): {e}",
+                commands_dir.display()
+            );
+        }
+    }
+}
+
+/// Core of [`provision_fleet_commands_for_session`]: create `commands_dir` and
+/// write every bundled command file into it (overwrite/idempotent), returning the
+/// count written. Split out so a unit test can drive it against a tempdir and
+/// assert the result — mirroring how `provision_agent_definitions` factored out
+/// its `_from_root` core.
+fn provision_fleet_commands_into(commands_dir: &Path) -> std::io::Result<usize> {
+    std::fs::create_dir_all(commands_dir)?;
+    let mut written = 0usize;
+    for (name, contents) in FLEET_COMMANDS {
+        let dst = commands_dir.join(name);
+        std::fs::write(&dst, contents)?;
+        written += 1;
+    }
+    Ok(written)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provisions_both_fleet_commands_into_dir() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let commands_dir = tmp.path().join(".claude").join("commands");
+
+        let written = provision_fleet_commands_into(&commands_dir).expect("provision");
+        assert_eq!(written, 2, "should provision exactly two fleet commands");
+
+        let vet = commands_dir.join("vet-plan.md");
+        let implement = commands_dir.join("implement-plan.md");
+        assert!(vet.exists(), "vet-plan.md should exist");
+        assert!(implement.exists(), "implement-plan.md should exist");
+
+        let vet_body = std::fs::read_to_string(&vet).expect("read vet-plan.md");
+        let implement_body = std::fs::read_to_string(&implement).expect("read implement-plan.md");
+        assert!(!vet_body.is_empty(), "vet-plan.md should be non-empty");
+        assert!(
+            !implement_body.is_empty(),
+            "implement-plan.md should be non-empty"
+        );
+
+        // Substrings verified present near the top of each staged file
+        // (the `# Vet Plan` / `# Implement Plan` H1 headings).
+        assert!(
+            vet_body.contains("Vet Plan"),
+            "vet-plan.md should contain 'Vet Plan'"
+        );
+        assert!(
+            implement_body.contains("Implement Plan"),
+            "implement-plan.md should contain 'Implement Plan'"
+        );
+    }
+
+    #[test]
+    fn provision_is_idempotent_overwrite() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let commands_dir = tmp.path().join(".claude").join("commands");
+
+        assert_eq!(provision_fleet_commands_into(&commands_dir).unwrap(), 2);
+        // Second run over the same dir must succeed (overwrite, not error).
+        assert_eq!(provision_fleet_commands_into(&commands_dir).unwrap(), 2);
+    }
+}

--- a/src-tauri/src/fleet_commands/implement-plan.md
+++ b/src-tauri/src/fleet_commands/implement-plan.md
@@ -1,0 +1,1222 @@
+# Implement Plan
+
+Execute an approved implementation plan end-to-end in a single session, without stopping between phases.
+
+**Prerequisites:** A plan must already exist and be approved in the current conversation.
+
+## Arguments
+- `$ARGUMENTS` - Optional: specific notes or constraints for this implementation run
+
+## Instructions
+
+This skill orchestrates the full implementation workflow. **Phases run as subagents to save context.** The main conversation tracks progress and coordinates — heavy work happens in agents.
+
+### Step 0: Create Phase Checklist
+
+Create a task checklist so progress is tracked. Use TaskCreate for one task per phase, plus tasks for manual testing, spec updates, and commit as applicable. Mark each task complete (TaskUpdate) immediately when done.
+
+### Step 0.3: Name this session + terminal after the plan
+
+Derive a human name from the plan filename and use it to title the session
+and the terminal window. The rule: take the plan **stem** (filename without
+`.md` or directory — the same `<plan-stem>` Step 0.6 computes), strip a
+leading `YYYY-MM-DD-` date prefix, and strip a trailing ` plan` / `-plan` /
+`_plan` word if present.
+(e.g. `2026-05-21-coordination-improvements` → `coordination-improvements`;
+`2026-06-02-fleet-auth-plan` → `fleet-auth`.)
+
+Run this once, substituting `<plan-stem>`:
+
+```bash
+DISPLAY=$(printf '%s' "<plan-stem>" \
+  | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-//; s/[-_ ][Pp][Ll][Aa][Nn]$//')
+mkdir -p "$HOME/.qontinui/session-titles"
+printf '%s\n' "$DISPLAY" > "$HOME/.qontinui/session-titles/$CLAUDE_CODE_SESSION_ID"
+echo "$DISPLAY"
+```
+
+**Terminal title:** automatic. Writing the title-hint file is all you need —
+the `set-terminal-title.sh` Stop hook reads it and titles the terminal when
+this turn ends. Do NOT try to `echo` an escape sequence yourself; the harness
+strips tool-stdout control bytes, so it would silently no-op.
+
+**Session label (`/rename`):** this is the one thing a command cannot set on
+its own — Claude Code only renames the session when the operator types
+`/rename`, never programmatically mid-turn. So surface the derived name to the
+operator as a ready-to-paste line, e.g.:
+
+> Session named `coordination-improvements`. To set the Claude session label,
+> paste: `/rename coordination-improvements`
+
+The paste only affects the in-app session label; the terminal title is already
+handled by the title-hint file above.
+
+This step is best-effort: if `$CLAUDE_CODE_SESSION_ID` is unset or the write
+fails, skip it silently and continue — naming never blocks implementation.
+
+### Step 0.4: Verify dependencies satisfied
+
+Before stamping the plan IN PROGRESS, check whether the plan declares any
+upstream dependencies and confirm they're satisfied. This gate exists so
+that a plan whose upstream prerequisites haven't shipped doesn't silently
+get implemented against a half-built substrate.
+
+#### Read the plan's `Depends-On:` field
+
+A plan MAY declare upstream dependencies inline in its status blockquote
+using a `Depends-On:` suffix:
+
+```markdown
+> **Status: VETTED 2026-05-21.** <summary>. Depends-On: 2026-05-20-default-tenant-propagation, 2026-05-19-some-other-plan.
+```
+
+Parser rule (kept consistent with `/vet-plan` and `/verify-plan-status`):
+
+1. Look at the status blockquote (the first `> **Status:` block under the
+   H1) and find EVERY case-sensitive `Depends-On:` occurrence — a block
+   often carries one in the headline sentence and another in a trailing
+   `History:` / re-vet line.
+2. For each occurrence, consider only the remainder of that PHYSICAL line
+   — never the following blockquote lines or paragraphs, which may name
+   unrelated plans in prose.
+3. Within that line, keep only date-prefixed plan-stem-shaped tokens
+   (`YYYY-MM-DD-<kebab-slug>`, e.g. `2026-06-02-some-plan`). Prose, bare
+   dates (`2026-05-21.`), and trailing punctuation never produce tokens
+   — a stem requires at least one `-word` segment after the date. Each
+   token is a bare plan **stem** — no `.md` extension, no path.
+4. Union the stems across all occurrences, deduped, order-preserving.
+
+   (A naive first-occurrence + split-on-commas parse mis-handled real
+   status blocks whose prose contained a second `Depends-On:` or commas —
+   it produced phantom missing-dep aborts. Fixed in the canonical resolver
+   2026-06-04; this inline fallback mirrors it.)
+
+**Canonical resolver (preferred):** the procedure above is implemented in
+`qontinui-stack/scripts/resolve-plan-deps.py`. When the stack repo is
+available, shell out to the helper instead of re-implementing the parse
+inline:
+
+```bash
+python D:/qontinui-root/qontinui-stack/scripts/resolve-plan-deps.py \
+    D:/qontinui-root/plans/<this-plan>.md --json
+```
+
+It emits `{plan_stem, depends_on[{stem, status, location, summary}],
+all_satisfied, unsatisfied[{stem, reason}]}` and exits 0 / 1 / 2 (all
+satisfied / some unsatisfied / input error). The `reason` field
+distinguishes `missing_file`, `not_yet_shipped`, and `terminal_blocker`,
+which maps directly onto the gate behavior below. Fall back to the inline
+procedure when the script isn't checked out (containers, CI without the
+stack repo, etc.) — both paths are kept in sync as Phase 3.2 of
+`2026-05-21-coordination-improvements`.
+
+If the plan has no `Depends-On:` field, skip this step silently and proceed
+to Step 0.5. **This is the common case.**
+
+#### Look up each dep's status
+
+For each dep stem, resolve to a plan file:
+
+1. Try `D:/qontinui-root/plans/<stem>.md` first (in-progress location).
+2. If that doesn't exist, try `D:/qontinui-root/qontinui-dev-notes/plans/<stem>.md`
+   (shipped archive).
+3. If neither exists, the dep is **missing** — abort (see below).
+
+Use `Read` (a failure is the not-found signal) or `Glob` against the
+absolute path. Once located, read the dep file's status blockquote and
+parse the lifecycle word — one of `DRAFT`, `VETTED`, `IN PROGRESS`,
+`SHIPPED`, `PARTIAL`, `NOT STARTED`, `SUPERSEDED`, `OBSOLETE`. A plan with
+no status blockquote at all is treated as `DRAFT`.
+
+#### Gate behavior
+
+After resolving every dep, apply these rules:
+
+- **All deps `SHIPPED`** → proceed silently to Step 0.5. No prompt.
+- **Any dep in `DRAFT` / `VETTED` / `IN PROGRESS` / `NOT STARTED` / `PARTIAL`**
+  → surface a conflict via `AskUserQuestion` (see below). Do NOT stamp
+  IN PROGRESS until the operator resolves.
+- **Any dep file is missing** (neither directory has `<stem>.md`)
+  → **abort the skill** with an actionable error before stamping anything.
+  Example error text:
+  ```
+  Cannot start implementation: plan declares Depends-On: <stem>, but no
+  matching plan file exists at:
+    D:/qontinui-root/plans/<stem>.md
+    D:/qontinui-root/qontinui-dev-notes/plans/<stem>.md
+
+  Fix the Depends-On stem in the plan's status block (typo? renamed
+  upstream?) or remove the entry if the dep no longer applies, then
+  re-run /implement-plan.
+  ```
+  Do not auto-correct or guess at the intended stem — that's the
+  operator's call. An abort here is correct behavior: a Depends-On that
+  references nothing is a broken graph edge.
+- **Any dep stamped `SUPERSEDED` or `OBSOLETE`** → surface via
+  `AskUserQuestion` the same as the unfinished-dep case. The dep being
+  terminally closed doesn't necessarily mean the current plan should
+  proceed (its premise may have moved); the operator picks.
+
+#### Conflict prompt (`AskUserQuestion`)
+
+Header: `Dependency not satisfied`
+
+Question body: list each unresolved dep with its stem, current status,
+and resolved location, e.g.:
+
+```
+This plan declares Depends-On dependencies that aren't fully shipped:
+
+  - 2026-05-20-default-tenant-propagation — IN PROGRESS (plans/)
+  - 2026-05-19-some-other-plan — VETTED (plans/)
+
+How do you want to proceed?
+```
+
+Options:
+
+- **Abort** — stop the skill. Releases any coord claims this session
+  already acquired (per Step 0.6 try/finally semantics) and exits without
+  stamping the plan or launching phase agents.
+- **Override-and-proceed** — operator accepts the risk; continue to
+  Step 0.5. Capture the override decision in the IN PROGRESS stamp's
+  body (e.g., `History: Started despite unresolved deps — operator
+  override 2026-05-21.`) so future verifiers see the trail.
+- **Pause-until-resolved** — stop the skill *without* aborting the
+  broader chain. Emit a single-line note to the operator that the plan
+  will need to be re-driven once the upstream lands, then exit. Do not
+  stamp the plan.
+
+#### Why this gate exists
+
+`Depends-On:` is an explicit edge in the plan graph — authored, not
+inferred. The gate is the read-side enforcement of that edge: when the
+graph says "plan A depends on plan B," `/implement-plan` MUST NOT silently
+proceed on A while B is still open. The three-way choice (abort / override
+/ pause) gives the operator control without forcing a hard block.
+
+This step runs **before** the IN PROGRESS stamp so an aborted run leaves
+no trail in the plan file — concurrent agents and future operators see a
+clean VETTED plan, not a half-stamped one.
+
+### Step 0.45: Concurrent-work reconnaissance (cheap process guard)
+
+The coord phase claim (Step 0.6) catches another session that is
+**live-acquiring the same plan+phase right now**. It does NOT catch work
+that already **merged** — a claim is released on completion, so a peer that
+finished the same plan an hour ago leaves no live claim, and you'd
+re-implement a superset that's already on `main`
+([[feedback_check_main_for_concurrent_plan_work]]). This step is the cheap,
+no-coord-dependency complement: a 10-second look for already-done or
+in-flight work BEFORE you stamp IN PROGRESS.
+
+Do all three (they're fast and independent):
+
+1. **The plan's own status block.** Re-read the top of the plan you're
+   about to implement. If it already reads `SHIPPED` / `IN PROGRESS` (with
+   a recent date + a different session marker) / `SUPERSEDED` / `OBSOLETE`,
+   STOP and surface to the operator — another run already took it (Step 0.5
+   covers the lifecycle rules, but check here *before* stamping so you
+   don't race).
+2. **Merged work on `main`.** For each repo the plan touches, scan recent
+   history for the plan's stem, session tags, or distinctive symbols:
+   ```bash
+   git -C <repo> log origin/main -20 --oneline | grep -iE "<plan-stem keywords>"
+   ```
+   A hit means the plan (or a superset) may already be live — read the
+   commit, and if it covers the plan's scope, surface to the operator
+   rather than re-implementing.
+3. **Open PRs.** Check for an open PR implementing the same plan:
+   ```bash
+   gh pr list --repo <owner/repo> --state open --search "<plan-stem keywords>"
+   ```
+   An open PR from another session means a live peer — coordinate rather
+   than double-build.
+
+If any surface shows the work is already done or in-flight, surface a
+one-line summary + the evidence (commit SHA / PR number) via
+`AskUserQuestion` (header `Already implemented?`, options: **Abort** /
+**Proceed anyway** — e.g. the existing work is partial). If all three are
+clean, proceed to Step 0.5. This is a read-only reconnaissance — it never
+mutates anything and adds ~10s, far cheaper than building a redundant PR
+that gets closed.
+
+### Step 0.5: Stamp the plan as IN PROGRESS
+
+Before any code changes land, edit the plan .md to update its status block to:
+
+```markdown
+> **Status: IN PROGRESS <YYYY-MM-DD>.** Implementation started by
+> session <short session id or branch name>. Phase tasks: <N>. Started
+> from <prior status — usually VETTED <date>>.
+```
+
+Rules:
+- If the existing block is `Status: VETTED <date>`, replace it with the IN PROGRESS line above and reference the vet date in the body (`Started from VETTED 2026-05-02.`).
+- If the existing block is `Status: DRAFT` or absent, add the IN PROGRESS block but warn the user in your first text turn that the plan was not vetted — give them a chance to abort and run `/vet-plan` first.
+- If the existing block is `Status: PARTIAL` or `Status: NOT STARTED` (set by `/verify-plan-status`), replace it with the IN PROGRESS block and capture the prior state in the body's `History:` line. Don't run `/vet-plan` first unless the user asks — `/verify-plan-status` doesn't supplant a vet pass, but a recent NOT STARTED is also not a reason to re-vet.
+- If the existing block is already `IN PROGRESS`, refresh the date and append your session marker — multiple agents may pick up the same plan; keep the trail.
+- If the existing block is `SHIPPED` / `SUPERSEDED` / `OBSOLETE`, STOP — implementing a shipped plan is almost certainly a mistake. Confirm with the user before proceeding.
+
+**Push the stamp under ingest-scanned roots.** IN PROGRESS / SHIPPED stamps drive
+`plan_status` gates via coord's plan-ingest worker, which mirrors
+`qontinui-dev-notes/plans/` origin/main into `coord.plans` every ~60s — a registry
+upsert alone is reverted by the next tick (coord #564). When the plan file lives
+under an ingest-scanned root, commit + push the stamped file (for SHIPPED, the
+Step-6 archive commit already does this). Workspace-root `plans/` on dev boxes is
+typically NOT prod-ingested — the push matters only for ingest-scanned roots.
+(claude-config is NOT a coord sole-authority repo — its PRs land via normal
+GitHub flow.)
+
+#### Single-stamp invariant — applies to Step 0.5 and Step 6
+
+A plan must have **exactly one** `> **Status:` blockquote between the H1
+and the body. Before writing your stamp:
+
+1. Read the top of the plan. Identify EVERY top-of-file blockquote that
+   asserts a status, lifecycle state, or verification date — lines
+   starting `> **Status:`, `> **Edit YYYY-MM-DD —`, or `> **Update:`
+   all count.
+2. Use `Edit` to **delete every existing status-adjacent blockquote** —
+   even if a different skill wrote it (`/vet-plan` writes `VETTED`;
+   `/verify-plan-status` writes `PARTIAL` / `NOT STARTED`). Yours
+   replaces all of them.
+3. Then `Edit` again to insert your single new `> **Status:` block.
+4. If folding in history is useful (`Started from VETTED 2026-05-02`),
+   put it in **one trailing line inside your new block**, prefixed
+   `History:`, `Started from:`, or `Previously:`. Never as a sibling
+   blockquote.
+
+This stamp is mandatory before Step 1. It makes concurrent agents see
+"another session is implementing this" via a quick `head -5 plan.md`
+and avoids duplicate work.
+
+### Step 0.6: Coord claim pre-flight (per-phase spawn coordination)
+
+Before launching ANY phase agent in Step 1, acquire a Phase-kind claim from
+the coord claims API so a second `/implement-plan` running on the same plan +
+phase from another machine (or another shell) sees an immediate structured
+conflict signal instead of silently double-spawning. This wires the
+`/implement-plan` entrypoint into the L3(b) coordination layer shipped in
+the agent-spawn-coordination plan.
+
+**Skip-and-warn for non-coord environments.** If neither
+`QONTINUI_MACHINE_ID` nor `~/.qontinui/machine.json` is available (e.g.
+running on a developer laptop that isn't a registered qontinui device),
+emit a single-line warning to the user (`⚠️ coord pre-flight skipped: no
+machine_id available — running without claim coordination`) and proceed
+without claims. This skill MUST remain usable in non-coord environments.
+
+#### Resolution chain
+
+For each phase you are about to launch:
+
+1. **Plan-stem.** From the plan path (e.g. `D:/qontinui-root/plans/2026-05-18-agent-spawn-coordination.md`),
+   take the filename without `.md` — `2026-05-18-agent-spawn-coordination`.
+2. **Resource key.** `plan:<plan-stem>:phase:<phase-number>` —
+   e.g. `plan:2026-05-18-agent-spawn-coordination:phase:3`.
+3. **`machine_id`.** Env `QONTINUI_MACHINE_ID` first. Else read
+   `~/.qontinui/machine.json` and parse the `"machine_id"` string value
+   (UUID). DO NOT fabricate a value if neither source provides one —
+   take the skip-and-warn path above.
+4. **Coord HTTP base.** Env `COORD_HTTP_URL` first. Else
+   `https://coord.qontinui.io`.
+
+#### Session-id resolution (owner-token discriminator)
+
+The phase claim's *holder identity* is a session-scoped **owner token**
+(`<machine_id>:<agent_session_id>`), per plan
+`2026-06-03-coord-session-scoped-claim-owner`. Sending `agent_session_id`
+is what makes a SECOND `/implement-plan` session on the SAME machine see a
+structured `held` conflict instead of silently taking over the first's
+phase claim (the bug this guards against). Resolve a stable per-session
+UUID ONCE, before the first acquire, and reuse it for every
+acquire/heartbeat/release in this run:
+
+```bash
+AGENT_SESSION_ID="${QONTINUI_AGENT_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+```
+
+`CLAUDE_CODE_SESSION_ID` is the harness session UUID — per-session-unique
+and inherited by spawned phase agents (they run in the same Claude
+session), so a child agent's heartbeat owner-token matches the parent's
+acquire automatically. If both are empty (older Claude Code), omit the
+field — coord's `None` fallback preserves today's machine-only behavior.
+(The `coord-curl.sh` wrapper injects the same value with the same
+precedence for any coord call that omits it; sending it explicitly here is
+belt-and-braces and keeps the claim path independent of the wrapper.)
+
+#### Pre-flight call
+
+For each phase, issue (via the Bash tool):
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/claims/acquire" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "kind": "phase",
+  "resource_key": "plan:<plan-stem>:phase:<n>",
+  "machine_id": "<machine_id>",
+  "agent_session_id": "$AGENT_SESSION_ID",
+  "metadata": {
+    "plan": "<absolute-plan-path>",
+    "phase": <n>,
+    "skill": "implement-plan"
+  }
+}
+EOF
+)"
+```
+
+(Omit the `agent_session_id` line entirely if `$AGENT_SESSION_ID` resolved
+empty — don't send an empty string.)
+
+Per `coord/src/claims.rs` the response's `result` discriminator is
+snake_case-tagged. Parse it:
+
+- `"claimed"` / `"renewed"` → claim acquired. Capture the response's
+  `correlation_id` if present (the spawned child agent will heartbeat
+  against this claim via `/claims/heartbeat`). **Then cancel any pending
+  continuation for this plan (takeover — see below)**, and proceed to
+  launch the phase agent for this phase.
+- `"held"` → another agent already holds the claim. **DO NOT launch
+  the phase agent.** Enter the conflict resolution flow below.
+- `"topic_conflict"` / `"topic_unknown"` / `"invalid_topic"` → surface
+  the error verbatim to the operator and abort the skill. These are
+  not expected from the call shape above but handle defensively.
+
+#### Cancel a pending continuation on takeover
+
+Taking the phase claim directly means THIS session is doing the work a
+`plan_ready` gate's continuation may have queued as a fresh runner-terminal
+spawn. Leaving that pending continuation alive means the runner spawns a
+**redundant terminal** on its next WS reconnect (its in-process dedupe set is
+forgotten across restarts, and the pending row survives up to 24h). So,
+**best-effort, right after the FIRST phase claim of this run succeeds** (do it
+once per run, not per phase):
+
+1. Resolve the `plan_id` for this plan-stem via
+   `GET $COORD_HTTP_URL/coord/plans/<plan-stem>` (or the upsert used elsewhere).
+2. Query the plan's gates for a pending continuation:
+   `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>` → rows where
+   `continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
+   continuation_cancelled_at == null`.
+3. For each such gate, fire (operator/`TenantId` bearer — same auth layer as
+   mute/reopen; tenant derives server-side):
+
+   ```bash
+   curl -fsS -X POST "$COORD_HTTP_URL/coord/gates/<gate_id>/continuation-cancel" \
+     -H "Content-Type: application/json" \
+     -d "$(cat <<EOF
+   { "cancelled_by": "$AGENT_SESSION_ID", "reason": "taken over by session $AGENT_SESSION_ID" }
+   EOF
+   )"
+   ```
+
+This is **best-effort and MUST NOT block** the phase launch: a non-2xx, a 404
+(nothing was ever dispatched — nothing pending), or a network failure is fine —
+narrate it and proceed. A **409 `already_consumed`** means a spawn already
+happened: report it honestly (do not claim a clean takeover) but still proceed
+with this session's work. Narrate the outcome either way — "cancelled pending
+continuation `<gate_id>`" or "no pending continuation to cancel".
+
+(canonical spec: `_gate-registration` → "Continuation cancel + refresh" — keep in sync)
+
+#### Conflict resolution flow (on `"held"`)
+
+Surface to the operator (text-mode UI — `/implement-plan` runs in the
+terminal, no webview). The `held` response carries `current_holder` (the
+holder's machine_id) and, when the holder is session-scoped,
+`current_holder_session`. When `current_holder` equals THIS machine and
+`current_holder_session` differs from `$AGENT_SESSION_ID`, the conflict is
+**another session on THIS machine** — say so explicitly rather than
+implying a different box:
+
+```
+Another session on THIS machine (session <current_holder_session>) is
+already implementing plan:<plan-stem>:phase:<n>.
+```
+
+Otherwise (different machine, or a legacy holder with no session):
+
+```
+Another agent (machine <current_holder>) is already implementing
+plan:<plan-stem>:phase:<n>.
+```
+
+Then, in both cases:
+
+```
+Options:
+  (1) Abort — stop the implement-plan chain
+  (2) Wait  — poll every 30s until the claim clears, then resume
+              (default timeout 30 min; override with --wait-timeout=<Nm>)
+  (3) Steal — revoke the other agent's claim (admin OR same-machine
+              originator only)
+```
+
+Use `AskUserQuestion` with header `Claim conflict` and the three options.
+Handle the selection:
+
+- **Abort.** Stop the skill. Do not launch any further phase agents
+  even for phases that DID acquire a claim — release those before
+  exiting (see "Claim release" below).
+- **Wait.** Poll the claims by-resource read every 30 seconds with
+  `kind=phase&key=<rk>` (the query param is `key`, not `resource_key` —
+  `routes.rs::ByResourceQuery`; URL-encode the `<rk>` value, which contains
+  `:`). **Credential the read dual-shape** (claims-read-auth-hardening):
+  read the workspace `.mcp.json` and branch on its `coord-mcp` entry —
+  - *Proxy shape* (device-provisioned session: loopback
+    `http://127.0.0.1:<port>/coord-mcp` url + `X-Coord-Mcp-Proxy-Key`
+    header): `curl GET <proxy_base>/claims/by-resource?kind=phase&key=<rk>`
+    with the `X-Coord-Mcp-Proxy-Key: <nonce>` header (the runner injects a
+    live device JWT).
+  - *Static-bearer shape* (agent-spawn session: real coord url +
+    `Authorization` header): `curl GET
+    $COORD_HTTP_URL/coord/claims/by-resource?...` with that
+    `Authorization: Bearer` header. Never route an agent bearer through
+    the device proxy (scope elevation).
+  - *Neither shape / no `.mcp.json`*: today's anonymous
+    `curl GET $COORD_HTTP_URL/coord/claims/by-resource?...` (works until
+    `COORD_CLAIMS_READ_AUTH_REQUIRED` enforcement arms). On a failed
+    credentialed call, fail open to the anonymous form once.
+
+  The endpoint returns `Option<ClaimHolder>` (now including the
+  holder's `session_id`); when it returns `null` / no holder, retry
+  `/claims/acquire` once. If acquire succeeds, proceed. Bound the wait by `--wait-timeout=<Nm>` from
+  `$ARGUMENTS` (default 30 min). On timeout, ask the operator again
+  (abort/wait/steal).
+- **Steal.** Ask for a free-text reason (default: `"operator initiated steal"`),
+  then call:
+
+  ```bash
+  curl -fsS -X POST "$COORD_HTTP_URL/coord/claims/steal" \
+    -H "Content-Type: application/json" \
+    -d "$(cat <<'EOF'
+  {
+    "kind": "phase",
+    "resource_key": "plan:<plan-stem>:phase:<n>",
+    "machine_id": "<machine_id>",
+    "reason": "<reason>"
+  }
+  EOF
+  )"
+  ```
+
+  On success, retry `/claims/acquire` — it should return `"claimed"`.
+  On 403 (not admin AND not originator), surface the error and ask
+  again (abort/wait — steal is not available). The coord side emits
+  `events.coord.claim.stolen.machine.<displaced_machine_id>` so the
+  displaced agent's runner will surface a stolen-claim banner.
+
+#### Claim release on phase completion
+
+After each phase agent reports — whether success OR failure — release
+the claim:
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/claims/release" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "kind": "phase",
+  "resource_key": "plan:<plan-stem>:phase:<n>",
+  "machine_id": "<machine_id>",
+  "agent_session_id": "$AGENT_SESSION_ID"
+}
+EOF
+)"
+```
+
+Release MUST carry the SAME `agent_session_id` used at acquire — the
+owner token is the match key, so a release that omits it (or sends a
+different session) will not match a session-scoped claim and returns
+`"not_held"` instead of `"released"`. (Omit the line if `$AGENT_SESSION_ID`
+is empty, exactly as at acquire.) The same applies to any
+`/claims/heartbeat` the spawned phase agent sends — it must reuse the
+inherited `$AGENT_SESSION_ID`.
+
+The release endpoint is idempotent — a `"not_held"` response is fine
+(heartbeat-based eviction may have already cleaned up if the phase ran
+longer than the claim's TTL with no heartbeat). Treat release as
+try/finally semantics: release MUST fire even on phase-agent failure,
+even on `/implement-plan` skill abort. If the operator chose Abort in
+the conflict-resolution flow, release every claim this session already
+acquired for earlier phases before exiting.
+
+Phase claims have a 7200s (2 hour) default TTL per `claims.rs:121`.
+For phases expected to exceed 2 hours, the spawned phase agent should
+heartbeat via `POST $COORD_HTTP_URL/claims/heartbeat` every TTL/3 seconds.
+This skill currently does NOT auto-heartbeat between phase launches;
+phases under 2 hours run safely on the initial acquire alone.
+
+#### `/loop` gap (documented limitation)
+
+`/loop` is built into Claude Code itself, NOT a user-editable slash
+command in `~/.claude/skills/` or `.claude/commands/`. As of 2026-05-18
+there is no way to inject this pre-flight into `/loop`-spawned phase
+agents from the skill layer. Operators using `/loop` for plan-phase work
+should either:
+
+- Manually pre-flight via the same `curl` shape above before invoking
+  `/loop`, and release on completion, OR
+- Wait for a future Claude Code update that exposes `/loop` as an
+  editable skill or adds a pre-flight hook mechanism, OR
+- Use `/implement-plan` directly for plan-phase work (this skill is the
+  canonical plan-driven entrypoint and IS pre-flight-coordinated).
+
+The runner-side spawn flow (Phase 3 of the agent-spawn-coordination
+plan) covers Tauri-IDE-initiated spawns through the same `/claims/acquire`
+gate; `/loop` is the remaining un-coordinated entrypoint.
+
+### Step 0.6.5: Publish activity to `coord.device_status`
+
+After acquiring the phase claim, UPSERT a status row so the operator
+dashboard's live "current activity" tile reflects what this agent is
+doing right now. This is the read-side of Phase 1.1 + 1.3 of plan
+`2026-05-21-coordination-improvements.md` — Phase 1.1 added the
+`tenant_id` column on `coord.device_status`; Phase 1.3 wires the
+dashboard's `MachineCard` to poll/subscribe `GET /coord/status?tenant_id=…`.
+This step fills the rows the dashboard renders.
+
+The UPSERT is keyed on `device_id`, so each new call overwrites the
+prior row for this machine. That's the correct shape — only one task
+can be "current" per machine at a time. The 1h `prune_stale()` job on
+coord (`status.rs:171-184`) handles cleanup if a skill crashes without
+clearing.
+
+**Skip-and-warn for non-coord environments.** Mirrors Step 0.6 — if
+`device_id` is not resolvable (env `QONTINUI_MACHINE_ID` unset AND
+`~/.qontinui/machine.json` missing or unreadable), emit a single-line
+warning and proceed. Status publication is observability, not gating.
+
+**Failure handling.** Any non-2xx response to the POST is logged as a
+single-line warning (`⚠️ coord status publish failed: <status> <body>`)
+and the skill continues. NEVER abort the implement-plan chain on a
+status publication error — the dashboard tile is observability, not
+a gate.
+
+#### Resolution chain (same identity sources as Step 0.6)
+
+1. **`device_id`.** Env `QONTINUI_MACHINE_ID` first. Else read
+   `~/.qontinui/machine.json` and parse the `"device_id"` field (the
+   canonical name post-unified-devices); fall back to `"machine_id"`
+   if present (legacy shape). The coord wire-field name is `device_id`
+   regardless of which local key supplied the UUID.
+2. **`current_repo`.** `basename "$(git rev-parse --show-toplevel)"`
+   from the worktree the skill is executing in.
+3. **`current_branch`.** `git symbolic-ref --short HEAD` from the same
+   worktree.
+4. **`tenant_id`.** Env `QONTINUI_TENANT_ID` if set; otherwise omit
+   the field entirely (the coord column is nullable and will default
+   to NULL).
+5. **Coord HTTP base.** Env `COORD_HTTP_URL` first. Else
+   `https://coord.qontinui.io` — same as Step 0.6.
+
+#### Initial UPSERT (after the first phase claim acquires)
+
+For the FIRST phase claim of this skill invocation, after the
+`/claims/acquire` returned `"claimed"` or `"renewed"`, issue:
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/coord/status" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "device_id": "<device_id>",
+  "current_task": "implement-plan: <plan-stem>",
+  "current_repo": "<repo basename>",
+  "current_branch": "<branch name>",
+  "details": {"phase": "<n>/<total>"},
+  "tenant_id": "<QONTINUI_TENANT_ID, omit field entirely if unset>"
+}
+EOF
+)"
+```
+
+`<n>/<total>` reflects the FIRST phase number being launched and the
+plan's total phase count from Step 0's checklist (e.g. `"1/14"`).
+
+#### Phase-launch UPSERT (before each subsequent phase agent)
+
+In Step 1, immediately BEFORE launching each phase agent (after that
+phase's `/claims/acquire`), issue the same POST with `details.phase`
+updated to that phase's `n/total`:
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/coord/status" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "device_id": "<device_id>",
+  "current_task": "implement-plan: <plan-stem>",
+  "current_repo": "<repo basename>",
+  "current_branch": "<branch name>",
+  "details": {"phase": "<n>/<total>"}
+}
+EOF
+)"
+```
+
+For parallel phase launches, fire one UPSERT per phase sequentially
+just before each Agent call — the rows overwrite each other quickly,
+but the "most recent" task is what the dashboard tile shows, and
+that's the right semantic for a single-machine fan-out.
+
+#### Final UPSERT — clear on completion (Step 6)
+
+When Step 6 (SHIPPED stamp + archive) completes successfully, POST one
+final upsert that clears `current_task` so the dashboard tile stops
+showing this plan as in-flight:
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/coord/status" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "device_id": "<device_id>",
+  "current_task": null,
+  "current_repo": "<repo basename>",
+  "current_branch": "<branch name>",
+  "details": {}
+}
+EOF
+)"
+```
+
+If the skill aborts before Step 6 (e.g. operator chose Abort in the
+Step 0.6 conflict-resolution flow, or a phase agent fails fatally),
+fire this clearing POST best-effort alongside the `/claims/release`
+calls in the same try/finally. If even that fails, the `prune_stale()`
+TTL will clean it up within an hour.
+
+#### `/loop` activity-publication gap
+
+The same `/loop` limitation from Step 0.6 applies here: `/loop` has no
+hook surface, so a `/loop`-spawned chain can't auto-publish its
+activity. Operators driving plan-phase work via `/loop` should either
+manually POST the same `/coord/status` shape above before invoking
+`/loop` and clear it on completion, OR use `/implement-plan` directly
+(this skill is status-instrumented end-to-end).
+
+### Step 0.7: UI Bridge wire-through pre-flight
+
+Before launching phase agents, scan the plan and the touched-files list for any of the SDK files below; if matched, include the reminder block in the agent prompt so the agent knows the SDK change has parallel runner layers it must wire through.
+
+> **UI Bridge wire-through reminder.** If your changes touch any of:
+> - `ui-bridge/packages/ui-bridge/src/server/handlers.ts`
+> - `ui-bridge/packages/ui-bridge/src/server/types.ts` (especially `UI_BRIDGE_ROUTES`)
+> - `ui-bridge/packages/ui-bridge/src/server/relay-handlers.ts`
+> - `ui-bridge/packages/ui-bridge/src/react/commandHandlers.ts`
+>
+> …the change MUST also be wired through the runner's three parallel layers, or it will silently 404 / drop fields against a live runner:
+> 1. **Direct HTTP handlers** in `qontinui-runner/src-tauri/src/mcp/ui_bridge/<family>.rs`. Register in the family's `routes()` AND `route_entries()` (per-family static manifest concatenated by `mod.rs::route_manifest()`).
+> 2. **WS-transport outer wrappers** in `qontinui-runner/src-tauri/src/mcp/sdk_client.rs` for browser-based consumers under `/ui-bridge/sdk/*`.
+> 3. **Frontend IPC bridge** in `qontinui-runner/src/hooks/ui-bridge-events/utils.ts` (and the family-specific `use*Events.ts` siblings) when the route depends on data only the React frontend has.
+>
+> Verify with: `cargo test manifest_matches_route_calls` (internal drift) AND `cargo test sdk_manifest_routes_are_exposed_by_runner` (SDK↔runner diff — Phase 2a). See `qontinui-runner/src-tauri/src/mcp/ui_bridge/CONTRACT.md` for the full per-route classification.
+>
+> For deeper assurance — query-param drops, field-stripping, status-code mismatches that the manifest diff can't see — run `pwsh qontinui-runner/scripts/contract-smoke.ps1` against a live supervisor (port 9875). It spawns a temp runner, hits every `UI_BRIDGE_ROUTES` entry, asserts the three known shape contracts (`revealsAny=` filters, `scope` round-trips, `expect` returns 422 on timeout), and stops the runner cleanly. ~3-5 minutes; required if your changes alter response shape, query handling, or status-code mapping.
+
+### Step 0.7.5: Semantic-resource reserve handshake (predict-then-reserve)
+
+Before a phase agent **authors** a change to a known **shared semantic
+resource**, it must reserve that resource through coord first — so two
+concurrent sessions don't hand-pick the same `down_revision` / registry
+slot and fork `main`. This is the read-side of the auto-reconcile +
+handshake layer (plan
+`2026-06-02-coord-conflict-autoreconcile-and-agent-handshake`); it pairs
+with the auto-rebase that re-points a loser when a fork *does* slip
+through, and with Plan A's CI gate that enforces the reservation existed.
+
+**Mandatory-reserve scope.** A resource is mandatory-reserve iff coord has
+a **registered `SemanticResource` grammar** for it. Today that is exactly:
+
+- **Alembic migration heads** — any phase that authors a new migration
+  (a `down_revision` pick). coord owns chain succession now: ask for a
+  **slot** and coord ASSIGNS your `down_revision`. Reserve it with
+  **`coord_migration_reserve`** (HTTP: `POST $COORD_HTTP_URL/coord/migrations/reserve`),
+  NOT `coord_claim_acquire` / `coord_reserve_resource`. The old
+  `kind=alembic_revision` claim is retired and returns **410**; the CI gate
+  matches your PR against your reservation and auto-binds it (no
+  `coord.claims_audit` claim to keep alive).
+- **The MCP tool registry** — any phase that adds/renumbers a tool
+  registration or a grammar-tracked count assertion. Resource:
+  `mcp-tool-registry:<mount>` (the registry mount, e.g. `phase11` — not
+  the repo), reserved via `coord_reserve_resource`.
+
+Other tracked-but-not-yet-grammared resources (enums, lockfiles) are
+**advisory** — reserve if convenient, but the CI gate is not (yet) keyed
+on them. The grammar registry is the single source of truth for "must
+reserve"; when a new grammar ships, that class becomes mandatory
+automatically — do not maintain a separate hand-edited list here.
+
+**Scan + inject.** Before launching each phase agent (alongside the
+Step 0.7 UI-Bridge scan), check whether the phase's touched-files /
+description authors a mandatory-reserve resource. If so, include this
+block in the agent prompt:
+
+> **Reserve-before-author handshake.** Before you author this change,
+> reserve the resource over MCP — the call differs by resource class:
+>
+> **Migration (alembic):** ask coord for a slot —
+> `POST $COORD_HTTP_URL/coord/migrations/reserve {"repo":"<repo>","revision":"<your-new-rev-id>","machine_id":...,"agent_session_id":...}`
+> (MCP: `coord_migration_reserve` when available). The response ASSIGNS your
+> `down_revision` — use it verbatim; never compute the head from a local
+> checkout. `position > 1` means you're stacked behind in-flight migrations
+> (fine — author against the assigned head). No heartbeat, no claim juggling:
+> push your PR and the CI gate auto-binds it; merge releases the slot. If a
+> predecessor expires/withdraws, coord re-points you — the gate (and a PR
+> comment) tells you the corrected `down_revision`; update the file and
+> re-push. Withdraw an abandoned slot:
+> `POST /coord/migrations/:id/withdraw {"reason":...}`. The old
+> `kind=alembic_revision` claim returns 410.
+>
+> **Tool registry / enum / lockfile:** call
+> **`coord_reserve_resource(kind, name)`** — `kind` is the lowercase-kebab
+> class (`mcp-tool-registry`, `enum`, `lockfile`); `name` is the instance
+> (e.g. the mount `phase11`). coord keys a `semantic_resource` claim on
+> `<kind>:<name>`.
+>
+> **Branch on the `coord_reserve_resource` result (tool-registry / enum /
+> lockfile):**
+> - **`Granted`** (or `claimed` with no `forking_siblings`) → you hold the
+>   reservation; proceed to author.
+> - **`Held { holder }`** → another agent owns it. **Do NOT hand-pick a
+>   value.** Wait for release (poll `coord_claim_check`) or coordinate with
+>   the holder, then re-reserve.
+> - **`ForkRisk { siblings }`** / a non-empty **`forking_siblings`** →
+>   sibling PR(s) are already racing this resource. Do **not** pick a value
+>   off the old head — chain off the current head or coordinate with the
+>   named siblings, so you don't author the fork.
+>
+> For the tool-registry path, heartbeat (`coord_claim_heartbeat`) if
+> authoring takes a while; release (`coord_claim_release`) once your commit
+> that claims the slot lands. (Migrations need none of this — the
+> reservation binds to your PR and is released by merge.)
+
+The semantic-resource tools live on coord's `phase11` MCP mount
+(`coord_claim_acquire/heartbeat/release/check`, `coord_reserve_resource`);
+migration reservations use `coord_migration_reserve` / `_bind_pr` /
+`_withdraw` / `_queue`. If a phase agent has no MCP access to coord, fall
+back to the HTTP API: migrations use
+`POST $COORD_HTTP_URL/coord/migrations/reserve` (coord assigns the
+`down_revision`); other semantic resources use
+`POST $COORD_HTTP_URL/claims/acquire` with
+`kind: "semantic_resource", resource_key: "<class>:<name>"`.
+
+**Skip-and-warn for non-coord environments.** Mirrors Step 0.6 — if no
+`machine_id` / coord base is resolvable, emit a single-line warning
+(`⚠️ reserve handshake skipped: no coord available`) and let the phase
+proceed without a reservation. The reserve is coordination, not a hard
+gate (the CI gate + auto-rebase are the backstops); never block authoring
+on a reserve failure.
+
+### Step 0.7.6: Edit-effect loop wire-through (predict → gate → verify)
+
+Include this block in EVERY phase agent's prompt — it wires the phase
+agent into coord's edit-effect D3 loop (plan
+`2026-06-05-edit-effect-loop-adoption`). The gate is advisory: it never
+blocks a phase, it informs the coordinator's decision.
+
+> **Edit-effect loop — predict, gate, verify.** Run coord's edit-effect
+> loop around your edits. Every call is **best-effort**: a failed or
+> unreachable coord NEVER blocks the phase — warn once and proceed.
+> `COORD_HTTP_URL` overrides the base (default `https://coord.qontinui.io`).
+>
+> **1. Pre-edit (after worktree allocation, before the first `Edit`):**
+> call predict-and-check with `{repo: "<repo basename>", paths: <the
+> phase's planned touched files>, head_sha: "<git rev-parse HEAD in the
+> worktree>", declared_globs: <plan/work-plan globs when present>,
+> declared_intent: "<plan-stem>: <phase title>"}`.
+> - **MCP (preferred):** `coord_edit_predict_and_check(<same JSON>)`.
+> - **HTTP fallback (universal):** `curl -fsS -X POST
+>   "$COORD_HTTP_URL/coord/edits/predict-and-check" -H "Content-Type:
+>   application/json" -d '<same JSON>'`.
+>
+> **2. Branch on the response envelope** (`{predicted_effect, resolution,
+> risk_factors}`). Read `resolution.action`: anything that is **not**
+> explicitly `escalate` (e.g. `proceed`) → continue silently. On
+> `escalate` → list the `risk_factors` strings; proceed only when EVERY
+> factor is blast-radius-shaped AND the plan's file inventory explicitly
+> scopes that many files. Otherwise STOP and report the factors verbatim
+> to the coordinator in your phase report — the coordinator applies the
+> decision framework (the gate creates no `agent_questions` row; you
+> never ask the operator directly).
+>
+> **3. Post-edit verify (after the phase commit):** call verify with
+> `{repo, paths: <files actually touched>, head_sha: "<the new commit
+> sha>", tests_predicted: <the predict response's `detail.affected_tests`,
+> when present>}` — MCP `coord_edit_verify(<JSON>)` or HTTP `curl -fsS -X
+> POST "$COORD_HTTP_URL/coord/edits/verify" …`. Record the composed
+> outcome (`composed_outcome` + the per-subspace summary) in your phase
+> report. A `Contradiction`/`Failure` composed outcome is a phase-report
+> **red flag**, NOT an automatic revert.
+
+### Step 0.8: Coordinator mode (when the plan scope is too large)
+
+If you complained earlier that the plan scope is too large to implement directly,
+**do not stop or hand back to the operator**. The main session pivots into
+coordinator mode and ships the plan by orchestrating subagents. The coordinator
+never writes feature code itself — its job is to spawn, review, decide, and
+unblock.
+
+#### Coordinator responsibilities
+
+1. **Spawn.** For each phase (and, within a phase, each independently-buildable
+   chunk if the phase itself is too large for one agent), launch an Agent with
+   a self-contained prompt — full phase description from the plan, file paths,
+   relevant context, and explicit instructions to implement fully (no stubs /
+   TODOs), run type checks + lints, fix what it finds, and report a structured
+   summary (files changed, decisions made, issues hit + how resolved, any
+   remaining concerns). Launch independent phases / chunks in parallel via
+   multiple Agent tool calls in a single message.
+2. **Review.** When each agent returns, read its summary critically. Spot-check
+   the actual diff with `git diff` / `Read` — don't trust the summary alone
+   (see [[feedback_verify_function_exists_before_trusting_stamp]]). Confirm:
+   the phase contract is met, no stubs were left behind, types/lints pass, no
+   half-finished abstractions, no backward-compat shims, no dead code, no
+   feature flags hiding incomplete work.
+3. **Decide autonomously.** When an agent surfaces an ambiguity, conflict, or
+   judgment call ("two ways to wire this — should I do A or B?"), DO NOT bounce
+   it back to the operator. Resolve it using the decision framework below and
+   issue the agent (or a follow-up agent) a concrete instruction. The operator
+   asked for a coordinated implementation, not a stream of questions.
+4. **Fix.** If an agent's output is wrong, incomplete, or violates the
+   framework, fix it — either by editing directly in the main context (for
+   small mechanical issues) or by spawning a follow-up agent with explicit
+   instructions on what to change and why. Never accept "good enough" output
+   that the framework would reject.
+5. **Integrate.** After each wave of parallel agents, do a cross-phase
+   integration pass in the main context: verify imports/exports line up,
+   shared types are consistent across boundaries, no two agents introduced
+   conflicting abstractions for the same concept. Reconcile divergences via
+   direct edit or a targeted follow-up agent.
+
+#### Decision framework
+
+When weighing options as the coordinator — whether resolving an agent's
+ambiguity, choosing between two implementation paths, or deciding whether to
+accept an agent's output — optimize against these priorities, in order:
+
+1. **Powerful features.** Prefer the option that unlocks more capability or
+   composes better with planned future work. A more powerful primitive beats
+   a narrower one even if the narrower one is "enough for now."
+2. **Scalability.** Prefer the option that holds up as data volume, user
+   count, concurrency, or call-site count grows. Reject choices that look
+   fine at current scale but have a known cliff.
+3. **Robustness.** Prefer the option that fails predictably, surfaces errors
+   clearly, and recovers cleanly. Bias toward explicit invariants, structured
+   errors, and verification at boundaries.
+4. **Clean code.** Prefer the option that future readers will understand
+   without archeology — clear names, focused functions, minimal indirection,
+   no dead branches, no comments explaining what the code already says.
+
+**Explicitly NOT factors:** programming effort (your time / token budget /
+agent count is not a constraint here — ship the right thing), backward
+compatibility (per CLAUDE.md, breaking changes are expected; delete-over-
+deprecate; refactor fearlessly).
+
+When two options tie on priorities 1–4, pick the one that leaves less
+follow-up work for the next plan. If you genuinely cannot decide after
+applying the framework, pick the option you'd defend in a code review and
+note the trade-off in the phase commit message — do not stall the chain
+asking the operator. (If priority-unresolvable decisions recur, propose
+expanding the priority sets at wrap-up.)
+
+#### Implementation priorities (execution)
+
+The engineering priorities above — with the UX gates for user-facing
+surfaces (memory: `ux-priorities-alongside-engineering`) — decide **what**
+to build. A third orthogonal set, the **implementation priorities** (memory:
+`implementation-priorities`), decides **how and when** the coordinator
+executes, in order:
+
+1. **Verified throughput.** Ship the most work that is built AND verified
+   this session; unverified volume counts as zero. Verification is tiered
+   by consumer: user-facing → goal observed on the page; consumer-free
+   infra → green CI + the documented autonomous checks. Delegate the
+   majority of the work to subagents to conserve coordinator context.
+2. **Early risk retirement.** Sequence waves most-falsifiable-first — run
+   the probe that can kill an assumption before the builds that depend on
+   it.
+3. **Autonomy with checks.** Proceed on checks, not permission. Merge,
+   production deploy, migration, new security surfaces, cross-repo scope
+   growth, and spend are all autonomous when their documented checks pass
+   (no-live-users era; merge = no-reap + serialize, deploy = no-users,
+   migrate = single head).
+4. **Momentum through re-planning.** A falsified plan assumption never
+   halts the session — see the escalation rules below.
+
+#### When to escalate to the operator anyway
+
+The coordinator is autonomous but not unconditional. Per the implementation
+priorities, exactly two things justify an `AskUserQuestion`:
+
+- **Operator-resource needs** — something only the operator can physically
+  do: start the primary runner, unlock a phone, complete an interactive
+  login, add a payment method.
+- **Oversize-plan handoff** — a re-planned or combined plan too large even
+  for coordinator-style orchestration: author it, vet it with a subagent,
+  then present it for a fresh session.
+
+Everything that used to be escalation-worthy is resolved in-session:
+
+- **Falsified premise or goal-changing finding** (e.g., "the feature already
+  exists under a different name") — re-evaluate against the priority sets
+  and select the new correct path automatically. If it fits the original
+  plan, incorporate it and keep building; if bigger, author a new/combined
+  plan, vet it with a subagent, and execute it coordinator-style; only the
+  oversize case above goes to the operator.
+- **Production deploys / migrations / new security surfaces** — autonomous
+  when the documented checks pass (see implementation priority 3).
+- **Questions no priority set breaks** — decide yourself; by definition it
+  is not important enough for the operator to have an opinion on. If this
+  recurs, propose expanding the priority sets at wrap-up.
+
+Destructive git and the rest of CLAUDE.md's "executing actions with care"
+list still get care — prefer the reversible path — but care means checks,
+not questions.
+
+Routine implementation choices — library selection, API shape, file layout,
+error-handling strategy, test structure — are NOT escalation triggers. Decide
+and move on.
+
+### Step 1: Implement All Phases (using subagents)
+
+For each phase in the approved plan, **launch an Agent** (not a Skill call). The agent prompt must include:
+
+1. The full phase description from the plan
+2. The relevant file paths and context the agent needs
+3. Instructions to: implement fully (no stubs/TODOs), run type checks/lints after, fix any issues found, and report what was changed
+
+**Coord claim pre-flight (per Step 0.6).** Immediately BEFORE launching
+the Agent for a given phase, run the Step 0.6 pre-flight for THAT phase
+(`POST /claims/acquire` with `kind=phase, resource_key=plan:<stem>:phase:<n>`).
+If `"held"`, resolve the conflict (abort/wait/steal) before proceeding to
+the Agent launch. When launching phases in parallel, pre-flight each
+phase's claim sequentially first (parallel acquires against distinct
+resource keys are safe but easier to surface conflicts on linearly),
+then launch the surviving phase Agents in parallel.
+
+**Coord activity UPSERT (per Step 0.6.5).** Immediately AFTER each
+phase's `/claims/acquire` succeeds and BEFORE launching that phase's
+Agent, fire the Step 0.6.5 phase-launch UPSERT with `details.phase`
+set to that phase's `<n>/<total>`. Failure is non-fatal (warn-and-
+continue per Step 0.6.5 rules). For parallel launches: fire the
+UPSERTs sequentially in launch order, then launch the Agents in
+parallel.
+
+**Reserve handshake (per Step 0.7.5).** If a phase authors a
+mandatory-reserve semantic resource (a new migration / a tool-registry
+change), include the Step 0.7.5 reserve-before-author block in that
+phase's Agent prompt so the agent reserves the resource (and, for
+migrations, uses the `down_revision` coord assigns) before authoring —
+never hand-picking a colliding value.
+
+**Edit-effect loop (per Step 0.7.6).** Include the Step 0.7.6
+predict→gate→verify block in EVERY phase Agent prompt so the agent
+predicts before its first edit, surfaces any `escalate` risk_factors to
+you, and verifies after its commit. Best-effort — never blocks a launch.
+
+**Launch independent phases in parallel** using multiple Agent tool calls in a single message. Only serialize phases that have true dependencies on each other.
+
+Each agent should:
+- Implement the phase completely
+- Run type checks and lints (`cargo check`, `npx tsc --noEmit`, `ruff check`, etc.)
+- Fix any errors or warnings
+- Report back: files changed, what was implemented, any issues found and fixed
+
+**Claim release (per Step 0.6).** AFTER each phase Agent returns —
+success OR failure — release that phase's claim via
+`POST /claims/release`. Treat as try/finally: release MUST fire even on
+agent failure or exception. On skill abort, release every claim this
+session acquired for any phase before exiting.
+
+After all phase agents complete, do a quick integration check in the main context:
+- Verify cross-phase wiring (imports, exports, type consistency across boundaries)
+- Run a combined type check/lint across affected repos
+- Fix any integration issues directly
+
+### Step 2: Manual Testing (if UI changes exist)
+
+If the feature has UI or runner-facing changes, **invoke `/manual-test` using the Skill tool:**
+
+```
+Skill: manual-test
+Args: <describe what to test based on the implemented features>
+```
+
+Fix any errors found. Re-invoke `/manual-test` after fixes. Repeat until passing.
+
+Skip this step if the feature is purely backend/library code with no UI changes.
+
+> **Runner UI changes — verify on a temp runner; NEVER the primary, NEVER stall, NEVER ask the operator.** This step is MANDATORY for a runner-facing UI change before the plan can be called done — a UX change is only verified by observing it rendered ([[feedback_verify_goal_on_page_not_inference]]). Do NOT leave the PR "pending on-device verification," do NOT propose that building+running the change "would disrupt the primary," and do NOT ask the operator to verify — all three are false and block autonomous development. The supervisor on `:9875` is INDEPENDENT of the primary on `:9876`: `POST /runners/spawn-test` builds the code into its own pool and spawns an isolated temp runner (port 9877+, own UI Bridge) with ZERO primary impact. Use `{"rebuild":true}` for origin/main, or slot-patch the worktree binary for PR/uncommitted code (`{"rebuild":false}`); drive the UI-Bridge visual check against the temp runner's port; `POST /runners/<id>/stop` when done. Full mechanics: `/manual-test` skill + memory `feedback_any_verification_uses_temp_runner_never_stall`.
+
+### Step 3: Write Specs (if UI pages affected)
+
+If any UI pages were created or modified, **invoke `/update-spec` using the Skill tool** for each affected page.
+
+### Step 4: Commit
+
+Use `/clean-commit` or commit manually. Do NOT include AI attribution.
+
+**Cooperative abort-report (commit-action effect signatures §6.2).** If a
+`git commit` is REJECTED by a pre-commit hook (non-zero exit), forward the
+reason to coord before fixing + retrying:
+`bash D:/qontinui-root/.claude/scripts/report-commit-abort.sh "<captured hook output>"`
+— best-effort, fail-open; it never edits git or blocks. `/clean-commit` Phase 4
+does this automatically; do the same on a manual commit. Never `--no-verify` to
+bypass the hook — that defeats both the hook and the supervision signal.
+
+### Step 5: UI Bridge Improvement Plan (if manual testing was performed)
+
+If manual testing was performed in Step 2, create a plan (using EnterPlanMode) for UI Bridge improvements based on friction encountered during testing. This plan is for a future session — do not implement it now.
+
+### Step 6: Mark the plan done and archive it
+
+Once Steps 1–5 land cleanly:
+
+1. **Stamp a status block at the top of the plan .md** (just below the H1 title) summarizing what shipped — applying the single-stamp invariant from Step 0.5 (delete the existing IN PROGRESS block, write SHIPPED in its place):
+   ```markdown
+   > **Status: SHIPPED <YYYY-MM-DD>.** <one-paragraph summary of what's
+   > live and where to find it — repo + key commit SHAs at minimum>.
+   ```
+   Keep it short — 3–6 lines. List the canonical commit SHAs (one per repo touched). If there's a follow-up plan with open items, name it.
+
+2. **Move the plan from in-progress to the completed archive.** Workspace convention:
+   - In-progress: `D:/qontinui-root/plans/` (workspace root, not git-tracked).
+   - Completed: `qontinui-dev-notes/plans/` (git-tracked archive).
+
+   Use a plain `mv plans/<name>.md qontinui-dev-notes/plans/<name>.md`. The plan's followup file (if any) stays in whichever location matches its own state — completed plans go to dev-notes, plans with open items stay at the workspace root.
+
+3. **Commit the archived plan in dev-notes.** Single commit with message like `plans: archive <plan-name> as shipped (<commit-sha-summary>)`. Push. This push is also what durably transitions the `coord.plans` registry row for `plan_status` gates (the ingest worker mirrors dev-notes origin/main; a registry upsert alone is reverted by the next tick — coord #564) — don't skip it.
+
+4. **If the plan was already authored inside `qontinui-dev-notes/plans/`** (e.g. it was vetted there from the start), skip the move; just edit the status block in place and commit.
+
+5. **Clear coord activity status (per Step 0.6.5).** Fire the final
+   clearing `POST /coord/status` documented in Step 0.6.5 with
+   `current_task: null` so the dashboard tile stops showing this plan
+   as in-flight. Failure is non-fatal — `prune_stale()` TTLs the row
+   within an hour.
+
+This step is mandatory. Plans without a status stamp lose context within weeks; plans left in the in-progress dir after they ship clutter triage and confuse future agents into thinking work is still pending.
+
+### Step 6.5: Offer to register a coord gate for any deferred/blocked phase
+
+*(canonical spec: `_gate-registration` — keep copies in sync)*
+
+This fires whenever a phase is **deferred or blocked on an observable condition**
+— a phase agent failed/aborted on something coord can watch (a PR must merge, a
+deploy must go healthy, CI must go green, a metric must cross a threshold, a time
+window must elapse, an operator must approve), OR Step 6 records a "follow-up
+plan with open items" that waits on such a condition. A deferral with no
+observable trigger (open-ended TODO) is NOT a gate — skip those.
+
+- **Default = explicit offer.** Ask via `AskUserQuestion` (header `Register
+  gate?`, options Register / Skip), showing the derived anchor, predicate kind,
+  and human-readable condition. Under opt-in auto mode (env `QONTINUI_AUTO_GATE=1`)
+  register WITHOUT asking and report what was registered (gate_id + predicate).
+- **Anchor (zero user input):** `plan_id` from `POST $COORD_HTTP_URL/coord/plans/upsert`
+  with the plan stem as `slug` (or `GET /coord/plans/<slug>`); `phase_name` from
+  the phase heading. Anchor = (plan_id, phase_name). Claim-bound deferrals use the
+  claim-anchored shape (`claim_kind`+`resource_key`) instead.
+- **Register:** prefer MCP `coord_register_gate` (kinds: `pr_merged`,
+  `deploy_healthy`, `claim_terminal`, `operator_approval`, `ci_green`,
+  `ref_exists`, `metric_threshold`, `time_elapsed`, `plan_ready`,
+  `migration_at_head`, `infra_drift_clear`, `file_exists`, `sql_count`,
+  `plan_status`, `gate_cleared`; optional
+  `continuation_prompt` e.g. `run /implement-phase <stem> "Phase N"` for
+  auto-resume). **HTTP fallback** when MCP is unavailable — for a plan-anchored gate
+  walk the transport cascade, first reachable wins: (1) the **device loopback
+  write-forwarder** `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<slug>`
+  with header `X-Coord-Mcp-Proxy-Key: <nonce from the live .mcp.json>`, no body
+  bearer (proxy injects the device JWT) — the **only `plan_ready`-capable device
+  door** (`{runner_port}` parsed from the live `.mcp.json` proxy URL, NOT `:9876`);
+  (2) the direct device-authed `POST $COORD_HTTP_URL/coord/plans/<slug>/register-gate`
+  when a raw device JWT is held (resolves tenant from the device JWT + upserts the
+  plan by slug + registers in one call — the operator-only `/coord/gates/register` +
+  `/coord/plans/upsert` 403 `tenant_not_resolved` for a device JWT); (3) MCP only
+  when a `plan_id` is already known; else (claim-anchored, or no device identity)
+  `POST $COORD_HTTP_URL/coord/gates/register` (default `https://coord.qontinui.io`).
+  Tenant derives server-side — never pass it.
+- **`clearance_audience`:** set `agent` for agent-verifiable facts ("/vet-plan
+  was run", "crate exists + tests green", "a dual run emitted evidence") so the
+  session that completes the work can attest the gate itself; set `operator` for
+  business/judgment/strategy or on-page-human-verification gates. Default is
+  `operator` if omitted; the sensitive-work rule always forces `operator`.
+- **Predicate choice:** wait-on-PR → `pr_merged`; wait-on-deploy →
+  `deploy_healthy`; wait-on-CI → `ci_green`; burn-in / wait-N-days →
+  `time_elapsed`; metric condition → `metric_threshold` (explicit `labels` — e.g.
+  `coord_ci_runner_count` MUST filter `{status:"idle"}`); a vetted plan that is
+  ready, dispatchable work → `plan_ready` (**NOT** `operator_approval` —
+  `operator_approval` is for genuine human decisions, not a work queue);
+  schema/alembic-at-head → `migration_at_head` `{schema}`; infra drift cleared →
+  `infra_drift_clear`; a repo file/workflow existing → `file_exists`
+  `{repo,path,on_ref?}` (contents, not refs); a coord data count crossing a bound
+  → `sql_count` `{query_id,op,n}` (whitelisted `query_id`, never raw SQL); an
+  umbrella plan reaching a status → `plan_status` `{plan_slug,status}`; another
+  cross-anchor gate clearing → `gate_cleared` `{gate_id}`;
+  needs-human → `operator_approval`. Anything **security / credential / billing /
+  strategy-sensitive** registers as `operator_approval` + notify — never an
+  auto-resuming gate, never silently auto-registered.
+- **Masked-tool honesty:** per-agent MCP allow-set curation can mask
+  `coord_register_gate` as unknown (coord `mcp/mod.rs`). If the call fails as
+  unknown/method-not-found, report **"gate NOT registered — coord_register_gate
+  not in this session's tool allow-set"** and fall back to HTTP (or surface to the
+  operator). NEVER report a gate registered without a returned `gate_id`.
+- The optional plan-file `## Gates` block is a **local convenience mirror only** —
+  coord is the source of truth; never require it, never read it back as
+  authoritative.
+
+**Attest-on-completion (close the loop).** When this run instead COMPLETES work
+that a registered gate was watching (e.g. a deferred phase that an earlier
+session gated now finishes), it MUST attest that gate — otherwise an agent-fact
+gate rots open until a human clicks it.
+
+- **Find the gate:** by the `gate_id` recorded at registration, or by lookup
+  `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>&phase_name=<name>` — the OPEN
+  gate whose condition the completed work satisfies.
+- **Attest:** prefer MCP `coord_attest_gate` (pass `gate_id` — works from a device
+  session since attest takes no plan upsert); fall back to the device loopback
+  forwarder `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/{gate_id}/attest`
+  (header `X-Coord-Mcp-Proxy-Key`, no body bearer — maskless fallback), then the
+  direct device-authed `POST $COORD_HTTP_URL/coord/gates/:gate_id/attest`. Tenant
+  derives server-side — never pass it. Legal only on an OPEN `operator_approval`
+  gate with `clearance_audience = 'agent'` in the caller's own tenant; coord flips
+  it to `cleared` and fires the same fanout as operator approve.
+- **Masked-tool honesty:** if `coord_attest_gate` is unknown/METHOD_NOT_FOUND it
+  isn't in this session's allow-set → fall back to the HTTP attest route. NEVER
+  claim a gate attested without a returned cleared `gate_id`.
+- **Honesty:** NEVER report a deferred item as done without EITHER a cleared
+  `gate_id` OR an explicit "gate not found" note.
+
+**Continuation cancel (refresh + takeover).** A CLEARED `plan_ready` gate may have
+dispatched a pending runner-terminal continuation. If you **re-register** a gate
+for the same plan/anchor, or this run **directly takes over** the work a pending
+continuation was queued for (the active takeover wiring lives in Step 0.6), first
+cancel that pending continuation so the runner does not spawn a redundant
+terminal: find it via `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>` (rows with
+`continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
+continuation_cancelled_at == null`), then
+`POST $COORD_HTTP_URL/coord/gates/:gate_id/continuation-cancel`
+`{cancelled_by, reason}` (`TenantId` auth — **NOT** available over the device
+loopback write-forwarder, which serves only `register-plan` + `attest`; cancel
+stays on the operator/`TenantId` path, unchanged). Best-effort, never blocking:
+404 = nothing pending; **409 `already_consumed` = a spawn already happened, report
+it honestly** rather than claiming the cancel landed. Narrate the cancelled
+`gate_id`. (canonical spec: `_gate-registration` → "Continuation cancel + refresh".)
+
+## Rules
+
+- **Phases run as Agents, not Skill calls** — this keeps implementation work out of the main context
+- **Never stop between phases** — the entire plan executes in one session
+- **Complete ALL work** — never skip tasks due to size or complexity
+- **Fix, don't report** — fix issues immediately, don't just list them
+- **Parallel by default** — launch independent phases concurrently; only serialize when there are true data dependencies
+- **Edit work runs in an allocated worktree, never the primary checkout** — before launching a phase Agent that will `Edit` / `Write` / run `git` against a coord-registered repo, the coordinator creates an isolated git worktree for that repo directly — `git -C <repo> worktree add -b <branch> <workspace-root>/<repo>-wt-<slug> origin/main` — and passes that path as the Agent's working directory. (The former HTTP face, `POST /agents/allocate-local`, was removed as dead code in runner #443; the in-process `agent_worktree::isolated_edit` facade serves runner-internal spawns only.) The Agent treats that path as its repo root; every edit lands there, never in the operator's primary checkout. Sibling to the `/manual-test` "never touch the primary runner" rule — same shape (don't share the primary), different substrate (git worktree vs supervisor temp runner). Remove the worktree (and its isolated CARGO_TARGET_DIR, kept OUTSIDE the worktree) after the work ships. **Why:** see `plans/2026-05-28-isolate-session-edit-work-in-worktrees.md` — the proximate cause was two concurrent skill chains editing the same primary checkout simultaneously.
+
+## Implementation Notes
+
+$ARGUMENTS

--- a/src-tauri/src/fleet_commands/vet-plan.md
+++ b/src-tauri/src/fleet_commands/vet-plan.md
@@ -1,0 +1,598 @@
+# Vet Plan
+
+Read a plan, research the codebase to validate its claims, and edit the plan in place to fix anything wrong, missing, or out-of-date. The plan is the deliverable — leave it stronger than you found it.
+
+## Decision priorities
+
+When the plan's choices need to be evaluated — pattern selection, abstraction boundaries, scope, sequencing, migration approach — judge them against the project's priorities, in this order:
+
+1. **Powerful features** — does the design unlock real capability, or settle for a thin shim?
+2. **Scalability** — does it hold up as data, concurrency, or surface area grows?
+3. **Robustness** — does it fail safely, handle edge cases, and stay correct under adversarial conditions?
+4. **Clean code** — is the structure clear, small, and consistent with how the codebase already solves similar problems?
+
+These four are the **engineering priorities** — they decide *what* gets built. Two sibling sets bind alongside them:
+
+- **UX priorities** (ordered: predictability → discoverability without clutter → no-surprise reversibility → honesty about uncertainty) — gates for any user-facing surface: an option that fails one is rejected even if it wins on power. Engineering breaks ties within UX. (Memory: `ux-priorities-alongside-engineering`.)
+- **Implementation priorities** (ordered: verified throughput → early risk retirement → autonomy with checks → momentum through re-planning) — govern *how and when* work executes, orthogonal to the other two sets. (Memory: `implementation-priorities`.) For vetting they bind in three places: **sequence phases most-falsifiable-first** (assumption-killing probes before the builds that depend on them); **size the plan against `/implement-plan` coordinator orchestration** — a plan too large even for subagent-delegated execution must be split or explicitly flagged for a fresh-session handoff; and the **escalation rule** in the Decision policy below.
+
+**Programming effort and backward compatibility are NOT factors.** Do not preserve a worse design because rewriting it would be more work, and do not flag a defect just because the fix is invasive. Do not endorse an awkward shape because it avoids breaking existing callers — breaking changes are expected in this project. If a plan's design is justified primarily by "less work" or "doesn't break X," that is itself a defect worth flagging.
+
+## Arguments
+
+- `$ARGUMENTS` — Path to the plan file (e.g. `C:/tmp/some-plan.md` or relative). If omitted, look for the most recently modified `*plan*.md` file under `C:/tmp` and the working tree root, and ask the user to confirm before editing.
+
+## Decision policy (binding)
+
+When vetting surfaces a question, a fork in the road, or an unresolved trade-off, **answer it yourself** using these priorities, in order:
+
+1. **Powerful features** — does this unlock capability the alternative cannot?
+2. **Scalability** — does this hold up across many runners, many users, many specs, many tenants?
+3. **Robustness** — fewer failure modes, clearer invariants, less silent drift?
+4. **Clean code** — simpler model, fewer special cases, better separation of concerns?
+
+**Explicitly NOT factors:**
+- Programming effort, implementation time, lines of code, refactor cost
+- Backward compatibility, migration burden, "would break existing callers"
+- "More conservative" or "smaller blast radius" as a tiebreaker
+
+If two options tie on the priorities above, prefer the one that **deletes more code** (delete over deprecate) and the one that **avoids new abstractions** when an existing one fits.
+
+Do not escalate questions to the user. If the priority sets (engineering, plus the UX gates for user-facing surfaces) genuinely don't resolve a question, it is by definition not important enough for the operator to have an opinion on — pick the option you'd defend in review and justify it in the plan edit. If priority-unresolvable questions recur, note in the vet summary that the priority sets should be expanded. The only things worth surfacing to the operator are **operator-resource needs** (something only they can physically do) and a plan **too large even for coordinator-style orchestration** (per the implementation priorities).
+
+When you resolve a question this way, write the decision into the plan with one sentence of rationale that names the priority that decided it (e.g. "**Resolved.** Use the registry-backed lookup — scales to N tenants without per-app caches.").
+
+## Instructions
+
+### 0. Publish activity to `coord.device_status`
+
+Before reading the plan, UPSERT a status row so the operator dashboard
+shows this session as vetting. This is the read-side of Phase 1.1 + 1.3
+of plan `2026-05-21-coordination-improvements.md` — Phase 1.1 added the
+`tenant_id` column on `coord.device_status`; Phase 1.3 wires the
+dashboard's `MachineCard` to render it. This step fills the row.
+
+The UPSERT is keyed on `device_id`, so each call overwrites the prior
+row for this machine. Skip-and-warn if `device_id` cannot be resolved —
+status publication is observability, not gating.
+
+**Resolution chain:**
+
+1. **`device_id`.** Env `QONTINUI_MACHINE_ID` first. Else read
+   `~/.qontinui/machine.json` and parse the `"device_id"` field; fall
+   back to `"machine_id"` if present (legacy shape). If neither
+   source supplies a UUID, emit a single-line warning and skip the
+   UPSERT (proceed to Step 1).
+2. **`current_repo`.** `basename "$(git rev-parse --show-toplevel)"`.
+3. **`current_branch`.** `git symbolic-ref --short HEAD`.
+4. **`tenant_id`.** Env `QONTINUI_TENANT_ID` if set; otherwise omit
+   the field (coord column is nullable).
+5. **Coord HTTP base.** Env `COORD_HTTP_URL` first, else
+   `https://coord.qontinui.io`.
+
+**`<plan-stem>`** is the plan filename without `.md` extension or
+directory prefix (e.g. `2026-05-21-coordination-improvements`).
+
+**Initial UPSERT** (fire before reading the plan):
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/coord/status" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "device_id": "<device_id>",
+  "current_task": "vet-plan: <plan-stem>",
+  "current_repo": "<repo basename>",
+  "current_branch": "<branch name>",
+  "details": {},
+  "tenant_id": "<QONTINUI_TENANT_ID, omit field entirely if unset>"
+}
+EOF
+)"
+```
+
+**Failure handling.** Any non-2xx response is logged as a single-line
+warning (`⚠️ coord status publish failed: <status> <body>`) and the
+skill continues. NEVER abort vetting on a status publication error.
+
+**Clear on completion (Step 6).** After Step 5 stamps the plan as
+VETTED, fire a clearing UPSERT with `current_task: null` so the
+dashboard tile stops showing this vet session as in-flight:
+
+```bash
+curl -fsS -X POST "$COORD_HTTP_URL/coord/status" \
+  -H "Content-Type: application/json" \
+  -d "$(cat <<EOF
+{
+  "device_id": "<device_id>",
+  "current_task": null,
+  "current_repo": "<repo basename>",
+  "current_branch": "<branch name>",
+  "details": {}
+}
+EOF
+)"
+```
+
+If the skill aborts before Step 5 (e.g. the plan was already SHIPPED
+and the user declined to overwrite), fire the clearing POST
+best-effort. If that also fails, `prune_stale()` TTLs the row within
+an hour.
+
+### 0.9. Name this session + terminal after the plan
+
+Derive a human name from the plan filename and use it to title the session
+and the terminal window. The rule: take the plan **stem** (filename without
+`.md` or directory), strip a leading `YYYY-MM-DD-` date prefix, and strip a
+trailing ` plan` / `-plan` / `_plan` word if present.
+(e.g. `2026-05-21-coordination-improvements` → `coordination-improvements`;
+`2026-06-02-fleet-auth-plan` → `fleet-auth`.)
+
+Run this once, substituting `<plan-stem>` (the same stem Step 0 computed):
+
+```bash
+DISPLAY=$(printf '%s' "<plan-stem>" \
+  | sed -E 's/^[0-9]{4}-[0-9]{2}-[0-9]{2}-//; s/[-_ ][Pp][Ll][Aa][Nn]$//')
+mkdir -p "$HOME/.qontinui/session-titles"
+printf '%s\n' "$DISPLAY" > "$HOME/.qontinui/session-titles/$CLAUDE_CODE_SESSION_ID"
+echo "$DISPLAY"
+```
+
+**Terminal title:** automatic. Writing the title-hint file is all you need —
+the `set-terminal-title.sh` Stop hook reads it and titles the terminal when
+this turn ends. Do NOT try to `echo` an escape sequence yourself; the harness
+strips tool-stdout control bytes, so it would silently no-op.
+
+**Session label (`/rename`):** this is the one thing a command cannot set on
+its own — Claude Code only renames the session when the operator types
+`/rename`, never programmatically mid-turn. So surface the derived name to the
+operator as a ready-to-paste line, e.g.:
+
+> Session named `coordination-improvements`. To set the Claude session label,
+> paste: `/rename coordination-improvements`
+
+The paste only affects the in-app session label; the terminal title is already
+handled by the title-hint file above.
+
+This step is best-effort: if `$CLAUDE_CODE_SESSION_ID` is unset or the write
+fails, skip it silently and continue — naming never blocks vetting.
+
+### 1. Read the plan in full
+
+Use `Read` on the path. Don't skim — note every concrete claim:
+- File paths, function names, line numbers
+- "There is no X" / "we'll need to add Y" assertions
+- Architectural decisions presented as locked
+- Estimates and phase breakdowns
+
+A plan written by someone else (or by past-you) usually has 2–4 things that look right but aren't. Your job is to find them.
+
+### 2. Verify every concrete claim
+
+For each claim in the plan, validate against the current codebase. Run these in parallel where possible:
+- **File / module exists** → `Glob` or `Read`
+- **Function or symbol exists** → `Grep` for the exact name
+- **"No prior art for this" assertions** → `Grep` aggressively for related patterns; the prior art is usually one rename away (e.g. plan says "wrappers need a proxy" — search for `*proxy*.rs` across the repo)
+- **Architectural assumptions** → spot-check 1–2 representative files
+- **Memory references** → cross-check against `MEMORY.md` entries (memories can be stale; verify before quoting)
+
+When the plan proposes a NEW abstraction, always check whether an existing one already covers it. The single most common defect in plans is "let's add helper X" when helper X already exists under a different name.
+
+If the plan touches any of the SDK files below, also verify the runner-side parallel implementations exist — a plan that only edits the SDK side without naming the runner-side wireups is incomplete and should be flagged as a defect.
+
+> **UI Bridge wire-through reminder.** If your changes touch any of:
+> - `ui-bridge/packages/ui-bridge/src/server/handlers.ts`
+> - `ui-bridge/packages/ui-bridge/src/server/types.ts` (especially `UI_BRIDGE_ROUTES`)
+> - `ui-bridge/packages/ui-bridge/src/server/relay-handlers.ts`
+> - `ui-bridge/packages/ui-bridge/src/react/commandHandlers.ts`
+>
+> …the change MUST also be wired through the runner's three parallel layers, or it will silently 404 / drop fields against a live runner:
+> 1. **Direct HTTP handlers** in `qontinui-runner/src-tauri/src/mcp/ui_bridge/<family>.rs`. Register in the family's `routes()` AND `route_entries()` (per-family static manifest concatenated by `mod.rs::route_manifest()`).
+> 2. **WS-transport outer wrappers** in `qontinui-runner/src-tauri/src/mcp/sdk_client.rs` for browser-based consumers under `/ui-bridge/sdk/*`.
+> 3. **Frontend IPC bridge** in `qontinui-runner/src/hooks/ui-bridge-events/utils.ts` (and the family-specific `use*Events.ts` siblings) when the route depends on data only the React frontend has.
+>
+> Verify with: `cargo test manifest_matches_route_calls` (internal drift) AND `cargo test sdk_manifest_routes_are_exposed_by_runner` (SDK↔runner diff — Phase 2a). See `qontinui-runner/src-tauri/src/mcp/ui_bridge/CONTRACT.md` for the full per-route classification.
+>
+> If the plan ALSO touches response shape, query-param parsing, or status-code mapping (not just route registration), flag the absence of a `qontinui-runner/scripts/contract-smoke.ps1` run as a vet defect — the manifest diff catches missing routes but not field-stripping, query drops, or status-code drift.
+
+### 3. Identify defects
+
+Categorize what you find:
+- **Wrong** — claim contradicts the code (path, signature, behavior)
+- **Redundant** — proposes new code that duplicates existing infrastructure
+- **Missing** — overlooks a concrete consumer, edge case, or coupled subsystem
+- **Misaligned** — proposes a pattern inconsistent with how the codebase already solves the same problem
+- **Stale** — built on a prior assumption that has since changed
+
+Don't flag style preferences or hypothetical concerns — only material defects.
+
+### 4. Edit the plan in place
+
+Use `Edit` (not `Write`) to surgically fix the plan, preserving the author's voice and structure. Specifically:
+- **Add a "Discovered prior art" section** near the top if the plan missed existing infrastructure. Include a small table with `Piece | Location | Notes`.
+- **Rewrite speculative sections** ("search for X, it might be in Y") to point at the actual file:line.
+- **Replace proposed abstractions** that duplicate existing ones — show the existing pattern as the template.
+- **Update file inventories** to match what will actually be created/modified.
+- **Resolve open questions** inline. Two ways a question gets resolved:
+  - *Research answered it* — strike through and explain (`~~...~~ **Resolved.** ...`).
+  - *No new evidence, but the question is about an engineering trade-off* — apply the **Decision policy** above. Pick the option that wins on power → scalability → robustness → clean code, and write the decision into the plan with one sentence of rationale naming the deciding priority. Do NOT punt the question back to the user just because it requires judgment.
+- **Add concrete file:line citations** where the plan was vague.
+- **Verify `Depends-On:` targets exist** — see [Depends-On verification](#depends-on-verification) below.
+- **Don't gut sections that are already correct** — the goal is targeted fixes, not a rewrite.
+
+If the plan's overall direction is sound but an entire phase is wrong, rewrite that phase. If the overall direction is wrong, stop and surface that to the user before editing — don't silently rewrite the architectural premise.
+
+#### Depends-On verification
+
+A plan MAY declare upstream dependencies inline in its status blockquote
+using a `Depends-On:` suffix:
+
+```markdown
+> **Status: VETTED 2026-05-21.** <summary>. Depends-On: 2026-05-20-default-tenant-propagation, 2026-05-19-some-other-plan.
+```
+
+Parser rule (same as `/verify-plan-status` and `/implement-plan` — keep
+these three skills aligned):
+
+1. Look at the status blockquote (the first `> **Status:` block under the
+   H1) and find EVERY case-sensitive `Depends-On:` occurrence — a block
+   often carries one in the headline sentence and another in a trailing
+   `History:` / re-vet line.
+2. For each occurrence, consider only the remainder of that PHYSICAL line
+   — never the following blockquote lines or paragraphs, which may name
+   unrelated plans in prose.
+3. Within that line, keep only date-prefixed plan-stem-shaped tokens
+   (`YYYY-MM-DD-<kebab-slug>`, e.g. `2026-06-02-some-plan`). Prose, bare
+   dates (`2026-05-21.`), and trailing punctuation never produce tokens
+   — a stem requires at least one `-word` segment after the date. Each
+   token is a bare plan **stem** — no `.md` extension, no path.
+4. Union the stems across all occurrences, deduped, order-preserving.
+
+   (A naive first-occurrence + split-on-commas parse mis-handled real
+   status blocks whose prose contained a second `Depends-On:` or commas —
+   it produced phantom missing-dep aborts. Fixed in the canonical resolver
+   2026-06-04; this inline fallback mirrors it.)
+
+For each dep stem, resolve to a plan file using the lookup chain:
+
+1. Try `D:/qontinui-root/plans/<stem>.md` first (in-progress location).
+2. If that doesn't exist, try `D:/qontinui-root/qontinui-dev-notes/plans/<stem>.md`
+   (shipped archive).
+3. If neither exists, the dep is **missing** — flag it as a vet defect.
+
+Use `Read` (a failure is the not-found signal) or `Glob` to check both
+locations. A missing dep is a `Wrong` or `Stale` defect per Step 3's
+categories — it means the plan references upstream work that either was
+renamed, never written, or already archived under a different stem.
+
+When you find missing-dep defects:
+
+- Add them to the report under "Missing dependencies" with the exact
+  unresolved stem.
+- Include them in the auto-fix count if you correct the stem in the plan
+  (the plan author may have typo'd the stem). If you can't determine the
+  correct stem, leave the typo'd value in the plan but flag it for the
+  user — do NOT silently delete the Depends-On entry.
+- A plan with one or more missing deps is still vettable; the missing-dep
+  finding does not block stamping `VETTED`. It just gets surfaced in the
+  report.
+
+A plan with no `Depends-On:` field is the common case — no verification
+needed.
+
+### 5. Stamp the plan as VETTED
+
+After surgical fixes are written, add a status block immediately below the
+H1 title. Use the same format `/verify-plan-status` and `/implement-plan`
+use, so the lifecycle reads cleanly:
+
+```markdown
+# <Plan Title>
+
+> **Status: VETTED <YYYY-MM-DD>.** <one-line summary of what was checked
+> and what survived the audit>. Defects found: <count>. Auto-fixed: <count>.
+> Surfaced for user: <count>. <Optional: pointer to follow-up plan if you
+> created one in the report.>
+```
+
+#### Single-stamp invariant — read before stamping
+
+A plan must have **exactly one** `> **Status:` blockquote between the H1
+and the body. Before writing your stamp:
+
+1. Read the top of the plan. Identify EVERY top-of-file blockquote that
+   asserts a status, lifecycle state, or verification date — lines
+   starting with `> **Status:`, `> **Edit YYYY-MM-DD —`, or `> **Update:`
+   all count. Don't be picky about format; if it reads like a status
+   declaration, it counts.
+2. Use `Edit` to **delete every existing status-adjacent blockquote** —
+   even if it came from a different skill (`/verify-plan-status` writes
+   `NOT STARTED` / `PARTIAL`; `/implement-plan` writes `IN PROGRESS` /
+   `SHIPPED`; older `/vet-plan` runs may have left `Status: VETTED ...`).
+   Yours replaces all of them.
+3. Then `Edit` again to insert your single new `> **Status: VETTED …`
+   block.
+4. If folding in history is useful (e.g., the plan was previously
+   `NOT STARTED` per a verify pass, or had earlier verifier findings
+   in a separate `> **Edit:` block), include the salient info in
+   **one trailing line inside your new block**, prefixed `History:` or
+   `Previously:`. Never as a sibling blockquote.
+
+When `/vet-plan` and `/verify-plan-status` disagree on what the status
+should be (the plan is both VETTED *and* NOT STARTED — a vetted plan
+that nobody has implemented yet), consolidate: write the lifecycle
+stage in the heading (`Status: VETTED <date> — implementation not
+started.`) and put the verifier's findings in the body. The two
+skills do NOT both stamp side-by-side.
+
+#### Lifecycle states
+
+| State | Owner skill | Means |
+|---|---|---|
+| DRAFT | author | plan written, not yet vetted |
+| VETTED | `/vet-plan` | claims audited; ready to implement |
+| IN PROGRESS | `/implement-plan` | implementation underway |
+| SHIPPED | `/implement-plan` or `/verify-plan-status` | all phases live in code |
+| PARTIAL | `/verify-plan-status` | some phases live, some open |
+| NOT STARTED | `/verify-plan-status` | no implementation evidence |
+| SUPERSEDED / OBSOLETE | any | terminal states |
+
+`/vet-plan` writes only `VETTED`. If the existing block is `SHIPPED`,
+`SUPERSEDED`, or `OBSOLETE`, do NOT overwrite — surface to the user
+that they're vetting a closed plan and confirm they actually want this
+rewrite. (`PARTIAL` and `NOT STARTED` are fine to overwrite — your vet
+pass produces fresher information.)
+
+This stamp is mandatory. A vetted plan without the stamp is
+indistinguishable from a draft, and `/implement-plan` will treat it as
+still-aspirational.
+
+After stamping, fire the clearing `POST /coord/status` documented in
+Step 0 with `current_task: null` so the dashboard tile stops showing
+this vet session as in-flight.
+
+### 5.4. Register a `plan_ready` gate for the vetted plan (dispatchable-work queue)
+
+*(canonical spec: `_gate-registration` — keep copies in sync)*
+
+A VETTED plan is **ready, dispatchable work** — not a human decision. When you
+stamp VETTED, register (or **refresh** an existing) `plan_ready` gate so coord
+turns the ready plan into a queued continuation that dispatches into a session
+the operator can **see**, instead of leaving the plan to rot until someone
+clicks. This **replaces** the old `operator_approval`-bootstrap gate that used
+to queue ready work: a work queue is `plan_ready`, NOT `operator_approval`
+(`operator_approval` is for genuine human decisions only — see the predicate
+guidance in `_gate-registration`).
+
+Register exactly once per VETTED stamp (refresh, don't duplicate):
+
+> **Agent sessions: use the device-authed door.** A vetting agent holds a coord
+> **device JWT** (carrying `tenant_id`) but **no `OperatorContext`**, so the
+> operator-only `POST /coord/plans/upsert` and `POST /coord/gates/register` both
+> 403 `tenant_not_resolved` — the designed §5.4 auto-dispatch silently never
+> fired from a vetting agent. For a `plan_ready` gate the MCP tool is **not**
+> usable from a proxy-shaped device session (it needs a pre-resolved `plan_id` and
+> `/coord/plans/upsert` 403s a bare device JWT), so prefer, in order: (1) the
+> **device loopback write-forwarder**
+> `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<plan stem>`
+> with header `X-Coord-Mcp-Proxy-Key: <nonce from the live .mcp.json>` and **no
+> body bearer** (the runner proxy injects a fresh device JWT → coord's
+> `/coord/plans/<slug>/register-gate`; atomic slug-upsert + register) — the only
+> device-reachable door for `plan_ready`; `{runner_port}` = parse the proxy URL in
+> the live `.mcp.json` (NOT `:9876`), nonce = `X-Coord-Mcp-Proxy-Key` from that
+> same file (prefer the coord-repo `.mcp.json`)
+> (`2026-06-15-coord-mcp-live-token-write-forwarder`); (2) the **direct
+> device-authed HTTP endpoint** `POST $COORD_HTTP_URL/coord/plans/<plan
+> stem>/register-gate` when a raw device JWT is actually held, which resolves
+> tenant from the device JWT, **upserts the plan row by slug (folding step 1)**,
+> and registers the gate in one call — NOT the operator-only routes; (3) MCP
+> `coord_register_gate` only when a `plan_id` is already known (non-`plan_ready`).
+> Only if no device identity is available at all does the acting-user-token dance
+> apply. (`2026-06-15-coord-device-authed-plan-ready-gate-registration`.)
+
+1. **Resolve `plan_id`.** For the MCP path, `POST $COORD_HTTP_URL/coord/plans/upsert`
+   with `{ "slug": "<plan stem>", "title": "<plan H1>" }` (idempotent on slug; the
+   stem is the filename without `.md`/path, the same `<plan-stem>` Step 0 used) —
+   but this route is operator-only and **403s for an agent session**, so a vetting
+   agent should instead use the device-authed `register-gate` endpoint in step 4,
+   which upserts the plan itself. The returned `plan_id` anchors the gate.
+2. **Resolve the operator's `device_id` DYNAMICALLY** (never hardcode a UUID):
+   env `QONTINUI_MACHINE_ID` first, else read `~/.qontinui/machine.json` and parse
+   `"device_id"` (fall back to `"machine_id"` if present). If neither yields a
+   UUID, skip the continuation spawn but still register the gate (notify-only) and
+   note it in the report.
+3. **Check for an existing gate** anchored to this plan
+   (`GET $COORD_HTTP_URL/coord/gates?plan_id=<id>` — find an OPEN `plan_ready`
+   gate for this plan). If one exists, **refresh** it (re-register / update the
+   continuation) rather than creating a duplicate. **Before refreshing, cancel
+   the prior gate's PENDING continuation** so the old queued runner-terminal spawn
+   does not fire alongside the new one: for any row in that GET with
+   `continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
+   continuation_cancelled_at == null`, fire
+   `POST $COORD_HTTP_URL/coord/gates/:gate_id/continuation-cancel`
+   `{cancelled_by:"<this session>", reason:"refreshed — superseded by re-registration"}`
+   (`TenantId` auth, tenant derives server-side — **NOT** available over the device
+   loopback write-forwarder, which serves only `register-plan` + `attest`; cancel
+   stays on the operator/`TenantId` path). Best-effort: a 404 = nothing pending; a
+   409 `already_consumed` = a spawn already happened (report it, don't pretend the
+   cancel landed). (canonical spec: `_gate-registration` →
+   "Continuation cancel + refresh".)
+4. **Register** via the transport cascade in the blockquote above: for a proxy-shaped
+   device session, the **device loopback write-forwarder**
+   `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<plan stem>`
+   (header `X-Coord-Mcp-Proxy-Key`, no body bearer — proxy injects the device JWT)
+   is the only `plan_ready`-capable door; when a raw device JWT is held, the direct
+   device-authed `POST $COORD_HTTP_URL/coord/plans/<plan stem>/register-gate`
+   (resolves tenant from the device JWT, upserts the plan by the `:slug` path param,
+   then registers; body omits `slug`/`plan_id`, which come from the path + JWT). MCP
+   `coord_register_gate` only when a `plan_id` is already known. The legacy
+   operator-only `POST /coord/gates/register` 403s for an agent — do not fall back
+   to it.
+   - **Predicate:** `{"kind": "plan_ready", "plan_slug": "<plan stem>"}` — coord
+     auto-clears it when `coord.plans.status == 'vetted'` AND every other gate
+     anchored to this plan is cleared. (The device-authed endpoint accepts any
+     **predicate-cleared** kind; only `operator_approval` — a human decision — is
+     rejected 403, so it can never become a work-queue-as-decision fallback.)
+   - **Anchor:** the plan. On the device-authed endpoint the `plan_id` comes from
+     the by-slug upsert; pass `phase_name` (the plan title, or a synthetic label
+     like `"vet→implement handoff"` for a whole-plan gate — `phase_name` is
+     **required**, since coord's plan anchor is `plan_id` + `phase_name` together).
+   - **`continuation_spawn`:** target the operator's device with a **visible**
+     session —
+     ```json
+     {
+       "target_device_id": "<device_id from step 2>",
+       "presentation": "terminal",
+       "initial_prompt": "run /implement-plan plans/<plan stem>.md",
+       "continuation_prompt": "run /implement-plan plans/<plan stem>.md",
+       "repos": ["<the plan's repo slug(s) — see below>"]
+     }
+     ```
+     `presentation: "terminal"` (coord PR #356) opens a VISIBLE terminal window on
+     the target device running the `claude` CLI with the prompt as argv — the
+     operator sees it and can interrupt (that is the point of a visible
+     continuation, per the visible-gate-continuations plan).
+     **Populate `repos` with the plan's declared repo(s)** (from the plan's
+     `**Repo(s):**` line, or the repos the plan touches) — do NOT leave it `[]`.
+     An empty `repos` makes `acquire_continuation_workdir` skip worktree
+     allocation and drop the continuation's terminal cwd onto the SHARED ROOT
+     (`D:/qontinui-root`) uncoordinated — the exact concurrent-WIP clobber the
+     coordination layer exists to prevent. With `repos` set, the runner
+     provisions an isolated `.agent-worktrees/<id>/<repo>` worktree (the first
+     repo) as the cwd, so the session edits a per-session worktree under a
+     `kind=worktree` claim from the first tick. If the plan genuinely touches no
+     repo (a pure-investigation plan), `[]` is acceptable.
+   - **`clearance_audience`:** `plan_ready` auto-clears by predicate, so audience
+     is moot for *clearing*; register consistently with the model (default
+     `operator`) — the typed predicate, not a human, is what clears it.
+5. **Masked-tool honesty + verification:** if `coord_register_gate` reads as
+   unknown/method-not-found (per-agent allow-set masking) fall back to HTTP, and
+   NEVER report a gate registered/refreshed without a returned `gate_id`.
+
+(If coord doesn't yet accept `plan_ready` — e.g. the deploy that ships coord
+PR #356 hasn't landed — report the gate as NOT registered with the reason, rather
+than silently registering an `operator_approval` fallback that would re-create the
+work-queue-as-decision antipattern.)
+
+**Push the stamped file (ingest-scanned roots).** If the plan lives under an
+ingest-scanned root (`qontinui-dev-notes/plans/` archive — the active root on
+dev boxes), the VETTED stamp MUST be committed + pushed: a registry upsert alone
+is reverted by the next plan-ingest tick (coord #564) until the edge-trigger fix
+ships, and even after, the push is what makes the transition durable-by-design —
+file edges are the canonical transition signal. (claude-config is NOT a coord
+sole-authority repo — its PRs land via normal GitHub flow.)
+
+### 5.5. Offer to register a coord gate for a flagged-but-not-fixed item
+
+*(canonical spec: `_gate-registration` — keep copies in sync)*
+
+If vetting surfaces an item you flagged for the user that **cannot be resolved
+now because it gates on an observable condition** (an upstream PR must merge, a
+deploy/CI must go green, a metric must cross a threshold, a time window must
+elapse, or an operator must approve), offer to register a coord gate for it — so
+coord watches the condition rather than the finding rotting in the report. A
+flagged item with no observable trigger (a product/scope call) is NOT a gate;
+leave it in the report.
+
+- **Default = explicit offer** via `AskUserQuestion` (header `Register gate?`,
+  options Register / Skip), showing the derived anchor + predicate + condition.
+  Under opt-in auto mode (env `QONTINUI_AUTO_GATE=1`) register without asking and
+  note the gate_id in the report.
+- **Anchor (zero user input):** `plan_id` from `POST $COORD_HTTP_URL/coord/plans/upsert`
+  with the plan stem as `slug` (or `GET /coord/plans/<slug>`); `phase_name` from
+  the relevant phase/section heading. Anchor = (plan_id, phase_name).
+- **Register:** prefer MCP `coord_register_gate` (kinds: `pr_merged`,
+  `deploy_healthy`, `claim_terminal`, `operator_approval`, `ci_green`,
+  `ref_exists`, `metric_threshold`, `time_elapsed`, `plan_ready`,
+  `migration_at_head`, `infra_drift_clear`, `file_exists`, `sql_count`,
+  `plan_status`, `gate_cleared`; optional
+  `continuation_prompt`). **HTTP fallback** when MCP is unavailable — for a
+  plan-anchored gate walk the transport cascade, first reachable wins: (1) the
+  **device loopback write-forwarder**
+  `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<slug>` with
+  header `X-Coord-Mcp-Proxy-Key: <nonce from the live .mcp.json>`, no body bearer
+  (proxy injects the device JWT) — the **only `plan_ready`-capable device door**
+  (`{runner_port}` parsed from the live `.mcp.json` proxy URL, NOT `:9876`);
+  (2) the direct device-authed `POST $COORD_HTTP_URL/coord/plans/<slug>/register-gate`
+  when a raw device JWT is held; (3) MCP only when a `plan_id` is already known;
+  else (claim-anchored, or no device identity)
+  `POST $COORD_HTTP_URL/coord/gates/register` (default `https://coord.qontinui.io`).
+  Tenant derives server-side — never pass it.
+- **`clearance_audience`:** set `agent` for agent-verifiable facts ("/vet-plan
+  was run", "crate exists + tests green", "a dual run emitted evidence") so the
+  session that completes the work can attest the gate itself; set `operator` for
+  business/judgment/strategy or on-page-human-verification gates. Default is
+  `operator` if omitted; the sensitive-work rule always forces `operator`.
+- **Predicate choice:** wait-on-PR → `pr_merged`; wait-on-deploy →
+  `deploy_healthy`; wait-on-CI → `ci_green`; burn-in → `time_elapsed`; metric →
+  `metric_threshold` (explicit `labels` — e.g. `coord_ci_runner_count` MUST filter
+  `{status:"idle"}`); a vetted plan that is ready, dispatchable work → `plan_ready`
+  (**NOT** `operator_approval` — `operator_approval` is for genuine human
+  decisions, not a work queue); schema/alembic-at-head → `migration_at_head`
+  `{schema}`; infra drift cleared → `infra_drift_clear`; a repo file/workflow
+  existing → `file_exists` `{repo,path,on_ref?}` (contents, not refs); a coord
+  data count crossing a bound → `sql_count` `{query_id,op,n}` (whitelisted
+  `query_id`, never raw SQL); an umbrella plan reaching a status → `plan_status`
+  `{plan_slug,status}`; another cross-anchor gate clearing → `gate_cleared`
+  `{gate_id}`; needs-human → `operator_approval`. Anything
+  **security / credential / billing / strategy-sensitive** → `operator_approval` +
+  notify, never an auto-resuming gate, never silently auto-registered.
+- **Masked-tool honesty:** if `coord_register_gate` fails as unknown/
+  method-not-found (per-agent MCP allow-set masking, coord `mcp/mod.rs`), report
+  **"gate NOT registered — coord_register_gate not in this session's tool
+  allow-set"** and fall back to HTTP (or surface to the operator). NEVER report a
+  gate registered without a returned `gate_id`.
+- The plan-file `## Gates` block is a **local convenience mirror only** — coord is
+  the source of truth; never require it, never read it back as authoritative.
+- **Re-registering for the same plan/anchor:** first cancel the prior gate's
+  PENDING continuation (the §5.4 refresh-cancel rule applies to any
+  continuation-carrying gate too) — `GET .../coord/gates?plan_id=<id>` for rows
+  with `continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
+  continuation_cancelled_at == null`, then
+  `POST .../coord/gates/:gate_id/continuation-cancel {cancelled_by, reason}`
+  (`TenantId` auth, best-effort). (canonical spec: `_gate-registration` →
+  "Continuation cancel + refresh".)
+
+**Attest-on-completion (close the loop).** Vetting normally registers gates
+rather than completing gated work — but if this run also COMPLETES work that a
+registered gate was watching, it MUST attest that gate (otherwise an agent-fact
+gate rots open until a human clicks it).
+
+- **Find the gate:** by the `gate_id` recorded at registration, or by lookup
+  `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>&phase_name=<name>` — the OPEN
+  gate whose condition the completed work satisfies.
+- **Attest:** prefer MCP `coord_attest_gate` (pass `gate_id` — works from a device
+  session since attest takes no plan upsert); fall back to the device loopback
+  forwarder `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/{gate_id}/attest`
+  (header `X-Coord-Mcp-Proxy-Key`, no body bearer — maskless fallback), then the
+  direct device-authed `POST $COORD_HTTP_URL/coord/gates/:gate_id/attest`. Tenant
+  derives server-side — never pass it. Legal only on an OPEN `operator_approval`
+  gate with `clearance_audience = 'agent'` in the caller's own tenant; coord flips
+  it to `cleared` and fires the same fanout as operator approve.
+- **Masked-tool honesty:** if `coord_attest_gate` is unknown/METHOD_NOT_FOUND it
+  isn't in this session's allow-set → fall back to the HTTP attest route. NEVER
+  claim a gate attested without a returned cleared `gate_id`.
+- **Honesty:** NEVER report a deferred item as done without EITHER a cleared
+  `gate_id` OR an explicit "gate not found" note.
+
+### 6. Report
+
+Brief — under 150 words. State:
+- What the plan was about (one sentence)
+- The 2–5 material defects found, each with the section they were in
+- What you changed (referenced by section name, not full diff)
+- The status stamp you added (`Status: VETTED <date>`)
+- Open questions you **resolved using the Decision policy**, with the deciding priority in parentheses (e.g. "picked registry-backed lookup (scalability)")
+- Anything you flagged for the user that you did NOT auto-fix — limit this to product/scope/stakeholder calls the Decision policy can't decide; engineering trade-offs should already be resolved in the plan
+
+End-of-turn summary: one or two sentences.
+
+## Rules
+
+- **Edit the plan, don't rewrite it.** Surgical changes only. Preserve the author's structure unless an entire section is wrong.
+- **Cite the code.** Every claim added to the plan should reference a file:line. "Almost certainly exists" is not good enough.
+- **Verify memories before quoting them.** `MEMORY.md` entries are point-in-time observations; check the current code before treating a memory as fact.
+- **Don't add new phases or scope.** If you find work the plan missed, note it in the report — adding a new phase is a decision for the user.
+- **Parallelize research.** Use Glob, Grep, and Read in parallel; spawn `Explore` for broad surveys.
+- **No new files.** The plan file is the only thing you should be writing to.
+- **Decide; don't escalate.** Engineering trade-offs surfaced during vetting must be resolved in the plan using the Decision policy. Effort and backward compatibility are not factors. Only kick a question up to the user when it's genuinely a product/scope/stakeholder call.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -77,6 +77,7 @@ mod fixer;
 // (was `coord.machines` pre-Phase-3-Unified-Devices-Registry) so
 // `GET /coord/fleet` can answer "where do I have agent capacity?".
 mod fleet;
+mod fleet_commands;
 mod flow_control;
 mod follow_up;
 mod fs_atomic;


### PR DESCRIPTION
## Phase 0 — fleet-plan-lifecycle-orchestrator

Makes the canonical vet/implement procedures **fleet-portable**. A gate-continuation session is spawned with a fresh worktree as its cwd; on a non-operator device there is no `~/.claude/commands` and no `qontinui-claude-config` checkout, so `/vet-plan` and `/implement-plan` were unresolvable — the core blocker to "works for every user, not just the operator's box."

### What
- New module `src-tauri/src/fleet_commands.rs`: embeds the two procedures via `include_str!` and `provision_fleet_commands_for_session(workdir)` writes them into `<session-cwd>/.claude/commands/` (fail-soft, idempotent).
- Wired into `run_continuation_terminal` (next to the existing `.mcp.json` provisioning) and the agent-spawn worktree-materialization path.
- The fleet-portable (binary-bundled) sibling of `provision_agent_definitions` — see that fn's doc, which named this exact follow-up.

### Verification
- `cargo check --bin qontinui-runner` green; 2 new unit tests pass (`fleet_commands::tests`).
- **Make-or-break assumption empirically confirmed:** a headless `claude -p "/probe-fleet"` resolved + executed a command provisioned ONLY at `<cwd>/.claude/commands/` with an empty `~/.claude/commands` — proving project-scoped command discovery from the provisioned session cwd is home-independent.

### Follow-up (not this PR)
- Make the bundle the single source of truth and deprecate the per-operator claude-config copies (plan Risk: "prompt drift").
- Audit the procedures for self-containment on a device with no claude-config helper scripts.

Plan: `plans/2026-06-17-fleet-plan-lifecycle-orchestrator.md` (Phase 0).