### PR TITLE
fix(release): Windows-only v1.0.0 + fix bundle resources glob

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,12 +114,14 @@ jobs:
             name: windows-x64
 
     runs-on: ${{ matrix.platform }}
-    # macOS builds are currently broken (x86_64 cross-compile + Python deps);
-    # tolerate their failure so the release still ships Windows + Linux. The
-    # `build` job stays a hard gate for Windows/Linux, so publish-update-json
-    # only runs when those succeed (never an empty/assetless release). Tracked
-    # as a follow-up to repair macOS and drop continue-on-error.
-    continue-on-error: ${{ startsWith(matrix.platform, 'macos') }}
+    # v1.0.0 ships WINDOWS-ONLY. macOS (x86_64 cross-compile) and Linux release
+    # bundles are currently broken; tolerate their failure so the Windows
+    # installers still publish. Windows is the only platform v0.1.0 ever shipped,
+    # and the download page shows build-from-source for the rest. Only
+    # windows-latest is a hard gate, so publish-update-json runs iff the Windows
+    # installers build (never an empty/assetless release). Tracked as a follow-up
+    # to repair macOS + Linux and drop continue-on-error.
+    continue-on-error: ${{ matrix.platform != 'windows-latest' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -226,7 +228,10 @@ jobs:
         # env:
         #   TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         #   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: pnpm run tauri build -- --target ${{ matrix.target }}
+        # --verbose surfaces the exact bundler step/file if bundling fails
+        # (the terse "cannot find the file specified (os error 2)" otherwise
+        # hides which resource/tool Tauri couldn't resolve).
+        run: pnpm run tauri build --verbose -- --target ${{ matrix.target }}
 
       # - name: Sign Windows executable
       #   if: runner.os == 'Windows'

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "resources/qontinui-setup-mcp/src/qontinui_setup_mcp": "qontinui-setup-mcp/src/qontinui_setup_mcp"
+      "resources/qontinui-setup-mcp/src/qontinui_setup_mcp/**/*": "qontinui-setup-mcp/src/qontinui_setup_mcp"
     },
     "createUpdaterArtifacts": true
   },


### PR DESCRIPTION
## What
Gets a publishable **Windows-only** `v1.0.0` and fixes the Windows bundle regression.

1. **`bundle.resources` glob.** The entry pointed at a bare **directory** (`resources/qontinui-setup-mcp/src/qontinui_setup_mcp`), added 2026-06-19 (after v0.1.0). Tauri v2's resource map resolves files/globs; the bundle died with `failed to bundle project: The system cannot find the file specified (os error 2)` right as it processes resources. Switch to the structure-preserving glob `…/qontinui_setup_mcp/**/*`. **Target path is unchanged**, so the setup-wizard runtime lookup (`<resource_dir>/qontinui-setup-mcp/src/qontinui_setup_mcp/__init__.py`) still resolves.
2. **Windows-only gating.** `continue-on-error` now covers every non-Windows platform — only `windows-latest` is a hard gate, so `publish-update-json` runs iff the Windows installers build. macOS (cross-compile) and Linux (also broken) ship later.
3. **`tauri --verbose`** so any future bundle failure names the exact file/tool instead of the terse os-error-2.

## Why
The re-tagged `v1.0.0` run failed on **all** platforms: Windows compiled+linked but **bundling** failed; Linux was cancelled mid-compile; macOS cross-compile is broken. This is pre-existing (v0.1.0's run also failed). Windows is closest — only packaging was broken — and was the only platform v0.1.0 ever shipped.

## Test
`tauri.conf.json` valid JSON, `release.yml` valid YAML, `continue-on-error` = `${{ matrix.platform != 'windows-latest' }}`. Real validation is the re-tagged `v1.0.0` run after this lands — Windows should now bundle MSI+NSIS and the release publish as latest (non-draft, non-prerelease).

## Follow-up
Repair Linux + macOS release bundles and drop `continue-on-error`.