### PR TITLE
feat(terminal): pop out an entire page into its own window

### DIFF
--- a/src-tauri/src/commands/terminal_windows.rs
+++ b/src-tauri/src/commands/terminal_windows.rs
@@ -68,10 +68,21 @@ struct SessionAssignmentChanged {
 fn build_pop_out_webview(
     app: &tauri::AppHandle,
     label: &str,
+    bound_page: Option<&str>,
 ) -> Result<tauri::WebviewWindow, String> {
     // Same embedded bundle; the boot hint makes it render Terminal-only and
     // adopt `term-N` as its window identity (via getCurrentWindow().label).
-    let url = tauri::WebviewUrl::App(format!("index.html?view=terminal&window={}", label).into());
+    // A page-bound pop-out also carries `&page=<id>` so the frontend pins
+    // itself to that one terminal page (ignoring the shared active-page) and
+    // renders only that page's grid.
+    // Page ids are always `"default"` or a v4 UUID (see `useTerminalPages`
+    // `addPage`), both URL-safe — no percent-encoding needed.
+    let url = match bound_page {
+        Some(page) => tauri::WebviewUrl::App(
+            format!("index.html?view=terminal&window={}&page={}", label, page).into(),
+        ),
+        None => tauri::WebviewUrl::App(format!("index.html?view=terminal&window={}", label).into()),
+    };
 
     let mut builder = tauri::WebviewWindowBuilder::new(app, label, url)
         .title(format!("Qontinui Terminal — {}", label))
@@ -101,11 +112,12 @@ pub async fn open_terminal_window(
     app: tauri::AppHandle,
     assignments: tauri::State<'_, Arc<WindowAssignments>>,
     placement: Option<SpawnPlacement>,
+    bound_page: Option<String>,
 ) -> Result<WindowRecord, String> {
-    let record = assignments.create_window(None, None, now_ms());
+    let record = assignments.create_window(None, None, bound_page.clone(), now_ms());
     let label = record.label.clone();
 
-    let window = build_pop_out_webview(&app, &label)?;
+    let window = build_pop_out_webview(&app, &label, bound_page.as_deref())?;
 
     // Apply placement (physical global coords) when provided; otherwise let the
     // OS place it (cascaded near the focused window).
@@ -154,11 +166,18 @@ pub fn restore_pop_out_windows(
     // P2 (orphan sweep): a persisted pop-out's PTYs never survive the process
     // restart — terminal ids are a fresh uuid per launch and are never
     // recreated — so EVERY persisted `session_owner` entry is stale on boot and
-    // every `term-N` record is genuinely empty (no live tab can claim it).
-    // Restoring them just produces empty, un-closable windows whose monotonic
-    // `term-N` counter keeps climbing (the observed orphan-accumulation loop,
-    // `term-19`). So FIRST clear the stale owner map, THEN prune the now-empty
-    // pop-out records, so we neither restore them nor resurrect them next boot.
+    // every PER-ID `term-N` record is genuinely empty (no live tab can claim
+    // it). Restoring those just produces empty, un-closable windows whose
+    // monotonic `term-N` counter keeps climbing (the observed orphan-
+    // accumulation loop, `term-19`). So FIRST clear the stale owner map, THEN
+    // prune the now-empty pop-out records, so we neither restore them nor
+    // resurrect them next boot.
+    //
+    // PAGE-BOUND pop-outs are the exception and are deliberately PRESERVED by
+    // `prune_empty_pop_outs` (they claim terminals by stable `page_id`, not the
+    // cleared owner map). They fall through to the restore loop below and are
+    // rebuilt with their `&page=` boot hint; the page's sessions re-attach there
+    // via the pinned page's normal restore path.
     let cleared = assignments.clear_session_owners();
     let pruned = assignments.prune_empty_pop_outs();
     if cleared > 0 || !pruned.is_empty() {
@@ -176,7 +195,7 @@ pub fn restore_pop_out_windows(
         if app.get_webview_window(&label).is_some() {
             continue; // already open — don't double-build
         }
-        let window = match build_pop_out_webview(app, &label) {
+        let window = match build_pop_out_webview(app, &label, record.bound_page.as_deref()) {
             Ok(w) => w,
             Err(e) => {
                 tracing::warn!(window = %label, error = %e, "restore_pop_out_windows: build failed — skipping");
@@ -223,8 +242,10 @@ pub fn sweep_empty_pop_out_windows(
     let mut swept: Vec<String> = Vec::new();
     for record in assignments.pop_out_records() {
         let label = &record.label;
-        if assignments.has_assigned_sessions(label) {
-            continue; // still hosts a tab — leave it
+        if assignments.has_assigned_sessions(label) || record.bound_page.is_some() {
+            // Still hosts a tab, OR is a page-bound window (claims terminals by
+            // page_id, not the session_owner map) — leave it.
+            continue;
         }
         // Destroy (not close) the live OS window if one is open (best-effort):
         // close() leaves WebView2 pop-outs visible; destroy() forces teardown.

--- a/src-tauri/src/window_assignments.rs
+++ b/src-tauri/src/window_assignments.rs
@@ -78,6 +78,16 @@ pub struct WindowRecord {
     /// Last-known geometry, for Phase-2 restore. Optional today.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub geometry: Option<WindowGeometry>,
+    /// The terminal PAGE this window is bound to, when it hosts a whole
+    /// detached page (the "pop out page" feature) rather than an ad-hoc set of
+    /// individually-moved terminals. Page ids are STABLE across process
+    /// restarts (unlike terminal ids, which are regenerated each launch), so a
+    /// page-bound pop-out is the only kind of pop-out that can survive a reboot:
+    /// its terminals are re-bound by `page_id`, not by the stale `session_owner`
+    /// map. A page-bound window is restored on boot (and skipped by the empty-
+    /// pop-out prune) even though it owns no `session_owner` entries.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub bound_page: Option<String>,
     /// Unix-millis creation time.
     pub created_at: i64,
 }
@@ -147,6 +157,7 @@ impl WindowAssignments {
                     kind: WindowKind::Main,
                     title: None,
                     geometry: None,
+                    bound_page: None,
                     created_at: now_ms,
                 },
             );
@@ -163,6 +174,7 @@ impl WindowAssignments {
         &self,
         title: Option<String>,
         geometry: Option<WindowGeometry>,
+        bound_page: Option<String>,
         now_ms: i64,
     ) -> WindowRecord {
         let (record, snapshot) = {
@@ -179,6 +191,7 @@ impl WindowAssignments {
                         kind: WindowKind::PopOut,
                         title,
                         geometry,
+                        bound_page,
                         created_at: now_ms,
                     };
                 }
@@ -189,6 +202,7 @@ impl WindowAssignments {
                 kind: WindowKind::PopOut,
                 title,
                 geometry,
+                bound_page,
                 created_at: now_ms,
             };
             s.windows.insert(label, record.clone());
@@ -394,10 +408,21 @@ impl WindowAssignments {
             };
             let owned: std::collections::HashSet<&str> =
                 s.session_owner.values().map(|v| v.as_str()).collect();
+            // A PAGE-BOUND pop-out is intentionally retained even with no
+            // `session_owner` entry: its terminals are claimed by `page_id`
+            // (stable across restarts), not by the per-terminal owner map. The
+            // boot orphan sweep clears `session_owner` (all stale), which would
+            // otherwise make every page-bound window look empty and prune it —
+            // defeating page restore. Per-id pop-outs (no `bound_page`) still
+            // prune when empty, exactly as before.
             let empties: Vec<WindowLabel> = s
                 .windows
                 .values()
-                .filter(|r| r.kind == WindowKind::PopOut && !owned.contains(r.label.as_str()))
+                .filter(|r| {
+                    r.kind == WindowKind::PopOut
+                        && r.bound_page.is_none()
+                        && !owned.contains(r.label.as_str())
+                })
                 .map(|r| r.label.clone())
                 .collect();
             if empties.is_empty() {
@@ -545,8 +570,8 @@ mod tests {
     fn create_window_allocates_monotonic_term_labels() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let a = wa.create_window(None, None, 10);
-        let b = wa.create_window(None, None, 20);
+        let a = wa.create_window(None, None, None, 10);
+        let b = wa.create_window(None, None, None, 20);
         assert_eq!(a.label, "term-1");
         assert_eq!(b.label, "term-2");
         assert_eq!(a.kind, WindowKind::PopOut);
@@ -572,7 +597,7 @@ mod tests {
     fn close_window_reassigns_all_its_sessions_to_main() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let w = wa.create_window(None, None, 10);
+        let w = wa.create_window(None, None, None, 10);
         wa.assign_session("sess-A", &w.label);
         wa.assign_session("sess-B", &w.label);
         wa.assign_session("sess-C", "term-2"); // a different window
@@ -607,21 +632,21 @@ mod tests {
         {
             let wa = WindowAssignments::open(&path).unwrap();
             wa.ensure_main(1);
-            let w = wa.create_window(Some("Pop 1".into()), None, 10);
+            let w = wa.create_window(Some("Pop 1".into()), None, None, 10);
             wa.assign_session("sess-A", &w.label);
         }
         let wa = WindowAssignments::open(&path).unwrap();
         assert_eq!(wa.owner_of("sess-A"), "term-1");
         assert!(wa.snapshot().windows.contains_key("term-1"));
         // Next allocation continues monotonically after restore.
-        assert_eq!(wa.create_window(None, None, 20).label, "term-2");
+        assert_eq!(wa.create_window(None, None, None, 20).label, "term-2");
     }
 
     #[test]
     fn update_geometry_persists_only_on_change() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let w = wa.create_window(None, None, 10);
+        let w = wa.create_window(None, None, None, 10);
         let g = WindowGeometry {
             x: 100,
             y: 200,
@@ -648,8 +673,8 @@ mod tests {
     fn pop_out_records_excludes_main() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        wa.create_window(None, None, 10);
-        wa.create_window(None, None, 20);
+        wa.create_window(None, None, None, 10);
+        wa.create_window(None, None, None, 20);
         let pops = wa.pop_out_records();
         assert_eq!(pops.len(), 2);
         assert!(pops.iter().all(|r| r.kind == WindowKind::PopOut));
@@ -660,7 +685,7 @@ mod tests {
     fn reconcile_orphans_reassigns_dangling_owners_to_main() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let w = wa.create_window(None, None, 10); // term-1 exists
+        let w = wa.create_window(None, None, None, 10); // term-1 exists
         wa.assign_session("sess-live", &w.label); // valid owner
         wa.assign_session("sess-orphan", "term-7"); // term-7 never existed
         let reassigned = wa.reconcile_orphans();
@@ -675,7 +700,7 @@ mod tests {
     fn has_assigned_sessions_reflects_owner_map() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let w = wa.create_window(None, None, 10); // term-1, no sessions yet
+        let w = wa.create_window(None, None, None, 10); // term-1, no sessions yet
         assert!(
             !wa.has_assigned_sessions(&w.label),
             "a freshly-created pop-out owns no sessions"
@@ -698,9 +723,9 @@ mod tests {
     fn prune_empty_pop_outs_removes_only_session_less_popouts() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let empty1 = wa.create_window(None, None, 10); // term-1, empty
-        let live = wa.create_window(None, None, 20); // term-2, will hold a session
-        let empty2 = wa.create_window(None, None, 30); // term-3, empty
+        let empty1 = wa.create_window(None, None, None, 10); // term-1, empty
+        let live = wa.create_window(None, None, None, 20); // term-2, will hold a session
+        let empty2 = wa.create_window(None, None, None, 30); // term-3, empty
         wa.assign_session("sess-live", &live.label);
 
         let mut pruned = wa.prune_empty_pop_outs();
@@ -722,8 +747,8 @@ mod tests {
     fn clear_session_owners_then_prune_removes_all_popouts_on_boot() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let a = wa.create_window(None, None, 10);
-        let b = wa.create_window(None, None, 20);
+        let a = wa.create_window(None, None, None, 10);
+        let b = wa.create_window(None, None, None, 20);
         // Simulate the persisted (now-stale) owner map from a prior session.
         wa.assign_session("dead-tid-1", &a.label);
         wa.assign_session("dead-tid-2", &b.label);
@@ -750,12 +775,54 @@ mod tests {
     fn prune_empty_pop_outs_noop_when_all_have_sessions() {
         let (_d, wa) = store();
         wa.ensure_main(1);
-        let a = wa.create_window(None, None, 10);
-        let b = wa.create_window(None, None, 20);
+        let a = wa.create_window(None, None, None, 10);
+        let b = wa.create_window(None, None, None, 20);
         wa.assign_session("s1", &a.label);
         wa.assign_session("s2", &b.label);
         assert!(wa.prune_empty_pop_outs().is_empty());
         assert_eq!(wa.pop_out_records().len(), 2);
+    }
+
+    #[test]
+    fn prune_keeps_page_bound_popouts_but_removes_empty_per_id_ones() {
+        let (_d, wa) = store();
+        wa.ensure_main(1);
+        // A page-bound pop-out owns NO session_owner entry (it claims terminals
+        // by page_id) yet must survive the prune.
+        let bound = wa.create_window(None, None, Some("page-A".into()), 10);
+        // A per-id pop-out with no sessions is genuinely empty → pruned.
+        let empty = wa.create_window(None, None, None, 20);
+
+        let pruned = wa.prune_empty_pop_outs();
+        assert_eq!(pruned, vec![empty.label.clone()]);
+        let remaining: std::collections::HashSet<String> =
+            wa.pop_out_records().into_iter().map(|r| r.label).collect();
+        assert_eq!(remaining, [bound.label.clone()].into());
+    }
+
+    #[test]
+    fn page_bound_window_survives_boot_sweep_and_persists_binding() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("window-assignments.json");
+        {
+            let wa = WindowAssignments::open(&path).unwrap();
+            wa.ensure_main(1);
+            wa.create_window(None, None, Some("page-A".into()), 10); // page-bound
+            wa.create_window(None, None, None, 20); // per-id, will be empty on boot
+                                                    // Simulate the prior session's (now-stale) owner map.
+            wa.assign_session("dead-tid", "term-2");
+        }
+        // Reopen (process restart) and run the boot sweep order from
+        // `restore_pop_out_windows`: clear stale owners, then prune empties.
+        let wa = WindowAssignments::open(&path).unwrap();
+        assert_eq!(wa.clear_session_owners(), 1);
+        wa.prune_empty_pop_outs();
+        // The page-bound window survives with its binding intact; the per-id
+        // window is gone.
+        let pops = wa.pop_out_records();
+        assert_eq!(pops.len(), 1, "only the page-bound pop-out survives");
+        assert_eq!(pops[0].label, "term-1");
+        assert_eq!(pops[0].bound_page.as_deref(), Some("page-A"));
     }
 
     #[test]

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,6 +74,7 @@ import { TerminalPage } from "./components/terminal";
 import { TerminalPageTabBar } from "./components/terminal/TerminalPageTabBar";
 import { SessionRecoveryBanner } from "./components/terminal/SessionRecoveryBanner";
 import { useTerminalPages } from "./components/terminal/useTerminalPages";
+import { useTerminalWindowActions } from "./components/terminal/useTerminalWindowActions";
 import { TerminalPageProvider } from "./components/terminal/TerminalPageContext";
 import { TerminalSessionProvider } from "./components/terminal/contexts";
 import { WindowAssignmentsProvider } from "./components/terminal/contexts/WindowAssignmentsContext";
@@ -155,6 +156,7 @@ function AppContent() {
   } = useAppNavigation();
 
   const terminalPages = useTerminalPages();
+  const { popOutPage } = useTerminalWindowActions();
   const [showReorganize, setShowReorganize] = useState(false);
 
   const handleReorganize = useCallback(
@@ -598,6 +600,7 @@ function AppContent() {
                   onRemovePage={terminalPages.removePage}
                   onRenamePage={terminalPages.renamePage}
                   onReorganize={() => setShowReorganize(true)}
+                  isPinned={terminalPages.isPinned}
                   onPopOut={() => {
                     // Open a new pop-out OS window (same process) that hosts its
                     // own terminal tabs — the visible counterpart to the
@@ -605,6 +608,13 @@ function AppContent() {
                     // created in that window belong to it (window_assignments).
                     void invoke("open_terminal_window", { placement: null }).catch((err) =>
                       console.error("Failed to open pop-out window:", err),
+                    );
+                  }}
+                  onPopOutPage={(pageId) => {
+                    // Detach the whole page (all its terminals + zone layout)
+                    // into its own bound pop-out window.
+                    void popOutPage(pageId).catch((err) =>
+                      console.error("Failed to pop out page:", err),
                     );
                   }}
                 />

--- a/src/components/terminal/TerminalPage.tsx
+++ b/src/components/terminal/TerminalPage.tsx
@@ -6,6 +6,7 @@ import { TerminalNotification } from "./TerminalNotification";
 import { FileConflictBanner } from "./FileConflictBanner";
 import { SessionManagerPanel } from "./SessionManagerPanel";
 import { ZoneGrid } from "./ZoneGrid";
+import { useTerminalWindowActions } from "./useTerminalWindowActions";
 import { ZoneLayoutPicker } from "./ZoneLayoutPicker";
 import { DocFinderModal } from "./DocFinderModal";
 import { ZoneMinimap } from "./ZoneMinimap";
@@ -113,6 +114,9 @@ function TerminalPageInner({
   // (see line ~71). `/metrics` + `/history` slash actions pop a card here.
   const { showCard } = useResultCard();
 
+  // Per-page / per-terminal window detach actions (pop-out-page UI Bridge action).
+  const { popOutPage } = useTerminalWindowActions();
+
   // Register page-level UI Bridge actions so AI agents can discover
   // and invoke terminal operations without knowing element IDs.
   useUIComponent({
@@ -177,6 +181,19 @@ function TerminalPageInner({
             windowLabel: rec.label,
           });
           return { window: rec.label, terminalId: activeId };
+        },
+      },
+      {
+        id: "pop-out-page",
+        label: "Pop Out Page",
+        description:
+          "Detach an ENTIRE terminal page (all its terminals + zone layout) into its own pop-out window bound to the page. Params: { pageId?: string } (defaults to the active page). Returns { window, pageId }.",
+        paramSchema: { pageId: "string (optional; defaults to the active page)" },
+        handler: async (params?: unknown) => {
+          const { pageId: target } = (params ?? {}) as { pageId?: string };
+          const pid = target || pageId;
+          const label = await popOutPage(pid);
+          return { window: label, pageId: pid };
         },
       },
       {

--- a/src/components/terminal/TerminalPageTabBar.tsx
+++ b/src/components/terminal/TerminalPageTabBar.tsx
@@ -12,6 +12,13 @@ interface TerminalPageTabBarProps {
   onReorganize?: () => void;
   /** Open a new pop-out OS window (same process) hosting its own terminals. */
   onPopOut?: () => void;
+  /** Detach an entire page (all its terminals + layout) into its own window. */
+  onPopOutPage?: (pageId: string) => void;
+  /**
+   * True in a page-pinned pop-out window — it shows ONE fixed page, so render a
+   * minimal static title bar instead of the interactive multi-page tab strip.
+   */
+  isPinned?: boolean;
 }
 
 export function TerminalPageTabBar({
@@ -23,6 +30,8 @@ export function TerminalPageTabBar({
   onRenamePage,
   onReorganize,
   onPopOut,
+  onPopOutPage,
+  isPinned,
 }: TerminalPageTabBarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
@@ -52,6 +61,18 @@ export function TerminalPageTabBar({
     const name = `Page ${pages.length + 1}`;
     onAddPage(name);
   };
+
+  // Page-pinned pop-out window: one fixed page, no tab strip — just a label.
+  if (isPinned) {
+    const page = pages[0];
+    return (
+      <div className="flex items-center gap-2 px-3 py-1 bg-[#13141f] border-b border-[#2a2d3d] shrink-0">
+        <SquareArrowOutUpRight className="w-3 h-3 text-[#7aa2f7]" />
+        <span className="text-[11px] text-[#c0caf5] truncate">{page?.name ?? "Terminal"}</span>
+        <span className="text-[9px] text-[#565f89] uppercase tracking-wider">detached page</span>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center gap-0.5 px-2 py-1 bg-[#13141f] border-b border-[#2a2d3d] shrink-0">
@@ -100,6 +121,26 @@ export function TerminalPageTabBar({
             title={`Switch to ${page.name}`}
           >
             <span className="truncate max-w-[120px]">{page.name}</span>
+            {onPopOutPage && (
+              <span
+                role="button"
+                tabIndex={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPopOutPage(page.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.stopPropagation();
+                    onPopOutPage(page.id);
+                  }
+                }}
+                className="p-0.5 rounded opacity-0 group-hover:opacity-100 text-[#565f89] hover:text-[#7aa2f7] hover:bg-[#7aa2f7]/10 transition-all"
+                title="Pop out this page into its own window"
+              >
+                <SquareArrowOutUpRight className="w-3 h-3" />
+              </span>
+            )}
             {pages.length > 1 && (
               <span
                 role="button"

--- a/src/components/terminal/contexts/TerminalSessionContext.tsx
+++ b/src/components/terminal/contexts/TerminalSessionContext.tsx
@@ -226,7 +226,7 @@ const PageSessionScope = memo(function PageSessionScope({
   // `tabs === allTabs` and every downstream consumer behaves byte-identically.
   // Read first so the window label flows into the terminal manager below
   // (Phase 2: the create-time pane key is tagged with the owning window).
-  const { windowLabel: myWindowLabel, isOwned } = useWindowAssignments();
+  const { windowLabel: myWindowLabel, isOwned, windowForPage } = useWindowAssignments();
 
   // ---- TerminalCore ----
   const terminalManager = useTerminalManager(pageId, myWindowLabel);
@@ -238,7 +238,18 @@ const PageSessionScope = memo(function PageSessionScope({
     renameTab,
     createTerminal,
   } = terminalManager;
-  const tabs = useMemo(() => allTabs.filter((t) => isOwned(t.id)), [allTabs, isOwned]);
+  // Pop-out-page binding takes precedence over the per-terminal owner map: when
+  // this whole page is detached into a window, that window renders ALL of the
+  // page's tabs and every other window renders NONE of them. Otherwise fall
+  // back to the per-terminal `isOwned` filter (single-terminal "send to
+  // window"; everything stays on "main" in the common single-window case).
+  const boundWindow = windowForPage(pageId);
+  const tabs = useMemo(() => {
+    if (boundWindow) {
+      return boundWindow === myWindowLabel ? allTabs : [];
+    }
+    return allTabs.filter((t) => isOwned(t.id));
+  }, [allTabs, isOwned, boundWindow, myWindowLabel]);
 
   // A terminal created in a pop-out window must belong to THAT window, not the
   // default "main". Assign it immediately after creation (the broadcast event

--- a/src/components/terminal/contexts/WindowAssignmentsContext.tsx
+++ b/src/components/terminal/contexts/WindowAssignmentsContext.tsx
@@ -29,11 +29,20 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
+import { setPageBindings } from "@/lib/pageBindings";
 
 export const MAIN_WINDOW_LABEL = "main";
 
 /** Map of sessionId/terminalId → owning window label. */
 export type SessionOwnerMap = Record<string, string>;
+
+/** Minimal mirror of the Rust `WindowRecord` — only fields the UI needs. */
+interface WindowRecordLite {
+  label: string;
+  kind?: "main" | "pop_out";
+  /** The terminal page this window hosts as a whole (pop-out-page feature). */
+  bound_page?: string | null;
+}
 
 interface WindowAssignmentsValue {
   /** This window's own label ("main" | "term-N"). */
@@ -44,6 +53,10 @@ interface WindowAssignmentsValue {
   ownerOf: (sessionId: string) => string;
   /** Whether a session is owned by THIS window. */
   isOwned: (sessionId: string) => boolean;
+  /** The window hosting a whole detached page, or null when the page is docked. */
+  windowForPage: (pageId: string) => string | null;
+  /** The page THIS window is bound to (pop-out-page windows only), else null. */
+  boundPage: string | null;
 }
 
 function readWindowLabel(): string {
@@ -65,6 +78,16 @@ interface SessionAssignmentChanged {
 
 interface WindowAssignmentsSnapshot {
   session_owner?: SessionOwnerMap;
+  windows?: Record<string, WindowRecordLite>;
+}
+
+/** Derive the `pageId → windowLabel` map from the window registry. */
+function bindingsFromWindows(windows: Record<string, WindowRecordLite>): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const rec of Object.values(windows)) {
+    if (rec.bound_page) map[rec.bound_page] = rec.label;
+  }
+  return map;
 }
 
 export function WindowAssignmentsProvider({ children }: { children: ReactNode }) {
@@ -72,21 +95,34 @@ export function WindowAssignmentsProvider({ children }: { children: ReactNode })
   // a plain render-safe value).
   const [windowLabel] = useState<string>(readWindowLabel);
   const [assignments, setAssignments] = useState<SessionOwnerMap>({});
+  // `pageId → windowLabel` for pages detached into a pop-out (pop-out-page
+  // feature). Sourced from the Rust window registry; also mirrored to
+  // `localStorage` so `useTerminalPages` can read it synchronously at boot.
+  const [pageBindings, setPageBindingsState] = useState<Record<string, string>>({});
 
   useEffect(() => {
     let mounted = true;
 
-    // Hydrate from the persisted snapshot.
-    invoke<WindowAssignmentsSnapshot>("get_window_assignments")
-      .then((snap) => {
-        if (mounted && snap?.session_owner) setAssignments(snap.session_owner);
-      })
-      .catch(() => {
-        // Command unavailable (older backend) — stay single-window safe.
-      });
+    // Recompute the window registry from the Rust snapshot and refresh both the
+    // in-context state and the synchronous localStorage mirror. Called on mount
+    // and whenever a window opens/closes (those events carry no full registry).
+    const refresh = () =>
+      invoke<WindowAssignmentsSnapshot>("get_window_assignments")
+        .then((snap) => {
+          if (!mounted) return;
+          if (snap?.session_owner) setAssignments(snap.session_owner);
+          const bindings = bindingsFromWindows(snap?.windows ?? {});
+          setPageBindingsState(bindings);
+          setPageBindings(bindings); // sync the localStorage mirror to Rust truth
+        })
+        .catch(() => {
+          // Command unavailable (older backend) — stay single-window safe.
+        });
 
-    // Track moves. "to === main" means the entry is cleared (default rule).
-    const unlistenPromise = listen<SessionAssignmentChanged>(
+    void refresh();
+
+    // Track per-terminal moves. "to === main" means the entry is cleared.
+    const unlistenAssign = listen<SessionAssignmentChanged>(
       "session-assignment-changed",
       (event) => {
         if (!mounted) return;
@@ -103,9 +139,20 @@ export function WindowAssignmentsProvider({ children }: { children: ReactNode })
       },
     );
 
+    // A window opening/closing changes the page-binding map — re-pull the
+    // registry so `windowForPage` (and the mirror) stay current in EVERY window.
+    const unlistenOpened = listen("window-opened", () => {
+      if (mounted) void refresh();
+    });
+    const unlistenClosed = listen("window-closed", () => {
+      if (mounted) void refresh();
+    });
+
     return () => {
       mounted = false;
-      unlistenPromise.then((un) => un()).catch(() => {});
+      unlistenAssign.then((un) => un()).catch(() => {});
+      unlistenOpened.then((un) => un()).catch(() => {});
+      unlistenClosed.then((un) => un()).catch(() => {});
     };
   }, []);
 
@@ -119,9 +166,21 @@ export function WindowAssignmentsProvider({ children }: { children: ReactNode })
     [ownerOf, windowLabel],
   );
 
+  const windowForPage = useCallback(
+    (pageId: string): string | null => pageBindings[pageId] ?? null,
+    [pageBindings],
+  );
+
+  const boundPage = useMemo<string | null>(() => {
+    for (const [pid, label] of Object.entries(pageBindings)) {
+      if (label === windowLabel) return pid;
+    }
+    return null;
+  }, [pageBindings, windowLabel]);
+
   const value = useMemo<WindowAssignmentsValue>(
-    () => ({ windowLabel, assignments, ownerOf, isOwned }),
-    [windowLabel, assignments, ownerOf, isOwned],
+    () => ({ windowLabel, assignments, ownerOf, isOwned, windowForPage, boundPage }),
+    [windowLabel, assignments, ownerOf, isOwned, windowForPage, boundPage],
   );
 
   return (
@@ -142,6 +201,8 @@ export function useWindowAssignments(): WindowAssignmentsValue {
       assignments: {},
       ownerOf: () => MAIN_WINDOW_LABEL,
       isOwned: () => true,
+      windowForPage: () => null,
+      boundPage: null,
     }),
     [],
   );

--- a/src/components/terminal/useTerminalPages.ts
+++ b/src/components/terminal/useTerminalPages.ts
@@ -1,7 +1,8 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { instanceStorage } from "@/lib/instance-storage";
+import { getPageBindings, subscribePageBindings } from "@/lib/pageBindings";
 
 export interface TerminalPageConfig {
   id: string;
@@ -11,6 +12,21 @@ export interface TerminalPageConfig {
 
 const STORAGE_KEY = "qontinui-terminal-pages";
 const ACTIVE_PAGE_KEY = "qontinui-terminal-active-page";
+
+/**
+ * A page-pinned pop-out window carries `?page=<id>` (set by the pop-out-page
+ * boot hint in `terminal_windows.rs`). Such a window shows ONLY that one page,
+ * fixes it as active, and never mutates the shared page list / active-page key —
+ * it is a read-only detached view of one page. Returns null in the main window.
+ */
+function readPinnedPageId(): string | null {
+  try {
+    const v = new URLSearchParams(window.location.search).get("page");
+    return v && v.trim() ? v : null;
+  } catch {
+    return null;
+  }
+}
 
 function loadPages(): TerminalPageConfig[] {
   const pages = instanceStorage.getJSON<TerminalPageConfig[]>(STORAGE_KEY, []);
@@ -93,15 +109,42 @@ export function reconcilePages(
 }
 
 export function useTerminalPages() {
-  const [pages, setPages] = useState<TerminalPageConfig[]>(loadPages);
-  const [activePageId, setActivePageIdState] = useState<string>(
-    () => instanceStorage.getItem(ACTIVE_PAGE_KEY) || "default",
+  // A page-pinned pop-out window is fixed to one page for its whole lifetime.
+  const [pinnedPageId] = useState<string | null>(readPinnedPageId);
+  const isPinned = pinnedPageId !== null;
+
+  const [allPages, setPages] = useState<TerminalPageConfig[]>(loadPages);
+  const [activePageId, setActivePageIdState] = useState<string>(() =>
+    isPinned ? pinnedPageId! : instanceStorage.getItem(ACTIVE_PAGE_KEY) || "default",
   );
 
-  const setActivePageId = useCallback((id: string) => {
-    setActivePageIdState(id);
-    instanceStorage.setItem(ACTIVE_PAGE_KEY, id);
-  }, []);
+  // `pageId → windowLabel` for pages currently detached into a pop-out. Read
+  // synchronously from the localStorage mirror so the FIRST render already
+  // hides detached pages (and never picks one as active) — avoiding the
+  // boot race where main would briefly restore a page the pop-out owns.
+  // `WindowAssignmentsContext` keeps the mirror in sync with the Rust truth.
+  const [boundPages, setBoundPages] = useState<Record<string, string>>(getPageBindings);
+  useEffect(() => subscribePageBindings(() => setBoundPages(getPageBindings())), []);
+
+  const setActivePageId = useCallback(
+    (id: string) => {
+      if (isPinned) return; // pinned window: active page is fixed
+      setActivePageIdState(id);
+      instanceStorage.setItem(ACTIVE_PAGE_KEY, id);
+    },
+    [isPinned],
+  );
+
+  // The pages this window should surface: a pinned pop-out shows ONLY its page;
+  // the main window shows every page NOT detached into a pop-out (those live in
+  // their own window). Memoized so the normalize-active effect below is stable.
+  const pages = useMemo<TerminalPageConfig[]>(() => {
+    if (isPinned) {
+      const found = allPages.find((p) => p.id === pinnedPageId);
+      return [found ?? { id: pinnedPageId!, name: "Terminal", createdAt: 0 }];
+    }
+    return allPages.filter((p) => !boundPages[p.id]);
+  }, [isPinned, pinnedPageId, allPages, boundPages]);
 
   const addPage = useCallback(
     (name: string) => {
@@ -259,6 +302,10 @@ export function useTerminalPages() {
   // Run reconciliation once on mount and on a debounced `terminal-created`
   // event (a burst of continuations collapses to a single reconcile).
   useEffect(() => {
+    // A pinned pop-out renders one fixed page and must not touch the shared
+    // page list — skip reconciliation entirely.
+    if (isPinned) return;
+
     let unlisten: (() => void) | null = null;
     let timer: ReturnType<typeof setTimeout> | null = null;
     let disposed = false;
@@ -289,7 +336,29 @@ export function useTerminalPages() {
       if (timer) clearTimeout(timer);
       unlisten?.();
     };
-  }, [reconcile]);
+  }, [reconcile, isPinned]);
+
+  // Keep the active page valid for the MAIN window: when the active page gets
+  // detached into a pop-out (or otherwise disappears from the visible set),
+  // fall back to the first visible page. If EVERY page is detached, mint a
+  // fresh docked page so the main window always has something to show.
+  useEffect(() => {
+    if (isPinned) return;
+    const visibleIds = pages.map((p) => p.id);
+    if (visibleIds.length === 0) {
+      // Intentional sync from an EXTERNAL system (page bindings written by other
+      // windows): the active page was detached out from under us with no docked
+      // page left, so mint one. Rare, idempotent (a fresh page is never bound),
+      // and converges in one extra render — same exception the reconcile effect
+      // above relies on.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      addPage("Terminal");
+      return;
+    }
+    if (!visibleIds.includes(activePageId)) {
+      setActivePageId(visibleIds[0]);
+    }
+  }, [isPinned, pages, activePageId, addPage, setActivePageId]);
 
   return {
     pages,
@@ -299,5 +368,7 @@ export function useTerminalPages() {
     openPage,
     removePage,
     renamePage,
+    /** True in a page-pinned pop-out window (shows one fixed page, minimal chrome). */
+    isPinned,
   };
 }

--- a/src/components/terminal/useTerminalWindowActions.ts
+++ b/src/components/terminal/useTerminalWindowActions.ts
@@ -1,5 +1,8 @@
 import { useCallback } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { instanceStorage } from "@/lib/instance-storage";
+import { setPageBinding } from "@/lib/pageBindings";
+import { zoneLayoutStorageKey } from "./useZoneLayout";
 
 /**
  * A runner-owned OS window (the main window or a `term-N` pop-out), as
@@ -39,5 +42,39 @@ export function useTerminalWindowActions() {
     return await invoke<RunnerWindowRecord[]>("list_runner_windows");
   }, []);
 
-  return { popOutTab, moveTabToWindow, listWindows };
+  /**
+   * Detach an ENTIRE page into its own pop-out window (the "pop out page"
+   * feature). Opens a window BOUND to `pageId` (so its terminals are claimed by
+   * page, survive restarts, and vanish from the main window), copies the page's
+   * zone layout so the grid looks identical, and records the binding in the
+   * synchronous mirror so the main window hides the page immediately. Returns
+   * the new window's label.
+   *
+   * No per-terminal `assign_session_to_window` calls are needed: page-binding
+   * (`WindowRecord.bound_page`) is what routes every one of the page's tabs to
+   * the new window.
+   */
+  const popOutPage = useCallback(async (pageId: string): Promise<string> => {
+    const rec = await invoke<{ label: string }>("open_terminal_window", {
+      placement: null,
+      boundPage: pageId,
+    });
+    // Preserve the visual grid: clone the page's main-window layout into the
+    // pop-out's per-(page, window) key BEFORE its React app reads it on boot.
+    try {
+      const srcKey = zoneLayoutStorageKey(pageId, "main");
+      const layout = instanceStorage.getJSON<unknown>(srcKey, null);
+      if (layout !== null) {
+        instanceStorage.setJSON(zoneLayoutStorageKey(pageId, rec.label), layout);
+      }
+    } catch {
+      // Layout copy is best-effort — the pop-out falls back to auto-layout.
+    }
+    // Optimistic mirror update so the main window hides + switches off the page
+    // without waiting for the Rust snapshot refresh (window-opened) to arrive.
+    setPageBinding(pageId, rec.label);
+    return rec.label;
+  }, []);
+
+  return { popOutTab, moveTabToWindow, listWindows, popOutPage };
 }

--- a/src/components/terminal/useZoneLayout.ts
+++ b/src/components/terminal/useZoneLayout.ts
@@ -218,6 +218,16 @@ function storageKey(pageId: string, windowLabel: string = "main"): string {
   return windowLabel === "main" ? base : `${base}:window:${windowLabel}`;
 }
 
+/**
+ * Public form of the per-(page, window) zone-layout storage key. Exported so the
+ * pop-out-page action can COPY a page's layout from the main window's key to the
+ * new pop-out window's key, preserving the grid preset + zone assignments when a
+ * whole page is detached. Keep in lockstep with {@link storageKey}.
+ */
+export function zoneLayoutStorageKey(pageId: string, windowLabel: string = "main"): string {
+  return storageKey(pageId, windowLabel);
+}
+
 function loadPersistedState(pageId: string, windowLabel?: string): PersistedState | null {
   return instanceStorage.getJSON<PersistedState | null>(storageKey(pageId, windowLabel), null);
 }

--- a/src/lib/pageBindings.test.ts
+++ b/src/lib/pageBindings.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+// The project's vitest environment is "node" (no DOM). Mock the storage layer
+// with an in-memory map (avoids `getApiPort`'s `window` access) and give the
+// module a real EventTarget as `window` so the change-event path is exercised.
+const store = new Map<string, string>();
+vi.mock("./instance-storage", () => ({
+  instanceStorage: {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    getJSON: <T>(k: string, fallback: T): T => {
+      const raw = store.get(k);
+      return raw ? (JSON.parse(raw) as T) : fallback;
+    },
+    setJSON: (k: string, v: unknown) => void store.set(k, JSON.stringify(v)),
+  },
+}));
+
+beforeAll(() => {
+  if (typeof (globalThis as { window?: unknown }).window === "undefined") {
+    (globalThis as { window?: unknown }).window = new EventTarget();
+  }
+});
+
+afterEach(() => {
+  store.clear();
+});
+
+// Imported after the mock is registered (vi.mock is hoisted).
+const {
+  PAGE_BINDINGS_EVENT,
+  getPageBindings,
+  setPageBinding,
+  setPageBindings,
+  subscribePageBindings,
+  windowForPage,
+} = await import("./pageBindings");
+
+describe("pageBindings", () => {
+  it("defaults to an empty map and null window-for-page", () => {
+    expect(getPageBindings()).toEqual({});
+    expect(windowForPage("page-A")).toBeNull();
+  });
+
+  it("binds and unbinds a single page", () => {
+    setPageBinding("page-A", "term-1");
+    expect(getPageBindings()).toEqual({ "page-A": "term-1" });
+    expect(windowForPage("page-A")).toBe("term-1");
+
+    setPageBinding("page-A", null);
+    expect(getPageBindings()).toEqual({});
+    expect(windowForPage("page-A")).toBeNull();
+  });
+
+  it("overwrites the whole map with setPageBindings", () => {
+    setPageBinding("page-A", "term-1");
+    setPageBindings({ "page-B": "term-2" });
+    expect(getPageBindings()).toEqual({ "page-B": "term-2" });
+  });
+
+  it("emits a change event on mutation but not on a no-op", () => {
+    const cb = vi.fn();
+    const unsub = subscribePageBindings(cb);
+
+    setPageBinding("page-A", "term-1");
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // No-op: same single binding again → no event.
+    setPageBinding("page-A", "term-1");
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // No-op: identical full map → no event.
+    setPageBindings({ "page-A": "term-1" });
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    setPageBindings({ "page-A": "term-1", "page-B": "term-2" });
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    unsub();
+    setPageBinding("page-C", "term-3");
+    expect(cb).toHaveBeenCalledTimes(2); // unsubscribed
+  });
+
+  it("uses the documented event name", () => {
+    const cb = vi.fn();
+    window.addEventListener(PAGE_BINDINGS_EVENT, cb);
+    setPageBinding("page-A", "term-1");
+    expect(cb).toHaveBeenCalledTimes(1);
+    window.removeEventListener(PAGE_BINDINGS_EVENT, cb);
+  });
+});

--- a/src/lib/pageBindings.ts
+++ b/src/lib/pageBindings.ts
@@ -1,0 +1,89 @@
+/**
+ * Page → pop-out-window bindings (the "pop out page" feature).
+ *
+ * When a whole terminal PAGE is detached into its own OS window, that window is
+ * bound to the page by its stable `pageId`. The authoritative store is the Rust
+ * `window_assignments` registry (`WindowRecord.bound_page`), but the frontend
+ * needs this mapping SYNCHRONOUSLY at first render — `useTerminalPages` must
+ * know, before it picks an active page, which pages live in a pop-out so the
+ * main window neither shows their tab nor tries to restore them (which would
+ * race the pop-out's own restore). An async `get_window_assignments` round-trip
+ * can't satisfy that.
+ *
+ * So this module keeps a `localStorage` MIRROR of `pageId → windowLabel`,
+ * refreshed from the Rust truth on every load + window event by
+ * `WindowAssignmentsContext`. It is shared across this process's windows (same
+ * port-namespaced `instanceStorage`), and persists across restarts so the
+ * synchronous boot read is correct before the Rust snapshot arrives.
+ *
+ * Mutations dispatch a `window` CustomEvent so same-window listeners
+ * (`useTerminalPages`) update without polling. Cross-window propagation is
+ * handled by each window recomputing from the Rust snapshot on the broadcast
+ * `window-opened` / `window-closed` Tauri events.
+ */
+
+import { instanceStorage } from "./instance-storage";
+
+const KEY = "qontinui-page-bindings";
+
+/** Fired (same-window) whenever the binding map changes. */
+export const PAGE_BINDINGS_EVENT = "qontinui:page-bindings-changed";
+
+/** `pageId → windowLabel` for every page currently detached into a pop-out. */
+export type PageBindings = Record<string, string>;
+
+/** Synchronous read of the current bindings (safe default `{}`). */
+export function getPageBindings(): PageBindings {
+  const raw = instanceStorage.getJSON<PageBindings | null>(KEY, null);
+  return raw && typeof raw === "object" ? raw : {};
+}
+
+/** The window hosting a detached page, or `null` when the page is docked. */
+export function windowForPage(pageId: string): string | null {
+  return getPageBindings()[pageId] ?? null;
+}
+
+/**
+ * Overwrite the whole binding map (used when recomputing from the Rust
+ * snapshot). No-ops + emits nothing when the map is unchanged.
+ */
+export function setPageBindings(next: PageBindings): void {
+  const prev = getPageBindings();
+  if (shallowEqual(prev, next)) return;
+  instanceStorage.setJSON(KEY, next);
+  emitChange();
+}
+
+/** Bind (`label`) or unbind (`null`) a single page. */
+export function setPageBinding(pageId: string, label: string | null): void {
+  const next = { ...getPageBindings() };
+  if (label === null) {
+    if (!(pageId in next)) return;
+    delete next[pageId];
+  } else {
+    if (next[pageId] === label) return;
+    next[pageId] = label;
+  }
+  instanceStorage.setJSON(KEY, next);
+  emitChange();
+}
+
+/** Subscribe to binding changes. Returns an unsubscribe fn. */
+export function subscribePageBindings(cb: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(PAGE_BINDINGS_EVENT, cb);
+  return () => window.removeEventListener(PAGE_BINDINGS_EVENT, cb);
+}
+
+function emitChange(): void {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(PAGE_BINDINGS_EVENT));
+  }
+}
+
+function shallowEqual(a: PageBindings, b: PageBindings): boolean {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) => a[k] === b[k]);
+}


### PR DESCRIPTION
## What this adds

A one-click **page-level pop-out**: detach an ENTIRE terminal page (all its terminals in their zone-grid layout) into its own dedicated OS window. This complements the existing per-terminal "send to window" pop-out already on main.

- **UI trigger**: a per-page pop-out icon in `TerminalPageTabBar` (hover-revealed on each page tab) + a `pop-out-page` UI Bridge action on the `terminal-page` component.
- **Action**: `useTerminalWindowActions.popOutPage(pageId)` opens a window bound to the page (`open_terminal_window { boundPage }`), copies the page's zone layout into the pop-out's per-window key so the grid looks identical, and optimistically updates the binding mirror so main hides the page immediately.

## How it differs from main's tab-level pop-out

| | tab-level (on main) | page-level (this PR) |
|---|---|---|
| unit moved | one terminal | a whole page (all terminals + layout) |
| routing key | per-terminal `session_owner` map | stable `page_id` via new `WindowRecord.bound_page` |
| survives restart | no (terminal ids regenerate) | **yes** (page ids are stable; bound window restored with `&page=` boot hint) |

New `pageBindings.ts` abstraction (`PageBindings = Record<pageId, windowLabel>`, `getPageBindings`/`setPageBinding`/`windowForPage`/`subscribePageBindings`, event `qontinui:page-bindings-changed`) keeps a synchronous localStorage mirror of the Rust `bound_page` truth so the main window can hide a detached page at first render and skip restoring it — avoiding the boot race where main and the pop-out both restore the same sessions.

Robust model details:
- A page-pinned pop-out boots with `?page=<id>`, pins itself to that one page, hides the multi-page tab strip (minimal chrome), and never mutates the shared active-page.
- Tab filtering: a detached page's tabs render ONLY in its bound window (precedence over the per-terminal owner map).
- Boot sweep: page-bound windows are preserved by the empty-pop-out prune (they own no `session_owner` entry but claim terminals by `page_id`); per-id pop-outs still prune when empty, as before.

## Verification

- **Local**: `tsc --noEmit` clean; eslint clean (0 errors); vitest 635/635 pass (incl. `pageBindings.test.ts`); `cargo check`, `cargo clippy --all-targets -D warnings`, and `cargo test window_assignments` (16/16, incl. 2 new page-bound boot-sweep tests) all green. cargo fmt clean.
- **Live temp-runner** (gitSha `0213131c` of this branch): drove the UI Bridge to navigate to the terminal page, create a terminal, then invoke `pop-out-page`. Result: a new pop-out window `term-1` was created with `bound_page: "default"` and real geometry (1500x1080), the `pageBindings` mirror updated to `{"default":"term-1"}`, and the main window correctly minted a fresh docked page when its active page was detached. No errors.
