### PR TITLE
chore(release): publish runner releases as latest (non-draft, non-prerelease)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,3 +337,18 @@ jobs:
           files: update.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # All platform installers, checksums, and the update manifest are now
+      # uploaded to the draft release. Flip it to published + non-prerelease as
+      # the final step so it resolves as GitHub's "latest" release (which the
+      # qontinui.io download endpoints query) and the auto-updater can see it.
+      # Doing this last means users never see a release with missing assets.
+      # The "(Beta)" label stays in the release title.
+      - name: Publish release (un-draft, mark as latest)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "v${{ needs.create-release.outputs.release_version }}" \
+            --repo "${{ github.repository }}" \
+            --draft=false \
+            --prerelease=false


### PR DESCRIPTION
## What
The release workflow created every release as **`draft: true` + `prerelease: true`**, which means:
- A **draft** release isn't publicly downloadable and its asset URLs require auth.
- A **prerelease** is excluded from `github.com/.../releases/latest`.

So tagged releases were never actually consumable. This blocks the new qontinui.io download endpoints (qontinui-web #646), which resolve installers against the GitHub `/releases/latest` API, and it also blocks the Tauri auto-updater, whose endpoint points at the latest release.

## Change
Adds a final step to the existing `publish-update-json` job (which already `needs: [create-release, build]`) that flips the release to **published + non-prerelease** with `gh release edit --draft=false --prerelease=false`, **after** all platform installers, checksums, and the update manifest have been uploaded to the draft.

```yaml
- name: Publish release (un-draft, mark as latest)
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    gh release edit "v${{ needs.create-release.outputs.release_version }}" \
      --repo "${{ github.repository }}" \
      --draft=false \
      --prerelease=false
```

### Why publish *last* rather than flip the create step
Keeping the build-time upload steps as `draft: true` means the release stays hidden while assets upload (tens of minutes across the platform matrix). Publishing in the final step is atomic from a viewer's perspective — users never see a "latest" release with missing or partial assets.

The `(Beta)` label stays in the release title (`release_name`); only the prerelease *flag* changes, which is what GitHub's "latest" resolution keys on.

## Test
- `release.yml` parses as valid YAML; the `publish-update-json` job now ends with the publish step. `gh` CLI is preinstalled on `ubuntu-latest`.
- End-to-end exercise requires pushing a `v*` tag (out of scope for this PR).

## Related
- qontinui-web #646 — the download endpoints + page that consume the now-resolvable latest release.