### PR TITLE
backend-generator(Fork D): real subprocess security gate replaces static stand-in

### DIFF
--- a/crates/qontinui-backend-generator/src/enforcement.rs
+++ b/crates/qontinui-backend-generator/src/enforcement.rs
@@ -5,19 +5,29 @@
 //! finding fed back into the next codegen prompt); a finding outside `block_on` is
 //! advisory (recorded, not fatal).
 //!
-//! ## Honesty boundary (structurally-present, NOT run in this crate's tests)
+//! ## What actually runs here (no longer a static stand-in)
 //!
-//! This module builds the **hook + the interface** the orchestration loop drives, and a
-//! deterministic, self-contained [`builtin_static_checks`] gate (a real, runnable
-//! scan — no external skill process — that flags a small set of insecure patterns).
-//! What it does NOT do here is *spawn the actual `code-reviewer` / `security-scan` skill
-//! subprocesses*: those are claude-config skills invoked by the conductor/runner in the
-//! live loop, not reachable as a unit-testable library call from this crate. So the
-//! `run`-named skills are wired as an [`EnforcementGate`] trait the loop dispatches to,
-//! with the built-in static gate as the one gate that genuinely runs here. The
-//! integration with the real skills is flagged honestly as
-//! **structurally-present-but-not-run** rather than faked.
+//! The headline gate is [`SubprocessSecurityGate`]: it **materializes the generated
+//! backend to a temp dir and runs a real security scanner subprocess on it**
+//! (`bandit -r <dir> -f json` — the exact static analyzer the claude-config
+//! `security-scan` skill invokes for Python projects: `poetry run bandit -r .`),
+//! parses the scanner's JSON findings into the existing [`EnforcementReport`] shape
+//! (severity → fatal-if-`block_on`), and removes the temp dir afterwards. So the
+//! blocking path is exercised against a *real* scan of the *real* generated source, not
+//! a hand-rolled pattern list.
+//!
+//! The [`EnforcementGate`] trait is retained so a deterministic test double
+//! ([`BuiltinStaticGate`]) stays available for CI (which has no scanner) and so the
+//! loop can inject alternative gates. `code-reviewer` is wired *structurally* as an
+//! advisory gate ([`SubprocessReviewGate`]) — it is an LLM skill (`claude -p
+//! "/code-reviewer"`), non-deterministic and slow, so it is dispatched only when
+//! explicitly enabled and otherwise recorded in `deferred_gates`, honestly flagged.
 
+use std::path::Path;
+use std::process::Command;
+
+use qontinui_types::completeness_verdict::{CoverageGap, GapReason, SpecSection};
+use qontinui_types::functional_spec::SpecProvenance;
 use qontinui_types::priorities_profile::{EnforcementProfile, Profile};
 
 use crate::scaffold::GeneratedBackend;
@@ -45,8 +55,9 @@ pub struct EnforcementReport {
     pub blocking: Vec<Finding>,
     /// Findings outside `block_on` — recorded, not fatal.
     pub advisory: Vec<Finding>,
-    /// Gates named in `run` that were NOT executed here (the external skills) — listed
-    /// so the caller can honestly report what's structurally-wired vs actually-run.
+    /// Gates named in `run` that were NOT executed here (e.g. the LLM `code-reviewer`
+    /// skill when not enabled) — listed so the caller can honestly report what is
+    /// structurally-wired vs actually-run.
     pub deferred_gates: Vec<String>,
 }
 
@@ -55,11 +66,28 @@ impl EnforcementReport {
     pub fn passed(&self) -> bool {
         self.blocking.is_empty()
     }
+
+    /// A single human-readable summary of the blocking findings, suitable for feeding
+    /// back into the next codegen prompt so the model can fix the vulnerability.
+    pub fn blocking_feedback(&self) -> String {
+        if self.blocking.is_empty() {
+            return String::new();
+        }
+        let mut out = String::from(
+            "The previous generated backend was REJECTED by the security gate. Fix every \
+             finding below and re-emit the handler bodies WITHOUT introducing them again:\n",
+        );
+        for f in &self.blocking {
+            out.push_str(&format!("- [{}] {}: {}\n", f.gate, f.file, f.detail));
+        }
+        out
+    }
 }
 
