### PR TITLE
fix(release): ship Windows+Linux even when macOS builds fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,13 @@ env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
 jobs:
-  # Build Python executor for bundling (optional)
+  # Build Python executor for bundling (optional). Opt-in via workflow_dispatch
+  # only — tag releases skip it to cut build-failure surface (the macOS Python
+  # dependency install is flaky and the bundled executor is optional; the runner
+  # falls back to a system Python). The `build` job already tolerates its absence
+  # via the conditional "Download Python executor" step.
   build-python-executor:
-    if: ${{ github.event.inputs.include_bundled_python != 'false' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.include_bundled_python != 'false' }}
     uses: ./.github/workflows/build-python-executor.yml
     with:
       include_cuda: ${{ github.event.inputs.include_cuda == 'true' }}
@@ -91,6 +95,9 @@ jobs:
     # Run even if build-python-executor was skipped (when include_bundled_python is false)
     if: ${{ always() && needs.create-release.result == 'success' }}
     strategy:
+      # Don't let one platform's failure cancel the others — a broken macOS leg
+      # must not take down healthy Windows/Linux builds.
+      fail-fast: false
       matrix:
         include:
           - platform: ubuntu-22.04
@@ -107,6 +114,12 @@ jobs:
             name: windows-x64
 
     runs-on: ${{ matrix.platform }}
+    # macOS builds are currently broken (x86_64 cross-compile + Python deps);
+    # tolerate their failure so the release still ships Windows + Linux. The
+    # `build` job stays a hard gate for Windows/Linux, so publish-update-json
+    # only runs when those succeed (never an empty/assetless release). Tracked
+    # as a follow-up to repair macOS and drop continue-on-error.
+    continue-on-error: ${{ startsWith(matrix.platform, 'macos') }}
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## What
Makes the release workflow resilient so a broken macOS leg can't sink the whole release.

- `strategy.fail-fast: false` on the `build` matrix — one platform's failure no longer cancels the others.
- `continue-on-error: ${{ startsWith(matrix.platform, 'macos') }}` — macOS legs may fail without failing the `build` job. **Windows and Linux stay hard gates**, so `publish-update-json` (`needs: [build]`) only runs when those succeed → never an empty/assetless release.
- Skip the optional **bundled-Python executor** on tag pushes (now `workflow_dispatch`-only). Its macOS Python-dep install is flaky and `build` already tolerates its absence via the conditional download step.

## Why
The `v1.0.0` tag's release run **failed and published nothing**:
- `build (macos-x64)` → `error[E0463]: can't find crate for 'core'` (the `x86_64-apple-darwin` std isn't installed — GitHub's `macos-latest` is Apple Silicon now; Intel cross-compile needs `rustup target add x86_64-apple-darwin`).
- `build-python-executor (macos-arm64)` → Python dep install failed.
- `fail-fast` then **cancelled the healthy Windows/Linux builds**, and `publish-update-json` was skipped.

This macOS breakage is **pre-existing** — the prior **v0.1.0 release run also failed**. This PR unblocks shipping Windows + Linux now (matching the download page, which already shows "build from source" for macOS/Linux without assets).

## Follow-up (separate)
Repair macOS properly — `rustup target add x86_64-apple-darwin` (+ an arm64 build), fix the Python-dep install — then drop `continue-on-error`.

## Test
`release.yml` parses as valid YAML; `build` now has `fail-fast: false` + macOS-only `continue-on-error`; `build-python-executor` gated to `workflow_dispatch`. Full exercise is the re-tagged `v1.0.0` release run after this lands.