### PR TITLE
fix(runner): keep idle agent sessions alive — claude-present liveness, not descendant-count

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2327,7 +2327,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
 
                     use session::session_lifecycle_store::{classify, PollAction};
 
-                    // claudeSessionId -> consecutive zero-descendant ticks,
+                    // claudeSessionId -> consecutive claude-absent ticks,
                     // carried across ticks to debounce `NeedsConfirm`.
                     let mut consecutive_dead: StdHashMap<String, u32> = StdHashMap::new();
                     // claudeSessionId -> consecutive NO-MATCHING-TERMINAL
@@ -2375,18 +2375,32 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                     })
                                 });
 
-                            let (live_is_alive, descendant_count, snapshot_ok) = match info {
-                                None => (None, 0usize, true),
+                            let (live_is_alive, claude_present, snapshot_ok) = match info {
+                                None => (None, false, true),
                                 Some(info) => {
                                     let pid = info.pid.unwrap_or(0);
-                                    let (descendants, parent_map) =
-                                        crate::process_capture::process_tree::discover_descendants_with_parent_map(pid)
-                                            .await;
+                                    // Take the FULL process snapshot: the
+                                    // claude-present signal needs image names
+                                    // and the PID-reuse guard needs creation
+                                    // times — neither of which
+                                    // discover_descendants_with_parent_map
+                                    // hands back.
+                                    let snap = crate::process_capture::process_tree::snapshot_process_table_public().await;
                                     // A totally-empty system parent_map means
                                     // the snapshot helper failed → Skip.
-                                    let snapshot_ok = !parent_map.is_empty();
+                                    let snapshot_ok = !snap.parent_map.is_empty();
                                     let alive = crate::process_capture::health::pid_alive(pid);
-                                    (Some(alive), descendants.len(), snapshot_ok)
+                                    // Liveness = "is a live Claude present in
+                                    // this PID's inclusive subtree?" — correct
+                                    // for both the operator (claude is a child
+                                    // of the shell) and agent (tracked PID *is*
+                                    // claude, idle with zero children) shapes.
+                                    let claude_present = crate::process_capture::process_tree::claude_present_in_inclusive_subtree(
+                                        pid,
+                                        &snap,
+                                        rec.opened_at,
+                                    );
+                                    (Some(alive), claude_present, snapshot_ok)
                                 }
                             };
 
@@ -2409,7 +2423,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                             let restore_pending = rec.restore_pending_at.is_some();
                             let action = classify(
                                 live_is_alive,
-                                descendant_count,
+                                claude_present,
                                 prior,
                                 prior_no_match,
                                 snapshot_ok,
@@ -2438,7 +2452,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                                     consecutive_no_match.remove(&rec.claude_session_id);
                                     tracing::debug!(
                                         claude_session = %rec.claude_session_id,
-                                        "session lifecycle poll: zero descendants — confirming before close"
+                                        "session lifecycle poll: no claude in subtree — confirming before close"
                                     );
                                 }
                                 PollAction::Close => {

--- a/src-tauri/src/process_capture/process_tree.rs
+++ b/src-tauri/src/process_capture/process_tree.rs
@@ -10,9 +10,11 @@
 //! / `service_pid`; Phase 2 reads `service_pid` to detect inner-worker death.
 //!
 //! Windows uses `Get-CimInstance Win32_Process` via PowerShell to snapshot
-//! `(ProcessId, ParentProcessId, CreationDate)` for every running process,
-//! then BFS in Rust. Unix reads `/proc/<pid>/task/<pid>/children` recursively
-//! and `/proc/<pid>/stat` for the start time.
+//! `(ProcessId, ParentProcessId, CreationDate, Name)` for every running
+//! process, then BFS in Rust. Unix reads `/proc/<pid>/stat` for the parent and
+//! start time and `/proc/<pid>/comm` for the image name. The `Name`/`comm`
+//! image powers [`claude_present_in_inclusive_subtree`], the session-liveness
+//! signal.
 
 use std::collections::HashMap;
 
@@ -35,11 +37,74 @@ pub struct PidWithSpawnedAt {
 /// `parent_map[parent_pid] -> [child_pid, ...]` is the BFS index;
 /// `creation_times[pid] -> unix_secs` carries the lookup table built from
 /// the same snapshot so Phase 4 can sanity-filter persisted PIDs without
-/// re-querying WMI.
+/// re-querying WMI; `names[pid] -> image_name` carries each process's image
+/// (e.g. `claude.exe` on Windows, `comm` on Unix) so the session liveness
+/// poll can ask "is a live Claude process present in this subtree?" — the
+/// signal [`claude_present_in_inclusive_subtree`] reads.
 #[derive(Debug, Default)]
 pub struct ProcessSnapshot {
     pub parent_map: HashMap<u32, Vec<u32>>,
     pub creation_times: HashMap<u32, i64>,
+    pub names: HashMap<u32, String>,
+}
+
+/// Skew tolerance (millis) for the PID-reuse creation-time vs `opened_at`
+/// comparison in [`claude_present_in_inclusive_subtree`]. Creation times come
+/// from WMI at second granularity (and `opened_at` is wall-clock millis at
+/// session open), so a freshly-spawned Claude can legitimately show a creation
+/// time a beat after its session record's `opened_at`. Only treat a tracked
+/// PID as reused when its creation predates the open by more than this slack.
+const PID_REUSE_SKEW_MS: i64 = 5_000;
+
+/// True iff a live Claude process is present in the **inclusive** subtree
+/// rooted at `root_pid` — i.e. `root_pid`'s own image is `claude*`, OR any
+/// descendant's image is `claude*`. This is the liveness signal the terminal-
+/// session poll uses: a session is alive iff there is a live Claude here, which
+/// is the correct question for **both** session shapes:
+/// - **Operator session:** tracked PID is the shell; `claude` is a child →
+///   present via a descendant.
+/// - **Agent / gate-continuation session:** tracked PID *is* `claude` (it is the
+///   portable-pty child) → present via the root, even when idle with zero
+///   children (the bug the old `descendant_count > 0` heuristic mis-closed).
+///
+/// `opened_at_unix_millis` guards PID reuse: if the tracked `root_pid`'s
+/// creation time predates the session's open time (beyond [`PID_REUSE_SKEW_MS`]),
+/// the kernel recycled that PID into an unrelated process — its image name must
+/// not be trusted, so the subtree is treated as claude-absent. The comparison
+/// normalizes units: `creation_times` is epoch **seconds**, `opened_at` is
+/// epoch **millis**.
+pub fn claude_present_in_inclusive_subtree(
+    root_pid: u32,
+    snapshot: &ProcessSnapshot,
+    opened_at_unix_millis: i64,
+) -> bool {
+    // PID-reuse guard on the tracked root (seconds → millis before comparing).
+    if let Some(&created_secs) = snapshot.creation_times.get(&root_pid) {
+        if created_secs > 0 && created_secs * 1000 + PID_REUSE_SKEW_MS < opened_at_unix_millis {
+            return false;
+        }
+    }
+    if is_claude_image(snapshot.names.get(&root_pid)) {
+        return true;
+    }
+    bfs_descendants_from(root_pid, &snapshot.parent_map, &snapshot.creation_times)
+        .iter()
+        .any(|d| is_claude_image(snapshot.names.get(&d.pid)))
+}
+
+/// Case-insensitive basename match on `claude` / `claude.exe`. Tolerates a
+/// path-qualified name (takes the basename) and a trailing `.exe`.
+fn is_claude_image(name: Option<&String>) -> bool {
+    let Some(name) = name else {
+        return false;
+    };
+    let base = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(name)
+        .to_ascii_lowercase();
+    let stem = base.strip_suffix(".exe").unwrap_or(&base);
+    stem == "claude"
 }
 
 /// Discover every descendant of `root_pid` (NOT including the root itself).
@@ -209,7 +274,7 @@ fn collect_descendants_from_snapshot(
 async fn snapshot_process_table() -> ProcessSnapshot {
     // ConvertTo-Json on a single row drops the array; force an array with @().
     const SCRIPT: &str = "$ErrorActionPreference='SilentlyContinue'; \
-        @(Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate) | \
+        @(Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,CreationDate,Name) | \
         ConvertTo-Json -Compress -Depth 3";
 
     let output = match tokio::task::spawn_blocking(|| {
@@ -251,6 +316,8 @@ struct WmiProcessRow {
     parent_process_id: Option<u32>,
     #[serde(rename = "CreationDate", default)]
     creation_date: Option<serde_json::Value>,
+    #[serde(rename = "Name", default)]
+    name: Option<String>,
 }
 
 #[cfg(windows)]
@@ -276,6 +343,9 @@ fn parse_powershell_snapshot(json: &str) -> ProcessSnapshot {
             .map(parse_wmi_creation_date)
             .unwrap_or(0);
         snap.creation_times.insert(row.process_id, secs);
+        if let Some(name) = row.name {
+            snap.names.insert(row.process_id, name);
+        }
     }
     snap
 }
@@ -391,6 +461,21 @@ fn snapshot_process_table_sync() -> ProcessSnapshot {
         };
         snap.parent_map.entry(ppid).or_default().push(pid);
         snap.creation_times.insert(pid, spawned_at_unix);
+        // Image name for the claude-present liveness signal. `/proc/<pid>/comm`
+        // is the kernel's `TASK_COMM` (≤15 chars, no path) — `claude` fits.
+        // Fall back to the `comm` field already parsed out of `stat` (the text
+        // between the first '(' and last ')') if the dedicated file is gone.
+        let name = std::fs::read_to_string(format!("/proc/{pid}/comm"))
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                let open = stat.find('(')?;
+                Some(stat[open + 1..close].to_string())
+            });
+        if let Some(name) = name {
+            snap.names.insert(pid, name);
+        }
     }
     snap
 }
@@ -464,6 +549,103 @@ mod tests {
         let creation_times: HashMap<u32, i64> = HashMap::new();
         let out = bfs_descendants_from(42, &parent_map, &creation_times);
         assert!(out.is_empty());
+    }
+
+    fn snap_with(
+        parent_map: &[(u32, &[u32])],
+        creation: &[(u32, i64)],
+        names: &[(u32, &str)],
+    ) -> ProcessSnapshot {
+        let mut s = ProcessSnapshot::default();
+        for (p, kids) in parent_map {
+            s.parent_map.insert(*p, kids.to_vec());
+        }
+        for (pid, t) in creation {
+            s.creation_times.insert(*pid, *t);
+        }
+        for (pid, n) in names {
+            s.names.insert(*pid, n.to_string());
+        }
+        s
+    }
+
+    // `opened_at` (millis) is ≈ when the session's process spawned, so a
+    // non-reused PID has `creation_secs * 1000 >= opened_at` (minus skew). The
+    // alive fixtures below use creation 1_000s (== 1_000_000ms) with an
+    // `opened_at` at/just-before that instant so the PID-reuse guard is a no-op
+    // and the tests exercise the image-name logic, not reuse.
+    const OPEN_AT_FRESH: i64 = 1_000_000;
+
+    #[test]
+    fn claude_present_root_is_claude() {
+        // Agent / gate-continuation session: tracked PID *is* claude, zero
+        // children — the exact idle shape the old descendant-count heuristic
+        // mis-closed as poll-dead.
+        let snap = snap_with(&[], &[(100, 1_000)], &[(100, "claude.exe")]);
+        assert!(claude_present_in_inclusive_subtree(
+            100,
+            &snap,
+            OPEN_AT_FRESH
+        ));
+        // Case-insensitive, no extension, path-qualified — all match.
+        let snap2 = snap_with(&[], &[(100, 1_000)], &[(100, "C:/bin/Claude")]);
+        assert!(claude_present_in_inclusive_subtree(
+            100,
+            &snap2,
+            OPEN_AT_FRESH
+        ));
+    }
+
+    #[test]
+    fn claude_present_descendant_is_claude() {
+        // Operator session: tracked PID is the shell; claude is a child.
+        let snap = snap_with(
+            &[(200, &[201])],
+            &[(200, 1_000), (201, 1_001)],
+            &[(200, "powershell.exe"), (201, "claude")],
+        );
+        assert!(claude_present_in_inclusive_subtree(
+            200,
+            &snap,
+            OPEN_AT_FRESH
+        ));
+    }
+
+    #[test]
+    fn claude_present_false_when_no_claude() {
+        // Bare shell, operator quit claude: no claude anywhere in the subtree
+        // → genuine poll-dead (the cleanup Option B preserves). `opened_at` is
+        // fresh so this exercises genuine absence, not the reuse guard.
+        let snap = snap_with(
+            &[(300, &[301])],
+            &[(300, 1_000), (301, 1_001)],
+            &[(300, "pwsh.exe"), (301, "node.exe")],
+        );
+        assert!(!claude_present_in_inclusive_subtree(
+            300,
+            &snap,
+            OPEN_AT_FRESH
+        ));
+    }
+
+    #[test]
+    fn claude_present_false_on_pid_reuse() {
+        // Tracked PID's image says claude, but its creation time predates the
+        // session open by more than the skew → the kernel reused the PID →
+        // don't trust the name. (1_000s == 1_000_000ms, opened_at 2_000_000ms.)
+        let reused = snap_with(&[], &[(400, 1_000)], &[(400, "claude.exe")]);
+        assert!(!claude_present_in_inclusive_subtree(
+            400, &reused, 2_000_000
+        ));
+        // Within the skew window (3ms later) it is NOT reuse — a freshly
+        // spawned claude whose creation rounds just past opened_at.
+        let fresh = snap_with(&[], &[(400, 1_000)], &[(400, "claude.exe")]);
+        assert!(claude_present_in_inclusive_subtree(400, &fresh, 1_000_003));
+        // Unresolved creation time (0) must never count as reuse.
+        let unknown = snap_with(&[], &[(400, 0)], &[(400, "claude.exe")]);
+        assert!(claude_present_in_inclusive_subtree(
+            400, &unknown, 2_000_000
+        ));
     }
 
     #[test]
@@ -555,5 +737,28 @@ mod tests {
             Some(&[3u32][..])
         );
         assert_eq!(snap.creation_times.get(&2).copied(), Some(1715911100));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn parse_powershell_snapshot_captures_name() {
+        let json = r#"[
+            {"ProcessId":10,"ParentProcessId":0,"CreationDate":"/Date(1715911000000)/","Name":"powershell.exe"},
+            {"ProcessId":11,"ParentProcessId":10,"CreationDate":"/Date(1715911000000)/","Name":"claude.exe"}
+        ]"#;
+        let snap = parse_powershell_snapshot(json);
+        assert_eq!(
+            snap.names.get(&10).map(|s| s.as_str()),
+            Some("powershell.exe")
+        );
+        assert_eq!(snap.names.get(&11).map(|s| s.as_str()), Some("claude.exe"));
+        // End-to-end: the inclusive-subtree helper sees claude under the shell.
+        // opened_at == the shell's creation in millis so the reuse guard is a
+        // no-op (creation does not predate open).
+        assert!(claude_present_in_inclusive_subtree(
+            10,
+            &snap,
+            1_715_911_000_000
+        ));
     }
 }