-/// A gate that can scan a generated tree. The built-in static gate implements this;
-/// the external `code-reviewer` / `security-scan` skills are dispatched to by the loop
-/// via the same interface (their adapters live in the runner, not this crate).
+/// A gate that can scan a generated tree. The real subprocess gate
+/// ([`SubprocessSecurityGate`]) and the deterministic test double
+/// ([`BuiltinStaticGate`]) both implement this; the LLM `code-reviewer` skill is
+/// dispatched to via the same interface.
 pub trait EnforcementGate {
     /// The gate's name (matched against `EnforcementProfile.run`).
     fn name(&self) -> &str;
@@ -67,17 +95,19 @@ pub trait EnforcementGate {
     fn scan(&self, backend: &GeneratedBackend) -> Vec<Finding>;
 }
 
-/// Run the enforcement gates declared by the profile over a generated backend.
+/// Run the enforcement gates declared by the profile over a generated backend, using the
+/// **real subprocess scanner** for `security-scan`.
 ///
-/// Only gates with an in-crate implementation actually run here (the built-in static
-/// scan); any other gate named in `run` is recorded in `deferred_gates` so the report is
-/// honest about what executed. `block_on` decides which findings are fatal.
+/// Any gate named in `run` without an executing adapter (e.g. `code-reviewer` when the
+/// LLM gate is not enabled) is recorded in `deferred_gates` so the report is honest about
+/// what executed. `block_on` decides which findings are fatal.
 pub fn run_enforcement(profile: &Profile, backend: &GeneratedBackend) -> EnforcementReport {
     let enforcement = profile.enforcement.clone().unwrap_or_default();
-    run_enforcement_with(&enforcement, backend, &available_gates())
+    run_enforcement_with(&enforcement, backend, &default_gates())
 }
 
-/// Lower-level entry: run an explicit gate set. Lets the loop inject real skill adapters.
+/// Lower-level entry: run an explicit gate set. Lets the loop (or a test) inject the real
+/// subprocess gate or a deterministic double.
 pub fn run_enforcement_with(
     enforcement: &EnforcementProfile,
     backend: &GeneratedBackend,
@@ -98,7 +128,7 @@ pub fn run_enforcement_with(
                 }
             }
             None => {
-                // Named in `run` but no in-crate adapter — structurally wired, not run here.
+                // Named in `run` but no executing adapter — structurally wired, not run.
                 report.deferred_gates.push(requested.clone());
             }
         }
@@ -106,26 +136,315 @@ pub fn run_enforcement_with(
     report
 }
 
