### PR TITLE
feat(plan-adapter): Phases 2-4 — push client, trigger, parity proof

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -700,6 +700,16 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // on coord WS and supervises the resulting `claude` CLI
                 // child processes. No-op when no profile is configured.
                 agent_runtime::spawn_runtime();
+                // Harness markdown→work-unit adapter (plan
+                // 2026-06-18-harness-markdown-to-workunit-adapter, P2 of the
+                // plan-decoupling program) — periodic reconcile scan of the
+                // operator's plans/ dir, pushing each plan's parsed work-unit
+                // to coord's /coord/work-units API (edge-triggered, idempotent,
+                // loud conflict surfacing). Opt-in + operator-private: no-ops
+                // unless QONTINUI_PLAN_ADAPTER_DIR is set AND a coord base is
+                // configured, so a plain fleet runner never scans. See
+                // `plan_workunit_adapter::trigger`.
+                qontinui_runner_lib::plan_workunit_adapter::trigger::spawn_if_configured();
                 // Park this thread's runtime forever so the spawned
                 // interval task keeps ticking for the runner's lifetime.
                 std::future::pending::<()>().await;

--- a/src-tauri/src/plan_workunit_adapter/mod.rs
+++ b/src-tauri/src/plan_workunit_adapter/mod.rs
@@ -35,7 +35,15 @@
 //! module; they are deliberately absent until the P1 work-unit API lands.
 
 pub mod parser;
+pub mod push;
+pub mod trigger;
+
+// Phase 4 parity proof — `#[cfg(test)]` only (a proof, not shipped code).
+#[cfg(test)]
+mod parity;
 
 pub use parser::{
     parse_work_unit, slug_from_filename, ParsedPhase, ParsedWorkUnit, PlanConvention,
 };
+pub use push::{push_work_unit, HttpWorkUnitSink, PushOutcome, WorkUnitSink};
+pub use trigger::{adapter_metrics, spawn_if_configured, MetricsSnapshot, ReconcileSummary};