--- a/src-tauri/src/session/session_lifecycle_store.rs
+++ b/src-tauri/src/session/session_lifecycle_store.rs
@@ -66,15 +66,16 @@ const RESTORABLE_POLL_DEAD_MS: i64 = 600_000;
 /// live sessions are touched every ~45s by the poll, so anything on screen
 /// at shutdown sits well inside it).
 const RESTORABLE_OPEN_ANCHOR_GRACE_MS: i64 = 600_000;
-/// Number of consecutive zero-descendant ticks a *live* shell (`Some(true)`)
-/// must accumulate before the poll closes it `poll-dead`. A live Claude
-/// session routinely idles with zero descendants between tool calls / while
-/// waiting on the user, so closing on a single confirm tick (~90s) races a
-/// restart into dropping a still-live session. Requiring several ticks
-/// (≈ N × 45s poll interval) only closes shells that are idle-with-no-children
-/// for an extended, unambiguous stretch. A `Some(false)` (pty actually dead)
-/// shell still closes immediately — that path is unambiguous and bypasses
-/// this debounce entirely.
+/// Number of consecutive claude-absent ticks a *live* shell (`Some(true)` with
+/// no Claude in its inclusive subtree) must accumulate before the poll closes
+/// it `poll-dead`. A live Claude in the subtree is KeepAlive immediately and
+/// never reaches this debounce. The debounce only governs the claude-absent
+/// case: it absorbs a transient process-snapshot miss and gives an in-flight
+/// relaunch a window, so a momentary blip doesn't drop a session. Requiring
+/// several ticks (≈ N × 45s poll interval) only closes shells that are
+/// claude-absent for an extended, unambiguous stretch (operator quit claude;
+/// bare shell lingers). A `Some(false)` (pty actually dead) shell still closes
+/// immediately — that path is unambiguous and bypasses this debounce entirely.
 const LIVE_SHELL_DEAD_TICKS: u32 = 3;
 /// Number of consecutive NO-MATCHING-TERMINAL ticks an open record must
 /// accumulate before the poll closes it `"no-terminal"`. A record whose