-/// The gates this crate can actually run. The built-in static scan stands in as a real,
-/// runnable `security`-category gate (so the loop's blocking path is exercised in tests)
-/// AND is registered under the `security-scan` name so a profile that requests
-/// `security-scan` gets a genuine scan rather than a deferral.
-fn available_gates() -> Vec<Box<dyn EnforcementGate>> {
+/// The gates the live loop runs by default: the **real** subprocess security scanner
+/// registered under the `security-scan` name. `code-reviewer` is intentionally NOT in
+/// this default set (it is an LLM skill — see [`SubprocessReviewGate`]); it falls through
+/// to `deferred_gates` unless the caller opts in via [`gates_with_review`].
+pub fn default_gates() -> Vec<Box<dyn EnforcementGate>> {
+    vec![Box::new(SubprocessSecurityGate::default())]
+}
+
+/// Default gates plus the advisory `code-reviewer` LLM gate, for callers that want it run.
+pub fn gates_with_review(claude_bin: &str) -> Vec<Box<dyn EnforcementGate>> {
     vec![
-        Box::new(BuiltinStaticGate {
-            name: "security-scan".to_string(),
-        }),
-        Box::new(BuiltinStaticGate {
-            name: "builtin-static".to_string(),
+        Box::new(SubprocessSecurityGate::default()),
+        Box::new(SubprocessReviewGate {
+            name: "code-reviewer".to_string(),
+            claude_bin: claude_bin.to_string(),
         }),
     ]
 }
 
-/// A deterministic, self-contained static scan: flags a small set of obviously-insecure
-/// patterns in the generated python. Real and runnable (no external process) — it is the
-/// gate that genuinely executes in this crate's tests, proving the blocking path works.
+// ===========================================================================
+// The REAL gate: materialize → run scanner subprocess → parse → clean up
+// ===========================================================================
+
+/// A real security gate that runs an external scanner subprocess on the *materialized*
+/// generated backend. Defaults to `bandit` (the static Python analyzer the claude-config
+/// `security-scan` skill invokes: `poetry run bandit -r .`), invoked as
+/// `bandit -r <dir> -f json`.
+///
+/// Registered under the `security-scan` name so a profile that requests `security-scan`
+/// gets a genuine scan. The scan:
+/// 1. writes the [`GeneratedBackend`] file tree to a fresh temp dir,
+/// 2. runs the scanner subprocess on that dir,
+/// 3. parses its JSON findings (severity-mapped) into [`Finding`]s with category
+///    `security`,
+/// 4. removes the temp dir.
+pub struct SubprocessSecurityGate {
+    /// The gate name (matched against `EnforcementProfile.run`). Default `security-scan`.
+    pub name: String,
+    /// The scanner executable. Default `bandit`.
+    pub scanner_bin: String,
+    /// Bandit test-ids to skip (e.g. `B101 assert_used`, which fires on every pytest
+    /// `assert` and is NOT a production vulnerability). Default skips `B101`; the test
+    /// suite is additionally excluded by path. Application-code vulnerabilities (SQLi,
+    /// hardcoded secrets, etc.) are unaffected.
+    pub skip_test_ids: Vec<String>,
+    /// Glob fragments whose matching files are excluded from the scan (bandit `--exclude`).
+    /// Default excludes the generated `tests/` tree — a security gate audits the
+    /// *application* code it ships, not its own test asserts.
+    pub exclude_globs: Vec<String>,
+}
+
+impl Default for SubprocessSecurityGate {
+    fn default() -> Self {
+        Self {
+            name: "security-scan".to_string(),
+            scanner_bin: "bandit".to_string(),
+            skip_test_ids: vec!["B101".to_string()],
+            exclude_globs: vec!["*/tests/*".to_string(), "*/conftest.py".to_string()],
+        }
+    }
+}
+
+impl EnforcementGate for SubprocessSecurityGate {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn scan(&self, backend: &GeneratedBackend) -> Vec<Finding> {
+        match self.scan_real(backend) {
+            Ok(findings) => findings,
+            Err(e) => {
+                // The scanner could not be run (not installed / spawn failure). Do NOT
+                // fake a block and do NOT silently pass: surface the failure as a
+                // diagnostic finding the caller must handle. It is categorized `security`
+                // so a `block_on:[security]` profile treats an un-runnable scanner as a
+                // blocker (fail closed), never a green light.
+                vec![Finding {
+                    gate: self.name.clone(),
+                    category: "security".to_string(),
+                    file: String::new(),
+                    detail: format!("security scanner did not run: {e}"),
+                }]
+            }
+        }
+    }
+}
+
+impl SubprocessSecurityGate {
+    /// Run the real scan, returning an error only when the scanner could not be invoked
+    /// at all (so the caller can distinguish "scanner missing" from "scanner found
+    /// nothing").
+    fn scan_real(&self, backend: &GeneratedBackend) -> Result<Vec<Finding>, String> {
+        let dir = TempDir::new("backgen-scan").map_err(|e| format!("temp dir: {e}"))?;
+        backend
+            .materialize_to(dir.path())
+            .map_err(|e| format!("materialize: {e}"))?;
+
+        // bandit -r <dir> -f json [--skip <ids>] [--exclude <globs>]. Exit code is
+        // nonzero when findings exist (that is expected and NOT an error); we only treat a
+        // missing executable / no-stdout as an invocation failure. Bandit writes the JSON
+        // report to stdout. We skip B101 (pytest `assert`) and exclude the test tree so
+        // the gate audits application code for real vulnerabilities, not test asserts.
+        let mut cmd = Command::new(&self.scanner_bin);
+        cmd.arg("-r").arg(dir.path()).arg("-f").arg("json");
+        if !self.skip_test_ids.is_empty() {
+            cmd.arg("--skip").arg(self.skip_test_ids.join(","));
+        }
+        if !self.exclude_globs.is_empty() {
+            cmd.arg("--exclude").arg(self.exclude_globs.join(","));
+        }
+        let output = cmd
+            .output()
+            .map_err(|e| format!("spawn {}: {e}", self.scanner_bin))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        if stdout.trim().is_empty() {
+            return Err(format!(
+                "{} produced no JSON (stderr: {})",
+                self.scanner_bin,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ));
+        }
+
+        let findings = parse_bandit_json(&self.name, &stdout, dir.path())
+            .map_err(|e| format!("parse {} output: {e}", self.scanner_bin))?;
+        // dir is removed on drop.
+        Ok(findings)
+    }
+}
+
+/// Parse `bandit -f json` output into [`Finding`]s. Every bandit result becomes a
+/// `security`-category finding; the path is relativized against the scanned root so the
+/// finding's `file` matches the generated tree's relative path.
+pub fn parse_bandit_json(gate: &str, json: &str, root: &Path) -> Result<Vec<Finding>, String> {
+    let v: serde_json::Value = serde_json::from_str(json).map_err(|e| e.to_string())?;
+    let results = v
+        .get("results")
+        .and_then(|r| r.as_array())
+        .ok_or_else(|| "no `results` array in bandit output".to_string())?;
+
+    let mut findings = Vec::new();
+    for r in results {
+        let abs = r.get("filename").and_then(|f| f.as_str()).unwrap_or("");
+        let rel = Path::new(abs)
+            .strip_prefix(root)
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .unwrap_or_else(|_| abs.replace('\\', "/"));
+        let test_id = r.get("test_id").and_then(|t| t.as_str()).unwrap_or("?");
+        let test_name = r.get("test_name").and_then(|t| t.as_str()).unwrap_or("");
+        let severity = r
+            .get("issue_severity")
+            .and_then(|s| s.as_str())
+            .unwrap_or("UNDEFINED");
+        let confidence = r
+            .get("issue_confidence")
+            .and_then(|s| s.as_str())
+            .unwrap_or("UNDEFINED");
+        let line = r.get("line_number").and_then(|l| l.as_u64()).unwrap_or(0);
+        let text = r
+            .get("issue_text")
+            .and_then(|t| t.as_str())
+            .unwrap_or("")
+            .trim();
+        findings.push(Finding {
+            gate: gate.to_string(),
+            category: "security".to_string(),
+            file: rel,
+            detail: format!(
+                "{test_id} {test_name} (severity {severity}, confidence {confidence}, line {line}): {text}"
+            ),
+        });
+    }
+    Ok(findings)
+}
+
+// ===========================================================================
+// Advisory LLM gate (code-reviewer) — structurally wired, opt-in
+// ===========================================================================
+
+/// The `code-reviewer` claude-config skill, dispatched as an advisory subprocess
+/// (`claude -p "/code-reviewer ..."`). Non-deterministic and slow, so it is only in the
+/// gate set when the caller explicitly opts in ([`gates_with_review`]); otherwise the
+/// gate name falls through to `deferred_gates`. Findings are category `review` (advisory
+/// unless a profile blocks on `review`).
+pub struct SubprocessReviewGate {
+    pub name: String,
+    pub claude_bin: String,
+}
+
+impl EnforcementGate for SubprocessReviewGate {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn scan(&self, backend: &GeneratedBackend) -> Vec<Finding> {
+        let dir = match TempDir::new("backgen-review") {
+            Ok(d) => d,
+            Err(_) => return Vec::new(),
+        };
+        if backend.materialize_to(dir.path()).is_err() {
+            return Vec::new();
+        }
+        let prompt = format!(
+            "/code-reviewer Review the generated Python backend under {} for correctness, \
+             security, and best-practice issues. List each issue on its own line prefixed \
+             with FINDING:.",
+            dir.path().display()
+        );
+        let output = Command::new(&self.claude_bin)
+            .arg("-p")
+            .arg(&prompt)
+            .arg("--add-dir")
+            .arg(dir.path())
+            .output();
+        let Ok(output) = output else {
+            return Vec::new();
+        };
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        stdout
+            .lines()
+            .filter_map(|l| l.trim().strip_prefix("FINDING:"))
+            .map(|detail| Finding {
+                gate: self.name.clone(),
+                category: "review".to_string(),
+                file: String::new(),
+                detail: detail.trim().to_string(),
+            })
+            .collect()
+    }
+}
+
+// ===========================================================================
+// Feedback loop: blocker → re-dispatch CoverageGap
+// ===========================================================================
+
+/// Turn an unresolved blocking enforcement report into a [`CoverageGap`] work-list item,
+/// so an enforcement blocker that survived the bounded codegen retries surfaces as a
+/// **re-dispatch signal** (the reconciler re-generates the affected operation) rather
+/// than a silent pass.
+///
+/// `op_ref` is the dotted spec ref of the operation whose handler is being gated
+/// (e.g. `"operations.pairConfirm"`). Returns `None` when nothing blocks.
+pub fn unresolved_blocker_gap(report: &EnforcementReport, op_ref: &str) -> Option<CoverageGap> {
+    if report.passed() {
+        return None;
+    }
+    let detail = report
+        .blocking
+        .iter()
+        .map(|f| f.detail.clone())
+        .collect::<Vec<_>>()
+        .join("; ");
+    Some(CoverageGap {
+        r#ref: op_ref.to_string(),
+        section: SpecSection::Operations,
+        node_provenance: SpecProvenance::Observed,
+        reason: GapReason::BehaviorMismatch,
+        detail: Some(format!(
+            "enforcement gate blocked after bounded retries: {detail}"
+        )),
+    })
+}
+
+/// The default bound on codegen feedback retries when a security blocker is found.
+pub const DEFAULT_ENFORCEMENT_RETRIES: u32 = 2;
+
+/// Drive the enforcement feedback loop over a single operation's generated handler.
+///
+/// `regenerate` is the codegen callback: given the previous report's blocking feedback
+/// (empty on the first attempt) it must return a fresh [`GeneratedBackend`] revision. The
+/// loop runs the configured gates after each attempt; a clean report admits the revision;
+/// a blocking report feeds [`EnforcementReport::blocking_feedback`] into the next
+/// `regenerate` call, up to `max_retries`. On exhaustion the final report is returned
+/// still-blocking so the caller can call [`unresolved_blocker_gap`] — never a silent pass.
+pub fn enforce_with_feedback<F>(
+    enforcement: &EnforcementProfile,
+    gates: &[Box<dyn EnforcementGate>],
+    max_retries: u32,
+    mut regenerate: F,
+) -> (GeneratedBackend, EnforcementReport)
+where
+    F: FnMut(&str) -> GeneratedBackend,
+{
+    let mut feedback = String::new();
+    let mut backend = regenerate(&feedback);
+    let mut report = run_enforcement_with(enforcement, &backend, gates);
+
+    let mut attempts = 0;
+    while !report.passed() && attempts < max_retries {
+        feedback = report.blocking_feedback();
+        backend = regenerate(&feedback);
+        report = run_enforcement_with(enforcement, &backend, gates);
+        attempts += 1;
+    }
+    (backend, report)
+}
+
+// ===========================================================================
+// Deterministic test double (CI has no scanner) + tiny temp-dir helper
+// ===========================================================================
+
+/// A deterministic, self-contained static scan, used as a **test double** so the
+/// enforcement loop's blocking/advisory logic is unit-testable in CI (which has no
+/// scanner subprocess). It implements [`EnforcementGate`] exactly like the real gate but
+/// flags a fixed pattern set in-process. The *real* coverage of the scan path is the
+/// `#[ignore]`d gated test in `tests/enforcement_subprocess.rs`, which runs the actual
+/// `bandit` subprocess.
 pub struct BuiltinStaticGate {
-    name: String,
+    pub name: String,
 }
 
 impl EnforcementGate for BuiltinStaticGate {
@@ -138,8 +457,8 @@ impl EnforcementGate for BuiltinStaticGate {
     }
 }
 
-/// The actual checks. Flags: `eval(`/`exec(` usage, a hard-coded `password=` literal in
-/// source, and `DEBUG = True`. Category `security` so it hits the `block_on` path.
+/// The double's checks: flags `eval(`/`exec(`, a hard-coded password literal, and
+/// `DEBUG = True`. Category `security` so it hits the `block_on` path.
 pub fn builtin_static_checks(gate: &str, backend: &GeneratedBackend) -> Vec<Finding> {
     let mut findings = Vec::new();
     for (rel, src) in &backend.files {
@@ -168,6 +487,38 @@ pub fn builtin_static_checks(gate: &str, backend: &GeneratedBackend) -> Vec<Find
     findings
 }
 
+/// A minimal RAII temp directory (no external crate): creates a uniquely-named dir under
+/// the OS temp dir and removes it (recursively) on drop. Enough for materialize→scan→clean.
+struct TempDir {
+    path: std::path::PathBuf,
+}
+
+impl TempDir {
+    fn new(prefix: &str) -> std::io::Result<Self> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        let path = std::env::temp_dir().join(format!("{prefix}-{pid}-{nanos}-{n}"));
+        std::fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -186,6 +537,12 @@ mod tests {
         }
     }
 
+    fn double_gates() -> Vec<Box<dyn EnforcementGate>> {
+        vec![Box::new(BuiltinStaticGate {
+            name: "security-scan".to_string(),
+        })]
+    }
+
     #[test]
     fn clean_tree_passes() {
         let b = backend_with(&[("app/main.py", "def f():\n    return 1\n")]);
@@ -195,7 +552,7 @@ mod tests {
                 block_on: vec!["security".to_string()],
             },
             &b,
-            &available_gates(),
+            &double_gates(),
         );
         assert!(
             report.passed(),
@@ -213,11 +570,12 @@ mod tests {
                 block_on: vec!["security".to_string()],
             },
             &b,
-            &available_gates(),
+            &double_gates(),
         );
         assert!(!report.passed(), "eval() must block");
         assert_eq!(report.blocking.len(), 1);
         assert_eq!(report.blocking[0].category, "security");
+        assert!(report.blocking_feedback().contains("REJECTED"));
     }
 
     #[test]
@@ -229,23 +587,125 @@ mod tests {
                 block_on: vec![], // nothing blocks → advisory only
             },
             &b,
-            &available_gates(),
+            &double_gates(),
         );
         assert!(report.passed(), "no block_on → advisory only");
         assert_eq!(report.advisory.len(), 1);
     }
 
     #[test]
-    fn unimplemented_skill_is_deferred_not_faked() {
+    fn unrun_skill_is_deferred_not_faked() {
         let b = backend_with(&[("app/main.py", "x = 1\n")]);
+        // code-reviewer is not in the default gate set → deferred, not faked.
         let report = run_enforcement_with(
             &EnforcementProfile {
                 run: vec!["code-reviewer".to_string()],
                 block_on: vec![],
             },
             &b,
-            &available_gates(),
+            &default_gates(),
         );
         assert_eq!(report.deferred_gates, vec!["code-reviewer".to_string()]);
+    }
+
+    #[test]
+    fn unresolved_blocker_becomes_redispatch_gap() {
+        let b = backend_with(&[("app/api/x.py", "def h():\n    return eval(\"1+1\")\n")]);
+        let report = run_enforcement_with(
+            &EnforcementProfile {
+                run: vec!["security-scan".to_string()],
+                block_on: vec!["security".to_string()],
+            },
+            &b,
+            &double_gates(),
+        );
+        let gap = unresolved_blocker_gap(&report, "operations.pairConfirm")
+            .expect("blocking report yields a gap");
+        assert_eq!(gap.r#ref, "operations.pairConfirm");
+        assert_eq!(gap.section, SpecSection::Operations);
+        assert!(matches!(gap.reason, GapReason::BehaviorMismatch));
+        assert!(unresolved_blocker_gap(&EnforcementReport::default(), "x").is_none());
+    }
+
+    #[test]
+    fn feedback_loop_retries_then_recovers() {
+        // First attempt is vulnerable; the second (after feedback) is clean.
+        let enforcement = EnforcementProfile {
+            run: vec!["security-scan".to_string()],
+            block_on: vec!["security".to_string()],
+        };
+        let mut calls = 0;
+        let (_, report) = enforce_with_feedback(
+            &enforcement,
+            &double_gates(),
+            DEFAULT_ENFORCEMENT_RETRIES,
+            |feedback| {
+                calls += 1;
+                if calls == 1 {
+                    assert!(feedback.is_empty(), "first attempt has no feedback");
+                    backend_with(&[("app/api/x.py", "def h():\n    return eval(\"1\")\n")])
+                } else {
+                    assert!(feedback.contains("REJECTED"), "retry gets feedback");
+                    backend_with(&[("app/api/x.py", "def h():\n    return 1\n")])
+                }
+            },
+        );
+        assert!(report.passed(), "loop recovers after feedback");
+        assert_eq!(calls, 2, "exactly one retry");
+    }
+
+    #[test]
+    fn feedback_loop_exhausts_to_blocking_gap_never_silent() {
+        // Always-vulnerable: the loop must end still-blocking (re-dispatch), not pass.
+        let enforcement = EnforcementProfile {
+            run: vec!["security-scan".to_string()],
+            block_on: vec!["security".to_string()],
+        };
+        let mut calls = 0;
+        let (_, report) = enforce_with_feedback(&enforcement, &double_gates(), 2, |_| {
+            calls += 1;
+            backend_with(&[("app/api/x.py", "def h():\n    return eval(\"1\")\n")])
+        });
+        assert!(!report.passed(), "exhausted loop must remain blocking");
+        assert_eq!(calls, 3, "1 initial + 2 retries");
+        assert!(unresolved_blocker_gap(&report, "operations.pairConfirm").is_some());
+    }
+
+    #[test]
+    fn bandit_json_parses_into_security_findings() {
+        // A representative bandit -f json payload (B608 SQL-injection + B105 password).
+        let json = r#"{
+          "results": [
+            {"filename": "/tmp/scan/app/api/x.py", "test_id": "B608",
+             "test_name": "hardcoded_sql_expressions", "issue_severity": "MEDIUM",
+             "issue_confidence": "MEDIUM", "line_number": 7,
+             "issue_text": "Possible SQL injection vector through string-based query construction."},
+            {"filename": "/tmp/scan/app/api/x.py", "test_id": "B105",
+             "test_name": "hardcoded_password_string", "issue_severity": "LOW",
+             "issue_confidence": "MEDIUM", "line_number": 2,
+             "issue_text": "Possible hardcoded password: 'hunter2'"}
+          ]
+        }"#;
+        let findings = parse_bandit_json("security-scan", json, Path::new("/tmp/scan")).unwrap();
+        assert_eq!(findings.len(), 2);
+        assert!(findings.iter().all(|f| f.category == "security"));
+        assert_eq!(findings[0].file, "app/api/x.py");
+        assert!(findings[0].detail.contains("B608"));
+        assert!(findings[1].detail.contains("B105"));
+    }
+
+    #[test]
+    fn missing_scanner_fails_closed_not_open() {
+        // A scanner binary that cannot exist → the gate emits a blocking diagnostic
+        // finding (fail closed), never a silent pass.
+        let gate = SubprocessSecurityGate {
+            scanner_bin: "definitely-not-a-real-scanner-xyz".to_string(),
+            ..SubprocessSecurityGate::default()
+        };
+        let b = backend_with(&[("app/main.py", "x = 1\n")]);
+        let findings = gate.scan(&b);
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].category, "security");
+        assert!(findings[0].detail.contains("did not run"));
     }
 }

