### PR TITLE
fix(release): Windows NSIS-only bundle + disable unsigned updater artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,12 @@ jobs:
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
             name: windows-x64
+            # NSIS only: the WiX/MSI bundler fails on the GitHub windows-latest
+            # image with a bare "cannot find the file specified (os error 2)" at
+            # bundle start (tool not found). NSIS is self-contained and produces
+            # the -setup.exe installer the download page offers. Re-add msi once
+            # WiX is fixed.
+            bundles: nsis
 
     runs-on: ${{ matrix.platform }}
     # v1.0.0 ships WINDOWS-ONLY. macOS (x86_64 cross-compile) and Linux release
@@ -231,7 +237,7 @@ jobs:
         # --verbose surfaces the exact bundler step/file if bundling fails
         # (the terse "cannot find the file specified (os error 2)" otherwise
         # hides which resource/tool Tauri couldn't resolve).
-        run: pnpm run tauri build --verbose -- --target ${{ matrix.target }}
+        run: pnpm run tauri build --verbose ${{ matrix.bundles && format('--bundles {0}', matrix.bundles) || '' }} -- --target ${{ matrix.target }}
 
       # - name: Sign Windows executable
       #   if: runner.os == 'Windows'
@@ -270,8 +276,8 @@ jobs:
           elif [[ "${{ matrix.platform }}" == "macos-latest" ]]; then
             shasum -a 256 dmg/*.dmg > checksums-${{ matrix.name }}.txt
           elif [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
-            certutil -hashfile msi/*.msi SHA256 > checksums-${{ matrix.name }}.txt
-            certutil -hashfile nsis/*.exe SHA256 >> checksums-${{ matrix.name }}.txt
+            # NSIS-only build (see matrix.bundles) — no msi/ dir is produced.
+            certutil -hashfile nsis/*.exe SHA256 > checksums-${{ matrix.name }}.txt
           fi
 
       - name: Upload release assets (Linux)
@@ -306,7 +312,6 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
             src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
             src-tauri/target/${{ matrix.target }}/release/bundle/checksums-${{ matrix.name }}.txt
         env:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -31,7 +31,7 @@
     "resources": {
       "resources/qontinui-setup-mcp/src/qontinui_setup_mcp/**/*": "qontinui-setup-mcp/src/qontinui_setup_mcp"
     },
-    "createUpdaterArtifacts": true
+    "createUpdaterArtifacts": false
   },
   "plugins": {
     "updater": {


### PR DESCRIPTION
## What
Second iteration toward a publishable **Windows-only** `v1.0.0`. The resources-glob fix (#645) did **not** resolve the Windows bundle failure — it still dies with `failed to bundle project: The system cannot find the file specified (os error 2)` immediately after the app builds, **before any bundler output even with `--verbose`**. That signature = Tauri spawning the **WiX/MSI** bundler tool and it's not found (`targets: "all"` attempts MSI first).

- **NSIS-only for Windows** via a matrix `bundles: nsis` field → skips WiX entirely. NSIS is self-contained and produces the `-setup.exe` the download page already lists. Checksum + upload steps updated to expect only the NSIS `.exe`.
- **`createUpdaterArtifacts: false`** — it requires `TAURI_SIGNING_PRIVATE_KEY`, which CI doesn't set (signing is commented out), so it would fail the build right after NSIS bundling. The auto-updater is unusable without signing regardless.

## Why
The Windows leg compiles + links fine (~1h) but bundling fails at the first tool spawn. Ruling out resources (the #645 glob fix didn't help) leaves the WiX toolchain as the culprit; NSIS sidesteps it. This is the only hard gate for the Windows-only release, so if NSIS bundles, the release publishes.

## Test
`tauri.conf.json` valid JSON (`createUpdaterArtifacts: false`); `release.yml` valid YAML; the Windows matrix entry carries `bundles: nsis` and the build step appends `--bundles nsis` only for Windows. Real validation is the re-tagged `v1.0.0` run after this lands.

## Follow-up
Install/repair WiX to re-enable MSI; add signing to re-enable the updater + the macOS/Linux bundles. (`--verbose` stays on so any remaining failure names itself.)