@@ -563,9 +564,10 @@ fn write_map(path: &Path, map: &HashMap<String, TerminalSessionRecord>) -> std::
 pub enum PollAction {
     /// The session is alive and busy — refresh its `last_seen_at`.
     KeepAlive,
-    /// The session's shell is alive but has zero descendants and has not yet
-    /// reached [`LIVE_SHELL_DEAD_TICKS`] consecutive zero-descendant ticks —
-    /// wait more ticks before closing (debounce idle lulls between tool calls).
+    /// The session's shell pty is alive but no live Claude is present in its
+    /// inclusive subtree, and it has not yet reached [`LIVE_SHELL_DEAD_TICKS`]
+    /// consecutive claude-absent ticks — wait more ticks before closing
+    /// (debounce a transient snapshot miss / an in-flight relaunch).
     NeedsConfirm,
     /// The session is dead — flip it to `closed` (reason `"poll-dead"`).
     Close,
@@ -588,8 +590,16 @@ pub enum PollAction {
 ///
 /// - `live_is_alive`: `Some(true)` shell pty alive, `Some(false)` dead,
 ///   `None` no matching pty for this session.
-/// - `descendant_count`: number of descendant processes of the shell pid.
-/// - `consecutive_dead`: count of prior consecutive zero-descendant ticks.
+/// - `claude_present`: whether a live Claude process is present in the tracked
+///   PID's *inclusive* subtree (the tracked PID's own image is `claude*`, or any
+///   descendant's is). This replaces the old `descendant_count > 0` heuristic,
+///   which mis-closed an idle **agent** session whose tracked PID *is* `claude`
+///   (it spawns zero children while parked on a gate). The invariant: the
+///   `Some(true)` arm never reaches `Close` while `claude_present` — a live
+///   Claude here is the normal state, never a dead signal. `Close` is reachable
+///   from `Some(true)` only when claude is ABSENT for `LIVE_SHELL_DEAD_TICKS`
+///   (the preserved bare-shell cleanup: operator quit claude, shell PID lingers).
+/// - `consecutive_dead`: count of prior consecutive claude-absent ticks.
 /// - `consecutive_no_match`: count of prior consecutive ticks where NO live
 ///   terminal matched this record. "No matching terminal in THIS instance
 ///   for many consecutive ticks" is not uncertainty — it is an orphan that
@@ -610,7 +620,7 @@ pub enum PollAction {
 ///   `NoMatchWait`.
 pub fn classify(
     live_is_alive: Option<bool>,
-    descendant_count: usize,
+    claude_present: bool,
     consecutive_dead: u32,
     consecutive_no_match: u32,
     snapshot_ok: bool,
@@ -629,15 +639,19 @@ pub fn classify(
         }
         Some(false) => PollAction::Close,
         Some(true) => {
-            if descendant_count > 0 {
+            if claude_present {
+                // A live Claude in the inclusive subtree — KeepAlive
+                // unconditionally, no matter how long it has idled. This is the
+                // floor that fixes the false poll-dead close of idle agents.
                 PollAction::KeepAlive
             } else if consecutive_dead < LIVE_SHELL_DEAD_TICKS {
-                // A live shell idling with no children is the normal between-
-                // tool-calls state of a Claude session — debounce several
-                // ticks before treating it as dead, so a restart in this
+                // No Claude present, but debounce several ticks before closing:
+                // absorbs a transient snapshot miss, and a restart in this
                 // window does not drop a still-live session.
                 PollAction::NeedsConfirm
             } else {
+                // Claude absent for the full debounce — genuine poll-dead (e.g.
+                // operator quit claude and only the bare shell PID lingers).
                 PollAction::Close
             }
         }
@@ -1011,18 +1025,18 @@ mod tests {
     fn classify_skip_on_snapshot_failure() {
         // snapshot_ok=false dominates every other input.
         assert_eq!(
-            classify(Some(false), 0, 5, 0, false, false),
+            classify(Some(false), false, 5, 0, false, false),
             PollAction::Skip
         );
         assert_eq!(
-            classify(Some(true), 3, 0, 0, false, false),
+            classify(Some(true), true, 0, 0, false, false),
             PollAction::Skip
         );
-        assert_eq!(classify(None, 0, 0, 0, false, false), PollAction::Skip);
+        assert_eq!(classify(None, false, 0, 0, false, false), PollAction::Skip);
         // Even a no-match streak past the orphan threshold must Skip (not
         // CloseNoTerminal) when the snapshot failed.
         assert_eq!(
-            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS + 5, false, false),
+            classify(None, false, 0, NO_TERMINAL_ORPHAN_TICKS + 5, false, false),
             PollAction::Skip
         );
     }
@@ -1034,14 +1048,14 @@ mod tests {
         // NOT close on a brief registration race.
         for prior in 0..NO_TERMINAL_ORPHAN_TICKS {
             assert_eq!(
-                classify(None, 0, 0, prior, true, false),
+                classify(None, false, 0, prior, true, false),
                 PollAction::NoMatchWait,
                 "no match, {prior} prior no-match ticks must NoMatchWait"
             );
         }
-        // descendant/dead-tick inputs are irrelevant to the no-match arm.
+        // claude_present/dead-tick inputs are irrelevant to the no-match arm.
         assert_eq!(
-            classify(None, 9, 9, 0, true, false),
+            classify(None, true, 9, 0, true, false),
             PollAction::NoMatchWait
         );
     }
@@ -1052,54 +1066,102 @@ mod tests {
         // orphan — close it with the (non-restorable) "no-terminal" reason.
         // With a 45s poll the close lands on the 4th consecutive tick ≈ 3min.
         assert_eq!(
-            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS, true, false),
+            classify(None, false, 0, NO_TERMINAL_ORPHAN_TICKS, true, false),
             PollAction::CloseNoTerminal
         );
         assert_eq!(
-            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS + 5, true, false),
+            classify(None, false, 0, NO_TERMINAL_ORPHAN_TICKS + 5, true, false),
             PollAction::CloseNoTerminal
         );
     }
 
     #[test]
     fn classify_close_on_dead_shell() {
+        // A dead pty closes regardless of claude_present — the unambiguous
+        // confident-dead signal.
         assert_eq!(
-            classify(Some(false), 0, 0, 0, true, false),
+            classify(Some(false), false, 0, 0, true, false),
             PollAction::Close
         );
         assert_eq!(
-            classify(Some(false), 5, 0, 0, true, false),
+            classify(Some(false), true, 0, 0, true, false),
             PollAction::Close
         );
     }
 
     #[test]
-    fn classify_keepalive_when_alive_with_descendants() {
+    fn classify_keepalive_when_claude_present() {
+        // Claude present in the inclusive subtree ⇒ KeepAlive immediately —
+        // even with zero prior dead ticks (the idle-agent bug) and even after
+        // a long prior claude-absent streak (claude came back).
         assert_eq!(
-            classify(Some(true), 1, 0, 0, true, false),
+            classify(Some(true), true, 0, 0, true, false),
             PollAction::KeepAlive
         );
         assert_eq!(
-            classify(Some(true), 7, 9, 0, true, false),
+            classify(Some(true), true, 9, 0, true, false),
             PollAction::KeepAlive
+        );
+    }
+
+    #[test]
+    fn classify_idle_agent_session_is_kept_alive() {
+        // Regression for the live incident (2026-06-19): an idle agent /
+        // gate-continuation session whose tracked PID *is* claude spawns zero
+        // children while parked on a gate. Under the old `descendant_count > 0`
+        // heuristic this read as dead and was closed `poll-dead` in ~135s while
+        // perfectly alive. With `claude_present` the answer is KeepAlive on the
+        // very first tick, forever, no matter how long it idles.
+        assert_eq!(
+            classify(Some(true), true, 0, 0, true, false),
+            PollAction::KeepAlive
+        );
+        assert_eq!(
+            classify(
+                Some(true),
+                true,
+                LIVE_SHELL_DEAD_TICKS + 100,
+                0,
+                true,
+                false
+            ),
+            PollAction::KeepAlive
+        );
+    }
+
+    #[test]
+    fn classify_operator_quit_claude_closes_after_debounce() {
+        // The preserved bare-shell cleanup: operator quits claude, the shell
+        // PID stays alive but no claude remains in its subtree → NeedsConfirm
+        // through the debounce, then Close. (prior < LIVE_SHELL_DEAD_TICKS is
+        // NeedsConfirm, NOT Close — the plan's test-plan "prior=2 ⇒ Close" bullet
+        // predated keeping the 3-tick debounce; Change #2 keeps it, so Close
+        // requires the full streak.)
+        assert_eq!(
+            classify(Some(true), false, LIVE_SHELL_DEAD_TICKS - 1, 0, true, false),
+            PollAction::NeedsConfirm
+        );
+        assert_eq!(
+            classify(Some(true), false, LIVE_SHELL_DEAD_TICKS, 0, true, false),
+            PollAction::Close
         );
     }
 
     #[test]
     fn classify_needs_confirm_while_below_live_shell_dead_ticks() {
-        // A live shell with zero descendants stays in NeedsConfirm for every
+        // A live shell with NO claude present stays in NeedsConfirm for every
         // tick strictly below LIVE_SHELL_DEAD_TICKS — it must NOT close on a
-        // brief idle lull (the poll-dead race this fix closes).
+        // brief blip (a transient snapshot miss / in-flight relaunch).
         for prior in 0..LIVE_SHELL_DEAD_TICKS {
             assert_eq!(
-                classify(Some(true), 0, prior, 0, true, false),
+                classify(Some(true), false, prior, 0, true, false),
                 PollAction::NeedsConfirm,
-                "live shell, 0 descendants, {prior} prior ticks must NeedsConfirm"
+                "live shell, claude absent, {prior} prior ticks must NeedsConfirm"
             );
         }
         // Specifically: the second tick (prior == 1) no longer closes.
         assert_eq!(
-            classify(Some(true), 0, 1, 0, true, false),
+            classify(Some(true), false, 1, 0, true, false),
             PollAction::NeedsConfirm
         );
     }
@@ -1107,13 +1169,14 @@ mod tests {
     #[test]
     fn classify_close_only_after_live_shell_dead_ticks_reached() {
         // Only once we've accumulated LIVE_SHELL_DEAD_TICKS consecutive
-        // zero-descendant ticks does a live shell finally close.
+        // claude-absent ticks does a live shell finally close (operator quit
+        // claude; the bare shell PID lingers).
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, 0, true, false),
+            classify(Some(true), false, LIVE_SHELL_DEAD_TICKS, 0, true, false),
             PollAction::Close
         );
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, 0, true, false),
+            classify(Some(true), false, LIVE_SHELL_DEAD_TICKS + 5, 0, true, false),
             PollAction::Close
         );
     }
@@ -1123,38 +1186,44 @@ mod tests {
         // The incident shape: a restored pane whose resume silently failed.
         // Dead pty (the restore shell died / was never matched) → Skip, NOT
         // Close — the durable `open` record must survive for the next attempt.
-        assert_eq!(classify(Some(false), 0, 0, 0, true, true), PollAction::Skip);
-        // Plain shell idling with zero descendants, even past the debounce
-        // ticks (the exact poll-dead flip the incident hit) → Skip.
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS, 0, true, true),
+            classify(Some(false), false, 0, 0, true, true),
+            PollAction::Skip
+        );
+        // Plain shell with no claude present, even past the debounce ticks
+        // (the exact poll-dead flip the incident hit) → Skip.
+        assert_eq!(
+            classify(Some(true), false, LIVE_SHELL_DEAD_TICKS, 0, true, true),
             PollAction::Skip
         );
         assert_eq!(
-            classify(Some(true), 0, LIVE_SHELL_DEAD_TICKS + 5, 0, true, true),
+            classify(Some(true), false, LIVE_SHELL_DEAD_TICKS + 5, 0, true, true),
             PollAction::Skip
         );
         // Below the debounce it must not even accumulate NeedsConfirm ticks.
