### PR TITLE
fix: bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6645,9 +6645,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What
Bumps the transitive dependency `quinn-proto` **0.11.14 → 0.11.15** (via `cargo update -p quinn-proto`), a semver-compatible patch.

## Why
The required **`security`** check (`cargo audit`) began failing **fleet-wide** after [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) was published — *"Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly."* The advisory DB is fetched fresh on every run, so this started failing on time, not on any code change: the `security` job was green on `main` as of 2026-06-22 and is now red on `main` and every open runner PR. `quinn-proto` is pulled in transitively via `quinn 0.11.9` (not referenced in any `Cargo.toml`); `0.11.15` is the patched release.

## Verification
```
# before
$ cargo audit --file Cargo.lock --ignore RUSTSEC-2023-0071
Crate: quinn-proto  ID: RUSTSEC-2026-0185 ... error: 1 vulnerability found!

$ cargo update -p quinn-proto        # 0.11.14 -> 0.11.15

# after
$ cargo audit --file Cargo.lock --ignore RUSTSEC-2023-0071 ; echo $?
0
```
Lockfile change is exactly the `quinn-proto` version + checksum (2 lines). The build is verified by this PR's required `test (ubuntu-22.04)` / `test (windows-latest)` jobs.

## Impact
Unblocks the `security` gate for `main` and all open runner PRs — including #639 (the release-workflow change), which this should land ahead of.