--- a/crates/qontinui-backend-generator/src/lib.rs
+++ b/crates/qontinui-backend-generator/src/lib.rs
@@ -43,7 +43,9 @@ pub mod scaffold;
 
 pub use codegen::{build_prompt, llm_author_handler, LlmOutcome};
 pub use enforcement::{
-    run_enforcement, run_enforcement_with, EnforcementGate, EnforcementReport, Finding,
+    default_gates, enforce_with_feedback, gates_with_review, run_enforcement, run_enforcement_with,
+    unresolved_blocker_gap, BuiltinStaticGate, EnforcementGate, EnforcementReport, Finding,
+    SubprocessReviewGate, SubprocessSecurityGate, DEFAULT_ENFORCEMENT_RETRIES,
 };
 pub use quality::{generate_phase3, min_coverage_pct, DEFAULT_MIN_COVERAGE_PCT};
 pub use route_map::{openapi_document, route_for, RouteBinding};

--- a/crates/qontinui-backend-generator/src/quality.rs
+++ b/crates/qontinui-backend-generator/src/quality.rs
@@ -23,9 +23,12 @@
 //!    tier runs `pytest --cov` **inside the container** and asserts real line coverage
 //!    ≥ `min_coverage_pct`; a below-bar node surfaces as a [`CoverageGap`] (re-dispatch
 //!    signal), never a silent pass.
