### PR TITLE
ci: add secret-scan caller (S4.1)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,8 @@
+name: Secret Scan
+
+on:
+  pull_request:
+
+jobs:
+  secret-scan:
+    uses: qontinui/qontinui-coord/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
Add secret-scan job that calls the reusable workflow from qontinui-coord.

Part of S4.1 safety net implementation.

Co-Authored-By: Joshua Spinak <jspinak@gmail.com>