### PR TITLE
docs(fleet): migrate bundled vet/implement gate skills to coord work-units (P4 B3 unblock)

### DIFF
--- a/src-tauri/src/fleet_commands/implement-plan.md
+++ b/src-tauri/src/fleet_commands/implement-plan.md
@@ -258,15 +258,17 @@ Rules:
 - If the existing block is already `IN PROGRESS`, refresh the date and append your session marker — multiple agents may pick up the same plan; keep the trail.
 - If the existing block is `SHIPPED` / `SUPERSEDED` / `OBSOLETE`, STOP — implementing a shipped plan is almost certainly a mistake. Confirm with the user before proceeding.
 
-**Push the stamp under ingest-scanned roots.** IN PROGRESS / SHIPPED stamps drive
-`plan_status` gates via coord's plan-ingest worker, which mirrors
-`qontinui-dev-notes/plans/` origin/main into `coord.plans` every ~60s — a registry
-upsert alone is reverted by the next tick (coord #564). When the plan file lives
-under an ingest-scanned root, commit + push the stamped file (for SHIPPED, the
-Step-6 archive commit already does this). Workspace-root `plans/` on dev boxes is
-typically NOT prod-ingested — the push matters only for ingest-scanned roots.
-(claude-config is NOT a coord sole-authority repo — its PRs land via normal
-GitHub flow.)
+**Set the work-unit status directly.** IN PROGRESS / SHIPPED transitions drive
+`unit_status` gates via coord's work-unit registry — there is no longer a
+plan-ingest worker mirroring `qontinui-dev-notes/plans/` file edges into
+`coord.plans`. Transition the work unit explicitly:
+`POST $COORD_HTTP_URL/coord/work-units/<plan stem>/transition`
+`{to_status:"in_progress", by_actor:"<session>"}` (the device-authed registry
+route). The plan .md stamp + archive still apply (commit + push the stamped file
+when archiving — the markdown artifact, its stamps, and the archive step all STAY);
+only the coord-registry transition moved from "push a file edge" to "call the
+transition route". (claude-config is NOT a coord sole-authority repo — its PRs
+land via normal GitHub flow.)
 
 #### Single-stamp invariant — applies to Step 0.5 and Step 6
 
@@ -389,17 +391,17 @@ snake_case-tagged. Parse it:
 #### Cancel a pending continuation on takeover
 
 Taking the phase claim directly means THIS session is doing the work a
-`plan_ready` gate's continuation may have queued as a fresh runner-terminal
+`unit_ready` gate's continuation may have queued as a fresh runner-terminal
 spawn. Leaving that pending continuation alive means the runner spawns a
 **redundant terminal** on its next WS reconnect (its in-process dedupe set is
 forgotten across restarts, and the pending row survives up to 24h). So,
 **best-effort, right after the FIRST phase claim of this run succeeds** (do it
 once per run, not per phase):
 