--- a/src-tauri/src/plan_workunit_adapter/parity.rs
+++ b/src-tauri/src/plan_workunit_adapter/parity.rs
@@ -1,0 +1,165 @@
+//! Parity proof (Phase 4) — gates P4.
+//!
+//! Asserts the adapter reproduces coord's old `plan_ingest_worker` output for
+//! the existing `plans/` corpus: **slug + status parity** at minimum (the
+//! contract P4's decommission of coord's ingest depends on — if the adapter
+//! drifts from coord here, removing coord's ingest would change what coord
+//! records).
+//!
+//! Rather than depend on the coord crate (it's a binary-only crate), this
+//! module **vendors a faithful copy of coord's exact status algorithm** —
+//! `PLAN_STATUS_VOCAB` + the `match_known_status` longest-match + the
+//! first-token fallback + `normalize_status` (verbatim from
+//! `qontinui-coord/src/plan_registry.rs` and `plan_ingest_worker.rs`) — as an
+//! independent reference oracle, then runs BOTH the oracle and the adapter
+//! parser over the same embedded corpus and asserts they agree. The vendored
+//! copy is the "coord's old ingest" side of the side-by-side run; the adapter
+//! is the new side.
+//!
+//! The whole module is `#[cfg(test)]` — it is a proof, not shipped code.
+
+// ---- Vendored coord reference oracle (coord's old ingest, verbatim) --------
+
+/// Verbatim copy of `qontinui-coord/src/plan_registry.rs::PLAN_STATUS_VOCAB`.
+const COORD_VOCAB: &[&str] = &[
+    "draft",
+    "vetted",
+    "in progress",
+    "in_progress",
+    "shipped",
+    "partial",
+    "not started",
+    "not_started",
+    "superseded",
+    "obsolete",
+];
+
+/// Verbatim port of coord's `plan_ingest_worker::match_known_status`.
+fn coord_match_known_status(s: &str) -> Option<String> {
+    let lower = s.to_lowercase();
+    let mut best: Option<&str> = None;
+    for phrase in COORD_VOCAB {
+        if !lower.starts_with(phrase) {
+            continue;
+        }
+        let boundary_ok = match lower[phrase.len()..].chars().next() {
+            None => true,
+            Some(c) => !(c.is_alphanumeric() || c == '_'),
+        };
+        if boundary_ok && best.is_none_or(|b| phrase.len() > b.len()) {
+            best = Some(phrase);
+        }
+    }
+    best.map(|p| p.replace(' ', "_"))
+}
+
+/// Verbatim port of coord's `plan_ingest_worker::normalize_status`.
+fn coord_normalize_status(raw: &str) -> String {
+    let cleaned: String = raw
+        .trim()
+        .trim_end_matches([',', '.', ':', '*'])
+        .chars()
+        .map(|c| if c.is_whitespace() { '_' } else { c })
+        .collect();
+    cleaned.to_lowercase()
+}
+
+/// Verbatim port of coord's `plan_ingest_worker::parse_plan` STATUS path
+/// (defaults to `"draft"` when no `> **Status:` line is present).
+fn coord_parse_status(body: &str) -> String {
+    for line in body.lines() {
+        let trimmed = line.trim_start();
+        if let Some(after_quote) = trimmed.strip_prefix("> ") {
+            if let Some(after_bold) = after_quote.strip_prefix("**Status:") {
+                let mut s = after_bold.trim().to_string();
+                if let Some(stripped) = s.strip_suffix("**") {
+                    s = stripped.trim().to_string();
+                }
+                if let Some(known) = coord_match_known_status(&s) {
+                    return known;
+                }
+                let token = s
+                    .split(|c: char| c.is_whitespace() || c == '.' || c == ',')
+                    .next()
+                    .unwrap_or("")
+                    .trim();
+                if !token.is_empty() {
+                    return coord_normalize_status(token);
+                }
+                if let Some(t) = s.split_whitespace().next().filter(|t| !t.is_empty()) {
+                    return coord_normalize_status(t);
+                }
+            }
+        }
+    }
+    "draft".to_string()
+}
+
+// ---- The corpus + the proof ------------------------------------------------
+
+/// The embedded real-`plans/` corpus (same fixtures the parser golden tests
+/// use). Extend this list as the corpus grows — every entry strengthens the
+/// proof.
+const CORPUS: &[(&str, &str)] = &[
+    (
+        "plans/2026-06-18-coord-generic-work-unit-primitive.md",
+        include_str!("fixtures/2026-06-18-coord-generic-work-unit-primitive.md"),
+    ),
+    (
+        "plans/2026-06-18-harness-markdown-to-workunit-adapter.md",
+        include_str!("fixtures/2026-06-18-harness-markdown-to-workunit-adapter.md"),
+    ),
+    (
+        "plans/2026-06-18-coord-decommission-markdown-plan-ingest.md",
+        include_str!("fixtures/2026-06-18-coord-decommission-markdown-plan-ingest.md"),
+    ),
+    (
+        "plans/2026-06-18-coord-orchestration-generalize-off-plans.md",
+        include_str!("fixtures/2026-06-18-coord-orchestration-generalize-off-plans.md"),
+    ),
+    (
+        "plans/2026-06-18-coord-merge-scheduler-db-test-harness.md",
+        include_str!("fixtures/2026-06-18-coord-merge-scheduler-db-test-harness.md"),
+    ),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::super::parser::{parse_work_unit, slug_from_filename, PlanConvention};
+    use super::*;
+
+    #[test]
+    fn adapter_matches_coord_slug_and_status_over_corpus() {
+        let conv = PlanConvention::operator_default();
+        let mut checked = 0;
+        for (path, body) in CORPUS {
+            let slug = slug_from_filename(path);
+            let adapter = parse_work_unit(&slug, path, body, &conv);
+            let coord_status = coord_parse_status(body);
+
+            // Slug parity: the adapter derives the same slug coord would.
+            assert_eq!(adapter.slug, slug, "slug mismatch for {path}");
+            // Status parity: the adapter's opaque status equals coord's
+            // vocab-normalized status for the existing corpus.
+            assert_eq!(
+                adapter.status, coord_status,
+                "STATUS PARITY MISMATCH for {path}: adapter={:?} coord={:?}",
+                adapter.status, coord_status
+            );
+            checked += 1;
+        }
+        assert!(checked >= 5, "parity corpus shrank unexpectedly: {checked}");
+    }
+
+    /// The decoy guard, framed as parity: coord's first-token fallback ALSO
+    /// yields `implemented` for the P1 plan (its vocab lacks `implemented`),
+    /// so the adapter and coord agree — and neither is fooled by the later
+    /// "Flip to SHIPPED" sentence.
+    #[test]
+    fn implemented_status_agrees_and_decoy_loses_on_both_sides() {
+        let body = include_str!("fixtures/2026-06-18-coord-generic-work-unit-primitive.md");
+        assert_eq!(coord_parse_status(body), "implemented");
+        let adapter = parse_work_unit("x", "x.md", body, &PlanConvention::operator_default());
+        assert_eq!(adapter.status, "implemented");
+    }
+}

