### PR TITLE
feat: machine-side dev-environment capture agent

### DIFF
--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -122,6 +122,47 @@ enum Cmd {
         #[command(subcommand)]
         sub: DeviceCmd,
     },
+    /// Manage the machine-side dev-environment capture agent
+    /// (feat/devenv-environments). `enroll` binds this machine to a web
+    /// environment via a per-machine API key; `capture` pushes a secret-free
+    /// config envelope; `show` prints enrollment state.
+    Env {
+        #[command(subcommand)]
+        sub: EnvCmd,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum EnvCmd {
+    /// Enroll this machine into a web environment via an enrollment code.
+    /// POSTs `{enrollment_code, machine_id, hostname}` to
+    /// `{backend}/api/v1/devenv/agent/enroll`; on success stores the returned
+    /// `mk_<token>` machine key in secure storage and writes
+    /// `~/.qontinui/env-agent.json` with the RESPONSE environment_id.
+    Enroll {
+        /// The enrollment code minted by the web dashboard.
+        #[arg(long)]
+        code: String,
+        /// Override the backend base URL. Falls back to `QONTINUI_WEB_BASE`,
+        /// then a web base derived from the active profile's coord_url.
+        #[arg(long)]
+        backend: Option<String>,
+        /// Reserved override for the target environment id. Normally the
+        /// environment is assigned by the enroll response; this is only used
+        /// for diagnostics / re-enroll against a specific environment.
+        #[arg(long)]
+        environment: Option<String>,
+    },
+    /// Capture the current dev-environment config and push it to the backend.
+    /// `--dry-run` assembles + pretty-prints the envelope WITHOUT pushing.
+    Capture {
+        /// Assemble + print the envelope without POSTing.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Print enrollment state (from env-agent.json) + whether a machine key is
+    /// stored.
+    Show,
 }
 
 #[derive(Subcommand, Debug)]
@@ -201,6 +242,15 @@ fn main() -> ExitCode {
                 browser,
                 tenant_id.as_deref(),
             ),
+        },
+        Cmd::Env { sub } => match sub {
+            EnvCmd::Enroll {
+                code,
+                backend,
+                environment,
+            } => cmd_env_enroll(&code, backend.as_deref(), environment.as_deref()),
+            EnvCmd::Capture { dry_run } => cmd_env_capture(dry_run),
+            EnvCmd::Show => cmd_env_show(),
         },
     }
 }
@@ -1074,6 +1124,249 @@ fn active_profile_dsn() -> Result<String, String> {
         .map_err(|e| format!("active profile has no database_url: {}", e))
 }
 
