### PR TITLE
docs(runner): fix stale agent_pusher module header (Bearer, not basic-auth)

### DIFF
--- a/src-tauri/src/agent_pusher/mod.rs
+++ b/src-tauri/src/agent_pusher/mod.rs
@@ -10,14 +10,17 @@
 //! ref-update storms) and runs:
 //!
 //! ```text
-//! git -C <worktree_path> push <coord-origin>/git/<repo>.git <branch>
+//! git -C <worktree_path> -c http.extraHeader="Authorization: Bearer <jwt>" \
+//!     push <coord-origin>/git/<repo-basename>.git refs/heads/<branch>:refs/agent/<m>-<a>
 //! ```
 //!
 //! against the coord-hosted git origin (Row 9 Phase 2, §3.4). The push
-//! is authenticated by the agent's coord-issued JWT injected into the
-//! URL as the `x-access-token` basic-auth user (same scheme coord uses
-//! when async-mirroring out to GitHub — see
-//! `qontinui-coord/src/outbound_mirror.rs::inject_token`).
+//! is authenticated by the agent's coord-issued JWT handed to git as an
+//! `Authorization: Bearer` header via `-c http.extraHeader` — coord's
+//! git-http gate is Bearer-only and rejects GitHub-style
+//! `x-access-token:<jwt>@host` basic-auth in the URL
+//! (`qontinui-coord/src/git_replication.rs`), so the origin URL stays
+//! credential-free. See [`build_origin_url`] / [`push_one`].
 //!
 //! ## Why it exists
 //!


### PR DESCRIPTION
Comment-only follow-up to the landed pusher auth fix (commit `21163887`, PR #634).

The `agent_pusher` module-level doc comment still described the old GitHub-style
`x-access-token` basic-auth scheme + the `outbound_mirror::inject_token` reference.
Updated the example `git push` command and the auth paragraph to match what
`build_origin_url` / `push_one` now do: `Authorization: Bearer` via
`-c http.extraHeader`, credential-free URL, repo basename. No code change.

Plan: 2026-06-16-wire-agent-durability-daemons

🤖 Generated with [Claude Code](https://claude.com/claude-code)