-        assert_eq!(classify(Some(true), 0, 0, 0, true, true), PollAction::Skip);
+        assert_eq!(
+            classify(Some(true), false, 0, 0, true, true),
+            PollAction::Skip
+        );
         // No matching pty → Skip, NOT NoMatchWait: a mid-restore row keeps
         // its OLD terminal_id until the re-assert and must never accumulate
         // no-match ticks toward an orphan close.
-        assert_eq!(classify(None, 0, 0, 0, true, true), PollAction::Skip);
+        assert_eq!(classify(None, false, 0, 0, true, true), PollAction::Skip);
         // Even a streak past the orphan threshold must not close while the
         // restore-pending marker is set.
         assert_eq!(
-            classify(None, 0, 0, NO_TERMINAL_ORPHAN_TICKS + 1, true, true),
+            classify(None, false, 0, NO_TERMINAL_ORPHAN_TICKS + 1, true, true),
             PollAction::Skip
         );
     }
 
     #[test]
     fn classify_restore_pending_passes_through_confident_alive() {
-        // A confidently-alive session (descendants running) classifies
-        // KeepAlive even while restore-pending — the caller uses this to
-        // self-heal a stale marker.
+        // A confidently-alive session (claude present) classifies KeepAlive
+        // even while restore-pending — the caller uses this to self-heal a
+        // stale marker.
         assert_eq!(
-            classify(Some(true), 2, 0, 0, true, true),
+            classify(Some(true), true, 0, 0, true, true),
             PollAction::KeepAlive
         );
     }