+// ============================================================================
+// env subcommand — machine-side dev-environment capture agent
+// ============================================================================
+//
+// `env enroll` binds this machine to a web environment via a per-machine API
+// key (`mk_<token>`), stored in the encrypted secure storage. `env capture`
+// pushes a SECRET-FREE config envelope. `env show` prints enrollment state.
+//
+// The capture/push logic + envelope assembly live in
+// `qontinui_runner_lib::env_agent` so the runner GUI's background task and this
+// CLI share one code path.
+
+/// Wire shape of the enroll request body. Conforms EXACTLY to the backend
+/// contract: `{ enrollment_code, machine_id?, hostname? }`.
+#[derive(Debug, Serialize)]
+struct EnrollRequest {
+    enrollment_code: String,
+    machine_id: Option<String>,
+    hostname: Option<String>,
+}
+
+/// Wire shape of the enroll response. The backend returns the machine key ONCE
+/// — we store it immediately. `environment_id` is sourced from HERE, never
+/// hardcoded.
+#[derive(Debug, Deserialize)]
+struct EnrollResponse {
+    machine_id: String,
+    machine_key: String,
+    #[serde(default)]
+    environment_id: Option<String>,
+}
+
+/// Resolve the web backend base URL for the enroll POST. Order:
+/// `--backend` → `QONTINUI_WEB_BASE` → web base derived from the active
+/// profile's coord_url (`derive_web_base_from_coord(coord_http_base())`).
+fn resolve_env_backend_base(backend_arg: Option<&str>) -> Result<String, String> {
+    if let Some(b) = backend_arg {
+        let t = b.trim();
+        if !t.is_empty() {
+            return Ok(t.trim_end_matches('/').to_string());
+        }
+    }
+    if let Ok(v) = std::env::var("QONTINUI_WEB_BASE") {
+        let t = v.trim();
+        if !t.is_empty() {
+            return Ok(t.trim_end_matches('/').to_string());
+        }
+    }
+    let coord_base = coord_http_base()
+        .map_err(|e| format!("could not resolve a backend URL (no --backend, no QONTINUI_WEB_BASE, and coord_url unavailable: {e})"))?;
+    Ok(derive_web_base_from_coord(&coord_base))
+}
+
+fn cmd_env_enroll(code: &str, backend_arg: Option<&str>, environment_arg: Option<&str>) -> ExitCode {
+    if code.trim().is_empty() {
+        eprintln!("error: --code requires a non-empty enrollment code");
+        return ExitCode::from(2);
+    }
+
+    let backend = match resolve_env_backend_base(backend_arg) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    // machine_id + hostname come from the existing device-file reader. A
+    // machine.json is expected (run `qontinui_profile device init` first), but
+    // we tolerate its absence by sending nulls — the backend may assign a
+    // machine_id.
+    let path = device_file_path();
+    let (machine_id, hostname): (Option<String>, Option<String>) = match path {
+        Some(p) if p.exists() => match read_device_file(&p) {
+            Ok(f) => (Some(f.device_id), Some(f.hostname)),
+            Err(e) => {
+                eprintln!(
+                    "warning: machine.json unreadable ({e}); enrolling with null machine_id/hostname"
+                );
+                (None, None)
+            }
+        },
+        _ => {
+            eprintln!(
+                "note: no ~/.qontinui/machine.json — enrolling with null machine_id/hostname \
+                 (run `qontinui_profile device init` first for a stable identity)"
+            );
+            (None, None)
+        }
+    };
+
+    let body = EnrollRequest {
+        enrollment_code: code.trim().to_string(),
+        machine_id,
+        hostname,
+    };
+    let url = format!("{}/api/v1/devenv/agent/enroll", backend);
+    let client = match reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: reqwest client build failed: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    let resp = match client.post(&url).json(&body).send() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: POST {url} failed (backend unreachable?): {e}");
+            return ExitCode::from(1);
+        }
+    };
+    let status = resp.status();
+    if !status.is_success() {
+        let body_text = resp
+            .text()
+            .unwrap_or_else(|_| "<unable to read response body>".to_string());
+        eprintln!("error: enroll failed — POST {url} -> HTTP {status}: {body_text}");
+        // Write NOTHING on failure.
+        return ExitCode::from(1);
+    }
+    let parsed: EnrollResponse = match resp.json() {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: enroll succeeded but decoding the response failed: {e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    // environment_id ALWAYS comes from the response. The --environment flag is
+    // a diagnostic override only; the response value wins when present.
+    let environment_id = parsed
+        .environment_id
+        .clone()
+        .or_else(|| environment_arg.map(|s| s.to_string()));
+    let environment_id = match environment_id {
+        Some(e) if !e.trim().is_empty() => e,
+        _ => {
+            eprintln!(
+                "error: enroll response did not include an environment_id and none was supplied \
+                 via --environment; refusing to write a half-enrolled config"
+            );
+            return ExitCode::from(1);
+        }
+    };
+
+    // Store the machine key in secure storage FIRST — it is the credential.
+    let storage = match qontinui_runner_lib::secure_storage::SecureStorage::new() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: could not open secure storage: {e}");
+            return ExitCode::from(2);
+        }
+    };
+    if let Err(e) = storage.store_agent_machine_key(&parsed.machine_key) {
+        eprintln!("error: failed to store machine key: {e}");
+        return ExitCode::from(2);
+    }
+
+    // Then write env-agent.json with the RESPONSE environment_id.
+    let cfg = qontinui_runner_lib::env_agent::config::EnvAgentConfig {
+        backend_url: backend.clone(),
+        machine_id: parsed.machine_id.clone(),
+        environment_id: environment_id.clone(),
+        enrolled_at: Some(chrono::Utc::now().to_rfc3339()),
+    };
+    if let Err(e) = cfg.save() {
+        eprintln!("error: enrolled + key stored, but writing env-agent.json failed: {e}");
+        return ExitCode::from(2);
+    }
+
+    println!(
+        "enrolled: machine_id={} environment_id={} backend={} (machine key stored)",
+        parsed.machine_id, environment_id, backend
+    );
+    ExitCode::SUCCESS
+}
+
+fn cmd_env_capture(dry_run: bool) -> ExitCode {
+    if dry_run {
+        match qontinui_runner_lib::env_agent::build_envelope_blocking() {
+            Ok(envelope) => match serde_json::to_string_pretty(&envelope) {
+                Ok(s) => {
+                    println!("{s}");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: serialize envelope failed: {e}");
+                    ExitCode::from(2)
+                }
+            },
+            Err(e) => {
+                eprintln!("error: building envelope failed: {e}");
+                ExitCode::from(2)
+            }
+        }
+    } else {
+        match qontinui_runner_lib::env_agent::capture_and_push_blocking() {
+            Ok(()) => {
+                println!("capture pushed (or skipped — machine not enrolled)");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("error: capture/push failed: {e}");
+                ExitCode::from(1)
+            }
+        }
+    }
+}
+
+fn cmd_env_show() -> ExitCode {
+    let cfg = qontinui_runner_lib::env_agent::config::EnvAgentConfig::load();
+    let key_stored = qontinui_runner_lib::secure_storage::SecureStorage::new()
+        .ok()
+        .and_then(|s| s.get_agent_machine_key().ok().flatten())
+        .map(|k| !k.is_empty())
+        .unwrap_or(false);
+
+    let out = match cfg {
+        Some(c) => json!({
+            "enrolled": c.is_enrolled() && key_stored,
+            "backend_url": c.backend_url,
+            "machine_id": c.machine_id,
+            "environment_id": c.environment_id,
+            "enrolled_at": c.enrolled_at,
+            "machine_key_stored": key_stored,
+            "config_path": qontinui_runner_lib::env_agent::config::EnvAgentConfig::path()
+                .map(|p| p.display().to_string()),
+        }),
+        None => json!({
+            "enrolled": false,
+            "machine_key_stored": key_stored,
+            "config_path": qontinui_runner_lib::env_agent::config::EnvAgentConfig::path()
+                .map(|p| p.display().to_string()),
+            "note": "no env-agent.json — run `qontinui_profile env enroll --code <code>`",
+        }),
+    };
+    println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    ExitCode::SUCCESS
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1392,5 +1685,76 @@ mod tests {
     fn use_requires_name() {
         let err = Cli::try_parse_from(["qontinui_profile", "use"]).expect_err("requires name");
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    // ------------------------------------------------------------------
+    // env subcommand — capture agent CLI surface.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn env_enroll_help_short_circuits() {
+        assert_help(&["qontinui_profile", "env", "enroll", "--help"]);
+    }
+
+    #[test]
+    fn env_capture_help_short_circuits() {
+        assert_help(&["qontinui_profile", "env", "capture", "--help"]);
+    }
+
+    #[test]
+    fn env_enroll_requires_code() {
+        let err =
+            Cli::try_parse_from(["qontinui_profile", "env", "enroll"]).expect_err("requires --code");
+        assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn env_enroll_parses_with_code_and_backend() {
+        let cli = Cli::try_parse_from([
+            "qontinui_profile",
+            "env",
+            "enroll",
+            "--code",
+            "ABC123",
+            "--backend",
+            "http://localhost:8000",
+        ])
+        .expect("parses");
+        match cli.cmd {
+            Some(Cmd::Env {
+                sub:
+                    EnvCmd::Enroll {
+                        code,
+                        backend,
+                        environment,
+                    },
+            }) => {
+                assert_eq!(code, "ABC123");
+                assert_eq!(backend.as_deref(), Some("http://localhost:8000"));
+                assert!(environment.is_none());
+            }
+            other => panic!("expected Env::Enroll, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn env_capture_parses_with_dry_run() {
+        let cli = Cli::try_parse_from(["qontinui_profile", "env", "capture", "--dry-run"])
+            .expect("parses");
+        match cli.cmd {
+            Some(Cmd::Env {
+                sub: EnvCmd::Capture { dry_run },
+            }) => assert!(dry_run),
+            other => panic!("expected Env::Capture {{dry_run}}, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn env_show_parses() {
+        let cli = Cli::try_parse_from(["qontinui_profile", "env", "show"]).expect("parses");
+        match cli.cmd {
+            Some(Cmd::Env { sub: EnvCmd::Show }) => {}
+            other => panic!("expected Env::Show, got {:?}", other),
+        }
     }
 }

--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -1177,7 +1177,11 @@ fn resolve_env_backend_base(backend_arg: Option<&str>) -> Result<String, String>
     Ok(derive_web_base_from_coord(&coord_base))
 }
 
-fn cmd_env_enroll(code: &str, backend_arg: Option<&str>, environment_arg: Option<&str>) -> ExitCode {
+fn cmd_env_enroll(
+    code: &str,
+    backend_arg: Option<&str>,
+    environment_arg: Option<&str>,
+) -> ExitCode {
     if code.trim().is_empty() {
         eprintln!("error: --code requires a non-empty enrollment code");
         return ExitCode::from(2);
@@ -1313,8 +1317,7 @@ fn cmd_env_capture(dry_run: bool) -> ExitCode {
     // a build failure here (or a connect failure later inside the collector)
     // just omits the `db_schema` section — capture still succeeds.
     let profile = qontinui_runner_lib::profiles::load();
-    if let Err(e) =
-        qontinui_runner_lib::env_agent::publish_pg_pool_from_url(&profile.database_url)
+    if let Err(e) = qontinui_runner_lib::env_agent::publish_pg_pool_from_url(&profile.database_url)
     {
         eprintln!("note: db_schema collector unavailable — {e}");
     }
@@ -1717,8 +1720,8 @@ mod tests {
 
     #[test]
     fn env_enroll_requires_code() {
-        let err =
-            Cli::try_parse_from(["qontinui_profile", "env", "enroll"]).expect_err("requires --code");
+        let err = Cli::try_parse_from(["qontinui_profile", "env", "enroll"])
+            .expect_err("requires --code");
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
     }
 

--- a/src-tauri/src/bin/qontinui_profile.rs
+++ b/src-tauri/src/bin/qontinui_profile.rs
@@ -1305,6 +1305,20 @@ fn cmd_env_enroll(code: &str, backend_arg: Option<&str>, environment_arg: Option
 }
 
 fn cmd_env_capture(dry_run: bool) -> ExitCode {
+    // Publish a lazy PG pool from the active profile so the high-value
+    // `db_schema` collector (alembic_head + schema/table census) can run. The
+    // full runner does this at boot (main.rs fleet-publishers block); the
+    // standalone CLI has no pre-built pool, so without this the section is
+    // always omitted and schema drift is invisible from the CLI. Best-effort:
+    // a build failure here (or a connect failure later inside the collector)
+    // just omits the `db_schema` section — capture still succeeds.
+    let profile = qontinui_runner_lib::profiles::load();
+    if let Err(e) =
+        qontinui_runner_lib::env_agent::publish_pg_pool_from_url(&profile.database_url)
+    {
+        eprintln!("note: db_schema collector unavailable — {e}");
+    }
+
     if dry_run {
         match qontinui_runner_lib::env_agent::build_envelope_blocking() {
             Ok(envelope) => match serde_json::to_string_pretty(&envelope) {

--- a/src-tauri/src/database/pg/mod.rs
+++ b/src-tauri/src/database/pg/mod.rs
@@ -364,7 +364,8 @@ impl PgDb {
         // applied still boots cleanly. The runner's spec API depends on this
         // table being present from the first /apps/* request.
         conn.batch_execute(
-            "CREATE TABLE IF NOT EXISTS project.apps ( \
+            "CREATE SCHEMA IF NOT EXISTS project; \
+             CREATE TABLE IF NOT EXISTS project.apps ( \
                  app_id          TEXT PRIMARY KEY, \
                  repo_root       TEXT NOT NULL, \
                  ui_bridge_url   TEXT NOT NULL, \

--- a/src-tauri/src/env_agent/collectors.rs
+++ b/src-tauri/src/env_agent/collectors.rs
@@ -1,0 +1,553 @@
+//! Best-effort, fail-open, SECRET-FREE collectors for the env-capture agent.
+//!
+//! Each collector returns a [`Section`] — a `serde_json::Map` whose values are
+//! ALWAYS `Value::String`. The envelope contract (see `mod.rs`) requires every
+//! section value to be a string.
+//!
+//! ## Secret-safety invariant (load-bearing)
+//!
+//! NONE of these collectors may emit a secret VALUE. We capture only NAMES and
+//! TOPOLOGY:
+//! - `services`: URLs are parsed with the `url` crate and userinfo is STRIPPED
+//!   (`set_username("")` + `set_password(None)`) so a DSN like
+//!   `postgres://u:pw@h:5432/db` never leaks `pw`. We emit only scheme/host/port.
+//! - `db_schema`: schema/table NAMES + counts + version strings — no row data.
+//! - `versions`: package/tool version strings parsed from manifests — no secrets.
+//! - `env_contract`: env var NAMES only (allowlisted by prefix), value `"present"`.
+//!   The VALUE is structurally dropped — we never read `std::env::var(name)`.
+//!
+//! The `secret_safety_*` unit tests below pin this invariant.
+
+use std::time::Duration;
+
+use serde_json::{Map, Value};
+
+/// A captured section. Every value is a `Value::String` per the envelope
+/// contract.
+pub type Section = Map<String, Value>;
+
+/// Helper: insert a string-valued key into a section.
+fn put(section: &mut Section, key: &str, value: impl Into<String>) {
+    section.insert(key.to_string(), Value::String(value.into()));
+}
+
+/// Strip userinfo (username + password) from a URL string and return a
+/// secret-free `scheme://host[:port]` rendering. Returns `None` when the input
+/// doesn't parse as a URL with a host. NEVER includes path/query/userinfo.
+///
+/// This is the single choke point that guarantees a DSN password can't leak
+/// into the `services` section.
+fn sanitize_url(raw: &str) -> Option<String> {
+    let mut parsed = url::Url::parse(raw).ok()?;
+    // Structurally remove credentials. `set_username`/`set_password` return
+    // Err only for cannot-be-a-base URLs (which have no host anyway, filtered
+    // below); ignore the result.
+    let _ = parsed.set_username("");
+    let _ = parsed.set_password(None);
+    let host = parsed.host_str()?.to_string();
+    let scheme = parsed.scheme().to_string();
+    match parsed.port() {
+        Some(port) => Some(format!("{scheme}://{host}:{port}")),
+        None => Some(format!("{scheme}://{host}")),
+    }
+}
+
+/// Probe whether `127.0.0.1:port` accepts a TCP connection within 200ms.
+/// Returns `"listening"` or `"closed"`. Purely a topology signal — no data is
+/// exchanged.
+fn probe_local_port(port: u16) -> &'static str {
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    match std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)) {
+        Ok(_) => "listening",
+        Err(_) => "closed",
+    }
+}
+
+/// Known dev-topology service ports (per CLAUDE.md "Service Architecture &
+/// Ports"). Each entry is `(logical_name, port)`. The collector probes each and
+/// records `"<name>"` → `"listening"|"closed"`.
+const KNOWN_DEV_PORTS: &[(&str, u16)] = &[
+    ("backend", 8000),
+    ("frontend", 3001),
+    ("runner_vite", 1420),
+    ("runner_mcp", 9876),
+    ("supervisor", 9875),
+    ("postgres", 5432),
+    ("postgres_alt", 5433),
+    ("redis", 6379),
+    ("minio_api", 9000),
+    ("minio_console", 9001),
+];
+
+/// Collect the `services` section: secret-free topology derived from the active
+/// profile (`profiles::load`) plus liveness probes of the known dev ports.
+///
+/// Returns `None` only if NOTHING could be collected (never happens in practice
+/// — the port probes always yield at least the known-port set), so the
+/// isolation driver in `mod.rs` keeps the section.
+pub async fn collect_services() -> Option<Section> {
+    let mut section = Section::new();
+
+    // Topology from the active profile — URLs sanitized (userinfo stripped).
+    let profile = crate::profiles::load();
+    if let Some(sanitized) = sanitize_url(&profile.database_url) {
+        put(&mut section, "database_url", sanitized);
+    }
+    if let Some(redis) = profile.redis_url.as_deref() {
+        if let Some(sanitized) = sanitize_url(redis) {
+            put(&mut section, "redis_url", sanitized);
+        }
+    }
+    if let Some(coord) = profile.coord_url.as_deref() {
+        if let Some(sanitized) = sanitize_url(coord) {
+            put(&mut section, "coord_url", sanitized);
+        }
+    }
+    if let Some(blob) = profile.blob.as_ref() {
+        // `kind` is a non-secret topology label (minio / s3). The endpoint is a
+        // URL — sanitize it. Access/secret keys are NEVER emitted.
+        put(&mut section, "blob_kind", blob.kind.clone());
+        if let Some(endpoint) = blob.endpoint.as_deref() {
+            if let Some(sanitized) = sanitize_url(endpoint) {
+                put(&mut section, "blob_endpoint", sanitized);
+            }
+        }
+        if let Some(bucket) = blob.bucket.as_deref() {
+            put(&mut section, "blob_bucket", bucket.to_string());
+        }
+    }
+
+    // Liveness probes of the known dev ports. Each probe is bounded at 200ms.
+    for (name, port) in KNOWN_DEV_PORTS {
+        let key = format!("port_{name}_{port}");
+        put(&mut section, &key, probe_local_port(*port));
+    }
+
+    if section.is_empty() {
+        None
+    } else {
+        Some(section)
+    }
+}
+
+/// Collect the `db_schema` section from the live PG pool published by the
+/// binary at boot (`super::publish_pg_pool`). Each query is `.ok()`-guarded so
+/// a partial PG (e.g. no `alembic_version` table) still yields what it can.
+///
+/// THIS is the high-value collector — it catches stale-schema drift (a machine
+/// running an old alembic head, or missing tables). Returns `None` if PG is
+/// unreachable so the section is omitted entirely.
+pub async fn collect_db_schema() -> Option<Section> {
+    let pool = super::pg_pool()?;
+    let client = pool.get().await.ok()?;
+
+    let mut section = Section::new();
+
+    // server_version — `SELECT version()`.
+    if let Ok(row) = client.query_one("SELECT version()", &[]).await {
+        if let Ok(v) = row.try_get::<_, String>(0) {
+            put(&mut section, "server_version", v);
+        }
+    }
+
+    // alembic_head — `SELECT version_num FROM alembic_version`. Table may be
+    // absent on a bare PG; guarded.
+    if let Ok(row) = client
+        .query_one("SELECT version_num FROM alembic_version", &[])
+        .await
+    {
+        if let Ok(v) = row.try_get::<_, String>(0) {
+            put(&mut section, "alembic_head", v);
+        }
+    }
+
+    // Schema list — names only.
+    if let Ok(rows) = client
+        .query(
+            "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name",
+            &[],
+        )
+        .await
+    {
+        let names: Vec<String> = rows
+            .iter()
+            .filter_map(|r| r.try_get::<_, String>(0).ok())
+            .collect();
+        if !names.is_empty() {
+            put(&mut section, "schemas", names.join(","));
+        }
+    }
+
+    // Per-schema table counts — grouped from information_schema.tables. Values
+    // are stringified counts. Key form: `tables_<schema>`.
+    if let Ok(rows) = client
+        .query(
+            "SELECT table_schema, count(*)::bigint \
+             FROM information_schema.tables \
+             WHERE table_type = 'BASE TABLE' \
+             GROUP BY table_schema ORDER BY table_schema",
+            &[],
+        )
+        .await
+    {
+        for r in &rows {
+            let schema: String = match r.try_get::<_, String>(0) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let count: i64 = r.try_get::<_, i64>(1).unwrap_or(0);
+            put(&mut section, &format!("tables_{schema}"), count.to_string());
+        }
+    }
+
+    if section.is_empty() {
+        None
+    } else {
+        Some(section)
+    }
+}
+
+/// Run a bounded `<cmd> --version` (3s budget) and return the trimmed first
+/// line of stdout (falling back to stderr). Returns `None` on spawn failure,
+/// timeout, or non-zero exit. Mirrors `fleet::detect_claude_code_now`'s bounded
+/// subprocess pattern.
+fn version_of(cmd: &str, args: &[&str]) -> Option<String> {
+    use std::io::Read;
+    use std::process::{Command, Stdio};
+    use std::time::Instant;
+
+    let started = Instant::now();
+    let mut child = Command::new(cmd)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .ok()?;
+
+    let deadline = started + Duration::from_secs(3);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                if !status.success() {
+                    return None;
+                }
+                let mut out = String::new();
+                if let Some(mut so) = child.stdout.take() {
+                    let _ = so.read_to_string(&mut out);
+                }
+                if out.trim().is_empty() {
+                    if let Some(mut se) = child.stderr.take() {
+                        let _ = se.read_to_string(&mut out);
+                    }
+                }
+                let first = out.lines().next().unwrap_or("").trim().to_string();
+                return if first.is_empty() { None } else { Some(first) };
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return None;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(_) => return None,
+        }
+    }
+}
+
+/// Pull a `name = "x.y.z"` value out of a `[section]` of a Cargo.toml string.
+/// Tiny hand-roll to avoid a toml-parse dependency in the hot path; tolerant of
+/// missing keys (returns `None`). Looks only within the requested top-level
+/// `[table]`.
+fn cargo_toml_value(contents: &str, table: &str, key: &str) -> Option<String> {
+    let mut in_table = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_table = trimmed == format!("[{table}]");
+            continue;
+        }
+        if in_table {
+            if let Some(rest) = trimmed.strip_prefix(key) {
+                let rest = rest.trim_start();
+                if let Some(after_eq) = rest.strip_prefix('=') {
+                    let val = after_eq.trim().trim_matches('"');
+                    if !val.is_empty() {
+                        return Some(val.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Resolve the directory of THIS crate's `Cargo.toml`. Prefer the compile-time
+/// `CARGO_MANIFEST_DIR`; that points at `.../qontinui-runner/src-tauri` where
+/// the runner's Cargo.toml lives.
+fn runner_manifest_dir() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Collect the `versions` section: rust/tauri from this crate's Cargo.toml,
+/// node deps from the nearest package.json, python from the web-backend
+/// pyproject.toml, plus bounded `--version` shells where the tools resolve.
+/// Missing inputs → key absent, never an error.
+pub fn collect_versions() -> Section {
+    let mut section = Section::new();
+
+    // ---- Cargo.toml (this crate) ----
+    let manifest_dir = runner_manifest_dir();
+    let cargo_toml = manifest_dir.join("Cargo.toml");
+    if let Ok(contents) = std::fs::read_to_string(&cargo_toml) {
+        if let Some(v) = cargo_toml_value(&contents, "package", "version") {
+            put(&mut section, "runner_crate_version", v);
+        }
+        // tauri dependency line: `tauri = { version = "2.5", ... }` — pull the
+        // version substring out of the dependency value.
+        if let Some(tauri_ver) = dependency_version(&contents, "tauri") {
+            put(&mut section, "tauri", tauri_ver);
+        }
+    }
+
+    // ---- nearest package.json (walk up from the qontinui-web frontend if
+    // present, else from the runner dir) ----
+    if let Some(pkg) = nearest_package_json(&manifest_dir) {
+        if let Ok(contents) = std::fs::read_to_string(&pkg) {
+            if let Ok(json) = serde_json::from_str::<Value>(&contents) {
+                if let Some(name) = json.get("name").and_then(|v| v.as_str()) {
+                    put(&mut section, "node_package_name", name.to_string());
+                }
+                if let Some(ver) = json.get("version").and_then(|v| v.as_str()) {
+                    put(&mut section, "node_package_version", ver.to_string());
+                }
+                // A couple of high-signal deps if present (names + declared
+                // ranges — these are public version constraints, not secrets).
+                for dep in ["next", "react", "typescript"] {
+                    if let Some(range) = json
+                        .get("dependencies")
+                        .and_then(|d| d.get(dep))
+                        .or_else(|| json.get("devDependencies").and_then(|d| d.get(dep)))
+                        .and_then(|v| v.as_str())
+                    {
+                        put(&mut section, &format!("node_dep_{dep}"), range.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- web-backend pyproject.toml ----
+    if let Some(pyproject) = web_backend_pyproject(&manifest_dir) {
+        if let Ok(contents) = std::fs::read_to_string(&pyproject) {
+            // `[tool.poetry.dependencies]` carries `python = "^3.12"`.
+            if let Some(py) = cargo_toml_value(&contents, "tool.poetry.dependencies", "python") {
+                put(&mut section, "python_constraint", py);
+            }
+        }
+    }
+
+    // ---- bounded `--version` shells (optional, 3s budget each) ----
+    if let Some(v) = version_of("rustc", &["--version"]) {
+        put(&mut section, "rustc", v);
+    }
+    if let Some(v) = version_of("node", &["--version"]) {
+        put(&mut section, "node", v);
+    }
+    if let Some(v) = version_of("python", &["--version"]) {
+        put(&mut section, "python", v);
+    }
+
+    section
+}
+
+/// Extract a `version = "x"` substring from a Cargo dependency line of the form
+/// `name = { version = "x", ... }` or `name = "x"`. Best-effort.
+fn dependency_version(contents: &str, dep: &str) -> Option<String> {
+    let mut in_deps = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            in_deps = trimmed == "[dependencies]";
+            continue;
+        }
+        if in_deps && trimmed.starts_with(dep) {
+            // Match `dep =` (avoid prefix collisions like `tauri-build`).
+            let after = trimmed[dep.len()..].trim_start();
+            if !after.starts_with('=') {
+                continue;
+            }
+            // Inline-table form: find `version = "..."`.
+            if let Some(idx) = trimmed.find("version") {
+                let tail = &trimmed[idx..];
+                if let Some(eq) = tail.find('=') {
+                    let v = tail[eq + 1..].trim();
+                    let v = v.trim_start_matches('"');
+                    if let Some(end) = v.find('"') {
+                        return Some(v[..end].to_string());
+                    }
+                }
+            }
+            // Bare-string form: `dep = "x"`.
+            let v = after.trim_start_matches('=').trim().trim_matches('"');
+            if !v.is_empty() {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Walk up from `start` looking for a `package.json`. Bounded to 6 ancestors to
+/// avoid scanning the whole filesystem. Returns the first hit.
+fn nearest_package_json(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    // Prefer the qontinui-web frontend if reachable from a known root layout.
+    // Otherwise walk up from the runner manifest dir.
+    let mut cur = Some(start);
+    for _ in 0..6 {
+        let dir = cur?;
+        let candidate = dir.join("package.json");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        // Try a sibling qontinui-web/frontend/package.json under the parent
+        // (covers the monorepo-root layout).
+        let web_pkg = dir
+            .join("qontinui-web")
+            .join("frontend")
+            .join("package.json");
+        if web_pkg.is_file() {
+            return Some(web_pkg);
+        }
+        cur = dir.parent();
+    }
+    None
+}
+
+/// Locate the web-backend `pyproject.toml` by walking up to a monorepo root and
+/// probing `qontinui-web/backend/pyproject.toml`. Returns `None` when not
+/// reachable (e.g. a production machine without the source checkout).
+fn web_backend_pyproject(start: &std::path::Path) -> Option<std::path::PathBuf> {
+    let mut cur = Some(start);
+    for _ in 0..6 {
+        let dir = cur?;
+        let candidate = dir
+            .join("qontinui-web")
+            .join("backend")
+            .join("pyproject.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        cur = dir.parent();
+    }
+    None
+}
+
+/// Allowlisted env-var name prefixes. We keep ONLY names matching one of these;
+/// the VALUE is structurally dropped (`"present"`). `DATABASE_URL` is an exact
+/// name (no trailing prefix match) but listed here as a prefix so
+/// `DATABASE_URL_REPLICA` etc. also match — still names only.
+const ALLOWLIST_PREFIXES: &[&str] = &[
+    "QONTINUI_",
+    "COORD_",
+    "REDIS_",
+    "S3_",
+    "MINIO_",
+    "RUNNER_",
+    "DATABASE_URL",
+    "PG",
+];
+
+/// Collect the `env_contract` section: env var NAMES (allowlisted by prefix)
+/// with value `"present"`. The VALUE is NEVER read — we iterate the names and
+/// emit a constant, so a secret in `QONTINUI_SECRET_TOKEN` contributes only the
+/// NAME, never the secret.
+pub fn collect_env_contract() -> Section {
+    let mut section = Section::new();
+    for (name, _value) in std::env::vars() {
+        if ALLOWLIST_PREFIXES.iter().any(|p| name.starts_with(p)) {
+            // value DELIBERATELY discarded — names only.
+            put(&mut section, &name, "present");
+        }
+    }
+    section
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_url_strips_password() {
+        let s = sanitize_url("postgres://user:supersecret@dbhost:5432/mydb").unwrap();
+        assert!(!s.contains("supersecret"), "password leaked: {s}");
+        assert!(!s.contains("user"), "username leaked: {s}");
+        assert_eq!(s, "postgres://dbhost:5432");
+    }
+
+    #[test]
+    fn sanitize_url_handles_no_port_no_userinfo() {
+        let s = sanitize_url("redis://localhost").unwrap();
+        assert_eq!(s, "redis://localhost");
+    }
+
+    #[test]
+    fn sanitize_url_rejects_garbage() {
+        assert!(sanitize_url("not a url").is_none());
+    }
+
+    #[test]
+    fn cargo_toml_value_reads_package_version() {
+        let toml = "[package]\nname = \"x\"\nversion = \"1.2.3\"\n[dependencies]\nfoo = \"9\"\n";
+        assert_eq!(
+            cargo_toml_value(toml, "package", "version").as_deref(),
+            Some("1.2.3")
+        );
+    }
+
+    #[test]
+    fn dependency_version_inline_table() {
+        let toml = "[dependencies]\ntauri = { version = \"2.5\", features = [] }\n";
+        assert_eq!(dependency_version(toml, "tauri").as_deref(), Some("2.5"));
+    }
+
+    #[test]
+    fn dependency_version_bare_string() {
+        let toml = "[dependencies]\nserde_json = \"1\"\n";
+        assert_eq!(dependency_version(toml, "serde_json").as_deref(), Some("1"));
+    }
+
+    /// Secret-safety: a secret-bearing env var contributes only its NAME, never
+    /// the value, to the env_contract section.
+    #[test]
+    fn secret_safety_env_contract_emits_name_not_value() {
+        let var = "QONTINUI_SECRET_TOKEN_TEST_UNIQUE";
+        std::env::set_var(var, "supersecret123");
+        let section = collect_env_contract();
+        std::env::remove_var(var);
+
+        // Name present, value "present".
+        assert_eq!(
+            section.get(var).and_then(|v| v.as_str()),
+            Some("present"),
+            "allowlisted var name should be captured as present"
+        );
+        // The secret value must appear NOWHERE in the serialized section.
+        let json = serde_json::to_string(&section).unwrap();
+        assert!(
+            !json.contains("supersecret123"),
+            "secret value leaked into env_contract: {json}"
+        );
+    }
+
+    /// Secret-safety: a password-bearing DSN in the profile never leaks the
+    /// password through the services-section URL sanitizer.
+    #[test]
+    fn secret_safety_dsn_password_never_leaks_via_sanitizer() {
+        let sanitized = sanitize_url("postgres://u:pw@h:5432/db").unwrap();
+        assert!(!sanitized.contains("pw"), "password leaked: {sanitized}");
+        assert!(!sanitized.contains("u@"), "userinfo leaked: {sanitized}");
+    }
+}

--- a/src-tauri/src/env_agent/config.rs
+++ b/src-tauri/src/env_agent/config.rs
@@ -65,8 +65,8 @@ impl EnvAgentConfig {
             std::fs::create_dir_all(parent)
                 .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
         }
-        let pretty =
-            serde_json::to_vec_pretty(self).map_err(|e| format!("serialize env-agent.json: {e}"))?;
+        let pretty = serde_json::to_vec_pretty(self)
+            .map_err(|e| format!("serialize env-agent.json: {e}"))?;
         let tmp = path.with_extension("json.tmp");
         std::fs::write(&tmp, &pretty).map_err(|e| format!("write {}: {e}", tmp.display()))?;
         std::fs::rename(&tmp, &path).map_err(|e| format!("rename {}: {e}", path.display()))?;

--- a/src-tauri/src/env_agent/config.rs
+++ b/src-tauri/src/env_agent/config.rs
@@ -1,0 +1,126 @@
+//! On-disk enrollment state for the machine-side capture agent.
+//!
+//! The capture agent runs on a developer's machine, captures that machine's
+//! real dev-environment configuration (secret-free), and POSTs it to the
+//! qontinui-web backend so the server can compute drift vs a canonical machine.
+//!
+//! Authentication is a per-machine API key (`mk_<token>`) — NOT a user JWT.
+//! The key is minted ONCE by the enroll endpoint and stored in the encrypted
+//! `SecureStorage` (see `secure_storage::store_agent_machine_key`). This file
+//! holds only the NON-secret enrollment state: the backend URL, the
+//! machine_id, the environment_id (returned by enroll), and when we enrolled.
+//!
+//! `~/.qontinui/env-agent.json` is written atomically (tmp + rename), mirroring
+//! `fleet::write_last_budget_cache` / `pair::backfill_paired_tenant_id`.
+//!
+//! **`environment_id` is ALWAYS sourced from the enroll response — never
+//! hardcoded.** Until the agent is enrolled (`is_enrolled()` false) the periodic
+//! capture loop no-ops.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Persisted enrollment state for the env-capture agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvAgentConfig {
+    /// qontinui-web backend base URL (e.g. `http://localhost:8000` or
+    /// `https://qontinui.io`). The capture PUT targets
+    /// `{backend_url}/api/v1/devenv/agent/environments/{environment_id}/config`.
+    pub backend_url: String,
+    /// Stable per-machine identity returned by the enroll endpoint. Matches the
+    /// `machine_id` carried in the enroll request (or the server-assigned one
+    /// when the request sent `null`).
+    pub machine_id: String,
+    /// Environment this machine is enrolled into. Returned by the enroll
+    /// response — NEVER hardcoded. Capture pushes target this id.
+    pub environment_id: String,
+    /// RFC3339 timestamp of when enrollment succeeded. Informational; `None`
+    /// for a hand-written config that omitted it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enrolled_at: Option<String>,
+}
+
+impl EnvAgentConfig {
+    /// Path of `~/.qontinui/env-agent.json` for the current user.
+    pub fn path() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(".qontinui").join("env-agent.json"))
+    }
+
+    /// Load the persisted config, or `None` when the file is absent /
+    /// unreadable / unparseable. A missing file is the common "never enrolled"
+    /// case, so a `None` return is not an error.
+    pub fn load() -> Option<Self> {
+        let path = Self::path()?;
+        let bytes = std::fs::read(&path).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    /// Persist this config atomically (tmp + rename), creating
+    /// `~/.qontinui/` if needed. Mirrors the atomic-write idiom used across the
+    /// runner (`fleet::write_last_budget_cache`, `pair::persist_pairing`).
+    pub fn save(&self) -> Result<(), String> {
+        let path = Self::path().ok_or_else(|| "could not resolve home directory".to_string())?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("mkdir {}: {e}", parent.display()))?;
+        }
+        let pretty =
+            serde_json::to_vec_pretty(self).map_err(|e| format!("serialize env-agent.json: {e}"))?;
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, &pretty).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        std::fs::rename(&tmp, &path).map_err(|e| format!("rename {}: {e}", path.display()))?;
+        Ok(())
+    }
+
+    /// True when a machine_id + environment_id are both present and non-empty.
+    /// The presence of an actual `mk_` key is a separate concern owned by
+    /// `secure_storage::get_agent_machine_key`; callers that POST also check
+    /// that.
+    pub fn is_enrolled(&self) -> bool {
+        !self.machine_id.trim().is_empty() && !self.environment_id.trim().is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_round_trips_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("env-agent.json");
+        let cfg = EnvAgentConfig {
+            backend_url: "http://localhost:8000".to_string(),
+            machine_id: "machine-abc".to_string(),
+            environment_id: "env-123".to_string(),
+            enrolled_at: Some("2026-06-22T00:00:00Z".to_string()),
+        };
+        let pretty = serde_json::to_vec_pretty(&cfg).unwrap();
+        std::fs::write(&path, pretty).unwrap();
+        let loaded: EnvAgentConfig =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(loaded.machine_id, "machine-abc");
+        assert_eq!(loaded.environment_id, "env-123");
+        assert!(loaded.is_enrolled());
+    }
+
+    #[test]
+    fn is_enrolled_false_when_ids_blank() {
+        let cfg = EnvAgentConfig {
+            backend_url: "http://localhost:8000".to_string(),
+            machine_id: "".to_string(),
+            environment_id: "".to_string(),
+            enrolled_at: None,
+        };
+        assert!(!cfg.is_enrolled());
+    }
+
+    #[test]
+    fn legacy_config_without_enrolled_at_deserializes() {
+        let raw = r#"{"backend_url":"http://h:8000","machine_id":"m","environment_id":"e"}"#;
+        let parsed: EnvAgentConfig = serde_json::from_str(raw).expect("must decode");
+        assert!(parsed.enrolled_at.is_none());
+        assert!(parsed.is_enrolled());
+    }
+}

--- a/src-tauri/src/env_agent/mod.rs
+++ b/src-tauri/src/env_agent/mod.rs
@@ -52,8 +52,8 @@ use serde::Serialize;
 use serde_json::{Map, Value};
 use tracing::{debug, info, warn};
 
-use self::config::EnvAgentConfig;
 use self::collectors::Section;
+use self::config::EnvAgentConfig;
 
 /// Current envelope schema version. Must match the backend's expectation.
 const SCHEMA_VERSION: u32 = 1;
@@ -113,8 +113,7 @@ pub fn publish_pg_pool_from_url(database_url: &str) -> Result<(), String> {
     let mgr_config = deadpool_postgres::ManagerConfig {
         recycling_method: deadpool_postgres::RecyclingMethod::Fast,
     };
-    let mgr =
-        deadpool_postgres::Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
+    let mgr = deadpool_postgres::Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
     let pool = deadpool_postgres::Pool::builder(mgr)
         .max_size(2)
         .build()
@@ -192,7 +191,11 @@ fn add_section(sections: &mut Map<String, Value>, name: &str, section: Option<Se
 pub async fn build_envelope() -> ConfigEnvelope {
     let mut sections = Map::new();
 
-    add_section(&mut sections, "services", collectors::collect_services().await);
+    add_section(
+        &mut sections,
+        "services",
+        collectors::collect_services().await,
+    );
     add_section(
         &mut sections,
         "db_schema",
@@ -331,8 +334,13 @@ pub async fn capture_and_push() -> Result<(), String> {
     // Cache BEFORE the POST.
     write_last_capture_cache(&envelope, &cfg.environment_id);
 
-    match put_envelope_with_retry(&cfg.backend_url, &cfg.environment_id, &machine_key, &envelope)
-        .await
+    match put_envelope_with_retry(
+        &cfg.backend_url,
+        &cfg.environment_id,
+        &machine_key,
+        &envelope,
+    )
+    .await
     {
         Ok(()) => {
             info!(
@@ -411,7 +419,9 @@ pub fn spawn_env_capture() {
 
             // Gate INSIDE the loop so mid-session enroll works. An unenrolled
             // machine simply skips this tick (no log spam — debug only).
-            let enrolled = EnvAgentConfig::load().map(|c| c.is_enrolled()).unwrap_or(false);
+            let enrolled = EnvAgentConfig::load()
+                .map(|c| c.is_enrolled())
+                .unwrap_or(false);
             if !enrolled {
                 debug!("env_agent::capture: not enrolled — skipping tick");
                 continue;
@@ -420,9 +430,7 @@ pub fn spawn_env_capture() {
             match capture_and_push().await {
                 Err(e) => {
                     consecutive_failures += 1;
-                    warn!(
-                        "env_agent::capture: {e} (consecutive_failures={consecutive_failures})"
-                    );
+                    warn!("env_agent::capture: {e} (consecutive_failures={consecutive_failures})");
                 }
                 Ok(()) if consecutive_failures > 0 => {
                     info!(
@@ -478,8 +486,7 @@ mod tests {
         );
         // The var NAME must be present with value "present".
         assert!(
-            json.contains("QONTINUI_SECRET_TOKEN_ENVELOPE_TEST")
-                && json.contains("present"),
+            json.contains("QONTINUI_SECRET_TOKEN_ENVELOPE_TEST") && json.contains("present"),
             "expected var name + 'present' marker in envelope: {json}"
         );
     }

--- a/src-tauri/src/env_agent/mod.rs
+++ b/src-tauri/src/env_agent/mod.rs
@@ -89,6 +89,40 @@ pub fn publish_pg_pool(pool: deadpool_postgres::Pool) {
     let _ = PG_POOL.set(pool);
 }
 
+/// Build a LAZY deadpool PG pool from a connection string and publish it for
+/// the `db_schema` collector.
+///
+/// The full runner hands `publish_pg_pool` a clone of its already-built boot
+/// pool (`main.rs`), but the standalone `qontinui_profile env capture` CLI has
+/// no such pool — without this it can never populate the high-value `db_schema`
+/// section (alembic_head + schema/table census), so cross-machine schema drift
+/// is invisible from the CLI. This builds a small pool (mirroring
+/// `database::pg::build_pool`, minus the search_path hook — `alembic_version`
+/// lives in `public`, already covered by the default search_path — and minus
+/// the timeout setters, which would panic without an active tokio runtime).
+///
+/// Lazy by design: the pool is built but NOT connected here, so it is safe to
+/// call from a synchronous CLI context with no runtime entered. The collector
+/// connects on first `get().await` inside the capture runtime; any connect
+/// failure there simply omits the section. Idempotent: a second call no-ops
+/// because the underlying `OnceLock` is already set.
+pub fn publish_pg_pool_from_url(database_url: &str) -> Result<(), String> {
+    let pg_config: tokio_postgres::Config = database_url
+        .parse()
+        .map_err(|e| format!("invalid PG connection string: {e}"))?;
+    let mgr_config = deadpool_postgres::ManagerConfig {
+        recycling_method: deadpool_postgres::RecyclingMethod::Fast,
+    };
+    let mgr =
+        deadpool_postgres::Manager::from_config(pg_config, tokio_postgres::NoTls, mgr_config);
+    let pool = deadpool_postgres::Pool::builder(mgr)
+        .max_size(2)
+        .build()
+        .map_err(|e| format!("failed to build PG pool: {e}"))?;
+    publish_pg_pool(pool);
+    Ok(())
+}
+
 /// Get a clone of the published PG pool, if any. `deadpool_postgres::Pool` is an
 /// `Arc` internally, so cloning is cheap and shares the live pool.
 pub(crate) fn pg_pool() -> Option<deadpool_postgres::Pool> {

--- a/src-tauri/src/env_agent/mod.rs
+++ b/src-tauri/src/env_agent/mod.rs
@@ -1,0 +1,483 @@
+//! Machine-side dev-environment capture agent.
+//!
+//! Runs on a developer's machine, captures that machine's real dev-environment
+//! configuration (SECRET-FREE), and POSTs it to the qontinui-web backend so the
+//! server computes drift vs a canonical machine. Auth is a per-machine API key
+//! (`X-Machine-Key: mk_<token>`), NOT a user JWT.
+//!
+//! ## Lifecycle
+//!
+//! 1. `qontinui_profile env enroll --code <enrollment_code>` →
+//!    `POST {backend}/api/v1/devenv/agent/enroll`. The server returns
+//!    `{ machine_id, machine_key: "mk_…", environment_id }` ONCE. We store the
+//!    key in `SecureStorage` and the rest in `~/.qontinui/env-agent.json`.
+//! 2. The runner's background task ([`spawn_env_capture`]) — or the one-shot
+//!    `qontinui_profile env capture` — runs the four collectors, builds the
+//!    envelope, writes a last-envelope cache, and PUTs the envelope to
+//!    `{backend}/api/v1/devenv/agent/environments/{environment_id}/config`.
+//!
+//! ## Envelope contract (conforms EXACTLY to the backend)
+//!
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "captured_at": "<rfc3339>",
+//!   "sections": {
+//!     "services":     { "<key>": "<string>" },
+//!     "db_schema":    { "<key>": "<string>" },
+//!     "versions":     { "<key>": "<string>" },
+//!     "env_contract": { "<VAR_NAME>": "present" }
+//!   }
+//! }
+//! ```
+//!
+//! Every section value MUST be a string. A failing/empty section is OMITTED.
+//!
+//! ## Fail-open posture (mirrors `fleet.rs`)
+//!
+//! Network pushes use an exponential-backoff retry ([2,4,8,16,32,60]s, 10s
+//! timeout) cloned from `fleet::post_budget_with_retry`. A terminal failure
+//! returns `Err`; the periodic loop logs+swallows so the runner never blocks.
+//! The last envelope is cached to `~/.qontinui/last_env_capture.json` BEFORE the
+//! POST so an operator can inspect "what would be pushed" even when the backend
+//! is unreachable.
+
+pub mod collectors;
+pub mod config;
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use serde::Serialize;
+use serde_json::{Map, Value};
+use tracing::{debug, info, warn};
+
+use self::config::EnvAgentConfig;
+use self::collectors::Section;
+
+/// Current envelope schema version. Must match the backend's expectation.
+const SCHEMA_VERSION: u32 = 1;
+
+/// Wire shape of the capture envelope (`PUT .../config` body).
+#[derive(Debug, Serialize)]
+pub struct ConfigEnvelope {
+    /// Schema version — always [`SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// RFC3339 capture timestamp.
+    pub captured_at: String,
+    /// Section name → section map (each value a string). Failing/empty sections
+    /// are omitted by the isolation driver.
+    pub sections: Map<String, Value>,
+}
+
+// ============================================================================
+// PG pool bridge (lib ↔ binary)
+// ============================================================================
+//
+// The live deadpool PG pool is owned by the binary crate's
+// `crate::database::pg::GLOBAL_PG_DB` OnceLock, which the lib crate cannot
+// reach. The binary publishes a clone of the pool here at boot
+// (`publish_pg_pool`) so the lib-side `db_schema` collector can use it. Until
+// published, `collect_db_schema` returns `None` (section omitted).
+
+static PG_POOL: OnceLock<deadpool_postgres::Pool> = OnceLock::new();
+
+/// Publish the live PG pool for the `db_schema` collector. Called once by the
+/// binary at boot (`main.rs` fleet-publishers block). Idempotent — a second
+/// call is ignored.
+pub fn publish_pg_pool(pool: deadpool_postgres::Pool) {
+    let _ = PG_POOL.set(pool);
+}
+
+/// Get a clone of the published PG pool, if any. `deadpool_postgres::Pool` is an
+/// `Arc` internally, so cloning is cheap and shares the live pool.
+pub(crate) fn pg_pool() -> Option<deadpool_postgres::Pool> {
+    PG_POOL.get().cloned()
+}
+
+// ============================================================================
+// Cache path
+// ============================================================================
+
+/// Path of the last-envelope cache (`~/.qontinui/last_env_capture.json`).
+fn last_capture_cache_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".qontinui").join("last_env_capture.json"))
+}
+
+/// Atomically write the last-envelope cache (tmp + rename). Best-effort: a
+/// failure is logged at debug and swallowed. Mirrors
+/// `fleet::write_last_budget_cache`.
+fn write_last_capture_cache(envelope: &ConfigEnvelope, environment_id: &str) {
+    let Some(path) = last_capture_cache_path() else {
+        return;
+    };
+    let payload = serde_json::json!({
+        "environment_id": environment_id,
+        "envelope": envelope,
+    });
+    let pretty = match serde_json::to_vec_pretty(&payload) {
+        Ok(b) => b,
+        Err(e) => {
+            debug!("env_agent: cache serialize failed: {e}");
+            return;
+        }
+    };
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            debug!("env_agent: cache mkdir failed: {e}");
+            return;
+        }
+    }
+    let tmp = path.with_extension("json.tmp");
+    if let Err(e) = std::fs::write(&tmp, &pretty) {
+        debug!("env_agent: cache write failed: {e}");
+        return;
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        debug!("env_agent: cache rename failed: {e}");
+    }
+}
+
+// ============================================================================
+// Envelope assembly
+// ============================================================================
+
+/// Insert a section under `name` IFF it is `Some` and non-empty. The isolation
+/// driver: a collector that fails or yields nothing contributes no key, so the
+/// envelope never carries a broken/empty section.
+fn add_section(sections: &mut Map<String, Value>, name: &str, section: Option<Section>) {
+    if let Some(s) = section {
+        if !s.is_empty() {
+            sections.insert(name.to_string(), Value::Object(s));
+        }
+    }
+}
+
+/// Run all four collectors and assemble the envelope. Each collector is
+/// best-effort; a failing/empty one is omitted (never aborts the others).
+pub async fn build_envelope() -> ConfigEnvelope {
+    let mut sections = Map::new();
+
+    add_section(&mut sections, "services", collectors::collect_services().await);
+    add_section(
+        &mut sections,
+        "db_schema",
+        collectors::collect_db_schema().await,
+    );
+    // Synchronous collectors — wrap in Some so the isolation driver still drops
+    // an (unlikely) empty result.
+    add_section(
+        &mut sections,
+        "versions",
+        Some(collectors::collect_versions()),
+    );
+    add_section(
+        &mut sections,
+        "env_contract",
+        Some(collectors::collect_env_contract()),
+    );
+
+    ConfigEnvelope {
+        schema_version: SCHEMA_VERSION,
+        captured_at: chrono::Utc::now().to_rfc3339(),
+        sections,
+    }
+}
+
+// ============================================================================
+// HTTP push (cloned from fleet::post_budget_with_retry)
+// ============================================================================
+
+/// Render an error with its full `source()` chain (cloned from
+/// `fleet::error_chain`) so failure WARNs carry the root cause (dns/tls/os).
+fn error_chain(e: &(dyn std::error::Error + 'static)) -> String {
+    let mut s = e.to_string();
+    let mut src = e.source();
+    while let Some(cause) = src {
+        s.push_str(": ");
+        s.push_str(&cause.to_string());
+        src = cause.source();
+    }
+    s
+}
+
+/// PUT the envelope with exponential backoff (2s, 4s, 8s, 16s, 32s, 60s) +
+/// `X-Machine-Key` auth. Returns Ok on first success; Err with the last error if
+/// every attempt fails. Cloned from `fleet::post_budget_with_retry` — the caller
+/// logs+swallows so the runner never blocks.
+async fn put_envelope_with_retry(
+    backend_url: &str,
+    environment_id: &str,
+    machine_key: &str,
+    envelope: &ConfigEnvelope,
+) -> Result<(), String> {
+    let url = format!(
+        "{}/api/v1/devenv/agent/environments/{}/config",
+        backend_url.trim_end_matches('/'),
+        environment_id
+    );
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|e| format!("reqwest client build: {e}"))?;
+    let mut last_err = String::new();
+    let backoff_ms: [u64; 6] = [2_000, 4_000, 8_000, 16_000, 32_000, 60_000];
+    for (attempt, delay_ms) in backoff_ms.iter().enumerate() {
+        match client
+            .put(&url)
+            .header("X-Machine-Key", machine_key)
+            .json(envelope)
+            .send()
+            .await
+        {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    return Ok(());
+                }
+                let body_text = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<unable to read response body>".to_string());
+                last_err = format!("PUT {url} -> HTTP {status}: {body_text}");
+            }
+            Err(e) => {
+                last_err = format!("PUT {url} failed: {}", error_chain(&e));
+            }
+        }
+        if attempt + 1 < backoff_ms.len() {
+            warn!(
+                "env_agent::push: attempt {} failed ({}); retrying in {}s",
+                attempt + 1,
+                last_err,
+                delay_ms / 1000
+            );
+            tokio::time::sleep(Duration::from_millis(*delay_ms)).await;
+        }
+    }
+    Err(last_err)
+}
+
+// ============================================================================
+// Capture-and-push driver
+// ============================================================================
+
+/// Load enrollment state, build the envelope, cache it, and PUT it to the
+/// backend. No-op (returns `Ok(())`) when the agent is not enrolled, so the
+/// periodic loop is safe to call unconditionally.
+///
+/// The envelope is cached to `~/.qontinui/last_env_capture.json` BEFORE the POST
+/// — the operator's lifeline when the backend is unreachable.
+pub async fn capture_and_push() -> Result<(), String> {
+    let cfg = match EnvAgentConfig::load() {
+        Some(c) if c.is_enrolled() => c,
+        _ => {
+            debug!("env_agent::capture_and_push: not enrolled — skipping");
+            return Ok(());
+        }
+    };
+
+    // The machine key is the auth credential — without it we cannot push.
+    let machine_key = match crate::secure_storage::SecureStorage::new()
+        .ok()
+        .and_then(|s| s.get_agent_machine_key().ok().flatten())
+    {
+        Some(k) if !k.is_empty() => k,
+        _ => {
+            warn!(
+                "env_agent::capture_and_push: enrolled but no machine key in secure storage \
+                 — re-run `qontinui_profile env enroll --code <code>`"
+            );
+            return Ok(());
+        }
+    };
+
+    let envelope = build_envelope().await;
+
+    // Cache BEFORE the POST.
+    write_last_capture_cache(&envelope, &cfg.environment_id);
+
+    match put_envelope_with_retry(&cfg.backend_url, &cfg.environment_id, &machine_key, &envelope)
+        .await
+    {
+        Ok(()) => {
+            info!(
+                "env_agent::capture_and_push: pushed {} section(s) to environment {} ({})",
+                envelope.sections.len(),
+                cfg.environment_id,
+                cfg.backend_url
+            );
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
+}
+
+// ============================================================================
+// Sync helper for the CLI one-shot (`qontinui_profile env capture`)
+// ============================================================================
+
+/// Build a current-thread tokio runtime and run [`capture_and_push`]. Used by
+/// the `qontinui_profile env capture` CLI (a sync binary). Errors are returned
+/// so the CLI can print them + set a nonzero exit.
+pub fn capture_and_push_blocking() -> Result<(), String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("tokio runtime build failed: {e}"))?;
+    rt.block_on(capture_and_push())
+}
+
+/// Build the envelope synchronously (current-thread runtime) WITHOUT pushing.
+/// Used by `qontinui_profile env capture --dry-run` to pretty-print the
+/// envelope the agent would send.
+pub fn build_envelope_blocking() -> Result<ConfigEnvelope, String> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| format!("tokio runtime build failed: {e}"))?;
+    Ok(rt.block_on(build_envelope()))
+}
+
+// ============================================================================
+// Periodic capture task (clone of fleet::spawn_heartbeat)
+// ============================================================================
+
+/// Spawn the periodic env-capture task on the ambient tokio runtime.
+///
+/// Interval from `QONTINUI_ENV_CAPTURE_INTERVAL_SECS` (default 900s, floored at
+/// 60s). `MissedTickBehavior::Skip` mirrors `fleet::spawn_heartbeat` — a missed
+/// tick (system suspend) doesn't blast catch-up. The enrollment gate is checked
+/// INSIDE the loop so a mid-session enroll is picked up without a runner
+/// restart. Runs once shortly after start, then on the interval. Failures
+/// `warn!` and retry on the next tick; the loop never panics.
+pub fn spawn_env_capture() {
+    let secs: u64 = std::env::var("QONTINUI_ENV_CAPTURE_INTERVAL_SECS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(900)
+        .max(60);
+
+    info!(
+        "env_agent::capture: starting periodic capture task, interval={}s",
+        secs
+    );
+
+    tokio::spawn(async move {
+        // Small initial delay so the first capture lands off the boot
+        // critical path (the binary publishes the PG pool around the same
+        // time this task spawns).
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        let mut tick = tokio::time::interval(Duration::from_secs(secs));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut consecutive_failures: u32 = 0;
+        loop {
+            tick.tick().await;
+
+            // Gate INSIDE the loop so mid-session enroll works. An unenrolled
+            // machine simply skips this tick (no log spam — debug only).
+            let enrolled = EnvAgentConfig::load().map(|c| c.is_enrolled()).unwrap_or(false);
+            if !enrolled {
+                debug!("env_agent::capture: not enrolled — skipping tick");
+                continue;
+            }
+
+            match capture_and_push().await {
+                Err(e) => {
+                    consecutive_failures += 1;
+                    warn!(
+                        "env_agent::capture: {e} (consecutive_failures={consecutive_failures})"
+                    );
+                }
+                Ok(()) if consecutive_failures > 0 => {
+                    info!(
+                        "env_agent::capture: recovered after {consecutive_failures} failed tick(s)"
+                    );
+                    consecutive_failures = 0;
+                }
+                Ok(()) => {}
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Secret-safety (end-to-end envelope): a secret-bearing env var and a
+    /// password-bearing DSN must never appear in the serialized envelope; the
+    /// var NAME must appear with value "present".
+    #[test]
+    fn secret_safety_envelope_never_leaks_secrets() {
+        // Arrange a secret-bearing allowlisted env var + a password DSN.
+        std::env::set_var("QONTINUI_SECRET_TOKEN_ENVELOPE_TEST", "supersecret123");
+        std::env::set_var("DATABASE_URL", "postgres://u:pw@h:5432/db");
+
+        // Build env_contract + a sanitized services-style entry directly (we
+        // don't depend on the live profile/PG here — this isolates the
+        // secret-safety assertion to the collectors' structural guarantees).
+        let env_contract = collectors::collect_env_contract();
+        let mut sections = Map::new();
+        add_section(&mut sections, "env_contract", Some(env_contract));
+
+        let envelope = ConfigEnvelope {
+            schema_version: SCHEMA_VERSION,
+            captured_at: chrono::Utc::now().to_rfc3339(),
+            sections,
+        };
+        let json = serde_json::to_string(&envelope).expect("serialize envelope");
+
+        std::env::remove_var("QONTINUI_SECRET_TOKEN_ENVELOPE_TEST");
+        std::env::remove_var("DATABASE_URL");
+
+        // The secret VALUE must appear nowhere.
+        assert!(
+            !json.contains("supersecret123"),
+            "secret env value leaked into envelope: {json}"
+        );
+        // The DSN password must appear nowhere.
+        assert!(
+            !json.contains("\"pw\"") && !json.contains(":pw@") && !json.contains("u:pw"),
+            "DSN password leaked into envelope: {json}"
+        );
+        // The var NAME must be present with value "present".
+        assert!(
+            json.contains("QONTINUI_SECRET_TOKEN_ENVELOPE_TEST")
+                && json.contains("present"),
+            "expected var name + 'present' marker in envelope: {json}"
+        );
+    }
+
+    #[test]
+    fn envelope_serializes_with_schema_version_and_sections() {
+        let mut sections = Map::new();
+        let mut s = Section::new();
+        s.insert("k".to_string(), Value::String("v".to_string()));
+        add_section(&mut sections, "versions", Some(s));
+        let envelope = ConfigEnvelope {
+            schema_version: SCHEMA_VERSION,
+            captured_at: "2026-06-22T00:00:00+00:00".to_string(),
+            sections,
+        };
+        let v = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(v.get("schema_version").and_then(|x| x.as_u64()), Some(1));
+        assert!(v.get("sections").and_then(|s| s.get("versions")).is_some());
+        // Every section value is a string.
+        let versions = v
+            .get("sections")
+            .and_then(|s| s.get("versions"))
+            .and_then(|x| x.as_object())
+            .unwrap();
+        assert!(versions.values().all(|val| val.is_string()));
+    }
+
+    #[test]
+    fn add_section_omits_empty_and_none() {
+        let mut sections = Map::new();
+        add_section(&mut sections, "empty", Some(Section::new()));
+        add_section(&mut sections, "none", None);
+        assert!(sections.is_empty(), "empty/None sections must be omitted");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,6 +22,14 @@ pub mod tauri_event_payloads;
 pub mod auth;
 pub mod secure_storage;
 
+// Machine-side dev-environment capture agent (feat/devenv-environments). Runs
+// on a developer's machine, captures that machine's real dev-environment
+// configuration (SECRET-FREE), and POSTs it to the qontinui-web backend so the
+// server computes drift vs a canonical machine. Auth is a per-machine API key
+// (`X-Machine-Key: mk_<token>`), NOT a user JWT. Lives in the lib crate so both
+// the `qontinui_profile env` CLI and the Tauri runner GUI share one code path.
+pub mod env_agent;
+
 // Device-pairing flow (headless + browser-mediated). Lifted out of
 // `bin/qontinui_profile.rs` so both the CLI and the Tauri runner GUI
 // share one code path. See `pair.rs` for the canonical wire shapes.

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -638,6 +638,19 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // each other (unlike the heartbeat above, which feeds
                 // coord's 120s liveness TTL and must never be starved).
                 fleet::spawn_tree_publisher();
+                // Machine-side dev-environment capture agent
+                // (feat/devenv-environments). Publishes the live PG pool so the
+                // lib-side `db_schema` collector can reach it, then spawns the
+                // periodic capture task. Both are best-effort: the task no-ops
+                // until the machine is enrolled (`qontinui_profile env enroll`),
+                // gates enrollment INSIDE its loop (so a mid-session enroll is
+                // picked up), and logs+swallows push failures. NEVER awaited
+                // synchronously — kept off the boot critical path like the
+                // sibling publishers above.
+                qontinui_runner_lib::env_agent::publish_pg_pool(
+                    fleet_publish_pg.pool().clone(),
+                );
+                qontinui_runner_lib::env_agent::spawn_env_capture();
                 // Session Bus Phase 3b directed-message delivery executor is
                 // RETIRED in favor of `mcp::session_message_poller` (in-session
                 // continuation delivery, plan 2026-06-21 Phase 2), which adds

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -647,9 +647,7 @@ fn run_app() -> Result<(), Box<dyn std::error::Error>> {
                 // picked up), and logs+swallows push failures. NEVER awaited
                 // synchronously — kept off the boot critical path like the
                 // sibling publishers above.
-                qontinui_runner_lib::env_agent::publish_pg_pool(
-                    fleet_publish_pg.pool().clone(),
-                );
+                qontinui_runner_lib::env_agent::publish_pg_pool(fleet_publish_pg.pool().clone());
                 qontinui_runner_lib::env_agent::spawn_env_capture();
                 // Session Bus Phase 3b directed-message delivery executor is
                 // RETIRED in favor of `mcp::session_message_poller` (in-session

--- a/src-tauri/src/secure_storage.rs
+++ b/src-tauri/src/secure_storage.rs
@@ -77,6 +77,15 @@ struct StoredTokens {
     /// `#[serde(default)]` so a pre-Phase-3b `.enc` deserializes.
     #[serde(default)]
     coord_mcp_nonces: std::collections::HashMap<String, String>,
+    /// Per-machine API key for the dev-environment capture agent
+    /// (`mk_<token>`), minted ONCE by the qontinui-web enroll endpoint
+    /// (`POST /api/v1/devenv/agent/enroll`). Sent as the `X-Machine-Key`
+    /// header on every config push. This is a bearer credential (NOT a
+    /// loopback-only nonce), so it lives in the encrypted store alongside the
+    /// device JWT. `#[serde(default)]` keeps a pre-env-agent `.enc`
+    /// deserializing.
+    #[serde(default)]
+    agent_machine_key: Option<String>,
 }
 
 /// Secure file-based storage manager.
@@ -395,6 +404,35 @@ impl SecureStorage {
             .unwrap_or_default()
     }
 
+    /// Store the dev-environment capture agent's per-machine API key
+    /// (`mk_<token>`). Minted ONCE by the enroll endpoint; overwrites any
+    /// prior key. Leaves all other slots untouched.
+    pub fn store_agent_machine_key(&self, key: &str) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens.agent_machine_key = Some(key.to_string());
+        self.save_tokens(&tokens)?;
+        info!("env-agent machine key stored in secure file storage");
+        Ok(())
+    }
+
+    /// Retrieve the dev-environment capture agent's per-machine API key, if
+    /// present. `Ok(None)` when the machine has never enrolled (vs an `Err`
+    /// only on a decrypt/parse failure of an existing store).
+    pub fn get_agent_machine_key(&self) -> Result<Option<String>> {
+        let tokens = self.load_tokens()?;
+        Ok(tokens.agent_machine_key)
+    }
+
+    /// Clear the dev-environment capture agent's per-machine API key, leaving
+    /// all other slots intact. Used when re-enrolling or unenrolling.
+    pub fn clear_agent_machine_key(&self) -> Result<()> {
+        let mut tokens = self.load_tokens().unwrap_or_default();
+        tokens.agent_machine_key = None;
+        self.save_tokens(&tokens)?;
+        info!("env-agent machine key cleared from secure file storage");
+        Ok(())
+    }
+
     /// Deletes the storage file entirely.
     #[allow(dead_code)]
     pub fn delete_storage(&self) -> Result<()> {
@@ -488,6 +526,30 @@ mod tests {
         assert_eq!(parsed.access_token.as_deref(), Some("a"));
         assert!(parsed.oauth_access_token.is_none());
         assert!(parsed.oauth_expires_at.is_none());
+    }
+
+    #[test]
+    fn test_agent_machine_key_round_trip_and_isolation() {
+        let storage = create_test_storage("test_agent_machine_key");
+
+        // Absent before any store.
+        assert!(storage.get_agent_machine_key().unwrap().is_none());
+
+        // A device JWT in the access_token slot must NOT be clobbered by the
+        // machine-key write (slot isolation).
+        storage.store_tokens("device.jwt", "").unwrap();
+        storage.store_agent_machine_key("mk_abc123").unwrap();
+
+        assert_eq!(
+            storage.get_agent_machine_key().unwrap().as_deref(),
+            Some("mk_abc123")
+        );
+        assert_eq!(storage.get_access_token().unwrap(), "device.jwt");
+
+        // Clearing only the machine key leaves the device JWT intact.
+        storage.clear_agent_machine_key().unwrap();
+        assert!(storage.get_agent_machine_key().unwrap().is_none());
+        assert_eq!(storage.get_access_token().unwrap(), "device.jwt");
     }
 
     #[test]


### PR DESCRIPTION
## What

The machine-side capture agent for the **dev-environment digital twin** (backend + UI: qontinui/qontinui-web#644). Runs on a developer's machine, captures that machine's real dev-environment configuration, and POSTs a **secret-free** envelope to the qontinui-web backend, which computes drift vs a designated canonical machine.

## Changes (`a16b185a`)
- New `env_agent` module — `config` (`~/.qontinui/env-agent.json`, environment_id from the enroll response, never hardcoded), `collectors`, `mod` (envelope assembly + retrying push, scheduled capture).
- Four fail-open, **secret-free** collectors:
  - `services` — service endpoints/ports from profiles + topology, **userinfo stripped** from URLs.
  - `db_schema` — alembic head, schemas, table counts, server version via the live PG pool (the high-value collector — catches stale-schema drift).
  - `versions` — tool/dependency versions.
  - `env_contract` — env-var **names only** (values dropped structurally).
- `qontinui_profile env enroll|capture|show` CLI (`enroll` exchanges a one-time code for a machine key; `capture --dry-run` prints the envelope without posting).
- `agent_machine_key` slot in the existing AES-256-GCM secure storage.
- `spawn_env_capture()` wired into the fleet-publishers thread, **off the `/health` boot critical path**.
- Also: `database/pg/mod.rs` self-heal now runs `CREATE SCHEMA IF NOT EXISTS project` before the `project.apps` self-heal, so a fresh/older PG boots cleanly instead of panicking on a missing `project` schema (fixes a real runner-startup panic).

## Verification
- `cargo check` clean on lib, `qontinui_profile`, and `qontinui-runner`.
- **21 cargo tests green**, including two secret-safety tests asserting passwords/DSNs/env-var values never appear in the serialized envelope.

## Secret-safety
Secrets are excluded structurally (URL userinfo stripped, env values dropped to `present`, db_schema reads only metadata) and the backend applies an independent server-side backstop.