-//! 4. **Enforcement hook** (Fork D): [`crate::enforcement`] wires `code-reviewer` +
-//!    `security-scan` as post-generation gates structurally (honestly flagged as
-//!    structurally-present, see that module).
+//! 4. **Enforcement hook** (Fork D): [`crate::enforcement`] runs `security-scan` as a
+//!    **real scanner subprocess** (`bandit`) over the materialized generated backend — a
+//!    `security` finding (per `block_on`) blocks, feeds back into the next codegen prompt
+//!    (bounded retries), and an unresolved blocker surfaces as a re-dispatch
+//!    [`CoverageGap`]. `code-reviewer` is wired as an advisory LLM gate (opt-in). See
+//!    that module.
 
 use std::collections::BTreeMap;
 

--- a/crates/qontinui-backend-generator/tests/enforcement_subprocess.rs
+++ b/crates/qontinui-backend-generator/tests/enforcement_subprocess.rs
@@ -1,0 +1,220 @@
+//! Fork D — the enforcement loop's **REAL** security gate, `#[ignore]`d for CI.
+//!
+//! These tests run an ACTUAL security scanner subprocess (`bandit`, the static Python
+//! analyzer the claude-config `security-scan` skill invokes: `poetry run bandit -r .`)
+//! over a *materialized* generated backend. They are `#[ignore]`d because CI hosts have
+//! no scanner installed; run them on a dev host that has one:
+//!
+//! ```sh
+//! python -m pip install bandit            # if not present
+//! cargo test -p qontinui-backend-generator --test enforcement_subprocess -- --ignored --nocapture
+//! ```
+//!
+//! Two cases, proven against the REAL scan (output printed with `--nocapture`):
+//!
+//! 1. A backend whose generated handler does raw SQL string-concat of user input AND
+//!    embeds a hardcoded secret → the real scan FLAGS it (B608 + B105), the gate BLOCKS,
+//!    and an unresolved blocker surfaces as a re-dispatch `CoverageGap`.
+//! 2. The clean, deterministically-generated Phase-3 backend → the real scan finds no
+//!    blocking `security` finding and the gate PASSES.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use qontinui_backend_generator::{
+    generate_phase3, unresolved_blocker_gap, BreakMode, EnforcementGate, GeneratedBackend,
+    SubprocessSecurityGate,
+};
+use qontinui_types::completeness_verdict::SpecSection;
+use qontinui_types::functional_spec::FunctionalSpec;
+use qontinui_types::priorities_profile::{EnforcementProfile, Profile};
+
+fn crate_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    crate_dir().join("../../../qontinui-schemas/rust/tests/fixtures/functional_spec")
+}
+
+fn load_spec() -> FunctionalSpec {
+    serde_json::from_str(
+        &std::fs::read_to_string(fixtures_dir().join("connect-runner.functional_spec.json"))
+            .expect("read spec fixture"),
+    )
+    .expect("parse spec")
+}
+
+fn load_profile() -> Profile {
+    serde_json::from_str(
+        &std::fs::read_to_string(fixtures_dir().join("connect-runner.profile.json"))
+            .expect("read profile fixture"),
+    )
+    .expect("parse profile")
+}
+
+/// The `block_on: [security]` enforcement config (matches the connect-runner profile).
+fn security_blocks() -> EnforcementProfile {
+    EnforcementProfile {
+        run: vec!["security-scan".to_string()],
+        block_on: vec!["security".to_string()],
+    }
+}
+
+/// Skip (with a printed note) if bandit is not installed, so the test is a no-op rather
+/// than a false failure on a host without the scanner.
+fn bandit_present() -> bool {
+    let direct = Command::new("bandit").arg("--version").output();
+    if direct.map(|o| o.status.success()).unwrap_or(false) {
+        return true;
+    }
+    Command::new("python")
+        .args(["-m", "bandit", "--version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// The real subprocess security gate, scanning with the `bandit` console script
+/// (installed alongside the module by `pip install bandit`).
+fn security_gate() -> SubprocessSecurityGate {
+    SubprocessSecurityGate::default()
+}
+
+#[test]
+#[ignore = "runs the real bandit subprocess; CI has no scanner"]
+fn vulnerable_generated_backend_is_blocked_by_real_scan() {
+    if !bandit_present() {
+        eprintln!("SKIP: bandit not installed (pip install bandit); not a failure.");
+        return;
+    }
+    let spec = load_spec();
+    let profile = load_profile();
+
+    // Start from the real generated Phase-3 backend, then inject a deliberately-vulnerable
+    // handler: raw SQL string-concat of user input (SQL injection) + a hardcoded secret.
+    // This is exactly the kind of body an LLM codegen pass could emit, so blocking it is
+    // the loop doing its job.
+    let mut backend: GeneratedBackend = generate_phase3(&spec, &profile, BreakMode::None);
+    let vulnerable = r#""""DELIBERATELY VULNERABLE handler (test fixture for the security gate)."""
+import sqlite3
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+API_SECRET = "sk_live_super_secret_hardcoded_key_123456"  # hardcoded secret
+
+
+@router.get("/api/v1/devices/lookup")
+def lookup_device(device_id: str) -> dict:
+    conn = sqlite3.connect("app.db")
+    cur = conn.cursor()
+    # SQL injection: user input concatenated straight into the query string.
+    query = "SELECT * FROM devices WHERE device_id = '" + device_id + "'"
+    cur.execute(query)
+    return {"rows": cur.fetchall(), "secret": API_SECRET}
+"#;
+    backend.files.insert(
+        "app/api/lookup_device.py".to_string(),
+        vulnerable.to_string(),
+    );
+
+    let gate = security_gate();
+    let findings = gate.scan(&backend);
+
+    println!("\n========== REAL SCAN OUTPUT (VULNERABLE backend) ==========");
+    println!("scanner: {} (gate `{}`)", gate.scanner_bin, gate.name());
+    println!("findings: {}", findings.len());
+    for f in &findings {
+        println!("  - {} :: {}", f.file, f.detail);
+    }
+    println!("===========================================================\n");
+
+    // The real scan must flag the injected vulnerabilities.
+    assert!(
+        !findings.is_empty(),
+        "real scan must produce findings on the vulnerable backend"
+    );
+    assert!(
+        findings.iter().any(|f| f.detail.contains("B608")),
+        "real scan must flag SQL injection (B608); got: {findings:#?}"
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.detail.contains("B105") || f.detail.contains("B106")),
+        "real scan must flag the hardcoded secret (B105/B106); got: {findings:#?}"
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.file == "app/api/lookup_device.py"),
+        "finding must point at the injected handler; got: {findings:#?}"
+    );
+
+    // Run the full enforcement: a `security` finding under `block_on:[security]` blocks,
+    // and the unresolved blocker surfaces as a re-dispatch CoverageGap (never a silent pass).
+    let report = qontinui_backend_generator::run_enforcement_with(
+        &security_blocks(),
+        &backend,
+        &[Box::new(security_gate()) as Box<dyn EnforcementGate>],
+    );
+    assert!(!report.passed(), "gate must BLOCK the vulnerable backend");
+    assert!(
+        !report.blocking.is_empty(),
+        "blocking findings must be recorded"
+    );
+
+    let gap = unresolved_blocker_gap(&report, "operations.pairConfirm")
+        .expect("an unresolved blocker must surface a re-dispatch CoverageGap");
+    assert_eq!(gap.section, SpecSection::Operations);
+    println!(
+        "re-dispatch CoverageGap emitted: ref={} reason={:?}",
+        gap.r#ref, gap.reason
+    );
+    println!(
+        "blocking feedback fed to next codegen prompt:\n{}",
+        report.blocking_feedback()
+    );
+}
+
+#[test]
+#[ignore = "runs the real bandit subprocess; CI has no scanner"]
+fn clean_generated_backend_passes_real_scan() {
+    if !bandit_present() {
+        eprintln!("SKIP: bandit not installed (pip install bandit); not a failure.");
+        return;
+    }
+    let spec = load_spec();
+    let profile = load_profile();
+
+    // The clean, deterministically-generated Phase-3 backend (no injected vuln).
+    let backend = generate_phase3(&spec, &profile, BreakMode::None);
+
+    let gate = security_gate();
+    let findings = gate.scan(&backend);
+
+    println!("\n========== REAL SCAN OUTPUT (CLEAN backend) ==========");
+    println!("scanner: {} (gate `{}`)", gate.scanner_bin, gate.name());
+    println!("findings: {}", findings.len());
+    for f in &findings {
+        println!("  - {} :: {}", f.file, f.detail);
+    }
+    println!("======================================================\n");
+
+    let report = qontinui_backend_generator::run_enforcement_with(
+        &security_blocks(),
+        &backend,
+        &[Box::new(security_gate()) as Box<dyn EnforcementGate>],
+    );
+    assert!(
+        report.passed(),
+        "clean generated backend must PASS the real scan; blocking findings: {:#?}",
+        report.blocking
+    );
+    assert!(
+        unresolved_blocker_gap(&report, "operations.pairConfirm").is_none(),
+        "a passing report yields no re-dispatch gap"
+    );
+}


### PR DESCRIPTION
## What

Makes the backend-generator's enforcement loop (Fork D) **real**: replaces the in-crate static-scan stand-in in `enforcement.rs` with a `SubprocessSecurityGate` that materializes the generated backend to a temp dir and runs an **actual security scanner subprocess** (`bandit -r <dir> -f json` — the static Python analyzer the claude-config `security-scan` skill invokes: `poetry run bandit -r .`), parses its JSON findings into the existing `EnforcementReport` shape (severity → fatal-if-`block_on`), and removes the temp dir afterward.

## Changes

- **`SubprocessSecurityGate`** (registered as `security-scan`): real materialize → scan → parse → cleanup. Fails **closed** — an un-runnable scanner emits a blocking `security` finding, never a silent pass. Skips `B101` (pytest `assert`) and excludes the generated `tests/` tree so the gate audits shipped application code for real vulnerabilities.
- **`EnforcementGate` trait retained** plus a deterministic `BuiltinStaticGate` double so CI (no scanner) still unit-tests the blocking/advisory logic.
- **Feedback loop**: `enforce_with_feedback` feeds a fatal finding's message into the next codegen prompt (bounded retries, default 2); an unresolved blocker surfaces as a re-dispatch `CoverageGap` via `unresolved_blocker_gap` — never a silent pass.
- **`code-reviewer`** wired as an opt-in advisory LLM gate (`SubprocessReviewGate`, `claude -p "/code-reviewer"`); otherwise deferred and honestly flagged.

## Proven for real

`tests/enforcement_subprocess.rs` (`#[ignore]`d — CI has no scanner; runs the actual bandit subprocess on a dev host):

**Vulnerable generated backend** (injected handler: raw SQL string-concat of user input + hardcoded secret) — FLAGGED + BLOCKED:
```
findings: 2
  - app/api/lookup_device.py :: B105 hardcoded_password_string (severity LOW, confidence MEDIUM, line 8): Possible hardcoded password: 'sk_live_super_secret_hardcoded_key_123456'
  - app/api/lookup_device.py :: B608 hardcoded_sql_expressions (severity MEDIUM, confidence LOW, line 16): Possible SQL injection vector through string-based query construction.
re-dispatch CoverageGap emitted: ref=operations.pairConfirm reason=BehaviorMismatch
```

**Clean generated Phase-3 backend** — PASSES:
```
findings: 0
```

## Verification

- `cargo test -p qontinui-backend-generator` (isolated target dir): 11 lib unit tests + 3 golden_phase1 + 5 golden_phase3 green; the 2 new subprocess tests are `#[ignore]`d (run with `-- --ignored`).
- Both `#[ignore]`d gated tests pass against the **real** `bandit` 1.9.4 subprocess.
- `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean.
- No `Cargo.lock` change (std + serde_json only — already deps).

## Deferred / honest boundary

- `code-reviewer` LLM gate is structurally wired (`SubprocessReviewGate`) but **not run** in the gated tests (non-deterministic, slow); it's opt-in via `gates_with_review` and otherwise listed in `deferred_gates`.
- The `qontinui-devtools security scan` subcommand referenced by the skill does **not exist** in the installed devtools v0.1.1; the skill's own `bandit` invocation is the runnable, deterministic scanner and is what this gate drives.