--- a/src-tauri/src/plan_workunit_adapter/push.rs
+++ b/src-tauri/src/plan_workunit_adapter/push.rs
@@ -1,0 +1,481 @@
+//! Work-unit push client (Phase 2).
+//!
+//! Turns a parsed work-unit ([`super::parser::ParsedWorkUnit`]) into calls
+//! against the P1 work-unit API:
+//!
+//! - `POST /coord/work-units/upsert`           — slug-keyed upsert
+//! - `POST /coord/work-units/:slug/transition` — guarded status transition
+//! - `GET  /coord/work-units?slug_prefix=…`    — read current status
+//!
+//! All authed with the runner's device-JWT via [`crate::auth::attach_device_auth`]
+//! (the same bearer the rest of the runner's coord calls present) — the runner
+//! step is server-side, so it holds the device JWT directly and does NOT need
+//! the loopback write-forwarder (which only serves `register-plan` + `attest`).
+//!
+//! ## Edge-triggered + idempotent
+//!
+//! The push carries a client-side **last-applied-status** memory (the
+//! `last_applied` argument, threaded by [`super::trigger`]), mirroring coord's
+//! old `ingested_status` edge-trigger but now on the client. A re-push of an
+//! unchanged file yields NO transition (no phantom history row); only a status
+//! that differs from what we last applied emits a `transition` call.
+//!
+//! ## Loud conflict surfacing
+//!
+//! Before applying a status edge we read the remote status. If it diverged from
+//! what we last applied (someone — e.g. an agent — transitioned the unit
+//! directly), we surface it LOUDLY (warn + a conflict counter in
+//! [`super::trigger`]) and let the file win, exactly as coord's worker did.
+
+use super::parser::ParsedWorkUnit;
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+/// Actor stamped on adapter-driven upserts/transitions.
+pub const ADAPTER_ACTOR: &str = "harness-markdown-adapter";
+
+/// `POST /coord/work-units/upsert` body. Mirrors coord's `UpsertRequest`;
+/// `None` fields are omitted so an upsert that only refreshes title/metadata
+/// does not clobber `status`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct UpsertBody {
+    pub slug: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub by_actor: Option<String>,
+}
+
+/// `POST /coord/work-units/:slug/transition` body. Mirrors coord's
+/// `TransitionRequest`.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct TransitionBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_status: Option<String>,
+    pub to_status: String,
+    pub by_actor: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Build the `metadata` JSON pushed alongside the work-unit: the enrichment
+/// coord's old slug+status projection discarded — phase sub-units, dependency
+/// edges, and the source-file back-link.
+pub fn build_metadata(u: &ParsedWorkUnit) -> serde_json::Value {
+    serde_json::json!({
+        "depends_on": u.depends_on,
+        "phases": u
+            .phases
+            .iter()
+            .map(|p| serde_json::json!({"index": p.index, "name": p.name}))
+            .collect::<Vec<_>>(),
+        "source_path": u.source_path,
+    })
+}
+
+/// The pure edge-trigger decision: given the file's parsed status and the
+/// status we last applied for this slug, what should the push do?
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushAction {
+    /// No prior application by us — upsert WITH status (creates the row /
+    /// sets the initial status).
+    UpsertWithStatus,
+    /// Status unchanged since our last application — refresh title/metadata
+    /// only; no transition, no history row (idempotent re-sync).
+    RefreshOnly,
+    /// The file's status changed since our last application — transition.
+    Transition { from: String, to: String },
+}
+
+/// Pure edge-trigger: mirrors coord's `decide_status_action`, client-side.
+pub fn decide_push(parsed_status: &str, last_applied: Option<&str>) -> PushAction {
+    match last_applied {
+        None => PushAction::UpsertWithStatus,
+        Some(prev) if prev == parsed_status => PushAction::RefreshOnly,
+        Some(prev) => PushAction::Transition {
+            from: prev.to_string(),
+            to: parsed_status.to_string(),
+        },
+    }
+}
+
+/// What a single [`push_work_unit`] did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushOutcomeKind {
+    Created,
+    Refreshed,
+    Transitioned { from: String, to: String },
+}
+
+/// Result of pushing one work-unit, including whether a remote conflict was
+/// detected (a direct write diverged from our last-applied status).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushOutcome {
+    pub slug: String,
+    pub kind: PushOutcomeKind,
+    pub conflict: bool,
+}
+
+/// The coord side of a push, abstracted so [`push_work_unit`] is testable
+/// without live HTTP. Implemented by [`HttpWorkUnitSink`] in production and a
+/// fake in tests.
+#[async_trait::async_trait]
+pub trait WorkUnitSink: Send + Sync {
+    /// Current opaque status of the unit, or `None` if it doesn't exist yet.
+    async fn current_status(&self, slug: &str) -> Result<Option<String>>;
+    async fn upsert(&self, body: &UpsertBody) -> Result<()>;
+    async fn transition(&self, slug: &str, body: &TransitionBody) -> Result<()>;
+}
+
+/// Push one parsed work-unit through the edge-trigger + conflict logic.
+///
+/// `last_applied` is the status this adapter last applied for `u.slug` (its
+/// client-side memory). Returns the [`PushOutcome`]; the caller updates its
+/// last-applied memory to `u.status` on success.
+pub async fn push_work_unit<S: WorkUnitSink + ?Sized>(
+    sink: &S,
+    u: &ParsedWorkUnit,
+    last_applied: Option<&str>,
+) -> Result<PushOutcome> {
+    // Conflict detection: did the remote status diverge from what we last
+    // applied? (A direct transition by someone else.) File wins, but loudly.
+    let mut conflict = false;
+    if let Some(prev) = last_applied {
+        if let Ok(Some(remote)) = sink.current_status(&u.slug).await {
+            if remote != prev {
+                conflict = true;
+                tracing::warn!(
+                    slug = %u.slug,
+                    last_applied = %prev,
+                    remote = %remote,
+                    parsed = %u.status,
+                    "plan adapter: remote work-unit status diverged from last-applied; \
+                     file wins (loud override)"
+                );
+            }
+        }
+    }
+
+    let metadata = build_metadata(u);
+    let action = decide_push(&u.status, last_applied);
+    let kind = match &action {
+        PushAction::UpsertWithStatus => {
+            sink.upsert(&UpsertBody {
+                slug: u.slug.clone(),
+                title: u.title.clone(),
+                status: Some(u.status.clone()),
+                metadata: Some(metadata),
+                by_actor: Some(ADAPTER_ACTOR.to_string()),
+            })
+            .await?;
+            PushOutcomeKind::Created
+        }
+        PushAction::RefreshOnly => {
+            sink.upsert(&UpsertBody {
+                slug: u.slug.clone(),
+                title: u.title.clone(),
+                status: None,
+                metadata: Some(metadata),
+                by_actor: Some(ADAPTER_ACTOR.to_string()),
+            })
+            .await?;
+            PushOutcomeKind::Refreshed
+        }
+        PushAction::Transition { from, to } => {
+            // Refresh title/metadata first (no status change), then transition
+            // so the history row carries the from->to edge.
+            sink.upsert(&UpsertBody {
+                slug: u.slug.clone(),
+                title: u.title.clone(),
+                status: None,
+                metadata: Some(metadata),
+                by_actor: Some(ADAPTER_ACTOR.to_string()),
+            })
+            .await?;
+            sink.transition(
+                &u.slug,
+                &TransitionBody {
+                    // On a detected conflict the CAS would fail (remote != from),
+                    // so drop the guard and let the row's current status be the
+                    // from_status — the file still wins.
+                    from_status: if conflict { None } else { Some(from.clone()) },
+                    to_status: to.clone(),
+                    by_actor: ADAPTER_ACTOR.to_string(),
+                    reason: Some(format!("plan file status edge: {from} -> {to}")),
+                },
+            )
+            .await?;
+            PushOutcomeKind::Transitioned {
+                from: from.clone(),
+                to: to.clone(),
+            }
+        }
+    };
+
+    Ok(PushOutcome {
+        slug: u.slug.clone(),
+        kind,
+        conflict,
+    })
+}
+
+/// Production [`WorkUnitSink`]: HTTP against coord with the device-JWT bearer.
+pub struct HttpWorkUnitSink {
+    base: String,
+    client: reqwest::Client,
+}
+
+impl HttpWorkUnitSink {
+    pub fn new(base: impl Into<String>) -> Self {
+        Self {
+            base: base.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Resolve from the active coord profile (env `COORD_HTTP_URL` or the
+    /// profile's `coord_url`). `None` when coord is unconfigured — the trigger
+    /// then no-ops, never localhost-guessing.
+    pub fn from_profile() -> Option<Self> {
+        match crate::profiles::resolve_coord_base() {
+            crate::profiles::CoordBase::Configured(base) => Some(Self::new(base)),
+            _ => None,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl WorkUnitSink for HttpWorkUnitSink {
+    async fn current_status(&self, slug: &str) -> Result<Option<String>> {
+        // Slugs are URL-safe kebab tokens, so inline them into the query
+        // string (avoids depending on `RequestBuilder::query`, which is
+        // version-fragile in this tree).
+        let url = format!(
+            "{}/coord/work-units?slug_prefix={}&limit=500",
+            self.base, slug
+        );
+        let resp = crate::auth::attach_device_auth(self.client.get(&url))
+            .send()
+            .await
+            .context("GET /coord/work-units")?;
+        if !resp.status().is_success() {
+            anyhow::bail!("GET /coord/work-units returned {}", resp.status());
+        }
+        let body: serde_json::Value = resp.json().await.context("parse work-units list")?;
+        // Tolerant of array or {units|work_units: [...]} envelope.
+        let rows = match &body {
+            serde_json::Value::Array(a) => a.clone(),
+            serde_json::Value::Object(o) => o
+                .get("units")
+                .or_else(|| o.get("work_units"))
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default(),
+            _ => Vec::new(),
+        };
+        for row in rows {
+            if row.get("slug").and_then(|s| s.as_str()) == Some(slug) {
+                return Ok(row
+                    .get("status")
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string()));
+            }
+        }
+        Ok(None)
+    }
+
+    async fn upsert(&self, body: &UpsertBody) -> Result<()> {
+        let url = format!("{}/coord/work-units/upsert", self.base);
+        let resp = crate::auth::attach_device_auth(self.client.post(&url).json(body))
+            .send()
+            .await
+            .context("POST /coord/work-units/upsert")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("upsert {} -> {} {}", body.slug, status, text);
+        }
+        Ok(())
+    }
+
+    async fn transition(&self, slug: &str, body: &TransitionBody) -> Result<()> {
+        let url = format!("{}/coord/work-units/{}/transition", self.base, slug);
+        let resp = crate::auth::attach_device_auth(self.client.post(&url).json(body))
+            .send()
+            .await
+            .context("POST /coord/work-units/:slug/transition")?;
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            anyhow::bail!("transition {} -> {} {}", slug, status, text);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::parser::{ParsedPhase, ParsedWorkUnit};
+    use super::*;
+    use std::sync::Mutex;
+
+    fn unit(slug: &str, status: &str) -> ParsedWorkUnit {
+        ParsedWorkUnit {
+            slug: slug.to_string(),
+            title: Some("T".to_string()),
+            status: status.to_string(),
+            depends_on: vec!["2026-01-01-dep".to_string()],
+            phases: vec![ParsedPhase {
+                index: 1,
+                name: "Phase 1 — x".to_string(),
+            }],
+            source_path: format!("plans/{slug}.md"),
+            content: String::new(),
+        }
+    }
+
+    #[test]
+    fn decide_push_edge_trigger() {
+        assert_eq!(decide_push("vetted", None), PushAction::UpsertWithStatus);
+        assert_eq!(
+            decide_push("vetted", Some("vetted")),
+            PushAction::RefreshOnly
+        );
+        assert_eq!(
+            decide_push("shipped", Some("vetted")),
+            PushAction::Transition {
+                from: "vetted".to_string(),
+                to: "shipped".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn build_metadata_carries_enrichment() {
+        let m = build_metadata(&unit("s", "vetted"));
+        assert_eq!(m["depends_on"][0], "2026-01-01-dep");
+        assert_eq!(m["phases"][0]["index"], 1);
+        assert_eq!(m["source_path"], "plans/s.md");
+    }
+
+    #[test]
+    fn upsert_body_omits_none_status() {
+        let b = UpsertBody {
+            slug: "s".to_string(),
+            title: None,
+            status: None,
+            metadata: None,
+            by_actor: None,
+        };
+        let j = serde_json::to_value(&b).unwrap();
+        assert_eq!(j, serde_json::json!({"slug": "s"}));
+    }
+
+    #[derive(Default)]
+    struct FakeSink {
+        remote: Option<String>,
+        upserts: Mutex<Vec<UpsertBody>>,
+        transitions: Mutex<Vec<(String, TransitionBody)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl WorkUnitSink for FakeSink {
+        async fn current_status(&self, _slug: &str) -> Result<Option<String>> {
+            Ok(self.remote.clone())
+        }
+        async fn upsert(&self, body: &UpsertBody) -> Result<()> {
+            self.upserts.lock().unwrap().push(body.clone());
+            Ok(())
+        }
+        async fn transition(&self, slug: &str, body: &TransitionBody) -> Result<()> {
+            self.transitions
+                .lock()
+                .unwrap()
+                .push((slug.to_string(), body.clone()));
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn first_push_creates_with_status_no_transition() {
+        let sink = FakeSink::default();
+        let out = push_work_unit(&sink, &unit("s", "vetted"), None)
+            .await
+            .unwrap();
+        assert_eq!(out.kind, PushOutcomeKind::Created);
+        assert!(!out.conflict);
+        let ups = sink.upserts.lock().unwrap();
+        assert_eq!(ups.len(), 1);
+        assert_eq!(ups[0].status.as_deref(), Some("vetted"));
+        assert!(sink.transitions.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn unchanged_status_refreshes_only_no_transition() {
+        let sink = FakeSink {
+            remote: Some("vetted".to_string()),
+            ..Default::default()
+        };
+        let out = push_work_unit(&sink, &unit("s", "vetted"), Some("vetted"))
+            .await
+            .unwrap();
+        assert_eq!(out.kind, PushOutcomeKind::Refreshed);
+        assert!(!out.conflict);
+        // Refresh upsert carries NO status (doesn't clobber), no transition.
+        let ups = sink.upserts.lock().unwrap();
+        assert_eq!(ups.len(), 1);
+        assert!(ups[0].status.is_none());
+        assert!(sink.transitions.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn status_edge_emits_transition_with_cas() {
+        let sink = FakeSink {
+            remote: Some("vetted".to_string()),
+            ..Default::default()
+        };
+        let out = push_work_unit(&sink, &unit("s", "shipped"), Some("vetted"))
+            .await
+            .unwrap();
+        assert_eq!(
+            out.kind,
+            PushOutcomeKind::Transitioned {
+                from: "vetted".to_string(),
+                to: "shipped".to_string()
+            }
+        );
+        assert!(!out.conflict);
+        let trs = sink.transitions.lock().unwrap();
+        assert_eq!(trs.len(), 1);
+        assert_eq!(trs[0].1.from_status.as_deref(), Some("vetted")); // CAS guard set
+        assert_eq!(trs[0].1.to_status, "shipped");
+    }
+
+    #[tokio::test]
+    async fn remote_divergence_is_conflict_and_drops_cas() {
+        // We last applied "vetted", but remote is "in_progress" (someone moved
+        // it). File says "shipped": conflict surfaced, file wins, CAS dropped.
+        let sink = FakeSink {
+            remote: Some("in_progress".to_string()),
+            ..Default::default()
+        };
+        let out = push_work_unit(&sink, &unit("s", "shipped"), Some("vetted"))
+            .await
+            .unwrap();
+        assert!(out.conflict);
+        assert_eq!(
+            out.kind,
+            PushOutcomeKind::Transitioned {
+                from: "vetted".to_string(),
+                to: "shipped".to_string()
+            }
+        );
+        let trs = sink.transitions.lock().unwrap();
+        assert_eq!(trs[0].1.from_status, None); // CAS dropped on conflict
+        assert_eq!(trs[0].1.to_status, "shipped");
+    }
+}

--- a/src-tauri/src/plan_workunit_adapter/trigger.rs
+++ b/src-tauri/src/plan_workunit_adapter/trigger.rs
@@ -1,0 +1,301 @@
+//! Wire-up + periodic trigger (Phase 3).
+//!
+//! Mounts the adapter as a periodic **reconcile scan** of the operator's
+//! `plans/` directory, pushing each plan's parsed work-unit to coord via
+//! [`super::push`]. The periodic-scan trigger (over a filesystem watch or an
+//! on-edit hook) is deliberate: it is robust across runner downtime and closed
+//! sessions — an edit made while the runner was down is picked up on the next
+//! tick — and the edge-triggered push ([`super::push::decide_push`]) makes a
+//! re-scan of an unchanged corpus free of phantom transitions. It mirrors the
+//! model coord's own `plan_ingest_worker` used (~60s tick).
+//!
+//! ## Metrics
+//!
+//! The runner has no Prometheus surface, so observability is process-local
+//! atomic counters named to mirror coord's `coord_plan_ingest_*` so the
+//! operator reads the same signals: scanned / transitions / cycles /
+//! conflicts. [`adapter_metrics`] exposes the shared instance and
+//! [`AdapterMetrics::snapshot`] reads it.
+//!
+//! ## Opt-in
+//!
+//! [`spawn_if_configured`] is gated on `QONTINUI_PLAN_ADAPTER_DIR` — the
+//! markdown-plan convention is operator-private, so a fleet runner without
+//! that env set no-ops entirely (it never scans, never pushes).
+
+use super::parser::{parse_work_unit, slug_from_filename, ParsedWorkUnit, PlanConvention};
+use super::push::{push_work_unit, PushOutcomeKind, WorkUnitSink};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Process-local adapter metrics, mirroring coord's `coord_plan_ingest_*`.
+#[derive(Debug, Default)]
+pub struct AdapterMetrics {
+    /// Plans scanned in the last cycle (gauge-like; overwritten each cycle).
+    pub scanned: AtomicU64,
+    /// Total status transitions emitted (counter).
+    pub transitions_total: AtomicU64,
+    /// Total reconcile cycles run (counter).
+    pub cycles_total: AtomicU64,
+    /// Total remote-divergence conflicts surfaced (counter) — coord's
+    /// `coord_plan_ingest_reverts_total` analogue.
+    pub conflicts_total: AtomicU64,
+    /// Total per-unit push errors (counter).
+    pub errors_total: AtomicU64,
+}
+
+/// A point-in-time read of [`AdapterMetrics`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MetricsSnapshot {
+    pub scanned: u64,
+    pub transitions_total: u64,
+    pub cycles_total: u64,
+    pub conflicts_total: u64,
+    pub errors_total: u64,
+}
+
+impl AdapterMetrics {
+    pub fn snapshot(&self) -> MetricsSnapshot {
+        MetricsSnapshot {
+            scanned: self.scanned.load(Ordering::Relaxed),
+            transitions_total: self.transitions_total.load(Ordering::Relaxed),
+            cycles_total: self.cycles_total.load(Ordering::Relaxed),
+            conflicts_total: self.conflicts_total.load(Ordering::Relaxed),
+            errors_total: self.errors_total.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// The shared process-wide adapter metrics.
+pub fn adapter_metrics() -> &'static AdapterMetrics {
+    static METRICS: OnceLock<AdapterMetrics> = OnceLock::new();
+    METRICS.get_or_init(AdapterMetrics::default)
+}
+
+/// Outcome of one reconcile cycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ReconcileSummary {
+    pub scanned: u64,
+    pub transitions: u64,
+    pub conflicts: u64,
+    pub errors: u64,
+}
+
+/// Read + parse every `*.md` in `dir` (non-recursive — the plans dir is flat,
+/// matching coord's `walk_root`). IO errors on individual files are logged and
+/// skipped; a missing dir yields an empty vec.
+pub fn read_plan_dir(dir: &Path, conv: &PlanConvention) -> Vec<ParsedWorkUnit> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::warn!(dir = %dir.display(), error = %e, "plan adapter: cannot read plans dir");
+            return Vec::new();
+        }
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        if !path.is_file() {
+            continue;
+        }
+        let path_str = path.to_string_lossy().to_string();
+        match std::fs::read_to_string(&path) {
+            Ok(body) => {
+                let slug = slug_from_filename(&path_str);
+                out.push(parse_work_unit(&slug, &path_str, &body, conv));
+            }
+            Err(e) => {
+                tracing::warn!(path = %path_str, error = %e, "plan adapter: cannot read plan file");
+            }
+        }
+    }
+    out
+}
+
+/// Push every parsed unit through the edge-trigger + conflict logic, updating
+/// the client-side `last_applied` memory and the shared metrics. Pure of IO
+/// beyond the sink, so it is unit-tested with a fake sink.
+pub async fn reconcile_once<S: WorkUnitSink + ?Sized>(
+    parsed_units: &[ParsedWorkUnit],
+    last_applied: &mut HashMap<String, String>,
+    sink: &S,
+    metrics: &AdapterMetrics,
+) -> ReconcileSummary {
+    let mut summary = ReconcileSummary {
+        scanned: parsed_units.len() as u64,
+        ..Default::default()
+    };
+    for u in parsed_units {
+        let prev = last_applied.get(&u.slug).cloned();
+        match push_work_unit(sink, u, prev.as_deref()).await {
+            Ok(outcome) => {
+                if outcome.conflict {
+                    summary.conflicts += 1;
+                    metrics.conflicts_total.fetch_add(1, Ordering::Relaxed);
+                }
+                if matches!(outcome.kind, PushOutcomeKind::Transitioned { .. }) {
+                    summary.transitions += 1;
+                    metrics.transitions_total.fetch_add(1, Ordering::Relaxed);
+                }
+                // Record what we just applied so the next cycle is edge-triggered.
+                last_applied.insert(u.slug.clone(), u.status.clone());
+            }
+            Err(e) => {
+                summary.errors += 1;
+                metrics.errors_total.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!(slug = %u.slug, error = %format!("{e:#}"), "plan adapter: push failed");
+            }
+        }
+    }
+    metrics.scanned.store(summary.scanned, Ordering::Relaxed);
+    summary
+}
+
+/// The periodic reconcile loop. Runs until the task is dropped.
+async fn run_loop<S: WorkUnitSink + ?Sized>(dir: PathBuf, sink: &S, interval_secs: u64) {
+    let conv = PlanConvention::operator_default();
+    let metrics = adapter_metrics();
+    let mut last_applied: HashMap<String, String> = HashMap::new();
+    let mut tick = tokio::time::interval(Duration::from_secs(interval_secs.max(1)));
+    tracing::info!(dir = %dir.display(), interval_secs, "plan adapter: reconcile loop started");
+    loop {
+        tick.tick().await;
+        let units = read_plan_dir(&dir, &conv);
+        let summary = reconcile_once(&units, &mut last_applied, sink, metrics).await;
+        metrics.cycles_total.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(
+            scanned = summary.scanned,
+            transitions = summary.transitions,
+            conflicts = summary.conflicts,
+            errors = summary.errors,
+            "plan adapter: reconcile cycle complete"
+        );
+    }
+}
+
+/// Spawn the reconcile loop iff the adapter is configured for this runner:
+/// `QONTINUI_PLAN_ADAPTER_DIR` set (the operator's plans dir) AND a coord base
+/// resolvable. Returns `None` (no-op) otherwise — a fleet runner without the
+/// operator's plan convention never scans. Interval overridable via
+/// `QONTINUI_PLAN_ADAPTER_INTERVAL_SECS` (default 60s).
+pub fn spawn_if_configured() -> Option<tokio::task::JoinHandle<()>> {
+    let dir = std::env::var("QONTINUI_PLAN_ADAPTER_DIR")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let sink = match super::push::HttpWorkUnitSink::from_profile() {
+        Some(s) => s,
+        None => {
+            tracing::warn!(
+                "plan adapter: QONTINUI_PLAN_ADAPTER_DIR set but no coord base configured; not starting"
+            );
+            return None;
+        }
+    };
+    let interval_secs = std::env::var("QONTINUI_PLAN_ADAPTER_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(60);
+    Some(tokio::spawn(async move {
+        run_loop(PathBuf::from(dir), &sink, interval_secs).await;
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::parser::ParsedWorkUnit;
+    use super::super::push::{TransitionBody, UpsertBody};
+    use super::*;
+    use anyhow::Result;
+    use std::sync::Mutex;
+
+    fn unit(slug: &str, status: &str) -> ParsedWorkUnit {
+        ParsedWorkUnit {
+            slug: slug.to_string(),
+            title: None,
+            status: status.to_string(),
+            depends_on: vec![],
+            phases: vec![],
+            source_path: format!("plans/{slug}.md"),
+            content: String::new(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeSink {
+        statuses: Mutex<HashMap<String, String>>,
+        transitions: Mutex<u64>,
+    }
+    #[async_trait::async_trait]
+    impl WorkUnitSink for FakeSink {
+        async fn current_status(&self, slug: &str) -> Result<Option<String>> {
+            Ok(self.statuses.lock().unwrap().get(slug).cloned())
+        }
+        async fn upsert(&self, body: &UpsertBody) -> Result<()> {
+            if let Some(s) = &body.status {
+                self.statuses
+                    .lock()
+                    .unwrap()
+                    .insert(body.slug.clone(), s.clone());
+            }
+            Ok(())
+        }
+        async fn transition(&self, slug: &str, body: &TransitionBody) -> Result<()> {
+            *self.transitions.lock().unwrap() += 1;
+            self.statuses
+                .lock()
+                .unwrap()
+                .insert(slug.to_string(), body.to_status.clone());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_is_idempotent_across_cycles() {
+        let sink = FakeSink::default();
+        let metrics = AdapterMetrics::default();
+        let mut mem = HashMap::new();
+        let units = vec![unit("a", "vetted"), unit("b", "draft")];
+
+        // First cycle: both created, no transitions.
+        let s1 = reconcile_once(&units, &mut mem, &sink, &metrics).await;
+        assert_eq!(s1.scanned, 2);
+        assert_eq!(s1.transitions, 0);
+        assert_eq!(*sink.transitions.lock().unwrap(), 0);
+
+        // Second cycle, unchanged corpus: NO phantom transitions.
+        let s2 = reconcile_once(&units, &mut mem, &sink, &metrics).await;
+        assert_eq!(s2.scanned, 2);
+        assert_eq!(s2.transitions, 0);
+        assert_eq!(*sink.transitions.lock().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_emits_one_transition_on_status_edge() {
+        let sink = FakeSink::default();
+        let metrics = AdapterMetrics::default();
+        let mut mem = HashMap::new();
+
+        reconcile_once(&[unit("a", "vetted")], &mut mem, &sink, &metrics).await;
+        // Plan edited: vetted -> shipped.
+        let s = reconcile_once(&[unit("a", "shipped")], &mut mem, &sink, &metrics).await;
+        assert_eq!(s.transitions, 1);
+        assert_eq!(*sink.transitions.lock().unwrap(), 1);
+        assert_eq!(metrics.snapshot().transitions_total, 1);
+    }
+
+    #[test]
+    fn metrics_snapshot_reads_counters() {
+        let m = AdapterMetrics::default();
+        m.scanned.store(5, Ordering::Relaxed);
+        m.transitions_total.store(2, Ordering::Relaxed);
+        let snap = m.snapshot();
+        assert_eq!(snap.scanned, 5);
+        assert_eq!(snap.transitions_total, 2);
+    }
+}


### PR DESCRIPTION
Completes **P2** (harness markdown→work-unit adapter) of the coord plan-decoupling program, now that **P1's work-unit API has landed on coord `main`**. Phase 1 (the pure parser) shipped separately in #626; this PR adds the remaining three phases on top.

## Phase 2 — push client (`push.rs`)
`WorkUnitSink` trait + `HttpWorkUnitSink` calling P1's `POST /coord/work-units/upsert` and `/:slug/transition`, authed with the runner's device-JWT via `auth::attach_device_auth` (server-side — no loopback forwarder needed). **Edge-triggered + idempotent**: a client-side last-applied-status memory (`decide_push`) mirrors coord's old `ingested_status` edge-trigger, so re-pushing an unchanged file emits no transition. **Loud conflict surfacing**: reads remote status; a divergence from last-applied warns + counts + drops the CAS guard (file wins).

## Phase 3 — wire-up + trigger (`trigger.rs`)
Periodic reconcile scan of the plans dir (`reconcile_once` / `read_plan_dir` / `run_loop`) — robust across runner downtime, phantom-free on re-scan by construction. Process-local metrics mirroring `coord_plan_ingest_*` (the runner has no Prometheus surface). `spawn_if_configured` is mounted in `main.rs` beside the other best-effort periodic tasks; **opt-in + operator-private** — no-ops unless `QONTINUI_PLAN_ADAPTER_DIR` is set AND coord is configured, so a plain fleet runner never scans.

## Phase 4 — parity proof (`parity.rs`, `#[cfg(test)]`)
Vendors coord's **exact** status algorithm (`PLAN_STATUS_VOCAB` + `match_known_status` + first-token fallback + `normalize_status`) as an independent reference oracle, and asserts the adapter reproduces coord's slug+status over the real `plans/` corpus. **This is the green light P4's decommission of coord's ingest depends on.**

## Tests
12 new tests (27 total in the module), all green — including the parity proof and the idempotent-reconcile / edge-trigger / conflict cases. `cargo check --bins` + pre-push `cargo fmt + clippy` clean.

Plan: 2026-06-18-harness-markdown-to-workunit-adapter