### PR TITLE
fix: stop transcript_watcher flooding agent_logs with session_started

### DIFF
--- a/src-tauri/src/terminal/transcript_watcher.rs
+++ b/src-tauri/src/terminal/transcript_watcher.rs
@@ -412,15 +412,24 @@ async fn tail_session(
     // is unreadable, or `session_id` isn't a UUID — so the per-line emit below
     // costs nothing in the common (gate-off) case. Held for the tail's
     // lifetime; the drain thread flushes on channel disconnect at function exit
-    // (RAII) — we deliberately emit NO `session_closed` milestone since a tail
-    // teardown (cancel / rotation / workflow re-check) isn't a reliable
-    // CLI-session-end signal.
+    // (RAII).
+    //
+    // We emit NEITHER a `session_started` NOR a `session_closed` milestone here:
+    // a single real CLI session produces MANY `tail_session` invocations (file
+    // rotation/truncation re-opens the cursor, the discovery loop reschedules a
+    // torn-down tail on the next `Modify`, a runner restart re-discovers every
+    // live transcript), so neither a tail start nor a tail teardown is a
+    // reliable session-lifecycle signal — emitting `started()` per tail floods
+    // `coord.agent_logs` with duplicate `session_started` rows (~one per tail
+    // re-spawn). The per-line `assistant` / `tool_use` emits below ARE the
+    // activity signal, and they are inherently de-duplicated by the byte cursor
+    // (only lines past `cursor` emit), so re-invocation never double-counts
+    // content. The once-per-session `session_started` milestone belongs to the
+    // UI-interactive spawn path (`session.rs`), which fires exactly once per
+    // genuine `ClaudeSession::spawn`.
     let agent_log_emitter = uuid::Uuid::parse_str(&session_id)
         .ok()
         .and_then(AgentLogEmitter::start);
-    if let Some(em) = agent_log_emitter.as_ref() {
-        em.started("interactive CLI session");
-    }
 
     debug!(
         "transcript_watcher: tail started for {} at offset {} ({})",


### PR DESCRIPTION
## What
Follow-up to the interactive-agent-logs plan (Phases 1–3, all shipped). During the gate-ON (`QONTINUI_AGENT_LOGS_FROM_SESSIONS`) burn-in, `coord.agent_logs` filled with **content-free `session_started` rows — ~25 per session over ~2 minutes** (9 distinct sessions, all `is_interactive=true`, nothing but `session_started`).

## Root cause
Phase 2's `transcript_watcher::tail_session` called `em.started(...)` once per invocation — but a single real CLI session produces **many** `tail_session` invocations:
- file rotation/truncation re-opens the cursor,
- the discovery loop reschedules a torn-down tail on the next `Modify`,
- a runner restart re-discovers every live transcript.

So a tail *start* is not a reliable session-start signal (exactly symmetric to why Phase 2 already omits `session_closed` on tail teardown). Enabled broadly this would flood `coord.agent_logs` (the plan's Risk #3).

## Fix
Remove the watcher's `session_started` milestone (1 file). The per-line `assistant` / `tool_use` emits remain and are **inherently de-duplicated by the byte cursor** — reschedules resume at EOF (`start_at_eof: true`), so re-invocation never replays content. The once-per-session `session_started` milestone stays on the **UI-interactive spawn path** (`session.rs`), which fires exactly once per genuine `ClaudeSession::spawn`.

## Verify
`cargo check` green. Re-running the gate-ON burn-in on a temp runner to confirm zero `session_started` flood before the gate is enabled on the primary (the `dev-start.ps1` enable is staged but intentionally NOT committed until this lands + the re-run is clean).

Plan: `2026-06-17-interactive-agent-logs-to-coord-dashboard` (post-ship burn-in fix).