### PR TITLE
fix(deps): bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185, clears CI security)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6645,9 +6645,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Bump `quinn-proto` 0.11.14 → 0.11.15 (clears the CI `security` job)

The CI **`security`** job (`cargo audit`, `.github/workflows/ci.yml:503`) is failing on **1 vulnerability**:

- **`quinn-proto 0.11.14` — RUSTSEC-2026-0185**: *remote memory exhaustion from unbounded out-of-order stream reassembly* (published 2026-06-20). Patched in **0.11.15**.

`quinn-proto` is a transitive dep (via `quinn`). This is a **lockfile-only, single-package** bump.

### Not a regression from any feature PR
The advisory was published 2026-06-20 and propagated into the cargo-audit advisory DB after `main`'s last green `security` run (2026-06-22) — so **`main` itself fails this audit today**; it's a fleet-wide, time-of-check dependency advisory, not introduced by recent changes. (It's why the unrelated docs PR #638 also shows a red `security` check.)

The 24 `cargo audit` **warnings** (unmaintained gtk-rs GTK3 bindings, yanked `core2`, `memmap2` unsoundness, …) are not affected here — they're warnings, not vulnerabilities, and the job already tolerates them (no `--deny warnings`).

### Verification
Ran the **exact** CI command locally after the bump:
```
cargo audit --file Cargo.lock --ignore RUSTSEC-2023-0071
```
→ **exit 0, 0 vulnerabilities** (only the pre-existing allowed warnings remain). Diff is `Cargo.lock` only (2 lines: version + checksum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