### PR DESCRIPTION
## Problem (live-caught 2026-06-19)

The terminal-session liveness poll falsely closed **live, idle headless agent
sessions** as `poll-dead`. Four registry rows were `closed/closeReason=poll-dead`
while their `claude.exe` processes ran for **hours** afterward. They then aged
past the 10-min restore grace before the runner reopened → the user-visible
"saved terminal pages don't restore their sessions."

**Root cause:** `classify`'s `Some(true)` arm treated `descendant_count == 0` as
a dead signal. That only works for an **operator** session (tracked PID = the
powershell shell, `claude` a persistent child → BFS ≥ 1). For an **agent /
gate-continuation** session the tracked PID *is* `claude` (the portable-pty
child), and an idle Claude parked on a gate spawns zero children → BFS = 0 →
`Close("poll-dead")` in ~135s while perfectly alive.

## Fix — "Claude present in the inclusive subtree"

Replace `descendant_count > 0` with `claude_present_in_inclusive_subtree`: a
session is alive iff a live Claude process is present in the tracked PID's
inclusive subtree (the PID's own image is `claude*`, or any descendant's is).
This asks the one question correct for **both** shapes. The bare-shell cleanup
is preserved — operator quits claude → no claude in subtree → genuine poll-dead
after the debounce.

### Changes
- **`process_tree.rs`** — thread process image `names` through `ProcessSnapshot`
  (WMI `Name` column on Windows, `/proc/<pid>/comm` on Unix); add
  `claude_present_in_inclusive_subtree` with a PID-reuse guard that **normalizes
  units** (`creation_times` are epoch **seconds**, `opened_at` is epoch
  **millis** — a naive compare would flag every PID as reused and defeat the fix).
- **`session_lifecycle_store.rs`** — `classify` third param
  `descendant_count: usize` → `claude_present: bool`; `Some(true)` arm KeepAlive
  while claude present, else the existing 3-tick debounce then Close.
  Restore-pending / dead-pty / snapshot-fail arms unchanged.
- **`main.rs`** — poll loop takes the full `ProcessSnapshot`
  (`snapshot_process_table_public`) and computes `claude_present` per record.

No restore-grace change — restore is anchor-relative and self-heals once the
false close stops; widening the grace would resurrect genuinely-dead sessions.

### Tests (in-crate, run under `--bins`)
`classify` regression for the idle-agent incident + the operator-quit
transition; `claude_present` root / descendant / absent / PID-reuse cases + the
WMI `Name`-column parse. All green (`cargo test --bins`), `cargo fmt` + `clippy`
clean.

Plan: plans/2026-06-19-runner-poll-dead-false-close-idle-agents.md