-1. Resolve the `plan_id` for this plan-stem via
-   `GET $COORD_HTTP_URL/coord/plans/<plan-stem>` (or the upsert used elsewhere).
-2. Query the plan's gates for a pending continuation:
-   `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>` → rows where
+1. Resolve the `work_unit_id` for this plan-stem via
+   `GET $COORD_HTTP_URL/coord/work-units/<plan-stem>` (or the upsert used elsewhere).
+2. Query the work unit's gates for a pending continuation:
+   `GET $COORD_HTTP_URL/coord/gates?work_unit_id=<id>` → rows where
    `continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
    continuation_cancelled_at == null`.
 3. For each such gate, fire (operator/`TenantId` bearer — same auth layer as
@@ -1091,7 +1093,7 @@ Once Steps 1–5 land cleanly:
 
    Use a plain `mv plans/<name>.md qontinui-dev-notes/plans/<name>.md`. The plan's followup file (if any) stays in whichever location matches its own state — completed plans go to dev-notes, plans with open items stay at the workspace root.
 
-3. **Commit the archived plan in dev-notes.** Single commit with message like `plans: archive <plan-name> as shipped (<commit-sha-summary>)`. Push. This push is also what durably transitions the `coord.plans` registry row for `plan_status` gates (the ingest worker mirrors dev-notes origin/main; a registry upsert alone is reverted by the next tick — coord #564) — don't skip it.
+3. **Commit the archived plan in dev-notes.** Single commit with message like `plans: archive <plan-name> as shipped (<commit-sha-summary>)`. Push. The archive commit is the durable record of the markdown artifact; it no longer drives the coord registry (the ingest worker is gone). Transition the work unit's status to SHIPPED explicitly via `POST $COORD_HTTP_URL/coord/work-units/<plan stem>/transition {to_status:"shipped", by_actor:"<session>"}` so any `unit_status` gate clears — don't skip either.
 
 4. **If the plan was already authored inside `qontinui-dev-notes/plans/`** (e.g. it was vetted there from the start), skip the move; just edit the status block in place and commit.
 
@@ -1118,27 +1120,28 @@ observable trigger (open-ended TODO) is NOT a gate — skip those.
   gate?`, options Register / Skip), showing the derived anchor, predicate kind,
   and human-readable condition. Under opt-in auto mode (env `QONTINUI_AUTO_GATE=1`)
   register WITHOUT asking and report what was registered (gate_id + predicate).
-- **Anchor (zero user input):** `plan_id` from `POST $COORD_HTTP_URL/coord/plans/upsert`
-  with the plan stem as `slug` (or `GET /coord/plans/<slug>`); `phase_name` from
-  the phase heading. Anchor = (plan_id, phase_name). Claim-bound deferrals use the
-  claim-anchored shape (`claim_kind`+`resource_key`) instead.
+- **Anchor (zero user input):** `work_unit_id` from
+  `POST $COORD_HTTP_URL/coord/work-units/upsert` with the plan stem as `slug`
+  (or `GET /coord/work-units/<slug>`); `phase_name` from the phase heading. Anchor
+  = (work_unit_id, phase_name). Claim-bound deferrals use the claim-anchored shape
+  (`claim_kind`+`resource_key`) instead.
 - **Register:** prefer MCP `coord_register_gate` (kinds: `pr_merged`,
   `deploy_healthy`, `claim_terminal`, `operator_approval`, `ci_green`,
-  `ref_exists`, `metric_threshold`, `time_elapsed`, `plan_ready`,
+  `ref_exists`, `metric_threshold`, `time_elapsed`, `unit_ready`,
   `migration_at_head`, `infra_drift_clear`, `file_exists`, `sql_count`,
-  `plan_status`, `gate_cleared`; optional
+  `unit_status`, `gate_cleared`; optional
   `continuation_prompt` e.g. `run /implement-phase <stem> "Phase N"` for
-  auto-resume). **HTTP fallback** when MCP is unavailable — for a plan-anchored gate
-  walk the transport cascade, first reachable wins: (1) the **device loopback
-  write-forwarder** `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<slug>`
-  with header `X-Coord-Mcp-Proxy-Key: <nonce from the live .mcp.json>`, no body
-  bearer (proxy injects the device JWT) — the **only `plan_ready`-capable device
-  door** (`{runner_port}` parsed from the live `.mcp.json` proxy URL, NOT `:9876`);
-  (2) the direct device-authed `POST $COORD_HTTP_URL/coord/plans/<slug>/register-gate`
-  when a raw device JWT is held (resolves tenant from the device JWT + upserts the
-  plan by slug + registers in one call — the operator-only `/coord/gates/register` +
-  `/coord/plans/upsert` 403 `tenant_not_resolved` for a device JWT); (3) MCP only
-  when a `plan_id` is already known; else (claim-anchored, or no device identity)
+  auto-resume). **HTTP fallback** when MCP is unavailable — for a work-unit-anchored
+  gate it is a **TWO-call flow** (the register route never upserts the work unit,
+  and 404s `work_unit_not_found` if the slug isn't present): (1) first
+  `POST $COORD_HTTP_URL/coord/work-units/upsert {slug, title?, status?}` and
+  capture `work_unit_id` from the response; (2) then
+  `POST $COORD_HTTP_URL/coord/work-units/<slug>/register-gate` with a raw device JWT
+  (resolves tenant from the device JWT; body omits `slug`/`work_unit_id`, which come
+  from the path + the predicate). All work-unit routes are device-authed
+  (`require_jwt`), so a device session reaches them directly; the operator-only
+  `/coord/gates/register` is not used for a work-unit anchor. For a claim-anchored
+  gate (no work unit) or with no device identity, fall back to
   `POST $COORD_HTTP_URL/coord/gates/register` (default `https://coord.qontinui.io`).
   Tenant derives server-side — never pass it.
 - **`clearance_audience`:** set `agent` for agent-verifiable facts ("/vet-plan
@@ -1150,14 +1153,14 @@ observable trigger (open-ended TODO) is NOT a gate — skip those.
   `deploy_healthy`; wait-on-CI → `ci_green`; burn-in / wait-N-days →
   `time_elapsed`; metric condition → `metric_threshold` (explicit `labels` — e.g.
   `coord_ci_runner_count` MUST filter `{status:"idle"}`); a vetted plan that is
-  ready, dispatchable work → `plan_ready` (**NOT** `operator_approval` —
-  `operator_approval` is for genuine human decisions, not a work queue);
-  schema/alembic-at-head → `migration_at_head` `{schema}`; infra drift cleared →
-  `infra_drift_clear`; a repo file/workflow existing → `file_exists`
+  ready, dispatchable work → `unit_ready` `{work_unit_id, ready_status}` (**NOT**
+  `operator_approval` — `operator_approval` is for genuine human decisions, not a
+  work queue); schema/alembic-at-head → `migration_at_head` `{schema}`; infra drift
+  cleared → `infra_drift_clear`; a repo file/workflow existing → `file_exists`
   `{repo,path,on_ref?}` (contents, not refs); a coord data count crossing a bound
   → `sql_count` `{query_id,op,n}` (whitelisted `query_id`, never raw SQL); an
-  umbrella plan reaching a status → `plan_status` `{plan_slug,status}`; another
-  cross-anchor gate clearing → `gate_cleared` `{gate_id}`;
+  umbrella work unit reaching a status → `unit_status` `{work_unit_id, status}`;
+  another cross-anchor gate clearing → `gate_cleared` `{gate_id}`;
   needs-human → `operator_approval`. Anything **security / credential / billing /
   strategy-sensitive** registers as `operator_approval` + notify — never an
   auto-resuming gate, never silently auto-registered.
@@ -1176,7 +1179,7 @@ session gated now finishes), it MUST attest that gate — otherwise an agent-fac
 gate rots open until a human clicks it.
 
 - **Find the gate:** by the `gate_id` recorded at registration, or by lookup
-  `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>&phase_name=<name>` — the OPEN
+  `GET $COORD_HTTP_URL/coord/gates?work_unit_id=<id>&phase_name=<name>` — the OPEN
   gate whose condition the completed work satisfies.
 - **Attest:** prefer MCP `coord_attest_gate` (pass `gate_id` — works from a device
   session since attest takes no plan upsert); fall back to the device loopback
@@ -1192,18 +1195,17 @@ gate rots open until a human clicks it.
 - **Honesty:** NEVER report a deferred item as done without EITHER a cleared
   `gate_id` OR an explicit "gate not found" note.
 
-**Continuation cancel (refresh + takeover).** A CLEARED `plan_ready` gate may have
+**Continuation cancel (refresh + takeover).** A CLEARED `unit_ready` gate may have
 dispatched a pending runner-terminal continuation. If you **re-register** a gate
-for the same plan/anchor, or this run **directly takes over** the work a pending
-continuation was queued for (the active takeover wiring lives in Step 0.6), first
-cancel that pending continuation so the runner does not spawn a redundant
-terminal: find it via `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>` (rows with
+for the same work-unit/anchor, or this run **directly takes over** the work a
+pending continuation was queued for (the active takeover wiring lives in Step 0.6),
+first cancel that pending continuation so the runner does not spawn a redundant
+terminal: find it via `GET $COORD_HTTP_URL/coord/gates?work_unit_id=<id>` (rows with
 `continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
 continuation_cancelled_at == null`), then
 `POST $COORD_HTTP_URL/coord/gates/:gate_id/continuation-cancel`
-`{cancelled_by, reason}` (`TenantId` auth — **NOT** available over the device
-loopback write-forwarder, which serves only `register-plan` + `attest`; cancel
-stays on the operator/`TenantId` path, unchanged). Best-effort, never blocking:
+`{cancelled_by, reason}` (`TenantId` auth, on the operator/`TenantId` path,
+unchanged). Best-effort, never blocking:
 404 = nothing pending; **409 `already_consumed` = a spawn already happened, report
 it honestly** rather than claiming the cancel landed. Narrate the cancelled
 `gate_id`. (canonical spec: `_gate-registration` → "Continuation cancel + refresh".)

--- a/src-tauri/src/fleet_commands/vet-plan.md
+++ b/src-tauri/src/fleet_commands/vet-plan.md
@@ -351,59 +351,54 @@ After stamping, fire the clearing `POST /coord/status` documented in
 Step 0 with `current_task: null` so the dashboard tile stops showing
 this vet session as in-flight.
 
-### 5.4. Register a `plan_ready` gate for the vetted plan (dispatchable-work queue)
+### 5.4. Register a `unit_ready` gate for the vetted plan (dispatchable-work queue)
 
 *(canonical spec: `_gate-registration` — keep copies in sync)*
 
 A VETTED plan is **ready, dispatchable work** — not a human decision. When you
-stamp VETTED, register (or **refresh** an existing) `plan_ready` gate so coord
+stamp VETTED, register (or **refresh** an existing) `unit_ready` gate so coord
 turns the ready plan into a queued continuation that dispatches into a session
 the operator can **see**, instead of leaving the plan to rot until someone
 clicks. This **replaces** the old `operator_approval`-bootstrap gate that used
-to queue ready work: a work queue is `plan_ready`, NOT `operator_approval`
+to queue ready work: a work queue is `unit_ready`, NOT `operator_approval`
 (`operator_approval` is for genuine human decisions only — see the predicate
 guidance in `_gate-registration`).
 
 Register exactly once per VETTED stamp (refresh, don't duplicate):
 
-> **Agent sessions: use the device-authed door.** A vetting agent holds a coord
-> **device JWT** (carrying `tenant_id`) but **no `OperatorContext`**, so the
-> operator-only `POST /coord/plans/upsert` and `POST /coord/gates/register` both
-> 403 `tenant_not_resolved` — the designed §5.4 auto-dispatch silently never
-> fired from a vetting agent. For a `plan_ready` gate the MCP tool is **not**
-> usable from a proxy-shaped device session (it needs a pre-resolved `plan_id` and
-> `/coord/plans/upsert` 403s a bare device JWT), so prefer, in order: (1) the
-> **device loopback write-forwarder**
-> `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<plan stem>`
-> with header `X-Coord-Mcp-Proxy-Key: <nonce from the live .mcp.json>` and **no
-> body bearer** (the runner proxy injects a fresh device JWT → coord's
-> `/coord/plans/<slug>/register-gate`; atomic slug-upsert + register) — the only
-> device-reachable door for `plan_ready`; `{runner_port}` = parse the proxy URL in
-> the live `.mcp.json` (NOT `:9876`), nonce = `X-Coord-Mcp-Proxy-Key` from that
-> same file (prefer the coord-repo `.mcp.json`)
-> (`2026-06-15-coord-mcp-live-token-write-forwarder`); (2) the **direct
-> device-authed HTTP endpoint** `POST $COORD_HTTP_URL/coord/plans/<plan
-> stem>/register-gate` when a raw device JWT is actually held, which resolves
-> tenant from the device JWT, **upserts the plan row by slug (folding step 1)**,
-> and registers the gate in one call — NOT the operator-only routes; (3) MCP
-> `coord_register_gate` only when a `plan_id` is already known (non-`plan_ready`).
-> Only if no device identity is available at all does the acting-user-token dance
-> apply. (`2026-06-15-coord-device-authed-plan-ready-gate-registration`.)
+> **Agent sessions: use the device-authed work-unit door.** A vetting agent holds
+> a coord **device JWT** (carrying `tenant_id`) but **no `OperatorContext`**. The
+> work-unit DML routes are on the same `require_jwt` sub-router as the gate
+> register, so a device/agent JWT reaches all of them — the operator-only
+> `/coord/gates/register` is not used here. Registration is now a **TWO-call
+> flow**: first `POST /coord/work-units/upsert` to create the row (capture its
+> `work_unit_id` UUID), then `POST /coord/work-units/<slug>/register-gate` — the
+> register route does **NOT** upsert (unlike the old `register_plan_gate`) and
+> **404s `work_unit_not_found`** if the slug isn't present. Prefer the transports
+> in order: (1) MCP `coord_register_gate` over the `/coord-mcp` proxy (now
+> device-usable, since `/coord/work-units/upsert` is device-authed); (2) the
+> **direct device-authed HTTP route** `POST $COORD_HTTP_URL/coord/work-units/<plan
+> stem>/register-gate` with a raw device JWT, after the upsert; (3) the
+> acting-user-service-token on the same routes only if no device identity is
+> available at all. (`2026-06-18-coord-generic-work-unit-primitive`.)
 
-1. **Resolve `plan_id`.** For the MCP path, `POST $COORD_HTTP_URL/coord/plans/upsert`
-   with `{ "slug": "<plan stem>", "title": "<plan H1>" }` (idempotent on slug; the
-   stem is the filename without `.md`/path, the same `<plan-stem>` Step 0 used) —
-   but this route is operator-only and **403s for an agent session**, so a vetting
-   agent should instead use the device-authed `register-gate` endpoint in step 4,
-   which upserts the plan itself. The returned `plan_id` anchors the gate.
+1. **Upsert the work unit, capture `work_unit_id`.**
+   `POST $COORD_HTTP_URL/coord/work-units/upsert` with
+   `{ "slug": "<plan stem>", "title": "<plan H1>" }` (idempotent on slug; the
+   stem is the filename without `.md`/path, the same `<plan-stem>` Step 0 used).
+   This route is **device-authed** (`require_jwt`), so it works from a vetting
+   agent's device JWT. Capture `work_unit_id` (a UUID) from the response — it
+   anchors the gate AND is carried inside the `unit_ready` predicate. Optionally
+   set `"status"` if you want the row stamped (statuses are opaque caller strings,
+   not a vocabulary); the gate's `ready_status` decides clearing, not this.
 2. **Resolve the operator's `device_id` DYNAMICALLY** (never hardcode a UUID):
    env `QONTINUI_MACHINE_ID` first, else read `~/.qontinui/machine.json` and parse
    `"device_id"` (fall back to `"machine_id"` if present). If neither yields a
    UUID, skip the continuation spawn but still register the gate (notify-only) and
    note it in the report.
-3. **Check for an existing gate** anchored to this plan
-   (`GET $COORD_HTTP_URL/coord/gates?plan_id=<id>` — find an OPEN `plan_ready`
-   gate for this plan). If one exists, **refresh** it (re-register / update the
+3. **Check for an existing gate** anchored to this work unit
+   (`GET $COORD_HTTP_URL/coord/gates?work_unit_id=<id>` — find an OPEN `unit_ready`
+   gate for this work unit). If one exists, **refresh** it (re-register / update the
    continuation) rather than creating a duplicate. **Before refreshing, cancel
    the prior gate's PENDING continuation** so the old queued runner-terminal spawn
    does not fire alongside the new one: for any row in that GET with
@@ -411,32 +406,29 @@ Register exactly once per VETTED stamp (refresh, don't duplicate):
    continuation_cancelled_at == null`, fire
    `POST $COORD_HTTP_URL/coord/gates/:gate_id/continuation-cancel`
    `{cancelled_by:"<this session>", reason:"refreshed — superseded by re-registration"}`
-   (`TenantId` auth, tenant derives server-side — **NOT** available over the device
-   loopback write-forwarder, which serves only `register-plan` + `attest`; cancel
-   stays on the operator/`TenantId` path). Best-effort: a 404 = nothing pending; a
-   409 `already_consumed` = a spawn already happened (report it, don't pretend the
-   cancel landed). (canonical spec: `_gate-registration` →
+   (`TenantId` auth, tenant derives server-side). Best-effort: a 404 = nothing
+   pending; a 409 `already_consumed` = a spawn already happened (report it, don't
+   pretend the cancel landed). (canonical spec: `_gate-registration` →
    "Continuation cancel + refresh".)
-4. **Register** via the transport cascade in the blockquote above: for a proxy-shaped
-   device session, the **device loopback write-forwarder**
-   `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<plan stem>`
-   (header `X-Coord-Mcp-Proxy-Key`, no body bearer — proxy injects the device JWT)
-   is the only `plan_ready`-capable door; when a raw device JWT is held, the direct
-   device-authed `POST $COORD_HTTP_URL/coord/plans/<plan stem>/register-gate`
-   (resolves tenant from the device JWT, upserts the plan by the `:slug` path param,
-   then registers; body omits `slug`/`plan_id`, which come from the path + JWT). MCP
-   `coord_register_gate` only when a `plan_id` is already known. The legacy
-   operator-only `POST /coord/gates/register` 403s for an agent — do not fall back
-   to it.
-   - **Predicate:** `{"kind": "plan_ready", "plan_slug": "<plan stem>"}` — coord
-     auto-clears it when `coord.plans.status == 'vetted'` AND every other gate
-     anchored to this plan is cleared. (The device-authed endpoint accepts any
+4. **Register** via the transport cascade in the blockquote above, AFTER step 1's
+   upsert (the register route never creates the work unit and 404s
+   `work_unit_not_found` if you skip the upsert): the direct device-authed
+   `POST $COORD_HTTP_URL/coord/work-units/<plan stem>/register-gate` (resolves
+   tenant from the device JWT; body omits `slug`/`work_unit_id`, which come from
+   the path + the predicate), or MCP `coord_register_gate` over the `/coord-mcp`
+   proxy. The legacy operator-only `POST /coord/gates/register` is not used here.
+   - **Predicate:** `{"kind": "unit_ready", "work_unit_id": "<uuid from step 1>",
+     "ready_status": "vetted"}` — coord auto-clears it when
+     `coord.work_units.status == <ready_status>` AND every other gate anchored to
+     this work unit is cleared. (The device-authed endpoint accepts any
      **predicate-cleared** kind; only `operator_approval` — a human decision — is
      rejected 403, so it can never become a work-queue-as-decision fallback.)
-   - **Anchor:** the plan. On the device-authed endpoint the `plan_id` comes from
-     the by-slug upsert; pass `phase_name` (the plan title, or a synthetic label
-     like `"vet→implement handoff"` for a whole-plan gate — `phase_name` is
-     **required**, since coord's plan anchor is `plan_id` + `phase_name` together).
+   - **Anchor:** the work unit. The `work_unit_id` comes from step 1's upsert
+     (and must match the `work_unit_id` inside the predicate — coord enforces this
+     cross-anchor guard). Pass `phase_name` (the plan title, or a synthetic label
+     like `"vet→implement handoff"` for a whole-unit gate — `phase_name` is
+     **required**, since coord's work-unit anchor is `work_unit_id` + `phase_name`
+     together).
    - **`continuation_spawn`:** target the operator's device with a **visible**
      session —
      ```json
@@ -462,25 +454,28 @@ Register exactly once per VETTED stamp (refresh, don't duplicate):
      repo) as the cwd, so the session edits a per-session worktree under a
      `kind=worktree` claim from the first tick. If the plan genuinely touches no
      repo (a pure-investigation plan), `[]` is acceptable.
-   - **`clearance_audience`:** `plan_ready` auto-clears by predicate, so audience
+   - **`clearance_audience`:** `unit_ready` auto-clears by predicate, so audience
      is moot for *clearing*; register consistently with the model (default
      `operator`) — the typed predicate, not a human, is what clears it.
 5. **Masked-tool honesty + verification:** if `coord_register_gate` reads as
    unknown/method-not-found (per-agent allow-set masking) fall back to HTTP, and
    NEVER report a gate registered/refreshed without a returned `gate_id`.
 
-(If coord doesn't yet accept `plan_ready` — e.g. the deploy that ships coord
-PR #356 hasn't landed — report the gate as NOT registered with the reason, rather
-than silently registering an `operator_approval` fallback that would re-create the
-work-queue-as-decision antipattern.)
+(If coord doesn't yet accept `unit_ready` — e.g. the deploy that ships the
+work-unit primitive hasn't landed — report the gate as NOT registered with the
+reason, rather than silently registering an `operator_approval` fallback that
+would re-create the work-queue-as-decision antipattern.)
 
-**Push the stamped file (ingest-scanned roots).** If the plan lives under an
-ingest-scanned root (`qontinui-dev-notes/plans/` archive — the active root on
-dev boxes), the VETTED stamp MUST be committed + pushed: a registry upsert alone
-is reverted by the next plan-ingest tick (coord #564) until the edge-trigger fix
-ships, and even after, the push is what makes the transition durable-by-design —
-file edges are the canonical transition signal. (claude-config is NOT a coord
-sole-authority repo — its PRs land via normal GitHub flow.)
+**Set the work-unit status directly + push the stamped file.** Transition the
+work unit's status in coord by calling
+`POST $COORD_HTTP_URL/coord/work-units/<plan stem>/transition`
+`{to_status:"vetted", by_actor:"<this session>"}` (the device-authed registry
+route — there is no plan-ingest worker mirroring file edits any more). Separately,
+the plan .md's VETTED stamp + its archive still apply: if the plan lives under
+`qontinui-dev-notes/plans/`, commit + push the stamped file (the markdown artifact,
+its stamps, and the archive step all STAY — only the coord-registry transition
+moved from "push a file edge" to "call the transition route"). (claude-config is
+NOT a coord sole-authority repo — its PRs land via normal GitHub flow.)
 
 ### 5.5. Offer to register a coord gate for a flagged-but-not-fixed item
 
@@ -498,24 +493,24 @@ leave it in the report.
   options Register / Skip), showing the derived anchor + predicate + condition.
   Under opt-in auto mode (env `QONTINUI_AUTO_GATE=1`) register without asking and
   note the gate_id in the report.
-- **Anchor (zero user input):** `plan_id` from `POST $COORD_HTTP_URL/coord/plans/upsert`
-  with the plan stem as `slug` (or `GET /coord/plans/<slug>`); `phase_name` from
-  the relevant phase/section heading. Anchor = (plan_id, phase_name).
+- **Anchor (zero user input):** `work_unit_id` from
+  `POST $COORD_HTTP_URL/coord/work-units/upsert` with the plan stem as `slug`
+  (or `GET /coord/work-units/<slug>`); `phase_name` from the relevant
+  phase/section heading. Anchor = (work_unit_id, phase_name).
 - **Register:** prefer MCP `coord_register_gate` (kinds: `pr_merged`,
   `deploy_healthy`, `claim_terminal`, `operator_approval`, `ci_green`,
-  `ref_exists`, `metric_threshold`, `time_elapsed`, `plan_ready`,
+  `ref_exists`, `metric_threshold`, `time_elapsed`, `unit_ready`,
   `migration_at_head`, `infra_drift_clear`, `file_exists`, `sql_count`,
-  `plan_status`, `gate_cleared`; optional
+  `unit_status`, `gate_cleared`; optional
   `continuation_prompt`). **HTTP fallback** when MCP is unavailable — for a
-  plan-anchored gate walk the transport cascade, first reachable wins: (1) the
-  **device loopback write-forwarder**
-  `POST http://127.0.0.1:{runner_port}/coord-mcp/gates/register-plan/<slug>` with
-  header `X-Coord-Mcp-Proxy-Key: <nonce from the live .mcp.json>`, no body bearer
-  (proxy injects the device JWT) — the **only `plan_ready`-capable device door**
-  (`{runner_port}` parsed from the live `.mcp.json` proxy URL, NOT `:9876`);
-  (2) the direct device-authed `POST $COORD_HTTP_URL/coord/plans/<slug>/register-gate`
-  when a raw device JWT is held; (3) MCP only when a `plan_id` is already known;
-  else (claim-anchored, or no device identity)
+  work-unit-anchored gate it is a **TWO-call flow** (the register route never
+  upserts, and 404s `work_unit_not_found` if the slug isn't present): (1) first
+  `POST $COORD_HTTP_URL/coord/work-units/upsert {slug, title?, status?}` and
+  capture `work_unit_id`; (2) then `POST $COORD_HTTP_URL/coord/work-units/<slug>/register-gate`
+  with a raw device JWT (resolves tenant from the JWT; body omits
+  `slug`/`work_unit_id`). All work-unit routes are device-authed (`require_jwt`),
+  so a device session reaches them directly. For a claim-anchored gate (no work
+  unit) or with no device identity, fall back to
   `POST $COORD_HTTP_URL/coord/gates/register` (default `https://coord.qontinui.io`).
   Tenant derives server-side — never pass it.
 - **`clearance_audience`:** set `agent` for agent-verifiable facts ("/vet-plan
@@ -526,15 +521,15 @@ leave it in the report.
 - **Predicate choice:** wait-on-PR → `pr_merged`; wait-on-deploy →
   `deploy_healthy`; wait-on-CI → `ci_green`; burn-in → `time_elapsed`; metric →
   `metric_threshold` (explicit `labels` — e.g. `coord_ci_runner_count` MUST filter
-  `{status:"idle"}`); a vetted plan that is ready, dispatchable work → `plan_ready`
-  (**NOT** `operator_approval` — `operator_approval` is for genuine human
-  decisions, not a work queue); schema/alembic-at-head → `migration_at_head`
-  `{schema}`; infra drift cleared → `infra_drift_clear`; a repo file/workflow
-  existing → `file_exists` `{repo,path,on_ref?}` (contents, not refs); a coord
-  data count crossing a bound → `sql_count` `{query_id,op,n}` (whitelisted
-  `query_id`, never raw SQL); an umbrella plan reaching a status → `plan_status`
-  `{plan_slug,status}`; another cross-anchor gate clearing → `gate_cleared`
-  `{gate_id}`; needs-human → `operator_approval`. Anything
+  `{status:"idle"}`); a vetted plan that is ready, dispatchable work → `unit_ready`
+  `{work_unit_id, ready_status}` (**NOT** `operator_approval` — `operator_approval`
+  is for genuine human decisions, not a work queue); schema/alembic-at-head →
+  `migration_at_head` `{schema}`; infra drift cleared → `infra_drift_clear`; a repo
+  file/workflow existing → `file_exists` `{repo,path,on_ref?}` (contents, not
+  refs); a coord data count crossing a bound → `sql_count` `{query_id,op,n}`
+  (whitelisted `query_id`, never raw SQL); an umbrella work unit reaching a status
+  → `unit_status` `{work_unit_id, status}`; another cross-anchor gate clearing →
+  `gate_cleared` `{gate_id}`; needs-human → `operator_approval`. Anything
   **security / credential / billing / strategy-sensitive** → `operator_approval` +
   notify, never an auto-resuming gate, never silently auto-registered.
 - **Masked-tool honesty:** if `coord_register_gate` fails as unknown/
@@ -544,9 +539,9 @@ leave it in the report.
   gate registered without a returned `gate_id`.
 - The plan-file `## Gates` block is a **local convenience mirror only** — coord is
   the source of truth; never require it, never read it back as authoritative.
-- **Re-registering for the same plan/anchor:** first cancel the prior gate's
+- **Re-registering for the same work-unit/anchor:** first cancel the prior gate's
   PENDING continuation (the §5.4 refresh-cancel rule applies to any
-  continuation-carrying gate too) — `GET .../coord/gates?plan_id=<id>` for rows
+  continuation-carrying gate too) — `GET .../coord/gates?work_unit_id=<id>` for rows
   with `continuation_dispatched_at != null ∧ continuation_consumed_at == null ∧
   continuation_cancelled_at == null`, then
   `POST .../coord/gates/:gate_id/continuation-cancel {cancelled_by, reason}`
@@ -559,7 +554,7 @@ registered gate was watching, it MUST attest that gate (otherwise an agent-fact
 gate rots open until a human clicks it).
 
 - **Find the gate:** by the `gate_id` recorded at registration, or by lookup
-  `GET $COORD_HTTP_URL/coord/gates?plan_id=<id>&phase_name=<name>` — the OPEN
+  `GET $COORD_HTTP_URL/coord/gates?work_unit_id=<id>&phase_name=<name>` — the OPEN
   gate whose condition the completed work satisfies.
 - **Attest:** prefer MCP `coord_attest_gate` (pass `gate_id` — works from a device
   session since attest takes no plan upsert); fall back to the device loopback


### PR DESCRIPTION
## Migrate bundled fleet vet/implement gate-registration skills to coord work-units

**Why (precondition for the P4 plan-decoupling work).** These two `.md` files are compiled into the runner binary via `include_str!` (`fleet_commands.rs`) and provisioned into every spawned fleet session — they are the **fleet-wide** copy of the gate-registration harness. Coord's plan-coupled gate surface (`plan_ready`/`plan_status`/`/coord/plans*`) is being removed in P4; this migrates the bundled skills onto coord's already-shipped work-unit door (P3) so P4 can land without breaking the fleet's vet→implement→gate loop.

**B3 unblock** for `plans/2026-06-18-coord-decommission-markdown-plan-ingest.md` (precondition — NOT the P4 removal itself). Pairs with claude-config PR #100 (the operator-local copies).

### What changed (`src-tauri/src/fleet_commands/{vet-plan,implement-plan}.md`)
- Routes → `/coord/work-units/{upsert,:slug/register-gate,:slug/transition}`.
- Predicates `plan_ready`/`plan_status` → `unit_ready {work_unit_id, ready_status}` / `unit_status {work_unit_id, status}` (UUID, not slug).
- **Two-call flow:** upsert work-unit (capture `work_unit_id`) → register-gate (404s if upsert skipped).
- Registration via `coord_work_unit_upsert` + `coord_register_gate` MCP over the `/coord-mcp` proxy; device-JWT/acting-service HTTP fallbacks.
- Attest unchanged (`gate_id`); status-set via `/coord/work-units/<slug>/transition`. Plan-artifact workflow (stamps, `Depends-On`, archive) preserved.

### Verification
`cargo check` clean; `cargo test fleet_commands` green (incl. `provisions_both_fleet_commands_into_dir` — confirms `include_str!` still compiles). Migration cross-checked against coord origin/main; adversarially reviewed; no residual live `plan_*` instructions.

### Land order (important)
Opened as **draft** intentionally — land this (and #100) **before** the coord P4 removal PR, and after `QONTINUI_PLAN_ADAPTER_DIR` is set + the adapter verified mirroring. Both surfaces coexist until P4, so it's safe whenever you're ready; draft keeps coord from auto-landing it before your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
