### PR TITLE
feat(plan-adapter): Phase 1 — pure markdown→work-unit parser

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,14 @@ pub mod cognito;
 // command produce an identical report.
 pub mod coord_doctor;
 
+// Harness markdown -> work-unit adapter (plan
+// `2026-06-18-harness-markdown-to-workunit-adapter`, P2 of the plan-decoupling
+// program). Phase 1 = the pure parser that turns operator plan markdown into a
+// structured work-unit (slug + opaque status + phase sub-units + dependency
+// edges), richer than coord's old slug+status projection. Later phases add the
+// push client + trigger as siblings under this module.
+pub mod plan_workunit_adapter;
+
 // ============================================================================
 // Main window label abstraction
 // ============================================================================

--- a/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-decommission-markdown-plan-ingest.md
+++ b/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-decommission-markdown-plan-ingest.md
@@ -1,0 +1,78 @@
+# Decommission coord's markdown plan ingest + plan-specific code (P4 of the plan-decoupling program)
+
+> **Status: DRAFT 2026-06-18.** The REMOVAL plan — deletes coord's knowledge of "plans" once the
+> generic work-unit (P1), the harness adapter (P2, proven), and the orchestration generalization
+> (P3) are live. Hard-gated on those. See memory `project_coord_generic_ir_execution_engine`.
+> **Repo(s):** qontinui-coord (primary).
+
+## Program context
+
+P4 of 5 — runs **LAST**. Hard preconditions: **P1** live (work-unit API), **P2** parity-proven (the
+harness adapter reproduces coord's current ingest output — else the operator's own loop goes dark),
+**P3** live (gates/conductor/delivery/web no longer need plan_* ). Siblings: P1
+(`...-generic-work-unit-primitive`), P2 (`...-harness-markdown-to-workunit-adapter`), P3
+(`...-orchestration-generalize-off-plans`), P5 (`...-workunit-authz-graduated-trust`).
+
+## 1. Problem
+
+These coord components encode the operator-private plan convention and must be removed so the
+shared/open-core coordinator carries no plan knowledge:
+
+- `plan_ingest_worker.rs` — the `*.md` scanner (FS root + `qontinui-dev-notes` git mirror).
+- `COORD_PLANS_ROOT_DIR` (default `D:/qontinui-root/plans/`), `COORD_PLANS_ARCHIVE_DIR`,
+  `COORD_PLANS_ARCHIVE_GIT_REPO`/`_SUBDIR` env knobs.
+- `plan_registry.rs`'s `PLAN_STATUS_VOCAB` + markdown-status parsing (`match_known_status`,
+  `normalize_vocab_status`) + `markdown_path`/`version_hash`/`ingested_status` columns.
+- `coord.plans` / `coord.plan_status_history` tables (data migrated to `work_units` or archived).
+- `plan_ingest_*` metrics and the "inert worker" alert.
+- The `plan_ready`/`plan_status` shims left by P3.
+
+## 2. Prior art / inventory
+
+| Piece | Location | Disposition |
+|---|---|---|
+| Ingest worker | `qontinui-coord/src/plan_ingest_worker.rs` | DELETE (whole module + its `tokio::spawn` wiring in `main.rs`). |
+| Status vocab + md parse | `plan_registry.rs` (`PLAN_STATUS_VOCAB`:182, `normalize_vocab_status`, `match_known_status`) | DELETE; `work_unit` status is opaque (P1). |
+| Plan routes/MCP | `/coord/plans*` routes, `coord_*` plan MCP tools, `routes.rs`/`mcp/tools.rs` refs | DELETE or 410 (decide at vet; prefer remove since P1 supplies the generic verbs). |
+| Tables | `coord.plans`, `coord.plan_status_history` (+ Phase-2 columns) | Backfill into `work_units` if any live rows matter, then DROP via migration. |
+| Metrics/alert | `plan_ingest_*` series, inert-worker alert, `gate_metrics.rs` plan labels | Remove; ensure no dashboard references a dropped series (coordinate w/ P3 web work). |
+
+> Vet note: produce the EXACT deletion inventory (grep `plan` across `qontinui-coord/src`) at /vet-plan; the 9 files touching `plan_ready`/`plan_status` were enumerated 2026-06-18 (routes, plan_registry, mcp/tools, main, gates, api/dev_overview, api/gate_routes, plan_ingest_worker, gate_metrics).
+
+## 3. Phases
+
+**Phase 1 — precondition gate.** Verify P1 live, P2 parity green, P3 live. Register a coord gate
+chain so this plan cannot start until those hold (P2's parity proof is the load-bearing one).
+
+**Phase 2 — stop ingestion.** Remove the `plan_ingest_worker` spawn + the env knobs + the
+`qontinui-dev-notes` mirror path. Confirm the operator's loop still runs (now fed by the P2 adapter).
+
+**Phase 3 — remove the model.** Delete `PLAN_STATUS_VOCAB`/md-parse, the plan routes/MCP tools, the
+plan-specific columns; drop the plan_* gate shims from P3.
+
+**Phase 4 — data + schema.** Backfill any live `coord.plans` rows into `work_units` (if needed),
+then DROP the plan tables via migration. Self-provision the test harness for any DB tests touched
+(`reference_coord_db_tests_migrator_digest_lags_web_migrations`).
+
+**Phase 5 — sweep.** `grep -ri plan` across `qontinui-coord/src` returns only incidental matches
+(comments/unrelated). No dangling env knob, metric, route, or doc references coord-side plans.
+
+## 4. Acceptance
+
+- coord builds + all tests green with ZERO plan-specific code/config/tables/metrics/routes.
+- The operator's autonomous loop is unaffected (fed entirely by the P2 adapter via the P1 API),
+  verified live for at least one full vet→implement→gate cycle.
+- A fresh coord deploy with no `COORD_PLANS_*` env set behaves identically (the dev-box path default
+  is gone).
+- `grep -ri "plan" qontinui-coord/src` shows no load-bearing plan concept.
+
+## 5. Risks / out-of-scope
+
+- **Out of scope:** everything additive (P1/P2/P3) and authz (P5). This plan only removes.
+- **Risk (highest in the program):** removing ingest before the adapter is solid = the operator's
+  loop dies. Mitigation: the Phase-1 precondition gate hard-blocks on P2 parity; keep both running
+  until then; this plan is irreversible-ish (data drop) so stage the table DROP last, behind a
+  backup/backfill.
+- **Risk:** an external consumer still calls `/coord/plans*`. Inventory callers (web/mobile/agents)
+  before removing routes; 410 with a pointer to `/coord/work-units` for a deprecation window if any
+  remain.

--- a/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-generic-work-unit-primitive.md
+++ b/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-generic-work-unit-primitive.md
@@ -1,0 +1,158 @@
+# coord generic work-unit primitive + API (P1 of the plan-decoupling program)
+
+> **Status: IMPLEMENTED 2026-06-19 — PRs open, not yet on main.** All 4 phases built +
+> tested green on branch `agent/workunit-primitive-p1`. **qontinui-web#623** (migrations
+> `coord_workunits_01_work_units` + `coord_workunits_02_gate_anchor`, commit `6a4ec551`) and
+> **qontinui-coord#710** (code, commit `9e13860`). Coord #710 carries
+> `coord:downstream-of=qontinui/qontinui-web#623` (merge web first) **+ `coord:blocked`** held
+> until the migrations are confirmed APPLIED to prod RDS (downstream-of orders merge, not
+> migration-apply — without the block coord crash-loops on the `require_table` boot gate).
+> Coord tests: opaque-status/no-422, history emission, stale-CAS reject, cross-tenant 409,
+> work-unit gate round-trip, both-anchor + partial-anchor rejection (16 work_unit + 3 anchor +
+> 139 mcp, all green). **Flip to SHIPPED + archive to dev-notes once both land on origin/main.**
+> Started from VETTED 2026-06-19 (5 defects auto-fixed; core thesis — generalize
+> `plan_registry.rs` → `work_unit_registry.rs` — confirmed sound).
+> Authored from the strategic decision that a "plan" is operator-private and
+> coord must NOT encode it (see memory
+> `project_plans_operator_private_coord_generic_workunit` /
+> `project_coord_generic_ir_execution_engine`). Foundation plan — P2/P3/P4/P5 depend on this.
+> **Repo(s):** qontinui-coord (code) **+ qontinui-web** (alembic migrations — coord
+> schema is alembic-authored there, NOT in coord; see §2 + Phase 1).
+
+## Program context
+
+This is **P1 of 5** in the "coord stops knowing about plans" migration. The program:
+
+1. **P1 (this) — generic work-unit primitive + API.** The additive foundation: a
+   `coord.work_units` anchor coord does NOT semantically interpret, plus an authz'd
+   upsert/transition/list API and gate-anchoring on units. Ships first, breaks nothing.
+2. **P2 — harness markdown→work-unit adapter** (`2026-06-18-harness-markdown-to-workunit-adapter`):
+   move the markdown parse OUT of coord INTO the operator harness, richer than today.
+3. **P3 — generalize orchestration off "plan"** (`2026-06-18-coord-orchestration-generalize-off-plans`):
+   `plan_ready`/`plan_status` gate kinds, conductor, delivery verdict, web surfaces → work-unit.
+4. **P4 — decommission coord markdown ingest** (`2026-06-18-coord-decommission-markdown-plan-ingest`):
+   delete `plan_ingest_worker`, `PLAN_STATUS_VOCAB`, `COORD_PLANS_ROOT_DIR`/archive/dev-notes mirror.
+   Gated on P1+P2+P3 live and P2 proven.
+5. **P5 — work-unit authz / graduated trust** (`2026-06-18-coord-workunit-authz-graduated-trust`):
+   retire the operator write-wall; evidence-based + separation-of-duties authz. Independent enhancement on P1's API.
+
+Sequencing: **P1 → (P2 ∥ P3) → P4**; **P5** any time after P1.
+
+## 1. Problem
+
+coord's shared, open-core coordinator hard-codes an operator-private concept. `coord.plans`
+(`plan_registry.rs`; the table was created by alembic revision `consolidation_phase2_v_28`
+and the markdown columns `markdown_path`/`version_hash`/`status`/`ingested_status` were added
+by revision `coord_plans` — see plan_registry.rs:14-23) is a **mirror of operator markdown** — a thin, lossy projection
+(slug + a status string from `PLAN_STATUS_VOCAB`) of a rich document. Other qontinui users
+will create/run work their own way or not have "plans" at all, so the coordinator cannot be
+plan-shaped. We need a **generic anchor** coord coordinates over without interpreting, populated
+by *any* front-end via API — never by reading a disk or a git repo.
+
+## 2. Prior art (reuse, don't rebuild)
+
+| Piece | Location | Notes |
+|---|---|---|
+| Existing plan model + routes | `qontinui-coord/src/plan_registry.rs` (`PlanRow`:73, `UpsertRequest`:122, `TransitionRequest`:157, `/coord/plans*` routes) | The new API is a **generalization** of this exact shape — keep the upsert/transition/history/list verbs, drop the markdown/vocab specifics. |
+| Status history table | `coord.plan_status_history` (+ `StatusHistoryRow`:89) | Generalize to `work_unit_status_history`; the transition-record mechanism is reused verbatim. |
+| Gate anchoring | `gates.rs` — gates anchor on `(plan_id + phase_name)` OR `(claim_kind + resource_key)` | Add `(work_unit_id + phase_name)` as a third anchor; do NOT rip out plan anchoring yet (P3/P4 retire it). |
+| Tenant resolution + JWT sub-router | the `require_jwt` sub-router used by the device-authed gate registration (coord #650) | The work-unit write API mounts here; tenant from session claims, not args. Minimal authz is conservative tenant-scoped fail-closed (P5 evolves it). |
+| Cross-tenant slug guard | the `coord.plans.slug` global-uniqueness 409 guard | `work_units.slug` carries the same global-unique + cross-tenant 409 guard. Pattern at `plan_registry.rs:256` (`idx_plans_slug` partial UNIQUE) + `post_upsert` cross-tenant reject at `plan_registry.rs:747-758`; test at `:1610` (`post_upsert_rejects_cross_tenant_slug_with_409`). |
+| **Alembic schema authoring** | `qontinui-web/backend/alembic/versions/` (e.g. `coord_plans.py`) | **coord does NOT author its own schema** — alembic in qontinui-web is the sole author; Rust no longer self-heals (`plan_registry.rs:14-23,37-42`). The new `coord.work_units` migration MUST live in qontinui-web, making P1 a **two-repo change**. |
+| **Boot `require_table` gate** | `main.rs:809` (`ALEMBIC_OWNED_TABLES`, list at `:733-807`) | Every alembic-owned coord table coord DMLs against is boot-asserted; if work_units joins it, the HARD deploy-order rule binds (web migration applied to prod RDS **before** the coord image — see Phase 1). |
+| `coord.work_plans` (NOT the same thing) | `work_plans.rs` (alembic `coord_singleauthored_08_work_plans.py`) | **Naming proximity only** — `work_plans` is the PROPOSE→APPROVE intent→multi-repo-session orchestration backend, *not* a generic status anchor (`work_plans.rs:1-12`). Does not duplicate `work_units`. Its `ensure_work_plans_table` test fixture (`work_plans.rs:49-55`) is a **second template** (alongside `plan_registry.rs::create_plans_for_test`:1169) for the Phase 1 self-provision step. |
+
+> ~~Vet note: confirm exact line numbers + the migration revision name during /vet-plan.~~
+> **Resolved (vet 2026-06-19).** All four §2 line citations confirmed exact at coord HEAD
+> (`PlanRow`:73, `StatusHistoryRow`:89, `UpsertRequest`:122, `TransitionRequest`:157; gate
+> anchor enum gates.rs:776-779 + XOR enforcement gates.rs:851-875). The coord.plans migration
+> revision is **`consolidation_phase2_v_28`** (created the table) **+ `coord_plans`** (added the
+> markdown/status columns). Naming-collision note: `work_unit_id` already appears in
+> `coord_report_status` (mcp/tools.rs:655) as a free-text label — unrelated to this table.
+
+## 3. Target design
+
+A `coord.work_units` row: `id` (uuid) / `slug` (globally unique, tenant-scoped 409) / `tenant_id`
+/ `status` (**opaque caller-supplied string — coord does NOT validate against a vocab**) /
+`title` (human label, optional) / `metadata` (jsonb — arbitrary, e.g. a link back to the source
+artifact, phase list, dependency hints) / `created_at` / `updated_at`. No `markdown_path`, no
+`version_hash`, no `ingested_status`.
+
+API (on the `require_jwt` sub-router; tenant from claims):
+- `POST /coord/work-units/upsert` — create/update by slug; emits a history row on status change.
+- `POST /coord/work-units/:slug/transition` — guarded status transition (optional `from_status` CAS).
+- `GET  /coord/work-units` — list with slug/status/tenant filters.
+- `GET  /coord/work-units/:slug/history` — status history.
+
+Gate anchoring: `coord_register_gate` accepts `work_unit_id + phase_name`. Generic `unit_ready`
+gate (clears when status == a caller-declared ready value AND all sibling gates cleared) is added
+in P3; P1 only needs the anchor + plain gate attachment.
+
+`status` is **uninterpreted** by coord: coord stores it, history-tracks it, and lets gates compare
+it to caller-supplied values. No `draft`/`vetted`/`shipped` knowledge anywhere.
+
+## 4. Phases
+
+**Phase 1 — schema (additive). This is a two-repo change.** The migration is authored in
+**`qontinui-web/backend/alembic/versions/`** (alembic is the SOLE author of `coord.*` schema;
+coord does not self-heal — `plan_registry.rs:14-23,37-42`). New revision creates `coord.work_units`
++ `coord.work_unit_status_history` (+ indexes; partial-UNIQUE `slug` index mirroring
+`idx_plans_slug`). Leave `coord.plans` untouched (P4 removes it).
+- **Boot gate (decided — robustness).** Add `"work_units"` + `"work_unit_status_history"` to the
+  `ALEMBIC_OWNED_TABLES` boot list (`main.rs:733-807`, asserted at `:809`) so coord fail-fasts at
+  boot if the migration hasn't run, rather than NPE-ing on the first DML — the same posture as every
+  sibling alembic-owned table. **This makes the deploy-order HARD RULE binding:** the web migration
+  MUST be confirmed applied to prod RDS **before** the coord image carrying P1 deploys, or coord
+  crash-loops at boot (cf. `migration_reservations` / `release_observations` comments at `main.rs:740-745`).
+  Sequence the merge with the `coord:downstream-of` label on the coord PR + a `migration_at_head` gate —
+  the label alone is insufficient (`reference_coord_downstream_label_insufficient_for_schema_deploy_order`;
+  first-party migration-drift gate machinery is live per `project_first_party_migration_drift_shipped`).
+- **Test fixture.** Self-provision both tables in an in-crate `#[cfg(test)]` DB helper
+  (`CREATE TABLE/INDEX IF NOT EXISTS`, race-tolerant), mirroring `plan_registry.rs::create_plans_for_test`:1169
+  and `work_plans.rs::ensure_work_plans_table`:49-55 — NOT bumping the migrator digest (the
+  migrator-digest-lag gotcha, `reference_coord_db_tests_migrator_digest_lags_web_migrations`).
+
+**Phase 2 — model + API.** `work_unit_registry.rs` mirroring `plan_registry.rs` minus vocab/markdown:
+`WorkUnitRow`, `UpsertRequest`, `TransitionRequest`, the 4 routes, conservative tenant-scoped authz,
+the global-unique-slug 409 guard. In-crate `#[cfg(test)]` DB tests (coord is binary-only → `--bins`).
+
+**Phase 3 — gate anchor. Also a two-repo change (new gates column).** Today a gate carries
+**exactly one of two** anchors — `(claim_kind+resource_key)` XOR `(plan_id+phase_name)` — enforced
+at `gates.rs:851-875`. Adding `(work_unit_id+phase_name)` as a third option requires:
+- **Schema:** a new nullable `work_unit_id uuid` column on `coord.gates` → **another alembic migration
+  in qontinui-web** (Phase 3 originally omitted this). `coord.gates` is already boot-gated
+  (`main.rs:681`), so the same deploy-order rule from Phase 1 applies.
+- **Code:** extend `NewGate` (`gates.rs:776-779`) with `work_unit_id`; widen the XOR enforcement
+  (`gates.rs:851-875`) from "exactly one of TWO" to "exactly one of THREE" (this is the §6 "anchoring
+  to both" guard, made concrete); add the column to the INSERT/SELECT column lists
+  (`gates.rs:900,989,1081,1115`).
+- **Surface:** `coord_register_gate` MCP tool (`mcp/tools.rs:785`) + the HTTP register-gate route accept
+  the new anchor; gates fire/clear against it exactly like the plan anchor.
+- Lockstep test mirroring the plan-anchor tests.
+
+**Phase 4 — MCP surface.** Add `coord_*` MCP tools for work-unit upsert/transition/list (the agent
++ harness write path). Tenant from session.
+
+## 5. Acceptance
+
+- A work-unit can be created/transitioned/listed via API + MCP with a tenant-scoped JWT; status is
+  any string (no 422 on an unknown vocab word).
+- A gate anchors to a work-unit and clears identically to a plan-anchored gate.
+- Zero behavior change to `coord.plans` / ingest / existing gates (additive only) — proven by the
+  existing plan suite staying green.
+- New in-crate DB tests green on CI (self-provisioned schema).
+
+## 6. Risks / out-of-scope
+
+- **Out of scope:** the markdown parser (P2), gate-kind renames + conductor/delivery/web (P3),
+  removing `coord.plans`/ingest (P4), the graduated-trust authz model (P5). P1 ships with minimal
+  conservative authz only.
+- **Risk:** double anchor (plan_id ∥ work_unit_id) transiently coexist — fine, P4 removes the plan
+  side after the harness cuts over. Guard against a gate accidentally anchoring to both.
+- ~~**Risk:** slug global-uniqueness collision with existing `coord.plans` slugs during the overlap —
+  decide namespacing during vet.~~ **Resolved (vet 2026-06-19 — clean code).** `work_units` is a
+  separate table from `plans`, so `work_units.slug`'s UNIQUE index is independent of
+  `plans.slug`'s — they do NOT share a slug space and there is no shared join. A work-unit and a plan
+  may carry the same slug with zero collision. **No namespacing prefix needed**; adding one would be a
+  special-case for a problem the separate-table design already eliminates. (The per-table cross-tenant
+  409 guard still applies within `work_units` itself.)

--- a/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-merge-scheduler-db-test-harness.md
+++ b/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-merge-scheduler-db-test-harness.md
@@ -1,0 +1,113 @@
+# Add a `coord_test` DB harness to `merge_scheduler.rs` + land-push-failure transition/lease-gauge tests
+
+> **Status: IN PROGRESS 2026-06-18 — implemented, coord PR #694 OPEN pending merge.**
+> Harness + DB tests built on branch `test/land-push-failure-db-tests` (worktree
+> `qontinui-coord-wt-landfail`), +993 lines in `merge_scheduler.rs` (tests-only).
+> All new tests PASS in CI (4115 passed); the sole `coord-db-tests` red was an
+> UNRELATED flake — `escalation_metrics_worker::tests::test_metrics_log_file_creation`
+> (shared process-global metrics-log path, races under `--test-threads=2`; that file
+> is NOT in this PR's diff) — re-run triggered to clear it. Upstream wedge fix #687
+> MERGED + SHIPPED (`4dd316b`). A `pr_merged` gate auto-resumes the SHIPPED stamp +
+> archive on #694 merge. Started from DRAFT 2026-06-18 (implemented without a separate
+> vet pass — the plan was small + tests-only). Depends-On: 2026-06-17-coord-land-push-failure-wedge-and-terminal-classification.
+
+## Why
+
+`on_land_push_failure` (row-state) and `land_or_shadow`'s push-failure lease release
+are new and unverified end-to-end. The lease math is the dangerous part: `release_main_merge_claims`
+decrements `MAIN_MERGE_LEASES_HELD` on **both** `Released` and `NotHeld`
+(`merge_scheduler.rs:~12176`), so a release for a never-acquired claim underflows the
+gauge — exactly the bug the wedge-fix design avoided by keeping release path-specific.
+A regression here is silent (a wrong gauge), so it needs a DB-backed assertion.
+
+## Discovered prior art (reuse — do NOT invent a harness)
+
+| Piece | Location | Notes |
+|---|---|---|
+| Per-module test-state builder | `agent_sessions.rs:122` `async fn test_state() -> Option<Arc<AppState>>` | Reads `COORD_TEST_PG_DSN`; `None` ⇒ test returns early (skips when no DB). Copy this shape verbatim. |
+| State constructor | `crate::state::build_test_state(&dsn, "redis://127.0.0.1:6379/0")` | Builds `Arc<AppState>` from params (no `set_var` races). |
+| Idempotent DDL bootstrap | `agent_sessions.rs:130` `ensure_schema` → `crate::test_fixtures::batch_execute_ddl_locked(&conn, r#"CREATE SCHEMA IF NOT EXISTS coord; CREATE TABLE IF NOT EXISTS …"#)` | Advisory-locked so parallel tests don't race the DDL. Bootstrap only the tables this test touches. |
+| Skip guard | `match test_state().await { Some(s) => s, None => return }` | Standard early-return; CI sets `COORD_TEST_PG_DSN` (ci.yml `cargo test --bins`, COORD_TEST_PG_DSN exported), local-without-PG just skips. |
+| Claim primitives | `crate::claims::acquire` / `release` (kind `MainMerge`, `resource_key=format!("repo:{}", repo)`, `machine_id = state.leader.holder_id()`) | Same calls the production land paths use — acquire to set up "lease held", assert the gauge, then drive the release. |
+| Gauge | `static MAIN_MERGE_LEASES_HELD` | Read `.load(Ordering::Relaxed)` before/after; assert deltas, not absolutes (it's process-global). |
+| Partial counter | `static MERGE_PARTIAL_MULTI_REPO_LAND` (added by #687) | Same before/after-delta read. |
+| Existing test module | `merge_scheduler.rs:12390` `mod tests` (`use serial_test::serial;` already imported) | Add the harness + DB tests here. The pure-helper `on_land_push_failure_branch_selection` test (`:~12424`) stays; the new DB tests assert the real side effects it can't. |
+
+## Scope
+
+In scope: a `test_state`/`ensure_schema` harness local to `merge_scheduler.rs`'s test
+module, and DB-backed tests for (a) `on_land_push_failure`'s three row transitions +
+metric increment, (b) the land-layer lease-release gauge balance.
+Out of scope: a shared cross-module harness refactor (every module rolls its own
+`test_state` today — follow that convention, don't boil the ocean); changing any
+production code in `merge_scheduler.rs`/`outbound_git.rs` (this is tests-only — if a
+test reveals a seam is untestable, note it, don't refactor under a test plan).
+
+## Design
+
+### Phase 1 — harness in the `merge_scheduler` test module
+Add (inside `mod tests`, gated like `agent_sessions`):
+- `async fn test_state() -> Option<Arc<AppState>>` — copy `agent_sessions.rs:122`.
+- `async fn ensure_schema(state)` — `batch_execute_ddl_locked` bootstrapping ONLY what
+  these tests touch: `coord.merge_proposals` (the columns `on_land_push_failure`/`set_error`
+  write: `proposal_id`, `status`, `error`, `updated_at`, plus any NOT NULL the production
+  INSERT path needs — derive the minimal subset from the real migration, mirroring how
+  `agent_sessions::ensure_schema` mirrors its Phase-1 migration) and the `coord.claims`
+  table(s) `crate::claims::acquire/release` read/write. Idempotent (`IF NOT EXISTS`).
+  **Vet must confirm** the exact NOT-NULL/column set against the live migrations
+  (`alembic/versions/`) and against `claims.rs` — under-bootstrapping a NOT NULL column
+  is the classic first-CI-red (cf. `test_support::create_plans_for_test` lesson, memory
+  [[reference_cross_repo_schema_add_drift_gate_deadlock]] sibling).
+- A small `seed_landing_proposal(state, proposal_id, repos)` helper that INSERTs a
+  `coord.merge_proposals` row in `status='landing'`.
+
+### Phase 2 — `on_land_push_failure` row-transition tests (`#[serial]`, DB)
+Seed a `landing` row, call `on_land_push_failure(&state, pid, repos_pushed, &err)`
+directly (no git needed — it only does DB writes), assert the row afterward:
+1. **Transient** (`PushError::Transient` or an opaque error classifying transient),
+   `repos_pushed=[]` → row `status='queued'`, `error` set.
+2. **Deterministic** (`anyhow::Error::new(PushError::Rejected{deterministic:true,..})`,
+   optionally `.context("fast-forward push to …")` to prove downcast-through-context),
+   `repos_pushed=[]` → row `status='conflict'`, error names the deterministic reason.
+3. **Partial multi-repo** (`repos_pushed=["repo-a"]`, any class) → row `status='conflict'`,
+   `error` names the pushed repo, AND `MERGE_PARTIAL_MULTI_REPO_LAND` delta == 1.
+   (`fanout_conflict` will no-op / best-effort without a real PR — assert it doesn't panic;
+   the row write is the contract.)
+
+### Phase 3 — lease-release gauge-balance test (`#[serial]`, DB)
+The new wiring is "`land_or_shadow` releases the land-layer lease on a push failure."
+Two ways to exercise it — vet/implementer picks by cost:
+- **Preferred (true integration)** if the existing git-temp-repo helpers make a *failing*
+  land push cheap: set up a scratch repo whose push to its "main" is rejected (non-FF or a
+  bare remote that refuses), acquire the `MainMerge` claim for the repo (assert gauge +1),
+  drive `land_or_shadow` (or the smallest seam that reaches `land_all_repos`' push), and
+  assert: row left `landing`? NO — moved to `queued`/`conflict`; claim **released**; gauge
+  delta == 0 (back to baseline). This is the only test that proves the end-to-end wiring.
+- **Fallback (contract test)** if a deterministic failing push is too costly to stage:
+  acquire the `MainMerge` claim (gauge +1), call the exact release `land_or_shadow` makes on
+  failure — `release_main_merge_claims(&state, &cfg, &specs, &holder)` — assert claim released
+  + gauge delta == 0. Plus a guard test: calling it for a **never-acquired** repo decrements
+  the gauge (documents the underflow hazard ⇒ proves WHY release must stay path-specific and
+  must never run for the lease-less batch path).
+Prefer the integration form; fall back only with a code comment explaining the staging cost.
+
+## Tests / verification
+- `cargo test --bins -- on_land_push_failure` + the new gauge test names, with
+  `COORD_TEST_PG_DSN` pointed at a local `coord_test` Postgres (the CI shape — ci.yml
+  `cargo test --bins`, `--test-threads=2`).
+- Without `COORD_TEST_PG_DSN` the new tests early-return (skip) — confirm `cargo test`
+  still green on a no-PG box (parity with every other `test_state`-gated module).
+- `cargo clippy --workspace --tests -- -D warnings` clean.
+
+## Non-goals
+- No production-code changes (tests only).
+- No shared/global test-harness extraction (per-module `test_state` is the house style).
+- Not asserting `fanout_conflict`'s PR side effects (needs a GitHub stub — separate concern).
+
+## File inventory
+| Piece | Location | Change |
+|---|---|---|
+| Test harness | `merge_scheduler.rs:12390` `mod tests` | add `test_state`/`ensure_schema`/`seed_landing_proposal` |
+| Row-transition tests | same module | 3 `#[serial]` DB tests over `on_land_push_failure` |
+| Gauge-balance test | same module | 1–2 `#[serial]` DB tests over the release path |
+| Harness deps (already exist) | `crate::state::build_test_state`, `crate::test_fixtures::batch_execute_ddl_locked`, `crate::claims::{acquire,release}` | reuse, no change |

--- a/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-orchestration-generalize-off-plans.md
+++ b/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-coord-orchestration-generalize-off-plans.md
@@ -1,0 +1,144 @@
+# Generalize coord orchestration off "plan" onto work-unit (P3 of the plan-decoupling program)
+
+> **Status: VETTED 2026-06-19.** Audited every concrete claim against coord/runner/web code.
+> Defects found: 4. Auto-fixed: 4. Surfaced for user: 0. Core thesis (decouple gate kinds +
+> delivery + web from plan vocabulary) is sound. Key corrections: (1) the Approach-D conductor is
+> **already plan-agnostic** — Phase 2 rewritten from "conductor retarget" to "generic gate
+> registration surface"; (2) `plan_status` is already caller-supplied-status (only its *registration
+> validation* couples to vocab) while `plan_ready` hard-codes `"vetted"` — §1 corrected; (3) plan_*
+> must NOT become work-unit shims (would break all existing plan gates during overlap) — replaced
+> with a shared-evaluation-core design (robustness); (4) plan is **coord + web only**, not
+> coord/web/runner. Depends-On: 2026-06-18-coord-generic-work-unit-primitive.
+> **Repo(s):** qontinui-coord (primary), qontinui-web (dashboard surfaces).
+
+## Program context
+
+P3 of 5. Depends on **P1** (`2026-06-18-coord-generic-work-unit-primitive`). Parallel with **P2**.
+Should be live before **P4** removes the plan side. Siblings: P1, P2
+(`...-harness-markdown-to-workunit-adapter`), P4 (`...-decommission-markdown-plan-ingest`), P5
+(`...-workunit-authz-graduated-trust`).
+
+## 1. Problem
+
+The plan concept leaks beyond the registry into coord's orchestration brain and its read surfaces:
+
+- **Gate kinds** encode plan semantics — but the two couple to the vocab _differently_ (vet
+  2026-06-19, `gates.rs`):
+  - `plan_ready` (`GatePredicate::PlanReady { plan_slug }`, `gates.rs:136`; evaluator
+    `PlanReadyEvaluator`, `gates.rs:1990`) **hard-codes** the ready status: `const
+    PLAN_READY_STATUS = "vetted"` (`gates.rs:1993`). This is the genuine vocab bake-in.
+  - `plan_status` (`GatePredicate::PlanStatus { plan_slug, status }`, `gates.rs:222`; evaluator
+    `PlanStatusEvaluator`, `gates.rs:2535`) already takes a **caller-supplied** `status` string in
+    the predicate — the evaluator is vocabulary-free. Its only vocab coupling is **registration-time
+    validation** against `PLAN_STATUS_VOCAB` (the gate-route upsert at `api/gate_routes.rs:362-378`
+    and the MCP/registry path at `plan_registry.rs:790-792`). So `unit_status` is `plan_status`
+    minus that registration validation — the predicate logic is reusable as-is.
+- **The conductor / Approach-D engine** is _already_ plan-agnostic (vet 2026-06-19 — corrects the
+  original premise). The Approach-D conductor (`qontinui-runner/src-tauri/src/orchestration_loop/
+  conductor.rs` + `coord_gate.rs`, runner main `836edabb` / #583) orchestrates a **runner-local
+  `orchestration.runs/subtasks` ledger** and registers only `ci_green` / `pr_merged` /
+  `deploy_healthy` coord gates as subtask checkpoints (`coord_gate.rs` `GatePredicateSpec`) — it has
+  **zero** `coord.plans` / `plan_ready` / `plan_status` / `plan_slug` reads. The fleet
+  plan-lifecycle orchestrator's in-coord anchor (`plan_lifecycle.rs`,
+  `project_fleet_plan_lifecycle_orchestrator` Phase 2) **does not exist yet** (dark/un-built). So
+  there is no conductor "plan-anchor" to retarget — see the rewritten Phase 2.
+- **The delivery verdict** (`delivery_view.rs`, coord #655) joins plan status ⋈ PR-merged ⋈ deploy.
+- **Web surfaces** render "plans": the gate/rollout dashboard (`/admin/coord/gates`) and the
+  digital-twin Delivery tab (`project_twin_delivery_verdict_impl`).
+
+All of these must operate on the generic work-unit and a caller-supplied "ready" value, with no
+hard-coded vocabulary.
+
+## 2. Prior art (reuse, don't rebuild)
+
+| Piece | Location | Notes |
+|---|---|---|
+| `plan_ready` predicate + evaluator | `gates.rs:136` (`PlanReady{plan_slug}`) + `gates.rs:1990` (`PlanReadyEvaluator`), `const PLAN_READY_STATUS="vetted"` `gates.rs:1993` | Add `UnitReady{work_unit_id, ready_status, phase_name}`: ready value is a **gate param**, not a const. Counts open sibling gates by `work_unit_id` (P1's third anchor), mirroring how `PlanReadyEvaluator` counts by `plan_id`. |
+| `plan_status` predicate + evaluator | `gates.rs:222` (`PlanStatus{plan_slug,status}`) + `gates.rs:2535` (`PlanStatusEvaluator`) | Predicate already vocab-free → `UnitStatus{work_unit_id, status}` reuses the evaluator logic verbatim against `work_units`. The only thing to drop is the **registration-time vocab validation** (next row). |
+| Vocab validation at registration | `api/gate_routes.rs:362-378` + `plan_registry.rs:790-792` (`normalize_vocab_status` / `PLAN_STATUS_VOCAB`) | `unit_*` gates must register with **no** vocab validation — the caller's status/ready value is opaque. Do NOT route unit-gate registration through `normalize_vocab_status`. |
+| Gate anchoring (from P1) | `gates.rs` gate-anchor enum (`NewGate`, P1 `gates.rs:776-779`) + XOR→tri enforcement (P1 `gates.rs:851-875`); `work_unit_id` column added by P1 Phase 3 | `unit_*` gates anchor on `(work_unit_id + phase_name)`. **Hard dep on P1** — this anchor does not exist until P1 (web#623 + coord#710) lands on prod. |
+| Gate metrics / dev overview | `gate_metrics.rs`, `api/dev_overview.rs`, `api/gate_routes.rs` | Generalize labels/series from plan→unit; keep old series during overlap. |
+| Conductor / orchestrator | runner `orchestration_loop/conductor.rs` + `coord_gate.rs` (#583); fleet `fleet_commands.rs` (#622) | **Already plan-agnostic** (vet 2026-06-19). Conductor registers only `ci_green`/`pr_merged`/`deploy_healthy` gates over its own `orchestration` ledger — nothing to retarget. The only plan-coupled orchestration is the fleet vet→implement command bundler + its §5.4 `plan_ready` gate, which the Phase-1 shim covers. DAG-aware scheduling stays a follow-on. |
+| Delivery verdict | `qontinui-coord/src/delivery_view.rs` (reads `coord.plans.status`, lines 7/67/203; coord #655) + web Delivery tab | Join `work_units` instead of `plans`; `drift_class` semantics unchanged. |
+| Web gate dashboard | `qontinui-web/frontend/src/app/(app)/admin/coord/gates/*` + `digital-twin/_components/DeliveryVerdictCard.tsx` + `_hooks/useDeliveryVerdict.ts` + backend `app/api/v1/endpoints/digital_twin.py` | Render generic units (title + opaque status + metadata) instead of plan-specific fields. |
+
+> ~~Vet note: confirm exact `gates.rs` predicate sites + the conductor's plan-anchor reads.~~
+> **Resolved (vet 2026-06-19).** Predicate sites pinned above. The conductor has **no** plan-anchor
+> reads — it is already plan-agnostic (see §1 + Phase 2). Net effect: this plan is **coord + web
+> only**; `qontinui-runner` is NOT in scope, so the §5.4 continuation `repos` stays
+> `["qontinui-coord","qontinui-web"]`.
+
+## 3. Target design
+
+- **`unit_ready` gate:** clears when the anchored work-unit's status equals a caller-declared
+  ready value (gate param, e.g. `ready_status: "vetted"` for the operator's convention) AND every
+  other gate on the same unit is cleared. No coord-side vocabulary.
+- **`unit_status` gate:** clears when the unit reaches a caller-supplied status string.
+- **plan_ready / plan_status keep reading `coord.plans` directly — they do NOT delegate through a
+  work-unit.** ~~become thin shims delegating to the unit gates against a plan's work-unit.~~
+  **Resolved (vet 2026-06-19 — robustness).** Delegating `plan_*` through "a plan's work-unit"
+  assumes every plan has a `work_units` row, but P1 keeps `plans` and `work_units` as **separate
+  tables** and nothing backfills a unit-per-plan until P2's harness adapter runs. A shim that
+  resolves plan→unit would therefore make every existing `plan_ready`/`plan_status` gate fail-open
+  to `Open` **forever** (no unit found) during the P1→P4 overlap — directly violating the
+  acceptance criterion "plan_ready/plan_status still work so nothing breaks pre-P4." Instead:
+  **factor the shared evaluation core** (status-equals-ready-value AND siblings-cleared, counting
+  siblings by anchor id) into a generic helper parameterized by `(status source table, anchor id,
+  ready value)`. `PlanReadyEvaluator`/`PlanStatusEvaluator` call it against `coord.plans` +
+  `plan_id`; the new `UnitReady`/`UnitStatus` evaluators call it against `coord.work_units` +
+  `work_unit_id`. Both anchors evaluate independently; P4 deletes the plan_* arms cleanly. This
+  also satisfies clean-code (one evaluation core, no special cases) without a cross-table bridge.
+- **Conductor + delivery + web:** read the work-unit anchor. Status is rendered as an opaque label;
+  any "is this ready/shipped" judgment uses caller-supplied values or derived predicates
+  (shipped = delivery verdict), never a hard-coded word.
+
+## 4. Phases
+
+**Phase 1 — generic gate kinds.** Extract the shared `plan_ready`/`plan_status` evaluation core
+(status-equals-ready-value AND siblings-cleared, sibling count by anchor id) into a generic helper;
+add `GatePredicate::UnitReady{work_unit_id, ready_status, phase_name}` and
+`UnitStatus{work_unit_id, status}` that call it against `coord.work_units` + `work_unit_id` (P1's
+third anchor). `plan_*` keep calling the same core against `coord.plans` + `plan_id` — **not** as
+work-unit shims (see §3 robustness resolution). Register `unit_*` gates with **no**
+`PLAN_STATUS_VOCAB` validation (do not route through `normalize_vocab_status`, `gate_routes.rs:362`
+/ `plan_registry.rs:790`). Lockstep tests mirroring the existing `plan_ready_*` / `plan_status_*`
+gate tests in `gates.rs` (e.g. `plan_ready_verdict_non_vetted_names_status`, `gates.rs:6384`).
+
+**Phase 2 — generic gate registration surface (NOT a conductor retarget).** The Approach-D
+conductor is already plan-agnostic (§1) — there is nothing to retarget there. The actual work is
+making the `unit_*` gates registrable through the same surfaces `plan_*` use: the
+`coord_register_gate` MCP tool (`mcp/tools.rs`) and the device-authed `register-gate` HTTP route,
+accepting the `(work_unit_id + phase_name)` anchor P1 added. The fleet vet→implement orchestrator
+(`fleet_commands.rs` #622) and its §5.4 `plan_ready` gate continue to work via the Phase-1 plan_*
+core unchanged; no runner change is required. (DAG-aware scheduling over `metadata.depends_on`
+remains a follow-on, out of scope.)
+
+**Phase 3 — delivery verdict.** `delivery_view.rs` joins `work_units`; keep the
+`shipped_but_unmerged` / `merged_but_unstamped` drift classes. Regen OpenAPI snapshots if the web
+proxy route shape changes.
+
+**Phase 4 — web surfaces.** Gate dashboard + Delivery tab render generic units. ruff/format + OpenAPI
+snapshot gates (the `project_twin_delivery_verdict_impl` CI gotchas).
+
+## 5. Acceptance
+
+- A `unit_ready` gate clears on a work-unit with no coord-side vocabulary, parameterized by a
+  caller-supplied ready value.
+- Conductor drives work off the work-unit anchor; delivery verdict + dashboards render generic units.
+- `plan_ready`/`plan_status` still work (as shims) so nothing breaks pre-P4.
+- Web CI (ruff format, OpenAPI snapshots) green.
+
+## 6. Risks / out-of-scope
+
+- **Out of scope:** the work-unit primitive (P1), the markdown adapter (P2), deleting plan code (P4),
+  authz (P5), and the DAG-scheduling conductor upgrade (follow-on).
+- ~~**Risk:** the conductor lives partly in the runner — coordinate the runner-side retarget.~~
+  **Retired (vet 2026-06-19):** the conductor needs no retarget (already plan-agnostic), so there is
+  no runner-side change to sequence. This plan is coord + web only.
+- **Hard dependency on P1:** `unit_*` gates anchor on the `work_unit_id` gate column + `coord.work_units`
+  table that P1 (web#623 + coord#710) adds. P1 is IMPLEMENTED but its PRs are not yet on `main` /
+  applied to prod RDS. Do not start Phase 1 until P1 has landed and the migrations are confirmed
+  applied (P1 carries `coord:blocked` until then). A `migration_at_head`/`pr_merged` gate on P1 is the
+  right trigger.
+- **Risk:** dashboard/delivery consumers (mobile, `project_mobile_coord_first_ia_shipped`) read plan
+  fields — inventory + dual-render during overlap.

--- a/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-harness-markdown-to-workunit-adapter.md
+++ b/src-tauri/src/plan_workunit_adapter/fixtures/2026-06-18-harness-markdown-to-workunit-adapter.md
@@ -1,0 +1,138 @@
+# Harness markdown→work-unit adapter (P2 of the plan-decoupling program)
+
+> **Status: IN PROGRESS 2026-06-19.** Implementing Phase 1 only (the pure markdown→work-unit
+> parser + golden tests in qontinui-runner) — fully unblocked. Phases 2–4 are deferred behind a
+> coord gate: P1's work-unit API (coord#710 + web#623) is IMPLEMENTED but NOT on `origin/main`
+> (both PRs OPEN; coord#710 `coord:blocked` pending prod-RDS migration apply), so the push client
+> and parity proof cannot be end-to-end verified yet. History: Started from VETTED 2026-06-19 (4
+> defects auto-fixed). Operator decision 2026-06-19: implement unblocked Phase 1, gate Phases 2–4
+> on P1 landing on coord main (`resolve-plan-deps.py` false-positived SHIPPED off a "Flip to
+> SHIPPED" sentence; verified not-on-main). Depends-On: 2026-06-18-coord-generic-work-unit-primitive.
+> **Repo(s):** qontinui-runner (primary — push mechanism + trigger) and qontinui-claude-config
+> (the operator-private markdown parser/convention config).
+
+## Program context
+
+P2 of 5. Depends on **P1** (`2026-06-18-coord-generic-work-unit-primitive`) — the work-unit API
+must exist to push to. Runs in parallel with **P3**. Must be **proven** before **P4** deletes
+coord's ingest worker (else the operator's own autonomous loop goes dark). Siblings: P1, P3
+(`...-orchestration-generalize-off-plans`), P4 (`...-decommission-markdown-plan-ingest`), P5
+(`...-workunit-authz-graduated-trust`).
+
+## Discovered prior art (added during /vet-plan)
+
+P1's work-unit API is **already built** (branch `agent/workunit-primitive-p1`, coord#710 +
+web#623 — IMPLEMENTED, not yet on main). Phase 2 should target these concrete endpoints, not an
+abstract "P1 upsert/transition":
+
+| Piece | Location | Notes |
+|---|---|---|
+| P1 push target (routes) | `qontinui-coord/src/routes.rs:411-431` (branch `agent/workunit-primitive-p1`) | `POST /coord/work-units/upsert`, `POST /coord/work-units/:slug/transition`, `GET /coord/work-units`, `GET /coord/work-units/:slug/history`. All under `require_jwt` — tenant + identity lifted from the verified device-JWT `AuthContext`, **never** from arguments. |
+| Registry impl | `qontinui-coord/src/work_unit_registry.rs` (`post_upsert`/`post_transition`/`get_list`/`get_history`, ~1367 lines) | Slug-keyed; status is **OPAQUE** (stored verbatim, no vocab, no 422); stale-CAS reject; cross-tenant slug-collision = the lone 409; history rows on transition. |
+| Parser/edge-trigger/metrics to PORT | `qontinui-coord/src/plan_ingest_worker.rs` | The thing being moved out. Re-use its `decide_status_action` edge-trigger semantics (#564), the `ingested_status` last-applied memory (now client-side), and the `coord_plan_ingest_*` metric names. |
+| Vocabulary to DROP | `qontinui-coord/src/plan_registry.rs:182` `PLAN_STATUS_VOCAB` | The old parse normalized status against this fixed vocab. P1 work-unit status is opaque, so the adapter ports the parse but **drops** vocab normalization (free-text status flows straight through). |
+
+**Consequence for sequencing:** Phase 1 (pure parser + golden tests) is fully implementable now
+with zero P1 dependency. Phases 2–4 can be *written* against the contract above but cannot be
+end-to-end verified until P1 lands on `origin/main` and deploys to prod (or against a local coord
+build of the P1 branch). The Phase-4 parity proof in particular needs both adapters live.
+
+## 1. Problem
+
+Today coord auto-discovers plans by scanning `COORD_PLANS_ROOT_DIR` (default `D:/qontinui-root/plans/`)
+and a `qontinui-dev-notes` git mirror, parsing each `*.md` into a `coord.plans` row
+(`plan_ingest_worker.rs`). This is operator-specific (a dev-box path defaulted in a cloud service)
+and **lossy** — it extracts only slug + a `PLAN_STATUS_VOCAB` status, discarding the phase
+structure, work-items, and dependencies that are the actual value of a plan.
+
+We are deliberately removing this from coord (P4). To **preserve frictionless ambient authoring**
+("the markdown I'd write anyway IS the coordination object"), the parse moves into the operator
+harness — where it can be as opinionated and rich as we like without coupling or endangering the
+shared plane. This is the same rule as
+`feedback_fleet_wide_capabilities_belong_in_runner_not_claude_config`, applied inversely:
+operator-specific ingest belongs in the operator harness, NOT coord.
+
+## 2. The source→IR reframe
+
+Markdown plan = **source**; the work-unit (DAG) = **IR**; coord = the **runtime** that executes IR.
+coord must not parse source. The adapter is the compiler front-end: operator markdown → structured
+work-unit(s) via P1's API. Other users bring other front-ends (Linear/Jira/GitHub-Projects sync, a
+UI, an LLM reading a freeform doc, or nothing) — none of which coord needs to know about.
+
+## 3. Target design
+
+A harness component (decision below) that, on a trigger, reads the operator's `plans/` markdown and
+**pushes structured work-units to coord's API** (P1):
+
+- **Richer than coord's parse.** Extract not just slug+status but the phase structure → sub-units
+  (or `metadata.phases`), declared dependencies / sibling-plan edges (the "Program context" links
+  in these very plans) → `metadata.depends_on`, and a back-link to the source file as provenance.
+- **Edge-triggered + idempotent.** Re-running yields no spurious transitions (carry the
+  last-applied status, mirroring the old `ingested_status` edge-trigger, issue #564 — but now
+  client-side). A status change in the file → one `transition` call.
+- **Conflict posture.** The file remains the operator's source of truth; a direct API transition
+  (e.g. by an agent) that diverges from the file is surfaced LOUDLY (warn/metric) the way the old
+  worker did, but resolution policy lives in the harness now.
+
+### Decisions (resolved during /vet-plan)
+- **Home — RESOLVED: runner hosts the push mechanism + trigger; the markdown-parsing convention is
+  a claude-config-supplied parser/config the runner invokes.** A pure claude-config hook fires only
+  on the operator's machine and dies with the session, so it can never push a plan edited while no
+  TUI is open — exactly the closed-session delivery gap the session-bus preamble was moved to the
+  runner to close (`feedback_fleet_wide_capabilities_belong_in_runner_not_claude_config`; runner
+  `fleet_commands.rs` / `provision_agent_definitions` are the established home for this kind of
+  fleet infra). Keeping the *mechanism* (scan → diff → push, idempotency memory, metrics) generic
+  in the runner and the operator-private *markdown convention* as config preserves the
+  mechanism/policy split: the runner stays fleet-portable while operator policy never pollutes
+  fleet code. (Decided by **scalability** — survives closed sessions and generalizes to other
+  front-ends; clean mechanism/policy separation breaks the tie.)
+- **Trigger — RESOLVED: periodic reconcile scan (mirror the existing `plan_ingest_worker` ~60s
+  tick), optionally nudged by an explicit `/sync-plans` for instant sync.** A filesystem watch or
+  on-edit hook is lower-latency but misses every edit made while the runner is down and needs a
+  reconcile scan anyway to be correct; the edge-triggered/idempotent design (last-applied status
+  memory) is built precisely so re-scanning is free of phantom transitions. (Decided by
+  **robustness** — no missed edits across downtime/closed sessions; it is the model coord's own
+  proven ingest already uses.)
+
+## 4. Phases
+
+**Phase 1 — parser (pure, unit-tested).** Port + enrich the markdown parse: slug from filename,
+status from the stamp, PLUS phases→sub-units and dependency edges. Pure function, golden-file tests
+over the real `plans/` corpus (it's a great fixture set — these 5 plans included).
+
+**Phase 2 — push client.** Call P1's `upsert`/`transition` with a tenant-scoped JWT; idempotent,
+edge-triggered, last-applied-status memory; loud conflict surfacing.
+
+**Phase 3 — wire-up + trigger.** Mount in the chosen home with the chosen trigger; metrics
+(scanned/transitions/conflicts) mirroring `coord_plan_ingest_*` so the operator keeps the same
+observability.
+
+**Phase 4 — parity proof (gates P4).** Run adapter + coord's old ingest **side by side** over the
+live `plans/` corpus and assert the resulting work-units match the plans coord would have produced
+(slug+status parity at minimum; structure is bonus). This green light is P4's precondition.
+
+## 5. Acceptance
+
+- Editing a plan markdown file results in a corresponding coord work-unit upsert/transition via the
+  API, with zero manual steps (ambient authoring preserved).
+- Re-sync is idempotent (no phantom transitions on an unchanged file).
+- Parity run matches coord's current ingest output for the existing `plans/` corpus → P4 unblocked.
+- Parser tests green over the real corpus.
+
+## 6. Risks / out-of-scope
+
+- **Out of scope:** the coord API itself (P1), removing coord's ingest (P4), gate/conductor/web
+  generalization (P3).
+- **Risk:** cutover gap — if the adapter is buggy when P4 removes coord's ingest, the loop stops.
+  Mitigation: the Phase-4 parity proof is a hard gate on P4; keep coord's ingest running until
+  parity is green (the two coexist harmlessly — both just upsert).
+- **Risk: secret/auth for the push — RESOLVED.** P1's work-unit routes sit behind the SAME
+  `require_jwt` device/agent-JWT posture as the device-authed gate-registration path
+  (`routes.rs:411-431`; tenant lifted from claims, never args), so the harness's existing device
+  JWT is sufficient — no new auth surface. **One concrete wiring gap to note:** the runner's
+  loopback write-forwarder currently exposes only `register-plan` + `attest`
+  (`2026-06-15-coord-mcp-live-token-write-forwarder`), so reaching `/coord/work-units/*` over the
+  proxy needs EITHER a raw device JWT minted in the runner step (it runs in-process, so it can) OR
+  a small new forwarder route (`/coord-mcp/work-units/*`) injecting the device JWT. Prefer the
+  raw-JWT-in-runner path — the runner step is server-side, not a proxy-shaped agent session, so it
+  can hold the JWT directly without the forwarder indirection.

--- a/src-tauri/src/plan_workunit_adapter/mod.rs
+++ b/src-tauri/src/plan_workunit_adapter/mod.rs
@@ -1,0 +1,41 @@
+//! Harness markdown -> work-unit adapter.
+//!
+//! Plan reference:
+//! `D:/qontinui-root/plans/2026-06-18-harness-markdown-to-workunit-adapter.md`
+//! (P2 of the plan-decoupling program).
+//!
+//! ## Why this lives in the runner
+//!
+//! coord used to auto-discover plans by scanning a filesystem root and
+//! parsing each `*.md` into a `coord.plans` row
+//! (`qontinui-coord/src/plan_ingest_worker.rs`). That coupling bakes an
+//! operator-specific markdown convention into the shared coordination plane
+//! and is *lossy* — it keeps only slug + a fixed-vocabulary status and throws
+//! away the phase structure and dependency edges that are the real value of a
+//! plan.
+//!
+//! The plan-decoupling program moves that parse OUT of coord (the shared
+//! plane) and INTO the operator harness, where it can be as rich as we like
+//! without coupling the shared plane. The markdown plan is the **source**, the
+//! work-unit DAG is the **IR**, and coord is the **runtime** that executes the
+//! IR — coord must not parse source.
+//!
+//! ## Phase 1 (this module today)
+//!
+//! [`parser`] is the pure, IO-free front-end of that compiler: operator plan
+//! markdown -> [`parser::ParsedWorkUnit`]. It is *richer* than coord's old
+//! projection — it also extracts the phase structure (-> sub-units) and the
+//! declared dependency edges — and it treats status as **opaque** (it
+//! tokenizes against an operator-supplied [`parser::PlanConvention`] but never
+//! *rejects* an unknown status the way coord's fixed vocabulary did), matching
+//! the opaque-status work-unit model of the P1 work-unit API.
+//!
+//! Later phases (the push client that calls coord's `/coord/work-units/*` API,
+//! and the periodic trigger) slot in as siblings of [`parser`] under this
+//! module; they are deliberately absent until the P1 work-unit API lands.
+
+pub mod parser;
+
+pub use parser::{
+    parse_work_unit, slug_from_filename, ParsedPhase, ParsedWorkUnit, PlanConvention,
+};

--- a/src-tauri/src/plan_workunit_adapter/parser.rs
+++ b/src-tauri/src/plan_workunit_adapter/parser.rs
@@ -1,0 +1,545 @@
+//! Pure markdown -> work-unit parser (Phase 1).
+//!
+//! IO-free. Turns one plan markdown file's `(slug, source_path, body)` into a
+//! [`ParsedWorkUnit`]: slug, title, an **opaque** status, the declared
+//! dependency edges, and the phase structure as sub-units.
+//!
+//! ## Relationship to coord's old parser
+//!
+//! This is a port + enrichment of coord's `plan_ingest_worker::parse_plan`
+//! (`qontinui-coord/src/plan_ingest_worker.rs`). Two deliberate differences:
+//!
+//! 1. **Status is opaque.** coord normalized the parsed status against a fixed
+//!    `PLAN_STATUS_VOCAB` and could drop an unknown stamp to a fallback token.
+//!    Here the convention's phrase list is used ONLY to *tokenize* a multi-word
+//!    stamp (so `IN PROGRESS 2026-06-19.` resolves to `in_progress`, not the
+//!    first token `in`); an unrecognized stamp is kept verbatim (lowercased +
+//!    underscore-joined) rather than rejected, matching the opaque-status model
+//!    of the coord work-unit API this adapter pushes to. Seeding
+//!    [`PlanConvention::operator_default`] with exactly coord's vocabulary
+//!    yields byte-identical status output to coord's parser for every known
+//!    status — the property the future parity proof relies on.
+//! 2. **Richer projection.** We also extract [`ParsedWorkUnit::depends_on`]
+//!    (the canonical `Depends-On:` edges) and [`ParsedWorkUnit::phases`] (one
+//!    sub-unit per `Phase N` heading), which coord discarded.
+
+/// The operator's markdown convention, supplied as configuration rather than
+/// baked into fleet semantics. Today it carries the set of known lifecycle
+/// status phrases used to *tokenize* (never reject) a status stamp.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlanConvention {
+    /// Lowercase status phrases, longest-match-wins. Multi-word phrases (e.g.
+    /// `"in progress"`) MUST be present so a stamp like `IN PROGRESS 2026-...`
+    /// tokenizes to the whole phrase instead of the first word.
+    pub status_phrases: Vec<String>,
+}
+
+impl PlanConvention {
+    /// The operator's current plan-markdown convention. The phrase set mirrors
+    /// coord's `PLAN_STATUS_VOCAB` (plus `implemented`, which the operator uses
+    /// for "built, PRs open, not yet on main") so known statuses parse
+    /// identically to coord's ingest.
+    pub fn operator_default() -> Self {
+        Self {
+            status_phrases: [
+                "draft",
+                "vetted",
+                "in progress",
+                "shipped",
+                "partial",
+                "not started",
+                "superseded",
+                "obsolete",
+                "implemented",
+            ]
+            .iter()
+            .map(|s| s.to_string())
+            .collect(),
+        }
+    }
+}
+
+impl Default for PlanConvention {
+    fn default() -> Self {
+        Self::operator_default()
+    }
+}
+
+/// One phase of a plan, projected to a work sub-unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedPhase {
+    /// The phase number parsed from the `Phase N` heading.
+    pub index: u32,
+    /// The heading text (bold-span content or heading line), trimmed of markers.
+    pub name: String,
+}
+
+/// The pure result of parsing a plan markdown file. No IO, no clock, no env.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedWorkUnit {
+    /// Slug — supplied by the caller (derived from the filename, not the body).
+    pub slug: String,
+    /// First `# ` H1, if any.
+    pub title: Option<String>,
+    /// Opaque status: lowercased + underscore-joined. Defaults to `"draft"`
+    /// when no `> **Status:` stamp is present. Never rejected against a vocab.
+    pub status: String,
+    /// Canonical `Depends-On:` plan stems from the status blockquote, deduped
+    /// and order-preserving.
+    pub depends_on: Vec<String>,
+    /// Phase structure -> sub-units, in document order, deduped by index.
+    pub phases: Vec<ParsedPhase>,
+    /// Provenance back-link: the source file path the caller supplied.
+    pub source_path: String,
+    /// Raw body, retained like coord's `ParsedPlan.content`.
+    pub content: String,
+}
+
+/// Derive the plan slug from a file path: strip directory and a trailing
+/// `.md` extension. Mirrors coord's filename->slug derivation.
+pub fn slug_from_filename(path: &str) -> String {
+    let normalized = path.replace('\\', "/");
+    let base = normalized.rsplit('/').next().unwrap_or(&normalized);
+    base.strip_suffix(".md").unwrap_or(base).to_string()
+}
+
+/// Match the longest convention status phrase at the start of `s`
+/// (case-insensitive, word-boundary terminated so `drafty` does NOT match
+/// `draft`). Returns the underscore-normalized canonical status on a match.
+/// Ported verbatim from coord's `match_known_status`, with the vocabulary
+/// supplied by [`PlanConvention`] instead of a hardcoded constant.
+fn match_known_status(s: &str, conv: &PlanConvention) -> Option<String> {
+    let lower = s.to_lowercase();
+    let mut best: Option<&str> = None;
+    for phrase in &conv.status_phrases {
+        let phrase = phrase.as_str();
+        if !lower.starts_with(phrase) {
+            continue;
+        }
+        // Boundary check: the phrase must be the whole remainder or be
+        // followed by a non-word character (whitespace, `.`, `,`, ...).
+        let boundary_ok = match lower[phrase.len()..].chars().next() {
+            None => true,
+            Some(c) => !(c.is_alphanumeric() || c == '_'),
+        };
+        if boundary_ok && best.is_none_or(|b| phrase.len() > b.len()) {
+            best = Some(phrase);
+        }
+    }
+    best.map(|p| p.replace(' ', "_"))
+}
+
+/// Normalize a raw status token (`IN_PROGRESS`, `In Progress`, `shipped`) to
+/// the canonical lowercased + underscore-joined form. Ported from coord's
+/// `normalize_status`.
+fn normalize_status(raw: &str) -> String {
+    let cleaned: String = raw
+        .trim()
+        .trim_end_matches([',', '.', ':', '*'])
+        .chars()
+        .map(|c| if c.is_whitespace() { '_' } else { c })
+        .collect();
+    cleaned.to_lowercase()
+}
+
+/// Parse the remainder of a `> **Status:` stamp into an opaque status string.
+/// Uses the convention's phrases for multi-word tokenization, but NEVER rejects
+/// an unknown stamp — an unrecognized status flows through verbatim
+/// (normalized), unlike coord which gated against its fixed vocabulary.
+fn parse_status_value(stamp_remainder: &str, conv: &PlanConvention) -> String {
+    let mut s = stamp_remainder.trim().to_string();
+    // Drop a trailing `**` if the stamp closes the bold span on this line.
+    if let Some(stripped) = s.strip_suffix("**") {
+        s = stripped.trim().to_string();
+    }
+    if let Some(known) = match_known_status(&s, conv) {
+        return known;
+    }
+    // Unknown status: keep it (opaque). Take the first whitespace/`.`/`,`
+    // terminated token so a trailing date/prose doesn't bleed into the status.
+    let token = s
+        .split(|c: char| c.is_whitespace() || c == '.' || c == ',')
+        .next()
+        .unwrap_or("")
+        .trim();
+    if !token.is_empty() {
+        normalize_status(token)
+    } else {
+        s.split_whitespace()
+            .next()
+            .map(normalize_status)
+            .unwrap_or_default()
+    }
+}
+
+/// Collect the lines of the first `> **Status:` blockquote (the contiguous run
+/// of `>`-prefixed lines starting at the status line). Used for `Depends-On:`
+/// extraction, which the canonical rule confines to this block.
+fn status_blockquote_lines(body: &str) -> Vec<&str> {
+    let mut lines = body.lines();
+    // Advance to the first `> **Status:` line.
+    let mut collecting = false;
+    let mut out: Vec<&str> = Vec::new();
+    for line in lines.by_ref() {
+        let t = line.trim_start();
+        if !collecting {
+            if t.starts_with("> **Status:") {
+                collecting = true;
+                out.push(line);
+            }
+            continue;
+        }
+        // Contiguous blockquote: stop at the first non-`>` line.
+        if t.starts_with('>') {
+            out.push(line);
+        } else {
+            break;
+        }
+    }
+    out
+}
+
+/// True iff `tok` is a date-prefixed plan stem (`YYYY-MM-DD-<kebab>`), the same
+/// token shape the canonical `resolve-plan-deps.py` keeps.
+fn is_plan_stem(tok: &str) -> bool {
+    let b = tok.as_bytes();
+    if b.len() < 12 {
+        return false;
+    }
+    let digit = |i: usize| b[i].is_ascii_digit();
+    if !(digit(0) && digit(1) && digit(2) && digit(3)) || b[4] != b'-' {
+        return false;
+    }
+    if !(digit(5) && digit(6)) || b[7] != b'-' {
+        return false;
+    }
+    if !(digit(8) && digit(9)) || b[10] != b'-' {
+        return false;
+    }
+    let rest = &tok[11..];
+    !rest.is_empty()
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Extract canonical `Depends-On:` stems from the status blockquote.
+///
+/// Mirrors `resolve-plan-deps.py`: every case-sensitive `Depends-On:`
+/// occurrence contributes the date-prefixed stem tokens on the REMAINDER of
+/// that physical line; union deduped, order-preserving.
+fn extract_depends_on(body: &str) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for line in status_blockquote_lines(body) {
+        let mut search_from = 0usize;
+        while let Some(rel) = line[search_from..].find("Depends-On:") {
+            let abs = search_from + rel;
+            let remainder = &line[abs + "Depends-On:".len()..];
+            for raw in remainder.split([' ', '\t', ',']) {
+                let tok = raw.trim_matches(|c: char| !(c.is_alphanumeric() || c == '-'));
+                if is_plan_stem(tok) && !out.iter().any(|e| e == tok) {
+                    out.push(tok.to_string());
+                }
+            }
+            search_from = abs + "Depends-On:".len();
+        }
+    }
+    out
+}
+
+/// Detect `Phase N` headings (markdown `#`-heading or `**`-bold forms only —
+/// never mid-line prose) and project each to a [`ParsedPhase`], deduped by
+/// index (first occurrence wins), in document order.
+fn detect_phases(body: &str) -> Vec<ParsedPhase> {
+    let mut out: Vec<ParsedPhase> = Vec::new();
+    for line in body.lines() {
+        let t = line.trim();
+        let started_bold = t.starts_with("**");
+        // The heading text after the leading marker (`#...` or `**`).
+        let rest = if t.starts_with('#') {
+            t.trim_start_matches('#').trim_start()
+        } else if started_bold {
+            &t[2..]
+        } else {
+            continue;
+        };
+        // Must be `Phase` followed by a whitespace boundary, then digits.
+        let after_phase = match rest.strip_prefix("Phase") {
+            Some(a) => a,
+            None => continue,
+        };
+        match after_phase.chars().next() {
+            Some(c) if c.is_whitespace() => {}
+            _ => continue,
+        }
+        let digits: String = after_phase
+            .trim_start()
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        let index: u32 = match digits.parse() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        if out.iter().any(|p| p.index == index) {
+            continue;
+        }
+        // Name: for a bold heading, the bold-span content (up to the closing
+        // `**`); for a `#` heading, the whole line minus trailing markers.
+        let name = if started_bold {
+            match rest.find("**") {
+                Some(i) => rest[..i].trim().to_string(),
+                None => rest.trim_end_matches(['*']).trim().to_string(),
+            }
+        } else {
+            rest.trim_end_matches(['#', '*']).trim().to_string()
+        };
+        out.push(ParsedPhase { index, name });
+    }
+    out
+}
+
+/// Parse a plan markdown body into a [`ParsedWorkUnit`]. Pure — no IO. `slug`
+/// and `source_path` are caller-supplied (the slug comes from the filename, not
+/// the body — see [`slug_from_filename`]).
+///
+/// Status defaults to `"draft"` when no `> **Status:` line is present; title
+/// defaults to `None` when no `# ` H1 is present (both matching coord).
+pub fn parse_work_unit(
+    slug: &str,
+    source_path: &str,
+    body: &str,
+    conv: &PlanConvention,
+) -> ParsedWorkUnit {
+    let mut title: Option<String> = None;
+    let mut status: Option<String> = None;
+
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        // First H1 wins.
+        if title.is_none() {
+            if let Some(rest) = trimmed.strip_prefix("# ") {
+                let t = rest.trim();
+                if !t.is_empty() {
+                    title = Some(t.to_string());
+                }
+            }
+        }
+        // First `> **Status: ...` blockquote wins.
+        if status.is_none() {
+            if let Some(after_quote) = trimmed.strip_prefix("> ") {
+                if let Some(after_bold) = after_quote.strip_prefix("**Status:") {
+                    status = Some(parse_status_value(after_bold, conv));
+                }
+            }
+        }
+        if title.is_some() && status.is_some() {
+            break;
+        }
+    }
+
+    ParsedWorkUnit {
+        slug: slug.to_string(),
+        title,
+        status: status.unwrap_or_else(|| "draft".to_string()),
+        depends_on: extract_depends_on(body),
+        phases: detect_phases(body),
+        source_path: source_path.to_string(),
+        content: body.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conv() -> PlanConvention {
+        PlanConvention::operator_default()
+    }
+
+    fn parse(body: &str) -> ParsedWorkUnit {
+        parse_work_unit("test-slug", "plans/test-slug.md", body, &conv())
+    }
+
+    // --- slug derivation -----------------------------------------------------
+
+    #[test]
+    fn slug_strips_dir_and_extension() {
+        assert_eq!(
+            slug_from_filename("D:/qontinui-root/plans/2026-06-18-foo-bar.md"),
+            "2026-06-18-foo-bar"
+        );
+        assert_eq!(
+            slug_from_filename("plans\\2026-06-18-foo.md"),
+            "2026-06-18-foo"
+        );
+        assert_eq!(slug_from_filename("2026-06-18-foo"), "2026-06-18-foo");
+    }
+
+    // --- status tokenization (ported coord edge cases, opaque variant) -------
+
+    #[test]
+    fn multiword_in_progress_with_trailing_date() {
+        let u = parse("# T\n\n> **Status: IN PROGRESS 2026-05-19.** more prose here\n");
+        assert_eq!(u.status, "in_progress");
+    }
+
+    #[test]
+    fn single_word_status_with_trailing_bold_and_punct() {
+        assert_eq!(parse("> **Status: shipped**\n").status, "shipped");
+        assert_eq!(parse("> **Status: VETTED.**\n").status, "vetted");
+    }
+
+    #[test]
+    fn unknown_status_survives_verbatim_not_rejected() {
+        // coord would fall back to a token too, but the point here is the
+        // status is KEPT (opaque), not dropped/rejected.
+        let u = parse("> **Status: IMPLEMENTED 2026-06-19 — PRs open.** body\n");
+        assert_eq!(u.status, "implemented");
+    }
+
+    #[test]
+    fn shipped_decoy_later_in_block_does_not_win() {
+        // The lifecycle word is at the START of the stamp; a "Flip to SHIPPED"
+        // phrase later in the same block must not override it.
+        let body = "# T\n\n> **Status: IMPLEMENTED 2026-06-19.** Flip to SHIPPED once it lands.\n";
+        assert_eq!(parse(body).status, "implemented");
+    }
+
+    #[test]
+    fn absent_status_defaults_to_draft() {
+        assert_eq!(parse("# Title only\n\nbody\n").status, "draft");
+    }
+
+    #[test]
+    fn first_h1_wins_and_status_block_wins() {
+        let u = parse("# First\n# Second\n\n> **Status: vetted**\n");
+        assert_eq!(u.title.as_deref(), Some("First"));
+        assert_eq!(u.status, "vetted");
+    }
+
+    #[test]
+    fn drafty_does_not_match_draft_boundary() {
+        // Boundary check: `drafty` is not `draft`; falls back to the token.
+        assert_eq!(parse("> **Status: drafty**\n").status, "drafty");
+    }
+
+    // --- depends_on ----------------------------------------------------------
+
+    #[test]
+    fn depends_on_extracts_stem_from_status_block() {
+        let body = "# T\n\n> **Status: VETTED 2026-06-19.** summary. Depends-On: 2026-06-18-coord-generic-work-unit-primitive.\n";
+        assert_eq!(
+            parse(body).depends_on,
+            vec!["2026-06-18-coord-generic-work-unit-primitive".to_string()]
+        );
+    }
+
+    #[test]
+    fn depends_on_ignores_prose_and_bare_dates_outside_block() {
+        // A stem mentioned in the body (not the status block) is NOT a dep.
+        let body = "# T\n\n> **Status: vetted**\n\nSee 2026-01-01-some-other-plan in the body.\n";
+        assert!(parse(body).depends_on.is_empty());
+    }
+
+    #[test]
+    fn depends_on_dedupes_and_preserves_order() {
+        let body = "> **Status: vetted. Depends-On: 2026-01-01-a, 2026-01-02-b\n> trailing. Depends-On: 2026-01-01-a, 2026-01-03-c\n\nbody";
+        assert_eq!(
+            parse(body).depends_on,
+            vec![
+                "2026-01-01-a".to_string(),
+                "2026-01-02-b".to_string(),
+                "2026-01-03-c".to_string()
+            ]
+        );
+    }
+
+    // --- phases --------------------------------------------------------------
+
+    #[test]
+    fn phases_detect_bold_and_heading_forms_not_prose() {
+        let body = "# T\n\n> **Status: in progress 2026-06-19.** Implementing Phase 1 only; gate Phases 2-4.\n\n**Phase 1 — parser.** body\n\n## Phase 2: push client\n\nProse mentioning Phase 1 again should not count.\n";
+        let p = parse(body);
+        assert_eq!(p.phases.len(), 2);
+        assert_eq!(
+            p.phases[0],
+            ParsedPhase {
+                index: 1,
+                name: "Phase 1 — parser.".to_string()
+            }
+        );
+        assert_eq!(p.phases[1].index, 2);
+        assert_eq!(p.phases[1].name, "Phase 2: push client");
+    }
+
+    // --- golden-file tests over the real plans corpus ------------------------
+
+    #[test]
+    fn golden_p1_primitive_opaque_implemented_no_deps() {
+        let body = include_str!("fixtures/2026-06-18-coord-generic-work-unit-primitive.md");
+        let u = parse_work_unit(
+            "2026-06-18-coord-generic-work-unit-primitive",
+            "plans/2026-06-18-coord-generic-work-unit-primitive.md",
+            body,
+            &conv(),
+        );
+        assert_eq!(
+            u.status, "implemented",
+            "decoy 'Flip to SHIPPED' must not win"
+        );
+        assert!(u.depends_on.is_empty(), "foundation plan has no Depends-On");
+        assert!(u.title.is_some());
+    }
+
+    #[test]
+    fn golden_adapter_in_progress_with_dep_and_four_phases() {
+        let body = include_str!("fixtures/2026-06-18-harness-markdown-to-workunit-adapter.md");
+        let u = parse_work_unit(
+            "2026-06-18-harness-markdown-to-workunit-adapter",
+            "plans/2026-06-18-harness-markdown-to-workunit-adapter.md",
+            body,
+            &conv(),
+        );
+        assert_eq!(u.status, "in_progress");
+        assert_eq!(
+            u.depends_on,
+            vec!["2026-06-18-coord-generic-work-unit-primitive".to_string()]
+        );
+        assert_eq!(u.phases.len(), 4, "phases: {:?}", u.phases);
+        assert_eq!(u.phases.first().map(|p| p.index), Some(1));
+        assert_eq!(u.phases.last().map(|p| p.index), Some(4));
+        assert!(u.phases[0].name.contains("parser"));
+        assert!(u.phases[3].name.contains("parity"));
+    }
+
+    #[test]
+    fn golden_draft_vetted_in_progress_status_and_deps() {
+        let cases: &[(&str, &str, &str, &[&str])] = &[
+            (
+                "fixtures/2026-06-18-coord-decommission-markdown-plan-ingest.md",
+                include_str!("fixtures/2026-06-18-coord-decommission-markdown-plan-ingest.md"),
+                "draft",
+                &[],
+            ),
+            (
+                "fixtures/2026-06-18-coord-orchestration-generalize-off-plans.md",
+                include_str!("fixtures/2026-06-18-coord-orchestration-generalize-off-plans.md"),
+                "vetted",
+                &["2026-06-18-coord-generic-work-unit-primitive"],
+            ),
+            (
+                "fixtures/2026-06-18-coord-merge-scheduler-db-test-harness.md",
+                include_str!("fixtures/2026-06-18-coord-merge-scheduler-db-test-harness.md"),
+                "in_progress",
+                &["2026-06-17-coord-land-push-failure-wedge-and-terminal-classification"],
+            ),
+        ];
+        for (path, body, want_status, want_deps) in cases {
+            let u = parse_work_unit(&slug_from_filename(path), path, body, &conv());
+            assert_eq!(&u.status, want_status, "status mismatch for {path}");
+            let want: Vec<String> = want_deps.iter().map(|s| s.to_string()).collect();
+            assert_eq!(u.depends_on, want, "deps mismatch for {path}");
+        }
+    }
+}


### PR DESCRIPTION
Phase 1 of **P2** (harness markdown→work-unit adapter) in the coord plan-decoupling program.

## What this is
A pure, IO-free markdown→work-unit parser in the runner — the compiler front-end that turns operator plan markdown (the *source*) into a structured work-unit (the *IR*), richer than coord's old slug+status projection. New module `src-tauri/src/plan_workunit_adapter/`.

- **Ports** coord's `plan_ingest_worker` parse (first-H1 title, first `> **Status:` stamp, multi-word status tokenization).
- **Enriches** with: opaque status (tokenized via a `PlanConvention` phrase list, never *rejected* — free-text statuses like `implemented` survive, matching the coord work-unit API's opaque-status model); `depends_on` edges (canonical `Depends-On:` rule, mirrors `resolve-plan-deps.py`, confined to the status blockquote); and `phases` (one sub-unit per `Phase N` heading; `#`/`**` heading forms only, mid-line prose excluded).
- **Convention is config, not fleet policy:** `PlanConvention::operator_default()` seeds coord's vocabulary so known statuses parse identically — the parity property Phase 4 will rely on.

## Tests
15 tests incl. 3 golden tests over the real `plans/` corpus (fixtures embedded via `include_str!`): the IMPLEMENTED-not-SHIPPED decoy, the adapter's own dep + 4 phases, and draft/vetted/in_progress + dep extraction. `cargo check`, `cargo test`, and the pre-push `cargo fmt + clippy` hook all green.

## Scope / sequencing
Phase 1 only. Phases 2–4 (push client → coord `/coord/work-units/*`, periodic trigger, parity proof) are deferred behind coord gate `ad65964a-36e7-4544-ba25-b248cd86a55f` until P1's work-unit API (coord#710 + web#623, currently OPEN) lands on coord `main`.

Plan: 2026-06-18-harness-markdown-to-workunit-adapter